### PR TITLE
changes for github.com/tdunning/h2o-matrix

### DIFF
--- a/h2o-core/src/main/water/H2O.java
+++ b/h2o-core/src/main/water/H2O.java
@@ -501,7 +501,7 @@ final public class H2O {
     return memsz;
   }
 
-  static void waitForCloudSize(int x, long ms) {
+  public static void waitForCloudSize(int x, long ms) {
     long start = System.currentTimeMillis();
     while( System.currentTimeMillis() - start < ms ) {
       if( CLOUD.size() >= x && Paxos._commonKnowledge )

--- a/h2o-core/src/main/water/fvec/Chunk.java
+++ b/h2o-core/src/main/water/fvec/Chunk.java
@@ -39,7 +39,7 @@ public abstract class Chunk extends Iced implements Cloneable {
    * JIT'd code (similar issue to using iterator objects).
    * <p>
    * Slightly slower than 'at80' since it range checks within a chunk. */
-  final double at( long i ) { 
+  public final double at( long i ) { 
     long x = i-_start;
     if( 0 <= x && x < _len ) return at0((int)x);
     throw new ArrayIndexOutOfBoundsException(""+_start+" <= "+i+" < "+(_start+_len));
@@ -67,13 +67,13 @@ public abstract class Chunk extends Iced implements Cloneable {
    *  if the long does not fit in a double (value is larger magnitude than
    *  2^52), AND float values are stored in Vector.  In this case, there is no
    *  common compatible data representation. */
-  final long   set( long i, long   l) { long x = i-_start; return (0 <= x && x < _len) ? set0((int)x,l) : _vec.set(i,l); }
+  public final long   set( long i, long   l) { long x = i-_start; return (0 <= x && x < _len) ? set0((int)x,l) : _vec.set(i,l); }
   /** Write element the slow way, as a double.  Double.NaN will be treated as
    *  a set of a missing element. */
-  final double set( long i, double d) { long x = i-_start; return (0 <= x && x < _len) ? set0((int)x,d) : _vec.set(i,d); }
+  public final double set( long i, double d) { long x = i-_start; return (0 <= x && x < _len) ? set0((int)x,d) : _vec.set(i,d); }
   /** Write element the slow way, as a float.  Float.NaN will be treated as
    *  a set of a missing element. */
-  final float  set( long i, float  f) { long x = i-_start; return (0 <= x && x < _len) ? set0((int)x,f) : _vec.set(i,f); }
+  public final float  set( long i, float  f) { long x = i-_start; return (0 <= x && x < _len) ? set0((int)x,f) : _vec.set(i,f); }
   /** Set the element as missing the slow way.  */
   final boolean setNA( long i )       { long x = i-_start; return (0 <= x && x < _len) ? setNA0((int)x) : _vec.setNA(i); }
   

--- a/h2o-core/src/main/water/fvec/Frame.java
+++ b/h2o-core/src/main/water/fvec/Frame.java
@@ -108,6 +108,19 @@ public class Frame extends Lockable {
     _vecs = fr.vecs().clone();
   }
 
+  public Frame deepcopy() {
+    return new MRTask() {
+      @Override public void map(Chunk []cs, NewChunk []ncs) {
+        for (int col = 0; col < cs.length; col++) {
+          Chunk c = cs[col];
+          NewChunk nc = ncs[col];
+          for (int row = 0; row < c._len; row++) {
+            nc.addNum(c.at0(row));
+          }
+        }
+      }
+    }.doAll(this.numCols(),this).outputFrame(this.names(),this.domains());
+  }
   /** Returns a subframe of this frame containing only vectors with desired names.
    *
    * @param names list of vector names

--- a/h2o-core/src/main/water/fvec/Vec.java
+++ b/h2o-core/src/main/water/fvec/Vec.java
@@ -136,7 +136,7 @@ public class Vec extends Keyed {
     fs.blockForPending();
     return v;
   }
-  private static Vec makeConSeq(double x, int len) {
+  public static Vec makeConSeq(double x, int len) {
     Futures fs = new Futures();
     AppendableVec av = new AppendableVec(VectorGroup.VG_LEN1.addVec());
     NewChunk nc = new NewChunk(av,0);
@@ -388,7 +388,7 @@ public class Vec extends Keyed {
   // Cache of last Chunk accessed via at/set api
   transient Chunk _cache;
   /** The Chunk for a row#.  Warning: this loads the data locally!  */
-  final Chunk chunkForRow(long i) {
+  public final Chunk chunkForRow(long i) {
     Chunk c = _cache;
     return (c != null && c._chk2==null && c._start <= i && i < c._start+c._len) ? c : (_cache = chunkForRow_impl(i));
   }
@@ -409,16 +409,17 @@ public class Vec extends Keyed {
    *  common compatible data representation.
    *
    *  */
-  final long   set( long i, long   l) {return chunkForRow(i).set(i,l);}
+  public final long   set( long i, long   l) {return chunkForRow(i).set(i,l);}
 
   /** Write element the slow way, as a double.  Double.NaN will be treated as
    *  a set of a missing element.
    *  */
-  final double set( long i, double d) {return chunkForRow(i).set(i,d);}
+  public final double set( long i, double d) {return chunkForRow(i).set(i,d);}
   /** Write element the slow way, as a float.  Float.NaN will be treated as
    *  a set of a missing element.
    *  */
-  final float  set( long i, float  f) {return chunkForRow(i).set(i,f);}
+  public final float  set( long i, float  f) {return chunkForRow(i).set(i,f);}
+
   /** Set the element as missing the slow way.  */
   final boolean setNA( long i ) { return chunkForRow(i).setNA(i);}
 
@@ -443,6 +444,11 @@ public class Vec extends Keyed {
     DKV.remove(rollupStatsKey(),fs);
     super.remove(fs);
     return fs;
+  }
+  @Override public void remove() {
+    Futures fs = new Futures();
+    remove(fs);
+    fs.blockForPending();
   }
 
   @Override public boolean equals( Object o ) {

--- a/h2o-core/src/main/water/util/FrameUtils.java
+++ b/h2o-core/src/main/water/util/FrameUtils.java
@@ -1,0 +1,24 @@
+package water.util;
+
+import java.io.File;
+
+import water.Key;
+import water.fvec.*;
+import water.parser.*;
+
+public class FrameUtils {
+  /** Parse given file into the form of frame represented by the given key.
+   *
+   * @param okey  destination key for parsed frame
+   * @param file  file to parse
+   * @return a new frame
+   */
+  public static Frame parseFrame(Key okey, File file) {
+    if( !file.exists() )
+      throw new RuntimeException("File not found " + file);
+    if(okey == null)
+      okey = Key.make(file.getName());
+    Key fkey = NFSFileVec.make(file)._key;
+    return ParseDataset2.parse(okey, fkey);
+  }
+}

--- a/h2o-core/src/main/water/util/Utils.java
+++ b/h2o-core/src/main/water/util/Utils.java
@@ -1,0 +1,43 @@
+package water.util;
+
+public class Utils {
+  public static byte[] add(byte[] a, byte[] b) {
+    for(int i = 0; i < a.length; i++ ) a[i] += b[i];
+    return a;
+  }
+  public static int[] add(int[] a, int[] b) {
+    for(int i = 0; i < a.length; i++ ) a[i] += b[i];
+    return a;
+  }
+  public static int[][] add(int[][] a, int[][] b) {
+    for(int i = 0; i < a.length; i++ ) add(a[i],b[i]);
+    return a;
+  }
+  public static long[] add(long[] a, long[] b) {
+    if( b==null ) return a;
+    for(int i = 0; i < a.length; i++ ) a[i] += b[i];
+    return a;
+  }
+  public static long[][] add(long[][] a, long[][] b) {
+    for(int i = 0; i < a.length; i++ ) add(a[i],b[i]);
+    return a;
+  }
+  public static float[] add(float[] a, float[] b) {
+    if( b==null ) return a;
+    for(int i = 0; i < a.length; i++ ) a[i] += b[i];
+    return a;
+  }
+  public static float[][] add(float[][] a, float[][] b) {
+    for(int i = 0; i < a.length; i++ ) add(a[i],b[i]);
+    return a;
+  }
+  public static double[] add(double[] a, double[] b) {
+    if( a==null ) return b;
+    for(int i = 0; i < a.length; i++ ) a[i] += b[i];
+    return a;
+  }
+  public static double[][] add(double[][] a, double[][] b) {
+    for(int i = 0; i < a.length; i++ ) a[i] = add(a[i],b[i]);
+    return a;
+  }
+}


### PR DESCRIPTION
- water.fvec.Frame.deepcopy()
  - new method to deep clone a Frame (including data)
- water.fvec.Vec.remove(void)
  - convenience wrapper around remove(Futures)
- water.utils.FrameUtils.parseFrame()
  - forward port from h2o.git with minor API changes
- Publicize
  - water.fvec.Vec.makeConSeq()
  - water.fvec.Vec.chunkForRow()
  - water.fvec.Vec.set()
  - water.fvec.Chunk.set()
  - water.fvec.Chunk.at()
  - water.H2O.waitForCloudSize()

Signed-off-by: Anand Avati avati@redhat.com
