### PR TITLE
Weaver: load Icer classes through currentClassLoader explicitly

### DIFF
--- a/h2o-core/src/main/java/water/Weaver.java
+++ b/h2o-core/src/main/java/water/Weaver.java
@@ -77,7 +77,7 @@ public class Weaver {
     CtClass icer_cc = _pool.getOrNull(icer_name); // Full Name Lookup of Icer
     if( icer_cc != null ) {
       synchronized( iced_clazz ) {
-        if( !icer_cc.isFrozen() ) icer_cc.toClass(); // Load class (but does not link & init)
+        if( !icer_cc.isFrozen() ) icer_cc.toClass(Weaver.class.getClassLoader()); // Load class (but does not link & init)
         return Class.forName(icer_name); // Found a pre-cooked Icer implementation
       }
     }
@@ -99,7 +99,7 @@ public class Weaver {
       icer_cc = _pool.getOrNull(icer_name); // Retry under lock
       if( icer_cc != null ) return Class.forName(icer_name); // Found a pre-cooked Icer implementation
       icer_cc = genIcerClass(id,iced_cc,iced_clazz,icer_name,super_id,super_icer_cc,super_has_jfields);
-      icer_cc.toClass();               // Load class (but does not link & init)
+      icer_cc.toClass(Weaver.class.getClassLoader());               // Load class (but does not link & init)
       return Class.forName(icer_name); // Initialize class now, before subclasses
     }
   }


### PR DESCRIPTION
javassist loads classes through thread context classloader. But
scalatest sets a child URLClassLoader as the thread context
classloader. So the Class.forName() which immediately follows
the CtClass.toClass() is unable to find the Icer class, because
the current classloader is the parent and threfore unable to find
the Icer class.

While it does not matter for standalone H2O, it is probably a good
practice to explicitly set javassist's classloader to be the
current classloader. This fixes the Mahout scalatest failures too.

Signed-off-by: Anand Avati avati@redhat.com
