### PR TITLE
Adding R Setup instructions for Windows and OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Install [Node.js](http://nodejs.org/download/) and add installed directory `C:\P
 
 Step 3. Install R and the required packages
 
-Install [R](http://www.r-project.org/) and add the installed bin\x64 directory to your PATH.
+Install [R](http://www.r-project.org/) and add the preferred bin\i386 or bin\x64 directory to your PATH.
 
-Install the following packages: [RCurl](http://cran.r-project.org/package=RCurl), [rjson](http://cran.r-project.org/package=rjson), [statmod](http://cran.r-project.org/package=statmod), and [bitops](http://cran.r-project.org/package=bitops).
+Install the following R packages: [RCurl](http://cran.r-project.org/package=RCurl), [rjson](http://cran.r-project.org/package=rjson), [statmod](http://cran.r-project.org/package=statmod), and [bitops](http://cran.r-project.org/package=bitops).
 
     cd Downloads
     R CMD INSTALL RCurl_x.xx-x.x.zip
@@ -109,9 +109,9 @@ Otherwise install from the [NodeJS website](http://nodejs.org/download/).
 
 Step 3. Install R and the required packages
 
-Install [R](http://www.r-project.org/) and add the installed bin directory to your PATH if not already included.
+Install [R](http://www.r-project.org/) and add the bin directory to your PATH if not already included.
 
-Install the following packages: [RCurl](http://cran.r-project.org/package=RCurl), [rjson](http://cran.r-project.org/package=rjson), [statmod](http://cran.r-project.org/package=statmod), and [bitops](http://cran.r-project.org/package=bitops).
+Install the following R packages: [RCurl](http://cran.r-project.org/package=RCurl), [rjson](http://cran.r-project.org/package=rjson), [statmod](http://cran.r-project.org/package=statmod), and [bitops](http://cran.r-project.org/package=bitops).
 
     cd Downloads
     R CMD INSTALL RCurl_x.xx-x.x.tgz


### PR DESCRIPTION
Hi,
I recently checked out the h2o-dev project, followed the setup instructions in the README.md for both Win 7 64 and OS X, and to my dismay the builds failed. At that point I had to debug the build and google around to find the missing packages.

It would have saved me a bunch of time if the links/information that I'm including with this patch had been there for me when I started out.
