### PR TITLE
fixed sys.platform for windows os.

### DIFF
--- a/h2o-py/h2o/connection.py
+++ b/h2o-py/h2o/connection.py
@@ -270,7 +270,7 @@ class H2OConnection(object):
 
   @staticmethod
   def _tmp_file(type):
-    if sys.platform == "windows":
+    if sys.platform == "win32":
       usr = re.sub("[^A-Za-z0-9]", "_", os.getenv("USERNAME"))
     else:
       usr = re.sub("[^A-Za-z0-9]", "_", os.getenv("USER"))


### PR DESCRIPTION
output for sys.platform on windows is 'win32' not 'windows'.
https://docs.python.org/2/library/sys.html#sys.platform