### PR TITLE
fixed links in help of predict function

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -347,8 +347,8 @@ h2o.getFutureModel <- function(object) {
 #' @param ... additional arguments to pass on.
 #' @return Returns an H2O Frame object with probabilites and
 #'         default predictions.
-#' @seealso \code{link{h2o.deeplearning}}, \code{link{h2o.gbm}},
-#'          \code{link{h2o.glm}}, \code{link{h2o.randomForest}} for model
+#' @seealso \code{\link{h2o.deeplearning}}, \code{\link{h2o.gbm}},
+#'          \code{\link{h2o.glm}}, \code{\link{h2o.randomForest}} for model
 #'          generation in h2o.
 #' @export
 predict.H2OModel <- function(object, newdata, ...) {


### PR DESCRIPTION
replaced \code{link{}} with \code{\link{}} to get correct links.