### PR TITLE
Changes that enable running h2o in cloud: Basic Authentication and containers integration.

### DIFF
--- a/buildSrc/src/main/java/H2OBuildVersion.java
+++ b/buildSrc/src/main/java/H2OBuildVersion.java
@@ -137,7 +137,7 @@ public class H2OBuildVersion {
   }
 
   private String calcCompiledBy() {
-    return System.getProperty("user.name");
+    return System.getProperty("user.name").replace('\\', '/');
   }
 
   private String getProjectVersion() {

--- a/h2o-core/src/main/java/water/AuthConfig.java
+++ b/h2o-core/src/main/java/water/AuthConfig.java
@@ -1,0 +1,28 @@
+package water;
+
+public class AuthConfig {
+
+    private static final String DEFAULT_REALM = "h2o";
+
+    private final String username;
+    private final String password;
+    private final String realm = DEFAULT_REALM;
+
+    public AuthConfig(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+}

--- a/h2o-core/src/main/java/water/BasicAuthSecurityHandlerFactory.java
+++ b/h2o-core/src/main/java/water/BasicAuthSecurityHandlerFactory.java
@@ -1,0 +1,40 @@
+package water;
+
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.security.authentication.BasicAuthenticator;
+import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.util.security.Credential;
+
+public class BasicAuthSecurityHandlerFactory {
+
+    private static final String USER_ROLE = "user";
+    
+    public static final SecurityHandler basicAuth(AuthConfig config) {
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
+        securityHandler.setAuthenticator(new BasicAuthenticator());
+        securityHandler.setRealmName(config.getRealm());
+
+        ConstraintMapping constraintMapping = new ConstraintMapping();
+
+        Constraint constraint = new Constraint(Constraint.__BASIC_AUTH, USER_ROLE);
+        constraint.setAuthenticate(true);
+
+        constraintMapping.setConstraint(constraint);
+
+        constraintMapping.setPathSpec("/*");
+
+        securityHandler.addConstraintMapping(constraintMapping);
+
+        HashLoginService loginService = new HashLoginService();
+        loginService.putUser(config.getUsername(), Credential.getCredential(config.getPassword()),
+                new String[] {USER_ROLE});
+        loginService.setName(config.getRealm());
+
+        securityHandler.setLoginService(loginService);
+
+        return securityHandler;
+    }
+}

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -115,6 +115,12 @@ final public class H2O {
             "    -ice_root <fileSystemPath>\n" +
             "          The directory where H2O spills temporary data to disk.\n" +
             "\n" +
+            "    -username <username>\n " +
+            "          Username for HTTP Basic Authentication.\n " +
+            "\n" +
+            "    -password <password>\n " +
+            "          Password for HTTP Basic Authentication.\n " +
+            "\n" +
             "    -log_dir <fileSystemPath>\n" +
             "          The directory where H2O writes logs to disk.\n" +
             "          (This usually has a good default that you need not change.)\n" +
@@ -238,6 +244,15 @@ final public class H2O {
 
     /** --ga_opt_out; Turns off usage reporting to Google Analytics  */
     public boolean ga_opt_out = false;
+
+    //-----------------------------------------------------------------------------------
+    // Authentication
+    //-----------------------------------------------------------------------------------
+    /** -username=username; username for HTTP Basic Authentication */
+    public String web_username;
+
+    /** -password=password; password for HTTP Basic Authentication */
+    public String web_password;
 
     //-----------------------------------------------------------------------------------
     // Debugging
@@ -431,6 +446,13 @@ final public class H2O {
         // JUnits pass this as a system property, but it usually a flag without an arg
         if (i+1 < args.length && args[i+1].equals("yes")) i++;
         ARGS.ga_opt_out = true;
+      }
+      else if (s.matches("username")) {
+        i = s.incrementAndCheck(i, args);
+        ARGS.web_username = args[i];
+      } else if (s.matches("password")) {
+        i = s.incrementAndCheck(i, args);
+        ARGS.web_password = args[i];
       }
       else if (s.matches("log_level")) {
         i = s.incrementAndCheck(i, args);

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1144,7 +1144,7 @@ final public class H2O {
   public static String DEFAULT_ICE_ROOT() {
     String username = System.getProperty("user.name");
     if (username == null) username = "";
-    String u2 = username.replaceAll(" ", "_");
+    String u2 = username.replaceAll(" ", "_").replace('\\', '/');
     if (u2.length() == 0) u2 = "unknown";
     return "/tmp/h2o-" + u2;
   }

--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -112,6 +112,8 @@ public class JettyHTTPD {
   // Jetty server object.
   private Server _server;
 
+  private AuthConfig _authConfig;
+
   /**
    * Create bare Jetty object.
    */
@@ -148,6 +150,10 @@ public class JettyHTTPD {
 
   public void setServer(Server value) {
     _server = value;
+  }
+
+  public void setAuthConfig(AuthConfig authConfig) {
+    this._authConfig = authConfig;
   }
 
   public void setup(String ip, int port) {
@@ -218,6 +224,11 @@ public class JettyHTTPD {
     ServletContextHandler context = new ServletContextHandler(
             ServletContextHandler.SECURITY | ServletContextHandler.SESSIONS
     );
+    if (_authConfig != null) {
+      Log.info("Enable basic authentication. Username=" + _authConfig.getUsername()
+          + ", password=" + _authConfig.getPassword());
+      context.setSecurityHandler(BasicAuthSecurityHandlerFactory.basicAuth(_authConfig));
+    }
     context.setContextPath("/");
 
     context.addServlet(H2oNpsBinServlet.class,   "/3/NodePersistentStorage.bin/*");

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -1,5 +1,6 @@
 package water.init;
 
+import water.AuthConfig;
 import water.H2O;
 import water.H2ONode;
 import water.H2ONode.H2OSmallMessage;
@@ -322,7 +323,11 @@ public class NetworkInit {
 
     // Late instantiation of Jetty object, if needed.
     if (H2O.getJetty() == null) {
-      H2O.setJetty(new JettyHTTPD());
+      JettyHTTPD jettyHTTPD = new JettyHTTPD();
+      if (H2O.ARGS.web_username != null && H2O.ARGS.web_password != null) {
+        jettyHTTPD.setAuthConfig(new AuthConfig(H2O.ARGS.web_username, H2O.ARGS.web_password));
+      }
+      H2O.setJetty(jettyHTTPD);
     }
 
     while (true) {

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -79,6 +79,8 @@ public class h2odriver extends Configured implements Tool {
   static boolean enableSuspend = false;
   static int debugPort = 5005;    // 5005 is the default from IDEA
   static String flowDir = null;
+  static String username = null;
+  static String password = null;
   static ArrayList<String> extraArguments = new ArrayList<String>();
   static ArrayList<String> extraJvmArguments = new ArrayList<String>();
   static String jksFileName = null;
@@ -482,6 +484,8 @@ public class h2odriver extends Configured implements Tool {
                     "          [-nthreads <maximum typical worker threads, i.e. cpus to use>]\n" +
                     "          [-baseport <starting HTTP port for H2O nodes; default is 54321>]\n" +
                     "          [-flow_dir <server side directory or hdfs directory>]\n " +
+                    "          [-username <username for HTTP Basic Authentication>]\n " +
+                    "          [-password <password for HTTP Basic Authentication>]\n " +
                     "          [-ea]\n" +
                     "          [-verbose:gc]\n" +
                     "          [-XX:+PrintGCDetails]\n" +
@@ -518,6 +522,8 @@ public class h2odriver extends Configured implements Tool {
                     "             The file contains one line with the IP and port of the embedded\n" +
                     "             web server for one of the H2O nodes in the cluster.  e.g.\n" +
                     "                 192.168.1.100:54321\n" +
+                    "          o  -username and -password enables HTTP Basic Authentication in h2o.\n" +
+                    "             Running driver without these options will spawn insecure H2O cluster.\n" +
                     "          o  All mappers must start before the H2O cloud is considered up.\n" +
                     "\n" +
                     "Examples:\n" +
@@ -765,6 +771,14 @@ public class h2odriver extends Configured implements Tool {
       else if (s.equals("-flow_dir")) {
         i++; if (i >= args.length) { usage(); }
         flowDir = args[i];
+      }
+      else if (s.equals("-username")) {
+        i++; if (i >= args.length) { usage(); }
+        username = args[i];
+      }
+      else if (s.equals("-password")) {
+        i++; if (i >= args.length) { usage(); }
+        password = args[i];
       }
       else if (s.equals("-J")) {
         i++; if (i >= args.length) { usage(); }
@@ -1192,6 +1206,12 @@ public class h2odriver extends Configured implements Tool {
     }
     if (flowDir != null) {
       addMapperArg(conf, "-flow_dir", flowDir);
+    }
+    if (username != null) {
+      addMapperArg(conf, "-username", username);
+    }
+    if (password != null) {
+      addMapperArg(conf, "-password", password);
     }
     if((new File(".h2o_no_collect")).exists() || (new File(System.getProperty("user.home")+"/.h2o_no_collect")).exists()) {
       addMapperArg(conf, "-ga_opt_out");

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -1075,7 +1075,8 @@ public class h2odriver extends Configured implements Tool {
     }
     driverCallbackSocket = new ServerSocket();
     driverCallbackSocket.setReuseAddress(true);
-    InetSocketAddress sa = new InetSocketAddress(driverCallbackIp, driverCallbackPort);
+    // listen on all interfaces to allow for running driver from inside containers like Docker
+    InetSocketAddress sa = new InetSocketAddress("0.0.0.0", driverCallbackPort);
     driverCallbackSocket.bind(sa, driverCallbackPort);
     int actualDriverCallbackPort = driverCallbackSocket.getLocalPort();
     CallbackManager cm = new CallbackManager();

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -412,7 +412,7 @@ class H2OCloud:
 
         # Randomly choose a seven digit cloud number.
         n = random.randint(1000000, 9999999)
-        user = getpass.getuser()
+        user = getpass.getuser().replace('\\', '/')
         user = ''.join(user.split())
 
         self.cloud_name = "H2O_runit_{}_{}".format(user, n)


### PR DESCRIPTION
- Basic Authentication
- driver listens on all addresses to be able to run it in containers (for example docker)
- small changes to allow users with '\' in username to run build project