### PR TITLE
Add proxy support

### DIFF
--- a/h2o-py/h2o/connection.py
+++ b/h2o-py/h2o/connection.py
@@ -24,7 +24,7 @@ class H2OConnection(object):
   """
 
   def __init__(self, ip="localhost", port=54321, size=1, start_h2o=False, enable_assertions=False,
-               license=None, max_mem_size_GB=None, min_mem_size_GB=None, ice_root=None, strict_version_check=True):
+               license=None, max_mem_size_GB=None, min_mem_size_GB=None, ice_root=None, strict_version_check=True, proxies=None):
     """
     Instantiate the package handle to the H2O cluster.
     :param ip: An IP address, default is "localhost"
@@ -46,6 +46,7 @@ class H2OConnection(object):
     self._cld = None
     self._ip = ip
     self._port = port
+    self._proxies = proxies
     self._session_id = None
     self._rest_version = __H2O_REST_API_VERSION__
     self._child = getattr(__H2OCONN__, "_child") if hasattr(__H2OCONN__, "_child") else None
@@ -125,6 +126,7 @@ class H2OConnection(object):
       ["H2O cluster healthy: ", str(cluster_health)],
       ["H2O Connection ip: ", ip],
       ["H2O Connection port: ", __H2OCONN__._port],
+      ["H2O Connection proxy: ", __H2OCONN__._proxies],
       ]
     __H2OCONN__._cld = H2OConnection.get_json(url_suffix="Cloud")   # update the cached version of cld
     h2o.H2ODisplay(cluster_info)
@@ -334,6 +336,9 @@ class H2OConnection(object):
   def ip(): return __H2OCONN__._ip
 
   @staticmethod
+  def proxies(): return __H2OCONN__._proxies
+
+  @staticmethod
   def current_connection(): return __H2OCONN__
 
   @staticmethod
@@ -351,7 +356,7 @@ class H2OConnection(object):
     """
     if not isinstance(conn, H2OConnection): raise ValueError("`conn` must be an H2OConnection object")
     rv = conn.current_connection()._attempt_rest(url="http://{0}:{1}/".format(conn.ip(), conn.port()), method="GET",
-                                                 post_body="", file_upload_info="")
+                                                 post_body="", file_upload_info="", proxies=conn.proxies())
     return rv.status_code == 200 or rv.status_code == 301
 
   """
@@ -378,19 +383,19 @@ class H2OConnection(object):
   def get(url_suffix, **kwargs):
     if __H2OCONN__ is None:
       raise ValueError("No h2o connection. Did you run `h2o.init()` ?")
-    return __H2OCONN__._do_raw_rest(url_suffix, "GET", None, **kwargs)
+    return __H2OCONN__._do_raw_rest(url_suffix, "GET", None, proxies=__H2OCONN__._proxies, **kwargs)
 
   @staticmethod
   def post(url_suffix, file_upload_info=None, **kwargs):
     if __H2OCONN__ is None:
       raise ValueError("No h2o connection. Did you run `h2o.init()` ?")
-    return __H2OCONN__._do_raw_rest(url_suffix, "POST", file_upload_info, **kwargs)
+    return __H2OCONN__._do_raw_rest(url_suffix, "POST", file_upload_info, proxies=__H2OCONN__._proxies, **kwargs)
 
   @staticmethod
   def delete(url_suffix, **kwargs):
     if __H2OCONN__ is None:
       raise ValueError("No h2o connection. Did you run `h2o.init()` ?")
-    return __H2OCONN__._do_raw_rest(url_suffix, "DELETE", None, **kwargs)
+    return __H2OCONN__._do_raw_rest(url_suffix, "DELETE", None, proxies=__H2OCONN__._proxies, **kwargs)
 
   @staticmethod
   def get_json(url_suffix, **kwargs):
@@ -404,15 +409,15 @@ class H2OConnection(object):
       raise ValueError("No h2o connection. Did you run `h2o.init()` ?")
     return __H2OCONN__._rest_json(url_suffix, "POST", file_upload_info, **kwargs)
 
-  def _rest_json(self, url_suffix, method, file_upload_info, **kwargs):
-    raw_txt = self._do_raw_rest(url_suffix, method, file_upload_info, **kwargs)
+  def _rest_json(self, url_suffix, method, file_upload_info, proxies=None, **kwargs):
+    raw_txt = self._do_raw_rest(url_suffix, method, file_upload_info, proxies=__H2OCONN__._proxies, **kwargs)
     return self._process_tables(raw_txt.json())
 
   # Massage arguments into place, call _attempt_rest
-  def _do_raw_rest(self, url_suffix, method, file_upload_info, **kwargs):
+  def _do_raw_rest(self, url_suffix, method, file_upload_info, proxies=None, **kwargs):
     if not url_suffix:
       raise ValueError("No url suffix supplied.")
-    
+
     # allow override of REST version, currently used for Rapids which is /99
     if '_rest_version' in kwargs:
       _rest_version = kwargs['_rest_version']
@@ -463,7 +468,7 @@ class H2OConnection(object):
 
     global _rest_ctr; _rest_ctr = _rest_ctr+1
     begin_time_seconds = time.time()
-    http_result = self._attempt_rest(url, method, post_body, file_upload_info)
+    http_result = self._attempt_rest(url, method, post_body, file_upload_info, proxies)
     end_time_seconds = time.time()
     elapsed_time_seconds = end_time_seconds - begin_time_seconds
     elapsed_time_millis = elapsed_time_seconds * 1000
@@ -496,19 +501,21 @@ class H2OConnection(object):
     return http_result
 
   # Low level request call
-  def _attempt_rest(self, url, method, post_body, file_upload_info):
+  def _attempt_rest(self, url, method, post_body, file_upload_info, proxies=None):
+    proxies = proxies or {}
+
     headers = {'User-Agent': 'H2O Python client/'+string.replace(sys.version, '\n', '')}
     try:
       if method == "GET":
-        return requests.get(url, headers=headers)
+        return requests.get(url, headers=headers, proxies=proxies)
       elif file_upload_info:
         files = {file_upload_info["file"] : open(file_upload_info["file"], "rb")}
-        return requests.post(url, files=files, headers=headers)
+        return requests.post(url, files=files, headers=headers, proxies=proxies)
       elif method == "POST":
         headers["Content-Type"] = "application/x-www-form-urlencoded"
-        return requests.post(url, data=post_body, headers=headers)
+        return requests.post(url, data=post_body, headers=headers, proxies=proxies)
       elif method == "DELETE":
-        return requests.delete(url, headers=headers)
+        return requests.delete(url, headers=headers, proxies=proxies)
       else:
         raise ValueError("Unknown HTTP method " + method)
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -658,6 +658,19 @@ def init(ip="localhost", port=54321, size=1, start_h2o=False, enable_assertions=
     Minimum heap size (jvm option Xms) in gigabytes.
   ice_root : str
     A temporary directory (default location is determined by tempfile.mkdtemp()) to hold H2O log files.
+  proxies : dict
+    A dictionary with keys 'ftp', 'http', 'https' and values that correspond to a proxy path.
+
+  Examples
+  --------
+  Using the 'proxies' parameter
+
+  >>> import h2o
+  >>> import urllib
+  >>> proxy_dict = urllib.getproxies()
+  >>> h2o.init(proxies=proxy_dict)
+  Starting H2O JVM and connecting: ............... Connection successful!
+
   """
   H2OConnection(ip=ip, port=port,start_h2o=start_h2o,enable_assertions=enable_assertions,license=license,max_mem_size_GB=max_mem_size_GB,min_mem_size_GB=min_mem_size_GB,ice_root=ice_root,strict_version_check=strict_version_check, proxies=proxies)
   return None

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -633,7 +633,7 @@ def cluster_status():
 
 
 def init(ip="localhost", port=54321, size=1, start_h2o=False, enable_assertions=False,
-         license=None, max_mem_size_GB=None, min_mem_size_GB=None, ice_root=None, strict_version_check=False):
+         license=None, max_mem_size_GB=None, min_mem_size_GB=None, ice_root=None, strict_version_check=False, proxies=None):
   """
   Initiate an H2O connection to the specified ip and port.
 
@@ -659,7 +659,7 @@ def init(ip="localhost", port=54321, size=1, start_h2o=False, enable_assertions=
   ice_root : str
     A temporary directory (default location is determined by tempfile.mkdtemp()) to hold H2O log files.
   """
-  H2OConnection(ip=ip, port=port,start_h2o=start_h2o,enable_assertions=enable_assertions,license=license,max_mem_size_GB=max_mem_size_GB,min_mem_size_GB=min_mem_size_GB,ice_root=ice_root,strict_version_check=strict_version_check)
+  H2OConnection(ip=ip, port=port,start_h2o=start_h2o,enable_assertions=enable_assertions,license=license,max_mem_size_GB=max_mem_size_GB,min_mem_size_GB=min_mem_size_GB,ice_root=ice_root,strict_version_check=strict_version_check, proxies=proxies)
   return None
 
 


### PR DESCRIPTION
I was just at h2o-world and was having trouble connecting to h2o (in Python) through my company proxy. Here's a (really) rough spike adding a proxy parameter to the h2o connection that requests already supports. My hand testing suggests that it works for at least initialization and simple model builds.