### PR TITLE
fix collisions in frame._py_tmp_key()

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # import numpy    no numpy cuz windoz
-import collections, csv, itertools, os, re, tempfile, urllib2, sys, urllib,imp, traceback
+import collections, csv, itertools, os, re, tempfile, urllib2, sys, urllib, imp, traceback, uuid
 import h2o
 from expr import ExprNode
 from astfun import _bytecode_decompile_lambda
@@ -2057,9 +2057,7 @@ class H2OFrame(object):
 # private static methods
 _id_ctr = 0
 def _py_tmp_key():
-  global _id_ctr
-  _id_ctr=_id_ctr+1
-  return "py_" + str(_id_ctr)
+  return "py_" + str(uuid.uuid4()).replace('-','')
 def _gen_header(cols): return ["C" + str(c) for c in range(1, cols + 1, 1)]
 def _check_lists_of_lists(python_obj):
   # all items in the list must be a list too


### PR DESCRIPTION
I'm running several python clients at the same time.
I've seen the case were they both use the tmp id py_2 at the same time,
conflict, and fail with error “Temp ID py_2 already exists”.

Detailed error that this commit fixes:
Fill foo
  predict_frame[col] = input_frame[col]
File "(...)pyenv/lib/python2.7/site-packages/h2o/frame.py", line 1071, in __setitem__
  self._frame()  # setitem is eager
File "(...)pyenv/lib/python2.7/site-packages/h2o/frame.py", line 392, in _frame
  def _frame(self):  self._ex._eager_frame(); return self
File "(...)pyenv/lib/python2.7/site-packages/h2o/expr.py", line 64, in _eager_frame
  return self._eval_driver(True)
File "(...)pyenv/lib/python2.7/site-packages/h2o/expr.py", line 78, in _eval_driver
  res = h2o.rapids(exec_str)
File "(...)pyenv/lib/python2.7/site-packages/h2o/h2o.py", line 452, in rapids
  return H2OConnection.post_json("Rapids", ast=urllib.quote(expr), _rest_version=99)
File "(...)pyenv/lib/python2.7/site-packages/h2o/connection.py", line 405, in post_json
  return __H2OCONN__._rest_json(url_suffix, "POST", file_upload_info, **kwargs)
File "(...)pyenv/lib/python2.7/site-packages/h2o/connection.py", line 408, in _rest_json
  raw_txt = self._do_raw_rest(url_suffix, method, file_upload_info, **kwargs)
File "(...)pyenv/lib/python2.7/site-packages/h2o/connection.py", line 484, in _do_raw_rest
  .format(http_result.status_code,http_result.reason,method,url,detailed_error_msgs))
EnvironmentError: h2o-py got an unexpected HTTP status code:
 400 Bad Request (method = POST; url = http://localhost:54321/99/Rapids).
detailed error messages: Temp ID py_2 already exists