### PR TITLE
Fix real bugs, perf bugs in parser, nbhm hashcode,

### DIFF
--- a/h2o-core/src/main/java/water/nbhm/NonBlockingHashMap.java
+++ b/h2o-core/src/main/java/water/nbhm/NonBlockingHashMap.java
@@ -1,6 +1,5 @@
 package water.nbhm;
 import sun.misc.Unsafe;
-import water.util.Log;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -116,6 +115,7 @@ public class NonBlockingHashMap<TypeK, TypeV>
     int h = key.hashCode();     // The real hashCode call
     h ^= (h>>>20) ^ (h>>>12);
     h ^= (h>>> 7) ^ (h>>> 4);
+    h += h<<7; // smear low bits up high, for hashcodes that only differ by 1
     return h;
   }
 

--- a/h2o-core/src/main/java/water/parser/BufferedString.java
+++ b/h2o-core/src/main/java/water/parser/BufferedString.java
@@ -43,19 +43,19 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
 
    @Override public int hashCode(){
      int hash = 0;
-     int n = getOffset() + length();
-     for (int i = getOffset(); i < n; ++i)
-       hash = 31 * hash + getBuffer()[i];
+     int n = _off + _len;
+     for (int i = _off; i < n; ++i) // equivalent to String.hashCode
+       hash = 31 * hash + (char)_buf[i];
      return hash;
    }
 
    void addChar(){_len++;}
 
    void addBuff(byte [] bits){
-     byte [] buf = new byte[length()];
-     int l1 = getBuffer().length- getOffset();
-     System.arraycopy(getBuffer(), getOffset(), buf, 0, l1);
-     System.arraycopy(bits, 0, buf, l1, length()-l1);
+     byte [] buf = new byte[_len];
+     int l1 = _buf.length- _off;
+     System.arraycopy(_buf, _off, buf, 0, l1);
+     System.arraycopy(bits, 0, buf, l1, _len-l1);
      _off = 0;
      _buf = buf;
    }
@@ -132,21 +132,26 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
   @Override public boolean equals(Object o){
     if(o instanceof BufferedString) {
       BufferedString str = (BufferedString) o;
-      if (str.length() != _len) return false;
+      if (str._len != _len) return false;
       for (int i = 0; i < _len; ++i)
-        if (getBuffer()[getOffset() + i] != str.getBuffer()[str.getOffset() + i]) return false;
+        if (_buf[_off + i] != str._buf[str._off + i]) return false;
       return true;
     } // FIXME: Called in NA_String detection during CsvParser, UTF-8 sensitive
      else if (o instanceof String) {
       String str = (String) o;
-      if (str.length() != length()) return false;
-      for (int i = 0; i < length(); ++i)
-        if (getBuffer()[getOffset() + i] != str.charAt(i)) return false;
+      if (str.length() != _len) return false;
+      for (int i = 0; i < _len; ++i)
+        if (_buf[_off + i] != str.charAt(i)) return false;
       return true;
     }
     return false; //FIXME find out if this is required for some case or if an exception can be thrown
   }
-  public final byte [] getBuffer() {return _buf;}
+  // Thou Shalt Not use accessors in performance critical code - because it
+  // obfuscates the code's cost model.  All file-local uses of the accessors
+  // has been stripped, please do not re-insert them.  In particular, the
+  // hashcode and equals calls are made millions (billions?) of times a second
+  // when parsing categoricals.
+  public final byte [] getBuffer() {return _buf;} 
   public final int getOffset() {return _off;}
   public final int length() {return _len;}
 

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -574,7 +574,7 @@ MAIN_LOOP:
     for( int i = 0; i < s1.length; ++i ) {
       if( s1[i] == 0 ) continue;   // Separator does not appear; ignore it
       if( s1[max] < s1[i] ) max=i; // Largest count sep on 1st line
-      if( s1[i] == s2[i] ) {       // Sep counts are equal?
+      if( s1[i] == s2[i] && s1[i] >= s1[max]>>1 ) {  // Sep counts are equal?  And at nearly as large as the larger header sep?
         try {
           String[] t1 = determineTokens(l1, separators[i], singleQuote);
           String[] t2 = determineTokens(l2, separators[i], singleQuote);

--- a/h2o-core/src/test/java/water/parser/ParserTest.java
+++ b/h2o-core/src/test/java/water/parser/ParserTest.java
@@ -14,7 +14,7 @@ public class ParserTest extends TestUtil {
   private final char[] SEPARATORS = new char[] {',', ' '};
 
   // Make a ByteVec with the specific Chunks
-  public static Key makeByteVec(String... data) {
+  static Key makeByteVec(String... data) {
     Futures fs = new Futures();
     long[] espc  = new long[data.length+1];
     for( int i = 0; i < data.length; ++i ) espc[i+1] = espc[i]+data[i].length();
@@ -29,7 +29,7 @@ public class ParserTest extends TestUtil {
     return k;
   }
 
-  public static boolean compareDoubles(double a, double b, double threshold) {
+  private static boolean compareDoubles(double a, double b, double threshold) {
     if( a==b ) return true;
     if( ( Double.isNaN(a) && !Double.isNaN(b)) ||
         (!Double.isNaN(a) &&  Double.isNaN(b)) ) return false;
@@ -122,7 +122,7 @@ public class ParserTest extends TestUtil {
     Key k1 = makeByteVec(sb1.toString());
     Key r1 = Key.make("r1");
     Frame fr = ParseDataset.parse(r1, k1);
-    Assert.assertTrue(fr.vec(0).get_type_str()=="Enum");
+    Assert.assertTrue(fr.vec(0).get_type_str().equals("Enum"));
     fr.delete();
   }
 
@@ -293,6 +293,18 @@ public class ParserTest extends TestUtil {
       testParsed(r, expDouble);
     }
   }
+
+  @Test public void testMajoritySep() {
+    String data = 
+      "a,b,c,d,e,f,g,h,i,j,k,space 1,l,space 2,m,space 3,n,o,p,q,r,s,t,u,v,w,x,y,z\n"+ // 26+3 cols, exactly 3 spaces
+      "1,2,3,4,5,6,7,8,9,0,1,catag 1,2,catag 2,3,catag 3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9\n"; // a few extra cols, exactly 3 spaces
+    Key k1 = ParserTest.makeByteVec(data);
+    Key r1 = Key.make("r1");
+    Frame fr = ParseDataset.parse(r1, k1);
+    Assert.assertTrue(fr.numCols()==26+3);
+    fr.delete();
+  }
+
  @Test public void testMultipleNondecimalColumns() {
     String data[] = {
         "foo| 2|one\n"
@@ -331,7 +343,6 @@ public class ParserTest extends TestUtil {
       testParsed(r, expDouble);
     }
   }
-
 
   // Test if the empty column is correctly handled.
   // NOTE: this test makes sense only for comma separated columns
@@ -405,10 +416,10 @@ public class ParserTest extends TestUtil {
     }
   }
 
-  public static String[] getDataForSeparator(char sep, String[] data) {
+  static String[] getDataForSeparator(char sep, String[] data) {
     return getDataForSeparator('|', sep, data);
   }
-  static String[] getDataForSeparator(char placeholder, char sep, String[] data) {
+  private static String[] getDataForSeparator(char placeholder, char sep, String[] data) {
     String[] result = new String[data.length];
     for (int i = 0; i < data.length; i++) {
       result[i] = data[i].replace(placeholder, sep);


### PR DESCRIPTION
Parser column heuristic was getting fooled if 1st 2 rows had unequal col counts, plus also equal counts of blanks.
String hashcode varies by 1 for strings which vary by last character; NBHM hash spreader did not spread the low bits; runs of strings that just walk up the alphabet turn into sequential slots in NBHM, which then degrades to a linear scan.  Provoked an O(n^2) bug in parser enum unification.  Hot BufferedString.hashCode was obfuscated with accessors (and showed up in all profiles because was being called O(n^2) times).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/43)
<!-- Reviewable:end -->
