### PR TITLE
h2o-r: simpler install and minor fixes

### DIFF
--- a/h2o-r/README.md
+++ b/h2o-r/README.md
@@ -1,12 +1,12 @@
 # Using H2O from R
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/h2o)](http://cran.r-project.org/web/packages/h2o)
-[![Downloads](http://cranlogs.r-pkg.org/badges/h2o)](http://cran.rstudio.com/package=h2o)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/h2o)](https://cran.r-project.org/package=h2o)
+[![Downloads](http://cranlogs.r-pkg.org/badges/h2o)](https://cran.rstudio.com/package=h2o)
 
 ## Downloading
 
 You can always download the latest stable version of the **h2o** R package from the following page: [http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html](http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html) 
 
-Alternatively, you can build the h2o R package from source (see below), or install the package from [CRAN](https://cran.r-project.org/web/packages/h2o/index.html).
+Alternatively, you can build the h2o R package from source (see below), or install the package from [CRAN](https://cran.r-project.org/package=h2o).
 
 
 ## Building it yourself
@@ -31,16 +31,10 @@ The output of the build is a CRAN-like layout in the R directory.
 ###  Installation from within R
 
 0. Detach any currently loaded H2O package for R.  
-`if ("package:h2o" %in% search()) { detach("package:h2o", unload=TRUE) }`  
-
-	```
-	Removing package from ‘/Users/H2O_User/.Rlibrary’
-	(as ‘lib’ is unspecified)
-	```
+`if ("package:h2o" %in% search()) detach("package:h2o", unload=TRUE)`  
 
 0. Remove any previously installed H2O package for R.  
-`if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }`
-
+`if ("h2o" %in% rownames(installed.packages())) remove.packages("h2o")`
 
 	```
 	Removing package from ‘/Users/H2O_User/.Rlibrary’
@@ -52,23 +46,18 @@ The output of the build is a CRAN-like layout in the R directory.
    **Note**: This list may change as new capabilities are added to H2O. The commands are reproduced below, but we strongly recommend visiting the H2O download page at [h2o.ai/download](http://h2o.ai/download) for the most up-to-date list of dependencies. 
    
 	```
-  	if (! ("methods" %in% rownames(installed.packages()))) { install.packages("methods") }
-	if (! ("statmod" %in% rownames(installed.packages()))) { install.packages("statmod") }
-	if (! ("stats" %in% rownames(installed.packages()))) { install.packages("stats") }
-	if (! ("graphics" %in% rownames(installed.packages()))) { install.packages("graphics") }
-	if (! ("RCurl" %in% rownames(installed.packages()))) { install.packages("RCurl") }
-	if (! ("jsonlite" %in% rownames(installed.packages()))) { install.packages("jsonlite") }
-	if (! ("tools" %in% rownames(installed.packages()))) { install.packages("tools") }
-	if (! ("utils" %in% rownames(installed.packages()))) { install.packages("utils") }
+	pkgs <- c("methods","statmod","stats","graphics","RCurl","jsonlite","tools","utils")
+	new.pkgs <- setdiff(pkgs, rownames(installed.packages()))
+	if (length(new.pkgs)) install.packages(new.pkgs)
 	```
 
 0. Install the H2O R package from your build directory.  
-  `install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/master/****/R")))`
+`install.packages("h2o", type="source", repos="https://h2o-release.s3.amazonaws.com/h2o/rel-turchin/9/R")`
 
-   **Note**: Do not copy and paste the command above. You must replace the asterisks (*) with the current H2O build number. Refer to the H2O download page at [h2o.ai/download](http://h2o.ai/download) for latest build number. 
+   **Note**: Do not copy and paste the command above. You may need to replace `rel-turchin/9` with the current H2O build number. Refer to the H2O download page at [h2o.ai/download](http://h2o.ai/download) for latest build number. 
 
 	```
-	Installing package into ‘/Users/tomk/.Rlibrary’
+	Installing package into ‘/Users/H2O_User/.Rlibrary’
 	(as ‘lib’ is unspecified)
 	source repository is unavailable to check versions
 	

--- a/h2o-r/build.gradle
+++ b/h2o-r/build.gradle
@@ -106,7 +106,7 @@ task setPackageFiles << {
     def txt = ""
     def today = new Date()
     txt = DESC_TEMP.text
-    txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION).replaceAll("SUBST_PROJECT_BRANCH", BUILD_BRANCH).replaceAll("SUBST_PROJECT_DATE", today.toString())
+    txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION).replaceAll("SUBST_PROJECT_BRANCH", BUILD_BRANCH).replaceAll("SUBST_PROJECT_DATE", today.format("YYYY-MM-dd"))
     DESCRIPTION.write(txt)
     txt = h2oRd_TEMP.text
     txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION).replaceAll("SUBST_PROJECT_BRANCH", BUILD_BRANCH).replaceAll("SUBST_PROJECT_DATE", today.toString())
@@ -149,12 +149,9 @@ task buildPKG(type: Exec) { commandLine getOsSpecificCommandLine(['R', 'CMD', 'b
 task cpToR << {
     new File([T, "R", "src", "contrib"].join(File.separator)).mkdirs()
     copyFile([T, "README.md"], [T, "R", "README.md"])
-    copyFile([T, "h2o-package", "DESCRIPTION"], [T, "PACKAGES"])
-    copyFile([T, "PACKAGES"], [T, "R", "src", "contrib", "PACKAGES"])
-    gzip(new File([T,"PACKAGES"].join(File.separator)).text, [T,"PACKAGES.gz"].join(File.separator))
-    copyFile([T, "PACKAGES.gz"], [T, "R", "src", "contrib", "PACKAGES.gz"])
     copyFile([T, H2O_R_SOURCE_FILE], [T, "R", "src", "contrib", H2O_R_SOURCE_FILE])
 }
+task publishPKG(type: Exec) { commandLine getOsSpecificCommandLine(['Rscript', "-e", "tools::write_PACKAGES('R/src/contrib')"]) }
 
 
 task cleanUp << {
@@ -200,7 +197,8 @@ genPDF.dependsOn buildPackageDocumentation
 cpPDF.dependsOn genPDF
 buildPKG.dependsOn cpPDF
 cpToR.dependsOn buildPKG
-untar.dependsOn cpToR
+publishPKG.dependsOn cpToR
+untar.dependsOn publishPKG
 cleaner.dependsOn untar
 task build_rh2o(dependsOn: cleaner)
 build.dependsOn build_rh2o

--- a/h2o-r/h2o-DESCRIPTION.template
+++ b/h2o-r/h2o-DESCRIPTION.template
@@ -2,7 +2,7 @@ Package: h2o
 Version: SUBST_PROJECT_VERSION
 Type: Package
 Title: R Interface for H2O
-Date: 2015-11-18
+Date: SUBST_PROJECT_DATE
 Author: Spencer Aiello, Tom Kraljevic and Petr Maj, with contributions from the H2O.ai team
 Maintainer: Tom Kraljevic <tomk@0xdata.com>
 Description: R scripting functionality for H2O, the open source


### PR DESCRIPTION
h2o-r/README.md:
- [x] fixed cran urls to use [canonical](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) ones
- [x] use https urls where available
- [x] `detach` does not echo `Removing package...`
- [x] simplified install R deps
- [x] added working link, I see no point to keep `*` here

h2o-r/build.gradle:
- [x] added formatting for date to DESCRIPTION file as [recommended](https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file)
- [x] changed publishing CRAN-like repository to use `tools::write_PACKAGES` as [recommended](https://cran.r-project.org/doc/manuals/R-admin.html#Setting-up-a-package-repository) - **if you rely on DESCRIPTION file as `src/contrib/PACKAGES` it would be a breaking change**

h2o-r/h2o-DESCRIPTION.template:
- [x] fixed hardcoded `2015-11-18` date in DESCRIPTION file to dynamic variable

---

Tested on latest H2O and R 3.3.0 using [this](https://github.com/jangorecki/dockerfiles/blob/master/h2o-dev/Dockerfile) image. There was no R 3.3.0 related code used so should pass R 3.2.2 tests in jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/48)
<!-- Reviewable:end -->
