### PR TITLE
dynamic default of cluster connection in h2o.init

### DIFF
--- a/h2o-py/h2o/connection.py
+++ b/h2o-py/h2o/connection.py
@@ -35,6 +35,7 @@ class H2OConnection(object):
   """
   H2OConnection is a class that represents a connection to the H2O cluster.
   It is specified by an IP address and a port number.
+  Environment vars H2O_IP and H2O_PORT can be used to override defaults.
 
   Objects of type H2OConnection are not instantiated directly!
 
@@ -45,7 +46,7 @@ class H2OConnection(object):
   __ENCODING__ = "utf-8"
   __ENCODING_ERROR__ = "replace"
 
-  def __init__(self, ip, port, start_h2o, enable_assertions, license, nthreads, max_mem_size, min_mem_size, ice_root,
+  def __init__(self, ip=None, port=None, start_h2o, enable_assertions, license, nthreads, max_mem_size, min_mem_size, ice_root,
                strict_version_check, proxy, https, insecure, username, password, cluster_name, max_mem_size_GB, min_mem_size_GB, proxies, size):
     """
     Instantiate the package handle to the H2O cluster.
@@ -75,6 +76,10 @@ class H2OConnection(object):
     :return: None
     """
 
+    if ip is None:
+        ip = os.environ.get("H2O_IP", "localhost")
+    if port is None:
+        port = os.environ.get("H2O_PORT", 54321)
     port = as_int(port)
     if not (isinstance(port, int) and 0 <= port <= sys.maxsize): raise ValueError("Port out of range, "+port)
     

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -8,6 +8,8 @@
 #'
 #' Once connected, the method checks to see if the local H2O R package version matches the version of H2O running on the server. If there is a mismatch and the user indicates she wishes to upgrade, it will remove the local H2O R package and download/install the H2O R package from the server.
 #'
+#' Arguments \code{ip} and \code{port} can be configured by environment variables \code{H2O_IP} and \code{H2O_PORT}.
+#'
 #' @param ip Object of class \code{character} representing the IP address of the server where H2O is running.
 #' @param port Object of class \code{numeric} representing the port number of the H2O server.
 #' @param startH2O (Optional) A \code{logical} value indicating whether to try to start H2O from R if no connection with H2O is detected. This is only possible if \code{ip = "localhost"} or \code{ip = "127.0.0.1"}.  If an existing connection is detected, R does not start H2O.
@@ -49,7 +51,8 @@
 #' h2o.init(max_mem_size = "5g")
 #' }
 #' @export
-h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = FALSE,
+h2o.init <- function(ip = Sys.getenv("H2O_IP", "localhost"), port = as.integer(Sys.getenv("H2O_PORT", 54321)),
+                     startH2O = TRUE, forceDL = FALSE,
                      enable_assertions = TRUE, license = NULL, nthreads = -2,
                      max_mem_size = NULL, min_mem_size = NULL,
                      ice_root = tempdir(), strict_version_check = TRUE, proxy = NA_character_,


### PR DESCRIPTION
allows to avoid hardcoding ip and port in R scripts.
Useful for automation by configuring cluster details in bash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/51)
<!-- Reviewable:end -->
