### PR TITLE
bugfix with sparse categoricals

### DIFF
--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -451,7 +451,7 @@ public class NewChunk extends Chunk {
       return Vec.T_BAD;
     if(_strCnt > 0)
       return Vec.T_STR;
-    if(_catCnt > 0 && _catCnt + _naCnt == _len)
+    if(_catCnt > 0 && _catCnt + _naCnt + (isSparseZero()? _len-_sparseLen : 0) == _len)
       return Vec.T_CAT; // All are Strings+NAs ==> Categorical Chunk
     // UUIDs?
     if( _uuidCnt > 0 ) return Vec.T_UUID;
@@ -478,10 +478,12 @@ public class NewChunk extends Chunk {
   public void addCategorical(int e) {
     if(_ms == null || _ms.len() == _sparseLen)
       append2slow();
-    _ms.set(_sparseLen,e);
-    _xs.setCategorical(_sparseLen);
-    if(_id != null) _id[_sparseLen] = _len;
-    ++_sparseLen;
+    if( e != 0 || !isSparseZero() ) {
+      _ms.set(_sparseLen,e);
+      _xs.setCategorical(_sparseLen);
+      if(_id != null) _id[_sparseLen] = _len;
+      ++_sparseLen;
+    }
     ++_len;
   }
   public void addNA() {


### PR DESCRIPTION
1st bug: after flipping to sparse after adding 16 0 cat's, the 17th (and later) 0 cat was not added sparsely.

2nd bug: in a column with mixed sparse 0's and non-sparse 0's, the cat type was lost even if only ever "NewChunk.addCategorical") was called, and the chunk was declared numeric... and the non-sparse 0 cat's got converted to NA's.  Later the whole column could still be declared categorical.  Effect was to convert a bunch of 0's to NA's.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/53)
<!-- Reviewable:end -->
