### PR TITLE
Only quote fields in CSV files if needed

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1380,9 +1380,11 @@ public class Frame extends Lockable<Frame> {
     public volatile int _curChkIdx;
     long _row;
 
-    // Quote string x if it contains non-ASCII characters or the column separator
+    // Quote string x if it contains non-ASCII characters or the column
+    // separator or is empty
     private boolean needsQuote( String x ) {
       int len = x.length();
+      if( len == 0 ) return true; // Have to quote the empty string, or else it prints as nothing at all!
       for( int i=0; i<len; i++ ) {
         char c = x.charAt(i);
         if( c < ' ' || c >= 128 || c==',' ) 


### PR DESCRIPTION
Quote if field contains a field-sep (comma) or a non-ascii or control character.  Cuts down emitted CSV file size by 20% or more for files with small fields (i.e., lots of boolean data).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/58)
<!-- Reviewable:end -->
