### PR TITLE
Use addNum() rather than addCategorical() to fix overwriting 0s to NA…

### DIFF
--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -85,7 +85,7 @@ public class VecUtils {
             nc.addNA();
           } else {
             c.atStr(bs, row);
-            nc.addCategorical(lookupTable.get(bs.bytesToString()));
+            nc.addNum(lookupTable.get(bs.bytesToString()), 0);
           }
         }
       }

--- a/h2o-core/src/test/java/water/fvec/CategoricalTest.java
+++ b/h2o-core/src/test/java/water/fvec/CategoricalTest.java
@@ -1,0 +1,39 @@
+package water.fvec;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.H2O;
+import water.Key;
+import water.MRTask;
+import water.TestUtil;
+import water.parser.BufferedString;
+import water.parser.ParseDataset;
+import water.parser.ParseSetup;
+import water.util.VecUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+
+public class CategoricalTest extends TestUtil{
+  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+
+  @Test public void testCancelSparseCategoricals() {
+    Frame frame = null;
+    Vec stringVec = null;
+    Vec catVec = null;
+    try {
+      frame = parse_test_file("smalldata/junit/iris.csv");
+      Vec vec = frame.lastVec();
+      assert vec.naCnt() == 0;
+      stringVec = vec.toStringVec();
+      assert stringVec.naCnt() == 0;
+      catVec = stringVec.toCategoricalVec();
+      assert catVec.naCnt() == 0;
+    } finally {
+      if (frame != null) frame.delete();
+      if (stringVec != null) stringVec.remove();
+      if (catVec != null) catVec.remove();
+    }
+  }
+}


### PR DESCRIPTION
…s in toCategoricalVec()

Bug: String to categorical conversion overwrites zeros to NAs in some cases.

Explanation: Tracking categoricals added with addCategorical() is buggy when canceling a sparse-zero NewChunk. 

Solution: There is no need for addCategorical(), since you can just use addNum() along with a domain. I added a test case to ensure that string to categorical conversion no longer corrupts the data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/59)
<!-- Reviewable:end -->
