### PR TITLE
[PUBDEV-3180] ProfileCredentialsProvider appended to auth chain for S3 access

### DIFF
--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -13,6 +13,7 @@ import water.util.Log;
 import water.util.RIStream;
 import com.amazonaws.*;
 import com.amazonaws.auth.*;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
@@ -58,7 +59,8 @@ public final class PersistS3 extends Persist {
       super(new H2OArgCredentialsProvider(),
           new InstanceProfileCredentialsProvider(),
           new EnvironmentVariableCredentialsProvider(),
-          new SystemPropertiesCredentialsProvider());
+          new SystemPropertiesCredentialsProvider(),
+          new ProfileCredentialsProvider());
     }
   }
 


### PR DESCRIPTION
The ProfileCredentialsProvider reads configuration from ~/.aws/credentials.properties.
The way used by MarkC's customer.

Critical for release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/63)
<!-- Reviewable:end -->
