### PR TITLE
PUBDEV-3201: Implementation of parallel CSV export

### DIFF
--- a/h2o-core/src/main/java/water/api/FramesHandler.java
+++ b/h2o-core/src/main/java/water/api/FramesHandler.java
@@ -255,7 +255,7 @@ public class FramesHandler<I extends FramesHandler.Frames, S extends SchemaV3<I,
   public FramesV3 export(int version, FramesV3 s) {
     Frame fr = getFromDKV("key", s.frame_id.key());
     Log.info("ExportFiles processing (" + s.path + ")");
-    s.job = new JobV3(Frame.export(fr, s.path, s.frame_id.key().toString(),s.force));
+    s.job = new JobV3(Frame.export(fr, s.path, s.frame_id.key().toString(), s.force, s.num_parts));
     return s;
   }
 

--- a/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
@@ -34,6 +34,9 @@ public class FramesV3 extends SchemaV3<Frames,FramesV3> {
   @API(help="Overwrite existing file",json=false)
   public boolean force;
 
+  @API(help="Number of part files to use (1=single file,-1=automatic)",json=false)
+  public int num_parts = 1;
+
   @API(help="Job for export file",direction=API.Direction.OUTPUT)
   public JobV3 job;
 

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1381,16 +1381,6 @@ public class Frame extends Lockable<Frame> {
     return f2.vecs();
   }
 
-  private boolean isLastRowOfCurrentNonEmptyChunk(int chunkIdx, long row) {
-    long[] espc = anyVec().espc();
-    long lastRowOfCurrentChunk = espc[chunkIdx + 1] - 1;
-    // Assert chunk is non-empty.
-    assert espc[chunkIdx + 1] > espc[chunkIdx];
-    // Assert row numbering sanity.
-    assert row <= lastRowOfCurrentChunk;
-    return row >= lastRowOfCurrentChunk;
-  }
-
   public static Job export(Frame fr, String path, String frameName, boolean overwrite) {
     // Validate input
     boolean fileExists = H2O.getPM().exists(path);
@@ -1409,43 +1399,65 @@ public class Frame extends Lockable<Frame> {
    *  is compatible with R 3.1's recent change to read.csv()'s behavior.
    *  @return An InputStream containing this Frame as a CSV */
   public InputStream toCSV(boolean headers, boolean hex_string) {
-    return new CSVStream(headers, hex_string);
+    return new CSVStream(this, headers, hex_string);
   }
 
-  public class CSVStream extends InputStream {
+  public static class CSVStream extends InputStream {
     private final boolean _hex_string;
     byte[] _line;
     int _position;
-    public volatile int _curChkIdx;
-    long _row;
+    int _chkRow;
+    Chunk[] _curChks;
+    int _lastChkIdx;
+    public volatile int _curChkIdx; // used only for progress reporting
 
-    CSVStream(boolean headers, boolean hex_string) {
-      _curChkIdx=0;
+    public CSVStream(Frame fr, boolean headers, boolean hex_string) {
+      this(firstChunks(fr), headers ? fr.names() : null, fr.anyVec().nChunks(), hex_string);
+    }
+
+    private static Chunk[] firstChunks(Frame fr) {
+      if (fr.anyVec().nChunks() == 0) {
+        return null;
+      }
+      Chunk[] chks = new Chunk[fr.vecs().length];
+      for (int i = 0; i < fr.vecs().length; i++) {
+        chks[i] = fr.vec(i).chunkForRow(0);
+      }
+      return chks;
+    }
+
+    public CSVStream(Chunk[] chks, String[] names, int nChunks, boolean hex_string) {
+      if ((chks == null) && (nChunks != 0)) {
+        // Empty Frame
+        throw new IllegalArgumentException("If chunks are not defined, number of chunks to export need to be 0.");
+      }
+      _lastChkIdx = (chks != null) ? chks[0].cidx() + nChunks - 1 : -1;
       _hex_string = hex_string;
       StringBuilder sb = new StringBuilder();
-      Vec vs[] = vecs();
-      if( headers ) {
-        sb.append('"').append(_names[0]).append('"');
-        for(int i = 1; i < vs.length; i++)
-          sb.append(',').append('"').append(_names[i]).append('"');
+      if (names != null) {
+        sb.append('"').append(names[0]).append('"');
+        for(int i = 1; i < names.length; i++)
+          sb.append(',').append('"').append(names[i]).append('"');
         sb.append('\n');
       }
       _line = sb.toString().getBytes();
+      _chkRow = -1; // first process the header line
+      _curChks = chks;
     }
 
     byte[] getBytesForRow() {
       StringBuilder sb = new StringBuilder();
-      Vec vs[] = vecs();
       BufferedString tmpStr = new BufferedString();
-      for( int i = 0; i < vs.length; i++ ) {
+      for (int i = 0; i < _curChks.length; i++ ) {
+        Vec v = _curChks[i]._vec;
         if(i > 0) sb.append(',');
-        if(!vs[i].isNA(_row)) {
-          if( vs[i].isCategorical() ) sb.append('"').append(vs[i].factor(vs[i].at8(_row))).append('"');
-          else if( vs[i].isUUID() ) sb.append(PrettyPrint.UUID(vs[i].at16l(_row), vs[i].at16h(_row)));
-          else if( vs[i].isInt() ) sb.append(vs[i].at8(_row));
-          else if (vs[i].isString()) sb.append('"').append(vs[i].atStr(tmpStr, _row)).append('"');
+        if(!_curChks[i].isNA(_chkRow)) {
+          if( v.isCategorical() ) sb.append('"').append(v.factor(_curChks[i].at8(_chkRow))).append('"');
+          else if( v.isUUID() ) sb.append(PrettyPrint.UUID(_curChks[i].at16l(_chkRow), _curChks[i].at16h(_chkRow)));
+          else if( v.isInt() ) sb.append(_curChks[i].at8(_chkRow));
+          else if (v.isString()) sb.append('"').append(_curChks[i].atStr(tmpStr, _chkRow)).append('"');
           else {
-            double d = vs[i].at(_row);
+            double d = _curChks[i].atd(_chkRow);
             // R 3.1 unfortunately changed the behavior of read.csv().
             // (Really type.convert()).
             //
@@ -1470,27 +1482,43 @@ public class Frame extends Lockable<Frame> {
         return _line.length - _position;
       }
 
-      // Case 2:  Out of data.
-      if (_row == numRows()) {
+      // Case 2:  There are no chunks to work with (eg. the whole Frame was empty).
+      if (_curChks == null) {
         return 0;
       }
 
-      // Case 3:  Return data for the current row.
-      //          Note this will fast-forward past empty chunks.
-      _curChkIdx = anyVec().elem2ChunkIdx(_row);
-      _line = getBytesForRow();
-      _position = 0;
+      _chkRow++;
+      Chunk anyChunk = _curChks[0];
 
-      // Flush non-empty remote chunk if we're done with it.
-      if (isLastRowOfCurrentNonEmptyChunk(_curChkIdx, _row)) {
-        for (Vec v : vecs()) {
-          Key k = v.chunkKey(_curChkIdx);
-          if( !k.home() )
-            H2O.raw_remove(k);
-        }
+      // Case 3:  Out of data.
+      if (anyChunk._start + _chkRow == anyChunk._vec.length()) {
+        return 0;
       }
 
-      _row++;
+      // Case 4:  Out of data in the current chunks => fast-forward to the next set of non-empty chunks.
+      if (_chkRow == anyChunk.len()) {
+        _curChkIdx = anyChunk._vec.elem2ChunkIdx(anyChunk._start + _chkRow); // skips empty chunks
+        // Case 4:  Processed all requested chunks.
+        if (_curChkIdx > _lastChkIdx) {
+          return 0;
+        }
+        // fetch the next non-empty chunks
+        Chunk[] newChks = new Chunk[_curChks.length];
+        for (int i = 0; i < _curChks.length; i++) {
+          newChks[i] = _curChks[i]._vec.chunkForChunkIdx(_curChkIdx);
+          // flush the remote chunk
+          Key oldKey = _curChks[i]._vec.chunkKey(_curChks[i]._cidx);
+          if (! oldKey.home()) {
+            H2O.raw_remove(oldKey);
+          }
+        }
+        _curChks = newChks;
+        _chkRow = 0;
+      }
+
+      // Case 5:  Return data for the current row.
+      _line = getBytesForRow();
+      _position = 0;
 
       return _line.length;
     }

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1404,9 +1404,6 @@ public class Frame extends Lockable<Frame> {
                 "Empty directory is expected.");
       }
     }
-    if (nParts == -1) {
-      throw new UnsupportedOperationException("Unsupported: cannot automatically derive optimal number of part files.");
-    }
     // Make directory for part files
     if ((! forceSingle) && (! fileExists)) {
       H2O.getPM().mkdirs(path);
@@ -1464,6 +1461,12 @@ public class Frame extends Lockable<Frame> {
       _line = sb.toString().getBytes();
       _chkRow = -1; // first process the header line
       _curChks = chks;
+    }
+
+    public int getCurrentRowSize() throws IOException {
+      int av = available();
+      assert av > 0;
+      return _line.length;
     }
 
     byte[] getBytesForRow() {

--- a/h2o-core/src/main/java/water/persist/Persist.java
+++ b/h2o-core/src/main/java/water/persist/Persist.java
@@ -201,6 +201,10 @@ public abstract class Persist {
     throw new RuntimeException("Not implemented");
   }
 
+  public boolean isDirectory(String path) {
+    throw new RuntimeException("Not implemented");
+  }
+
   public long length(String path) {
     throw new RuntimeException("Not implemented");
   }

--- a/h2o-core/src/main/java/water/persist/PersistFS.java
+++ b/h2o-core/src/main/java/water/persist/PersistFS.java
@@ -166,6 +166,11 @@ final class PersistFS extends Persist {
     return new File(URI.create(path)).exists();
   }
 
+  @Override
+  public boolean isDirectory(String path) {
+    return new File(URI.create(path)).isDirectory();
+  }
+
   private PersistEntry getPersistEntry(File f) {
     return new PersistEntry(f.getName(), f.length(), f.lastModified());
   }

--- a/h2o-core/src/main/java/water/persist/PersistManager.java
+++ b/h2o-core/src/main/java/water/persist/PersistManager.java
@@ -325,6 +325,17 @@ public class PersistManager {
     return f.exists();
   }
 
+  public boolean isDirectory(String path) {
+    if (isHdfsPath(path)) {
+      validateHdfsConfigured();
+      boolean b = I[Value.HDFS].isDirectory(path);
+      return b;
+    }
+
+    File f = new File(path);
+    return f.isDirectory();
+  }
+
   public long length(String path) {
     if (isHdfsPath(path)) {
       validateHdfsConfigured();

--- a/h2o-core/src/test/java/water/fvec/ExportTest.java
+++ b/h2o-core/src/test/java/water/fvec/ExportTest.java
@@ -30,8 +30,8 @@ public class ExportTest extends TestUtil {
     Key rebalancedKey = Key.make("rebalanced");
     Frame rebalanced = null;
     Frame imported = null;
-    int[] partSpec = {1, 4, 7, 30};
-    int[] expPart = {1, 4, 6, 17};
+    int[] partSpec = {1, 4, 7, 30, -1};
+    int[] expPart = {1, 4, 6, 17, -1};
     for (int i = 0; i < partSpec.length; i++) {
       Log.info("Testing export to " + partSpec[i] + " files.");
       try {
@@ -42,13 +42,16 @@ public class ExportTest extends TestUtil {
         File target = (parts == 1) ? new File(folder, "data.csv") : folder;
         Log.info("Should output #" + expPart[i] + " part files to " + target.getPath() + ".");
         Frame.export(rebalanced, target.getPath(), "export", false, parts).get();
-        assertEquals(expPart[i], folder.listFiles().length);
-        if (parts == 1) {
-          assertTrue(target.exists());
-        } else {
-          for (int j = 0; j < expPart[i]; j++) {
-            String suffix = (j < 10) ? "0000" + j : "000" + j;
-            assertTrue(new File(folder, "part-m-" + suffix).exists());
+        // check the number of produced part files (only if the number was given)
+        if (expPart[i] != -1) {
+          assertEquals(expPart[i], folder.listFiles().length);
+          if (parts == 1) {
+            assertTrue(target.exists());
+          } else {
+            for (int j = 0; j < expPart[i]; j++) {
+              String suffix = (j < 10) ? "0000" + j : "000" + j;
+              assertTrue(new File(folder, "part-m-" + suffix).exists());
+            }
           }
         }
         assertTrue(target.exists());

--- a/h2o-core/src/test/java/water/fvec/ExportTest.java
+++ b/h2o-core/src/test/java/water/fvec/ExportTest.java
@@ -1,0 +1,88 @@
+package water.fvec;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import water.*;
+import water.parser.ParseDataset;
+import water.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ExportTest extends TestUtil {
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @BeforeClass public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test public void testExport() throws IOException {
+    Frame fr = parse_test_file("smalldata/airlines/airlineUUID.csv");
+    Key rebalancedKey = Key.make("rebalanced");
+    Frame rebalanced = null;
+    Frame imported = null;
+    int[] partSpec = {1, 4, 7, 30};
+    int[] expPart = {1, 4, 6, 17};
+    for (int i = 0; i < partSpec.length; i++) {
+      Log.info("Testing export to " + partSpec[i] + " files.");
+      try {
+        int parts = partSpec[i];
+        Scope.enter();
+        rebalanced = rebalance(fr, rebalancedKey, 17);
+        File folder = tmpFolder.newFolder("export_" + parts);
+        File target = (parts == 1) ? new File(folder, "data.csv") : folder;
+        Log.info("Should output #" + expPart[i] + " part files to " + target.getPath() + ".");
+        Frame.export(rebalanced, target.getPath(), "export", false, parts).get();
+        assertEquals(expPart[i], folder.listFiles().length);
+        if (parts == 1) {
+          assertTrue(target.exists());
+        } else {
+          for (int j = 0; j < expPart[i]; j++) {
+            String suffix = (j < 10) ? "0000" + j : "000" + j;
+            assertTrue(new File(folder, "part-m-" + suffix).exists());
+          }
+        }
+        assertTrue(target.exists());
+        imported = parseFolder(folder);
+        assertEquals(fr.numRows(), imported.numRows());
+        assertTrue(isBitIdentical(fr, imported));
+      } finally {
+        if (rebalanced != null) rebalanced.delete();
+        if (imported != null) imported.delete();
+        Scope.exit();
+      }
+    }
+    fr.delete();
+  }
+
+  private static Frame rebalance(Frame fr, Key targetKey, int nChunks) {
+    RebalanceDataSet rb = new RebalanceDataSet(fr, targetKey, nChunks);
+    H2O.submitTask(rb);
+    rb.join();
+    return DKV.get(targetKey).get();
+  }
+
+  private static Frame parseFolder(File folder) {
+    assert folder.isDirectory();
+    File[] files = folder.listFiles();
+    assert files != null;
+    Arrays.sort(files);
+    ArrayList<Key> keys = new ArrayList<>();
+    for( File f : files )
+      if( f.isFile() )
+        keys.add(NFSFileVec.make(f)._key);
+    Key[] res = new Key[keys.size()];
+    keys.toArray(res);
+    return ParseDataset.parse(Key.make(), res);
+  }
+
+}

--- a/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
@@ -449,6 +449,19 @@ public final class PersistHdfs extends Persist {
   }
 
   @Override
+  public boolean isDirectory(String path) {
+    Path p = new Path(path);
+    URI uri = p.toUri();
+    try {
+      FileSystem fs = FileSystem.get(uri, CONF);
+      return fs.isDirectory(p);
+    }
+    catch (IOException e) {
+      throw new HDFSIOException(path, CONF.toString(), e);
+    }
+  }
+
+  @Override
   public long length(String path) {
     Path p = new Path(path);
     URI uri = p.toUri();

--- a/h2o-r/h2o-package/R/constants.R
+++ b/h2o-r/h2o-package/R/constants.R
@@ -90,9 +90,7 @@ assign("LOG_FILE_NAME", NULL,  .pkg.env)
 .h2o.__MODEL_BUILDERS <- function(algo) paste0("ModelBuilders/", algo)
 
 #' Export Files Endpoint Generator
-.h2o.__EXPORT_FILES <- function(frame,path,force) {
-  paste0("Frames/", h2o.getId(frame), "/export/",path,"/overwrite/",force)
-}
+.h2o.__EXPORT_FILES <- function(frame) paste0("Frames/", h2o.getId(frame), '/export')
 
 #' Model Endpoint
 .h2o.__MODELS         <- "Models"

--- a/h2o-r/tests/testdir_misc/runit_export_file.R
+++ b/h2o-r/tests/testdir_misc/runit_export_file.R
@@ -5,7 +5,7 @@ source("../../scripts/h2o-r-test-setup.R")
 #Export file with h2o.export_file and compare with R counterpart when re importing file to check for parity.
 
 
-test.export.file <- function() {
+test.export.file <- function(parts) {
   pros.hex <- h2o.uploadFile(locate("smalldata/prostate/prostate.csv"))
   pros.hex[,2] <- as.factor(pros.hex[,2])
   pros.hex[,4] <- as.factor(pros.hex[,4])
@@ -21,20 +21,31 @@ test.export.file <- function() {
 
   fname <- paste(paste0(sample(letters, 3, replace = TRUE), collapse = ""),
                  paste0(sample(0:9, 3, replace = TRUE), collapse = ""),
-                 "predict.csv", sep = "_")
-  dname <- paste(sandbox(), fname, sep = .Platform$file.sep)
+                 parts, "predict.csv", sep = "_")
+  dname <- file.path(sandbox(), fname)
 
   Log.info("Exporting File...")
-  h2o.exportFile(mypred, dname)
+  h2o.exportFile(mypred, dname, parts = parts)
 
   Log.info("Comparing file with R...")
-  R.pred <- read.csv(dname, colClasses=c("factor",NA,NA))
+  rfiles <- ifelse(parts > 1, list.files(dname, full.names = TRUE), dname)
+  Log.info(sprintf("Results stored in files: %s", paste(rfiles, collapse = ", ")))
+  R.pred <- NULL
+  # Note: this test doens't actually check the number of part files
+  # (it will likely be just a one part file because the input is tiny)
+  for (rfile in rfiles) {
+    part <- read.csv(rfile, colClasses=c("factor",NA,NA))
+    R.pred <- rbind(R.pred, part)
+  }
   print(head(R.pred))
   H.pred <- as.data.frame(mypred)
   print(head(H.pred))
-  expect_identical(R.pred, H.pred)
 
-  
+  expect_identical(R.pred, H.pred)
 }
 
-doTest("Testing Exporting Files", test.export.file)
+test.export.file.single <- function() test.export.file(1)
+test.export.file.multipart <- function() test.export.file(2)
+
+doTest("Testing Exporting Files (single file)", test.export.file.single)
+doTest("Testing Exporting Files (part files)", test.export.file.multipart)


### PR DESCRIPTION
@tomasnykodym This is an initial implementation of parallel CSV export.

Parallel export is exposed in
- REST API,
- R API.

Support for Python and Flow will be handled separately.

This PR also provides considerable speed-up of non-parallel CSV Export and CSV Download.

I tested the code on airlines/allyears.1987.2013.csv (approx 15GB data, hex compressed 5GB) running on 4-node H2O cluster.

4 tests were performed:
 1. Original H2O implementation v3.8.3.4: 50 minutes
 2. PR implementation, export to single file: 10 minutes
 3. PR implementation, export to multiple parts (automatically determined): 1 minute
 4. PR implementation, export to multiple parts (given number, num_parts = 7): 3 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/67)
<!-- Reviewable:end -->
