### PR TITLE
[WIP] Improves performance of importing many small files into H2O

### DIFF
--- a/h2o-core/src/main/java/water/fvec/HDFSFileVec.java
+++ b/h2o-core/src/main/java/water/fvec/HDFSFileVec.java
@@ -2,26 +2,50 @@ package water.fvec;
 
 import water.*;
 
+import java.util.Arrays;
+
 /**
  * Vec representation of file stored on HDFS.
  */
 public final class HDFSFileVec extends FileVec {
-  private HDFSFileVec(Key key, long len) {
-    super(key, len, Value.HDFS);
+
+  public final String[] _files;
+  public final long[] _offsets;
+
+  private HDFSFileVec(Key key, String[] files, long[] offsets, long size) {
+    super(key, size, Value.HDFS);
+    _files = files;
+    _offsets = offsets;
+  }
+
+  public int findPartIdx(long skip) {
+    int part = Arrays.binarySearch(_offsets, skip);
+    part = (part < 0) ? -part-2 : part;
+    assert _offsets[part] <= skip;
+    return part;
+  }
+
+  public long getPartLen(int part) {
+    return _offsets[part + 1] - _offsets[part];
   }
 
   public static Key make(String path, long size) {
     Futures fs = new Futures();
-    Key key = make(path, size, fs);
+    Key key = make(path, new String[]{path}, new long[]{size}, fs);
     fs.blockForPending();
     return key;
   }
-  public static Key make(String path, long size, Futures fs) {
+
+  public static Key make(String path, String[] files, long[] sizes, Futures fs) {
+    if (files.length != sizes.length) {
+      throw new IllegalArgumentException("Inconsistent parameters, params <files> and <sizes> must have equal length.");
+    }
     Key k = Key.make(path);
     Key k2 = Vec.newKey(k);
     new Frame(k).delete_and_lock();
+    long[] offsets = cumSum(sizes);
     // Insert the top-level FileVec key into the store
-    Vec v = new HDFSFileVec(k2,size);
+    Vec v = new HDFSFileVec(k2, files, offsets, offsets[sizes.length]);
     DKV.put(k2, v, fs);
     Frame fr = new Frame(k,new String[]{path},new Vec[]{v});
     fr.update();
@@ -29,5 +53,13 @@ public final class HDFSFileVec extends FileVec {
     return k;
   }
 
+  private static long[] cumSum(long[] input) {
+    long[] sums = new long[input.length + 1];
+    sums[0] = 0L;
+    for (int i = 0; i < input.length; i++) {
+      sums[i + 1] = sums[i] + input[i];
+    }
+    return sums;
+  }
 
 }


### PR DESCRIPTION
@tomasnykodym This is a preview pull request demonstrating the concept.

Performance of H2O suffers considerably when we try to import hundreds
or thousands of input "part" files into a single Frame. This is caused
by H2O's chunk distribution algorithm. Because chunk location is
determined based on chunk index, chunks read from small files are not
uniformly spread accross the cluster. They are concetrated
on a single node (or few nodes, depending on the size of part file).
The parsing is then also not distributed but performed by a single node.

The idea of this change is to create a single Vec for all part files.
First chunk of each part file (also every other chunk) has a different
index in the Vec. This leads to better distribution of chunks
and true parallel parsing. From the point of view of import functionality
and also chunk distribution there is no difference between working
with bunch of files and a single large continuos file.

This implementation is limited for HDFS files as of now. In can be further
generalized and pushed down to a FileVec level.

This change was tested on 50GB dataset consisting of 500 part files of similar size.
Original implementation crashed the first node when trying to import the data. This was
caused by OOM error.
The modified implementation presented in this pull request imported and parsed
the same dataset in about 1 minute. The computation was seemingly uniformly spread
across all nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/79)
<!-- Reviewable:end -->
