### PR TITLE
HEXDEV-608 

### DIFF
--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -16,15 +16,10 @@ import hex.glm.GLMModel.GLMParameters;
 import hex.glm.GLMModel.GLMParameters.Family;
 import water.*;
 import water.H2O.H2OCountedCompleter;
-import water.exceptions.H2OIllegalArgumentException;
-import water.exceptions.H2OModelBuilderIllegalArgumentException;
 import water.fvec.*;
 import water.parser.BufferedString;
 import water.parser.ParseDataset;
 import water.util.ArrayUtils;
-import water.util.IcedHashMap;
-
-import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -1729,13 +1729,8 @@ public class GLMTest  extends TestUtil {
     }
   }
 
-
-  public class TestC implements Serializable {
-    H2OIllegalArgumentException _exp;
-  }
   @Test public void testAbalone() {
     Scope.enter();
-
     GLMModel model = null;
     try {
       Frame fr = parse_test_file("smalldata/glm_test/Abalone.gz");

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -16,12 +16,15 @@ import hex.glm.GLMModel.GLMParameters;
 import hex.glm.GLMModel.GLMParameters.Family;
 import water.*;
 import water.H2O.H2OCountedCompleter;
+import water.exceptions.H2OIllegalArgumentException;
 import water.exceptions.H2OModelBuilderIllegalArgumentException;
 import water.fvec.*;
 import water.parser.BufferedString;
 import water.parser.ParseDataset;
 import water.util.ArrayUtils;
+import water.util.IcedHashMap;
 
+import java.io.Serializable;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 
@@ -1727,8 +1730,12 @@ public class GLMTest  extends TestUtil {
   }
 
 
+  public class TestC implements Serializable {
+    H2OIllegalArgumentException _exp;
+  }
   @Test public void testAbalone() {
     Scope.enter();
+
     GLMModel model = null;
     try {
       Frame fr = parse_test_file("smalldata/glm_test/Abalone.gz");

--- a/h2o-core/src/main/java/water/H2OError.java
+++ b/h2o-core/src/main/java/water/H2OError.java
@@ -2,6 +2,7 @@ package water;
 
 import water.util.HttpResponseStatus;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 import water.util.Log;
 
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public class H2OError extends Iced {
       public int _error_id;*/
 
   /** Any values that are relevant to reporting or handling this error.  Examples are a key name if the error is on a key, or a field name and object name if it's on a specific field. */
-  public IcedHashMap.IcedHashMapStringObject _values;
+  public IcedHashMapGeneric.IcedHashMapStringObject _values;
 
   /** Exception type, if any. */
   public String _exception_type;
@@ -42,11 +43,11 @@ public class H2OError extends Iced {
   /** Stacktrace, if any. */
   public String[] _stacktrace;
 
-  public H2OError(String error_url, String msg, String dev_msg, int http_status, IcedHashMap.IcedHashMapStringObject values, Exception e) {
+  public H2OError(String error_url, String msg, String dev_msg, int http_status, IcedHashMapGeneric.IcedHashMapStringObject values, Exception e) {
     this(System.currentTimeMillis(), error_url, msg, dev_msg, http_status, values, e);
   }
 
-  public H2OError(long timestamp, String error_url, String msg, String dev_msg, int http_status, IcedHashMap.IcedHashMapStringObject values, Throwable e) {
+  public H2OError(long timestamp, String error_url, String msg, String dev_msg, int http_status, IcedHashMapGeneric.IcedHashMapStringObject values, Throwable e) {
     Log.err(e);
     this._timestamp = timestamp;
     this._error_url = error_url;
@@ -105,7 +106,7 @@ public class H2OError extends Iced {
   }
 
   public H2OError(Throwable e, String error_url) {
-    this(System.currentTimeMillis(), error_url, e.getMessage(), e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(), new IcedHashMap.IcedHashMapStringObject(), e);
+    this(System.currentTimeMillis(), error_url, e.getMessage(), e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(), new IcedHashMapGeneric.IcedHashMapStringObject(), e);
   }
 
   static public String httpStatusHeader(int status_code) {

--- a/h2o-core/src/main/java/water/H2OModelBuilderError.java
+++ b/h2o-core/src/main/java/water/H2OModelBuilderError.java
@@ -4,6 +4,7 @@ import hex.Model;
 import hex.ModelBuilder;
 import water.exceptions.H2OModelBuilderIllegalArgumentException;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 /**
  * Class which represents a ModelBuilder back-end error which will be returned to the client.
@@ -18,7 +19,7 @@ public class H2OModelBuilderError extends H2OError {
   public ModelBuilder.ValidationMessage[] _messages;
   public int _error_count;
 
-  public H2OModelBuilderError(long timestamp, String error_url, String msg, String dev_msg, int http_status, IcedHashMap.IcedHashMapStringObject values, H2OModelBuilderIllegalArgumentException e) {
+  public H2OModelBuilderError(long timestamp, String error_url, String msg, String dev_msg, int http_status, IcedHashMapGeneric.IcedHashMapStringObject values, H2OModelBuilderIllegalArgumentException e) {
     super(timestamp, error_url, msg, dev_msg, http_status, values, e);
     this._parameters = (Model.Parameters) values.get("parameters");
     this._messages = (ModelBuilder.ValidationMessage[]) values.get("messages");

--- a/h2o-core/src/main/java/water/Job.java
+++ b/h2o-core/src/main/java/water/Job.java
@@ -314,7 +314,9 @@ public final class Job<T extends Keyed> extends Keyed<Job> {
   }
   private static class Barrier1OnExCom extends JAtomic {
     final byte[] _dex;
-    Barrier1OnExCom(Throwable ex) { _dex = AutoBuffer.javaSerializeWritePojo(ex); }
+    Barrier1OnExCom(Throwable ex) {
+      _dex = AutoBuffer.javaSerializeWritePojo(ex);
+    }
     @Override boolean abort(Job job) { return job._ex != null && job._end_time!=0; } // Already stopped & exception'd
     @Override void update(Job job) {
       if( job._ex == null ) job._ex = _dex; // Keep first exception ever

--- a/h2o-core/src/main/java/water/TypeMap.java
+++ b/h2o-core/src/main/java/water/TypeMap.java
@@ -57,8 +57,8 @@ public class TypeMap {
     // Beginning to hunt for files
     water.util.IcedHashMap.class.getName(),
     water.util.IcedHashMapBase.class.getName(),
-    water.util.IcedHashMap.IcedHashMapStringString.class.getName(),
-    water.util.IcedHashMap.IcedHashMapStringObject.class.getName(),
+    water.util.IcedHashMapGeneric.IcedHashMapStringString.class.getName(),
+    water.util.IcedHashMapGeneric.IcedHashMapStringObject.class.getName(),
     TypeaheadV3.class.getName(),    // Allow typeahead without locking
 
   };

--- a/h2o-core/src/main/java/water/TypeMap.java
+++ b/h2o-core/src/main/java/water/TypeMap.java
@@ -57,6 +57,7 @@ public class TypeMap {
     // Beginning to hunt for files
     water.util.IcedHashMap.class.getName(),
     water.util.IcedHashMapBase.class.getName(),
+    water.util.IcedHashMapGeneric.class.getName(),
     water.util.IcedHashMapGeneric.IcedHashMapStringString.class.getName(),
     water.util.IcedHashMapGeneric.IcedHashMapStringObject.class.getName(),
     TypeaheadV3.class.getName(),    // Allow typeahead without locking

--- a/h2o-core/src/main/java/water/api/FindHandler.java
+++ b/h2o-core/src/main/java/water/api/FindHandler.java
@@ -12,6 +12,7 @@ import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 class FindHandler extends Handler {
 
@@ -45,7 +46,7 @@ class FindHandler extends Handler {
         } catch( NumberFormatException e ) {
           if( vecs.length==1 ) {
             // There's only one Vec and it's a numeric Vec and our search string isn't a number
-            IcedHashMap.IcedHashMapStringObject values = new IcedHashMap.IcedHashMapStringObject();
+            IcedHashMapGeneric.IcedHashMapStringObject values = new IcedHashMapGeneric.IcedHashMapStringObject();
             String msg = "Frame: " + frame._key.toString() + " as only one column, it is numeric, and the find pattern is not numeric: " + find.match;
             values.put("frame_name", frame._key.toString());
             values.put("column_name", frame.name(i));

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -419,7 +419,7 @@ public class RequestServer extends HttpServlet {
               e.toString(),
               e.toString(),
               HttpResponseStatus.INTERNAL_SERVER_ERROR.getCode(),
-              new IcedHashMap.IcedHashMapStringObject(),
+              new IcedHashMapGeneric.IcedHashMapStringObject(),
               e);
       Log.err("Caught assertion error: " + error.toString());
       return serveError(error);

--- a/h2o-core/src/main/java/water/api/Schema.java
+++ b/h2o-core/src/main/java/water/api/Schema.java
@@ -331,7 +331,7 @@ abstract public class Schema<I extends Iced, S extends Schema<I,S>> extends Iced
           API api = (API) f.getAnnotations()[0]; // TODO: is there a more specific way we can do this?
           if (api.required()) {
             if (parms.getProperty(f.getName()) == null) {
-              IcedHashMap.IcedHashMapStringObject values = new IcedHashMap.IcedHashMapStringObject();
+              IcedHashMapGeneric.IcedHashMapStringObject values = new IcedHashMapGeneric.IcedHashMapStringObject();
               values.put("schema", this.getClass().getSimpleName());
               values.put("argument", f.getName());
               throw new H2OIllegalArgumentException(
@@ -709,7 +709,7 @@ abstract public class Schema<I extends Iced, S extends Schema<I,S>> extends Iced
       // TODO: render examples and other stuff, if it's passed in
     }
     catch (Exception e) {
-      IcedHashMap.IcedHashMapStringObject values = new IcedHashMap.IcedHashMapStringObject();
+      IcedHashMapGeneric.IcedHashMapStringObject values = new IcedHashMapGeneric.IcedHashMapStringObject();
       values.put("schema", this);
       // TODO: This isn't quite the right exception type:
       throw new H2OIllegalArgumentException("Caught exception using reflection on schema: " + this,

--- a/h2o-core/src/main/java/water/api/SchemaMetadata.java
+++ b/h2o-core/src/main/java/water/api/SchemaMetadata.java
@@ -7,6 +7,7 @@ import water.Weaver;
 import water.api.schemas3.*;
 import water.exceptions.H2OIllegalArgumentException;
 import water.util.IcedHashMapBase;
+import water.util.IcedHashMapGeneric;
 import water.util.Log;
 import water.util.ReflectionUtils;
 
@@ -229,7 +230,7 @@ public final class SchemaMetadata extends Iced {
         return consType(schema, clz.getComponentType(), field_name, annotation) + "[]";
 
       if (Map.class.isAssignableFrom(clz)) {
-        if (IcedHashMapBase.class.isAssignableFrom(clz)) {
+        if (IcedHashMapGeneric.class.isAssignableFrom(clz)) {
           String type0 = ReflectionUtils.findActualClassParameter(clz, 0).getSimpleName();
           String type1 = ReflectionUtils.findActualClassParameter(clz, 1).getSimpleName();
           if ("String".equals(type0)) type0 = "string";

--- a/h2o-core/src/main/java/water/api/SchemaMetadata.java
+++ b/h2o-core/src/main/java/water/api/SchemaMetadata.java
@@ -230,7 +230,7 @@ public final class SchemaMetadata extends Iced {
         return consType(schema, clz.getComponentType(), field_name, annotation) + "[]";
 
       if (Map.class.isAssignableFrom(clz)) {
-        if (IcedHashMapGeneric.class.isAssignableFrom(clz)) {
+        if (IcedHashMapGeneric.class.isAssignableFrom(clz) || IcedHashMapBase.class.isAssignableFrom(clz)) {
           String type0 = ReflectionUtils.findActualClassParameter(clz, 0).getSimpleName();
           String type1 = ReflectionUtils.findActualClassParameter(clz, 1).getSimpleName();
           if ("String".equals(type0)) type0 = "string";

--- a/h2o-core/src/main/java/water/api/schemas3/H2OErrorV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/H2OErrorV3.java
@@ -4,6 +4,7 @@ import water.H2OError;
 import water.api.API;
 import water.api.SpecifiesHttpResponseCode;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 
 /**
@@ -33,7 +34,7 @@ public class H2OErrorV3<I extends H2OError, S extends H2OErrorV3<I, S>>
 //  public int error_id;
 
   @API(help="Any values that are relevant to reporting or handling this error.  Examples are a key name if the error is on a key, or a field name and object name if it's on a specific field.", direction=API.Direction.OUTPUT)
-  public IcedHashMap.IcedHashMapStringObject values;
+  public IcedHashMapGeneric.IcedHashMapStringObject values;
 
   @API(help="Exception type, if any.", direction=API.Direction.OUTPUT)
   public String exception_type;

--- a/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
@@ -5,6 +5,7 @@ import hex.ModelCategory;
 import water.Weaver;
 import water.api.API;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 import water.util.Log;
 
 import java.lang.reflect.Field;
@@ -68,7 +69,7 @@ public class ModelOutputSchemaV3<O extends Model.Output, S extends ModelOutputSc
   public long run_time;
 
   @API(help="Help information for output fields", direction=API.Direction.OUTPUT)
-  public IcedHashMap.IcedHashMapStringString help;
+  public IcedHashMapGeneric.IcedHashMapStringString help;
 
   public ModelOutputSchemaV3() {
     super();
@@ -82,7 +83,7 @@ public class ModelOutputSchemaV3<O extends Model.Output, S extends ModelOutputSc
   }
 
   private void fillHelp() {
-    this.help = new IcedHashMap.IcedHashMapStringString();
+    this.help = new IcedHashMapGeneric.IcedHashMapStringString();
     try {
       Field[] dest_fields = Weaver.getWovenFields(this.getClass());
       for (Field f : dest_fields) {

--- a/h2o-core/src/main/java/water/exceptions/H2OAbstractRuntimeException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OAbstractRuntimeException.java
@@ -3,6 +3,7 @@ package water.exceptions;
 import water.util.HttpResponseStatus;
 import water.H2OError;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 /**
  * RuntimeException which results in an http 400 error, and serves as a base class for other error types.
@@ -13,9 +14,9 @@ abstract public class H2OAbstractRuntimeException extends RuntimeException {
 
   public long timestamp;
   public String dev_message;
-  public IcedHashMap.IcedHashMapStringObject values;
+  public IcedHashMapGeneric.IcedHashMapStringObject values;
 
-  public H2OAbstractRuntimeException(String message, String dev_message, IcedHashMap.IcedHashMapStringObject values) {
+  public H2OAbstractRuntimeException(String message, String dev_message, IcedHashMapGeneric.IcedHashMapStringObject values) {
     super(message);
 
     this.timestamp = System.currentTimeMillis();
@@ -24,7 +25,7 @@ abstract public class H2OAbstractRuntimeException extends RuntimeException {
   }
 
   public H2OAbstractRuntimeException(String msg, String dev_msg) {
-    this(msg, dev_msg, new IcedHashMap.IcedHashMapStringObject());
+    this(msg, dev_msg, new IcedHashMapGeneric.IcedHashMapStringObject());
   }
 
   public H2OError toH2OError() {

--- a/h2o-core/src/main/java/water/exceptions/H2OCategoricalLevelNotFoundArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OCategoricalLevelNotFoundArgumentException.java
@@ -1,6 +1,7 @@
 package water.exceptions;
 
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 /**
  * Exception signalling that an categorical level was not found.
@@ -10,7 +11,7 @@ public class H2OCategoricalLevelNotFoundArgumentException extends H2ONotFoundArg
   public H2OCategoricalLevelNotFoundArgumentException(String argument, String categorical_level, String frame_name, String column_name) {
     super("Categorical level: " + categorical_level + " not found in column_name: " + column_name + " in frame: " + frame_name + " from argument: " + argument + ": " + argument.toString(),
           "Categorical level: " + categorical_level + " not found in column_name: " + column_name + " in frame: " + frame_name + " from argument: " + argument + ": " + argument.toString());
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("argument", argument);
     this.values.put("categorical_level", categorical_level);
     this.values.put("frame_name", frame_name);

--- a/h2o-core/src/main/java/water/exceptions/H2OColumnNotFoundArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OColumnNotFoundArgumentException.java
@@ -2,6 +2,7 @@ package water.exceptions;
 
 import water.fvec.Frame;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 /**
  * Exception signalling that a Vec was not found.
@@ -22,7 +23,7 @@ public class H2OColumnNotFoundArgumentException extends H2ONotFoundArgumentExcep
   public H2OColumnNotFoundArgumentException(String argument, String frame_name, String column_name) {
     super("Column: " + column_name + " not found in frame: " + frame_name + " from argument: " + argument + ": " + argument.toString(),
           "Column: " + column_name + " not found in frame: " + frame_name + " from argument: " + argument + ": " + argument.toString());
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("argument", argument);
     this.values.put("frame_name", frame_name);
     this.values.put("column_name", column_name);
@@ -35,7 +36,7 @@ public class H2OColumnNotFoundArgumentException extends H2ONotFoundArgumentExcep
   public H2OColumnNotFoundArgumentException(String frame_name, String column_name) {
     super("Column: " + column_name + " not found in frame: " + frame_name + ".",
           "Column: " + column_name + " not found in frame: " + frame_name + ".");
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("frame_name", frame_name);
     this.values.put("column_name", column_name);
   }

--- a/h2o-core/src/main/java/water/exceptions/H2OIllegalArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OIllegalArgumentException.java
@@ -2,6 +2,7 @@ package water.exceptions;
 
 import water.util.HttpResponseStatus;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 public class H2OIllegalArgumentException extends H2OAbstractRuntimeException {
   protected int HTTP_RESPONSE_CODE() { return HttpResponseStatus.PRECONDITION_FAILED.getCode(); }
@@ -9,14 +10,14 @@ public class H2OIllegalArgumentException extends H2OAbstractRuntimeException {
   public H2OIllegalArgumentException(String argument, String function, Object value) {
     super("Illegal argument: " + argument + " of function: " + function + ": " + (value == null ? "null":value.toString()),
           "Illegal argument: " + argument + " of function: " + function + ": " + (value == null ? "null":value.toString()) + " of class: " + (value == null ? "null":value.getClass()));
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("function", function);
     this.values.put("argument", argument);
     if (value!=null) this.values.put("value", value);
   }
 
   /** Raw-message constructor for use by subclasses. */
-  public H2OIllegalArgumentException(String message, String dev_message, IcedHashMap.IcedHashMapStringObject values) {
+  public H2OIllegalArgumentException(String message, String dev_message, IcedHashMapGeneric.IcedHashMapStringObject values) {
     super(message, dev_message, values);
   }
 
@@ -35,7 +36,7 @@ public class H2OIllegalArgumentException extends H2OAbstractRuntimeException {
             new H2OIllegalArgumentException(
                   expectedType + " argument: " + fieldName + " with value: " + keyName + " points to a non-" + expectedType + " object: " + actualType.getSimpleName(),
                   expectedType + " argument: " + fieldName + " with value: " + keyName + " points to a non-" + expectedType + " object: " + actualType.getName());
-    e.values = new IcedHashMap.IcedHashMapStringObject();
+    e.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     e.values.put("argument", fieldName);
     e.values.put("value", keyName);
     e.values.put("expected_type", expectedType);

--- a/h2o-core/src/main/java/water/exceptions/H2OIllegalValueException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OIllegalValueException.java
@@ -1,6 +1,7 @@
 package water.exceptions;
 
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 /**
  * Exception indicating that we found an illegal value which was not passed in as an argument.
@@ -10,7 +11,7 @@ public class H2OIllegalValueException extends H2OAbstractRuntimeException {
     super("Illegal value for field: " + field + " of object: " + object + ": " + value.toString(),
             "Illegal value for field: " + field + " of object: " + object + ": " + value.toString() + " of class: " + value.getClass());
 
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("field", field);
     this.values.put("object", object);
     this.values.put("value", value);
@@ -19,7 +20,7 @@ public class H2OIllegalValueException extends H2OAbstractRuntimeException {
   public H2OIllegalValueException(String field, Object value) {
     super("Illegal value for field: " + field + ": " + value.toString(),
           "Illegal value for field: " + field + ": " + value.toString() + " of class: " + value.getClass());
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("field", field);
     this.values.put("value", value);
 

--- a/h2o-core/src/main/java/water/exceptions/H2OKeyNotFoundArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OKeyNotFoundArgumentException.java
@@ -2,6 +2,7 @@ package water.exceptions;
 
 import water.Key;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 /**
  * Exception signalling that a Key was not found.
@@ -16,7 +17,7 @@ public class  H2OKeyNotFoundArgumentException extends H2ONotFoundArgumentExcepti
   public H2OKeyNotFoundArgumentException(String argument, String function, String name) {
     super("Object '" + name.toString() + "' not found in function: " + function + " for argument: " + argument,
             "Object '" + name.toString() + "' not found in function: " + function + " for argument: " + argument);
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("function", function);
     this.values.put("argument", argument);
     this.values.put("name", name);
@@ -25,7 +26,7 @@ public class  H2OKeyNotFoundArgumentException extends H2ONotFoundArgumentExcepti
   public H2OKeyNotFoundArgumentException(String argument, String name) {
     super("Object '" + name.toString() + "' not found for argument: " + argument,
             "Object '" + name.toString() + "' not found for argument: " + argument);
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("argument", argument);
     this.values.put("name", name);
   }
@@ -37,7 +38,7 @@ public class  H2OKeyNotFoundArgumentException extends H2ONotFoundArgumentExcepti
   public H2OKeyNotFoundArgumentException(String name) {
     super("Object not found: " + name.toString(),
           "Object not found: " + name.toString());
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("name", name);
   }
 

--- a/h2o-core/src/main/java/water/exceptions/H2OKeyWrongTypeArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OKeyWrongTypeArgumentException.java
@@ -3,6 +3,7 @@ package water.exceptions;
 import water.util.HttpResponseStatus;
 import water.Keyed;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 public class H2OKeyWrongTypeArgumentException extends H2OIllegalArgumentException {
   protected int HTTP_RESPONSE_CODE() { return HttpResponseStatus.NOT_FOUND.getCode(); }
@@ -11,7 +12,7 @@ public class H2OKeyWrongTypeArgumentException extends H2OIllegalArgumentExceptio
 
     super("Expected a " + expected.getSimpleName() + " for key argument: " + argument + " with value: " + value + ".  Found a: " + actual.getSimpleName(),
           "Expected a " + expected.getCanonicalName() + " for key argument: " + argument + " with value: " + value + ".  Found a: " + actual.getCanonicalName());
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("argument", argument);
     this.values.put("value", value);
     this.values.put("expected_type", expected.getCanonicalName());

--- a/h2o-core/src/main/java/water/exceptions/H2OKeysNotFoundArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OKeysNotFoundArgumentException.java
@@ -1,13 +1,14 @@
 package water.exceptions;
 
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 public class H2OKeysNotFoundArgumentException extends H2ONotFoundArgumentException {
 
   public H2OKeysNotFoundArgumentException(String argument, String[] names) {
     super("Objects not found: " + argument + ": " + names.toString(),
             "Objects not found: " + argument + ": " + names.toString());
-    this.values = new IcedHashMap.IcedHashMapStringObject();
+    this.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     this.values.put("argument", argument);
     this.values.put("names", names);
   }

--- a/h2o-core/src/main/java/water/exceptions/H2OModelBuilderIllegalArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OModelBuilderIllegalArgumentException.java
@@ -4,6 +4,7 @@ import hex.Model;
 import hex.ModelBuilder;
 import water.H2OModelBuilderError;
 import water.util.IcedHashMap;
+import water.util.IcedHashMapGeneric;
 
 public class H2OModelBuilderIllegalArgumentException extends H2OIllegalArgumentException {
   /** Raw-message constructor for use by the factory method. */
@@ -18,7 +19,7 @@ public class H2OModelBuilderIllegalArgumentException extends H2OIllegalArgumentE
 
     H2OModelBuilderIllegalArgumentException exception = new H2OModelBuilderIllegalArgumentException(msg, msg);
 
-    exception.values = new IcedHashMap.IcedHashMapStringObject();
+    exception.values = new IcedHashMapGeneric.IcedHashMapStringObject();
     exception.values.put("algo", algo);
     exception.values.put("parameters", parameters);
     exception.values.put("error_count", builder.error_count());

--- a/h2o-core/src/main/java/water/util/IcedHashMap.java
+++ b/h2o-core/src/main/java/water/util/IcedHashMap.java
@@ -74,8 +74,4 @@ public class IcedHashMap<K, V> extends IcedHashMapBase<K,V> implements Concurren
     default: throw H2O.fail();
     }
   }
-
-  // Subtypes which allow us to determine the type parameters at runtime, for generating schema metadata.
-  public static class IcedHashMapStringString extends IcedHashMap<String, String> {}
-  public static class IcedHashMapStringObject extends IcedHashMap<String, Object> {}
 }

--- a/h2o-core/src/main/java/water/util/IcedHashMapGeneric.java
+++ b/h2o-core/src/main/java/water/util/IcedHashMapGeneric.java
@@ -12,7 +12,15 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Iced / Freezable NonBlockingHashMap abstract base class.
+ *
+ * Generalization of standard IcedHashMap (Iced NBHM wrapper) with relaxed restrictions on K/V pairs.
+ *
+ * K/V pairs do not have to follow the same mode, each K/V pair is independent and can be one of:
+ *
+ * String | Freezable  -> Integer | String | Freezable | Freezable[].
+ *
+ * Values are type checked during put operation.
+ *
  */
 public  class IcedHashMapGeneric<K, V> extends Iced implements Map<K, V>, Cloneable, Serializable {
 

--- a/h2o-core/src/test/java/water/IcedHasMapGenericTest.java
+++ b/h2o-core/src/test/java/water/IcedHasMapGenericTest.java
@@ -1,0 +1,49 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.parser.BufferedString;
+import water.util.IcedDouble;
+import water.util.IcedHashMapGeneric;
+import water.util.IcedLong;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by tomas on 8/10/16.
+ */
+public class IcedHasMapGenericTest extends TestUtil {
+  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+
+  @Test
+  public void testSerialization(){
+    IcedHashMapGeneric m = new IcedHashMapGeneric();
+    m.put("haha","gaga"); // String -> String pair
+    m.put("str->freezable", new IcedDouble(3.14)); // String -> String pair
+    m.put("str->freezable[]", new Freezable[]{new IcedDouble(3.14)}); // String -> String pair
+    m.put("str->Object", new Double(3.14)); // String -> String pair
+
+    m.put(new BufferedString("haha2"),"gaga"); // Freezable -> String pair
+    m.put(new BufferedString("str->freezable2"), new IcedDouble(3.14)); // String -> String pair
+    m.put(new BufferedString("str->freezable[]2"), new Freezable[]{new IcedDouble(3.14)}); // String -> String pair
+    m.put(new BufferedString("str->Object2"), new Double(3.14)); // String -> String pair
+    m.put(new IcedLong(1234), new Long(1234)); // String -> String pair
+    m.put(new Long(1234),new Long(54321));
+
+    byte [] buf = new AutoBuffer().put(m).buf();
+    IcedHashMapGeneric m2 = new AutoBuffer(buf).get();
+    assertEquals(m.size(),m2.size());
+    Set<Map.Entry> entries = m.entrySet();
+    for(Map.Entry e:entries){
+      if(e.getValue() instanceof Freezable[])
+        assert Arrays.deepEquals((Freezable[]) e.getValue(), (Freezable[]) m2.get(e.getKey()));
+      else
+        assertEquals(e.getValue(),m2.get(e.getKey()));
+    }
+  }
+}

--- a/h2o-core/src/test/java/water/IcedHasMapGenericTest.java
+++ b/h2o-core/src/test/java/water/IcedHasMapGenericTest.java
@@ -26,14 +26,13 @@ public class IcedHasMapGenericTest extends TestUtil {
     m.put("haha","gaga"); // String -> String pair
     m.put("str->freezable", new IcedDouble(3.14)); // String -> String pair
     m.put("str->freezable[]", new Freezable[]{new IcedDouble(3.14)}); // String -> String pair
-    m.put("str->Object", new Double(3.14)); // String -> String pair
+    m.put("str->Integer", 314); // String -> String pair
 
     m.put(new BufferedString("haha2"),"gaga"); // Freezable -> String pair
     m.put(new BufferedString("str->freezable2"), new IcedDouble(3.14)); // String -> String pair
     m.put(new BufferedString("str->freezable[]2"), new Freezable[]{new IcedDouble(3.14)}); // String -> String pair
-    m.put(new BufferedString("str->Object2"), new Double(3.14)); // String -> String pair
-    m.put(new IcedLong(1234), new Long(1234)); // String -> String pair
-    m.put(new Long(1234),new Long(54321));
+    m.put(new BufferedString("str->Integer2"), 314); // String -> String pair
+    m.put(new IcedLong(1234), 1234); // String -> String pair
 
     byte [] buf = new AutoBuffer().put(m).buf();
     IcedHashMapGeneric m2 = new AutoBuffer(buf).get();


### PR DESCRIPTION
Fixes the issue with H2O* Exception/Error serialization.

There was a bug in IcedHashMapSerialization(when reading it failed to recognize mode 5 as having String key so it would try to read String as Freezable). Fixed that.

Furthermore, IcedHashMap is not really suitable for the use, since it has restrictions on Key Value pairs: all have to be the same mode (e.g. ALL Freezable -> Freezable, or ALL String -> Freezable[]) and also only String,Freezable and Freezable[] is allowed as value. H2OExceptions used it with general objects.

Added IcedHashMapGeneric and a test.

IcedHashMapgeneric does not have restriction on the same K/V mode plus allows any java serializable as value (not sure this is a good idea).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/85)
<!-- Reviewable:end -->
