### PR TITLE
Updating Correlation Calculation (Making it more simpler and robust)

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstCorrelation.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstCorrelation.java
@@ -12,7 +12,6 @@ import water.rapids.vals.ValNum;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
 import water.util.ArrayUtils;
-
 import java.util.Arrays;
 
 /**
@@ -61,7 +60,6 @@ public class AstCorrelation extends AstPrimitive {
       default:
         throw new IllegalArgumentException("unknown use mode: " + use);
     }
-
     return fry.numRows() == 1 ? scalar(frx, fry, mode) : array(frx, fry, mode);
   }
 
@@ -88,12 +86,13 @@ public class AstCorrelation extends AstPrimitive {
     for (int r = 0; r < ncols; r++) {
       xval = vecxs[r].at(0);
       yval = vecys[r].at(0);
-      if (!(Double.isNaN(xval) || Double.isNaN(yval)))
+      if (!(Double.isNaN(xval) || Double.isNaN(yval))) {
         //Compute variance of x and y vars
         xvar += Math.pow((vecxs[r].at(0) - xmean), 2);
-      yvar += Math.pow((vecys[r].at(0) - ymean), 2);
-      //Compute sum of squares of x and y
-      ss += (vecxs[r].at(0) - xmean) * (vecys[r].at(0) - ymean);
+        yvar += Math.pow((vecys[r].at(0) - ymean), 2);
+        //Compute sum of squares of x and y
+        ss += (vecxs[r].at(0) - xmean) * (vecys[r].at(0) - ymean);
+      }
     }
     xsd = Math.sqrt(xvar / (frx.numRows())); //Sample Standard Deviation
     ysd = Math.sqrt(yvar / (fry.numRows())); //Sample Standard Deviation
@@ -123,68 +122,49 @@ public class AstCorrelation extends AstPrimitive {
     Vec[] vecys = fry.vecs();
     int ncoly = vecys.length;
 
-    if (mode.equals(Mode.Everything) || mode.equals(Mode.AllObs)) {
-      if (mode.equals(Mode.AllObs)) {
-        for (Vec v : vecxs)
-          if (v.naCnt() != 0)
-            throw new IllegalArgumentException("Mode is 'all.obs' but NAs are present");
-      }
-      CorTaskEverything[] cvs = new CorTaskEverything[ncoly];
-
-      double[] xmeans = new double[ncolx];
-      for (int x = 0; x < ncolx; x++) {
-        xmeans[x] = vecxs[x].mean();
-      }
-
-      // Start up tasks. Does all Xs vs one Y.
-      for (int y = 0; y < ncoly; y++)
-        cvs[y] = new CorTaskEverything(vecys[y].mean(), xmeans).dfork(new Frame(vecys[y]).add(frx));
-
-      // One col will return a scalar.
-      if (ncolx == 1 && ncoly == 1) {
-        return new ValNum(cvs[0].getResult()._cors[0]);
-      }
-
-      // Gather all the Xs-vs-Y correlation arrays and build out final Frame of correlations.
-      Vec[] res = new Vec[ncoly];
-      Key<Vec>[] keys = Vec.VectorGroup.VG_LEN1.addVecs(ncoly);
-      for (int y = 0; y < ncoly; y++)
-        res[y] = Vec.makeVec(cvs[y].getResult()._cors, keys[y]);
-
-      return new ValFrame(new Frame(fry._names, res));
-
-    } else {
-
-      CorTaskCompleteObsMean taskCompleteObsMean = new CorTaskCompleteObsMean(ncoly, ncolx).doAll(new Frame(fry).add(frx));
-      long NACount = taskCompleteObsMean._NACount;
-      double[] ymeans = ArrayUtils.div(taskCompleteObsMean._ysum, fry.numRows() - NACount);
-      double[] xmeans = ArrayUtils.div(taskCompleteObsMean._xsum, fry.numRows() - NACount);
-
-      // Start up tasks. Does all Xs vs one Y.
-      CorTaskCompleteObs cvs = new CorTaskCompleteObs(ymeans, xmeans).doAll(new Frame(fry).add(frx));
-
-      // One col will return a scalar.
-      if (ncolx == 1 && ncoly == 1) {
-        return new ValNum(cvs._cors[0][0] / (fry.numRows() - 1 - NACount));
-      }
-
-      // Gather all the Xs-vs-Y covariance arrays; divide by rows
-      Vec[] res = new Vec[ncoly];
-      Key<Vec>[] keys = Vec.VectorGroup.VG_LEN1.addVecs(ncoly);
-      for (int y = 0; y < ncoly; y++)
-        res[y] = Vec.makeVec(ArrayUtils.div(cvs._cors[y], (fry.numRows() - 1 - NACount)), keys[y]);
-
-      return new ValFrame(new Frame(fry._names, res));
+    if (mode.equals(Mode.AllObs)) {
+      for (Vec v : vecxs)
+        if (v.naCnt() != 0)
+          throw new IllegalArgumentException("Mode is 'all.obs' but NAs are present");
     }
+
+
+    CorTaskMean taskMean = new CorTaskMean(ncoly, ncolx, mode.equals(Mode.CompleteObs)?true:false).doAll(new Frame(fry).add(frx));
+
+    long NACount = taskMean._NACount;
+    double[] ymeans = ArrayUtils.div(taskMean._ysum, fry.numRows() - NACount);
+    double[] xmeans = ArrayUtils.div(taskMean._xsum, fry.numRows() - NACount);
+
+    CorTask[] cvs = new CorTask[ncoly];
+
+    // Launch tasks; each does all Xs vs one Y
+    for (int y = 0; y < ymeans.length; y++)
+      cvs[y] = new CorTask(ymeans[y], xmeans,true).dfork(new Frame(vecys[y]).add(frx));
+
+    // 1-col returns scalar
+    if (ncolx == 1 && ncoly == 1) {
+      return new ValNum(cvs[0].getResult()._cors[0] / cvs[0].getResult()._denom[0]);
+    }
+
+    // Gather all the Xs-vs-Y covariance arrays; divide by rows
+    Vec[] res = new Vec[ncoly];
+    Key<Vec>[] keys = Vec.VectorGroup.VG_LEN1.addVecs(ncoly);
+    for (int y = 0; y < ncoly; y++)
+      res[y] = Vec.makeVec(ArrayUtils.div(cvs[y].getResult()._cors, cvs[y].getResult()._denom), keys[y]);
+
+    return new ValFrame(new Frame(fry._names, res));
   }
 
-  private static class CorTaskEverything extends MRTask<CorTaskEverything> {
+  private static class CorTask extends MRTask<CorTask> {
     double[] _cors;
+    double[] _denom;
     final double _xmeans[], _ymean;
+    boolean _completeObs;
 
-    CorTaskEverything(double ymean, double[] xmeans) {
+    CorTask(double ymean, double[] xmeans, boolean completeObs) {
       _ymean = ymean;
       _xmeans = xmeans;
+      _completeObs = completeObs;
     }
 
     @Override
@@ -193,6 +173,7 @@ public class AstCorrelation extends AstPrimitive {
       final Chunk cy = cs[0];
       final int len = cy._len;
       _cors = new double[ncolsx];
+      _denom = new double[ncolsx];
       double sum;
       double varx;
       double vary;
@@ -203,28 +184,44 @@ public class AstCorrelation extends AstPrimitive {
         final Chunk cx = cs[x + 1];
         final double xmean = _xmeans[x];
         for (int row = 0; row < len; row++) {
-          varx += ((cx.atd(row) - xmean) * (cx.atd(row) - xmean)) / (len - 1); //Compute variance for x
-          vary += ((cy.atd(row) - _ymean) * (cy.atd(row) - _ymean)) / (len - 1); //Compute variance for y
-          sum += ((cx.atd(row) - xmean) * (cy.atd(row) - _ymean)) / (len - 1); //Compute sum of square
+          if(_completeObs){
+            //If mode is "complete.obs", then we omit rows with NA's
+            //Checking for NA's and omitting any rows with an NA value.
+            //This same check is done for the mean vector (See CorTaskMean)
+            if(!(cx.isNA(row)) && !(cy.isNA(row))){
+              varx += (cx.atd(row) - xmean) * (cx.atd(row) - xmean); //Compute variance for x
+              vary += (cy.atd(row) - _ymean) * (cy.atd(row) - _ymean); //Compute variance for y
+              sum += (cx.atd(row) - xmean) * (cy.atd(row) - _ymean); //Compute sum of square
+            }
+          }
+          else {
+            varx += (cx.atd(row) - xmean) * (cx.atd(row) - xmean); //Compute variance for x
+            vary += (cy.atd(row) - _ymean) * (cy.atd(row) - _ymean); //Compute variance for y
+            sum += (cx.atd(row) - xmean) * (cy.atd(row) - _ymean); //Compute sum of square
+          }
         }
-        _cors[x] = sum / (Math.sqrt(varx) * Math.sqrt(vary)); //Pearsons correlation coefficient
+        _cors[x] = sum;
+        _denom[x] = Math.sqrt(varx) * Math.sqrt(vary);
       }
     }
 
     @Override
-    public void reduce(CorTaskEverything cvt) {
+    public void reduce(CorTask cvt) {
       ArrayUtils.add(_cors, cvt._cors);
+      ArrayUtils.add(_denom, cvt._denom);
     }
   }
-
-  private static class CorTaskCompleteObsMean extends MRTask<CorTaskCompleteObsMean> {
+  
+  private static class CorTaskMean extends MRTask<CorTaskMean> {
     double[] _xsum, _ysum;
     long _NACount;
     int _ncolx, _ncoly;
+    boolean _completeObs;
 
-    CorTaskCompleteObsMean(int ncoly, int ncolx) {
+    CorTaskMean(int ncoly, int ncolx, boolean completeObs) {
       _ncolx = ncolx;
       _ncoly = ncoly;
+      _completeObs = completeObs;
     }
 
     @Override
@@ -240,15 +237,15 @@ public class AstCorrelation extends AstPrimitive {
       int len = cs[0]._len;
       for (int row = 0; row < len; row++) {
         add = true;
-        //reset existing arrays to 0. Will save on GC.
+        //reset existing arrays to 0. Should save on GC.
         Arrays.fill(xvals, 0);
         Arrays.fill(yvals, 0);
 
         for (int y = 0; y < _ncoly; y++) {
           final Chunk cy = cs[y];
           yval = cy.atd(row);
-          //if any yval along a row is NA, discard the entire row
-          if (Double.isNaN(yval)) {
+          //if any yval along a row is NA and _completeObs is true, discard the entire row
+          if (Double.isNaN(yval) && _completeObs) {
             _NACount++;
             add = false;
             break;
@@ -259,8 +256,8 @@ public class AstCorrelation extends AstPrimitive {
           for (int x = 0; x < _ncolx; x++) {
             final Chunk cx = cs[x + _ncoly];
             xval = cx.atd(row);
-            //if any xval along a row is NA, discard the entire row
-            if (Double.isNaN(xval)) {
+            //if any yval along a row is NA and _completeObs is true, discard the entire row
+            if (Double.isNaN(xval) && _completeObs) {
               _NACount++;
               add = false;
               break;
@@ -277,77 +274,11 @@ public class AstCorrelation extends AstPrimitive {
     }
 
     @Override
-    public void reduce(CorTaskCompleteObsMean cvt) {
+    public void reduce(CorTaskMean cvt) {
       ArrayUtils.add(_xsum, cvt._xsum);
       ArrayUtils.add(_ysum, cvt._ysum);
       _NACount += cvt._NACount;
     }
   }
-
-  private static class CorTaskCompleteObs extends MRTask<CorTaskCompleteObs> {
-    double[][] _cors;
-    final double _xmeans[], _ymeans[];
-
-    CorTaskCompleteObs(double[] ymeans, double[] xmeans) {
-      _ymeans = ymeans;
-      _xmeans = xmeans;
-    }
-
-    @Override
-    public void map(Chunk cs[]) {
-      int ncolx = _xmeans.length;
-      int ncoly = _ymeans.length;
-      double[] xvals = new double[ncolx];
-      double[] yvals = new double[ncoly];
-      _cors = new double[ncoly][ncolx];
-      double[] _cors_y;
-      double xval, yval, ymean;
-      boolean add;
-      int len = cs[0]._len;
-      for (int row = 0; row < len; row++) {
-        add = true;
-        //reset existing arrays to 0. Will save on GC.
-        Arrays.fill(xvals, 0);
-        Arrays.fill(yvals, 0);
-
-        for (int y = 0; y < ncoly; y++) {
-          final Chunk cy = cs[y];
-          yval = cy.atd(row);
-          //if any yval along a row is NA, discard the entire row
-          if (Double.isNaN(yval)) {
-            add = false;
-            break;
-          }
-          yvals[y] = yval;
-        }
-        if (add) {
-          for (int x = 0; x < ncolx; x++) {
-            final Chunk cx = cs[x + ncoly];
-            xval = cx.atd(row);
-            //if any xval along a row is NA, discard the entire row
-            if (Double.isNaN(xval)) {
-              add = false;
-              break;
-            }
-            xvals[x] = xval;
-          }
-        }
-        //add is true iff row has been traversed and found no NAs among yvals and xvals
-        if (add) {
-          for (int y = 0; y < ncoly; y++) {
-            _cors_y = _cors[y];
-            yval = yvals[y];
-            ymean = _ymeans[y];
-            for (int x = 0; x < ncolx; x++)
-              _cors_y[x] += ((xvals[x] - _xmeans[x]) * (yval - ymean)) / (Math.sqrt(Math.pow(xvals[x] - _xmeans[x], 2)) * Math.sqrt(Math.pow(yval - ymean, 2)));
-          }
-        }
-      }
-    }
-
-    @Override
-    public void reduce(CorTaskCompleteObs cvt) {
-      ArrayUtils.add(_cors, cvt._cors);
-    }
-  }
 }
+

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -253,6 +253,10 @@ public class ArrayUtils {
     for (int i=0; i<ds.length; i++) ds[i]/=n[i];
     return ds;
   }
+  public static double[] div(double[] ds, double[] n) {
+    for (int i=0; i<ds.length; i++) ds[i]/=n[i];
+    return ds;
+  }
   public static float[] mult(float[] nums, float n) {
 //    assert !Float.isInfinite(n) : "Trying to multiply " + Arrays.toString(nums) + " by  " + n; // Almost surely not what you want
     for (int i=0; i<nums.length; i++) nums[i] *= n;

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2015,9 +2015,9 @@ kurtosis.H2OFrame <- h2o.kurtosis
 #' @param y \code{NULL} (default) or an H2OFrame. The default is equivalent to y = x.
 #' @param na.rm \code{logical}. Should missing values be removed?
 #' @param use An optional character string indicating how to handle missing values. This must be one of the following: 
-#   "everything"            - outputs NaNs whenever one of its contributing observations is missing
-#   "all.obs"               - presence of missing observations will throw an error
-#   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
+#'   "everything"            - outputs NaNs whenever one of its contributing observations is missing
+#'   "all.obs"               - presence of missing observations will throw an error
+#'   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
 #' @seealso \code{\link[stats]{var}} for the base R implementation. \code{\link{h2o.sd}} for standard deviation.
 #' @examples
 #' \donttest{
@@ -2058,9 +2058,9 @@ var <- function(x, y = NULL, na.rm = FALSE, use)  {
 #' @param y \code{NULL} (default) or an H2OFrame. The default is equivalent to y = x.
 #' @param na.rm \code{logical}. Should missing values be removed?
 #' @param use An optional character string indicating how to handle missing values. This must be one of the following:
-#   "everything"            - outputs NaNs whenever one of its contributing observations is missing
-#   "all.obs"               - presence of missing observations will throw an error
-#   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
+#'   "everything"            - outputs NaNs whenever one of its contributing observations is missing
+#'   "all.obs"               - presence of missing observations will throw an error
+#'   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
 #' @examples
 #' \donttest{
 #' h2o.init()

--- a/h2o-r/tests/testdir_munging/unop/runit_cor_matrix.R
+++ b/h2o-r/tests/testdir_munging/unop/runit_cor_matrix.R
@@ -1,0 +1,59 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+##
+# Test out the cor() functionality
+##
+
+
+test.cor <- function() {
+  #1 row case
+  n <- 20
+  g <- runif(n)
+  h <- runif(n)
+  run.cor.tests(g,h,one_row=TRUE)
+  g[4] <- NA
+  run.cor.tests(g,h,one_row=TRUE, has_nas=TRUE)
+
+  #1 column case
+  run.cor.tests(g,h, has_nas = TRUE)
+  g[4] <- runif(1)
+  run.cor.tests(g,h)
+
+  #Matrices
+  g <- matrix(runif(n),nrow=4)
+  h <- matrix(runif(12),nrow=4)
+  run.cor.tests(g,h)
+  g[2,3] <- NA
+  g[1,4] <- NA
+  h[2,3] <- NA
+  run.cor.tests(g,h,has_nas=TRUE)
+}
+
+run.cor.tests <- function (g,h,one_row=FALSE,has_nas=FALSE) {
+  h2o_g <- as.h2o(g)
+  h2o_h <- as.h2o(h)
+  h2o_g = h2o.rbind(h2o_g,h2o_g,h2o_g) #Ensure across chunks
+  h2o_h = h2o.rbind(h2o_h,h2o_h,h2o_h) #Ensure across chunks
+  uses <- c("everything", "all.obs", "complete.obs")
+  if (has_nas) uses <- uses[-2]
+  for (na.rm in c(FALSE, TRUE)) {
+    for (use in uses) {
+      #2 inputs
+      if (one_row) {
+        h2o_cor <- cor(as.h2o((g)),as.h2o((h)), na.rm = na.rm, use = use)
+      } else {
+        h2o_cor <- cor(h2o_g, h2o_h, na.rm = na.rm, use = use)
+      }
+      R_cor <- cor(g,h, na.rm = na.rm, use = use)
+      print("H2O cor():")
+      print(h2o_cor)
+
+      print("R cor():")
+      print(R_cor)
+      h2o_and_R_equal(h2o_cor, R_cor)
+    }
+  }
+}
+
+
+doTest("Test out the cor() functionality", test.cor)


### PR DESCRIPTION
Modified docstring to show `uses` in h2o.var() and h2o.cor()
Modified calculation of Pearson Correlation Coefficient:
 - Removed CorTaskCompleteObs and now use CorTask as main worker in calculating correlation.
 - Removed CorTaskCompleteObsMean and now use CorMean to get mean across Vecs/columns.
 - Added another runit for h2o.cor(). Matches base R implementation. 
 - This new implementation is simpler and achieves the same results. 
 - Previously this had issues across multiple chunks. Does not seem to be the issue anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/87)
<!-- Reviewable:end -->
