### PR TITLE
Simple fix in the new chunk + added test.

### DIFF
--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -934,9 +934,12 @@ public class NewChunk extends Chunk {
             _ms.move(i - cs, i);
             _xs.move(i - cs, i);
             _id[i - cs] = i;
-            if(sparsity_type != Compress.NA && _missing != null)_missing.set(i-cs,_missing.get(i));
+            if(sparsity_type != Compress.NA && _missing != null){
+              _missing.set(i-cs,_missing.get(i));
+            }
           }
         }
+        _missing.clear(num_noncompressibles,_missing.length());
       }
     } else {
       assert num_noncompressibles <= _ds.length;

--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -939,8 +939,8 @@ public class NewChunk extends Chunk {
             }
           }
         }
-        if(_missing != null)
-          _missing.clear(num_noncompressibles,_missing.length());
+        if(_missing != null && _missing.length() > num_noncompressibles)
+            _missing.clear(num_noncompressibles, _missing.length());
       }
     } else {
       assert num_noncompressibles <= _ds.length;

--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -939,7 +939,8 @@ public class NewChunk extends Chunk {
             }
           }
         }
-        _missing.clear(num_noncompressibles,_missing.length());
+        if(_missing != null)
+          _missing.clear(num_noncompressibles,_missing.length());
       }
     } else {
       assert num_noncompressibles <= _ds.length;

--- a/h2o-core/src/test/java/water/fvec/NewChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkTest.java
@@ -522,5 +522,40 @@ public class NewChunkTest extends TestUtil {
     } finally { remove(); }
   }
 
+
+private static double []  test_seq = new double[]{
+    2,0,0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,3,0,0,0,Double.NaN,Double.NaN,Double.NaN,Double.NaN,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,10,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,3,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,10,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,3,0,0,0,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,3,0,0,1,0,0,0,0,0,0,0,0,2,0,0,3,0,0,0,0,0,0,0,0,0,3,32,0,0,0,17,6,2,0,0,0,0,0,0,0,0,67,0,0,0,0,0,0,0
+};
+@Test public void testSparseWithMissing(){
+  // DOUBLES
+  av = new AppendableVec(Vec.newKey(), Vec.T_NUM);
+  nc = new NewChunk(av, 0);
+  for(double d:test_seq)
+    nc.addNum(d);
+  Chunk c = nc.compress();
+  for(int i =0 ; i < test_seq.length; ++i) {
+    if(Double.isNaN(test_seq[i]))
+      Assert.assertTrue(c.isNA(i));
+    else
+      Assert.assertEquals("mismatch at line " + i + ": expected " + test_seq[i] + ", got " + c.atd(i), +  test_seq[i],c.atd(i),0);
+  }
+  // INTS
+  av = new AppendableVec(Vec.newKey(), Vec.T_NUM);
+  nc = new NewChunk(av, 0);
+  for(double d:test_seq)
+    if(Double.isNaN(d)) nc.addNA();
+    else nc.addNum((int)d,0);
+  c = nc.compress();
+  for(int i =0 ; i < test_seq.length; ++i) {
+    if(Double.isNaN(test_seq[i]))
+      Assert.assertTrue(c.isNA(i));
+    else
+      Assert.assertEquals("mismatch at line " + i + ": expected " + test_seq[i] + ", got " + c.atd(i), +  test_seq[i],c.atd(i),0);
+  }
+
+}
+
+
+
 }
 


### PR DESCRIPTION
New Chunk was not clearing bitset with NAs markers when switching to sparse (compressing to the left) which resulted into non-NA values being turned into NAs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/88)
<!-- Reviewable:end -->
