### PR TITLE
PUBDEV-3237 & PUBDEV-3238

### DIFF
--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
@@ -2114,7 +2114,7 @@ public class DeepLearningTest extends TestUtil {
       Assert.assertEquals(87.26206135855, ((ModelMetricsRegression)dl._output._training_metrics)._mean_residual_deviance,1e-4);
       Assert.assertEquals(87.26206135855, ((ModelMetricsRegression)dl._output._validation_metrics)._mean_residual_deviance,1e-4);
       Assert.assertEquals(117.8014, ((ModelMetricsRegression)dl._output._cross_validation_metrics)._mean_residual_deviance,1e-4);
-      Assert.assertEquals(117.8014, Double.parseDouble((String)(dl._output._cross_validation_metrics_summary).get(2,0)), 1);
+      Assert.assertEquals(117.8014, Double.parseDouble((String)(dl._output._cross_validation_metrics_summary).get(3,0)), 1);
 
     } finally {
       if (tfr != null) tfr.remove();

--- a/h2o-core/src/main/java/hex/ModelMetricsRegression.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsRegression.java
@@ -10,6 +10,7 @@ public class ModelMetricsRegression extends ModelMetricsSupervised {
   public double residual_deviance() { return _mean_residual_deviance; }
   public final double _mean_residual_deviance;
   public final double _mean_absolute_error;
+  public double mae() { return _mean_absolute_error; }
   public ModelMetricsRegression(Model model, Frame frame, long nobs, double mse, double sigma, double mae, double meanResidualDeviance) {
     super(model, frame, nobs, mse, null, sigma);
     _mean_residual_deviance = meanResidualDeviance;

--- a/h2o-core/src/main/java/hex/ModelMetricsRegression.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsRegression.java
@@ -101,7 +101,7 @@ public class ModelMetricsRegression extends ModelMetricsSupervised {
       // Compute error
       double err = yact[0] - ds[0]; // Error: distance from the actual
       _sumsqe += w*err*err;       // Squared error
-      _abserror += Math.abs(err);
+      _abserror += w*Math.abs(err);
       assert !Double.isNaN(_sumsqe);
       if (m!=null && m._parms._distribution!=Distribution.Family.huber)
         _sumdeviance += m.deviance(w, yact[0], ds[0]);


### PR DESCRIPTION
Added observation weights for MAE
Added MAE to Cross-Validation Metrics Summary
Modified `testCategoricalEncodingRegressionHuber()` to account for MAE being in the CV Metrics Summary (moved everything down in the table and thus changes indexes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/96)
<!-- Reviewable:end -->
