### PR TITLE
PUBDEV-3246

### DIFF
--- a/h2o-core/src/test/java/water/FuturesTest.java
+++ b/h2o-core/src/test/java/water/FuturesTest.java
@@ -1,0 +1,128 @@
+package water;
+
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+/**
+ * Created by tomas on 8/16/16.
+ */
+public class FuturesTest extends TestUtil {
+
+  @BeforeClass
+  public static void setup() { stall_till_cloudsize(1); }
+
+  public static class TstFuture implements Future {
+    private boolean _isDone;
+    private boolean _isCancelled;
+    public ExecutionException _exex;
+    public RuntimeException _rex;
+
+    @Override
+    public synchronized boolean cancel(boolean mayInterruptIfRunning) {
+      _isCancelled = true;
+      notifyAll();
+      return true;
+    }
+
+    public synchronized void complete(){
+      _isDone = true;
+      notifyAll();
+    }
+
+    public synchronized void complete(Throwable t){
+      if(t instanceof ExecutionException)
+        _exex = (ExecutionException) t;
+      else if(t instanceof RuntimeException)
+        _rex = (RuntimeException) t;
+      else throw new IllegalArgumentException();
+      _isDone = true;
+      notifyAll();
+    }
+
+
+    @Override
+    public boolean isCancelled() {return _isCancelled;}
+
+    @Override
+    public boolean isDone() {return _isDone || _isCancelled;}
+
+    @Override
+    public Object get() throws InterruptedException, ExecutionException {
+      while(!isDone()){
+        synchronized(this){
+          wait();
+        }
+      }
+      if(_isCancelled) throw new CancellationException();
+      if(_exex != null) throw _exex;
+      if(_rex != null) throw _rex;
+      return this;
+    }
+
+    @Override
+    public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+      return null;
+    }
+  }
+  private static class TstException extends RuntimeException {
+    public TstException(String msg){super(msg);}
+  }
+
+  @Test
+  // Test exceptions are correctly rethrown even if the future is eagerly removed
+  public void testExceptions(){
+    // 0 test exception from pending task is thrown
+    Futures fs = new Futures();
+    TstFuture cf = new TstFuture();
+    fs.add(cf);
+    Assert.assertEquals(1,fs._pending_cnt); // task is already completed
+    cf.complete(new ExecutionException(new TstException("a")));
+    try{
+      fs.blockForPending();
+      Assert.assertTrue("should've thrown",false);
+    } catch(RuntimeException t) {
+      Assert.assertTrue(t.getCause() instanceof TstException);
+    }
+    // 1 test exception from already completed task is rethrown in blockForPending
+    fs = new Futures();
+    cf = new TstFuture();
+    cf.complete(new ExecutionException(new TstException("a")));
+    fs.add(cf);
+    Assert.assertEquals(0,fs._pending_cnt); // task is already completed
+    try{
+      fs.blockForPending();
+      Assert.assertTrue("should've thrown",false);
+    } catch(RuntimeException t) {
+      Assert.assertTrue(t.getCause() instanceof TstException);
+    }
+    // 2 test exception is recorded and re-thrown if task is eagerly cleaned
+    fs = new Futures();
+    cf = new TstFuture();
+    fs.add(cf);
+    Assert.assertEquals(1,fs._pending_cnt);
+    cf.complete(new TstException("eager cleanup"));
+    for(int i =0; i < 3; ++i) {
+      fs.add(cf = new TstFuture());
+      Assert.assertEquals(1, fs._pending_cnt);
+      cf.complete();
+    }
+    try{
+      fs.blockForPending();
+      Assert.assertTrue("should've thrown",false);
+    } catch(RuntimeException t) {
+      Assert.assertTrue(t.getCause() instanceof TstException);
+      Assert.assertEquals("eager cleanup",t.getCause().getMessage());
+    }
+    // 3 test cancellation exceptions are ignored
+    fs = new Futures();
+    cf = new TstFuture();
+    cf.cancel(true);
+    fs.add(cf);
+    fs.blockForPending();
+
+  }
+}


### PR DESCRIPTION
Fix Futures to prevent them from swallowing exceptions.

Futures are eagerly removing finished (exceptionally or not) tasks from the queue.
Tasks are eagerly removed if
   a) they are completed before being added to the list
   b) they are completed at the time of futures resize (internal array resize).

Since the finished tasks were not tested for exceptional completion, any exceptions from the eagerly removed tasks were lost.

Made two changes to the Futures:

 1) check for exception when eagerly removing tasks (call get()).
     and store any potential exceptions and re-throw them later when blockForPending() is called.
  2) wait for all the tasks to finish before re-throwing any exceptions in blockForPending.

+ Added test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/99)
<!-- Reviewable:end -->