### PR TITLE
Add support for adding/fetching frames from/to non-h2o environment

### DIFF
--- a/h2o-core/src/main/java/water/ExternalFrameHandler.java
+++ b/h2o-core/src/main/java/water/ExternalFrameHandler.java
@@ -1,0 +1,84 @@
+package water;
+
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * <p>This class is used to coordinate the requests for accessing/obtaining H2O frames from non-H2O environments
+ * ( ie. Spark Executors).</p>
+ *
+ * <p>The user should use {@code getConnection} method to open a connection to an H2O node. This method creates the socket channel
+ * in a way h2o internals expect it.</p>
+ *
+ * <p>The data can be written to h2o frame and read data from h2o frame.
+ * When writing, it is expected that empty H2O frame is already in DKV before using the writing API. The caller
+ * is responsible for finishing the frame once all data has been written to the frame. To read more about the writing
+ * API, please read documentation of {@link ExternalFrameWriterClient}</p>
+ *
+ * <p>When reading the data, it is expected that h2o frame is in DKV. To read more about the reading API, please read
+ * documentation of {@link ExternalFrameReaderClient}</p>
+ *
+ *
+ */
+final class ExternalFrameHandler {
+
+    /**
+     * This is used to inform us that another byte is coming.
+     * That byte can be either {@code MARKER_ORIGINAL_VALUE} or {@code MARKER_NA}. If it's
+     * {@code MARKER_ORIGINAL_VALUE}, that means
+     * the value sent is in the previous data sent, otherwise the value is NA.
+     */
+    static final byte NUM_MARKER_NEXT_BYTE_FOLLOWS = 127;
+
+    /**
+     * Same as above, but for Strings. We are using unicode code for CONTROL, which should be very very rare
+     * String to send as usual String data.
+     */
+    static final String STR_MARKER_NEXT_BYTE_FOLLOWS = "\u0080";
+
+    /**
+     *  Marker informing us that the data are not NA and are stored in the previous byte
+     */
+    static final byte MARKER_ORIGINAL_VALUE = 0;
+
+    /**
+     * Marker informing us that the data being sent is NA
+     */
+    static final byte MARKER_NA = 1;
+
+    /** Byte signaling that new communication has been started on a existing/newly created socket channel
+     *  Since connections can reused at the caller site ( for example spark executor ) we have to identify whether the
+     *  the connection has been reused for sending more data or not
+     * */
+    static final byte INIT_BYTE = 42;
+
+    /**
+     * Bytes used for signaling that either reading from h2o frame or writing to h2o frame has finished.
+     * It is important for these 2 bytes to be different, otherwise we could confirm writing by reading byte, which
+     * would lead to unwanted states.
+     */
+    static final byte CONFIRM_READING_DONE = 1;
+    static final byte CONFIRM_WRITING_DONE = 2;
+
+    /**
+     * Main task codes
+     */
+    static final byte CREATE_FRAME = 0;
+    static final byte DOWNLOAD_FRAME = 1;
+
+    /**
+     * Method which receives the {@link SocketChannel} and {@link AutoBuffer} and dispatches the request for further processing
+     */
+    void process(SocketChannel sock, AutoBuffer ab) throws IOException {
+        int requestType = ab.get1();
+        switch (requestType) {
+            case CREATE_FRAME:
+                ExternalFrameWriterBackend.handleWriteToChunk(sock, ab);
+                break;
+            case DOWNLOAD_FRAME:
+                ExternalFrameReaderBackend.handleReadingFromChunk(sock, ab);
+                break;
+        }
+    }
+}

--- a/h2o-core/src/main/java/water/ExternalFrameHandlerThread.java
+++ b/h2o-core/src/main/java/water/ExternalFrameHandlerThread.java
@@ -1,0 +1,52 @@
+package water;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * <p>This class is a thread which exists per each new connection of type {@code TCPReceiverThread.TCP_EXTERNAL}</p>
+ *
+ * <p>It is started for the connection and waits for the {@code INIT_BYTE}. If the {@code INIT_BYTE} has been received,
+ * the socket channel and corresponding {@link AutoBuffer} is sent to {@link ExternalFrameHandler} to handle the
+ * particular request.</p>
+ *
+ * <p>The {@code INIT_BYTE} has to be sent since the connection can be reused on the caller side and we need to know
+ * that new bunch of requests or data is coming.</p>
+ */
+class ExternalFrameHandlerThread extends Thread {
+    private SocketChannel _sock;
+    private AutoBuffer _ab;
+
+    ExternalFrameHandlerThread(SocketChannel sock, AutoBuffer ab) {
+        super("TCP-"+sock);
+        _sock = sock;
+        _ab = ab;
+        setPriority(MAX_PRIORITY-1);
+    }
+
+    @Override
+    public void run() {
+        while (true) { // Loop, reading fresh TCP requests until the sender closes
+
+            try {
+                // blocking call
+                if(_ab.get1() != ExternalFrameHandler.INIT_BYTE){
+                    // check whether this channel contains data for next frame task
+                    // otherwise close the connection here
+                    throw new IOException("This connection is idle, expected data are not available");
+                }
+                new ExternalFrameHandler().process(_sock, _ab);
+                // Reuse open sockets for the next task
+                if (!_sock.isOpen()) break;
+                _ab = new AutoBuffer(_sock, null);
+            } catch (Exception e) {
+                // Exceptions here are *normal*, this is an idle TCP connection and
+                // either the OS can time it out, or the cloud might shutdown.  We
+                // don't care what happens to this socket.
+                break;         // Ignore all errors; silently die if socket is closed
+            }
+        }
+
+    }
+}
+

--- a/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
@@ -1,0 +1,95 @@
+package water;
+
+import water.fvec.Chunk;
+import water.fvec.ChunkUtils;
+import water.fvec.Frame;
+import water.parser.BufferedString;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+import java.util.UUID;
+
+import static water.ExternalFrameUtils.*;
+
+/**
+ * This class contains methods used on the h2o backend to read data from H2O Frame.
+ */
+final class ExternalFrameReaderBackend {
+
+    /**
+     * Internal method use on the h2o backend side to handle reading from the chunk from non-h2o environment
+     * @param channel socket channel originating from non-h2o node
+     * @param initAb {@link AutoBuffer} containing information necessary for preparing backend for reading
+     */
+    static void handleReadingFromChunk(SocketChannel channel, AutoBuffer initAb) throws IOException {
+        // receive required information
+        String frameKey = initAb.getStr();
+        int chunkIdx = initAb.getInt();
+        byte[] expectedTypes = initAb.getA1();
+        assert expectedTypes != null : "Expected types can't be null";
+        int[] selectedColumnIndices = initAb.getA4();
+        assert selectedColumnIndices != null : "Selected column indices can't be null";
+        Frame fr = DKV.getGet(frameKey);
+        Chunk[] chunks = ChunkUtils.getChunks(fr, chunkIdx);
+
+        // write number of rows
+        AutoBuffer ab = new AutoBuffer();
+        ab.putInt(chunks[0]._len);
+        writeToChannel(ab, channel);
+
+        // buffered string to be reused for strings to avoid multiple allocation in the loop
+        BufferedString valStr = new BufferedString();
+        for (int rowIdx = 0; rowIdx < chunks[0]._len; rowIdx++) {
+            for(int i = 0; i < selectedColumnIndices.length; i++){
+                if (chunks[selectedColumnIndices[i]].isNA(rowIdx)) {
+                    ExternalFrameUtils.sendNA(ab, channel, expectedTypes[i]);
+                } else {
+                    final Chunk chnk = chunks[selectedColumnIndices[i]];
+                    switch (expectedTypes[selectedColumnIndices[i]]) {
+                        case EXPECTED_BOOL:
+                            ExternalFrameUtils.sendBoolean(ab, channel, (byte)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_BYTE:
+                            ExternalFrameUtils.sendByte(ab, channel, (byte)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_CHAR:
+                            ExternalFrameUtils.sendChar(ab, channel, (char)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_SHORT:
+                            ExternalFrameUtils.sendShort(ab, channel, (short)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_INT:
+                            ExternalFrameUtils.sendInt(ab, channel, (int)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_FLOAT:
+                            ExternalFrameUtils.sendFloat(ab, channel, (float)chnk.atd(rowIdx));
+                            break;
+                        case EXPECTED_LONG:
+                            ExternalFrameUtils.sendLong(ab, channel, chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_DOUBLE:
+                            ExternalFrameUtils.sendDouble(ab, channel, chnk.atd(rowIdx));
+                            break;
+                        case EXPECTED_TIMESTAMP:
+                            ExternalFrameUtils.sendTimestamp(ab, channel, chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_STRING:
+                            if (chnk.vec().isCategorical()) {
+                                ExternalFrameUtils.sendString(ab, channel, chnk.vec().domain()[(int) chnk.at8(rowIdx)]);
+                            } else if (chnk.vec().isString()) {
+                                ExternalFrameUtils.sendString(ab, channel, chnk.atStr(valStr, rowIdx).toString());
+                            } else if (chnk.vec().isUUID()) {
+                                UUID uuid = new UUID(chnk.at16h(rowIdx), chnk.at16l(rowIdx));
+                                ExternalFrameUtils.sendString(ab, channel, uuid.toString());
+                            } else {
+                                assert false : "Can never be here";
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+        ab.put1(ExternalFrameHandler.CONFIRM_READING_DONE);
+        writeToChannel(ab, channel);
+    }
+}

--- a/h2o-core/src/main/java/water/ExternalFrameReaderClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderClient.java
@@ -1,0 +1,180 @@
+package water;
+
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.sql.Timestamp;
+
+import static water.ExternalFrameUtils.writeToChannel;
+
+/**
+ * <p>This class is used to read data from H2O Frames from non-H2O environments, such as Spark Executors.
+ * It is expected that the frame we want to read is already in the DKV. The check for the presence is up on the
+ * user of this class.<p>
+ *
+ * <strong>Example usage of this class:</strong></br>
+ *
+ * <p>
+ * First we need to open the connection to H2O and initialize the reader:</br>
+ * <pre>
+ * {@code
+ * // specify indexes of columns we want to read data from
+ * int[] selectedColumnIndices = {0, 1};
+ * // specify expected types for the selected columns
+ * byte[] expectedTypes = {ExternalFrameHandler.EXPECTED_BOOL, ExternalFrameHandler.EXPECTED_INT};
+ * ByteChannel channel = ExternalFrameUtils.getConnection("ip:port");
+ * ExternalFrameReader reader = new ExternalFrameReader(channel, "frameName", 0, selectedColumnIndices);
+ * }
+ * </pre>
+ * </p>
+ *
+ * <p>
+ * In the next step we can read the data we expect, in our case boolean and integer:</br>
+ * <pre>
+ * {@code
+ * int rowsRead = 0;
+ * while(rowsRead < reader.getNumRows){
+ *     boolean b = reader.readBool();
+ *     if(reader.isLastNA{
+ *         // it is NA
+ *     }else{
+ *         // it is value
+ *     }
+ *
+ *     int i = reader.readInt()
+ *     if(reader.isLastNA{
+ *     // it is NA
+ *     }else{
+ *         // it is value
+ *     }
+ * }
+ * }
+ * </pre>
+ * </p>
+ *
+ * <p>
+ * And at the end we need to make sure to force to code wait for all data to be read:</br>
+ * <pre>
+ * {@code
+ * reader.waitUntilAllReceived();
+ * }
+ * </pre>
+ * </p>
+ */
+final public class ExternalFrameReaderClient {
+
+    private boolean isLastNA = false;
+    private AutoBuffer ab;
+    private String frameKey;
+    private int chunkIdx;
+    private int[] selectedColumnIndices;
+    private ByteChannel channel;
+    private int numRows;
+    private byte[] expectedTypes = null;
+
+    /**
+     *
+     * @param channel channel to h2o node
+     * @param frameKey name of frame we want to read from
+     * @param chunkIdx chunk index from we want to read
+     * @param selectedColumnIndices indices of columns we want to read from
+     * @param expectedTypes expected types for
+     */
+    public ExternalFrameReaderClient(ByteChannel channel, String frameKey, int chunkIdx, int[] selectedColumnIndices, byte[] expectedTypes) throws IOException{
+        this.channel = channel;
+        this.frameKey = frameKey;
+        this.chunkIdx = chunkIdx;
+        this.expectedTypes = expectedTypes;
+        this.selectedColumnIndices = selectedColumnIndices;
+        this.ab = initAndGetAb();
+    }
+
+    public int getNumRows(){
+        return numRows;
+    }
+
+    public boolean readBoolean(){
+        boolean data = ab.getZ();
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+
+    public byte readByte(){
+        byte data = ab.get1();
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+    public char readChar(){
+        char data = ab.get2();
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+    public short readShort(){
+        short data = ab.get2s();
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+    public int readInt(){
+        int data = ab.getInt();
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+    public long readLong(){
+        long data = ab.get8();
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+    public float readFloat(){
+        float data = ab.get4f();
+        isLastNA = ExternalFrameUtils.isNA(data);
+        return data;
+    }
+    public double readDouble(){
+        double data = ab.get8d();
+        isLastNA = ExternalFrameUtils.isNA(data);
+        return data;
+    }
+    public String readString(){
+        String data = ab.getStr();
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+    public Timestamp readTimestamp(){
+        Timestamp data = new Timestamp(ab.get8());
+        isLastNA = ExternalFrameUtils.isNA(ab, data);
+        return data;
+    }
+
+    /**
+     * This method is used to check if the last received value was marked as NA by H2O backend
+     */
+    public boolean isLastNA(){
+        return isLastNA;
+    }
+
+    /**
+     * This method ensures the application waits for all bytes to be received before continuing in the
+     * application's control flow.
+     *
+     * It has to be called at the end of reading.
+     */
+    public void waitUntilAllReceived(){
+        // blocking call
+        byte controlByte = ab.get1();
+        assert(controlByte == ExternalFrameHandler.CONFIRM_READING_DONE);
+    }
+
+    private AutoBuffer initAndGetAb() throws IOException{
+        AutoBuffer sentAb = new AutoBuffer();
+        sentAb.put1(ExternalFrameHandler.INIT_BYTE);
+        sentAb.put1(ExternalFrameHandler.DOWNLOAD_FRAME);
+        sentAb.putStr(frameKey);
+        sentAb.putInt(chunkIdx);
+        sentAb.putA1(expectedTypes);
+        sentAb.putA4(selectedColumnIndices);
+        writeToChannel(sentAb, channel);
+        AutoBuffer receiveAb = new AutoBuffer(channel, null);
+        // once we send H2O all information it needs to prepare for reading, it sends us back number of rows
+        this.numRows = receiveAb.getInt();
+        return receiveAb;
+    }
+}

--- a/h2o-core/src/main/java/water/ExternalFrameUtils.java
+++ b/h2o-core/src/main/java/water/ExternalFrameUtils.java
@@ -1,0 +1,242 @@
+package water;
+
+import water.fvec.Vec;
+
+import javax.print.DocFlavor;
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.sql.Timestamp;
+
+import static water.ExternalFrameHandler.*;
+
+/**
+ * Various utilities methods to help with external frame handling.
+ */
+public class ExternalFrameUtils {
+
+    /**
+     * Hints for expected types in order to improve performance network communication.
+     * We make use of these to send and receive data we actually have.
+     *
+     * Each supported type for conversion has to be specified here
+     */
+    public static final byte EXPECTED_BOOL = 0;
+    public static final byte EXPECTED_BYTE = 1;
+    public static final byte EXPECTED_CHAR = 2;
+    public static final byte EXPECTED_SHORT = 3;
+    public static final byte EXPECTED_INT = 4;
+    public static final byte EXPECTED_FLOAT = 5;
+    public static final byte EXPECTED_LONG = 6;
+    public static final byte EXPECTED_DOUBLE = 7;
+    public static final byte EXPECTED_STRING = 8;
+    public static final byte EXPECTED_TIMESTAMP = 9;
+
+    /**
+     * Get connection to a specific h2o node. The caller of this method is usually non-H2O node who wants to read H2O
+     * frames or write to H2O frames from non-H2O environment, such as Spark executor.
+     */
+    public static ByteChannel getConnection(String h2oNodeHostname, int h2oNodeApiPort) throws IOException{
+        return H2ONode.openChan(TCPReceiverThread.TCP_EXTERNAL, null, h2oNodeHostname, h2oNodeApiPort +1);
+
+    }
+
+    public static ByteChannel getConnection(String ipPort) throws IOException{
+        String[] split = ipPort.split(":");
+        return getConnection(split[0], Integer.parseInt(split[1]));
+    }
+
+    public static byte[] vecTypesFromExpectedTypes(byte[] expectedTypes){
+        byte[] vecTypes = new byte[expectedTypes.length];
+        for (int i = 0; i < expectedTypes.length; i++) {
+            switch (expectedTypes[i]){
+                case EXPECTED_BOOL: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_BYTE: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_CHAR: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_SHORT: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_INT: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_LONG: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_FLOAT: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_DOUBLE: vecTypes[i] = Vec.T_NUM; break;
+                case EXPECTED_STRING: vecTypes[i] = Vec.T_STR; break;
+                case EXPECTED_TIMESTAMP: vecTypes[i] = Vec.T_TIME; break;
+                default: throw new IllegalArgumentException("Unknown expected type: "+expectedTypes[i]);
+            }
+        }
+        return vecTypes;
+    }
+
+    public static byte[] prepareExpectedTypes(Class[] javaClasses){
+        byte[] expectedTypes = new byte[javaClasses.length];
+        for (int i = 0; i < javaClasses.length; i++) {
+            Class clazz = javaClasses[i];
+            if(clazz == Boolean.class){
+                expectedTypes[i] = EXPECTED_BOOL;
+            } else if(clazz == Byte.class){
+                expectedTypes[i] = EXPECTED_BYTE;
+            }else if(clazz == Short.class){
+                expectedTypes[i] = EXPECTED_SHORT;
+            }else if(clazz == Character.class){
+                expectedTypes[i] = EXPECTED_CHAR;
+            }else if(clazz == Integer.class){
+                expectedTypes[i] = EXPECTED_INT;
+            }else if(clazz == Long.class){
+                expectedTypes[i] = EXPECTED_LONG;
+            }else if(clazz == Float.class){
+                expectedTypes[i] = EXPECTED_FLOAT;
+            }else if(clazz == Double.class){
+                expectedTypes[i] = EXPECTED_DOUBLE;
+            }else if(clazz == String.class){
+                expectedTypes[i] = EXPECTED_STRING;
+            }else if(clazz == Timestamp.class){
+                expectedTypes[i] = EXPECTED_TIMESTAMP;
+            }else{
+                throw new IllegalArgumentException("Unknown java class " + clazz);
+            }
+        }
+        return expectedTypes;
+    }
+    
+    static void sendBoolean(AutoBuffer ab, ByteChannel channel, boolean data) throws IOException{
+        sendBoolean(ab, channel, data ? (byte)1 : (byte)0);
+    }
+
+    static void sendBoolean(AutoBuffer ab, ByteChannel channel, byte boolData) throws IOException{
+        ab.put1(boolData);
+        putMarkerAndSend(ab, channel, boolData);
+    }
+
+    static void sendByte(AutoBuffer ab, ByteChannel channel, byte data) throws IOException{
+        ab.put1(data);
+        putMarkerAndSend(ab, channel, data);
+    }
+
+    static void sendChar(AutoBuffer ab, ByteChannel channel, char data) throws IOException{
+        ab.put2(data);
+        putMarkerAndSend(ab, channel, data);
+    }
+
+    static void sendShort(AutoBuffer ab, ByteChannel channel, short data) throws IOException{
+        ab.put2s(data);
+        putMarkerAndSend(ab, channel, data);
+    }
+
+    static void sendInt(AutoBuffer ab, ByteChannel channel, int data) throws IOException{
+        ab.putInt(data);
+        putMarkerAndSend(ab, channel, data);
+    }
+
+    static void sendLong(AutoBuffer ab, ByteChannel channel, long data) throws IOException{
+        ab.put8(data);
+        putMarkerAndSend(ab, channel, data);
+    }
+
+    static void sendFloat(AutoBuffer ab, ByteChannel channel, float data) throws IOException{
+        ab.put4f(data);
+        writeToChannel(ab, channel);
+    }
+
+    static void sendDouble(AutoBuffer ab, ByteChannel channel, double data) throws IOException{
+        ab.put8d(data);
+        writeToChannel(ab, channel);
+    }
+
+    static void sendString(AutoBuffer ab, ByteChannel channel, String data) throws IOException{
+        ab.putStr(data);
+        if(data != null && data.equals(STR_MARKER_NEXT_BYTE_FOLLOWS)){
+            ab.put1(MARKER_ORIGINAL_VALUE);
+        }
+        writeToChannel(ab, channel);
+    }
+
+    static void sendTimestamp(AutoBuffer ab, ByteChannel channel, long time) throws IOException{
+        sendLong(ab, channel, time);
+    }
+
+    static void sendTimestamp(AutoBuffer ab, ByteChannel channel, Timestamp data) throws IOException{
+        sendLong(ab, channel, data.getTime());
+    }
+
+    static void sendNA(AutoBuffer ab, ByteChannel channel, byte expectedType) throws IOException{
+        switch (expectedType){
+            case EXPECTED_BOOL: // // fall through to byte since BOOL is internally stored in frame as number (byte)
+            case EXPECTED_BYTE:
+                ab.put1(NUM_MARKER_NEXT_BYTE_FOLLOWS);
+                ab.put1(MARKER_NA);
+                writeToChannel(ab, channel);
+                break;
+            case EXPECTED_CHAR:
+                ab.put2(NUM_MARKER_NEXT_BYTE_FOLLOWS);
+                ab.put1(MARKER_NA);
+                writeToChannel(ab, channel);
+                break;
+            case EXPECTED_SHORT:
+                ab.put2s(NUM_MARKER_NEXT_BYTE_FOLLOWS);
+                ab.put1(MARKER_NA);
+                writeToChannel(ab, channel);
+                break;
+            case EXPECTED_INT:
+                ab.putInt(NUM_MARKER_NEXT_BYTE_FOLLOWS);
+                ab.put1(MARKER_NA);
+                writeToChannel(ab, channel);
+                break;
+            case EXPECTED_TIMESTAMP: // fall through to long since TIMESTAMP is internally stored in frame as long
+            case EXPECTED_LONG:
+                ab.put8(NUM_MARKER_NEXT_BYTE_FOLLOWS);
+                ab.put1(MARKER_NA);
+                writeToChannel(ab, channel);
+                break;
+            case EXPECTED_FLOAT:
+                ab.put4f(Float.NaN);
+                writeToChannel(ab, channel);
+                break;
+            case EXPECTED_DOUBLE:
+                ab.put8d(Double.NaN);
+                writeToChannel(ab, channel);
+                break;
+            case EXPECTED_STRING:
+                ab.putStr(STR_MARKER_NEXT_BYTE_FOLLOWS);
+                ab.put1(MARKER_NA);
+                writeToChannel(ab, channel);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown expected type " + expectedType);
+        }
+    }
+
+    public static boolean isNA(AutoBuffer ab, boolean data){
+        return isNA(ab, data ? (long) 1: 0);
+    }
+
+    public static boolean isNA(AutoBuffer ab, long data){
+        return data == NUM_MARKER_NEXT_BYTE_FOLLOWS && ab.get1() == MARKER_NA;
+    }
+
+    public static boolean isNA(double data){
+        return Double.isNaN(data);
+    }
+
+    public static boolean isNA(AutoBuffer ab, Timestamp data){
+        return isNA(ab, data.getTime());
+    }
+
+    public static boolean isNA(AutoBuffer ab, String data){
+        return data != null && data.equals(STR_MARKER_NEXT_BYTE_FOLLOWS) && ab.get1() == MARKER_NA;
+    }
+
+    /**
+     * Sends another byte as a marker if it's needed and send the data
+     */
+    private static void putMarkerAndSend(AutoBuffer ab, ByteChannel channel, long data) throws IOException{
+        if(data == NUM_MARKER_NEXT_BYTE_FOLLOWS){
+            // we need to send another byte because zero is represented as 00 ( 2 bytes )
+            ab.put1(MARKER_ORIGINAL_VALUE);
+        }
+        writeToChannel(ab, channel);
+    }
+
+    static void writeToChannel(AutoBuffer ab, ByteChannel channel) throws IOException {
+        ab.flipForReading();
+        channel.write(ab._bb);
+        ab.clearForWriting(H2O.MAX_PRIORITY);
+    }
+}

--- a/h2o-core/src/main/java/water/ExternalFrameWriterBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterBackend.java
@@ -1,0 +1,102 @@
+package water;
+
+import water.fvec.ChunkUtils;
+import water.fvec.NewChunk;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+import static water.ExternalFrameUtils.*;
+
+/**
+ * This class contains methods used on the h2o backend to store incoming data as H2O Frame
+ */
+final class ExternalFrameWriterBackend {
+    /**
+     * Internal method use on the h2o backend side to handle writing to the chunk from non-h2o environment
+     * @param sock socket channel originating from non-h2o node
+     * @param ab {@link AutoBuffer} containing information necessary for preparing backend for writing
+     */
+    static void handleWriteToChunk(SocketChannel sock, AutoBuffer ab) throws IOException {
+        String frameKey = ab.getStr();
+        byte[] expectedTypes = ab.getA1();
+        assert expectedTypes != null;
+        byte[] vecTypes = vecTypesFromExpectedTypes(expectedTypes);
+        int expectedNumRows = ab.getInt();
+        int currentRowIdx = 0;
+        int chunk_id = ab.getInt();
+        NewChunk[] nchnk = ChunkUtils.createNewChunks(frameKey, vecTypes, chunk_id);
+        assert nchnk != null;
+        while (currentRowIdx < expectedNumRows) {
+            for(int colIdx = 0; colIdx<expectedTypes.length; colIdx++){
+                switch (expectedTypes[colIdx]) {
+                    case EXPECTED_BOOL: // fall through to byte since BOOL is internally stored in frame as number (byte)
+                    case EXPECTED_BYTE:
+                        store(ab, nchnk[colIdx], ab.get1());
+                        break;
+                    case EXPECTED_CHAR:
+                        store(ab, nchnk[colIdx], ab.get2());
+                        break;
+                    case EXPECTED_SHORT:
+                        store(ab, nchnk[colIdx], ab.get2s());
+                        break;
+                    case EXPECTED_INT:
+                        store(ab, nchnk[colIdx], ab.getInt());
+                        break;
+                    case EXPECTED_TIMESTAMP: // fall through to long since TIMESTAMP is internally stored in frame as long
+                    case EXPECTED_LONG:
+                        store(ab, nchnk[colIdx], ab.get8());
+                        break;
+                    case EXPECTED_FLOAT:
+                        store(nchnk[colIdx], ab.get4f());
+                        break;
+                    case EXPECTED_DOUBLE:
+                        store(nchnk[colIdx], ab.get8d());
+                        break;
+                    case EXPECTED_STRING:
+                        store(ab, nchnk[colIdx], ab.getStr());
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown expected type: " + expectedTypes[colIdx]);
+                }
+            }
+            currentRowIdx++;
+        }
+        // close chunks at the end
+        ChunkUtils.closeNewChunks(nchnk);
+
+        // Flag informing sender that all work is done and
+        // chunks are ready to be finalized.
+        //
+        // This also needs to be sent because in the sender we have to
+        // wait for all chunks to be written to DKV; otherwise we get race during finalizing and
+        // it happens that we try to finalize frame with chunks not ready yet
+        AutoBuffer outputAb = new AutoBuffer();
+        outputAb.put1(ExternalFrameHandler.CONFIRM_WRITING_DONE);
+        writeToChannel(outputAb, sock);
+    }
+
+    private static void store(AutoBuffer ab, NewChunk chunk, long data){
+        if(isNA(ab, data)){
+            chunk.addNA();
+        }else{
+            chunk.addNum(data);
+        }
+    }
+
+    private static void store(NewChunk chunk, double data){
+        if(isNA(data)){
+            chunk.addNA();
+        }else{
+            chunk.addNum(data);
+        }
+    }
+
+    private static void store(AutoBuffer ab, NewChunk chunk, String data){
+        if(isNA(ab, data)){
+            chunk.addNA();
+        }else{
+            chunk.addStr(data);
+        }
+    }
+}

--- a/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
@@ -1,0 +1,157 @@
+package water;
+
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.sql.Timestamp;
+
+import static water.ExternalFrameUtils.writeToChannel;
+
+/**
+ * <p>This class is used to create and write data to H2O Frames from non-H2O environments, such as Spark Executors.</p>
+ *
+ * <strong>Example usage of this class:</strong></br>
+ *
+ * <p>First we need to open the connection to H2O and initialize the writer:
+ * <pre>
+ * {@code
+ * // Prepare expected bytes from Java Classes.
+ * // We don't specify vector types since they are deterministically inferred from the expected types
+ * byte[] expectedBytes = ExternalFrameUtils.prepareExpectedTypes(new Class[]{Boolean.class, Integer.class});
+ * ByteChannel channel = ExternalFrameUtils.getConnection("ip:port");
+ * ExternalFrameWriter writer = new ExternalFrameWriter(channel);
+ * writer.createChunks("frameName", expectedTypes, chunkIdx, numOfRowsToBeWritten);
+ * }
+ * </pre>
+ * </p>
+ *
+ * <p>
+ * Then we can write the data:
+ * <pre>{@code
+ * int rowsWritten = 0;
+ * while(rowsWritten < totalNumOfRows){
+ *  writer.sendBool(true);
+ *  writer.sendInt(657);
+ * }
+ * }
+ * </pre>
+ * </p>
+ *
+ * <p>
+ * And at the end we need to make sure to force to code wait for all data to be written
+ * <pre>
+ * {@code
+ * writer.waitUntilAllWritten();
+ * }
+ * </pre>
+ * </p>
+ */
+final public class ExternalFrameWriterClient {
+
+    private AutoBuffer ab;
+    private ByteChannel channel;
+    private byte[] expectedTypes;
+    // we discover the current column index based on number of data sent
+    private int currentColIdx = 0;
+
+    /**
+     * Initialize the External frame writer
+     *
+     * This method expects expected types in order to ensure we send the data in optimal way.
+     * @param channel communication channel to h2o node
+     */
+    public ExternalFrameWriterClient(ByteChannel channel){
+        this.ab = new AutoBuffer();
+        this.channel = channel;
+    }
+
+
+    /**
+     * Create chunks on the h2o backend. This method creates chunk in en empty frame.
+     * @param frameKey name of the frame
+     * @param expectedTypes expected types
+     * @param chunkId chunk index
+     * @param totalNumRows total number of rows which is about to be sent
+     */
+    public void createChunks(String frameKey, byte[] expectedTypes, int chunkId, int totalNumRows) throws IOException {
+        ab.put1(ExternalFrameHandler.INIT_BYTE);
+        ab.put1(ExternalFrameHandler.CREATE_FRAME);
+        ab.putStr(frameKey);
+        this.expectedTypes = expectedTypes;
+        ab.putA1(expectedTypes);
+        ab.putInt(totalNumRows);
+        ab.putInt(chunkId);
+        writeToChannel(ab, channel);
+    }
+
+    public void sendBoolean(boolean data) throws IOException{
+        ExternalFrameUtils.sendBoolean(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendByte(byte data) throws IOException{
+        ExternalFrameUtils.sendByte(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendChar(char data) throws IOException{
+        ExternalFrameUtils.sendChar(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendShort(short data) throws IOException{
+        ExternalFrameUtils.sendShort(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendInt(int data) throws IOException{
+        ExternalFrameUtils.sendInt(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendLong(long data) throws IOException{
+        ExternalFrameUtils.sendLong(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendFloat(float data) throws IOException{
+        ExternalFrameUtils.sendFloat(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendDouble(double data) throws IOException{
+        ExternalFrameUtils.sendDouble(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendString(String data) throws IOException{
+        ExternalFrameUtils.sendString(ab, channel, data);
+        increaseCurrentColIdx();
+    }
+
+    public void sendTimestamp(Timestamp timestamp) throws IOException{
+        ExternalFrameUtils.sendTimestamp(ab, channel, timestamp);
+        increaseCurrentColIdx();
+    }
+
+    public void sendNA() throws IOException{
+        ExternalFrameUtils.sendNA(ab, channel, expectedTypes[currentColIdx]);
+        increaseCurrentColIdx();
+    }
+
+    /**
+     * This method ensures the application waits for all bytes to be written before continuing in the control flow.
+     *
+     * It has to be called at the end of writing.
+     */
+    public void waitUntilAllWritten() throws IOException{
+        AutoBuffer confirmAb = new AutoBuffer(channel, null);
+        // this needs to be here because confirmAb.getInt() forces this code to wait for result and
+        // all the previous work to be done on the recipient side. The assert around it is just additional, not
+        // so important check
+        assert(confirmAb.get1() == ExternalFrameHandler.CONFIRM_WRITING_DONE);
+    }
+
+    private void increaseCurrentColIdx(){
+        currentColIdx = (currentColIdx+1) % expectedTypes.length;
+    }
+}

--- a/h2o-core/src/main/java/water/fvec/ChunkUtils.java
+++ b/h2o-core/src/main/java/water/fvec/ChunkUtils.java
@@ -1,0 +1,41 @@
+package water.fvec;
+
+
+import water.DKV;
+import water.Key;
+
+/**
+ * Simple helper class which publishes some frame and chunk package private methods as public
+ */
+public class ChunkUtils {
+
+    public static NewChunk[] createNewChunks(String name, byte[] vecTypes, int chunkId){
+        return Frame.createNewChunks(name, vecTypes, chunkId);
+    }
+
+    public static void closeNewChunks(NewChunk[] nchks){
+        Frame.closeNewChunks(nchks);
+    }
+
+    public static Chunk[] getChunks(Frame fr, int cidx) {
+        Chunk[] chunks = new Chunk[fr.vecs().length];
+        for(int i=0; i<fr.vecs().length; i++){
+            chunks[i] = fr.vec(i).chunkForChunkIdx(cidx);
+        }
+       return chunks;
+    }
+
+    public static void initFrame(String keyName, String[] names) {
+        Frame fr = new water.fvec.Frame(Key.<Frame>make(keyName));
+        fr.preparePartialFrame(names);
+        // Save it directly to DKV
+        fr.update();
+    }
+
+    public static Frame finalizeFrame(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains){
+        Frame fr = DKV.getGet(keyName);
+        fr.finalizePartialFrame(rowsPerChunk, colDomains, colTypes);
+        return fr;
+    }
+
+}

--- a/h2o-core/src/test/java/water/ExternalFrameReaderClientTest.java
+++ b/h2o-core/src/test/java/water/ExternalFrameReaderClientTest.java
@@ -1,0 +1,111 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ExternalFrameReaderClientTest extends TestUtil{
+    @BeforeClass()
+    public static void setup() {
+        stall_till_cloudsize(3);
+    }
+
+    // We keep this one for assertion errors occurred in different threads
+    private volatile AssertionError exc;
+
+    @Test
+    public void testReading() throws IOException, InterruptedException {
+
+        final String frameName = "testFrame";
+        final long[] chunkLayout = {2, 2, 2, 1};
+        final Frame testFrame = new TestFrameBuilder()
+                .withName(frameName)
+                .withColNames("ColA", "ColB")
+                .withVecTypes(Vec.T_NUM, Vec.T_STR)
+                .withDataForCol(0, ard(Double.NaN, 1, 2, 3, 4, 5.6, 7, -1, 3.14))
+                .withDataForCol(1, ar("A", "B", "C", "E", "F", "I", "J", "\u0000", null))
+                .withChunkLayout(chunkLayout)
+                .build();
+
+
+        // create frame
+        final String[] nodes = new String[H2O.CLOUD._memary.length];
+        // get ip and ports of h2o nodes
+        for (int i = 0; i < nodes.length; i++) {
+            nodes[i] = H2O.CLOUD._memary[i].getIpPortString();
+        }
+
+        final int[] selectedColumnIndices = {0, 1};
+        // specify expected types for selected columns
+        final byte[] expectedTypes = {ExternalFrameUtils.EXPECTED_DOUBLE, ExternalFrameUtils.EXPECTED_STRING};
+        final int nChunks = testFrame.anyVec().nChunks();
+
+        // we will read from all chunks at the same time
+        Thread[] threads = new Thread[nChunks];
+
+        try {
+            // open all connections in connStrings array
+            for (int idx = 0; idx < nChunks; idx++) {
+                final int currentChunkIdx = idx;
+                threads[idx] = new Thread() {
+                    @Override
+                    public void run() {
+                        try {
+                            ByteChannel sock = ExternalFrameUtils.getConnection(nodes[currentChunkIdx % nodes.length]);
+                            ExternalFrameReaderClient reader = new ExternalFrameReaderClient(sock, frameName, currentChunkIdx, selectedColumnIndices, expectedTypes);
+
+                            int rowsRead = 0;
+                            assertEquals(reader.getNumRows(), chunkLayout[currentChunkIdx]);
+
+                            while (rowsRead < reader.getNumRows()) {
+
+                                if (rowsRead == 0 & currentChunkIdx == 0) {
+                                    reader.readDouble();
+                                    assertTrue("[0,0] in chunk 0 should be NA", reader.isLastNA());
+                                } else {
+                                    reader.readDouble();
+                                    assertFalse("Should not be NA", reader.isLastNA());
+                                }
+
+                                reader.readString();
+                                assertFalse("Should not be NA", reader.isLastNA());
+
+                                rowsRead++;
+                            }
+
+                            assertEquals("Num or rows read was " + rowsRead + ", expecting " + reader.getNumRows(), rowsRead, reader.getNumRows());
+
+                            reader.waitUntilAllReceived();
+                            sock.close();
+                        } catch (AssertionError e) {
+                            exc = e;
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                };
+                threads[idx].start();
+            }
+
+            // wait for all writer thread to finish
+            for (Thread t : threads) {
+                t.join();
+                if (exc != null) {
+                    throw exc;
+                }
+            }
+        }finally {
+            testFrame.remove();
+        }
+    }
+
+}

--- a/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
+++ b/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
@@ -1,0 +1,147 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.fvec.Frame;
+import water.fvec.ChunkUtils;
+import water.fvec.Vec;
+import water.parser.BufferedString;
+import water.util.ArrayUtils;
+
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.sql.Timestamp;
+import java.util.Calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test external frame writer test
+ */
+public class ExternalFrameWriterClientTest extends TestUtil {
+    @BeforeClass()
+    public static void setup() {
+        stall_till_cloudsize(3);
+    }
+
+    @Test
+    public void testWriting() throws IOException{
+        final String[] nodes = new String[H2O.CLOUD._memary.length];
+
+        // get ip and ports of h2o nodes
+        for (int i = 0; i < nodes.length; i++) {
+            nodes[i] = H2O.CLOUD._memary[i].getIpPortString();
+        }
+
+        // we will open 2 connection per h2o node
+        final String[] connStrings = ArrayUtils.join(nodes, nodes);
+
+        // The api expects that empty frame has to be in the DKV before we start working with it
+        final String frameName = "fr";
+        String[] colNames = {"NUM", "BOOL", "STR", "TIMESTAMP"};
+
+        // vector types are inferred from expected types
+        final byte[] expectedTypes = ExternalFrameUtils.prepareExpectedTypes(new Class[]{
+                Integer.class,
+                Boolean.class,
+                String.class,
+                Timestamp.class});
+
+
+        ChunkUtils.initFrame(frameName, colNames);
+        final long[] rowsPerChunk = new long[connStrings.length]; // number of chunks will be number of h2o nodes
+
+        Thread[] threads = new Thread[connStrings.length];
+
+        // open all connections in connStrings array
+        for (int idx = 0; idx < connStrings.length; idx++) {
+            final int currentIndex = idx;
+            threads[idx] = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        ByteChannel sock = ExternalFrameUtils.getConnection(connStrings[currentIndex]);
+                        ExternalFrameWriterClient writer = new ExternalFrameWriterClient(sock);
+                        writer.createChunks(frameName, expectedTypes,  currentIndex, 1000);
+
+                        Timestamp time = new Timestamp(Calendar.getInstance().getTime().getTime());
+                        for (int i = 0; i < 997; i++) {
+                            writer.sendInt(i);
+                            writer.sendBoolean(true);
+                            writer.sendString("str_" + i);
+                            writer.sendTimestamp(time);
+                        }
+                        writer.sendInt(0);
+                        writer.sendBoolean(true);
+                        writer.sendString(null);
+                        writer.sendTimestamp(time);
+
+                        writer.sendInt(1);
+                        writer.sendBoolean(true);
+                        writer.sendString("\u0080");
+                        writer.sendTimestamp(time);
+
+                        // send NA for all columns
+                        writer.sendNA();
+                        writer.sendNA();
+                        writer.sendNA();
+                        writer.sendNA();
+
+                        writer.waitUntilAllWritten();
+                        sock.close();
+                        rowsPerChunk[currentIndex] = 1000;
+                    } catch (IOException ignore) {
+                    }
+                }
+
+            };
+            threads[idx].start();
+        }
+
+        // wait for all writer thread to finish
+        for (Thread t : threads) {
+            try {
+                t.join();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+
+        ChunkUtils.finalizeFrame(frameName, rowsPerChunk, ExternalFrameUtils.vecTypesFromExpectedTypes(expectedTypes), null);
+
+        Frame frame = null;
+        try {
+            frame = DKV.getGet(frameName);
+            assertEquals(frame.anyVec().nChunks(), connStrings.length);
+            assertEquals(frame._names.length, 4);
+            assertEquals(frame.numCols(), 4);
+            assertEquals(frame._names[0], "NUM");
+            assertEquals(frame._names[1], "BOOL");
+            assertEquals(frame._names[2], "STR");
+            assertEquals(frame._names[3], "TIMESTAMP");
+            assertEquals(frame.vec(0).get_type(), Vec.T_NUM);
+            assertEquals(frame.vec(1).get_type(), Vec.T_NUM);
+            assertEquals(frame.vec(2).get_type(), Vec.T_STR);
+            assertEquals(frame.vec(3).get_type(), Vec.T_TIME);
+            assertEquals(frame.numRows(), 1000 * connStrings.length);
+            // last row should be NA
+            assertEquals(frame.vec(0).at8(0), 0);
+
+            BufferedString buff = new BufferedString();
+            assertEquals(frame.vec(2).atStr(buff, 996).toString(), "str_996");
+            assertEquals(frame.vec(2).atStr(buff, 997), null);
+            assertEquals(frame.vec(2).atStr(buff, 998).toString(), "\u0080");
+            assertTrue(frame.vec(0).isNA(999));
+            assertTrue(frame.vec(1).isNA(999));
+            assertTrue(frame.vec(2).isNA(999));
+            assertTrue(frame.vec(3).isNA(999));
+
+        }finally {
+            if(frame != null){
+                frame.remove();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit add support to add and get frames from non-h2o environment - for example from Spark executors.

It is implemented by new channel type ( 3 ) which is used for communication with external h2o nodes. It is always expected that before reading/writing the frame is in the DKV ( before writing just empty frame )

It is needed in order to make stable sparkling water architecture work

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/100)

<!-- Reviewable:end -->
