### PR TITLE
[SWPRIVATE-14] Move a method creating center table to a util class.

### DIFF
--- a/h2o-algos/src/main/java/hex/kmeans/KMeans.java
+++ b/h2o-algos/src/main/java/hex/kmeans/KMeans.java
@@ -368,42 +368,6 @@ public class KMeans extends ClusteringModelBuilder<KMeansModel,KMeansModel.KMean
     }
   }
 
-  static public TwoDimTable createCenterTable(KMeansModel.KMeansOutput output, boolean standardized) {
-    String name = standardized ? "Standardized Cluster Means" : "Cluster Means";
-    if(output._size == null || output._names == null || output._domains == null || output._centers_raw == null ||
-            (standardized && output._centers_std_raw == null)) {
-      TwoDimTable table = new TwoDimTable(name, null, new String[] {"1"}, new String[]{"C1"}, new String[]{"double"},
-              new String[]{"%f"}, "Centroid");
-      table.set(0,0,Double.NaN);
-      return table;
-    }
-
-    String[] rowHeaders = new String[output._size.length];
-    for(int i = 0; i < rowHeaders.length; i++)
-      rowHeaders[i] = String.valueOf(i+1);
-    String[] colTypes = new String[output._names.length];
-    String[] colFormats = new String[output._names.length];
-    for (int i = 0; i < output._domains.length; ++i) {
-      colTypes[i] = output._domains[i] == null ? "double" : "String";
-      colFormats[i] = output._domains[i] == null ? "%f" : "%s";
-    }
-    TwoDimTable table = new TwoDimTable(name, null, rowHeaders, output._names, colTypes, colFormats, "Centroid");
-
-    for (int j=0; j<output._domains.length; ++j) {
-      boolean string = output._domains[j] != null;
-      if (string) {
-        for (int i=0; i<output._centers_raw.length; ++i) {
-          table.set(i, j, output._domains[j][(int)output._centers_raw[i][j]]);
-        }
-      } else {
-        for (int i=0; i<output._centers_raw.length; ++i) {
-          table.set(i, j, standardized ? output._centers_std_raw[i][j] : output._centers_raw[i][j]);
-        }
-      }
-    }
-    return table;
-  }
-
   // -------------------------------------------------------------------------
   // Initial sum-of-square-distance to nearest cluster center
   private static class TotSS extends MRTask<TotSS> {

--- a/h2o-algos/src/main/java/hex/kmeans/KMeansModel.java
+++ b/h2o-algos/src/main/java/hex/kmeans/KMeansModel.java
@@ -41,9 +41,6 @@ public class KMeansModel extends ClusteringModel<KMeansModel,KMeansModel.KMeansP
     // Sum squared distance between each point and its cluster center.
     public double[/*k*/] _withinss;   // Within-cluster sum of square error
 
-    // Cluster size. Defined as the number of rows in each cluster.
-    public long[/*k*/] _size;
-
     // Sum squared distance between each point and its cluster center.
     public double _tot_withinss;      // Within-cluster sum-of-square error
     public double[/*iterations*/] _history_withinss = new double[0];

--- a/h2o-algos/src/main/java/hex/schemas/KMeansModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/KMeansModelV3.java
@@ -2,6 +2,7 @@ package hex.schemas;
 
 import hex.kmeans.KMeans;
 import hex.kmeans.KMeansModel;
+import hex.util.ClusteringUtils;
 import water.api.API;
 import water.api.schemas3.ModelOutputSchemaV3;
 import water.api.schemas3.ModelSchemaV3;
@@ -19,9 +20,9 @@ public class KMeansModelV3 extends ModelSchemaV3<KMeansModel, KMeansModelV3, KMe
 
     @Override public KMeansModelOutputV3 fillFromImpl(KMeansModel.KMeansOutput impl) {
       KMeansModelOutputV3 kmv3 = super.fillFromImpl(impl);
-      kmv3.centers = new TwoDimTableV3().fillFromImpl(KMeans.createCenterTable(impl, false));
+      kmv3.centers = new TwoDimTableV3().fillFromImpl(ClusteringUtils.createCenterTable(impl, false));
       if (impl._centers_std_raw != null)
-        kmv3.centers_std = new TwoDimTableV3().fillFromImpl(KMeans.createCenterTable(impl, true));
+        kmv3.centers_std = new TwoDimTableV3().fillFromImpl(ClusteringUtils.createCenterTable(impl, true));
       return kmv3;
     }
 

--- a/h2o-algos/src/main/java/hex/util/ClusteringUtils.java
+++ b/h2o-algos/src/main/java/hex/util/ClusteringUtils.java
@@ -1,0 +1,44 @@
+package hex.util;
+
+import hex.ClusteringModel;
+import water.util.TwoDimTable;
+
+public class ClusteringUtils {
+
+    static public TwoDimTable createCenterTable(ClusteringModel.ClusteringOutput output, boolean standardized) {
+        String name = standardized ? "Standardized Cluster Means" : "Cluster Means";
+        if(output._size == null || output._names == null || output._domains == null || output._centers_raw == null ||
+                (standardized && output._centers_std_raw == null)) {
+            TwoDimTable table = new TwoDimTable(name, null, new String[] {"1"}, new String[]{"C1"}, new String[]{"double"},
+                    new String[]{"%f"}, "Centroid");
+            table.set(0,0,Double.NaN);
+            return table;
+        }
+
+        String[] rowHeaders = new String[output._size.length];
+        for(int i = 0; i < rowHeaders.length; i++)
+            rowHeaders[i] = String.valueOf(i+1);
+        String[] colTypes = new String[output._names.length];
+        String[] colFormats = new String[output._names.length];
+        for (int i = 0; i < output._domains.length; ++i) {
+            colTypes[i] = output._domains[i] == null ? "double" : "String";
+            colFormats[i] = output._domains[i] == null ? "%f" : "%s";
+        }
+        TwoDimTable table = new TwoDimTable(name, null, rowHeaders, output._names, colTypes, colFormats, "Centroid");
+
+        for (int j=0; j<output._domains.length; ++j) {
+            boolean string = output._domains[j] != null;
+            if (string) {
+                for (int i=0; i<output._centers_raw.length; ++i) {
+                    table.set(i, j, output._domains[j][(int)output._centers_raw[i][j]]);
+                }
+            } else {
+                for (int i=0; i<output._centers_raw.length; ++i) {
+                    table.set(i, j, standardized ? output._centers_std_raw[i][j] : output._centers_raw[i][j]);
+                }
+            }
+        }
+        return table;
+    }
+
+}

--- a/h2o-core/src/main/java/hex/ClusteringModel.java
+++ b/h2o-core/src/main/java/hex/ClusteringModel.java
@@ -28,6 +28,9 @@ public abstract class ClusteringModel<M extends ClusteringModel<M,P,O>, P extend
     public double[] _normSub;
     public double[] _normMul;
 
+    // Cluster size. Defined as the number of rows in each cluster.
+    public long[/*k*/] _size;
+
     public ClusteringOutput() {
       this(null);
     }


### PR DESCRIPTION
Trying to wrap Spark clustering algorithms (starting with Gaussian Mixture, then LDA, then PIC) and could use the `createCenterTable` from `KMeans`.

Pretty simple change:
* Moved `createCenterTable` to a util class
* Made it generic by accepting `ClusteringModel.ClusteringOutput`
* Moved `_size` to `ClusteringModel.ClusteringOutput` 

Adding for review @st-pasha as last commiter, @mmalohlava as the SW guy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/101)
<!-- Reviewable:end -->
