### PR TITLE
PUBDEV-3198

### DIFF
--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -3,14 +3,8 @@ Downloading H2O
 
 To download H2O, go to our `downloads page <http://www.h2o.ai/download>`__. Select a build type (bleeding edge or latest stable), then select an installation method (standalone, R, Python, Hadoop, or Maven) by clicking the tabs at the top of the page. Follow the instructions in the tab to install H2O.
 
-**Note**: OS X El Capitan users must include the ``--user`` flag when starting H2O from the command line or from Python. For example:
-
-::
-
-	java -jar h2o.jar --user
-
-or
+**Note**: When installing H2O from ``pip`` in OS X El Capitan, users must include the ``--user`` flag. For example:
 
 ::
 	
-	pip install http://h2o-release.s3.amazonaws.com/h2o/rel-turing/3/Python/h2o-3.10.0.3-py2.py3-none-any.whl --user
+	pip install --user http://h2o-release.s3.amazonaws.com/h2o/rel-turing/3/Python/h2o-3.10.0.3-py2.py3-none-any.whl

--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -2,3 +2,15 @@ Downloading H2O
 ===============
 
 To download H2O, go to our `downloads page <http://www.h2o.ai/download>`__. Select a build type (bleeding edge or latest stable), then select an installation method (standalone, R, Python, Hadoop, or Maven) by clicking the tabs at the top of the page. Follow the instructions in the tab to install H2O.
+
+**Note**: OS X El Capitan users must include the ``--user`` flag when starting H2O from the command line or from Python. For example:
+
+::
+
+	java -jar h2o.jar --user
+
+or
+
+::
+	
+	pip install http://h2o-release.s3.amazonaws.com/h2o/rel-turing/3/Python/h2o-3.10.0.3-py2.py3-none-any.whl --user

--- a/h2o-docs/src/product/starting-h2o.rst
+++ b/h2o-docs/src/product/starting-h2o.rst
@@ -14,6 +14,12 @@ From Python
 
 To use H2O in Python, follow the instructions on the `Python download page <http://www.h2o.ai/download/h2o/python>`_.
 
+  **Note**: OS X El Capitan users must include the ``--user`` flag when starting H2O from Python. For example:
+
+  ::
+	
+	pip install http://h2o-release.s3.amazonaws.com/h2o/rel-turing/3/Python/h2o-3.10.0.3-py2.py3-none-any.whl --user
+
 On Spark
 --------
 
@@ -28,7 +34,15 @@ From the Command Line
 .. todo:: provide examples for most common clusters
 
 You can use Terminal (OS X) or the Command Prompt (Windows) to launch
-H2O 3.0. When you launch from the command line, you can include
+H2O 3.0. 
+
+  **Note**: OS X El Capitan users must include the ``--user`` flag when starting H2O from the command line. For example:
+
+  ::
+
+		java -jar h2o.jar --user
+
+When you launch from the command line, you can include
 additional instructions to H2O 3.0, such as how many nodes to launch,
 how much memory to allocate for each node, assign names to the nodes in
 the cloud, and more.

--- a/h2o-docs/src/product/starting-h2o.rst
+++ b/h2o-docs/src/product/starting-h2o.rst
@@ -14,11 +14,11 @@ From Python
 
 To use H2O in Python, follow the instructions on the `Python download page <http://www.h2o.ai/download/h2o/python>`_.
 
-  **Note**: OS X El Capitan users must include the ``--user`` flag when starting H2O from Python. For example:
+**Note**: When installing H2O from ``pip`` in OS X El Capitan, users must include the ``--user`` flag. For example:
 
-  ::
+::
 	
-	pip install http://h2o-release.s3.amazonaws.com/h2o/rel-turing/3/Python/h2o-3.10.0.3-py2.py3-none-any.whl --user
+	pip install --user http://h2o-release.s3.amazonaws.com/h2o/rel-turing/3/Python/h2o-3.10.0.3-py2.py3-none-any.whl
 
 On Spark
 --------
@@ -34,13 +34,7 @@ From the Command Line
 .. todo:: provide examples for most common clusters
 
 You can use Terminal (OS X) or the Command Prompt (Windows) to launch
-H2O 3.0. 
-
-  **Note**: OS X El Capitan users must include the ``--user`` flag when starting H2O from the command line. For example:
-
-  ::
-
-		java -jar h2o.jar --user
+H2O. 
 
 When you launch from the command line, you can include
 additional instructions to H2O 3.0, such as how many nodes to launch,


### PR DESCRIPTION
For El Capitan users, added note stating that the --user flag is
required when starting H2O from command line or python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/103)
<!-- Reviewable:end -->
