### PR TITLE
PUBDEV-3248

### DIFF
--- a/h2o-docs/src/product/faq.rst
+++ b/h2o-docs/src/product/faq.rst
@@ -1492,6 +1492,8 @@ including dependencies:
 - ``data.table``
 - ``cvAUC``
 
+Finally, if you are running R on Linux, then you must install ``libcurl``, which allows H2O to communicate with R.
+
 --------------
 
 **How can I install the H2O R package if I am having permissions
@@ -1642,12 +1644,15 @@ example:
 
 --------------
 
-**I'm using CentOS and I want to run H2O in R - are there any
+**I'm using Linux and I want to run H2O in R - are there any
 dependencies I need to install?**
 
 Yes, make sure to install ``libcurl``, which allows H2O to communicate
 with R. We also recommend disabling SElinux and any firewalls, at least
 initially until you have confirmed H2O can initialize.
+
+- On Ubuntu, run: ``apt-get install libcurl4-openssl-dev``
+- On CentOS, run: ``yum install libcurl-devel``
 
 --------------
 

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -356,6 +356,11 @@ To check which version of H2O is installed in R, use
    describes how to use RStudio to connect to Sparkling Water.
 
 
+**Note**: If you are running R on Linux, then you must install ``libcurl``, which allows H2O to communicate with R. We also recommend disabling SElinux and any firewalls, at least initially until you have confirmed H2O can initialize.
+
+- On Ubuntu, run: ``apt-get install libcurl4-openssl-dev``
+- On CentOs, run: ``yum install libcurl-devel``
+
 Ensembles
 ---------
 


### PR DESCRIPTION
Added libcurl requirement for R users on Linux. This is in response to
the following question:
http://stackoverflow.com/questions/38972111/error-in-installing-h2o-ai-r
-package-in-biginsights-cluster-in-bluemix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/104)
<!-- Reviewable:end -->
