### PR TITLE
PUBDEV-3264: Return unique values of a categorical column as a Pythonic list

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1851,6 +1851,22 @@ class H2OFrame(object):
         """
         return bool(ExprNode("any.factor", self)._eager_scalar())
 
+
+    def categories(self):
+        """Create a list of categorical levels for a H2OFrame factor(enum) column.
+
+        Returns
+        -------
+          Pythonic list of categorical levels.
+        """
+        if self._ex._cache.ncols > 1:
+            raise ValueError("This operation only applies to a single factor column")
+        if not self.isfactor()[0]:
+            raise ValueError("Input is not a factor. This operation only applies to a single factor column")
+
+        fr = self.levels()[0]
+        return fr
+
     def transpose(self):
         """Transpose rows and columns of H2OFrame.
 

--- a/h2o-py/tests/testdir_munging/pyunit_categories.py
+++ b/h2o-py/tests/testdir_munging/pyunit_categories.py
@@ -1,0 +1,19 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+
+def pyunit_categories():
+
+    iris = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris.csv"))
+    category_list =  iris['C5'].categories()
+    print(category_list)
+    assert set(category_list) == set(['Iris-setosa', 'Iris-versicolor', 'Iris-virginica'])
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pyunit_categories)
+else:
+    pyunit_categories()


### PR DESCRIPTION
- Currently, `unique()` returns all unique levels of a factor column, but if you convert it to Python object it will return a list of lists, which can be hard to deal with for some users.  

- This PR will take in a factor column from a H2OFrame and return all unique levels as a Pythonic list and remedy the above problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/108)
<!-- Reviewable:end -->
