### PR TITLE
Fix bug in diagnostics function

### DIFF
--- a/h2o-py/demos/kmeans_aic_bic_diagnostics.ipynb
+++ b/h2o-py/demos/kmeans_aic_bic_diagnostics.ipynb
@@ -1661,7 +1661,7 @@
     "\n",
     "def diagnostics_from_clusteringmodel(model):\n",
     "    total_within_sumofsquares = model.tot_withinss()\n",
-    "    number_of_clusters = len(model.centers()[0])\n",
+    "    number_of_clusters = len(model.centers())\n",
     "    number_of_dimensions = len(model.centers())\n",
     "    number_of_rows = sum(model.size())\n",
     "    \n",


### PR DESCRIPTION
It was calling `len(model.centers()[0])`, which returns the length of the first cluster definition (i.e. the number of variables), rather than `len(model.centers())` which returns the number of centers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/109)
<!-- Reviewable:end -->
