### PR TITLE
PUBDEV-3086: hist() fails for constant numeric columns

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstHist.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstHist.java
@@ -43,7 +43,8 @@ public class AstHist extends AstPrimitive {
     if (f.numCols() != 1) throw new IllegalArgumentException("Hist only applies to single numeric columns.");
     Vec vec = f.anyVec();
     if (!vec.isNumeric()) throw new IllegalArgumentException("Hist only applies to single numeric columns.");
-
+    if(vec.isConst()) throw new IllegalArgumentException("Hist does not apply to constant numeric columns.");
+    
     AstRoot a = asts[2];
     String algo = null;
     int numBreaks = -1;


### PR DESCRIPTION
Currently, hist() and h2o.hist() will fail with a ZeroDivisionError when it encounters a constant numeric column. This PR adds a better exception message for the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/111)
<!-- Reviewable:end -->
