### PR TITLE
PUBDEV-2958: Fixing R error in build_too_old

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -612,6 +612,11 @@ h2o.clusterInfo <- function() {
   assign("IS_CLIENT", is_client, .pkg.env)
   m <- ": \n"
   if( is_client ) m <- " (in client mode): \n"
+  
+  if (is.null(res$build_too_old)) {
+    res$build_too_old <- TRUE
+    res$build_age <- "PREHISTORIC"
+  }
 
   cat(paste0("R is connected to the H2O cluster", m))
   cat("    H2O cluster uptime:        ", .readableTime(as.numeric(res$cloud_uptime_millis)), "\n")


### PR DESCRIPTION
If the user connects to an H2O cluster that doesn't have the `build_too_old` field, using a newer (3.10.*+) version of the H2O R API, an error occurs.  If the field is not available, we set `build_too_old` to TRUE and `build_age` to "PREHISTORIC".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/112)
<!-- Reviewable:end -->
