### PR TITLE
[PUBDEV-3173] Client does not need to provide full flatfile anymore to connect to the flatfile-based cluster.

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1326,9 +1326,9 @@ final public class H2O {
     return flow_dir;
   }
 
-  /* Static list of acceptable Cloud members passed via -flatfile option.
+  /* A static list of acceptable Cloud members passed via -flatfile option.
    * It is updated also when a new client appears. */
-  public static HashSet<H2ONode> STATIC_H2OS = null;
+  private static HashSet<H2ONode> STATIC_H2OS = null;
 
   // Reverse cloud index to a cloud; limit of 256 old clouds.
   static private final H2O[] CLOUDS = new H2O[256];
@@ -1912,5 +1912,51 @@ final public class H2O {
       catch (Exception ignore) {};
       GAUtils.logStartup();
     }
+  }
+
+  /** Add node to a manual multicast list.
+   *  Note: the method is valid only if -flatfile option was specified on commandline*
+   * @param node  h2o node
+   * @return true if node was already in the multicast list.
+   */
+  public static boolean addNodeToFlatfile(H2ONode node) {
+    assert isFlatfileEnabled() : "Trying to use flatfile, but flatfile is not enabled!";
+    return STATIC_H2OS.add(node);
+  }
+
+  /** Check if a node is included in a manual multicast list.
+   *  Note: the method is valid only if -flatfile option was specified on commandline
+   *
+   * @param node  h2o node
+   * @return true if node was already in the multicast list.
+   */
+  public static boolean isNodeInFlatfile(H2ONode node) {
+    assert isFlatfileEnabled() : "Trying to use flatfile, but flatfile is not enabled!";
+    return STATIC_H2OS.contains(node);
+  }
+
+  /**
+   * Is manual multicast enabled?
+   * @return  true if `-flatfile` option was specified on commandline
+   */
+  public static boolean isFlatfileEnabled() {
+    return STATIC_H2OS != null;
+  }
+
+  /** Setup a set of nodes which should be contacted during
+   * manual multicast.
+   * @param nodes  set of H2O nodes.
+   */
+  public static void setFlatfile(HashSet<H2ONode> nodes) {
+    STATIC_H2OS = nodes;
+  }
+
+  /** Returns a set of nodes which are contacted during manual
+   * multicast. The returned value can be modified by the user since
+   * the call return a copy of the original set.
+   * @return  set of nodes
+   */
+  public static HashSet<H2ONode> getFlatfile() {
+    return (HashSet<H2ONode>) STATIC_H2OS.clone();
   }
 }

--- a/h2o-core/src/main/java/water/MultiReceiverThread.java
+++ b/h2o-core/src/main/java/water/MultiReceiverThread.java
@@ -24,7 +24,7 @@ class MultiReceiverThread extends Thread {
   @SuppressWarnings("resource")
   @Override public void run() {
     // No multicast?  Then do not bother with listening for them
-    if( H2O.STATIC_H2OS != null ) return;
+    if (H2O.isFlatfileEnabled()) return;
     Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
 
     MulticastSocket sock = null, errsock = null;

--- a/h2o-core/src/main/java/water/TypeMap.java
+++ b/h2o-core/src/main/java/water/TypeMap.java
@@ -23,6 +23,7 @@ public class TypeMap {
     water.FetchClazz.class.getName(),   // used to fetch IDs from leader
     water.FetchId.class.getName(),      // used to fetch IDs from leader
     water.DTask.class.getName(),        // Needed for those first Tasks
+    water.UDPClientEvent.ClientEvent.class.getName(), // Needed for client event broadcast
 
     water.fvec.Chunk.class.getName(),   // parent of Chunk
     water.fvec.C1NChunk.class.getName(),// used as constant in parser

--- a/h2o-core/src/main/java/water/UDP.java
+++ b/h2o-core/src/main/java/water/UDP.java
@@ -19,6 +19,7 @@ public abstract class UDP {
     heartbeat     ( true, new UDPHeartbeat(),H2O.MAX_PRIORITY),
     rebooted      ( true, new UDPRebooted() ,H2O.MAX_PRIORITY), // This node has rebooted recently
     timeline      (false, new TimeLine()    ,H2O.MAX_PRIORITY), // Get timeline dumps from across the Cloud
+    client_event  ( true, new UDPClientEvent(), H2O.MAX_PRIORITY), // This packet informs about a client action (connect/disconnect)
 
     // All my *reliable* tasks (below), are sent to remote nodes who then ACK
     // back an answer.  To be reliable, I might send the TASK multiple times.
@@ -40,7 +41,7 @@ public abstract class UDP {
     // identical result ACK packets.
     exec(false,new RPC.RemoteHandler(),H2O.DESERIAL_PRIORITY), // Remote hi-q execution request
     i_o (false,new UDP.IO_record(),(byte)-1); // Only used to profile I/O
-    
+
     final UDP _udp;           // The Callable S.A.M. instance
     final byte _prior;        // Priority
     final boolean _paxos;     // Ignore (or not) packets from outside the Cloud

--- a/h2o-core/src/main/java/water/UDPClientEvent.java
+++ b/h2o-core/src/main/java/water/UDPClientEvent.java
@@ -1,0 +1,50 @@
+package water;
+
+/**
+ * A simple message which informs cluster about a new client
+ * which was connected. The event is used only in flatfile mode
+ * to allow client to connect to a single node, which will
+ * inform a cluster about the client.
+ * Hence, the rest of nodes will start ping client with heartbeat, and
+ * vice versa.
+ */
+public class UDPClientEvent extends UDP {
+
+  @Override
+  AutoBuffer call(AutoBuffer ab) {
+    // Handle only by non-client nodes
+    if (ab._h2o != H2O.SELF
+        && !H2O.ARGS.client
+        && H2O.isFlatfileEnabled()) {
+      ClientEvent ce = new ClientEvent().read(ab);
+      if (ce.type == ClientEvent.Type.CONNECT) {
+        H2O.addNodeToFlatfile(ce.clientNode);
+      }
+    }
+
+    return ab;
+  }
+
+  public static class ClientEvent extends Iced<ClientEvent> {
+
+    public enum Type {
+      CONNECT,
+      DISCONNECT;
+
+      public void broadcast(H2ONode clientNode) {
+        ClientEvent ce = new ClientEvent(this, clientNode);
+        ce.write(new AutoBuffer(H2O.SELF, udp.client_event._prior).putUdp(udp.client_event)).close();
+      }
+    }
+    // Type of client event
+    public Type type;
+    // Client
+    public H2ONode clientNode;
+
+    public ClientEvent() {}
+    public ClientEvent(Type type, H2ONode clientNode) {
+      this.type = type;
+      this.clientNode = clientNode;
+    }
+  }
+}

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -502,9 +502,9 @@ public class NetworkInit {
 
     // Read a flatfile of allowed nodes
     if (embeddedConfigFlatfile != null)
-      H2O.STATIC_H2OS = parseFlatFileFromString(embeddedConfigFlatfile);
+      H2O.setFlatfile(parseFlatFileFromString(embeddedConfigFlatfile));
     else 
-      H2O.STATIC_H2OS = parseFlatFile(H2O.ARGS.flatfile);
+      H2O.setFlatfile(parseFlatFile(H2O.ARGS.flatfile));
 
     // All the machines has to agree on the same multicast address (i.e., multicast group)
     // Hence use the cloud name to generate multicast address
@@ -532,7 +532,7 @@ public class NetworkInit {
   }
 
   static private void multicast2( ByteBuffer bb, byte priority ) {
-    if( H2O.STATIC_H2OS == null ) {
+    if( !H2O.isFlatfileEnabled() ) {
       byte[] buf = new byte[bb.remaining()];
       bb.get(buf);
 
@@ -581,7 +581,7 @@ public class NetworkInit {
 
       // Hideous O(n) algorithm for broadcast - avoid the memory allocation in
       // this method (since it is heavily used)
-      HashSet<H2ONode> nodes = (HashSet<H2ONode>)H2O.STATIC_H2OS.clone();
+      HashSet<H2ONode> nodes = H2O.getFlatfile();
       nodes.addAll(water.Paxos.PROPOSED.values());
       bb.mark();
       for( H2ONode h2o : nodes ) {


### PR DESCRIPTION
Before this fix, the client was required to provide a flatfile with a list
of all nodes it would like to speak with (in fact all nodes in the cluster).

This fix changes the behaviour in the following way:
  - an H2O client needs only a subset of all nodes to list in the flatfile, but at least a single node
  - a regular H2O node which receives a heartbeat from a client node, adds it into a list of multicasted nodes and also
    sends a message to all visible nodes with information about client connection (which contains address of client).
    - when a regular node receives this event about client connection, it appends the received client information into
      the list of nodes for multicast. Hence, the node is going send hearbeats to the client as well (not only the first node which was
      contacted by the client initially).
  - on the client side, when the client receives a message from a node outside its flatfile, it just appends the node into the list
    of nodes for multicast

Missing parts:
  - the fix intentionally does not work in mixed environments (for example, backend based on multicast, client outside of multicast zone connecting via flatfile)
  - explicit client disconnect event implementation (different jira)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/113)
<!-- Reviewable:end -->
