### PR TITLE
PUBDEV-3098: Add methods to get actual and default parameters of a model

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -62,6 +62,36 @@ class ModelBase(backwards_compatible()):
                          "actual": self.parms[p]["actual_value"]}
         return params
 
+    @property
+    def default_params(self):
+        """
+        Get default parameters of a model
+
+        :return: A dictionary of default parameters for the model
+        """
+        params = {}
+        for p in self.parms:
+            params[p] = self.parms[p]["default_value"]
+        return params
+
+    @property
+    def actual_params(self):
+        """
+        Get actual parameters of a model
+
+        :return: A dictionary of actual parameters for the model
+        """
+        params_to_select = {'model_id':'name', \
+                            'response_column':'column_name', \
+                            'training_frame': 'name', \
+                            'validation_frame':'name'}
+        params = {}
+        for p in self.parms:
+            if p in params_to_select.keys():
+                params[p] = self.parms[p]["actual_value"].get(params_to_select[p], None)
+            else:
+                params[p] = self.parms[p]["actual_value"]
+        return params
 
     @property
     def full_parameters(self):


### PR DESCRIPTION
Currently, `self.params` & `self.full_parameters` in `model_base.py` return very messy output about model parameters (actual & default) that can be hard to decipher for users. This PR adds two methods that can extract actual and default parameters and produce a nice dictionary of these values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/114)
<!-- Reviewable:end -->
