### PR TITLE
[HOTFIX] ORC Parser Junit 

### DIFF
--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -283,7 +283,7 @@ public class TestUtil extends Iced {
    */
   protected Frame parse_test_folder( String fname, String na_string, int check_header, byte[] column_types ) {
     File folder = find_test_file(fname);
-    assert folder.isDirectory();
+    assert folder != null && folder.isDirectory():"Folder "+fname+" is not a directory.";
     File[] files = folder.listFiles();
     Arrays.sort(files);
     ArrayList<Key> keys = new ArrayList<>();

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
@@ -24,10 +24,8 @@ public class ParseTestMultiFileOrc extends TestUtil {
     int totalFilesTested = 0;
     int numberWrong = 0;
 
-    private String[] csvDirectories = {"bigdata/laptop/parser/orc/pubdev_3200/air05_csv",
-            "bigdata/laptop/parser/orc/milsongs_orc_csv", "smalldata/synthetic_perfect_separation"};
-    private String[] orcDirectories = {"bigdata/laptop/parser/orc/pubdev_3200/air05_orc",
-            "bigdata/laptop/parser/orc/milsongs_orc", "smalldata/parser/orc/synthetic_perfect_separation"};
+    private String[] csvDirectories = {"smalldata/synthetic_perfect_separation"};
+    private String[] orcDirectories = {"smalldata/parser/orc/synthetic_perfect_separation"};
 
     @BeforeClass
     static public void setup() { TestUtil.stall_till_cloudsize(5); }


### PR DESCRIPTION
1. Changed ParseTestMultiFileOrc.java.

   private String[] csvDirectories = {"bigdata/laptop/parser/orc/pubdev_3200/air05_csv",
            "bigdata/laptop/parser/orc/milsongs_orc_csv", "smalldata/synthetic_perfect_separation"};
    private String[] orcDirectories = {"bigdata/laptop/parser/orc/pubdev_3200/air05_orc",
            "bigdata/laptop/parser/orc/milsongs_orc", "smalldata/parser/orc/synthetic_perfect_separation"};

Removed datasets in bigdata/laptop.  For gradle_tests we do not want to do long tests.

private String[] csvDirectories = {"smalldata/synthetic_perfect_separation"};
private String[] orcDirectories = {"smalldata/parser/orc/synthetic_perfect_separation"};

2. Changed TestUtil.java to check for null pointer and print out better error messages.

From:

assert folder.isDirectory();

To:

ssert folder != null && folder.isDirectory():"Folder "+fname+" is not a directory.";

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/122)
<!-- Reviewable:end -->
