### PR TITLE
PUBDEV-3276: H2OFrame.drop() leaves the frame in inconsistent state

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1262,12 +1262,16 @@ class H2OFrame(object):
 
     def drop(self, index, axis=1):
         """
-        Drop a set of columns or rows from the current H2OFrame.
+        Drop a single column or row or a set of columns or rows from a H2OFrame.
+        Dropping a column or row is not in-place.
+        Dropping a column or row by index or a set of indexes is zero-based.
 
         Parameters
         ----------
-          index : list
-            A list of column indexes, column names, or row indexes to drop.
+          index : list,str,int
+            A list of column indexes, column names, or row indexes to drop
+            A string to drop a single column by column name
+            An int to drop a single column by index
 
           axis : int, default = 1
             Type of drop to conduct.
@@ -1279,34 +1283,63 @@ class H2OFrame(object):
           H2OFrame with the respective dropped columns or rows. Returns a new H2OFrame.
         """
         if axis == 1:
-            if is_type(index, str):
-                index = self.names.index(index)
+            if not isinstance(index,list):
+                #If input is a string, i.e., "C1":
+                if is_type(index, str):
+                    #Check if index is an actual column(s) in the frame
+                    if index not in self.names:
+                        raise H2OValueError("Column(s) selected to drop are not in original frame: %r" % index)
+                    index = self.names.index(index)
+                #If input is an int indicating a column index, i.e., 3:
+                elif is_type(index, int):
+                    #Check if index is an actual column index in the frame
+                    if index > self.ncol:
+                        raise H2OValueError("Column index selected to drop is not part of the frame: %r" % index)
+                    if index < 0:
+                        raise H2OValueError("Column index selected to drop is not positive: %r" % index)
+
                 fr = H2OFrame._expr(expr=ExprNode("cols", self, -(index + 1)), cache=self._ex._cache)
                 fr._ex._cache.ncols -= 1
                 fr._ex._cache.names = self.names[:index] + self.names[index + 1:]
                 fr._ex._cache.types = {name: self.types[name] for name in fr._ex._cache.names}
                 return fr
-            if all(isinstance(item, int) for item in index):
-                for i in range(len(index)):
-                        index[i] = index[i] + 1
-                index = [-x for x in index]
+
+            elif isinstance(index,list):
+                #If input is an int array indicating a column index, i.e., [3] or [1,2,3]:
+                if is_type(index,[int]):
+                    if max(index) > self.ncol:
+                        raise H2OValueError("Column index selected to drop is not part of the frame: %r" % index)
+                    if min(index) < 0:
+                        raise H2OValueError("Column index selected to drop is not positive: %r" % index)
+                    for i in range(len(index)):
+                        index[i] = -(index[i] + 1)
+                #If index is a string array, i.e., ["C1", "C2"]
+                elif is_type(index,[str]):
+                    #Check if index is an actual column(s) in the frame
+                    if set(index).issubset(self.names) == False:
+                        raise H2OValueError("Column(s) selected to drop are not in original frame: %r" % index)
+                    for i in range(len(index)):
+                        index[i] = -(self.names.index(index[i]) + 1)
                 fr = H2OFrame._expr(expr=ExprNode("cols", self, index), cache=self._ex._cache)
-            elif all(isinstance(item, str) for item in index):
-                for i in range(len(index)):
-                    if is_type(index[i], str):
-                        index[i] = self.names.index(index[i]) + 1
-                index = [-x for x in index]
-                fr = H2OFrame._expr(expr=ExprNode("cols", self, index), cache=self._ex._cache)
+                fr._ex._cache.ncols -= len(index)
+                fr._ex._cache.names = [i for i in self.names if self.names.index(i) not in list(map(lambda x: abs(x) - 1, index))]
+                fr._ex._cache.types = {name: fr.types[name] for name in fr._ex._cache.names}
+
             else:
-                raise ValueError("Invalid column index types. Must either be a list of all int indexes or "
-                                 "a list of all column names (strings) for dropping columns.")
+                raise ValueError("Invalid column index types. Must either be a list of all int indexes, "
+                                 "a string list of all column names, a single int index, or"
+                                 "a single string for dropping columns.")
             return fr
         elif axis == 0:
-            if all(isinstance(item, int) for item in index):
-                for i in range(len(index)):
-                    index[i] = index[i] + 1
-                index = [-x for x in index]
+            if is_type(index,[int]):
+                #Check if index is an actual column index in the frame
+                if max(index) > self.nrow:
+                    raise H2OValueError("Row index selected to drop is not part of the frame: %r" % index)
+                if min(index) < 0:
+                    raise H2OValueError("Row index selected to drop is not positive: %r" % index)
+                index = [-(x+1) for x in index]
                 fr = H2OFrame._expr(expr=ExprNode("rows", self, index), cache=self._ex._cache)
+                fr._ex._cache.nrows -= len(index)
             else:
                 raise ValueError("Invalid row indexes. Must be a list of int row indexes to drop from the H2OFrame.")
         return fr

--- a/h2o-py/tests/testdir_misc/pyunit_drop.py
+++ b/h2o-py/tests/testdir_misc/pyunit_drop.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+
+
+def frame_checker(frame):
+    assert frame.ncol == len(frame.names) == len(frame.types)
+    assert set(frame.names) == set(frame.types)
+
+def pyunit_drop():
+
+    #Import data and collect number of columns and number of rows
+    pros = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate.csv"))
+    nc = pros.ncol
+    nr = pros.nrow
+
+    #There are two ways to drop a single column: Pass in an int index or a string column,i.e., 1 or "C1"
+    dropped_col_int = pros.drop(0)
+    frame_checker(dropped_col_int) #call on frame_checker()
+    dropped_col_string = pros.drop("ID")
+    frame_checker(dropped_col_string) #call on frame_checker()
+
+    #There are two ways to drop a set of columns: Pass in an int array or a string array, i.e., [1,2] or ["C1", "C2"]
+    dropped_col_int_array = pros.drop([0,1])
+    frame_checker(dropped_col_int_array) #call on frame_checker()
+    dropped_col_string_array = pros.drop(["ID","CAPSULE"])
+    frame_checker(dropped_col_string_array) #call on frame_checker()
+
+    #Drop a first few rows from the frame (0 based)
+    dropped_row_array_0 = pros.drop([0],axis=0)
+    dropped_row_array_1 = pros.drop([0,1],axis=0)
+    dropped_row_array_2 = pros.drop([0,1,2],axis=0)
+
+    #Drop last few rows from the frame (0 based)
+    dropped_row_array_380 = pros.drop([379],axis=0)
+    dropped_row_array_378 = pros.drop([378,379],axis=0)
+    dropped_row_array_377 = pros.drop([377, 378, 379],axis=0)
+
+    #Check number of columns after drop are correct
+    assert dropped_col_int.ncol==nc-1
+    assert dropped_col_string.ncol==nc-1
+    assert dropped_col_int_array.ncol==nc-2
+    assert dropped_col_string_array.ncol==nc-2
+
+    # #Check column names are correct after drop
+    assert dropped_col_int.names == pros.names[1:]
+    assert dropped_col_string.names == pros.names[1:]
+    assert dropped_col_int_array.names == pros.names[2:]
+    assert dropped_col_string_array.names == pros.names[2:]
+
+    # #Check column types are correct after drop
+    assert dropped_col_int.types == pros[1:].types
+    assert dropped_col_string.types == pros[1:].types
+    assert dropped_col_int_array.types == pros[2:].types
+    assert dropped_col_string_array.types == pros[2:].types
+
+    #Check number of rows after drop are correct
+    assert dropped_row_array_0.nrow == nr-1
+    assert dropped_row_array_1.nrow == nr-2
+    assert dropped_row_array_2.nrow == nr-3
+    assert dropped_row_array_380.nrow == nr-1
+    assert dropped_row_array_378.nrow == nr-2
+    assert dropped_row_array_377.nrow == nr-3
+
+    #Check original frame preserves number of columns and rows
+    assert pros.ncol == nc
+    assert pros.nrow == nr
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pyunit_drop)
+else:
+    pyunit_drop()


### PR DESCRIPTION
* drop() now handles a single int index or a single str column name or a list of column indexes/names to drop
* To drop a row or a set of rows one passes in a list of indexes, i.e., [1] or [1,4,5]
* Column names and types are modified after the drop
* A pyunit is added to test these functionalities

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/129)
<!-- Reviewable:end -->
