### PR TITLE
PUBDEV-1612: orc parser.  Added airline_05 test to HDFS.

### DIFF
--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
@@ -15,7 +15,6 @@ import water.parser.*;
 import water.persist.PersistHdfs;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import static water.fvec.FileVec.getPathForKey;

--- a/h2o-py/tests/testdir_hdfs/index.list
+++ b/h2o-py/tests/testdir_hdfs/index.list
@@ -7,4 +7,5 @@ pyunit_INTERNAL_HDFS_milsongs_orc_large.py
 pyunit_INTERNAL_HDFS_orc_parser.py
 pyunit_INTERNAL_HDFS_prostate_orc.py
 pyunit_INTERNAL_HDFS_timestamp_date_orc.py
-
+pyunit_INTERNAL_HDFS_import_folder_orc.py
+pyunit_INTERNAL_HDFS_baddata_orc.py

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_airlines_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_airlines_orc.py
@@ -24,52 +24,59 @@ def hdfs_orc_parser():
         tol_numeric = 1e-5
 
         hdfs_name_node = pyunit_utils.hadoop_namenode()
-        hdfs_orc_file = "/datasets/airlines_all_orc_parts"
-        hdfs_csv_file = "/datasets/air_csv_part"
 
-        col_types = ['real', 'real', 'real', 'real', 'real', 'real', 'real', 'real', 'enum', 'real', 'enum', 'real',
-                     'real', 'enum', 'real', 'real', 'enum', 'enum', 'real', 'enum', 'enum', 'real', 'real', 'real',
-                     'enum', 'enum', 'enum', 'enum', 'enum', 'enum', 'enum']
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_airlines_orc.py"))
+            pass
+        else:
 
-        # import CSV file
-        print("Import airlines 116M dataset in original csv format from HDFS")
-        url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
+            hdfs_orc_file = "/datasets/airlines_all_orc_parts"
+            hdfs_csv_file = "/datasets/air_csv_part"
 
-        startcsv = time.time()
-        multi_file_csv = h2o.import_file(url_csv, na_strings=['\\N'], col_types=col_types)
-        endcsv = time.time()
+            col_types = ['real', 'real', 'real', 'real', 'real', 'real', 'real', 'real', 'enum', 'real', 'enum', 'real',
+                         'real', 'enum', 'real', 'real', 'enum', 'enum', 'real', 'enum', 'enum', 'real', 'real', 'real',
+                         'enum', 'enum', 'enum', 'enum', 'enum', 'enum', 'enum']
 
-        startcsv1 = time.time()
-        multi_file_csv1 = h2o.import_file(url_csv)
-        endcsv1 = time.time()
-        h2o.remove(multi_file_csv1)
+            # import CSV file
+            print("Import airlines 116M dataset in original csv format from HDFS")
+            url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
 
-        multi_file_csv.summary()
-        csv_summary = h2o.frame(multi_file_csv.frame_id)["frames"][0]["columns"]
+            startcsv = time.time()
+            multi_file_csv = h2o.import_file(url_csv, na_strings=['\\N'], col_types=col_types)
+            endcsv = time.time()
 
-        # import ORC file with same column types as CSV file
-        print("Import airlines 116M dataset in ORC format from HDFS")
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            startcsv1 = time.time()
+            multi_file_csv1 = h2o.import_file(url_csv)
+            endcsv1 = time.time()
+            h2o.remove(multi_file_csv1)
 
-        startorc1 = time.time()
-        multi_file_orc1 = h2o.import_file(url_orc)
-        endorc1 = time.time()
-        h2o.remove(multi_file_orc1)
+            multi_file_csv.summary()
+            csv_summary = h2o.frame(multi_file_csv.frame_id)["frames"][0]["columns"]
 
-        startorc = time.time()
-        multi_file_orc = h2o.import_file(url_orc, col_types=col_types)
-        endorc = time.time()
+            # import ORC file with same column types as CSV file
+            print("Import airlines 116M dataset in ORC format from HDFS")
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
 
-        multi_file_orc.summary()
-        orc_summary = h2o.frame(multi_file_orc.frame_id)["frames"][0]["columns"]
+            startorc1 = time.time()
+            multi_file_orc1 = h2o.import_file(url_orc)
+            endorc1 = time.time()
+            h2o.remove(multi_file_orc1)
 
-        print("************** CSV (without column type forcing) parse time is {0}".format(endcsv1-startcsv1))
-        print("************** CSV (with column type forcing) parse time is {0}".format(endcsv-startcsv))
-        print("************** ORC (without column type forcing) parse time is {0}".format(endorc1-startorc1))
-        print("************** ORC (with column type forcing) parse time is {0}".format(endorc-startorc))
+            startorc = time.time()
+            multi_file_orc = h2o.import_file(url_orc, col_types=col_types)
+            endorc = time.time()
 
-    # compare frame read by orc by forcing column type,
-        pyunit_utils.compare_frame_summary(csv_summary, orc_summary)
+            multi_file_orc.summary()
+            orc_summary = h2o.frame(multi_file_orc.frame_id)["frames"][0]["columns"]
+
+            print("************** CSV (without column type forcing) parse time is {0}".format(endcsv1-startcsv1))
+            print("************** CSV (with column type forcing) parse time is {0}".format(endcsv-startcsv))
+            print("************** ORC (without column type forcing) parse time is {0}".format(endorc1-startorc1))
+            print("************** ORC (with column type forcing) parse time is {0}".format(endorc-startorc))
+
+            # compare frame read by orc by forcing column type,
+            pyunit_utils.compare_frame_summary(csv_summary, orc_summary)
 
     else:
         raise EnvironmentError

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_baddata_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_baddata_orc.py
@@ -19,20 +19,31 @@ def hdfs_orc_parser():
     if hadoop_namenode_is_accessible:
         hdfs_name_node = pyunit_utils.hadoop_namenode()
 
-        hdfs_orc_file = "/datasets/orc_parser/orc/TestOrcFile.testStringAndBinaryStatistics.orc"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        assert pyunit_utils.expect_warnings(url_orc, "UserWarning:", "Skipping field:", 1),\
-            "Expect warnings from orc parser for file "+url_orc+"!"
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_baddata_orc.py"))
+            pass
+        else:
+            hdfs_orc_file = "/datasets/orc_parser/orc/TestOrcFile.testStringAndBinaryStatistics.orc"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            print("Parsing the orc file {0}".format(url_orc))
+            assert pyunit_utils.expect_warnings(url_orc, warn_phrase="UserWarning:",
+                                                warn_string_of_interest="Skipping field:", in_hdfs=True,
+                                                number_of_times=1), "Expect warnings from orc parser for file "+url_orc+"!"
 
-        hdfs_orc_file = "/datasets/orc_parser/orc/TestOrcFile.emptyFile.orc"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        assert pyunit_utils.expect_warnings(url_orc, "UserWarning:", "Skipping field:", 1), \
-            "Expect warnings from orc parser for file "+url_orc+"!"
+            hdfs_orc_file = "/datasets/orc_parser/orc/TestOrcFile.emptyFile.orc"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            print("Parsing the orc file {0}".format(url_orc))
+            assert pyunit_utils.expect_warnings(url_orc, warn_phrase="UserWarning:",
+                                                warn_string_of_interest="Skipping field:", in_hdfs=True,
+                                                number_of_times=1), "Expect warnings from orc parser for file "+url_orc+"!"
 
-        hdfs_orc_file = "/datasets/orc_parser/orc/nulls-at-end-snappy.orc"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        assert pyunit_utils.expect_warnings(url_orc, "UserWarning:", "Skipping field:", 1), \
-            "Expect warnings from orc parser for file "+url_orc+"!"
+            hdfs_orc_file = "/datasets/orc_parser/orc/nulls-at-end-snappy.orc"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            print("Parsing the orc file {0}".format(url_orc))
+            assert pyunit_utils.expect_warnings(url_orc, warn_phrase="UserWarning:",
+                                                warn_string_of_interest="Long.MIN_VALUE:", in_hdfs=True,
+                                                number_of_times=1), "Expect warnings from orc parser for file "+url_orc+"!"
 
     else:
         raise EnvironmentError

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_hexdev_29_import_types_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_hexdev_29_import_types_orc.py
@@ -18,22 +18,28 @@ def hdfs_orc_parser():
 
     if hadoop_namenode_is_accessible:
         hdfs_name_node = pyunit_utils.hadoop_namenode()
-        hdfs_orc_file = "/datasets/orc_parser/orc/hexdev_29.orc"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        hdfs_csv_file = "/datasets/orc_parser/csv/hexdev_29.csv"
-        url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
 
-        numElements2Compare = 0
-        tol_time = 200
-        tol_numeric = 1e-5
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_hexdex_29_import_types_orc.py"))
+            pass
+        else:
+            hdfs_orc_file = "/datasets/orc_parser/orc/hexdev_29.orc"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            hdfs_csv_file = "/datasets/orc_parser/csv/hexdev_29.csv"
+            url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
 
-        ctypes = ["enum"]*3
-        h2oframe_csv = h2o.import_file(url_csv, col_types=ctypes)
-        h2oframe_orc = h2o.import_file(url_orc, col_types=ctypes)
+            numElements2Compare = 0
+            tol_time = 200
+            tol_numeric = 1e-5
 
-        # compare the two frames
-        assert pyunit_utils.compare_frames(h2oframe_orc, h2oframe_csv, numElements2Compare, tol_time, tol_numeric,
-                                           True), "H2O frame parsed from orc and csv files are different!"
+            ctypes = ["enum"]*3
+            h2oframe_csv = h2o.import_file(url_csv, col_types=ctypes)
+            h2oframe_orc = h2o.import_file(url_orc, col_types=ctypes)
+
+            # compare the two frames
+            assert pyunit_utils.compare_frames(h2oframe_orc, h2oframe_csv, numElements2Compare, tol_time, tol_numeric,
+                                               True), "H2O frame parsed from orc and csv files are different!"
 
     else:
         raise EnvironmentError

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_folder_airline_05_orc_large.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_folder_airline_05_orc_large.py
@@ -21,48 +21,53 @@ def hdfs_orc_parser():
     if hadoop_namenode_is_accessible:
         hdfs_name_node = pyunit_utils.hadoop_namenode()
 
-        hdfs_orc_file = "/datasets/orc_parser/air05_orc"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        hdfs_csv_file = "/datasets/orc_parser/air05_csv"
-        url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_import_folder_airline_05_orc.py"))
+            pass
+        else:
+            hdfs_orc_file = "/datasets/orc_parser/air05_orc"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            hdfs_csv_file = "/datasets/orc_parser/air05_csv"
+            url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
 
-        startcsv = time.time()
-        multi_file_csv = h2o.import_file(hdfs_csv_file, na_strings=['\\N'])
-        endcsv = time.time()
+            startcsv = time.time()
+            multi_file_csv = h2o.import_file(url_csv, na_strings=['\\N'])
+            endcsv = time.time()
 
-        csv_type_dict = multi_file_csv.types
+            csv_type_dict = multi_file_csv.types
 
-        multi_file_csv.summary()
-        csv_summary = h2o.frame(multi_file_csv.frame_id)["frames"][0]["columns"]
+            multi_file_csv.summary()
+            csv_summary = h2o.frame(multi_file_csv.frame_id)["frames"][0]["columns"]
 
-        col_ind_name = dict()
-        # change column types from real to enum according to multi_file_csv column types
-        for key_name in list(csv_type_dict):
-            col_ind = key_name.split('C')
-            new_ind = int(str(col_ind[1]))-1
-            col_ind_name[new_ind] = key_name
+            col_ind_name = dict()
+            # change column types from real to enum according to multi_file_csv column types
+            for key_name in list(csv_type_dict):
+                col_ind = key_name.split('C')
+                new_ind = int(str(col_ind[1]))-1
+                col_ind_name[new_ind] = key_name
 
-        col_types = []
-        for ind in range(len(col_ind_name)):
-            col_types.append(csv_type_dict[col_ind_name[ind]])
+            col_types = []
+            for ind in range(len(col_ind_name)):
+                col_types.append(csv_type_dict[col_ind_name[ind]])
 
-        startorc1 = time.time()
-        multi_file_orc1 = h2o.import_file(url_orc)
-        endorc1 = time.time()
-        h2o.remove(multi_file_orc1)
+            startorc1 = time.time()
+            multi_file_orc1 = h2o.import_file(url_orc)
+            endorc1 = time.time()
+            h2o.remove(multi_file_orc1)
 
-        startorc = time.time()
-        multi_file_orc = h2o.import_file(url_orc,col_types=col_types)
-        endorc = time.time()
+            startorc = time.time()
+            multi_file_orc = h2o.import_file(url_orc,col_types=col_types)
+            endorc = time.time()
 
-        multi_file_orc.summary()
-        orc_summary = h2o.frame(multi_file_orc.frame_id)["frames"][0]["columns"]
+            multi_file_orc.summary()
+            orc_summary = h2o.frame(multi_file_orc.frame_id)["frames"][0]["columns"]
 
-        print("************** CSV parse time is {0}".format(endcsv-startcsv))
-        print("************** ORC (without column type forcing) parse time is {0}".format(endorc1-startorc1))
-        print("************** ORC (with column type forcing) parse time is {0}".format(endorc-startorc))
-        # compare frame read by orc by forcing column type,
-        pyunit_utils.compare_frame_summary(csv_summary, orc_summary)
+            print("************** CSV parse time is {0}".format(endcsv-startcsv))
+            print("************** ORC (without column type forcing) parse time is {0}".format(endorc1-startorc1))
+            print("************** ORC (with column type forcing) parse time is {0}".format(endorc-startorc))
+            # compare frame read by orc by forcing column type,
+            pyunit_utils.compare_frame_summary(csv_summary, orc_summary)
     else:
         raise EnvironmentError
 

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_iris_import_types_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_iris_import_types_orc.py
@@ -18,22 +18,28 @@ def hdfs_orc_parser():
     if hadoop_namenode_is_accessible:
         hdfs_name_node = pyunit_utils.hadoop_namenode()
 
-        numElements2Compare = 100
-        tol_time = 200
-        tol_numeric = 1e-5
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_iris_import_types_orc.py"))
+            pass
+        else:
 
-        hdfs_orc_file = "/datasets/orc_parser/orc/iris.orc"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        hdfs_csv_file = "/datasets/orc_parser/csv/iris.csv"
-        url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
+            numElements2Compare = 100
+            tol_time = 200
+            tol_numeric = 1e-5
 
-        h2oframe_csv = h2o.import_file(url_csv)
-        data_types = ['real', 'real', 'real', 'real', 'enum']
-        h2oframe_orc = h2o.import_file(url_orc, col_types = data_types)
+            hdfs_orc_file = "/datasets/orc_parser/orc/iris.orc"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            hdfs_csv_file = "/datasets/orc_parser/csv/iris.csv"
+            url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
 
-        # compare the two frames
-        assert pyunit_utils.compare_frames(h2oframe_orc, h2oframe_csv, numElements2Compare, tol_time, tol_numeric,
-                                           True), "H2O frame parsed from orc and csv files are different!"
+            h2oframe_csv = h2o.import_file(url_csv)
+            data_types = ['real', 'real', 'real', 'real', 'enum']
+            h2oframe_orc = h2o.import_file(url_orc, col_types = data_types)
+
+            # compare the two frames
+            assert pyunit_utils.compare_frames(h2oframe_orc, h2oframe_csv, numElements2Compare, tol_time, tol_numeric,
+                                               True), "H2O frame parsed from orc and csv files are different!"
     else:
         raise EnvironmentError
 

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_milsongs_orc_large.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_milsongs_orc_large.py
@@ -20,21 +20,27 @@ def hdfs_orc_parser():
 
     if hadoop_namenode_is_accessible:
         hdfs_name_node = pyunit_utils.hadoop_namenode()
-        hdfs_orc_file = "/datasets/orc_parser/milsongs_orc"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        hdfs_csv_file = "/datasets/orc_parser/milsongs_csv"
-        url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
 
-        multi_file_csv = h2o.import_file(url_csv)
-        multi_file_orc = h2o.import_file(url_orc)
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+          "skipped.".format("pyunit_INTERNAL_HDFS_milsongs_orc.py"))
+            pass
+        else:
+            hdfs_orc_file = "/datasets/orc_parser/milsongs_orc"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            hdfs_csv_file = "/datasets/orc_parser/milsongs_csv"
+            url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
 
-        multi_file_csv.summary()
-        csv_summary = h2o.frame(multi_file_csv.frame_id)["frames"][0]["columns"]
+            multi_file_csv = h2o.import_file(url_csv)
+            multi_file_orc = h2o.import_file(url_orc)
 
-        multi_file_orc.summary()
-        orc_summary = h2o.frame(multi_file_orc.frame_id)["frames"][0]["columns"]
+            multi_file_csv.summary()
+            csv_summary = h2o.frame(multi_file_csv.frame_id)["frames"][0]["columns"]
 
-        pyunit_utils.compare_frame_summary(csv_summary, orc_summary)
+            multi_file_orc.summary()
+            orc_summary = h2o.frame(multi_file_orc.frame_id)["frames"][0]["columns"]
+
+            pyunit_utils.compare_frame_summary(csv_summary, orc_summary)
     else:
         raise EnvironmentError
 

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_orc_parser.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_orc_parser.py
@@ -22,34 +22,40 @@ def hdfs_orc_parser():
 
         hdfs_name_node = pyunit_utils.hadoop_namenode()
 
-        allOrcFiles = ["/datasets/orc_parser/orc/TestOrcFile.columnProjection.orc",
-                       "/datasets/orc_parser/orc/bigint_single_col.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.emptyFile.orc",
-                       "/datasets/orc_parser/orc/bool_single_col.orc",
-                       "/datasets/orc_parser/orc/demo-11-zlib.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testDate1900.orc",
-                       "/datasets/orc_parser/orc/demo-12-zlib.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testDate2038.orc",
-                       "/datasets/orc_parser/orc/double_single_col.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testMemoryManagementV11.orc",
-                       "/datasets/orc_parser/orc/float_single_col.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testMemoryManagementV12.orc",
-                       "/datasets/orc_parser/orc/int_single_col.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testPredicatePushdown.orc",
-                       "/datasets/orc_parser/orc/nulls-at-end-snappy.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testSnappy.orc",
-                       "/datasets/orc_parser/orc/orc_split_elim.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testStringAndBinaryStatistics.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testStripeLevelStats.orc",
-                       "/datasets/orc_parser/orc/smallint_single_col.orc",
-                       "/datasets/orc_parser/orc/string_single_col.orc",
-                       "/datasets/orc_parser/orc/tinyint_single_col.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testWithoutIndex.orc"]
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_orc_parser.py"))
+            pass
+        else:
+
+            allOrcFiles = ["/datasets/orc_parser/orc/TestOrcFile.columnProjection.orc",
+                           "/datasets/orc_parser/orc/bigint_single_col.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.emptyFile.orc",
+                           "/datasets/orc_parser/orc/bool_single_col.orc",
+                           "/datasets/orc_parser/orc/demo-11-zlib.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testDate1900.orc",
+                           "/datasets/orc_parser/orc/demo-12-zlib.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testDate2038.orc",
+                           "/datasets/orc_parser/orc/double_single_col.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testMemoryManagementV11.orc",
+                           "/datasets/orc_parser/orc/float_single_col.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testMemoryManagementV12.orc",
+                           "/datasets/orc_parser/orc/int_single_col.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testPredicatePushdown.orc",
+                           "/datasets/orc_parser/orc/nulls-at-end-snappy.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testSnappy.orc",
+                           "/datasets/orc_parser/orc/orc_split_elim.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testStringAndBinaryStatistics.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testStripeLevelStats.orc",
+                           "/datasets/orc_parser/orc/smallint_single_col.orc",
+                           "/datasets/orc_parser/orc/string_single_col.orc",
+                           "/datasets/orc_parser/orc/tinyint_single_col.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testWithoutIndex.orc"]
 
 
-        for fIndex in range(len(allOrcFiles)):
-            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, allOrcFiles[fIndex])
-            tab_test = h2o.import_file(url_orc)
+            for fIndex in range(len(allOrcFiles)):
+                url_orc = "hdfs://{0}{1}".format(hdfs_name_node, allOrcFiles[fIndex])
+                tab_test = h2o.import_file(url_orc)
     else:
         raise EnvironmentError
 

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_prostate_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_prostate_orc.py
@@ -23,21 +23,29 @@ def hdfs_orc_parser():
     if hadoop_namenode_is_accessible:
         hdfs_name_node = pyunit_utils.hadoop_namenode()
 
-        tol_time = 200              # comparing in ms or ns
-        tol_numeric = 1e-5          # tolerance for comparing other numeric fields
-        numElements2Compare = 10   # choose number of elements per column to compare.  Save test time.
+        # run a quick test to determine if the hive-exec is too old.
 
-        hdfs_orc_file = "/datasets/orc_parser/orc/prostate_NA.orc"
-        hdfs_csv_file = "/datasets/orc_parser/csv/prostate_NA.csv"
-        url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
-        url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_prostate_orc.py"))
+            pass
+        else:
 
-        h2oOrc = h2o.import_file(url_orc)
-        h2oCsv = h2o.import_file(url_csv)
+            tol_time = 200              # comparing in ms or ns
+            tol_numeric = 1e-5          # tolerance for comparing other numeric fields
+            numElements2Compare = 10   # choose number of elements per column to compare.  Save test time.
 
-        # compare the two frames
-        assert pyunit_utils.compare_frames(h2oOrc, h2oCsv, numElements2Compare, tol_time, tol_numeric), \
-            "H2O frame parsed from orc and csv files are different!"
+            hdfs_orc_file = "/datasets/orc_parser/orc/prostate_NA.orc"
+            hdfs_csv_file = "/datasets/orc_parser/csv/prostate_NA.csv"
+            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_orc_file)
+            url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
+
+            h2oOrc = h2o.import_file(url_orc)
+            h2oCsv = h2o.import_file(url_csv)
+
+            # compare the two frames
+            assert pyunit_utils.compare_frames(h2oOrc, h2oCsv, numElements2Compare, tol_time, tol_numeric), \
+                "H2O frame parsed from orc and csv files are different!"
     else:
         raise EnvironmentError
 

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_timestamp_date_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_timestamp_date_orc.py
@@ -26,27 +26,32 @@ def hdfs_orc_parser():
     if hadoop_namenode_is_accessible:
         hdfs_name_node = pyunit_utils.hadoop_namenode()
 
-        tol_time = 200              # comparing in ms or ns
-        tol_numeric = 1e-5          # tolerance for comparing other numeric fields
-        numElements2Compare = 100   # choose number of elements per column to compare.  Save test time.
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_timestamp_date_orc.py"))
+            pass
+        else:
+            tol_time = 200              # comparing in ms or ns
+            tol_numeric = 1e-5          # tolerance for comparing other numeric fields
+            numElements2Compare = 100   # choose number of elements per column to compare.  Save test time.
 
-        allOrcFiles = ["/datasets/orc_parser/orc/TestOrcFile.testDate1900.orc",
-                       "/datasets/orc_parser/orc/TestOrcFile.testDate2038.orc",
-                       "/datasets/orc_parser/orc/orc_split_elim.orc"]
+            allOrcFiles = ["/datasets/orc_parser/orc/TestOrcFile.testDate1900.orc",
+                           "/datasets/orc_parser/orc/TestOrcFile.testDate2038.orc",
+                           "/datasets/orc_parser/orc/orc_split_elim.orc"]
 
-        allCsvFiles = ["/datasets/orc_parser/csv/TestOrcFile.testDate1900.csv",
-                       "/datasets/orc_parser/csv/TestOrcFile.testDate2038.csv",
-                       "/datasets/orc_parser/csv/orc_split_elim.csv"]
+            allCsvFiles = ["/datasets/orc_parser/csv/TestOrcFile.testDate1900.csv",
+                           "/datasets/orc_parser/csv/TestOrcFile.testDate2038.csv",
+                           "/datasets/orc_parser/csv/orc_split_elim.csv"]
 
-        for fIndex in range(len(allOrcFiles)):
-            url_orc = "hdfs://{0}{1}".format(hdfs_name_node, allOrcFiles[fIndex])
-            url_csv = "hdfs://{0}{1}".format(hdfs_name_node, allCsvFiles[fIndex])
-            h2oOrc = h2o.import_file(url_orc)
-            h2oCsv = h2o.import_file(url_csv)
+            for fIndex in range(len(allOrcFiles)):
+                url_orc = "hdfs://{0}{1}".format(hdfs_name_node, allOrcFiles[fIndex])
+                url_csv = "hdfs://{0}{1}".format(hdfs_name_node, allCsvFiles[fIndex])
+                h2oOrc = h2o.import_file(url_orc)
+                h2oCsv = h2o.import_file(url_csv)
 
-            # compare the two frames
-            assert pyunit_utils.compare_frames(h2oOrc, h2oCsv, numElements2Compare, tol_time, tol_numeric), \
-                "H2O frame parsed from orc and csv files are different!"
+                # compare the two frames
+                assert pyunit_utils.compare_frames(h2oOrc, h2oCsv, numElements2Compare, tol_time, tol_numeric), \
+                    "H2O frame parsed from orc and csv files are different!"
     else:
         raise EnvironmentError
 

--- a/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_air_csv_milsongs_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_air_csv_milsongs_orc.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import time
+from tests import pyunit_utils
+#----------------------------------------------------------------------
+# This test is used to show what happens if we mix csv and orc files of
+# different datasets in the same directory.  We expect it to throw an error.
+#----------------------------------------------------------------------
+
+
+def hdfs_orc_parser():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_import_folder_orc.py"))
+            pass
+        else:
+            mix_folder = "/datasets/air_csv_milsongs_orc"
+            url_csv1 = "hdfs://{0}{1}".format(hdfs_name_node, mix_folder)
+            multi_file_mixed = h2o.import_file(url_csv1)
+    else:
+        raise EnvironmentError
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_orc_parser)
+else:
+    hdfs_orc_parser()

--- a/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_csv_milsongs_air.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_csv_milsongs_air.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import time
+from tests import pyunit_utils
+#----------------------------------------------------------------------
+# This test is used to show what happens if we mix datasets but keep the
+# file format as csv.  We expect it to throw an error.
+#----------------------------------------------------------------------
+
+
+def hdfs_orc_parser():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_import_folder_orc.py"))
+            pass
+        else:
+            mix_folder = "/datasets/air_csv_milsongs_orc"
+            url_csv1 = "hdfs://{0}{1}".format(hdfs_name_node, mix_folder)
+            multi_file_mixed = h2o.import_file(url_csv1)
+    else:
+        raise EnvironmentError
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_orc_parser)
+else:
+    hdfs_orc_parser()

--- a/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_csv_orc_same_milsongs.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_csv_orc_same_milsongs.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import time
+from tests import pyunit_utils
+#----------------------------------------------------------------------
+# This test is used to show what happens if we split the same datasets
+# into one part csv, one part orc
+#----------------------------------------------------------------------
+
+
+def hdfs_orc_parser():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_import_folder_orc.py"))
+            pass
+        else:
+            mix_folder = "/datasets/csv_orc_same_milsongs"
+            url_csv1 = "hdfs://{0}{1}".format(hdfs_name_node, mix_folder)
+            multi_file_mixed = h2o.import_file(url_csv1)
+    else:
+        raise EnvironmentError
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_orc_parser)
+else:
+    hdfs_orc_parser()

--- a/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_milsongs_orc_air_csv.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_milsongs_orc_air_csv.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import time
+from tests import pyunit_utils
+#----------------------------------------------------------------------
+# This test is used to find out what happens if we mix different datasets
+# in different formats into the same directory.
+#----------------------------------------------------------------------
+
+
+def hdfs_orc_parser():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_import_folder_orc.py"))
+            pass
+        else:
+            mix_folder = "/datasets/milsongs_orc_air_csv"
+            url_csv1 = "hdfs://{0}{1}".format(hdfs_name_node, mix_folder)
+            multi_file_mixed = h2o.import_file(url_csv1)
+    else:
+        raise EnvironmentError
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_orc_parser)
+else:
+    hdfs_orc_parser()

--- a/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_orc_csv_same_milsongs.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_orc_csv_same_milsongs.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import time
+from tests import pyunit_utils
+#----------------------------------------------------------------------
+# This test is used to find out what happens if we mix datasets and
+# orc/csv files in the same folder
+#----------------------------------------------------------------------
+
+
+def hdfs_orc_parser():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_import_folder_orc.py"))
+            pass
+        else:
+            mix_folder = "/datasets/orc_csv_same_milsongs"
+            url_csv1 = "hdfs://{0}{1}".format(hdfs_name_node, mix_folder)
+            multi_file_mixed = h2o.import_file(url_csv1)
+    else:
+        raise EnvironmentError
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_orc_parser)
+else:
+    hdfs_orc_parser()

--- a/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_orc_milsongs_air.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_NOFEATURE_INTERNAL_HDFS_import_folder_orc_milsongs_air.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import time
+from tests import pyunit_utils
+#----------------------------------------------------------------------
+# This test is used to show what happens if we mix datasets but keep
+# the file format to orc.  We expect it to throw an error.
+#----------------------------------------------------------------------
+
+
+def hdfs_orc_parser():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+
+        if pyunit_utils.cannaryHDFSTest(hdfs_name_node, "/datasets/orc_parser/orc/orc_split_elim.orc"):
+            print("Your hive-exec version is too old.  Orc parser test {0} is "
+                  "skipped.".format("pyunit_INTERNAL_HDFS_import_folder_orc.py"))
+            pass
+        else:
+            mix_folder = "/datasets/orc_milsongs_air"
+            url_csv1 = "hdfs://{0}{1}".format(hdfs_name_node, mix_folder)
+            multi_file_mixed = h2o.import_file(url_csv1)
+    else:
+        raise EnvironmentError
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_orc_parser)
+else:
+    hdfs_orc_parser()


### PR DESCRIPTION
Summary:

Mainly added/modified HDFS tests and test harness to detect when a user's hive-exec version is too old.  We have Jenkins tests for Hadoop versions:

CDH 5.7 (Done)
CDH 5.3.5 (Done)
HDP 2.2 (Done)
HDP 2.4 (In progress)

Should not conflict with other people's changes I hope.




PUBDEV-1612: orc parser.  Remove all other tests but focused on the one that failed.

PUBDEV-1612: orc parser.  Fixed bug in test HDFS_import_folder_airline_05_orc_large.py

PUBDEV-1612: orc parser.  Fixed another bug in test pyunit_INTERNAL_HDFS_import_folder_airline_05_orc_large.py

PUBDEV-1612: orc parser.  Added the last two failing tests in HDFS.

PUBDEV-1612: orc parser.  The h2o.import_file takes different arguments under HDFS.  Put this into our test infrastructure for orc parser.

PUBDEV-1612: orc parser.  Added HDFS tests back.  Two more bad tests to debug for tomorrow.

PUBDEV-162: orc parser.  Reduce gradle.properties setting for Orc.

PUBDEV-1612: orc parser.  Revert Hadoop and Orc Hive Exec versions back to what Michal has.  Cannot go any lower to accomodate J6.

PUBDEV-1612: orc parser.  Changed to lower HDP version for gradle.properties.

PUBDEV-1612: orc parser.  Added more printouts to test_HDFS.

PUBDEV-1612: orc parser.  Fixed bug in test_HDFS.

PUBDEV-1612: orc parser.  Revert Hive/Orc module versions.  Cannot find a way to make orc work in Java 6.  Michal is going to skip tests for Orc under Java6.

PUBDEV-1612: orc parser.  Added more printings to aid debugging.

PUBDEV-1612: orc parser.  Added more printing to test harness.

PUBDEV-1612: orc parser.  Fixed bug in HDFS test: looking for the wrong warning string.

PUBDEV-1612: orc parser.  Copy test from pyunit to HDFS.

PUBDEV-1612: orc parser.  Fixed bug in dataset path.

PUBDEV-1612: orc parser.  Fixed test harness bug.

PUBDEV-1612: orc parser.  Done translating and debugging all Pyunit tests to HDFS!  Yeah.

PUBDEV-1612: orc parser.  Implemented Michal method to detect early version of hive-exec.

PUBDEV-1612: orc parser.  Added provisions in test_hdfs to not fail test but skip it if the hive-exec version is too old.

PUBDEV-1612: orc parser.  Fixed bugs in hive-exec version checking.

PUBDEV-1612: orc parser.  Completed adding all hive-exec version checks to all hdfs ORC parser tests.

PUBDEV-1612: orc parser.  Removed h2o frame built to test hive-exec version.  Some hadoop versions do not like this.

PUBDEV-1612: orc parser.  Changed cannary file to be orc_split_elim_orc which contains decimal and will throw an error for earlier hive-exec versions.

PUBDEV-1612: orc parser.  Add hive-exec version check inside orcparser.java

PUBDEV-1612: orc parser.  Remove the hive check in java side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/130)
<!-- Reviewable:end -->
