### PR TITLE
PUBDEV-3288: ORC file format now supported

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -44,7 +44,7 @@ H2O currently supports the following file types:
 - XLST
 - Avro (without multifile parsing or column type modification)
 
-*Note that ORC parsing in H2O using Python is only supported over HDFS. 
+*Note that ORC is available only if H2O is running as Hadoop job. 
 
 
 New Users

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -44,7 +44,7 @@ H2O currently supports the following file types:
 - XLST
 - Avro (without multifile parsing or column type modification)
 
-*Note that ORC is available only if H2O is running as Hadoop job. 
+*Note that ORC is available only if H2O is running as a Hadoop job. 
 
 
 New Users

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -31,6 +31,21 @@ The `Recommended Systems <http://www.h2o.ai/product/recommended-systems-for-h2o/
    `Sparkling Water <https://github.com/h2oai/sparkling-water>`__.
 
 
+Supported File Formats
+----------------------
+
+H2O currently supports the following file types:
+
+- CSV (delimited) files
+- ORC*
+- SVMLite
+- ARFF
+- XLS
+- XLST
+- Avro (without multifile parsing or column type modification)
+
+*Note that ORC parsing in H2O using Python is only supported over HDFS. 
+
 
 New Users
 ---------


### PR DESCRIPTION
PUBDEV 1612 introduces ORC parsing support. I was going to add this to the list of supported file formats in the User Guide, but I needed to create that list first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/132)
<!-- Reviewable:end -->
