### PR TITLE
Initial implementation of Parquet Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ ext {
       project(':h2o-bindings'),
       project(':h2o-avro-parser'),
       project(':h2o-orc-parser'),
+      project(':h2o-parquet-parser')
     ]
 
     javaProjects = [
@@ -71,6 +72,7 @@ ext {
       project(':h2o-bindings'),
       project(':h2o-avro-parser'),
       project(':h2o-orc-parser'),
+      project(':h2o-parquet-parser')
     ]
 
     scalaProjects = [

--- a/h2o-assembly/build.gradle
+++ b/h2o-assembly/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   if (project.hasProperty("doIncludeOrc") && project.doIncludeOrc == "true") {
     compile project(":h2o-orc-parser")
   }
+  compile project(":h2o-parquet-parser")
   compile "org.slf4j:slf4j-log4j12:1.7.5"
 }
 

--- a/h2o-core/src/main/java/water/parser/FVecParseReader.java
+++ b/h2o-core/src/main/java/water/parser/FVecParseReader.java
@@ -32,4 +32,5 @@ public class FVecParseReader implements ParseReader {
   @Override public long getGlobalByteOffset(){
     return _goffset;
   }
+  public Chunk getChunk() { return _chk; }
 }

--- a/h2o-core/src/main/java/water/parser/FVecParseReader.java
+++ b/h2o-core/src/main/java/water/parser/FVecParseReader.java
@@ -32,5 +32,11 @@ public class FVecParseReader implements ParseReader {
   @Override public long getGlobalByteOffset(){
     return _goffset;
   }
+  /**
+   * Exposes directly the underlying chunk. This function is safe to be used only
+   * in implementations of Parsers that cannot be used in a streaming context.
+   * Use with caution.
+   * @return underlying Chunk
+   */
   public Chunk getChunk() { return _chk; }
 }

--- a/h2o-hadoop/assemblyjar.gradle
+++ b/h2o-hadoop/assemblyjar.gradle
@@ -36,6 +36,7 @@ dependencies {
       transitive = false
     }
   }
+  compile(project(":h2o-parquet-parser"))
 }
 
 

--- a/h2o-parsers/h2o-parquet-parser/build.gradle
+++ b/h2o-parsers/h2o-parquet-parser/build.gradle
@@ -1,0 +1,33 @@
+//
+// H2O Parquet Parser
+//
+description = "H2O Parquet Parser"
+
+def parquetHadoopVersion = binding.variables.get("hadoopVersion") ?
+  binding.variables.get("hadoopVersion") : defaultHadoopClientVersion
+
+dependencies {
+  compile project(":h2o-core")
+  // Parquet support
+  // Use the same version as Spark 1.5-2.0
+  compile("org.apache.parquet:parquet-hadoop:1.7.0")
+  compile("org.apache.parquet:parquet-avro:1.7.0")
+  compile("org.apache.hadoop:hadoop-common:$parquetHadoopVersion") {
+    transitive = false
+  }
+
+  testCompile "junit:junit:${junitVersion}"
+  testCompile project(path: ":h2o-core", configuration: "testArchives")
+  // We need correct version of MapRe Hadoop to run JUnits
+  testCompile("org.apache.hadoop:hadoop-client:$parquetHadoopVersion")
+}
+
+apply from: "${rootDir}/gradle/dataCheck.gradle"
+
+test {
+  dependsOn ":h2o-core:testJar"
+  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+
+  // Defeat task 'test' by running no tests.
+  exclude '**'
+}

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/org/apache/parquet/hadoop/VecParquetReader.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/org/apache/parquet/hadoop/VecParquetReader.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import org.apache.parquet.avro.AvroReadSupport;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.MetadataFilter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+import water.fvec.Vec;
+import water.parser.parquet.VecDataInputStream;
+import water.parser.parquet.VecFileSystem;
+import water.util.Log;
+
+import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
+import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
+
+/**
+ * Implementation of Parquet Reader working on H2O's Vecs.
+ *
+ * Note: This class was derived from Parquet's ParquetReader implementation. We cannot directly
+ * use the original implementation because it uses Hadoop FileSystem to access source data (and also Parquet summary files),
+ * it uses its own parallel implementation for reading metadata information which doesn't fit into H2O's architecture.
+ * We need to keep this class in package "org.apache.parquet.hadoop" to get access to Parquet's InternalParquetRecordReader.
+ */
+public class VecParquetReader implements Closeable {
+
+  private static ParquetMetadataConverter converter = new ParquetMetadataConverter();
+
+  private final Vec vec;
+  private final ParquetMetadata metadata;
+
+  private InternalParquetRecordReader<GenericRecord> reader;
+
+  public VecParquetReader(Vec vec, ParquetMetadata metadata) {
+    this.vec = vec;
+    this.metadata = metadata;
+  }
+
+  /**
+   * @return the next record or null if finished
+   * @throws IOException
+   */
+  public GenericRecord read() throws IOException {
+    try {
+      if (reader == null) {
+        initReader();
+      }
+      assert reader != null;
+      if (reader.nextKeyValue()) {
+        return reader.getCurrentValue();
+      } else {
+        return null;
+      }
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private void initReader() throws IOException {
+    assert reader == null;
+    List<BlockMetaData> blocks = metadata.getBlocks();
+    MessageType fileSchema = metadata.getFileMetaData().getSchema();
+    reader = new InternalParquetRecordReader<>(new AvroReadSupport<GenericRecord>());
+    Configuration conf = VecFileSystem.makeConfiguration(vec);
+    reader.initialize(fileSchema, metadata.getFileMetaData().getKeyValueMetaData(), VecFileSystem.VEC_PATH, blocks, conf);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (reader != null) {
+      reader.close();
+    }
+  }
+
+  public static ParquetMetadata readFooter(Vec vec, MetadataFilter filter) {
+    FSDataInputStream f = null;
+    try {
+      f = new FSDataInputStream(new VecDataInputStream(vec));
+      final int FOOTER_LENGTH_SIZE = 4;
+      if (vec.length() < MAGIC.length + FOOTER_LENGTH_SIZE + MAGIC.length) { // MAGIC + data + footer + footerIndex + MAGIC
+        throw new RuntimeException("Vec doesn't represent a Parquet data (too short)");
+      }
+      long footerLengthIndex = vec.length() - FOOTER_LENGTH_SIZE - MAGIC.length;
+      f.seek(footerLengthIndex);
+      int footerLength = readIntLittleEndian(f);
+      byte[] magic = new byte[MAGIC.length];
+      f.readFully(magic);
+      if (!Arrays.equals(MAGIC, magic)) {
+        throw new RuntimeException("Vec is not a Parquet file. expected magic number at tail " +
+                Arrays.toString(MAGIC) + " but found " + Arrays.toString(magic));
+      }
+      long footerIndex = footerLengthIndex - footerLength;
+      if (footerIndex < MAGIC.length || footerIndex >= footerLengthIndex) {
+        throw new RuntimeException("corrupted file: the footer index is not within the Vec");
+      }
+      f.seek(footerIndex);
+      return converter.readParquetMetadata(f, filter);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read Parquet metadata", e);
+    } finally {
+      try {
+        if (f != null) f.close();
+      } catch (Exception e) {
+        Log.warn("Failed to close Vec data input stream", e);
+      }
+    }
+  }
+
+}

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParser.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParser.java
@@ -1,0 +1,169 @@
+package water.parser.parquet;
+
+import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.VecParquetReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import water.Job;
+import water.Key;
+
+import water.fvec.ByteVec;
+import water.fvec.Chunk;
+import water.fvec.Vec;
+import water.parser.*;
+import water.parser.parquet.compat.AvroUtil;
+import water.util.Log;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Parquet parser for H2O distributed parsing subsystem.
+ *
+ * The implementation relies on Avro compatibility layer. We use Parquet's support to read data as Avro's
+ * GenericRecords and re-use the existing Avro parser implementation to store the data to Chunks.
+ */
+public class ParquetParser extends Parser {
+
+  ParquetParser(ParseSetup setup, Key<Job> jobKey) {
+    super(setup, jobKey);
+  }
+
+  @Override
+  protected final ParseWriter parseChunk(int cidx, ParseReader din, ParseWriter dout) {
+    if (! (din instanceof FVecParseReader)) {
+      // TODO: Should we modify the interface to expose the underlying chunk for non-streaming parsers?
+      throw new IllegalStateException("We only accept parser readers backed by a Vec (no streaming support!).");
+    }
+    Chunk chunk = ((FVecParseReader) din).getChunk();
+    Vec vec = chunk.vec();
+    // extract metadata, we want to read only the row groups that have centers in this chunk
+    ParquetMetadataConverter.MetadataFilter chunkFilter = ParquetMetadataConverter.range(
+            chunk.start(), chunk.start() + chunk.len());
+    ParquetMetadata metadata = VecParquetReader.readFooter(vec, chunkFilter);
+    if (metadata.getBlocks().isEmpty()) {
+      Log.trace("Chunk #", cidx, " doesn't contain any Parquet block center.");
+      return dout;
+    }
+    Log.info("Processing ", metadata.getBlocks().size(), " blocks of chunk #", cidx);
+    VecParquetReader reader = new VecParquetReader(vec, metadata);
+    try {
+      GenericRecord record;
+      while ((record = reader.read()) != null) {
+        write2frame(record, AvroUtil.flatSchema(record.getSchema()), dout);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to parse records", e);
+    }
+    return dout;
+  }
+
+  // TODO: Extracted from Avro parser with minor modifications, we need custom Parquet parser
+  private static void write2frame(GenericRecord gr, Schema.Field[] inSchema, ParseWriter dout) {
+    BufferedString bs = new BufferedString();
+    for (int cIdx = 0; cIdx < inSchema.length; cIdx++) {
+      int inputFieldIdx = inSchema[cIdx].pos();
+      Schema.Type inputType = AvroUtil.toPrimitiveType(inSchema[cIdx].schema());
+      Object value = gr.get(inputFieldIdx);
+      if (value == null) {
+        dout.addInvalidCol(cIdx);
+      } else {
+        switch (inputType) {
+          case BOOLEAN:
+            dout.addNumCol(cIdx, ((Boolean) value) ? 1 : 0);
+            break;
+          case INT:
+            dout.addNumCol(cIdx, ((Integer) value), 0);
+            break;
+          case LONG:
+            dout.addNumCol(cIdx, ((Long) value), 0);
+            break;
+          case FLOAT:
+            dout.addNumCol(cIdx, (Float) value);
+            break;
+          case DOUBLE:
+            dout.addNumCol(cIdx, (Double) value);
+            break;
+          case ENUM:
+            // Note: this code expects ordering of categoricals provided by Avro remain same
+            // as in H2O!!!
+            GenericData.EnumSymbol es = (GenericData.EnumSymbol) value;
+            dout.addNumCol(cIdx, es.getSchema().getEnumOrdinal(es.toString()));
+            break;
+          case BYTES:
+            dout.addStrCol(cIdx, bs.set(((ByteBuffer) value).array()));
+            break;
+          case STRING:
+            dout.addStrCol(cIdx, bs.set(((String) value).getBytes()));
+            break;
+          case NULL:
+            dout.addInvalidCol(cIdx);
+            break;
+        }
+      }
+    }
+  }
+
+  public static ParseSetup guessSetup(ByteVec vec, byte[] bits) {
+    if (bits.length < MAGIC.length) {
+      return null;
+    }
+    for (int i = 0; i < MAGIC.length; i++) {
+      if (bits[i] != MAGIC[i]) return null;
+    }
+    // seems like we have a Parquet file
+    List<GenericRecord> records = readFirstRecords(vec, 1);
+    if (records.isEmpty()) {
+      throw new RuntimeException("File is empty, unable to guess setup.");
+    }
+    GenericRecord record = records.get(0);
+    Schema.Field[] fields = AvroUtil.flatSchema(record.getSchema());
+    String[] names = new String[fields.length];
+    byte[] types = new byte[fields.length];
+    String[] example = new String[fields.length];
+    for (int i = 0; i < fields.length; i++) {
+      names[i] = fields[i].name();
+      types[i] = AvroUtil.schemaToColumnType(fields[i].schema());
+      example[i] = String.valueOf(record.get(fields[i].name()));
+    }
+    return new ParseSetup(
+            ParquetParserProvider.PARQUET_INFO, (byte) '|', true, ParseSetup.HAS_HEADER,
+            names.length, names, types, new String[names.length][], null, new String[][] { example }
+    );
+  }
+
+  private static List<GenericRecord> readFirstRecords(ByteVec vec, int cnt) {
+    ParquetMetadata metadata = VecParquetReader.readFooter(vec, ParquetMetadataConverter.NO_FILTER);
+    ParquetMetadata startMetadata = new ParquetMetadata(metadata.getFileMetaData(), Collections.singletonList(findFirstBlock(metadata)));
+    VecParquetReader reader = new VecParquetReader(vec, startMetadata);
+    List<GenericRecord> records = new ArrayList<>(cnt);
+    try {
+      GenericRecord record;
+      while ((records.size() < cnt) && ((record = reader.read()) != null)) {
+        records.add(record);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read the first few records", e);
+    }
+    return records;
+  }
+
+  private static BlockMetaData findFirstBlock(ParquetMetadata metadata) {
+    BlockMetaData firstBlockMeta = metadata.getBlocks().get(0);
+    for (BlockMetaData meta : metadata.getBlocks()) {
+      if (firstBlockMeta.getStartingPos() < firstBlockMeta.getStartingPos()) {
+        firstBlockMeta = meta;
+      }
+    }
+    return firstBlockMeta;
+  }
+
+}

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
@@ -1,0 +1,42 @@
+package water.parser.parquet;
+
+import water.Job;
+import water.Key;
+import water.fvec.ByteVec;
+import water.parser.DefaultParserProviders;
+import water.parser.ParseSetup;
+import water.parser.Parser;
+import water.parser.ParserInfo;
+import water.parser.ParserProvider;
+
+/**
+ * Parquet parser provider.
+ */
+public class ParquetParserProvider extends ParserProvider {
+
+  /* Setup for this parser */
+  static ParserInfo PARQUET_INFO = new ParserInfo("PARQUET", DefaultParserProviders.MAX_CORE_PRIO + 30, true, true);
+
+  @Override
+  public ParserInfo info() {
+    return PARQUET_INFO;
+  }
+
+  @Override
+  public Parser createParser(ParseSetup setup, Key<Job> jobKey) {
+    return new ParquetParser(setup, jobKey);
+  }
+
+  @Override
+  public ParseSetup guessSetup(ByteVec vec, byte[] bits, byte sep, int ncols, boolean singleQuotes,
+                               int checkHeader, String[] columnNames, byte[] columnTypes,
+                               String[][] domains, String[][] naStrings) {
+    return ParquetParser.guessSetup(vec, bits);
+  }
+
+  @Override
+  public ParseSetup createParserSetup(Key[] inputs, ParseSetup requiredSetup) {
+    return requiredSetup;
+  }
+
+}

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/VecDataInputStream.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/VecDataInputStream.java
@@ -1,0 +1,152 @@
+package water.parser.parquet;
+
+import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.Seekable;
+import water.fvec.Chunk;
+import water.fvec.Vec;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Seekable and PositionedReadable implementation of InputStream backed by a Vec data source.
+ */
+public class VecDataInputStream extends InputStream implements Seekable, PositionedReadable {
+
+  private static final byte[] EMPTY_BUFFER = new byte[0];
+
+  private final Vec _v;
+
+  private byte[] _buffer;
+  private long _offset;
+  private int _pos;
+
+  public VecDataInputStream(Vec v) {
+    this._v = v;
+    flushBuffer(0L);
+  }
+
+  private int buffAvailable() {
+    return _buffer.length - _pos;
+  }
+
+  private long globAvailable() {
+    return _v.length() - (_offset + _pos);
+  }
+
+  private void fetchData(long position) {
+    Chunk chk = _v.chunkForRow(position);
+    _buffer = chk.asBytes();
+    _offset = chk.start();
+    _pos = (int) (position - _offset);
+    assert _buffer.length > 0;
+  }
+
+  private void flushBuffer(long position) {
+    _buffer = EMPTY_BUFFER;
+    _pos = 0;
+    _offset = position;
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (buffAvailable() <= 0) {
+      if (globAvailable() <= 0L) {
+        return -1;
+      }
+      fetchData(_offset + _pos);
+    }
+    return _buffer[_pos++] & 0xff;
+  }
+
+  @Override
+  public int read(byte[] buffer, int offset, int length) throws IOException {
+    int read = read(_offset + _pos, buffer, offset, length);
+    int skipped = (int) skip(read);
+    assert skipped == read;
+    return read;
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    if (n == 0L) {
+      return 0L;
+    }
+    long target = _offset + _pos + n;
+    if (inBuffer(target)) {
+      seekInBuffer(target);
+    } else {
+      if (target > _v.length()) {
+        n -= target - _v.length();
+        target = _v.length();
+      }
+      flushBuffer(target);
+    }
+    return n;
+  }
+
+  @Override
+  public int read(final long position, byte[] buffer, int offset, int length) throws IOException {
+    int loaded = 0;
+    long currentPosition = position;
+    while ((loaded < length) && (currentPosition < _v.length())) {
+      byte[] buff;
+      int pos;
+      if (inBuffer(currentPosition)) {
+        buff = _buffer;
+        pos = (int) (currentPosition - _offset);
+      } else {
+        Chunk chunk = _v.chunkForRow(currentPosition);
+        buff = chunk.asBytes();
+        pos = (int) (currentPosition - chunk.start());
+      }
+      int avail = Math.min(buff.length - pos, length - loaded);
+      System.arraycopy(buff, pos, buffer, offset + loaded, avail);
+      loaded += avail;
+      currentPosition += avail;
+    }
+    return loaded;
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+    int loaded = read(position, buffer, offset, length);
+    if (loaded != length) {
+      throw new EOFException("Reached the end of the Vec while reading into buffer.");
+    }
+  }
+
+  @Override
+  public void readFully(long position, byte[] buffer) throws IOException {
+    readFully(position, buffer, 0, buffer.length);
+  }
+
+  @Override
+  public void seek(long position) throws IOException {
+    if (inBuffer(position)) {
+      seekInBuffer(position);
+    } else {
+      flushBuffer(position);
+    }
+  }
+
+  private void seekInBuffer(long position) {
+    _pos = (int) (position - _offset);
+  }
+
+  private boolean inBuffer(long position) {
+    return (position >= _offset) && (position < _offset + _buffer.length);
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return _offset + _pos;
+  }
+
+  @Override
+  public boolean seekToNewSource(long targetPos) throws IOException {
+    throw new UnsupportedOperationException("Intentionally not implemented");
+  }
+
+}

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/VecFileSystem.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/VecFileSystem.java
@@ -1,0 +1,103 @@
+package water.parser.parquet;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import water.DKV;
+import water.fvec.Vec;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Virtual implementation of a Hadoop FileSystem backed by a Vec.
+ * Instances of this class provide read-only access to a single provided Vec.
+ * The Vec instance is injected using a ContextAwareConfiguration - the Vec object constitutes the context in this case.
+ */
+public class VecFileSystem extends FileSystem {
+
+  private static final String KEY_PROP = "fs.hex.vec.key";
+
+  public static Path VEC_PATH = new Path("hex:/vec");
+
+  private Vec _v;
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void initialize(URI name, Configuration conf) throws IOException {
+    String keyStr = conf.get(KEY_PROP);
+    if (keyStr == null) {
+      throw new IllegalArgumentException("Configuration needs to a reference to a Vec (set property 'fs.hex.vec.key').");
+    }
+    _v = DKV.getGet(keyStr);
+    super.initialize(name, conf);
+  }
+
+  @Override
+  public URI getUri() {
+    return URI.create("hex:/");
+  }
+
+  @Override
+  public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+    if (! f.equals(VEC_PATH)) {
+      throw new IllegalArgumentException("Invalid path specified, expected " + VEC_PATH);
+    }
+    return new FSDataInputStream(new VecDataInputStream(_v));
+  }
+
+  @Override
+  public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite, int bufferSize, short replication, long blockSize, Progressable progress) throws IOException {
+    throw new UnsupportedOperationException("This is a virtual file system backed by a single Vec, 'create' not supported!");
+  }
+
+  @Override
+  public FSDataOutputStream append(Path f, int bufferSize, Progressable progress) throws IOException {
+    throw new UnsupportedOperationException("This is a virtual file system backed by a single Vec, 'append' not supported!");
+  }
+
+  @Override
+  public boolean rename(Path src, Path dst) throws IOException {
+    throw new UnsupportedOperationException("This is a virtual file system backed by a single Vec, 'rename' not supported!");
+  }
+
+  @Override
+  public boolean delete(Path f, boolean recursive) throws IOException {
+    throw new UnsupportedOperationException("This is a virtual file system backed by a single Vec, 'delete' not supported!");
+  }
+
+  @Override
+  public FileStatus[] listStatus(Path f) throws IOException {
+    return new FileStatus[0];
+  }
+
+  @Override
+  public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+    throw new UnsupportedOperationException("This is a virtual file system backed by a single Vec, 'mkdirs' not supported!");
+  }
+
+  @Override
+  public void setWorkingDirectory(Path newDir) {
+
+  }
+
+  @Override
+  public Path getWorkingDirectory() {
+    return null;
+  }
+
+  @Override
+  public FileStatus getFileStatus(Path f) throws IOException {
+    return null;
+  }
+
+  public static Configuration makeConfiguration(Vec v) {
+    Configuration conf = new Configuration(false);
+    conf.setBoolean("fs.hex.impl.disable.cache", true);
+    conf.setClass("fs.hex.impl", VecFileSystem.class, FileSystem.class);
+    conf.set("fs.hex.vec.key", v._key.toString());
+    return conf;
+  }
+
+}

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/compat/AvroUtil.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/compat/AvroUtil.java
@@ -1,0 +1,159 @@
+package water.parser.parquet.compat;
+
+import org.apache.avro.Schema;
+import water.fvec.Vec;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utilities to work with Avro schema.
+ *
+ * TODO: This file was copied from Avro Parser module and is meant to be removed when we have native Parquet support.
+ */
+public final class AvroUtil {
+
+  /** Return true if the given schema can be transformed
+   * into h2o type.
+   *
+   * @param s  avro field schema
+   * @return  true if the schema can be transformed into H2O type
+   */
+  public static boolean isSupportedSchema(Schema s) {
+    Schema.Type typ =  s.getType();
+    switch (typ) {
+      case BOOLEAN:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case ENUM:
+      case STRING:
+      case NULL:
+      case BYTES:
+        return true;
+      case UNION: // Flattenize the union
+        List<Schema> unionSchemas = s.getTypes();
+        if (unionSchemas.size() == 1) {
+          return isSupportedSchema(unionSchemas.get(0));
+        } else if (unionSchemas.size() == 2) {
+          Schema s1 = unionSchemas.get(0);
+          Schema s2 = unionSchemas.get(1);
+          return s1.getType().equals(Schema.Type.NULL) && isSupportedSchema(s2)
+                 || s2.getType().equals(Schema.Type.NULL) && isSupportedSchema(s1);
+        }
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Transform Avro schema into H2O type.
+   *
+   * @param s  avro schema
+   * @return  a byte representing H2O column type
+   * @throws IllegalArgumentException  if schema is not supported
+   */
+  public static byte schemaToColumnType(Schema s) {
+    Schema.Type typ =  s.getType();
+    switch (typ) {
+      case BOOLEAN:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        return Vec.T_NUM;
+      case ENUM:
+        return Vec.T_CAT;
+      case STRING:
+        return Vec.T_STR;
+      case NULL:
+        return Vec.T_BAD;
+      case BYTES:
+        return Vec.T_STR;
+      case UNION: // Flattenize the union
+        List<Schema> unionSchemas = s.getTypes();
+        if (unionSchemas.size() == 1) {
+          return schemaToColumnType(unionSchemas.get(0));
+        } else if (unionSchemas.size() == 2) {
+          Schema s1 = unionSchemas.get(0);
+          Schema s2 = unionSchemas.get(1);
+          if (s1.getType().equals(Schema.Type.NULL)) return schemaToColumnType(s2);
+          else if (s2.getType().equals(Schema.Type.NULL)) return schemaToColumnType(s1);
+        }
+      default:
+        throw new IllegalArgumentException("Unsupported Avro schema type: " + s);
+    }
+  }
+
+  public static String[] getDomain(Schema fieldSchema) {
+    if (fieldSchema.getType() == Schema.Type.ENUM) {
+      return fieldSchema.getEnumSymbols().toArray(new String[] {});
+    } else if (fieldSchema.getType() == Schema.Type.UNION) {
+      List<Schema> unionSchemas = fieldSchema.getTypes();
+      if (unionSchemas.size() == 1) {
+        return getDomain(unionSchemas.get(0));
+      } else if (unionSchemas.size() == 2) {
+        Schema s1 = unionSchemas.get(0);
+        Schema s2 = unionSchemas.get(1);
+        if (s1.getType() == Schema.Type.NULL) return getDomain(s2);
+        else if (s2.getType() == Schema.Type.NULL) return getDomain(s1);
+      }
+    }
+    throw new IllegalArgumentException("Cannot get domain from field: " + fieldSchema);
+  }
+
+  /**
+   * Transform Avro schema into its primitive representation.
+   *
+   * @param s  avro schema
+   * @return  primitive type as a result of transformation
+   * @throws IllegalArgumentException if the schema has no primitive transformation
+   */
+  public static Schema.Type toPrimitiveType(Schema s) {
+    Schema.Type typ = s.getType();
+    switch(typ) {
+      case BOOLEAN:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case ENUM:
+      case STRING:
+      case NULL:
+      case BYTES:
+        return typ;
+      case UNION:
+        List<Schema> unionSchemas = s.getTypes();
+        if (unionSchemas.size() == 1) {
+          return toPrimitiveType(unionSchemas.get(0));
+        } else if (unionSchemas.size() == 2) {
+          Schema s1 = unionSchemas.get(0);
+          Schema s2 = unionSchemas.get(1);
+          if (s1.getType().equals(Schema.Type.NULL)) return toPrimitiveType(s2);
+          else if (s2.getType().equals(Schema.Type.NULL)) return toPrimitiveType(s1);
+        }
+      default:
+        throw new IllegalArgumentException("Unsupported Avro schema type: " + s);
+    }
+  }
+
+  /**
+   * The method "flattenize" the given Avro schema.
+   * @param s  Avro schema
+   * @return  List of supported fields which were extracted from original Schema
+   */
+  public static Schema.Field[] flatSchema(Schema s) {
+    List<Schema.Field> fields = s.getFields();
+    Schema.Field[] flatSchema = new Schema.Field[fields.size()];
+    int cnt = 0;
+    for (Schema.Field f : fields) {
+      if (isSupportedSchema(f.schema())) {
+        flatSchema[cnt] = f;
+        cnt++;
+      }
+    }
+    // Return resized array
+    return cnt != flatSchema.length ? Arrays.copyOf(flatSchema, cnt) : flatSchema;
+  }
+}

--- a/h2o-parsers/h2o-parquet-parser/src/main/resources/META-INF/services/water.parser.ParserProvider
+++ b/h2o-parsers/h2o-parquet-parser/src/main/resources/META-INF/services/water.parser.ParserProvider
@@ -1,0 +1,1 @@
+water.parser.parquet.ParquetParserProvider

--- a/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/ParseTestParquet.java
+++ b/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/ParseTestParquet.java
@@ -1,0 +1,47 @@
+package water.parser.parquet;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.Vec;
+
+/**
+ * Test suite for Parquet parser.
+ */
+public class ParseTestParquet extends TestUtil {
+
+  @BeforeClass
+  static public void setup() { TestUtil.stall_till_cloudsize(1); }
+
+  @Test
+  public void testParseSimple() {
+    Frame parsed = null, expected = null, actual = null;
+    try {
+      parsed = parse_test_file("smalldata/airlines/AirlinesTrain.csv.zip");
+      // convert all categorical vecs to String vec (we don't support categoricals in Parquet parser yet)
+      expected = new Frame();
+      for (String name : parsed.names()) {
+        Vec v = parsed.vec(name);
+        if (v.isCategorical()) {
+          v = v.toStringVec();
+        }
+        expected.add(name, v);
+      }
+      actual = TestUtil.parse_test_file("smalldata/parser/parquet/airlines-simple.snappy.parquet");
+
+      assertEquals(Arrays.asList(expected._names), Arrays.asList(actual._names));
+      assertTrue(isBitIdentical(expected, actual));
+    } finally {
+      if (parsed != null) parsed.delete();
+      if (expected != null) expected.delete();
+      if (actual != null) actual.delete();
+    }
+  }
+
+}

--- a/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/VecDataInputStreamTest.java
+++ b/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/VecDataInputStreamTest.java
@@ -1,0 +1,146 @@
+package water.parser.parquet;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.DKV;
+import water.Key;
+import water.MRTask;
+import water.TestUtil;
+import water.fvec.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class VecDataInputStreamTest extends TestUtil {
+
+  @BeforeClass
+  static public void setup() { TestUtil.stall_till_cloudsize(1); }
+
+  @Test
+  public void testReadVecAsInputStream() throws Exception {
+    Vec v0 = Vec.makeCon(0.0d, 10000L, 10, true);
+    Vec v = makeRandomByteVec(v0);
+    try {
+      InputStream t = new TestInputStream(v);
+      assertTrue(t.read() >= 0);
+      assertTrue(t.skip(1) >= 0);
+      assertTrue(t.read() >= 0);
+      assertTrue(t.skip(5000) >= 0);
+      assertTrue(t.read() >= 0);
+      assertTrue(t.read(new byte[1333], 33, 67) >= 0);
+      assertTrue(t.skip(100000L) >= 0);
+      assertEquals(-1, t.read()); // reached the end of the stream
+      assertEquals(0, t.available());
+    } finally {
+      if (v0 != null) v0.remove();
+      if (v != null) v.remove();
+    }
+  }
+
+  private static class TestInputStream extends InputStream {
+
+    private InputStream ref;
+    private InputStream tst;
+
+    private TestInputStream(Vec v) {
+      this.ref = new ByteArrayInputStream(chunkBytes(v));
+      this.tst = new VecDataInputStream(v);
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+      byte[] ref_b = Arrays.copyOf(b, b.length);
+      int res = tst.read(b);
+      assertEquals(ref.read(ref_b), res);
+      assertArrayEquals(ref_b, b);
+      return res;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      byte[] ref_b = Arrays.copyOf(b, b.length);
+      int res = tst.read(b, off, len);
+      assertEquals(ref.read(ref_b, off, len), res);
+      assertArrayEquals(ref_b, b);
+      return res;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      long res = tst.skip(n);
+      assertEquals(ref.skip(n), res);
+      return res;
+    }
+
+    @Override
+    public int available() throws IOException {
+      int res = tst.available();
+      assertEquals(ref.available(), res);
+      return res;
+    }
+
+    @Override
+    public int read() throws IOException {
+      int res = tst.read();
+      assertEquals(ref.read(), res);
+      return res;
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+      throw new UnsupportedOperationException("Intentionally not implemented");
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+      throw new UnsupportedOperationException("Intentionally not implemented");
+    }
+
+    @Override
+    public boolean markSupported() {
+      throw new UnsupportedOperationException("Intentionally not implemented");
+    }
+
+    @Override
+    public void close() throws IOException {
+      throw new UnsupportedOperationException("Intentionally not implemented");
+    }
+  }
+
+  private static Vec makeRandomByteVec(Vec blueprint) {
+    final Vec v0 = new Vec(blueprint.group().addVec(), blueprint._rowLayout, null, Vec.T_NUM);
+    final int nchunks = v0.nChunks();
+    new MRTask() {
+      @Override protected void setupLocal() {
+        for( int i=0; i<nchunks; i++ ) {
+          Key k = v0.chunkKey(i);
+          if (k.home()) {
+            int len = (int) (v0.espc()[i + 1] - v0.espc()[i]);
+            byte[] bytes = new byte[len];
+            new Random(i).nextBytes(bytes);
+            DKV.put(k,new C1NChunk(bytes),_fs);
+          }
+        }
+      }
+    }.doAllNodes();
+    DKV.put(v0._key, v0);
+    return v0;
+  }
+
+  private static byte[] chunkBytes(Vec v) {
+    byte[] local = new byte[(int) v.length()];
+    int len = 0;
+    for (int i = 0; i < v.nChunks(); i++) {
+      byte src[] = v.chunkForChunkIdx(i).asBytes();
+      System.arraycopy(src, 0, local, len, src.length);
+      len += src.length;
+    }
+    return local;
+  }
+
+}

--- a/h2o-parsers/h2o-parquet-parser/testMultiNode.sh
+++ b/h2o-parsers/h2o-parquet-parser/testMultiNode.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Clean out any old sandbox, make a new one
+OUTDIR=sandbox
+rm -fr $OUTDIR; mkdir -p $OUTDIR
+
+# Check for os
+SEP=:
+case "`uname`" in
+    CYGWIN* )
+      SEP=";"
+      ;;
+esac
+
+function cleanup () {
+  kill -9 ${PID_1} ${PID_2} ${PID_3} ${PID_4} 1> /dev/null 2>&1
+  wait 1> /dev/null 2>&1
+  RC=`cat $OUTDIR/status.0`
+  if [ $RC -ne 0 ]; then
+    cat $OUTDIR/out.0
+    echo h2o-parquet-parser junit tests FAILED
+  else
+    echo h2o-parquet-parser junit tests PASSED
+  fi
+  exit $RC
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Find java command
+if [ -z "$TEST_JAVA_HOME" ]; then
+  # Use default
+  JAVA_CMD="java"
+else
+  # Use test java home
+  JAVA_CMD="$TEST_JAVA_HOME/bin/java"
+  # Increase XMX since JAVA_HOME can point to java6
+  JAVA6_REGEXP=".*1\.6.*"
+  if [[ $TEST_JAVA_HOME =~ $JAVA6_REGEXP ]]; then
+    JAVA_CMD="${JAVA_CMD}"
+  fi
+fi
+# Gradle puts files:
+#   build/classes/main - Main h2o core classes
+#   build/classes/test - Test h2o core classes
+#   build/resources/main - Main resources (e.g. page.html)
+JVM="nice $JAVA_CMD -ea -Xmx3g -Xms3g -cp build/libs/h2o-parquet-parser-test.jar${SEP}build/libs/h2o-parquet-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../lib/*"
+echo "$JVM" > $OUTDIR/jvm_cmd.txt
+# Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
+# Also, sometimes see test files in the main-class directory, so put the test
+# classpath before the main classpath.
+#JVM="nice java -ea -cp build/classes/test${SEP}build/classes/main${SEP}../h2o-core/build/classes/test${SEP}../h2o-core/build/classes/main${SEP}../lib/*"
+
+# Tests
+# Must run first, before the cloud locks (because it tests cloud locking)
+JUNIT_TESTS_BOOT="<NOTHING>"
+JUNIT_TESTS_BIG="<NOTHING>"
+
+# Runner
+# Default JUnit runner is org.junit.runner.JUnitCore
+JUNIT_RUNNER="water.junit.H2OTestRunner"
+
+# find all java in the src/test directory
+# Cut the "./water/MRThrow.java" down to "water/MRThrow.java"
+# Cut the   "water/MRThrow.java" down to "water/MRThrow"
+# Slash/dot "water/MRThrow"      becomes "water.MRThrow"
+
+# On this h2o-algos testMultiNode.sh only, force the tests.txt to be in the same order for all machines.
+# If sorted, the result of the cd/grep varies by machine. 
+# If randomness is desired, replace sort with the unix 'shuf'
+# Use /usr/bin/sort because of cygwin on windows. 
+# Windows has sort.exe which you don't want. Fails? (is it a lineend issue)
+(cd src/test/java; /usr/bin/find . -name '*.java' | cut -c3- | sed 's/.....$//' | sed -e 's/\//./g') | grep -v $JUNIT_TESTS_BOOT | grep -v $JUNIT_TESTS_BIG | /usr/bin/sort > $OUTDIR/tests.txt
+
+# Output the comma-separated list of ignored/dooonly tests
+# Ignored tests trump do-only tests
+echo $IGNORE > $OUTDIR/tests.ignore.txt
+echo $DOONLY > $OUTDIR/tests.doonly.txt
+
+# Launch 4 helper JVMs.  All output redir'd at the OS level to sandbox files.
+CLUSTER_NAME=junit_cluster_$$
+CLUSTER_BASEPORT=44000
+$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1 2>&1 & PID_1=$!
+$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2 2>&1 & PID_2=$!
+$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3 2>&1 & PID_3=$!
+$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4 2>&1 & PID_4=$!
+
+# Launch last driver JVM.  All output redir'd at the OS level to sandbox files.
+echo Running h2o-parquet-parser junit tests...
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JUNIT_RUNNER `cat $OUTDIR/tests.txt` 2>&1 ; echo $? > $OUTDIR/status.0) 1> $OUTDIR/out.0 2>&1
+
+grep EXECUTION $OUTDIR/out.0 | sed -e "s/.*TEST \(.*\) EXECUTION TIME: \(.*\) (Wall.*/\2 \1/" | sort -gr | head -n 10 >> $OUTDIR/out.0
+
+cleanup

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2742,9 +2742,9 @@ def compare_frame_summary(frame1_summary, frame2_summary, compareNames=False, co
 
             if isinstance(val1, list) or isinstance(val1, dict):
                 if isinstance(val1, dict):
-                    assert cmp(val1, val2) == 0, "failed column summary comparison for column {0} and summary " \
-                                                 "type {1}, frame 1 value is {2}, frame 2 value is " \
-                                                 "{3}".format(col_index, str(key_val), val1, val2)
+                    assert val1 == val2, "failed column summary comparison for column {0} and summary " \
+                                         "type {1}, frame 1 value is {2}, frame 2 value is " \
+                                         "{3}".format(col_index, str(key_val), val1, val2)
                 else:
                     if len(val1) > 0:
                         # find if elements are float
@@ -2764,9 +2764,9 @@ def compare_frame_summary(frame1_summary, frame2_summary, compareNames=False, co
                                                                             "{3}".format(col_index, str(key_val),
                                                                                          val1[ind], val2[ind])
                         else:
-                            assert cmp(val1, val2) == 0, "failed column summary comparison for column {0} and summary" \
-                                                         " type {1}, frame 1 value is {2}, frame 2 value is " \
-                                                         "{3}".format(col_index, str(key_val), val1, val2)
+                            assert val1 == val2, "failed column summary comparison for column {0} and summary" \
+                                                 " type {1}, frame 1 value is {2}, frame 2 value is " \
+                                                 "{3}".format(col_index, str(key_val), val1, val2)
             else:
                 if isinstance(val1, float):
                     assert abs(val1-val2) < 1e-5, "failed column summary comparison for column {0} and summary type " \

--- a/h2o-py/tests/testdir_parser/pyunit_parquet_parser_simple.py
+++ b/h2o-py/tests/testdir_parser/pyunit_parquet_parser_simple.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+
+def parquet_parse_simple():
+    """
+    Tests Parquet parser by comparing the summary of the original csv frame with the h2o parsed Parquet frame.
+    Basic use case of importing files that only have string and numeric columns.
+    :return: None if passed.  Otherwise, an exception will be thrown.
+    """
+    col_types = ["string", "string", "string", "string", "numeric", "numeric", "string", "string", "string", "numeric", "string", "numeric"]
+
+    csv = h2o.import_file(path=pyunit_utils.locate("smalldata/airlines/AirlinesTrain.csv.zip"), col_types=col_types)
+    parquet = h2o.import_file(path=pyunit_utils.locate("smalldata/parser/parquet/airlines-simple.snappy.parquet"), col_types=col_types)
+
+    csv.summary()
+    csv_summary = h2o.frame(csv.frame_id)["frames"][0]["columns"]
+
+    parquet.summary()
+    parquet_summary = h2o.frame(parquet.frame_id)["frames"][0]["columns"]
+
+    pyunit_utils.compare_frame_summary(csv_summary, parquet_summary)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(parquet_parse_simple)
+else:
+    parquet_parse_simple()

--- a/h2o-r/tests/testdir_parser/runit_parquet_parser_simple.R
+++ b/h2o-r/tests/testdir_parser/runit_parquet_parser_simple.R
@@ -1,0 +1,21 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Tests Parquet parser by comparing the summary of the original csv frame with the h2o parsed Parquet frame
+
+test.parseSimple <- function() {
+  col.names <- c("fYear", "fMonth", "fDayofMonth", "fDayOfWeek", "DepTime", "ArrTime", "UniqueCarrier", "Origin", "Dest", "Distance", "IsDepDelayed", "IsDepDelayed_REC")
+  col.types <- c("String", "String", "String", "String", "Numeric", "Numeric", "String", "String", "String", "Numeric", "String", "Numeric")
+  
+  csv.input <- locate("smalldata/airlines/AirlinesTrain.csv.zip")
+  parquet.input <- locate("smalldata/parser/parquet/airlines-simple.snappy.parquet")
+
+  csv = h2o.importFile(csv.input, destination_frame = "csv", col.names = col.names, col.types = col.types, header = TRUE)
+
+  parquet = h2o.importFile(parquet.input, destination_frame = "parquet", col.names = col.names, col.types = col.types)
+
+  expect_equal(dim(csv), dim(parquet))
+  expect_equal(summary(csv, exact_quantiles=TRUE), summary(parquet, exact_quantiles=TRUE))
+}
+
+doTest("Test Parquet parser: simple case - only string/numerical columns", test.parseSimple)

--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.4.45"
+    "h2o-flow": "0.4.47"
   },
   "devDependencies": {}
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ include 'h2o-test-integ'
 include 'h2o-test-accuracy'
 include 'h2o-avro-parser'
 include 'h2o-orc-parser'
+include 'h2o-parquet-parser'
 
 // Reconfigure scala projects to support cross compilation
 // The following code will create two projects for each included item:
@@ -31,7 +32,7 @@ scalaCrossCompile {
 
 // Make structure flat and avoid annoying dummy modules
 rootProject.children.each { project ->
-  if (project.name.equals("h2o-avro-parser") || project.name.equals("h2o-orc-parser")) {
+  if (project.name.startsWith("h2o-") && project.name.endsWith("-parser")) {
     String projectDirName = "h2o-parsers/${project.name}"
     project.projectDir = new File(settingsDir, projectDirName)
   }


### PR DESCRIPTION
The idea is to rely on Avro-compatibility layer in the first version. I purposefully copied few classes from Avro parser (and modified some of them). I don't want to introduce direct dependency on avro-parser.

The goal for the final version is to get rid of avro compatibility layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/136)
<!-- Reviewable:end -->
