### PR TITLE
Expose Kerberos login in Hadoop driver + added convenience not to specify krb.conf

### DIFF
--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -85,6 +85,7 @@ public class h2odriver extends Configured implements Tool {
   static String jksPass = null;
   static boolean hashLogin = false;
   static boolean ldapLogin = false;
+  static boolean kerberosLogin = false;
   static String loginConfFileName = null;
   static String userName = System.getProperty("user.name");
 
@@ -788,6 +789,9 @@ public class h2odriver extends Configured implements Tool {
       else if (s.equals("-ldap_login")) {
         ldapLogin = true;
       }
+      else if (s.equals("-kerberos_login")) {
+        kerberosLogin = true;
+      }
       else if (s.equals("-login_conf")) {
         i++; if (i >= args.length) { usage(); }
         loginConfFileName = args[i];
@@ -1205,6 +1209,9 @@ public class h2odriver extends Configured implements Tool {
     }
     if (ldapLogin) {
       addMapperArg(conf, "-ldap_login");
+    }
+    if (kerberosLogin) {
+      addMapperArg(conf, "-kerberos_login");
     }
     addMapperArg(conf, "-user_name", userName);
 

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -1034,10 +1034,9 @@ public class h2odriver extends Configured implements Tool {
   }
 
   private void addMapperConf(Configuration conf, String name, String value, String payloadFileName) {
-    String payload = "";
     try {
-      byte[] byteArr = readBinaryFile(payloadFileName);
-      payload = convertByteArrToString(byteArr);
+      byte[] payloadData = readBinaryFile(payloadFileName);
+      addMapperConf(conf, name, value, payloadData);
     }
     catch (Exception e) {
       StringBuilder sb = new StringBuilder();
@@ -1049,6 +1048,10 @@ public class h2odriver extends Configured implements Tool {
 
       error(sb.toString());
     }
+  }
+
+  private void addMapperConf(Configuration conf, String name, String value, byte[] payloadData) {
+    String payload = convertByteArrToString(payloadData);
 
     conf.set(h2omapper.H2O_MAPPER_CONF_ARG_BASE + Integer.toString(mapperConfLength), name);
     conf.set(h2omapper.H2O_MAPPER_CONF_BASENAME_BASE + Integer.toString(mapperConfLength), value);
@@ -1227,6 +1230,14 @@ public class h2odriver extends Configured implements Tool {
     }
     if (loginConfFileName != null) {
       addMapperConf(conf, "-login_conf", "login.conf", loginConfFileName);
+    } else if (kerberosLogin) {
+      // Use default Kerberos configuration file
+      final byte[] krbConfData = (
+              "krb5loginmodule {\n" +
+              "     com.sun.security.auth.module.Krb5LoginModule required;\n" +
+              "};"
+      ).getBytes();
+      addMapperConf(conf, "-login_conf", "login.conf", krbConfData);
     }
 
     conf.set(h2omapper.H2O_MAPPER_CONF_LENGTH, Integer.toString(mapperConfLength));


### PR DESCRIPTION
This change adds support to use Kerberos login in hadoop driver directly (without using the indirect way of passing options to H2O using the '-J' option).

It also allows user to omit the kerberos config file (if the user is comfortable with the default).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/140)
<!-- Reviewable:end -->
