### PR TITLE
PUBDEV-3296: In R, allow x to be missing (meaning take all columns except y) for all supervised algo's	

### DIFF
--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -4,6 +4,7 @@
 #' Builds a feed-forward multilayer artificial neural network on an H2OFrame
 #'
 #' @param x A vector containing the \code{character} names of the predictors in the model.
+#'        If x is missing,then all columns except y are used.
 #' @param y The name of the response variable in the model.
 #' @param training_frame An H2OFrame object containing the variables in the model.
 #' @param model_id (Optional) The unique id assigned to the resulting model. If
@@ -222,6 +223,15 @@ h2o.deeplearning <- function(x, y, training_frame,
                              keep_cross_validation_fold_assignment = FALSE
                              )
 {
+
+  #If x is missing, then assume user wants to use all columns as features.
+  if(missing(x)){
+    if(is.numeric(y)){
+      x <- setdiff(col(training_frame),y)
+    }else{
+      x <- setdiff(colnames(training_frame),y)
+    }
+  }
 
   # Training_frame and validation_frame may be a key or an H2OFrame object
   if (!is.H2OFrame(training_frame))

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -7,6 +7,7 @@
 #' enum for "bernoulli" or "multinomial".
 #'
 #' @param x A vector containing the names or indices of the predictor variables to use in building the GBM model.
+#'        If x is missing,then all columns except y are used.
 #' @param y The name or index of the response variable. If the data does not contain a header, this is the column index
 #'        number starting at 0, and increasing from left to right. (The response must be either an integer or a
 #'        categorical variable).
@@ -132,6 +133,14 @@ h2o.gbm <- function(x, y, training_frame,
                     max_abs_leafnode_pred
                     )
 {
+   #If x is missing, then assume user wants to use all columns as features.
+   if(missing(x)){
+     if(is.numeric(y)){
+       x <- setdiff(col(training_frame),y)
+     }else{
+       x <- setdiff(colnames(training_frame),y)
+     }
+   }
   # Required maps for different names params, including deprecated params
   .gbm.map <- c("x" = "ignored_columns",
                 "y" = "response_column")

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -3,6 +3,7 @@
 #' Fit a generalized linear model, specified by a response variable, a set of predictors, and a description of the error distribution.
 #'
 #' @param x A vector containing the names or indices of the predictor variables to use in building the GLM model.
+#'        If x is missing,then all columns except y are used.
 #' @param y A character string or index that represent the response variable in the model.
 #' @param training_frame An H2OFrame object containing the variables in the model.
 #' @param model_id (Optional) The unique id assigned to the resulting model. If none is given, an id will automatically be generated.
@@ -144,6 +145,14 @@ h2o.glm <- function(x, y, training_frame, model_id,
                     max_runtime_secs = 0,
                     missing_values_handling = c("MeanImputation","Skip"))
 {
+  #If x is missing, then assume user wants to use all columns as features.
+  if(missing(x)){
+    if(is.numeric(y)){
+      x <- setdiff(col(training_frame),y)
+    }else{
+      x <- setdiff(colnames(training_frame),y)
+    }
+  }
   # if (!is.null(beta_constraints)) {
   #     if (!inherits(beta_constraints, "data.frame") && !is.H2OFrame(beta_constraints))
   #       stop(paste("`beta_constraints` must be an H2OH2OFrame or R data.frame. Got: ", class(beta_constraints)))

--- a/h2o-r/h2o-package/R/naivebayes.R
+++ b/h2o-r/h2o-package/R/naivebayes.R
@@ -11,6 +11,7 @@
 #' calculation during prediction.
 #'
 #' @param x A vector containing the names or indices of the predictor variables to use in building the model.
+#'        If x is missing,then all columns except y are used.
 #' @param y The name or index of the response variable. If the data does not contain a header, this is the
 #'        column index number starting at 0, and increasing from left to right. The response must be a categorical
 #'        variable with at least two levels.
@@ -66,6 +67,14 @@ h2o.naiveBayes <- function(x, y, training_frame,
                            compute_metrics = TRUE,
                            max_runtime_secs=0)
 {
+   #If x is missing, then assume user wants to use all columns as features.
+   if(missing(x)){
+     if(is.numeric(y)){
+       x <- setdiff(col(training_frame),y)
+     }else{
+       x <- setdiff(colnames(training_frame),y)
+     }
+   }
   # Training_frame may be a key or an H2OFrame object
   if (!is.H2OFrame(training_frame))
     tryCatch(training_frame <- h2o.getFrame(training_frame),

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -3,7 +3,7 @@
 #' Builds a Random Forest Model on an H2OFrame
 #'
 #' @param x A vector containing the names or indices of the predictor variables
-#'        to use in building the RF model.
+#'        to use in building the RF model. If x is missing,then all columns except y are used.
 #' @param y The name or index of the response variable. If the data does not
 #'        contain a header, this is the column index number starting at 1, and
 #'        increasing from left to right. (The response must be either an integer
@@ -108,6 +108,14 @@ h2o.randomForest <- function(x, y, training_frame,
                              histogram_type = c("AUTO","UniformAdaptive","Random","QuantilesGlobal","RoundRobin")
                              )
 {
+  #If x is missing, then assume user wants to use all columns as features.
+  if(missing(x)){
+    if(is.numeric(y)){
+      x <- setdiff(col(training_frame),y)
+    }else{
+      x <- setdiff(colnames(training_frame),y)
+    }
+  }
   # Training_frame and validation_frame may be a key or an H2OFrame object
   if (!is.H2OFrame(training_frame))
     tryCatch(training_frame <- h2o.getFrame(training_frame),


### PR DESCRIPTION
- If parameters x is not provided, then use all columns (except response) as predictors.
- If y is numeric, then take the `setdiff()` of column indexes and y.
- If y is a character, then take the `setdiff()` of columns names and y.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/141)
<!-- Reviewable:end -->
