### PR TITLE
Decentralized control of _compute_algo in H2OEstimator

### DIFF
--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1088,6 +1088,10 @@ class H2ODeepLearningEstimator(H2OEstimator):
     def elastic_averaging_regularization(self, value):
         self._parms["elastic_averaging_regularization"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "deeplearning"
+
 class H2OAutoEncoderEstimator(H2ODeepLearningEstimator):
     """
     Examples

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -5,6 +5,7 @@
 #
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import abc
 import inspect
 import types
 import warnings
@@ -243,19 +244,10 @@ class H2OEstimator(ModelBase):
         H2OEstimator.mixin(self, model_class)
         self.__dict__.update(m.__dict__.copy())
 
-    # TODO: replace with a property which is overriden in subclasses
+    @abc.abstractmethod
     def _compute_algo(self):
-        name = self.__class__.__name__
-        if name == "H2ODeepLearningEstimator": return "deeplearning"
-        if name == "H2OAutoEncoderEstimator": return "deeplearning"
-        if name == "H2OGradientBoostingEstimator": return "gbm"
-        if name == "H2OGeneralizedLinearEstimator": return "glm"
-        if name == "H2OGeneralizedLowRankEstimator": return "glrm"
-        if name == "H2OKMeansEstimator": return "kmeans"
-        if name == "H2ONaiveBayesEstimator": return "naivebayes"
-        if name == "H2ORandomForestEstimator": return "drf"
-        if name == "H2OPCA": return "pca"
-        if name == "H2OSVD": return "svd"
+        """Overridden in subclasses"""
+        return NotImplemented
 
     @staticmethod
     def mixin(obj, cls):

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -5,7 +5,6 @@
 #
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import abc
 import inspect
 import types
 import warnings
@@ -244,10 +243,9 @@ class H2OEstimator(ModelBase):
         H2OEstimator.mixin(self, model_class)
         self.__dict__.update(m.__dict__.copy())
 
-    @abc.abstractmethod
     def _compute_algo(self):
         """Overridden in subclasses"""
-        return NotImplemented
+        raise NotImplementedError()
 
     @staticmethod
     def mixin(obj, cls):

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -603,3 +603,6 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     def max_abs_leafnode_pred(self, value):
         self._parms["max_abs_leafnode_pred"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "gbm"

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -637,3 +637,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         m._resolve_model(model_json["model_id"]["name"], model_json)
         return m
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "glm"
+

--- a/h2o-py/h2o/estimators/glrm.py
+++ b/h2o-py/h2o/estimators/glrm.py
@@ -385,3 +385,7 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
     def max_runtime_secs(self, value):
         self._parms["max_runtime_secs"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "glrm"
+

--- a/h2o-py/h2o/estimators/kmeans.py
+++ b/h2o-py/h2o/estimators/kmeans.py
@@ -228,3 +228,7 @@ class H2OKMeansEstimator(H2OEstimator):
     def max_runtime_secs(self, value):
         self._parms["max_runtime_secs"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "kmeans"
+

--- a/h2o-py/h2o/estimators/naive_bayes.py
+++ b/h2o-py/h2o/estimators/naive_bayes.py
@@ -321,3 +321,7 @@ class H2ONaiveBayesEstimator(H2OEstimator):
     def max_runtime_secs(self, value):
         self._parms["max_runtime_secs"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "naivebayes"
+

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -192,3 +192,7 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     def max_runtime_secs(self, value):
         self._parms["max_runtime_secs"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "pca"
+

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -526,3 +526,7 @@ class H2ORandomForestEstimator(H2OEstimator):
     def histogram_type(self, value):
         self._parms["histogram_type"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "drf"
+

--- a/h2o-py/h2o/estimators/svd.py
+++ b/h2o-py/h2o/estimators/svd.py
@@ -191,3 +191,7 @@ class H2OSingularValueDecompositionEstimator(H2OEstimator):
     def max_runtime_secs(self, value):
         self._parms["max_runtime_secs"] = value
 
+    # overrides superclass
+    def _compute_algo(self):
+        return "svd"
+


### PR DESCRIPTION
Fixed a bug in `H2OEstimator` that prevented use of `H2OPrincipalComponentAnalysisEstimator` (and SVD)
  - There were two bugs where hardcoded strings changed (H2OPCA changed to H2OPrincipalComponentAnalysisEstimator, and SVD also changed)
  - This makes for a more OOP structure in classes

Below is an example of the bug in action:

```
--> 159     model = H2OJob(H2OConnection.post_json("ModelBuilders/"+algo, **kwargs), job_type=(algo+" Model Build"))
    160 
    161     if self._future:

TypeError: cannot concatenate 'str' and 'NoneType' objects
```

This happens because the prior `_compute_algo` method ultimately returned `None` if none of the conditions were met, and since the class name for `H2OPrincipalComponentAnalysisEstimator` changed, this method returned `None` (same with SVD):

    # TODO: replace with a property which is overriden in subclasses
    def _compute_algo(self):
        name = self.__class__.__name__
        if name == "H2ODeepLearningEstimator": return "deeplearning"
        if name == "H2OAutoEncoderEstimator": return "deeplearning"
        if name == "H2OGradientBoostingEstimator": return "gbm"
        if name == "H2OGeneralizedLinearEstimator": return "glm"
        if name == "H2OGeneralizedLowRankEstimator": return "glrm"
        if name == "H2OKMeansEstimator": return "kmeans"
        if name == "H2ONaiveBayesEstimator": return "naivebayes"
        if name == "H2ORandomForestEstimator": return "drf"
        if name == "H2OPCA": return "pca"
        if name == "H2OSVD": return "svd"

My proposed change fixes the bugs as well as taking care of your TODO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/154)
<!-- Reviewable:end -->
