### PR TITLE
HOQE-54: REST_API_REGRESSION_V3.  Fixed change of absolute_MCC to abs…

### DIFF
--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -516,11 +516,17 @@ class H2OBinomialModelMetrics(MetricsBase):
         # make lists out of metrics and thresholds arguments
         if metrics is None and thresholds is None: metrics = ["f1"]
 
+
+
         if isinstance(metrics, list):
+            if 'absolute_MCC' in metrics:   # metrics is a list
+                metrics[metrics.index('absolute_MCC')] = 'absolute_mcc'
             metrics_list = metrics
         elif metrics is None:
             metrics_list = []
         else:
+            if (metrics is not None) and (metrics == 'absolute_MCC'):   # replace element with correct metric name
+                metrics = 'absolute_mcc'
             metrics_list = [metrics]
 
         if isinstance(thresholds, list):
@@ -537,8 +543,8 @@ class H2OBinomialModelMetrics(MetricsBase):
         if not all(m in ["min_per_class_accuracy", "absolute_mcc", "precision", "recall", "specificity", "accuracy",
                          "f0point5", "f2", "f1", "mean_per_class_accuracy"] for m in metrics_list):
             raise ValueError(
-                "The only allowable metrics are min_per_class_accuracy, absolute_mcc, precision, accuracy, f0point5, "
-                "f2, f1, mean_per_class_accuracy")
+                "The only allowable metrics are min_per_class_accuracy, absolute_mcc (or absolute_MCC - deprecated), "
+                "precision, accuracy, f0point5, f2, f1, mean_per_class_accuracy")
 
         # make one big list that combines the thresholds and metric-thresholds
         metrics_thresholds = [self.find_threshold_by_max_metric(m) for m in metrics_list]
@@ -578,6 +584,10 @@ class H2OBinomialModelMetrics(MetricsBase):
         :param metric: A string in {"min_per_class_accuracy", "absolute_mcc", "precision", "recall", "specificity", "accuracy", "f0point5", "f2", "f1", "mean_per_class_accuracy"}
         :return: the threshold at which the given metric is maximum.
         """
+
+        if (metric is not None) and (metric == 'absolute_MCC'):
+            metric = 'absolute_mcc'     # absolute_MCC has been replaced with absolute_mcc now
+
         crit2d = self._metric_json['max_criteria_and_metric_scores']
 
         for e in crit2d.cell_values:


### PR DESCRIPTION
Added support in Python client code to support name change from absolute_MCC to absolute_mcc.  In essence, we will be supporting both names right now in order to be able to be backward compatible with REST API V3.

REST_API_REGRESSION_V3 branch is green.

My personal Jenkins (wendy_jenkins containing the same code) are green except the Junit which changes between green and red.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/155)
<!-- Reviewable:end -->
