### PR TITLE
PUBDEV-3315

### DIFF
--- a/h2o-core/src/main/java/water/fvec/ByteVec.java
+++ b/h2o-core/src/main/java/water/fvec/ByteVec.java
@@ -54,30 +54,44 @@ public class ByteVec extends Vec {
     }
   }
 
-  /** Open a stream view over the underlying data  */
+  /**
+   * Open a stream view over the underlying data
+   */
   public InputStream openStream(final Key job_key) {
-    return new InputStream() {
-      final long [] sz = new long[1];
+    InputStream is = new InputStream() {
+      final long[] sz = new long[1];
       private int _cidx, _pidx, _sz;
       private C1NChunk _c0;
-      @Override public int available() {
-        if( _c0 == null || _sz >= _c0._len) {
-          sz[0] += _c0 != null? _c0._len :0;
-          if( _cidx >= nChunks() ) return 0;
+
+      @Override
+      public int available() {
+        if (_c0 == null || _sz >= _c0._len) {
+          sz[0] += _c0 != null ? _c0._len : 0;
+          if (_cidx >= nChunks()) return 0;
           _c0 = chunkForChunkIdx(_cidx++);
           _sz = C1NChunk._OFF;
           if (job_key != null)
-            Job.update(_c0._len,job_key);
+            Job.update(_c0._len, job_key);
         }
-        return _c0._len -_sz;
+        return _c0._len - _sz;
       }
-      @Override public void close() { _cidx = nChunks(); _c0 = null; _sz = 0;}
-      @Override public int read() throws IOException {
-        return available() == 0 ? -1 : 0xFF&_c0._mem[_sz++];
+
+      @Override
+      public void close() {
+        _cidx = nChunks();
+        _c0 = null;
+        _sz = 0;
       }
-      @Override public int read(byte[] b, int off, int len) {
-        if( b==null ) { // Back-channel read of cidx
-          if ( _cidx > _pidx) { // Remove prev chunk from memory
+
+      @Override
+      public int read() throws IOException {
+        return available() == 0 ? -1 : 0xFF & _c0._mem[_sz++];
+      }
+
+      @Override
+      public int read(byte[] b, int off, int len) {
+        if (b == null) { // Back-channel read of cidx
+          if (_cidx > _pidx) { // Remove prev chunk from memory
             Value v = Value.STORE_get(chunkKey(_pidx++));
             if (v != null && v.isPersisted()) {
               v.freePOJO();           // Eagerly toss from memory
@@ -87,13 +101,19 @@ public class ByteVec extends Vec {
           return _cidx;
         }
         int sz = available();
-        if( sz == 0 )
+        if (sz == 0)
           return -1;
-        len = Math.min(len,sz);
-        System.arraycopy(_c0._mem,_sz,b,off,len);
+        len = Math.min(len, sz);
+        System.arraycopy(_c0._mem, _sz, b, off, len);
         _sz += len;
         return len;
       }
     };
+    try {
+      is.available();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return is;
   }
 }

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -76,7 +76,6 @@ public abstract class Parser extends Iced {
     parseChunk(cidx, din, dout);     // Parse the remaining partial 32K buffer
     return dout;
   }
-
   // ------------------------------------------------------------------------
   // Zipped file; no parallel decompression; decompress into local chunks,
   // parse local chunks; distribute chunks later.


### PR DESCRIPTION
Parse fixes:

1) Fix stream parse. Stream parse branch used for non-parallel parse was broken,  replaced it with unimpl.
2) Parallel Stream parse branch does not require data to be compressed, removed it from the condition.
3) added call to available() to ByteVecStream to initialize it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/159)
<!-- Reviewable:end -->
