### PR TITLE
h2odriver can be used on OS X (for local Hadoop development)

### DIFF
--- a/h2o-hadoop/assemblyjar.gradle
+++ b/h2o-hadoop/assemblyjar.gradle
@@ -45,7 +45,11 @@ def hadoopShadowJarExcludes = ['META-INF/*.DSA',
                             'uploader.properties',
                             'test.properties',
                             'cockpitlite.properties',
-                            'devpay_products.properties']
+                            'devpay_products.properties',
+                            // the license files are excluded for OS X compatibility (this is mainly for development)
+                            // OS X is unable to unpack these files from the jar on filesystem that is not case sensitive
+                            'LICENSE', 'license', 'LICENSE/*', 'license/*', 'META-INF/license', 'META-INF/LICENSE'
+]
 
 shadowJar {
   mergeServiceFiles()


### PR DESCRIPTION
This change enables the h2odriver to be used for local Hadoop development on OS X.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/161)
<!-- Reviewable:end -->
