### PR TITLE
[PUBDEV-3321] Allow arbitrary S3 connection end point/region.

### DIFF
--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -39,7 +39,7 @@ public final class PersistS3 extends Persist {
           try {
             H2OAWSCredentialsProviderChain c = new H2OAWSCredentialsProviderChain();
             ClientConfiguration cc = s3ClientCfg();
-            _s3 = new AmazonS3Client(c, cc);
+            _s3 = configureClient(new AmazonS3Client(c, cc));
           } catch( Throwable e ) {
             e.printStackTrace();
             StringBuilder msg = new StringBuilder();
@@ -299,6 +299,9 @@ public final class PersistS3 extends Persist {
   public final static String S3_MAX_HTTP_CONNECTIONS_PROP = SYSTEM_PROP_PREFIX + "persist.s3.maxHttpConnections";
   /** S3 force HTTP traffic */
   public final static String S3_FORCE_HTTP = SYSTEM_PROP_PREFIX + "persist.s3.force.http";
+  /** S3 end-point, for example: "https://localhost:9000 */
+  public final static String S3_END_POINT = SYSTEM_PROP_PREFIX + "persist.s3.endPoint";
+
 
   static ClientConfiguration s3ClientCfg() {
     ClientConfiguration cfg = new ClientConfiguration();
@@ -310,6 +313,13 @@ public final class PersistS3 extends Persist {
     if (prop.containsKey(S3_FORCE_HTTP)) cfg.setProtocol(Protocol.HTTP);
 
     return cfg;
+  }
+
+  static  AmazonS3Client configureClient(AmazonS3Client s3Client) {
+    if (System.getProperty(S3_END_POINT) != null) {
+      s3Client.setEndpoint(System.getProperty(S3_END_POINT));
+    }
+    return s3Client;
   }
 
   @Override public void delete(Value v) {

--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -14,8 +14,11 @@ import water.util.RIStream;
 import com.amazonaws.*;
 import com.amazonaws.auth.*;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.regions.*;
+import com.amazonaws.regions.Region;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.*;
 
 import com.google.common.io.ByteStreams;
@@ -301,6 +304,12 @@ public final class PersistS3 extends Persist {
   public final static String S3_FORCE_HTTP = SYSTEM_PROP_PREFIX + "persist.s3.force.http";
   /** S3 end-point, for example: "https://localhost:9000 */
   public final static String S3_END_POINT = SYSTEM_PROP_PREFIX + "persist.s3.endPoint";
+  /** S3 region, for example "us-east-1",
+   * see {@link com.amazonaws.regions.Region#getRegion(com.amazonaws.regions.Regions)} for region list */
+  public final static String S3_REGION = SYSTEM_PROP_PREFIX + "persist.s3.region";
+  /** Enable S3 path style access via setting the property to true.
+   * See: {@link com.amazonaws.services.s3.S3ClientOptions#setPathStyleAccess(boolean)} */
+  public final static String S3_ENABLE_PATH_STYLE = SYSTEM_PROP_PREFIX + "persist.s3.enable.path.style";
 
 
   static ClientConfiguration s3ClientCfg() {
@@ -317,7 +326,20 @@ public final class PersistS3 extends Persist {
 
   static  AmazonS3Client configureClient(AmazonS3Client s3Client) {
     if (System.getProperty(S3_END_POINT) != null) {
-      s3Client.setEndpoint(System.getProperty(S3_END_POINT));
+      String endPoint = System.getProperty(S3_END_POINT);
+      Log.debug("S3 endpoint specified: ", endPoint);
+      s3Client.setEndpoint(endPoint);
+    }
+    if (System.getProperty(S3_REGION) != null) {
+      String region = System.getProperty(S3_REGION);
+      Log.debug("S3 region specified: ", region);
+      s3Client.setRegion(RegionUtils.getRegion(region));
+    }
+    if (System.getProperty(S3_ENABLE_PATH_STYLE) != null && Boolean.valueOf(System.getProperty(S3_ENABLE_PATH_STYLE))) {
+      Log.debug("S3 path style access enabled");
+      S3ClientOptions sco = new S3ClientOptions();
+      sco.setPathStyleAccess(true);
+      s3Client.setS3ClientOptions(sco);
     }
     return s3Client;
   }


### PR DESCRIPTION
The fix:
  - exposes system property "sys.ai.h2o.persist.s3.endPoint" which can override default
  S3 connection end point. For example, `java -Dsys.ai.h2o.persist.s3.endPoint="https://localhost:9000" -jar h2o.jar`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/164)
<!-- Reviewable:end -->
