### PR TITLE
PUBDEV-3329: median() should return a list of medians from an entire frame

### DIFF
--- a/h2o-py/tests/testdir_misc/pyunit_space_headers.py
+++ b/h2o-py/tests/testdir_misc/pyunit_space_headers.py
@@ -19,7 +19,7 @@ def space_headers():
 
     h2o_median = f["start station id"].median()
 
-    assert h2o_median == 444, "Expected median for \"start station id\" to be 444, but got {0}".format(h2o_median)
+    assert h2o_median[0] == 444, "Expected median for \"start station id\" to be 444, but got {0}".format(h2o_median)
 
 
 

--- a/h2o-py/tests/testdir_munging/unop/pyunit_median.py
+++ b/h2o-py/tests/testdir_munging/unop/pyunit_median.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+# Test out the h2o.median() functionality
+
+import numpy as np
+
+def med():
+
+
+
+    iris_h2o = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    iris_np = np.genfromtxt(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"),
+                            delimiter=',',
+                            skip_header=1,
+                            usecols=(0, 1, 2, 3))
+
+    med_np = np.median(iris_np, axis=0)
+    med_h2o = iris_h2o.median()
+    for i in range(4):
+        assert abs(med_np[i] - med_h2o[i]) < 1e-10, "expected medians to be the same"
+
+    print("Medians from Numpy: ")
+    print(med_np)
+    print("Medians from H2O: ")
+    print(med_h2o)
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(med)
+else:
+    med()

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -680,6 +680,7 @@ h2o.unique <- function(x) .newExpr("unique", x)
 #' h2o.init()
 #' prosPath <- system.file("extdata", "prostate.csv", package="h2o")
 #' prostate.hex <- h2o.uploadFile(path = prosPath, destination_frame = "prostate.hex")
+#' h2o.median(prostate.hex)
 #' }
 #' @export
 h2o.median <- function(x, na.rm = TRUE) .eval.scalar(.newExpr("median",x,na.rm))

--- a/h2o-r/tests/testdir_docexamples/runit_Rdoc_median.R
+++ b/h2o-r/tests/testdir_docexamples/runit_Rdoc_median.R
@@ -1,0 +1,15 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.rdocmean.golden <- function() {
+
+prosPath <- locate("smalldata/extdata/prostate.csv")
+prostate.hex <- h2o.uploadFile(path = prosPath, destination_frame = "prostate.hex")
+h2o.median(prostate.hex$AGE)
+
+
+}
+
+doTest("R Doc Median", test.rdocmean.golden)

--- a/h2o-r/tests/testdir_munging/unop/runit_median.R
+++ b/h2o-r/tests/testdir_munging/unop/runit_median.R
@@ -1,0 +1,21 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+# Test out the h2o.median() functionality
+
+test.median <- function() {
+  Log.info("Uploading iris/iris_wheader.csv")
+  iris.hex <- h2o.importFile(locate("smalldata/iris/iris_wheader.csv"), "iris_wheader.hex")
+  iris.dat <- read.csv(locate("smalldata/iris/iris_wheader.csv"))
+
+  Log.info("Median of each column: ")
+  for(i in 1:4) {
+    iris_Median <- median(iris.dat[,i])
+    iris_H2Omedian <- h2o.median(iris.hex[,i])
+    Log.info(paste("Column", i, ": Median in R:", iris_Median, "\tMedian in H2O:", iris_H2Omedian))
+    expect_equal(iris_Median, iris_H2Omedian)
+  }
+
+
+}
+
+doTest("Test out the h2o.median() functionality", test.median)


### PR DESCRIPTION
Median now returns a list of medians for each column of a frame.
Relevant unit tests are added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/170)
<!-- Reviewable:end -->
