### PR TITLE
PUBDEV-3334: Conduct rbind and cbind on multiple frames

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1436,13 +1436,17 @@ class H2OFrame(object):
         -------
           Returns this H2OFrame with all frames in data appended column-wise.
         """
-        for frames in data:
-            if not isinstance(frames, H2OFrame):
-                raise ValueError("`frames` must be an H2OFrame, but got {0}".format(type(frames)))
-            fr = H2OFrame._expr(expr=ExprNode("cbind", self, frames), cache=self._ex._cache)
-            self = fr #Update frame with new columns
-        for frames in data:
-            fr._ex._cache.ncols = self.ncol + frames.ncol #Update column count
+        if not isinstance(data,list):
+            fr = H2OFrame._expr(expr=ExprNode("cbind", self, data), cache=self._ex._cache)
+            fr._ex._cache.ncols = self.ncol + data.ncol #Update column count
+        else:
+            for frames in data:
+                if not isinstance(frames, H2OFrame):
+                    raise ValueError("`frames` must be an H2OFrame, but got {0}".format(type(frames)))
+                fr = H2OFrame._expr(expr=ExprNode("cbind", self, frames), cache=self._ex._cache)
+                self = fr #Update frame with new columns
+            for frames in data:
+                fr._ex._cache.ncols = self.ncol + frames.ncol #Update column count
         fr._ex._cache.names = None  # invalidate for possibly duplicate names
         fr._ex._cache.types = None  # invalidate for possibly duplicate names
         return fr
@@ -1460,13 +1464,17 @@ class H2OFrame(object):
         -------
           Returns this H2OFrame with all frames in data appended row-wise.
         """
-        for frames in data:
-            if not isinstance(frames, H2OFrame):
-                raise ValueError("`frames` must be an H2OFrame, but got {0}".format(type(frames)))
-            fr = H2OFrame._expr(expr=ExprNode("rbind", self, frames), cache=self._ex._cache)
-            self = fr #Update frame with new rows
-        for frames in data:
-            fr._ex._cache.nrows = self.nrow + frames.nrow #Update row count
+        if not isinstance(data,list):
+            fr = H2OFrame._expr(expr=ExprNode("rbind", self, data), cache=self._ex._cache)
+            fr._ex._cache.nrows = self.nrow + data.nrow #Update row count
+        else:
+            for frames in data:
+                if not isinstance(frames, H2OFrame):
+                    raise ValueError("`frames` must be an H2OFrame, but got {0}".format(type(frames)))
+                fr = H2OFrame._expr(expr=ExprNode("rbind", self, frames), cache=self._ex._cache)
+                self = fr #Update frame with new rows
+            for frames in data:
+                fr._ex._cache.nrows = self.nrow + frames.nrow #Update row count
         return fr
 
     def split_frame(self, ratios=None, destination_frames=None, seed=None):

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1413,9 +1413,6 @@ class H2OFrame(object):
         """
         if len(frames) == 0:
             raise ValueError("Input list of frames is empty! Nothing to concat.")
-        elif len(frames) == 1:
-            raise ValueError(
-                "Input list of frames is of length one. Better to use cbind or rbind for one frame/column.")
 
         if axis == 1:
             df = self.cbind(frames)

--- a/h2o-py/tests/testdir_munging/slice/pyunit_concat.py
+++ b/h2o-py/tests/testdir_munging/slice/pyunit_concat.py
@@ -8,22 +8,14 @@ def concat():
     df2 = h2o.create_frame(integer_fraction=1,binary_fraction=0,categorical_fraction=0,seed=2)
     df3 = h2o.create_frame(integer_fraction=1,binary_fraction=0,categorical_fraction=0,seed=3)
 
-    print(df1)
-    print(df2)
-    print(df3)
-
     #Frame to Frame concat (column-wise)
     df123 = df1.concat([df2,df3])
     rows, cols = df123.dim
-    print(rows,cols)
-    print(df123)
     assert rows == 10000 and cols == 30, "unexpected dimensions in column concatenation for a Frame"
 
     #Frame to Frame concat (row wise)
     df123_row = df1.concat([df2,df3], axis = 0)
     rows2, cols2 = df123_row.dim
-    print(rows2,cols2)
-    print(df123_row)
     assert rows2 == 30000 and cols2 == 10, "unexpected dimensions in row concatenation for a Frame"
 
     #Frame to Vec concat (column wise)
@@ -31,8 +23,6 @@ def concat():
     zz = df3[0]
     hdf = df1.concat([yy,zz])
     rows3, cols3 = hdf.dim
-    print(rows3,cols3)
-    print(hdf)
     assert rows3 == 10000 and cols3 == 12, "unexpected dimensions in Frame to Vec concatenation"
 
     #Vec to Vec concat (column wise)
@@ -41,8 +31,6 @@ def concat():
     zz = df3[0]
     hdf2 = xx.concat([yy,zz])
     rows4, cols4 = hdf2.dim
-    print(rows4,cols4)
-    print(hdf2)
     assert rows4 == 10000 and cols4 == 3, "unexpected dimensions in Vec to Vec concatenation"
 
     #Frame to Vec concat (row wise)
@@ -50,8 +38,6 @@ def concat():
     zz = df3[0,:]
     hdf3 = df1.concat([yy,zz],axis=0)
     rows5, cols5 = hdf3.dim
-    print(rows5,cols5)
-    print(hdf3)
     assert rows5 == 10002 and cols5 == 10, "unexpected dimensions in Frame to Vec concatenation"
 
     #Vec to Vec concat (row wise)
@@ -60,8 +46,6 @@ def concat():
     zz = df3[0,:]
     hdf4 = xx.concat([yy,zz],axis=0)
     rows6, cols6 = hdf4.dim
-    print(rows6,cols6)
-    print(hdf4)
     assert rows6 == 3 and cols6 == 10, "unexpected dimensions in Vec to Vec concatenation"
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows rbind/cbind on multiple frames.
Also, it will keep an alias function called `concat()` to adhere to Pandas. Python users will most likely look for this function rather than `rbind` or `cbind`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/172)
<!-- Reviewable:end -->
