### PR TITLE
kerb doc edit where java options are now in kerb.conf

### DIFF
--- a/h2o-docs/src/product/security.rst
+++ b/h2o-docs/src/product/security.rst
@@ -368,7 +368,9 @@ Example **kerb.conf**:
 ::
 
     krb5loginmodule {
-         com.sun.security.auth.module.Krb5LoginModule required;
+         com.sun.security.auth.module.Krb5LoginModule required
+         java.security.krb5.realm="0XDATA.LOC"
+         java.security.krb5.kdc="ldap.0xdata.loc";
     };
 
 For more detail about Kerberos configuration:
@@ -392,17 +394,12 @@ The following options are required for Kerberos authentication:
     -user_name <username>
           Override name of user for which access is allowed
 
-The following JVM options must be set:
-
-::
-
-     -Djava.security.krb5.realm=kerberos_realm -Djava.security.krb5.kdc=kdc_server_hostname
 
 Example:
 
 ::
 
-    java  -Djava.security.krb5.realm="0XDATA.LOC" -Djava.security.krb5.kdc="ldap.0xdata.loc" -jar h2o.jar -kerberos_login -login_conf kerb.conf -user_name kerb_principal
+    java -jar h2o.jar -kerberos_login -login_conf kerb.conf -user_name kerb_principal
 
 H2O on Hadoop
 '''''''''''''
@@ -420,14 +417,11 @@ The following options are available:
     -user_name <username>
           Override name of user for which access is allowed
 
-Use the -JJ option flag to send the environment variables to 
-the worker nodes
-
 Example:
 
 ::
 
-    hadoop jar h2odriver.jar -JJ "-Djava.security.krb5.realm=0XDATA.LOC -Djava.security.krb5.kdc=ldap.0xdata.loc" -n 3 -mapperXmx 10g -kerberos_login -login_conf kerb.conf -output hdfsOutputDirectory -user_name kerb_principal
+    hadoop jar h2odriver.jar -n 3 -mapperXmx 10g -kerberos_login -login_conf kerb.conf -output hdfsOutputDirectory -user_name kerb_principal
 
 Sparkling Water
 '''''''''''''''
@@ -444,18 +438,12 @@ The following Spark conf properties exist for Kerberos configuration:
 | spark.ext.h2o.user.name        | Name of user for which access is allowed   |
 +--------------------------------+--------------------------------------------+
 
-Also, spark.driver.extraJavaOptions must be used to configure the
-Kerberos authentication service:
-
-::
-
-    --conf "spark.driver.extraJavaOptions=-Djava.security.krb5.realm=kerberos_realm -Djava.security.krb5.kdc=kdc_server_hostname" 
 
 Example:
 
 ::
 
-    $SPARK_HOME/bin/spark-submit --class water.SparklingWaterDriver --conf spark.ext.h2o.kerberos.login=true --conf spark.ext.h2o.user.name=kerb_principal --conf spark.ext.h2o.login.conf=kerb.conf --conf "spark.driver.extraJavaOptions=-Djava.security.krb5.realm=0XDATA.LOC -Djava.security.krb5.kdc=ldap.0xdata.loc" sparkling-water-assembly-0.2.17-SNAPSHOT-all.jar
+    $SPARK_HOME/bin/spark-submit --class water.SparklingWaterDriver --conf spark.ext.h2o.kerberos.login=true --conf spark.ext.h2o.user.name=kerb_principal --conf spark.ext.h2o.login.conf=kerb.conf sparkling-water-assembly-0.2.17-SNAPSHOT-all.jar
 
 
 LDAP authentication


### PR DESCRIPTION
Now that java options can be placed in the config file, using the kerberos login is alot cleaner. Docs now reflect this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/177)
<!-- Reviewable:end -->
