### PR TITLE
Dynamic Load/Reload Classes

### DIFF
--- a/h2o-core/src/main/java/water/TypeMap.java
+++ b/h2o-core/src/main/java/water/TypeMap.java
@@ -1,10 +1,12 @@
 package water;
 
-import java.util.Arrays;
-
 import water.api.schemas3.*;
 import water.nbhm.NonBlockingHashMap;
 import water.util.Log;
+
+import java.util.Arrays;
+
+import static water.Weaver.classForName;
 
 /** Internal H2O class used to build and maintain the cloud-wide type mapping.
  *  Only public to expose a few constants to subpackages.  No exposed user
@@ -65,11 +67,11 @@ public class TypeMap {
 
   };
   // Class name -> ID mapping
-  static private final NonBlockingHashMap<String, Integer> MAP = new NonBlockingHashMap<>();
+  public static final NonBlockingHashMap<String, Integer> MAP = new NonBlockingHashMap<>();
   // ID -> Class name mapping
   static String[] CLAZZES;
   // ID -> pre-allocated Golden Instance of Icer
-  static private Icer[] GOLD;
+  public static Icer[] GOLD;
   // Unique IDs
   static private int IDS;
   // JUnit helper flag
@@ -199,7 +201,14 @@ public class TypeMap {
       }
     }
   }
+  static void drop(String ice_clz) {
+    Integer I = MAP.get(ice_clz);
+    if( I==null ) return; // no icer, no problem
+    synchronized( TypeMap.class ) {  // install null
+      GOLD[I] = null;
+    }
 
+  }
   static Iced newInstance(int id) { return (Iced) newFreezable(id); }
 
   /** Create a new freezable object based on its unique ID.
@@ -225,13 +234,13 @@ public class TypeMap {
   public static Freezable theFreezable(int id) {
     try {
       Icer f = goForGold(id);
-      return (f==null ? getIcer(id, Class.forName(className(id))) : f).theFreezable();
+      return (f==null ? getIcer(id, classForName(className(id))) : f).theFreezable();
     } catch( ClassNotFoundException e ) {
       throw Log.throwErr(e);
     }
   }
   public static Freezable getTheFreezableOrThrow(int id) throws ClassNotFoundException {
     Icer f = goForGold(id);
-    return (f==null ? getIcer(id, Class.forName(className(id))) : f).theFreezable();
+    return (f==null ? getIcer(id, classForName(className(id))) : f).theFreezable();
   }
 }

--- a/h2o-core/src/main/java/water/TypeMap.java
+++ b/h2o-core/src/main/java/water/TypeMap.java
@@ -67,11 +67,11 @@ public class TypeMap {
 
   };
   // Class name -> ID mapping
-  public static final NonBlockingHashMap<String, Integer> MAP = new NonBlockingHashMap<>();
+  static private final NonBlockingHashMap<String, Integer> MAP = new NonBlockingHashMap<>();
   // ID -> Class name mapping
   static String[] CLAZZES;
   // ID -> pre-allocated Golden Instance of Icer
-  public static Icer[] GOLD;
+  static private Icer[] GOLD;
   // Unique IDs
   static private int IDS;
   // JUnit helper flag

--- a/h2o-core/src/main/java/water/Weaver.java
+++ b/h2o-core/src/main/java/water/Weaver.java
@@ -8,7 +8,11 @@ import water.nbhm.UtilUnsafe;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Class to auto-gen serializer delegate classes.  */
 public class Weaver {
@@ -40,6 +44,24 @@ public class Weaver {
   private static final CtClass _dtask, _enum, _serialize;//, _iced, _h2cc, _freezable;
   private static final Unsafe _unsafe = UtilUnsafe.getUnsafe();
 
+  /** Map of class names to their respective loader.
+   * Contains references of the node-local ClassLoaders
+   * so that {@link TypeMap#theFreezable(int)} can make the correct
+   * {@link Class#forName(String, boolean, ClassLoader)} call.
+   */
+  private static final transient Map<String/*className*/,ClassLoader> CLASSLOADERS;
+
+  /** Map of class names to their respective ClassPath instance in
+   * the {@link Weaver#_pool}. Class reloads will prune their classpaths.
+   */
+  private static final transient Map<String/*className*/, ClassPath> CLASSPATHS;
+
+  static Class classForName(String className) throws ClassNotFoundException {
+    ClassLoader c = CLASSLOADERS.get(className);  // was this class dynamically loaded?
+    if( c==null ) return Class.forName(className); // class not dynamically loaded, use Weaver's ClassLoader
+    return Class.forName(className,true,c);
+  }
+
   static {
     try { 
       _pool = ClassPool.getDefault();
@@ -50,22 +72,12 @@ public class Weaver {
 //      _iced = _pool.get("water.Iced");     // Base of serialization
 //      _h2cc = _pool.get("water.H2O$H2OCountedCompleter"); // Base of serialization
 //      _freezable = _pool.get("water.Freezable");      // Base of serialization
+      CLASSLOADERS = new HashMap<>();
+      CLASSPATHS   = new HashMap<>();
 
     } catch( NotFoundException nfe ) { throw new RuntimeException(nfe); }
   }
 
-  /**
-   * Obtain the H2O {@link ClassPool} to help manage classes that are generated
-   * dynamically.
-   *
-   * It is desirable to push classes generated at runtime onto the search path
-   * via {@link ClassPool#insertClassPath(ClassPath)}, so that
-   * {@link Weaver#javassistLoadClass(int, Class)} can attempt to find the class
-   * and generate any {@link Icer}s.
-   *
-   * @return {@link ClassPool}
-   */
-  public static ClassPool getPool() { return _pool; }
 
   public static <T extends Freezable> Icer<T> genDelegate( int id, Class<T> clazz ) {
     Exception e2;
@@ -108,6 +120,74 @@ public class Weaver {
 //    }
 //    return false;
 //  }
+
+  /**
+   * Load/Reload classes defined at runtime.
+   *
+   * Loading classes at runtime is a matter of simply injecting the
+   * new code into the {@link ClassPool}, and then {@link Weaver#javassistLoadClass(int, Class)}
+   * resolves the generation of (de)serializers. In order to reload classes, though,
+   * each dynamically loaded class must have its very own {@link ClassLoader}, and all
+   * previous {@link Icer}s must be removed. In order to maintain cluster-wide coherency
+   * about which classes are loaded, the {@link TypeMap} is likewise updated whenever a class
+   * is reloaded.
+   *
+   * In order to successfully load classes at runtime (for example a subclass of {@link MRTask}),
+   * each node takes the bytecode and class name and puts a new {@link ByteArrayClassPath} onto
+   * {@link Weaver#_pool}'s classpath. Since there is no mechanism for retrieving these
+   * {@link ClassPath} instances later, they are stored in {@link Weaver#CLASSPATHS} so that
+   * reload events can remove the old paths. Similarly, {@link Weaver#CLASSLOADERS} holds on
+   * to the loaders of dynamically created classes so that classes can be reloaded and old
+   * {@link ClassLoader} instances pruned.
+   *
+   * Finally, in order to {@link Weaver#genDelegate(int, Class)} during a class reload, then the
+   * previous {@link Icer} must be {@link CtClass#detach}ed. In addition, the {@link TypeMap#goForGold(int)}
+   * must turn a null for the {@link Icer}.
+   *
+   * @param name class name
+   * @param b bytecode
+   */
+  public static void loadDynamic(final String name, final byte[] b) {
+    Futures fs = new Futures();
+    fs.add(RPC.call(H2O.CLOUD.leader(), new LoadClazz(name,b))).blockForPending(); // leader node loads first
+    new MRTask() {
+      @Override public void setupLocal() {
+        if( H2O.SELF != H2O.CLOUD.leader() ) // already loaded on the leader, load all others
+          new LoadClazz(name,b).compute2();
+      }
+    }.doAllNodes();
+  }
+
+  private static class LoadClazz extends DTask<LoadClazz> {
+    private final String _name;
+    private final byte[] _bytes;
+    LoadClazz(String name, byte[] bytes) { _name=name; _bytes=bytes; }
+    @Override public void compute2() {
+      try {
+        loadClass(_name, _bytes);
+      } catch (NotFoundException e) {
+      } catch (CannotCompileException e) {
+        throw new RuntimeException(e);
+      }
+      tryComplete();
+    }
+    static void loadClass(String name, byte[] bytes) throws NotFoundException, CannotCompileException {
+      ClassPath path;
+      ClassLoader loader;
+      CtClass ctc = _pool.getOrNull(name);
+      if( ctc!=null ) {
+        ctc.defrost();
+        ctc.detach();
+        _pool.get(implClazzName(name)).detach();  // drop the Icer
+        _pool.removeClassPath(CLASSPATHS.get(name));
+        TypeMap.drop(name);  // drop the icer from the typemap
+      }
+      CLASSPATHS.put(name, path=new ByteArrayClassPath(name, bytes));
+      _pool.insertClassPath(path);
+      CLASSLOADERS.put(name, loader = new URLClassLoader(new URL[0], _pool.getClassLoader()));
+      _pool.get(name).toClass(loader);
+    }
+  }
 
   // See if javaassist can find this class, already generated
   private static Class javassistLoadClass(int id, Class iced_clazz) throws CannotCompileException, NotFoundException, InstantiationException, IllegalAccessException, NoSuchFieldException, ClassNotFoundException, InvocationTargetException {

--- a/h2o-core/src/main/java/water/Weaver.java
+++ b/h2o-core/src/main/java/water/Weaver.java
@@ -178,7 +178,8 @@ public class Weaver {
       if( ctc!=null ) {
         ctc.defrost();
         ctc.detach();
-        _pool.get(implClazzName(name)).detach();  // drop the Icer
+        CtClass icer = _pool.getOrNull(implClazzName(name));
+        if( icer!=null ) icer.detach(); // drop the Icer
         _pool.removeClassPath(CLASSPATHS.get(name));
         TypeMap.drop(name);  // drop the icer from the typemap
       }

--- a/h2o-core/src/test/java/water/WeaverPoolTest.java
+++ b/h2o-core/src/test/java/water/WeaverPoolTest.java
@@ -1,15 +1,11 @@
 package water;
 
-import javassist.ByteArrayClassPath;
-import javassist.CannotCompileException;
-import javassist.ClassPool;
-import javassist.NotFoundException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class WeaverPoolTest extends TestUtil {
 
-  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+  @BeforeClass() public static void setup() { stall_till_cloudsize(3); }
 
   @Test public void testGenClass() {
     String name = "A";
@@ -22,31 +18,34 @@ public class WeaverPoolTest extends TestUtil {
       117, 110, 116, 101, 100, 67, 111, 109, 112, 108, 101, 116, 101, 114, 59, 41, 86, 12, 0, 26, 0, 29, 10, 0, 8, 0, 30, 1, 0, 4, 40, 66, 41, 86, 12, 0, 26, 0, 32, 10, 0, 8, 0, 33, 0, 33, 0, 2, 0, 8, 0, 0, 0, 0, 0, 4, 0, 0, 0, 9, 0, 10, 0, 1, 0, 25, 0, 0, 0,
       21, 0, 2, 0, 1, 0, 0, 0, 9, -78, 0, 16, 18, 18, -74, 0, 24, -79, 0, 0, 0, 0, 0, 1, 0, 26, 0, 10, 0, 1, 0, 25, 0, 0, 0, 17, 0, 1, 0, 1, 0, 0, 0, 5, 42, -73, 0, 28, -79, 0, 0, 0, 0, 0, 4, 0, 26, 0, 29, 0, 1, 0, 25, 0, 0, 0, 18, 0, 2, 0, 2, 0, 0, 0, 6, 42,
       43, -73, 0, 31, -79, 0, 0, 0, 0, 0, 4, 0, 26, 0, 32, 0, 1, 0, 25, 0, 0, 0, 18, 0, 2, 0, 2, 0, 0, 0, 6, 42, 27, -73, 0, 34, -79, 0, 0, 0, 0, 0, 1, 0, 5, 0, 0, 0, 2, 0, 6};
-    broadCast(name, bytecode);
-    try {
-      ((MRTask)Class.forName("A").newInstance()).doAllNodes();
-    } catch (ClassNotFoundException e) {
-      e.printStackTrace();
-    } catch (InstantiationException e) {
-      e.printStackTrace();
-    } catch (IllegalAccessException e) {
-      e.printStackTrace();
-    }
+    Weaver.loadDynamic(name, bytecode);
+    runClass(name);
+
+    // now load again
+    Weaver.loadDynamic(name, bytecode);
+    runClass(name);
+
+    byte[] bytecode2 = new byte[]{-54, -2, -70, -66, 0, 0, 0, 51, 0, 35, 1, 0, 1, 65, 7, 0, 1, 1, 0, 16, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 79, 98, 106, 101, 99, 116, 7, 0, 3, 1, 0, 10, 83, 111, 117, 114, 99, 101, 70, 105, 108, 101, 1, 0, 6, 65, 46,
+      106, 97, 118, 97, 1, 0, 12, 119, 97, 116, 101, 114, 47, 77, 82, 84, 97, 115, 107, 7, 0, 7, 1, 0, 10, 115, 101, 116, 117, 112, 76, 111, 99, 97, 108, 1, 0, 3, 40, 41, 86, 1, 0, 16, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 121, 115, 116, 101, 109,
+      7, 0, 11, 1, 0, 3, 111, 117, 116, 1, 0, 21, 76, 106, 97, 118, 97, 47, 105, 111, 47, 80, 114, 105, 110, 116, 83, 116, 114, 101, 97, 109, 59, 12, 0, 13, 0, 14, 9, 0, 12, 0, 15, 1, 0, 30, 116, 104, 101, 115, 101, 32, 115, 99, 104, 110, 111, 122, 98, 101,
+      114, 114, 105, 101, 115, 32, 116, 97, 115, 116, 101, 32, 108, 105, 107, 101, 8, 0, 17, 1, 0, 19, 106, 97, 118, 97, 47, 105, 111, 47, 80, 114, 105, 110, 116, 83, 116, 114, 101, 97, 109, 7, 0, 19, 1, 0, 7, 112, 114, 105, 110, 116, 108, 110, 1, 0, 21, 40,
+      76, 106, 97, 118, 97, 47, 108, 97, 110, 103, 47, 83, 116, 114, 105, 110, 103, 59, 41, 86, 12, 0, 21, 0, 22, 10, 0, 20, 0, 23, 1, 0, 4, 67, 111, 100, 101, 1, 0, 6, 60, 105, 110, 105, 116, 62, 12, 0, 26, 0, 10, 10, 0, 8, 0, 27, 1, 0, 34, 40, 76, 119, 97,
+      116, 101, 114, 47, 72, 50, 79, 36, 72, 50, 79, 67, 111, 117, 110, 116, 101, 100, 67, 111, 109, 112, 108, 101, 116, 101, 114, 59, 41, 86, 12, 0, 26, 0, 29, 10, 0, 8, 0, 30, 1, 0, 4, 40, 66, 41, 86, 12, 0, 26, 0, 32, 10, 0, 8, 0, 33, 0, 33, 0, 2, 0, 8, 0,
+      0, 0, 0, 0, 4, 0, 0, 0, 9, 0, 10, 0, 1, 0, 25, 0, 0, 0, 21, 0, 2, 0, 1, 0, 0, 0, 9, -78, 0, 16, 18, 18, -74, 0, 24, -79, 0, 0, 0, 0, 0, 1, 0, 26, 0, 10, 0, 1, 0, 25, 0, 0, 0, 17, 0, 1, 0, 1, 0, 0, 0, 5, 42, -73, 0, 28, -79, 0, 0, 0, 0, 0, 4, 0, 26, 0, 29,
+      0, 1, 0, 25, 0, 0, 0, 18, 0, 2, 0, 2, 0, 0, 0, 6, 42, 43, -73, 0, 31, -79, 0, 0, 0, 0, 0, 4, 0, 26, 0, 32, 0, 1, 0, 25, 0, 0, 0, 18, 0, 2, 0, 2, 0, 0, 0, 6, 42, 27, -73, 0, 34, -79, 0, 0, 0, 0, 0, 1, 0, 5, 0, 0, 0, 2, 0, 6};
+
+    // reload once more with different bytecode
+    Weaver.loadDynamic(name, bytecode2);
+    runClass(name);
   }
 
-  private static void broadCast(final String name, final byte[] b) {
-    new MRTask() {
-      @Override public void setupLocal() {
-        ClassPool cp = Weaver.getPool();
-        cp.insertClassPath( new ByteArrayClassPath(name,b));
-        try {
-          cp.get(name).toClass();
-        } catch (CannotCompileException e) {
-          e.printStackTrace();
-        } catch (NotFoundException e) {
-          e.printStackTrace();
-        }
-      }
-    }.doAllNodes();
+  private static void runClass(String name) {
+    try {
+      ((MRTask)Weaver.classForName(name).newInstance()).doAllNodes();
+    } catch (ClassNotFoundException e) {
+    } catch (InstantiationException e) {
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
Hello,

This commit allows classes defined at runtime to be loaded/reloaded. For reloading classes, the GOLD array of Icers in TypeMap needs to be mutated (so that Icer's will be regen'd for the same classname). If Class C is being reloaded, its type id (this is the int that the leader node first assigned C) remains the same, but the Icer associated with this id is invalidated, along with any supporting Class definitions from Weaver's ClassPool.

This commit does away with the need for a getter for Weaver's _pool member (as all manipulation can simply be done within the class itself).

There are at least two potential uses of Weaver.loadDynamic, one of them being loop-fused Rapids calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/179)
<!-- Reviewable:end -->
