### PR TITLE
HEXDEV-497.  Merged Gzip Files not read properly.  Added code to read…

### DIFF
--- a/h2o-core/src/main/java/water/fvec/ByteVec.java
+++ b/h2o-core/src/main/java/water/fvec/ByteVec.java
@@ -1,14 +1,13 @@
 package water.fvec;
 
+import water.Job;
+import water.Key;
+import water.Value;
+import water.exceptions.H2OIllegalArgumentException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-
-import water.Key;
-import water.Job;
-import water.exceptions.H2OIllegalArgumentException;
-import water.Value;
-import water.H2O;
 
 /**
  * A vector of plain Bytes.

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -831,17 +831,18 @@ public final class ParseDataset {
           // Zipped file; no parallel decompression;
           InputStream bvs = vec.openStream(_jobKey);
           ZipInputStream zis = new ZipInputStream(bvs);
+
+          if (ZipUtil.isZipDirectory(key)) {  // file is a zip if multiple files
+            zis.getNextEntry();          // first ZipEntry describes the directory
+          }
+
           ZipEntry ze = zis.getNextEntry(); // Get the *FIRST* entry
           // There is at least one entry in zip file and it is not a directory.
           if( ze != null && !ze.isDirectory() )
             _dout[_lo] = streamParse(zis,localSetup, makeDout(localSetup,chunkStartIdx,vec.nChunks()), bvs);
             _errors = _dout[_lo].removeErrors();
-            // check for more files in archive
-            ZipEntry ze2 = zis.getNextEntry();
-            if (ze2 != null && !ze.isDirectory()) {
-              Log.warn("Only single file zip archives are currently supported, only file: "+ze.getName()+" has been parsed.  Remaining files have been ignored.");
-            }
-          else zis.close();       // Confused: which zipped file to decompress
+
+          zis.close();       // Confused: which zipped file to decompress
           chunksAreLocal(vec,chunkStartIdx,key);
           break;
         }

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -258,6 +258,7 @@ public class ParseSetup extends Iced {
    * @return ParseSetup settings from looking at all files
    */
   public static ParseSetup guessSetup( Key[] fkeys, ParseSetup userSetup ) {
+
     //Guess setup of each file and collect results
     GuessSetupTsk t = new GuessSetupTsk(userSetup);
     t.doAll(fkeys).getResult();
@@ -328,11 +329,14 @@ public class ParseSetup extends Iced {
         _empty = false;
 
         // get file size
-        float decompRatio = ZipUtil.decompressionRatio(bv);
-        if (decompRatio > 1.0)
-          _totalParseSize += bv.length() * decompRatio; // estimate file size
-        else  // avoid numerical distortion of file size when not compressed
-          _totalParseSize += bv.length();
+//        float decompRatio = ZipUtil.decompressionRatio(bv);
+//        if (decompRatio > 1.0)
+//          _totalParseSize += bv.length() * decompRatio; // estimate file size
+//        else  // avoid numerical distortion of file size when not compressed
+
+        // since later calculation of chunk size and later number of chunks do not consider the
+        // compression ratio, we should not do that here either.  Quick fix proposed by Tomas.  Sleek!
+        _totalParseSize += bv.length();
 
         // Check for supported encodings
         checkEncoding(bits);

--- a/h2o-core/src/main/java/water/parser/ZipUtil.java
+++ b/h2o-core/src/main/java/water/parser/ZipUtil.java
@@ -1,17 +1,39 @@
 package water.parser;
 
-import java.io.*;
-import java.util.Arrays;
-import java.util.zip.*;
+import water.DKV;
+import water.Iced;
+import water.Key;
+import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.ByteVec;
 import water.fvec.FileVec;
+import water.fvec.Frame;
 import water.util.Log;
 import water.util.UnsafeUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+import static water.fvec.FileVec.getPathForKey;
 
 abstract class ZipUtil {
 
   public enum Compression { NONE, ZIP, GZIP }
 
+  /**
+   * This method will attempt to read the few bytes off a file which will in turn be used
+   * to guess what kind of parsers we should use to parse the file.
+   *
+   * @param bv
+   * @return
+   */
   static byte [] getFirstUnzippedBytes( ByteVec bv ) {
     try {
       byte[] bits = bv.getFirstBytes();
@@ -20,6 +42,104 @@ abstract class ZipUtil {
       Log.debug("Cannot get unzipped bytes from ByteVec!", e);
       return null;
     }
+  }
+
+  /**
+   * This method check if the input argument is a zip directory containing files.
+   *
+   * @param key
+   * @return true if bv is a zip directory containing files, false otherwise.
+   */
+  static boolean isZipDirectory(Key key) {
+    Iced ice = DKV.getGet(key);
+    if (ice == null) throw new H2OIllegalArgumentException("Missing data", "Did not find any data under " +
+            "key " + key);
+    ByteVec bv = (ByteVec) (ice instanceof ByteVec ? ice : ((Frame) ice).vecs()[0]);
+
+    return isZipDirectory(bv);
+  }
+
+  static boolean isZipDirectory(ByteVec bv) {
+    byte[] bits = bv.getFirstBytes();
+    ZipUtil.Compression compressionMethod = guessCompressionMethod(bits);
+    try {
+      if (compressionMethod == Compression.ZIP) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(bits);
+        ZipInputStream zis = new ZipInputStream(bais);
+        ZipEntry ze = zis.getNextEntry(); // Get the *FIRST* entry
+        boolean isDir = ze.isDirectory();
+        zis.close();
+        // There is at least one entry in zip file and it is not a directory.
+        return isDir;
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return false;
+  }
+
+  static ArrayList<String> getFileNames(ByteVec bv) {
+    ArrayList<String> fileList = new ArrayList<String>();
+
+    if (bv instanceof FileVec) {
+      String strPath = getPathForKey(((FileVec) bv)._key);
+
+      try {
+        ZipFile zipFile = new ZipFile(strPath);
+
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+
+        while (entries.hasMoreElements()) {
+          ZipEntry entry = entries.nextElement();
+          if (!entry.isDirectory()) {// add file to list to parse if not a directory.
+            fileList.add(entry.getName());
+          }
+        }
+        zipFile.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    return fileList;
+  }
+
+
+  /**
+   *   When a file is a zip file that contains multiple files, this method will return the decompression ratio.
+   *
+   * @param bv
+   * @return
+   */
+  static float getDecompressionRatio(ByteVec bv) {
+    long totalSize = 0L;
+    long totalCompSize = 0L;
+
+    if (bv instanceof FileVec) {
+      String strPath = getPathForKey(((FileVec) bv)._key);
+
+      try {
+        ZipFile zipFile = new ZipFile(strPath);
+
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+
+        while (entries.hasMoreElements()) {
+          ZipEntry entry = entries.nextElement();
+          if (!entry.isDirectory()) {// add file to list to parse if not a directory.
+            totalSize = totalSize + entry.getSize();
+            totalCompSize = totalCompSize + entry.getCompressedSize();
+          }
+        }
+        zipFile.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    if (totalCompSize == 0) // something is wrong.  Return no compression.
+      return 1;
+    else
+      return totalSize/totalCompSize;
   }
 
   static Compression guessCompressionMethod(byte [] bits) {
@@ -36,11 +156,31 @@ abstract class ZipUtil {
     ZipUtil.Compression cpr = ZipUtil.guessCompressionMethod(zips);
     if (cpr == Compression.NONE )
       return 1; // no compression
-    else {
+    else if (cpr == Compression.ZIP) {
+      ByteArrayInputStream bais = new ByteArrayInputStream(zips);
+      ZipInputStream zis = new ZipInputStream(bais);
+      ZipEntry ze = null; // Get the *FIRST* entry
+
+      try {
+        ze = zis.getNextEntry();
+        boolean isDir = ze.isDirectory();
+
+        if (isDir) {
+          return getDecompressionRatio(bv);
+        } else {
+          byte[] bits = ZipUtil.unzipBytes(zips, cpr, FileVec.DFLT_CHUNK_SIZE);
+          return bits.length / zips.length;
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    } else {
       byte[] bits = ZipUtil.unzipBytes(zips, cpr, FileVec.DFLT_CHUNK_SIZE);
       return bits.length / zips.length;
     }
+    return 1;
   }
+
 
   static byte[] unzipBytes( byte[] bs, Compression cmp, int chkSize ) {
     if( cmp == Compression.NONE ) return bs; // No compression
@@ -52,7 +192,8 @@ abstract class ZipUtil {
         ZipInputStream zis = new ZipInputStream(bais);
         ZipEntry ze = zis.getNextEntry(); // Get the *FIRST* entry
         // There is at least one entry in zip file and it is not a directory.
-        if( ze == null || ze.isDirectory() ) return bs; // Don't crash, ignore file if cannot unzip
+        if( ze == null || ze.isDirectory() )
+          zis.getNextEntry(); // read the next entry which should be a file
         is = zis;
       } else {
         assert cmp == Compression.GZIP;
@@ -83,24 +224,47 @@ abstract class ZipUtil {
     return bs;
   }
 
-  static public int getFileCount(ByteVec bv) {
-    int cnt = 0;
-    byte[] zips = bv.getFirstBytes();
-    ZipUtil.Compression cpr = guessCompressionMethod(zips);
-    if (cpr == Compression.NONE || cpr == Compression.GZIP)
-      cnt = 1;
-    else { //ZIP archives allow multiple files in a single archive
-      try {
-        ZipInputStream zis = new ZipInputStream(bv.openStream(null));
-        ZipEntry ze = zis.getNextEntry(); // Get the *FIRST* entry
-        while (ze != null && !ze.isDirectory()) {
-          cnt++;
-          ze = zis.getNextEntry();
+  /**
+   * This method will read a compressed zip file and return the uncompressed bits so that we can
+   * check the beginning of the file and make sure it does not contain the column names.
+   *
+   * @param bs
+   * @param chkSize
+   * @return
+   */
+  static byte[] unzipForHeader( byte[] bs, int chkSize ) {
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(bs);
+    ZipInputStream zis = new ZipInputStream(bais);
+
+    InputStream is = zis;
+
+    // Now read from the compressed stream
+    int off = 0;
+
+    try {
+      while( off < bs.length ) {
+        int len = 0;
+        len = is.read(bs, off, bs.length - off);
+        if( len < 0 )
+          break;
+        off += len;
+        if( off == bs.length ) { // Dataset is uncompressing alot! Need more space...
+          if( bs.length >= chkSize )
+            break; // Already got enough
+          bs = Arrays.copyOf(bs, bs.length * 2);
         }
-      } catch(IOException ioe) {
-          throw new RuntimeException(ioe);
       }
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-    return cnt;
+
+    try {
+      is.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return bs;
   }
 }

--- a/h2o-core/src/test/java/water/parser/ClientParserZipGzipTest.java
+++ b/h2o-core/src/test/java/water/parser/ClientParserZipGzipTest.java
@@ -1,0 +1,38 @@
+package water.parser;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.TestUtil;
+import water.fvec.Frame;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class ClientParserZipGzipTest extends TestUtil {
+  //
+  // This JUnit test is used to verify that fixes for HEXDEV-497: parsing zip files
+  // is working.  We are only testing it with a small dataset.  More comprehensive tests
+  // can be found with Pyunit tests.
+  //
+
+  @BeforeClass static public void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test public void testBasic() throws IOException {
+
+      // airlines_small_csv.zip is a zip file that contains 4 csv files
+    Frame one_zip_directory = parse_test_file("smalldata/parser/hexdev_497/airlines_small_csv.zip");
+
+      // airlines_small_csv is a folder that contains the 4 csv files not compressed.
+    Frame one_csv_directory = parse_test_file("smalldata/parser/hexdev_497/airlines_small_csv/all_airlines.csv");
+
+      // H2O frames built from both sources should be equal.  Verify that here.
+    assertTrue(TestUtil.isBitIdentical(one_zip_directory, one_csv_directory));
+
+    if (one_zip_directory != null) one_zip_directory.delete();
+    if (one_csv_directory != null) one_csv_directory.delete();
+
+  }
+}

--- a/h2o-py/tests/testdir_parser/pyunit_hexdev_497_import_gzip_airlines.py
+++ b/h2o-py/tests/testdir_parser/pyunit_hexdev_497_import_gzip_airlines.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+# This test is to make sure that we have fixed the following JIRA properly using airlines data:
+# HEXDEV-497: Merged Gzip Files not read properly.
+# I will import the original files and then the zip directory and compare them to see if they are the same.
+
+def import_folder():
+
+  tol_time = 200              # comparing in ms or ns for timestamp columns
+  tol_numeric = 1e-5          # tolerance for comparing other numeric fields
+  numElements2Compare = 0   # choose number of elements per column to compare.  Save test time.
+
+  multi_file_gzip_comp = h2o.import_file(path=pyunit_utils.locate("smalldata/parser/hexdev_497/airlines_small_csv.zip"))
+#  multi_file_csv = h2o.import_file(path=pyunit_utils.locate("smalldata/parser/hexdev_497/airlines_small_csv"))
+  multi_file_csv = h2o.import_file(path=pyunit_utils.locate("smalldata/parser/hexdev_497/airlines_small_csv/all_airlines.csv"))
+
+  # make sure H2O frames built from a zip file of a directory and the original files are the same.
+  assert pyunit_utils.compare_frames(multi_file_csv, multi_file_gzip_comp, numElements2Compare, tol_time, tol_numeric,
+                                     True), "H2O frame parsed from zip directory and unzipped directory are different!"
+
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(import_folder)
+else:
+  import_folder()

--- a/h2o-py/tests/testdir_parser/pyunit_hexdev_497_import_gzip_milsongs_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_hexdev_497_import_gzip_milsongs_large.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+# This test is to make sure that we have fixed the following JIRA properly using milsongs data:
+# HEXDEV-497: Merged Gzip Files not read properly.
+# I will import the original files and then the zip directory and compare them to see if they are the same.
+
+def import_folder():
+
+  tol_time = 200              # comparing in ms or ns
+  tol_numeric = 1e-5          # tolerance for comparing other numeric fields
+  numElements2Compare = 100   # choose number of elements per column to compare.  Save test time.
+
+  # compressed the whole directory of files.
+  multi_file_gzip_comp = h2o.import_file(path=pyunit_utils.locate("bigdata/laptop/parser/hexdev_497/milsongs_csv.zip"))
+
+  # directory containing the gzip version of csv files here.
+  multi_file_csv = h2o.import_file(path=pyunit_utils.locate("bigdata/laptop/parser/hexdev_497/milsongs_csv_gzip"))
+
+  try:
+    # make sure the two agrees
+    assert pyunit_utils.compare_frames(multi_file_csv, multi_file_gzip_comp, numElements2Compare, tol_time,
+                                       tol_numeric, True), "H2O frame parsed from multiple orc and single orc " \
+                                                           "files are different!"
+  except: # in case the files are listed differently, we can always just check to see if the summary agrees.
+    multi_file_gzip_comp.summary()
+    zip_summary = h2o.frame(multi_file_gzip_comp.frame_id)["frames"][0]["columns"]
+
+    multi_file_csv.summary()
+    csv_summary = h2o.frame(multi_file_csv.frame_id)["frames"][0]["columns"]
+    pyunit_utils.compare_frame_summary(zip_summary, csv_summary)
+
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(import_folder)
+else:
+  import_folder()


### PR DESCRIPTION
Summary:

Added code to parse a zip file which is actually a compressed directory of files.  Pyunit tests and JUNIT tests are added to make sure we are actually parsing correctly.

Since the files in the single zip file are parsed in serial, the customer will be better off if they just unzip the file and parse the whole directory instead.

#########################################
… zip file that is compressed from a directory.

HEXDEV-497.  Merged Gzip Files not read properly.   Changed ByteVec.java back to original form.

HEXDEV-497. Parser cannot read zip directory.  Added code and unit tests to enable our parser to parse a zip file that is actually a directory of files.

HEXDEV-497.  Merged Gzip Files not read properly. Incorporate Tomas suggestion to read in the last bit of a chunk at the end of a file.  This fixed the problem I had with reading in large datasets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/180)
<!-- Reviewable:end -->
