### PR TITLE
Fix Parquet Parse test, wait for cloud size 5

### DIFF
--- a/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/ParseTestParquet.java
+++ b/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/ParseTestParquet.java
@@ -17,7 +17,7 @@ import water.fvec.Vec;
 public class ParseTestParquet extends TestUtil {
 
   @BeforeClass
-  static public void setup() { TestUtil.stall_till_cloudsize(1); }
+  static public void setup() { TestUtil.stall_till_cloudsize(5); }
 
   @Test
   public void testParseSimple() {


### PR DESCRIPTION
The Parquet parse test is executed as multi-node test but waits only for cloud of size 1. The test can be executed on a partially formed cloud (3 instead of 5) which results in killing of the cluster and a test failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/183)
<!-- Reviewable:end -->
