### PR TITLE
Added description/overview of H2O

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -91,7 +91,7 @@
       <div class="col-md-4">
         <div class="well well-sm">
           <h3>H2O</h3>
-          <a href="h2o-docs/faq.html#h2o">What is H2O?</a>
+          <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html">What is H2O?</a>
           <br>
           <a href="h2o-docs/index.html">H2O User Guide</a>
           <br>

--- a/h2o-docs/src/product/faq.rst
+++ b/h2o-docs/src/product/faq.rst
@@ -1,16 +1,6 @@
 FAQ
 ===
 
-H2O
----
-
-**What is H2O?**
-
-H2O is an open-source platform for scalable and distributed machine
-learning, and set of algorithms implemented on that platform.
-
---------------
-
 General Troubleshooting Tips
 ----------------------------
 

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -1,6 +1,14 @@
 Welcome to H2O 3
 ==================
 
+H2O is an open source, in-memory, distributed, fast, and scalable machine learning and predictive analytics platform that allows you to build machine learning models on big data and provides easy productionalization of those models in an enterprise environment.
+
+H2O core code is in JAVA. Inside H2O, a Distributed Key/Value store is used to access and reference data, models, objects, etc., across all nodes/machines. The algoritms are implemented in a map reduce style and utilize the JAVA Fork/Join framework. The data is read in parallel and is distributed across the cluster and stored in memory in a columnar format in a compressed way. H2O’s data parser has built-in intelligence to guess the schema of the incoming dataset and supports data ingest from multiple sources in various formats.
+
+H2O’s REST API allows access to all the capabilities of H2O from an external program or script via JSON over HTTP. The Rest API is used by H2O’s web interface (Flow UI), R binding (H2O-R), and Python binding (H2O-Python).
+
+The speed, quality, ease-of-use, and model-deployment for the various cutting edge Supervised and Unsupervised algorithms like Deep Learning, Tree Ensembles, and GLRM make H2O a highly sought after API for big data data science.
+
 Requirements
 ------------
 

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -3,7 +3,7 @@ Welcome to H2O 3
 
 H2O is an open source, in-memory, distributed, fast, and scalable machine learning and predictive analytics platform that allows you to build machine learning models on big data and provides easy productionalization of those models in an enterprise environment.
 
-H2O core code is in JAVA. Inside H2O, a Distributed Key/Value store is used to access and reference data, models, objects, etc., across all nodes/machines. The algoritms are implemented in a map reduce style and utilize the JAVA Fork/Join framework. The data is read in parallel and is distributed across the cluster and stored in memory in a columnar format in a compressed way. H2O’s data parser has built-in intelligence to guess the schema of the incoming dataset and supports data ingest from multiple sources in various formats.
+H2O's core code is written in Java. Inside H2O, a Distributed Key/Value store is used to access and reference data, models, objects, etc., across all nodes and machines. The algorithms are implemented on top of H2O's distributed Map/Reduce framework and utilize the Java Fork/Join framework for multi-threading. The data is read in parallel and is distributed across the cluster and stored in memory in a columnar format in a compressed way. H2O’s data parser has built-in intelligence to guess the schema of the incoming dataset and supports data ingest from multiple sources in various formats.
 
 H2O’s REST API allows access to all the capabilities of H2O from an external program or script via JSON over HTTP. The Rest API is used by H2O’s web interface (Flow UI), R binding (H2O-R), and Python binding (H2O-Python).
 


### PR DESCRIPTION
Currently, the h2o.ai/docs page includes a link to “What is H2O?” This link points to a single sentence in the FAQ. I added some text to the
beginning of the UG that includes a larger description of H2O, and I
removed the tiny FAQ. Finally, I changed the “What is H2O?” link on the h2o.ai/docs page to point to the new Welcome text instead of the FAQ.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/186)
<!-- Reviewable:end -->
