### PR TITLE
Reduce runtime of h2o-algos JUnits by running 5 H2O clusters in parallel. Also run them in single-node mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build.local.conf
 flatfile*
 ice
 pytest_flatfile-*
-sandbox
+sandbox*/
 syn_datasets
 build/
 lib/

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -53,3 +53,17 @@ plugins.withType(org.gradle.api.publish.maven.plugins.MavenPublishPlugin) {
         toPublish javadocJar
     }
 }
+
+
+clean {
+    doLast {
+        def sandboxes = projectDir.list()
+        sandboxes.each { fname ->
+            if (fname.startsWith("sandbox")) {
+                delete file(fname)
+            }
+        }
+    }
+}
+
+

--- a/gradle/multiNodeTesting.gradle
+++ b/gradle/multiNodeTesting.gradle
@@ -1,4 +1,18 @@
 // Actually run the tests by building a cluster of free-running JVMs first.
+task testSingleNode(type: Exec) {
+    dependsOn jar, testJar
+    if (project.hasProperty("java6Convert")) {
+      environment "TEST_JAVA_HOME", System.getenv("JAVA_6_HOME")
+    }
+    environment "PROJECT_NAME", project.name
+    environment "BUILD_DIR", project.buildDir
+
+    def args = ['bash', './testSingleNode.sh']
+    if (project.hasProperty("jacocoCoverage")) {
+        args << 'jacoco'
+    }
+    commandLine args
+}
 task testMultiNode(type: Exec) {
     dependsOn jar, testJar
     if (project.hasProperty("java6Convert")) {

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -22,8 +22,10 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 // level) to files - then scrape the files later for test results.
 test {
   dependsOn ":h2o-core:testJar"
-  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+  dependsOn smalldataCheck, cpLibs, jar, testJar, testSingleNode, testMultiNode
 
   // Defeat task 'test' by running no tests.
   exclude '**'
 }
+
+testMultiNode.shouldRunAfter testSingleNode

--- a/h2o-algos/src/test/java/hex/AAA_PreCloudLock.java
+++ b/h2o-algos/src/test/java/hex/AAA_PreCloudLock.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertFalse;
  */
 public class AAA_PreCloudLock extends TestUtil {
   static boolean testRan = false;
-  static final int CLOUD_SIZE = 5;
+  static final int CLOUD_SIZE = 2;
   static final int PARTIAL_CLOUD_SIZE = 2;
 
   @BeforeClass() public static void setup() { stall_till_cloudsize(CLOUD_SIZE); }

--- a/h2o-algos/src/test/java/hex/AAA_PreCloudLock.java
+++ b/h2o-algos/src/test/java/hex/AAA_PreCloudLock.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertFalse;
  */
 public class AAA_PreCloudLock extends TestUtil {
   static boolean testRan = false;
-  static final int CLOUD_SIZE = 2;
+  static final int CLOUD_SIZE = 4;
   static final int PARTIAL_CLOUD_SIZE = 2;
 
   @BeforeClass() public static void setup() { stall_till_cloudsize(CLOUD_SIZE); }

--- a/h2o-algos/src/test/java/hex/ModelParametersChecksumTest.java
+++ b/h2o-algos/src/test/java/hex/ModelParametersChecksumTest.java
@@ -15,7 +15,7 @@ public class ModelParametersChecksumTest extends TestUtil {
 
   @BeforeClass()
   public static void setup() {
-    stall_till_cloudsize(5);
+    stall_till_cloudsize(1);
   }
 
   @Test

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
@@ -23,7 +23,7 @@ public class DeepLearningAutoEncoderTest extends TestUtil {
   static final String PATH = "smalldata/anomaly/ecg_discord_train.csv"; //first 20 points
   static final String PATH2 = "smalldata/anomaly/ecg_discord_test.csv"; //first 22 points
 
-  @BeforeClass() public static void setup() { stall_till_cloudsize(5); }
+  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
 
   @Test
   public void run() {

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
@@ -51,7 +51,7 @@ public class DeepLearningCheckpointReporting extends TestUtil {
       try { Thread.sleep(1000); } catch( InterruptedException ex ) { } //to avoid rounding issues with printed time stamp (1 second resolution)
 
       DeepLearningModel model = new DeepLearning(p).trainModel().get();
-      long sleepTime = 3; //seconds
+      long sleepTime = 5; //seconds
       try { Thread.sleep(sleepTime*1000); } catch( InterruptedException ex ) { }
 
       // checkpoint restart after sleep

--- a/h2o-algos/src/test/java/hex/glrm/GLRMCategoricalTest.java
+++ b/h2o-algos/src/test/java/hex/glrm/GLRMCategoricalTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ExecutionException;
 
 public class GLRMCategoricalTest extends TestUtil {
   public final double TOLERANCE = 1e-6;
-  @BeforeClass public static void setup() { stall_till_cloudsize(5); }
+  @BeforeClass public static void setup() { stall_till_cloudsize(1); }
 
   private static String colFormat(String[] cols, String format) {
     int[] idx = new int[cols.length];

--- a/h2o-algos/src/test/java/hex/grep/GrepTest.java
+++ b/h2o-algos/src/test/java/hex/grep/GrepTest.java
@@ -12,7 +12,7 @@ import water.fvec.Vec;
 import java.io.File;
 
 public class GrepTest extends TestUtil {
-  @BeforeClass() public static void setup() { stall_till_cloudsize(5); }
+  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
   
   @Test public void testIris() {
     GrepModel kmm = null;

--- a/h2o-algos/src/test/java/hex/kmeans/KMeansTest.java
+++ b/h2o-algos/src/test/java/hex/kmeans/KMeansTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 
 public class KMeansTest extends TestUtil {
   public final double threshold = 1e-6;
-  @BeforeClass() public static void setup() { stall_till_cloudsize(5); }
+  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
   
   // Run KMeans with a given seed, & check all clusters are non-empty
   private static KMeansModel doSeed( KMeansModel.KMeansParameters parms, long seed ) {

--- a/h2o-algos/src/test/java/hex/util/AggregatorTest.java
+++ b/h2o-algos/src/test/java/hex/util/AggregatorTest.java
@@ -108,6 +108,7 @@ public class AggregatorTest extends TestUtil {
   }
 
   @Test public void testAggregatorOneHot() {
+    Scope.enter();
     CreateFrame cf = new CreateFrame();
     cf.rows = 1000;
     cf.cols = 10;
@@ -137,6 +138,7 @@ public class AggregatorTest extends TestUtil {
     output.remove();
     frame.remove();
     agg.remove();
+    Scope.exit();
   }
 
   @Test public void testCovtype() {
@@ -195,6 +197,7 @@ public class AggregatorTest extends TestUtil {
     frame.delete();
   }
 
+  @Ignore
   @Test public void testCovtypeMemberIndices() {
     Frame frame = parse_test_file("smalldata/covtype/covtype.20k.data");
 

--- a/h2o-algos/testMultiNode.sh
+++ b/h2o-algos/testMultiNode.sh
@@ -23,7 +23,7 @@ esac
 function cleanup () {
   kill -9 ${PID_11} ${PID_21} ${PID_31} ${PID_41} ${PID_51} 1> /dev/null 2>&1
   wait 1> /dev/null 2>&1
-  RC="`paste $OUTDIR/status.* | sed 's/\s*//g'`"
+  RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
   if [ "$RC" != "00000" ]; then
     cat $OUTDIR/out.*
     echo h2o-algos junit tests FAILED
@@ -118,11 +118,11 @@ fi
 # Launch last driver JVM.  All output redir'd at the OS level to sandbox files.
 echo Running h2o-algos junit tests...
 
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | sed -n '1~5p'` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.2 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | sed -n '2~5p'` 2>&1 ; echo $? > $OUTDIR/status.2) 1> $OUTDIR/out.2 2>&1 & PID_2=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.3 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | sed -n '3~5p'` 2>&1 ; echo $? > $OUTDIR/status.3) 1> $OUTDIR/out.3 2>&1 & PID_3=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.4 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | sed -n '4~5p'` 2>&1 ; echo $? > $OUTDIR/status.4) 1> $OUTDIR/out.4 2>&1 & PID_4=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.5 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | sed -n '5~5p'` 2>&1 ; echo $? > $OUTDIR/status.5) 1> $OUTDIR/out.5 2>&1 & PID_5=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==0'` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.2 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==1'` 2>&1 ; echo $? > $OUTDIR/status.2) 1> $OUTDIR/out.2 2>&1 & PID_2=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.3 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==2'` 2>&1 ; echo $? > $OUTDIR/status.3) 1> $OUTDIR/out.3 2>&1 & PID_3=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.4 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==3'` 2>&1 ; echo $? > $OUTDIR/status.4) 1> $OUTDIR/out.4 2>&1 & PID_4=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.5 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==4'` 2>&1 ; echo $? > $OUTDIR/status.5) 1> $OUTDIR/out.5 2>&1 & PID_5=$!
 
 wait ${PID_1} ${PID_2} ${PID_3} ${PID_4} ${PID_5} 1> /dev/null 2>&1
 grep EXECUTION $OUTDIR/out.* | sed -e "s/.*TEST \(.*\) EXECUTION TIME: \(.*\) (Wall.*/\2 \1/" | sort -gr | head -n 10 >> $OUTDIR/out.0

--- a/h2o-algos/testMultiNode.sh
+++ b/h2o-algos/testMultiNode.sh
@@ -9,7 +9,7 @@ else
 fi
 
 # Clean out any old sandbox, make a new one
-OUTDIR=sandbox.multi
+OUTDIR=sandbox/multi
 rm -fr $OUTDIR; mkdir -p $OUTDIR
 
 # Check for os
@@ -22,6 +22,8 @@ esac
 
 function cleanup () {
   kill -9 ${PID_11} ${PID_21} ${PID_31} ${PID_41} ${PID_51} 1> /dev/null 2>&1
+  kill -9 ${PID_12} ${PID_22} ${PID_32} ${PID_42} ${PID_52} 1> /dev/null 2>&1
+  kill -9 ${PID_13} ${PID_23} ${PID_33} ${PID_43} ${PID_53} 1> /dev/null 2>&1
   wait 1> /dev/null 2>&1
   RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
   if [ "$RC" != "00000" ]; then
@@ -54,7 +56,7 @@ fi
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
 
-MAX_MEM="-Xmx4g"
+MAX_MEM="-Xmx2500m"
 
 # Check if coverage should be run
 if [ $JACOCO_ENABLED = true ]
@@ -65,7 +67,7 @@ then
 else
     COVERAGE=""
 fi
-JVM="nice $JAVA_CMD $COVERAGE -ea $MAX_MEM -Xms3g -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD $COVERAGE -ea $MAX_MEM -Xms2g -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test
@@ -98,14 +100,24 @@ JUNIT_RUNNER="water.junit.H2OTestRunner"
 echo $IGNORE > $OUTDIR/tests.ignore.txt
 echo $DOONLY > $OUTDIR/tests.doonly.txt
 
-# Launch 4 helper JVMs.  All output redir'd at the OS level to sandbox files.
+# Launch 3 helper JVMs for each of the 5 parallel clouds.  All output redir'd at the OS level to sandbox files.
 CLUSTER_NAME=junit_cluster_$$
 CLUSTER_BASEPORT=44000
 $JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1.1 2>&1 & PID_11=$!
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1.2 2>&1 & PID_12=$!
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1.3 2>&1 & PID_13=$!
 $JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2.1 2>&1 & PID_21=$!
+$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2.2 2>&1 & PID_22=$!
+$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2.3 2>&1 & PID_23=$!
 $JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3.1 2>&1 & PID_31=$!
+$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3.2 2>&1 & PID_32=$!
+$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3.3 2>&1 & PID_33=$!
 $JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4.1 2>&1 & PID_41=$!
+$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4.2 2>&1 & PID_42=$!
+$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4.3 2>&1 & PID_43=$!
 $JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.5.1 2>&1 & PID_51=$!
+$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.5.2 2>&1 & PID_52=$!
+$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.5.3 2>&1 & PID_53=$!
 
 # If coverage is being run, then pass a system variable flag so that timeout limits are increased.
 if [ $JACOCO_ENABLED = true ]

--- a/h2o-algos/testMultiNode.sh
+++ b/h2o-algos/testMultiNode.sh
@@ -102,22 +102,26 @@ echo $DOONLY > $OUTDIR/tests.doonly.txt
 
 # Launch 3 helper JVMs for each of the 5 parallel clouds.  All output redir'd at the OS level to sandbox files.
 CLUSTER_NAME=junit_cluster_$$
-CLUSTER_BASEPORT=44000
-$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1.1 2>&1 & PID_11=$!
-$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1.2 2>&1 & PID_12=$!
-$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1.3 2>&1 & PID_13=$!
-$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2.1 2>&1 & PID_21=$!
-$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2.2 2>&1 & PID_22=$!
-$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2.3 2>&1 & PID_23=$!
-$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3.1 2>&1 & PID_31=$!
-$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3.2 2>&1 & PID_32=$!
-$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3.3 2>&1 & PID_33=$!
-$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4.1 2>&1 & PID_41=$!
-$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4.2 2>&1 & PID_42=$!
-$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4.3 2>&1 & PID_43=$!
-$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.5.1 2>&1 & PID_51=$!
-$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.5.2 2>&1 & PID_52=$!
-$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.5.3 2>&1 & PID_53=$!
+CLUSTER_BASEPORT_1=44000
+CLUSTER_BASEPORT_2=45000
+CLUSTER_BASEPORT_3=46000
+CLUSTER_BASEPORT_4=47000
+CLUSTER_BASEPORT_5=48000
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT_1 -ga_opt_out 1> $OUTDIR/out.1.1 2>&1 & PID_11=$!
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT_1 -ga_opt_out 1> $OUTDIR/out.1.2 2>&1 & PID_12=$!
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT_1 -ga_opt_out 1> $OUTDIR/out.1.3 2>&1 & PID_13=$!
+$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT_2 -ga_opt_out 1> $OUTDIR/out.2.1 2>&1 & PID_21=$!
+$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT_2 -ga_opt_out 1> $OUTDIR/out.2.2 2>&1 & PID_22=$!
+$JVM water.H2O -name $CLUSTER_NAME.2 -baseport $CLUSTER_BASEPORT_2 -ga_opt_out 1> $OUTDIR/out.2.3 2>&1 & PID_23=$!
+$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT_3 -ga_opt_out 1> $OUTDIR/out.3.1 2>&1 & PID_31=$!
+$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT_3 -ga_opt_out 1> $OUTDIR/out.3.2 2>&1 & PID_32=$!
+$JVM water.H2O -name $CLUSTER_NAME.3 -baseport $CLUSTER_BASEPORT_3 -ga_opt_out 1> $OUTDIR/out.3.3 2>&1 & PID_33=$!
+$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT_4 -ga_opt_out 1> $OUTDIR/out.4.1 2>&1 & PID_41=$!
+$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT_4 -ga_opt_out 1> $OUTDIR/out.4.2 2>&1 & PID_42=$!
+$JVM water.H2O -name $CLUSTER_NAME.4 -baseport $CLUSTER_BASEPORT_4 -ga_opt_out 1> $OUTDIR/out.4.3 2>&1 & PID_43=$!
+$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT_5 -ga_opt_out 1> $OUTDIR/out.5.1 2>&1 & PID_51=$!
+$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT_5 -ga_opt_out 1> $OUTDIR/out.5.2 2>&1 & PID_52=$!
+$JVM water.H2O -name $CLUSTER_NAME.5 -baseport $CLUSTER_BASEPORT_5 -ga_opt_out 1> $OUTDIR/out.5.3 2>&1 & PID_53=$!
 
 # If coverage is being run, then pass a system variable flag so that timeout limits are increased.
 if [ $JACOCO_ENABLED = true ]
@@ -130,11 +134,11 @@ fi
 # Launch last driver JVM.  All output redir'd at the OS level to sandbox files.
 echo Running h2o-algos junit tests...
 
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==0'` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.2 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==1'` 2>&1 ; echo $? > $OUTDIR/status.2) 1> $OUTDIR/out.2 2>&1 & PID_2=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.3 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==2'` 2>&1 ; echo $? > $OUTDIR/status.3) 1> $OUTDIR/out.3 2>&1 & PID_3=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.4 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==3'` 2>&1 ; echo $? > $OUTDIR/status.4) 1> $OUTDIR/out.4 2>&1 & PID_4=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.5 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==4'` 2>&1 ; echo $? > $OUTDIR/status.5) 1> $OUTDIR/out.5 2>&1 & PID_5=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT_1 -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==0'` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.2 -Dai.h2o.baseport=$CLUSTER_BASEPORT_2 -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==1'` 2>&1 ; echo $? > $OUTDIR/status.2) 1> $OUTDIR/out.2 2>&1 & PID_2=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.3 -Dai.h2o.baseport=$CLUSTER_BASEPORT_3 -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==2'` 2>&1 ; echo $? > $OUTDIR/status.3) 1> $OUTDIR/out.3 2>&1 & PID_3=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.4 -Dai.h2o.baseport=$CLUSTER_BASEPORT_4 -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==3'` 2>&1 ; echo $? > $OUTDIR/status.4) 1> $OUTDIR/out.4 2>&1 & PID_4=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.5 -Dai.h2o.baseport=$CLUSTER_BASEPORT_5 -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt | awk 'NR%5==4'` 2>&1 ; echo $? > $OUTDIR/status.5) 1> $OUTDIR/out.5 2>&1 & PID_5=$!
 
 wait ${PID_1} ${PID_2} ${PID_3} ${PID_4} ${PID_5} 1> /dev/null 2>&1
 grep EXECUTION $OUTDIR/out.* | sed -e "s/.*TEST \(.*\) EXECUTION TIME: \(.*\) (Wall.*/\2 \1/" | sort -gr | head -n 10 >> $OUTDIR/out.0

--- a/h2o-algos/testMultiNode.sh
+++ b/h2o-algos/testMultiNode.sh
@@ -24,13 +24,14 @@ function cleanup () {
   kill -9 ${PID_11} ${PID_21} ${PID_31} ${PID_41} ${PID_51} 1> /dev/null 2>&1
   wait 1> /dev/null 2>&1
   RC="`paste $OUTDIR/status.* | sed 's/\s*//g'`"
-  if [ $RC != "00000" ]; then
+  if [ "$RC" != "00000" ]; then
     cat $OUTDIR/out.*
     echo h2o-algos junit tests FAILED
+    exit 1
   else
     echo h2o-algos junit tests PASSED
+    exit 0
   fi
-  exit $RC
 }
 
 trap cleanup SIGTERM SIGINT

--- a/h2o-algos/testSingleNode.sh
+++ b/h2o-algos/testSingleNode.sh
@@ -9,7 +9,7 @@ else
 fi
 
 # Clean out any old sandbox, make a new one
-OUTDIR=sandbox.single
+OUTDIR=sandbox/single
 rm -fr $OUTDIR; mkdir -p $OUTDIR
 
 # Check for os
@@ -52,7 +52,7 @@ fi
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
 
-MAX_MEM="-Xmx3g"
+MAX_MEM="-Xmx2200m"
 
 # Check if coverage should be run
 if [ $JACOCO_ENABLED = true ]
@@ -63,7 +63,7 @@ then
 else
     COVERAGE=""
 fi
-JVM="nice $JAVA_CMD $COVERAGE -ea $MAX_MEM -Xms3g -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD $COVERAGE -ea $MAX_MEM -Xms2g -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-algos/testSingleNode.sh
+++ b/h2o-algos/testSingleNode.sh
@@ -22,13 +22,14 @@ esac
 
 function cleanup () {
   RC="`paste $OUTDIR/status.* | sed 's/\s*//g'`"
-  if [ $RC != "00000" ]; then
+  if [ "$RC" != "00000" ]; then
     cat $OUTDIR/out.*
     echo h2o-algos junit tests FAILED
+    exit 1
   else
     echo h2o-algos junit tests PASSED
+    exit 0
   fi
-  exit $RC
 }
 
 trap cleanup SIGTERM SIGINT

--- a/h2o-algos/testSingleNode.sh
+++ b/h2o-algos/testSingleNode.sh
@@ -99,10 +99,6 @@ echo $DOONLY > $OUTDIR/tests.doonly.txt
 # Launch 4 helper JVMs.  All output redir'd at the OS level to sandbox files.
 CLUSTER_NAME=junit_cluster_$$
 CLUSTER_BASEPORT=44000
-#$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.1 2>&1 & PID_1=$!
-#$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.2 2>&1 & PID_2=$!
-#$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.3 2>&1 & PID_3=$!
-#$JVM water.H2O -name $CLUSTER_NAME -baseport $CLUSTER_BASEPORT -ga_opt_out 1> $OUTDIR/out.4 2>&1 & PID_4=$!
 
 # If coverage is being run, then pass a system variable flag so that timeout limits are increased.
 if [ $JACOCO_ENABLED = true ]

--- a/h2o-algos/testSingleNode.sh
+++ b/h2o-algos/testSingleNode.sh
@@ -21,7 +21,7 @@ case "`uname`" in
 esac
 
 function cleanup () {
-  RC="`paste $OUTDIR/status.* | sed 's/\s*//g'`"
+  RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
   if [ "$RC" != "00000" ]; then
     cat $OUTDIR/out.*
     echo h2o-algos junit tests FAILED
@@ -115,11 +115,11 @@ fi
 # Launch last driver JVM.  All output redir'd at the OS level to sandbox files.
 echo Running h2o-algos junit tests...
 
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | sed -n '1~5p'` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.2 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | sed -n '2~5p'` 2>&1 ; echo $? > $OUTDIR/status.2) 1> $OUTDIR/out.2 2>&1 & PID_2=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.3 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | sed -n '3~5p'` 2>&1 ; echo $? > $OUTDIR/status.3) 1> $OUTDIR/out.3 2>&1 & PID_3=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.4 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | sed -n '4~5p'` 2>&1 ; echo $? > $OUTDIR/status.4) 1> $OUTDIR/out.4 2>&1 & PID_4=$!
-($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.5 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | sed -n '5~5p'` 2>&1 ; echo $? > $OUTDIR/status.5) 1> $OUTDIR/out.5 2>&1 & PID_5=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==0'` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.2 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==1'` 2>&1 ; echo $? > $OUTDIR/status.2) 1> $OUTDIR/out.2 2>&1 & PID_2=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.3 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==2'` 2>&1 ; echo $? > $OUTDIR/status.3) 1> $OUTDIR/out.3 2>&1 & PID_3=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.4 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==3'` 2>&1 ; echo $? > $OUTDIR/status.4) 1> $OUTDIR/out.4 2>&1 & PID_4=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.5 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==4'` 2>&1 ; echo $? > $OUTDIR/status.5) 1> $OUTDIR/out.5 2>&1 & PID_5=$!
 
 wait ${PID_1} ${PID_2} ${PID_3} ${PID_4} ${PID_5} 1> /dev/null 2>&1
 grep EXECUTION $OUTDIR/out.* | sed -e "s/.*TEST \(.*\) EXECUTION TIME: \(.*\) (Wall.*/\2 \1/" | sort -gr | head -n 10 >> $OUTDIR/out.0


### PR DESCRIPTION
#<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/189)
<!-- Reviewable:end -->


**Before:** All h2o-algos JUnits run in distributed mode.  There's one 5-node H2O cluster.  Took about 40 minutes on a dual-Xeon server.

11:14:06 Running h2o-algos junit tests...
11:53:15 h2o-algos junit tests PASSED
11:53:15 :h2o-algos:testMultiNode took 2349.323 secs


**Now:** All h2o-algos JUnits run first in single-node mode, and if that passes, then they all run again in distributed mode (4 JVMs). For both cases, there's 5 H2O clusters in parallel.  Takes less than 15 minutes for both.

16:58:16 :h2o-algos:testSingleNode
16:58:16 Running h2o-algos junit tests...
17:01:29 h2o-algos junit tests PASSED
17:01:29 :h2o-algos:testSingleNode took 192.303 secs
17:01:29 :h2o-algos:testMultiNode
17:01:29 Running h2o-algos junit tests...
17:16:06 h2o-algos junit tests PASSED
17:16:06 :h2o-algos:testMultiNode took 877.816 secs

http://172.17.2.151:8080/view/arno/job/arno_junit/445/console


Side-effect of this is that the memory requirements went from 5x3GB to 20x2.5GB, but that should be fine for servers.

Once we create a separate suite for distributed JUnits (hopefully fewer tests), we should be able to reduce the memory requirements again.