### PR TITLE
PUBDEV-3394 Fix gson serialization of raw models

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/RawModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/RawModel.java
@@ -15,7 +15,7 @@ import java.util.zip.ZipFile;
  * Prediction model based on the persisted binary data.
  */
 abstract public class RawModel extends GenModel {
-    protected ContentReader _reader;
+    protected transient ContentReader _reader;
     protected hex.ModelCategory _category;
     protected String _uuid;
     protected boolean _supervised;
@@ -25,7 +25,6 @@ abstract public class RawModel extends GenModel {
     protected double _defaultThreshold;
     protected double[] _priorClassDistrib;
     protected double[] _modelClassDistrib;
-    protected String _offsetColumn;
 
     /**
      * Primary factory method for constructing RawModel instances.


### PR DESCRIPTION
gson serialization didn't work on raw models because of a duplicate field and a circular reference. This fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/194)
<!-- Reviewable:end -->
