### PR TITLE
Add CDH 5.8.0 to list of support Hadoop versions

### DIFF
--- a/h2o-docs/src/product/hadoop.rst
+++ b/h2o-docs/src/product/hadoop.rst
@@ -11,6 +11,7 @@ Currently supported versions:
 -  CDH 5.5.3
 -  CDH 5.6.0
 -  CDH 5.7.0
+-  CDH 5.8.0
 -  HDP 2.1
 -  HDP 2.2
 -  HDP 2.3


### PR DESCRIPTION
Simple fix to list CDH 5.8.0 as a supported Hadoop version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/198)
<!-- Reviewable:end -->
