### PR TITLE
PUBDEV-3401: Make sure parsed Vec has the same #chunks as source Vec

### DIFF
--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -87,7 +87,10 @@ public abstract class Parser extends Iced {
     StreamParseWriter nextChunk = dout;
     int zidx = bvs.read(null,0,0); // Back-channel read of chunk index
     assert zidx==1;
-    while( is.available() > 0 ) {
+    int streamAvailable = is.available();
+    while(streamAvailable > 0) {
+      parseChunk(cidx++, din, nextChunk);
+      streamAvailable = is.available(); // Can (also!) rollover to the next input chunk
       int xidx = bvs.read(null,0,0); // Back-channel read of chunk index
       if( xidx > zidx ) {  // Advanced chunk index of underlying ByteVec stream?
         zidx = xidx;       // Record advancing of chunk
@@ -98,7 +101,6 @@ public abstract class Parser extends Iced {
         }
         nextChunk = nextChunk.nextChunk();
       }
-      parseChunk(cidx++, din, nextChunk);
     }
     parseChunk(cidx, din, nextChunk);     // Parse the remaining partial 32K buffer
     nextChunk.close();

--- a/h2o-core/src/main/java/water/parser/ZipUtil.java
+++ b/h2o-core/src/main/java/water/parser/ZipUtil.java
@@ -83,24 +83,4 @@ abstract class ZipUtil {
     return bs;
   }
 
-  static public int getFileCount(ByteVec bv) {
-    int cnt = 0;
-    byte[] zips = bv.getFirstBytes();
-    ZipUtil.Compression cpr = guessCompressionMethod(zips);
-    if (cpr == Compression.NONE || cpr == Compression.GZIP)
-      cnt = 1;
-    else { //ZIP archives allow multiple files in a single archive
-      try {
-        ZipInputStream zis = new ZipInputStream(bv.openStream(null));
-        ZipEntry ze = zis.getNextEntry(); // Get the *FIRST* entry
-        while (ze != null && !ze.isDirectory()) {
-          cnt++;
-          ze = zis.getNextEntry();
-        }
-      } catch(IOException ioe) {
-          throw new RuntimeException(ioe);
-      }
-    }
-    return cnt;
-  }
 }


### PR DESCRIPTION
Makes sure that we call streamParseWriter.nextChunk anytime the source stream reads a new chunk and that the resulting Vec will have the same number of chunks as the source ByteVec.

The bug was that for a specific input we didn't call nextChunk on the StreamParseWriter when the rollover to the next source chunk happened in is.available() method in the last processed chunk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/211)
<!-- Reviewable:end -->
