### PR TITLE
[PUBDEV-3428] Do not show stack trace when the user cancels a running job

### DIFF
--- a/h2o-py/h2o/exceptions.py
+++ b/h2o-py/h2o/exceptions.py
@@ -9,7 +9,7 @@ All H2O exceptions derive from :class:`H2OError`.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 __all__ = ("H2OStartupError", "H2OConnectionError", "H2OServerError", "H2OResponseError",
-           "H2OValueError", "H2OTypeError")
+           "H2OValueError", "H2OTypeError", "H2OJobCancelled")
 
 
 class H2OError(Exception):
@@ -136,3 +136,16 @@ class H2OServerError(H2OError):
         """
         super(H2OServerError, self).__init__(message)
         self.stacktrace = stacktrace
+
+
+#-----------------------------------------------------------------------------------------------------------------------
+# H2OJobCancelled
+#-----------------------------------------------------------------------------------------------------------------------
+
+class H2OJobCancelled(H2OError):
+    """
+    Raised when the user interrupts a running job.
+
+    By default, this exception will not trigger any output (as if it is caught and ignored), however the user still
+    has an ability to catch this explicitly and perform a custom action.
+    """

--- a/h2o-py/h2o/job.py
+++ b/h2o-py/h2o/job.py
@@ -13,6 +13,7 @@ from __future__ import division, print_function, absolute_import, unicode_litera
 import warnings
 
 import h2o
+from h2o.exceptions import H2OJobCancelled
 from h2o.utils.progressbar import ProgressBar
 from h2o.utils.shared_utils import clamp
 
@@ -65,12 +66,10 @@ class H2OJob(object):
         if self.warnings:
             for w in self.warnings:
                 warnings.warn(w)
-        # TODO: this needs to be thought through more carefully
-        #       Right now if the user presses Ctrl+C the progress bar handles this gracefully and passes the
-        #       exception up, but these calls create ugly stacktrace dumps...
+
         # check if failed... and politely print relevant message
         if self.status == "CANCELLED":
-            raise EnvironmentError("Job with key {} was cancelled by the user.".format(self.job_key))
+            raise H2OJobCancelled("Job<%s> was cancelled by the user." % self.job_key)
         if self.status == "FAILED":
             if (isinstance(self.job, dict)) and ("stacktrace" in list(self.job)):
                 raise EnvironmentError("Job with key {} failed with an exception: {}\nstacktrace: "

--- a/h2o-py/h2o/utils/debugging.py
+++ b/h2o-py/h2o/utils/debugging.py
@@ -13,7 +13,7 @@ import sys
 from colorama import Style, Fore
 from types import ModuleType
 
-from h2o.exceptions import H2OSoftError
+from h2o.exceptions import H2OJobCancelled, H2OSoftError
 from h2o.utils.compatibility import *  # NOQA
 
 # Nothing to import; this module's only job is to install an exception hook for debugging.
@@ -87,6 +87,8 @@ def _except_hook(exc_type, exc_value, exc_tb):
                    frame of the outermost expression being evaluated). We need to walk down the list (by repeatedly
                    moving to exc_tb.tb_next) in order to find the execution frame where the actual exception occurred.
     """
+    if isinstance(exc_value, H2OJobCancelled):
+        return
     if isinstance(exc_value, H2OSoftError):
         _handle_soft_error(exc_type, exc_value, exc_tb)
     else:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/218)
<!-- Reviewable:end -->
