### PR TITLE
order h2o.tail args, docs update, closes PUBDEV-3439

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1428,7 +1428,7 @@ h2o.setLevels <- function(x, levels) .newExpr("setDomain", chk.H2OFrame(x), leve
 #' @name h2o.head
 #' @param x An H2OFrame object.
 #' @param n (Optional) A single integer. If positive, number of rows in x to return. If negative, all but the n first/last number of rows in x.
-#' @param ... Further arguments passed to or from other methods.
+#' @param ... Ignored.
 #' @return An H2OFrame containing the first or last n rows of an H2OFrame object.
 #' @examples
 #' \donttest{
@@ -1456,7 +1456,7 @@ head.H2OFrame <- h2o.head
 
 #' @rdname h2o.head
 #' @export
-h2o.tail <- function(x, ..., n=6L) {
+h2o.tail <- function(x,n=6L,...) {
   endidx <- nrow(x)
   n <- ifelse(n < 0L, max(endidx + n, 0L), min(n, endidx))
   if( n==0L ) head(x,n=0L)


### PR DESCRIPTION
`h2o.head` was already handled in f581d03f1de8d7fc9bdef2af1ef3af94f5a5503a, this updates `h2o.tail` and docs on `...` to reflect the actual state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/221)
<!-- Reviewable:end -->
