### PR TITLE
[PY-3] Implement config file reader

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -7,6 +7,7 @@ h2o -- module for using H2O services.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 import os
 import re
 import warnings
@@ -14,6 +15,7 @@ import warnings
 from h2o.backend import H2OConnection
 from h2o.backend import H2OLocalServer
 from h2o.exceptions import H2OConnectionError, H2OValueError
+from h2o.utils.config import H2OConfigReader
 from h2o.utils.shared_utils import deprecated, gen_header, is_list_of_lists, py_tmp_key, quoted, urlopen
 from h2o.utils.typechecks import assert_is_type, assert_satisfies, BoundInt, BoundNumeric, I, is_type, numeric, U
 from .estimators.deeplearning import H2OAutoEncoderEstimator
@@ -37,7 +39,7 @@ from .utils.compatibility import *  # NOQA
 from .utils.compatibility import PY3
 warnings.simplefilter("always", DeprecationWarning)
 
-
+logging.basicConfig()
 
 h2oconn = None
 
@@ -86,7 +88,6 @@ def connection():
 
 def version_check():
     """Used to verify that h2o-python module and the H2O server are compatible with each other."""
-    if os.environ.get("H2O_DISABLE_STRICT_VERSION_CHECK"): return
     ci = h2oconn.cluster
     if not ci:
         raise H2OConnectionError("Connection not initialized. Did you run h2o.connect()?")
@@ -121,7 +122,7 @@ def version_check():
 
 def init(url=None, ip=None, port=None, https=None, insecure=False, username=None, password=None, cluster_id=None,
          proxy=None, start_h2o=True, nthreads=-1, ice_root=None, enable_assertions=True,
-         max_mem_size=None, min_mem_size=None, strict_version_check=True, **kwargs):
+         max_mem_size=None, min_mem_size=None, strict_version_check=None, **kwargs):
     """
     Attempt to connect to a local server, or if not successful start a new server and connect to it.
 
@@ -160,7 +161,7 @@ def init(url=None, ip=None, port=None, https=None, insecure=False, username=None
     assert_is_type(enable_assertions, bool)
     assert_is_type(max_mem_size, int, str, None)
     assert_is_type(min_mem_size, int, str, None)
-    assert_is_type(strict_version_check, bool)
+    assert_is_type(strict_version_check, bool, None)
     assert_is_type(kwargs, {"proxies": {str: str}, "max_mem_size_GB": int, "min_mem_size_GB": int,
                             "force_connect": bool})
 
@@ -188,6 +189,24 @@ def init(url=None, ip=None, port=None, https=None, insecure=False, username=None
     mmax = get_mem_size(max_mem_size, kwargs.get("max_mem_size_GB"))
     mmin = get_mem_size(min_mem_size, kwargs.get("min_mem_size_GB"))
     auth = (username, password) if username and password else None
+    check_version = True
+
+    # Apply the config file
+    config = H2OConfigReader.get_config()
+    if url is None and ip is None and port is None and https is None and "init.url" in config:
+        url = config["init.url"]
+    if proxy is None and "init.proxy" in config:
+        proxy = config["init.proxy"]
+    if cluster_id is None and "init.cluster_id" in config:
+        cluster_id = int(config["init.cluster_id"])
+    if strict_version_check is None:
+        if "init.check_version" in config:
+            check_version = config["init.check_version"].lower() != "false"
+        elif os.environ.get("H2O_DISABLE_STRICT_VERSION_CHECK"):
+            check_version = False
+    else:
+        check_version = strict_version_check
+
     if not start_h2o:
         print("Warning: if you don't want to start local H2O server, then use of `h2o.connect()` is preferred.")
     if ip and ip != "localhost" and ip != "127.0.0.1" and start_h2o:
@@ -206,7 +225,7 @@ def init(url=None, ip=None, port=None, https=None, insecure=False, username=None
                                   min_mem_size=mmin, ice_root=ice_root, port=port)
         h2oconn = H2OConnection.open(server=hs, https=https, verify_ssl_certificates=not insecure,
                                      auth=auth, proxy=proxy, cluster_id=cluster_id, verbose=True)
-    if strict_version_check:
+    if check_version:
         version_check()
     h2oconn.cluster.show_status()
 

--- a/h2o-py/h2o/utils/config.py
+++ b/h2o-py/h2o/utils/config.py
@@ -34,7 +34,7 @@ class H2OConfigReader(object):
     #-------------------------------------------------------------------------------------------------------------------
 
     _allowed_config_keys = {
-        "init.check_version", "init.proxy", "init.url", "init.cluster_id"
+        "init.check_version", "init.proxy", "init.url", "init.cluster_id", "init.verify_ssl_certificates"
     }
 
     def __init__(self):

--- a/h2o-py/h2o/utils/config.py
+++ b/h2o-py/h2o/utils/config.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright 2016 H2O.ai; Apache License Version 2.0;  -*- encoding: utf-8 -*-
+"""Read h2opy configuration file(s)."""
+
+import io
+import logging
+import os
+import re
+
+__all__ = ("H2OConfigReader", )
+
+
+class H2OConfigReader(object):
+    """
+    Helper class responsible for reading h2o config files.
+
+    This module will look for file(s) named ".h2oconfig" in the current folder, in all parent folders, and finally in
+    the user's home directory. The first such file found will be used for configuration purposes. The format for such
+    file is a simple "key = value" store, with possible section names in square brackets. Single-line comments starting
+    with '#' are also allowed.
+    """
+
+    @staticmethod
+    def get_config():
+        """Retrieve the config as a dictionary of key-value pairs."""
+        self = H2OConfigReader._get_instance()
+        if not self._config_loaded:
+            self._read_config()
+        return self._config
+
+
+    #-------------------------------------------------------------------------------------------------------------------
+    # Private
+    #-------------------------------------------------------------------------------------------------------------------
+
+    _allowed_config_keys = {
+        "init.check_version", "init.proxy", "init.url", "init.cluster_id"
+    }
+
+    def __init__(self):
+        """Initialize the singleton instance of H2OConfigReader."""
+        assert not hasattr(H2OConfigReader, "_instance"), "H2OConfigReader is intended to be used as a singleton"
+        self._logger = logging.getLogger("h2opy")
+        self._config = {}
+        self._config_loaded = False
+
+    @staticmethod
+    def _get_instance():
+        """Return the singleton instance of H2OConfigReader."""
+        if not hasattr(H2OConfigReader, "_instance"):
+            H2OConfigReader._instance = H2OConfigReader()
+        return H2OConfigReader._instance
+
+    def _read_config(self):
+        """Find and parse config file, storing all variables in ``self._config``."""
+        self._config_loaded = True
+        conf = []
+        for f in self._candidate_log_files():
+            if os.path.isfile(f):
+                self._logger.info("Reading config file %s" % f)
+                section_rx = re.compile(r"^\[(\w+)\]$")
+                keyvalue_rx = re.compile(r"^(\w+:)?([\w\.]+)\s*=\s*(.*)$")
+                with io.open(f, "rt", encoding="utf-8") as config_file:
+                    section_name = None
+                    for lineno, line in enumerate(config_file):
+                        line = line.strip()
+                        if line == "" or line.startswith("#"): continue
+                        m1 = section_rx.match(line)
+                        if m1:
+                            section_name = m1.group(1)
+                            continue
+                        m2 = keyvalue_rx.match(line)
+                        if m2:
+                            lng = m2.group(1)
+                            key = m2.group(2)
+                            val = m2.group(3)
+                            if lng and lng.lower() != "py:": continue
+                            if section_name:
+                                key = section_name + "." + key
+                            if key in H2OConfigReader._allowed_config_keys:
+                                conf.append((key, val))
+                            else:
+                                self._logger.error("Key %s is not a valid config key" % key)
+                            continue
+                        self._logger.error("Syntax error in config file line %d" % lineno)
+                self._config = dict(conf)
+                return
+
+    def _candidate_log_files(self):
+        """Return possible locations for the .h2oconfig file, one at a time."""
+        # Search for .h2oconfig in the current directory and all parent directories
+        relpath = ".h2oconfig"
+        prevpath = None
+        while True:
+            abspath = os.path.abspath(relpath)
+            if abspath == prevpath: break
+            prevpath = abspath
+            relpath = "../" + relpath
+            yield abspath
+        # Also check if .h2oconfig exists in the user's directory
+        yield os.path.expanduser("~/.h2oconfig")


### PR DESCRIPTION
This creates facility for reading settings from the .h2oconfig file. Currently defined keys are: `{"init.check_version", "init.proxy", "init.url", "init.cluster_id"}`.

For example, if the user creates file .h2oconfig in his/her user/project directory with the following content:
```
[init]
check_version = false
url = https://example.com:5555
```
then the `strict_version_check()` on startup will be effectively disabled, and `h2o.init()` without parameters will connect to the example.com server on port 5555 over https.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/226)
<!-- Reviewable:end -->
