### PR TITLE
Allow html schemas

### DIFF
--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -593,6 +593,8 @@ public class RequestServer extends HttpServlet {
     return serveError(error);
   }
 
+  public abstract static interface WithInputStream { public InputStream is(); }
+
   private static NanoResponse serveSchema(Schema s, RequestType type) {
     // Convert Schema to desired output flavor
     String http_response_header = H2OError.httpStatusHeader(HttpResponseStatus.OK.getCode());
@@ -620,7 +622,10 @@ public class RequestServer extends HttpServlet {
 
     // TODO: remove this entire switch
     switch (type) {
-      case html: // return JSON for html requests
+      case html:
+        if( s instanceof WithInputStream )
+          return new NanoResponse(http_response_header, MIME_HTML, ((WithInputStream)s).is());
+        // Fall through
       case json:
         return new NanoResponse(http_response_header, MIME_JSON, s.toJsonString());
       case xml:


### PR DESCRIPTION
Allow schemas return HTML instead of JSON, for applications derived from
H2O that wish to emit dynamically generated HTML

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/227)
<!-- Reviewable:end -->
