### PR TITLE
HEXDEV-634: Fixes handling of NAs in Parquet Parser

### DIFF
--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkConverter.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkConverter.java
@@ -25,13 +25,13 @@ import water.parser.ParseWriter;
  */
 class ChunkConverter extends GroupConverter {
 
-  private final ParseWriter _writer;
+  private final WriterDelegate _writer;
   private final Converter[] _converters;
 
   private int _currentRecordIdx = -1;
 
   ChunkConverter(MessageType parquetSchema, byte[] chunkSchema, ParseWriter writer) {
-    _writer = writer;
+    _writer = new WriterDelegate(writer, chunkSchema.length);
     int colIdx = 0;
     _converters = new Converter[chunkSchema.length];
     for (Type parquetField : parquetSchema.getFields()) {
@@ -49,11 +49,12 @@ class ChunkConverter extends GroupConverter {
   @Override
   public void start() {
     _currentRecordIdx++;
+    _writer.startLine();
   }
 
   @Override
   public void end() {
-    _writer.newLine();
+    _writer.endLine();
     assert _writer.lineNum() - 1 == _currentRecordIdx;
   }
 
@@ -85,11 +86,11 @@ class ChunkConverter extends GroupConverter {
 
     private final BufferedString _bs = new BufferedString();
     private final int _colIdx;
-    private final ParseWriter _writer;
+    private final WriterDelegate _writer;
     private final boolean _dictionarySupport;
     private String[] _dict;
 
-    StringConverter(ParseWriter writer, int colIdx, boolean dictionarySupport) {
+    StringConverter(WriterDelegate writer, int colIdx, boolean dictionarySupport) {
       _colIdx = colIdx;
       _writer = writer;
       _dictionarySupport = dictionarySupport;
@@ -124,10 +125,10 @@ class ChunkConverter extends GroupConverter {
   private static class NumberConverter extends PrimitiveConverter {
 
     private final int _colIdx;
-    private final ParseWriter _writer;
+    private final WriterDelegate _writer;
     private final BufferedString _bs = new BufferedString();
 
-    NumberConverter(int _colIdx, ParseWriter _writer) {
+    NumberConverter(int _colIdx, WriterDelegate _writer) {
       this._colIdx = _colIdx;
       this._writer = _writer;
     }
@@ -167,9 +168,9 @@ class ChunkConverter extends GroupConverter {
   private static class TimestampConverter extends PrimitiveConverter {
 
     private final int _colIdx;
-    private final ParseWriter _writer;
+    private final WriterDelegate _writer;
 
-    TimestampConverter(int _colIdx, ParseWriter _writer) {
+    TimestampConverter(int _colIdx, WriterDelegate _writer) {
       this._colIdx = _colIdx;
       this._writer = _writer;
     }
@@ -178,6 +179,51 @@ class ChunkConverter extends GroupConverter {
     public void addLong(long value) {
       _writer.addNumCol(_colIdx, value, 0);
     }
+  }
+
+  private static class WriterDelegate {
+
+    private final ParseWriter _writer;
+    private final int _numCols;
+    private int _col;
+
+    WriterDelegate(ParseWriter writer, int numCols) {
+      _writer = writer;
+      _numCols = numCols;
+      _col = Integer.MIN_VALUE;
+    }
+
+    void startLine() {
+      _col = -1;
+    }
+
+    void endLine() {
+      moveToCol(_numCols);
+      _writer.newLine();
+    }
+
+    int moveToCol(int colIdx) {
+      for (int c = _col + 1; c < colIdx; c++) _writer.addInvalidCol(c);
+      _col = colIdx;
+      return _col;
+    }
+
+    void addNumCol(int colIdx, long number, int exp) {
+      _writer.addNumCol(moveToCol(colIdx), number, exp);
+    }
+
+    void addNumCol(int colIdx, double d) {
+      _writer.addNumCol(moveToCol(colIdx), d);
+    }
+
+    void addStrCol(int colIdx, BufferedString str) {
+      _writer.addStrCol(moveToCol(colIdx), str);
+    }
+
+    long lineNum() {
+      return _writer.lineNum();
+    }
+
   }
 
 }


### PR DESCRIPTION
The existing tests for NAs worked only because FVecParseWriter handles missing value at the tail of the row itself. The parser was fixed in order to correctly mark also inner missing values.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/246)
<!-- Reviewable:end -->