### PR TITLE
[PUBDEV-3412] Fix list -> frame constructor

### DIFF
--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -96,8 +96,8 @@ def _handle_python_lists(python_obj, check_header):
     if _is_list_of_lists(python_obj):  # do we have a list of lists: [[...], ..., [...]] ?
         ncols = _check_lists_of_lists(python_obj)  # must be a list of flat lists, raise ValueError if not
     elif isinstance(python_obj, (list, tuple)):  # single list
-        ncols = len(python_obj)
-        python_obj = [python_obj]
+        ncols = 1
+        python_obj = [[e] for e in python_obj]
     else:  # scalar
         python_obj = [[python_obj]]
         ncols = 1

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -97,8 +97,8 @@ def check_models(model1, model2, use_cross_validation=False, op='e'):
 
 def check_dims_values(python_obj, h2o_frame, rows, cols, dim_only=False):
     """
-    Check that the dimensions and values of the python object and H2OFrame are equivalent. Assumes that the python object
-    conforms to the rules specified in the h2o frame documentation.
+    Check that the dimensions and values of the python object and H2OFrame are equivalent. Assumes that the python
+    object conforms to the rules specified in the h2o frame documentation.
 
     :param python_obj: a (nested) list, tuple, dictionary, numpy.ndarray, ,or pandas.DataFrame
     :param h2o_frame: an H2OFrame
@@ -114,10 +114,12 @@ def check_dims_values(python_obj, h2o_frame, rows, cols, dim_only=False):
         if isinstance(python_obj, (list, tuple)):
             for c in range(cols):
                 for r in range(rows):
-                    pval = python_obj[r][c] if rows > 1 else python_obj[c]
-                    hval = h2o_frame[r,c]
-                    assert pval == hval, "expected H2OFrame to have the same values as the python object for row {0} " \
-                                         "and column {1}, but h2o got {2} and python got {3}.".format(r, c, hval, pval)
+                    pval = python_obj[r]
+                    if isinstance(pval, (list, tuple)): pval = pval[c]
+                    hval = h2o_frame[r, c]
+                    assert pval == hval or abs(pval - hval) < 1e-10, \
+                        "expected H2OFrame to have the same values as the python object for row {0} " \
+                        "and column {1}, but h2o got {2} and python got {3}.".format(r, c, hval, pval)
         elif isinstance(python_obj, dict):
             for r in range(rows):
                 for k in list(python_obj.keys()):

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_2891.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_2891.py
@@ -1,27 +1,25 @@
-import sys
-sys.path.insert(1,"../../")
 import h2o
 from tests import pyunit_utils
 
 def pubdev_2891():
 
     #check header is respected
-    names = ["a", "b","c","d"]
-    python_obj = [names,[1,1,1,1]]
-    the_frame_1 = h2o.H2OFrame.from_python(python_obj,header=1)
+    names = ["a", "b", "c", "d"]
+    python_obj = [names, [1, 1, 1, 1]]
+    the_frame_1 = h2o.H2OFrame.from_python(python_obj, header=1)
     print(the_frame_1)
     assert the_frame_1.col_names == names
 
     #check the dimension of the frame
-    python_obj = ["a", "b","c","asdfasdf"]
+    python_obj = ["a", "b", "c", "asdfasdf"]
     the_frame_1 = h2o.H2OFrame(python_obj)
     print(the_frame_1)
-    pyunit_utils.check_dims_values(python_obj, the_frame_1, rows=1, cols=4)
+    pyunit_utils.check_dims_values(python_obj, the_frame_1, rows=4, cols=1)
 
     the_frame_1 = h2o.H2OFrame.from_python(python_obj, header=1)
     print(the_frame_1)
-    assert the_frame_1.names == python_obj
-    assert the_frame_1.nrow == 0
+    assert the_frame_1.names == ["a"]
+    assert the_frame_1.nrows == 3
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_misc/pyunit_small_py_objects.py
+++ b/h2o-py/tests/testdir_misc/pyunit_small_py_objects.py
@@ -1,26 +1,24 @@
-import sys
-sys.path.insert(1,"../../")
 import h2o
 from tests import pyunit_utils
 
 
 def pyunit_small_py_objects():
 
-  d = h2o.H2OFrame([3.2])
-  d.show()
-  assert d.nrow == d.ncol == 1
-  
-  d = h2o.H2OFrame([[3.2],[3.2]])
-  assert d.nrow == 2
-  assert d.ncol == 1
-  d.show()
-  
-  d = h2o.H2OFrame([3.2,3.2])
-  d.show()
-  assert d.nrow == 1
-  assert d.ncol == 2
+    d = h2o.H2OFrame([3.2])
+    d.show()
+    assert d.nrow == d.ncol == 1
+
+    d = h2o.H2OFrame([[3.2], [3.2]])
+    assert d.nrow == 2
+    assert d.ncol == 1
+    d.show()
+
+    d = h2o.H2OFrame([3.2, 3.2])
+    d.show()
+    assert d.nrow == 2
+    assert d.ncol == 1
 
 if __name__ == "__main__":
-  pyunit_utils.standalone_test(pyunit_small_py_objects)
+    pyunit_utils.standalone_test(pyunit_small_py_objects)
 else:
-  pyunit_small_py_objects()
+    pyunit_small_py_objects()

--- a/h2o-py/tests/testdir_munging/pyunit_to_H2OFrame.py
+++ b/h2o-py/tests/testdir_munging/pyunit_to_H2OFrame.py
@@ -11,9 +11,9 @@ def to_H2OFrame():
 
     ## 1. list
     #   a. single col
-    python_obj = [1, "a", 2.5, "bcd", 0]
+    python_obj = [1, 2, 2.5, -100.9, 0]
     the_frame = h2o.H2OFrame(python_obj)
-    pyunit_utils.check_dims_values(python_obj, the_frame, rows=1, cols=5)
+    pyunit_utils.check_dims_values(python_obj, the_frame, rows=5, cols=1)
 
     #   b. 1 col, 5 rows
     python_obj = [[1], [2], [3.7], [8], [9]]
@@ -37,9 +37,9 @@ def to_H2OFrame():
 
     ## 2. tuple
     #   a. single row
-    python_obj = (1, "a", 2.5, "bcd", 0)
+    python_obj = (1, 1e-5, 2.5, 23, 0)
     the_frame = h2o.H2OFrame(python_obj)
-    pyunit_utils.check_dims_values(python_obj, the_frame, rows=1, cols=5)
+    pyunit_utils.check_dims_values(python_obj, the_frame, rows=5, cols=1)
 
     #   b. single column
     python_obj = ((1,), (2,), (3.7,), (8,), (9,))
@@ -126,7 +126,7 @@ def to_H2OFrame():
     #   a. single row
     python_obj = np.array([1, "a", 2.5, "bcd", 0])
     the_frame = h2o.H2OFrame(python_obj)
-    pyunit_utils.check_dims_values(python_obj, the_frame, rows=1, cols=5)
+    pyunit_utils.check_dims_values(python_obj, the_frame, rows=5, cols=1)
 
     #   b. single column
     python_obj = np.array([[1], [2], [3.7], [8], [9]])


### PR DESCRIPTION
Previously `H2OFrame([1, 2, 3, 4, 5])` would have created a frame with 5 columns; now it instead creates a frame with 1 column and 5 rows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/247)
<!-- Reviewable:end -->
