### PR TITLE
[PUBDEV-565] allow ~ to be used in paths in h2o.upload_file()

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -303,6 +303,8 @@ def upload_file(path, destination_frame="", header=0, sep=None, col_names=None, 
     assert_is_type(col_names, [str], None)
     assert_is_type(col_types, [coltype], {str: coltype}, None)
     assert_is_type(na_strings, [natype], {str: natype}, None)
+    if path.startswith("~"):
+        path = os.path.expanduser(path)
     return H2OFrame()._upload_parse(path, destination_frame, header, sep, col_names, col_types, na_strings)
 
 
@@ -352,6 +354,10 @@ def import_file(path=None, destination_frame="", parse=True, header=0, sep=None,
     assert_is_type(col_names, [str], None)
     assert_is_type(col_types, [coltype], {str: coltype}, None)
     assert_is_type(na_strings, [natype], {str: natype}, None)
+    patharr = path if isinstance(path, list) else [path]
+    if any(os.path.split(p)[0] == "~" for p in patharr):
+        raise H2OValueError("Paths relative to a current user (~) are not valid in the server environment. "
+                            "Please use absolute paths if possible.")
     if not parse:
         return lazy_import(path)
     else:


### PR DESCRIPTION
(but not in `h2o.import_file()` which is supposed to import server-side datafiles)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/252)
<!-- Reviewable:end -->
