### PR TITLE
PUBDEV-3422: Create Method to Return Columns of Specific Type

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/AstRoot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/AstRoot.java
@@ -239,6 +239,7 @@ public abstract class AstRoot extends Iced<AstRoot> {
     init(new AstLevels());
     init(new AstMerge());
     init(new AstNaOmit());
+    init(new AstColumnsByType());
     init(new AstNcol());
     init(new AstNLevels());
     init(new AstNrow());

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstColumnsByType.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstColumnsByType.java
@@ -1,0 +1,96 @@
+package water.rapids.ast.prims.mungers;
+
+import water.fvec.*;
+import water.rapids.Env;
+import water.rapids.Val;
+import water.rapids.ast.AstPrimitive;
+import water.rapids.ast.AstRoot;
+import water.rapids.vals.ValNums;
+import java.util.ArrayList;
+
+/**
+ * Get column indexes of an H2OFrame that are of a certain data type.
+ * <p/>
+ * This will take an H2OFrame and return all column indexes based on a specific data type (numeric, categorical,
+ * string,time, uuid, and bad)
+ * <p/>
+ *
+ * @author navdeepgill
+ * @version 3.10
+ * @since  3.10
+ *
+ */
+public class AstColumnsByType extends AstPrimitive {
+    @Override
+    public String[] args() {
+        return new String[]{"ary","type"};
+    }
+
+    private enum DType {Numeric,Categorical,String,Time,UUID,Bad}
+
+    @Override
+    public String str() {
+        return "columnsByType";
+    }
+
+    @Override
+    public int nargs() {
+        return 1 + 2;
+    } //ary type
+
+    @Override
+    public Val apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
+        Frame fr = stk.track(asts[1].exec(env)).getFrame();
+        String type = stk.track(asts[2].exec(env)).getStr();
+        DType dtype;
+        switch (type) {
+            case "numeric": // Numeric, but not categorical or time
+                dtype = DType.Numeric;
+                break;
+            case "categorical": // Integer, with a categorical/factor String mapping
+                dtype = DType.Categorical;
+                break;
+            case "string": // String
+                dtype = DType.String;
+                break;
+            case "time": // Long msec since the Unix Epoch - with a variety of display/parse options
+                dtype = DType.Time;
+                break;
+            case "uuid": // UUID
+                dtype = DType.UUID;
+                break;
+            case "bad": // No none-NA rows (triple negative! all NAs or zero rows)
+                dtype = DType.Bad;
+                break;
+            default:
+                throw new IllegalArgumentException("unknown data type to filter by: " + type);
+        }
+        Vec vecs[] = fr.vecs();
+        ArrayList<Double> idxs = new ArrayList<>();
+        for (double i = 0; i < fr.numCols(); i++)
+            if (dtype.equals(DType.Numeric) && vecs[(int) i].isNumeric()){
+                    idxs.add(i);
+            }
+            else if (dtype.equals(DType.Categorical) && vecs[(int) i].isCategorical()){
+                idxs.add(i);
+            }
+            else if (dtype.equals(DType.String) && vecs[(int) i].isString()){
+                idxs.add(i);
+            }
+            else if (dtype.equals(DType.Time) && vecs[(int) i].isTime()){
+                idxs.add(i);
+            }
+            else if (dtype.equals(DType.UUID) && vecs[(int) i].isUUID()){
+                idxs.add(i);
+            } else if (dtype.equals(DType.Bad) && vecs[(int) i].isBad()){
+                idxs.add(i);
+            }
+
+        double[] include_cols = new double[idxs.size()];
+        int i = 0;
+        for (double d : idxs)
+            include_cols[i++] = (int) d;
+        return new ValNums(include_cols);
+    }
+}
+

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -306,6 +306,27 @@ class H2OFrame(object):
         """
         return ExprNode("filterNACols", self, frac)._eager_scalar()
 
+    def columns_by_type(self, coltype="numeric"):
+        """ Obtain a list of columns that are specified by `coltype`
+
+        Parameters
+        ----------
+        coltype : str
+            A character string indicating which column type to filter by. This must be one of the following:
+                "numeric"      - Numeric, but not categorical or time
+                "categorical"  - Integer, with a categorical/factor String mapping
+                "string"       - String column
+                "time"         - Long msec since the Unix Epoch - with a variety of display/parse options
+                "uuid"         - UUID
+                "bad"          - No none-NA rows (triple negative! all NAs or zero rows)
+        Returns
+        -------
+          A list of column indices that correspond to `coltype`
+        """
+        assert_is_type(coltype, "numeric", "categorical", "string", "time", "uuid", "bad")
+        assert_is_type(self,H2OFrame)
+        return ExprNode("columnsByType", self, coltype)._eager_scalar()
+
     def __iter__(self):
         return (self[i] for i in range(self.ncol))
 

--- a/h2o-py/tests/testdir_misc/pyunit_columns_by_type.py
+++ b/h2o-py/tests/testdir_misc/pyunit_columns_by_type.py
@@ -1,0 +1,49 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+def pyunit_columns_by_types():
+
+    #Positive case. All coltypes available
+    fr = h2o.import_file(pyunit_utils.locate("smalldata/jira/filter_type.csv"))
+    fr["e"] = fr["e"].asfactor() #Not parsed as a factor
+
+    #Negative case frame. All coltypes are ints
+    frame = h2o.create_frame(rows=10,integer_fraction=1,binary_ones_fraction=0, missing_fraction=0)
+
+    #Positive case. Look for all coltypes
+    num_type = fr.columns_by_type() #numeric by default
+    cat_type = fr.columns_by_type(coltype="categorical")
+    str_type = fr.columns_by_type(coltype="string")
+    time_type = fr.columns_by_type(coltype="time")
+    uuid_type = fr.columns_by_type(coltype="uuid")
+    bad_type = fr.columns_by_type(coltype="bad")
+
+    #Negative case. Look for categoricals,strings,times,uuid, and bad when there are none. Should return an empty list.
+    neg_cat = frame.columns_by_type(coltype="categorical")
+    neg_string = frame.columns_by_type(coltype="string")
+    neg_time = frame.columns_by_type(coltype="time")
+    neg_uuid = frame.columns_by_type(coltype="uuid")
+    neg_bad = frame.columns_by_type(coltype="bad")
+
+    #Positive Test
+    assert num_type == [0,2],"Expected numeric type in column indexes 0,2"
+    assert cat_type == [4],"Expected categorical type in column indexes 4"
+    assert str_type == [1],"Expected string type in column indexes 1"
+    assert time_type == [3],"Expected time type in column indexes 3"
+    assert uuid_type == [5],"Expected uuid type in column indexes 5"
+    assert bad_type == [2],"Expected bad type in column indexes 2"
+
+    #Negative test
+    assert neg_cat == [],"Expect an empty list since there are no categoricals"
+    assert neg_string == [],"Expect an empty list since there are no string"
+    assert neg_time == [],"Expect an empty list since there are no time variables"
+    assert neg_uuid == [],"Expect an empty list since there are no uuids"
+    assert neg_bad == [],"Expect an empty list since there are no bad variable types"
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pyunit_columns_by_types)
+else:
+    pyunit_columns_by_types()

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -780,6 +780,41 @@ h2o.na_omit <- function(object, ...){
 #' @export
 na.omit.H2OFrame <- h2o.na_omit
 
+#' Obtain a list of columns that are specified by `coltype`
+#'
+#' @rdname h2o.columns_by_type
+#' @param object H2OFrame object
+#' @param coltype A character string indicating which column type to filter by. This must be one of the following:
+#'   "numeric"      - Numeric, but not categorical or time
+#'   "categorical"  - Integer, with a categorical/factor String mapping
+#'   "string"       - String column
+#'   "time"         - Long msec since the Unix Epoch - with a variety of display/parse options
+#'   "uuid"         - UUID
+#'   "bad"          - No none-NA rows (triple negative! all NAs or zero rows)
+#' @param ... Ignored
+#' @return A list of column indices that correspond to "type"
+#' @examples
+#' \donttest{
+#' h2o.init()
+#' prosPath <- system.file("extdata", "prostate.csv", package="h2o")
+#' prostate.hex <- h2o.uploadFile(path = prosPath)
+#' h2o.columns_by_type(prostate.hex,coltype="numeric")
+#' }
+#' @export
+h2o.columns_by_type <- function(object,coltype="numeric",...){
+  if(!is.H2OFrame(object)){
+    stop("h2o.filter_type only operates on H2OFrames.")
+  }
+  if(!is.character(coltype)){
+    stop("`coltype` variable should be of type character.")
+  }
+  if(!(coltype %in% c("numeric", "categorical", "string", "time", "uuid", "bad"))){
+    stop(paste0("`coltype` must be one of the following: numeric, categorical, string, time, uuid, or bad but got "
+    , coltype))
+  }
+  .eval.scalar(.newExpr("columnsByType", object,.quote(coltype))) + 1
+}
+
 #' Conduct a lag 1 transform on a numeric H2OFrame column
 #'
 #' @rdname h2o.diff

--- a/h2o-r/tests/testdir_misc/runit_columns_by_type.R
+++ b/h2o-r/tests/testdir_misc/runit_columns_by_type.R
@@ -1,0 +1,51 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+# setupRandomSeed(1994831827)
+
+test_columns_by_type <- function() {
+
+    #Positive case. All coltypes available
+    fr <- h2o.importFile(locate("smalldata/jira/filter_type.csv"), "hex")
+    fr$e = as.factor(fr$e)
+
+    #Negative case frame. All coltypes are ints
+    frame = h2o.createFrame(rows = 10, cols = 10, randomize = TRUE, value = 0,
+              real_range = 100, categorical_fraction = 0, factors = 0,
+              integer_fraction = 1, integer_range = 100, binary_fraction = 0,
+              binary_ones_fraction = 0, time_fraction = 0, string_fraction = 0,
+              missing_fraction = 0,has_response = FALSE)
+
+    #Positive case. Look for all coltypes
+    num_type = h2o.columns_by_type(fr) #numeric by default
+    cat_type = h2o.columns_by_type(fr,coltype="categorical")
+    str_type = h2o.columns_by_type(fr,coltype="string")
+    time_type = h2o.columns_by_type(fr,coltype="time")
+    uuid_type = h2o.columns_by_type(fr,coltype="uuid")
+    bad_type = h2o.columns_by_type(fr,coltype="bad")
+
+    #Negative case. Look for categoricals,strings,times,uuid, and bad when there are none. Should return an empty list.
+    neg_cat = h2o.columns_by_type(frame,coltype="categorical")
+    neg_string = h2o.columns_by_type(frame,coltype="string")
+    neg_time = h2o.columns_by_type(frame,coltype="time")
+    neg_uuid = h2o.columns_by_type(frame,coltype="uuid")
+    neg_bad = h2o.columns_by_type(frame,coltype="bad")
+
+    #Positive Test
+    expect_that(num_type, equals(c(1,3)))
+    expect_that(cat_type, equals(c(5)))
+    expect_that(str_type, equals(c(2)))
+    expect_that(time_type, equals(c(4)))
+    expect_that(uuid_type, equals(c(6)))
+    expect_that(bad_type, equals(c(3)))
+
+    #Negative Test
+    expect_that(neg_cat, equals(numeric(0)))
+    expect_that(neg_string, equals(numeric(0)))
+    expect_that(neg_time, equals(numeric(0)))
+    expect_that(neg_uuid, equals(numeric(0)))
+    expect_that(neg_bad, equals(numeric(0)))
+
+}
+
+doTest("Filter frame by col types", test_columns_by_type)


### PR DESCRIPTION
Retrieve indexes of columns that are of a certain type,i.e., numeric,categorical, etc. This way one can subset a frame with columns of certain data types. 

Example
```
fr = as.h2o(iris)
fr2 = fr[h2o.filter_type(fr,type="categorical")]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/253)
<!-- Reviewable:end -->
