### PR TITLE
PUBDEV-3446

### DIFF
--- a/h2o-docs/src/product/grid-search.rst
+++ b/h2o-docs/src/product/grid-search.rst
@@ -79,7 +79,6 @@ Shared Tree Hyperparameters
 -  ``balance_classes``
 -  ``class_sampling_factors``
 -  ``max_after_balance_size``
--  ``max_hit_ratio_k``
 -  ``ntrees``
 -  ``max_depth``
 -  ``min_rows``
@@ -168,7 +167,6 @@ Deep Learning Hyperparameters
 -  ``class_sampling_factors``
 -  ``max_after_balance_size``
 -  ``max_confusion_matrix_size``
--  ``max_hit_ratio_k``
 -  ``overwrite_with_best_model``
 -  ``use_all_factor_levels``
 -  ``standardize``


### PR DESCRIPTION
Removed `max_hit_ratio_k` from list of hyper parameters in the Grid
Search topic. This was listed under the Shared Tree Hyperparemeters and Deep Learning Hyperparameters sections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/259)
<!-- Reviewable:end -->
