### PR TITLE
Add parquet to list of supported file types

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -45,14 +45,15 @@ Supported File Formats
 H2O currently supports the following file types:
 
 - CSV (delimited) files
-- ORC*
+- ORC
 - SVMLite
 - ARFF
 - XLS
-- XLST
+- XLSX
 - Avro (without multifile parsing or column type modification)
+- Parquet
 
-*Note that ORC is available only if H2O is running as a Hadoop job. 
+Note that ORC is available only if H2O is running as a Hadoop job. 
 
 
 New Users


### PR DESCRIPTION
Pull request 12 adds support for Parquet file type. Including this in
the documentation. Driveby fix: Changed XLST to XLSX to match  types in
src/ext/components/parse-input.coffee.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/260)
<!-- Reviewable:end -->
