### PR TITLE
Fixed ArrayUtils (remove() was broken)

### DIFF
--- a/h2o-algos/src/test/java/hex/splitframe/ShuffleSplitFrameTest.java
+++ b/h2o-algos/src/test/java/hex/splitframe/ShuffleSplitFrameTest.java
@@ -38,7 +38,7 @@ public class ShuffleSplitFrameTest extends TestUtil {
   /** Simple testing scenario, splitting frame in the middle and comparing the values */
   static void testScenario(Frame f, String[] expValues) {
     double[] ratios = ard(0.5, 0.5);
-    Key[] keys = aro(Key.make("test.hex"), Key.make("train.hex"));
+    Key<Frame>[] keys = aro(Key.<Frame>make("test.hex"), Key.<Frame>make("train.hex"));
     Frame[] splits = null;
     try {
       splits = ShuffleSplitFrame.shuffleSplitFrame(f, keys, ratios, 42);

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -8,10 +8,7 @@ import water.exceptions.H2OIllegalArgumentException;
 import water.parser.BufferedString;
 import water.rapids.Merge;
 import water.persist.Persist;
-import water.util.FrameUtils;
-import water.util.Log;
-import water.util.PrettyPrint;
-import water.util.TwoDimTable;
+import water.util.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -582,9 +579,11 @@ public class Frame extends Lockable<Frame> {
     _names2[0] = name;
     _vecs2 [0] = vec;
     _keys2 [0] = vec._key;
-    System.arraycopy(_names, 0, _names2, 1, len);
-    System.arraycopy(_vecs,  0, _vecs2,  1, len);
-    System.arraycopy(_keys,  0, _keys2,  1, len);
+    if (_names != null) {
+      System.arraycopy(_names, 0, _names2, 1, len);
+      System.arraycopy(_vecs,  0, _vecs2,  1, len);
+      System.arraycopy(_keys,  0, _keys2,  1, len);
+    }
     _names = _names2;
     _vecs  = _vecs2;
     _keys  = _keys2;
@@ -817,16 +816,10 @@ public class Frame extends Lockable<Frame> {
     int len = _names.length;
     if( idx < 0 || idx >= len ) return null;
     Vec v = vecs()[idx];
-    String[] names = Arrays.copyOf(_names, len);
-    Vec[] vecs = Arrays.copyOf(_vecs, len);
-    Key<Vec>[] keys = Arrays.copyOf(_keys, len);
-    System.arraycopy(names,idx+1,names,idx,len-idx-1);
-    System.arraycopy(vecs ,idx+1,vecs ,idx,len-idx-1);
-    System.arraycopy(keys ,idx+1,keys ,idx,len-idx-1);
-    _names = Arrays.copyOf(names,len-1);
-    _vecs  = Arrays.copyOf(vecs ,len-1);
-    _keys  = Arrays.copyOf(keys ,len-1);
     if( v == _col0 ) _col0 = null;
+    _vecs = ArrayUtils.remove(_vecs, idx);
+    _names = ArrayUtils.remove(_names, idx);
+    _keys = ArrayUtils.remove(_keys, idx);
     return v;
   }
 
@@ -1293,7 +1286,7 @@ public class Frame extends Lockable<Frame> {
     @Override public void map(Chunk[] cs) {
       int i=0;
       for(Chunk c: cs) {
-        Chunk c2 = (Chunk)c.clone();
+        Chunk c2 = c.clone();
         c2._vec=null;
         c2._start=-1;
         c2._cidx=-1;

--- a/h2o-core/src/main/java/water/parser/SVMLightFVecParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/SVMLightFVecParseWriter.java
@@ -37,11 +37,13 @@ public class SVMLightFVecParseWriter extends FVecParseWriter {
   @Override public void addStrCol(int idx, BufferedString str){addInvalidCol(idx);}
   @Override public boolean isString(int idx){return false;}
   @Override public FVecParseWriter close(Futures fs) {
+    if (_nvs != null) {
     for(NewChunk nc:_nvs) {
       nc.addZeros((int) _nLines - nc._len);
       assert nc._len == _nLines:"incompatible number of lines after parsing chunk, " + _nLines + " != " + nc._len;
     }
-    _nCols = _nvs.length;
+    }
+    _nCols = _nvs == null ? 0 : _nvs.length;
     return super.close(fs);
   }
   private void addColumns(int newColCnt){

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -269,15 +269,15 @@ public class ArrayUtils {
   }
   public static double[][] mult(double[][] ary, double n) {
     if(ary == null) return null;
-    for (int i=0; i<ary.length; i++) mult(ary[i], n);
+    for (double[] row : ary) mult(row, n);
     return ary;
   }
-  
+
   public static double[] mult(double[] nums, double[] nums2) {
     for (int i=0; i<nums.length; i++) nums[i] *= nums2[i];
     return nums;
   }
-  
+
   public static double[] invert(double[] ary) {
     if(ary == null) return null;
     for(int i=0;i<ary.length;i++) ary[i] = 1. / ary[i];
@@ -458,12 +458,12 @@ public class ArrayUtils {
       if (o != null && o.getClass().isArray()) {
         Class klazz = ary[i].getClass();
         result[i] = byte[].class.equals(klazz) ? Arrays.toString((byte[]) o) :
-                    short[].class.equals(klazz) ? Arrays.toString((short[]) o) :
-                    int[].class.equals(klazz) ? Arrays.toString((int[]) o) :
+            short[].class.equals(klazz) ? Arrays.toString((short[]) o) :
+                int[].class.equals(klazz) ? Arrays.toString((int[]) o) :
                     long[].class.equals(klazz) ? Arrays.toString((long[]) o) :
-                    boolean[].class.equals(klazz) ? Arrays.toString((boolean[]) o) :
-                    float[].class.equals(klazz) ? Arrays.toString((float[]) o) :
-                    double[].class.equals(klazz) ? Arrays.toString((double[]) o) : Arrays.toString((Object[]) o);
+                        boolean[].class.equals(klazz) ? Arrays.toString((boolean[]) o) :
+                            float[].class.equals(klazz) ? Arrays.toString((float[]) o) :
+                                double[].class.equals(klazz) ? Arrays.toString((double[]) o) : Arrays.toString((Object[]) o);
 
       } else {
         result[i] = String.valueOf(o);
@@ -817,7 +817,7 @@ public class ArrayUtils {
     int cIinB = numInts(b);
     // Trivial case - all strings or ints, sorted
     if (cIinA==0 && cIinB==0   // only strings
-            || cIinA==a.length && cIinB==b.length ) // only integers
+        || cIinA==a.length && cIinB==b.length ) // only integers
       return union(a, b, cIinA==0);
     // Be little bit clever here: sort string representing numbers first and append
     // a,b were sorted by Array.sort() but can contain some numbers.
@@ -891,20 +891,20 @@ public class ArrayUtils {
     return res;
   }
 
-  public static final boolean hasNaNsOrInfs(double [] ary){
+  public static boolean hasNaNsOrInfs(double [] ary){
     for(double d:ary)
       if(Double.isNaN(d) || Double.isInfinite(d))
         return true;
     return false;
   }
-  public static final boolean hasNaNs(double [] ary){
+  public static boolean hasNaNs(double [] ary){
     for(double d:ary)
       if(Double.isNaN(d))
         return true;
     return false;
   }
 
-  public static final boolean hasNaNsOrInfs(float [] ary){
+  public static boolean hasNaNsOrInfs(float [] ary){
     for(float d:ary)
       if(Double.isNaN(d) || Double.isInfinite(d))
         return true;
@@ -925,8 +925,8 @@ public class ArrayUtils {
     if (b == null) return a.clone();
     int[] r = new int[a.length];
     int cnt = 0;
-    for (int i=0; i<a.length; i++) {
-      if (!contains(b, a[i])) r[cnt++] = a[i];
+    for (int x : a) {
+      if (!contains(b, x)) r[cnt++] = x;
     }
     return Arrays.copyOf(r, cnt);
   }
@@ -937,8 +937,8 @@ public class ArrayUtils {
     if (b == null) return a.clone();
     String[] r = new String[a.length];
     int cnt = 0;
-    for (int i=0; i<a.length; i++) {
-      if (!contains(b, a[i])) r[cnt++] = a[i];
+    for (String s : a) {
+      if (!contains(b, s)) r[cnt++] = s;
     }
     return Arrays.copyOf(r, cnt);
   }
@@ -964,6 +964,26 @@ public class ArrayUtils {
     return c;
   }
 
+  static public int[] append( int[] a, int[] b ) {
+    if( a==null ) return b;
+    if( b==null ) return a;
+    if( a.length==0 ) return b;
+    if( b.length==0 ) return a;
+    int[] c = Arrays.copyOf(a,a.length+b.length);
+    System.arraycopy(b,0,c,a.length,b.length);
+    return c;
+  }
+
+  static public long[] append( long[] a, long[] b ) {
+    if( a==null ) return b;
+    if( b==null ) return a;
+    if( a.length==0 ) return b;
+    if( b.length==0 ) return a;
+    long[] c = Arrays.copyOf(a,a.length+b.length);
+    System.arraycopy(b,0,c,a.length,b.length);
+    return c;
+  }
+
   static public double[] append( double[] a, double[] b ) {
     if( a==null ) return b;
     if( b==null ) return a;
@@ -983,6 +1003,7 @@ public class ArrayUtils {
     return c;
   }
 
+  // Java7+  @SafeVarargs
   public static <T> T[] append(T[] a, T... b) {
     if( a==null ) return b;
     T[] tmp = Arrays.copyOf(a,a.length+b.length);
@@ -1268,11 +1289,11 @@ public class ArrayUtils {
    *  @param names names of frame columns
    *  @param rows  data given in the form of rows
    *  @return new frame which contains columns named according given names and including given data */
-  public static Frame frame(Key key, String[] names, double[]... rows) {
+  public static Frame frame(Key<Frame> key, String[] names, double[]... rows) {
     assert names == null || names.length == rows[0].length;
     Futures fs = new Futures();
     Vec[] vecs = new Vec[rows[0].length];
-    Key keys[] = Vec.VectorGroup.VG_LEN1.addVecs(vecs.length);
+    Key<Vec>[] keys = Vec.VectorGroup.VG_LEN1.addVecs(vecs.length);
     int rowLayout = -1;
     for( int c = 0; c < vecs.length; c++ ) {
       AppendableVec vec = new AppendableVec(keys[c], Vec.T_NUM);
@@ -1288,7 +1309,7 @@ public class ArrayUtils {
     return fr;
   }
   public static Frame frame(double[]... rows) { return frame(null, rows); }
-  public static Frame frame(String[] names, double[]... rows) { return frame(Key.make(), names, rows); }
+  public static Frame frame(String[] names, double[]... rows) { return frame(Key.<Frame>make(), names, rows); }
   public static Frame frame(String name, Vec vec) { Frame f = new Frame(); f.add(name, vec); return f; }
 
   /**
@@ -1343,9 +1364,31 @@ public class ArrayUtils {
   }
 
   public static <T> T[] remove( T[] ary, int id) {
+    if(id < 0 || id >= ary.length) return Arrays.copyOf(ary,ary.length);
     if(id == ary.length-1) return Arrays.copyOf(ary,id);
-    if(id == 0) return Arrays.copyOfRange(ary,id,ary.length);
-    return append(Arrays.copyOf(ary,id), Arrays.copyOfRange(ary,id,ary.length));
+    if(id == 0) return Arrays.copyOfRange(ary,1,ary.length);
+    return append(Arrays.copyOf(ary,id), Arrays.copyOfRange(ary,id+1,ary.length));
+  }
+
+  public static byte[] remove(byte[] ary, int id) {
+    if(id < 0 || id >= ary.length) return Arrays.copyOf(ary,ary.length);
+    if(id == ary.length-1) return Arrays.copyOf(ary,id);
+    if(id == 0) return Arrays.copyOfRange(ary,1,ary.length);
+    return append(Arrays.copyOf(ary,id), Arrays.copyOfRange(ary,id+1,ary.length));
+  }
+
+  public static int[] remove(int[] ary, int id) {
+    if(id < 0 || id >= ary.length) return Arrays.copyOf(ary,ary.length);
+    if(id == ary.length-1) return Arrays.copyOf(ary,id);
+    if(id == 0) return Arrays.copyOfRange(ary,1,ary.length);
+    return append(Arrays.copyOf(ary,id), Arrays.copyOfRange(ary,id+1,ary.length));
+  }
+
+  public static long[] remove(long[] ary, int id) {
+    if(id < 0 || id >= ary.length) return Arrays.copyOf(ary,ary.length);
+    if(id == ary.length-1) return Arrays.copyOf(ary,id);
+    if(id == 0) return Arrays.copyOfRange(ary,1,ary.length);
+    return append(Arrays.copyOf(ary,id), Arrays.copyOfRange(ary,id+1,ary.length));
   }
 
   public static double[] padUniformly(double[] origPoints, int newLength) {
@@ -1382,7 +1425,6 @@ public class ArrayUtils {
         uniqueValidPoints[count++]= min;
         if (pos> min) uniqueValidPoints[count++]=pos;
         last=pos;
-        continue;
       }
       //last one
       else if (pos > maxEx) {

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -96,8 +96,7 @@ public class TestUtil extends Iced {
       }
       if( 10 < leaked_keys ) System.err.println("... and "+(leaked_keys-10)+" more leaked keys");
     }
-    System.out.println("leaked_keys = " + leaked_keys + ", cnt = " + cnt);
-    assertTrue("No keys leaked, leaked_keys = " + leaked_keys + ", cnt = " + cnt, leaked_keys <= 0 || cnt == 0);
+    assertTrue("Keys leaked: " + leaked_keys + ", cnt = " + cnt, leaked_keys <= 0 || cnt == 0);
     // Bulk brainless key removal.  Completely wipes all Keys without regard.
     new MRTask(){
       @Override public void setupLocal() {  H2O.raw_clear();  water.fvec.Vec.ESPC.clear(); }
@@ -298,8 +297,8 @@ public class TestUtil extends Iced {
   /**
    * Parse a folder with csv files when a single na_string is specified.
    *
-   * @param fname
-   * @param na_string
+   * @param fname name of folder
+   * @param na_string string for NA in a column
    * @return
    */
   protected static Frame parse_test_folder( String fname, String na_string, int check_header, byte[] column_types ) {
@@ -349,7 +348,7 @@ public class TestUtil extends Iced {
    *  @param rows Data
    *  @return The Vec  */
   public static Vec vec(String[] domain, int ...rows) { 
-    Key k = Vec.VectorGroup.VG_LEN1.addVec();
+    Key<Vec> k = Vec.VectorGroup.VG_LEN1.addVec();
     Futures fs = new Futures();
     AppendableVec avec = new AppendableVec(k,Vec.T_NUM);
     avec.setDomain(domain);
@@ -377,6 +376,8 @@ public class TestUtil extends Iced {
     for (int i=0; i<a.length;i++) r[i][0] = a[i];
     return r;
   }
+
+// Java7+  @SafeVarargs
   public static <T> T[] aro(T ...a) { return a ;}
 
   // ==== Comparing Results ====
@@ -384,9 +385,8 @@ public class TestUtil extends Iced {
   public static void assertVecEquals(Vec expecteds, Vec actuals, double delta) {
     assertEquals(expecteds.length(), actuals.length());
     for(int i = 0; i < expecteds.length(); i++) {
-      if(expecteds.at(i) != actuals.at(i))
-        System.out.println(i + ": " + expecteds.at(i) + " != " + actuals.at(i) + ", chunkIds = " + expecteds.elem2ChunkIdx(i) + ", " + actuals.elem2ChunkIdx(i) + ", row in chunks = " + (i - expecteds.chunkForRow(i).start()) + ", " + (i - actuals.chunkForRow(i).start()));
-      assertEquals(expecteds.at(i), actuals.at(i), delta);
+      final String message = i + ": " + expecteds.at(i) + " != " + actuals.at(i) + ", chunkIds = " + expecteds.elem2ChunkIdx(i) + ", " + actuals.elem2ChunkIdx(i) + ", row in chunks = " + (i - expecteds.chunkForRow(i).start()) + ", " + (i - actuals.chunkForRow(i).start());
+      assertEquals(message, expecteds.at(i), actuals.at(i), delta);
     }
   }
 
@@ -447,7 +447,7 @@ public class TestUtil extends Iced {
     for( String arg : args ) {
       try {
         System.out.println("=== Starting "+arg);
-        Class clz = Class.forName(arg);
+        Class<?> clz = Class.forName(arg);
         Method main = clz.getDeclaredMethod("main");
         main.invoke(null);
       } catch( InvocationTargetException ite ) {

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -79,6 +79,7 @@ public class FrameTest extends TestUtil {
       subset1.delete();
 //      subset2.delete();
       if (x != null) x.delete();
+      if (y != null) y.delete();
     }
   }
 

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -7,6 +7,10 @@ import water.H2O;
 import water.Key;
 import water.Scope;
 import water.TestUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 import static org.junit.Assert.assertTrue;
@@ -24,25 +28,28 @@ public class FrameTest extends TestUtil {
   public void testRemoveColumn() {
     Scope.enter();
     Frame testData = parse_test_file(Key.make("test_deep_select_1"), "smalldata/sparse/created_frame_binomial.svm.zip");
+    Set<Vec> removedVecs = new HashSet<>();
+
     try {
       // dataset to split
       int initialSize = testData.numCols();
-      testData.remove(-1);
+      removedVecs.add(testData.remove(-1));
       assertEquals(initialSize, testData.numCols());
-      testData.remove(0);
+      removedVecs.add(testData.remove(0));
       assertEquals(initialSize - 1, testData.numCols());
       assertEquals("C2", testData._names[0]);
-      testData.remove(initialSize - 2);
+      removedVecs.add(testData.remove(initialSize - 2));
       assertEquals(initialSize - 2, testData.numCols());
       assertEquals("C" + (initialSize - 1), testData._names[initialSize - 3]);
-      testData.remove(42);
+      removedVecs.add(testData.remove(42));
       assertEquals(initialSize - 3, testData.numCols());
       assertEquals("C43", testData._names[41]);
       assertEquals("C45", testData._names[42]);
     } finally {
       Scope.exit();
+      for (Vec v : removedVecs) if (v != null) v.remove();
       testData.delete();
-      H2O.STORE.clear(); // TODO(vlad): figure out how come it's dirty after deletion of columns
+      H2O.STORE.clear();
     }
   }
 

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -3,14 +3,16 @@ package water.fvec;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import water.H2O;
 import water.Key;
 import water.Scope;
 import water.TestUtil;
+import static org.junit.Assert.*;
 
 import static org.junit.Assert.assertTrue;
 
 /**
- * Created by tomas on 3/16/16.
+ * Tests for Frame.java
  */
 public class FrameTest extends TestUtil {
   @BeforeClass
@@ -18,6 +20,33 @@ public class FrameTest extends TestUtil {
     stall_till_cloudsize(1);
   }
 
+  @Test
+  public void testRemoveColumn() {
+    Scope.enter();
+    Frame testData = parse_test_file(Key.make("test_deep_select_1"), "smalldata/sparse/created_frame_binomial.svm.zip");
+    try {
+      // dataset to split
+      int initialSize = testData.numCols();
+      testData.remove(-1);
+      assertEquals(initialSize, testData.numCols());
+      testData.remove(0);
+      assertEquals(initialSize - 1, testData.numCols());
+      assertEquals("C2", testData._names[0]);
+      testData.remove(initialSize - 2);
+      assertEquals(initialSize - 2, testData.numCols());
+      assertEquals("C" + (initialSize - 1), testData._names[initialSize - 3]);
+      testData.remove(42);
+      assertEquals(initialSize - 3, testData.numCols());
+      assertEquals("C43", testData._names[41]);
+      assertEquals("C45", testData._names[42]);
+    } finally {
+      Scope.exit();
+      testData.delete();
+      H2O.STORE.clear(); // TODO(vlad): figure out how come it's dirty after deletion of columns
+    }
+  }
+
+  // _names=C1,... - C10001
   @Ignore
   @Test public void testDeepSelectSparse() {
     Scope.enter();
@@ -43,7 +72,6 @@ public class FrameTest extends TestUtil {
       subset1.delete();
 //      subset2.delete();
       if (x != null) x.delete();
-      if (y != null) y.delete();
     }
   }
 

--- a/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
@@ -1,0 +1,185 @@
+package water.util;
+
+import hex.CreateFrame;
+import hex.ToEigenVec;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.hamcrest.CoreMatchers;
+import water.DKV;
+import water.Key;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import static org.junit.Assert.*;
+import static water.util.ArrayUtils.*;
+
+/**
+ * Test FrameUtils interface.
+ */
+public class ArrayUtilsTest extends TestUtil {
+  @BeforeClass
+  static public void setup() {  stall_till_cloudsize(1); }
+
+  @Test
+  public void testAppendBytes() {
+    byte[] sut = {1, 2, 3};
+    byte[] sut2 = {3, 4};
+    byte[] expected = {1, 2, 3, 3, 4};
+    byte[] empty = {};
+    assertArrayEquals(null, append((byte[]) null, null));
+    assertArrayEquals(sut, append(null, sut));
+    assertArrayEquals(sut, append(sut, null));
+    assertArrayEquals(empty, append(null, empty));
+    assertArrayEquals(empty, append(empty, null));
+    assertArrayEquals(sut, append(empty, sut));
+    assertArrayEquals(sut, append(sut, empty));
+    assertArrayEquals(expected, append(sut, sut2));
+  }
+
+  @Test
+  public void testAppendInts() {
+    int[] sut = {1, 2, 3};
+    int[] sut2 = {3, 4};
+    int[] expected = {1, 2, 3, 3, 4};
+    int[] empty = {};
+    assertArrayEquals(null, append((int[]) null, null));
+    assertArrayEquals(sut, append(null, sut));
+    assertArrayEquals(sut, append(sut, null));
+    assertArrayEquals(empty, append(null, empty));
+    assertArrayEquals(empty, append(empty, null));
+    assertArrayEquals(sut, append(empty, sut));
+    assertArrayEquals(sut, append(sut, empty));
+    assertArrayEquals(expected, append(sut, sut2));
+  }
+
+  @Test
+  public void testAppendLongs() {
+    long[] sut = {1, 2, 3};
+    long[] sut2 = {3, 4};
+    long[] expected = {1, 2, 3, 3, 4};
+    long[] empty = {};
+    assertArrayEquals(null, append((int[]) null, null));
+    assertArrayEquals(sut, append(null, sut));
+    assertArrayEquals(sut, append(sut, null));
+    assertArrayEquals(empty, append(null, empty));
+    assertArrayEquals(empty, append(empty, null));
+    assertArrayEquals(sut, append(empty, sut));
+    assertArrayEquals(sut, append(sut, empty));
+    assertArrayEquals(expected, append(sut, sut2));
+  }
+
+  @Test
+  public void testRemoveOneObject() {
+    Integer[] sut = {1, 2, 3};
+    Integer[] sutWithout1 = {2, 3};
+    Integer[] sutWithout2 = {1, 3};
+    Integer[] sutWithout3 = {1, 2};
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MIN_VALUE));
+    assertArrayEquals("Should not have deleted ",   sut, remove(sut, -1));
+    assertArrayEquals("Should have deleted first",  sutWithout1, remove(sut, 0));
+    assertArrayEquals("Should have deleted second", sutWithout2, remove(sut, 1));
+    assertArrayEquals("Should have deleted third",  sutWithout3, remove(sut, 2));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, 3));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testRemoveOneObjectFromSingleton() {
+    Integer[] sut = {1};
+    Integer[] sutWithout1 = {};
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MIN_VALUE));
+    assertArrayEquals("Should not have deleted ",   sut, remove(sut, -1));
+    assertArrayEquals("Should have deleted first",  sutWithout1, remove(sut, 0));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, 1));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testRemoveOneObjectFromEmpty() {
+    Integer[] sut = {};
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, -1));
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, 0));
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, 1));
+  }
+
+  @Test
+  public void testRemoveOneByte() {
+    byte[] sut = {1, 2, 3};
+    byte[] sutWithout1 = {2, 3};
+    byte[] sutWithout2 = {1, 3};
+    byte[] sutWithout3 = {1, 2};
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MIN_VALUE));
+    assertArrayEquals("Should not have deleted ",   sut, remove(sut, -1));
+    assertArrayEquals("Should have deleted first",  sutWithout1, remove(sut, 0));
+    assertArrayEquals("Should have deleted second", sutWithout2, remove(sut, 1));
+    assertArrayEquals("Should have deleted third",  sutWithout3, remove(sut, 2));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, 3));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testRemoveOneByteFromSingleton() {
+    byte[] sut = {1};
+    byte[] sutWithout1 = {};
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MIN_VALUE));
+    assertArrayEquals("Should not have deleted ",   sut, remove(sut, -1));
+    assertArrayEquals("Should have deleted first",  sutWithout1, remove(sut, 0));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, 1));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testRemoveOneByteFromEmpty() {
+    byte[] sut = {};
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, -1));
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, 0));
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, 1));
+  }
+
+  @Test
+  public void testRemoveOneInt() {
+    int[] sut = {1, 2, 3};
+    int[] sutWithout1 = {2, 3};
+    int[] sutWithout2 = {1, 3};
+    int[] sutWithout3 = {1, 2};
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MIN_VALUE));
+    assertArrayEquals("Should not have deleted ",   sut, remove(sut, -1));
+    assertArrayEquals("Should have deleted first",  sutWithout1, remove(sut, 0));
+    assertArrayEquals("Should have deleted second", sutWithout2, remove(sut, 1));
+    assertArrayEquals("Should have deleted third",  sutWithout3, remove(sut, 2));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, 3));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testRemoveOneIntFromSingleton() {
+    int[] sut = {1};
+    int[] sutWithout1 = {};
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MIN_VALUE));
+    assertArrayEquals("Should not have deleted ",   sut, remove(sut, -1));
+    assertArrayEquals("Should have deleted first",  sutWithout1, remove(sut, 0));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, 1));
+    assertArrayEquals("Should have not deleted",    sut,         remove(sut, Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void testRemoveOneIntFromEmpty() {
+    int[] sut = {};
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, -1));
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, 0));
+    assertArrayEquals("Nothing to remove",    sut, remove(sut, 1));
+  }
+
+  @Test
+  public void testCountNonZeroes() {
+    double[] empty = {};
+    assertEquals(0, countNonzeros(empty));
+    double[] singlenz = {1.0};
+    assertEquals(1, countNonzeros(singlenz));
+    double[] threeZeroes = {0.0, 0.0, 0.0};
+    assertEquals(0, countNonzeros(threeZeroes));
+    double[] somenz = {-1.0, Double.MIN_VALUE, 0.0, Double.MAX_VALUE, 0.001, 0.0, 42.0};
+    assertEquals(5, countNonzeros(somenz));
+  }
+}


### PR DESCRIPTION
Added more remove() versions, for a bunch of primitives
Changed one of Frame.remove()s so it uses ArrayUtils.remove() (others to follow)
Addedd a test for this Frame.remove()
Blocked a couple of NPEs in SVMLightFVecParseWriter (they were happening)
in Frame.get() added a better exception message for the case index is out of bounds (happens in a sparse example, will have to investigate it carefully)
Fixed a bunch of smart intellij warnings.
Fixed a line that caused Michal's concern, in ArrayUtils.

This is take 3; for some reason every rebase bumps the diffs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/278)
<!-- Reviewable:end -->
