### PR TITLE
PUBDEV-3505 Fixed handling of (na) sparse uuid columns, added test.

### DIFF
--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -783,6 +783,8 @@ public class NewChunk extends Chunk {
   }
   // Slow-path append data
   private void append2slowUUID() {
+    if(_id != null)
+      cancel_sparse();
     if( _ds==null && _ms!=null ) { // This can happen for columns with all NAs and then a UUID
       _xs=null;
       _ms.switchToLongs();
@@ -897,6 +899,7 @@ public class NewChunk extends Chunk {
   //Sparsify. Compressible element can be 0 or NA. Store noncompressible elements in _ds OR _ls and _xs OR _is and 
   // their row indices in _id.
   protected void set_sparse(int num_noncompressibles, Compress sparsity_type) {
+    assert !isUUID():"sparse for uuids is not supported";
     if ((sparsity_type == Compress.ZERO && isSparseNA()) || (sparsity_type == Compress.NA && isSparseZero()))
       cancel_sparse();
     if (sparsity_type == Compress.NA) {
@@ -991,7 +994,7 @@ public class NewChunk extends Chunk {
         _xs = xs;
         _missing = missing;
         _ms = ms;
-      } else {
+      } else{
         double [] ds = MemoryManager.malloc8d(_len);
         _missing = new BitSet();
         if (_sparseNA) Arrays.fill(ds, Double.NaN);

--- a/h2o-core/src/test/java/water/fvec/NewChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class NewChunkTest extends TestUtil {
@@ -52,6 +53,23 @@ public class NewChunkTest extends TestUtil {
     assertEquals(Math.PI,c.atd(N+1),1e-16);
   }
 
+  @Test public void testSparseNAs() {
+    NewChunk nc = new NewChunk(null, 0, true);
+    nc.addNAs(128);
+    assertTrue(nc.isSparseNA());
+    for (int i = 0; i < 512; i++)
+      nc.addUUID(i, i);
+    assertFalse(nc.isSparseNA());
+    Chunk c = nc.compress();
+    assertEquals(128 + 512, c.len());
+    for (int i = 0; i < 128; ++i)
+      assertTrue(c.isNA(i));
+    for (int i = 0; i < 512; i++) {
+      assertEquals(i, c.at16l(128 + i));
+      assertEquals(i, c.at16h(128 + i));
+    }
+  }
+
   private static class NewChunkTestCpy extends NewChunk {
     NewChunkTestCpy(Vec vec, int cidx) {super(vec, cidx);}
     public NewChunkTestCpy() { super(null,0); }
@@ -60,6 +78,7 @@ public class NewChunkTest extends TestUtil {
     int missingSize()  {return _missing == null?0:_missing.size();}
   }
 
+  
   private void testIntegerChunk(long [] values, int mantissaSize) {
     Vec v = Vec.makeCon(0,0);
     // single bytes


### PR DESCRIPTION
UUIDs currently do not support sparse. If the column starts with bunch of NAs it is stored as na-sparse numbers initially.
It is flipped to uuids after hitting first non-na uuid value, however, at this point, the parse was not cancelled.
This lead to unsupported state where part of data was stored sparse while the rest was dense -> lead to AIOB.

Fixed by cancelling the sparse when flipping to UUIDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/279)
<!-- Reviewable:end -->
