### PR TITLE
Use the correct iris dataset for K-Means estimate_k junit. Also cast …

### DIFF
--- a/h2o-algos/src/main/java/hex/kmeans/KMeans.java
+++ b/h2o-algos/src/main/java/hex/kmeans/KMeans.java
@@ -368,7 +368,7 @@ public class KMeans extends ClusteringModelBuilder<KMeansModel,KMeansModel.KMean
         for( int col=0; col<hi[i].length; col++ ) {
           if (_isCats[col]!=null) continue; // can't split a cluster along categorical direction
           range[col] = hi[i][col] - lo[i][col];
-          if (range[col] > maxRange) {
+          if ((float)range[col] > (float)maxRange) { //break ties
             clusterToSplit = i;
             dimToSplit = col;
             maxRange = range[col];

--- a/h2o-algos/src/test/java/hex/kmeans/KMeansTest.java
+++ b/h2o-algos/src/test/java/hex/kmeans/KMeansTest.java
@@ -95,11 +95,11 @@ public class KMeansTest extends TestUtil {
     KMeansModel kmm = null;
     Frame fr = null, fr2= null;
     try {
-      fr = parse_test_file("smalldata/iris/iris_wheader.csv");
+      fr = parse_test_file("smalldata/iris/iris_wheader_correct.csv");
 
       KMeansModel.KMeansParameters parms = new KMeansModel.KMeansParameters();
       parms._train = fr._key;
-      parms._ignored_columns = new String[]{"class"};
+      parms._ignored_columns = new String[]{"species"};
       parms._k = 100;  // large enough
       parms._standardize = false;
       parms._estimate_k = true;
@@ -108,7 +108,7 @@ public class KMeansTest extends TestUtil {
       for (int i=0;i<kmm._output._centers_raw.length;++i) {
         Log.info(Arrays.toString(kmm._output._centers_raw[i]));
       }
-      Assert.assertEquals("expected 4 centroids", 4, kmm._output._k[kmm._output._k.length-1]);
+      Assert.assertEquals("expected 3 centroids", 3, kmm._output._k[kmm._output._k.length-1]);
 
       // Done building model; produce a score column with cluster choices
       fr2 = kmm.score(fr);


### PR DESCRIPTION
…bounding boxes to float to get less sensitivity to full double precision noise. Now finds 3 cluster for iris.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/282)
<!-- Reviewable:end -->
