### PR TITLE
[HEXDEV-639] Remove Java7+ specific code/config

### DIFF
--- a/h2o-core/src/main/java/water/network/SSLProperties.java
+++ b/h2o-core/src/main/java/water/network/SSLProperties.java
@@ -12,7 +12,7 @@ class SSLProperties extends Properties {
         return null;
     }
 
-    String h2o_ssl_protocol() { return getProperty("h2o_ssl_protocol", "TLSv1.2"); }
+    String h2o_ssl_protocol() { return getProperty("h2o_ssl_protocol", SecurityUtils.defaultTLSVersion()); }
 
     String h2o_ssl_jks_internal() { return getProperty("h2o_ssl_jks_internal"); }
     String h2o_ssl_jks_password() { return getProperty("h2o_ssl_jks_password"); }

--- a/h2o-core/src/main/java/water/network/SecurityUtils.java
+++ b/h2o-core/src/main/java/water/network/SecurityUtils.java
@@ -86,7 +86,7 @@ public class SecurityUtils {
 
     public static String generateSSLConfig(SSLCredentials credentials, String file) throws IOException {
         Properties sslConfig = new Properties();
-        sslConfig.put("h2o_ssl_protocol", "TLSv1.2");
+        sslConfig.put("h2o_ssl_protocol", defaultTLSVersion());
         sslConfig.put("h2o_ssl_jks_internal", credentials.jks.getLocation());
         sslConfig.put("h2o_ssl_jks_password", credentials.jks.pass);
         sslConfig.put("h2o_ssl_jts", credentials.jts.getLocation());
@@ -94,6 +94,10 @@ public class SecurityUtils {
         FileOutputStream output = new FileOutputStream(file);
         sslConfig.store(output, "");
         return file;
+    }
+
+    public static String defaultTLSVersion() {
+        return System.getProperty("java.version", "NA").startsWith("1.6") ? "TLSv1" : "TLSv1.2";
     }
 
     public static class StoreCredentials {

--- a/h2o-core/src/test/java/water/network/SSLSocketChannelFactoryTest.java
+++ b/h2o-core/src/test/java/water/network/SSLSocketChannelFactoryTest.java
@@ -2,7 +2,6 @@ package water.network;
 
 import org.junit.Test;
 import water.TestUtil;
-import water.util.Log;
 
 import javax.net.ssl.SSLException;
 import java.io.IOException;
@@ -11,7 +10,6 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
@@ -24,7 +22,7 @@ public class SSLSocketChannelFactoryTest {
     @Test
     public void shouldHandshake() throws IOException, SSLContextException, BrokenBarrierException, InterruptedException {
         SSLProperties props = new SSLProperties();
-        props.put("h2o_ssl_protocol", "TLSv1.2");
+        props.put("h2o_ssl_protocol", SecurityUtils.defaultTLSVersion());
         props.put("h2o_ssl_jks_internal", TestUtil.find_test_file_static("src/test/resources/keystore.jks").getPath());
         props.put("h2o_ssl_jks_password", "password");
         props.put("h2o_ssl_jts", TestUtil.find_test_file_static("src/test/resources/cacerts.jks").getPath());
@@ -75,7 +73,7 @@ public class SSLSocketChannelFactoryTest {
             readBuffer.get(dst, 0, 12);
             readBuffer.clear();
 
-            assertEquals("hello, world", new String(dst, StandardCharsets.UTF_8));
+            assertEquals("hello, world", new String(dst, "UTF-8"));
             testOne.await();
 
             // SECOND TEST: SSL -> SSL BIG COMMUNICATION
@@ -94,7 +92,7 @@ public class SSLSocketChannelFactoryTest {
                 } else {
                     readBufferBig.compact();
                 }
-                assertEquals("hello, world" + (read % 9) + "!!!", new String(dstBig, StandardCharsets.UTF_8));
+                assertEquals("hello, world" + (read % 9) + "!!!", new String(dstBig, "UTF-8"));
                 read += 16;
             }
 
@@ -124,7 +122,7 @@ public class SSLSocketChannelFactoryTest {
             readBuffer.get(dst, 0, 12);
             readBuffer.clear();
 
-            assertNotEquals("hello, world", new String(dst, StandardCharsets.UTF_8));
+            assertNotEquals("hello, world", new String(dst, "UTF-8"));
         } catch (IOException | InterruptedException | BrokenBarrierException e) {
             e.printStackTrace();
         }
@@ -169,7 +167,7 @@ public class SSLSocketChannelFactoryTest {
 
                 // FIRST TEST: SSL -> SSL SMALL COMMUNICATION
                 ByteBuffer write = ByteBuffer.allocate(1024);
-                write.put("hello, world".getBytes(StandardCharsets.UTF_8));
+                write.put("hello, world".getBytes("UTF-8"));
                 write.flip();
                 wrappedChannel.write(write);
 
@@ -182,7 +180,7 @@ public class SSLSocketChannelFactoryTest {
                     while (toWriteBig.hasRemaining()) {
                         toWriteBig.put(
                                 ("hello, world" + ((i * 64 * 1024 + toWriteBig.position()) % 9) + "!!!")
-                                        .getBytes(StandardCharsets.UTF_8)
+                                        .getBytes("UTF-8")
                         );
                     }
                     toWriteBig.flip();
@@ -193,7 +191,7 @@ public class SSLSocketChannelFactoryTest {
 
                 // THIRD TEST: NON-SSL -> SSL COMMUNICATION
                 write.clear();
-                write.put("hello, world".getBytes(StandardCharsets.UTF_8));
+                write.put("hello, world".getBytes("UTF-8"));
                 write.flip();
                 sock.write(write);
 
@@ -201,7 +199,7 @@ public class SSLSocketChannelFactoryTest {
 
                 // FOURTH TEST: SSL -> NON-SSL COMMUNICATION
                 write.clear();
-                write.put("hello, world".getBytes(StandardCharsets.UTF_8));
+                write.put("hello, world".getBytes("UTF-8"));
                 write.flip();
                 wrappedChannel.write(write);
 

--- a/h2o-core/src/test/java/water/network/SecurityUtilsTest.java
+++ b/h2o-core/src/test/java/water/network/SecurityUtilsTest.java
@@ -20,7 +20,7 @@ public class SecurityUtilsTest {
 
             Properties sslConfig = new Properties();
             sslConfig.load(new FileInputStream(configPath));
-            assertEquals("TLSv1.2", sslConfig.getProperty("h2o_ssl_protocol"));
+            assertEquals(SecurityUtils.defaultTLSVersion(), sslConfig.getProperty("h2o_ssl_protocol"));
             assertEquals("h2o-keystore-test.jks", sslConfig.getProperty("h2o_ssl_jks_internal"));
             assertEquals("test123", sslConfig.getProperty("h2o_ssl_jks_password"));
             assertEquals("h2o-keystore-test.jks", sslConfig.getProperty("h2o_ssl_jts"));


### PR DESCRIPTION
* Set TLSv1 as default for Java6 env
* Remove `StandardCharsets` from test (since Java 7)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/283)
<!-- Reviewable:end -->
