### PR TITLE
PCA-doc-fix: Scree and cumulative variance plots

### DIFF
--- a/h2o-docs/src/product/data-science/pca.rst
+++ b/h2o-docs/src/product/data-science/pca.rst
@@ -86,12 +86,6 @@ Interpreting a PCA Model
 PCA output returns a table displaying the number of components specified
 by the value for ``k``.
 
-Scree and cumulative variance plots for the components are returned as
-well. Users can access them by clicking on the black button labeled
-"Scree and Variance Plots" at the top left of the results page. A scree
-plot shows the variance of each component, while the cumulative variance
-plot shows the total variance accounted for by the set of components.
-
 The output for PCA includes the following:
 
 -  Model parameters (hidden)


### PR DESCRIPTION
Removed a paragraph in the PCA section that described how to retrieve Scree and Variance plots. These are not available. This paragraph will be added back in after PUBDEV-2788 is resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/291)
<!-- Reviewable:end -->
