### PR TITLE
Make MetricBuilderUnsupervised class generic (as its parent), 

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -446,7 +446,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
    * @param destination_key Frame Id for output
    * @return Frame containing k rows and n columns, where each row corresponds to an archetype
    */
-  @Override public Frame scoreArchetypes(Frame frame, Key destination_key, boolean reverse_transform) {
+  @Override public Frame scoreArchetypes(Frame frame, Key<Frame> destination_key, boolean reverse_transform) {
     final int ncols = _output._names.length;
     Frame adaptedFr = new Frame(frame);
     adaptTestForTrain(adaptedFr, true, false);
@@ -473,7 +473,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     }
 
     // Convert projection of archetypes into a frame with correct domains
-    Frame f = ArrayUtils.frame((null == destination_key ? Key.make() : destination_key), adaptedFr.names(), proj);
+    Frame f = ArrayUtils.frame((destination_key == null ? Key.<Frame>make() : destination_key), adaptedFr.names(), proj);
     for(int i = 0; i < ncols; i++) f.vec(i).setDomain(adaptedDomme[i]);
     return f;
   }
@@ -483,7 +483,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     final int _ncolX;   // Number of cols in X (rank k)
     final boolean _save_imputed;  // Save imputed data into new vecs?
     final boolean _reverse_transform;   // Reconstruct original training data by reversing transform?
-    ModelMetrics.MetricBuilder _mb;
+    ModelMetricsGLRM.GlrmModelMetricsBuilder _mb;
 
     GLRMScore( int ncolA, int ncolX, boolean save_imputed ) {
       this(ncolA, ncolX, save_imputed, _parms._impute_original);
@@ -517,7 +517,6 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     }
 
     @Override public void reduce(GLRMScore other) {
-      // FIXME: IntelliJ raises a valid warning here; need to adjust the definition of _mb
       if (_mb != null) _mb.reduce(other._mb);
     }
 
@@ -583,7 +582,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     return (ModelMetricsGLRM) mm;
   }
 
-  @Override public ModelMetrics.MetricBuilder makeMetricBuilder(String[] domain) {
-    return new ModelMetricsGLRM.GLRMModelMetrics(_parms._k, _output._permutation, _parms._impute_original);
+  @Override public ModelMetricsGLRM.GlrmModelMetricsBuilder makeMetricBuilder(String[] domain) {
+    return new ModelMetricsGLRM.GlrmModelMetricsBuilder(_parms._k, _output._permutation, _parms._impute_original);
   }
 }

--- a/h2o-algos/src/main/java/hex/glrm/ModelMetricsGLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/ModelMetricsGLRM.java
@@ -23,15 +23,15 @@ public class ModelMetricsGLRM extends ModelMetricsUnsupervised {
     _catcnt = catcnt;
   }
 
-  public static class GLRMModelMetrics extends MetricBuilderUnsupervised {
+  public static class GlrmModelMetricsBuilder extends MetricBuilderUnsupervised<GlrmModelMetricsBuilder> {
     public double _miscls;     // Number of misclassified categorical values
     public long _numcnt;      // Number of observed numeric entries
     public long _catcnt;     // Number of observed categorical entries
     public int[] _permutation;  // Permutation array for shuffling cols
     public boolean _impute_original;
 
-    public GLRMModelMetrics(int dims, int[] permutation) { this(dims, permutation, false); }
-    public GLRMModelMetrics(int dims, int[] permutation, boolean impute_original) {
+    public GlrmModelMetricsBuilder(int dims, int[] permutation) { this(dims, permutation, false); }
+    public GlrmModelMetricsBuilder(int dims, int[] permutation, boolean impute_original) {
       _work = new double[dims];
       _miscls = _numcnt = _catcnt = 0;
       _permutation = permutation;
@@ -69,8 +69,7 @@ public class ModelMetricsGLRM extends ModelMetricsUnsupervised {
     }
 
     @Override
-    public void reduce(MetricBuilder mb) {
-      GLRMModelMetrics mm = (GLRMModelMetrics) mb;
+    public void reduce(GlrmModelMetricsBuilder mm) {
       super.reduce(mm);
       _miscls += mm._miscls;
       _numcnt += mm._numcnt;

--- a/h2o-algos/src/main/java/hex/pca/ModelMetricsPCA.java
+++ b/h2o-algos/src/main/java/hex/pca/ModelMetricsPCA.java
@@ -11,7 +11,7 @@ public class ModelMetricsPCA extends ModelMetricsUnsupervised {
   }
 
   // PCA currently does not have any model metrics to compute during scoring
-  public static class PCAModelMetrics extends MetricBuilderUnsupervised {
+  public static class PCAModelMetrics extends MetricBuilderUnsupervised<PCAModelMetrics> {
     public PCAModelMetrics(int dims) {
       _work = new double[dims];
     }

--- a/h2o-algos/src/main/java/hex/svd/SVDModel.java
+++ b/h2o-algos/src/main/java/hex/svd/SVDModel.java
@@ -88,7 +88,7 @@ public class SVDModel extends Model<SVDModel,SVDModel.SVDParameters,SVDModel.SVD
     @Override public ModelCategory getModelCategory() { return ModelCategory.DimReduction; }
   }
 
-  public SVDModel(Key selfKey, SVDParameters parms, SVDOutput output) { super(selfKey,parms,output); }
+  public SVDModel(Key<SVDModel> selfKey, SVDParameters parms, SVDOutput output) { super(selfKey, parms, output); }
 
   @Override protected Futures remove_impl( Futures fs ) {
     if (null != _output._u_key)
@@ -120,7 +120,7 @@ public class SVDModel extends Model<SVDModel,SVDModel.SVDParameters,SVDModel.SVD
     }
 
     // SVD currently does not have any model metrics to compute during scoring
-    public static class SVDModelMetrics extends MetricBuilderUnsupervised {
+    public static class SVDModelMetrics extends MetricBuilderUnsupervised<SVDModelMetrics> {
       public SVDModelMetrics(int dims) {
         _work = new double[dims];
       }

--- a/h2o-core/src/main/java/hex/ModelMetricsAutoEncoder.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsAutoEncoder.java
@@ -11,7 +11,7 @@ public class ModelMetricsAutoEncoder extends ModelMetricsUnsupervised {
     super(model, frame, nobs, mse);
   }
 
-  public static class MetricBuilderAutoEncoder extends MetricBuilderUnsupervised {
+  public static class MetricBuilderAutoEncoder extends MetricBuilderUnsupervised<MetricBuilderAutoEncoder> {
     public MetricBuilderAutoEncoder(int dims) {
       _work = new double[dims];
     }

--- a/h2o-core/src/main/java/hex/ModelMetricsClustering.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsClustering.java
@@ -72,12 +72,12 @@ public class ModelMetricsClustering extends ModelMetricsUnsupervised {
       int col = 0;
       table.set(k, col++, k+1);
       table.set(k, col++, _size[k]);
-      table.set(k, col++, _withinss[k]);
+      table.set(k, col, _withinss[k]);
     }
     return table;
   }
 
-  public static class MetricBuilderClustering extends MetricBuilderUnsupervised {
+  public static class MetricBuilderClustering extends MetricBuilderUnsupervised<MetricBuilderClustering> {
     public long[] _size;        // Number of elements in cluster
     public double[] _within_sumsqe;   // Within-cluster sum of squared error
     private double[/*features*/] _colSum;  // Sum of each column
@@ -125,8 +125,7 @@ public class ModelMetricsClustering extends ModelMetricsUnsupervised {
     }
 
     @Override
-    public void reduce(MetricBuilder mb) {
-      MetricBuilderClustering mm = (MetricBuilderClustering) mb;
+    public void reduce(MetricBuilderClustering mm) {
       super.reduce(mm);
       ArrayUtils.add(_size, mm._size);
       ArrayUtils.add(_within_sumsqe, mm._within_sumsqe);

--- a/h2o-core/src/main/java/hex/ModelMetricsUnsupervised.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsUnsupervised.java
@@ -7,6 +7,6 @@ public class ModelMetricsUnsupervised extends ModelMetrics {
     super(model, frame, nobs, MSE, null);
   }
 
-  public static abstract class MetricBuilderUnsupervised extends MetricBuilder {
-  }
+  public static abstract class MetricBuilderUnsupervised<T extends MetricBuilderUnsupervised<T>>
+          extends MetricBuilder<T> {}
 }


### PR DESCRIPTION
which solves several warnings in the downstream classes. Also rename GLRMModelMetrics => GlrmModelMetricsBuilder, because otherwise it was too easy to confuse with ModelMetricsGLRM class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/293)
<!-- Reviewable:end -->
