### PR TITLE
PUBDEV-3305 - fixed flat file to deactivate dead nodes

### DIFF
--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -39,6 +39,14 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   transient public volatile HeartBeat _heartbeat;  // My health info.  Changes 1/sec.
   transient public int _tcp_readers;               // Count of started TCP reader threads
 
+  public boolean _removed_from_cloud;
+  public void stopSendThread(){
+    if(_sendThread != null) {
+      _sendThread._stopRequested = true;
+      _sendThread = null;
+    }
+    _removed_from_cloud = true;
+  }
   // A JVM is uniquely named by machine IP address and port#
   public final H2Okey _key;
 
@@ -295,6 +303,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   // Buffers the small messages together and sends the bytes over via TCP channel.
   class UDP_TCP_SendThread extends Thread {
 
+    volatile boolean _stopRequested;
     private ByteChannel _chan;  // Lazily made on demand; closed & reopened on error
     private final ByteBuffer _bb; // Reusable output large buffer
   
@@ -335,7 +344,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   
     @Override public void run(){
       try {
-        while (true) {            // Forever loop
+        while (!_stopRequested) {            // Forever loop
           try {
             ByteBuffer bb = _msgQ.take(); // take never returns null but blocks instead
             while( bb != null ) {         // while have an BB to process
@@ -357,11 +366,10 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     void sendBuffer(){
       int retries = 0;
       _bb.flip();                 // limit set to old position; position set to 0
-      while( _bb.hasRemaining() ) {
+      while( !_stopRequested && _bb.hasRemaining()) {
         try {
           ByteChannel chan = _chan == null ? (_chan=openChan()) : _chan;
           chan.write(_bb);
-  
         } catch(IOException ioe) {
           _bb.rewind();           // Position to zero; limit unchanged; retry the operation
           // Log if not shutting down, and not middle-of-cloud-formation where
@@ -369,7 +377,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
           // comes up - such as when not all nodes mentioned in a flatfile will be
           // booted.  Basically the ERRR log will show endless repeat attempts to
           // connect to the missing node
-          if( !H2O.getShutdownRequested() && (Paxos._cloudLocked || retries++ > 300) ) {
+          if( !_stopRequested && !H2O.getShutdownRequested() && (Paxos._cloudLocked || retries++ > 300) ) {
             Log.err("Got IO error when sending batch UDP bytes: ",ioe);
             retries = 150;      // Throttle the pace of error msgs
           }
@@ -381,7 +389,6 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
           try {Thread.sleep(sleep);} catch (InterruptedException e) {/*ignored*/}
         }
       }
-  
       _bb.clear();            // Position set to 0; limit to capacity
     }
   

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -359,8 +359,12 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
             }
             sendBuffer();         // Send final trailing BBs
           } catch (InterruptedException e) { /*ignore*/ }
-        } 
+        }
       } catch(Throwable t) { throw Log.throwErr(t); }
+      if(_chan != null) {
+        try {_chan.close();} catch (IOException e) {}
+        _chan = null;
+      }
     }
   
     void sendBuffer(){

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -147,6 +147,15 @@ public abstract class Paxos {
       while( !_commonKnowledge )
         try { Paxos.class.wait(); } catch( InterruptedException ignore ) { }
       _cloudLocked = true;
+      // remove nodes which are not in the cluster (e.g. nodes from flat-file which are not actually used)
+      if(H2O.isFlatfileEnabled()){
+        for(H2ONode n: H2O.getFlatfile()){
+          if(!n._heartbeat._client && !PROPOSED.containsKey(n._key)){
+            Log.info("Flatile::" + n._key + " not active in this cloud. Removing it from the list.");
+            n.stopSendThread();
+          }
+        }
+      }
     }
   }
 

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 import water.H2O;
 import water.H2ONode;
 import water.JettyHTTPD;
+import water.Paxos;
 import water.util.Log;
 import water.util.NetworkUtils;
 import water.util.OSUtils;
@@ -582,10 +583,13 @@ public class NetworkInit {
 
       // Hideous O(n) algorithm for broadcast - avoid the memory allocation in
       // this method (since it is heavily used)
+
       HashSet<H2ONode> nodes = H2O.getFlatfile();
       nodes.addAll(water.Paxos.PROPOSED.values());
       bb.mark();
       for( H2ONode h2o : nodes ) {
+        if(h2o._removed_from_cloud)
+          continue;
         try {
           bb.reset();
           if(H2O.ARGS.useUDP) {


### PR DESCRIPTION
Quick fix to prevent endless attempted sends to nodes which are present in flat file but not in the active cloud. 

At the time of the cloud lock, deactivate any dead flat file nodes. Deactivating nodes will prevent them from being included in the multicast sends and will stop udp sender thread for the node.

There is still and open question what to do with clients (same situation can occur with disconnected client) but this issue needs a fix asap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/297)
<!-- Reviewable:end -->
