### PR TITLE
Tomas pubdev 3455

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -1068,22 +1068,22 @@ public class DataInfo extends Keyed<DataInfo> {
       }
       if(_weights) {
         rows[i].weight = chunks[weightChunkId()].atd(i);
-        if(Double.isNaN(rows[i].weight)) {
+        if(Double.isNaN(rows[i].weight))
           rows[i].predictors_bad = true;
-          continue;
-        }
       }
     }
     // categoricals
     for (int i = 0; i < _cats; ++i) {
       for (int r = 0; r < chunks[0]._len; ++r) {
         Row row = rows[r];
-        int cid = getCategoricalId(i,chunks[i].isNA(r)? _catNAFill[i]:(int)chunks[i].at8(r));
+        boolean isMissing = chunks[i].isNA(r);
+        if(_skipMissing && isMissing){
+          row.predictors_bad = true;
+          continue;
+        }         
+        int cid = getCategoricalId(i,isMissing? _catNAFill[i]:(int)chunks[i].at8(r));
         if(cid >=0)
           row.binIds[row.nBins++] = cid;
-        else if(_skipMissing) {
-          row.predictors_bad = true;
-        }
       }
     }
     // generic numbers + interactions

--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -17,6 +17,7 @@ import water.util.Log;
 import water.util.MathUtils;
 
 import java.util.Arrays;
+import java.util.Comparator;
 
 public final class ComputationState {
   final boolean _intercept;
@@ -127,36 +128,47 @@ public final class ComputationState {
    *
    * @return indices of expected active predictors.
    */
-  protected int applyStrongRules(double lambdaNew, double lambdaOld) {
+  protected void applyStrongRules(double lambdaNew, double lambdaOld) {
     lambdaNew = Math.min(_lambdaMax,lambdaNew);
     lambdaOld = Math.min(_lambdaMax,lambdaOld);
-    if(_parms._family == Family.multinomial)
-      return applyStrongRulesMultinomial(lambdaNew,lambdaOld);
+    if (_parms._family == Family.multinomial /* && _parms._solver != GLMParameters.Solver.L_BFGS */) {
+      applyStrongRulesMultinomial(lambdaNew, lambdaOld);
+      return;
+    }
     int P = _dinfo.fullN();
-    int newlySelected = 0;
     _activeBC = _bc;
     _activeData = _activeData != null?_activeData:_dinfo;
     _allIn = _allIn || _parms._alpha[0]*lambdaNew == 0 || _activeBC.hasBounds();
     if (!_allIn) {
+      int newlySelected = 0;
       final double rhs = Math.max(0,_alpha * (2 * lambdaNew - lambdaOld));
       int [] newCols = MemoryManager.malloc4(P);
       int j = 0;
-      int[] oldActiveCols = _activeData._activeCols == null ? new int[0] : _activeData.activeCols();
+      int[] oldActiveCols = _activeData._activeCols == null ? new int[]{P} : _activeData.activeCols();
       for (int i = 0; i < P; ++i) {
-        if (j < oldActiveCols.length && i == oldActiveCols[j]) {
-          ++j;
-          newCols[newlySelected++] = i; // todo
-        } else if (_ginfo._gradient[i] > rhs || -_ginfo._gradient[i] > rhs) {
+        if(j < oldActiveCols.length && oldActiveCols[j] == i)
+          j++;
+        else if (_ginfo._gradient[i] > rhs || -_ginfo._gradient[i] > rhs)
           newCols[newlySelected++] = i;
-        }
       }
+      if(_parms._max_active_predictors != -1 && (oldActiveCols.length + newlySelected -1) > _parms._max_active_predictors){
+        Integer [] bigInts = ArrayUtils.toIntegers(newCols, 0, newlySelected);
+        Arrays.sort(bigInts, new Comparator<Integer>() {
+          @Override
+          public int compare(Integer o1, Integer o2) {
+            return (int)Math.signum(_ginfo._gradient[o2.intValue()]*_ginfo._gradient[o2.intValue()] - _ginfo._gradient[o1.intValue()]*_ginfo._gradient[o1.intValue()]);
+          }
+        });
+        newCols = ArrayUtils.toInt(bigInts,0,_parms._max_active_predictors - oldActiveCols.length + 1);
+        Arrays.sort(newCols);
+      } else newCols = Arrays.copyOf(newCols,newlySelected);
+      newCols = ArrayUtils.sortedMerge(oldActiveCols,newCols);
       // merge already active columns in
-      int active = newlySelected;
+      int active = newCols.length;
       _allIn = active == P;
       if(!_allIn) {
         int [] cols = newCols;
-        cols[newlySelected++] = P; // intercept is always selected, even if it is false (it's gonna be dropped later, it is needed for other stuff too)
-        cols = Arrays.copyOf(cols, newlySelected);
+        assert cols[active-1] == P; // intercept is always selected, even if it is false (it's gonna be dropped later, it is needed for other stuff too)
         _beta = ArrayUtils.select(_beta, cols);
         if(_u != null) _u = ArrayUtils.select(_u,cols);
         _activeData = _dinfo.filterExpandedColumns(cols);
@@ -165,12 +177,11 @@ public final class ComputationState {
         _ginfo = new GLMGradientInfo(_ginfo._likelihood, _ginfo._objVal, ArrayUtils.select(_ginfo._gradient, cols));
         _activeBC = _bc.filterExpandedColumns(_activeData.activeCols());
         _gslvr = new GLMGradientSolver(_job,_parms,_activeData,(1-_alpha)*_lambda,_bc);
-        assert _beta.length == newlySelected;
-        return newlySelected;
+        assert _beta.length == cols.length;
+        return;
       }
     }
     _activeData = _dinfo;
-    return _dinfo.fullN();
   }
 
   public boolean _lsNeeded = false;
@@ -249,7 +260,12 @@ public final class ComputationState {
    *
    * @return indices of expected active predictors.
    */
-  protected int applyStrongRulesMultinomial(double lambdaNew, double lambdaOld) {
+  /**
+   * Apply strong rules to filter out expected inactive (with zero coefficient) predictors.
+   *
+   * @return indices of expected active predictors.
+   */
+  protected int applyStrongRulesMultinomial_old(double lambdaNew, double lambdaOld) {
     int P = _dinfo.fullN();
     int N = P+1;
     int selected = 0;
@@ -281,6 +297,69 @@ public final class ComputationState {
       _allIn = selected == cols.length;
     }
     return selected;
+  }
+
+  /**
+   * Apply strong rules to filter out expected inactive (with zero coefficient) predictors.
+   *
+   * @return indices of expected active predictors.
+   */
+  protected void applyStrongRulesMultinomial(double lambdaNew, double lambdaOld) {
+    int P = _dinfo.fullN();
+    int N = P+1;
+    int selected = 0;
+    _activeBC = _bc;
+    _activeData = _dinfo;
+    if (!_allIn) {
+      if(_activeDataMultinomial == null)
+        _activeDataMultinomial = new DataInfo[_nclasses];
+      final double rhs = _alpha * (2 * lambdaNew - lambdaOld);
+      int [] cols = MemoryManager.malloc4(N*_nclasses);
+
+      int oldActiveColsTotal = 0;
+      for(int c = 0; c < _nclasses; ++c) {
+        int j = 0;
+        int[] oldActiveCols = _activeDataMultinomial[c] == null ? new int[]{P} : _activeDataMultinomial[c]._activeCols;
+        oldActiveColsTotal += oldActiveCols.length;
+        for (int i = 0; i < P; ++i) {
+          if (j < oldActiveCols.length && i == oldActiveCols[j]) {
+            ++j;
+          } else if (_ginfo._gradient[c*N+i] > rhs || _ginfo._gradient[c*N+i] < -rhs) {
+            cols[selected++] = c*N + i;
+          }
+        }
+      }
+      if(_parms._max_active_predictors != -1 && _parms._max_active_predictors - oldActiveColsTotal + _nclasses < selected) {
+        Integer[] bigInts = ArrayUtils.toIntegers(cols, 0, selected);
+        Arrays.sort(bigInts, new Comparator<Integer>() {
+          @Override
+          public int compare(Integer o1, Integer o2) {
+            return (int) Math.signum(_ginfo._gradient[o2.intValue()] * _ginfo._gradient[o2.intValue()] - _ginfo._gradient[o1.intValue()] * _ginfo._gradient[o1.intValue()]);
+          }
+        });
+        cols = ArrayUtils.toInt(bigInts, 0, _parms._max_active_predictors - oldActiveColsTotal + _nclasses);
+        Arrays.sort(cols);
+        selected = cols.length;
+      }
+      int i = 0;
+      int [] cs = new int[P+1];
+      int sum = 0;
+      for(int c = 0; c < _nclasses; ++c){
+        int [] classcols = cs;
+        int[] oldActiveCols = _activeDataMultinomial[c] == null ? new int[]{P} : _activeDataMultinomial[c]._activeCols;
+        int k = 0;
+        while(i < selected && cols[i] < (c+1)*N)
+          classcols[k++] = cols[i++]-c*N;
+        classcols = ArrayUtils.sortedMerge(oldActiveCols,Arrays.copyOf(classcols,k));
+        sum += classcols.length;
+        if(classcols.length < 30)
+          System.out.println("active cols for class " + c + " = " + Arrays.toString(classcols));
+        _activeDataMultinomial[c] = _dinfo.filterExpandedColumns(classcols);
+
+      }
+      assert _parms._max_active_predictors == -1 || sum <= _parms._max_active_predictors + _nclasses:"sum = " + sum + " max_active_preds = " + _parms._max_active_predictors + ", nclasses = " + _nclasses;
+      _allIn = sum == N*_nclasses;
+    }
   }
 
   protected boolean checkKKTsMultinomial(){
@@ -323,7 +402,9 @@ public final class ComputationState {
     _beta = beta;
     _u = u;
     _activeBC = null;
-    if(!_allIn) {
+    if(_parms._max_active_predictors == _activeData.fullN()){
+      Log.info("skipping KKT check, reached maximum number of active predictors ("  + _parms._max_active_predictors + ")");
+    } else if(!_allIn) {
       int[] failedCols = new int[64];
       int fcnt = 0;
       for (int i = 0; i < grad.length - 1; ++i) {

--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -352,10 +352,7 @@ public final class ComputationState {
           classcols[k++] = cols[i++]-c*N;
         classcols = ArrayUtils.sortedMerge(oldActiveCols,Arrays.copyOf(classcols,k));
         sum += classcols.length;
-        if(classcols.length < 30)
-          System.out.println("active cols for class " + c + " = " + Arrays.toString(classcols));
         _activeDataMultinomial[c] = _dinfo.filterExpandedColumns(classcols);
-
       }
       assert _parms._max_active_predictors == -1 || sum <= _parms._max_active_predictors + _nclasses:"sum = " + sum + " max_active_preds = " + _parms._max_active_predictors + ", nclasses = " + _nclasses;
       _allIn = sum == N*_nclasses;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1039,6 +1039,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         updateProgress(false);
       // lambda search loop
       for (int i = 0; i < _parms._lambda.length; ++i) {  // lambda search
+        if(_parms._max_iterations != -1 && _state._iter >= _parms._max_iterations)
+          break;
         Submodel sm = computeSubmodel(i,_parms._lambda[i]);
         double trainDev = sm.devianceTrain;
         double testDev = sm.devianceTest;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -958,11 +958,13 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     }
     int intercept = _parms._intercept ? 1 : 0;
     if(_output.nclasses() > 2) {
-      _output._model_summary.set(0, 3 + lambdaSearch,_output.bestSubmodel().beta.length);
+      _output._model_summary.set(0, 3 + lambdaSearch,_output.nclasses()*_output._coefficient_names.length);
+      _output._model_summary.set(0, 4 + lambdaSearch, Integer.toString(_output.rank() - _output.nclasses()*intercept));
     } else {
       _output._model_summary.set(0, 3 + lambdaSearch, beta().length - 1);
+      _output._model_summary.set(0, 4 + lambdaSearch, Integer.toString(_output.rank() - intercept));
     }
-    _output._model_summary.set(0, 4 + lambdaSearch, Integer.toString(_output.rank() - intercept));
+
     _output._model_summary.set(0, 5 + lambdaSearch, Integer.valueOf(iter));
     _output._model_summary.set(0, 6 + lambdaSearch, train.toString());
     return _output._model_summary;

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
@@ -61,18 +61,18 @@ public class GLMBasicTestMultinomial extends TestUtil {
       params._alpha = new double[]{1};
       params._objective_epsilon = 1e-6;
       params._beta_epsilon = 1e-4;
-      params._max_iterations = 300;
       double[] alpha = new double[]{1};
       double[] expected_deviance = new double[]{25499.76};
       double[] lambda = new double[]{2.544750e-05};
       for (Solver s : new Solver[]{Solver.IRLSM, Solver.COORDINATE_DESCENT, Solver.L_BFGS}) {
         System.out.println("solver = " + s);
         params._solver = s;
+        params._max_iterations = params._solver == Solver.L_BFGS?300:10;
         for (int i = 0; i < alpha.length; ++i) {
           params._alpha[0] = alpha[i];
           params._lambda[0] = lambda[i];
           model = new GLM(params).trainModel().get();
-//          GLMTest.testScoring(model,_covtype);
+          System.out.println(model._output._model_summary);
           System.out.println(model._output._training_metrics);
           System.out.println(model._output._validation_metrics);
           assertTrue(model._output._training_metrics.equals(model._output._validation_metrics));
@@ -91,4 +91,86 @@ public class GLMBasicTestMultinomial extends TestUtil {
       if(preds != null)preds.delete();
     }
   }
+
+  @Test
+  public void testCovtypeMinActivePredictors(){
+    GLMParameters params = new GLMParameters(Family.multinomial);
+    GLMModel model = null;
+    Frame preds = null;
+    try {
+      params._response_column = "C55";
+      params._train = _covtype._key;
+      params._valid = _covtype._key;
+      params._lambda = new double[]{4.881e-05};
+      params._alpha = new double[]{1};
+      params._objective_epsilon = 1e-6;
+      params._beta_epsilon = 1e-4;
+      params._max_active_predictors = 50;
+      params._max_iterations = 10;
+      double[] alpha = new double[]{.99};
+      double expected_deviance = 33000;
+      double[] lambda = new double[]{2.544750e-05};
+      Solver s = Solver.COORDINATE_DESCENT;
+      System.out.println("solver = " + s);
+      params._solver = s;
+      model = new GLM(params).trainModel().get();
+      System.out.println(model._output._model_summary);
+      System.out.println(model._output._training_metrics);
+      System.out.println(model._output._validation_metrics);
+      System.out.println("rank = " + model._output.rank() + ", max active preds = " + params._max_active_predictors);
+      assertTrue(model._output.rank() < params._max_active_predictors + model._output.nclasses());
+      assertTrue(model._output._training_metrics.equals(model._output._validation_metrics));
+      assertTrue(((ModelMetricsMultinomialGLM) model._output._training_metrics)._resDev <= expected_deviance * 1.1);
+      preds = model.score(_covtype);
+      ModelMetricsMultinomialGLM mmTrain = (ModelMetricsMultinomialGLM) hex.ModelMetricsMultinomial.getFromDKV(model, _covtype);
+      assertTrue(model._output._training_metrics.equals(mmTrain));
+      model.delete();
+      model = null;
+      preds.delete();
+      preds = null;
+    } finally{
+      if(model != null)model.delete();
+      if(preds != null)preds.delete();
+    }
+  }
+
+
+  @Test
+  public void testCovtypeLS(){
+    GLMParameters params = new GLMParameters(Family.multinomial);
+    GLMModel model = null;
+    Frame preds = null;
+    try {
+      double expected_deviance = 33000;
+      params._nlambdas = 3;
+      params._response_column = "C55";
+      params._train = _covtype._key;
+      params._valid = _covtype._key;
+      params._alpha = new double[]{.99};
+      params._objective_epsilon = 1e-6;
+      params._beta_epsilon = 1e-4;
+      params._max_active_predictors = 50;
+      params._max_iterations = 500;
+      params._solver = Solver.AUTO;
+      params._lambda_search = true;
+      model = new GLM(params).trainModel().get();
+      System.out.println(model._output._training_metrics);
+      System.out.println(model._output._validation_metrics);
+      assertTrue(model._output._training_metrics.equals(model._output._validation_metrics));
+      preds = model.score(_covtype);
+      ModelMetricsMultinomialGLM mmTrain = (ModelMetricsMultinomialGLM) hex.ModelMetricsMultinomial.getFromDKV(model, _covtype);
+      assertTrue(model._output._training_metrics.equals(mmTrain));
+      assertTrue(((ModelMetricsMultinomialGLM) model._output._training_metrics)._resDev <= expected_deviance);
+      System.out.println(model._output._model_summary);
+      model.delete();
+      model = null;
+      preds.delete();
+      preds = null;
+    } finally{
+      if(model != null)model.delete();
+      if(preds != null)preds.delete();
+    }
+  }
+
+
 }

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -804,6 +804,20 @@ public class ArrayUtils {
     return res;
   }
 
+  public static Integer[] toIntegers(int[] a, int off, int len) {
+    Integer [] res = new Integer[len];
+    for(int i = 0; i < len; ++i)
+      res[i] = a[off+i];
+    return res;
+  }
+
+  public static int[] toInt(Integer[] a, int off, int len) {
+    int [] res = new int[len];
+    for(int i = 0; i < len; ++i)
+      res[i] = a[off+i];
+    return res;
+  }
+
   /** Clever union of String arrays.
    *
    * For union of numeric arrays (strings represent integers) it is expecting numeric ordering.
@@ -1078,6 +1092,17 @@ public class ArrayUtils {
     return da;
   }
 
+  public static int [] sortedMerge(int[] a, int [] b) {
+    int [] c = MemoryManager.malloc4(a.length + b.length);
+    int i = 0, j = 0;
+    for(int k = 0; k < c.length; ++k){
+      if(i == a.length) c[k] = b[j++];
+      else if(j == b.length)c[k] = a[i++];
+      else if(b[j] < a[i]) c[k] = b[j++];
+      else c[k] = a[i++];
+    }
+    return c;
+  }
   // sparse sortedMerge (ids and vals)
   public static void sortedMerge(int[] aIds, double [] aVals, int[] bIds, double [] bVals, int [] resIds, double [] resVals) {
     int i = 0, j = 0;


### PR DESCRIPTION
Fixes handling of max_active_predictors and and max_iterations parameters in glm + added test.

Both params were dropped in the last update and were never used. 
Slightly changed behavior of max_active_predictors - used to stop the computation when the max number was reached, now it continues the computation taking only up to the max_actove_predictors predictors into the model (pick the ones with highest absolute gradient).

No effect if there is fewer active predictors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/298)
<!-- Reviewable:end -->
