### PR TITLE
PUBDEV-3481: Add new categorical_encoding option to docs

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/DeepLearningBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/DeepLearningBooklet.tex
@@ -99,8 +99,8 @@ Printed in the United States of America.
 
 \newpage
 \thispagestyle{empty}%remove pg#
+
 \tableofcontents
-\thispagestyle{empty}%remove pg#
 
 %----------------------------------------------------------------------
 %----------------------------------------------------------------------
@@ -927,6 +927,15 @@ Refer to {\textbf{\nameref{sssec:AdaptiveLearning}}} for more details.
 \item \texttt{input\_dropout\_ratio}: Specifies the fraction of the features for each training row to omit from training to improve generalization. The default is 0, which always uses all features.  Refer to {\textbf{\nameref{ssec:Regularization}}} for more details.
 
 \item \texttt{hidden\_dropout\_ratios}:  Specifies the fraction of the inputs for each hidden layer to omit from training to improve generalization. The default is 0.5 for each hidden layer.  Refer to {\textbf{\nameref{ssec:Regularization}}} for more details.
+
+\item \texttt{categorical\_encoding}:  Specify one of the following encoding schemes for handling categorical features:
+\begin{itemize}
+\item \texttt{auto}: Allow the algorithm to decide
+\item \texttt{one\_hot\_internal}: On the fly N+1 new cols for categorical features with N levels (default)
+\item \texttt{one\_hot\_explicit}: N+1 new columns for categorical features with N levels
+\item \texttt{binary}: No more than 32 columns per categorical feature
+\item \texttt{eigen}: $k$ columns per categorical feature, keeping projections of one-hot-encoded matrix onto $k$-dim eigen space only
+\end{itemize}
 
 \item \texttt{l1}: Specifies the $\ell_1$ (L1) regularization, which constrains the absolute value of the weights (can add stability and improve generalization, causes many weights to become 0). The default is 0, for no L1 regularization. Refer to {\textbf{\nameref{ssec:Regularization}}} for more details.
 

--- a/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
@@ -475,6 +475,14 @@ This section describes the functions of the parameters for GBM.
 \item {\texttt{min\_rows}}: The minimum number of rows to assign to the terminal nodes. The default is 10.
 \item {\texttt{max\_abs\_leafnode\_pred}}: Limits the maximum absolute value of a leaf node prediction. The default is Double.MAX\_VALUE.
 \item {\texttt{pred\_noise\_bandwidth}}: The bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions. If this parameter is specified with a value greater than 0, then every leaf node prediction is randomly scaled by a number drawn from a Normal distribution centered around 1 with a bandwidth given by this parameter. The default is 0 (disabled).
+\item \texttt{categorical\_encoding}:  Specify one of the following encoding schemes for handling categorical features:
+\begin{itemize}
+\item \texttt{auto}: Allow the algorithm to decide (default)
+\item \texttt{enum}: 1 column per categorical feature
+\item \texttt{one\_hot\_explicit}: N+1 new columns for categorical features with N levels
+\item \texttt{binary}: No more than 32 columns per categorical feature
+\item \texttt{eigen}: $k$ columns per categorical feature, keeping projections of one-hot-encoded matrix onto $k$-dim eigen space only
+\end{itemize}
 \item {\texttt{nbins}}: For numerical columns (real/int), build a histogram of at least the specified number of bins, then split at the best point The default is 20.
 \item {\texttt{nbins\_cats}}: For categorical columns (enum), build a histogram of the specified number of bins, then split at the best point. Higher values can lead to more overfitting.  The default is 1024. \label{nbins_cats}
 \item {\texttt{nbins\_top\_level}}: For numerical columns (real/int), build a histogram of (at most) this many bins at the root level, then decrease by factor of two per level.

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -148,6 +148,14 @@ recommended, as model performance can vary greatly.
    improve generalization. Specify one value per hidden layer. The range
    is >= 0 to <1, and the default is 0.5.
 
+-  **categorical_encoding**: Specify one of the following encoding schemes for handling categorical features:
+
+  - ``auto``: Allow the algorithm to decide
+  - ``one_hot_internal``: On the fly N+1 new cols for categorical features with N levels (default)
+  - ``one_hot_explicit``: N+1 new columns for categorical features with N levels
+  - ``binary``: No more than 32 columns per categorical feature
+  - ``eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
+
 -  **l1**: Specify the L1 regularization to add stability and improve
    generalization; sets the value of many weights to 0.
 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -225,6 +225,14 @@ Defining a DRF Model
 
     **Note**: H2O supports extremely randomized trees via ``histogram_type="Random"``. In extremely randomized trees (Extra-Trees), randomness goes one step further in the way splits are computed. As in Random Forests, a random subset of candidate features is used, but instead of looking for the best split, thresholds (for the split) are drawn at random for each candidate feature, and the best of these randomly-generated thresholds is picked as the splitting rule. This usually allows to reduce the variance of the model a bit more, at the expense of a slightly greater increase in bias.
 
+- **categorical_encoding**: Specify one of the following encoding schemes for handling categorical features:
+
+  - ``auto``: Allow the algorithm to decide (default)
+  - ``enum``: 1 column per categorical feature
+  - ``one_hot_explicit``: N+1 new columns for categorical features with N levels
+  - ``binary``: No more than 32 columns per categorical feature
+  - ``eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
+
 -  **keep\_cross\_validation\_predictions**: Enable this option to keep the
    cross-validation prediction.
 

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -144,6 +144,14 @@ Defining a GBM Model
 
 -  **pred\_noise\_bandwidth**: The bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions. If this parameter is specified with a value greater than 0, then every leaf node prediction is randomly scaled by a number drawn from a Normal distribution centered around 1 with a bandwidth given by this parameter. The default is 0 (disabled). 
 
+- **categorical_encoding**: Specify one of the following encoding schemes for handling categorical features:
+
+  - ``auto``: Allow the algorithm to decide (default)
+  - ``enum``: 1 column per categorical feature
+  - ``one_hot_explicit``: N+1 new columns for categorical features with N levels
+  - ``binary``: No more than 32 columns per categorical feature
+  - ``eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
+
 -  **min\_split\_improvement**: The value of this option specifies the minimum relative improvement in squared error reduction in order for a split to happen. When properly tuned, this option can help reduce overfitting. Optimal values would be in the 1e-10...1e-3 range.  
 
 -  **random\_split_points**: By default GBM bins from min...max in steps of (max-min)/N. When this option is enabled, GBM will instead sample N-1 points from min...max and use the sorted list of those for split finding.


### PR DESCRIPTION
Added categorical_encoding option to DRF, GBM, and DeepLearning
sections in the User Guide.

GBM/DRF: Specify one of the following encoding schemes for handling
categorical features:
- ``auto``: Allow the algorithm to decide (default)
- ``enum``: 1 column per categorical feature
- ``one_hot_explicit``: N+1 new columns for categorical features with
N levels
- ``binary``: No more than 32 columns per categorical feature
- ``eigen``: *k* columns per categorical feature, keeping projections
of one-hot-encoded matrix onto *k*-dim eigen space only

Deep Learning: Specify one of the following encoding schemes for
handling categorical features:

- ``auto``: Allow the algorithm to decide
- ``one_hot_internal``: On the fly N+1 new cols for categorical
features with N levels (default)
- ``one_hot_explicit``: N+1 new columns for categorical features with
N levels
- ``binary``: No more than 32 columns per categorical feature
- ``eigen``: *k* columns per categorical feature, keeping projections
of one-hot-encoded matrix onto *k*-dim eigen space only

Also updated GBM and Deep Learning booklets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/311)
<!-- Reviewable:end -->
