### PR TITLE
throw a more informative exception for the user when wrapper gets a s…

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -463,6 +463,18 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
             value = Double.parseDouble(s);
           }
         } else if (o instanceof Double) {
+          String s = (String) o;
+          value = Double.parseDouble(s);
+        }
+        else if (o instanceof Double) {
+          String s = (String) o;
+          try {
+            value = Double.parseDouble(s);
+          } catch(NumberFormatException nfe) {
+            throw new PredictException("Unable to parse value: " + s + ", from column: "+ dataColumnName + ", as Double; " + nfe.getMessage());
+          }
+        }
+        else if (o instanceof Double) {
           value = (Double) o;
         } else if (o instanceof byte[] && isImage) {
           // Read the image from raw bytes

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -4,6 +4,7 @@ import hex.ModelCategory;
 import hex.genmodel.GenModel;
 import hex.genmodel.algos.deepwater.DeepwaterMojoModel;
 import hex.genmodel.easy.exception.PredictException;
+import hex.genmodel.easy.exception.PredictNumberFormatException;
 import hex.genmodel.easy.exception.PredictUnknownCategoricalLevelException;
 import hex.genmodel.easy.exception.PredictUnknownTypeException;
 import hex.genmodel.easy.prediction.*;
@@ -460,21 +461,13 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
           }
           else {
             // numeric
-            value = Double.parseDouble(s);
+            try {
+              value = Double.parseDouble(s);
+            } catch(NumberFormatException nfe) {
+              throw new PredictNumberFormatException("Unable to parse value: " + s + ", from column: "+ dataColumnName + ", as Double; " + nfe.getMessage());
+            }
           }
         } else if (o instanceof Double) {
-          String s = (String) o;
-          value = Double.parseDouble(s);
-        }
-        else if (o instanceof Double) {
-          String s = (String) o;
-          try {
-            value = Double.parseDouble(s);
-          } catch(NumberFormatException nfe) {
-            throw new PredictException("Unable to parse value: " + s + ", from column: "+ dataColumnName + ", as Double; " + nfe.getMessage());
-          }
-        }
-        else if (o instanceof Double) {
           value = (Double) o;
         } else if (o instanceof byte[] && isImage) {
           // Read the image from raw bytes

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/exception/PredictNumberFormatException.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/exception/PredictNumberFormatException.java
@@ -1,0 +1,14 @@
+package hex.genmodel.easy.exception;
+
+/**
+ * Unknown type exception.
+ *
+ * When a RowData observation is provided to a predict method, the value types are extremely restricted.
+ * This exception occurs if the value of a numeric feature fails to parse as Double. Ex. empty string
+ *
+ */
+public class PredictNumberFormatException extends PredictException {
+  public PredictNumberFormatException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
…trange value.

@tomkraljevic @tomasnykodym @arnocandel @mmalohlava @st-pasha 

Tom cautioned changes to this API should "go through the ringer", so added you all...

Motivation: when user passes in empty string for numerical feature parseDouble throws NumberFormatException. This can easily happen when filling RowData from some other store in a loop, where an empty string is a missing value (I think this makes sense). The NFE message sucks and it's not obvious what to do, so I think this at least is a little better. (customer ran into this)

Further question though: before parseDouble, the value is already NaN, so if you didn't add the feature to RowData, it will be interpreted as missing (correctly) anyways. With that behavior in place I believe it strange to throw an exception when feature value = ""... in my mind it's clearly missing... (Tom mentioned that sparse case is different somehow but that's beyond my knowledge...)

Perhaps one of these approaches next?

- either interpret value="" as missing for numericals by default
- add explicit flags like: setConvertEmptyStringToZero(true)), setConvertEmptyStringToNa(true))
- to avoid potentially adding flags for cases X,Y,Z in the future (since we already have this essentially same flag for unseen categorical to be NAs) ... create a flexible approach to let the user decide like... interpretNumerical(from, to) 

thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/313)
<!-- Reviewable:end -->
