### PR TITLE
[HOTFIX] Fix path in partial dependence plot unit test

### DIFF
--- a/h2o-r/tests/testdir_misc/runit_partialPlot.R
+++ b/h2o-r/tests/testdir_misc/runit_partialPlot.R
@@ -19,8 +19,7 @@ test <- function() {
   # r_race_pp = partialPlot(x = prostate_rf, pred.data = prostate_df, x.var = "RACE")
   
   ## Import prostate dataset
-  prostate_path = system.file("extdata", "prostate.csv", package="h2o")
-  prostate_hex = h2o.importFile(prostate_path)
+  prostate_hex = h2o.uploadFile(locate("smalldata/logreg/prostate.csv"), "prostate.hex")
 
   ## Change CAPSULE to Enum
   prostate_hex[, "CAPSULE"] = as.factor(prostate_hex[, "CAPSULE"])


### PR DESCRIPTION
*This PR is a potential fix for `runit_partialDependence.R` failing in the Jenkins PR build.
*Essentially, I changed the path of the prostate dataset and now pull it from `smalldata`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/320)
<!-- Reviewable:end -->
