### PR TITLE
PUBDEV-3528. SVD init error.  Fixed bug and copied the matrices X, W …

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -397,6 +397,13 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
         InitialXSVD xtsk = new InitialXSVD(dsqrt, _parms._k, _ncolA, _ncolX);
         xtsk.doAll(fullFrm);
 
+        // fix for PUBDEV-3528.  Copy content of fullFrm into dfrm for X, W
+        int endIndex = _ncolX+_ncolA;
+        for (int index = _ncolA; index < endIndex; index++) {
+          int fullFrm_index = index+_ncolX;
+          dfrm.replace(index, fullFrm.vec(fullFrm_index));
+          dfrm.replace(fullFrm_index, fullFrm.vec(fullFrm_index));
+        }
       } else if (_parms._init == Initialization.PlusPlus) {  // Run k-means++ and set Y = resulting cluster centers, X = indicator matrix of assignments
         KMeansModel.KMeansParameters parms = new KMeansModel.KMeansParameters();
         parms._train = _parms._train;

--- a/h2o-core/src/main/java/hex/GainsLift.java
+++ b/h2o-core/src/main/java/hex/GainsLift.java
@@ -98,7 +98,7 @@ public class GainsLift extends Iced {
         } else {
           qp._probs = new double[]{0.99, 0.98, 0.97, 0.96, 0.95, 0.9, 0.85, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0};
         }
-        qm = job != null && !job.isDone() ? new Quantile(qp, job).trainModelNested() : new Quantile(qp).trainModel().get();
+        qm = job != null && !job.isDone() ? new Quantile(qp, job).trainModelNested(null) : new Quantile(qp).trainModel().get();
         _quantiles = qm._output._quantiles[0];
         // find uniques (is there a more elegant way?)
         TreeSet<Double> hs = new TreeSet<>();

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -772,7 +772,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     }
     Frame tr = _parms.train();
     if( tr == null ) { error("_train", "Missing training frame: "+_parms._train); return; }
-    if(_train == null)_train = new Frame(null /* not putting this into KV */, tr._names.clone(), tr.vecs().clone());
+    _train = new Frame(null /* not putting this into KV */, tr._names.clone(), tr.vecs().clone());
     if (expensive) {
       _parms.getOrMakeRealSeed();
     }

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -326,7 +326,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     if (grid.getModel(params) != null) return null;
     ModelBuilder mb = ModelBuilder.make(params.algoName(), _job, result);
     mb._parms = params;
-    mb.trainModelNested();
+    mb.trainModelNested(null);
     return mb;
   }
 

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -212,9 +212,8 @@ public class Frame extends Lockable<Frame> {
     }
   }
 
-  /** Quick compatibility check between Frames.  Used by some tests for efficient equality checks. */
+  /** Frames are compatible if they have the same layout (number of rows and chunking) and the same vector group (chunk placement).. */
   public boolean isCompatible( Frame fr ) {
-    if( numCols() != fr.numCols() ) return false;
     if( numRows() != fr.numRows() ) return false;
     for( int i=0; i<vecs().length; i++ )
       if( !vecs()[i].checkCompatible(fr.vecs()[i]) )


### PR DESCRIPTION
Computation was performed on frame fullFrm while the actual frame which contains the correct info is in dfrm.  Added code to fix that:

        // fix for PUBDEV-3528.  Copy content of fullFrm into dfrm for X, W
        int endIndex = _ncolX+_ncolA;
        for (int index = _ncolA; index < endIndex; index++) {
          int fullFrm_index = index+_ncolX;
          dfrm.replace(index, fullFrm.vec(fullFrm_index));
          dfrm.replace(fullFrm_index, fullFrm.vec(fullFrm_index));
        }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/323)
<!-- Reviewable:end -->
