### PR TITLE
Remove one_hot_explicit option

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/DeepLearningBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/DeepLearningBooklet.tex
@@ -932,7 +932,6 @@ Refer to {\textbf{\nameref{sssec:AdaptiveLearning}}} for more details.
 \begin{itemize}
 \item \texttt{auto}: Allow the algorithm to decide
 \item \texttt{one\_hot\_internal}: On the fly N+1 new cols for categorical features with N levels (default)
-\item \texttt{one\_hot\_explicit}: N+1 new columns for categorical features with N levels
 \item \texttt{binary}: No more than 32 columns per categorical feature
 \item \texttt{eigen}: $k$ columns per categorical feature, keeping projections of one-hot-encoded matrix onto $k$-dim eigen space only
 \end{itemize}

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -152,7 +152,6 @@ recommended, as model performance can vary greatly.
 
   - ``auto``: Allow the algorithm to decide
   - ``one_hot_internal``: On the fly N+1 new cols for categorical features with N levels (default)
-  - ``one_hot_explicit``: N+1 new columns for categorical features with N levels
   - ``binary``: No more than 32 columns per categorical feature
   - ``eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
 


### PR DESCRIPTION
In Deep Learning (booklet and user guide), removed “one_hot_explicit”
as an option to use with the categorical_encoding parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/327)
<!-- Reviewable:end -->
