### PR TITLE
py: accept full range of na_strings formats

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -126,7 +126,7 @@ class H2OFrame(object):
         assert_is_type(separator, I(str, lambda s: len(s) == 1))
         assert_is_type(column_names, None, [str])
         assert_is_type(column_types, None, [coltype])
-        assert_is_type(na_strings, None, [str])
+        assert_is_type(na_strings, None, [str], [[str]], { str: [str] })
         fr = H2OFrame()
         fr._upload_python_object(python_obj, destination_frame, header, separator, column_names, column_types,
                                  na_strings)


### PR DESCRIPTION
the docs indicate these are all accepted and the code that later handles
this handles the full range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/329)
<!-- Reviewable:end -->
