### PR TITLE
[PUBDEV-3035] always append session_id for all temporary frame ids used in rapids

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1547,7 +1547,7 @@ class H2OFrame(object):
 
         splits = []
         tmp_runif = self.runif(seed)
-        tmp_runif.frame_id = "%s_splitter" % _py_tmp_key()
+        tmp_runif.frame_id = "%s_splitter" % _py_tmp_key(h2o.connection().session_id)
 
         i = 0
         while i < num_slices:

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -85,7 +85,11 @@ def api(endpoint, data=None, json=None, filename=None, save_to=None):
 
 
 def connection():
-    """Return current H2OConnection handler."""
+    """
+    Return current H2OConnection handler.
+
+    :returns H2OConnection:
+    """
     return h2oconn
 
 

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -22,7 +22,7 @@ from h2o.utils.typechecks import assert_is_type, is_type, numeric
 _id_ctr = 0
 
 
-def _py_tmp_key(append=""):
+def _py_tmp_key(append):
     global _id_ctr
     _id_ctr += 1
     return "py_" + str(_id_ctr) + append


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/332)
<!-- Reviewable:end -->
