### PR TITLE
Fixed a bug in NewChunk

### DIFF
--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -1590,13 +1590,22 @@ public class NewChunk extends Chunk {
     assert _xs==null; 
     return _ds[i];
   }
+
+  private long loAt(int idx) { return _ms.get(idx); }
+  private long hiAt(int idx) { return Double.doubleToRawLongBits(_ds[idx]); }
+
   @Override protected long at16l_impl(int idx) {
-    if(_ms.get(idx) == C16Chunk._LO_NA) throw new RuntimeException("Attempting to access NA as integer value.");
+    long lo = loAt(idx);
+    if(lo == C16Chunk._LO_NA && hiAt(idx) == C16Chunk._HI_NA) {
+      throw new RuntimeException("Attempting to access NA as integer lo value at " + idx);
+    }
     return _ms.get(idx);
   }
   @Override protected long at16h_impl(int idx) {
     long hi = Double.doubleToRawLongBits(_ds[idx]);
-    if(hi == C16Chunk._HI_NA) throw new RuntimeException("Attempting to access NA as integer value.");
+    if(hi == C16Chunk._HI_NA && loAt(idx) == C16Chunk._LO_NA) {
+      throw new RuntimeException("Attempting to access NA as integer hi value at " + idx);
+    }
     return hi;
   }
   @Override public boolean isNA_impl( int i ) {

--- a/h2o-core/src/test/java/water/fvec/C16ChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/C16ChunkTest.java
@@ -3,58 +3,113 @@ package water.fvec;
 import org.junit.*;
 
 import water.TestUtil;
+import water.util.Pair;
+
 import java.util.Arrays;
+import java.util.UUID;
 
 public class C16ChunkTest extends TestUtil {
+
+  static UUID u(long lo, long hi) { return new UUID(lo, hi);}
+
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+  UUID[] sampleVals = new UUID[]{
+      u(6, 6),
+      u(C16Chunk._LO_NA, C16Chunk._HI_NA + 1),
+      u(C16Chunk._LO_NA, C16Chunk._HI_NA - 1),
+      u(C16Chunk._LO_NA+1, C16Chunk._HI_NA),
+      u(C16Chunk._LO_NA-1, C16Chunk._HI_NA),
+      u(Long.MIN_VALUE+1, 0),
+      u(Long.MIN_VALUE+1, 1L),
+      u(Long.MIN_VALUE+1, -1L),
+      u(Long.MIN_VALUE+1, Long.MIN_VALUE+1),
+      u(0L, Long.MIN_VALUE+1),
+      u(1L, Long.MIN_VALUE+1),
+      u(-1L, Long.MIN_VALUE+1),
+      u(Long.MAX_VALUE-1, 0),
+      u(Long.MAX_VALUE-1, 1L),
+      u(Long.MAX_VALUE-1, -1L),
+      u(0L, Long.MAX_VALUE-1),
+      u(1L, Long.MAX_VALUE-1),
+      u(-1L, Long.MAX_VALUE-1),
+      u(Long.MAX_VALUE-1, Long.MAX_VALUE-1),
+      u(Long.MAX_VALUE, 0),
+      u(Long.MAX_VALUE, 1L),
+      u(Long.MAX_VALUE, -1L),
+      u(0L, Long.MAX_VALUE),
+      u(1L, Long.MAX_VALUE),
+      u(-1L, Long.MAX_VALUE),
+      u(Long.MAX_VALUE, Long.MAX_VALUE),
+      u(0L, 0),
+      u(0L, 1L),
+      u(0L, -1L),
+      u(1L, 0L),
+      u(-1L, 0L),
+      u(1L, 0L),
+      u(1, 1L),
+      u(1, -1L),
+      u(-1L, 1L),
+      u(12312421425L, 12312421426L),
+      u(23523523423L, 23523523424L),
+      u(-823048234L,  -823048235L),
+      u(-123123L,     -123124L)};
+
+  Chunk buildTestData(boolean withNA) {
+    NewChunk nc = new NewChunk(null, 0);
+
+    if (withNA) nc.addNA();
+    for (UUID u : sampleVals) nc.addUUID(u.getLeastSignificantBits(), u.getMostSignificantBits());
+    nc.addNA();
+
+    return nc.compress();
+  }
+
   @Test
   public void test_inflate_impl() {
     for (int l=0; l<2; ++l) {
-      NewChunk nc = new NewChunk(null, 0);
+      boolean haveNA = l == 1;
+      Chunk cc = buildTestData(haveNA);
 
-      long[] vals = new long[]{Long.MIN_VALUE+1, Long.MAX_VALUE-1, 1l, 12312421425l, 23523523423l, Long.MIN_VALUE+1, Long.MAX_VALUE-1, -823048234l, -123123l};
-      if (l==1) nc.addNA();
-      for (long v : vals) nc.addUUID(v,v);
-      nc.addNA();
-
-      Chunk cc = nc.compress();
-      Assert.assertEquals(vals.length + 1 + l, cc._len);
+      Assert.assertEquals(sampleVals.length + 1 + l, cc._len);
       Assert.assertTrue(cc instanceof C16Chunk);
-      if (l==1) Assert.assertTrue(cc.isNA(0));
-      if (l==1) Assert.assertTrue(cc.isNA_abs(0));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc.at16l(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc.at16l_abs(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc.at16h(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc.at16h_abs(l + i));
-      Assert.assertTrue(cc.isNA(vals.length + l));
-      Assert.assertTrue(cc.isNA_abs(vals.length + l));
+      checkChunk(cc, l, haveNA);
 
-      nc = cc.inflate_impl(new NewChunk(null, 0));
+      NewChunk nc = cc.inflate_impl(new NewChunk(null, 0));
       nc.values(0, nc._len);
-      Assert.assertEquals(vals.length + 1 + l, nc._len);
-
-      if (l==1) Assert.assertTrue(nc.isNA(0));
-      if (l==1) Assert.assertTrue(nc.isNA_abs(0));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], nc.at16l(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], nc.at16l_abs(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], nc.at16h(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], nc.at16h_abs(l + i));
-      Assert.assertTrue(nc.isNA(vals.length + l));
-      Assert.assertTrue(nc.isNA_abs(vals.length + l));
+      Assert.assertEquals(sampleVals.length + 1 + l, nc._len);
+      checkChunk(nc, l, haveNA);
 
       Chunk cc2 = nc.compress();
-      Assert.assertEquals(vals.length + 1 + l, cc._len);
+      Assert.assertEquals(sampleVals.length + 1 + l, cc._len);
       Assert.assertTrue(cc2 instanceof C16Chunk);
-      if (l==1) Assert.assertTrue(cc2.isNA(0));
-      if (l==1) Assert.assertTrue(cc2.isNA_abs(0));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc2.at16l(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc2.at16l_abs(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc2.at16h(l + i));
-      for (int i = 0; i < vals.length; ++i) Assert.assertEquals(vals[i], cc2.at16h_abs(l + i));
-      Assert.assertTrue(cc2.isNA(vals.length + l));
-      Assert.assertTrue(cc2.isNA_abs(vals.length + l));
+      checkChunk(cc2, l, haveNA);
 
       Assert.assertTrue(Arrays.equals(cc._mem, cc2._mem));
     }
   }
+
+  private UUID uuidAt(Chunk cc, int i) {
+    return new UUID(cc.at16l(i), cc.at16h(i));
+  }
+
+  private void checkChunk(Chunk cc, int l, boolean haveNA) {
+    if (haveNA) Assert.assertTrue(cc.isNA(0));
+    if (haveNA) Assert.assertTrue(cc.isNA_abs(0));
+    for (int i = 0; i < sampleVals.length; ++i) {
+      UUID expected = sampleVals[i];
+      long expectedLo = expected.getLeastSignificantBits();
+      long expectedHi = expected.getMostSignificantBits();
+      Assert.assertEquals(expectedLo, cc.at16l(l + i));
+      Assert.assertEquals(expectedLo, cc.at16l_abs(l + i));
+      Assert.assertEquals(expectedHi, cc.at16h(l + i));
+      Assert.assertEquals(expectedHi, cc.at16h_abs(l + i));
+    }
+    Assert.assertTrue(cc.isNA(sampleVals.length + l));
+    Assert.assertTrue(cc.isNA_abs(sampleVals.length + l));
+  }
+
+  @Test
+  public void test_set_impl() {
+  }
+
 }


### PR DESCRIPTION
For example, it thought that we have a NA if higher bytes of a UUID are all zeroes.

Added a bunch of test cases for that in C16ChunkTest.