### PR TITLE
PUBDEV-3448: updated the GBM Booklet, the user guide, and the Flow re…

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1072,6 +1072,7 @@ h2o.runif <- function(x, seed = -1) {
 #' @param data A dataframe against which to create the fold column.
 #' @param nfolds The number of desired folds.
 #' @param seed A random seed, -1 indicates that H2O will choose one.
+#' @export
 h2o.kfold_column <- function(data,nfolds,seed=-1) .eval.frame(.newExpr("kfold_column",data,nfolds,seed))
 
 #' Check H2OFrame columns for factors


### PR DESCRIPTION
…adme to state that r2_stopping is no longer supported and ignored if set

add backslashes for special characters in gbm booklet so it wont break

fixed typo that broke booklet build

updated the api help string so that it is clear r2 stopping is no longer used, but was previously used to making trees. This commit will affect the help string for GBM and DRF since it is in the SharedTreeV3.java file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/334)
<!-- Reviewable:end -->
