### PR TITLE
Making sure all uuids in C16Chunk and NewChunk are legit.

### DIFF
--- a/h2o-core/src/main/java/water/fvec/C16Chunk.java
+++ b/h2o-core/src/main/java/water/fvec/C16Chunk.java
@@ -4,34 +4,47 @@ import water.*;
 import water.util.UnsafeUtils;
 
 public class C16Chunk extends Chunk {
-  public static final long _LO_NA = Long.MIN_VALUE;
-  public static final long _HI_NA = 0;
+  static final long _LO_NA = Long.MIN_VALUE;
+  static final long _HI_NA = 0;
   C16Chunk( byte[] bs ) { _mem=bs; _start = -1; set_len(_mem.length>>4); }
   @Override protected final long   at8_impl( int i ) { throw new IllegalArgumentException("at8_abs but 16-byte UUID");  }
   @Override protected final double atd_impl( int i ) { throw new IllegalArgumentException("atd but 16-byte UUID");  }
-  @Override protected final boolean isNA_impl( int i ) { return UnsafeUtils.get8(_mem,(i<<4))==_LO_NA && UnsafeUtils.get8(_mem,(i<<4)+8)==_HI_NA; }
-  @Override protected long at16l_impl(int idx) { 
-    long lo = UnsafeUtils.get8(_mem,(idx<<4)  );
-    long hi = UnsafeUtils.get8(_mem,(idx<<4)+8);
-    if( lo==_LO_NA && hi==_HI_NA ) throw new IllegalArgumentException("at16 but value is missing");
+
+  @Override protected final boolean isNA_impl( int i ) { return isNA(loAt(i), hiAt(i)); }
+  public static boolean isNA(long lo, long hi) { return lo ==_LO_NA && hi ==_HI_NA; }
+  private long loAt(int idx) { return UnsafeUtils.get8(_mem, idx*16); }
+  private long hiAt(int idx) { return UnsafeUtils.get8(_mem, idx*16+8); }
+
+  @Override protected long at16l_impl(int idx) {
+    long lo = loAt(idx);
+    if (lo == _LO_NA && hiAt(idx) == _HI_NA) {
+      throw new IllegalArgumentException("at16l but value is missing at " + idx);
+    }
     return lo;
   }
   @Override protected long at16h_impl(int idx) { 
-    long lo = UnsafeUtils.get8(_mem,(idx<<4)  );
-    long hi = UnsafeUtils.get8(_mem,(idx<<4)+8);
-    if( lo==_LO_NA && hi==_HI_NA ) throw new IllegalArgumentException("at16 but value is missing");
+    long hi = hiAt(idx);
+    if (hi == _HI_NA && loAt(idx) == _LO_NA) {
+      throw new IllegalArgumentException("at16h but value is missing at " + idx);
+    }
     return hi;
+  }
+  @Override boolean set_impl(int i, long lo, long hi) {
+    if (isNA(lo, hi)) throw new IllegalArgumentException("Illegal uid value");
+    UnsafeUtils.set8(_mem, i*16,     lo);
+    UnsafeUtils.set8(_mem, i*16 + 8, hi);
+    return true;
   }
   @Override boolean set_impl(int idx, long l) { return false; }
   @Override boolean set_impl(int i, double d) { return false; }
   @Override boolean set_impl(int i, float f ) { return false; }
-  @Override boolean setNA_impl(int idx) { UnsafeUtils.set8(_mem, (idx << 4), _LO_NA); UnsafeUtils.set8(_mem,(idx<<4),_HI_NA); return true; }
+  @Override boolean setNA_impl(int idx) { return set_impl(idx, _LO_NA, _HI_NA); }
   @Override public NewChunk inflate_impl(NewChunk nc) {
     nc.set_len(nc.set_sparseLen(0));
 
     for( int i=0; i< _len; i++ ) {
-      long lo = UnsafeUtils.get8(_mem,(i<<4)  );
-      long hi = UnsafeUtils.get8(_mem,(i << 4) + 8);
+      long lo = loAt(i);
+      long hi = hiAt(i);
       if(lo == _LO_NA && hi == _HI_NA)
         nc.addNA();
       else
@@ -42,7 +55,7 @@ public class C16Chunk extends Chunk {
   @Override protected final void initFromBytes () {
     _start = -1;  _cidx = -1;
     set_len(_mem.length>>4);
-    assert _mem.length == _len <<4;
+    assert _mem.length == _len * 16;
   }
 //  @Override protected int pformat_len0() { return 36; }
 }

--- a/h2o-core/src/main/java/water/fvec/Chunk.java
+++ b/h2o-core/src/main/java/water/fvec/Chunk.java
@@ -584,7 +584,7 @@ public abstract class Chunk extends Iced<Chunk> {
   abstract boolean set_impl  (int idx, float f );
   abstract boolean setNA_impl(int idx);
   boolean set_impl (int idx, String str) { throw new IllegalArgumentException("Not a String"); }
-
+  boolean set_impl(int i, long lo, long hi) { throw H2O.unimpl(); }
   //Zero sparse methods:
   
   /** Sparse Chunks have a significant number of zeros, and support for

--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -641,9 +641,14 @@ public class NewChunk extends Chunk {
     else { addStr(c.atStr(new BufferedString(), row)); _isAllASCII &= ((CStrChunk)c)._isAllASCII; }
   }
 
+  public void addUUID(UUID uuid) {
+    if (uuid == null) addNA();
+    else addUUID(uuid.getLeastSignificantBits(), uuid.getMostSignificantBits());
+  }
 
   // Append a UUID, stored in _ls & _ds
   public void addUUID( long lo, long hi ) {
+    if (C16Chunk.isNA(lo, hi)) throw new IllegalArgumentException("Cannot set illegal UUID value");
     if( _ms==null || _ds== null || _sparseLen >= _ms.len() )
       append2slowUUID();
     _ms.set(_sparseLen,lo);
@@ -653,12 +658,11 @@ public class NewChunk extends Chunk {
     assert _sparseLen <= _len;
   }
   public void addUUID( Chunk c, long row ) {
-    if( c.isNA_abs(row) ) addUUID(C16Chunk._LO_NA,C16Chunk._HI_NA);
+    if (c.isNA_abs(row)) addNA();
     else addUUID(c.at16l_abs(row),c.at16h_abs(row));
   }
   public void addUUID( Chunk c, int row ) {
-    if( c.isNA(row) ) addUUID(C16Chunk._LO_NA,C16Chunk._HI_NA);
-    else addUUID(c.at16l(row),c.at16h(row));
+    addUUID(c, (long) row);
   }
 
   public final boolean isUUID(){return _ms != null && _ds != null; }

--- a/h2o-core/src/main/java/water/parser/BufferedString.java
+++ b/h2o-core/src/main/java/water/parser/BufferedString.java
@@ -56,7 +56,7 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
    @Override public int hashCode(){
      int hash = 0;
      int n = _off + _len;
-     for (int i = _off; i < n; ++i) // equivalent to String.hashCode
+     for (int i = _off; i < n; ++i) // equivalent to String.hashCode (not actually)
        hash = 31 * hash + (char)_buf[i];
      return hash;
    }
@@ -80,9 +80,10 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
   // even if they are otherwise a valid member of the field/BufferedString.
   // Converting back to a BufferedString will then make something with fewer
   // characters than what you started with, and will fail all equals() tests.
+  // TODO(Vlad): figure out what to do about the buffer being not UTF-8 (who guarantees?)
   @Override
   public String toString() {
-    return new String(_buf, _off, _len, Charsets.UTF_8);
+    return new String(_buf, Math.max(0, _off), Math.min(_buf.length, _len), Charsets.UTF_8);
   }
 
   public String bytesToString() {

--- a/h2o-core/src/main/java/water/parser/FVecParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/FVecParseWriter.java
@@ -9,6 +9,7 @@ import water.fvec.Vec;
 import water.util.ArrayUtils;
 
 import java.util.Arrays;
+import java.util.UUID;
 
 /** Parsed data output specialized for fluid vecs.
  * @author tomasnykodym
@@ -116,9 +117,9 @@ public class FVecParseWriter extends Iced implements StreamParseWriter {
           _nvs[_col]._timCnt++; // Count histo of time parse patterns
         }
       } else if( _ctypes[colIdx] == Vec.T_UUID ) { // UUID column?  Only allow UUID parses
-        long[] uuid = ParseUUID.attemptUUIDParse(str);
+        UUID uuid = ParseUUID.attemptUUIDParse(str);
         // FIXME: what if colIdx > _nCols
-        if( colIdx < _nCols ) _nvs[_col = colIdx].addUUID(uuid[0], uuid[1]);
+        if( colIdx < _nCols ) _nvs[_col = colIdx].addUUID(uuid);
       } else if( _ctypes[colIdx] == Vec.T_STR ) {
         _nvs[_col = colIdx].addStr(str);
       } else { // categoricals

--- a/h2o-core/src/main/java/water/util/MRUtils.java
+++ b/h2o-core/src/main/java/water/util/MRUtils.java
@@ -41,7 +41,8 @@ public class MRUtils {
           if (rng.nextFloat() < fraction || (count == 0 && r == cs[0]._len-1) ) {
             count++;
             for (int i = 0; i < ncs.length; i++) {
-              if (cs[i] instanceof CStrChunk)
+              if (cs[i].isNA(r)) ncs[i].addNA();
+              else if (cs[i] instanceof CStrChunk)
                 ncs[i].addStr(cs[i].atStr(bStr,r));
               else if (cs[i] instanceof C16Chunk)
                 ncs[i].addUUID(cs[i].at16l(r),cs[i].at16h(r));

--- a/h2o-core/src/test/java/water/fvec/C16ChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/C16ChunkTest.java
@@ -7,9 +7,11 @@ import water.TestUtil;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static org.junit.Assert.fail;
+
 public class C16ChunkTest extends TestUtil {
 
-  static UUID u(long lo, long hi) { return new UUID(lo, hi);}
+  static UUID u(long lo, long hi) { return new UUID(hi, lo);}
 
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
   UUID[] sampleVals = new UUID[]{
@@ -84,6 +86,17 @@ public class C16ChunkTest extends TestUtil {
       checkChunk(cc2, l, haveNA);
 
       Assert.assertTrue(Arrays.equals(cc._mem, cc2._mem));
+    }
+  }
+
+  @Test
+  public void test_illegal_values() {
+    Chunk cc = buildTestData(false);
+    try {
+      cc.set_impl(4, C16Chunk._LO_NA, C16Chunk._HI_NA);
+      fail("Expected a failure on adding an illegal value");
+    } catch(IllegalArgumentException iae) {
+      // as expected
     }
   }
 

--- a/h2o-core/src/test/java/water/fvec/NewChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkTest.java
@@ -2,6 +2,7 @@ package water.fvec;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import water.DKV;
 import water.Futures;
@@ -10,9 +11,7 @@ import water.TestUtil;
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class NewChunkTest extends TestUtil {
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
@@ -58,7 +57,7 @@ public class NewChunkTest extends TestUtil {
     nc.addNAs(128);
     assertTrue(nc.isSparseNA());
     for (int i = 0; i < 512; i++)
-      nc.addUUID(i, i);
+      nc.addUUID(i, i/2+i/3);
     assertFalse(nc.isSparseNA());
     Chunk c = nc.compress();
     assertEquals(128 + 512, c.len());
@@ -66,7 +65,7 @@ public class NewChunkTest extends TestUtil {
       assertTrue(c.isNA(i));
     for (int i = 0; i < 512; i++) {
       assertEquals(i, c.at16l(128 + i));
-      assertEquals(i, c.at16h(128 + i));
+      assertEquals(i/2+i/3, c.at16h(128 + i));
     }
   }
 
@@ -553,39 +552,81 @@ public class NewChunkTest extends TestUtil {
     } finally { remove(); }
   }
 
-private static double []  test_seq = new double[]{
+
+
+  private static double []  test_seq = new double[]{
     2,0,0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,3,0,0,0,Double.NaN,Double.NaN,Double.NaN,Double.NaN,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,10,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,3,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,10,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,3,0,0,0,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,3,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,3,0,0,1,0,0,0,0,0,0,0,0,2,0,0,3,0,0,0,0,0,0,0,0,0,3,32,0,0,0,17,6,2,0,0,0,0,0,0,0,0,67,0,0,0,0,0,0,0
-};
-@Test public void testSparseWithMissing(){
-  // DOUBLES
-  av = new AppendableVec(Vec.newKey(), Vec.T_NUM);
-  nc = new NewChunk(av, 0);
-  for(double d:test_seq)
-    nc.addNum(d);
-  Chunk c = nc.compress();
-  for(int i =0 ; i < test_seq.length; ++i) {
-    if(Double.isNaN(test_seq[i]))
-      Assert.assertTrue(c.isNA(i));
-    else
-      Assert.assertEquals("mismatch at line " + i + ": expected " + test_seq[i] + ", got " + c.atd(i), +  test_seq[i],c.atd(i),0);
+  };
+
+  @Test
+  public void testSparseWithMissing() {
+    // DOUBLES
+    av = new AppendableVec(Vec.newKey(), Vec.T_NUM);
+    nc = new NewChunk(av, 0);
+    for (double d : test_seq)
+      nc.addNum(d);
+    Chunk c = nc.compress();
+    for (int i = 0; i < test_seq.length; ++i) {
+      if (Double.isNaN(test_seq[i]))
+        Assert.assertTrue(c.isNA(i));
+      else
+        Assert.assertEquals("mismatch at line " + i + ": expected " + test_seq[i] + ", got " + c.atd(i), +test_seq[i], c.atd(i), 0);
+    }
+    // INTS
+    av = new AppendableVec(Vec.newKey(), Vec.T_NUM);
+    nc = new NewChunk(av, 0);
+    for (double d : test_seq)
+      if (Double.isNaN(d)) nc.addNA();
+      else nc.addNum((int) d, 0);
+    c = nc.compress();
+    for (int i = 0; i < test_seq.length; ++i) {
+      if (Double.isNaN(test_seq[i]))
+        Assert.assertTrue(c.isNA(i));
+      else
+        Assert.assertEquals("mismatch at line " + i + ": expected " + test_seq[i] + ", got " + c.atd(i), +test_seq[i], c.atd(i), 0);
+    }
   }
-  // INTS
-  av = new AppendableVec(Vec.newKey(), Vec.T_NUM);
-  nc = new NewChunk(av, 0);
-  for(double d:test_seq)
-    if(Double.isNaN(d)) nc.addNA();
-    else nc.addNum((int)d,0);
-  c = nc.compress();
-  for(int i =0 ; i < test_seq.length; ++i) {
-    if(Double.isNaN(test_seq[i]))
-      Assert.assertTrue(c.isNA(i));
-    else
-      Assert.assertEquals("mismatch at line " + i + ": expected " + test_seq[i] + ", got " + c.atd(i), +  test_seq[i],c.atd(i),0);
+
+  @Test public void testAddIllegalUUID() {
+    nc = new NewChunk(av, 0);
+    nc.addUUID(123L, 456L);
+    nc.addNA();
+    assertTrue(nc.isNA(1));
+    assertTrue(nc.isNA2(1));
+    try {
+      nc.addUUID(C16Chunk._LO_NA, C16Chunk._HI_NA);
+      assertTrue(nc.isNA(2));
+      fail("Expected a failure on adding an illegal value");
+    } catch(IllegalArgumentException iae) {
+      // as expected
+    }
+/* TODO(Vlad): fix after UUID checks get through
+    nc.addNum(Double.NEGATIVE_INFINITY);
+    nc.addNum(Double.POSITIVE_INFINITY);
+    try {
+      nc.addNum(Double.NaN);
+      fail("Expected a failure on adding an illegal value");
+    } catch(IllegalArgumentException iae) {
+      // as expected
+    }
+    */
   }
 
-}
+  @Ignore("Vlad: will fix it after UUID")
+  @Test public void testAddIllegalNum() {
+    nc = new NewChunk(av, 0);
 
-
+    nc.addNum(Math.PI);
+    nc.addNum(Double.NEGATIVE_INFINITY);
+    nc.addNum(Double.POSITIVE_INFINITY);
+    try {
+      nc.addNum(Double.NaN);
+      assertTrue(nc.isNA(3));
+      fail("Expected a failure on adding an illegal value");
+    } catch(IllegalArgumentException iae) {
+      // as expected
+    }
+  }
 
 }
 

--- a/h2o-core/src/test/java/water/parser/ParseUUIDTest.java
+++ b/h2o-core/src/test/java/water/parser/ParseUUIDTest.java
@@ -40,7 +40,7 @@ public class ParseUUIDTest  extends TestUtil {
         int col2 = 0;
         for( int col = 0; col < fr.numCols(); col++ ) {
           if( vecs[col].isUUID() ) {
-            if( exp[row][col2]==C16Chunk._LO_NA && exp[row][col2+1]==C16Chunk._HI_NA ) {
+            if( C16Chunk.isNA(exp[row][col2], exp[row][col2+1]) ) {
               Assert.assertTrue("Frame " + fr._key + ", row=" + row + ", col=" + col + ", expect=NA",
                       vecs[col].isNA(row));
             } else {


### PR DESCRIPTION
C16Chunk - code deduplication; added a uuid setter (two longs); some encapsulation (replacing exporting _LO_NA, _HI_NA with method isNA())
Chunk - added addUUID() methods, one takes a UUID. Checking if UUID has a valid value.
NewChunk - implemented behavior for UUID
BufferedString - fixed an exception in toString()
FVecParseWriter, ParseUUID - switched from long[] to UUID for representing uuids
MRUtils.sampleFrame - checking value for a NA (or else it can throw)

Added test cases for illegal uuids.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/337)
<!-- Reviewable:end -->
