### PR TITLE
PUBDEV-3448: updated the GBM Booklet, the user guide, and the Flow re…

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -61,7 +61,7 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     @API(help="For categorical columns (factors), build a histogram of this many bins, then split at the best point. Higher values can lead to more overfitting.", level = API.Level.secondary, gridable = true)
     public int nbins_cats;
 
-    @API(help="Stop making trees when the R^2 metric equals or exceeds this", level = API.Level.secondary, gridable = true)
+    @API(help="r2_stopping is no longer supported and will be ignored if set - please use stopping_rounds, stopping_metric and stopping_tolerance instead. Previous version of H2O would stop making trees when the R^2 metric equals or exceeds this", level = API.Level.secondary, gridable = true)
     public double r2_stopping;
 
     @API(help = "Seed for pseudo random number generator (if applicable)", gridable = true)

--- a/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
@@ -506,13 +506,12 @@ This section describes the functions of the parameters for GBM.
 \item {\texttt{balance\_classes}}: Balance training data class counts via over or undersampling for imbalanced data. The default is {\texttt{FALSE}}.
 \item {\texttt{max\_confusion\_matrix\_size}}: Maximum size (number of classes) for confusion matrices to print in the H2O logs.  The default is 20.
 \item {\texttt{max\_hit\_ratio\_k}}: (for multi-class only) Maximum number (top K) of predictions to use for hit ratio computation.  To disable, enter  {\texttt{0}}. The default is 10.
-\item {\texttt{r2\_stopping}}: Stop making trees when the $R^2$ metric equals or exceeds this value.  The default is 0.999999.
+\item {\texttt{r2\_stopping}}: \\\texttt{r2\_stopping} is no longer supported and will be ignored if set. Please use \\\texttt{stopping\_rounds}, \\\texttt{stopping\_metric} and \\\texttt{stopping\_tolerance} instead.
 \item \texttt{stopping\_rounds}: Early stopping based on convergence of \\\texttt{stopping\_metric}. Stop if simple moving average of length k of the \texttt{stopping\_metric} does not improve for k:=\texttt{stopping\_rounds} scoring events. Can only trigger after at least 2k scoring events. To disable, specify \texttt{0}.
-\item \texttt{stopping\_metric}: Metric to use for early stopping (\texttt{AUTO}: \texttt{logloss} for classification, \texttt{deviance} for regression). Can be any of \texttt{AUTO, deviance, logloss, MSE, AUC, r2, misclassification}.
+\item \texttt{stopping\_metric}: Metric to use for early stopping (\texttt{AUTO}: \texttt{logloss} for classification, \texttt{deviance} for regression). Can be any of \texttt{AUTO, deviance, logloss, MSE, AUC, misclassification}.
 \item \texttt{stopping\_tolerance}: Relative tolerance for metric-based stopping criterion Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much).
 \item \texttt{max\_runtime\_secs}: Maximum allowed runtime in seconds for model training. Use 0 to disable.
 \item {\texttt{build\_tree\_one\_node}}: Specify if GBM should be run on one node only; no network overhead but fewer CPUs used. Suitable for small datasets.  The default is {\texttt{FALSE}}.
-\item {\texttt{binomial\_double\_trees}}: For binary classification: Builds twice as many trees (one per class), which can result in better accuracy. 
 \item {\texttt{quantile\_alpha}}: Desired quantile for quantile regression (from 0.0 to 1.0) when \texttt{distribution = "quantile"}.  The default is 0.5 (median, same as \texttt{distribution = "laplace"}).
 \item {\texttt{tweedie\_power}}: A numeric specifying the power for the Tweedie function when \texttt{distribution = "tweedie"}.  The default is 1.5.
 \item \texttt{huber\_alpha}: Specify the desired quantile for Huber/M-regression (the threshold between quadratic and linear loss). This value must be between 0 and 1.

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -202,9 +202,7 @@ Defining a GBM Model
    predictions to use for hit ratio computation. Applicable to
    multi-class only. To disable, enter 0.
 
--  **r2\_stopping**: Specify a threshold for the coefficient of
-   determination ((r^2)) metric value. When this threshold is met or
-   exceeded, H2O stops making trees.
+-  **r2\_stopping**: r2_stopping is no longer supported and will be ignored if set - please use stopping_rounds, stopping_metric and stopping_tolerance instead.
 
 -  **stopping\_rounds**: Stops training when the option selected for
    **stopping\_metric** doesn't improve for the specified number of
@@ -229,7 +227,6 @@ Defining a GBM Model
    -  **logloss**
    -  **MSE**
    -  **AUC**
-   -  **r2**
    -  **misclassification**
 
 -  **stopping\_tolerance**: Specify the relative tolerance for the

--- a/h2o-docs/src/product/flow/README.md
+++ b/h2o-docs/src/product/flow/README.md
@@ -552,7 +552,7 @@ The available options vary depending on the selected model. If an option is only
 
 - **max\_hit\_ratio\_k**: ([DRF](#DRF), [DL](#DL), [Naïve Bayes](#NB), [GBM](#GBM), [GLM](#GLM)) Specify the maximum number (top K) of predictions to use for hit ratio computation. Applicable to multinomial only. To disable, enter 0. 
 
-- **r2_stopping**: ([GBM](#GBM), [DRF](#DRF)) Specify a threshold for the coefficient of determination (r^2) metric value. When this threshold is met or exceeded, H2O stops making trees.   
+- **r2_stopping**: ([GBM](#GBM), [DRF](#DRF)) r2_stopping is no longer supported and will be ignored if set - please use stopping_rounds, stopping_metric and stopping_tolerance instead.
 
 - **build\_tree\_one\_node**: ([DRF](#DRF), [GBM](#GBM)) To run on a single node, check this checkbox. This is suitable for small datasets as there is no network overhead but fewer CPUs are used. The default setting is disabled. 
 


### PR DESCRIPTION
…adme to state that r2_stopping is no longer supported and ignored if set

add backslashes for special characters in gbm booklet so it wont break

fixed typo that broke booklet build

updated the api help string so that it is clear r2 stopping is no longer used, but was previously used to making trees. This commit will affect the help string for GBM and DRF since it is in the SharedTreeV3.java file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/349)
<!-- Reviewable:end -->
