### PR TITLE
HEXDEV-641: Prevent leakage of RollupStats

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -711,16 +711,12 @@ public class Frame extends Lockable<Frame> {
     if (v == null)
       return fs;
 
-    final int ncs = v.nChunks();
     _names = new String[0];
     _vecs = new Vec[0];
     _keys = makeVecKeys(0);
+
     // Bulk dumb local remove - no JMM, no ordering, no safety.
-    new MRTask() {
-      @Override public void setupLocal() {
-        for( Key k : keys ) if( k != null ) Vec.bulk_remove(k,ncs);
-      }
-    }.doAllNodes();
+    Vec.bulk_remove(keys, v.nChunks());
 
     return fs;
   }


### PR DESCRIPTION
There is a race condition when there is a running computation of RollupStats
and the Vec is being removed at the same time. This can result into
leakage of RollupStats. To prevent this we mark the Vec as mutating
before we start removing the vec from DKV.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/357)
<!-- Reviewable:end -->
