### PR TITLE
Add support for balance_classes to Deep Water

### DIFF
--- a/h2o-algos/src/main/java/hex/deepwater/DeepWaterModel.java
+++ b/h2o-algos/src/main/java/hex/deepwater/DeepWaterModel.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
 
 import static hex.ModelMetrics.calcVarImp;
@@ -73,11 +74,11 @@ public class DeepWaterModel extends Model<DeepWaterModel,DeepWaterParameters,Dee
 
   Key actual_best_model_key;
 
-  private final String unstable_msg = technote(4,
+  static final String unstable_msg = technote(4,
       "\n\nTrying to predict with an unstable model." +
           "\nJob was aborted due to observed numerical instability (exponential growth)."
           + "\nEither the weights or the bias values are unreasonably large or lead to large activation values."
-          + "\nTry a different initial distribution, a bounded activation function (Tanh), adding regularization"
+          + "\nTry a different network architecture, a bounded activation function (tanh), adding regularization"
           + "\n(via dropout) or use a smaller learning rate and/or momentum.");
 
   public DeepWaterScoringInfo last_scored() { return (DeepWaterScoringInfo) super.last_scored(); }

--- a/h2o-algos/src/main/java/hex/deepwater/DeepwaterMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/deepwater/DeepwaterMojoWriter.java
@@ -43,6 +43,8 @@ class DeepwaterMojoWriter extends ModelMojoWriter<DeepWaterModel, DeepWaterParam
     writekv("norm_resp_mul", _output._normRespMul);
     writekv("norm_resp_sub", _output._normRespSub);
     writekv("use_all_factor_levels", _output._useAllFactorLevels);
+    writekv("gpu", _parms._gpu);
+    writekv("device_id", _parms._device_id);
 
     writeblob("model_network", _model_info._network);
     writeblob("model_params", _model_info._modelparams);

--- a/h2o-algos/src/main/java/hex/schemas/DeepWaterV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DeepWaterV3.java
@@ -16,6 +16,9 @@ public class DeepWaterV3 extends ModelBuilderSchema<DeepWater,DeepWaterV3,DeepWa
         "training_frame",
         "validation_frame",
         "nfolds",
+        "balance_classes",
+        "max_after_balance_size",
+        "class_sampling_factors",
         "keep_cross_validation_predictions",
         "keep_cross_validation_fold_assignment",
         "fold_assignment",
@@ -336,8 +339,7 @@ public class DeepWaterV3 extends ModelBuilderSchema<DeepWater,DeepWaterV3,DeepWa
      * times the dataset size or larger).
      */
     @API(level = API.Level.expert, direction = API.Direction.INOUT, gridable = true,
-        help = "Enable shuffling of training data (recommended if training data is replicated and " +
-            "train_samples_per_iteration is close to #nodes x #rows, of if using balance_classes).")
+        help = "Enable global shuffling of training data.")
     public boolean shuffle_training_data;
 
     @API(level = API.Level.expert, direction=API.Direction.INOUT, gridable = true,
@@ -391,5 +393,32 @@ public class DeepWaterV3 extends ModelBuilderSchema<DeepWater,DeepWaterV3,DeepWa
     @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
         help = "If enabled, automatically standardize the data. If disabled, the user must provide properly scaled input data.")
     public boolean standardize;
+
+    /**
+     * For imbalanced data, balance training data class counts via
+     * over/under-sampling. This can result in improved predictive accuracy.
+     */
+    @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
+        help = "Balance training data class counts via over/under-sampling (for imbalanced data).")
+    public boolean balance_classes;
+
+    /**
+     * Desired over/under-sampling ratios per class (lexicographic order).
+     * Only when balance_classes is enabled.
+     * If not specified, they will be automatically computed to obtain class balance during training.
+     */
+    @API(level = API.Level.expert, direction = API.Direction.INOUT, gridable = true,
+        help = "Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling " +
+            "factors will be automatically computed to obtain class balance during training. Requires balance_classes.")
+    public float[] class_sampling_factors;
+
+    /**
+     * When classes are balanced, limit the resulting dataset size to the
+     * specified multiple of the original dataset size.
+     */
+    @API(level = API.Level.expert, direction = API.Direction.INOUT, gridable = false,
+        help = "Maximum relative size of the training data after balancing class counts (can be less than 1.0). " +
+            "Requires balance_classes.")
+    public float max_after_balance_size;
   }
 }

--- a/h2o-algos/src/test/java/hex/deepwater/DeepWaterAbstractIntegrationTest.java
+++ b/h2o-algos/src/test/java/hex/deepwater/DeepWaterAbstractIntegrationTest.java
@@ -693,6 +693,10 @@ public abstract class DeepWaterAbstractIntegrationTest extends TestUtil {
       p._backend = getBackend();
       p._train = (tr = parse_test_file("smalldata/deepwater/imagenet/binomial_image_urls.csv"))._key;
       p._response_column = "C2";
+      p._balance_classes = true;
+      p._epochs = 1;
+      p._max_after_balance_size = 2f;
+      p._class_sampling_factors = new float[]{3,5};
       DeepWater j = new DeepWater(p);
       m = j.trainModel().get();
       Assert.assertTrue((m._output._training_metrics).auc_obj()._auc > 0.90);

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -40,6 +40,7 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
     if (_auc != null) sb.append(" AUC: " + (float)_auc._auc + "\n");
     sb.append(" logloss: " + (float)_logloss + "\n");
     sb.append(" mean_per_class_error: " + (float)_mean_per_class_error + "\n");
+    sb.append(" default threshold: " + (_auc == null ? 0.5 : (float)_auc.defaultThreshold()) + "\n");
     if (cm() != null) sb.append(" CM: " + cm().toASCII());
     if (_gainsLift != null) sb.append(_gainsLift);
     return sb.toString();

--- a/h2o-core/src/main/java/water/util/MRUtils.java
+++ b/h2o-core/src/main/java/water/util/MRUtils.java
@@ -75,11 +75,15 @@ public class MRUtils {
         ArrayUtils.shuffleArray(idx, getRNG(seed));
         for (long anIdx : idx) {
           for (int i = 0; i < ncs.length; i++) {
-            ncs[i].addNum(cs[i].atd((int) anIdx));
+            if (cs[i] instanceof CStrChunk) {
+              ncs[i].addStr(cs[i],cs[i].start()+anIdx);
+            } else {
+              ncs[i].addNum(cs[i].atd((int) anIdx));
+            }
           }
         }
       }
-    }.doAll(fr.numCols(), Vec.T_NUM, fr).outputFrame(fr.names(), fr.domains());
+    }.doAll(fr.types(), fr).outputFrame(fr.names(), fr.domains());
   }
 
   /**
@@ -282,8 +286,14 @@ public class MRUtils {
             sampling_reps = (int)sampling_ratios[label] + (rng.nextFloat() < remainder ? 1 : 0);
           }
           for (int i = 0; i < ncs.length; i++) {
-            for (int j = 0; j < sampling_reps; ++j) {
-              ncs[i].addNum(cs[i].atd(r));
+            if (cs[i] instanceof CStrChunk) {
+              for (int j = 0; j < sampling_reps; ++j) {
+                ncs[i].addStr(cs[i],cs[0].start()+r);
+              }
+            } else {
+              for (int j = 0; j < sampling_reps; ++j) {
+                ncs[i].addNum(cs[i].atd(r));
+              }
             }
           }
         }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/deepwater/DeepwaterMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/deepwater/DeepwaterMojoModel.java
@@ -61,6 +61,8 @@ public class DeepwaterMojoModel extends MojoModel {
     if (_nclasses > 1) {
       for (int i = 0; i < predFloats.length; ++i)
         preds[1 + i] = predFloats[i];
+      if (_balanceClasses)
+        GenModel.correctProbabilities(preds, _priorClassDistrib, _modelClassDistrib);
       preds[0] = GenModel.getPrediction(preds, _priorClassDistrib, doubles, _defaultThreshold);
     } else {
       if (_normRespMul!=null && _normRespSub!=null)

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/deepwater/DeepwaterMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/deepwater/DeepwaterMojoReader.java
@@ -41,9 +41,9 @@ public class DeepwaterMojoReader extends ModelMojoReader<DeepwaterMojoModel> {
     _model._imageDataSet = new ImageDataSet(_model._width, _model._height, _model._channels);
 
     _model._opts = new RuntimeOptions();
-    _model._opts.setSeed(0); // ignored
-    _model._opts.setUseGPU(false); // don't use a GPU for inference
-    _model._opts.setDeviceID(0); // ignored
+    _model._opts.setSeed(0); // ignored - not needed during scoring
+    _model._opts.setUseGPU((boolean)readkv("gpu"));
+    _model._opts.setDeviceID((int[])readkv("device_id"));
 
     _model._backendParams = new BackendParams();
     _model._backendParams.set("mini_batch_size", 1);

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -26,18 +26,19 @@ class H2ODeepWaterEstimator(H2OEstimator):
     def __init__(self, **kwargs):
         super(H2ODeepWaterEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "checkpoint", "training_frame", "validation_frame", "nfolds",
-                      "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "fold_assignment",
-                      "fold_column", "response_column", "ignored_columns", "score_each_iteration",
-                      "categorical_encoding", "overwrite_with_best_model", "epochs", "train_samples_per_iteration",
-                      "target_ratio_comm_to_comp", "seed", "standardize", "learning_rate", "learning_rate_annealing",
-                      "momentum_start", "momentum_ramp", "momentum_stable", "distribution", "score_interval",
-                      "score_training_samples", "score_validation_samples", "score_duty_cycle", "stopping_rounds",
-                      "stopping_metric", "stopping_tolerance", "max_runtime_secs", "ignore_const_cols",
-                      "shuffle_training_data", "mini_batch_size", "clip_gradient", "network", "backend", "image_shape",
-                      "channels", "gpu", "device_id", "network_definition_file", "network_parameters_file",
-                      "mean_image_file", "export_native_parameters_prefix", "activation", "hidden",
-                      "input_dropout_ratio", "hidden_dropout_ratios", "problem_type"}
+        names_list = {"model_id", "checkpoint", "training_frame", "validation_frame", "nfolds", "balance_classes",
+                      "max_after_balance_size", "class_sampling_factors", "keep_cross_validation_predictions",
+                      "keep_cross_validation_fold_assignment", "fold_assignment", "fold_column", "response_column",
+                      "ignored_columns", "score_each_iteration", "categorical_encoding", "overwrite_with_best_model",
+                      "epochs", "train_samples_per_iteration", "target_ratio_comm_to_comp", "seed", "standardize",
+                      "learning_rate", "learning_rate_annealing", "momentum_start", "momentum_ramp", "momentum_stable",
+                      "distribution", "score_interval", "score_training_samples", "score_validation_samples",
+                      "score_duty_cycle", "stopping_rounds", "stopping_metric", "stopping_tolerance",
+                      "max_runtime_secs", "ignore_const_cols", "shuffle_training_data", "mini_batch_size",
+                      "clip_gradient", "network", "backend", "image_shape", "channels", "gpu", "device_id",
+                      "network_definition_file", "network_parameters_file", "mean_image_file",
+                      "export_native_parameters_prefix", "activation", "hidden", "input_dropout_ratio",
+                      "hidden_dropout_ratios", "problem_type"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -91,6 +92,47 @@ class H2ODeepWaterEstimator(H2OEstimator):
     def nfolds(self, nfolds):
         assert_is_type(nfolds, None, int)
         self._parms["nfolds"] = nfolds
+
+
+    @property
+    def balance_classes(self):
+        """
+        bool: Balance training data class counts via over/under-sampling (for imbalanced data). (Default: False)
+        """
+        return self._parms.get("balance_classes")
+
+    @balance_classes.setter
+    def balance_classes(self, balance_classes):
+        assert_is_type(balance_classes, None, bool)
+        self._parms["balance_classes"] = balance_classes
+
+
+    @property
+    def max_after_balance_size(self):
+        """
+        float: Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
+        balance_classes. (Default: 5.0)
+        """
+        return self._parms.get("max_after_balance_size")
+
+    @max_after_balance_size.setter
+    def max_after_balance_size(self, max_after_balance_size):
+        assert_is_type(max_after_balance_size, None, float)
+        self._parms["max_after_balance_size"] = max_after_balance_size
+
+
+    @property
+    def class_sampling_factors(self):
+        """
+        List[float]: Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling
+        factors will be automatically computed to obtain class balance during training. Requires balance_classes.
+        """
+        return self._parms.get("class_sampling_factors")
+
+    @class_sampling_factors.setter
+    def class_sampling_factors(self, class_sampling_factors):
+        assert_is_type(class_sampling_factors, None, [float])
+        self._parms["class_sampling_factors"] = class_sampling_factors
 
 
     @property
@@ -450,10 +492,7 @@ class H2ODeepWaterEstimator(H2OEstimator):
 
     @property
     def shuffle_training_data(self):
-        """
-        bool: Enable shuffling of training data (recommended if training data is replicated and
-        train_samples_per_iteration is close to #nodes x #rows, of if using balance_classes). (Default: True)
-        """
+        """bool: Enable global shuffling of training data. (Default: True)"""
         return self._parms.get("shuffle_training_data")
 
     @shuffle_training_data.setter

--- a/h2o-py/tests/testdir_algos/deepwater/pyunit_custom_regression_lending_deepwater.py
+++ b/h2o-py/tests/testdir_algos/deepwater/pyunit_custom_regression_lending_deepwater.py
@@ -27,13 +27,13 @@ def deepwater_custom_regression():
   train = h2o.import_file(pyunit_utils.locate("bigdata/laptop/lending-club/LoanStats3a.csv"))
 
   response = 'loan_amnt'
-  predictors = list(set(train.names) - set([response, 'id','emp_title','title','desc'])) ## remove high-cardinality columns
+  predictors = list(set(train.names) - set([response, 'id','emp_title','title','desc','revol_util','zip_code'])) ## remove high-cardinality columns
 
   print("Creating the model architecture from scratch using the MXNet Python API")
   net().save("/tmp/symbol-py.json")
 
   print("Importing the model architecture for training in H2O")
-  model = H2ODeepWaterEstimator(epochs=100, learning_rate=1e-3, mini_batch_size=64, hidden=[10], activation="tanh")
+  model = H2ODeepWaterEstimator(epochs=100, learning_rate=1e-4, mini_batch_size=64, hidden=[1], activation="tanh")
                                 #network='user', network_definition_file="/tmp/symbol-py.json")
                                 
   model.train(x=predictors,y=response, training_frame=train, nfolds=3)

--- a/h2o-py/tests/testdir_algos/deepwater/pyunit_custom_regression_lending_deepwater.py
+++ b/h2o-py/tests/testdir_algos/deepwater/pyunit_custom_regression_lending_deepwater.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.deepwater import H2ODeepWaterEstimator
+
+def net():
+    import mxnet as mx
+    data = mx.symbol.Variable('data')
+    fc1 = mx.symbol.FullyConnected(data=data, num_hidden=500)
+    act1 = mx.symbol.Activation(data=fc1, act_type="relu")
+
+    fc2 = mx.symbol.FullyConnected(data=act1, num_hidden=500)
+    act2 = mx.symbol.Activation(data=fc2, act_type="tanh")
+
+    fc3 = mx.symbol.FullyConnected(data=act2, num_hidden=500)
+    act3 = mx.symbol.Activation(data=fc3, act_type="tanh")
+
+    fc4 = mx.symbol.FullyConnected(data=act3, num_hidden=1)
+    net = mx.symbol.LinearRegressionOutput(data=fc4, name='softmax')
+    return net
+
+def deepwater_custom_regression():
+  if not H2ODeepWaterEstimator.available(): return
+
+  train = h2o.import_file(pyunit_utils.locate("bigdata/laptop/lending-club/LoanStats3a.csv"))
+
+  response = 'loan_amnt'
+  predictors = list(set(train.names) - set([response, 'id','emp_title','title','desc'])) ## remove high-cardinality columns
+
+  print("Creating the model architecture from scratch using the MXNet Python API")
+  net().save("/tmp/symbol-py.json")
+
+  print("Importing the model architecture for training in H2O")
+  model = H2ODeepWaterEstimator(epochs=100, learning_rate=1e-3, mini_batch_size=64, hidden=[10], activation="tanh")
+                                #network='user', network_definition_file="/tmp/symbol-py.json")
+                                
+  model.train(x=predictors,y=response, training_frame=train, nfolds=3)
+  model.show()
+  error = model.model_performance(xval=True).rmse()
+  assert error < 10, "mean xval rmse is too high : " + str(error)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(deepwater_custom_regression)
+else:
+  deepwater_custom_regression()


### PR DESCRIPTION
* add balance_classes, max_after_balance_size and class_sampling_factors (same as for GBM/DRF/DL)
* fix stratified sampling for string chunks
* use the same gpu and device_id as in training for MOJO scoring (by default) - this fixes the imageURLs test (CPU vs GPU was the difference)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/362)
<!-- Reviewable:end -->
