### PR TITLE
PUBDEV-3546: h2o.year() method does not return year

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -877,14 +877,13 @@ h2o.dct <- function(data, destination_frame, dimensions, inverse=FALSE) {
 #' Convert the entries of an H2OFrame object from milliseconds to years, indexed
 #' starting from 1900.
 #'
-# is this still true?
 #' This method calls the function of the MutableDateTime class in Java.
 #' @param x An H2OFrame object.
-#' @return An H2OFrame object containig the entries of \code{x} converted to years
-#'         starting from 1900, e.g. 69 corresponds to the year 1969.
+#' @return An H2OFrame object containing the entries of \code{x} converted to years
 #' @seealso \code{\link{h2o.month}}
 #' @export
-h2o.year <- function(x) .newExpr("-",.newExpr("year", chk.H2OFrame(x)),1900)
+h2o.year <- function(x) .newExpr("year", chk.H2OFrame(x))
+
 
 #' Convert Milliseconds to Months in H2O Datasets
 #'

--- a/h2o-r/tests/testdir_docexamples/runit_Rdoc_set_time_zone.R
+++ b/h2o-r/tests/testdir_docexamples/runit_Rdoc_set_time_zone.R
@@ -5,7 +5,7 @@ source("../../scripts/h2o-r-test-setup.R")
 
 print_diff <- function(r, h2o) {
   if (!isTRUE(all.equal(r,h2o))) {
-    Log.info (paste("R :", r))
+    Log.info (paste("R :", r+1900))
     Log.info (paste("H2O :" , h2o))
   }
 }
@@ -49,7 +49,7 @@ test.rdoc_settimezone.golden <- function() {
   hdf$day <- day(hdf$dates)
   hdf$hour <- hour(hdf$dates)
   ldf <- as.data.frame(hdf)
-  edf <- data.frame(year = c(114, 114, 114, 114, 114, 114, 114),
+  edf <- data.frame(year = c(114 + 1900, 114 + 1900, 114 + 1900, 114 + 1900, 114 + 1900, 114 + 1900, 114 + 1900),
                    month = c(1, 1, 1, 2, 2, 10, 11),
                    day = c(7, 30, 31, 1, 2, 31, 1),
                    hour = c(0, 0, 0, 0, 0, 0, 0)) 

--- a/h2o-r/tests/testdir_jira/runit_hex_1841_asdate_datemanipulation.R
+++ b/h2o-r/tests/testdir_jira/runit_hex_1841_asdate_datemanipulation.R
@@ -69,13 +69,13 @@ datetest <- function(){
   for( i in 2:10) {
     hdf[[paste("month",i,sep="")]] <- month(hdf[[paste("ds",i,sep="")]])
   }
-  
+
   # extract year & month from each date and put total month count in its own column (on server)
   for( i in 2:10) {
     hdf[[paste("idx",i,sep="")]] <- year(hdf[[paste("ds",i,sep="")]]) * 12 + month(hdf[[paste("ds",i,sep="")]])
   }
   #server dataframe is now 37 columns, 10 dates, 9 years, 9 months, 9 totalmonths
-  
+
   # set the column names for the new columns
   cc <- colnames(hdf)
   nn <- c( paste('year', 2:10, sep=''), paste('month', 2:10, sep=''), paste('idx', 2:10, sep='') )
@@ -99,16 +99,16 @@ datetest <- function(){
   rdf$ds10 <- as.Date(rdf$ds10, format='%Y_%m_%d')
 
   # create year, month, and totalmonth columns for R's version of the data
-  years <- data.frame(lapply(rdf, function(x) as.POSIXlt(x)$year))
+  years <- data.frame(lapply(rdf, function(x) as.POSIXlt(x)$year+1900))
   colnames(years) <- paste(rep("year",10),c(1:10),sep="")
 
   # as.POSIX.lt(x).mon returns a 0-11 range, but the R/H2O month(x) method returns 1-12
   months <- data.frame(lapply(rdf, function(x) as.POSIXlt(x)$mon + 1))
   colnames(months) <- paste(rep("month",10),c(1:10),sep="")
-  
+
   idx <- 12*years + months
   colnames(idx) <- paste(rep("idx",10),c(1:10),sep="")
-  
+
   rdf <- cbind(rdf, years, months, idx)
 
   #Compare the results imported from H2O (ldf) to R's results (rdf)
@@ -118,11 +118,11 @@ datetest <- function(){
     expect_that(ldf[[paste("year",i,sep="")]], equals(rdf[[paste("year",i,sep="")]]))
     print_diff(rdf[[paste("month",i,sep="")]], ldf[[paste("month",i,sep="")]])
     expect_that(ldf[[paste("month",i,sep="")]], equals(rdf[[paste("month",i,sep="")]]))
-    print_diff(rdf[[paste("idx",i,sep="")]], ldf[[paste("idx",i,sep="")]])    
+    print_diff(rdf[[paste("idx",i,sep="")]], ldf[[paste("idx",i,sep="")]])
     expect_that(ldf[[paste("idx",i,sep="")]], equals(rdf[[paste("idx",i,sep="")]]))
   }
-  
-  
+
+
   Log.info('Test 2')
   origTZ = h2o.getTimezone()
   #test 1
@@ -139,17 +139,17 @@ datetest <- function(){
   for (i in 2:11) {
     ldf[[paste("c",i,sep="")]] <- strftime(c1dates, formats[[i]], tz="America/Los_Angeles")
   }
-  
+
   #load data frame into H2O
   hdf = as.h2o(ldf, "hdf")
   #parse strings and enums into dates on H2O
   for (i in 1:11) {
     hdf[[paste("c",i,sep="")]] <- as.Date(hdf[[paste("c",i,sep="")]], formats[[i]])
   }
-  
+
   # convert dates in R into milliseconds
   lmillis <- data.frame(as.vector(unclass(as.POSIXct(c1dates, formats[1], tz="America/Los_Angeles")) * 1000))
-  
+
   #pull results back from H2O
   ldf <- as.data.frame(hdf)
   # compare milliseconds from R with those from H2O


### PR DESCRIPTION
Ensure h2o.year() returns the year instead of years since 1900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/372)
<!-- Reviewable:end -->
