### PR TITLE
PUBDEV-3454: GLRM Stalling.  Added runit test scripts used to measure…

### DIFF
--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_pubdev_3454_NOFEATURE.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_pubdev_3454_NOFEATURE.R
@@ -1,0 +1,28 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# I am trying to resolve a customer issue as captured in PUBDEV-3454.  Dmitry Tolstonogov (ADP)
+# said that he ran a GLRM model on a data set (which he has shared with us but would not want
+# us to put it out to public) with many categorical leves (~13000 columns in Y matrix).  Model
+# converges in ~1 hour for 76 iterations but job runs for another 6.5 hours while nothing happens.
+#  Bar indicates 10% done.
+#
+# The following test is written to duplicate this scenario and captured the stalling.  Once we
+# found the cause and fix it, this test will be used to test our results with a different dataset
+# with similar characteristic.
+
+test.glrm.pubdev_3454 <- function() {
+  Log.info("Input data files...")
+  feature_types = c("enum","int","int","enum","enum","real","enum","enum","enum","int")
+  data.hex <- h2o.uploadFile(locate("smalldata/glrm_test/glrm_data_DTolstonogov.csv"), destination_frame="data.hex", na.strings=rep("NA", 10), col.types=feature_types)
+
+  features = c("emps_cnt", "client_revenue", "esdb_state", "esdb_zip", "revenue_adp", "status", "revenue_region", "business_unit", "naics3")
+
+  ptm <- proc.time()
+  clients_glrm <- h2o.glrm(training_frame=data.hex, cols=features, k=9, model_id="clients_core_glrm", loading_name="arch_x", loss="Quadratic", transform="STANDARDIZE", multi_loss="Categorical", regularization_x="L2",  regularization_y="L1", gamma_x=0.2, gamma_y=0.5, max_iterations=1000, init="SVD")
+  timepassed = (proc.time() - ptm)
+  print("************** GLRM model run time (seconds): ")
+  print(timepassed)
+  }
+
+doTest("GLRM Test: PUBDEV-3454, GLRM stalling", test.glrm.pubdev_3454)

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_pubdev_3454_NOFEATURE_20runs.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_pubdev_3454_NOFEATURE_20runs.R
@@ -1,0 +1,32 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# I am trying to resolve a customer issue as captured in PUBDEV-3454.  Dmitry Tolstonogov (ADP)
+# said that he ran a GLRM model on a data set (which he has shared with us but would not want
+# us to put it out to public) with many categorical leves (~13000 columns in Y matrix).  Model
+# converges in ~1 hour for 76 iterations but job runs for another 6.5 hours while nothing happens.
+#  Bar indicates 10% done.
+#
+# The following test is written to duplicate this scenario and captured the stalling.  Once we
+# found the cause and fix it, this test will be used to test our results with a different dataset
+# with similar characteristic.
+
+test.glrm.pubdev_3454 <- function() {
+  seeds = c(762721188843,362599451725,494919281343,836007721552,861050109987,171079017268,154742969138,347804747898,444858585675,921135916205) #,812410751989,423764339023,202909469794,920103918882,492393598686,967746323564,369086779218,694340063019,778222247338)
+  for (seedy in seeds) {
+    Log.info("Input data files...")
+    feature_types = c("enum","int","int","enum","enum","real","enum","enum","enum","int")
+    data.hex <- h2o.uploadFile(locate("smalldata/glrm_test/glrm_data_DTolstonogov.csv"), destination_frame="data.hex", na.strings=rep("NA", 10), col.types=feature_types)
+
+    features = c("emps_cnt", "client_revenue", "esdb_state", "esdb_zip", "revenue_adp", "status", "revenue_region", "business_unit", "naics3")
+
+
+    ptm <- proc.time()
+    clients_glrm <- h2o.glrm(training_frame=data.hex, cols=features, k=9, model_id="clients_core_glrm", loading_name="arch_x", loss="Quadratic", transform="STANDARDIZE", multi_loss="Categorical", regularization_x="L2",  regularization_y="L1", gamma_x=0.2, gamma_y=0.5, max_iterations=1000, init="SVD", seed=seedy)
+    timepassed = (proc.time() - ptm)
+    print("************** GLRM model run time (seconds): ")
+    print(timepassed)
+  }
+ }
+
+doTest("GLRM Test: PUBDEV-3454, GLRM stalling", test.glrm.pubdev_3454)


### PR DESCRIPTION
Added Runit test scripts to measure GLRM run speed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/375)
<!-- Reviewable:end -->
