### PR TITLE
Brings back fix of PUBDEV-3401 that was reverted by incorrect merge

### DIFF
--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -182,7 +182,10 @@ public abstract class Parser extends Iced {
     // only check header for 2nd file onward since guess setup is already done on first file.
     if ((fileIndex > 0) && (!checkFileNHeader(is, dout, din, cidx)))
       return new StreamInfo(zidx, nextChunk);  // header is bad, quit now
-    while (is.available() > 0) {
+    int streamAvailable = is.available();
+    while (streamAvailable > 0) {
+      parseChunk(cidx++, din, nextChunk);
+      streamAvailable = is.available(); // Can (also!) rollover to the next input chunk
       int xidx = bvs.read(null, 0, 0); // Back-channel read of chunk index
       if (xidx > zidx) {  // Advanced chunk index of underlying ByteVec stream?
         zidx = xidx;       // Record advancing of chunk
@@ -193,7 +196,6 @@ public abstract class Parser extends Iced {
         }
         nextChunk = nextChunk.nextChunk();
       }
-      parseChunk(cidx++, din, nextChunk);
     }
     parseChunk(cidx, din, nextChunk);
     return new StreamInfo(zidx, nextChunk);


### PR DESCRIPTION
My fix of PUBDEB-3401 was most likely accidentally reverted by commint 8188c1106ab6221945d0f730bcd95dd4e30a6007

@wendycwong please review

@tomasnykodym was the original reviewer of fix for PUB-3401

Tests will fail without this fix: http://172.16.2.161:8080/job/h2o_master_DEV_runit_small/20451/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/382)
<!-- Reviewable:end -->
