### PR TITLE
[PUBDEV-3558] [PUBDEV-3413] [PUBDEV-3370] [PUBDEV-3115] Relocating h2o.jar distributed with the h2o python package

### DIFF
--- a/h2o-py/clean.sh
+++ b/h2o-py/clean.sh
@@ -1,3 +1,5 @@
 rm -rf h2o.egg-info/
 rm -rf build/
 rm -rf dist/
+rm -rf tests/results/
+rm -rf h2o/backend/bin/

--- a/h2o-py/conda/h2o/bld.bat
+++ b/h2o-py/conda/h2o/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/h2o-py/conda/h2o/build.sh
+++ b/h2o-py/conda/h2o/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/h2o-py/conda/h2o/meta.yaml
+++ b/h2o-py/conda/h2o/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: h2o
+  version: "3.10.0.8"
+
+source:
+  path: ../..
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - colorama
+    - future
+    - tabulate
+    - requests
+
+  run:
+    - python
+    - colorama
+    - future
+    - requests
+    - tabulate
+
+about:
+  home: https://github.com/h2oai/h2o-3.git
+  license: Apache License Version 2.0
+  license_family: Apache

--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -203,12 +203,16 @@ class H2OLocalServer(object):
     @staticmethod
     def _jar_paths():
         """Produce potential paths for an h2o.jar executable."""
-        # Check if running from an h2o-3 src folder, in which case use the freshly-built h2o.jar
+        # Check if running from an h2o-3 src folder (or any subfolder), in which case use the freshly-built h2o.jar
         cwd_chunks = os.path.abspath(".").split(os.path.sep)
         for i in range(len(cwd_chunks), 0, -1):
             if cwd_chunks[i - 1] == "h2o-3":
                 yield os.path.sep.join(cwd_chunks[:i] + ["build", "h2o.jar"])
-        # Finally try several alternative locations where h2o.jar might be installed
+        # Then check the backend/bin folder:
+        backend = os.path.split(os.path.realpath(__file__))[0]
+        yield os.path.join(backend, "bin", "h2o.jar")
+
+        # Then try several old locations where h2o.jar might have been installed
         prefix1 = prefix2 = sys.prefix
         # On Unix-like systems Python typically gets installed into /Library/... or /System/Library/... If one of
         # those paths is sys.prefix, then we also build its counterpart.

--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -209,8 +209,9 @@ class H2OLocalServer(object):
             if cwd_chunks[i - 1] == "h2o-3":
                 yield os.path.sep.join(cwd_chunks[:i] + ["build", "h2o.jar"])
         # Then check the backend/bin folder:
-        backend = os.path.split(os.path.realpath(__file__))[0]
-        yield os.path.join(backend, "bin", "h2o.jar")
+        # (the following works assuming this code is located in h2o/backend/server.py file)
+        backend_dir = os.path.split(os.path.realpath(__file__))[0]
+        yield os.path.join(backend_dir, "bin", "h2o.jar")
 
         # Then try several old locations where h2o.jar might have been installed
         prefix1 = prefix2 = sys.prefix

--- a/h2o-py/h2o/utils/progressbar.py
+++ b/h2o-py/h2o/utils/progressbar.py
@@ -562,7 +562,7 @@ class _ProgressBarCompoundWidget(ProgressBarWidget):
         """Find current STDOUT's width, in characters."""
         # If output is not terminal but a regular file, assume 100 chars width
         if not sys.stdout.isatty():
-            return 100
+            return 80
 
         # Otherwise, first try getting the dimensions from shell command `stty`:
         try:
@@ -584,7 +584,7 @@ class _ProgressBarCompoundWidget(ProgressBarWidget):
             pass
 
         # Finally check the COLUMNS environment variable
-        return int(os.environ.get("COLUMNS", 100))
+        return int(os.environ.get("COLUMNS", 80))
 
 
 

--- a/h2o-py/package_upload_steps.txt
+++ b/h2o-py/package_upload_steps.txt
@@ -1,5 +1,7 @@
 
-To Upload:
+====================================
+Upload to PyPi
+====================================
 
 Step 1:
 python setup.py bdist_wheel
@@ -29,8 +31,29 @@ If it's your first time:
 pip install --pre h2o
 
 
+====================================
+Upload to Anaconda
+====================================
+
+1. If this is your first time, then run
+
+        $ conda config --set anaconda_upload yes
+
+2. (This step can be skipped if you just built package for PyPi)
+
+        $ python setup.py bdist_wheel
+
+3. Modify package version number within this file (we need to automate this step somehow):
+
+        $ sublime conda/h2o/meta.yaml
+
+4. Build the conda package and upload to anaconda automatically
+        $ cd conda
+        $ conda build h2o
 
 
-To build the sphinx documentation:
+===================================
+Build Sphinx documentation
+===================================
 
 /usr/local/bin/sphinx-build -b html docs/ docs/docs/

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -14,10 +14,21 @@ with open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 packages = find_packages(exclude=["tests*"])
 print("Found packages: %r" % packages)
 
-# Copy h2o.jar to the source directory
-if not os.path.exists("h2o/backend/bin"):
-    os.makedirs("h2o/backend/bin")
-shutil.copyfile("../build/h2o.jar", "h2o/backend/bin/h2o.jar")
+
+# Copy h2o.jar to the h2o/backend/bin directory
+h2o_jar_src = os.path.join(here, "..", "build", "h2o.jar")
+h2o_jar_dst = os.path.join(here, "h2o", "backend", "bin", "h2o.jar")
+if not os.path.exists(os.path.dirname(h2o_jar_dst)):
+    os.makedirs(os.path.dirname(h2o_jar_dst))
+
+if os.path.exists(h2o_jar_src):
+    shutil.copyfile(h2o_jar_src, h2o_jar_dst)
+elif os.path.exists(h2o_jar_dst):
+    # The h2o.jar already exists in the target directory -- don't do anything (even if it's an old version)
+    pass
+else:
+    raise RuntimeError("Cannot locate %s to bundle with the h2o package (pwd: %s)." % (h2o_jar_src, here))
+
 
 if h2o.__version__ == "SUBST_PROJECT_VERSION":
     h2o.__version__ = "3.14.15.92653"

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -1,17 +1,26 @@
 # -*- encoding: utf-8 -*-
 from setuptools import setup, find_packages
 from codecs import open
-from os import path
+import os
+import shutil
 import h2o
 
-here = path.abspath(path.dirname(__file__))
+here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
+with open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 packages = find_packages(exclude=["tests*"])
 print("Found packages: %r" % packages)
+
+# Copy h2o.jar to the source directory
+if not os.path.exists("h2o/backend/bin"):
+    os.makedirs("h2o/backend/bin")
+shutil.copyfile("../build/h2o.jar", "h2o/backend/bin/h2o.jar")
+
+if h2o.__version__ == "SUBST_PROJECT_VERSION":
+    h2o.__version__ = "3.14.15.92653"
 
 setup(
     name='h2o',
@@ -66,15 +75,10 @@ setup(
 
     packages=packages,
     package_data={"h2o": [
-        "LICENSE",
-        "h2o_data/*.*",
+        "h2o_data/*.*",     # several small datasets used in demos/examples
+        "backend/bin/*.*",  # h2o.jar core Java library
     ]},
 
     # run-time dependencies
     install_requires=["requests", "tabulate", "future", "colorama"],
-
-    # Additional data files to include into the distribution
-    data_files=[
-        ("h2o_jar", ["../build/h2o.jar"]),
-    ],
 )


### PR DESCRIPTION
Currently we put h2o.jar into the h2o_jar folder at the root of python libraries folder (i.e. outside the `h2o` package folder). This makes installation very fragile: sometimes h2o.jar is hard to find, or the wrong h2o.jar is used (especially on Windows machines), or it doesn't work at all with certain virtual environments, etc.

This change tries to mitigate the issue by putting h2o.jar into the h2o/backend/bin folder within the h2o package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/389)
<!-- Reviewable:end -->
