### PR TITLE
fix missing @examples keyword, partially closes PUBDEV-3597

### DIFF
--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -130,6 +130,7 @@
 #' @param elastic_averaging_moving_rate Elastic averaging moving rate (only if elastic averaging is enabled). Defaults to 0.9.
 #' @param elastic_averaging_regularization Elastic averaging regularization strength (only if elastic averaging is enabled). Defaults to 0.001.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
+#' @examples
 #' \donttest{
 #' library(h2o)
 #' h2o.init()


### PR DESCRIPTION
we are getting `R CMD check` warning now:
```
* checking Rd files ... WARNING
checkRd: (7) h2o.deeplearning.Rd:268-276: Tag \donttest not recognized
```
this will fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/402)
<!-- Reviewable:end -->
