### PR TITLE
Bug in NBHM resize heuristic

### DIFF
--- a/h2o-core/src/main/java/water/nbhm/NonBlockingHashMap.java
+++ b/h2o-core/src/main/java/water/nbhm/NonBlockingHashMap.java
@@ -904,17 +904,20 @@ public class NonBlockingHashMap<TypeK, TypeV>
       // with a higher reprobe rate
       //if( sz >= (oldlen>>1) ) // If we are >50% full of keys then...
       //  newsz = oldlen<<1;    // Double size
-
-      // Last (re)size operation was very recent?  Then double again; slows
-      // down resize operations for tables subject to a high key churn rate.
+      
+      // Last (re)size operation was very recent?  Then double again
+      // despite having few live keys; slows down resize operations
+      // for tables subject to a high key churn rate - but do not
+      // forever grow the table.  If there is a high key churn rate
+      // the table needs a steady state of rare same-size resize
+      // operations to clean out the dead keys.
       long tm = System.currentTimeMillis();
-      long q=0;
       if( newsz <= oldlen && // New table would shrink or hold steady?
-          (tm <= topmap._last_resize_milli+10000 || // Recent resize (less than 10 sec ago)
-           (q=_slots.estimate_get()) >= (sz<<1)) )  // 1/2 of keys are dead?
+          tm <= topmap._last_resize_milli+10000)  // Recent resize (less than 10 sec ago)
         newsz = oldlen<<1;      // Double the existing size
 
-      // Do not shrink, ever
+      // Do not shrink, ever.  If we hit this size once, assume we
+      // will again.
       if( newsz < oldlen ) newsz = oldlen;
 
       // Convert to power-of-2


### PR DESCRIPTION
Bug would trigger endless growth of NBHM if seeing a high Key churn rate
- which effectively keeps dead Keys around indefinitly leading to a
  memory leak.  Seeing 100M dead keys being kept alive, at 100b each
  leading to a 10G total leak.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/412)

<!-- Reviewable:end -->
