### PR TITLE
Python documentation footer

### DIFF
--- a/h2o-py/docs/conf.py
+++ b/h2o-py/docs/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'H2O'
-copyright = u'2015, H2O.ai'
+copyright = u'2015-2016, H2O.ai'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -141,7 +141,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.


### PR DESCRIPTION
The Python API documentation showed “Copyright 2015, H2O.ai” in the footer. Updated this to include 2016 because updates continued this year. Also added the “last updated” tag to the footer.
Python docs built successfully on my local machine after these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/414)
<!-- Reviewable:end -->
