### PR TITLE
as.h2o generic, closes PUBDEV-3588

### DIFF
--- a/h2o-r/h2o-DESCRIPTION.template
+++ b/h2o-r/h2o-DESCRIPTION.template
@@ -23,7 +23,8 @@ Imports: graphics,
          RCurl,
          jsonlite
 Suggests: ggplot2,
-          mlbench
+          mlbench,
+          Matrix
 Collate:
          'astfun.R'
          'classes.R'

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2672,49 +2672,132 @@ h2o.range <- function(x,na.rm = FALSE,finite = FALSE) {
 #-----------------------------------------------------------------------------------------------------------------------
 
 #'
-#' R data.frame -> H2OFrame
+#' Is H2O Frame object
 #'
-#' Import a local R data frame to the H2O cloud.
+#' Test if object is H2O Frame.
 #'
-#' @param x An \code{R} data frame.
-#' @param destination_frame A string with the desired name for the H2OFrame.
-#' @param sparse Optional boolean flag indicating whether parameter x should be treated as a sparse matrix.
-#'        Sparse matrices from package Matrix are automatically treated as sparse.
+#' @param x An \code{R} object.
 #' @export
-as.h2o <- function(x, destination_frame= "", sparse = NULL) {
+is.h2o <- function(x) inherits(x, "H2OFrame")
+
+h2o.class.map <- function() {
+  c("integer64"="numeric",
+    "integer"="numeric",
+    "double"="numeric",
+    "complex"="numeric",
+    "logical"="enum",
+    "factor"="enum",
+    "character"="string",
+    "Date"="Time")
+}
+
+destination_frame.guess <- function(x) {
+  valid.key = isTRUE(try(.key.validate(x), silent=TRUE)) # simplify after .key.validate improvement
+  if (valid.key) x else ""
+}
+
+#'
+#' Create H2OFrame
+#'
+#' Import R object to the H2O cloud.
+#'
+#' @param x An \code{R} object.
+#' @param destination_frame A string with the desired name for the H2OFrame.
+#' @param \dots arguments passed to method arguments.
+#' @export
+#' @examples 
+#' \donttest{
+#' h2o.init()
+#' hi <- as.h2o(iris)
+#' he <- as.h2o(euro)
+#' hl <- as.h2o(letters)
+#' hm <- as.h2o(state.x77)
+#' hh <- as.h2o(hi)
+#' stopifnot(is.h2o(hi), dim(hi)==dim(iris),
+#'           is.h2o(he), dim(he)==c(length(euro),1L),
+#'           is.h2o(hl), dim(hl)==c(length(letters),1L),
+#'           is.h2o(hm), dim(hm)==dim(state.x77),
+#'           is.h2o(hh), dim(hh)==dim(hi))
+#' if (requireNamespace("Matrix", quietly=TRUE)) {
+#'   data <- rep(0, 100)
+#'   data[(1:10)^2] <- 1:10 * pi
+#'   m <- matrix(data, ncol = 20, byrow = TRUE)
+#'   m <- Matrix::Matrix(m, sparse = TRUE)
+#'   hs <- as.h2o(m)
+#'   stopifnot(is.h2o(hs), dim(hs)==dim(m))
+#' }
+#' }
+as.h2o <- function(x, destination_frame="", ...) {
   .key.validate(destination_frame)
+  UseMethod("as.h2o")
+}
 
-  dest_name <- if( destination_frame=="") deparse(substitute(x)) else destination_frame
-  if( nzchar(dest_name) && regexpr("^[a-zA-Z_][a-zA-Z0-9_.]*$", dest_name)[1L] == -1L )
-    dest_name <- destination_frame
+#' @rdname as.h2o
+#' @method as.h2o default
+#' @export
+as.h2o.default <- function(x, destination_frame="", ...) {
+  if( destination_frame=="" ) destination_frame <- deparse(substitute(x)) # guessing is done in as.h2o.data.frame
+  x <- if( length(x)==1L )
+    data.frame(C1=x)
+  else
+    as.data.frame(x, ...)
+  as.h2o.data.frame(x, destination_frame=destination_frame)
+}
 
-  if (is.null(sparse))
-    sparse = .h2o.is.sparse.matrix(x)
-
-  if (sparse) {
-    tmpf <- tempfile(fileext = ".svm")
-    .h2o.write.matrix.svmlight(x, file = tmpf)
-    h2f <- .h2o.readSVMLight(tmpf, destination_frame = dest_name)
-  } else {
-    # TODO: Be careful, there might be a limit on how long a vector you can define in console
-    if(!is.data.frame(x))
-      if( length(x)==1L ) x <- data.frame(C1=x)
-      else                x <- as.data.frame(x)
-    tmpf <- tempfile(fileext = ".csv")
-    types <- sapply(x, class)
-    types <- gsub("integer64", "numeric", types)
-    types <- gsub("integer", "numeric", types)
-    types <- gsub("double", "numeric", types)
-    types <- gsub("complex", "numeric", types)
-    types <- gsub("logical", "enum", types)
-    types <- gsub("factor", "enum", types)
-    types <- gsub("character", "string", types)
-    types <- gsub("Date", "Time", types)
-    write.csv(x, file = tmpf, row.names = FALSE, na="NA_h2o")
-    h2f <- h2o.uploadFile(tmpf, destination_frame = dest_name, header = TRUE, col.types=types,
-                          col.names=colnames(x, do.NULL=FALSE, prefix="C"), na.strings=rep(c("NA_h2o"),ncol(x)))
+#' @rdname as.h2o
+#' @method as.h2o H2OFrame
+#' @export
+as.h2o.H2OFrame <- function(x, destination_frame="", ...) {
+  if( destination_frame=="" ) {
+    subx <- destination_frame.guess(deparse(substitute(x)))
+    destination_frame <- .key.make(if(nzchar(subx)) subx else "copy")
   }
+  h2o.assign(x, key=destination_frame)
+}
 
+#' @rdname as.h2o
+#' @method as.h2o data.frame
+#' @export
+as.h2o.data.frame <- function(x, destination_frame="", ...) {
+  if( destination_frame=="" )
+    destination_frame <- deparse(substitute(x))
+  
+  destination_frame <- destination_frame.guess(destination_frame) # filter out invalid i.e. "abc::fun()"
+  .key.validate(destination_frame) # h2o.uploadFile already handle ""
+  
+  # TODO: Be careful, there might be a limit on how long a vector you can define in console
+  tmpf <- tempfile(fileext = ".csv")
+  # remap R data types to java data types
+  types <- sapply(x, function(x) class(x)[1L]) # ensure vector returned
+  class.map <- h2o.class.map()
+  types[types %in% names(class.map)] <- class.map[types[types %in% names(class.map)]]
+  write.csv(x, file = tmpf, row.names = FALSE, na="NA_h2o")
+  h2f <- h2o.uploadFile(tmpf, destination_frame = destination_frame, header = TRUE, col.types=types,
+                        col.names=colnames(x, do.NULL=FALSE, prefix="C"), na.strings=rep(c("NA_h2o"),ncol(x)))
+  file.remove(tmpf)
+  h2f
+}
+
+#' @rdname as.h2o
+#' @method as.h2o Matrix
+#' @export
+as.h2o.Matrix <- function(x, destination_frame="", ...) {
+  
+  if( destination_frame=="")
+    destination_frame <- deparse(substitute(x))
+  
+  sparse <- .h2o.is.sparse.matrix(x)
+  if(!sparse)
+    return(as.h2o.default(x, destination_frame=destination_frame, ...))
+  
+  destination_frame <- destination_frame.guess(destination_frame) # filter out invalid i.e. "abc::fun()"
+  .key.validate(destination_frame)
+  if ( destination_frame=="" ) # .h2o.readSVMLight wont handle ""
+    destination_frame <- .key.make("Matrix") # only used if `x` variable name not valid key
+  
+  tmpf <- tempfile(fileext = ".svm")
+  .h2o.write.matrix.svmlight(x, file = tmpf)
+  h2f <- .h2o.readSVMLight(tmpf, destination_frame = destination_frame)
   file.remove(tmpf)
   h2f
 }

--- a/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
+++ b/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
@@ -4,17 +4,17 @@ source("../../scripts/h2o-r-test-setup.R")
 test.as.h2o.sparse <- function() {
     data <- rep(0, 100)
     data[(1:10)^2] <- 1:10 * pi
-
     m <- matrix(data, ncol = 20, byrow = TRUE)
-
+    m <- Matrix::Matrix(m, sparse = TRUE)
+    
     Log.info("Loading a sparse matrix into H2O")
-    h2o.matrix <- as.h2o(m, "sparse_matrix", sparse = TRUE)
+    h2o.matrix <- as.h2o(m, "sparse_matrix")
 
     h2o.df <- as.data.frame(h2o.matrix)
     colnames(h2o.df) <- sprintf("V%s", 1:20)
 
     Log.info("Expect that number of rows in as.data.frame is same as the original file")
-    expect_equal(h2o.df, as.data.frame(m))
+    expect_equal(h2o.df, as.data.frame(as.matrix(m)))
 }
 
 doTest("Test as.h2o for sparse matrix", test.as.h2o.sparse)


### PR DESCRIPTION
PR makes `as.h2o` a generic method, and adds methods: `default`, `data.frame`, `Matrix`, `H2OFrame`.
Also:
- `Matrix` is optional dependency, it is R package among _recommended_ pkgs (since 2.9.0), and those are shipped together with R, so it isn't really _new_ dependency. It was added to have an example of usage `as.h2o` on sparse matrix.
-  new `is.h2o` function - used in examples where number of characters in line matter for CRAN check, short name of function like this will also make examples more readable.
- data type R-java dictionary has been moved to own _container_, a function `h2o.class.map`, not exported
- There are lot of lines related to `destination_frame` handling, this could be eventually simplified after PUBDEV-3608.
- `sparse` argument has been removed as it is related to input object to `as.h2o`, not h2o itself. Technically instead of `as.h2o(..., sparse=.)` it should be `as.h2o(Matrix(..., sparse=.))` as we do not want to convert to sparse matrix but to provide sparse matrix method. This is breaking change to feature added just a few days ago. Unit test updated.
- Added examples with basic tests for various classes, no new unit tests as any existing unit tests having `as.h2o` are also testing this PR.
- If there is a way to know if h2o frame was created from `.h2o.readSVMLight` call I could add extra unit test.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/416)

<!-- Reviewable:end -->
