### PR TITLE
Create test frame builder

### DIFF
--- a/h2o-core/src/test/java/water/fvec/TestFrameBuilder.java
+++ b/h2o-core/src/test/java/water/fvec/TestFrameBuilder.java
@@ -1,0 +1,321 @@
+package water.fvec;
+
+import water.DKV;
+import water.Key;
+
+import java.util.HashMap;
+
+/**
+ * Class used for creating simple test frames using builder pattern
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * final Frame builder = new TestFrameBuilder()
+ *   .withName("testFrame")
+ *   .withColNames("ColA", "ColB", "ColC")
+ *   .withVecTypes(Vec.T_NUM, Vec.T_STR, Vec.T_CAT)
+ *   .withDataForCol(0, ard(Double.NaN, 1, 2, 3, 4, 5.6, 7))
+ *   .withDataForCol(1, ar("A", "B", "C", "E", "F", "I", "J"))
+ *   .withDataForCol(2, ar("A", "B,", "A", "C", "A", "B", "A"))
+ *   .withChunkLayout(2, 2, 2, 1)
+ *   .build();
+ * }
+ * </pre>
+ * Data for categorical column are set in the same way as for string column and leves are created automatically.</br>
+ * All methods in this builder are optional:
+ * <ul>
+ * <li> Frame name is created it not provided.</li>
+ * <li> Column names are created automatically if not provided.</li>
+ * <li> Vector types are initialized to empty array when not provided. For example, creating empty frame (
+ *   no data, co columns) can be created as {@code Frame fr = new TestFrameBuilder().build()}.</li>
+ * <li> Column data are initialized to empty array when not provided. The following example creates frames with 2 columns,
+ *   but no data. {@code Frame fr = new TestFrameBuilder().withVecTypes(Vec.T_NUM).build()}.</li>
+ * <li> Only one chunk is created when chunk layout is not provided.</li>
+ * </ul>
+ */
+public class TestFrameBuilder {
+
+  private static final long NOT_SET = -1;
+  private HashMap<Integer, String[]> stringData = new HashMap<>();
+  private HashMap<Integer, double[]> numericData = new HashMap<>();
+  private String frameName;
+  private byte[] vecTypes;
+  private String[] colNames;
+  private long[] chunkLayout;
+  private int numCols;
+  private Key<Frame> key;
+  private long numRows = NOT_SET;
+  private String[][] domains = null;
+  private HashMap<Integer, int[]> categoriesPerCol = new HashMap<>();
+
+  /**
+   * Sets the name for the frame. Default name is created if this method is not called.
+   */
+  public TestFrameBuilder withName(String frameName) {
+    this.frameName = frameName;
+    return this;
+  }
+
+  /**
+   * Sets the names for the columns. Default names are created if this method is not called.
+   */
+  public TestFrameBuilder withColNames(String... colNames) {
+    this.colNames = colNames;
+    return this;
+  }
+
+  /**
+   * Sets the vector types. Vector types are initialized to empty array if this method is not called.
+   */
+  public TestFrameBuilder withVecTypes(byte... vecTypes) {
+    this.vecTypes = vecTypes;
+    return this;
+  }
+
+
+  /**
+   * Sets data for a particular column
+   *
+   * @param column for which to set data
+   * @param data   array of string data
+   */
+  public TestFrameBuilder withDataForCol(int column, String[] data) {
+    stringData.put(column, data);
+    return this;
+  }
+
+  /**
+   * Sets data for a particular column
+   *
+   * @param column for which to set data
+   * @param data   array of double data
+   */
+  public TestFrameBuilder withDataForCol(int column, double[] data) {
+    numericData.put(column, data);
+    return this;
+  }
+
+  /**
+   * Sets data for a particular column
+   *
+   * @param column for which to set data
+   * @param data   array of long data
+   */
+  public TestFrameBuilder withDataForCol(int column, long[] data) {
+    if(data == null){
+      numericData.put(column, null);
+    }else {
+      double[] doubles = new double[data.length];
+      for (int i = 0; i < data.length; i++) {
+        doubles[i] = data[i];
+      }
+      numericData.put(column, doubles);
+    }
+    return this;
+  }
+
+  public Frame build() {
+    prepareAndCheck();
+
+    // Create a frame
+    Frame f = new Frame(key);
+    f.preparePartialFrame(colNames);
+    f.update();
+
+    // Create chunks
+    int cidx = 0;
+    long start = 0;
+    for (long chnkSize : chunkLayout) {
+      createChunks(start, chnkSize, cidx);
+      cidx++;
+      start = start + chnkSize;
+    }
+
+    // Reload frame from DKV
+    f = DKV.get(key).get();
+    // Finalize frame
+    f.finalizePartialFrame(chunkLayout, domains, vecTypes);
+    return f;
+  }
+
+  private void prepareAndCheck(){
+    // this check has to be run as the first one
+    checkVecTypes();
+    checkNames();
+    // check that we have data for all columns and all columns have the same number of elements
+    checkColumnData();
+    checkFrameName();
+    checkChunkLayout();
+    prepareCategoricals();
+  }
+
+  // Utility method to get unique values from categorical domain
+  private String[] getUniqueValues(HashMap<String, Integer> mapping){
+   return mapping.keySet().toArray(new String[mapping.keySet().size()]);
+  }
+
+  // Utility method to convert domain into categories
+  private int[] getCategories(HashMap<String, Integer> mapping, String[] original){
+    int[] categoricals = new int[original.length];
+    for(int i = 0; i < original.length; i++) {
+      categoricals[i] = mapping.get(original[i]);
+    }
+    return categoricals;
+  }
+
+  // Utility method to get mapping from domain member to its level
+  private HashMap<String, Integer> getMapping(String[] array){
+   HashMap<String, Integer> mapping = new HashMap<>();
+    int level = 0;
+    for(int i = 0; i < array.length; i++){
+      if(!mapping.containsKey(array[i])){
+        mapping.put(array[i], level);
+        level++;
+      }
+    }
+    return mapping;
+  }
+
+  private void prepareCategoricals(){
+    // domains is not null if there is any T_CAT
+    for (int colIdx = 0; colIdx < vecTypes.length; colIdx++) {
+      if(vecTypes[colIdx]==Vec.T_CAT){
+        HashMap<String, Integer> mapping = getMapping(stringData.get(colIdx));
+        int[] categories = getCategories(mapping, stringData.get(colIdx));
+        domains[colIdx] = getUniqueValues(mapping);
+        categoriesPerCol.put(colIdx, categories);
+      }else{
+        if(domains != null) {
+          domains[colIdx] = null;
+        }
+      }
+    }
+  }
+
+  private void createChunks(long start, long length, int cidx) {
+    NewChunk[] nchunks = Frame.createNewChunks(key.toString(), vecTypes, cidx);
+    for (int i = (int) start; i < start + length; i++) {
+
+      for (int colIdx = 0; colIdx < vecTypes.length; colIdx++) {
+        switch (vecTypes[colIdx]) {
+          case Vec.T_NUM:
+            nchunks[colIdx].addNum(numericData.get(colIdx)[i]);
+            break;
+          case Vec.T_STR:
+            nchunks[colIdx].addStr(stringData.get(colIdx)[i]);
+            break;
+          case Vec.T_TIME:
+            nchunks[colIdx].addNum(numericData.get(colIdx)[i]);
+            break;
+          case Vec.T_CAT:
+            nchunks[colIdx].addCategorical(categoriesPerCol.get(colIdx)[i]);
+            break;
+          default:
+            throw new UnsupportedOperationException("Unsupported Vector type for the builder");
+
+        }
+      }
+    }
+    Frame.closeNewChunks(nchunks);
+  }
+
+  public TestFrameBuilder withChunkLayout(long... chunkLayout) {
+    this.chunkLayout = chunkLayout;
+    return this;
+  }
+
+
+  // this check has to be called as the first one
+  private void checkVecTypes() {
+    if(vecTypes==null){
+      vecTypes = new byte[0];
+    }
+    numCols = vecTypes.length;
+
+    for(int i=0; i<vecTypes.length; i++){
+      switch (vecTypes[i]){
+        case Vec.T_TIME:
+        case Vec.T_NUM:
+          if(numericData.get(i)==null){
+            numericData.put(i, new double[0]); // init with no data as default
+          }
+          break;
+        case Vec.T_CAT:
+          // initiate domains if there is any categorical column and fall-through
+          domains = new String[vecTypes.length][];
+        case Vec.T_STR:
+          if(stringData.get(i)==null){
+            stringData.put(i, new String[0]); // init with no data as default
+          }
+          break;
+      }
+    }
+
+  }
+
+  private void checkNames() {
+    if (colNames == null) {
+      colNames = new String[vecTypes.length];
+      for (int i = 0; i < vecTypes.length; i++) {
+        colNames[i] = "col_" + i;
+      }
+    }else {
+      throwIf(colNames.length != vecTypes.length, "Number of vector types and number of column names differ.");
+    }
+  }
+
+  private void checkFrameName() {
+    if (frameName == null) {
+      key = Key.make();
+    } else {
+      key = Key.make(frameName);
+    }
+  }
+
+  private void checkChunkLayout() {
+    // this expects that method checkColumnData has been executed
+    if (chunkLayout != null) {
+      // sum all numbers in the chunk layout, it should be smaller than the number of rows in the frame
+      int sum = 0;
+      for (long numPerChunk : chunkLayout) {
+        sum += numPerChunk;
+      }
+      throwIf(sum > numRows, "Chunk layout contains bad elements. Total sum is higher then available number of elements.");
+    } else {
+      // create chunk layout - by default 1 chunk
+      chunkLayout = new long[]{numRows};
+    }
+  }
+
+  private void checkColumnData() {
+    for (int colIdx = 0; colIdx < numCols; colIdx++) {
+      switch (vecTypes[colIdx]) {
+        case Vec.T_TIME: // fall-through to T_NUM
+        case Vec.T_NUM:
+          if (numRows == NOT_SET) {
+            numRows = numericData.get(colIdx).length;
+          } else {
+            throwIf(numRows != numericData.get(colIdx).length, "Columns has different number of elements");
+          }
+          break;
+        case Vec.T_CAT: // fall-through to T_CAT
+        case Vec.T_STR:
+          if (numRows == NOT_SET) {
+            numRows = stringData.get(colIdx).length;
+          } else {
+            throwIf(numRows != stringData.get(colIdx).length, "Columns have different number of elements");
+          }
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported Vector type for the builder");
+      }
+    }
+  }
+
+  private void throwIf(boolean condition, String msg){
+    if(condition){
+      throw new IllegalArgumentException(msg);
+    }
+  }
+}
+

--- a/h2o-core/src/test/java/water/fvec/TestFrameBuilderTest.java
+++ b/h2o-core/src/test/java/water/fvec/TestFrameBuilderTest.java
@@ -1,0 +1,168 @@
+package water.fvec;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.TestUtil;
+import water.parser.BufferedString;
+
+import static org.junit.Assert.*;
+
+public class TestFrameBuilderTest extends TestUtil {
+  @BeforeClass
+  public static void setup() { stall_till_cloudsize(1); }
+  private static double DELTA = 0.00001;
+
+  @Test
+  public void testEmpty(){
+    Frame fr = new TestFrameBuilder().build();
+
+    assertEquals(fr.vecs().length, 0);
+    assertEquals(fr.numRows(), 0);
+    assertEquals(fr.numCols(), 0);
+    assertNull(fr.anyVec()); // because we don't have any vectors
+    fr.remove();
+  }
+
+  @Test
+  public void testName(){
+    Frame fr = new TestFrameBuilder()
+            .withName("FrameName")
+            .build();
+
+    assertEquals(fr._key.toString(), "FrameName");
+    assertEquals(fr.vecs().length, 0);
+    assertEquals(fr.numRows(), 0);
+    assertEquals(fr.numCols(), 0);
+    assertNull(fr.anyVec()); // because we don't have any vectors
+    fr.remove();
+  }
+
+  @Test
+  public void testVecTypes(){
+    Frame fr = new TestFrameBuilder()
+            .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_TIME, Vec.T_STR)
+            .build();
+
+    assertArrayEquals(fr.names(), ar("col_0", "col_1", "col_2", "col_3"));
+    assertEquals(fr.vecs().length, 4);
+    assertEquals(fr.numRows(), 0);
+    assertEquals(fr.numCols(), 4);
+    assertEquals(fr.vec(0).get_type(), Vec.T_CAT);
+    assertEquals(fr.vec(1).get_type(), Vec.T_NUM);
+    assertEquals(fr.vec(2).get_type(), Vec.T_TIME);
+    assertEquals(fr.vec(3).get_type(), Vec.T_STR);
+    fr.remove();
+  }
+
+
+  /**
+   * This test throws exception because size of specified vectors and size of specified names differ
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testWrongVecNameSize(){
+    Frame fr = new TestFrameBuilder()
+            .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_TIME, Vec.T_STR)
+            .withColNames("A", "B")
+            .build();
+    fr.remove();
+  }
+
+  @Test
+  public void testColNames(){
+    Frame fr = new TestFrameBuilder()
+            .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_TIME, Vec.T_STR)
+            .withColNames("A", "B", "C", "D")
+            .build();
+
+    assertEquals(fr.vecs().length, 4);
+    assertEquals(fr.numRows(), 0);
+    assertEquals(fr.numCols(), 4);
+    assertArrayEquals(fr.names(), ar("A", "B", "C", "D"));
+    fr.remove();
+  }
+  @Test
+  public void testDefaultChunks(){
+    Frame fr = new TestFrameBuilder()
+            .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_TIME, Vec.T_STR)
+            .withColNames("A", "B", "C", "D")
+            .build();
+
+    assertArrayEquals(fr.anyVec().espc(), ar(0, 0)); // no data
+    assertEquals(fr.anyVec().nChunks(), 1); // 1 empty chunk
+    fr.remove();
+  }
+
+  /**
+   *  This test throws exception because it expects more data ( via chunk layout) than is actually available
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetChunksToMany(){
+    Frame fr = new TestFrameBuilder()
+            .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_TIME, Vec.T_STR)
+            .withColNames("A", "B", "C", "D")
+            .withChunkLayout(2, 2, 2, 1) // we are requesting 7 rows to be able to create 4 chunks, but we have 0 rows
+            .build();
+
+    fr.remove();
+  }
+
+  @Test
+  public void testSetChunks(){
+    final Frame fr = new TestFrameBuilder()
+            .withName("frameName")
+            .withColNames("ColA", "ColB")
+            .withVecTypes(Vec.T_NUM, Vec.T_STR)
+            .withDataForCol(0, ard(Double.NaN, 1, 2, 3, 4, 5.6, 7))
+            .withDataForCol(1, ar("A", "B", "C", null, "F", "I", "J"))
+            .withChunkLayout(2, 2, 2, 1)
+            .build();
+
+    assertEquals(fr.anyVec().nChunks(), 4);
+    assertArrayEquals(fr.anyVec().espc(), new long[]{0, 2, 4, 6, 7});
+    // check data in the frame
+    assertEquals(fr.vec(0).at(0), Double.NaN, DELTA);
+    assertEquals(fr.vec(0).at(5), 5.6, DELTA);
+    assertEquals(fr.vec(0).at(6), 7, DELTA);
+
+    BufferedString strBuf = new BufferedString();
+    assertEquals(fr.vec(1).atStr(strBuf,0).toString(), "A");
+    assertNull(fr.vec(1).atStr(strBuf,3));
+    assertEquals(fr.vec(1).atStr(strBuf,6).toString(), "J");
+
+    fr.remove();
+  }
+
+
+  /**
+   *  This test throws exception because the data has different length
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testDataDifferentSize(){
+    final Frame fr = new TestFrameBuilder()
+            .withVecTypes(Vec.T_NUM, Vec.T_STR)
+            .withDataForCol(0, ard(Double.NaN, 1)) // 2 elements
+            .withDataForCol(1, ar("A", "B", "C")) // 3 elements
+            .build();
+
+    fr.remove();
+  }
+
+  @Test
+  public void testCategorical(){
+    final Frame fr = new TestFrameBuilder()
+            .withName("frameName")
+            .withColNames("ColA")
+            .withVecTypes(Vec.T_CAT)
+            .withDataForCol(0, ar("A", "B", "C", "A")) // 2 A, 1 B, 1 C
+            .build();
+
+    assertArrayEquals(fr.vec(0).domain(), ar("A", "B", "C"));
+    assertEquals(fr.vec(0).cardinality(), 3);
+
+    assertEquals(fr.vec(0).at(0), 0, DELTA);
+    assertEquals(fr.vec(0).at(1), 1, DELTA);
+    assertEquals(fr.vec(0).at(2), 2, DELTA);
+    assertEquals(fr.vec(0).at(3), 0, DELTA);
+    fr.remove();
+  }
+}


### PR DESCRIPTION
Test frame builder which can be used in tests to create small frames.

Example usage:

```
         final Frame testFrame = new TestFrameBuilder()
                 .withName("frameName")
                 .withColNames("ColA", "ColB")
                 .withVecTypes(Vec.T_NUM, Vec.T_STR)
                 .withDataForCol(0, ard(Double.NaN, 1, 2, 3, 4, 5.6, 7))
                 .withDataForCol(1, ar("A", "B", "C", "E", "F", "I", "J"))
                 .withChunkLayout(2, 2, 2, 1)
                 .build();
```

If frame name is not set, it is created automatically.
if col names are not set, they are created automatically.
if chunk layout is not set, then only 1 chunk will be created

I just separated the code from the other branch where I was using it and improved it a bit. Didn't test it properly though yet.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/417)

<!-- Reviewable:end -->
