### PR TITLE
[PUBDEV-3614] Do not allow the user to create frames with invalid IDs

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -32,7 +32,7 @@ from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.compatibility import viewitems, viewvalues
 from h2o.utils.shared_utils import (_handle_numpy_array, _handle_pandas_data_frame, _handle_python_dicts,
                                     _handle_python_lists, _is_list, _is_str_list, _py_tmp_key, _quoted,
-                                    can_use_pandas, quote, normalize_slice, slice_is_normalized)
+                                    can_use_pandas, quote, normalize_slice, slice_is_normalized, check_frame_id)
 from h2o.utils.typechecks import (assert_is_type, assert_satisfies, I, is_type, numeric, numpy_ndarray,
                                   pandas_dataframe, scipy_sparse, U)
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="pandas", lineno=7)
@@ -126,7 +126,8 @@ class H2OFrame(object):
         assert_is_type(separator, I(str, lambda s: len(s) == 1))
         assert_is_type(column_names, None, [str])
         assert_is_type(column_types, None, [coltype], {str: coltype})
-        assert_is_type(na_strings, None, [str], [[str]], { str: [str] })
+        assert_is_type(na_strings, None, [str], [[str]], {str: [str]})
+        check_frame_id(destination_frame)
         fr = H2OFrame()
         fr._upload_python_object(python_obj, destination_frame, header, separator, column_names, column_types,
                                  na_strings)
@@ -280,6 +281,7 @@ class H2OFrame(object):
 
     @frame_id.setter
     def frame_id(self, newid):
+        check_frame_id(newid)
         if self._ex._cache._id is None:
             h2o.assign(self, newid)
         else:

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -269,7 +269,7 @@ def _import(path):
     return j["destination_frames"]
 
 
-def upload_file(path, destination_frame="", header=0, sep=None, col_names=None, col_types=None,
+def upload_file(path, destination_frame=None, header=0, sep=None, col_names=None, col_types=None,
                 na_strings=None):
     """
     Upload a dataset from the provided local path to the H2O cluster.
@@ -309,7 +309,7 @@ def upload_file(path, destination_frame="", header=0, sep=None, col_names=None, 
                 "categorical", "factor", "enum", "time")
     natype = U(str, [str])
     assert_is_type(path, str)
-    assert_is_type(destination_frame, str)
+    assert_is_type(destination_frame, str, None)
     assert_is_type(header, -1, 0, 1)
     assert_is_type(sep, None, I(str, lambda s: len(s) == 1))
     assert_is_type(col_names, [str], None)
@@ -321,7 +321,7 @@ def upload_file(path, destination_frame="", header=0, sep=None, col_names=None, 
     return H2OFrame()._upload_parse(path, destination_frame, header, sep, col_names, col_types, na_strings)
 
 
-def import_file(path=None, destination_frame="", parse=True, header=0, sep=None, col_names=None, col_types=None,
+def import_file(path=None, destination_frame=None, parse=True, header=0, sep=None, col_names=None, col_types=None,
                 na_strings=None):
     """
     Import a dataset that is already on the cluster.
@@ -360,7 +360,7 @@ def import_file(path=None, destination_frame="", parse=True, header=0, sep=None,
                 "categorical", "factor", "enum", "time")
     natype = U(str, [str])
     assert_is_type(path, str, [str])
-    assert_is_type(destination_frame, str)
+    assert_is_type(destination_frame, str, None)
     assert_is_type(parse, bool)
     assert_is_type(header, -1, 0, 1)
     assert_is_type(sep, None, I(str, lambda s: len(s) == 1))
@@ -464,7 +464,7 @@ def import_sql_select(connection_url, select_query, username, password, optimize
     return get_frame(j.dest_key)
 
 
-def parse_setup(raw_frames, destination_frame="", header=0, separator=None, column_names=None,
+def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, column_names=None,
                 column_types=None, na_strings=None):
     """
     Retrieve H2O's best guess as to what the structure of the data file is.
@@ -525,7 +525,8 @@ def parse_setup(raw_frames, destination_frame="", header=0, separator=None, colu
             warnings.warn(w)
     # TODO: really should be url encoding...
     # TODO: clean up all this
-    if destination_frame: j["destination_frame"] = destination_frame.replace("%", ".").replace("&", ".")
+    if destination_frame:
+        j["destination_frame"] = destination_frame
     if column_names is not None:
         if not isinstance(column_names, list): raise ValueError("col_names should be a list")
         if len(column_names) != len(j["column_types"]): raise ValueError(
@@ -598,7 +599,9 @@ def parse_raw(setup, id=None, first_line_is_header=0):
     assert_is_type(setup, dict)
     assert_is_type(id, str, None)
     assert_is_type(first_line_is_header, -1, 0, 1)
-    if id: setup["destination_frame"] = quoted(id).replace("%", ".").replace("&", ".")
+    check_frame_id(id)
+    if id:
+        setup["destination_frame"] = id
     if first_line_is_header != (-1, 0, 1):
         if first_line_is_header not in (-1, 0, 1): raise ValueError("first_line_is_header should be -1, 0, or 1")
         setup["check_header"] = first_line_is_header

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -31,6 +31,8 @@ def _py_tmp_key(append):
 
 def check_frame_id(frame_id):
     """Check that the provided frame id is valid in Rapids language."""
+    if frame_id is None:
+        return
     if frame_id.strip() == "":
         raise H2OValueError("Frame id cannot be an empty string: %r" % frame_id)
     for ch in frame_id:

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -29,7 +29,7 @@ def _py_tmp_key(append):
     return "py_" + str(_id_ctr) + append
 
 
-def check_frame_id(frame_id: str) -> None:
+def check_frame_id(frame_id):
     """Check that the provided frame id is valid in Rapids language."""
     if frame_id.strip() == "":
         raise H2OValueError("Frame id cannot be an empty string: %r" % frame_id)

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -15,6 +15,7 @@ import os
 import re
 import sys
 
+from h2o.exceptions import H2OValueError
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.typechecks import assert_is_type, is_type, numeric
 
@@ -26,6 +27,18 @@ def _py_tmp_key(append):
     global _id_ctr
     _id_ctr += 1
     return "py_" + str(_id_ctr) + append
+
+
+def check_frame_id(frame_id: str) -> None:
+    """Check that the provided frame id is valid in Rapids language."""
+    if frame_id.strip() == "":
+        raise H2OValueError("Frame id cannot be an empty string: %r" % frame_id)
+    for ch in frame_id:
+        if ch in " '\"\t\n\r\\()[]{}~":
+            raise H2OValueError("Character '%s' is illegal in frame id: %s" % (ch, frame_id))
+    if re.match(r"-?[0-9]", frame_id):
+        raise H2OValueError("Frame id cannot start with a number: %s" % frame_id)
+
 
 
 def temp_ctr():

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -24,8 +24,8 @@ _id_ctr = 0
 # The set of characters allowed in frame IDs. Since frame ids are used within REST API urls, they may
 # only contain characters allowed within the "segment" part of the URL (see RFC 3986).
 # Among those, we additionally forbid characters "'", "(", ")" since they have special meaning in the Rapids
-# language itself.
-_id_allowed_characters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$&*+,;=")
+# language itself. Character ";" is also excluded for internal h2o reasons.
+_id_allowed_characters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$&*+,=")
 
 
 def _py_tmp_key(append):

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -19,8 +19,13 @@ from h2o.exceptions import H2OValueError
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.typechecks import assert_is_type, is_type, numeric
 
-# private static methods
 _id_ctr = 0
+
+# The set of characters allowed in frame IDs. Since frame ids are used within REST API urls, they may
+# only contain characters allowed within the "segment" part of the URL (see RFC 3986).
+# Among those, we additionally forbid characters "'", "(", ")" since they have special meaning in the Rapids
+# language itself.
+_id_allowed_characters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$&*+,;=")
 
 
 def _py_tmp_key(append):
@@ -36,7 +41,7 @@ def check_frame_id(frame_id):
     if frame_id.strip() == "":
         raise H2OValueError("Frame id cannot be an empty string: %r" % frame_id)
     for ch in frame_id:
-        if ch in " '\"\t\n\r\\()[]{}~":
+        if ch not in _id_allowed_characters:
             raise H2OValueError("Character '%s' is illegal in frame id: %s" % (ch, frame_id))
     if re.match(r"-?[0-9]", frame_id):
         raise H2OValueError("Frame id cannot start with a number: %s" % frame_id)

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -22,10 +22,9 @@ from h2o.utils.typechecks import assert_is_type, is_type, numeric
 _id_ctr = 0
 
 # The set of characters allowed in frame IDs. Since frame ids are used within REST API urls, they may
-# only contain characters allowed within the "segment" part of the URL (see RFC 3986).
-# Among those, we additionally forbid characters "'", "(", ")" since they have special meaning in the Rapids
-# language itself. Character ";" is also excluded for internal h2o reasons.
-_id_allowed_characters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!$&*+,=")
+# only contain characters allowed within the "segment" part of the URL (see RFC 3986). Additionally, we
+# forbid all characters that are declared as "illegal" in Key.java.
+_id_allowed_characters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
 
 
 def _py_tmp_key(append):
@@ -40,7 +39,9 @@ def check_frame_id(frame_id):
         return
     if frame_id.strip() == "":
         raise H2OValueError("Frame id cannot be an empty string: %r" % frame_id)
-    for ch in frame_id:
+    for i, ch in enumerate(frame_id):
+        # '$' character has special meaning at the beginning of the string; and prohibited anywhere else
+        if ch == "$" and i == 0: continue
         if ch not in _id_allowed_characters:
             raise H2OValueError("Character '%s' is illegal in frame id: %s" % (ch, frame_id))
     if re.match(r"-?[0-9]", frame_id):

--- a/h2o-py/tests/testdir_jira/pyunit_hexdev_29_additional_parameters.py
+++ b/h2o-py/tests/testdir_jira/pyunit_hexdev_29_additional_parameters.py
@@ -1,55 +1,70 @@
-from builtins import range
-import sys
-sys.path.insert(1,"../../")
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
 import h2o
+from h2o.exceptions import H2OValueError
 from tests import pyunit_utils
-################################################################################
-##
-## Verifying that Python can support additional parameters of destination_frame,
-## column_names, and column_types and that certain characters are replaced.
-##
-################################################################################
-
-
 
 
 def additional_parameters():
+    """
+    Verifying that Python can support additional parameters of destination_frame,
+    column_names, and column_types and that certain characters are allowed.
+    """
+    input_file = pyunit_utils.locate("smalldata/jira/hexdev_29.csv")
 
-    #col_types as list
-    dest_frame="dev29&hex%"
+    # col_types as list
+    dest_frame = "-._~!$&*+,=0123456789"
     c_names = ["a", "b", "c"]
     c_types = ["enum", "enum", "string"]
 
-    fhex = h2o.import_file(pyunit_utils.locate("smalldata/jira/hexdev_29.csv"),
+    fhex = h2o.import_file(input_file,
                            destination_frame=dest_frame,
                            col_names=c_names,
                            col_types=c_types)
     fhex.describe()
 
-    assert fhex.frame_id == dest_frame.replace("%",".").replace("&",".")
-    assert fhex.col_names == c_names
+    assert fhex.frame_id == dest_frame
+    assert fhex.names == c_names
     col_summary = h2o.frame(fhex.frame_id)["frames"][0]["columns"]
     for i in range(len(col_summary)):
         assert col_summary[i]["type"] == c_types[i]
 
-    #col_types as dictionary
-    dest_frame="dev29&hex%"
+    # col_types as dictionary
+    dest_frame = "._~!$&-,=*+"
     c_names = ["a", "b", "c"]
-    c_types = {"c":"string", "a":"string"}
+    c_types = {"c": "string", "a": "string"}
 
-    fhex = h2o.import_file(pyunit_utils.locate("smalldata/jira/hexdev_29.csv"),
+    fhex = h2o.import_file(input_file,
                            destination_frame=dest_frame,
                            col_names=c_names,
                            col_types=c_types)
     fhex.describe()
 
-    assert fhex.frame_id == dest_frame.replace("%",".").replace("&",".")
+    assert fhex.frame_id == dest_frame
     assert fhex.col_names == c_names
     col_summary = h2o.frame(fhex.frame_id)["frames"][0]["columns"]
     for i in range(len(col_summary)):
-      name = c_names[i]
-      if name in c_types:
-        assert col_summary[i]["type"] == c_types[name]
+        name = c_names[i]
+        if name in c_types:
+            assert col_summary[i]["type"] == c_types[name]
+
+    def test_bad_id(frameid):
+        try:
+            h2o.import_file(input_file, destination_frame=frameid)
+            assert False, "Frame id '%s' should not have been allowed" % frameid
+        except H2OValueError:
+            pass
+
+    test_bad_id("ab;cd")
+    test_bad_id("one/two/three/four")
+    test_bad_id("I'm_declaring_a_thumb_war")
+    test_bad_id("five\\six\\seven\\eight")
+    test_bad_id("finger guns proliferate")
+    test_bad_id("9_10_11_12")
+    test_bad_id("digits|cant|protect|themselves")
+    test_bad_id("(thirteen,fourteen,fifteen,sixteen)")
+    test_bad_id("UNSC_cant_intervene?")
+
 
 
 

--- a/h2o-py/tests/testdir_jira/pyunit_hexdev_29_additional_parameters.py
+++ b/h2o-py/tests/testdir_jira/pyunit_hexdev_29_additional_parameters.py
@@ -13,7 +13,7 @@ def additional_parameters():
     input_file = pyunit_utils.locate("smalldata/jira/hexdev_29.csv")
 
     # col_types as list
-    dest_frame = "-._~!$&*+,=0123456789"
+    dest_frame = "-._~0123456789"
     c_names = ["a", "b", "c"]
     c_types = ["enum", "enum", "string"]
 
@@ -30,7 +30,7 @@ def additional_parameters():
         assert col_summary[i]["type"] == c_types[i]
 
     # col_types as dictionary
-    dest_frame = "._~!$&-,=*+"
+    dest_frame = "._~---"
     c_names = ["a", "b", "c"]
     c_types = {"c": "string", "a": "string"}
 
@@ -55,7 +55,7 @@ def additional_parameters():
         except H2OValueError:
             pass
 
-    test_bad_id("ab;cd")
+    test_bad_id("xk;cd;1753")
     test_bad_id("one/two/three/four")
     test_bad_id("I'm_declaring_a_thumb_war")
     test_bad_id("five\\six\\seven\\eight")
@@ -64,6 +64,12 @@ def additional_parameters():
     test_bad_id("digits|cant|protect|themselves")
     test_bad_id("(thirteen,fourteen,fifteen,sixteen)")
     test_bad_id("UNSC_cant_intervene?")
+    test_bad_id("_17_18_19_20$")
+    test_bad_id("Death@Destruction_is_aplenty")
+    test_bad_id("_21&22&23&24")
+    test_bad_id("LifeOnEarthIsNoMore!")
+    test_bad_id("_25_26_27_28#")
+    test_bad_id("we+must+earth+repopulate")
 
 
 


### PR DESCRIPTION
This brings stringent restrictions on the possible IDs for data frames. These restrictions are guided by several considerations:
* It should be possible to use the id anywhere within the Rapids language, and there should be no chance of accidentally confusing it with any other token.
* It should be possible to use the id in a REST API url (such as `GET /3/Frames/{frame_id}`) without having to escape it.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/420)
<!-- Reviewable:end -->
