### PR TITLE
PUBDEV-3610: Remove random-split-points

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
@@ -492,7 +492,6 @@ This section describes the functions of the parameters for GBM.
 \item {\texttt{col\_sample\_rate}}: Column sample rate (per split) (from 0.0 to 1.0). 
 \item {\texttt{col\_sample\_rate\_change\_per\_level}}: Specifies to change the column sampling rate as a function of the depth in the tree.
 \item {\texttt{min\_split\_improvement}}: The minimum relative improvement in squared error reduction in order for a split to happen. 
-\item {\texttt{random\_split\_points}}: When enabled, sample N-1 points from min...max and use the sorted list of those for split finding. 
 \item {\texttt{col\_sample\_rate\_per\_tree}}: Column sample rate per tree (from 0.0 to 1.0). 
 \item {\texttt{learn\_rate}}: An integer that defines the learning rate. The default is 0.1 and the range is 0.0 to 1.0.
 \item {\texttt{learn\_rate\_annealing}}: Reduces the {\texttt{learn\_rate}} by this factor after every tree. 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -209,8 +209,6 @@ Defining a DRF Model
 
 -  **min\_split\_improvement**: The value of this option specifies the minimum relative improvement in squared error reduction in order for a split to happen. When properly tuned, this option can help reduce overfitting. Optimal values would be in the 1e-10...1e-3 range.
 
-- **random\_split_points**: By default DRF bins from min...max in steps of (max-min)/N. When this option is enabled, DRF will instead sample N-1 points from min...max and use the sorted list of those for split finding.
-
 -  **histogram_type**: By default (AUTO) DRF bins from min...max in steps of (max-min)/N. Random split points or quantile-based split points can be selected as well. RoundRobin can be specified to cycle through all histogram types (one per tree). Use this option to specify the type of histogram to use for finding optimal split points:
 
 	- AUTO

--- a/h2o-docs/src/product/data-science/gbm-params/fold_assignment.rst
+++ b/h2o-docs/src/product/data-science/gbm-params/fold_assignment.rst
@@ -1,7 +1,7 @@
 ``fold_assignment``
 -------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, K-MeansF
+- Available in: GBM, DRF, Deep Learning, GLM, K-Means
 - Hyperparameter: no
 
 

--- a/h2o-docs/src/product/data-science/gbm-params/gbm-params.rst
+++ b/h2o-docs/src/product/data-science/gbm-params/gbm-params.rst
@@ -4,10 +4,10 @@ GBM Parameters
 .. toctree::
    :maxdepth: 2
 
-   fold_assignment
-   fold_column
    balance_classes
    class_sampling_factors
+   fold_assignment
+   fold_column
    max_after_balance_size
    max_depth
    max_hit_ratio_k

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -42,12 +42,12 @@ Defining a GBM Model
    model. **NOTE**: In Flow, if you click the **Build a model** button from the
    ``Parse`` cell, the training frame is entered automatically.
 
--  **validation\_frame**: (Optional) Specify the dataset used to evaluate
+-  `validation_frame <gbm-params/validation_frame.html>`__: (Optional) Specify the dataset used to evaluate
    the accuracy of the model.
 
--  **nfolds**: Specify the number of folds for cross-validation.
+-  `nfolds <gbm-params/nfolds.html>`__: Specify the number of folds for cross-validation.
 
--  **response\_column**: (Required) Specify the column to use as the
+-  `y <gbm-params/y.html>`__: (Required) Specify the column to use as the
    independent variable. The data can be numeric or categorical.
 
 -  **ignored\_columns**: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column
@@ -148,8 +148,6 @@ Defining a GBM Model
 
 -  **min\_split\_improvement**: The value of this option specifies the minimum relative improvement in squared error reduction in order for a split to happen. When properly tuned, this option can help reduce overfitting. Optimal values would be in the 1e-10...1e-3 range.  
 
--  **random\_split_points**: By default GBM bins from min...max in steps of (max-min)/N. When this option is enabled, GBM will instead sample N-1 points from min...max and use the sorted list of those for split finding.
-
 -  **histogram_type**: By default (AUTO) GBM bins from min...max in steps of (max-min)/N. Random split points or quantile-based split points can be selected as well. RoundRobin can be specified to cycle through all histogram types (one per tree). Use this option to specify the type of histogram to use for finding optimal split points:
 
 	- AUTO
@@ -161,7 +159,7 @@ Defining a GBM Model
 -  **score\_each\_iteration**: (Optional) Specify whether to score
    during each iteration of the model training.
 
--  **fold\_assignment**: (Applicable only if a value for **nfolds** is
+-  `fold_assignment <gbm-params/fold_assignment.html>`__: (Applicable only if a value for **nfolds** is
    specified and **fold\_column** is not specified) Specify the
    cross-validation fold assignment scheme. The available options are
    AUTO (which is Random), Random, 
@@ -170,15 +168,15 @@ Defining a GBM Model
 -  **score\_tree\_interval**: Score the model after every so many trees.
    Disabled if set to 0.
 
--  **fold\_column**: Specify the column that contains the
+-  `fold_column <gbm-params/fold_column.html>`__: Specify the column that contains the
    cross-validation fold index assignment per observation.
 
--  **offset\_column**: (Not applicable if the **distribution** is
+-  `offset_column <gbm-params/offset_column.html>`__: (Not applicable if the **distribution** is
    **multinomial**) Specify a column to use as the offset.
    
 	**Note**: Offsets are per-row "bias values" that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. If the **distribution** is **Bernoulli**, the value must be less than one.
 
--  **weights\_column**: Specify a column to use for the observation
+-  `weights_column <gbm-params/weights_column.html>`__: Specify a column to use for the observation
    weights, which are used for bias correction. The specified
    ``weights_column`` must be included in the specified
    ``training_frame``. 
@@ -198,7 +196,7 @@ Defining a GBM Model
 
 -  **r2\_stopping**: ``r2_stopping`` is no longer supported and will be ignored if set - please use ``stopping_rounds``, ``stopping_metric``, and ``stopping_tolerance`` instead.
 
--  **stopping\_rounds**: Stops training when the option selected for
+-  `stopping_rounds <gbm-params/stopping_rounds.html>`__: Stops training when the option selected for
    **stopping\_metric** doesn't improve for the specified number of
    training rounds, based on a simple moving average. To disable this
    feature, specify ``0``. The metric is computed on the validation data
@@ -210,7 +208,7 @@ Defining a GBM Model
     - The main model runs for the mean number of epochs.
     - N+1 models may be off by the number specified for **stopping\_rounds** from the best model, but the cross-validation metric estimates the performance of the main model for the resulting number of epochs (which may be fewer than the specified number of epochs).
 
--  **stopping\_metric**: Specify the metric to use for early stopping.
+-  `stopping_metric <gbm-params/stopping_metric.html>`__: Specify the metric to use for early stopping.
    The available options are:
 
    - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
@@ -222,7 +220,7 @@ Defining a GBM Model
    - ``misclassification``
    - ``mean_per_class_error``
 
--  **stopping\_tolerance**: Specify the relative tolerance for the
+-  `stopping_tolerance <gbm-params/stopping_tolerance.html>`__: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less
    than this value.
 


### PR DESCRIPTION
Removed random-split-points option from GBM and DRF sections of the
user guide. Also removed this option from the GBM booklet.
Driveby fixes: Fixed typo in fold_assignment description. Alphabetized current list of parameters in the appendix. Created links to the current parameters in the appendix from the GBM section of the user guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/422)
<!-- Reviewable:end -->
