### PR TITLE
PUBDEV-3621: Add R endpoint for cumsum, cumprod, cummin, and cummax

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2587,6 +2587,54 @@ h2o.prod <- function(x) {
 }
 
 #'
+#' Return the cumulative sum over a column or across a row
+#'
+#' @name h2o.cumsum
+#' @param x An H2OFrame object.
+#' @param axis An int that indicates whether to do down a column (0) or across a row (1).
+#' @seealso \code{\link[base]{cumsum}} for the base R implementation.
+#' @export
+h2o.cumsum <- function(x, axis = 0){
+  .newExpr("cumsum", chk.H2OFrame(x), axis)
+}
+
+#'
+#' Return the cumulative product over a column or across a row
+#'
+#' @name h2o.cumprod
+#' @param x An H2OFrame object.
+#' @param axis An int that indicates whether to do down a column (0) or across a row (1).
+#' @seealso \code{\link[base]{cumprod}} for the base R implementation.
+#' @export
+h2o.cumprod <- function(x, axis = 0){
+  .newExpr("cumprod", chk.H2OFrame(x), axis)
+}
+
+#'
+#' Return the cumulative min over a column or across a row
+#'
+#' @name h2o.cummin
+#' @param x An H2OFrame object.
+#' @param axis An int that indicates whether to do down a column (0) or across a row (1).
+#' @seealso \code{\link[base]{cummin}} for the base R implementation.
+#' @export
+h2o.cummin <- function(x, axis = 0){
+  .newExpr("cummin", chk.H2OFrame(x), axis)
+}
+
+#'
+#' Return the cumulative max over a column or across a row
+#'
+#' @name h2o.cummax
+#' @param x An H2OFrame object.
+#' @param axis An int that indicates whether to do down a column (0) or across a row (1).
+#' @seealso \code{\link[base]{cummax}} for the base R implementation.
+#' @export
+h2o.cummax <- function(x, axis = 0){
+  .newExpr("cummax", chk.H2OFrame(x), axis)
+}
+
+#'
 #' Given a set of logical vectors, are all of the values true?
 #'
 #' @name h2o.all

--- a/h2o-r/tests/testdir_munging/runit_cumsum_cumprod_cummin_cummax.R
+++ b/h2o-r/tests/testdir_munging/runit_cumsum_cumprod_cummin_cummax.R
@@ -1,0 +1,51 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.cumsumminprodmax <- function() {
+   #Test when axis = 0, columnar
+   x = seq(0,9)
+   y = seq(9,0)
+
+   fr = as.h2o(cbind(x,y))
+
+   cumsum1 = h2o.cumsum(fr[,1])
+   cummin1 = h2o.cummin(fr[,1])
+   cumprod1 = h2o.cumprod(fr[1:9,1])
+   cummax1 = h2o.cummax(fr[,1])
+
+   cumsum2 = base::cumsum(as.data.frame(fr[,2]))
+   cummin2 = base::cummin(as.data.frame(fr[,2]))
+   cumprod2 = base::cumprod(as.data.frame(fr[1:9,1]))
+   cummax2 = base::cummax(as.data.frame(fr[,2]))
+
+   expect_equal(cumsum1[10,1], cumsum2[10,1])
+   expect_equal(cummin1[10,1], cummin2[10,1])
+   expect_equal(cummax1[10,1], cummax2[10,1])
+   expect_equal(cumprod1[9,1],cumprod2[9,1])
+
+   #Test when axis = 1, row wise
+   a = seq(0,9)
+   b = seq(9,0)
+   c = seq(0,9)
+   d = seq(9,0)
+
+   fr = as.h2o(cbind(a,b,c,d))
+
+   cumsum1 = h2o.cumsum(fr[1,],axis=1)
+   cummin1 = h2o.cummin(fr[2,],axis=1)
+   cumprod1 = h2o.cumprod(fr[3,],axis=1)
+   cummax1 = h2o.cummax(fr[4,],axis=1)
+
+   cumsum2 = base::cumsum(as.data.frame(t(fr[1,])))
+   cummin2 = base::cummin(as.data.frame(t(fr[2,])))
+   cumprod2 = base::cumprod(as.data.frame(t(fr[3,])))
+   cummax2 = base::cummax(as.data.frame(t(fr[4,])))
+
+   expect_equal(as.data.frame(t(cumsum1)), cumsum2)
+   expect_equal(as.data.frame(t(cummin1)), cummin2)
+   expect_equal(as.data.frame(t(cummax1)), cummax2)
+   expect_equal(as.data.frame(t(cumprod1)),cumprod2)
+
+}
+
+doTest("Test cumsum,cumprod,cummin, and cummax", test.cumsumminprodmax)


### PR DESCRIPTION
- This PR adds an API endpoint for cumsum, cumprod, cummin, and cummax for the R API.
- We don't need to overload to the R namespace as we have an extra argument, `axis`, which indicates if the operation should be done down a column or across a row.
- Relevant Runit is attached (This is the same as the Pyunit for completeness)

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/428)

<!-- Reviewable:end -->
