### PR TITLE
Isolating AssertionError

### DIFF
--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningProstateTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningProstateTest.java
@@ -444,6 +444,8 @@ public class DeepLearningProstateTest extends TestUtil {
                                             String msg = "" + t.getMessage() + // this way we evade null messages
                                                 (t.getCause() == null ? "" : t.getCause().getMessage());
                                             Assert.assertTrue("Unexpected exception " + t + ": " + msg, msg.contains("unstable"));
+                                          } catch (AssertionError ae) {
+                                            throw ae; // test assertions should be preserved
                                           } catch (Throwable t) {
                                             t.printStackTrace();
                                             throw new RuntimeException(t);


### PR DESCRIPTION
 AssertionError was being intercepted together with other Throwables.

Actually, in a test, it's better to keep an AE (and rethrow), so a test assertion failure is clearly visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/445)
<!-- Reviewable:end -->
