### PR TITLE
as.h2o destination_frame handling duplicates, closes PUBDEV-3608

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2765,7 +2765,8 @@ h2o.class.map <- function() {
 
 destination_frame.guess <- function(x) {
   valid.key = isTRUE(try(.key.validate(x), silent=TRUE)) # simplify after .key.validate improvement
-  if (valid.key) x else ""
+  unique.key = !x %in% as.character(h2o.ls()$key)
+  if (valid.key && unique.key) x else ""
 }
 
 #'
@@ -2774,7 +2775,7 @@ destination_frame.guess <- function(x) {
 #' Import R object to the H2O cloud.
 #'
 #' @param x An \code{R} object.
-#' @param destination_frame A string with the desired name for the H2OFrame.
+#' @param destination_frame (Optional) character scalar, desired name for the H2OFrame.
 #' @param \dots arguments passed to method arguments.
 #' @export
 #' @examples 
@@ -2799,16 +2800,22 @@ destination_frame.guess <- function(x) {
 #'   stopifnot(is.h2o(hs), dim(hs)==dim(m))
 #' }
 #' }
-as.h2o <- function(x, destination_frame="", ...) {
-  .key.validate(destination_frame)
+as.h2o <- function(x, destination_frame=NULL, ...) {
+  if( !is.null(destination_frame) ) {
+    if( !(length(destination_frame)==1L && is.character(destination_frame)) )
+      stop("Argument 'destination_frame' must be a scalar character.")
+    .key.validate(destination_frame)
+    if( destination_frame %in% as.character(h2o.ls()$key) )
+      stop(paste0("Provided 'destination_frame' the H2O frame key '", destination_frame , "' already exists in your H2O Cluster. Please choose another key."))
+  }
   UseMethod("as.h2o")
 }
 
 #' @rdname as.h2o
 #' @method as.h2o default
 #' @export
-as.h2o.default <- function(x, destination_frame="", ...) {
-  if( destination_frame=="" ) destination_frame <- deparse(substitute(x)) # guessing is done in as.h2o.data.frame
+as.h2o.default <- function(x, destination_frame=paste(deparse(substitute(x), width.cutoff=500L), collapse=""), ...) {
+  force(destination_frame)
   x <- if( length(x)==1L )
     data.frame(C1=x)
   else
@@ -2819,30 +2826,27 @@ as.h2o.default <- function(x, destination_frame="", ...) {
 #' @rdname as.h2o
 #' @method as.h2o H2OFrame
 #' @export
-as.h2o.H2OFrame <- function(x, destination_frame="", ...) {
-  if( destination_frame=="" ) {
-    subx <- destination_frame.guess(deparse(substitute(x)))
-    destination_frame <- .key.make(if(nzchar(subx)) subx else "copy")
-  }
+as.h2o.H2OFrame <- function(x, destination_frame=paste(deparse(substitute(x), width.cutoff=500L), collapse=""), ...) {
+  subx <- destination_frame.guess(destination_frame)
+  destination_frame <- if(nzchar(subx)) subx else .key.make("Copy")
   h2o.assign(x, key=destination_frame)
 }
 
 #' @rdname as.h2o
 #' @method as.h2o data.frame
 #' @export
-as.h2o.data.frame <- function(x, destination_frame="", ...) {
-  if( destination_frame=="" )
-    destination_frame <- deparse(substitute(x))
-  
-  destination_frame <- destination_frame.guess(destination_frame) # filter out invalid i.e. "abc::fun()"
+as.h2o.data.frame <- function(x, destination_frame=paste(deparse(substitute(x), width.cutoff=500L), collapse=""), ...) {
+  destination_frame <- destination_frame.guess(destination_frame) # filter out invalid i.e. "abc::fun()" and duplicate
   .key.validate(destination_frame) # h2o.uploadFile already handle ""
   
-  # TODO: Be careful, there might be a limit on how long a vector you can define in console
-  tmpf <- tempfile(fileext = ".csv")
   # remap R data types to java data types
   types <- sapply(x, function(x) class(x)[1L]) # ensure vector returned
   class.map <- h2o.class.map()
   types[types %in% names(class.map)] <- class.map[types[types %in% names(class.map)]]
+  
+  # write csv and upload to h2o
+  # TODO: Be careful, there might be a limit on how long a vector you can define in console
+  tmpf <- tempfile(fileext = ".csv")
   write.csv(x, file = tmpf, row.names = FALSE, na="NA_h2o")
   h2f <- h2o.uploadFile(tmpf, destination_frame = destination_frame, header = TRUE, col.types=types,
                         col.names=colnames(x, do.NULL=FALSE, prefix="C"), na.strings=rep(c("NA_h2o"),ncol(x)))
@@ -2853,20 +2857,18 @@ as.h2o.data.frame <- function(x, destination_frame="", ...) {
 #' @rdname as.h2o
 #' @method as.h2o Matrix
 #' @export
-as.h2o.Matrix <- function(x, destination_frame="", ...) {
-  
-  if( destination_frame=="")
-    destination_frame <- deparse(substitute(x))
-  
+as.h2o.Matrix <- function(x, destination_frame=paste(deparse(substitute(x), width.cutoff=500L), collapse=""), ...) {
+  force(destination_frame)
   sparse <- .h2o.is.sparse.matrix(x)
-  if(!sparse)
+  if( !sparse )
     return(as.h2o.default(x, destination_frame=destination_frame, ...))
   
-  destination_frame <- destination_frame.guess(destination_frame) # filter out invalid i.e. "abc::fun()"
+  destination_frame <- destination_frame.guess(destination_frame) # filter out invalid i.e. "abc::fun()" and duplicate
   .key.validate(destination_frame)
-  if ( destination_frame=="" ) # .h2o.readSVMLight wont handle ""
-    destination_frame <- .key.make("Matrix") # only used if `x` variable name not valid key
+  if ( destination_frame=="" ) # .h2o.readSVMLight might not handle "" (?)
+    destination_frame <- .key.make("Matrix") # only used if `x` variable name not valid key or duplicate
   
+  # write svm file
   tmpf <- tempfile(fileext = ".svm")
   .h2o.write.matrix.svmlight(x, file = tmpf)
   h2f <- .h2o.readSVMLight(tmpf, destination_frame = destination_frame)

--- a/h2o-r/h2o-package/tests/test-duplicated-frame-key-PUBDEV-3608.R
+++ b/h2o-r/h2o-package/tests/test-duplicated-frame-key-PUBDEV-3608.R
@@ -1,0 +1,70 @@
+
+## unit tests for as.h2o generic and methods
+# output class
+# output dimensions
+# h2o frame key on collisions
+# tests imported from python from invalid names
+
+library(h2o)
+h2o.init()
+h2o.no_progress()
+hi <- as.h2o(iris)
+he <- as.h2o(euro)
+hl <- as.h2o(letters)
+hm <- as.h2o(state.x77)
+hh <- as.h2o(hi)
+stopifnot(
+  is.h2o(hi), dim(hi)==dim(iris), h2o.getId(hi)=="iris",
+  is.h2o(he), dim(he)==c(length(euro),1L), h2o.getId(he)=="euro",
+  is.h2o(hl), dim(hl)==c(length(letters),1L), h2o.getId(hl)=="letters",
+  is.h2o(hm), dim(hm)==dim(state.x77), h2o.getId(hm)=="state.x77",
+  is.h2o(hh), dim(hh)==dim(hi), h2o.getId(hh)=="hi"
+)
+if (requireNamespace("Matrix", quietly=TRUE)) {
+  data <- rep(0, 100)
+  data[(1:10)^2] <- 1:10 * pi
+  m <- matrix(data, ncol = 20, byrow = TRUE)
+  hs1 <- as.h2o(m <- Matrix::Matrix(m, sparse = TRUE))
+  hs2 <- as.h2o(m)
+  stopifnot(
+    is.h2o(hs1),
+    dim(hs1)==dim(m),
+    # also test proper name substitute
+    grepl("^Matrix", h2o.getId(hs1)), # random id with Matrix prefix
+    h2o.getId(hs2)=="m"
+  )
+} else {
+  cat("Matrix package not available, tests skipped\n")
+}
+
+x <- data.frame(a=1)
+h1 <- as.h2o(x)
+x <- data.frame(a=2)
+h2 <- as.h2o(x)
+x <- data.frame(a=3)
+h3 <- try(as.h2o(x, destination_frame="x"), silent=TRUE)
+h4 <- try(as.h2o(h2, destination_frame="x"), silent=TRUE) # as.h2o.H2OFrame method
+stopifnot(
+  h2o.getId(h1)=="x",
+  h2o.getId(h2)!="x", # this is random now because it is overlapping with existing one
+  inherits(h3, "try-error"), # error because user made attempt to override frame
+  inherits(h4, "try-error")
+)
+
+# tests imported from python for invalid names
+df <- data.frame(a=1)
+expr <- quote({
+  as.h2o(df, "ab;cd")
+  as.h2o(df, "one/two/three/four")
+  as.h2o(df, "I'm_declaring_a_thumb_war")
+  as.h2o(df, "five\\six\\seven\\eight")
+  as.h2o(df, "finger guns proliferate")
+  as.h2o(df, "9_10_11_12")
+  as.h2o(df, "digits|cant|protect|themselves")
+  as.h2o(df, "(thirteen,fourteen,fifteen,sixteen)")
+  as.h2o(df, "UNSC_cant_intervene?")
+})
+err <- sapply(as.list(expr)[-1L], function(x) tryCatch(eval(x), error = function(e) e$message))
+stopifnot(grepl("^`key` must match", err))
+
+q("no")

--- a/h2o-r/tests/testdir_docexamples/runit_Rdoc_set_time_zone.R
+++ b/h2o-r/tests/testdir_docexamples/runit_Rdoc_set_time_zone.R
@@ -40,6 +40,7 @@ test.rdoc_settimezone.golden <- function() {
   expect_that(act, equals(diff[,1]))
 
   #test 2 - make sure returned years/months have the same timezone as interpretation
+  h2o.rm(hdf)
   h2o.setTimezone("Etc/UTC")
   rdf <- data.frame(dates = c("2014-01-07", "2014-01-30", "2014-01-31", "2014-02-01", "2014-02-02", "2014-10-31", "2014-11-01"), stringsAsFactors = FALSE)
   hdf <- as.h2o(rdf, "hdf")


### PR DESCRIPTION
Unit tests in a new structure - moving towards PUBDEV-3611.
Default argument value is changing in `as.h2o` definition but behaviour stays the same. It will now raise error if user will try to import frame to existing key. Unit tests includes as.h2o generic method tests.
To maintain properly `substitute(x)` as h2o frame key, when calling as.h2o.* methods directly we should always provide `destination_frame`, can be `deparse(substitute(x))`. `x` name substitution must happen only once, in the first called as.h2o.* method, then `destination_frame` must be passed to further methods. When calling `as.h2o` generic it is of course not necessary. This way we ensure that variable name is properly substituted.
