### PR TITLE
PUBDEV-3656

### DIFF
--- a/h2o-docs/src/product/hadoop.rst
+++ b/h2o-docs/src/product/hadoop.rst
@@ -148,6 +148,9 @@ Hadoop Launch Parameters
    provide enough time for the nodes to launch. If H2O does not launch,
    try increasing this value (for example, ``-timeout 600``).
 -  ``-disown``: Exit the driver after the cluster forms.
+
+    **Note**: For Qubole users who include the ``-disown`` flag, if your cluster is dying right after launch, add ``-Dmapred.jobclient.killjob.onexit=false`` as a launch parameter.
+
 -  ``-notify <notification file name>``: Specify a file to write when
    the cluster is up. The file contains the IP and port of the embedded
    web server for one of the nodes in the cluster. All mappers must


### PR DESCRIPTION
Added a note in the Hadoop section `-disown` option for Qubole users.
This provides a workaround if their cluster dies right after launch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/466)
<!-- Reviewable:end -->
