### PR TITLE
PUBDEV-3675: Fix IAOB in ParseTime

### DIFF
--- a/h2o-core/src/main/java/water/parser/ParseTime.java
+++ b/h2o-core/src/main/java/water/parser/ParseTime.java
@@ -77,6 +77,7 @@ public abstract class ParseTime {
     final boolean dash = buf[i] == '-';
     if( dash ) i++;
     MM = digit(MM,buf[i++]);
+    // note: at this point we need guard every increment of "i" to avoid reaching outside of the buffer
     MM = i<end && buf[i]!='-' ? digit(MM,buf[i++]) : MM;
     if( MM < 1 || MM > 12 ) return Long.MIN_VALUE;
     if( (end-i)>=2 ) {
@@ -93,7 +94,7 @@ public abstract class ParseTime {
       if( i==end )
         return new DateTime(yyyy,MM,dd,0,0,0, getTimezone()).getMillis();
     } else {                    // yyyyMMdd-HH:mm:ss.SSS; dash AND time is now required
-      if( buf[i++] != '-' ) return Long.MIN_VALUE;
+      if( i==end || buf[i++] != '-' ) return Long.MIN_VALUE;
     }
 
     //Parse time

--- a/h2o-core/src/test/java/water/parser/ParseTimeTest.java
+++ b/h2o-core/src/test/java/water/parser/ParseTimeTest.java
@@ -304,4 +304,10 @@ public class ParseTimeTest extends TestUtil {
       Assert.assertEquals(exp[i],vec.at8(i));
     fr.delete();
   }
+
+  @Test public void testParseInvalidPubDev3675() {
+    long millis = ParseTime.attemptTimeParse(new BufferedString("XXXX0101"));
+    Assert.assertEquals("Expected Long.MIN_VALUE as a marker of invalid date", Long.MIN_VALUE, millis);
+  }
+
 }


### PR DESCRIPTION
One branch of execution was not properly guarded against IAOB exception.
The exception can be triggered by trying to parse a string of form
XXXXNNNN (where X are arbitrary characters and N are numbers).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/476)
<!-- Reviewable:end -->
