### PR TITLE
[PUBDEV-3484] Fix backward compatibility of Python mean function. (#472)

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -30,12 +30,12 @@ from h2o.group_by import GroupBy
 from h2o.job import H2OJob
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.compatibility import viewitems, viewvalues
+from h2o.utils.config import get_config_value
 from h2o.utils.shared_utils import (_handle_numpy_array, _handle_pandas_data_frame, _handle_python_dicts,
                                     _handle_python_lists, _is_list, _is_str_list, _py_tmp_key, _quoted,
                                     can_use_pandas, quote, normalize_slice, slice_is_normalized, check_frame_id)
 from h2o.utils.typechecks import (assert_is_type, assert_satisfies, I, is_type, numeric, numpy_ndarray,
                                   pandas_dataframe, scipy_sparse, U)
-warnings.filterwarnings("ignore", category=DeprecationWarning, module="pandas", lineno=7)
 
 __all__ = ("H2OFrame", )
 
@@ -1854,9 +1854,20 @@ class H2OFrame(object):
             na_rm = kwargs.pop("na_rm")
             assert_is_type(na_rm, bool)
             skipna = na_rm  # don't assign to skipna directly, to help with error reporting
+        # Determine whether to return a frame or a list
+        return_frame = get_config_value("general.allow_breaking_changes", False)
+        if "return_frame" in kwargs:
+            return_frame = kwargs.pop("return_frame")
+            assert_is_type(return_frame, bool)
         if kwargs:
             raise H2OValueError("Unknown parameters %r" % list(kwargs))
-        return H2OFrame._expr(ExprNode("mean", self, skipna, axis))
+
+        new_frame = H2OFrame._expr(ExprNode("mean", self, skipna, axis))
+        if return_frame:
+            return new_frame
+        else:
+            return new_frame.getrow()
+
 
     def skewness(self, na_rm=False):
         """

--- a/h2o-py/h2o/model/regression.py
+++ b/h2o-py/h2o/model/regression.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from h2o.model.model_base import ModelBase
 from h2o.utils.compatibility import *  # NOQA
+from h2o.utils.shared_utils import _colmean
 
 
 class H2ORegressionModel(ModelBase):
@@ -42,7 +43,7 @@ def _mean_var(frame, weights=None):
     :param weights: optional weights column
     :return: The (weighted) mean and variance
     """
-    return frame.mean().getrow()[0], frame.var()
+    return _colmean(frame), frame.var()
 
 
 def h2o_mean_absolute_error(y_actual, y_predicted, weights=None):
@@ -56,7 +57,7 @@ def h2o_mean_absolute_error(y_actual, y_predicted, weights=None):
 
     """
     ModelBase._check_targets(y_actual, y_predicted)
-    return (y_predicted - y_actual).abs().mean().getrow()[0]
+    return _colmean((y_predicted - y_actual).abs())
 
 
 def h2o_mean_squared_error(y_actual, y_predicted, weights=None):
@@ -69,7 +70,7 @@ def h2o_mean_squared_error(y_actual, y_predicted, weights=None):
     :return: loss (float) (best is 0.0)
     """
     ModelBase._check_targets(y_actual, y_predicted)
-    return ((y_predicted - y_actual) ** 2).mean().getrow()[0]
+    return _colmean((y_predicted - y_actual) ** 2)
 
 
 def h2o_median_absolute_error(y_actual, y_predicted):
@@ -113,7 +114,7 @@ def h2o_r2_score(y_actual, y_predicted, weights=1.):
     """
     ModelBase._check_targets(y_actual, y_predicted)
     numerator = (weights * (y_actual - y_predicted) ** 2).sum()
-    denominator = (weights * (y_actual - y_actual.mean().getrow()[0]) ** 2).sum()
+    denominator = (weights * (y_actual - _colmean(y_actual)) ** 2).sum()
 
     if denominator == 0.0:
         return 1. if numerator == 0. else 0.  # 0/0 => 1, else 0

--- a/h2o-py/h2o/transforms/preprocessing.py
+++ b/h2o-py/h2o/transforms/preprocessing.py
@@ -53,7 +53,7 @@ class H2OScaler(H2OTransformer):
         if isinstance(self.parms["center"], (tuple, list)): self._means = self.parms["center"]
         if isinstance(self.parms["scale"], (tuple, list)): self._stds = self.parms["scale"]
         if self.means is None and self.parms["center"]:
-            self._means = X.mean().getrow()
+            self._means = X.mean(return_frame=True).getrow()
         else:
             self._means = False
         if self.stds is None and self.parms["scale"]:

--- a/h2o-py/h2o/utils/config.py
+++ b/h2o-py/h2o/utils/config.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 
-__all__ = ("H2OConfigReader", )
+__all__ = ("H2OConfigReader", "get_config_value")
 
 
 class H2OConfigReader(object):
@@ -34,7 +34,8 @@ class H2OConfigReader(object):
     #-------------------------------------------------------------------------------------------------------------------
 
     _allowed_config_keys = {
-        "init.check_version", "init.proxy", "init.url", "init.cluster_id", "init.verify_ssl_certificates", "init.cookies"
+        "init.check_version", "init.proxy", "init.url", "init.cluster_id", "init.verify_ssl_certificates",
+        "init.cookies", "general.allow_breaking_changes"
     }
 
     def __init__(self):
@@ -99,3 +100,9 @@ class H2OConfigReader(object):
             yield abspath
         # Also check if .h2oconfig exists in the user's directory
         yield os.path.expanduser("~/.h2oconfig")
+
+
+
+def get_config_value(key, default=None):
+    """Return config value corresponding to the provided `key`."""
+    return H2OConfigReader.get_config().get(key, default)

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -225,6 +225,12 @@ def _locate(path):
         possible_result = os.path.join(tmp_dir, path)
 
 
+def _colmean(column):
+    """Return the mean of a single-column frame."""
+    assert column.ncols == 1
+    return column.mean(return_frame=True).flatten()
+
+
 def get_human_readable_bytes(size):
     """
     Convert given number of bytes into a human readable representation, i.e. add prefix such as kb, Mb, Gb,

--- a/h2o-py/scripts/h2o-py-test-setup.py
+++ b/h2o-py/scripts/h2o-py-test-setup.py
@@ -127,6 +127,7 @@ def h2o_test_setup(sys_args):
 
     print("[{0}] {1}\n".format(strftime("%Y-%m-%d %H:%M:%S", gmtime()), "Connect to h2o on IP: {0} PORT: {1}".format(_H2O_IP_, _H2O_PORT_)))
     h2o.init(ip=_H2O_IP_, port=_H2O_PORT_, strict_version_check=False, force_connect=_FORCE_CONNECT_)
+    h2o.utils.config.H2OConfigReader.get_config()["general.allow_breaking_changes"] = True
 
     #rest_log = os.path.join(_RESULTS_DIR_, "rest.log")
     #h2o.start_logging(rest_log)


### PR DESCRIPTION
* [PUBDEV-3484] Fix backward compatibility of Python mean function.

The change of Python API `Frame#mean` method introduced in PR-359 was partially reverted:
  - the method returns list as it was returning before
  - it accepts optional argument `return_frame` which forces new behavior (returning H2OFrame)
  - there's also a global config variable `general.allow_breaking_changes` which also forces new behavior (has lower precedence than the `return_frame` argument)

This commit porting the fix from rel-turing release branch back to master:
(cherry picked from commit 54716cf96f99b22d70f77b70e0d70560a45bc697)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/480)
<!-- Reviewable:end -->
