### PR TITLE
PUBDEV-3705: Issue a warning if Parser reaches outside of the known columns

### DIFF
--- a/h2o-core/src/jmh/java/water/parser/FVecParseWriterMissingBench.java
+++ b/h2o-core/src/jmh/java/water/parser/FVecParseWriterMissingBench.java
@@ -1,0 +1,122 @@
+package water.parser;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.StackProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import water.fvec.AppendableVec;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Collection of benchmarks testing performance of FVecParseWriter.add?(..) functions acting on missing columns
+ */
+@State(Scope.Thread)
+@Fork(value = 1, jvmArgsAppend = "-Xmx12g")
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class FVecParseWriterMissingBench {
+
+  @Param({"1000", "10000"})
+  private int cols;
+  @Param({"20", "100000"})
+  private int rows;
+
+  private static final BufferedString STR = new BufferedString("test-str");
+
+  private FVecParseWriter _writer;
+
+  @Benchmark // baseline, no missing columns added
+  public void newLine() {
+    _writer._errs = new ParseWriter.ParseErr[0];
+    for (int r = 0; r < rows; r++) {
+      _writer._col = 0; // force the writer to process the line
+      _writer.newLine();
+    }
+    checkErrors(0);
+  }
+
+  @Benchmark
+  public void addNumCols() {
+    _writer._errs = new ParseWriter.ParseErr[0];
+    for (int r = 0; r < rows; r++) {
+      for (int col = 0; col < cols; col++)
+        _writer.addNumCol(col, Math.E);
+      _writer._col = 0; // force the writer to process the line
+      _writer.newLine();
+    }
+    checkErrors(20);
+  }
+
+  @Benchmark
+  public void addNaNCols() {
+    _writer._errs = new ParseWriter.ParseErr[0];
+    for (int r = 0; r < rows; r++) {
+      for (int col = 0; col < cols; col++)
+        _writer.addNumCol(col, Double.NaN);
+      _writer._col = 0; // force the writer to process the line
+      _writer.newLine();
+    }
+    checkErrors(20);
+  }
+
+  @Benchmark
+  public void addEncNumCols() {
+    _writer._errs = new ParseWriter.ParseErr[0];
+    for (int r = 0; r < rows; r++) {
+      for (int col = 0; col < cols; col++)
+        _writer.addNumCol(col, 54321, 42);
+      _writer._col = 0; // force the writer to process the line
+      _writer.newLine();
+    }
+    checkErrors(20);
+  }
+
+  @Benchmark
+  public void addStrCols() {
+    _writer._errs = new ParseWriter.ParseErr[0];
+    for (int r = 0; r < rows; r++) {
+      for (int col = 0; col < cols; col++)
+        _writer.addStrCol(col, STR);
+      _writer._col = 0; // force the writer to process the line
+      _writer.newLine();
+    }
+    checkErrors(20);
+  }
+
+  @Benchmark
+  public void addInvalidCols() {
+    _writer._errs = new ParseWriter.ParseErr[0];
+    for (int r = 0; r < rows; r++) {
+      for (int col = 0; col < cols; col++)
+        _writer.addInvalidCol(col);
+      _writer._col = 0; // force the writer to process the line
+      _writer.newLine();
+    }
+    checkErrors(20);
+  }
+
+  private void checkErrors(int num) {
+    if (_writer._errs.length != num) throw new IllegalStateException("Expected " + num + " errors");
+  }
+
+  @Setup
+  public void setup() {
+    _writer = new FVecParseWriter(null, -1, null, null, -1, new AppendableVec[0]);
+    _writer._col = 0;
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+            .include(FVecParseWriterMissingBench.class.getSimpleName())
+            .addProfiler(StackProfiler.class)
+            .build();
+
+    new Runner(opt).run();
+  }
+
+}

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -333,7 +333,7 @@ public final class ParseDataset {
       // compute global line numbers for warnings/errs
       HashMap<String, Integer> fileChunkOffsets = new HashMap<>();
       for (int i = 0; i < mfpt._fileChunkOffsets.length; ++i)
-        fileChunkOffsets.put(fkeys[i].toString(), mfpt._fileChunkOffsets[i]);
+        fileChunkOffsets.put(FileVec.getPathForKey(fkeys[i]), mfpt._fileChunkOffsets[i]);
       long[] espc = fr.anyVec().espc();
       for (int i = 0; i < errs.length; ++i) {
         if(fileChunkOffsets.containsKey(errs[i]._file)) {
@@ -1016,7 +1016,7 @@ public final class ParseDataset {
         _outerMFPT._dout[_outerMFPT._lo] = _dout;
         if(_dout.hasErrors()) {
           ParseWriter.ParseErr [] errs = _dout.removeErrors();
-          for(ParseWriter.ParseErr err:errs)err._file = FileVec.getPathForKey(_srckey).toString();
+          for(ParseWriter.ParseErr err:errs)err._file = FileVec.getPathForKey(_srckey);
           Arrays.sort(errs, new Comparator<ParseWriter.ParseErr>() {
             @Override
             public int compare(ParseWriter.ParseErr o1, ParseWriter.ParseErr o2) {

--- a/h2o-core/src/main/java/water/parser/ParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/ParseWriter.java
@@ -9,10 +9,13 @@ public interface ParseWriter extends Freezable {
 
   class ParseErr extends Iced {
     public ParseErr(){}
-    public ParseErr(String err, int cidx, long lineNum, long byteOff){
+    public ParseErr(String err, int cidx, long lineNum) {
       _err = err;
       _cidx = cidx;
       _lineNum = lineNum;
+    }
+    public ParseErr(String err, int cidx, long lineNum, long byteOff){
+      this(err, cidx, lineNum);
       _byteOffset = byteOff;
     }
     // as recorded during parsing
@@ -24,7 +27,8 @@ public interface ParseWriter extends Freezable {
     // filled int he end (when we now the line-counts)
     long _gLineNum = -1;
     public String toString(){
-      return "ParseError at file " + _file + (_gLineNum == -1?"":" at line " + _lineNum + " ( destination line " + _gLineNum + " )") + "  at byte offset " + _byteOffset + "; error = \'" + _err + "\'";
+      return "ParseError at file " + _file + (_gLineNum == -1?"":" at line " + _lineNum + " ( destination line " + _gLineNum + " )") +
+              (_byteOffset == -1 ? "" : "  at byte offset " + _byteOffset) + "; error = \'" + _err + "\'";
     }
   }
 

--- a/h2o-core/src/test/java/water/parser/FVecParseWriterMissingColumnTest.java
+++ b/h2o-core/src/test/java/water/parser/FVecParseWriterMissingColumnTest.java
@@ -1,0 +1,76 @@
+package water.parser;
+
+import org.junit.Before;
+import org.junit.Test;
+import water.fvec.AppendableVec;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests behavior of FVecParseWriter when parsed line has more values than we have columns
+ */
+public class FVecParseWriterMissingColumnTest {
+
+  private FVecParseWriter _w;
+
+  @Before
+  public void setup() {
+    _w = new FVecParseWriter(null, 42, null, null, -1, new AppendableVec[0]);
+    _w._col = 17;
+    _w._nCols = _w._col + 1;
+  }
+
+  @Test
+  public void testBasic() {
+    _w.addNumCol(18, 133.12);
+    _w.addNumCol(19, 2, 3);
+    _w.addStrCol(20, new BufferedString("test"));
+    _w.addInvalidCol(21);
+
+    _w.newLine();
+
+    checkError(22, "133.12, 2000.0, test, null");
+  }
+
+  @Test
+  public void testOufOfOrderErrors() {
+    _w.addStrCol(20, new BufferedString("test"));
+    _w.addNumCol(19, Double.NaN);
+    _w.addNumCol(18, 133.12);
+    _w.addInvalidCol(21);
+    _w.addNumCol(22, 2, 3);
+
+    _w.newLine();
+
+    checkError(23, null);
+  }
+
+  @Test
+  public void testErrorValuesCapped() {
+    for (byte i = 0; i < 20; i++)
+      _w.addStrCol(18 + i, new BufferedString(new byte[]{(byte) (i + '0')}, 0, 1));
+
+    _w.newLine();
+
+    checkError(38, "0, 1, 2, 3, 4, 5, 6, 7, 8, 9");
+  }
+
+  @Test
+  public void testErrorValuesTruncated() {
+    for (byte i = 0; i < 20; i++)
+      _w.addNumCol(18 + i, 100 + i);
+
+    _w.newLine();
+
+    checkError(38, "100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 1...(truncated)");
+  }
+
+  private void checkError(int cols, String vals) {
+    assertNotNull(_w._errs);
+    assertEquals(1, _w._errs.length);
+    String expected = "Invalid line, found more columns than expected (found: " + cols + ", expected: 18)" +
+            (vals != null ? "; values = {" + vals + "}" : "");
+    assertEquals(expected, _w._errs[0]._err);
+  }
+
+}

--- a/h2o-core/src/test/java/water/parser/FVecParseWriterMissingColumnTest.java
+++ b/h2o-core/src/test/java/water/parser/FVecParseWriterMissingColumnTest.java
@@ -65,6 +65,23 @@ public class FVecParseWriterMissingColumnTest {
     checkError(38, "100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 1...(truncated)");
   }
 
+  @Test
+  public void testDoNothingIfErrsFull() {
+    final int maxErrs = 20;
+    _w._errs = new ParseWriter.ParseErr[maxErrs]; // deplete the available slots for errors
+
+    _w.addStrCol(20, new BufferedString("test"));
+    _w.addNumCol(19, Double.NaN);
+    _w.addNumCol(18, 133.12);
+    _w.addInvalidCol(21);
+    _w.addNumCol(22, 2, 3);
+
+    _w._errs = null; // make all errors slots available again just before we call newLine()
+    _w.newLine();
+
+    checkError(23, null); // missing column values were not recorded at all
+  }
+
   private void checkError(int cols, String vals) {
     assertNotNull(_w._errs);
     assertEquals(1, _w._errs.length);

--- a/h2o-r/tests/testdir_jira/runit_pubdev_3590_unexpected_column.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_3590_unexpected_column.R
@@ -1,0 +1,16 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+test.pubdev_3590 <- function() {
+    data.path <- locate("smalldata/jira/runit_pubdev_3590_unexpected_column.csv")
+
+    expected.warning <- sprintf("ParseError at file %s at line 3 ( destination line 3 ); error = '%s'", data.path,
+        "Invalid line, found more columns than expected (found: 4, expected: 2); values = {5.0, e}")
+
+    expect_warning(data <- h2o.importFile(data.path), expected.warning, fixed = TRUE)
+
+    expect_equal(nrow(data), 6)
+}
+
+doTest("PUBDEV-3590: Warning is produced if CSV file has unexpected number of columns", test.pubdev_3590)


### PR DESCRIPTION
- Produce a warning when the parser encounters unexpected number of columns.
- Reintroduce line numbers to ParseErr messages (missing due to file naming mismatch)

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/485)
<!-- Reviewable:end -->
