### PR TITLE
Speed up GBM for multi-CPU systems

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GBMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GBMV3.java
@@ -59,7 +59,11 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
       "histogram_type",
       "max_abs_leafnode_pred",
       "pred_noise_bandwidth",
-      "categorical_encoding"
+      "categorical_encoding",
+      "use_new_histo_tsk",
+      "col_block_sz",
+      "min_threads",
+      "shared_histo"
     };
 
     // Input fields
@@ -77,5 +81,15 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
 
     @API(help="Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions", level = API.Level.expert, gridable = true)
     public double pred_noise_bandwidth;
+
+    // TODO debug only, remove!
+    @API(help="Internal flag, use new version of histo tsk if set", level = API.Level.expert, gridable = false)
+    public boolean use_new_histo_tsk;
+    @API(help="Use with new histo task only! Internal flag, number of columns processed in parallel", level = API.Level.expert, gridable = false)
+    public int col_block_sz = 5;
+    @API(help="Use with new histo task only! Min threads to be run in parallel", level = API.Level.expert, gridable = false)
+    public int min_threads = -1;
+    @API(help="Use with new histo task only! Share histo (and use CAS) instead of making private copies", level = API.Level.expert, gridable = false)
+    public boolean shared_histo;
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/GBMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GBMV3.java
@@ -60,10 +60,11 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
       "max_abs_leafnode_pred",
       "pred_noise_bandwidth",
       "categorical_encoding",
-      "use_new_histo_tsk",
-      "col_block_sz",
-      "min_threads",
-      "shared_histo"
+//      "use_new_histo_tsk",
+//      "col_block_sz",
+//      "min_threads",
+//      "shared_histo",
+//      "unordered"
     };
 
     // Input fields
@@ -82,14 +83,16 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
     @API(help="Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions", level = API.Level.expert, gridable = true)
     public double pred_noise_bandwidth;
 
-    // TODO debug only, remove!
-    @API(help="Internal flag, use new version of histo tsk if set", level = API.Level.expert, gridable = false)
-    public boolean use_new_histo_tsk;
-    @API(help="Use with new histo task only! Internal flag, number of columns processed in parallel", level = API.Level.expert, gridable = false)
-    public int col_block_sz = 5;
-    @API(help="Use with new histo task only! Min threads to be run in parallel", level = API.Level.expert, gridable = false)
-    public int min_threads = -1;
-    @API(help="Use with new histo task only! Share histo (and use CAS) instead of making private copies", level = API.Level.expert, gridable = false)
-    public boolean shared_histo;
+//    // TODO debug only, remove!
+//    @API(help="Internal flag, use new version of histo tsk if set", level = API.Level.expert, gridable = false)
+//    public boolean use_new_histo_tsk;
+//    @API(help="Use with new histo task only! Internal flag, number of columns processed in parallel", level = API.Level.expert, gridable = false)
+//    public int col_block_sz = 5;
+//    @API(help="Use with new histo task only! Min threads to be run in parallel", level = API.Level.expert, gridable = false)
+//    public int min_threads = -1;
+//    @API(help="Use with new histo task only! Share histo (and use CAS) instead of making private copies", level = API.Level.expert, gridable = false)
+//    public boolean shared_histo;
+//    @API(help="Use with new histo task only! Access rows in order of the dataset, not in order of leafs ", level = API.Level.expert, gridable = false)
+//    public boolean unordered;
   }
 }

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -41,7 +41,6 @@ import java.util.Random;
  *
 */
 public final class DHistogram extends Iced {
-  public static int DEBUG_WEAVER = 1;
   public final transient String _name; // Column name (for debugging)
   public final double _minSplitImprovement;
   public final byte  _isInt;    // 0: float col, 1: int col, 2: categorical & int col

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -639,7 +639,6 @@ public final class DHistogram extends Iced {
   }
 
   public void updateHisto(double[] ws, double[] cs, double[] ys, int [] rows, int hi, int lo){
-    double minmax[] = new double[]{_min2,_maxIn};
     // Gather all the data for this set of rows, for 1 column and 1 split/NID
     // Gather min/max, wY and sum-squares.
     for(int r = lo; r< hi; ++r) {
@@ -647,8 +646,8 @@ public final class DHistogram extends Iced {
       double weight = ws[k];
       if (weight == 0) continue;
       double col_data = cs[k];
-      if( col_data < minmax[0] ) minmax[0] = col_data;
-      if( col_data > minmax[1] ) minmax[1] = col_data;
+      if( col_data < _min2 ) _min2 = col_data;
+      if( col_data > _maxIn ) _maxIn = col_data;
       double y = ys[k];
       assert(!Double.isNaN(y));
       double wy = weight * y;
@@ -664,9 +663,6 @@ public final class DHistogram extends Iced {
         _wYY[b] += wyy;
       }
     }
-    double d;
-    if( (d = minmax[0]) < _min2 )  _min2  = d;
-    if( (d = minmax[1]) > _maxIn)  _maxIn = d;
   }
 
   public void reducePrecision(){

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -530,9 +530,7 @@ public class DTree extends Iced {
         _nids[way] = nhists == null ? ScoreBuildHistogram.UNDECIDED_CHILD_NODE_ID : makeUndecidedNode(nhists)._nid;
       }
     }
-
-    public int getChildNodeID(Chunk chks[], int row ) {
-      double d = chks[_split._col].atd(row);
+    public int getChildNodeID(double d) {
       int bin;
       if (!Double.isNaN(d)) {
         if (_split._nasplit == DHistogram.NASplitDir.NAvsREST)

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -530,7 +530,9 @@ public class DTree extends Iced {
         _nids[way] = nhists == null ? ScoreBuildHistogram.UNDECIDED_CHILD_NODE_ID : makeUndecidedNode(nhists)._nid;
       }
     }
-    public int getChildNodeID(double d) {
+
+    public int getChildNodeID(Chunk [] chks, int row ) {
+      double d = chks[_split._col].atd(row);
       int bin;
       if (!Double.isNaN(d)) {
         if (_split._nasplit == DHistogram.NASplitDir.NAvsREST)

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram.java
@@ -3,6 +3,7 @@ package hex.tree;
 import hex.genmodel.utils.DistributionFamily;
 import water.H2O.H2OCountedCompleter;
 import water.MRTask;
+import water.MemoryManager;
 import water.fvec.C0DChunk;
 import water.fvec.Chunk;
 import water.fvec.Frame;
@@ -40,7 +41,7 @@ public class ScoreBuildHistogram extends MRTask<ScoreBuildHistogram> {
   final DTree _tree; // Read-only, shared (except at the histograms in the Nodes)
   final int   _leaf; // Number of active leaves (per tree)
   // Histograms for every tree, split & active column
-  final DHistogram _hcs[/*tree-relative node-id*/][/*column*/];
+  DHistogram _hcs[/*tree-relative node-id*/][/*column*/];
   final DistributionFamily _family;
   final int _weightIdx;
   final int _workIdx;
@@ -151,8 +152,7 @@ public class ScoreBuildHistogram extends MRTask<ScoreBuildHistogram> {
   // assigned DecidedNode, "scoring" the row against that Node's decision
   // criteria, and assigning the row to a new child UndecidedNode (and
   // giving it an improved prediction).
-  protected void score_decide(Chunk chks[], Chunk nids, int nnids[]) {
-    double [] split_col = MemoryManager.malloc8d(chks[0]._len);
+  protected final void score_decide(Chunk chks[], Chunk nids, int nnids[]) {
     for( int row=0; row<nids._len; row++ ) { // Over all rows
       int nid = (int)nids.at8(row);          // Get Node to decide from
       if( isDecidedRow(nid)) {               // already done
@@ -171,9 +171,8 @@ public class ScoreBuildHistogram extends MRTask<ScoreBuildHistogram> {
         nnids[row] = xnid-_leaf;
         dn = _tree.decided(nid); // Parent steers us
       }
-      chks[dn._split._col].getDoubles(split_col,0,split_col.length);
       assert !isDecidedRow(nid);
-      nid = dn.getChildNodeID(split_col[row]); // Move down the tree 1 level
+      nid = dn.getChildNodeID(chks,row); // Move down the tree 1 level
       if( !isDecidedRow(nid) ) {
         if( oob ) nid = nid2Oob(nid); // Re-apply OOB encoding
         nids.set(row, nid);

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -1,0 +1,349 @@
+package hex.tree;
+
+import hex.genmodel.utils.DistributionFamily;
+import jsr166y.CountedCompleter;
+import jsr166y.ForkJoinTask;
+import sun.util.resources.uk.CalendarData_uk;
+import water.*;
+import water.fvec.C0DChunk;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.util.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import water.fvec.Vec;
+import water.util.Log;
+import water.util.VecUtils;
+
+/**
+ * Created by tomas on 10/28/16.
+ *
+ * Experimental alternative for ScoreBuildHistogram.
+ *
+ * Allows for paralellization in both dimensions and histograms can be shared or deep cloned.
+ * In the first step, it computes leaf assignemnt and sorts the rows according to their leaf (might not be neccessary for not-shared histos).
+ * Second step is paralellized over columns (groups of columns) and possibly over rows and calculates histo usung results from step 1.
+ *
+ * The idea is to limit the number of CAS calls which causes issues on multiprocessor machines.
+ * Ideally we would paralllize by columns. Since histogram for different columns are independent, there are no conflicts.
+ * However, there is an overhead per given chunk of data (extracting response, weights) and there might be not enough paralellization this way.
+ * The first issue ais addressed by grouping the columns, thus reducing the per-chunk overhead. The lack of parallelization is when there is lfewer columns than cores.
+ * That can easily happen especially if the columns are grouped. For this reason, there is also a parallelization over row dimension.
+ * the histos in this can be shared or deep cloned. The idea is that since we're parallelizing over the columns, there is gonna be fewer threads working over the rows and less collisions (or lower memory overhead of deep cloned histos).
+ */
+public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
+  transient int []   _cids;
+  transient int [][] _nhs;
+  transient int [][] _rss;
+  transient int [][] _nnids;
+
+  Frame _fr2;
+
+  public static class SCBParms extends Iced{
+    public int blockSz;
+    public boolean sharedHisto;
+    public int min_threads;
+    public boolean _unordered;
+  }
+  SCBParms _parms;
+
+  public ScoreBuildHistogram2(H2O.H2OCountedCompleter cc, int k, int ncols, int nbins, int nbins_cats, DTree tree, int leaf, DHistogram[][] hcs, DistributionFamily family, int weightIdx, int workIdx, int nidIdx, SCBParms parms) {
+    super(cc, k, ncols, nbins, nbins_cats, tree, leaf, hcs, family, weightIdx, workIdx, nidIdx);
+    _parms = parms;
+  }
+
+  @Override
+  public ScoreBuildHistogram dfork2(byte[] types, Frame fr, boolean run_local) {
+    _fr2 = fr;
+    dfork((Key[])null);
+    return this;
+  }
+
+  @Override public void map(Chunk [] chks){
+    throw H2O.unimpl();
+  }
+  @Override
+  public void setupLocal() {
+    // Init all the internal tree fields after shipping over the wire
+    _tree.init_tree();
+    _cids = VecUtils.getLocalChunkIds(_fr2.anyVec());
+    _nhs = new int[_cids.length][];
+    _rss = new int[_cids.length][];
+    if(_parms._unordered)
+      _nnids = new int[_cids.length][];
+
+    H2O.submitTask(new LocalMR(new MRT(){
+      // more or less copied from ScoreBuildHistogram
+      private void map(int id, Chunk [] chks) {
+        final Chunk wrks = chks[_workIdx];
+        final Chunk nids = chks[_nidIdx];
+        final Chunk weight = _weightIdx>=0 ? chks[_weightIdx] : new C0DChunk(1, chks[0].len());
+
+        // Pass 1: Score a prior partially-built tree model, and make new Node
+        // assignments to every row.  This involves pulling out the current
+        // assigned DecidedNode, "scoring" the row against that Node's decision
+        // criteria, and assigning the row to a new child UndecidedNode (and
+        // giving it an improved prediction).
+        int nnids[] = new int[nids._len];
+        if(_parms._unordered)
+          _nnids[id] = nnids;
+        if( _leaf > 0)            // Prior pass exists?
+          score_decide(chks,nids,nnids);
+        else                      // Just flag all the NA rows
+          for( int row=0; row<nids._len; row++ ) {
+            if( weight.atd(row) == 0) continue;
+            if( isDecidedRow((int)nids.atd(row)) )
+              nnids[row] = DECIDED_ROW;
+          }
+        // Pass 2: accumulate all rows, cols into histograms
+        // Sort the rows by NID, so we visit all the same NIDs in a row
+        // Find the count of unique NIDs in this chunk
+        int nh[] = (_nhs[id] = new int[_hcs.length+1]);
+        for( int i : nnids )
+          if( i >= 0 )
+            nh[i+1]++;
+        // Rollup the histogram of rows-per-NID in this chunk
+        for( int i=0; i<_hcs.length; i++ ) nh[i+1] += nh[i];
+        // Splat the rows into NID-groups
+        if(_parms._unordered){
+          for(int i = 0; i < nnids.length; ++i)
+            nnids[i] -= _leaf;
+        } else {
+          int rows[] = (_rss[id] = new int[nnids.length]);
+          for (int row = 0; row < nnids.length; row++)
+            if (nnids[row] >= 0)
+              rows[nh[nnids[row]]++] = row;
+        }
+        // rows[] has Chunk-local ROW-numbers now, in-order, grouped by NID.
+        // nh[] lists the start of each new NID, and is indexed by NID+1.
+      }
+      @Override
+      void map(int id) {
+        Chunk [] chks = new Chunk[_fr2.numCols()];
+        Vec [] vecs = _fr2.vecs();
+        for(int i = 0; i < chks.length; ++i)
+          chks[i] = vecs[i].chunkForChunkIdx(_cids[id]);
+        map(id,chks);
+      }
+    })).join();
+    int ncores = H2O.NUMCPUS;
+
+    if(_parms.sharedHisto){
+      for (int l = _leaf; l < _tree._len; l++) {
+        DTree.UndecidedNode udn = _tree.undecided(l);
+        DHistogram hs[] = _hcs[l - _leaf];
+        int sCols[] = udn._scoreCols;
+        if (sCols != null) { // Sub-selecting just some columns?
+          for (int col : sCols) // For tracked cols
+            hs[col].init();
+        } else {                 // Else all columns
+          for (int j = 0; j < hs.length; j++) // For all columns
+            if (hs[j] != null)        // Tracking this column?
+              hs[j].init();
+        }
+      }
+    }
+    long [] espc = _fr2.anyVec().espc();
+    int largestChunkSz = 0;
+    for(int i = 1; i < espc.length; ++i){
+      int sz = (int)(espc[i] - espc[i-1]);
+      if(sz > largestChunkSz) largestChunkSz = sz;
+    }
+    int ncols = _ncols;
+    int colBlockSz= Math.min(ncols,_parms.blockSz);
+    while(0 < ncols - colBlockSz && ncols % colBlockSz != 0 && ncols % colBlockSz < (colBlockSz >> 1))
+      colBlockSz++;
+    int nrowThreads = 1;
+    int ncolBlocks = ncols/colBlockSz + (ncols%colBlockSz == 0?0:1);
+    while(ncolBlocks*nrowThreads < _parms.min_threads)nrowThreads++;
+    Log.info("column block sz = " + colBlockSz + ", nthreads per block = " + nrowThreads + ", shared histo = " + _parms.sharedHisto);
+    final int nthreads = nrowThreads;
+    ArrayList<ForkJoinTask> tsks = new ArrayList<>();
+    for(int i = 0; i < ncols; i += colBlockSz){
+      final int colFrom= i;
+      final int colTo = Math.min(ncols,colFrom+colBlockSz);
+      DHistogram[][] hcs = _hcs.clone();
+      for(int j = 0; j < hcs.length; ++j)
+        hcs[j] = Arrays.copyOfRange(hcs[j],colFrom,colTo);
+      tsks.add(new LocalMR<ComputeHistoThread>(new ComputeHistoThread(hcs,colFrom,colTo,largestChunkSz,_parms.sharedHisto,_parms._unordered),priority(),nthreads));
+    }
+    ForkJoinTask.invokeAll(tsks);
+  }
+
+  // Reduce for both local and remote
+  private static void mergeHistos(DHistogram [][] hcs, DHistogram [][] hcs2){
+    // Distributed histograms need a little work
+    for( int i=0; i< hcs.length; i++ ) {
+      DHistogram hs1[] = hcs[i], hs2[] = hcs2[i];
+      if( hs1 == null ) hcs[i] = hs2;
+      else if( hs2 != null )
+        for( int j=0; j<hs1.length; j++ )
+          if( hs1[j] == null ) hs1[j] = hs2[j];
+          else if( hs2[j] != null )
+            hs1[j].add(hs2[j]);
+    }
+  }
+
+  public static abstract class MRT<T extends MRT<T>> extends Iced<T> {
+    void init(){}
+    abstract void map(int id);
+    void reduce(T t){}
+    public MRT<T> makeCopy(){return clone();}
+  }
+  private class LocalMR<T extends MRT> extends H2O.H2OCountedCompleter<LocalMR> {
+    int _lo;
+    int _hi;
+    boolean _top = true;
+    final MRT _mrt;
+
+    AtomicInteger _cidx = new AtomicInteger();
+    AtomicInteger _tcnt = new AtomicInteger();
+
+
+
+    public LocalMR(MRT mrt, byte priority, int nthreads) { super(priority); _mrt = mrt; _lo = 0; _hi = nthreads;}
+    public LocalMR(MRT mrt, byte priority ) { this(mrt,priority,H2O.NUMCPUS);}
+    public LocalMR(MRT mrt) { _mrt = mrt; _lo = 0; _hi = H2O.NUMCPUS;}
+    public LocalMR(LocalMR src, int lo, int hi) {
+      super(src);
+      _mrt = src._mrt.makeCopy();
+      _lo = lo;
+      _hi = hi;
+      _cidx = src._cidx;
+      _tcnt = src._tcnt;
+      _top = false;
+    }
+
+    private LocalMR<T> _left;
+    private LocalMR<T> _rite;
+
+    volatile boolean completed;
+
+    @Override
+    public final void compute2() {
+      _tcnt.incrementAndGet();
+      if (_hi - _lo >= 2) {
+        int mid = _lo + ((_hi - _lo) >> 1);
+        addToPendingCount(1);
+        H2O.submitTask(_left = new LocalMR(this,_lo,mid));
+        if ((mid + 1) < _hi) {
+          addToPendingCount(1);
+          H2O.submitTask(_rite = new LocalMR(this,mid+1,_hi));
+        }
+      }
+      if(_hi > _lo) {
+        _mrt.init();
+        for (int i = _cidx.getAndIncrement(); i < _cids.length; i = _cidx.getAndIncrement())
+          _mrt.map(i);
+      } else throw new RuntimeException("should not get here, lo = " + _lo + ", hi = " + _hi);
+      completed = true;
+      tryComplete();
+    }
+
+    @Override
+    public final void onCompletion(CountedCompleter cc) {
+      assert cc == this || cc == _left || cc == _rite;
+      assert !_top || _tcnt.get() == _hi:"hi = " + _hi + ", tcnt = " + _tcnt.get();
+      if(_left != null) { assert _left.completed; _mrt.reduce(_left._mrt); _left = null;}
+      if(_rite != null) { assert _rite.completed; _mrt.reduce(_rite._mrt); _rite = null;}
+    }
+  }
+
+  private class ComputeHistoThread extends MRT<ComputeHistoThread> {
+    final int _maxChunkSz;
+    final int _colFrom, _colTo;
+    boolean _shareHisto = false;
+    boolean _unordered = false;
+    final DHistogram [][] _lhcs;
+
+    double [] cs = null;
+    double [] ws = null;
+    double [] ys = null;
+
+    ComputeHistoThread(DHistogram [][] hcs, int colFrom, int colTo, int maxChunkSz, boolean sharedHisto, boolean unordered){
+      _lhcs = hcs; _colFrom = colFrom; _colTo = colTo; _maxChunkSz = maxChunkSz;
+      _shareHisto = sharedHisto;
+      _unordered = unordered;
+    }
+
+    @Override
+    public ComputeHistoThread makeCopy() {
+      for(DHistogram[] dr:_lhcs)
+        for(DHistogram d:dr)
+          assert _shareHisto ||  d == null || d._w == null;
+      ComputeHistoThread res = new ComputeHistoThread(_shareHisto? _lhcs :ArrayUtils.deepClone(_lhcs),_colFrom,_colTo,_maxChunkSz,_shareHisto,_unordered);
+      return res;
+    }
+
+    void init(){
+      cs = MemoryManager.malloc8d(_maxChunkSz);
+      ys = MemoryManager.malloc8d(_maxChunkSz);
+      ws = MemoryManager.malloc8d(_maxChunkSz);
+      // start computing
+      if(!_shareHisto) {
+        for (int l = _leaf; l < _tree._len; l++) {
+          DTree.UndecidedNode udn = _tree.undecided(l);
+          DHistogram hs[] = _lhcs[l - _leaf];
+          int sCols[] = udn._scoreCols;
+          if (sCols != null) { // Sub-selecting just some columns?
+            for (int col : sCols) // For tracked cols
+              if (_colFrom <= col && col < _colTo) hs[col - _colFrom].init();
+          } else {                 // Else all columns
+            for (int j = 0; j < hs.length; j++) // For all columns
+              if (hs[j] != null)        // Tracking this column?
+                hs[j].init();
+          }
+        }
+      }
+    }
+
+    @Override
+    public void map(int id){
+      ScoreBuildHistogram.LocalHisto lh = _shareHisto?new ScoreBuildHistogram.LocalHisto(Math.max(_nbins,_nbins_cats)):null;
+      int cidx = _cids[id];
+      int [] nh = _nhs[id];
+      int [] rs = _rss[id];
+      int [] nnids = _unordered?_nnids[id]:null;
+      Chunk resChk = _fr2.vec(_workIdx).chunkForChunkIdx(cidx);
+      int len = resChk._len;
+      resChk.getDoubles(ys, 0, len);
+      if(_weightIdx != -1)
+        _fr2.vec(_weightIdx).chunkForChunkIdx(cidx).getDoubles(ws, 0, len);
+      else
+        Arrays.fill(ws,1);
+      final int hcslen = _lhcs.length;
+      for (int c = _colFrom; c < _colTo; c++) {
+        if(_unordered){
+          throw H2O.unimpl();
+        } else {
+          boolean extracted = false;
+          for (int n = 0; n < hcslen; n++) {
+            int sCols[] = _tree.undecided(n + _leaf)._scoreCols; // Columns to score (null, or a list of selected cols)
+            if (sCols == null || ArrayUtils.find(sCols, c) >= 0) {
+              if (!extracted) {
+                _fr2.vec(c).chunkForChunkIdx(cidx).getDoubles(cs, 0, len);
+                extracted = true;
+              }
+              DHistogram h = _lhcs[n][c - _colFrom];
+              if (h == null) continue; // Ignore untracked columns in this split
+              if (_shareHisto) {
+                lh.resizeIfNeeded(h._w.length);
+                h.updateSharedHistosAndReset(lh, ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
+              } else h.updateHisto(ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
+            }
+          }
+        }
+      }
+    }
+
+    @Override
+    public void reduce(ComputeHistoThread cc) {
+      if(!_shareHisto) {
+        assert _lhcs != cc._lhcs;
+        mergeHistos(_lhcs, cc._lhcs);
+      } else assert _lhcs == cc._lhcs;
+    }
+  }
+}

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -189,7 +189,6 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
     int nrowThreads = 1;
     int ncolBlocks = ncols/colBlockSz + (ncols%colBlockSz == 0?0:1);
     while(ncolBlocks*nrowThreads < _parms.min_threads)nrowThreads++;
-    Log.info("column block sz = " + colBlockSz + ", nthreads per block = " + nrowThreads + ", shared histo = " + _parms.sharedHisto);
     final int nthreads = nrowThreads;
     ArrayList<ForkJoinTask> tsks = new ArrayList<>();
     for(int i = 0; i < ncols; i += colBlockSz){

--- a/h2o-algos/src/main/java/hex/tree/drf/DRF.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRF.java
@@ -270,7 +270,7 @@ public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel
                   DecidedNode dn = tree.decided(nid);           // Must have a decision point
                   if (dn._split == null)     // Unable to decide?
                     dn = tree.decided(tree.node(nid).pid());    // Then take parent's decision
-                  leafnid = dn.getChildNodeID(chks[dn._split._col].atd(row)); // Decide down to a leafnode
+                  leafnid = dn.getChildNodeID(chks,row); // Decide down to a leafnode
                 }
                 // Setup Tree(i) - on the fly prediction of i-tree for row-th row
                 //   - for classification: cumulative number of votes for this row

--- a/h2o-algos/src/main/java/hex/tree/drf/DRF.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRF.java
@@ -193,7 +193,7 @@ public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel
       // Adds a layer to the trees each pass.
       int depth=0;
       for( ; depth<_parms._max_depth; depth++ ) {
-        hcs = buildLayer(_train, _parms._nbins, _parms._nbins_cats, ktrees, leafs, hcs, _parms._build_tree_one_node);
+        hcs = buildLayer(_train, _parms._nbins, _parms._nbins_cats, ktrees, leafs, hcs, _parms._build_tree_one_node,null);
         // If we did not make any new splits, then the tree is split-to-death
         if( hcs == null ) break;
       }
@@ -270,7 +270,7 @@ public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel
                   DecidedNode dn = tree.decided(nid);           // Must have a decision point
                   if (dn._split == null)     // Unable to decide?
                     dn = tree.decided(tree.node(nid).pid());    // Then take parent's decision
-                  leafnid = dn.getChildNodeID(chks, row); // Decide down to a leafnode
+                  leafnid = dn.getChildNodeID(chks[dn._split._col].atd(row)); // Decide down to a leafnode
                 }
                 // Setup Tree(i) - on the fly prediction of i-tree for row-th row
                 //   - for classification: cumulative number of votes for this row

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -161,7 +161,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         _scbParms.blockSz = _parms._col_block_sz;
         _scbParms.sharedHisto = _parms._shared_histo;
         _scbParms.min_threads = _parms._min_threads == -1?H2O.NUMCPUS:_parms._min_threads;
-        _scbParms._unordered = false;
+        _scbParms._unordered = _parms._unordered;
       }
       _mtry_per_tree = Math.max(1, (int)(_parms._col_sample_rate_per_tree * _ncols)); //per-tree
       if (!(1 <= _mtry_per_tree && _mtry_per_tree <= _ncols)) throw new IllegalArgumentException("Computed mtry_per_tree should be in interval <1,"+_ncols+"> but it is " + _mtry_per_tree);
@@ -873,7 +873,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
             DecidedNode dn = tree.decided(nid);           // Must have a decision point
             if( dn._split == null )                    // Unable to decide?
               dn = tree.decided(dn.pid());  // Then take parent's decision
-            int leafnid = dn.getChildNodeID(chks[dn._split._col].atd(row)); // Decide down to a leafnode
+            int leafnid = dn.getChildNodeID(chks,row); // Decide down to a leafnode
             assert leaf <= leafnid && leafnid < tree._len :
                     "leaf: " + leaf + " leafnid: " + leafnid + " tree._len: " + tree._len + "\ndn: " + dn;
             assert tree.node(leafnid) instanceof LeafNode;

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
@@ -20,6 +20,8 @@ public class GBMModel extends SharedTreeModel<GBMModel, GBMModel.GBMParameters, 
     public int _col_block_sz = 2;
     public int _min_threads = -1;
     public boolean _shared_histo;
+    public boolean _unordered;
+
 
 
     public GBMParameters() {

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
@@ -15,14 +15,12 @@ public class GBMModel extends SharedTreeModel<GBMModel, GBMModel.GBMParameters, 
     public double _col_sample_rate;
     public double _max_abs_leafnode_pred;
     public double _pred_noise_bandwidth;
-    // TODO these are only for debugging / meassuring effects of new histo task, should be removed
-    public boolean _use_new_histo_tsk = true;
-    public int _col_block_sz = 2;
-    public int _min_threads = -1;
-    public boolean _shared_histo;
-    public boolean _unordered;
-
-
+    // The following are internal  params for performance tuning of histogram building with defaults based on benchmark data.
+    public boolean _use_new_histo_tsk = true; // use the ScoreBuildHistogram2 instead of the originial one.
+    public int _col_block_sz = 2; // columns block processed in one task. can be between 1 - Integer.Max (meaning no column-wise paralellization)
+    public int _min_threads = -1; // desired parallellism, i.e. minimum number of tasks launched. defaults number of cores. Controls how many threads are launched per column block.
+    public boolean _shared_histo; // shared histo + CAS or private copies.
+    public boolean _unordered;    // only if histo is not shared. walk rows in order of the dataset, do not pre-sort by leaf membership.
 
     public GBMParameters() {
       super();

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
@@ -15,6 +15,12 @@ public class GBMModel extends SharedTreeModel<GBMModel, GBMModel.GBMParameters, 
     public double _col_sample_rate;
     public double _max_abs_leafnode_pred;
     public double _pred_noise_bandwidth;
+    // TODO these are only for debugging / meassuring effects of new histo task, should be removed
+    public boolean _use_new_histo_tsk = true;
+    public int _col_block_sz = 2;
+    public int _min_threads = -1;
+    public boolean _shared_histo;
+
 
     public GBMParameters() {
       super();

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -16,6 +16,7 @@ import water.fvec.Vec;
 import water.parser.ParseDataset;
 import water.util.*;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.TreeMap;
@@ -569,7 +570,7 @@ public class GBMTest extends TestUtil {
   // PUBDEV-557: Test dependency on # nodes (for small number of bins, but fixed number of chunks)
   @Test public void testReprodubilityAirline() {
     Frame tfr=null;
-    final int N = 1;
+    final int N = 5;
     double[] mses = new double[N];
 
     Scope.enter();
@@ -619,13 +620,18 @@ public class GBMTest extends TestUtil {
       if (tfr != null) tfr.remove();
     }
     Scope.exit();
+    System.out.println("MSEs start");
+    for(double d:mses)
+      System.out.println(d);
+    System.out.println("MSEs End");
+    System.out.flush();
     for( double mse : mses )
-      assertEquals(0.21919655106803468, mse, 1e-8); //check for the same result on 1 nodes and 5 nodes (will only work with enough chunks), mse, 1e-8); //check for the same result on 1 nodes and 5 nodes (will only work with enough chunks)
+      assertEquals(0.21919646108299456, mse, 1e-8); //check for the same result on 1 nodes and 5 nodes (will only work with enough chunks), mse, 1e-8); //check for the same result on 1 nodes and 5 nodes (will only work with enough chunks)
   }
 
   @Test public void testReprodubilityAirlineSingleNode() {
     Frame tfr=null;
-    final int N = 1;
+    final int N = 10;
     double[] mses = new double[N];
 
     Scope.enter();
@@ -664,6 +670,7 @@ public class GBMTest extends TestUtil {
         parms._balance_classes = true;
         parms._seed = 0;
         parms._build_tree_one_node = true;
+        parms._col_block_sz = i+1;
 
         // Build a first model; all remaining models should be equal
         GBMModel gbm = new GBM(parms).trainModel().get();
@@ -676,8 +683,11 @@ public class GBMTest extends TestUtil {
       if (tfr != null) tfr.remove();
     }
     Scope.exit();
+    System.out.println("MSE");
+    for(double d:mses)
+      System.out.println(d);
     for( double mse : mses )
-      assertEquals(0.21919655106803468, mse, 1e-8); //check for the same result on 1 nodes and 5 nodes (will only work with enough chunks)
+      assertEquals(0.21919646108299456, mse, 1e-8); //check for the same result on 1 nodes and 5 nodes (will only work with enough chunks)
   }
 
   // HEXDEV-223

--- a/h2o-core/src/main/java/water/DTask.java
+++ b/h2o-core/src/main/java/water/DTask.java
@@ -37,7 +37,7 @@ public abstract class DTask<T extends DTask> extends H2OCountedCompleter<T> {
   /** Capture the first exception in _ex.  Later setException attempts are ignored. */
   public synchronized void setException(Throwable ex) {
     if(_ex == null) {
-      _ex = AutoBuffer.javaSerializeWritePojo(((ex instanceof DistributedException) ? (DistributedException) ex : new DistributedException(ex)));
+      _ex = AutoBuffer.javaSerializeWritePojo(((ex instanceof DistributedException) ? (DistributedException) ex : new DistributedException(ex,false /* don't want this setException(ex) call in the stacktrace */)));
     }
   }
   /** The _ex field as a RuntimeException or null.

--- a/h2o-core/src/main/java/water/LocalMR.java
+++ b/h2o-core/src/main/java/water/LocalMR.java
@@ -1,0 +1,121 @@
+package water;
+
+import jsr166y.CountedCompleter;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Created by tomas on 11/5/16.
+ *
+ * Generic Local MRTask utility. Will launch requested number of tasks (on local node!), organized in a binary tree fashion.
+ * Tasks are launched via H2O.submit task rather than fork (assuming different usage pattern than MRT - use fewer longer running tasks -> push into global FJQ).
+ *
+ * User provides a MrFun function object with map/reduce/makeCopy functions.
+ *
+ * Here is a sample tree and reduce pairs for LocalMR creating 8 tasks
+ *          4
+ *        /  \
+ *      /     \
+ *     2      6
+ *    / \    / \
+ *   1   3  5  7
+ *   |
+ *   0
+ *
+ *   Reduce will be called for pairs (1,0), (2,1), (2,3), (4,2), (6,5), (6,7), (4,6)
+ *
+ */
+public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR> {
+  private int _lo;
+  private int _hi;
+  final MrFun _mrFun;
+  volatile Throwable _t;
+  protected volatile boolean  _cancelled;
+  private LocalMR<T> _root;
+
+  public LocalMR(MrFun mrt){this(mrt,H2O.NUMCPUS);}
+  public LocalMR(MrFun mrt, int nthreads){this(mrt,nthreads,null);}
+  public LocalMR(MrFun mrt, H2O.H2OCountedCompleter cc){this(mrt,H2O.NUMCPUS,cc,(byte)(H2O.H2OCallback.currThrPriority()+1));}
+  public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc){this(mrt,nthreads,cc,(byte)(H2O.H2OCallback.currThrPriority()+1));}
+  public LocalMR(MrFun mrt, int nthreads, byte priority) {this(mrt,nthreads,null,priority);}
+  public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc, byte priority) {
+    super(cc,priority);
+    if(nthreads <= 0) throw new IllegalArgumentException("nthreads must be positive");
+    _root = this;
+    _mrFun = mrt;
+    _lo = 0;
+    _hi = nthreads;
+  }
+
+  private LocalMR(LocalMR src, int lo, int hi) {
+    super(src);
+    _root = src._root;
+    _mrFun = src._mrFun.makeCopy();
+    _lo = lo;
+    _hi = hi;
+    _cancelled = src._cancelled;
+  }
+
+  private LocalMR<T> _left;
+  private LocalMR<T> _rite;
+
+  volatile boolean completed;
+
+  public boolean isCancelRequested(){return _root._cancelled;}
+
+  private int mid(){ return _lo + ((_hi - _lo) >> 1);}
+
+  @Override
+  public final void compute2() {
+    if (!_root._cancelled) {
+      try {
+        int mid = mid();
+        assert _hi > _lo;
+        int pending = 0;
+        if (_hi - _lo >= 2) {
+          _left = new LocalMR(this, _lo, mid);
+          pending++;
+          if ((mid + 1) < _hi) {
+            _rite = new LocalMR(this, mid + 1, _hi);
+            pending++;
+          }
+          addToPendingCount(pending);
+          H2O.submitTask(_left);
+          if(_rite != null) H2O.submitTask(_rite);
+        }
+        _mrFun.map(mid);
+      } catch (Throwable t) {
+        t.printStackTrace();
+        if (_root._t == null) {
+          _root._t = t;
+          _root._cancelled = true;
+        }
+      }
+    }
+    completed = true;
+    tryComplete();
+  }
+
+  @Override
+  public final void onCompletion(CountedCompleter cc) {
+    if(_cancelled){
+      assert this == _root;
+      completeExceptionally(_t == null?new CancellationException():_t); // instead of throw
+      return;
+    }
+    if(_root._cancelled) return;
+    assert cc == this || cc == _left || cc == _rite;
+    if (_left != null) {
+      assert _left.completed;
+      _mrFun.reduce(_left._mrFun);
+      _left = null;
+    }
+    if (_rite != null) {
+      assert _rite.completed;
+      _mrFun.reduce(_rite._mrFun);
+      _rite = null;
+    }
+  }
+
+}

--- a/h2o-core/src/main/java/water/MrFun.java
+++ b/h2o-core/src/main/java/water/MrFun.java
@@ -1,0 +1,14 @@
+package water;
+
+/**
+ * Created by tomas on 11/5/16.
+ * Interface to be used by LocalMR.
+ *
+ */
+public abstract class MrFun<T extends MrFun<T>> extends Iced<T> {
+  protected abstract void map(int id);
+  protected void reduce(T t) {}
+  protected MrFun<T> makeCopy() {
+    return clone();
+  }
+}

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -1495,4 +1495,8 @@ public class Vec extends Keyed<Vec> {
     UnsafeUtils.set4(k._kb, 6, cidx); // chunk#
     return k;
   }
+
+  public boolean isHomedLocally(int cidx){
+    return chunkKey(cidx).home();
+  }
 }

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -1490,4 +1490,9 @@ public class Vec extends Keyed<Vec> {
     public static void clear() { ESPCS.clear(); }
     @Override protected long checksum_impl() { throw H2O.fail(); }
   }
+
+  public static Key setChunkIdx(Key k, int cidx){
+    UnsafeUtils.set4(k._kb, 6, cidx); // chunk#
+    return k;
+  }
 }

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -1,9 +1,6 @@
 package water.util;
 
-import water.DKV;
-import water.Futures;
-import water.Key;
-import water.MemoryManager;
+import water.*;
 import water.fvec.*;
 
 import java.text.DecimalFormat;
@@ -180,6 +177,17 @@ public class ArrayUtils {
     double [][] res = ary.clone();
     for(int i = 0 ; i < res.length; ++i)
       res[i] = ary[i].clone();
+    return res;
+  }
+
+  public static <T extends Iced> T[][] deepClone(T [][] ary){
+    T [][] res = ary.clone();
+    for(int i = 0 ; i < res.length; ++i) {
+      res[i] = ary[i].clone();
+      for(int j = 0; j < res[i].length; ++j)
+        if(res[i][j] != null)
+          res[i][j] = (T)res[i][j].clone();
+    }
     return res;
   }
 

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -344,6 +344,20 @@ public class ArrayUtils {
     return res;
   }
 
+  public static <T> T[] cloneOrNull(T[] ary){return ary == null?null:ary.clone();}
+
+  public static <T> T[][] transpose(T[][] ary) {
+    if(ary == null|| ary.length == 0) return ary;
+    T [][] res  = Arrays.copyOf(ary,ary[0].length);
+    for(int i = 0; i < res.length; ++i)
+      res[i] = Arrays.copyOf(ary[0],ary.length);
+    for(int i = 0; i < res.length; i++) {
+      for(int j = 0; j < res[0].length; j++)
+        res[i][j] = ary[j][i];
+    }
+    return res;
+  }
+
   /**
    * Provide array from start to end in steps of 1
    * @param start beginning value (inclusive)

--- a/h2o-core/src/main/java/water/util/DistributedException.java
+++ b/h2o-core/src/main/java/water/util/DistributedException.java
@@ -12,26 +12,29 @@ import java.util.Arrays;
  * Created by tomas on 3/2/16.
  */
 public final class DistributedException extends RuntimeException  {
-  public DistributedException(){truncateStackTrace();}
-  public DistributedException(Throwable cause){
+  public DistributedException(){truncateStackTrace(true);}
+  public DistributedException(Throwable cause){ this(cause,true);}
+  public DistributedException(Throwable cause, boolean keepStackTrace){
     super("DistributedException from " + H2O.SELF,cause);
-    truncateStackTrace();
+    truncateStackTrace(keepStackTrace);
   }
   public DistributedException(String msg, Throwable cause){
     super(msg,cause);
     try {
-      truncateStackTrace();
+      truncateStackTrace(true);
     }catch(Throwable t) {
       // just in case it throws, do nothing, truncating stacktrace not really that important
     }
   }
   public String toString(){return getMessage() + ", caused by " + getCause().toString();}
-  private void truncateStackTrace(){
-    StackTraceElement [] stackTrace = getStackTrace();
-    int i = 0;
-    for(; i < stackTrace.length; ++i)
-      if(stackTrace[i].getFileName() != null && stackTrace[i].getFileName().equals("JettyHTTPD.java"))
-        break;
-    setStackTrace(Arrays.copyOf(stackTrace,i));
+  private void truncateStackTrace(boolean keepStackTrace){
+    if(keepStackTrace) {
+      StackTraceElement[] stackTrace = getStackTrace();
+      int i = 0;
+      for (; i < stackTrace.length; ++i)
+        if (stackTrace[i].getFileName() != null && stackTrace[i].getFileName().equals("JettyHTTPD.java"))
+          break;
+      setStackTrace(Arrays.copyOf(stackTrace, i));
+    } else setStackTrace(new StackTraceElement[0]);
   }
 }

--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -573,4 +573,16 @@ public class VecUtils {
       return dom;
     }
   }
+  public static int [] getLocalChunkIds(Vec v){
+    Key k = v._key;
+    int [] res = new int[Math.max(v.nChunks()/H2O.CLOUD.size(),1)];
+    int j = 0;
+    for(int i = 0; i < v.nChunks(); ++i){
+      if(Vec.setChunkIdx(k,i).home()) {
+        if(res.length == j) res = Arrays.copyOf(res,2*res.length);
+        res[j++] = i;
+      }
+    }
+    return j == res.length?res:Arrays.copyOf(res,j);
+  }
 }

--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -574,11 +574,10 @@ public class VecUtils {
     }
   }
   public static int [] getLocalChunkIds(Vec v){
-    Key k = v._key;
     int [] res = new int[Math.max(v.nChunks()/H2O.CLOUD.size(),1)];
     int j = 0;
     for(int i = 0; i < v.nChunks(); ++i){
-      if(Vec.setChunkIdx(k,i).home()) {
+      if(v.isHomedLocally(i)) {
         if(res.length == j) res = Arrays.copyOf(res,2*res.length);
         res[j++] = i;
       }

--- a/h2o-core/src/test/java/water/LocalMRTest.java
+++ b/h2o-core/src/test/java/water/LocalMRTest.java
@@ -1,0 +1,115 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.util.ArrayUtils;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by tomas on 11/6/16.
+ */
+public class LocalMRTest extends TestUtil {
+
+  @BeforeClass
+  static public void setup() { stall_till_cloudsize(1); }
+  private static class MrFunTest1 extends MrFun<MrFunTest1>{
+    int _exId;
+    public int [] _val;
+    public MrFunTest1(int exId){_exId = exId;}
+    public void map(int id){
+      _val = new int[]{id};
+    }
+    public void reduce(MrFunTest1 other){
+      _val = ArrayUtils.sortedMerge(_val,other._val);
+    }
+  }
+
+
+
+
+  private void testCnt(int cnt){
+    MrFunTest1 f = new MrFunTest1(-1);
+    H2O.submitTask(new LocalMR(f,cnt)).join();
+    assertEquals(cnt,f._val.length);
+    for(int i = 0; i < cnt; ++i)
+      assertEquals(i,f._val[i]);
+  }
+  @Test
+  public void testNormal() {
+    testCnt(1);
+    testCnt(2);
+    testCnt(3);
+    testCnt(4);
+    testCnt(5);
+    testCnt(10);
+    testCnt(15);
+    testCnt(53);
+    testCnt(64);
+    testCnt(100);
+    testCnt(111);
+  }
+
+  @Test
+  public void testIAE() {
+    try {
+      testCnt(0);
+      assertTrue("should've thrown IAE",false);
+    } catch(IllegalArgumentException e){}
+    try {
+      testCnt(-1);
+      assertTrue("should've thrown IAE",false);
+    } catch(IllegalArgumentException e){}
+  }
+
+  private static class TestException extends RuntimeException {}
+
+  private static class MrFunTest2 extends MrFun<MrFunTest2>{
+    final int exId;
+    String s;
+    AtomicInteger _active;
+
+    public MrFunTest2(int exId, AtomicInteger activeCnt){this.exId = exId; _active = activeCnt;}
+    @Override
+    protected void map(int id) {
+      if (id % exId == 0) throw new TestException();
+      _active.incrementAndGet();
+      try {Thread.sleep(10);} catch (InterruptedException e) {}
+      s = "" + id;
+      _active.decrementAndGet();
+    }
+    @Override public void reduce(MrFunTest2 other){
+      s = s + ", " + other.s;
+    }
+  }
+  @Test
+  public void testThrow() {
+    long seed = 87654321;
+    Random rnd = new Random(seed);
+    for(int k = 0; k < 10; ++k){
+      int cnt = Math.max(1,rnd.nextInt(50));
+      final int exId = Math.max(1,rnd.nextInt(cnt));
+      final AtomicInteger active = new AtomicInteger();
+      // test correct throw behavior with blocking call
+      try {
+        H2O.submitTask(new LocalMR(new MrFunTest2(exId,active),cnt)).join();
+        assertTrue("should've thrown test exception",false);
+      } catch(TestException t) {
+        assertEquals(0,active.get());
+      }
+      // and with completer
+      try {
+        H2O.H2OCountedCompleter cc = new H2O.H2OCountedCompleter(){};
+        H2O.submitTask(new LocalMR(new MrFunTest2(exId,active),cnt,cc));
+        cc.join();
+        assertTrue("should've thrown test exception",false);
+      } catch(TestException t) {
+        assertEquals(0,active.get());
+      }
+    }
+  }
+}


### PR DESCRIPTION
Improves gbm performance on multi-cpu systems by avoiding CAS. 

Added a new histogram building task (ScoreBuildHistogram2) which allows use of private copies of histogram instead of shared data + CAS to reduce the memory overhead it parallelizes by columns first and only generates limited number of threads (limited number of copies) per column.

Early benchmarking  shows speedup of 0 - 300%, depending on the dataset and machine. I.e. is at least as fast as the previous version, can be up to 4x faster. It's turned on only for GBM for now as it is not tested with DRF (or deep trees), it might be better to do the sharing+CAS in some cases.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/487)
<!-- Reviewable:end -->
