### PR TITLE
Decrease timeout to 5 sec for remoteSend() in R API

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -402,7 +402,7 @@ h2o.clusterStatus <- function() {
   try(.h2o.__remoteSend("InitID", method = "DELETE"), TRUE)
 }
 
-.Last <- function() { if ( .isConnected() ) try(.h2o.__remoteSend("InitID", method = "DELETE"), TRUE)}
+.Last <- function() { if ( .isConnected() ) try(.h2o.__remoteSend("InitID", method = "DELETE",timeout=5), TRUE)}
 
 .h2o.startJar <- function(nthreads = -1, max_memory = NULL, min_memory = NULL, enable_assertions = TRUE, forceDL = FALSE, license = NULL, ice_root, stdout) {
   command <- .h2o.checkJava()


### PR DESCRIPTION
* This PR decreases the timeout for `.h2o.__remoteSend` in `connection.R` to 5 sec.
* This will ensure that after a test passes the status is returned instead of hanging on the client side.
* This PR give a ~40 minute speed up for our runit testing framework.

@h2o-ops please test

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/488)
<!-- Reviewable:end -->
