### PR TITLE
allow to use arbitrary h2o.jar, closes PUBDEV-3534

### DIFF
--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -203,6 +203,14 @@ class H2OLocalServer(object):
     @staticmethod
     def _jar_paths():
         """Produce potential paths for an h2o.jar executable."""
+        
+        # PUBDEV-3534 hook to use arbitrary h2o.jar
+        own_jar = os.getenv("H2O_JAR_PATH", "")
+        if own_jar != "":
+            if not os.path.isfile(own_jar):
+                raise H2OStartupError("Environment variable H2O_JAR_PATH is set to '%d' but file does not exists, unset environment variable or provide valid path to h2o.jar file." % own_jar)
+            yield own_jar
+        
         # Check if running from an h2o-3 src folder (or any subfolder), in which case use the freshly-built h2o.jar
         cwd_chunks = os.path.abspath(".").split(os.path.sep)
         for i in range(len(cwd_chunks), 0, -1):

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -569,7 +569,14 @@ h2o.clusterStatus <- function() {
 # It will download a jar file if it needs to.
 .h2o.downloadJar <- function(overwrite = FALSE) {
   if(!is.logical(overwrite) || length(overwrite) != 1L || is.na(overwrite)) stop("`overwrite` must be TRUE or FALSE")
-
+  
+  # PUBDEV-3534 hook to use arbitrary h2o.jar
+  own_jar = Sys.getenv("H2O_JAR_PATH")
+  if (nzchar(own_jar)) {
+    if (!file.exists(own_jar)) stop(sprintf("Environment variable H2O_JAR_PATH is set to '%s' but file does not exists, unset environment variable or provide valid path to h2o.jar file.", own_jar))
+    return(own_jar)
+  }
+  
   if (is.null(.h2o.pkg.path)) {
     pkg_path = dirname(system.file(".", package = "h2o"))
   } else {


### PR DESCRIPTION
Very basic solution for PUBDEV-3534, as it became a blocker for PUBDEV-3689.
This PR allows to use custom defined h2o.jar in R and py packages. Path is controlled by `H2O_JAR_PATH` env var.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/499)
<!-- Reviewable:end -->
