### PR TITLE
Simple script to limit scope of Jenkins tests according to files modified

### DIFF
--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -34,9 +34,10 @@ def mark_flag_true(flag):
     environment[flag] = True
 
 def error(msg):
-    print('echo ""; ')
-    print('echo "%s"; ' % msg)
-    print('echo ""; ')
+    print('echo ""')
+    print('echo "WARNING: %s"' % msg)
+    print('echo "         All tests will be scheduled to run."')
+    print('echo ""')
     mark_all_flags_true()
 
 def get_list_of_modified_files(source_branch, target_branch):
@@ -71,4 +72,4 @@ def run():
 if __name__ == "__main__":
     run()
     for key, value in environment.items():
-        print("export H2O_RUN_%s_TESTS=\"%s\"; " % (key.upper(), str(value).lower()))
+        print("export H2O_RUN_%s_TESTS=\"%s\"" % (key.upper(), str(value).lower()))

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""
+This is a Jenkins script that is supposed to be run after the
+GithubPullRequestBuilder plugin. It will determine what files has changed in
+the PR being tested, and set up several environmental variables accordingly.
+
+In particular, the following variables will be emitted:
+    H2O_RUN_PY_TESTS
+    H2O_RUN_R_TESTS
+    H2O_RUN_JAVA_TESTS
+    H2O_RUN_JS_TESTS
+Each of these will have a string value of either "true" or "false". These
+variables determine which test suites should be then started by the Jenkins:
+if the PR affects only Python files, then only the `H2O_RUN_PY_TESTS` flag
+will be set, etc.
+
+We may extend the set of environment variables in the future.
+
+Since Python is unable to set environment variables on its own, it rather
+prints to stdout commands like `EXPORT H2O_RUN_PY_TESTS="true"`. Thus, the
+caller script should take the output of this python script and execute it
+using the `source` command.
+"""
+import os
+import subprocess
+
+environment = {"py": False, "r": False, "java": False, "js": False}
+
+def mark_all_flags_true():
+    for k in environment.keys():
+        environment[k] = True
+
+def mark_flag_true(flag):
+    environment[flag] = True
+
+def error(msg):
+    print("ECHO")
+    print("ECHO '%s'" % msg)
+    print("ECHO")
+    mark_all_flags_true()
+
+def get_list_of_modified_files(source_branch, target_branch):
+    out = subprocess.check_output(["get", "diff", "--name-only", source_branch, target_branch])
+    return out.split("\n")
+
+
+def run():
+    source_branch = os.environ.get("ghprbSourceBranch")
+    if not source_branch:
+        return error("Environment variable ghprbSourceBranch not set")
+
+    target_branch = os.environ.get("ghprbTargetBranch")
+    if not target_branch:
+        return error("Environment variable ghprbTargetBranch not set")
+
+    try:
+        files_changed = get_list_of_modified_files(source_branch, target_branch)
+    except Exception as e:
+        return error("%r when trying to retrieve the list of changed files" % e)
+
+    for fname in files_changed:
+        if fname.startswith("h2o-py/"):
+            mark_flag_true("py")
+        elif fname.startswith("h2o-r/"):
+            mark_flag_true("r")
+        else:
+            mark_all_flags_true()
+            break
+
+
+if __name__ == "__main__":
+    run()
+    for key, value in environment.items():
+        print("EXPORT H2O_RUN_%s_TESTS=\"%s\"" % (key.upper(), str(value).lower()))

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -34,9 +34,9 @@ def mark_flag_true(flag):
     environment[flag] = True
 
 def error(msg):
-    print("ECHO")
-    print("ECHO '%s'" % msg)
-    print("ECHO")
+    print("echo")
+    print('echo "%s"' % msg)
+    print("echo")
     mark_all_flags_true()
 
 def get_list_of_modified_files(source_branch, target_branch):
@@ -71,4 +71,4 @@ def run():
 if __name__ == "__main__":
     run()
     for key, value in environment.items():
-        print("EXPORT H2O_RUN_%s_TESTS=\"%s\"" % (key.upper(), str(value).lower()))
+        print("export H2O_RUN_%s_TESTS=\"%s\"" % (key.upper(), str(value).lower()))

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -58,9 +58,9 @@ def run():
         return error("%r when trying to retrieve the list of changed files" % e)
 
     for fname in files_changed:
-        if fname.startswith("h2o-py/"):
+        if fname.startswith("h2o-py/") or fname == "h2o-bindings/bin/gen_python.py":
             mark_flag_true("py")
-        elif fname.startswith("h2o-r/"):
+        elif fname.startswith("h2o-r/") or fname == "h2o-bindings/bin/gen_R.py":
             mark_flag_true("r")
         else:
             mark_all_flags_true()

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -38,8 +38,9 @@ def error(msg):
     mark_all_flags_true()
 
 def get_list_of_modified_files(source_branch, target_branch):
-    out = subprocess.check_output(["get", "diff", "--name-only", source_branch, target_branch])
-    return out.split("\n")
+    out1 = subprocess.check_output(["git", "merge-base", source_branch, target_branch]).decode().rstrip()
+    out2 = subprocess.check_output(["git", "diff", "--name-only", source_branch, out1]).decode().rstrip()
+    return out2.split("\n")
 
 
 def run():

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -34,9 +34,9 @@ def mark_flag_true(flag):
     environment[flag] = True
 
 def error(msg):
-    print("echo")
-    print('echo "%s"' % msg)
-    print("echo")
+    print('echo ""; ')
+    print('echo "%s"; ' % msg)
+    print('echo ""; ')
     mark_all_flags_true()
 
 def get_list_of_modified_files(source_branch, target_branch):
@@ -71,4 +71,4 @@ def run():
 if __name__ == "__main__":
     run()
     for key, value in environment.items():
-        print("export H2O_RUN_%s_TESTS=\"%s\"" % (key.upper(), str(value).lower()))
+        print("export H2O_RUN_%s_TESTS=\"%s\"; " % (key.upper(), str(value).lower()))

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -13,6 +13,8 @@ Presence / absence of each of these files indicates whether the corresponding
 group of tests should be run.
 
 We may extend the set of these flags in the future.
+
+
 """
 from __future__ import print_function
 import os
@@ -65,6 +67,8 @@ def run():
             mark_flag_true("py")
         elif fname.startswith("h2o-r/") or fname == "h2o-bindings/bin/gen_R.py":
             mark_flag_true("r")
+        elif fname.endswith(".md"):
+            pass  # Changes in .md files don't require any jobs to be run
         else:
             mark_all_flags_true()
             break

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -14,6 +14,7 @@ group of tests should be run.
 
 We may extend the set of these flags in the future.
 """
+from __future__ import print_function
 import os
 import subprocess
 
@@ -80,5 +81,5 @@ if __name__ == "__main__":
         else:
             if os.path.exists(target_file):
                 os.remove(target_file)
-        print("H2O_RUN_%s_TESTS = %s" % (key.upper()), str(value).lower())
+        print("H2O_RUN_%s_TESTS = %s" % (key.upper(), str(value).lower()))
     print()

--- a/scripts/detect_branch_changes.py
+++ b/scripts/detect_branch_changes.py
@@ -24,11 +24,13 @@ environment = {"py": False, "r": False, "java": False, "js": False}
 
 
 def mark_all_flags_true():
-    for k in environment.keys():
+    for k in environment:
         environment[k] = True
+
 
 def mark_flag_true(flag):
     environment[flag] = True
+
 
 def error(msg):
     print()
@@ -36,6 +38,7 @@ def error(msg):
     print("         All tests will be scheduled to run.")
     print()
     mark_all_flags_true()
+
 
 def get_list_of_modified_files(source_branch, target_branch):
     out1 = subprocess.check_output(["git", "merge-base", source_branch, target_branch]).decode().rstrip()
@@ -67,16 +70,14 @@ def run():
             break
 
 
-if __name__ == "__main__":
-    target_folder = os.path.join(os.path.dirname(__file__), target_folder)
-    if not os.path.exists(target_folder):
-        os.makedirs(target_folder)
-
-    run()
+def create_files(folder):
+    abs_folder = os.path.join(os.path.dirname(__file__), folder)
+    if not os.path.exists(abs_folder):
+        os.makedirs(abs_folder)
 
     print()
     for key, value in environment.items():
-        target_file = os.path.join(target_folder, "H2O_RUN_%s_TESTS" % key.upper())
+        target_file = os.path.join(abs_folder, "H2O_RUN_%s_TESTS" % key.upper())
         if value:
             with open(target_file, "w"): pass
         else:
@@ -84,3 +85,8 @@ if __name__ == "__main__":
                 os.remove(target_file)
         print("H2O_RUN_%s_TESTS = %s" % (key.upper(), str(value).lower()))
     print()
+
+
+if __name__ == "__main__":
+    run()
+    create_files(target_folder)


### PR DESCRIPTION
This script should be executed as a first step in Jenkins PR pipeline. It checks which files were changed by the PR, and based on that tries to decide which jobs should be run.

It signals its conclusions creating a set of empty files of the form H2O_RUN_PY_TESTS and similar (we wanted to use environment variables first, but couldn't quite make it to work).

The Jenkins job then can be configures to test the presence of each of this file, and run a corresponding job or set of jobs. For example, if it sees the H2O_RUN_PY_TESTS file, then it knows to run all pyunit* jobs.

This is the initial version, proof-of-concept. It can be further refined to support more groups of tests: documentation-only changes, algo-specific changes, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/509)
<!-- Reviewable:end -->
