### PR TITLE
[PUBDEV-3756] Allows to set a custom jetty context path.

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -260,6 +260,9 @@ final public class H2O {
     /** -disable_web; disable web API port (used by Sparkling Water) */
     public boolean disable_web = false;
 
+    /** -context_path=jetty_context_path; the context path for jetty */
+    public String context_path = "";
+
     //-----------------------------------------------------------------------------------
     // HDFS & AWS
     //-----------------------------------------------------------------------------------
@@ -456,6 +459,10 @@ final public class H2O {
       }
       else if (s.matches("disable_web")) {
         ARGS.disable_web = true;
+      }
+      else if (s.matches("context_path")) {
+        i = s.incrementAndCheck(i, args);
+        ARGS.context_path = args[i];
       }
       else if (s.matches("nthreads")) {
         i = s.incrementAndCheck(i, args);
@@ -1271,8 +1278,8 @@ final public class H2O {
 
   public static String getURL(String schema) {
     return String.format(H2O.SELF_ADDRESS instanceof Inet6Address
-                         ? "%s://[%s]:%d" : "%s://%s:%d",
-                         schema, H2O.SELF_ADDRESS.getHostAddress(), H2O.API_PORT);
+                         ? "%s://[%s]:%d%s" : "%s://%s:%d%s",
+                         schema, H2O.SELF_ADDRESS.getHostAddress(), H2O.API_PORT, H2O.ARGS.context_path);
   }
 
   // The multicast discovery port

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -462,7 +462,8 @@ final public class H2O {
       }
       else if (s.matches("context_path")) {
         i = s.incrementAndCheck(i, args);
-        ARGS.context_path = args[i];
+        String value = args[i];
+        ARGS.context_path = value.startsWith("/") ? value : "/" + value;
       }
       else if (s.matches("nthreads")) {
         i = s.incrementAndCheck(i, args);

--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -305,7 +305,13 @@ public class JettyHTTPD {
     ServletContextHandler context = new ServletContextHandler(
         ServletContextHandler.SECURITY | ServletContextHandler.SESSIONS
     );
-    context.setContextPath("/");
+
+    if(null != H2O.ARGS.context_path && !H2O.ARGS.context_path.isEmpty()) {
+      context.setContextPath(H2O.ARGS.context_path);
+    } else {
+      context.setContextPath("/");
+    }
+
     context.addServlet(NpsBinServlet.class,   "/3/NodePersistentStorage.bin/*");
     context.addServlet(PostFileServlet.class, "/3/PostFile.bin");
     context.addServlet(PostFileServlet.class, "/3/PostFile");
@@ -469,6 +475,14 @@ public class JettyHTTPD {
     response.setHeader("X-h2o-rest-api-version-max", Integer.toString(water.api.RequestServer.H2O_REST_API_VERSION));
     response.setHeader("X-h2o-cluster-id", Long.toString(H2O.CLUSTER_ID));
     response.setHeader("X-h2o-cluster-good", Boolean.toString(H2O.CLOUD.healthy()));
+    response.setHeader("X-h2o-context-path", sanatizeContextPath(H2O.ARGS.context_path));
+  }
+
+  private static String sanatizeContextPath(String context_path) {
+    if(null == context_path || context_path.isEmpty()) {
+      return "/";
+    }
+    return context_path + "/";
   }
 
 

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -665,7 +665,7 @@ public class RequestServer extends HttpServlet {
 
   private static NanoResponse redirectToFlow() {
     NanoResponse res = new NanoResponse(HTTP_REDIRECT, MIME_PLAINTEXT, "");
-    res.addHeader("Location", "/flow/index.html");
+    res.addHeader("Location", H2O.ARGS.context_path + "/flow/index.html");
     return res;
   }
 

--- a/h2o-core/src/main/resources/www/perfbar.js
+++ b/h2o-core/src/main/resources/www/perfbar.js
@@ -16,6 +16,7 @@ var timeoutDelayMillis = 200;
 var cloud_size = -1;
 var acknowledged_cloud_size = 0;
 var shutdownRequested = false;
+var context_path = "";
 
 function saturate0(value) {
 if (value < 0) {
@@ -265,16 +266,19 @@ function Perfbar(nodeIdx, nodeName, nodePort, numCores) {
 }
 
 function initializeCloud() {
+    if(window.location.pathname.split("/")[1]) {
+        context_path = "/" + window.location.pathname.split("/")[1];
+    }
+
     shutdownRequested = false;
 
-    var xmlhttp = new XMLHttpRequest();
+    xmlhttp = new XMLHttpRequest();
     xmlhttp.onreadystatechange = function() {
         if (shutdownRequested) {
             return
         }
 
         if (xmlhttp.readyState==4 && xmlhttp.status==200) {
-            console.log(xmlhttp.responseText);
             var obj = JSON.parse(xmlhttp.responseText);
             cloud_size = obj.cloud_size;
             console.log("cloud size is " + cloud_size);
@@ -293,7 +297,7 @@ function initializeCloud() {
             timeouts = new Array(cloud_size);
         }
     };
-    xmlhttp.open("GET","/3/Cloud",true);
+    xmlhttp.open("GET",context_path+"/3/Cloud",true);
     xmlhttp.send();
 }
 
@@ -357,7 +361,7 @@ function initializeNode(nodeIdx, nodeName, nodePort) {
             }
         }
     };
-    xmlhttp.open("GET","/3/WaterMeterCpuTicks/" + nodeIdx, true);
+    xmlhttp.open("GET",context_path+"/3/WaterMeterCpuTicks/" + nodeIdx, true);
     xmlhttp.send();
 }
 
@@ -386,7 +390,7 @@ function repaintAndArmTimeout(nodeIdx) {
             }, timeoutDelayMillis, nodeIdx);
         }
     };
-    xmlhttp.open("GET", "/3/WaterMeterCpuTicks/" + nodeIdx, true);
+    xmlhttp.open("GET", context_path+"/3/WaterMeterCpuTicks/" + nodeIdx, true);
     xmlhttp.send();
 }
 

--- a/h2o-core/src/main/resources/www/perfbar.js
+++ b/h2o-core/src/main/resources/www/perfbar.js
@@ -272,7 +272,7 @@ function initializeCloud() {
 
     shutdownRequested = false;
 
-    xmlhttp = new XMLHttpRequest();
+    var xmlhttp = new XMLHttpRequest();
     xmlhttp.onreadystatechange = function() {
         if (shutdownRequested) {
             return


### PR DESCRIPTION
Necessary for Steam's proxy to work with multiple H2O clusters. Allows the user to append a path to H2O URI i.e. 127.0.0.1:54321/h2o-1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/512)
<!-- Reviewable:end -->
