### PR TITLE
[HOTFIX] :fire: REST API registration failure under Java6

### DIFF
--- a/h2o-core/src/main/java/water/api/ModelBuildersHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelBuildersHandler.java
@@ -83,12 +83,18 @@ class ModelBuildersHandler extends Handler {
       try {
         ModelMojoWriter mmw = (ModelMojoWriter) retClass.newInstance();
         return mmw.mojoVersion();
-      } catch (InstantiationException | IllegalAccessException e) {
-        throw new RuntimeException("MojoWriter class " + retClass + " must define a no-arg constructor.\n" + e);
+      } catch (InstantiationException e) {
+        throw getMissingCtorException(retClass, e);
+      } catch (IllegalAccessException e) {
+        throw getMissingCtorException(retClass, e);
       }
     } catch (NoSuchMethodException e) {
       throw new RuntimeException("Model class " + modelClass + " is expected to have method getMojo();");
     }
+  }
+
+  private RuntimeException getMissingCtorException(Class<?> retClass, Exception e) {
+    return new RuntimeException("MojoWriter class " + retClass + " must define a no-arg constructor.\n" + e);
   }
 }
 


### PR DESCRIPTION
Java7 compiler translates `try-catch` block if you are using new syntax (`catch (FirstExceptionType | AnotherExceptionType e)`) and replaces it by a shared  parent  (`catch (RuntimeException e)`) - in our case one of commit introduced dependency on common parent `ReflectiveOperationException` which was only available in Java7 and not in Java6 - hence our rest api registration was failing.

It is tricky, but I hope we will get rid of Java6 soon…

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/514)
<!-- Reviewable:end -->
