### PR TITLE
Fix FJ pool async flag setting.

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1075,7 +1075,7 @@ final public class H2O {
       super((ARGS.nthreads <= 0) ? NUMCPUS : ARGS.nthreads,
             new FJWThrFact(cap),
             null,
-            p<MIN_HI_PRIORITY);
+            p>=MIN_HI_PRIORITY);
       _priority = p;
     }
     private H2OCountedCompleter poll2() { return (H2OCountedCompleter)pollSubmission(); }

--- a/h2o-core/src/test/java/water/MRTaskTest.java
+++ b/h2o-core/src/test/java/water/MRTaskTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MRTaskTest extends TestUtil {
-  @BeforeClass static public void setup() { stall_till_cloudsize(1); }
+  @BeforeClass static public void setup() { stall_till_cloudsize(5); }
 
   // test we reduce asap and do not produce more than tree_depth + P unreduced results
   @Test public void test_reductions(){

--- a/h2o-core/src/test/java/water/MRTaskTest.java
+++ b/h2o-core/src/test/java/water/MRTaskTest.java
@@ -5,9 +5,56 @@ import water.fvec.Vec;
 import water.fvec.Chunk;
 import water.util.PrettyPrint;
 
-public class MRTaskTest extends TestUtil {
-  @BeforeClass static public void setup() { stall_till_cloudsize(5); }
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MRTaskTest extends TestUtil {
+  @BeforeClass static public void setup() { stall_till_cloudsize(1); }
+
+  // test we reduce asap and do not produce more than tree_depth + P unreduced results
+  @Test public void test_reductions(){
+    for(int k = 0; k < 3; ++k) {
+      Key[] keys = new Key[2048]; // should have at most 10 + H2O.NUMCPUS active results
+      int depth = 11;
+      int log = 1;
+      while((1 << log) <= H2O.NUMCPUS)log++;
+      log--;
+      // maximum number of unreduced results given intended reduce strategy.
+      // (it is exact only if NUMCPUS is power of 2, otherwise it's an upper bound.)
+      // The max number of unreduced results it's depth of the tree per-thread
+      // (Some levels of the tree are used on launching the threads - hence it's (log2(numtasks) - log2(numcpus)*numcpus.
+      int max_unreduced_elems = (depth - log + 1)*H2O.NUMCPUS;
+      for (int i = 0; i < keys.length; ++i)
+        keys[i] = Key.make((byte) 1, Key.HIDDEN_USER_KEY, true, H2O.SELF);
+      final AtomicInteger cntr = new AtomicInteger();
+      final AtomicInteger maxCntr = new AtomicInteger();
+      new MRTask() {
+        public void map(Key k) {
+          int cnt = cntr.incrementAndGet();
+          int max = maxCntr.get();
+          while (cnt > max) {
+            maxCntr.compareAndSet(max, cnt);
+            max = maxCntr.get();
+          }
+          try {
+            Thread.sleep(1);
+          } catch (InterruptedException e) {
+          }
+        }
+
+        public void reduce(MRTask t) {
+          cntr.decrementAndGet();
+        }
+      }.doAll(keys);
+      int max_cnt = maxCntr.get();
+      System.out.println("max cnt = " + max_cnt);
+      int cnt = cntr.get();
+      assertEquals("Number of reductions should be (numtasks - 1). We add 1 per map, subtract one per reduce, there should be 1 left, got " + cnt,1,cnt);
+      assertTrue("too many unreduced results, should be <= " + max_unreduced_elems + " but was " + max_cnt, max_cnt < max_unreduced_elems);
+    }
+  }
   // Test speed of calling 1M map calls
   @Test
   public void testMillionMaps() {


### PR DESCRIPTION
We were launching all our low priority ForkjoinPools (i.e. all our MrTasks) in async mode, which I believe is a bug.

The default FJ behavior is for worker thread private queues to be LIFO, unless async flag is set, in which case they are FIFO.
This matters especially for MrTasks:
    An internal node in MrTask’s tree forks right, then proceeds to compute left;
    Leaf node invokes map() and attempts to call reduce() if sibling is already computed.

Thus the thread running MrT does depth first dive into its leftmost leaf.
The next task is then taken from the thread’s private queue.
We want to pick the task added last - our sibling - compute it and then reduce.
Taking the task added first (current behavior) means going back to the top of the tree and start expanding the right subtree.
Leads, at the very least, to too many intermediate result being held before they are reduced.
Possibly affecting speed elsewhere.

Added test which verified bad MrTask behavior (keeping too many unreduced results).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/523)
<!-- Reviewable:end -->
