### PR TITLE
Improvements to AstSum rapids function

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -160,6 +160,7 @@ public class Env extends Iced {
     init(new AstProdNa());
     init(new AstSdev());
     init(new AstSum());
+    init(new AstSumAxis());
     init(new AstSumNa());
 
     // Time

--- a/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstSumAxis.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstSumAxis.java
@@ -1,0 +1,171 @@
+package water.rapids.ast.prims.reducers;
+
+import water.Key;
+import water.MRTask;
+import water.fvec.*;
+import water.rapids.Env;
+import water.rapids.Val;
+import water.rapids.vals.ValFrame;
+import water.rapids.ast.AstPrimitive;
+import water.rapids.ast.AstRoot;
+import water.rapids.vals.ValRow;
+
+
+public class AstSumAxis extends AstPrimitive {
+  @Override
+  public String[] args() {
+    return new String[]{"frame", "na_rm", "axis"};
+  }
+
+  @Override
+  public String str() {
+    return "sumaxis";
+  }
+
+  @Override
+  public int nargs() {
+    return -1;  // 1 + 3;
+  }
+
+  @Override
+  public String example() {
+    return "(sumaxis frame na_rm axis)";
+  }
+
+  @Override
+  public String description() {
+    return "Compute the sum values within the provided frame. If axis = 0, then the sum is computed " +
+            "column-wise, and the result is a frame of shape [1 x ncols], where ncols is the number of columns in " +
+            "the original frame. If axis = 1, then the sum is computed row-wise, and the result is a frame of shape " +
+            "[nrows x 1], where nrows is the number of rows in the original frame. Flag na_rm controls treatment of " +
+            "the NA values: if it is 1, then NAs are ignored; if it is 0, then presence of NAs renders the result " +
+            "in that column (row) also NA.\n" +
+            "sum of a double / integer / binary column is a double value. sum of a categorical / string / uuid " +
+            "column is NA. sum of a time column is time. sum of a column with 0 rows is NaN.\n" +
+            "When computing row-wise sums, we try not to mix columns of different types. In particular, if there " +
+            "are any numeric columns, then all time columns are omitted from computation. However when computing " +
+            "sum over multiple time columns, then the Time result is returned. Lastly, binary columns are treated " +
+            "as NAs always.";
+  }
+
+  @Override
+  public Val apply(Env env, Env.StackHelp stk, AstRoot[] asts) {
+    Val val1 = asts[1].exec(env);
+    if (val1 instanceof ValFrame) {
+      Frame fr = stk.track(val1).getFrame();
+      boolean na_rm = asts[2].exec(env).getNum() == 1;
+      boolean axis = asts.length == 4 && (asts[3].exec(env).getNum() == 1);
+      return axis? rowwiseSum(fr, na_rm) : colwisesum(fr, na_rm);
+    }
+    else if (val1 instanceof ValRow) {
+      // This may be called from AstApply when doing per-row computations.
+      double[] row = val1.getRow();
+      boolean na_rm = asts[2].exec(env).getNum() == 1;
+      double d = 0;
+      int n = 0;
+      for (double r: row) {
+        if (Double.isNaN(r)) {
+          if (!na_rm)
+            return new ValRow(new double[]{Double.NaN}, null);
+        } else {
+          d += r;
+          n++;
+        }
+      }
+      return new ValRow(new double[]{d}, null);
+    } else
+      throw new IllegalArgumentException("Incorrect argument to (sum): expected a frame or a row, received " + val1.getClass());
+  }
+
+
+  /**
+   * Compute Frame sum for each row. This returns a frame consisting of a single Vec of sums in each row.
+   */
+  private ValFrame rowwiseSum(Frame fr, final boolean na_rm) {
+    String[] newnames = {"sum"};
+    Key<Frame> newkey = Key.make();
+
+    // Determine how many columns of different types we have
+    int n_numeric = 0, n_time = 0;
+    for (Vec vec : fr.vecs()) {
+      if (vec.isNumeric()) n_numeric++;
+      if (vec.isTime()) n_time++;
+    }
+    // Compute the type of the resulting column: if all columns are TIME then the result is also time; otherwise
+    // if at least one column is numeric then the result is also numeric.
+    byte resType = n_numeric > 0? Vec.T_NUM : Vec.T_TIME;
+
+    // Construct the frame over which the sum should be computed
+    Frame compFrame = new Frame();
+    for (int i = 0; i < fr.numCols(); i++) {
+      Vec vec = fr.vec(i);
+      if (n_numeric > 0? vec.isNumeric() : vec.isTime())
+        compFrame.add(fr.name(i), vec);
+    }
+    Vec anyvec = compFrame.anyVec();
+
+    //Certain corner cases
+    if (anyvec == null) {
+      Frame res = new Frame(newkey);
+      anyvec = fr.anyVec();
+      if (anyvec != null) {
+        // All columns in the original frame are non-numeric? Return a vec of NAs
+        res.add("sum", anyvec.makeCon(Double.NaN));
+      } // else the original frame is empty, in which case we return an empty frame too
+      return new ValFrame(res);
+    }
+    if (!na_rm && n_numeric < fr.numCols() && n_time < fr.numCols()) {
+      // If some of the columns are non-numeric and na_rm==false, then the result is a vec of NAs
+      Frame res = new Frame(newkey, newnames, new Vec[]{anyvec.makeCon(Double.NaN)});
+      return new ValFrame(res);
+    }
+
+    // Compute the sum over all rows
+    final int numCols = compFrame.numCols();
+    Frame res = new MRTask() {
+      @Override
+      public void map(Chunk[] cs, NewChunk nc) {
+        for (int i = 0; i < cs[0]._len; i++) {
+          double d = 0;
+          int numNaColumns = 0;
+          for (int j = 0; j < numCols; j++) {
+            double val = cs[j].atd(i);
+            if (Double.isNaN(val))
+              numNaColumns++;
+            else
+              d += val;
+          }
+          if (na_rm? numNaColumns < numCols : numNaColumns == 0)
+            nc.addNum(d);
+          else
+            nc.addNum(Double.NaN);
+        }
+      }
+    }.doAll(1, resType, compFrame)
+            .outputFrame(newkey, newnames, null);
+
+    // Return the result
+    return new ValFrame(res);
+  }
+
+
+  /**
+   * Compute column-wise sums and return a frame having a single row.
+   */
+  private ValFrame colwisesum(Frame fr, final boolean na_rm) {
+    Frame res = new Frame();
+
+    Vec vec1 = Vec.makeCon(null, 0);
+    assert vec1.length() == 1;
+
+    for (int i = 0; i < fr.numCols(); i++) {
+      Vec v = fr.vec(i);
+      boolean valid = (v.isNumeric() || v.isTime() || v.isBinary()) && v.length() > 0 && (na_rm || v.naCnt() == 0);
+      Vec newvec = vec1.makeCon(valid? v.mean() * (v.length() - v.naCnt()) : Double.NaN, v.isTime()? Vec.T_TIME : Vec.T_NUM);
+      res.add(fr.name(i), newvec);
+    }
+
+    vec1.remove();
+    return new ValFrame(res);
+  }
+}

--- a/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstSumAxisTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstSumAxisTest.java
@@ -1,0 +1,240 @@
+package water.rapids.ast.prims.reducers;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.DKV;
+import water.Key;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import water.rapids.Rapids;
+import water.rapids.Val;
+import water.rapids.vals.ValFrame;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Test the AstSumAxis.java class
+ */
+public class AstSumAxisTest extends TestUtil {
+    private static Vec vi1, vd1, vd2, vd3, vs1, vt1, vt2, vc1, vc2;
+    private static ArrayList<Frame> allFrames;
+
+    @BeforeClass public static void setup() {
+        stall_till_cloudsize(1);
+        vi1 = TestUtil.ivec(-1, -2, 0, 2, 1);
+        vd1 = TestUtil.dvec(1.5, 2.5, 3.5, 4.5, 8.0);
+        vd2 = TestUtil.dvec(0.2, 0.4, 0.6, 0.8, 1.0);
+        vd3 = TestUtil.dvec(1, 2, Double.NaN, 3, Double.NaN);
+        vs1 = TestUtil.svec("a", "b", "c", "d", "e");
+        vt1 = TestUtil.tvec(10000000, 10000020, 10000030, 10000040, 10000060);
+        vt2 = TestUtil.tvec(20000000, 20000020, 20000030, 20000040, 20000060);
+        vc1 = TestUtil.cvec(ar("N", "Y"), "Y", "N", "Y", "Y", "N");
+        vc2 = TestUtil.cvec("a", "c", "c", "b", "a");
+        allFrames = new ArrayList<>(10);
+    }
+
+    @AfterClass public static void teardown() {
+        for (Vec v : aro(vi1, vd1, vd2, vd3, vs1, vt1, vt2, vc1, vc2))
+            v.remove();
+        for (Frame f : allFrames)
+            f.delete();
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------
+    // Tests
+    //--------------------------------------------------------------------------------------------------------------------
+
+    @Test public void testAstSumGeneralStructure() {
+        AstSumAxis a = new AstSumAxis();
+        String[] args = a.args();
+        assertEquals(3, args.length);
+        String example = a.example();
+        assertTrue(example.startsWith("(sumaxis "));
+        String description = a.description();
+        assertTrue("Description for AstSum is too short", description.length() > 100);
+    }
+
+    @Test public void testColumnwisesumWithoutNaRm() {
+        Frame fr = register(new Frame(Key.<Frame>make(),
+                ar("I", "D", "DD", "DN", "T", "S", "C"),
+                aro(vi1, vd1, vd2, vd3, vt1, vs1, vc2)
+        ));
+        Val val1 = Rapids.exec("(sumaxis " + fr._key + " 0 0)");
+        assertTrue(val1 instanceof ValFrame);
+        Frame res = register(val1.getFrame());
+        assertArrayEquals(fr.names(), res.names());
+        assertArrayEquals(ar(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_TIME, Vec.T_NUM, Vec.T_NUM), res.types());
+        assertRowFrameEquals(ard(0.0, 20.0, 3.0, Double.NaN, 50000150.0, Double.NaN, Double.NaN), res);
+    }
+
+    @Test public void testColumnwiseSumWithNaRm() {
+        Frame fr = register(new Frame(Key.<Frame>make(),
+                ar("I", "D", "DD", "DN", "T", "S", "C"),
+                aro(vi1, vd1, vd2, vd3, vt1, vs1, vc2)
+        ));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 1 0)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertArrayEquals(fr.names(), res.names());
+        assertArrayEquals(ar(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_TIME, Vec.T_NUM, Vec.T_NUM), res.types());
+        assertRowFrameEquals(ard(0.0, 20.0, 3.0, 6.0, 50000150.0, Double.NaN, Double.NaN), res);
+    }
+
+    @Test public void testColumnwisesumOnEmptyFrame() {
+        Frame fr = register(new Frame(Key.<Frame>make()));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 0 0)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertEquals(res.numCols(), 0);
+        assertEquals(res.numRows(), 0);
+    }
+
+    @Test public void testColumnwisesumBinaryVec() {
+        assertTrue(vc1.isBinary() && !vc2.isBinary());
+        Frame fr = register(new Frame(Key.<Frame>make(), ar("C1", "C2"), aro(vc1, vc2)));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 1 0)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertArrayEquals(fr.names(), res.names());
+        assertArrayEquals(ar(Vec.T_NUM, Vec.T_NUM), res.types());
+        assertRowFrameEquals(ard(3.0, Double.NaN), res);
+    }
+
+    @Test public void testRowwisesumWithoutNaRm() {
+        Frame fr = register(new Frame(Key.<Frame>make(),
+                ar("i1", "d1", "d2", "d3"),
+                aro(vi1, vd1, vd2, vd3)
+        ));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 0 1)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertColFrameEquals(ard(1.7, 2.9, Double.NaN, 10.3, Double.NaN), res);
+        assertEquals("sum", res.name(0));
+    }
+
+    @Test public void testRowwisesumWithoutNaRmAndNonnumericColumn() {
+        Frame fr = register(new Frame(Key.<Frame>make(),
+                ar("i1", "d1", "d2", "d3", "s1"),
+                aro(vi1, vd1, vd2, vd3, vs1)
+        ));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 0 1)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertColFrameEquals(ard(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN), res);
+        assertEquals("sum", res.name(0));
+    }
+
+    @Test public void testRowwisesumWithNaRm() {
+        Frame fr = register(new Frame(Key.<Frame>make(),
+                ar("i1", "d1", "d2", "d3", "s1"),
+                aro(vi1, vd1, vd2, vd3, vs1)
+        ));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 1 1)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertEquals("Unexpected column name", "sum", res.name(0));
+        assertEquals("Unexpected column type", Vec.T_NUM, res.types()[0]);
+        assertColFrameEquals(ard(1.7, 2.9, 4.1, 10.3, 10.0), res);
+    }
+
+    @Test public void testRowwisesumOnFrameWithTimeColumnsOnly() {
+        Frame fr = register(new Frame(Key.<Frame>make(), ar("t1", "s", "t2"), aro(vt1, vs1, vt2)));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 1 1)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertEquals("Unexpected column name", "sum", res.name(0));
+        assertEquals("Unexpected column type", Vec.T_TIME, res.types()[0]);
+        assertColFrameEquals(ard(30000000, 30000040, 30000060, 30000080, 30000120), res);
+    }
+
+    @Test public void testRowwisesumOnFrameWithTimeandNumericColumn() {
+        Frame fr = register(new Frame(Key.<Frame>make(), ar("t1", "i1"), aro(vt1, vi1)));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 1 1)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertColFrameEquals(ard(-1, -2, 0, 2, 1), res);
+    }
+
+    @Test public void testRowwisesumOnEmptyFrame() {
+        Frame fr = register(new Frame(Key.<Frame>make()));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 0 1)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertEquals(res.numCols(), 0);
+        assertEquals(res.numRows(), 0);
+    }
+
+    @Test public void testRowwisesumOnFrameWithNonnumericColumnsOnly() {
+        Frame fr = register(new Frame(Key.<Frame>make(), ar("c1", "s1"), aro(vc2, vs1)));
+        Val val = Rapids.exec("(sumaxis " + fr._key + " 1 1)");
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertEquals("Unexpected column name", "sum", res.name(0));
+        assertEquals("Unexpected column type", Vec.T_NUM, res.types()[0]);
+        assertColFrameEquals(ard(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN), res);
+    }
+
+    @Test public void testBadFirstArgument() {
+        try {
+            Rapids.exec("(sumaxis " + vi1._key + " 1 0)");
+            fail();
+        } catch (IllegalArgumentException ignored) {}
+        try {
+            Rapids.exec("(sum hello 1 0)");
+            fail();
+        } catch (IllegalArgumentException ignored) {}
+        try {
+            Rapids.exec("(sum 2 1 0)");
+            fail();
+        } catch (IllegalArgumentException ignored) {}
+    }
+
+    @Test public void testValRowArgument() {
+        Frame fr = register(new Frame(Key.<Frame>make(),
+                ar("i1", "d1", "d2", "d3"),
+                aro(vi1, vd1, vd2, vd3)
+        ));
+        Val val = Rapids.exec("(apply " + fr._key + " 1 {x . (sumaxis x 1)})");  // skip NAs
+        assertTrue(val instanceof ValFrame);
+        Frame res = register(val.getFrame());
+        assertColFrameEquals(ard(1.7, 2.9, 4.1, 10.3, 10.0), res);
+
+        Val val2 = Rapids.exec("(apply " + fr._key + " 1 {x . (sumaxis x 0)})");  // do not skip NAs
+        assertTrue(val2 instanceof ValFrame);
+        Frame res2 = register(val2.getFrame());
+        assertColFrameEquals(ard(1.7, 2.9, Double.NaN, 10.3, Double.NaN), res2);
+    }
+
+
+    //--------------------------------------------------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------------------------------------------------
+
+    private static void assertRowFrameEquals(double[] expected, Frame actual) {
+        assertEquals(1, actual.numRows());
+        assertEquals(expected.length, actual.numCols());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("Wrong sum in column " + actual.name(i), expected[i], actual.vec(i).at(0), 1e-8);
+        }
+    }
+
+    private static void assertColFrameEquals(double[] expected, Frame actual) {
+        assertEquals(1, actual.numCols());
+        assertEquals(expected.length, actual.numRows());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("Wrong sum in row " + i, expected[i], actual.vec(0).at(i), 1e-8);
+        }
+    }
+
+    private static Frame register(Frame f) {
+        if (f._key != null) DKV.put(f._key, f);
+        allFrames.add(f);
+        return f;
+    }
+
+}

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2337,7 +2337,7 @@ class H2OFrame(object):
           mids, and density; otherwise produce the plot.
         """
         frame = H2OFrame._expr(expr=ExprNode("hist", self, breaks))._frame()
-        total = frame["counts"].sum(True)
+        total = frame["counts"].sum(True,return_frame=False)
         densities = [[(frame[i, "counts"] / total) * (1 / (frame[i, "breaks"] - frame[i - 1, "breaks"]))] for i in
                      range(1, frame["counts"].nrow)]
         densities.insert(0, [0])

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2563,8 +2563,8 @@ def compare_frames(frame1, frame2, numElements, tol_time=0, tol_numeric=0, stric
     assert rows1 == rows2 and cols1 == cols2, "failed dim check! frame 1 rows:{0} frame 2 rows:{1} frame 1 cols:{2} " \
                                               "frame2 cols:{3}".format(rows1, rows2, cols1, cols2)
 
-    na_frame1 = frame1.isna().sum()
-    na_frame2 = frame2.isna().sum()
+    na_frame1 = frame1.isna().sum().sum(axis=1)[:,0]
+    na_frame2 = frame2.isna().sum().sum(axis=1)[:,0]
 
     if compare_NA:      # check number of missing values
         assert na_frame1 == na_frame2, "failed numbers of NA check!  Frame 1 NA number: {0}, frame 2 " \

--- a/h2o-py/tests/testdir_misc/pyunit_empty_strings.py
+++ b/h2o-py/tests/testdir_misc/pyunit_empty_strings.py
@@ -14,18 +14,18 @@ def empty_strings():
     ,'f':["",""]
      }
   )
-  assert d.isna().sum() == 0
-  assert (d == '').sum() == d.nrow * d.ncol
+  assert d.isna().sum().sum(axis=1)[:,0] == 0
+  assert (d == '').sum().sum(axis=1)[:,0] == d.nrow * d.ncol
 
   #single list
   d = h2o.H2OFrame([""]*4)
-  assert d.isna().sum() == 0
-  assert (d == '').sum() == d.nrow * d.ncol
+  assert d.isna().sum().sum(axis=1)[:,0] == 0
+  assert (d == '').sum().sum(axis=1)[:,0] == d.nrow * d.ncol
 
   #list of lists
   d = h2o.H2OFrame([[""]*4]*3)
-  assert d.isna().sum() == 0
-  assert (d == '').sum() == d.nrow * d.ncol
+  assert d.isna().sum().sum(axis=1)[:,0] == 0
+  assert (d == '').sum().sum(axis=1)[:,0] == d.nrow * d.ncol
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_munging/unop/pyunit_frame_reducers.py
+++ b/h2o-py/tests/testdir_munging/unop/pyunit_frame_reducers.py
@@ -28,7 +28,7 @@ def frame_reducers():
     assert abs(h2o_val - num_val) < 1e-06, \
         "check unsuccessful! h2o computed {0} and numpy computed {1}. expected equal max values between h2o and " \
         "numpy".format(h2o_val,num_val)
-    h2o_val = h2o_data.sum()
+    h2o_val = h2o_data.sum().sum(axis=1)[:,0]
     num_val = np.sum(np_data)
     assert abs(h2o_val - num_val) < 1e-06, \
         "check unsuccessful! h2o computed {0} and numpy computed {1}. expected equal sum values between h2o and " \

--- a/h2o-py/tests/testdir_munging/unop/pyunit_frame_reducers2.py
+++ b/h2o-py/tests/testdir_munging/unop/pyunit_frame_reducers2.py
@@ -44,7 +44,7 @@ def expr_reducers():
     assert abs(h2o_val - num_val) < 1e-06, \
         "check unsuccessful! h2o computed {0} and numpy computed {1}. expected equal max values between h2o and " \
         "numpy".format(h2o_val,num_val)
-    h2o_val = h2o_data.sum()
+    h2o_val = h2o_data.sum().sum(axis=1)[:,0]
     num_val = np.sum(np_data)
     assert abs(h2o_val - num_val) < 1e-06, \
         "check unsuccessful! h2o computed {0} and numpy computed {1}. expected equal sum values between h2o and " \

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2582,15 +2582,21 @@ h2o.floor <- function(x) {
 }
 
 #'
-#' Return the sum of all the values present in its arguments.
+#' Compute the frame's sum by-column (or by-row).
 #'
 #' @name h2o.sum
 #' @param x An H2OFrame object.
 #' @param na.rm \code{logical}. indicating whether missing values should be removed.
+#' @param axis An int that indicates whether to do down a column (0) or across a row (1).
+#' @param return_frame A boolean that indicates whether to return an H2O frame or a list. Default is FALSE.
 #' @seealso \code{\link[base]{sum}} for the base R implementation.
 #' @export
-h2o.sum <- function(x,na.rm = FALSE) {
-  sum(x,na.rm = na.rm)
+h2o.sum <- function(x, na.rm = FALSE, axis = 0, return_frame = FALSE) {
+   if(return_frame){
+      .newExpr("sumaxis", chk.H2OFrame(x), na.rm, axis)
+  }else{
+    sum(x,na.rm = na.rm)
+  }
 }
 
 #'

--- a/h2o-r/tests/testdir_munging/unop/runit_sum_axis.R
+++ b/h2o-r/tests/testdir_munging/unop/runit_sum_axis.R
@@ -1,0 +1,107 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+##
+# Test out the h2o.sum() functionality
+##
+
+
+test.sum <- function(){
+    #Set up H2OFrame
+    fr <- h2o.createFrame(rows = 100, cols = 10, categorical_fraction = 0,
+    factors = 0, integer_fraction = 1.0, integer_range = 100,
+    binary_fraction = 0, time_fraction = 0, string_fraction = 0,
+    has_response = FALSE,seed = 123456789)
+
+    ################################################################
+    #Testing h2o.sum and have a frame returned
+    sum_return_frame <- h2o.sum(fr,return_frame = TRUE)
+
+    #Testing h2o.sum and have a list returned
+    sum_return_list <- h2o.sum(fr)
+
+    #Check types returned are correct
+    expect_equal(class(sum_return_frame),"H2OFrame")
+    expect_equal(class(sum_return_list),"numeric")
+
+    ################################################################
+    #Check axis arguments set to 1 (row sum) and compare to R
+    sum_frame_axis <- h2o.sum(fr,na.rm=TRUE,axis=1,return_frame=TRUE)
+    fr_df <- as.data.frame(fr)
+    sum_list_axis <- rowSums(fr_df,na.rm=TRUE)
+
+    #Convert previous H2O Frame to data frames for comparison
+    sum_frame_axis_df <- as.data.frame(sum_frame_axis)
+    sum_list_axis_df <- as.data.frame(sum_list_axis)
+    colnames(sum_list_axis_df) <- c("sum")
+    cat("Check axis arguments set to 1 (row sum) and compare to R\n")
+    print(sum_frame_axis_df)
+    print(sum_list_axis_df)
+    expect_equal(sum_frame_axis_df,sum_list_axis_df,tol=1e-6)
+    ################################################################
+    #Check axis arguments set to 0 (col sum) and compare to R
+    sum_frame_axis <- h2o.sum(fr,na.rm=TRUE,axis=0,return_frame=TRUE)
+    fr_df <- as.data.frame(fr)
+    sum_list_axis <- colSums(fr_df,na.rm=TRUE)
+
+    #Convert previous H2O Frame to data frames for comparison
+    sum_frame_axis_df <- as.data.frame(t(sum_frame_axis))
+    sum_list_axis_df <- as.data.frame(sum_list_axis)
+    colnames(sum_list_axis_df) <- c("sum")
+    colnames(sum_frame_axis_df) <- c("sum")
+    rownames(sum_frame_axis_df) <- c()
+    rownames(sum_list_axis_df) <- c()
+    cat("Check axis arguments set to 0 (col sum) and compare to R\n")
+    print(sum_frame_axis_df)
+    print(sum_list_axis_df)
+    expect_equal(sum_frame_axis_df,sum_list_axis_df,tol=1e-6)
+    ######################################################################################################################
+
+    #Check previous with na.rm=FALSE and add a couple NA's to columns
+    fr[1,1] <- NA
+    fr[2,2] <- NA
+    ################################################################
+    #Check axis arguments set to 1 (row sum) and compare to R
+    sum_frame_axis <- h2o.sum(fr,na.rm=FALSE,axis=1,return_frame=TRUE)
+    fr_df <- as.data.frame(fr)
+    sum_list_axis <- rowSums(fr_df,na.rm=FALSE)
+
+    #Convert previous H2O Frame to data frames for comparison
+    sum_frame_axis_df <- as.data.frame(sum_frame_axis)
+    sum_list_axis_df <- as.data.frame(sum_list_axis)
+    colnames(sum_list_axis_df) <- c("sum")
+    cat("Check axis arguments set to 1 (row sum) & na.rm = FALSE and compare to R\n")
+    print(sum_frame_axis_df)
+    print(sum_list_axis_df)
+    expect_equal(sum_frame_axis_df,sum_list_axis_df,tol=1e-6)
+    ################################################################
+    #Check axis arguments set to 0 (col sum) and compare to R
+    sum_frame_axis <- h2o.sum(fr,na.rm=FALSE,axis=0,return_frame=TRUE)
+    fr_df = as.data.frame(fr)
+    sum_list_axis <- colSums(fr_df,na.rm=FALSE)
+
+    #Convert previous H2O Frame to data frames for comparison
+    sum_frame_axis_df <- as.data.frame(t(sum_frame_axis))
+    sum_list_axis_df <- as.data.frame(sum_list_axis)
+    colnames(sum_list_axis_df) <- c("sum")
+    colnames(sum_frame_axis_df) <- c("sum")
+    rownames(sum_frame_axis_df) <- c()
+    rownames(sum_list_axis_df) <- c()
+    cat("Check axis arguments set to 0 (col sum) & na.rm = FALSE and compare to R\n")
+    print(sum_frame_axis_df)
+    print(sum_list_axis_df)
+    expect_equal(sum_frame_axis_df,sum_list_axis_df)
+
+    ################################################################
+    #Check if axis is ignored when return_frame=FALSE
+    sum_list <- h2o.sum(fr,na.rm=FALSE)
+    sum_list_ignore_row <- h2o.sum(fr,na.rm=FALSE,axis=1)
+    sum_list_ignore_col <- h2o.sum(fr,na.rm=FALSE,axis=0)
+    cat("Check if axis is ignored when return_frame=FALSE\n")
+    print(sum_list_ignore_row)
+    print(sum_list_ignore_col)
+    expect_equal(sum_list,sum_list_ignore_row)
+    expect_equal(sum_list,sum_list_ignore_col)
+    expect_equal(sum_list_ignore_col,sum_list_ignore_row)
+}
+
+doTest("Test out the h2o.sum() functionality", test.sum)


### PR DESCRIPTION
* Now it returns a ValFrame of sums per column or row instead of the sum for an entire frame, also added axis parameter (0 = column wise sum and 1 = row wise sum), and improved documentation. 
* Added AstSumTest junit, as well. 
* By default this function will return a list to ensure backward compatibility (assuming users were looping through columns and getting sums for each column).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/527)
<!-- Reviewable:end -->
