### PR TITLE
PUBDEV-3719: Update h2o.mean in R to match Python API

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1981,25 +1981,36 @@ summary.H2OFrame <- h2o.summary
 #-----------------------------------------------------------------------------------------------------------------------
 
 #'
-#' Mean of a column
-#'
-#' Obtain the mean of a column of a parsed H2O data object.
+#' Compute the frame's mean by-column (or by-row).
 #'
 #' @name h2o.mean
 #' @param x An H2OFrame object.
-#' @param ... Further arguments to be passed from or to other methods.
-#' @param na.rm A logical value indicating whether \code{NA} or missing values should be stripped before the computation.
+#' @param na.rm \code{logical}. Indicate whether missing values should be removed.
+#' @param axis \code{integer}. Indicate whether to calculate the mean down a column (0) or across a row (1).
+#'                             NOTE: This is only applied when return_frame is set to TRUE. Otherwise, this parameter
+#'                             is ignored.
+#' @param return_frame \code{logical}. Indicate whether to return an H2O frame or a list. Default is FALSE (returns a list).
 #' @seealso \code{\link[base]{mean}} for the base R implementation.
-#' @return Returns a list containing the mean for each column (NaN for non-numeric columns).
+#' @return Returns a list containing the mean for each column (NaN for non-numeric columns) if return_frame is set to FALSE.
+#'         If return_frame is set to TRUE, then it will return an H2O frame with means per column or row (depends on axis argument).
 #' @examples
 #' \donttest{
 #' h2o.init()
 #' prosPath <- system.file("extdata", "prostate.csv", package="h2o")
 #' prostate.hex <- h2o.uploadFile(path = prosPath)
-#' mean(prostate.hex$AGE)
+#' # Default behavior. Will return list of means per column.
+#' h2o.mean(prostate.hex$AGE)
+#' # return_frame set to TRUE. This will return an H2O Frame with mean per row or column (depends on axis argument)
+#' h2o.mean(prostate.hex,na.rm=TRUE,axis=1,return_frame=TRUE)
 #' }
 #' @export
-h2o.mean <- function(x, ..., na.rm=TRUE) .eval.scalar(.newExpr("getrow", .newExpr("mean",x,na.rm)))
+h2o.mean <- function(x, na.rm = FALSE, axis = 0, return_frame = FALSE, ...) {
+  if(return_frame){
+    .newExpr("mean", chk.H2OFrame(x), na.rm, axis)
+  }else{
+    .eval.scalar(.newExpr("getrow", .newExpr("mean",x,na.rm)))
+  }
+}
 
 #' @rdname h2o.mean
 #' @export

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1990,7 +1990,8 @@ summary.H2OFrame <- h2o.summary
 #'                             NOTE: This is only applied when return_frame is set to TRUE. Otherwise, this parameter
 #'                             is ignored.
 #' @param return_frame \code{logical}. Indicate whether to return an H2O frame or a list. Default is FALSE (returns a list).
-#' @seealso \code{\link[base]{mean}} for the base R implementation.
+#' @param ... Further arguments to be passed from or to other methods.
+#' @seealso \code{\link[base]{mean}} , \code{\link[base]{rowMeans}}, or \code{\link[base]{colMeans}} for the base R implementation
 #' @return Returns a list containing the mean for each column (NaN for non-numeric columns) if return_frame is set to FALSE.
 #'         If return_frame is set to TRUE, then it will return an H2O frame with means per column or row (depends on axis argument).
 #' @examples
@@ -2000,7 +2001,8 @@ summary.H2OFrame <- h2o.summary
 #' prostate.hex <- h2o.uploadFile(path = prosPath)
 #' # Default behavior. Will return list of means per column.
 #' h2o.mean(prostate.hex$AGE)
-#' # return_frame set to TRUE. This will return an H2O Frame with mean per row or column (depends on axis argument)
+#' # return_frame set to TRUE. This will return an H2O Frame
+#' # with mean per row or column (depends on axis argument)
 #' h2o.mean(prostate.hex,na.rm=TRUE,axis=1,return_frame=TRUE)
 #' }
 #' @export

--- a/h2o-r/tests/testdir_munging/unop/runit_mean_axis.R
+++ b/h2o-r/tests/testdir_munging/unop/runit_mean_axis.R
@@ -7,17 +7,17 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 test.mean <- function(){
   #Set up H2OFrame
-  fr = h2o.createFrame(rows = 100, cols = 10, categorical_fraction = 0,
+  fr <- h2o.createFrame(rows = 100, cols = 10, categorical_fraction = 0,
                     factors = 0, integer_fraction = 1.0, integer_range = 100,
                     binary_fraction = 0, time_fraction = 0, string_fraction = 0,
                     has_response = FALSE)
 
   ################################################################
   #Testing h2o.mean and have a frame returned
-  mean_return_frame = h2o.mean(fr,return_frame = TRUE)
+  mean_return_frame <- h2o.mean(fr,return_frame = TRUE)
 
   #Testing h2o.mean and have a list returned
-  mean_return_list = h2o.mean(fr)
+  mean_return_list <- h2o.mean(fr)
 
   #Check types returned are correct
   expect_equal(class(mean_return_frame),"H2OFrame")
@@ -25,71 +25,71 @@ test.mean <- function(){
 
   ################################################################
   #Check axis arguments set to 1 (row mean) and compare to R
-  mean_frame_axis = h2o.mean(fr,na.rm=TRUE,axis=1,return_frame=TRUE)
-  fr_df = as.data.frame(fr)
-  mean_list_axis = rowMeans(fr_df,na.rm=TRUE)
+  mean_frame_axis <- h2o.mean(fr,na.rm=TRUE,axis=1,return_frame=TRUE)
+  fr_df <- as.data.frame(fr)
+  mean_list_axis <- rowMeans(fr_df,na.rm=TRUE)
 
   #Convert previous H2O Frame to data frames for comparison
-  mean_frame_axis_df = as.data.frame(mean_frame_axis)
-  mean_list_axis_df = as.data.frame(mean_list_axis)
-  colnames(mean_list_axis_df) = c("mean")
+  mean_frame_axis_df <- as.data.frame(mean_frame_axis)
+  mean_list_axis_df <- as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) <- c("mean")
 
   expect_equal(mean_frame_axis_df,mean_list_axis_df,tol=1e-6)
 
   ################################################################
   #Check axis arguments set to 0 (col mean) and compare to R
-  mean_frame_axis = h2o.mean(fr,na.rm=TRUE,axis=0,return_frame=TRUE)
-  fr_df = as.data.frame(fr)
-  mean_list_axis = colMeans(fr_df,na.rm=TRUE)
+  mean_frame_axis <- h2o.mean(fr,na.rm=TRUE,axis=0,return_frame=TRUE)
+  fr_df <- as.data.frame(fr)
+  mean_list_axis <- colMeans(fr_df,na.rm=TRUE)
 
   #Convert previous H2O Frame to data frames for comparison
-  mean_frame_axis_df = as.data.frame(t(mean_frame_axis))
-  mean_list_axis_df = as.data.frame(mean_list_axis)
-  colnames(mean_list_axis_df) = c("mean")
-  colnames(mean_frame_axis_df) = c("mean")
-  rownames(mean_frame_axis_df) = c()
-  rownames(mean_list_axis_df) = c()
+  mean_frame_axis_df <- as.data.frame(t(mean_frame_axis))
+  mean_list_axis_df <- as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) <- c("mean")
+  colnames(mean_frame_axis_df) <- c("mean")
+  rownames(mean_frame_axis_df) <- c()
+  rownames(mean_list_axis_df) <- c()
   expect_equal(mean_frame_axis_df,mean_list_axis_df,tol=1e-6)
 
   ######################################################################################################################
 
   #Check previous with na.rm=FALSE and add a couple NA's to columns
-  fr[1,1] = NA
-  fr[2,2] = NA
+  fr[1,1] <- NA
+  fr[2,2] <- NA
   print(fr)
   ################################################################
   #Check axis arguments set to 1 (row mean) and compare to R
-  mean_frame_axis = h2o.mean(fr,na.rm=FALSE,axis=1,return_frame=TRUE)
-  fr_df = as.data.frame(fr)
-  mean_list_axis = rowMeans(fr_df,na.rm=FALSE)
+  mean_frame_axis <- h2o.mean(fr,na.rm=FALSE,axis=1,return_frame=TRUE)
+  fr_df <- as.data.frame(fr)
+  mean_list_axis <- rowMeans(fr_df,na.rm=FALSE)
 
   #Convert previous H2O Frame to data frames for comparison
-  mean_frame_axis_df = as.data.frame(mean_frame_axis)
-  mean_list_axis_df = as.data.frame(mean_list_axis)
-  colnames(mean_list_axis_df) = c("mean")
+  mean_frame_axis_df <- as.data.frame(mean_frame_axis)
+  mean_list_axis_df <- as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) <- c("mean")
 
   expect_equal(mean_frame_axis_df,mean_list_axis_df,tol=1e-6)
 
   ################################################################
   #Check axis arguments set to 0 (col mean) and compare to R
-  mean_frame_axis = h2o.mean(fr,na.rm=FALSE,axis=0,return_frame=TRUE)
+  mean_frame_axis <- h2o.mean(fr,na.rm=FALSE,axis=0,return_frame=TRUE)
   fr_df = as.data.frame(fr)
-  mean_list_axis = colMeans(fr_df,na.rm=FALSE)
+  mean_list_axis <- colMeans(fr_df,na.rm=FALSE)
 
   #Convert previous H2O Frame to data frames for comparison
-  mean_frame_axis_df = as.data.frame(t(mean_frame_axis))
-  mean_list_axis_df = as.data.frame(mean_list_axis)
-  colnames(mean_list_axis_df) = c("mean")
-  colnames(mean_frame_axis_df) = c("mean")
-  rownames(mean_frame_axis_df) = c()
-  rownames(mean_list_axis_df) = c()
+  mean_frame_axis_df <- as.data.frame(t(mean_frame_axis))
+  mean_list_axis_df <- as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) <- c("mean")
+  colnames(mean_frame_axis_df) <- c("mean")
+  rownames(mean_frame_axis_df) <- c()
+  rownames(mean_list_axis_df) <- c()
   expect_equal(mean_frame_axis_df,mean_list_axis_df)
 
   ################################################################
   #Check if axis is ignored when return_frame=FALSE
-  mean_list = h2o.mean(fr,na.rm=FALSE)
-  mean_list_ignore_row = h2o.mean(fr,na.rm=FALSE,axis=1)
-  mean_list_ignore_col = h2o.mean(fr,na.rm=FALSE,axis=0)
+  mean_list <- h2o.mean(fr,na.rm=FALSE)
+  mean_list_ignore_row <- h2o.mean(fr,na.rm=FALSE,axis=1)
+  mean_list_ignore_col <- h2o.mean(fr,na.rm=FALSE,axis=0)
   expect_equal(mean_list,mean_list_ignore_row)
   expect_equal(mean_list,mean_list_ignore_col)
   expect_equal(mean_list_ignore_col,mean_list_ignore_row)

--- a/h2o-r/tests/testdir_munging/unop/runit_mean_axis.R
+++ b/h2o-r/tests/testdir_munging/unop/runit_mean_axis.R
@@ -1,0 +1,98 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+##
+# Test out the h2o.mean() functionality
+##
+
+
+test.mean <- function(){
+  #Set up H2OFrame
+  fr = h2o.createFrame(rows = 100, cols = 10, categorical_fraction = 0,
+                    factors = 0, integer_fraction = 1.0, integer_range = 100,
+                    binary_fraction = 0, time_fraction = 0, string_fraction = 0,
+                    has_response = FALSE)
+
+  ################################################################
+  #Testing h2o.mean and have a frame returned
+  mean_return_frame = h2o.mean(fr,return_frame = TRUE)
+
+  #Testing h2o.mean and have a list returned
+  mean_return_list = h2o.mean(fr)
+
+  #Check types returned are correct
+  expect_equal(class(mean_return_frame),"H2OFrame")
+  expect_equal(class(mean_return_list),"numeric")
+
+  ################################################################
+  #Check axis arguments set to 1 (row mean) and compare to R
+  mean_frame_axis = h2o.mean(fr,na.rm=TRUE,axis=1,return_frame=TRUE)
+  fr_df = as.data.frame(fr)
+  mean_list_axis = rowMeans(fr_df,na.rm=TRUE)
+
+  #Convert previous H2O Frame to data frames for comparison
+  mean_frame_axis_df = as.data.frame(mean_frame_axis)
+  mean_list_axis_df = as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) = c("mean")
+
+  expect_equal(mean_frame_axis_df,mean_list_axis_df,tol=1e-6)
+
+  ################################################################
+  #Check axis arguments set to 0 (col mean) and compare to R
+  mean_frame_axis = h2o.mean(fr,na.rm=TRUE,axis=0,return_frame=TRUE)
+  fr_df = as.data.frame(fr)
+  mean_list_axis = colMeans(fr_df,na.rm=TRUE)
+
+  #Convert previous H2O Frame to data frames for comparison
+  mean_frame_axis_df = as.data.frame(t(mean_frame_axis))
+  mean_list_axis_df = as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) = c("mean")
+  colnames(mean_frame_axis_df) = c("mean")
+  rownames(mean_frame_axis_df) = c()
+  rownames(mean_list_axis_df) = c()
+  expect_equal(mean_frame_axis_df,mean_list_axis_df,tol=1e-6)
+
+  ######################################################################################################################
+
+  #Check previous with na.rm=FALSE and add a couple NA's to columns
+  fr[1,1] = NA
+  fr[2,2] = NA
+  print(fr)
+  ################################################################
+  #Check axis arguments set to 1 (row mean) and compare to R
+  mean_frame_axis = h2o.mean(fr,na.rm=FALSE,axis=1,return_frame=TRUE)
+  fr_df = as.data.frame(fr)
+  mean_list_axis = rowMeans(fr_df,na.rm=FALSE)
+
+  #Convert previous H2O Frame to data frames for comparison
+  mean_frame_axis_df = as.data.frame(mean_frame_axis)
+  mean_list_axis_df = as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) = c("mean")
+
+  expect_equal(mean_frame_axis_df,mean_list_axis_df,tol=1e-6)
+
+  ################################################################
+  #Check axis arguments set to 0 (col mean) and compare to R
+  mean_frame_axis = h2o.mean(fr,na.rm=FALSE,axis=0,return_frame=TRUE)
+  fr_df = as.data.frame(fr)
+  mean_list_axis = colMeans(fr_df,na.rm=FALSE)
+
+  #Convert previous H2O Frame to data frames for comparison
+  mean_frame_axis_df = as.data.frame(t(mean_frame_axis))
+  mean_list_axis_df = as.data.frame(mean_list_axis)
+  colnames(mean_list_axis_df) = c("mean")
+  colnames(mean_frame_axis_df) = c("mean")
+  rownames(mean_frame_axis_df) = c()
+  rownames(mean_list_axis_df) = c()
+  expect_equal(mean_frame_axis_df,mean_list_axis_df)
+
+  ################################################################
+  #Check if axis is ignored when return_frame=FALSE
+  mean_list = h2o.mean(fr,na.rm=FALSE)
+  mean_list_ignore_row = h2o.mean(fr,na.rm=FALSE,axis=1)
+  mean_list_ignore_col = h2o.mean(fr,na.rm=FALSE,axis=0)
+  expect_equal(mean_list,mean_list_ignore_row)
+  expect_equal(mean_list,mean_list_ignore_col)
+  expect_equal(mean_list_ignore_col,mean_list_ignore_row)
+}
+
+doTest("Test out the h2o.mean() functionality", test.mean)


### PR DESCRIPTION
* This PR updates the mean calculation in R.
* It provides a `return_frame` argument. Default is set to false to ensure we are not returning a frame, but instead returning a list (old behavior).
* If a user sets `return_frame` to TRUE, then they can utilize the `axis` argument. Otherwise, the `axis` argument is ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/534)
<!-- Reviewable:end -->
