### PR TITLE
Further GBM/DRF performance update.

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -232,7 +232,8 @@ public final class DHistogram extends Iced {
   public double bins(int b) { return w(b); }
 
   // Big allocation of arrays
-  public void init() {
+  public void init() { init(null);}
+  public void init(double [] vals) {
     assert _vals == null;
     if (_histoType==SharedTreeModel.SharedTreeParameters.HistogramType.Random) {
       // every node makes the same split points
@@ -272,7 +273,7 @@ public final class DHistogram extends Iced {
     else assert(_histoType== SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive);
     //otherwise AUTO/UniformAdaptive
     assert(_nbin>0);
-    _vals = MemoryManager.malloc8d(3*_nbin+3);
+    _vals = vals == null?MemoryManager.malloc8d(3*_nbin+3):vals;
   }
 
   // Add one row to a bin found via simple linear interpolation.
@@ -299,11 +300,11 @@ public final class DHistogram extends Iced {
   public void add( DHistogram dsh ) {
     assert _isInt == dsh._isInt && _nbin == dsh._nbin && _step == dsh._step &&
       _min == dsh._min && _maxEx == dsh._maxEx;
-    assert (_vals == null && dsh._vals == null) || (_vals != null && dsh._vals != null);
-    if( _vals == null ) return;
-    ArrayUtils.add(_vals,dsh._vals);
-    if( _min2 > dsh._min2  ) _min2 = dsh._min2;
-    if( _maxIn < dsh._maxIn) _maxIn = dsh._maxIn;
+    if( dsh._vals == null ) return;
+    if(_vals == null) init(dsh._vals);
+    else ArrayUtils.add(_vals, dsh._vals);
+    if (_min2 > dsh._min2) _min2 = dsh._min2;
+    if (_maxIn < dsh._maxIn) _maxIn = dsh._maxIn;
   }
 
   // Inclusive min & max

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -47,25 +47,27 @@ public final class DHistogram extends Iced {
   public char  _nbin;     // Bin count (excluding NA bucket)
   public double _step;     // Linear interpolation step per bin
   public final double _min, _maxEx; // Conservative Min/Max over whole collection.  _maxEx is Exclusive.
-  public double _w[];           // weighted count of observations per bin, shared, atomically incremented
-  protected double[] _wY;
-  protected double[] _wYY; // weighted response per bin and weighted squared response per bin, shared, atomically incremented
 
-  private double [] _naCnts;
+  protected double [] _vals;
+  public double w(int i){  return _vals[3*i+0];}
+  public double wY(int i){ return _vals[3*i+1];}
+  public double wYY(int i){return _vals[3*i+2];}
+
+
   public void addNasAtomic(double y, double wy, double wyy) {
-    AtomicUtils.DoubleArray.add(_naCnts,0,y);
-    AtomicUtils.DoubleArray.add(_naCnts,1,wy);
-    AtomicUtils.DoubleArray.add(_naCnts,2,wyy);
+    AtomicUtils.DoubleArray.add(_vals,3*_nbin+0,y);
+    AtomicUtils.DoubleArray.add(_vals,3*_nbin+1,wy);
+    AtomicUtils.DoubleArray.add(_vals,3*_nbin+2,wyy);
   }
   public void addNasPlain(double... ds) {
-    _naCnts[0] += ds[0];
-    _naCnts[1] += ds[1];
-    _naCnts[2] += ds[2];
+    _vals[3*_nbin+0] += ds[0];
+    _vals[3*_nbin+1] += ds[1];
+    _vals[3*_nbin+2] += ds[2];
   }
 
-  public double wNA()   { return _naCnts[0]; }
-  public double wYNA()  { return _naCnts[1]; }
-  public double wYYNA() { return _naCnts[2]; }
+  public double wNA()   { return _vals[3*_nbin+0]; }
+  public double wYNA()  { return _vals[3*_nbin+1]; }
+  public double wYYNA() { return _vals[3*_nbin+2]; }
 
 
 
@@ -192,9 +194,8 @@ public final class DHistogram extends Iced {
     }
     _nbin = (char) xbins;
     assert(_nbin>0);
-    assert(_w ==null);
-    assert(_wY ==null);
-    assert(_wYY ==null);
+    assert(_vals ==null);
+
 //    Log.info("Histogram: " + this);
     // Do not allocate the big arrays here; wait for scoreCols to pick which cols will be used.
   }
@@ -204,12 +205,13 @@ public final class DHistogram extends Iced {
     assert( !Double.isNaN(col_data) ); //NAs go to a separate bucket
     if (Double.isInfinite(col_data)) // Put infinity to most left/right bin
       if (col_data<0) return 0;
-      else return _w.length-1;
+      else return _nbin-1;
     assert _min <= col_data && col_data < _maxEx : "Coldata " + col_data + " out of range " + this;
     // When the model is exposed to new test data, we could have data that is
     // out of range of any bin - however this binning call only happens during
     // model-building.
     int idx1;
+
     double pos = _hasQuantiles ? col_data : ((col_data - _min) * _step);
     if (_splitPts != null) {
       idx1 = Arrays.binarySearch(_splitPts, pos);
@@ -217,8 +219,8 @@ public final class DHistogram extends Iced {
     } else {
       idx1 = (int) pos;
     }
-    if (idx1 == _w.length) idx1--; // Roundoff error allows idx1 to hit upper bound, so truncate
-    assert 0 <= idx1 && idx1 < _w.length : idx1 + " " + _w.length;
+    if (idx1 == _nbin) idx1--; // Roundoff error allows idx1 to hit upper bound, so truncate
+    assert 0 <= idx1 && idx1 < _nbin : idx1 + " " + _nbin;
     return idx1;
   }
   public double binAt( int b ) {
@@ -227,11 +229,11 @@ public final class DHistogram extends Iced {
   }
 
   public int nbins() { return _nbin; }
-  public double bins(int b) { return _w[b]; }
+  public double bins(int b) { return w(b); }
 
   // Big allocation of arrays
   public void init() {
-    assert _w == null;
+    assert _vals == null;
     if (_histoType==SharedTreeModel.SharedTreeParameters.HistogramType.Random) {
       // every node makes the same split points
       Random rng = RandomUtils.getRNG((Double.doubleToRawLongBits(((_step+0.324)*_min+8.3425)+89.342*_maxEx) + 0xDECAF*_nbin + 0xC0FFEE*_isInt + _seed));
@@ -270,10 +272,7 @@ public final class DHistogram extends Iced {
     else assert(_histoType== SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive);
     //otherwise AUTO/UniformAdaptive
     assert(_nbin>0);
-    _w = MemoryManager.malloc8d(_nbin);
-    _wY = MemoryManager.malloc8d(_nbin);
-    _wYY = MemoryManager.malloc8d(_nbin);
-    _naCnts = new double[3];
+    _vals = MemoryManager.malloc8d(3*_nbin+3);
   }
 
   // Add one row to a bin found via simple linear interpolation.
@@ -286,7 +285,7 @@ public final class DHistogram extends Iced {
     }
     assert Double.isInfinite(col_data) || (_min <= col_data && col_data < _maxEx) : "col_data "+col_data+" out of range "+this;
     int b = bin(col_data);      // Compute bin# via linear interpolation
-    water.util.AtomicUtils.DoubleArray.add(_w,b,w); // Bump count in bin
+    water.util.AtomicUtils.DoubleArray.add(_vals,3*b,w); // Bump count in bin
     // Track actual lower/upper bound per-bin
     if (!Double.isInfinite(col_data)) {
       setMin(col_data);
@@ -300,13 +299,11 @@ public final class DHistogram extends Iced {
   public void add( DHistogram dsh ) {
     assert _isInt == dsh._isInt && _nbin == dsh._nbin && _step == dsh._step &&
       _min == dsh._min && _maxEx == dsh._maxEx;
-    assert (_w == null && dsh._w == null) || (_w != null && dsh._w != null);
-    if( _w == null ) return;
-    ArrayUtils.add(_w,dsh._w);
+    assert (_vals == null && dsh._vals == null) || (_vals != null && dsh._vals != null);
+    if( _vals == null ) return;
+    ArrayUtils.add(_vals,dsh._vals);
     if( _min2 > dsh._min2  ) _min2 = dsh._min2;
     if( _maxIn < dsh._maxIn) _maxIn = dsh._maxIn;
-    add0(dsh);
-    addNasPlain(dsh._naCnts);
   }
 
   // Inclusive min & max
@@ -352,9 +349,9 @@ public final class DHistogram extends Iced {
   @Override public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(_name).append(":").append(_min).append("-").append(_maxEx).append(" step=" + (1 / _step) + " nbins=" + nbins() + " isInt=" + _isInt);
-    if( _w != null ) {
-      for(int b = 0; b< _w.length; b++ ) {
-        sb.append(String.format("\ncnt=%f, [%f - %f], mean/var=", _w[b],_min+b/_step,_min+(b+1)/_step));
+    if( _vals != null ) {
+      for(int b = 0; b< _nbin; b++ ) {
+        sb.append(String.format("\ncnt=%f, [%f - %f], mean/var=", w(b),_min+b/_step,_min+(b+1)/_step));
         sb.append(String.format("%6.2f/%6.2f,", mean(b), var(b)));
       }
       sb.append('\n');
@@ -362,8 +359,8 @@ public final class DHistogram extends Iced {
     return sb.toString();
   }
   double mean(int b) {
-    double n = _w[b];
-    return n>0 ? _wY[b]/n : 0;
+    double n = w(b);
+    return n>0 ? wY(b)/n : 0;
   }
 
   /**
@@ -372,30 +369,25 @@ public final class DHistogram extends Iced {
    * @return sample variance (>= 0)
    */
   public double var (int b) {
-    double n = _w[b];
+    double n = w(b);
     if( n<=1 ) return 0;
-    return Math.max(0, (_wYY[b] - _wY[b]* _wY[b]/n)/(n-1)); //not strictly consistent with what is done elsewhere (use n instead of n-1 to get there)
+    return Math.max(0, (wYY(b) - wY(b)* wY(b)/n)/(n-1)); //not strictly consistent with what is done elsewhere (use n instead of n-1 to get there)
   }
 
   // Add one row to a bin found via simple linear interpolation.
   // Compute response mean & variance.
   // Done racily instead F/J map calls, so atomic
   public void incr0( int b, double y, double w ) {
-    AtomicUtils.DoubleArray.add(_wY,b,(float)(w*y)); //See 'HistogramTest' JUnit for float-casting rationalization
-    AtomicUtils.DoubleArray.add(_wYY,b,(float)(w*y*y));
+    AtomicUtils.DoubleArray.add(_vals,3*b+1,(float)(w*y)); //See 'HistogramTest' JUnit for float-casting rationalization
+    AtomicUtils.DoubleArray.add(_vals,3*b+2,(float)(w*y*y));
   }
   // Same, except square done by caller
   public void incr1( int b, double y, double yy) {
-    AtomicUtils.DoubleArray.add(_wY,b,(float)y); //See 'HistogramTest' JUnit for float-casting rationalization
-    AtomicUtils.DoubleArray.add(_wYY,b,(float)yy);
+    AtomicUtils.DoubleArray.add(_vals,3*b+1,(float)y); //See 'HistogramTest' JUnit for float-casting rationalization
+    AtomicUtils.DoubleArray.add(_vals,3*b+2,(float)yy);
   }
 
-  // Merge two equal histograms together.
-  // Done in a F/J reduce, so no synchronization needed.
-  public void add0( DHistogram dsh ) {
-    ArrayUtils.add(_wY,dsh._wY);
-    ArrayUtils.add(_wYY,dsh._wYY);
-  }
+
 
   public DTree.Split findBestSplitPoint(int col, double min_rows) {
     final int nbins = nbins();
@@ -404,9 +396,7 @@ public final class DHistogram extends Iced {
     // Histogram arrays used for splitting, these are either the original bins
     // (for an ordered predictor), or sorted by the mean response (for an
     // unordered predictor, i.e. categorical predictor).
-    double[]   w =   _w;
-    double[]  wY =  _wY;
-    double[] wYY = _wYY;
+    double[]   vals =   _vals;
     int idxs[] = null;          // and a reverse index mapping
 
     // For categorical (unordered) predictors, sort the bins by average
@@ -417,18 +407,18 @@ public final class DHistogram extends Iced {
       idxs = MemoryManager.malloc4(nbins+1); // Reverse index
       for( int i=0; i<nbins+1; i++ ) idxs[i] = i;
       final double[] avgs = MemoryManager.malloc8d(nbins+1);
-      for( int i=0; i<nbins; i++ ) avgs[i] = _w[i]==0 ? 0 : _wY[i]/ _w[i]; // Average response
+      for( int i=0; i<nbins; i++ ) avgs[i] = w(i)==0 ? 0 : wY(i)/ w(i); // Average response
       avgs[nbins] = Double.MAX_VALUE;
       ArrayUtils.sort(idxs, avgs);
       // Fill with sorted data.  Makes a copy, so the original data remains in
       // its original order.
-        w = MemoryManager.malloc8d(nbins);
-       wY = MemoryManager.malloc8d(nbins);
-      wYY = MemoryManager.malloc8d(nbins);
+        vals = MemoryManager.malloc8d(3*nbins);
+
       for( int i=0; i<nbins; i++ ) {
-          w[i] =   _w[idxs[i]];
-         wY[i] =  _wY[idxs[i]];
-        wYY[i] = _wYY[idxs[i]];
+          int id = idxs[i];
+          vals[3*i+0] = _vals[3*id+0];
+          vals[3*i+1] = _vals[3*id+1];
+          vals[3*i+2] = _vals[3*id+2];
       }
     }
 
@@ -437,11 +427,12 @@ public final class DHistogram extends Iced {
     double  wYlo[] = MemoryManager.malloc8d(nbins+1);
     double wYYlo[] = MemoryManager.malloc8d(nbins+1);
     for( int b=1; b<=nbins; b++ ) {
-      double n0 =   wlo[b-1], n1 =   w[b-1];
+      int id = 3*(b-1);
+      double n0 =   wlo[b-1], n1 = vals[id+0];
       if( n0==0 && n1==0 )
         continue;
-      double m0 =  wYlo[b-1], m1 =  wY[b-1];
-      double s0 = wYYlo[b-1], s1 = wYY[b-1];
+      double m0 =  wYlo[b-1], m1 = vals[id+1];
+      double s0 = wYYlo[b-1], s1 = vals[id+2];
         wlo[b] = n0+n1;
        wYlo[b] = m0+m1;
       wYYlo[b] = s0+s1;
@@ -465,11 +456,11 @@ public final class DHistogram extends Iced {
     double  wYhi[] = MemoryManager.malloc8d(nbins+1);
     double wYYhi[] = MemoryManager.malloc8d(nbins+1);
     for( int b=nbins-1; b>=0; b-- ) {
-      double n0 =   whi[b+1], n1 =   w[b];
+      double n0 =   whi[b+1], n1 = vals[3*b];
       if( n0==0 && n1==0 )
         continue;
-      double m0 =  wYhi[b+1], m1 =  wY[b];
-      double s0 = wYYhi[b+1], s1 = wYY[b];
+      double m0 =  wYhi[b+1], m1 = vals[3*b+1];
+      double s0 = wYYhi[b+1], s1 = vals[3*b+2];
         whi[b] = n0+n1;
        wYhi[b] = m0+m1;
       wYYhi[b] = s0+s1;
@@ -504,7 +495,7 @@ public final class DHistogram extends Iced {
     int best=0;                         // The no-split
     byte equal=0;                       // Ranged check
     for( int b=1; b<=nbins-1; b++ ) {
-      if( w[b] == 0 ) continue; // Ignore empty splits
+      if( vals[3*b] == 0 ) continue; // Ignore empty splits
       if( wlo[b]+wNA < min_rows ) continue;
       if( whi[b]+wNA < min_rows ) break; // w1 shrinks at the higher bin#s, so if it fails once it fails always
       // We're making an unbiased estimator, so that MSE==Var.
@@ -643,9 +634,9 @@ public final class DHistogram extends Iced {
     } else {
       // increment local pre-thread histograms
       int b = bin(c);
-      _w[b] += w;
-      _wY[b] += wy;
-      _wYY[b] += wyy;
+      _vals[3*b] += w;
+      _vals[3*b+1] += wy;
+      _vals[3*b+2] += wyy;
       if(c < _min2 ) _min2  = c;
       if(c > _maxIn) _maxIn = c;
     }
@@ -671,18 +662,18 @@ public final class DHistogram extends Iced {
       } else {
         // increment local pre-thread histograms
         int b = bin(col_data);
-        _w[b] += weight;
-        _wY[b] += wy;
-        _wYY[b] += wyy;
+        _vals[3*b] += weight;
+        _vals[3*b+1] += wy;
+        _vals[3*b+2] += wyy;
       }
     }
   }
 
   public void reducePrecision(){
-    if(_w == null) return;
-    for(int i = 0; i < _wY.length; ++i) {
-      _wY[i] =  (float)_wY[i];
-      _wYY[i] = (float) _wYY[i];
+    if(_vals == null) return;
+    for(int i = 0; i < _vals.length-3 /* do not reduce precision of NAs */; i+=3) {
+      _vals[i+1] = (float)_vals[i+1];
+      _vals[i+2] = (float)_vals[i+2];
     }
   }
 
@@ -715,18 +706,18 @@ public final class DHistogram extends Iced {
     // Atomically update histograms
     setMin(minmax[0]);       // Track actual lower/upper bound per-bin
     setMaxIn(minmax[1]);
-    final int len = _w.length;
+    final int len = _nbin;
     for( int b=0; b<len; b++ ) {
       if (lh.w(b) != 0) {
-        AtomicUtils.DoubleArray.add(_w, b, lh.w(b));
+        AtomicUtils.DoubleArray.add(_vals, 3*b+0, lh.w(b));
         lh.wClear(b);
       }
       if (lh.wY(b) != 0) {
-        AtomicUtils.DoubleArray.add(_wY, b, (float) lh.wY(b));
+        AtomicUtils.DoubleArray.add(_vals, 3*b+1, (float) lh.wY(b));
         lh.wYClear(b);
       }
       if (lh.wYY(b) != 0) {
-        AtomicUtils.DoubleArray.add(_wYY,b,(float)lh.wYY(b));
+        AtomicUtils.DoubleArray.add(_vals, 3*b+2,(float)lh.wYY(b));
         lh.wYYClear(b);
       }
     }

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -233,7 +233,7 @@ public class DTree extends Iced {
         // unrelated column will not change the j'th columns min/max.
         // Tighten min/max based on actual observed data for tracked columns
         double min, maxEx;
-        if( h._w == null ) { // Not tracked this last pass?
+        if( h._vals == null ) { // Not tracked this last pass?
           min = h._min;         // Then no improvement over last go
           maxEx = h._maxEx;
         } else {                // Else pick up tighter observed bounds
@@ -256,7 +256,7 @@ public class DTree extends Iced {
           switch( _equal ) {
           case 0:  // Ranged split; know something about the left & right sides
             if (_nasplit != DHistogram.NASplitDir.NAvsREST) {
-              if (h._w[_bin] == 0)
+              if (h._vals[3*_bin] == 0)
                 throw H2O.unimpl(); // Here I should walk up & down same as split() above.
             }
             assert _bs==null : "splat not defined for BitSet splits";
@@ -402,7 +402,7 @@ public class DTree extends Iced {
       for( int i=0; i<nbins; i++ ) {
         for( DHistogram h : _hs ) {
           if( h == null ) continue;
-          if( i < h.nbins() && h._w != null ) {
+          if( i < h.nbins() && h._vals != null ) {
             p(sb, h.bins(i),cntW).append('/');
             p(sb, h.binAt(i),mmmW).append('/');
             p(sb, h.binAt(i+1),mmmW).append('/');

--- a/h2o-algos/src/main/java/hex/tree/Sample.java
+++ b/h2o-algos/src/main/java/hex/tree/Sample.java
@@ -23,7 +23,7 @@ public class Sample extends MRTask<Sample> {
   public void map(Chunk nids, Chunk ys) {
     C4VolatileChunk nids2 = (C4VolatileChunk) nids;
     Random rand = RandomUtils.getRNG(_tree._seed);
-    int [] is = nids2.getValuesForWriting();
+    int [] is = nids2.getValues();
     for (int row = 0; row < nids._len; row++) {
       boolean skip = ys.isNA(row);
       if (!skip) {

--- a/h2o-algos/src/main/java/hex/tree/Sample.java
+++ b/h2o-algos/src/main/java/hex/tree/Sample.java
@@ -1,6 +1,7 @@
 package hex.tree;
 
 import water.MRTask;
+import water.fvec.C4VolatileChunk;
 import water.fvec.Chunk;
 import water.util.RandomUtils;
 
@@ -20,7 +21,9 @@ public class Sample extends MRTask<Sample> {
 
   @Override
   public void map(Chunk nids, Chunk ys) {
+    C4VolatileChunk nids2 = (C4VolatileChunk) nids;
     Random rand = RandomUtils.getRNG(_tree._seed);
+    int [] is = nids2.getValuesForWriting();
     for (int row = 0; row < nids._len; row++) {
       boolean skip = ys.isNA(row);
       if (!skip) {
@@ -28,7 +31,7 @@ public class Sample extends MRTask<Sample> {
         rand.setSeed(_tree._seed + row + nids.start()); //seeding is independent of chunking
         skip = rand.nextFloat() >= rate; //float is good enough, half as much cost
       }
-      if (skip) nids.set(row, ScoreBuildHistogram.OUT_OF_BAG);     // Flag row as being ignored by sampling
+      if (skip) is[row] = ScoreBuildHistogram.OUT_OF_BAG;     // Flag row as being ignored by sampling
     }
   }
 }

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram.java
@@ -259,7 +259,7 @@ public class ScoreBuildHistogram extends MRTask<ScoreBuildHistogram> {
           }
           DHistogram h = hcs[n][c];
           if( h==null ) continue; // Ignore untracked columns in this split
-          lh.resizeIfNeeded(h._w.length);
+          lh.resizeIfNeeded(h._nbin);
           h.updateSharedHistosAndReset(lh, ws, cs, ys, rows, nh[n], n == 0 ? 0 : nh[n - 1]);
         }
       }

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram.java
@@ -152,7 +152,7 @@ public class ScoreBuildHistogram extends MRTask<ScoreBuildHistogram> {
   // assigned DecidedNode, "scoring" the row against that Node's decision
   // criteria, and assigning the row to a new child UndecidedNode (and
   // giving it an improved prediction).
-  protected final void score_decide(Chunk chks[], Chunk nids, int nnids[]) {
+  protected void score_decide(Chunk chks[], Chunk nids, int nnids[]) {
     for( int row=0; row<nids._len; row++ ) { // Over all rows
       int nid = (int)nids.at8(row);          // Get Node to decide from
       if( isDecidedRow(nid)) {               // already done

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -302,7 +302,7 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
     public ComputeHistoThread makeCopy() {
       for(DHistogram[] dr:_lhcs)
         for(DHistogram d:dr)
-          assert _shareHisto ||  d == null || d._w == null;
+          assert _shareHisto ||  d == null || d._vals == null;
       ComputeHistoThread res = new ComputeHistoThread(_shareHisto? _lhcs :ArrayUtils.deepClone(_lhcs),_colFrom,_colTo,_maxChunkSz,_shareHisto,_unordered,_cidx);
       return res;
     }
@@ -383,7 +383,7 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
               DHistogram h = _lhcs[n][c - _colFrom];
               if (h == null) continue; // Ignore untracked columns in this split
               if (_shareHisto) {
-                lh.resizeIfNeeded(h._w.length);
+                lh.resizeIfNeeded(h._nbin);
                 h.updateSharedHistosAndReset(lh, ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
               } else h.updateHisto(ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
             }

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -313,25 +313,25 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
       cs = MemoryManager.malloc8d(_maxChunkSz);
       ws = MemoryManager.malloc8d(_maxChunkSz);
       // start computing
-      if(_unordered) {
-        for(DHistogram [] dhary:_lhcs)
-          for(DHistogram dh:dhary)
-            if(dh != null) dh.init();
-      } else if(!_shareHisto) {
-        for (int l = _leaf; l < _tree._len; l++) {
-          DTree.UndecidedNode udn = _tree.undecided(l);
-          DHistogram hs[] = _lhcs[l - _leaf];
-          int sCols[] = udn._scoreCols;
-          if (sCols != null) { // Sub-selecting just some columns?
-            for (int col : sCols) // For tracked cols
-              if (_colFrom <= col && col < _colTo) hs[col - _colFrom].init();
-          } else {                 // Else all columns
-            for (int j = 0; j < hs.length; j++) // For all columns
-              if (hs[j] != null)        // Tracking this column?
-                hs[j].init();
-          }
-        }
-      }
+//      if(_unordered) {
+//        for(DHistogram [] dhary:_lhcs)
+//          for(DHistogram dh:dhary)
+//            if(dh != null) dh.init();
+//      } else if(!_shareHisto) {
+//        for (int l = _leaf; l < _tree._len; l++) {
+//          DTree.UndecidedNode udn = _tree.undecided(l);
+//          DHistogram hs[] = _lhcs[l - _leaf];
+//          int sCols[] = udn._scoreCols;
+//          if (sCols != null) { // Sub-selecting just some columns?
+//            for (int col : sCols) // For tracked cols
+//              if (_colFrom <= col && col < _colTo) hs[col - _colFrom].init();
+//          } else {                 // Else all columns
+//            for (int j = 0; j < hs.length; j++) // For all columns
+//              if (hs[j] != null)        // Tracking this column?
+//                hs[j].init();
+//          }
+//        }
+//      }
       for(int i = _cidx.getAndIncrement(); i < _cids.length; i = _cidx.getAndIncrement())
         computeChunk(i);
     }
@@ -382,10 +382,8 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
               }
               DHistogram h = _lhcs[n][c - _colFrom];
               if (h == null) continue; // Ignore untracked columns in this split
-              if (_shareHisto) {
-                lh.resizeIfNeeded(h._nbin);
-                h.updateSharedHistosAndReset(lh, ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
-              } else h.updateHisto(ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
+              if(h._vals == null)h.init();
+              h.updateHisto(ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
             }
           }
         }

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -59,19 +59,18 @@ import water.util.VecUtils;
  *    exp(nthreads) = max(1,H2O.NUMCPUS - num_cols/COL_BLOCK_SZ)
  *
  */
-public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
-  transient int []   _cids;
-  transient Chunk[][] _chks;
-  transient double [][] _ys;
-  transient double [][] _ws;
-  transient int [][] _nhs;
-  transient int [][] _rss;
-  Frame _fr2;
-  final int _numLeafs;
-  final IcedBitSet _activeCols;
+class ScoreBuildHistogram2 extends ScoreBuildHistogram {
+  private transient int []   _cids;
+  private transient Chunk[][] _chks;
+  private transient double [][] _ys;
+  private transient double [][] _ws;
+  private transient int [][] _nhs;
+  private transient int [][] _rss;
+  private Frame _fr2;
+  private final int _numLeafs;
+  private final IcedBitSet _activeCols;
 
-  private static int MIN_COL_BLOCK_SZ = 2;
-  public ScoreBuildHistogram2(H2O.H2OCountedCompleter cc, int k, int ncols, int nbins, int nbins_cats, DTree tree, int leaf, DHistogram[][] hcs, DistributionFamily family, int weightIdx, int workIdx, int nidIdxs) {
+  ScoreBuildHistogram2(H2O.H2OCountedCompleter cc, int k, int ncols, int nbins, int nbins_cats, DTree tree, int leaf, DHistogram[][] hcs, DistributionFamily family, int weightIdx, int workIdx, int nidIdxs) {
     super(cc, k, ncols, nbins, nbins_cats, tree, leaf, hcs, family, weightIdx, workIdx, nidIdxs);
     _numLeafs = _hcs.length;
 
@@ -123,7 +122,7 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
   // assigned DecidedNode, "scoring" the row against that Node's decision
   // criteria, and assigning the row to a new child UndecidedNode (and
   // giving it an improved prediction).
-  protected int[] score_decide(Chunk chks[], int nnids[]) {
+  private int[] score_decide(Chunk chks[], int nnids[]) {
     int [] res = nnids.clone();
     for( int row=0; row<nnids.length; row++ ) { // Over all rows
       int nid = nnids[row];          // Get Node to decide from
@@ -269,20 +268,6 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
     }).fork();
   }
 
-  // Reduce for both local and remote
-  private static void mergeHistos(DHistogram [][] hcs, DHistogram [][] hcs2){
-    // Distributed histograms need a little work
-    for( int i=0; i< hcs.length; i++ ) {
-      DHistogram hs1[] = hcs[i], hs2[] = hcs2[i];
-      if( hs1 == null ) hcs[i] = hs2;
-      else if( hs2 != null )
-        for( int j=0; j<hs1.length; j++ )
-          if( hs1[j] == null ) hs1[j] = hs2[j];
-          else if( hs2[j] != null ) {
-            hs1[j].add(hs2[j]);
-          }
-    }
-  }
   private static void mergeHistos(DHistogram [] hcs, DHistogram [] hcs2){
     // Distributed histograms need a little work
     for( int i=0; i< hcs.length; i++ ) {
@@ -310,8 +295,7 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
 
     @Override
     public ComputeHistoThread makeCopy() {
-      ComputeHistoThread res = new ComputeHistoThread(ArrayUtils.deepClone(_lh),_col,_maxChunkSz,_cidx);
-      return res;
+      return new ComputeHistoThread(ArrayUtils.deepClone(_lh),_col,_maxChunkSz,_cidx);
     }
 
     @Override

--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -2,16 +2,16 @@ package hex.tree;
 
 import hex.genmodel.utils.DistributionFamily;
 import jsr166y.CountedCompleter;
-import jsr166y.ForkJoinTask;
 import water.*;
 import water.fvec.*;
 import water.util.ArrayUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import water.util.Log;
+import water.util.IcedBitSet;
 import water.util.VecUtils;
 
 /**
@@ -48,40 +48,47 @@ import water.util.VecUtils;
  * the previous passes' DHistograms.
  *
  *
- * Non-shared histogram update:
+ * No CAS update:
  *
  * Sharing the histograms proved to be a performance problem on larger multi-cpu machines with many running threads, CAS was the bottleneck.
  *
- * To remove the CAS while minimizing the memory overhead of private copies of histograms, phase 2 is paralellized primarily over columns.
- * Each column (block of columns) is then processed in local mr task with number of tasks given by
+ * To remove the CAS while minimizing the memory overhead (private copies of histograms), phase 2 is paralellized both over columns and rows.
+ * Each column (block of columns) is processed in LocalMrTask.
+ * Expected number of tasks running in parallel (and hence private Historgam copies made) is given by
  *
- *    nthreads = max(1,desired_parallelization - num_cols/col_block_sz)
- *
- *    desired_parallization defaults to number of threads available to H2O, col_block_sz defsaults to 2 (empirical result).*
- *
- * If histogram sharing option is set to false (which it is default), the number of extra private copies made is exactly nthreads-1.
- * If histogram sharing is on, no private copies are made and histograms are still updated via CAS.
+ *    exp(nthreads) = max(1,H2O.NUMCPUS - num_cols/COL_BLOCK_SZ)
  *
  */
 public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
   transient int []   _cids;
+  transient Chunk[][] _chks;
+  transient double [][] _ys;
+  transient double [][] _ws;
   transient int [][] _nhs;
   transient int [][] _rss;
-  transient int [][] _nnids;
-
   Frame _fr2;
+  final int _numLeafs;
+  final IcedBitSet _activeCols;
 
-  public static class SCBParms extends Iced{
-    public int blockSz;
-    public boolean sharedHisto;
-    public int min_threads;
-    public boolean _unordered;
-  }
-  SCBParms _parms;
+  private static int MIN_COL_BLOCK_SZ = 2;
+  public ScoreBuildHistogram2(H2O.H2OCountedCompleter cc, int k, int ncols, int nbins, int nbins_cats, DTree tree, int leaf, DHistogram[][] hcs, DistributionFamily family, int weightIdx, int workIdx, int nidIdxs) {
+    super(cc, k, ncols, nbins, nbins_cats, tree, leaf, hcs, family, weightIdx, workIdx, nidIdxs);
+    _numLeafs = _hcs.length;
 
-  public ScoreBuildHistogram2(H2O.H2OCountedCompleter cc, int k, int ncols, int nbins, int nbins_cats, DTree tree, int leaf, DHistogram[][] hcs, DistributionFamily family, int weightIdx, int workIdx, int nidIdx, SCBParms parms) {
-    super(cc, k, ncols, nbins, nbins_cats, tree, leaf, parms._unordered?ArrayUtils.transpose(hcs):hcs, family, weightIdx, workIdx, nidIdx);
-    _parms = parms;
+    int hcslen = _hcs.length;
+    IcedBitSet activeCols = new IcedBitSet(ncols);
+    for (int n = 0; n < hcslen; n++) {
+      int [] acs = _tree.undecided(n + _leaf)._scoreCols;
+      if(acs != null) {
+        for (int c : acs) // Columns to score (null, or a list of selected cols)
+          activeCols.set(c);
+      } else {
+        activeCols = null;
+        break;
+      }
+    }
+    _activeCols = activeCols;
+    _hcs = ArrayUtils.transpose(_hcs);
   }
 
   @Override
@@ -153,6 +160,9 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
     // Init all the internal tree fields after shipping over the wire
     _tree.init_tree();
     _cids = VecUtils.getLocalChunkIds(_fr2.anyVec());
+    _chks = new Chunk[_cids.length][_fr2.numCols()];
+    _ys = new double[_cids.length][];
+    _ws = new double[_cids.length][];
     _nhs = new int[_cids.length][];
     _rss = new int[_cids.length][];
     long [] espc = _fr2.anyVec().espc();
@@ -162,8 +172,11 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
       if(sz > largestChunkSz) largestChunkSz = sz;
     }
     final int fLargestChunkSz = largestChunkSz;
-    if(_parms._unordered)
-      _nnids = new int[_cids.length][];
+    if(_weightIdx == -1){
+      double [] ws = new double[largestChunkSz];
+      Arrays.fill(ws,1);
+      Arrays.fill(_ws,ws);
+    }
     final AtomicInteger cidx = new AtomicInteger(0);
     // First do the phase 1 on all local data
     new LocalMR(new MrFun(){
@@ -177,93 +190,85 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
         // giving it an improved prediction).
         int [] nnids;
         if( _leaf > 0)            // Prior pass exists?
-          nnids = score_decide(chks,nids.getValuesForWriting());
+          nnids = score_decide(chks,nids.getValues());
         else {                     // Just flag all the NA rows
           nnids = new int[nids._len];
-          int [] is = nids.getValuesForWriting();
+          int [] is = nids.getValues();
           for (int row = 0; row < nids._len; row++) {
             if (isDecidedRow(is[row]))
               nnids[row] = DECIDED_ROW;
           }
         }
-        if(!_parms._unordered) {
-          // Pass 2: accumulate all rows, cols into histograms
-          // Sort the rows by NID, so we visit all the same NIDs in a row
-          // Find the count of unique NIDs in this chunk
-          int nh[] = (_nhs[id] = new int[_hcs.length + 1]);
-          for (int i : nnids)
-            if (i >= 0)
-              nh[i + 1]++;
-          // Rollup the histogram of rows-per-NID in this chunk
-          for (int i = 0; i < _hcs.length; i++) nh[i + 1] += nh[i];
-          // Splat the rows into NID-groups
-          int rows[] = (_rss[id] = new int[nnids.length]);
-          for (int row = 0; row < nnids.length; row++)
-            if (nnids[row] >= 0)
-              rows[nh[nnids[row]]++] = row;
-        }
+        // Pass 2: accumulate all rows, cols into histograms
+        // Sort the rows by NID, so we visit all the same NIDs in a row
+        // Find the count of unique NIDs in this chunk
+        int nh[] = (_nhs[id] = new int[_numLeafs + 1]);
+        for (int i : nnids)
+          if (i >= 0)
+            nh[i + 1]++;
+        // Rollup the histogram of rows-per-NID in this chunk
+        for (int i = 0; i <_numLeafs; i++) nh[i + 1] += nh[i];
+        // Splat the rows into NID-groups
+        int rows[] = (_rss[id] = new int[nnids.length]);
+        for (int row = 0; row < nnids.length; row++)
+          if (nnids[row] >= 0)
+            rows[nh[nnids[row]]++] = row;
         // rows[] has Chunk-local ROW-numbers now, in-order, grouped by NID.
         // nh[] lists the start of each new NID, and is indexed by NID+1.
       }
       @Override
       protected void map(int id) {
-        Chunk[] chks = new Chunk[_fr2.numCols()];
         Vec[] vecs = _fr2.vecs();
         for(id = cidx.getAndIncrement(); id < _cids.length; id = cidx.getAndIncrement()) {
           int cidx = _cids[id];
+          Chunk [] chks = _chks[id];
           for (int i = 0; i < chks.length; ++i)
             chks[i] = vecs[i].chunkForChunkIdx(cidx);
           map(id,chks);
+          Chunk resChk = chks[_workIdx];
+          int len = resChk.len();
+          if(resChk instanceof C8DVolatileChunk){
+            _ys[id] = ((C8DVolatileChunk)resChk).getValues();
+          } else _ys[id] = resChk.getDoubles(MemoryManager.malloc8d(len), 0, len);
+          if(_weightIdx != -1){
+            _ws[id] = chks[_weightIdx].getDoubles(MemoryManager.malloc8d(len), 0, len);
+          }
         }
       }
     },new H2O.H2OCountedCompleter(this){
       public void onCompletion(CountedCompleter cc){
-        // Now launch the phase 2 in parallel for each column block.
-        if(_parms.sharedHisto){
-          for (int l = _leaf; l < _tree._len; l++) {
-            DTree.UndecidedNode udn = _tree.undecided(l);
-            DHistogram hs[] = _hcs[l - _leaf];
-            int sCols[] = udn._scoreCols;
-            if (sCols != null) { // Sub-selecting just some columns?
-              for (int col : sCols) // For tracked cols
-                hs[col].init();
-            } else {                 // Else all columns
-              for (int j = 0; j < hs.length; j++) // For all columns
-                if (hs[j] != null)        // Tracking this column?
-                  hs[j].init();
-            }
+        final int ncols = _ncols;
+        final int [] active_cols = _activeCols == null?null:new int[Math.max(1,_activeCols.cardinality())];
+        int nactive_cols = active_cols == null?ncols:active_cols.length;
+        final int numWrks = _hcs.length*nactive_cols < 16*1024?H2O.NUMCPUS:Math.min(H2O.NUMCPUS,Math.max(4*H2O.NUMCPUS/nactive_cols,1));
+        final int rem = H2O.NUMCPUS-numWrks*ncols;
+        ScoreBuildHistogram2.this.addToPendingCount(1+nactive_cols);
+        if(active_cols != null) {
+          int j = 0;
+          for (int i = 0; i < ncols; ++i)
+            if (_activeCols.contains(i))
+              active_cols[j++] = i;
+        }
+        // MRTask (over columns) launching MrTasks (over number of workers) for each column.
+        // We want FJ to start processing all the columns before parallelizing within column to reduce memory overhead.
+        // (running single column in n threads means n-copies of the histogram)
+        // This is how it works:
+        //    1) Outer MRTask walks down it's tree, forking tasks with exponentially decreasing number of columns until reaching its left most leaf for columns 0.
+        //       At this point, the local fjq for this thread has a task for processing half of columns at the bottom, followed by task for 1/4 of columns and so on.
+        //       Other threads start stealing work from the bottom.
+        //    2) forks the leaf task and (because its polling from the top) executes the LocalMr for the column 0.
+        // This way we should have columns as equally distributed as possible without resorting to shared priority queue
+        new LocalMR(new MrFun() {
+          @Override
+          protected void map(int c) {
+            c = active_cols == null?c:active_cols[c];
+            new LocalMR(new ComputeHistoThread(_hcs.length == 0?new DHistogram[0]:_hcs[c],c,fLargestChunkSz,new AtomicInteger()),numWrks + (c < rem?1:0),ScoreBuildHistogram2.this).fork();
           }
-        }
-        int ncols = _ncols;
-        int colBlockSz= Math.min(ncols,_parms.blockSz);
-        while(0 < ncols - colBlockSz && ncols % colBlockSz != 0 && ncols % colBlockSz < (colBlockSz >> 1))
-          colBlockSz++;
-        int nrowThreads = 1;
-        int ncolBlocks = ncols/colBlockSz + (ncols%colBlockSz == 0?0:1);
-        while(ncolBlocks*nrowThreads < _parms.min_threads)nrowThreads++;
-        final int nthreads = nrowThreads;
-//        ArrayList<ForkJoinTask> tsks = new ArrayList<>();
-        for(int i = 0; i < ncols; i += colBlockSz){
-          ScoreBuildHistogram2.this.addToPendingCount(1);
-          final int colFrom= i;
-          final int colTo = Math.min(ncols,colFrom+colBlockSz);
-          DHistogram[][] hcs = _parms._unordered?Arrays.copyOfRange(_hcs,colFrom,colTo):_hcs.clone();
-          for(int j = 0; j < hcs.length; ++j)
-            hcs[j] = _parms._unordered?hcs[j].clone():Arrays.copyOfRange(hcs[j],colFrom,colTo);
-          if(i + colBlockSz < ncols)
-            H2O.submitTask(new LocalMR<ComputeHistoThread>(new ComputeHistoThread(hcs,colFrom,colTo,fLargestChunkSz,_parms.sharedHisto,_parms._unordered, new AtomicInteger()), nthreads, ScoreBuildHistogram2.this,priority()));
-          else // last one is forked to reuse current thread
-            new LocalMR<ComputeHistoThread>(new ComputeHistoThread(hcs,colFrom,colTo,fLargestChunkSz,_parms.sharedHisto,_parms._unordered, new AtomicInteger()), nthreads, ScoreBuildHistogram2.this,priority()).fork();
-        }
+        },nactive_cols,ScoreBuildHistogram2.this).fork();
       }
     }).fork();
   }
 
-  private static class Phase2 extends H2O.H2OCountedCompleter {
-    public void onCompletion(CountedCompleter cc){
-
-    }
-  }
   // Reduce for both local and remote
   private static void mergeHistos(DHistogram [][] hcs, DHistogram [][] hcs2){
     // Distributed histograms need a little work
@@ -278,134 +283,85 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
           }
     }
   }
+  private static void mergeHistos(DHistogram [] hcs, DHistogram [] hcs2){
+    // Distributed histograms need a little work
+    for( int i=0; i< hcs.length; i++ ) {
+      DHistogram hs1 = hcs[i], hs2 = hcs2[i];
+      if( hs1 == null ) hcs[i] = hs2;
+      else if( hs2 != null )
+        hs1.add(hs2);
+    }
+  }
 
   private class ComputeHistoThread extends MrFun<ComputeHistoThread> {
     final int _maxChunkSz;
-    final int _colFrom, _colTo;
-    boolean _shareHisto = false;
-    boolean _unordered = false;
-    final DHistogram [][] _lhcs;
+    final int _col;
+    final DHistogram [] _lh;
 
-    double [] cs = null;
-    double [] ws = null;
-    double [] _ys = null;
     AtomicInteger _cidx;
+    private boolean _done;
 
-    ComputeHistoThread(DHistogram [][] hcs, int colFrom, int colTo, int maxChunkSz, boolean sharedHisto, boolean unordered, AtomicInteger cidx){
-      _lhcs = hcs; _colFrom = colFrom; _colTo = colTo; _maxChunkSz = maxChunkSz;
-      _shareHisto = sharedHisto;
-      _unordered = unordered;
+    public boolean isDone(){return _done || (_done = _cidx.get() >= _cids.length);}
+
+    ComputeHistoThread(DHistogram [] hcs, int col, int maxChunkSz,AtomicInteger cidx){
+      _lh = hcs; _col = col; _maxChunkSz = maxChunkSz;
       _cidx = cidx;
     }
 
     @Override
     public ComputeHistoThread makeCopy() {
-      for(DHistogram[] dr:_lhcs)
-        for(DHistogram d:dr)
-          assert _shareHisto ||  d == null || d._vals == null;
-      ComputeHistoThread res = new ComputeHistoThread(_shareHisto? _lhcs :ArrayUtils.deepClone(_lhcs),_colFrom,_colTo,_maxChunkSz,_shareHisto,_unordered,_cidx);
+      ComputeHistoThread res = new ComputeHistoThread(ArrayUtils.deepClone(_lh),_col,_maxChunkSz,_cidx);
       return res;
     }
 
-
     @Override
     protected void map(int id){
-      cs = MemoryManager.malloc8d(_maxChunkSz);
-      ws = MemoryManager.malloc8d(_maxChunkSz);
-      // start computing
-//      if(_unordered) {
-//        for(DHistogram [] dhary:_lhcs)
-//          for(DHistogram dh:dhary)
-//            if(dh != null) dh.init();
-//      } else if(!_shareHisto) {
-//        for (int l = _leaf; l < _tree._len; l++) {
-//          DTree.UndecidedNode udn = _tree.undecided(l);
-//          DHistogram hs[] = _lhcs[l - _leaf];
-//          int sCols[] = udn._scoreCols;
-//          if (sCols != null) { // Sub-selecting just some columns?
-//            for (int col : sCols) // For tracked cols
-//              if (_colFrom <= col && col < _colTo) hs[col - _colFrom].init();
-//          } else {                 // Else all columns
-//            for (int j = 0; j < hs.length; j++) // For all columns
-//              if (hs[j] != null)        // Tracking this column?
-//                hs[j].init();
-//          }
-//        }
-//      }
-      for(int i = _cidx.getAndIncrement(); i < _cids.length; i = _cidx.getAndIncrement())
-        computeChunk(i);
-    }
-
-    public void updateHistoUnordered(DHistogram[] hcs, int len, double[] ws, double[] cs, double[] ys, int [] nids){
-      // Gather all the data for this set of rows, for 1 column and 1 split/NID
-      // Gather min/max, wY and sum-squares.
-      for(int r = 0; r< len; ++r) {
-        double w = ws[r];
-        if (w == 0) continue;
-        int nid = nids[r];
-        if(nid < 0) continue; // decided row?
-        DHistogram dh = hcs[nid];
-        if(dh == null) continue;
-        dh.updateHisto(w, cs[r], ys[r]);
+      double [] cs = null;
+      for(int i = _cidx.getAndIncrement(); i < _cids.length; i = _cidx.getAndIncrement()) {
+        if(cs == null) cs = MemoryManager.malloc8d(_maxChunkSz);
+        computeChunk(i,cs,_ws[i]);
       }
     }
 
-    private void computeChunk(int id){
-      ScoreBuildHistogram.LocalHisto lh = _shareHisto?new ScoreBuildHistogram.LocalHisto(Math.max(_nbins,_nbins_cats)):null;
-      int cidx = _cids[id];
+    private void computeChunk(int id, double [] cs, double [] ws){
       int [] nh = _nhs[id];
       int [] rs = _rss[id];
-      int [] nnids = _unordered?_nnids[id]:null;
-      Chunk resChk = _fr2.vec(_workIdx).chunkForChunkIdx(cidx);
+      Chunk resChk = _chks[id][_workIdx];
       int len = resChk._len;
-      double [] ys;
-      if(resChk instanceof C8DVolatileChunk){
-        ys = ((C8DVolatileChunk)resChk).getValuesForWriting();
-      } else ys = resChk.getDoubles(_ys == null?MemoryManager.malloc8d(cs.length):_ys, 0, len);
-      if(_weightIdx != -1)
-        _fr2.vec(_weightIdx).chunkForChunkIdx(cidx).getDoubles(ws, 0, len);
-      else
-        Arrays.fill(ws,1);
-      final int hcslen = _lhcs.length;
-      for (int c = _colFrom; c < _colTo; c++) {
-        if(_unordered){
-          _fr2.vec(c).chunkForChunkIdx(cidx).getDoubles(cs, 0, len);
-          updateHistoUnordered(_lhcs[c-_colFrom],len,ws,cs,ys,nnids);
-        } else {
-          boolean extracted = false;
-          for (int n = 0; n < hcslen; n++) {
-            int sCols[] = _tree.undecided(n + _leaf)._scoreCols; // Columns to score (null, or a list of selected cols)
-            if (sCols == null || ArrayUtils.find(sCols, c) >= 0) {
-              if (!extracted) {
-                _fr2.vec(c).chunkForChunkIdx(cidx).getDoubles(cs, 0, len);
-                extracted = true;
-              }
-              DHistogram h = _lhcs[n][c - _colFrom];
-              if (h == null) continue; // Ignore untracked columns in this split
-              if(h._vals == null)h.init();
-              h.updateHisto(ws, cs, ys, rs, nh[n], n == 0 ? 0 : nh[n - 1]);
-            }
+      double [] ys = ScoreBuildHistogram2.this._ys[id];
+      if(_weightIdx != -1) _chks[id][_weightIdx].getDoubles(ws, 0, len);
+      final int hcslen = _lh.length;
+      boolean extracted = false;
+      for (int n = 0; n < hcslen; n++) {
+        int sCols[] = _tree.undecided(n + _leaf)._scoreCols; // Columns to score (null, or a list of selected cols)
+        if (sCols == null || ArrayUtils.find(sCols, _col) >= 0) {
+          DHistogram h = _lh[n];
+          int hi = nh[n];
+          int lo = (n == 0 ? 0 : nh[n - 1]);
+          if (hi == lo || h == null) continue; // Ignore untracked columns in this split
+          if (h._vals == null) h.init();
+          if (!extracted) {
+            _chks[id][_col].getDoubles(cs,0,len);
+            extracted = true;
           }
+          h.updateHisto(ws, cs, ys, rs, hi, lo);
         }
       }
     }
 
     @Override
     protected void reduce(ComputeHistoThread cc) {
-      if(!_shareHisto) {
-        assert _lhcs != cc._lhcs;
-        mergeHistos(_lhcs, cc._lhcs);
-      } else assert _lhcs == cc._lhcs;
+      assert _lh != cc._lh;
+      mergeHistos(_lh, cc._lh);
     }
   }
+
   @Override public void postGlobal(){
-    if(_parms._unordered) _hcs = ArrayUtils.transpose(_hcs);
+    _hcs = ArrayUtils.transpose(_hcs);
     for(DHistogram [] ary:_hcs)
       for(DHistogram dh:ary) {
         if(dh == null) continue;
         dh.reducePrecision();
       }
-    // hack for now
-
   }
 }

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -283,9 +283,14 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
 
         // One Tree per class, each tree needs a NIDs.  For empty classes use a -1
         // NID signifying an empty regression tree.
-        for( int i=0; i<_nclass; i++ )
-          _train.add("NIDs_"+domain[i], _response.makeCon(_model._output._distribution==null ? 0 : (_model._output._distribution[i]==0?-1:0)));
-
+        String [] names = new String[_nclass];
+        final int [] cons = new int[_nclass];
+        for( int i=0; i<_nclass; i++ ) {
+          names[i] = "NIDs_" + domain[i];
+          cons[i] = (_model._output._distribution[i]==0?-1:0);
+        }
+        Vec [] vs = _response.makeVolatileInts(cons);
+        _train.add(names, vs);
         // Append number of trees participating in on-the-fly scoring
         _train.add("OUT_BAG_TREES", _response.makeZero());
 

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -273,13 +273,16 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
         //   nclass Vecs of working/temp data
         //   nclass Vecs of NIDs, allowing 1 tree per class
 
-        // Current forest values: results of summing the prior M trees
-        for( int i=0; i<_nclass; i++ )
-          _train.add("Tree_"+domain[i], _response.makeZero());
 
-        // Initial work columns.  Set-before-use in the algos.
-        for( int i=0; i<_nclass; i++ )
-          _train.add("Work_"+domain[i], _response.makeZero());
+        String [] twNames = new String[_nclass*2];
+
+        for(int i = 0; i < _nclass; ++i){
+          twNames[i] = "Tree_" + domain[i];
+          twNames[_nclass+i] = "Work_" + domain[i];
+        }
+        Vec [] twVecs = _response.makeVolatileDoubles(_nclass*2);
+        _train.add(twNames,twVecs);
+
 
         // One Tree per class, each tree needs a NIDs.  For empty classes use a -1
         // NID signifying an empty regression tree.

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -383,7 +383,7 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
   // --------------------------------------------------------------------------
   // Build an entire layer of all K trees
 //  protected DHistogram[][][] buildLayer(final Frame fr, final int nbins, int nbins_cats, final DTree ktrees[], final int leafs[], final DHistogram hcs[][][], boolean build_tree_one_node) {
-  protected DHistogram[][][] buildLayer(final Frame fr, final int nbins, int nbins_cats, final DTree ktrees[], final int leafs[], final DHistogram hcs[][][], boolean build_tree_one_node, ScoreBuildHistogram2.SCBParms parms) {
+  protected DHistogram[][][] buildLayer(final Frame fr, final int nbins, int nbins_cats, final DTree ktrees[], final int leafs[], final DHistogram hcs[][][], boolean build_tree_one_node) {
     // Build K trees, one per class.
 
     // Build up the next-generation tree splits from the current histograms.
@@ -411,7 +411,7 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
       // Async tree building
       // step 1: build histograms
       // step 2: split nodes
-      H2O.submitTask(sb1ts[k] = new ScoreBuildOneTree(this,k,nbins, nbins_cats, tree, leafs, hcs, fr2, build_tree_one_node, _improvPerVar, _model._parms._distribution, weightIdx, workIdx, nidIdx,parms));
+      H2O.submitTask(sb1ts[k] = new ScoreBuildOneTree(this,k,nbins, nbins_cats, tree, leafs, hcs, fr2, build_tree_one_node, _improvPerVar, _model._parms._distribution, weightIdx, workIdx, nidIdx));
     }
     // Block for all K trees to complete.
     boolean did_split=false;
@@ -451,10 +451,9 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
     final int _workIdx;
     final int _nidIdx;
 
-    ScoreBuildHistogram2.SCBParms _parms;
     boolean _did_split;
 
-    ScoreBuildOneTree(SharedTree st, int k, int nbins, int nbins_cats, DTree tree, int leafs[], DHistogram hcs[][][], Frame fr2, boolean build_tree_one_node, float[] improvPerVar, DistributionFamily family, int weightIdx, int workIdx, int nidIdx, ScoreBuildHistogram2.SCBParms parms) {
+    ScoreBuildOneTree(SharedTree st, int k, int nbins, int nbins_cats, DTree tree, int leafs[], DHistogram hcs[][][], Frame fr2, boolean build_tree_one_node, float[] improvPerVar, DistributionFamily family, int weightIdx, int workIdx, int nidIdx) {
       _st   = st;
       _k    = k;
       _nbins= nbins;
@@ -469,7 +468,6 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
       _weightIdx = weightIdx;
       _workIdx = workIdx;
       _nidIdx = nidIdx;
-      _parms = parms;
     }
     @Override public void compute2() {
       // Fuse 2 conceptual passes into one:
@@ -480,49 +478,33 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
       // Pass 2: Build new summary DHistograms on the new child Nodes every row
       // got assigned into.  Collect counts, mean, variance, min, max per bin,
       // per column.
-      if(_parms == null)
-        new ScoreBuildHistogram(this,_k, _st._ncols, _nbins, _nbins_cats, _tree, _leafOffsets[_k], _hcs[_k], _family, _weightIdx, _workIdx, _nidIdx).dfork2(null,_fr2,_build_tree_one_node);
-      else
-        new ScoreBuildHistogram2(this,_k, _st._ncols, _nbins, _nbins_cats, _tree, _leafOffsets[_k], _hcs[_k], _family, _weightIdx, _workIdx, _nidIdx, _parms).dfork2(null,_fr2,_build_tree_one_node);
+//      new ScoreBuildHistogram(this,_k, _st._ncols, _nbins, _nbins_cats, _tree, _leafOffsets[_k], _hcs[_k], _family, _weightIdx, _workIdx, _nidIdx).dfork2(null,_fr2,_build_tree_one_node);
+      new ScoreBuildHistogram2(this,_k, _st._ncols, _nbins, _nbins_cats, _tree, _leafOffsets[_k], _hcs[_k], _family, _weightIdx, _workIdx, _nidIdx).dfork2(null,_fr2,_build_tree_one_node);
     }
     @Override public void onCompletion(CountedCompleter caller) {
-      ScoreBuildHistogram sbh = (ScoreBuildHistogram)caller;
-//      for(int i = 0; i < sbh._hcs.length; ++i)
-//          for(int j = 0; j < sbh._hcs[i].length;++j) {
-//            System.out.println();
-//            System.out.println(i + ", " + j);
-//            DHistogram d = sbh._hcs[i][j];
-//            if (d == null) {
-//              System.out.println("null");
-//            } else {
-//              System.out.println("w: " + Arrays.toString(d._w));
-//              System.out.println("wY: " + Arrays.toString(d._wY));
-//              System.out.println("wYY: " + Arrays.toString(d._wYY));
-//            }
-//          }
-      //System.out.println(sbh.profString());
+      ScoreBuildHistogram sbh = (ScoreBuildHistogram) caller;
       final int leafOffset = _leafOffsets[_k];
       int tmax = _tree.len();   // Number of total splits in tree K
-      for(int leaf = leafOffset; leaf<tmax; leaf++ ) { // Visit all the new splits (leaves)
+      for (int leaf = leafOffset; leaf < tmax; leaf++) { // Visit all the new splits (leaves)
         DTree.UndecidedNode udn = _tree.undecided(leaf);
 //        System.out.println((_st._nclass==1?"Regression":("Class "+_st._response.domain()[_k]))+",\n  Undecided node:"+udn);
         // Replace the Undecided with the Split decision
-        DTree.DecidedNode dn = _st.makeDecided(udn,sbh._hcs[leaf-leafOffset]);
+        DTree.DecidedNode dn = _st.makeDecided(udn, sbh._hcs[leaf - leafOffset]);
 //        System.out.println(dn + "\n" + dn._split);
-        if( dn._split == null ) udn.do_not_split();
+        if (dn._split == null) udn.do_not_split();
         else {
           _did_split = true;
           DTree.Split s = dn._split; // Accumulate squared error improvements per variable
-          float improvement = (float)(s.pre_split_se()-s.se());
-          assert(improvement>=0);
-          AtomicUtils.FloatArray.add(_improvPerVar,s.col(),improvement);
+          float improvement = (float) (s.pre_split_se() - s.se());
+          assert (improvement >= 0);
+          AtomicUtils.FloatArray.add(_improvPerVar, s.col(), improvement);
         }
       }
-      _leafOffsets[_k]=tmax;          // Setup leafs for next tree level
-      int new_leafs = _tree.len()-tmax; //new_leafs can be 0 if no actual splits were made
+      _leafOffsets[_k] = tmax;          // Setup leafs for next tree level
+      int new_leafs = _tree.len() - tmax; //new_leafs can be 0 if no actual splits were made
       _hcs[_k] = new DHistogram[new_leafs][/*ncol*/];
-      for( int nl = tmax; nl<_tree.len(); nl ++ )
-        _hcs[_k][nl-tmax] = _tree.undecided(nl)._hs;
+      for (int nl = tmax; nl < _tree.len(); nl++)
+        _hcs[_k][nl - tmax] = _tree.undecided(nl)._hs;
 //      if (_did_split && new_leafs > 0) _tree._depth++;
       if (_did_split) _tree._depth++; //
     }

--- a/h2o-algos/src/main/java/hex/tree/drf/DRF.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRF.java
@@ -193,7 +193,7 @@ public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel
       // Adds a layer to the trees each pass.
       int depth=0;
       for( ; depth<_parms._max_depth; depth++ ) {
-        hcs = buildLayer(_train, _parms._nbins, _parms._nbins_cats, ktrees, leafs, hcs, _parms._build_tree_one_node,null);
+        hcs = buildLayer(_train, _parms._nbins, _parms._nbins_cats, ktrees, leafs, hcs, _parms._build_tree_one_node);
         // If we did not make any new splits, then the tree is split-to-death
         if( hcs == null ) break;
       }

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -506,13 +506,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
 
       // sanity check
       for (int k = 0; k < _nclass; k++) {
-        if (ktrees[k]!=null){
-          Vec v = vec_nids(_train,k);
-          if(v.isVolatile()){
-            System.out.println("haha");
-          }
-          assert(vec_nids(_train,k).mean()==0);
-        }
+        if (ktrees[k]!=null) assert(vec_nids(_train,k).mean()==0);
       }
 
       // Grow the model by K-trees

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -156,13 +156,6 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
   private class GBMDriver extends Driver {
     @Override protected boolean doOOBScoring() { return false; }
     @Override protected void initializeModelSpecifics() {
-      if(_parms._use_new_histo_tsk){
-        _scbParms = new ScoreBuildHistogram2.SCBParms();
-        _scbParms.blockSz = _parms._col_block_sz;
-        _scbParms.sharedHisto = _parms._shared_histo;
-        _scbParms.min_threads = _parms._min_threads == -1?H2O.NUMCPUS:_parms._min_threads;
-        _scbParms._unordered = _parms._unordered;
-      }
       _mtry_per_tree = Math.max(1, (int)(_parms._col_sample_rate_per_tree * _ncols)); //per-tree
       if (!(1 <= _mtry_per_tree && _mtry_per_tree <= _ncols)) throw new IllegalArgumentException("Computed mtry_per_tree should be in interval <1,"+_ncols+"> but it is " + _mtry_per_tree);
       _mtry = Math.max(1, (int)(_parms._col_sample_rate * _parms._col_sample_rate_per_tree * _ncols)); //per-split
@@ -188,7 +181,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
           @Override
           public void map(Chunk tree) {
             if(tree instanceof C8DVolatileChunk){
-              Arrays.fill(((C8DVolatileChunk)tree).getValuesForWriting(),init);
+              Arrays.fill(((C8DVolatileChunk)tree).getValues(),init);
             } else  for (int i = 0; i < tree._len; i++) tree.set(i, init);
           }
         }.doAll(vec_tree(_train, 0), _parms._build_tree_one_node); // Only setting tree-column 0
@@ -319,18 +312,18 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
             if( Double.isInfinite(sum) ) { // Overflow (happens for constant responses)
               for (int k = 0; k < _nclass; k++) {
                 wk = (C8DVolatileChunk) chk_work(chks, k);
-                wk.getValuesForWriting()[row] = (((int)y == k ? 1f : 0f) - (Double.isInfinite(fs[k + 1]) ? 1.0f : 0.0f));
+                wk.getValues()[row] = (((int)y == k ? 1f : 0f) - (Double.isInfinite(fs[k + 1]) ? 1.0f : 0.0f));
               }
             } else {
               for( int k=0; k<_nclass; k++ ) { // Save as a probability distribution
                 if( _model._output._distribution[k] != 0 ) {
                   wk = (C8DVolatileChunk) chk_work(chks, k);
-                  wk.getValuesForWriting()[row] = (((int)y == k ? 1f : 0f) - (float)(fs[k + 1] / sum));
+                  wk.getValues()[row] = (((int)y == k ? 1f : 0f) - (float)(fs[k + 1] / sum));
                 }
               }
             }
           } else {
-            wk.getValuesForWriting()[row] = ((float) dist.negHalfGradient(y, f));
+            wk.getValues()[row] = ((float) dist.negHalfGradient(y, f));
           }
         }
       }
@@ -425,7 +418,6 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         }
       }
     }
-    ScoreBuildHistogram2.SCBParms _scbParms;
 
     // --------------------------------------------------------------------------
     // Build the next k-trees, which is trying to correct the residual error from
@@ -561,7 +553,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       // Adds a layer to the trees each pass.
       int depth = 0;
       for (; depth < _parms._max_depth; depth++) {
-        hcs = buildLayer(_train, _parms._nbins, _parms._nbins_cats, ktrees, leaves, hcs, _parms._build_tree_one_node,_scbParms);
+        hcs = buildLayer(_train, _parms._nbins, _parms._nbins_cats, ktrees, leaves, hcs, _parms._build_tree_one_node);
         // If we did not make any new splits, then the tree is split-to-death
         if (hcs == null) break;
       }
@@ -631,7 +623,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
           if (ys.isNA(row)) continue;
           double f = preds.atd(row) + offset.atd(row);
           double y = ys.atd(row);
-          wk.getValuesForWriting()[row] = ((float) _dist.negHalfGradient(y, f));
+          wk.getValues()[row] = ((float) _dist.negHalfGradient(y, f));
         }
       }
     }
@@ -662,16 +654,18 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
 
     public class DiffMinusMedianDiff extends MRTask<DiffMinusMedianDiff> {
       Vec _strata;
+      final int _strataMin;
       double[] _terminalMedians;
       DiffMinusMedianDiff(Vec strata, double[] terminalMedians) {
         _strata = strata;
+        _strataMin = (int) strata.min();
         _terminalMedians = terminalMedians;
       }
       @Override
       public void map(Chunk[] chks) {
         final Chunk strata = chks[0];
         final Chunk diff = chks[1];
-        final int strataMin = (int)_strata.min();
+        final int strataMin = _strataMin;
         for (int i=0; i<chks[0].len(); ++i) {
           int nid = (int)strata.atd(i);
           diff.set(i, diff.atd(i) - _terminalMedians[nid-strataMin]);
@@ -683,21 +677,23 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       // INPUT
       final double _huberDelta;
       final Vec _strata;
+      final int _strataMin;
+      final int _strataMax;
       // OUTPUT
       double[/*leaves*/] _huberGamma, _wcounts;
       public HuberLeafMath(double huberDelta, Vec strata) {
         _huberDelta = huberDelta;
         _strata = strata;
+        _strataMin = (int)_strata.min();
+        _strataMax = (int)_strata.max();
       }
       @Override
       public void map(Chunk cs[]) {
-        final int strataMin = (int)_strata.min();
-        final int strataMax = (int)_strata.max();
-        if (strataMin < 0 || strataMax < 0) {
+        if (_strataMin < 0 || _strataMax < 0) {
           Log.warn("No Huber math can be done since there's no strata.");
           return;
         }
-        final int nstrata = strataMax - strataMin + 1;
+        final int nstrata = _strataMax - _strataMin + 1;
         Log.info("Computing Huber math for (up to) " + nstrata + " different strata.");
         _huberGamma = new double[nstrata];
         _wcounts = new double[nstrata];
@@ -705,7 +701,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         Chunk stratum = chk_nids(cs, 0 /*regression*/);
         Chunk diffMinusMedianDiff = cs[cs.length-1];
         for (int row=0;row<cs[0]._len;++row) {
-          int nidx = (int) stratum.at8(row) - strataMin; //get terminal node for this row
+          int nidx = (int) stratum.at8(row) - _strataMin; //get terminal node for this row
           _huberGamma[nidx] += weights.atd(row) * Math.signum(diffMinusMedianDiff.atd(row)) * Math.min(Math.abs(diffMinusMedianDiff.atd(row)), _huberDelta);
                   _wcounts[nidx] += weights.atd(row);
         }
@@ -848,7 +844,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
           final double denom[] = _denom[k] = new double[tree._len-leaf];
           final double num[] = _num[k] = new double[tree._len-leaf];
           final C4VolatileChunk nids = (C4VolatileChunk) chk_nids(chks, k); // Node-ids  for this tree/class
-          int [] nids_vals = nids.getValuesForWriting();
+          int [] nids_vals = nids.getValues();
           final Chunk ress = chk_work(chks, k); // Residuals for this tree/class
           final Chunk offset = hasOffsetCol() ? chk_offset(chks) : new C0DChunk(0, chks[0]._len); // Residuals for this tree/class
           final Chunk preds = chk_tree(chks,k);
@@ -917,9 +913,9 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
           final DTree tree = _ktrees[k];
           if( tree == null ) continue;
           final C4VolatileChunk nids = (C4VolatileChunk) chk_nids(chks,k);
-          final int [] nids_vals = nids.getValuesForWriting();
+          final int [] nids_vals = nids.getValues();
           final C8DVolatileChunk ct   = (C8DVolatileChunk) chk_tree(chks, k);
-          double [] ct_vals = ct.getValuesForWriting();
+          double [] ct_vals = ct.getValues();
           final Chunk y   = chk_resp(chks);
           final Chunk weights = hasWeightCol() ? chk_weight(chks) : new C0DChunk(1, chks[0]._len);
           long baseseed = (0xDECAF + _parms._seed) * (0xFAAAAAAB + k * _parms._ntrees + _model._output._ntrees);

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBMModel.java
@@ -14,6 +14,7 @@ public class GBMModel extends SharedTreeModel<GBMModel, GBMModel.GBMParameters, 
     public double _col_sample_rate;
     public double _max_abs_leafnode_pred;
     public double _pred_noise_bandwidth;
+
     // The following are internal  params for performance tuning of histogram building with defaults based on benchmark data.
     public boolean _use_new_histo_tsk = true; // use the ScoreBuildHistogram2 instead of the originial one.
     public int _col_block_sz = 2; // columns block processed in one task. can be between 1 - Integer.Max (meaning no column-wise paralellization)

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -563,7 +563,11 @@ public class GBMTest extends TestUtil {
       if (tfr != null) tfr.remove();
     }
     Scope.exit();
-    for( double mse : mses ) assertEquals(mse, mses[0], 1e-15);
+
+    for( double mse : mses )
+      System.out.println(mse);
+    for( double mse : mses )
+      assertEquals(mse, mses[0], 1e-15);
   }
 
   // PUBDEV-557: Test dependency on # nodes (for small number of bins, but fixed number of chunks)

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1075,7 +1075,7 @@ final public class H2O {
       super((ARGS.nthreads <= 0) ? NUMCPUS : ARGS.nthreads,
             new FJWThrFact(cap),
             null,
-            p>=MIN_HI_PRIORITY);
+            p>=MIN_HI_PRIORITY /* lowe priority FJQs should use the default FJ settings to use LIFO order of thread private queues. */);
       _priority = p;
     }
     private H2OCountedCompleter poll2() { return (H2OCountedCompleter)pollSubmission(); }

--- a/h2o-core/src/main/java/water/LocalMR.java
+++ b/h2o-core/src/main/java/water/LocalMR.java
@@ -3,38 +3,21 @@ package water;
 import jsr166y.CountedCompleter;
 
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Created by tomas on 11/5/16.
  *
  * Generic Local MRTask utility. Will launch requested number of tasks (on local node!), organized in a binary tree fashion.
- * Tasks are launched via H2O.submit task rather than fork (assuming different usage pattern than MRT - use fewer longer running tasks -> push into global FJQ).
- *
- * User provides a MrFun function object with map/reduce/makeCopy functions.
- *
- * Here is a sample tree and reduce pairs for LocalMR creating 8 tasks
- *          4
- *        /  \
- *      /     \
- *     2      6
- *    / \    / \
- *   1   3  5  7
- *   |
- *   0
- *
- *   Reduce will be called for pairs (1,0), (2,1), (2,3), (4,2), (6,5), (6,7), (4,6)
  *
  */
 public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR> {
   private int _lo;
   private int _hi;
-  final MrFun _mrFun;
+  MrFun _mrFun;
   volatile Throwable _t;
   protected volatile boolean  _cancelled;
   private LocalMR<T> _root;
 
-  public LocalMR(MrFun mrt){this(mrt,H2O.NUMCPUS);}
   public LocalMR(MrFun mrt, int nthreads){this(mrt,nthreads,null);}
   public LocalMR(MrFun mrt, H2O.H2OCountedCompleter cc){this(mrt,H2O.NUMCPUS,cc);}
   public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc){
@@ -44,20 +27,12 @@ public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR
     _mrFun = mrt;
     _lo = 0;
     _hi = nthreads;
+    _prevTsk = null;
   }
-  public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc, byte priority) {
-    super(cc,priority);
-    if(nthreads <= 0) throw new IllegalArgumentException("nthreads must be positive");
-    _root = this;
-    _mrFun = mrt;
-    _lo = 0;
-    _hi = nthreads;
-  }
-
-  private LocalMR(LocalMR src, int lo, int hi) {
+  private LocalMR(LocalMR src, LocalMR prevTsk,int lo, int hi) {
     super(src);
     _root = src._root;
-    _mrFun = src._mrFun.makeCopy();
+    _prevTsk = prevTsk;
     _lo = lo;
     _hi = hi;
     _cancelled = src._cancelled;
@@ -65,32 +40,40 @@ public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR
 
   private LocalMR<T> _left;
   private LocalMR<T> _rite;
+  private final LocalMR<T> _prevTsk; // right child will attempt to share MrFun with " left sibling" if the whole left subtree is done
 
-  volatile boolean completed;
 
+  volatile boolean completed; // this task and all it's children completed
+  volatile boolean started; // this task and all it's children completed
   public boolean isCancelRequested(){return _root._cancelled;}
 
   private int mid(){ return _lo + ((_hi - _lo) >> 1);}
 
   @Override
   public final void compute2() {
+    started = true;
     if (!_root._cancelled) {
       try {
         int mid = mid();
         assert _hi > _lo;
-        int pending = 0;
+        int pending = 1;
         if (_hi - _lo >= 2) {
-          _left = new LocalMR(this, _lo, mid);
-          pending++;
-          if ((mid + 1) < _hi) {
-            _rite = new LocalMR(this, mid + 1, _hi);
+          _left = new LocalMR(this, _prevTsk, _lo, mid);
+          if (mid < _hi) {
+            _rite = new LocalMR(this, _left, mid, _hi);
             pending++;
           }
           addToPendingCount(pending);
-          H2O.submitTask(_left);
-          if(_rite != null) H2O.submitTask(_rite);
+          if(_rite != null) _rite.fork();
+          _left.fork();
+        } else {
+
+          if(_prevTsk != null && _prevTsk.completed){
+            _mrFun = _prevTsk._mrFun;
+            _prevTsk._mrFun = null;
+          } else _mrFun = _root._mrFun.makeCopy();
+          _mrFun.map(mid);
         }
-        _mrFun.map(mid);
       } catch (Throwable t) {
         t.printStackTrace();
         if (_root._t == null) {
@@ -99,7 +82,6 @@ public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR
         }
       }
     }
-    completed = true;
     tryComplete();
   }
 
@@ -112,16 +94,19 @@ public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR
     }
     if(_root._cancelled) return;
     assert cc == this || cc == _left || cc == _rite;
-    if (_left != null) {
+    if (_left != null && _left._mrFun != null && _mrFun != _left._mrFun) {
       assert _left.completed;
-      _mrFun.reduce(_left._mrFun);
-      _left = null;
+      if(_mrFun == null)_mrFun = _left._mrFun;
+      else _mrFun.reduce(_left._mrFun);
     }
-    if (_rite != null) {
+    if (_rite != null && _mrFun != _rite._mrFun) {
       assert _rite.completed;
-      _mrFun.reduce(_rite._mrFun);
-      _rite = null;
+      if(_mrFun == null)_mrFun = _rite._mrFun;
+      else _mrFun.reduce(_rite._mrFun);
     }
+    _left = null;
+    _rite = null;
+    completed = true;
   }
 
 }

--- a/h2o-core/src/main/java/water/LocalMR.java
+++ b/h2o-core/src/main/java/water/LocalMR.java
@@ -36,9 +36,15 @@ public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR
 
   public LocalMR(MrFun mrt){this(mrt,H2O.NUMCPUS);}
   public LocalMR(MrFun mrt, int nthreads){this(mrt,nthreads,null);}
-  public LocalMR(MrFun mrt, H2O.H2OCountedCompleter cc){this(mrt,H2O.NUMCPUS,cc,(byte)(H2O.H2OCallback.currThrPriority()+1));}
-  public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc){this(mrt,nthreads,cc,(byte)(H2O.H2OCallback.currThrPriority()+1));}
-  public LocalMR(MrFun mrt, int nthreads, byte priority) {this(mrt,nthreads,null,priority);}
+  public LocalMR(MrFun mrt, H2O.H2OCountedCompleter cc){this(mrt,H2O.NUMCPUS,cc);}
+  public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc){
+    super(cc);
+    if(nthreads <= 0) throw new IllegalArgumentException("nthreads must be positive");
+    _root = this;
+    _mrFun = mrt;
+    _lo = 0;
+    _hi = nthreads;
+  }
   public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc, byte priority) {
     super(cc,priority);
     if(nthreads <= 0) throw new IllegalArgumentException("nthreads must be positive");

--- a/h2o-core/src/main/java/water/LocalMR.java
+++ b/h2o-core/src/main/java/water/LocalMR.java
@@ -1,30 +1,39 @@
 package water;
 
 import jsr166y.CountedCompleter;
+import jsr166y.RecursiveAction;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 
 /**
  * Created by tomas on 11/5/16.
  *
- * Generic Local MRTask utility. Will launch requested number of tasks (on local node!), organized in a binary tree fashion.
+ * Generic lightewight Local MRTask utility. Will launch requested number of tasks (on local node!), organized in a binary tree fashion, similar to MRTask.
+ * Will attempt to share local results (MrFun instances) if the previous task has completed before launching current task.
  *
+ * User expected to pass in MrFun implementing map(id), reduce(MrFun) and makeCopy() functions.
+ * At the end of the task, MrFun holds the result.
  */
-public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR> {
+public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR>  {
   private int _lo;
   private int _hi;
   MrFun _mrFun;
   volatile Throwable _t;
-  protected volatile boolean  _cancelled;
+  private  volatile boolean  _cancelled;
   private LocalMR<T> _root;
 
   public LocalMR(MrFun mrt, int nthreads){this(mrt,nthreads,null);}
   public LocalMR(MrFun mrt, H2O.H2OCountedCompleter cc){this(mrt,H2O.NUMCPUS,cc);}
   public LocalMR(MrFun mrt, int nthreads, H2O.H2OCountedCompleter cc){
     super(cc);
-    if(nthreads <= 0) throw new IllegalArgumentException("nthreads must be positive");
+    if(nthreads <= 0)
+      throw new IllegalArgumentException("nthreads must be positive");
     _root = this;
-    _mrFun = mrt;
+    _mrFun = mrt; // used as golden copy and also will hold the result after task has finished.
     _lo = 0;
     _hi = nthreads;
     _prevTsk = null;
@@ -40,7 +49,7 @@ public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR
 
   private LocalMR<T> _left;
   private LocalMR<T> _rite;
-  private final LocalMR<T> _prevTsk; // right child will attempt to share MrFun with " left sibling" if the whole left subtree is done
+  private final LocalMR<T> _prevTsk; //will attempt to share MrFun with "previous task" if it's done by the time we start
 
 
   volatile boolean completed; // this task and all it's children completed
@@ -52,61 +61,66 @@ public class LocalMR<T extends MrFun<T>> extends H2O.H2OCountedCompleter<LocalMR
   @Override
   public final void compute2() {
     started = true;
-    if (!_root._cancelled) {
+    if(_root._cancelled){
+      tryComplete();
+      return;
+    }
+    int mid = mid();
+    assert _hi > _lo;
+    if (_hi - _lo >= 2) {
+      _left = new LocalMR(this, _prevTsk, _lo, mid);
+      if (mid < _hi) {
+        addToPendingCount(1);
+        (_rite = new LocalMR(this, _left, mid, _hi)).fork();
+      }
+      _left.compute2();
+    } else {
+      if(_prevTsk != null && _prevTsk.completed){
+        _mrFun = _prevTsk._mrFun;
+        _prevTsk._mrFun = null;
+      } else if(this != _root)
+        _mrFun = _root._mrFun.makeCopy();
       try {
-        int mid = mid();
-        assert _hi > _lo;
-        int pending = 1;
-        if (_hi - _lo >= 2) {
-          _left = new LocalMR(this, _prevTsk, _lo, mid);
-          if (mid < _hi) {
-            _rite = new LocalMR(this, _left, mid, _hi);
-            pending++;
-          }
-          addToPendingCount(pending);
-          if(_rite != null) _rite.fork();
-          _left.fork();
-        } else {
-
-          if(_prevTsk != null && _prevTsk.completed){
-            _mrFun = _prevTsk._mrFun;
-            _prevTsk._mrFun = null;
-          } else _mrFun = _root._mrFun.makeCopy();
-          _mrFun.map(mid);
-        }
+        _mrFun.map(mid);
       } catch (Throwable t) {
-        t.printStackTrace();
         if (_root._t == null) {
           _root._t = t;
           _root._cancelled = true;
         }
       }
+      tryComplete();
     }
-    tryComplete();
   }
 
   @Override
   public final void onCompletion(CountedCompleter cc) {
-    if(_cancelled){
-      assert this == _root;
-      completeExceptionally(_t == null?new CancellationException():_t); // instead of throw
-      return;
+    try {
+      if (_cancelled) {
+        assert this == _root;
+        completeExceptionally(_t == null ? new CancellationException() : _t); // instead of throw
+        return;
+      }
+      if (_root._cancelled) return;
+      if (_left != null && _left._mrFun != null && _mrFun != _left._mrFun) {
+        assert _left.completed;
+        if (_mrFun == null) _mrFun = _left._mrFun;
+        else _mrFun.reduce(_left._mrFun);
+      }
+      if (_rite != null && _mrFun != _rite._mrFun) {
+        assert _rite.completed;
+        if (_mrFun == null) _mrFun = _rite._mrFun;
+        else _mrFun.reduce(_rite._mrFun);
+      }
+      _left = null;
+      _rite = null;
+      completed = true;
+    } catch(Throwable t){
+      if(this == _root){
+        completeExceptionally(t); // instead of throw
+      } else if (_root._t == null) {
+        _root._t = t;
+        _root._cancelled = true;
+      }
     }
-    if(_root._cancelled) return;
-    assert cc == this || cc == _left || cc == _rite;
-    if (_left != null && _left._mrFun != null && _mrFun != _left._mrFun) {
-      assert _left.completed;
-      if(_mrFun == null)_mrFun = _left._mrFun;
-      else _mrFun.reduce(_left._mrFun);
-    }
-    if (_rite != null && _mrFun != _rite._mrFun) {
-      assert _rite.completed;
-      if(_mrFun == null)_mrFun = _rite._mrFun;
-      else _mrFun.reduce(_rite._mrFun);
-    }
-    _left = null;
-    _rite = null;
-    completed = true;
   }
-
 }

--- a/h2o-core/src/main/java/water/MRTask.java
+++ b/h2o-core/src/main/java/water/MRTask.java
@@ -502,6 +502,7 @@ public abstract class MRTask<T extends MRTask<T>> extends DTask<T> implements Fo
     H2O.submitTask(this);
   }
 
+  protected boolean modifiesVolatileVecs(){return true;}
   /*
    * Set top-level fields and fire off remote work (if there is any to do) to 2 selected
    * child JVM/nodes. Setup for local work: fire off any global work to cloud neighbors; do all
@@ -512,6 +513,10 @@ public abstract class MRTask<T extends MRTask<T>> extends DTask<T> implements Fo
       (_profile = new MRProfile(this))._localstart = System.currentTimeMillis();
     // Make a blockable Futures for both internal and user work to block on.
     _fs = new Futures();
+    if(modifiesVolatileVecs() && _fr != null){
+      for(Vec v:_fr.vecs())
+        if(v.isVolatile())v.preWriting();
+    }
     _topLocal = true;
     // Check for global vs local work
     int selfidx = selfidx();

--- a/h2o-core/src/main/java/water/MemoryManager.java
+++ b/h2o-core/src/main/java/water/MemoryManager.java
@@ -255,7 +255,12 @@ abstract public class MemoryManager {
   public static int    [] malloc4 (int size) { return (int    [])malloc(size,size*4L, 4,null,0); }
   public static long   [] malloc8 (int size) { return (long   [])malloc(size,size*8L, 8,null,0); }
   public static float  [] malloc4f(int size) { return (float  [])malloc(size,size*4L, 5,null,0); }
-  public static double [] malloc8d(int size) { return (double [])malloc(size,size*8L, 9,null,0); }
+  public static double [] malloc8d(int size) {
+    if(size < 32) try { // fast path for small arrays (e.g. histograms in gbm)
+      return new double [size];
+    } catch (OutOfMemoryError oom){/* fall through */}
+    return (double [])malloc(size,size*8L, 9,null,0);
+  }
   public static double [][] malloc8d(int m, int n) {
     double [][] res = new double[m][];
     for(int i = 0; i < m; ++i)

--- a/h2o-core/src/main/java/water/MemoryManager.java
+++ b/h2o-core/src/main/java/water/MemoryManager.java
@@ -62,7 +62,6 @@ abstract public class MemoryManager {
   // A monotonically increasing total count memory allocated via MemoryManager.
   // Useful in tracking total memory consumed by algorithms - just ask for the
   // before & after amounts and diff them.
-  static final AtomicLong MEM_ALLOC = new AtomicLong();
 
   static void setMemGood() {
     if( CAN_ALLOC ) return;
@@ -221,7 +220,6 @@ abstract public class MemoryManager {
           try { _lock.wait(300*1000); } catch (InterruptedException ex) { }
         }
       }
-      MEM_ALLOC.addAndGet(bytes);
       try {
         switch( type ) {
         case  1: return new byte   [elems];

--- a/h2o-core/src/main/java/water/fvec/C4FVolatileChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C4FVolatileChunk.java
@@ -1,0 +1,84 @@
+package water.fvec;
+
+import water.H2O;
+import water.util.UnsafeUtils;
+
+/**
+ * The empty-compression function, where data is in 'double's.
+ */
+public class C4FVolatileChunk extends Chunk {
+  public transient final float [] _fs;
+  C4FVolatileChunk(float[] ds ) { _mem=new byte[0]; _start = -1; _len = ds.length; _fs = ds; }
+
+  @Override protected final long   at8_impl( int i ) {
+    double res = atd_impl(i);
+    if( Double.isNaN(res) ) throw new IllegalArgumentException("at8_abs but value is missing");
+    return (long)res;
+  }
+  @Override protected final double   atd_impl( int i ) {
+    return _fs[i] ;
+  }
+  @Override protected final boolean isNA_impl( int i ) { return Float.isNaN(_fs[i]); }
+  @Override boolean set_impl(int idx, long l) {
+    return false;
+  }
+
+  /**
+   * Fast explicit set for double.
+   * @param i
+   * @param d
+   */
+
+
+  @Override boolean set_impl(int i, double d) {
+    _fs[i] = (float)d;
+    return true;
+  }
+  @Override boolean set_impl(int i, float f ) {
+    _fs[i] = f;
+    return true;
+  }
+
+
+  @Override boolean setNA_impl(int idx) { UnsafeUtils.set8d(_mem,(idx<<3),Double.NaN); return true; }
+  @Override public NewChunk inflate_impl(NewChunk nc) {
+    //nothing to inflate - just copy
+    nc.alloc_doubles(_len);
+    for( int i=0; i< _len; i++ )
+      nc.doubles()[i] = _fs[i];
+    nc.set_sparseLen(nc.set_len(_len));
+    return nc;
+  }
+  // 3.3333333e33
+//  public int pformat_len0() { return 22; }
+//  public String pformat0() { return "% 21.15e"; }
+  @Override public final void initFromBytes () {
+    throw H2O.unimpl();
+  }
+
+  @Override
+  public double [] getDoubles(double [] vals, int from, int to){
+    throw H2O.unimpl();
+  }
+
+  /**
+   * Dense bulk interface, fetch values from the given range
+   * @param vals
+   * @param from
+   * @param to
+   */
+  @Override
+  public double [] getDoubles(double [] vals, int from, int to, double NA){
+    throw H2O.unimpl();
+  }
+  /**
+   * Dense bulk interface, fetch values from the given ids
+   * @param vals
+   * @param ids
+   */
+  @Override
+  public double [] getDoubles(double [] vals, int [] ids){
+    throw H2O.unimpl();
+  }
+
+}

--- a/h2o-core/src/main/java/water/fvec/C4VolatileChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C4VolatileChunk.java
@@ -8,8 +8,14 @@ import water.util.UnsafeUtils;
  */
 public class C4VolatileChunk extends Chunk {
   static protected final long _NA = Integer.MIN_VALUE;
-  transient public final int [] _is;
+  transient private final int [] _is;
+
   C4VolatileChunk(int[] is ) { _is = is; _mem = new byte[0]; _start = -1; _len = is.length; }
+
+  public int[] getValuesForWriting(){
+    _vec.preWriting();
+    return _is;
+  }
   @Override protected final long at8_impl( int i ) {
     long res = _is[i];
     if( res == _NA ) throw new IllegalArgumentException("at8_abs but value is missing");
@@ -82,4 +88,5 @@ public class C4VolatileChunk extends Chunk {
     }
     throw H2O.unimpl();
   }
+
 }

--- a/h2o-core/src/main/java/water/fvec/C4VolatileChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C4VolatileChunk.java
@@ -1,0 +1,85 @@
+package water.fvec;
+
+import water.H2O;
+import water.util.UnsafeUtils;
+
+/**
+ * The empty-compression function, where data is in 'int's.
+ */
+public class C4VolatileChunk extends Chunk {
+  static protected final long _NA = Integer.MIN_VALUE;
+  transient public final int [] _is;
+  C4VolatileChunk(int[] is ) { _is = is; _mem = new byte[0]; _start = -1; _len = is.length; }
+  @Override protected final long at8_impl( int i ) {
+    long res = _is[i];
+    if( res == _NA ) throw new IllegalArgumentException("at8_abs but value is missing");
+    return res;
+  }
+  @Override protected final double atd_impl( int i ) {
+    long res = _is[i];
+    return res == _NA?Double.NaN:res;
+  }
+  @Override protected final boolean isNA_impl( int i ) { return _is[i] == _NA; }
+  @Override boolean set_impl(int idx, long l) {
+    if( !(Integer.MIN_VALUE < l && l <= Integer.MAX_VALUE) ) return false;
+    _is[idx] = (int)l;
+    return true;
+  }
+  @Override boolean set_impl(int i, double d) {
+    return false; }
+  @Override boolean set_impl(int i, float f ) {
+    return false; }
+  @Override boolean setNA_impl(int idx) { _is[idx] = (int)_NA; return true; }
+  @Override public NewChunk inflate_impl(NewChunk nc) {
+    nc.set_sparseLen(0);
+    nc.set_len(0);
+    final int len = _len;
+    for( int i=0; i<len; i++ ) {
+      int res = _is[i];
+      if( res == _NA ) nc.addNA();
+      else             nc.addNum(res,0);
+    }
+    return nc;
+  }
+  @Override public final void initFromBytes () {throw H2O.unimpl();}
+  @Override public boolean hasFloat() {return false;}
+
+
+  /**
+   * Dense bulk interface, fetch values from the given range
+   * @param vals
+   * @param from
+   * @param to
+   */
+  @Override
+  public double [] getDoubles(double [] vals, int from, int to, double NA){
+    for(int i = from; i < to; ++i) {
+      long res = _is[i];
+      vals[i - from] = res != _NA?res:NA;
+    }
+    return vals;
+  }
+  /**
+   * Dense bulk interface, fetch values from the given ids
+   * @param vals
+   * @param ids
+   */
+  @Override
+  public double [] getDoubles(double [] vals, int [] ids){
+    int j = 0;
+    for(int i:ids){
+      long res = _is[i];
+      vals[j++] = res != _NA?res:Double.NaN;
+    }
+    return vals;
+  }
+
+  @Override
+  public int [] getIntegers(int [] vals, int from, int to, int NA){
+    if(NA == _NA) {
+      System.arraycopy(_is,from,vals,0,to-from);
+      return vals;
+    }
+    throw H2O.unimpl();
+  }
+}

--- a/h2o-core/src/main/java/water/fvec/C8DVolatileChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C8DVolatileChunk.java
@@ -1,0 +1,89 @@
+package water.fvec;
+
+import water.H2O;
+import water.util.UnsafeUtils;
+
+/**
+ * The empty-compression function, where data is in 'double's.
+ */
+public class C8DVolatileChunk extends Chunk {
+  private transient final double [] _ds;
+  C8DVolatileChunk(double[] ds ) { _mem=new byte[0]; _start = -1; _len = ds.length; _ds = ds; }
+
+  public double [] getValuesForWriting(){
+    _vec.preWriting();
+    return _ds;
+  }
+  @Override protected final long   at8_impl( int i ) {
+    double res = atd_impl(i);
+    if( Double.isNaN(res) ) throw new IllegalArgumentException("at8_abs but value is missing");
+    return (long)res;
+  }
+  @Override protected final double   atd_impl( int i ) {
+    return _ds[i] ;
+  }
+  @Override protected final boolean isNA_impl( int i ) { return Double.isNaN(_ds[i]); }
+  @Override boolean set_impl(int idx, long l) {
+    return false;
+  }
+
+  /**
+   * Fast explicit set for double.
+   * @param i
+   * @param d
+   */
+  public void set8D(int i, double d) {_ds[i] = d;}
+  public double get8D(int i) {return _ds[i];}
+
+  @Override boolean set_impl(int i, double d) {
+    _ds[i] = d;
+    return true;
+  }
+  @Override boolean set_impl(int i, float f ) {
+    _ds[i] = f;
+    return true;
+  }
+
+
+  @Override boolean setNA_impl(int idx) { UnsafeUtils.set8d(_mem,(idx<<3),Double.NaN); return true; }
+  @Override public NewChunk inflate_impl(NewChunk nc) {
+    //nothing to inflate - just copy
+    nc.alloc_doubles(_len);
+    for( int i=0; i< _len; i++ )
+      nc.doubles()[i] = _ds[i];
+    nc.set_sparseLen(nc.set_len(_len));
+    return nc;
+  }
+  // 3.3333333e33
+//  public int pformat_len0() { return 22; }
+//  public String pformat0() { return "% 21.15e"; }
+  @Override public final void initFromBytes () {
+    throw H2O.unimpl();
+  }
+
+  @Override
+  public double [] getDoubles(double [] vals, int from, int to){
+    throw H2O.unimpl();
+  }
+
+  /**
+   * Dense bulk interface, fetch values from the given range
+   * @param vals
+   * @param from
+   * @param to
+   */
+  @Override
+  public double [] getDoubles(double [] vals, int from, int to, double NA){
+    throw H2O.unimpl();
+  }
+  /**
+   * Dense bulk interface, fetch values from the given ids
+   * @param vals
+   * @param ids
+   */
+  @Override
+  public double [] getDoubles(double [] vals, int [] ids){
+    throw H2O.unimpl();
+  }
+
+}

--- a/h2o-core/src/main/java/water/fvec/C8DVolatileChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C8DVolatileChunk.java
@@ -5,17 +5,18 @@ import water.util.UnsafeUtils;
 
 /**
  * The empty-compression function, where data is in 'double's.
+ * Can only be used locally (intentionally does not serialize).
+ * Intended for temporary data which gets modified frequently.
+ * Exposes data directly as double[]
  */
-public class C8DVolatileChunk extends Chunk {
+public final class C8DVolatileChunk extends Chunk {
   private transient final double [] _ds;
   C8DVolatileChunk(double[] ds ) { _mem=new byte[0]; _start = -1; _len = ds.length; _ds = ds; }
 
-  public double [] getValuesForWriting(){
-    _vec.preWriting();
-    return _ds;
-  }
+
+  public double [] getValues(){return _ds;}
   @Override protected final long   at8_impl( int i ) {
-    double res = atd_impl(i);
+    double res = _ds[i];
     if( Double.isNaN(res) ) throw new IllegalArgumentException("at8_abs but value is missing");
     return (long)res;
   }
@@ -26,15 +27,6 @@ public class C8DVolatileChunk extends Chunk {
   @Override boolean set_impl(int idx, long l) {
     return false;
   }
-
-  /**
-   * Fast explicit set for double.
-   * @param i
-   * @param d
-   */
-  public void set8D(int i, double d) {_ds[i] = d;}
-  public double get8D(int i) {return _ds[i];}
-
   @Override boolean set_impl(int i, double d) {
     _ds[i] = d;
     return true;
@@ -43,8 +35,6 @@ public class C8DVolatileChunk extends Chunk {
     _ds[i] = f;
     return true;
   }
-
-
   @Override boolean setNA_impl(int idx) { UnsafeUtils.set8d(_mem,(idx<<3),Double.NaN); return true; }
   @Override public NewChunk inflate_impl(NewChunk nc) {
     //nothing to inflate - just copy
@@ -57,9 +47,7 @@ public class C8DVolatileChunk extends Chunk {
   // 3.3333333e33
 //  public int pformat_len0() { return 22; }
 //  public String pformat0() { return "% 21.15e"; }
-  @Override public final void initFromBytes () {
-    throw H2O.unimpl();
-  }
+  @Override public final void initFromBytes () {throw H2O.unimpl("should not be used for a volatile chunk");}
 
   @Override
   public double [] getDoubles(double [] vals, int from, int to){

--- a/h2o-core/src/main/java/water/fvec/Chunk.java
+++ b/h2o-core/src/main/java/water/fvec/Chunk.java
@@ -605,6 +605,23 @@ public abstract class Chunk extends Iced<Chunk> {
     return _cidx;
   }
 
+//  public final Chunk setVolatile(double [] ds) {
+//    Chunk res;
+//    DKV.put(_vec.chunkKey(_cidx),res = new C8DVolatileChunk(ds));
+//    return res;
+//  }
+//
+//  public final Chunk setVolatile(float [] fs) {
+//    Chunk res;
+//    DKV.put(_vec.chunkKey(_cidx),res = new C4FVolatileChunk(fs));
+//    return res;
+//  }
+  public final Chunk setVolatile(int[] vals) {
+      Chunk res;
+      DKV.put(_vec.chunkKey(_cidx),res = new C4VolatileChunk(vals));
+      return res;
+  }
+
   static class WrongType extends IllegalArgumentException {
     private final Class<?> expected;
     private final Class<?> actual;

--- a/h2o-core/src/main/java/water/fvec/Chunk.java
+++ b/h2o-core/src/main/java/water/fvec/Chunk.java
@@ -611,11 +611,17 @@ public abstract class Chunk extends Iced<Chunk> {
 //    return res;
 //  }
 //
-//  public final Chunk setVolatile(float [] fs) {
-//    Chunk res;
-//    DKV.put(_vec.chunkKey(_cidx),res = new C4FVolatileChunk(fs));
-//    return res;
-//  }
+  public final Chunk setVolatile(float [] fs) {
+    Chunk res;
+    DKV.put(_vec.chunkKey(_cidx),res = new C4FVolatileChunk(fs));
+    return res;
+  }
+  public final Chunk setVolatile(double [] ds) {
+    Chunk res;
+    DKV.put(_vec.chunkKey(_cidx),res = new C8DVolatileChunk(ds));
+    return res;
+  }
+
   public final Chunk setVolatile(int[] vals) {
       Chunk res;
       DKV.put(_vec.chunkKey(_cidx),res = new C4VolatileChunk(vals));

--- a/h2o-core/src/main/java/water/fvec/RollupStats.java
+++ b/h2o-core/src/main/java/water/fvec/RollupStats.java
@@ -254,6 +254,10 @@ final class RollupStats extends Iced {
   private static class Roll extends MRTask<Roll> {
     final Key _rskey;
     RollupStats _rs;
+
+    @Override
+    protected boolean modifiesVolatileVecs(){return false;}
+
     Roll( H2OCountedCompleter cmp, Key rskey ) { super(cmp); _rskey=rskey; }
     @Override public void map( Chunk c ) { _rs = new RollupStats(0).map(c); }
     @Override public void reduce( Roll roll ) { _rs.reduce(roll._rs); }

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -528,6 +528,35 @@ public class Vec extends Keyed<Vec> {
   }
 
   public Vec [] makeZeros(int n){return makeZeros(n,null,null);}
+
+//  public Vec [] makeVolatileFloats(int n){
+//    Vec [] vecs = makeZeros(n);
+//    new MRTask(){
+//      @Override public void map(Chunk [] cs){
+//        int len = cs[0].len();
+//        for(int i = 0; i < cs.length; ++i) {
+//          cs[i].setVolatile(MemoryManager.malloc4f(len));
+//        }
+//      }
+//    }.doAll(vecs);
+//    return vecs;
+//  }
+
+  public Vec [] makeVolatileInts(final int [] cons){
+    Vec [] vecs = makeZeros(cons.length);
+    new MRTask(){
+      @Override public void map(Chunk [] cs){
+        int len = cs[0].len();
+        for(int i = 0; i < cs.length; ++i) {
+          int [] vals = MemoryManager.malloc4(len);
+          Arrays.fill(vals,cons[i]);
+          cs[i].setVolatile(vals);
+        }
+      }
+    }.doAll(vecs);
+    return vecs;
+  }
+
   public Vec [] makeZeros(int n, String [][] domain, byte[] types){ return makeCons(n, 0, domain, types);}
 
   // Make a bunch of compatible zero Vectors

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -543,6 +543,14 @@ public class Vec extends Keyed<Vec> {
     return vecs;
   }
 
+  /**
+   * Make a temporary work vec of double [] .
+   * Volatile vecs can only be used locally (chunks do not serialize) and are assumed to change frequently(MRTask call preWiting() by default).
+   * Chunks stores as C8DVolatileChunk - expose data directly as double [].
+   *
+   * @param n number of columns
+   * @return
+   */
   public Vec [] makeVolatileDoubles(int n){
     Vec [] vecs = makeZeros(n);
     for(Vec v:vecs) {
@@ -561,6 +569,14 @@ public class Vec extends Keyed<Vec> {
     return vecs;
   }
 
+  /**
+   * Make a temporary work vec of int [] .
+   * Volatile vecs can only be used locally (chunks do not serialize) and are assumed to change frequently(MRTask call preWiting() by default).
+   * Chunks stores as C4VolatileChunk - expose data directly as int [].
+   *
+   * @param cons integer array with constant used to fill each column.
+   * @return
+   */
   public Vec [] makeVolatileInts(final int [] cons){
     Vec [] vecs = makeZeros(cons.length);
     for(Vec v:vecs) {
@@ -871,6 +887,7 @@ public class Vec extends Keyed<Vec> {
     return Key.make(bits);
   }
 
+  public transient int [] _cids; // local chunk ids
   /** Get a Chunk Key from a chunk-index.  Basically the index-to-key map.
    *  @return Chunk Key from a chunk-index */
   public Key chunkKey(int cidx ) { return chunkKey(_key,cidx); }

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -182,12 +182,15 @@ public class ArrayUtils {
 
   public static <T extends Iced> T[][] deepClone(T [][] ary){
     T [][] res = ary.clone();
-    for(int i = 0 ; i < res.length; ++i) {
-      res[i] = ary[i].clone();
-      for(int j = 0; j < res[i].length; ++j)
-        if(res[i][j] != null)
-          res[i][j] = (T)res[i][j].clone();
-    }
+    for(int i = 0 ; i < res.length; ++i)
+      res[i] = deepClone(res[i]);
+    return res;
+  }
+  public static <T extends Iced> T[] deepClone(T [] ary){
+    T [] res = ary.clone();
+    for(int j = 0; j < res.length; ++j)
+      if(res[j] != null)
+        res[j] = (T)res[j].clone();
     return res;
   }
 

--- a/h2o-core/src/main/java/water/util/IcedBitSet.java
+++ b/h2o-core/src/main/java/water/util/IcedBitSet.java
@@ -66,7 +66,7 @@ public class IcedBitSet extends Iced {
     int bytes = numBytes();
     if( _byteoff != 0 ) throw H2O.fail(); // TODO
     for(int i = 0; i < bytes; i++)
-      nbits += Integer.bitCount(_val[i]);
+      nbits += Integer.bitCount(0xFF&_val[i]);
     return nbits;
   }
 

--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -574,6 +574,7 @@ public class VecUtils {
     }
   }
   public static int [] getLocalChunkIds(Vec v){
+    if(v._cids != null) return v._cids;
     int [] res = new int[Math.max(v.nChunks()/H2O.CLOUD.size(),1)];
     int j = 0;
     for(int i = 0; i < v.nChunks(); ++i){
@@ -582,6 +583,6 @@ public class VecUtils {
         res[j++] = i;
       }
     }
-    return j == res.length?res:Arrays.copyOf(res,j);
+    return (v._cids = j == res.length?res:Arrays.copyOf(res,j));
   }
 }


### PR DESCRIPTION
Couple of changes further improving performance of GBM/DRF:
  1. DRF now uses ScoreBuildHistogram2.
  2. Added "volatile" vecs/chunks to store temporary values which are written into frequently.
      The intention is to keep these directly in double[]/int[]/float[] arrrays, currently no support for sending to remote, work only locally. Also MRTask are expected to write into volatile vecs by default (arrays are directly exposed, can't keep track of who actually writes).
  3. Use new volatile vecs for all temp vecs made during gbm (leaf assignment, response)
  4. Removed notion of column block in ScoreBuildHistogram. now always parallelize over single column (there is no more per-row-of-chunks work).
   5. improved paralelization of histogram computation 
      now launches LocalMR task over columns which launches LocalMRTask for each column. 
     This way worker threads work on all columns first before starting to parallelize within columns (reduces memory overhead of private histogram copies).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/541)
<!-- Reviewable:end -->
