### PR TITLE
Add config file reader for R

### DIFF
--- a/h2o-r/h2o-DESCRIPTION.template
+++ b/h2o-r/h2o-DESCRIPTION.template
@@ -28,6 +28,7 @@ Suggests: ggplot2,
 Collate:
          'astfun.R'
          'classes.R'
+         'config.R'
          'connection.R'
          'constants.R'
          'datasets.R'

--- a/h2o-r/h2o-package/R/config.R
+++ b/h2o-r/h2o-package/R/config.R
@@ -8,7 +8,7 @@
 
     #Allowed config keys
     allowed_config_keys = c("init.check_version", "init.proxy","init.cluster_id",
-    "init.verify_ssl_certificates","init.cookies")
+    "init.verify_ssl_certificates","init.cookies","general.allow_breaking_changes")
 
     #Read in config line by line
     connection <- file(h2oconfig_filename)

--- a/h2o-r/h2o-package/R/config.R
+++ b/h2o-r/h2o-package/R/config.R
@@ -1,0 +1,107 @@
+
+# R Parser for an h2o config file
+#
+# Input is the path to an .h2oconfig file
+# Returns the .h2oconfig file as a data frame with respective key-value pairs as headers
+.parse.h2oconfig <- function(h2oconfig_filename){
+    cat(paste0("Reading in config file: ",h2oconfig_filename,"\n"))
+
+    #Allowed config keys
+    allowed_config_keys = c("init.check_version", "init.proxy","init.cluster_id",
+    "init.verify_ssl_certificates","init.cookies")
+
+    #Read in config line by line
+    connection <- file(h2oconfig_filename)
+    Lines  <- readLines(connection)
+
+    #Check for correct section headers. In this case it is [init]. Can update in time.
+    if(grepl("\\[|\\]",Lines) && !("[init]" %in% Lines)){
+        return()
+    }
+    close(connection)
+
+    #Some sanity checks
+    Lines <- chartr("[]", "==", Lines)  # change section headers
+    Lines <- subset(Lines,!grepl("^#",Lines)) #Exclude hashtag comments
+    Lines <- subset(Lines,!grepl("^py:",ignore.case=TRUE,Lines)) #Exclude any Python specific parameters if present (Not case sensitive)
+    Lines <- gsub(".*^r:","",ignore.case=TRUE,Lines) #Get R specific parameters if present (Not case sensitive)
+    connection <- textConnection(Lines)
+
+    #If any empty sections after initial parse return NULL
+    if(length(Lines) == 0 || all(Lines == "")){
+        return()
+    }
+
+    #Get connection to previous parse and make initial data frame
+    d <- read.table(connection, as.is = TRUE, sep = "=", fill = TRUE)
+    #Trim whitespace from potential columns
+    d$V1 = trimws(d$V1)
+    #Only get last occurence of duplicates
+    d = d[!rev(duplicated(rev(d$V1))),]
+    close(connection)
+
+    #If no headers are present & no leading #(indicate comments) & no empty strings return NULL
+    if(grepl("^=",Lines) && !grepl("^#",Lines) && any(Lines=="")){
+        return()
+    }
+    #If no section headers, then we parse the list itself and return the final parsed data frame
+    if(!(grepl("^=",Lines)) && !grepl("^#",Lines)){
+        ini_to_df <- data.frame(t(d$V2))
+        colnames(ini_to_df) <- d$V1
+        colnames(ini_to_df) <- trimws(colnames(ini_to_df))
+
+        #Check if allowed keys are present. If none are present, return NULL
+        names <- colnames(ini_to_df)[which(colnames(ini_to_df) %in% allowed_config_keys)]
+        if(length(names) == 0){
+            return()
+        }
+        ini_to_df = ini_to_df[,names]
+        ini_to_df = data.frame(ini_to_df)
+        colnames(ini_to_df) <- names
+        ini_to_df <- data.frame(lapply(ini_to_df, trimws))
+        return(ini_to_df)
+    }
+
+    L <- d$V1 == ""                    # location of section breaks
+    d <- subset(transform(d, V3 = V2[which(L)[cumsum(L)]])[1:3], V1 != "")
+
+    ToParse  <- paste("ini_list$", d$V3, "$",  d$V1, " <- '",
+    d$V2, "'", sep="")
+
+    ini_list <- list()
+    eval(parse(text=ToParse))
+    col_name_sections <- names(ini_list)
+
+    ini_to_df <- as.data.frame.list(ini_list)
+    colnames(ini_to_df) <- trimws(colnames(ini_to_df))
+    names <- colnames(ini_to_df)[which(colnames(ini_to_df) %in% allowed_config_keys)]
+    if(length(names) == 0){
+        return()
+    }
+    ini_to_df = ini_to_df[,names]
+    colnames(ini_to_df) <- names
+    ini_to_df <- data.frame(lapply(ini_to_df, trimws))
+    return(ini_to_df)
+}
+
+
+#Helper function responsible for reading h2o config files.
+
+#This function will look for file(s) named ".h2oconfig" in the current folder, in all parent folders, and finally in
+#the user's home directory. The first such file found will be used for configuration purposes. The format for such
+#file is a simple "key = value" store, with possible section names in square brackets. Single-line comments starting
+#with '#' are also allowed.
+.h2o.candidate.config.files <- function(){
+    path_to_config = getwd()
+    current_directory = getwd()
+    while(identical(Sys.glob(".h2oconfig"),character(0))){
+        if(getwd() == "/"){
+            setwd(current_directory)
+            return()
+        }
+        setwd("..")
+        path_to_config = getwd()
+    }
+    setwd(current_directory)
+    return(paste0(path_to_config,"/.h2oconfig"))
+}

--- a/h2o-r/h2o-package/R/config.R
+++ b/h2o-r/h2o-package/R/config.R
@@ -15,7 +15,7 @@
     Lines  <- readLines(connection)
 
     #Check for correct section headers. In this case it is [init]. Can update in time.
-    if(grepl("\\[|\\]",Lines) && !("[init]" %in% Lines)){
+    if(grepl("\\[|\\]",Lines) && all(!("[init]" %in% Lines))){
         return()
     }
     close(connection)

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -56,6 +56,35 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
                      max_mem_size = NULL, min_mem_size = NULL,
                      ice_root = tempdir(), strict_version_check = TRUE, proxy = NA_character_,
                      https = FALSE, insecure = FALSE, username = NA_character_, password = NA_character_, cluster_id = NA_integer_, cookies = NA_character_) {
+
+    # Check for .h2oconfig file
+    # Find .h2oconfig file starting from currenting directory and going
+    # up all parent directories until it reaches the root directory.
+    config_path <- .h2o.candidate.config.files()
+
+    #Read in config if available
+    if(!(is.null(config_path))){
+
+      h2oconfig = .parse.h2oconfig(config_path)
+
+      #Check for each `allowed_config_keys` in the config file and set to counterparts in `h2o.init()`
+      if(strict_version_check != TRUE && "init.check_version" %in% colnames(h2oconfig)){
+        strict_version_check = as.logical(trimws(toupper(as.character(h2oconfig$init.check_version))))
+      }
+      if(is.na(proxy) && "init.proxy" %in% colnames(h2oconfig)){
+        proxy = trimws(as.character(h2oconfig$init.proxy))
+      }
+      if(is.na(cluster_id) && "init.cluster_id" %in% colnames(h2oconfig)){
+        cluster_id = as.numeric(as.character(h2oconfig$init.cluster_id))
+      }
+      if(insecure == FALSE && "init.verify_ssl_certificates" %in% colnames(h2oconfig)){
+        insecure = as.logical(trimws(toupper(as.character(h2oconfig$init.verify_ssl_certificates))))
+      }
+      if(is.na(cookies) && "init.cookies" %in% colnames(h2oconfig)){
+        cookies = as.vector(trimws(strsplit(as.character(h2oconfig$init.cookies),";")[[1]]))
+    }
+  }
+
   if(!is.character(ip) || length(ip) != 1L || is.na(ip) || !nzchar(ip))
     stop("`ip` must be a non-empty character string")
   if(!is.numeric(port) || length(port) != 1L || is.na(port) || port < 0 || port > 65536)

--- a/h2o-r/scripts/h2o-r-test-setup.R
+++ b/h2o-r/scripts/h2o-r-test-setup.R
@@ -148,7 +148,7 @@ function() {
         strict_version_check <- TRUE
     } else if (IS.RUNIT) {
         # source h2o-r/h2o-package/R. overrides h2o package load
-        to_src <- c("classes.R", "connection.R", "constants.R", "logging.R", "communication.R", "kvstore.R",
+        to_src <- c("classes.R", "connection.R","config.R", "constants.R", "logging.R", "communication.R", "kvstore.R",
                     "frame.R", "astfun.R", "import.R", "parse.R", "export.R", "models.R", "edicts.R", "gbm.R",
                     "glm.R", "glrm.R", "kmeans.R", "deeplearning.R", "deepwater.R", "randomforest.R", "naivebayes.R", "pca.R",
                     "svd.R", "locate.R","grid.R")

--- a/h2o-r/tests/testdir_misc/runit_h2oconfig.R
+++ b/h2o-r/tests/testdir_misc/runit_h2oconfig.R
@@ -1,0 +1,99 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.config <- function() {
+    if(!dir.exists("../results")){
+        dir.create("../results")
+        dir = "../results"
+    }else{
+        dir = "../results"
+    }
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("# key = value\n\n"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,NULL)
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("# key = value\n[init]\n"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,NULL)
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("[init]
+    check_version = False
+    proxy = http://127.12.34.99.10000
+    cluster_id = 3"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,data.frame(init.check_version = as.factor("False"), init.proxy = as.factor("http://127.12.34.99.10000"), init.cluster_id = as.factor(3)))
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("init.check_version = anything!  # rly?
+    init.cookies=A
+    py:init.cluster_id=7
+    # more comment"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,data.frame(init.check_version = as.factor("anything!"), init.cookies = as.factor("A")))
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("r:init.cluster_id=asf"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,data.frame(init.cluster_id = as.factor("asf")))
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("init.checkversion = True
+    init.clusterid = 7
+    proxy = None"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,NULL)
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("[something]
+    init.check_version = True"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,NULL)
+
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("init.check_version = True
+    init.check_version = False
+    init.check_version = Ambivolent"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,data.frame(init.check_version = as.factor("Ambivolent")))
+
+    #Delete tmp directory
+    unlink(dir,recursive=TRUE)
+}
+
+doTest("Test h2o config parsing", test.config)

--- a/h2o-r/tests/testdir_misc/runit_h2oconfig.R
+++ b/h2o-r/tests/testdir_misc/runit_h2oconfig.R
@@ -92,6 +92,18 @@ test.config <- function() {
     config = .parse.h2oconfig(h2oconfig_filename)
     expect_equal(config,data.frame(init.check_version = as.factor("Ambivolent")))
 
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("[something]
+    check_version = True
+    [init]
+    cluster_id = 3"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,data.frame(init.cluster_id = as.factor("3")))
+
     #Delete tmp directory
     unlink(dir,recursive=TRUE)
 }

--- a/h2o-r/tests/testdir_misc/runit_h2oconfig.R
+++ b/h2o-r/tests/testdir_misc/runit_h2oconfig.R
@@ -116,6 +116,18 @@ test.config <- function() {
     config = .parse.h2oconfig(h2oconfig_filename)
     expect_equal(config,data.frame(general.allow_breaking_changes = as.factor("True"),init.cluster_id = as.factor("3")))
 
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("[GEnEraL]
+    allow_breaking_changes = True
+    [INiT]
+    cluster_id = 3"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,data.frame(general.allow_breaking_changes = as.factor("True"),init.cluster_id = as.factor("3")))
+
     #Delete tmp directory
     unlink(dir,recursive=TRUE)
 }

--- a/h2o-r/tests/testdir_misc/runit_h2oconfig.R
+++ b/h2o-r/tests/testdir_misc/runit_h2oconfig.R
@@ -104,6 +104,18 @@ test.config <- function() {
     config = .parse.h2oconfig(h2oconfig_filename)
     expect_equal(config,data.frame(init.cluster_id = as.factor("3")))
 
+    #Creat tmp config
+    fileConn<-file(paste0(dir,"/.h2oconfig"))
+    writeLines(c("[general]
+    allow_breaking_changes = True
+    [init]
+    cluster_id = 3"),fileConn)
+
+    #Parse config and check if correct
+    h2oconfig_filename <- paste0(dir,"/.h2oconfig")
+    config = .parse.h2oconfig(h2oconfig_filename)
+    expect_equal(config,data.frame(general.allow_breaking_changes = as.factor("True"),init.cluster_id = as.factor("3")))
+
     #Delete tmp directory
     unlink(dir,recursive=TRUE)
 }


### PR DESCRIPTION
* This PR adds a config file reader for the R-API. Current fields supported are the following: "init.check_version", "init.proxy","init.cluster_id", "init.verify_ssl_certificates", "init.cookies" which correspond to their respective counterparts in the R API.

An explanation of how it works is below:
* File `.h2oconfig` is searched first in the current working directory, then in all parents up to the root, and finally in the user's home directory `~/.h2oconfig`. The first file found is used, the search does not continue.
* If a config file is found, it is parsed line-by-line, where each line can be:
  1) empty or a comment starting with `#` -- these lines are ignored
  2) a section name, of the form `[section]`
  3) a key-value pair of the form `key = value` or `prefix:key = value`. The `key` is a dotted identifier; then the name of the resulting config parameter is `section.key`. The `value` is an arbitrary string (quotes are not needed). Multiline values are not supported. If a non-string property is desired, the client should deserialize it from string manually. If `prefix` is supplied, then such key-value is ignored by all clients unless they recognize the prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/545)
<!-- Reviewable:end -->
