### PR TITLE
PUBDEV-3730: H2OFrame overwrite column name when some methods are applied

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/math/AstUniOp.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/math/AstUniOp.java
@@ -33,7 +33,7 @@ public abstract class AstUniOp extends AstPrimitive {
         Frame fr = val.getFrame();
         //Get length of columns in fr and append `op(colName)`. For example, a column named "income" that had
         //a log transformation would now be changed to `log(income)`.
-        String[] newNames = new String[fr.names().length];
+        String[] newNames = new String[fr.numCols()];
         for(int i = 0; i < newNames.length; i++){
           newNames[i] = asts[0].str() + "(" + fr.name(i) + ")";
         }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/math/AstUniOp.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/math/AstUniOp.java
@@ -35,7 +35,7 @@ public abstract class AstUniOp extends AstPrimitive {
         //a log transformation would now be changed to `log(income)`.
         String[] newNames = new String[fr.numCols()];
         for(int i = 0; i < newNames.length; i++){
-          newNames[i] = asts[0].str() + "(" + fr.name(i) + ")";
+          newNames[i] = str() + "(" + fr.name(i) + ")";
         }
         return new ValFrame(new MRTask() {
           @Override

--- a/h2o-core/src/main/java/water/rapids/ast/prims/math/AstUniOp.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/math/AstUniOp.java
@@ -31,6 +31,12 @@ public abstract class AstUniOp extends AstPrimitive {
         return new ValNum(op(val.getNum()));
       case Val.FRM:
         Frame fr = val.getFrame();
+        //Get length of columns in fr and append `op(colName)`. For example, a column named "income" that had
+        //a log transformation would now be changed to `log(income)`.
+        String[] newNames = new String[fr.names().length];
+        for(int i = 0; i < newNames.length; i++){
+          newNames[i] = asts[0].str() + "(" + fr.name(i) + ")";
+        }
         return new ValFrame(new MRTask() {
           @Override
           public void map(Chunk cs[], NewChunk ncs[]) {
@@ -41,7 +47,7 @@ public abstract class AstUniOp extends AstPrimitive {
                 nc.addNum(op(c.atd(i)));
             }
           }
-        }.doAll(fr.numCols(), Vec.T_NUM, fr).outputFrame());
+        }.doAll(fr.numCols(), Vec.T_NUM, fr).outputFrame(newNames, fr.domains()));
       case Val.ROW:
         double[] ds = new double[val.getRow().length];
         for (int i = 0; i < ds.length; ++i)

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -522,7 +522,10 @@ class H2OFrame(object):
 
 
     def _unop(self, op):
-        return H2OFrame._expr(expr=ExprNode(op, self), cache=self._ex._cache)
+        ret = H2OFrame._expr(expr=ExprNode(op, self), cache=self._ex._cache)
+        if ret._ex._cache._names is not None:
+            ret._ex._cache._names = ["%s(%s)" % (op, name) for name in ret._ex._cache._names]
+        return ret
 
 
     # Binary operations

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -525,6 +525,7 @@ class H2OFrame(object):
         ret = H2OFrame._expr(expr=ExprNode(op, self), cache=self._ex._cache)
         if ret._ex._cache._names is not None:
             ret._ex._cache._names = ["%s(%s)" % (op, name) for name in ret._ex._cache._names]
+            ret._ex._cache._types = {key: None for key in ret._ex._cache._names}
         return ret
 
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -525,7 +525,7 @@ class H2OFrame(object):
         ret = H2OFrame._expr(expr=ExprNode(op, self), cache=self._ex._cache)
         if ret._ex._cache._names is not None:
             ret._ex._cache._names = ["%s(%s)" % (op, name) for name in ret._ex._cache._names]
-            ret._ex._cache._types = {key: None for key in ret._ex._cache._names}
+            ret._ex._cache._types = None
         return ret
 
 

--- a/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
@@ -16,9 +16,7 @@ def pyunit_colname_uniop():
     assert set(frame.names) == {"A", "B", "C"}, "Expected original colnames to remain the same after uniop operation"
     #Check new colnames for modified frame are of the convention `op(colname)`
     assert ["asin(%s)" % (name) for name in frame.names] == frame_asin.names,"Expected equal col names after uniop operation"
-    #Check types are maintained before refresh
-    assert frame_asin.types == {"asin(A)": "real", "asin(B)": "real", "asin(C)": "int"}, "Expect equal col types after" \
-                                                                                         "uniop operation"
+
     #Check again after a refresh to the frame
     frame_asin.refresh()
     #Check new colnames for modified frame are of the convention `op(colname)`

--- a/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
@@ -13,10 +13,19 @@ def pyunit_colname_uniop():
     frame_asin = frame.asin()
 
     #Check colnames of original frame remain untouched.
-    assert frame.names == [u'A', u'C', u'B'], "Expected original colnames to remain the same after uniop operation"
+    assert set(frame.names) == {"A", "B", "C"}, "Expected original colnames to remain the same after uniop operation"
     #Check new colnames for modified frame are of the convention `op(colname)`
     assert ["asin(%s)" % (name) for name in frame.names] == frame_asin.names,"Expected equal col names after uniop operation"
-
+    #Check types are maintained
+    assert frame_asin.types == {"asin(A)": None, "asin(B)": None, "asin(C)": None}, "Expect equal col types after" \
+                                                                                          "uniop operation"
+    #Check again after a refresh to the frame
+    frame_asin.refresh()
+    #Check new colnames for modified frame are of the convention `op(colname)`
+    assert ["asin(%s)" % (name) for name in frame.names] == frame_asin.names,"Expected equal col names after uniop operation"
+    #Check types are maintained
+    assert frame_asin.types == {"asin(A)": "real", "asin(B)": "real", "asin(C)": "int"}, "Expect equal col types after" \
+                                                                                            "uniop operation"
 if __name__ == "__main__":
     pyunit_utils.standalone_test(pyunit_colname_uniop)
 else:

--- a/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
@@ -16,9 +16,9 @@ def pyunit_colname_uniop():
     assert set(frame.names) == {"A", "B", "C"}, "Expected original colnames to remain the same after uniop operation"
     #Check new colnames for modified frame are of the convention `op(colname)`
     assert ["asin(%s)" % (name) for name in frame.names] == frame_asin.names,"Expected equal col names after uniop operation"
-    #Check types are maintained
-    assert frame_asin.types == {"asin(A)": None, "asin(B)": None, "asin(C)": None}, "Expect equal col types after" \
-                                                                                          "uniop operation"
+    #Check types are maintained before refresh
+    assert frame_asin.types == {"asin(A)": "real", "asin(B)": "real", "asin(C)": "int"}, "Expect equal col types after" \
+                                                                                         "uniop operation"
     #Check again after a refresh to the frame
     frame_asin.refresh()
     #Check new colnames for modified frame are of the convention `op(colname)`

--- a/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_uniop_colname_domain.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+#Test to see if you apply H2O uniop methods to an H2OFrame it will not overwrite the original column headers & domains
+# & also update colnames of new frame with `op(colName)` where `op` is a uniop operator.
+
+def pyunit_colname_uniop():
+    dataframe = {'A': [1,0,3,4], 'B': [5,6,-6, -1], 'C':[-4, -6, -7, 8]}
+    frame = h2o.H2OFrame(dataframe)
+    frame_asin = frame.asin()
+
+    #Check colnames of original frame remain untouched.
+    assert frame.names == [u'A', u'C', u'B'], "Expected original colnames to remain the same after uniop operation"
+    #Check new colnames for modified frame are of the convention `op(colname)`
+    assert ["asin(%s)" % (name) for name in frame.names] == frame_asin.names,"Expected equal col names after uniop operation"
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pyunit_colname_uniop)
+else:
+    pyunit_colname_uniop()

--- a/h2o-r/tests/testdir_misc/runit_uniop_colname_domain.R
+++ b/h2o-r/tests/testdir_misc/runit_uniop_colname_domain.R
@@ -1,0 +1,24 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+#Test to see if you apply H2O uniop methods to an H2OFrame it will not overwrite the original column headers & domains
+# & also update colnames of new frame with `op(colName)` where `op` is a uniop operator.
+
+test.uniop <- function(){
+    #Set up H2OFrame
+    fr <- h2o.createFrame(rows = 100, cols = 5, categorical_fraction = 0,
+    factors = 0, integer_fraction = 1.0, integer_range = 100,
+    binary_fraction = 0, time_fraction = 0, string_fraction = 0,
+    has_response = FALSE,seed = 123456789)
+
+    #Conduct a log transform on entire frame
+    fr2 = log(fr)
+
+    #Check colnames of original frame remain untouched.
+    expect_equal(colnames(fr),c("C1","C2","C3","C4","C5"))
+
+    #Check new colnames for modified frame are of the convention `op(colname)`
+    expect_equal(paste0("log(",colnames(fr),")"),colnames(fr2))
+}
+
+doTest("Test new naming convention of uniop frames", test.uniop)


### PR DESCRIPTION
* This PR ensures that column names & domains are preserved after a uniop is applied to an H2O frame. 
* Previous behavior would produce column names such as `C1, C2, ...` after an operation was applied to a frame.
* Also, a unit test is added. Only uses `asin()` as the function of choice since all `uniop` operations extend `AstUniOp.java`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/546)
<!-- Reviewable:end -->
