### PR TITLE
[PUBDEV-3615] Assigning to frame the same id as it currently has should be a noop instead of failing

### DIFF
--- a/h2o-core/src/main/java/water/Scope.java
+++ b/h2o-core/src/main/java/water/Scope.java
@@ -71,12 +71,19 @@ public class Scope {
     return vec;
   }
 
-  static public Frame track( Frame fr ) {
-    Scope scope = _scope.get();                   // Pay the price of T.L.S. lookup
-    assert scope != null;
-    for( Vec vec: fr.vecs() ) track_impl(scope, vec._key);
-    track_impl(scope, fr._key);
-    return fr;
+  /**
+   * Track one or more {@link Frame}s, and return the first one. The tracked
+   * frames will be removed from DKV when {@link Scope#exit(Key[])} is called.
+   */
+  public static Frame track(Frame... frames) {
+    for (Frame fr : frames) {
+      Scope scope = _scope.get();
+      assert scope != null;
+      track_impl(scope, fr._key);
+      for (Vec vec : fr.vecs())
+        track_impl(scope, vec._key);
+    }
+    return frames[0];
   }
 
   static private void track_impl(Scope scope, Key key) {

--- a/h2o-core/src/main/java/water/rapids/Rapids.java
+++ b/h2o-core/src/main/java/water/rapids/Rapids.java
@@ -217,6 +217,7 @@ public class Rapids {
     ArrayList<String> strs = new ArrayList<>(10);
     while (isQuote(skipWS())) {
       strs.add(string());
+      if (skipWS() == ',') eatChar(',');
     }
     return new AstStrList(strs);
   }
@@ -247,7 +248,7 @@ public class Rapids {
         eatChar(':');
         skipWS();
         stride = number();
-        if (stride < 0)
+        if (stride < 0 || Double.isNaN(stride))
           throw new IllegalASTException("Stride must be positive, got " + stride);
       }
       if (count == 1 && stride != 1)

--- a/h2o-core/src/main/java/water/rapids/ast/params/AstNumList.java
+++ b/h2o-core/src/main/java/water/rapids/ast/params/AstNumList.java
@@ -2,7 +2,6 @@ package water.rapids.ast.params;
 
 import water.H2O;
 import water.rapids.Env;
-import water.rapids.Rapids;
 import water.rapids.Val;
 import water.rapids.ast.AstParameter;
 import water.util.ArrayUtils;
@@ -136,9 +135,14 @@ public class AstNumList extends AstParameter {
     int nrows = (int) cnt(), r = 0;
     // Fill in values
     double[] vals = new double[nrows];
-    for (int i = 0; i < _bases.length; i++)
-      for (double d = _bases[i]; d < _bases[i] + _cnts[i] * _strides[i]; d += _strides[i])
-        vals[r++] = d;
+    for (int i = 0; i < _bases.length; i++) {
+      if (Double.isNaN(_bases[i])) {
+        vals[r++] = Double.NaN;
+      } else {
+        for (double d = _bases[i]; d < _bases[i] + _cnts[i] * _strides[i]; d += _strides[i])
+          vals[r++] = d;
+      }
+    }
     return vals;
   }
 

--- a/h2o-core/src/main/java/water/rapids/ast/prims/assign/AstTmpAssign.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/assign/AstTmpAssign.java
@@ -2,11 +2,13 @@ package water.rapids.ast.prims.assign;
 
 import water.DKV;
 import water.Key;
+import water.Value;
 import water.fvec.Frame;
 import water.rapids.Env;
-import water.rapids.vals.ValFrame;
+import water.rapids.Val;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
+import water.rapids.vals.ValFrame;
 
 /**
  * Assign a temp.  All such assignments are final (cannot change), but the temp can be deleted.  Temp is returned for
@@ -30,10 +32,30 @@ public class AstTmpAssign extends AstPrimitive {
 
   @Override
   public ValFrame apply(Env env, Env.StackHelp stk, AstRoot[] asts) {
+    // Note: non-standard evaluation of the first argument! Instead of being
+    // executed, it is stringified. This, for example, allows us to write an
+    // expression as
+    //     (tmp= newid (* frame 3))
+    // instead of
+    //     (tmp= "newid" (* frame 3))
+    // On the other hand, this makes us unable to create dynamic identifiers
+    // in Rapids, for example this is invalid:
+    //     (tmp= (+ "id" 3) (* frame 3))
+    // Right now there is no need for dynamically generated identifiers, since
+    // we don't even have proper variables or loops or control structures yet.
+    //
     Key<Frame> id = Key.make(env.expand(asts[1].str()));
-    if (DKV.get(id) != null) throw new IllegalArgumentException("Temp ID " + id + " already exists");
-    Frame src = stk.track(asts[2].exec(env)).getFrame();
-    Frame dst = new Frame(id, src._names, src.vecs());
+    Val srcVal = stk.track(asts[2].exec(env));
+    Frame srcFrame = srcVal.getFrame();
+
+    Value v = DKV.get(id);
+    if (v != null) {
+      if (v.get().equals(srcFrame))
+        return (ValFrame) srcVal;
+      else
+        throw new IllegalArgumentException("Temp ID " + id + " already exists");
+    }
+    Frame dst = new Frame(id, srcFrame._names, srcFrame.vecs());
     return new ValFrame(env._ses.track_tmp(dst)); // Track new session-wide ID
   }
 }

--- a/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstCumuTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstCumuTest.java
@@ -7,8 +7,6 @@ import water.Scope;
 import water.TestUtil;
 import water.fvec.Frame;
 import water.fvec.TestFrameBuilder;
-import water.fvec.Vec;
-import water.rapids.Env;
 import water.rapids.Rapids;
 import water.rapids.Session;
 import water.rapids.Val;
@@ -27,16 +25,14 @@ public class AstCumuTest extends TestUtil {
     Scope.enter();
     try {
       Session sess = new Session();
-      Frame fr = new TestFrameBuilder()
-          .withName(new Env(sess).expand("$fr"))
+      new TestFrameBuilder()
+          .withName("$fr", sess)
           .withColNames("c1", "c2", "c3", "c4")
-          .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM)
           .withDataForCol(0, ard(1, 1))
           .withDataForCol(1, ard(2, 2))
           .withDataForCol(2, ard(3, 3))
           .withDataForCol(3, ard(4, 4))
           .build();
-      Scope.track(fr);
 
       Val val = Rapids.exec("(cumsum $fr 1)", sess);
       Assert.assertTrue(val instanceof ValFrame);

--- a/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstCumuTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstCumuTest.java
@@ -1,0 +1,69 @@
+package water.rapids.ast.prims.reducers;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+import water.rapids.Env;
+import water.rapids.Rapids;
+import water.rapids.Session;
+import water.rapids.Val;
+import water.rapids.vals.ValFrame;
+
+/**
+ * Test for the {@link AstCumu} class and its subclasses.
+ */
+public class AstCumuTest extends TestUtil {
+
+  @BeforeClass
+  public static void setup() { stall_till_cloudsize(1); }
+
+  @Test
+  public void testCumuSimple() {
+    Scope.enter();
+    try {
+      Session sess = new Session();
+      Frame fr = new TestFrameBuilder()
+          .withName(new Env(sess).expand("$fr"))
+          .withColNames("c1", "c2", "c3", "c4")
+          .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM)
+          .withDataForCol(0, ard(1, 1))
+          .withDataForCol(1, ard(2, 2))
+          .withDataForCol(2, ard(3, 3))
+          .withDataForCol(3, ard(4, 4))
+          .build();
+      Scope.track(fr);
+
+      Val val = Rapids.exec("(cumsum $fr 1)", sess);
+      Assert.assertTrue(val instanceof ValFrame);
+      Frame res = Scope.track(val.getFrame());
+      Assert.assertEquals(res.vec(0).at8(0L), 1);
+      Assert.assertEquals(res.vec(1).at8(0L), 3);
+      Assert.assertEquals(res.vec(2).at8(0L), 6);
+      Assert.assertEquals(res.vec(3).at8(0L), 10);
+
+      val = Rapids.exec("(cumsum $fr 0)", sess);
+      Assert.assertTrue(val instanceof ValFrame);
+      res = Scope.track(val.getFrame());
+      Assert.assertEquals(res.vec(0).at8(1L), 2);
+      Assert.assertEquals(res.vec(1).at8(1L), 4);
+      Assert.assertEquals(res.vec(2).at8(1L), 6);
+      Assert.assertEquals(res.vec(3).at8(1L), 8);
+
+      val = Rapids.exec("(cummax $fr 1)", sess);
+      Assert.assertTrue(val instanceof ValFrame);
+      res = Scope.track(val.getFrame());
+      Assert.assertEquals(res.vec(0).at8(0L), 1);
+      Assert.assertEquals(res.vec(1).at8(0L), 2);
+      Assert.assertEquals(res.vec(2).at8(0L), 3);
+      Assert.assertEquals(res.vec(3).at8(0L), 4);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+}


### PR DESCRIPTION
See [PUBDEV-3615](https://0xdata.atlassian.net/browse/PUBDEV-3615)

This also adds a unit test for the functionality created; as well as fixes several minor bugs in Rapids discovered while making the tests. Finally I improve slightly the `RapidsTest` unit test (so that those bugs can be tested too), and move the `testCumu` out of RapidsTest into a separate class `TestAstCumu` so that it can be more easily discovered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/553)
<!-- Reviewable:end -->
