### PR TITLE
WIP Debugging PR test failures.

### DIFF
--- a/h2o-algos/src/test/java/hex/AAA_PreCloudLock.java
+++ b/h2o-algos/src/test/java/hex/AAA_PreCloudLock.java
@@ -25,7 +25,7 @@ public class AAA_PreCloudLock extends TestUtil {
   static final int PARTIAL_CLOUD_SIZE = 2;
 
   @BeforeClass
-  public static void setup() { stall_till_cloudsize(CLOUD_SIZE); }
+  public static void setup() { stall_till_cloudsize(CLOUD_SIZE, DEFAULT_TIME_FOR_CLOUDING * 3); }
 
   private static void stall() {
     stall_till_cloudsize(PARTIAL_CLOUD_SIZE);

--- a/h2o-core/src/test/java/water/AAA_PreCloudLock.java
+++ b/h2o-core/src/test/java/water/AAA_PreCloudLock.java
@@ -13,7 +13,7 @@ public class AAA_PreCloudLock extends TestUtil {
   static final int CLOUD_SIZE = 5;
   static final int PARTIAL_CLOUD_SIZE = 2;
 
-  @BeforeClass() public static void setup() { stall_till_cloudsize(CLOUD_SIZE); }
+  @BeforeClass() public static void setup() { stall_till_cloudsize(CLOUD_SIZE, DEFAULT_TIME_FOR_CLOUDING * 3); }
 
   private static void stall() {
     stall_till_cloudsize(PARTIAL_CLOUD_SIZE);

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -36,6 +36,8 @@ public class TestUtil extends Iced {
   private static String[] doonlyTestsNames;
   protected static int _initial_keycnt = 0;
   protected static int MINCLOUDSIZE = Integer.parseInt(System.getProperty("cloudSize", "1"));
+  /** Default time in ms to wait for clouding */
+  protected static int DEFAULT_TIME_FOR_CLOUDING = 30000 /* ms */;
 
   public TestUtil() { this(1); }
   public TestUtil(int minCloudSize) {
@@ -58,21 +60,32 @@ public class TestUtil extends Iced {
 
   // ==== Test Setup & Teardown Utilities ====
   // Stall test until we see at least X members of the Cloud
-  public static void stall_till_cloudsize(int x) {
-    stall_till_cloudsize(new String[] {}, x);
+  protected static int getDefaultTimeForClouding() {
+    return JACOCO_ENABLED
+           ? DEFAULT_TIME_FOR_CLOUDING * 10
+           : DEFAULT_TIME_FOR_CLOUDING;
   }
+
+  public static void stall_till_cloudsize(int x) {
+    stall_till_cloudsize(x, getDefaultTimeForClouding());
+  }
+
+  public static void stall_till_cloudsize(int x, int timeout) {
+    stall_till_cloudsize(new String[] {}, x, timeout);
+  }
+
   public static void stall_till_cloudsize(String[] args, int x) {
+    stall_till_cloudsize(args, x, getDefaultTimeForClouding());
+  }
+
+  public static void stall_till_cloudsize(String[] args, int x, int timeout) {
     x = Math.max(MINCLOUDSIZE, x);
     if( !_stall_called_before ) {
       H2O.main(args);
       H2O.registerRestApis(System.getProperty("user.dir"));
       _stall_called_before = true;
     }
-    if (JACOCO_ENABLED) {
-      H2O.waitForCloudSize(x, 300000);
-    } else {
-      H2O.waitForCloudSize(x, 30000);
-    }
+    H2O.waitForCloudSize(x, timeout);
     _initial_keycnt = H2O.store_size();
   }
 
@@ -98,12 +111,13 @@ public class TestUtil extends Iced {
     }
     assertTrue("Keys leaked: " + leaked_keys + ", cnt = " + cnt, leaked_keys <= 0 || cnt == 0);
     // Bulk brainless key removal.  Completely wipes all Keys without regard.
-    new MRTask(){
-      @Override public void setupLocal() {  H2O.raw_clear();  water.fvec.Vec.ESPC.clear(); }
-    }.doAllNodes();
+    new DKVCleaner().doAllNodes();
     _initial_keycnt = H2O.store_size();
   }
 
+  private static class DKVCleaner extends MRTask<DKVCleaner> {
+    @Override public void setupLocal() {  H2O.raw_clear();  water.fvec.Vec.ESPC.clear(); }
+  }
 
   /** Execute this rule before each test to print test name and test class */
   @Rule transient public TestRule logRule = new TestRule() {


### PR DESCRIPTION
The commit:
  - Increases timeout for 1st test run before all junits.
  - Extracts "dkv cleaner" anonymous task into a private static class

Based on logs of failing jobs: the anonymous MRTask caused cloud lock.
Relevant portion of failure:
```
1) hex.AAA_PreCloudLock
java.lang.RuntimeException: Cloud size under 4
    at water.H2O.waitForCloudSize(H2O.java:1588)
    at water.TestUtil.stall_till_cloudsize(TestUtil.java:74)
    at water.TestUtil.stall_till_cloudsize(TestUtil.java:62)
    at hex.AAA_PreCloudLock.setup(AAA_PreCloudLock.java:28)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

Suspicious boot log message sequence:
```
11-28 14:50:25.170 172.16.2.143:45014    11808  main      INFO: Registered parsers: [GUESS, ARFF, XLS, SVMLight, CSV]
11-28 14:50:25.171 172.16.2.143:45014    11808  main      INFO: Registered 0 extensions in: 0mS
11-28 14:50:30.206 172.16.2.143:45014    11808  main      INFO: Registered: 136 REST APIs in: 5035mS
11-28 14:51:00.311 172.16.2.143:45014    11808  FJ-1-15   INFO: Locking cloud to new members, because water.TestUtil$1
11-28 14:51:12.061 172.16.2.143:45014    11808  FJ-126-15 INFO: Cloud of size 4 formed [/172.16.2.143:45008, /172.16.2.143:45010, /172.16.2.143:45012, /172.16.2.143:45014]
EE
```

Explanation:
  - EE means the first AAA_PreCloudLock failed
  - the test was block 30sec (=timeout for test clouding)
  - the first task executed on the cluster for `water.TestUtil$1` (DKV cleaner task)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/556)
<!-- Reviewable:end -->
