### PR TITLE
PUBDEV-3709: Add new stopping_metric options

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/stopping_metric.rst
+++ b/h2o-docs/src/product/data-science/algo-params/stopping_metric.rst
@@ -17,11 +17,14 @@ then the model will stop training after reaching three scoring events in a row i
 
 Available options for ``stopping_metric`` include the following:
 
-- ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
+- ``auto``: This defaults to ``logloss`` for classification, ``deviance`` for regression
 - ``deviance``
 - ``logloss``
-- ``MSE``
-- ``AUC``
+- ``mse``
+- ``rmse``
+- ``mae``
+- ``rmsle``
+- ``auc``
 - ``lift_top_group``
 - ``misclassification``
 - ``mean_per_class_error``

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -227,17 +227,20 @@ recommended, as model performance can vary greatly.
      3. N+1 models do *not* use **overwrite\_with\_best\_model**
      4. N+1 models may be off by the number specified for **stopping\_rounds** from the best model, but the cross-validation metric estimates the performance of the main model for the resulting number of epochs (which may be fewer than the specified number of epochs).
 
--  **stopping\_metric**: Specify the metric to use for early stopping.
+-  **stopping_metric**: Specify the metric to use for early stopping.
    The available options are:
 
-   - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
-   - ``deviance``
-   - ``logloss``
-   - ``MSE``
-   - ``AUC``
-   - ``lift_top_group``
-   - ``misclassification``
-   - ``mean_per_class_error``
+    - ``auto``: This defaults to ``logloss`` for classification, ``deviance`` for regression
+    - ``deviance``
+    - ``logloss``
+    - ``mse``
+    - ``rmse``
+    - ``mae``
+    - ``rmsle``
+    - ``auc``
+    - ``lift_top_group``
+    - ``misclassification``
+    - ``mean_per_class_error``
 
 -  **stopping\_tolerance**: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -154,14 +154,17 @@ Defining a DRF Model
 -  `stopping_metric <algo-params/stopping_metric.html>`__: Specify the metric to use for early stopping.
    The available options are:
 
-   - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
-   - ``deviance``
-   - ``logloss``
-   - ``MSE``
-   - ``AUC``
-   - ``lift_top_group``
-   - ``misclassification``
-   - ``mean_per_class_error``
+    - ``auto``: This defaults to ``logloss`` for classification, ``deviance`` for regression
+    - ``deviance``
+    - ``logloss``
+    - ``mse``
+    - ``rmse``
+    - ``mae``
+    - ``rmsle``
+    - ``auc``
+    - ``lift_top_group``
+    - ``misclassification``
+    - ``mean_per_class_error``
 
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -208,14 +208,17 @@ Defining a GBM Model
 -  `stopping_metric <algo-params/stopping_metric.html>`__: Specify the metric to use for early stopping.
    The available options are:
 
-   - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
-   - ``deviance``
-   - ``logloss``
-   - ``MSE``
-   - ``AUC``
-   - ``lift_top_group``
-   - ``misclassification``
-   - ``mean_per_class_error``
+    - ``auto``: This defaults to ``logloss`` for classification, ``deviance`` for regression
+    - ``deviance``
+    - ``logloss``
+    - ``mse``
+    - ``rmse``
+    - ``mae``
+    - ``rmsle``
+    - ``auc``
+    - ``lift_top_group``
+    - ``misclassification``
+    - ``mean_per_class_error``
 
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less


### PR DESCRIPTION
Added rmse, mae, rmsle, and lift_top_group options to the
stopping_metric parameter description in GBM, DRF, Deep Learning, and in the appendix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/560)
<!-- Reviewable:end -->
