### PR TITLE
PUBDEV-3501: variance metrics for GLRM.  Added code to extrac varianc…

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -155,6 +155,16 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     // Training time
     public ArrayList<Long> _training_time_ms = new ArrayList<>();
 
+    // Total column variance for expanded and transformed data
+    public double _total_variance;
+
+    // Standard deviation of each principal component
+    public double[] _std_deviation;
+
+    // Importance of principal components
+    // Standard deviation, proportion of variance explained, and cumulative proportion of variance explained
+    public TwoDimTable _importance;
+
     public GLRMOutput(GLRM b) { super(b); }
 
     /** Override because base class implements ncols-1 for features with the

--- a/h2o-algos/src/main/java/hex/schemas/GLRMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLRMModelV3.java
@@ -36,6 +36,9 @@ public class GLRMModelV3 extends ModelSchemaV3<GLRMModel, GLRMModelV3, GLRMModel
 
     @API(help = "Frame key name for X matrix")
     public String representation_name;
+
+    @API(help = "Standard deviation and importance of each principal component")
+    public TwoDimTableV3 importance;
   }
 
   // TODO: I think we can implement the following two in ModelSchemaV3, using reflection on the type parameters.

--- a/h2o-algos/src/main/java/hex/svd/SVD.java
+++ b/h2o-algos/src/main/java/hex/svd/SVD.java
@@ -384,6 +384,8 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
         } else if(_parms._svd_method == SVDParameters.Method.Power) {
           // Calculate and save Gram matrix of training data
           // NOTE: Gram computes A'A/n where n = nrow(A) = number of rows in training set (excluding rows with NAs)
+          // NOTE: the Gram also will apply the specified Transforms on the data before performing the operation.
+          // NOTE:  valid transforms are NONE, DEMEAN, STANDARDIZE...
           _job.update(1, "Begin distributed calculation of Gram matrix");
           GramTask gtsk = new GramTask(_job._key, dinfo).doAll(dinfo._adaptedFrame);
           Gram gram = gtsk._gram;   // TODO: This ends up with all NaNs if training data has too many missing values

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -537,6 +537,12 @@ public class TestUtil extends Iced {
       Assert.assertEquals(expected[i], actual[i], threshold);
   }
 
+  public static void checkIcedArrays(IcedWrapper[][] expected, IcedWrapper[][] actual, double threshold) {
+    for(int i = 0; i < actual.length; i++)
+      for (int j = 0; j < actual[0].length; j++)
+      Assert.assertEquals(expected[i][j].d, actual[i][j].d, threshold);
+  }
+
   public static boolean[] checkEigvec(double[][] expected, double[][] actual, double threshold) {
     int nfeat = actual.length;
     int ncomp = actual[0].length;

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -678,15 +678,13 @@ def generate_weights_glm(csv_weight_filename, col_count, data_type, min_w_value,
         elif data_type == 2:   # generate real intercept/weights
             weight = np.random.uniform(min_w_value, max_w_value, [col_count+1, 1])
         else:
-            print("dataType must be 1 or 2 for now.")
-            sys.exit(1)
+            assert False, "dataType must be 1 or 2 for now."
     elif ('binomial' in family_type.lower()) or ('multinomial' in family_type.lower()):
         if 'binomial' in family_type.lower():  # for binomial, only need 1 set of weight
             class_number -= 1
 
         if class_number <= 0:
-            print("class_number must be >= 2!")
-            sys.exit(1)
+            assert False, "class_number must be >= 2!"
 
         if isinstance(col_count, np.ndarray):
             temp_col_count = col_count[0]
@@ -698,8 +696,7 @@ def generate_weights_glm(csv_weight_filename, col_count, data_type, min_w_value,
         elif data_type == 2:   # generate real intercept/weights
             weight = np.random.uniform(min_w_value, max_w_value, [temp_col_count+1, class_number])
         else:
-            print("dataType must be 1 or 2 for now.")
-            sys.exit(1)
+            assert False, "dataType must be 1 or 2 for now."
 
     # save the generated intercept and weight
     np.savetxt(csv_weight_filename, weight.transpose(), delimiter=",")
@@ -746,8 +743,7 @@ def generate_training_set_glm(csv_filename, row_count, col_count, min_p_value, m
     elif data_type == 2:   # generate random real numbers
         x_mat = np.random.uniform(min_p_value, max_p_value, [row_count, col_count])
     else:
-        print("dataType must be 1 or 2 for now. ")
-        sys.exit(1)
+        assert False, "dataType must be 1 or 2 for now. "
 
     # generate the response vector to the input predictors
     response_y = generate_response_glm(weight, x_mat, noise_std, family_type,
@@ -779,8 +775,7 @@ def generate_clusters(cluster_center_list, cluster_pt_number_list, cluster_radiu
     k = len(cluster_pt_number_list)     # number of clusters to generate clusters for
 
     if (not(k == len(cluster_center_list))) or (not(k == len(cluster_radius_list))):
-        print("Length of list cluster_center_list, cluster_pt_number_list, cluster_radius_list must be the same!")
-        sys.exit(1)
+        assert False, "Length of list cluster_center_list, cluster_pt_number_list, cluster_radius_list must be the same!"
 
     training_sets = []
     for k_ind in range(k):
@@ -1053,8 +1048,7 @@ def one_hot_encoding(enum_level):
 
         return base_array
     else:
-        print ("enum_level must be >= 2.")
-        sys.exit(1)
+        assert False, "enum_level must be >= 2."
 
 
 def generate_response_glm(weight, x_mat, noise_std, family_type, class_method='probability',
@@ -1149,8 +1143,7 @@ def derive_discrete_response(prob_mat, class_method, class_margin):
 
         discrete_y[mat_bool] = -1
     else:
-        print('class_method should be set to "probability" or "threshold" only!')
-        sys.exit(1)
+        assert False, 'class_method should be set to "probability" or "threshold" only!'
 
     return discrete_y
 
@@ -1193,8 +1186,7 @@ def move_files(dir_path, old_name, new_file, action='move'):
         elif 'copy' in action:
             motion = 'cp '
         else:
-            print("Illegal action setting.  It can only be 'move' or 'copy'!")
-            sys.exit(1)
+            assert False, "Illegal action setting.  It can only be 'move' or 'copy'!"
 
         cmd = motion+old_name+' '+new_name           # generate cmd line string to move the file
 
@@ -1394,9 +1386,37 @@ def equal_two_arrays(array1, array2, eps, tolerance):
 
         return True                                     # return True, elements of two arrays are close enough
     else:
-        print("The two arrays are of different size!")
-        sys.exit(1)
+        assert False, "The two arrays are of different size!"
 
+def equal_2D_tables(table1, table2, tolerance=1e-6):
+    """
+    This function will compare the values of two python tuples.  First, if the values are below
+    eps which denotes the significance level that we care, no comparison is performed.  Next,
+    False is returned if the different between any elements of the two array exceeds some tolerance.
+
+    :param array1: numpy array containing some values of interest
+    :param array2: numpy array containing some values of interest that we would like to compare it with array1
+    :param eps: significance level that we care about in order to perform the comparison
+    :param tolerance: threshold for which we allow the two array elements to be different by
+
+    :return: True if elements in array1 and array2 are close and False otherwise
+    """
+
+    size1 = len(table1)
+    if size1 == len(table2):    # arrays must be the same size
+        # compare two arrays
+        for ind in range(size1):
+            if len(table1[ind]) == len(table2[ind]):
+                for ind2 in range(len(table1[ind])):
+                    if type(table1[ind][ind2]) == float:
+                        if abs(table1[ind][ind2]-table2[ind][ind2]) > tolerance:
+                            return False
+            else:
+                assert False, "The two arrays are of different size!"
+        return True
+
+    else:
+        assert False, "The two arrays are of different size!"
 
 def compare_two_arrays(array1, array2, eps, tolerance, comparison_string, array1_string, array2_string, error_string,
                        success_string, template_is_better, just_print=False):
@@ -1495,8 +1515,7 @@ def get_train_glm_params(model, what_param, family_type='gaussian'):
             return p_value_h2o
 
         else:
-            print("P-values are only available to Gaussian family.")
-            sys.exit(1)
+            assert False, "P-values are only available to Gaussian family."
 
     elif what_param == 'weights':
         if 'gaussian' in family_type.lower():
@@ -1528,8 +1547,7 @@ def get_train_glm_params(model, what_param, family_type='gaussian'):
         elif 'binomial' in family_type.lower():
             return model.confusion_matrix().table
     else:
-        print("parameter value not found in GLM model")
-        sys.exit(1)
+        assert False, "parameter value not found in GLM model"
 
 
 def less_than(val1, val2):
@@ -1597,8 +1615,7 @@ def remove_csv_files(dir_path, suffix=".csv", action='remove', new_dir_path=""):
             elif 'copy' in action:
                 move_files(new_dir_path, temp_fn, fn, action=action)
             else:
-                print("action string can only be 'remove' or 'copy.")
-                sys.exit(1)
+                assert False, "action string can only be 'remove' or 'copy."
 
 
 def extract_comparison_attributes_and_print(model_h2o, h2o_model_test_metrics, end_test_str, want_p_values,
@@ -1783,8 +1800,7 @@ def extract_comparison_attributes_and_print_multinomial(model_h2o, h2o_model_tes
         (template_weight, template_logloss_train, template_confusion_matrix_train, template_accuracy_train,
          template_logloss_test, template_confusion_matrix_test, template_accuracy_test) = template_params
     else:
-        print("No valid template parameters are given for comparison.")
-        sys.exit(1)
+        assert False, "No valid template parameters are given for comparison."
 
     # print and/or compare the weights between template and H2O
     compare_index = 0
@@ -1920,9 +1936,8 @@ def grab_model_params_metrics(model_h2o, h2o_model_test_metrics, family_type):
         h2o_accuracy_train = 1-float(h2o_confusion_matrix_train.cell_values[last_index][real_last_index])
         h2o_accuracy_test = 1-float(h2o_confusion_matrix_test.cell_values[last_index][real_last_index])
     else:
-        print("Only 'multinomial' and 'binomial' distribution families are supported for grab_model_params_metrics "
-              "function!")
-        sys.exit(1)
+        assert False, "Only 'multinomial' and 'binomial' distribution families are supported for " \
+                      "grab_model_params_metrics function!"
 
     return h2o_weight, h2o_logloss_train, h2o_confusion_matrix_train, h2o_accuracy_train, h2o_logloss_test,\
            h2o_confusion_matrix_test, h2o_accuracy_test
@@ -2013,8 +2028,7 @@ def add_fold_weights_offset_columns(h2o_frame, nfold_max_weight_offset, column_n
         elif 'offset_column' in column_type:
             temp_a = random.uniform(0, nfold_max_weight_offset)*np.asmatrix(np.ones(number_row)).transpose()
         else:
-            print("column_type must be either 'fold_assignment' or 'weights_column'!")
-            sys.exit(1)
+            assert False, "column_type must be either 'fold_assignment' or 'weights_column'!"
 
         fold_assignments = h2o.H2OFrame(temp_a)
         fold_assignments.set_names([column_names[index]])
@@ -2238,8 +2252,7 @@ def generate_random_words(word_length):
 
         return ''.join((random.choice(all_chars)) for index in range(int(word_length)))
     else:
-        print("word_length must be an integer greater than 0.")
-        sys.exit(1)
+        assert False, "word_length must be an integer greater than 0."
 
 
 def generate_redundant_parameters(hyper_params, gridable_parameters, gridable_defaults, error_number):
@@ -2336,8 +2349,7 @@ def error_diff_2_models(grid_table1, grid_table2, metric_name):
     if (num_model > 0):
         return metric_diff/num_model
     else:
-        print("error_diff_2_models: your table contains zero models.")
-        sys.exit(1)
+        assert False, "error_diff_2_models: your table contains zero models."
 
 
 def find_grid_runtime(model_list):

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3501_variance_metrics.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3501_variance_metrics.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+from h2o.transforms.decomposition import H2OPCA
+
+
+def glrm_arrests():
+  print("Importing USArrests.csv data...")
+  arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
+
+  pca_h2o = H2OPCA(k = 4, transform="STANDARDIZE")
+  pca_h2o.train(x=list(range(4)), training_frame=arrestsH2O)
+  pca_h2o.summary()
+  pca_h2o.show()
+
+  print("H2O GLRM on standardized data with quadratic loss:\n")
+  glrm_h2o = H2OGeneralizedLowRankEstimator(k=4, transform="STANDARDIZE", loss="Quadratic", gamma_x=0, gamma_y=0,
+                                            init="SVD", recover_svd=True)
+  glrm_h2o.train(x=arrestsH2O.names, training_frame=arrestsH2O)
+  glrm_h2o.show()
+
+  # compare table values and make sure they are the same between PCA and GLRM
+  if not(pyunit_utils.equal_2D_tables(pca_h2o._model_json["output"]["importance"]._cell_values,
+                               glrm_h2o._model_json["output"]["importance"]._cell_values, tolerance=1e-4)):
+    assert False, "PCA and GLRM variance metrics do not agree.  Fix it please."
+
+  sys.stdout.flush()
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(glrm_arrests)
+else:
+  glrm_arrests()

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3501_variance_metrics.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3501_variance_metrics.py
@@ -23,9 +23,9 @@ def glrm_arrests():
   glrm_h2o.show()
 
   # compare table values and make sure they are the same between PCA and GLRM
-  if not(pyunit_utils.equal_2D_tables(pca_h2o._model_json["output"]["importance"]._cell_values,
-                               glrm_h2o._model_json["output"]["importance"]._cell_values, tolerance=1e-4)):
-    assert False, "PCA and GLRM variance metrics do not agree.  Fix it please."
+  assert pyunit_utils.equal_2D_tables(pca_h2o._model_json["output"]["importance"]._cell_values,
+                                      glrm_h2o._model_json["output"]["importance"]._cell_values, tolerance=1e-4), \
+    "PCA and GLRM variance metrics do not agree.  Fix it please."
 
   sys.stdout.flush()
 

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -697,3 +697,23 @@ summarize_failures <- function(test_failed_array) {
 
   return(failure_message)
 }
+
+#----------------------------------------------------------------------
+# This function will compare a 2-D table results as a matrix
+#
+# Parameters:  table1, table2: 2D table from Java passed to R
+#
+# Returns:     Exception will be thrown if comparison failed
+#----------------------------------------------------------------------
+compare_tables <- function(table1, table2, tol=1e-6) {
+  dim1 = dim(table1)
+  dim2 = dim(table2)
+
+  expect_equal(dim1, dim2)
+
+  for (i in 1:dim1[1]) {
+    for (j in 1:dim1[2]) {
+      expect_equal(TRUE, (abs(table1[i,j]-table2[i,j]) < tol))
+    }
+  }
+}

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3501_variance_metrics.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3501_variance_metrics.R
@@ -1,0 +1,24 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# This test is written to add variance metrics for GLRM suggested by Erin in PUBDEV-3501.
+test.glrm.pubdev_3501.variance.metrics <- function() {
+#  ausPath <- system.file("extdata", "australia.csv", package="h2o")
+#  australia.hex = h2o.importFile(path = ausPath, destination_frame="australia.hex")
+  arrestsH2O <- h2o.uploadFile(locate("smalldata/pca_test/USArrests.csv"), destination_frame = "arrestsH2O")
+
+  browser()
+  
+  pca_model = h2o.prcomp(training_frame = arrestsH2O, k = 4, transform = "STANDARDIZE")
+  print(pca_model)
+  glrm_model = h2o.glrm(training_frame = arrestsH2O, k = 4, loss = "Quadratic", gamma_x = 0,
+  gamma_y = 0, max_iterations = 1000, recover_svd=TRUE, init="SVD", transform = "STANDARDIZE")
+  print(glrm_model)
+  print(glrm_model@model$importance)
+  
+  # compare the variance metrics between PCA and GLRM to make sure GLRM is generating the right input.
+  compare_tables(pca_model@model$importance, glrm_model@model$importance, 1e-4)
+  
+}
+
+doTest("PUBDEV-3501: add variance metrics for GLRM and Compare with PCA results", test.glrm.pubdev_3501.variance.metrics)


### PR DESCRIPTION
Added code in Java to calculate variance metrics in GLRM.  Added Junit and Runit tests to make sure the GLRM variance metrics are calculated correctly by comparing with PCA.

Please note that find GLRM, the variance metrics is found in the field of _output._importance just like the PCA.  The PCA assigned its _output._model_summary field to be the same as its _output._importance.  For GLRM, I did not do this because its _model_summary field was already taken by other information.  Let me know if this is a problem.  Otherwise, I will talk to Angela to make sure we inform the user where to find the variance metrics for GLRM. 

Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/568)
<!-- Reviewable:end -->
