### PR TITLE
PUBDEV-3534 further improvement for custom h2o.jar handling from url, better mock…

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -567,8 +567,10 @@ h2o.clusterStatus <- function() {
   
   # PUBDEV-3534 hook to use arbitrary h2o.jar
   own_jar = Sys.getenv("H2O_JAR_PATH")
-  if (nzchar(own_jar)) {
-    if (!file.exists(own_jar)) stop(sprintf("Environment variable H2O_JAR_PATH is set to '%s' but file does not exists, unset environment variable or provide valid path to h2o.jar file.", own_jar))
+  is_url = function(x) any(grepl("^(http|ftp)s?://", x), grepl("^(http|ftp)s://", x))
+  if (nzchar(own_jar) && !is_url(own_jar)) {
+    if (!file.exists(own_jar))
+      stop(sprintf("Environment variable H2O_JAR_PATH is set to '%s' but file does not exists, unset environment variable or provide valid path to h2o.jar file.", own_jar))
     return(own_jar)
   }
   
@@ -577,7 +579,7 @@ h2o.clusterStatus <- function() {
   } else {
     pkg_path = .h2o.pkg.path
 
-    # Find h2o-jar from testthat tests inside R-Studio.
+    # Find h2o-jar from testthat tests inside RStudio.
     if (length(grep("h2o-dev/h2o-r/h2o$", pkg_path)) == 1L) {
       tmp = substr(pkg_path, 1L, nchar(pkg_path) - nchar("h2o-dev/h2o-r/h2o"))
       return(sprintf("%s/h2o-dev/build/h2o.jar", tmp))
@@ -605,6 +607,11 @@ h2o.clusterStatus <- function() {
 
   buildnumFile <- file.path(pkg_path, "buildnum.txt")
   version <- readLines(buildnumFile)
+  
+  # mockup h2o package as CRAN release (no java/h2o.jar) hook h2o.jar url - PUBDEV-3534
+  jarFile <- file.path(pkg_path, "jar.txt")
+  if (file.exists(jarFile) && !nzchar(own_jar))
+    own_jar <- readLines(jarFile)
 
   dest_folder <- file.path(pkg_path, "java")
   if (!file.exists(dest_folder)) {
@@ -614,46 +621,47 @@ h2o.clusterStatus <- function() {
   dest_file <- file.path(dest_folder, "h2o.jar")
 
   # Download if h2o.jar doesn't already exist or user specifies force overwrite
-  if (TRUE) {
+  if (nzchar(own_jar) && is_url(own_jar)) {
+    h2o_url = own_jar # md5 must have same file name and .md5 suffix
+    md5_url = paste(own_jar, ".md5", sep="")
+  } else {
     base_url <- paste("s3.amazonaws.com/h2o-release/h2o", branch, version, "Rjar", sep = "/")
     h2o_url <- paste("http:/", base_url, "h2o.jar", sep = "/")
-
     # Get MD5 checksum
     md5_url <- paste("http:/", base_url, "h2o.jar.md5", sep = "/")
-    # ttt <- getURLContent(md5_url, binary = FALSE)
-    # tcon <- textConnection(ttt)
-    # md5_check <- readLines(tcon, n = 1)
-    # close(tcon)
-    md5_file <- tempfile(fileext = ".md5")
-    download.file(md5_url, destfile = md5_file, mode = "w", cacheOK = FALSE, quiet = TRUE)
-    md5_check <- readLines(md5_file, n = 1L)
-    if (nchar(md5_check) != 32) stop("md5 malformed, must be 32 characters (see ", md5_url, ")")
-    unlink(md5_file)
-
-    # Save to temporary file first to protect against incomplete downloads
-    temp_file <- paste(dest_file, "tmp", sep = ".")
-    cat("Performing one-time download of h2o.jar from\n")
-    cat("    ", h2o_url, "\n")
-    cat("(This could take a few minutes, please be patient...)\n")
-    download.file(url = h2o_url, destfile = temp_file, mode = "wb", cacheOK = FALSE, quiet = TRUE)
-
-    # Apply sanity checks
-    if(!file.exists(temp_file))
-      stop("Error: Transfer failed. Please download ", h2o_url, " and place h2o.jar in ", dest_folder)
-
-    md5_temp_file = md5sum(temp_file)
-    md5_temp_file_as_char = as.character(md5_temp_file)
-    if(md5_temp_file_as_char != md5_check) {
-      cat("Error: Expected MD5: ", md5_check, "\n")
-      cat("Error: Actual MD5  : ", md5_temp_file_as_char, "\n")
-      stop("Error: MD5 checksum of ", temp_file, " does not match ", md5_check)
-    }
-
-    # Move good file into final position
-    file.rename(temp_file, dest_file)
   }
-
-  return(dest_file)
+  # ttt <- getURLContent(md5_url, binary = FALSE)
+  # tcon <- textConnection(ttt)
+  # md5_check <- readLines(tcon, n = 1)
+  # close(tcon)
+  md5_file <- tempfile(fileext = ".md5")
+  download.file(md5_url, destfile = md5_file, mode = "w", cacheOK = FALSE, quiet = TRUE)
+  md5_check <- readLines(md5_file, n = 1L)
+  if (nchar(md5_check) != 32) stop("md5 malformed, must be 32 characters (see ", md5_url, ")")
+  unlink(md5_file)
+  
+  # Save to temporary file first to protect against incomplete downloads
+  temp_file <- paste(dest_file, "tmp", sep = ".")
+  cat("Performing one-time download of h2o.jar from\n")
+  cat("    ", h2o_url, "\n")
+  cat("(This could take a few minutes, please be patient...)\n")
+  download.file(url = h2o_url, destfile = temp_file, mode = "wb", cacheOK = FALSE, quiet = TRUE)
+  
+  # Apply sanity checks
+  if(!file.exists(temp_file))
+    stop("Error: Transfer failed. Please download ", h2o_url, " and place h2o.jar in ", dest_folder)
+  
+  md5_temp_file = md5sum(temp_file)
+  md5_temp_file_as_char = as.character(md5_temp_file)
+  if(md5_temp_file_as_char != md5_check) {
+    cat("Error: Expected MD5: ", md5_check, "\n")
+    cat("Error: Actual MD5  : ", md5_temp_file_as_char, "\n")
+    stop("Error: MD5 checksum of ", temp_file, " does not match ", md5_check)
+  }
+  
+  # Move good file into final position
+  file.rename(temp_file, dest_file)
+  return(dest_file[file.exists(dest_file)])
 }
 
 #' View Network Traffic Speed


### PR DESCRIPTION
…up CRAN installation in devel h2o.

This change allow to mockup CRAN release in h2o devel version, so h2o devel doesn't need to include `inst/h2o.jar`.
Logic is as follows:
- Env var `H2O_JAR_PATH` can contain path to h2o.jar, starting from this PR it can also contain url.
- If `H2O_JAR_PATH` is not set and `jar.txt` file is present then H2O_JAR_PATH is set to url provided in `jar.txt`.
- If there is no jar.txt and env var then `.h2o.downloadJar` will behave as usually so for devel h2o will fail to get h2o.jar.

When using links in jar.txt or env var we still need to have md5 file next to jar on web location.

This allows to ship devel h2o package without `java/h2o.jar`, jar is downloaded from location provided in `jar.txt`, this allows to mockup CRAN release of h2o package, which cannot ship h2o.jar due to cran policies.
```
> install.packages("h2o", repos="http://cran.0xdata.loc")
Installing package into ‘/home/jan/R/x86_64-pc-linux-gnu-library/3.3’
(as ‘lib’ is unspecified)
trying URL 'http://cran.0xdata.loc/src/contrib/h2o_3.11.0.99999.tar.gz'
Content type 'text/plain; charset=utf-8' length 313781 bytes (306 KB)
==================================================
downloaded 306 KB

* installing *source* package ‘h2o’ ...
** R
** demo
** inst
** preparing package for lazy loading
Creating a generic function for ‘summary’ from package ‘base’ in package ‘h2o’
Performing one-time download of h2o.jar from
     http://cran.0xdata.loc/java/h2o.jar 
(This could take a few minutes, please be patient...)
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded
* DONE (h2o)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/570)
<!-- Reviewable:end -->
