### PR TITLE
Minor PCA doc fix

### DIFF
--- a/h2o-docs/src/product/data-science/pca.rst
+++ b/h2o-docs/src/product/data-science/pca.rst
@@ -165,7 +165,7 @@ The covariance matrix :math:`C_{x}` is
 
 where :math:`n` is the number of observations, and :math:`C_{x}` is a square, symmetric :math:`m \times m` matrix, the diagonal entries of which are the variances of attributes, and the off-diagonal entries are covariances between attributes.
 
-PCA convergence is based on the method described by Gockenbach: "The rate of convergence of the power method depends on the ratio :math:`lambda_2|/|\lambda_1`. If this is small...then the power method converges rapidly. If the ratio is close to 1, then convergence is quite slow. The power method will fail if :math:`lambda_2| = |\lambda_1`." (567).
+PCA convergence is based on the method described by Gockenbach: "The rate of convergence of the power method depends on the ratio :math:`|\lambda_2|/|\lambda_1|`. If this is small...then the power method converges rapidly. If the ratio is close to 1, then convergence is quite slow. The power method will fail if :math:`|\lambda_2| = |\lambda_1|`." (567).
 
 The objective of PCA is to maximize variance while minimizing
 covariance.


### PR DESCRIPTION
Fixed issue with math display in PCA Algorithm section of the UG. Two
math equations were missing the beginning “\”.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/571)
<!-- Reviewable:end -->
