### PR TITLE
Add name attribute to h2o.coef output

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -997,9 +997,10 @@ h2o.giniCoef <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' @export
 h2o.coef <- function(object) {
   if( is(object, "H2OModel") ) {
-    coefs <- object@model$coefficients_table
-    if( is.null(coefs) ) stop("Can only extract coefficeints from GLMs")
-    return( coefs$coefficients )
+    if( is.null(object@model$coefficients_table) ) stop("Can only extract coefficeints from GLMs")
+    coefs <- object@model$coefficients_table$coefficients
+    names(coefs) <- object@model$coefficients_table$names
+    return(coefs)
   } else stop("Can only extract coefficients from GLMs")
 }
 
@@ -1010,9 +1011,10 @@ h2o.coef <- function(object) {
 #' @export
 h2o.coef_norm <- function(object) {
   if( is(object, "H2OModel") ) {
-    coefs <- object@model$coefficients_table
-    if( is.null(coefs) ) stop("Can only extract coefficeints from GLMs")
-    return( coefs[,3] )  # the normalized coefs are 3rd column, (labels is 1st col)
+    if( is.null(object@model$coefficients_table) ) stop("Can only extract coefficeints from GLMs")
+    coefs <- object@model$coefficients_table$standardized_coefficients
+    names(coefs) <- object@model$coefficients_table$names
+    return(coefs)
   } else stop("Can only extract coefficients from GLMs")
 }
 


### PR DESCRIPTION
Right now the output of `h2o.coef` and `h2o.coef_norm` has little value.

```R
library("h2o")

h2o.init()
data(mtcars)

mtcars$gear <- as.factor(mtcars$gear)

mt_train <- as.h2o(mtcars, destination_frame = "mt_train")
model <- h2o.glm(y = "mpg", 
                 x = c("cyl", "disp", "hp", "drat", "wt", "gear"),
                 training_frame = mt_train, 
                 family = "gaussian")
h2o.coef(model)
# [1] 28.195652311  0.000000000  0.000000000  0.000000000  0.000000000
# [6] -0.584696929 -0.006587693 -0.014063269  1.030997840 -1.433650631
```

Having the coefficient names is important. Right now the user has to inspect the model object to find them. This change sets a `names` attribute for `h2o.coef` and `h2o.coef_norm`.

```R
> h2o_coef(model)
#        Intercept           gear.3           gear.4           gear.5 
#     28.195652311      0.000000000      0.000000000      0.000000000 
# gear.missing(NA)              cyl             disp               hp 
#      0.000000000     -0.584696929     -0.006587693     -0.014063269 
#             drat               wt 
#      1.030997840     -1.433650631 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h2oai/h2o-3/574)
<!-- Reviewable:end -->
