### PR TITLE
[HOTFIX]: Add search for config in Windows OS

### DIFF
--- a/h2o-r/h2o-package/R/config.R
+++ b/h2o-r/h2o-package/R/config.R
@@ -109,10 +109,10 @@
     path_to_config = getwd()
     current_directory = getwd()
     while(identical(Sys.glob(".h2oconfig"),character(0))){
-        if(getwd() == "/"){
+        if(getwd() == "/" || getwd() == "C:/" || getwd() == "D:/"){ #Search up to root directory in Unix/Windows OS
           setwd(current_directory)
           return()
-      }
+        }
       setwd("..")
       path_to_config = getwd()
     }


### PR DESCRIPTION
* This PR looks for a config file in a Windows OS (`C:/` & `D:/` drives). If not found, then it just returns.