### PR TITLE
upgrade DESCRIPTION file syntax, url match to github, closes PUBDEV-3754

### DIFF
--- a/h2o-r/h2o-DESCRIPTION.template
+++ b/h2o-r/h2o-DESCRIPTION.template
@@ -3,15 +3,24 @@ Version: SUBST_PROJECT_VERSION
 Type: Package
 Title: R Interface for H2O
 Date: SUBST_PROJECT_DATE
-Author: The H2O.ai team
-Maintainer: Tom Kraljevic <tomk@0xdata.com>
+Authors@R: c(
+  person("Tom", "Kraljevic", role = c("aut", "cre"), email = "tomk@h2o.ai"),
+  person("Spencer", "Aiello", role = "aut"),
+  person("Navdeep", "Gill", role = "aut", email = "navdeep@h2o.ai"),
+  person("Arno", "Candel", role = "aut", email = "arno@h2o.ai"),
+  person("Matt", "Dowle", role = "aut", email = "mattd@h2o.ai"),
+  person("Jan", "Gorecki", role = "aut", email = "jan@h2o.ai"),
+  person("Surekha", "Jadhawani", role = "aut", email = "surekha@h2o.ai"),
+  person("Erin", "LeDell", role = "aut", email = "erin@h2o.ai"),
+  person("H2O.ai", role = "cph") )
 Description: R scripting functionality for H2O, the open source
   math engine for big data that computes parallel distributed
   machine learning algorithms such as generalized linear models,
   gradient boosting machines, random forests, and neural networks
   (deep learning) within various cluster environments.
 License: Apache License (== 2.0)
-URL: http://www.h2o.ai
+URL: https://github.com/h2oai/h2o-3
+BugReports: http://jira.h2o.ai
 NeedsCompilation: no
 SystemRequirements: Java (>= 1.7)
 Depends: R (>= 2.13.0),


### PR DESCRIPTION
On next CRAN submission this may require one-time confirmation from @tomkraljevic about his email changed (0xdata.com->h2o.ai).
h2o check produces unexpected NOTEs, but those are not related to change in this commit.