### PR TITLE
Modify search for config

### DIFF
--- a/h2o-r/h2o-package/R/config.R
+++ b/h2o-r/h2o-package/R/config.R
@@ -107,7 +107,7 @@
 #with '#' are also allowed.
 #Input is a list of file names or a single file name.
 #Returns path to first file found in files. Otherwise it returns NULL
-.find.files <- function(files = ".h2oconfig") {
+.find.config <- function(files = ".h2oconfig") {
   windows <- .Platform$OS.type == "windows" #Are we dealing with a Windows OS?
 
   #Function to check if in root directory

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -60,7 +60,7 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
     # Check for .h2oconfig file
     # Find .h2oconfig file starting from currenting directory and going
     # up all parent directories until it reaches the root directory.
-    config_path <- .h2o.candidate.config.files()
+    config_path <- .find.files()
 
     #Read in config if available
     if(!(is.null(config_path))){

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -60,7 +60,7 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
     # Check for .h2oconfig file
     # Find .h2oconfig file starting from currenting directory and going
     # up all parent directories until it reaches the root directory.
-    config_path <- .find.files()
+    config_path <- .find.config()
 
     #Read in config if available
     if(!(is.null(config_path))){


### PR DESCRIPTION
1.Do not change working directory when searching for config file
2.Account for Windows OS when searching for config, i.e., account for various Windows drivers (`C:\`, `D:\`, etc)
3.Make function to search for config more generic by changing name to `.find.files()` and passing a file name as an argument.