### PR TITLE
Pubdev 3728 glrm binary loss numeric

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -99,7 +99,7 @@ public class DataInfo extends Keyed<DataInfo> {
   public int _cats;  // "raw" number of categorical columns as they exist in the frame
   public int [] _catOffsets;   // offset column indices for the 1-hot expanded values (includes enum-enum interaction)
   public boolean [] _catMissing;  // bucket for missing levels
-  private int [] _catNAFill;    // majority class of each categorical col (or last bucket if _catMissing[i] is true)
+  public int [] _catNAFill;    // majority class of each categorical col (or last bucket if _catMissing[i] is true)
   public int [] _permutation; // permutation matrix mapping input col indices to adaptedFrame
   public double [] _normMul;  // scale the predictor column by this value
   public double [] _normSub;  // subtract from the predictor this value

--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -61,6 +61,8 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
   // Loss function for each column
   private transient GlrmLoss[] _lossFunc;
 
+  private ArrayList<Integer> _binaryColumnIndices;  // store binary columns using binary loss functions.
+
   @Override protected GLRMDriver trainModelImpl() { return new GLRMDriver(); }
   @Override public ModelCategory[] can_build() { return new ModelCategory[]{ModelCategory.Clustering}; }
 
@@ -210,6 +212,8 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
 
     if (_train == null) return;
 
+    _binaryColumnIndices = new ArrayList<Integer>();
+
     // Initialize the default loss functions for each column
     // Note: right now for binary columns `.isCategorical()` returns true. It has the undesired consequence that
     // such variables will get categorical loss function, and will get expanded into 2 columns.
@@ -241,16 +245,26 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
     for (int i = 0; i < _ncolA; i++) {
       Vec vi = _train.vec(i);
       GlrmLoss lossi = _lossFunc[i];
-      if (vi.isNumeric()) {
-        if (!lossi.isForNumeric())
-          error("_loss_by_col", "Loss function " + lossi + " cannot be applied to numeric column " + i);
-      } else if (vi.isCategorical()) {
-        if (!lossi.isForCategorical())
-          error("_loss_by_col", "Loss function " + lossi + " cannot be applied to categorical column " + i);
-      } else if (vi.isBinary()) {
-        // Allow numeric loss functions on binary columns too; but not the other way round!
-        if (!lossi.isForBinary() && !lossi.isForNumeric())
-          error("_loss_by_col", "Loss function " + lossi + " cannot be applied to binary column " + i);
+
+      if (vi.isNumeric())   { // numeric columns
+        if (!vi.isBinary()) { // non-binary numeric columns
+          if (!lossi.isForNumeric())
+            error("_loss_by_col", "Loss function "+lossi+" cannot be applied to numeric column "+i);
+        } else {  // binary numeric columns
+          if (!lossi.isForBinary() && !lossi.isForNumeric()) {
+            error("_loss_by_col", "Loss function "+lossi+" cannot be applied to binary column "+i);
+          }
+        }
+      } else if (vi.isCategorical()) {  // categorical columns
+        if (vi.isBinary())  {  // categorical binary columns
+          if (!lossi.isForBinary() && !lossi.isForCategorical())
+            error("_loss_by_col", "Loss function "+lossi+" cannot be applied to binary column "+i);
+          else if (lossi.isForBinary())
+            _binaryColumnIndices.add(i);  // collect column indices storing binary columns with binary loss function.
+        } else {  // categorical non-binary columns
+          if (!lossi.isForCategorical())
+            error("_loss_by_col","Loss function "+lossi+" cannot be applied to categorical column "+i);
+        }
       }
 
       // For "Periodic" loss function supply the period. We currently have no support for different periods for
@@ -409,7 +423,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
         parms._save_v_frame = false;
 
         SVDModel svd = ModelCacheManager.get(parms);
-        if (svd == null) svd = new SVD(parms, _job).trainModelNested(_rebalancedTrain);
+        if (svd == null) svd = new SVD(parms, _job, true, model).trainModelNested(_rebalancedTrain);
         model._output._init_key = svd._key;
 
         // Ensure SVD centers align with adapted training frame cols
@@ -461,7 +475,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
         // Permute cluster columns to align with dinfo, normalize nums, and expand out cats to indicator cols
         centers = ArrayUtils.permuteCols(km._output._centers_raw, tinfo.mapNames(km._output._names));
         centers = transform(centers, tinfo._normSub, tinfo._normMul, tinfo._cats, tinfo._nums);
-        centers_exp = expandCats(centers, tinfo);
+        centers_exp = expandCats(centers, tinfo); // expand categorical columns to N binary columns
       } else
         error("_init", "Initialization method " + _parms._init + " is undefined");
 
@@ -654,7 +668,25 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
 
         tempinfo = new DataInfo(_train, null, 0, true, _parms._transform, DataInfo.TransformType.NONE,
                 false, false, false, /* weights */ false, /* offset */ false, /* fold */ false);
- //       DKV.put(tempinfo._key, tempinfo);
+
+        correctForBinaryLoss(tinfo);
+
+        model._output._permutation = tinfo._permutation;
+        model._output._nnums = tinfo._nums;
+        model._output._ncats = tinfo._cats;
+        model._output._catOffsets = tinfo._catOffsets;
+        int[] numLevels = tinfo._adaptedFrame.cardinality();
+        // may have more numerical columns now since we may change binary columns with binary loss to numerical columns
+        for (int colIndex = tinfo._cats; colIndex < _train.numCols(); colIndex++) {
+          if (numLevels[colIndex] > -1)
+            numLevels[colIndex] = -1;
+          else
+            break;  // hit the numericcal columns already.  Nothing more need to be done here.
+        }
+        // need to prevent binary data column being expanded into two when the loss function is logistic here
+        if (error_count() > 0) throw new IllegalArgumentException("Found validation errors: " + validationErrors());
+        model._output._catOffsets = tinfo._catOffsets;
+        model._output._names_expanded = tinfo.coefNames();
 
         // Save training frame adaptation information for use in scoring later
         model._output._normSub = tinfo._normSub == null ? new double[tinfo._nums] : tinfo._normSub;
@@ -663,11 +695,6 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
           Arrays.fill(model._output._normMul, 1.0);
         } else
           model._output._normMul = tinfo._normMul;
-        model._output._permutation = tinfo._permutation;
-        model._output._nnums = tinfo._nums;
-        model._output._ncats = tinfo._cats;
-        model._output._catOffsets = tinfo._catOffsets;
-        model._output._names_expanded = tinfo.coefNames();
 
         // Save loss function for each column in adapted frame order
         assert _lossFunc != null && _lossFunc.length == _train.numCols();
@@ -696,7 +723,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
         DKV.put(dinfo._key, dinfo);
 
         int weightId = dinfo._weights ? dinfo.weightChunkId() : -1;
-        int[] numLevels = tinfo._adaptedFrame.cardinality();
+
 
         // Use closed form solution for X if quadratic loss and regularization
         _job.update(1, "Initializing X and Y matrices");   // One unit of work
@@ -717,7 +744,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
         // Assume regularization on initial X is finite, else objective can be NaN if \gamma_x = 0
         boolean regX = _parms._regularization_x != GlrmRegularizer.None && _parms._gamma_x != 0;
 
-        ObjCalc objtsk = new ObjCalc(_parms, yt, _ncolA, _ncolX, dinfo._cats, model._output._normSub,
+        ObjCalc objtsk = new ObjCalc(_parms, yt, _ncolA, _ncolX, tinfo._cats, model._output._normSub,
                                      model._output._normMul, model._output._lossFunc, weightId, regX);
         objtsk.doAll(dinfo._adaptedFrame);
 
@@ -740,7 +767,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
           // 1) Update X matrix given fixed Y
 
           // find out how much time it takes to update x
-          UpdateX xtsk = new UpdateX(_parms, yt, step/_ncolA, overwriteX, _ncolA, _ncolX, dinfo._cats, model._output._normSub, model._output._normMul, model._output._lossFunc, weightId);
+          UpdateX xtsk = new UpdateX(_parms, yt, step/_ncolA, overwriteX, _ncolA, _ncolX, tinfo._cats, model._output._normSub, model._output._normMul, model._output._lossFunc, weightId);
 
           xtsk.doAll(dinfo._adaptedFrame);
           model._output._updates++;
@@ -748,16 +775,16 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
           // 2) Update Y matrix given fixed X
           if (model._output._updates < _parms._max_updates) {
             // If max_updates is odd, we will terminate after the X update
-            UpdateY ytsk = new UpdateY(_parms, yt, step/_ncolA, _ncolA, _ncolX, dinfo._cats, model._output._normSub,
+            UpdateY ytsk = new UpdateY(_parms, yt, step/_ncolA, _ncolA, _ncolX, tinfo._cats, model._output._normSub,
                     model._output._normMul, model._output._lossFunc, weightId);
             double[][] yttmp = ytsk.doAll(dinfo._adaptedFrame)._ytnew;
-            ytnew = new Archetypes(yttmp, true, dinfo._catOffsets, numLevels);
+            ytnew = new Archetypes(yttmp, true, tinfo._catOffsets, numLevels);
             yreg = ytsk._yreg;
             model._output._updates++;
           }
 
           // 3) Compute average change in objective function
-          objtsk = new ObjCalc(_parms, ytnew, _ncolA, _ncolX, dinfo._cats, model._output._normSub, model._output._normMul, model._output._lossFunc, weightId);
+          objtsk = new ObjCalc(_parms, ytnew, _ncolA, _ncolX, tinfo._cats, model._output._normSub, model._output._normMul, model._output._lossFunc, weightId);
           objtsk.doAll(dinfo._adaptedFrame);
           double obj_new = objtsk._loss + _parms._gamma_x * xtsk._xreg + _parms._gamma_y * yreg;
           model._output._avg_change_obj = (model._output._objective - obj_new) / nobs;
@@ -851,6 +878,106 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
           }
         }
         Scope.untrack(keep);
+      }
+    }
+
+    /*
+    This funciton will
+    1. change categorical binary columns using binary loss function into numerical columns.  This involves
+    performing the following variables:
+    _nums, _cats, _catOffsets, _catMissing, _catNAFill, _permutation, _normMul, _normSub, _normMeans, _numOffsets
+      If no logistic loss is specified, no action will be performed.
+    2. for numeric columns using logistic loss, it will prevent it from being transformed to say zero mean
+    and unit variance columns.
+     */
+    private void correctForBinaryLoss(DataInfo tinfo) {
+
+      // set mean = 0 and mul = 1.0 for binary numeric columns using binary loss functions
+      for (int index = 0; index < tinfo._nums; index++) {
+        if (_lossFunc[tinfo._permutation[index+tinfo._cats]].isForBinary()) { // binary loss used on numeric columns
+          if (tinfo._normMul != null)
+            tinfo._normMul[index] = 1;
+
+          if (tinfo._normSub != null)
+            tinfo._normSub[index] = 0;
+        }
+      }
+      // change binary categorical columns using binary loss functions to binary numerical columns
+      if (!(_binaryColumnIndices == null) && (_binaryColumnIndices.size()>0)) {
+        // change the number of categorical and numerical column counts.
+        int binaryLossCols = _binaryColumnIndices.size(); // number of columns to change to numerics
+        int numCatColumns = tinfo._cats;  // store original categorical column number
+        int numNumColumns = tinfo._nums;  // store original numerical column number
+        tinfo._cats -= binaryLossCols;  // decrease the number of categorical columns
+        tinfo._nums += binaryLossCols;  // increase the number of numerical columns
+
+        int[] catOffsetsTemp = new int[tinfo._cats+1];   // offset column indices for the 1-hot expanded values (includes enum-enum interaction)
+        boolean[] catMissingTemp = new boolean[tinfo._cats];  // bucket for missing levels
+        int[] catNAFillTemp = new int[tinfo._cats];    // majority class of each categorical col (or last bucket if _catMissing[i] is true)
+        int[] permutationTemp = new int[tinfo._permutation.length]; // permutation matrix mapping input col indices to adaptedFrame
+        int[] numOffsetsTemp = new int[tinfo._nums];
+        int[] cardinalities = _train.cardinality();
+        int[] currentCardinality = new int[tinfo._cats];
+        double[] normMulTemp = new double[tinfo._nums];
+        double[] normSubTemp = new double[tinfo._nums];
+        double[] numMeansTemp = new double[tinfo._nums];
+        int newColIndex = 0;
+
+        for (int colIndex = 0; colIndex < numCatColumns; colIndex++) {  // go through all categoricals
+          if (!(_binaryColumnIndices.contains(tinfo._permutation[colIndex]))) {
+            permutationTemp[newColIndex] = tinfo._permutation[colIndex];
+            catMissingTemp[newColIndex] = tinfo._catMissing[colIndex];
+            catNAFillTemp[newColIndex] = tinfo._catNAFill[colIndex];
+            currentCardinality[newColIndex] = cardinalities[colIndex];
+            catOffsetsTemp[newColIndex+1] = catOffsetsTemp[newColIndex]+currentCardinality[newColIndex];
+
+            newColIndex++;
+          }
+        }
+        numOffsetsTemp[0] = catOffsetsTemp[newColIndex];
+        for (int colIndex = 0; colIndex < binaryLossCols; colIndex++) { // set infos for new numerical binary columns
+          permutationTemp[colIndex + newColIndex] = _binaryColumnIndices.get(colIndex);
+          normMulTemp[colIndex] = 1.0;
+          normSubTemp[colIndex] = 0.0;
+          numMeansTemp[colIndex] = 0.0;
+          if (colIndex > 0)
+            numOffsetsTemp[colIndex] = numOffsetsTemp[colIndex-1]+1;
+        }
+
+        // copy over original numerical columns
+        for (int colIndex = 0; colIndex < numNumColumns; colIndex++) {
+          int newColumnIndex = colIndex + binaryLossCols;
+          if (tinfo._normSub != null) {
+            normMulTemp[newColumnIndex] = tinfo._normMul[colIndex];
+          }
+          if (tinfo._normSub != null) {
+            normSubTemp[newColumnIndex] = tinfo._normSub[colIndex];
+          }
+          if (tinfo._numMeans != null) {
+            numMeansTemp[newColumnIndex] = tinfo._numMeans[colIndex];
+          }
+          numOffsetsTemp[newColumnIndex] = numOffsetsTemp[newColumnIndex-1]+1;
+
+          int numColIndex = newColumnIndex + tinfo._cats;
+          permutationTemp[numColIndex] = tinfo._permutation[numColIndex];
+        }
+
+        // copy the changed arrays back to tinfo information
+        tinfo._catOffsets = Arrays.copyOf(catOffsetsTemp, catOffsetsTemp.length);
+        tinfo._catMissing = Arrays.copyOf(catMissingTemp, tinfo._cats);
+        tinfo._catNAFill = Arrays.copyOf(catNAFillTemp, tinfo._cats);
+        tinfo._permutation = Arrays.copyOf(permutationTemp, tinfo._permutation.length);
+        tinfo._numOffsets = Arrays.copyOf(numOffsetsTemp, tinfo._nums);
+        if (tinfo._normMul != null) {
+          tinfo._normMul = Arrays.copyOf(normMulTemp, tinfo._nums);
+        }
+        if (tinfo._normSub != null) {
+          tinfo._normSub = Arrays.copyOf(normSubTemp, tinfo._nums);
+        }
+        if (tinfo._numMeans != null) {
+          tinfo._numMeans = Arrays.copyOf(numMeansTemp, tinfo._nums);
+        }
+        _ncolY = _ncolY-binaryLossCols;   // adjust for binary columns with binary loss changed to numerical columns
       }
     }
 
@@ -1230,10 +1357,10 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
         // Compute gradient of objective at row
         // Categorical columns
         for (int j = 0; j < _ncats; j++) {
+          if (Double.isNaN(a[j])) continue;   // Skip missing observations in row
           a[j] = cs[j].atd(row);
           int catColJLevel = _yt._numLevels[j];
           Arrays.fill(xy, 0, catColJLevel, 0);  // reset xy before accumulate sum
-          if (Double.isNaN(a[j])) continue;   // Skip missing observations in row
 
           // Calculate x_i * Y_j where Y_j is sub-matrix corresponding to categorical col j
           for (int level = 0; level < catColJLevel ; level++) {
@@ -1301,8 +1428,8 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
 
         // Numeric columns
         for (int j = _ncats; j < _ncolA; j++) {
-          int js = j - _ncats;
           if (Double.isNaN(a[j])) continue;   // Skip missing observations in row
+          int js = j - _ncats;
           double txy = _yt.lmulNumCol(xnew, js);
           _loss += _lossFunc[j].loss(txy, (a[j] - _normSub[js]) * _normMul[js]);
         }
@@ -1527,10 +1654,10 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
 
         // Categorical columns
         for (int j = 0; j < _ncats; j++) {
-          int catColJLevel = _yt._numLevels[j];
-          Arrays.fill(xy, 0, catColJLevel, 0);  // reset before next accumulation sum
           double a = cs[j].atd(row);
           if (Double.isNaN(a)) continue;
+          int catColJLevel = _yt._numLevels[j];
+          Arrays.fill(xy, 0, catColJLevel, 0);  // reset before next accumulation sum
 
           // Calculate x_i * Y_j where Y_j is sub-matrix corresponding to categorical col j
           for (int level = 0; level < catColJLevel; level++) {

--- a/h2o-algos/src/main/java/hex/svd/SVD.java
+++ b/h2o-algos/src/main/java/hex/svd/SVD.java
@@ -5,6 +5,7 @@ import Jama.QRDecomposition;
 import Jama.SingularValueDecomposition;
 import hex.*;
 import hex.DataInfo.Row;
+import hex.glrm.GLRMModel;
 import hex.gram.Gram;
 import hex.gram.Gram.GramTask;
 import hex.svd.SVDModel.SVDParameters;
@@ -35,6 +36,9 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
   // Maximum number of columns when categoricals expanded
   private final int MAX_COLS_EXPANDED = 5000;
 
+  private boolean _callFromGLRM;  // when SVD is used as an init method for GLRM, need to initialize properly
+  private GLRMModel _glrmModel;
+
   // Number of columns in training set (p)
   private transient int _ncolExp;    // With categoricals expanded into 0/1 indicator cols
 
@@ -46,8 +50,16 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
   @Override public boolean haveMojo() { return false; }
 
   // Called from an http request
-  public SVD(SVDModel.SVDParameters parms         ) { super(parms    ); init(false); }
-  public SVD(SVDModel.SVDParameters parms, Job job) { super(parms,job); init(false); }
+  public SVD(SVDModel.SVDParameters parms         ) { super(parms    ); init(false); _glrmModel=null; _callFromGLRM=false;}
+  public SVD(SVDModel.SVDParameters parms, Job job) { super(parms,job); init(false); _glrmModel=null; _callFromGLRM=false;}
+  public SVD(SVDModel.SVDParameters parms, Job job, boolean callFromGlrm, GLRMModel gmodel) {
+    super(parms,job);
+    init(false);
+    _callFromGLRM = callFromGlrm;
+    if (gmodel == null)
+      error("_train SVD for GLRM", "Your GLRM model parameter is null.");
+    _glrmModel = gmodel;
+  }
   public SVD(boolean startup_once) { super(new SVDParameters(),startup_once); }
 
   @Override
@@ -70,7 +82,10 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
       error("_max_iterations", "max_iterations must be at least 1");
 
     if(_train == null) return;
-    _ncolExp = LinearAlgebraUtils.numColsExp(_train,_parms._use_all_factor_levels);
+      if (_callFromGLRM)  // when used to initialize GLRM, need to treat binary numeric columns with binary loss as numeric columns
+        _ncolExp = _glrmModel._output._catOffsets[_glrmModel._output._catOffsets.length-1]+_glrmModel._output._nnums;
+      else
+        _ncolExp = LinearAlgebraUtils.numColsExp(_train,_parms._use_all_factor_levels);
     if (_ncolExp > MAX_COLS_EXPANDED)
       warn("_train", "_train has " + _ncolExp + " columns when categoricals are expanded. Algorithm may be slow.");
 
@@ -229,7 +244,7 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
           _job.update(1, "Iteration " + String.valueOf(model._output._iterations+1) + " of randomized subspace iteration");
 
           // 2) Form \tilde{Y}_j = A'Q_{j-1} and compute \tilde{Y}_j = \tilde{Q}_j \tilde{R}_j factorization
-          SMulTask stsk = new SMulTask(dinfo, _parms._nv);
+          SMulTask stsk = new SMulTask(dinfo, _parms._nv, _ncolExp);
           stsk.doAll(aqfrm);    // Pass in [A,Q]
 
           Matrix ysmall = new Matrix(stsk._atq);
@@ -237,7 +252,7 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
           double[][] ysmall_q = ysmall_qr.getQ().getArray();
 
           // 3) Form Y_j = A\tilde{Q}_j and compute Y_j = Q_jR_j factorization
-          BMulInPlaceTask tsk = new BMulInPlaceTask(dinfo, ArrayUtils.transpose(ysmall_q));
+          BMulInPlaceTask tsk = new BMulInPlaceTask(dinfo, ArrayUtils.transpose(ysmall_q), _ncolExp);
           tsk.doAll(ayfrm);
           qerr = LinearAlgebraUtils.computeQ(_job._key, yinfo, yqfrm);
           model._output._iterations++;
@@ -274,7 +289,7 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
 
         // 1) Form the matrix B' = A'Q = (Q'A)'
         _job.update(1, "Forming small matrix B = Q'A for direct SVD");
-        SMulTask stsk = new SMulTask(dinfo, _parms._nv);
+        SMulTask stsk = new SMulTask(dinfo, _parms._nv, _ncolExp);
         stsk.doAll(aqfrm);
 
         // 2) Compute SVD of small matrix: If B' = WDV', then B = VDW'
@@ -322,17 +337,7 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
         DKV.put(dinfo._key, dinfo);
 
         // Save adapted frame info for scoring later
-        model._output._normSub = dinfo._normSub == null ? new double[dinfo._nums] : dinfo._normSub;
-        if(dinfo._normMul == null) {
-          model._output._normMul = new double[dinfo._nums];
-          Arrays.fill(model._output._normMul, 1.0);
-        } else
-          model._output._normMul = dinfo._normMul;
-        model._output._permutation = dinfo._permutation;
-        model._output._nnums = dinfo._nums;
-        model._output._ncats = dinfo._cats;
-        model._output._catOffsets = dinfo._catOffsets;
-        model._output._names_expanded = dinfo.coefNames();
+        setSVDModel(model, dinfo);
 
         String u_name = (_parms._u_name == null || _parms._u_name.length() == 0) ? "SVDUMatrix_" + Key.rand() : _parms._u_name;
         String v_name = (_parms._v_name == null || _parms._v_name.length() == 0) ? "SVDVMatrix_" + Key.rand() : _parms._v_name;
@@ -485,6 +490,35 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
         Scope.untrack(keep);
       }
     }
+  }
+
+  /*
+  This method may make changes to the dinfo parameters if SVD is called by GLRM as a init method.
+   */
+  private void setSVDModel(SVDModel model, DataInfo dinfo) {
+    if (_callFromGLRM) {
+      dinfo._normSub = Arrays.copyOf(_glrmModel._output._normSub, _glrmModel._output._normSub.length);
+      dinfo._normMul = Arrays.copyOf(_glrmModel._output._normMul, _glrmModel._output._normMul.length);
+      dinfo._permutation = Arrays.copyOf(_glrmModel._output._permutation, _glrmModel._output._permutation.length);
+      dinfo._numMeans = Arrays.copyOf(dinfo._normSub, dinfo._normSub.length);
+      dinfo._nums = _glrmModel._output._nnums;
+      dinfo._cats = _glrmModel._output._ncats;
+      dinfo._catOffsets = Arrays.copyOf(_glrmModel._output._catOffsets, _glrmModel._output._catOffsets.length);
+      model._output._names_expanded = Arrays.copyOf(_glrmModel._output._names_expanded,
+              _glrmModel._output._names_expanded.length);
+    } else
+      model._output._names_expanded = dinfo.coefNames();
+
+    model._output._normSub = dinfo._normSub == null ? new double[dinfo._nums] : dinfo._normSub;
+    if (dinfo._normMul == null) {
+      model._output._normMul = new double[dinfo._nums];
+      Arrays.fill(model._output._normMul, 1.0);
+    } else
+      model._output._normMul = dinfo._normMul;
+    model._output._permutation = dinfo._permutation;
+    model._output._nnums = dinfo._nums;
+    model._output._ncats = dinfo._cats;
+    model._output._catOffsets = dinfo._catOffsets;
   }
 
   private TwoDimTable createModelSummaryTable(SVDModel.SVDOutput output) {

--- a/h2o-algos/src/main/java/hex/util/LinearAlgebraUtils.java
+++ b/h2o-algos/src/main/java/hex/util/LinearAlgebraUtils.java
@@ -58,9 +58,16 @@ public class LinearAlgebraUtils {
           continue;   // Skip if entry missing and no NA bucket. All indicators will be zero.
         else
           cidx = dinfo._catOffsets[col+1]-1;  // Otherwise, missing value turns into extra (last) factor
-      } else
-        cidx = dinfo.getCategoricalId(col, (int)row[col]);
-      if(cidx >= 0) tmp[cidx] = 1;
+      } else {
+        if ((dinfo._catOffsets[col + 1] - dinfo._catOffsets[col]) == 1)
+          cidx = dinfo.getCategoricalId(col, 0);
+        else
+          cidx = dinfo.getCategoricalId(col, (int) row[col]);
+      }
+
+      if (((dinfo._catOffsets[col+1]-dinfo._catOffsets[col]) == 1) && cidx >=0)  // binary data here, no column expansion, copy data
+        tmp[cidx] = row[col];
+      else if(cidx >= 0) tmp[cidx] = 1;
     }
 
     // Numeric columns
@@ -114,6 +121,13 @@ public class LinearAlgebraUtils {
       _yt = yt;
     }
 
+    public BMulInPlaceTask(DataInfo xinfo, double[][] yt, int nColsExp) {
+      assert yt != null && yt[0].length == nColsExp;
+      _xinfo = xinfo;
+      _ncolX = xinfo._adaptedFrame.numCols();
+      _yt = yt;
+    }
+
     @Override public void map(Chunk[] cs) {
       assert cs.length == _ncolX + _yt.length;
       // Copy over only X frame chunks
@@ -154,6 +168,13 @@ public class LinearAlgebraUtils {
       _ainfo = ainfo;
       _ncolA = ainfo._adaptedFrame.numCols();
       _ncolExp = numColsExp(ainfo._adaptedFrame,true);
+      _ncolQ = ncolQ;
+    }
+
+    public SMulTask(DataInfo ainfo, int ncolQ, int ncolExp) {
+      _ainfo = ainfo;
+      _ncolA = ainfo._adaptedFrame.numCols();
+      _ncolExp = ncolExp;   // when call from GLRM
       _ncolQ = ncolQ;
     }
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmLoss.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmLoss.java
@@ -120,7 +120,7 @@ public enum GlrmLoss {
     }
     @Override public double lgrad(double u, double a) {
       double s = 1 - 2*a;
-      return s/(1 + Math.exp(s*u));
+      return s/(1 + Math.exp(-s*u));
     }
     @Override public double impute(double u) {
       return u > 0? 1 : 0;
@@ -190,13 +190,8 @@ public enum GlrmLoss {
     @Override public boolean isForCategorical() { return true; }
     @Override public boolean isForBinary() { return false; }
 
-    @Override public double mloss(double[] u, int a) {
-      if (!(a >= 0 && a < u.length)) throw new IndexOutOfBoundsException("a must be between 0 and " + (u.length - 1));
-      double sum = 0;
-      for (int i = 0; i < u.length - 1; i++)
-        sum += a > i ? Math.max(1 - u[i], 0) : 1;
-      return sum;
-    }
+    @Override public double mloss(double[] u, int a) { return mloss(u, a, u.length); }
+
     @Override public double mloss(double[] u, int a, int u_len) {
       if (!(a >= 0 && a < u_len)) throw new IndexOutOfBoundsException("a must be between 0 and " + (u_len - 1));
       double sum = 0;
@@ -205,12 +200,10 @@ public enum GlrmLoss {
       return sum;
     }
     @Override public double[] mlgrad(double[] u, int a) {
-      if (!(a >= 0 && a < u.length)) throw new IndexOutOfBoundsException("a must be between 0 and " + (u.length - 1));
       double[] grad = new double[u.length];
-      for (int i = 0; i < u.length - 1; i++)
-        grad[i] = (a > i && 1 - u[i] > 0) ? -1 : 0;
-      return grad;
+      return mlgrad(u, a, grad, u.length);
     }
+
     @Override public double[] mlgrad(double[] u, int a, double[] grad, int u_len) {
       if (!(a >= 0 && a < u_len)) throw new IndexOutOfBoundsException("a must be between 0 and " + (u_len - 1));
       for (int i = 0; i < u_len - 1; i++)

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3728_binary_numeric.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3728_binary_numeric.py
@@ -1,0 +1,93 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+
+# This unit test is to make sure that logistic loss works with both binary columns read in as either
+# enum or numerics.  In addition, we check that logistic loss work with different init modes for GLRM,
+# namely plusplus (default), user, SVD, random.
+#
+# When the init mode is set to user, we have total control of the initial values of X and Y into the GLRM.  In
+# this case, the singular values obtained for GLRM when binary columns are read as numeric or enum should be the same.
+# This is what I use to make sure my logistic implementation is correct.  We will compare the singular values
+# and throw an error when this is not the case.  For other init modes, the values are close but not equal.
+def glrm_pubdev_3728_arrest():
+    print("Importing prostate.csv data...")
+
+    # frame binary data is read in as enums.  Let's see if it runs.
+    prostateF = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    prostateF_num = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    prostateF_num[0] = prostateF_num[0].asnumeric()
+    prostateF_num[4] = prostateF_num[4].asnumeric()
+
+    loss_all = ["Logistic", "Quadratic", "Categorical", "Categorical", "Logistic", "Quadratic", "Quadratic",
+                "Quadratic"]
+
+    print("check with init = plusplus")
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, transform="STANDARDIZE",
+                                              seed=12345)
+    glrm_h2o.train(x=prostateF.names, training_frame=prostateF, validation_frame=prostateF)
+    glrm_h2o.show()
+
+    # exercise logistic loss with numeric columns
+    glrm_h2o_num = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, transform="STANDARDIZE",
+                                                  seed=12345)
+    glrm_h2o_num.train(x=prostateF_num.names, training_frame=prostateF_num, validation_frame=prostateF_num)
+    glrm_h2o_num.show()
+
+    print("check with init = random")
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, transform="DEMEAN",
+                                              seed=12345, init="random")
+    glrm_h2o.train(x=prostateF.names, training_frame=prostateF, validation_frame=prostateF)
+    glrm_h2o.show()
+
+    # exercise logistic loss with numeric columns
+    glrm_h2o_num = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, transform="DEMEAN",
+                                                  seed=12345, init="random")
+    glrm_h2o_num.train(x=prostateF_num.names, training_frame=prostateF_num, validation_frame=prostateF_num)
+    glrm_h2o_num.show()
+
+    print("check with init = SVD")
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, seed=12345, init="SVD")
+    glrm_h2o.train(x=prostateF.names, training_frame=prostateF, validation_frame=prostateF)
+    glrm_h2o.show()
+
+    # exercise logistic loss with numeric columns
+    glrm_h2o_num = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, seed=12345, init="SVD")
+    glrm_h2o_num.train(x=prostateF_num.names, training_frame=prostateF_num, validation_frame=prostateF_num)
+    glrm_h2o_num.show()
+
+    print("check with init = user")
+    initial_y = [[-1.27675647831893E-15,64.87421383647799,2.0,1.0,2.0816681711721685E-16,8.533270440251574,
+                  9.380440251572328,5.886792452830188],
+                 [0.7297297297297298,66.05405405405405,2.0,0.0,1.0,23.270270270270274,9.589189189189193,
+                  7.27027027027027],
+                 [0.01754385964912314,70.35087719298245,2.0,1.0,-1.3877787807814457E-17,10.078947368421053,
+                  42.37543859649123,6.157894736842105],
+                 [0.9,65.95,2.0,0.0,0.2,81.94500000000001,16.375,7.4],
+                 [0.9999999999999989,65.48598130841121,2.0,3.0,1.3877787807814457E-16,13.3092523364486,
+                  13.268411214953275,6.747663551401869]]
+    initial_y_h2o = h2o.H2OFrame(list(initial_y))
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, transform="STANDARDIZE",
+                                              seed=12345, init="User", user_y=initial_y_h2o)
+    glrm_h2o.train(x=prostateF.names, training_frame=prostateF, validation_frame=prostateF)
+    glrm_h2o.show()
+
+    # exercise logistic loss with numeric columns
+    glrm_h2o_num = H2OGeneralizedLowRankEstimator(k=5, loss_by_col=loss_all, recover_svd=True, transform="STANDARDIZE",
+                                                  seed=12345, init="User", user_y=initial_y_h2o)
+    glrm_h2o_num.train(x=prostateF_num.names, training_frame=prostateF_num, validation_frame=prostateF_num)
+    glrm_h2o_num.show()
+
+    # singular values from glrm models should equal if binary columns with binary loss are read in as either
+    # categorical or numerics.  If not, something is wrong.
+    assert pyunit_utils.equal_two_arrays(glrm_h2o._model_json["output"]["singular_vals"],
+                                         glrm_h2o_num._model_json["output"]["singular_vals"], 1e-6, 1e-4), \
+        "Singular values obtained from logistic loss with column type as enum and numeric do not agree.  Fix it now."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glrm_pubdev_3728_arrest)
+else:
+    glrm_pubdev_3728_arrest()

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3728_binary_numeric.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3728_binary_numeric.R
@@ -1,0 +1,20 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# This test is written to check and make sure GLRM will run with logistic loss if the binary data is stored as
+# binary level factors or binary data read in as numeric but only contains two values.
+test.glrm.pubdev.3728 <- function() {
+  prostate.hex <- h2o.uploadFile(locate("smalldata/prostate/prostate_cat.csv"), destination_frame= "prostate.hex",
+  na.strings = rep("NA", 8))
+  loss_all <- c("Logistic", "Quadratic", "Categorical", "Categorical", "Logistic", "Quadratic", "Quadratic", "Quadratic")
+  # Boolean loss does not work on categorical binary columns
+  h2o.glrm(training_frame = prostate.hex, k = 5, loss_by_col = loss_all)
+
+  # Boolean loss does not work on numeric binary columns
+  prostate.hex$CAPSULE <- h2o.ifelse(prostate.hex$CAPSULE == "No", 0, 1)
+  prostate.hex$DCAPS <- h2o.ifelse(prostate.hex$DCAPS == "No", 0, 1)
+
+  h2o.glrm(training_frame = prostate.hex, k = 5, loss_by_col = loss_all)
+  }
+
+doTest("PUBDEV-3728: GLRM logistic loss with binary data as factors or numeric", test.glrm.pubdev.3728)


### PR DESCRIPTION
1. Added code to support using logistic loss for binary columns read in as either categorical or numeric for GLRM.

2. Added pyunit tests to check that our new addition works for all init modes.  In addition, we compare the glrm singular values calculated when the binary columns are read in as categorical and numerical to make sure I have implemented the change correctly.

3.  Added Runit test from Megan/User to make sure we have fixed their problem.

Truly appreciate any help/comments you may have.

-- Wendy