### PR TITLE
Tomas glm fixes 2

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -65,14 +65,14 @@ public final class ComputationState {
     _lambdaMax = lmax;
   }
   public void setLambda(double lambda) {
-    adjustToNewLambda(_lambda, 0);
+    adjustToNewLambda(0, _lambda);
     // strong rules are to be applied on the gradient with no l2 penalty
     // NOTE: we start with lambdaOld being 0, not lambda_max
     // non-recursive strong rules should use lambdaMax instead of _lambda
     // However, it seems tobe working nicely to use 0 instead and be more aggressive on the predictor pruning
     // (shoudl be safe as we check the KKTs anyways)
     applyStrongRules(lambda, _lambda);
-    adjustToNewLambda(0, lambda);
+    adjustToNewLambda(lambda, 0);
     _lambda = lambda;
     _gslvr = new GLMGradientSolver(_job,_parms,_activeData,l2pen(),_activeBC);
   }
@@ -114,9 +114,9 @@ public final class ComputationState {
           off += activeData.fullN()+1;
         }
       } else  for(int i = 0; i < _activeData.fullN(); ++i)
-        _ginfo._gradient[i] -= ldiff*_beta[i];
+        _ginfo._gradient[i] += ldiff*_beta[i];
     }
-    _ginfo = new GLMGradientInfo(_ginfo._likelihood, _ginfo._objVal - ldiff * l2pen, _ginfo._gradient);
+    _ginfo = new GLMGradientInfo(_ginfo._likelihood, _ginfo._objVal + ldiff * l2pen, _ginfo._gradient);
 
   }
 
@@ -498,7 +498,6 @@ public final class ComputationState {
     else System.arraycopy(beta,0,_beta,0,beta.length);
     _ginfo = ginfo;
     _likelihood = ginfo._likelihood;
-
     return (_relImprovement = (objOld - objective())/objOld);
   }
 

--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -449,8 +449,14 @@ public final class ComputationState {
     if(_lambda == 0) return 0;
     double l1norm = 0, l2norm = 0;
     if(_parms._family == Family.multinomial) {
+      int len = beta.length/_nclasses;
+      assert len*_nclasses == beta.length;
       for(int c = 0; c < _nclasses; ++c) {
-
+        for(int i = c*len; i < (c+1)*len-1; ++i) {
+          double d = beta[i];
+          l1norm += d >= 0?d:-d;
+          l2norm += d*d;
+        }
       }
     } else
       for(int i = 0; i < beta.length-1; ++i) {

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -610,7 +610,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       do {
         beta = beta.clone();
         for (int c = 0; c < _nclass; ++c) {
-          if (_state.activeDataMultinomial(c).fullN() == 0) continue;
+          boolean onlyIcpt = _state.activeDataMultinomial(c).fullN() == 0;
           _state.setActiveClass(c);
           LineSearchSolver ls = (_state.l1pen() == 0)
             ? new MoreThuente(_state.gslvrMultinomial(c), _state.betaMultinomial(c,beta), _state.ginfoMultinomial(c))
@@ -623,7 +623,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           long t3 = System.currentTimeMillis();
           double[] betaCnd = solveGram(s,t);
           long t4 = System.currentTimeMillis();
-          if (!ls.evaluate(ArrayUtils.subtract(betaCnd, ls.getX(), betaCnd))) {
+          if (!onlyIcpt && !ls.evaluate(ArrayUtils.subtract(betaCnd, ls.getX(), betaCnd))) {
             Log.info(LogMsg("Ls failed " + ls));
             continue;
           }

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestBinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestBinomial.java
@@ -1028,46 +1028,39 @@ public class GLMBasicTestBinomial extends TestUtil {
     params._beta_epsilon = 1e-4;
     GLM job0 = null;
     try {
-      job0 = new GLM(params);
       params._solver = Solver.L_BFGS;
+      job0 = new GLM(params);
       GLMModel model = job0.trainModel().get();
       assertFalse("should've thrown, p-values only supported with IRLSM",true);
     } catch(H2OModelBuilderIllegalArgumentException t) {
     }
     try {
-      job0 = new GLM(params);
       params._solver = Solver.COORDINATE_DESCENT_NAIVE;
+      job0 = new GLM(params);
       GLMModel model = job0.trainModel().get();
       assertFalse("should've thrown, p-values only supported with IRLSM",true);
     } catch(H2OModelBuilderIllegalArgumentException t) {
     }
     try {
-      job0 = new GLM(params);
       params._solver = Solver.COORDINATE_DESCENT;
+      job0 = new GLM(params);
       GLMModel model = job0.trainModel().get();
       assertFalse("should've thrown, p-values only supported with IRLSM",true);
     } catch(H2OModelBuilderIllegalArgumentException t) {
     }
     params._solver = Solver.IRLSM;
     try {
-      job0 = new GLM(params);
       params._lambda = new double[]{1};
+      job0 = new GLM(params);
       GLMModel model = job0.trainModel().get();
       assertFalse("should've thrown, p-values only supported with no regularization",true);
     } catch(H2OModelBuilderIllegalArgumentException t) {
     }
-    params._lambda = new double[]{0};
-    try {
-      params._lambda_search = true;
-      GLMModel model = job0.trainModel().get();
-      assertFalse("should've thrown, p-values only supported with no regularization (i.e. no lambda search)",true);
-    } catch(H2OModelBuilderIllegalArgumentException t) {
-    }
     params._lambda_search = false;
+    params._lambda = new double[]{0};
     GLM job = new GLM(params);
     GLMModel model = null;
     try {
-
       model = job.trainModel().get();
       String[] names_expected = new String[]{"Intercept", "ID", "AGE", "RACE.R2", "RACE.R3", "DPROS.b", "DPROS.c", "DPROS.d", "DCAPS.b", "PSA", "VOL", "GLEASON"};
       double[] stder_expected = new double[]{2.383945093, 0.001376361, 0.022369891, 1.542397413, 1.582718967, 0.395088333, 0.416197382, 0.542651183, 0.517959064, 0.011148747, 0.008753002, 0.182282351};


### PR DESCRIPTION
Few more minor fixes in GLM.
1. Multinomial with L1 penalty was selecting L_BFGS as default solver even if it did not have to (low count of active predictors).
2. Fix coordinate descent multinomial - can not skip classes with 0 active coefficients, intercept still needs to be adjusted.
3. fix some races in a test for illegal argument exceptions..