### PR TITLE
[SW-178] Fix bug and improve External Frame Reader Backend

### DIFF
--- a/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
@@ -45,7 +45,7 @@ final class ExternalFrameReaderBackend {
                     ExternalFrameUtils.sendNA(ab, channel, expectedTypes[i]);
                 } else {
                     final Chunk chnk = chunks[selectedColumnIndices[i]];
-                    switch (expectedTypes[selectedColumnIndices[i]]) {
+                    switch (expectedTypes[i]) {
                         case EXPECTED_BOOL:
                             ExternalFrameUtils.sendBoolean(ab, channel, (byte)chnk.at8(rowIdx));
                             break;


### PR DESCRIPTION
There is a bug in the current code that if the data in the chunk is NA, we send the NA to the client but with a wrong type ( since we don't have there expectedTypes[selectedColumnsIndeces[i]]]

Since this would need to be fixed I decided to improve the code a little bit and ensure sparkling-water side can be simpler.

Instead of sending expected types for all columns ( even for those we don't need ) we now send expected types just for the columns we need. The expected types has to be in the same order as the selected columns - so lets say selected columns are [2,1,0] then expected columns should be[expectedFor[2], expectedFor[1], expectedFor[0]]