### PR TITLE
[SW-100] Critical bug fix for external backend 2

### DIFF
--- a/h2o-core/src/main/java/water/ExternalFrameHandler.java
+++ b/h2o-core/src/main/java/water/ExternalFrameHandler.java
@@ -52,15 +52,7 @@ final class ExternalFrameHandler {
      *  the connection has been reused for sending more data or not
      * */
     static final byte INIT_BYTE = 42;
-
-    /**
-     * Bytes used for signaling that either reading from h2o frame or writing to h2o frame has finished.
-     * It is important for these 2 bytes to be different, otherwise we could confirm writing by reading byte, which
-     * would lead to unwanted states.
-     */
-    static final byte CONFIRM_READING_DONE = 1;
-    static final byte CONFIRM_WRITING_DONE = 2;
-
+    
     /**
      * Main task codes
      */

--- a/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
@@ -23,6 +23,7 @@ final class ExternalFrameReaderBackend {
      */
     static void handleReadingFromChunk(SocketChannel channel, AutoBuffer initAb) throws IOException {
         // receive required information
+        long threadId = initAb.get8();
         String frameKey = initAb.getStr();
         int chunkIdx = initAb.getInt();
         byte[] expectedTypes = initAb.getA1();
@@ -89,7 +90,7 @@ final class ExternalFrameReaderBackend {
                 }
             }
         }
-        ab.put1(ExternalFrameHandler.CONFIRM_READING_DONE);
+        ab.put8(threadId);
         writeToChannel(ab, channel);
     }
 }

--- a/h2o-core/src/main/java/water/ExternalFrameReaderClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderClient.java
@@ -70,6 +70,7 @@ final public class ExternalFrameReaderClient {
     private ByteChannel channel;
     private int numRows;
     private byte[] expectedTypes = null;
+    long threadId;
 
     /**
      *
@@ -85,6 +86,7 @@ final public class ExternalFrameReaderClient {
         this.chunkIdx = chunkIdx;
         this.expectedTypes = expectedTypes;
         this.selectedColumnIndices = selectedColumnIndices;
+        threadId = Thread.currentThread().getId();
         this.ab = initAndGetAb();
     }
 
@@ -159,14 +161,14 @@ final public class ExternalFrameReaderClient {
      */
     public void waitUntilAllReceived(){
         // blocking call
-        byte controlByte = ab.get1();
-        assert(controlByte == ExternalFrameHandler.CONFIRM_READING_DONE);
+        assert( ab.get8() == threadId);
     }
 
     private AutoBuffer initAndGetAb() throws IOException{
         AutoBuffer sentAb = new AutoBuffer();
         sentAb.put1(ExternalFrameHandler.INIT_BYTE);
         sentAb.put1(ExternalFrameHandler.DOWNLOAD_FRAME);
+        sentAb.put8(threadId);
         sentAb.putStr(frameKey);
         sentAb.putInt(chunkIdx);
         sentAb.putA1(expectedTypes);

--- a/h2o-core/src/main/java/water/ExternalFrameWriterBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterBackend.java
@@ -18,6 +18,7 @@ final class ExternalFrameWriterBackend {
      * @param ab {@link AutoBuffer} containing information necessary for preparing backend for writing
      */
     static void handleWriteToChunk(SocketChannel sock, AutoBuffer ab) throws IOException {
+        long threadId = ab.get8();
         String frameKey = ab.getStr();
         byte[] expectedTypes = ab.getA1();
         assert expectedTypes != null;
@@ -65,14 +66,14 @@ final class ExternalFrameWriterBackend {
         // close chunks at the end
         ChunkUtils.closeNewChunks(nchnk);
 
-        // Flag informing sender that all work is done and
+        // Flag informing sender's thread that all work is done and
         // chunks are ready to be finalized.
         //
         // This also needs to be sent because in the sender we have to
         // wait for all chunks to be written to DKV; otherwise we get race during finalizing and
         // it happens that we try to finalize frame with chunks not ready yet
         AutoBuffer outputAb = new AutoBuffer();
-        outputAb.put1(ExternalFrameHandler.CONFIRM_WRITING_DONE);
+        outputAb.put8(threadId);
         writeToChannel(outputAb, sock);
     }
 

--- a/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
@@ -52,6 +52,7 @@ final public class ExternalFrameWriterClient {
     private byte[] expectedTypes;
     // we discover the current column index based on number of data sent
     private int currentColIdx = 0;
+    private long threadId;
 
     /**
      * Initialize the External frame writer
@@ -62,6 +63,7 @@ final public class ExternalFrameWriterClient {
     public ExternalFrameWriterClient(ByteChannel channel){
         this.ab = new AutoBuffer();
         this.channel = channel;
+        threadId = Thread.currentThread().getId();
     }
 
 
@@ -75,6 +77,7 @@ final public class ExternalFrameWriterClient {
     public void createChunks(String frameKey, byte[] expectedTypes, int chunkId, int totalNumRows) throws IOException {
         ab.put1(ExternalFrameHandler.INIT_BYTE);
         ab.put1(ExternalFrameHandler.CREATE_FRAME);
+        ab.put8(threadId);
         ab.putStr(frameKey);
         this.expectedTypes = expectedTypes;
         ab.putA1(expectedTypes);
@@ -148,7 +151,7 @@ final public class ExternalFrameWriterClient {
         // this needs to be here because confirmAb.getInt() forces this code to wait for result and
         // all the previous work to be done on the recipient side. The assert around it is just additional, not
         // so important check
-        assert(confirmAb.get1() == ExternalFrameHandler.CONFIRM_WRITING_DONE);
+        assert(confirmAb.get8() == threadId);
     }
 
     private void increaseCurrentColIdx(){


### PR DESCRIPTION
Since we can have multiple threads on one spark executor it can happen this scenario:

We have thread A, B on single node

both threads start writing partitions to h2o backend,  A partition 0, B partition 1

A finish it’s job and sends acknowledgement to the node, whilst B is still working. But because A already sent the acknowledgement the node can already continue with the work thus race happens ( it doesn't wait for finishing for B) this race. The fix is easy - acknowledge for example with origin thread id