### PR TITLE
Pubdev 3778 glrm constant col error

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -391,7 +391,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     fullFrm.add(loadingFrm);
 
     GLRMScore gs = new GLRMScore(ncols, _parms._k, false).doAll(fullFrm);
-    ModelMetrics mm = gs._mb.makeModelMetrics(GLRMModel.this, adaptedFr, null, null);   // save error metrics based on imputed data
+    ModelMetrics mm = gs._mb.makeModelMetrics(GLRMModel.this, frame, null, null);   // save error metrics based on imputed data
     return (ModelMetricsGLRM) mm;
   }
 

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -21,7 +21,7 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   final Key _frameKey;
   final ModelCategory _model_category;
   final long _model_checksum;
-  long _frame_checksum;
+  long _frame_checksum;  // when constant column is dropped, frame checksum changed.  Need re-assign for GLRM.
   public final long _scoring_time;
 
   // Cached fields - cached them when needed

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3778_constant_col_err.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3778_constant_col_err.R
@@ -1,0 +1,29 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# error accessing archetypes: Error in res$model_metrics[[1L]] : subscript out of bounds
+# make sure we pass this one after the fix.
+test.glrm.pubdev.3778 <- function() {
+  data <- data.frame('C1' = c(1, 1, 1, 1, 1),
+                     'C2' = c(1, 8, 0, 9, 8),
+                     'C3' = c(5, 1, 8, 4, 9),
+                     'C4' = c(3, 4, 5, 4, 4),
+                     'C5' = c(8, 1, 4, 9, 6))
+  
+  data2 <- data.frame('C2' = c(1, 8, 0, 9, 8),
+                      'C3' = c(5, 1, 8, 4, 9),
+                      'C4' = c(3, 4, 5, 4, 4),
+                      'C5' = c(8, 1, 4, 9, 6))
+  data <- as.h2o(data)
+  data2 <- as.h2o(data2)
+  
+  # Build GLRM model
+  glrm_model2 <- h2o.glrm(data2,  k = 2, ignore_const_cols = TRUE, init="User")
+  glrm_model <- h2o.glrm(data,  k = 2, validation_frame = data, ignore_const_cols = TRUE, init="User")
+  
+  archetypes2 <- h2o.proj_archetypes(glrm_model2, data2)
+  archetypes <- h2o.proj_archetypes(glrm_model, data)
+  
+}
+
+doTest("GLRM Test: Iris with Various Transformations", test.glrm.pubdev.3778)


### PR DESCRIPTION
When the constant columns are removed, the frame_checksum is changed.  The model metrics for GLRM stored the new changed frame_checksum.  However, when we ask for the model metrics again, the model metrics was built with the original frame_checksum.  Hence, when the model is fetched, the handler will compare the model checksum and the frame_checksum.  If either one is different, no model metric is fetched.  That is why we are getting the null model metric back in this case.

I forced the GLRM model metrics to store the original frame_checksum instead and this solves the issue.
