### PR TITLE
Pubdev 3788 glrm loss by col error

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -391,7 +391,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     fullFrm.add(loadingFrm);
 
     GLRMScore gs = new GLRMScore(ncols, _parms._k, false).doAll(fullFrm);
-    ModelMetrics mm = gs._mb.makeModelMetrics(GLRMModel.this, adaptedFr, null, null);   // save error metrics based on imputed data
+    ModelMetrics mm = gs._mb.makeModelMetrics(GLRMModel.this, frame, null, null);   // save error metrics based on imputed data
     return (ModelMetricsGLRM) mm;
   }
 

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -21,7 +21,7 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   final Key _frameKey;
   final ModelCategory _model_category;
   final long _model_checksum;
-  long _frame_checksum;
+  long _frame_checksum;  // when constant column is dropped, frame checksum changed.  Need re-assign for GLRM.
   public final long _scoring_time;
 
   // Cached fields - cached them when needed

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3778_constant_col_err.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3778_constant_col_err.R
@@ -1,0 +1,29 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# error accessing archetypes: Error in res$model_metrics[[1L]] : subscript out of bounds
+# make sure we pass this one after the fix.
+test.glrm.pubdev.3778 <- function() {
+  data <- data.frame('C1' = c(1, 1, 1, 1, 1),
+                     'C2' = c(1, 8, 0, 9, 8),
+                     'C3' = c(5, 1, 8, 4, 9),
+                     'C4' = c(3, 4, 5, 4, 4),
+                     'C5' = c(8, 1, 4, 9, 6))
+  
+  data2 <- data.frame('C2' = c(1, 8, 0, 9, 8),
+                      'C3' = c(5, 1, 8, 4, 9),
+                      'C4' = c(3, 4, 5, 4, 4),
+                      'C5' = c(8, 1, 4, 9, 6))
+  data <- as.h2o(data)
+  data2 <- as.h2o(data2)
+  
+  # Build GLRM model
+  glrm_model2 <- h2o.glrm(data2,  k = 2, ignore_const_cols = TRUE, init="User")
+  glrm_model <- h2o.glrm(data,  k = 2, validation_frame = data, ignore_const_cols = TRUE, init="User")
+  
+  archetypes2 <- h2o.proj_archetypes(glrm_model2, data2)
+  archetypes <- h2o.proj_archetypes(glrm_model, data)
+  
+}
+
+doTest("GLRM Test: Iris with Various Transformations", test.glrm.pubdev.3778)

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3788_loss_by_col_err.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3788_loss_by_col_err.R
@@ -1,0 +1,30 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# error accessing archetypes: Error in res$model_metrics[[1L]] : subscript out of bounds
+# make sure we pass this one after the fix.
+test.glrm.pubdev.3788 <- function() {
+    # Create data frame with a constant column
+    data <- data.frame('NumericCol' = runif(50),
+    'ConstantCol' = rep(1, 50),
+    'CategoricalCol' = sample(c("A", "B", "C", "D"), size = 50, replace = T))
+
+    data <- as.h2o(data)
+
+    browser()
+    
+    # Specify loss by column and set ignore_const_cols to TRUE
+    glrm_model <- h2o.glrm(data, k = 2, model_id = "glrm_test.hex",
+    loss_by_col = c("Quadratic", "Categorical", "Categorical"),
+    loss_by_col_idx = c(0:2),
+    ignore_const_cols = TRUE)
+
+    archetypes <- h2o.proj_archetypes(glrm_model, data)  # make sure returned archetypes are not empty
+  
+    # check to make sure implementation is correct when no column indices are given since the 
+    # loss_by_col length is the same as the number of columns in the frame.
+    glrm_model2 <- h2o.glrm(data, k = 2, model_id = "glrm_test.hex",
+                           loss_by_col = c("Quadratic", "Categorical", "Categorical"), ignore_const_cols = TRUE)
+}
+
+doTest("GLRM Test: Iris with Various Transformations", test.glrm.pubdev.3788)


### PR DESCRIPTION
Added code to assign glrm loss by columns only to columns that have not been deleted by say remove constant columns actions and others.

Included Runit test from Megan Kurba to check correct implementation.

The only files that are changed are GLRM.java and the unit test.

This branch is based off PUBDEV-3778.