### PR TITLE
Need to refer to .h2o.jar.env in .onDetach()

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -411,7 +411,7 @@ h2o.clusterStatus <- function() {
 
 .onDetach <- function(libpath) {
   ip_   <- "127.0.0.1"
-  port_  <- if(!is.null(e$port)) e$port else 54321
+  port_  <- if(!is.null(.h2o.jar.env$port)) .h2o.jar.env$port else 54321
   myURL <- paste0("http://", ip_, ":", port_)
   print("A shutdown has been triggered. ")
   if( url.exists(myURL) ) {


### PR DESCRIPTION
* This pr calls `.h2o.jar.env` explicitly when detaching the H2O R package. Cannot use environment,i.e., `e`.