### PR TITLE
[PUBDEV-3796] correct column names in frame.isna()

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstIsNa.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstIsNa.java
@@ -6,19 +6,17 @@ import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.fvec.NewChunk;
 import water.fvec.Vec;
-import water.rapids.Env;
 import water.rapids.Val;
-import water.rapids.ast.AstRoot;
+import water.rapids.ast.AstBuiltin;
 import water.rapids.vals.ValFrame;
 import water.rapids.vals.ValNum;
-import water.rapids.ast.AstPrimitive;
 
 /**
  * Split out in it's own function, instead of Yet Another UniOp, because it
  * needs a "is.NA" check instead of just using the Double.isNaN hack... because
  * it works on UUID and String columns.
  */
-public class AstIsNa extends AstPrimitive {
+public class AstIsNa extends AstBuiltin<AstIsNa> {
   @Override
   public String[] args() {
     return new String[]{"ary"};
@@ -35,13 +33,18 @@ public class AstIsNa extends AstPrimitive {
   }
 
   @Override
-  public Val apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
-    Val val = stk.track(asts[1].exec(env));
+  public Val exec(Val... args) {
+    Val val = args[1];
     switch (val.type()) {
       case Val.NUM:
         return new ValNum(op(val.getNum()));
+
       case Val.FRM:
         Frame fr = val.getFrame();
+        String[] newNames = new String[fr.numCols()];
+        for (int i = 0; i < newNames.length; i++) {
+          newNames[i] = "isNA(" + fr.name(i) + ")";
+        }
         return new ValFrame(new MRTask() {
           @Override
           public void map(Chunk cs[], NewChunk ncs[]) {
@@ -52,9 +55,11 @@ public class AstIsNa extends AstPrimitive {
                 nc.addNum(c.isNA(i) ? 1 : 0);
             }
           }
-        }.doAll(fr.numCols(), Vec.T_NUM, fr).outputFrame());
+        }.doAll(fr.numCols(), Vec.T_NUM, fr).outputFrame(newNames, null));
+
       case Val.STR:
         return new ValNum(val.getStr() == null ? 1 : 0);
+
       default:
         throw H2O.unimpl("is.na unimpl: " + val.getClass());
     }

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2592,6 +2592,10 @@ class H2OFrame(object):
         """
         fr = H2OFrame._expr(expr=ExprNode("is.na", self))
         fr._ex._cache.nrows = self._ex._cache.nrows
+        fr._ex._cache.ncols = self._ex._cache.ncols
+        if self._ex._cache.names:
+            fr._ex._cache.names = ["isNA(%s)" % n  for n in self._ex._cache.names]
+            fr._ex._cache.types = {"isNA(%s)" % n: "int"  for n in self._ex._cache.names}
         return fr
 
     def year(self):

--- a/h2o-py/tests/testdir_munging/pyunit_isna.py
+++ b/h2o-py/tests/testdir_munging/pyunit_isna.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+from collections import OrderedDict
+
+import h2o
+from tests import pyunit_utils
+
+
+def test_isna():
+    nan = float("nan")
+    frame = h2o.H2OFrame.from_python(OrderedDict([
+        ("A", [1, 0, 3, 4, 8, 4, 7]),
+        ("B", [2, nan, -1, nan, nan, 9, 0]),
+        ("C", ["one", "", "two", "", "seventeen", "1", ""]),
+        ("D", ["oneteen", "", "twoteen", "", "sixteen", "twenteen", ""])
+    ]), na_strings=[""], column_types={"C": "enum", "D": "string"})
+
+    assert frame.shape == (7, 4)
+    assert frame.names == ["A", "B", "C", "D"]
+    assert frame.types == {"A": "int", "B": "int", "C": "enum", "D": "string"}, "Actual types: %r" % frame.types
+
+    isna = frame.isna()
+    rc = h2o.connection().requests_count
+    assert isna.shape == (7, 4)
+    assert isna.names == ["isNA(A)", "isNA(B)", "isNA(C)", "isNA(D)"]
+    # at some point we'll switch to 'bool' column type
+    assert isna.types == {"isNA(A)": "int", "isNA(B)": "int", "isNA(C)": "int", "isNA(D)": "int"}, \
+        "Actual types: %r" % isna.types
+    assert h2o.connection().requests_count == rc, "Frame isna should not be evaluated yet!"
+
+    print()
+    print(isna)
+
+    assert isna.shape == (7, 4)
+    assert isna.names == ["isNA(A)", "isNA(B)", "isNA(C)", "isNA(D)"]
+    assert isna.types == {"isNA(A)": "int", "isNA(B)": "int", "isNA(C)": "int", "isNA(D)": "int"}
+
+    df = isna.as_data_frame(use_pandas=False, header=False)
+    assert df == [
+        ["0", "0", "0", "0"],
+        ["0", "1", "1", "1"],
+        ["0", "0", "0", "0"],
+        ["0", "1", "1", "1"],
+        ["0", "1", "0", "0"],
+        ["0", "0", "0", "0"],
+        ["0", "0", "1", "1"],
+    ]
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_isna)
+else:
+    test_isna()
+


### PR DESCRIPTION
Similarly to uniops, now `frame.isna()` produces column names of the form `col1` => `isNA(col1)`