### PR TITLE
[PUBDEV-3749] Make AstNot to bear name 'not'

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -65,6 +65,10 @@ public class Env extends Iced {
     PRIMS.put(ast.str(), ast);
   }
 
+  static void init(AstPrimitive ast, String name) {
+    PRIMS.put(name, ast);
+  }
+
   static {
     // Constants
     CONSTS.put("FALSE", AstConst.FALSE);
@@ -104,6 +108,7 @@ public class Env extends Iced {
     init(new AstLog10());
     init(new AstNoOp());
     init(new AstNot());
+    init(new AstNot(), "!!");
     init(new AstRound());
     init(new AstSgn());
     init(new AstSignif());

--- a/h2o-core/src/main/java/water/rapids/ast/prims/math/AstNot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/math/AstNot.java
@@ -4,7 +4,7 @@ package water.rapids.ast.prims.math;
  */
 public class AstNot extends AstUniOp {
   public String str() {
-    return "!!";
+    return "not";
   }
 
   public double op(double d) {


### PR DESCRIPTION
The old name (`!!`) still remains as a synonym. The reason for the rename is (1) to make python's `frame.logical_negation()` to work; and (2) so that the produced column names are reasonable. Previously the columns would be named `!!(C1)`, `!!(C2)`, etc, which is confusing. Now the produced names are `not(C1)`, `not(C2)` which is much clearer.