### PR TITLE
Adding a ValNull value to Rapids

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -82,7 +82,7 @@ public class Env extends Iced {
     CONSTS.put("nan", AstConst.NAN);
     CONSTS.put("PI", AstConst.PI);
     CONSTS.put("Pi", AstConst.PI);
-    CONSTS.put("null", null);
+    CONSTS.put("null", AstConst.NULL);
 
     // Standard math functions
     init(new AstAbs());
@@ -142,7 +142,6 @@ public class Env extends Iced {
     init(new AstPlus());
     init(new AstPow());
     init(new AstSub());
-    init(new AstIfElse());
     init(new AstIfElse()); // this one is ternary
 
     // Reducers

--- a/h2o-core/src/main/java/water/rapids/Val.java
+++ b/h2o-core/src/main/java/water/rapids/Val.java
@@ -1,24 +1,25 @@
 package water.rapids;
 
-import water.fvec.Frame;
 import water.Iced;
+import water.fvec.Frame;
 import water.rapids.ast.AstPrimitive;
-import water.rapids.ast.AstRoot;
 
 /**
  * Generic execution values for the untyped stack.
  */
-abstract public class Val extends Iced {
-  // Things on the execution stack
-  final public static int NUM = 1;     // double
-  final public static int NUMS = 2;    // array of doubles
-  final public static int STR = 3;     // string
-  final public static int STRS = 4;    // array of strings
-  final public static int FRM = 5;     // Frame, not a Vec.  Can be a Frame of 1 Vec
-  final public static int ROW = 6;     // Row of data; limited to a single array of doubles
-  final public static int FUN = 7;     // Function
+public abstract class Val extends Iced {
 
-  abstract public int type();
+  // Things on the execution stack
+  public static final int NULL = 0;    // null
+  public static final int NUM = 1;     // double
+  public static final int NUMS = 2;    // array of doubles
+  public static final int STR = 3;     // string
+  public static final int STRS = 4;    // array of strings
+  public static final int FRM = 5;     // Frame, not a Vec.  Can be a Frame of 1 Vec
+  public static final int ROW = 6;     // Row of data; limited to a single array of doubles
+  public static final int FUN = 7;     // Function
+
+  public abstract int type();
 
   // One of these methods is overridden in each subclass
   public boolean isNum()   { return false; }

--- a/h2o-core/src/main/java/water/rapids/ast/params/AstConst.java
+++ b/h2o-core/src/main/java/water/rapids/ast/params/AstConst.java
@@ -1,32 +1,31 @@
 package water.rapids.ast.params;
 
 import water.rapids.Env;
-import water.rapids.Rapids;
+import water.rapids.Val;
 import water.rapids.ast.AstParameter;
+import water.rapids.vals.ValNull;
 import water.rapids.vals.ValNum;
 
 /**
  * Class for constants
  */
 public class AstConst extends AstParameter {
-  private final ValNum _v;
-  private final String name;
+  private Val value;
+  private String name;
 
-  final public static AstConst FALSE = new AstConst("False", 0);
-  final public static AstConst TRUE = new AstConst("True", 1);
-  final public static AstConst NAN = new AstConst("NaN", Double.NaN);
-  final public static AstConst PI = new AstConst("Pi", Math.PI);
-  final public static AstConst E = new AstConst("E", Math.E);
+  public static final AstConst NULL = new AstConst("null", new ValNull());
+  public static final AstConst FALSE = new AstConst("False", new ValNum(0));
+  public static final AstConst TRUE = new AstConst("True", new ValNum(1));
+  public static final AstConst NAN = new AstConst("NaN", new ValNum(Double.NaN));
+  public static final AstConst PI = new AstConst("Pi", new ValNum(Math.PI));
+  public static final AstConst E = new AstConst("E", new ValNum(Math.E));
 
 
-  public AstConst() {
-    name = null;
-    _v = null;
-  }
+  public AstConst() {}  // For Serializable
 
-  public AstConst(String name, double d) {
+  public AstConst(String name, Val value) {
     this.name = name;
-    this._v = new ValNum(d);
+    this.value = value;
   }
 
   @Override
@@ -35,8 +34,8 @@ public class AstConst extends AstParameter {
   }
 
   @Override
-  public ValNum exec(Env env) {
-    return _v;
+  public Val exec(Env env) {
+    return value;
   }
 
 }

--- a/h2o-core/src/main/java/water/rapids/vals/ValNull.java
+++ b/h2o-core/src/main/java/water/rapids/vals/ValNull.java
@@ -1,0 +1,42 @@
+package water.rapids.vals;
+
+import water.rapids.Val;
+
+/**
+ * Null value.
+ *
+ * <p>This value may be either produced by a Rapids literal {@code null}, or
+ * returned by some builtin function that normally would return {@code void}.
+ *
+ * <p>The null value can be treated as NaN when used in a place where a
+ * numeric value is expected, or as a null string when used in a string
+ * context. Later we may add more conversions into other types, if it would
+ * seem reasonable to do.
+ */
+public class ValNull extends Val {
+
+  @Override public int type() {
+    return Val.NULL;
+  }
+
+  @Override public boolean isNum() {
+    return true;
+  }
+
+  @Override public boolean isStr() {
+    return true;
+  }
+
+  @Override public double getNum() {
+    return Double.NaN;
+  }
+
+  @Override public String getStr() {
+    return null;
+  }
+
+  @Override public String toString() {
+    return "null";
+  }
+
+}


### PR DESCRIPTION
Previously "null" was a reserved word in Rapids, however trying to actually use it would have caused an NPE (for example the underlying code would try to call `exec()` on it).

This PR adds an actual `null` `AstConst`, which produces the new `ValNull` value.

This code doesn't introduce any use cases for the new "null" value -- this is deferred to future PRs.