### PR TITLE
Documentation site update for RSparkling readme

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -165,7 +165,7 @@
               <a href="h2o-docs/faq.html#sparkling-water">What is Sparkling Water?</a>
               <a href="h2o-docs/booklets/SparklingWaterBooklet.pdf">Sparkling Water Booklet</a>
               <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-1.6/py/README.rst">1.6</a></p>
-              <a href="https://github.com/h2oai/rsparkling">RSparkling Readme</a>
+              <a href="https://github.com/h2oai/rsparkling/blob/master/README.md">RSparkling Readme</a>
               <a href="https://github.com/h2oai/sparkling-water/blob/master/LICENSE">Open Source License (Apache V2)</a>
            </div>
           <hr>
@@ -337,7 +337,7 @@
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/demos">Examples and Demos</a>
               <a href="h2o-docs/faq.html#r">R FAQ</a>
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/ensemble/README.md">Ensemble R Package Readme</a>
-              <a href="https://github.com/h2oai/rsparkling">RSparkling Readme</a>
+              <a href="https://github.com/h2oai/rsparkling/blob/master/README.md">RSparkling Readme</a>
               <a href="h2o-docs/migrating.html">Migrating from H2O-2</a>
           </div>
         </div>

--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -165,7 +165,7 @@
               <a href="h2o-docs/faq.html#sparkling-water">What is Sparkling Water?</a>
               <a href="h2o-docs/booklets/SparklingWaterBooklet.pdf">Sparkling Water Booklet</a>
               <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-1.6/py/README.rst">1.6</a></p>
-              <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/r/README.md">RSparkling Readme</a>
+              <a href="https://github.com/h2oai/rsparkling">RSparkling Readme</a>
               <a href="https://github.com/h2oai/sparkling-water/blob/master/LICENSE">Open Source License (Apache V2)</a>
            </div>
           <hr>
@@ -337,7 +337,7 @@
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/demos">Examples and Demos</a>
               <a href="h2o-docs/faq.html#r">R FAQ</a>
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/ensemble/README.md">Ensemble R Package Readme</a>
-              <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/r/README.md">RSparkling Readme</a>
+              <a href="https://github.com/h2oai/rsparkling">RSparkling Readme</a>
               <a href="h2o-docs/migrating.html">Migrating from H2O-2</a>
           </div>
         </div>


### PR DESCRIPTION
The links for the RSparkling README now point to
https://github.com/h2oai/rsparkling instead of
https://github.com/h2oai/sparkling-water/blob/rel-2.0/r/README.md.
Note that while this is a change in Sparkling Water, the doc site is
still maintained under the h2o repo.