### PR TITLE
Handler2: a simple extension on top of Handler

### DIFF
--- a/h2o-core/src/main/java/water/api/Handler2.java
+++ b/h2o-core/src/main/java/water/api/Handler2.java
@@ -1,0 +1,26 @@
+package water.api;
+
+/**
+ * Common interface for <s>all</s> some REST endpoint handlers.
+ *
+ * @param <IS> input schema class
+ * @param <OS> output schema class
+ */
+public abstract class Handler2<IS extends Schema, OS extends Schema> extends Handler {
+
+  /** Suggested name for the endpoint in external libraries. */
+  public abstract String name();
+
+  /** Help for this endpoint (will be used in generated bindings). */
+  public abstract String help();
+
+  /**
+   * Execute the endpoint, returning the result as the output schema.
+   *
+   * @param ignored  TODO: remove this parameter
+   * @param input  input schema object
+   * @return  output schema object
+   */
+  public abstract OS exec(int ignored, IS input);
+
+}

--- a/h2o-core/src/main/java/water/api/RapidsHandler.java
+++ b/h2o-core/src/main/java/water/api/RapidsHandler.java
@@ -112,7 +112,7 @@ public class RapidsHandler extends Handler {
     return p;
   }
 
-  public static class StartSession4 extends Handler2<InputSchemaV4, SessionIdV4> {
+  public static class StartSession4 extends RestApiHandler<InputSchemaV4, SessionIdV4> {
     @Override public String name() {
       return "newSession4";
     }

--- a/h2o-core/src/main/java/water/api/RapidsHandler.java
+++ b/h2o-core/src/main/java/water/api/RapidsHandler.java
@@ -5,6 +5,8 @@ import water.H2O;
 import water.Key;
 import water.api.schemas3.*;
 import water.api.schemas3.RapidsHelpV3.RapidsExpressionV3;
+import water.api.schemas4.InputSchemaV4;
+import water.api.schemas4.SessionIdV4;
 import water.exceptions.H2OIllegalArgumentException;
 import water.rapids.ast.AstRoot;
 import water.rapids.Rapids;
@@ -109,4 +111,21 @@ public class RapidsHandler extends Handler {
     }
     return p;
   }
+
+  public static class StartSession4 extends Handler2<InputSchemaV4, SessionIdV4> {
+    @Override public String name() {
+      return "newSession4";
+    }
+    @Override public String help() {
+      return "Start a new Rapids session, and return the session id.";
+    }
+
+    @Override
+    public SessionIdV4 exec(int ignored, InputSchemaV4 input) {
+      SessionIdV4 out = new SessionIdV4();
+      out.session_key = "_sid" + Key.make().toString().substring(0, 5);
+      return out;
+    }
+  }
+
 }

--- a/h2o-core/src/main/java/water/api/RegisterV4Api.java
+++ b/h2o-core/src/main/java/water/api/RegisterV4Api.java
@@ -1,5 +1,6 @@
 package water.api;
 
+import static water.api.RequestServer.registerEndpoint;
 /**
  * Master-class for v4 REST APIs
  */
@@ -9,7 +10,7 @@ public class RegisterV4Api extends AbstractRegister {
   public void register(String relativeResourcePath) {
 
     //------------ Metadata: endpoints and schemas ---------------------------------------------------------------------
-    RequestServer.registerEndpoint("endpoints4",
+    registerEndpoint("endpoints4",
         "GET /4/endpoints",
         MetadataHandler.class, "listRoutes4",
         "Returns the list of all REST API (v4) endpoints."
@@ -17,13 +18,9 @@ public class RegisterV4Api extends AbstractRegister {
 
 
     //------------ Rapids ----------------------------------------------------------------------------------------------
-    RequestServer.registerEndpoint("newSession4",
-        "POST /4/sessions",
-        RapidsHandler.class, "startSession",
-        "Start a new Rapids session, and return the session id."
-    );
+    registerEndpoint("POST /4/sessions", RapidsHandler.StartSession4.class);
 
-    RequestServer.registerEndpoint("endSession4",
+    registerEndpoint("endSession4",
         "DELETE /4/sessions/{session_key}",
         RapidsHandler.class, "endSession",
         "Close the Rapids session."
@@ -31,7 +28,7 @@ public class RegisterV4Api extends AbstractRegister {
 
 
     //------------ Models ----------------------------------------------------------------------------------------------
-    RequestServer.registerEndpoint("modelsInfo",
+    registerEndpoint("modelsInfo",
         "GET /4/modelsinfo",
         ModelBuildersHandler.class, "modelsInfo",
         "Return basic information about all models available to train."

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -197,11 +197,11 @@ public class RequestServer extends HttpServlet {
    * @param method_uri combined method/url pattern of the endpoint, for
    *                   example: {@code "GET /3/Jobs/{job_id}"}
    * @param handler_clz class of the handler (should inherit from
-   *                    {@link Handler2}).
+   *                    {@link RestApiHandler}).
    */
-  public static Route registerEndpoint(String method_uri, Class<? extends Handler2> handler_clz) {
+  public static Route registerEndpoint(String method_uri, Class<? extends RestApiHandler> handler_clz) {
     try {
-      Handler2 handler = handler_clz.newInstance();
+      RestApiHandler handler = handler_clz.newInstance();
       return registerEndpoint(handler.name(), method_uri, handler_clz, null, handler.help());
     } catch (Exception e) {
       throw H2O.fail(e.getMessage());

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -191,6 +191,23 @@ public class RequestServer extends HttpServlet {
     }
   }
 
+  /**
+   * Register an HTTP request handler for the given URL pattern.
+   *
+   * @param method_uri combined method/url pattern of the endpoint, for
+   *                   example: {@code "GET /3/Jobs/{job_id}"}
+   * @param handler_clz class of the handler (should inherit from
+   *                    {@link Handler2}).
+   */
+  public static Route registerEndpoint(String method_uri, Class<? extends Handler2> handler_clz) {
+    try {
+      Handler2 handler = handler_clz.newInstance();
+      return registerEndpoint(handler.name(), method_uri, handler_clz, null, handler.help());
+    } catch (Exception e) {
+      throw H2O.fail(e.getMessage());
+    }
+  }
+
 
 
   //------ Handling Requests -------------------------------------------------------------------------------------------

--- a/h2o-core/src/main/java/water/api/RestApiHandler.java
+++ b/h2o-core/src/main/java/water/api/RestApiHandler.java
@@ -2,11 +2,13 @@ package water.api;
 
 /**
  * Common interface for <s>all</s> some REST endpoint handlers.
+ * <p>
+ * This class is a preferred way for adding new REST endpoints.
  *
  * @param <IS> input schema class
  * @param <OS> output schema class
  */
-public abstract class Handler2<IS extends Schema, OS extends Schema> extends Handler {
+public abstract class RestApiHandler<IS extends Schema, OS extends Schema> extends Handler {
 
   /** Suggested name for the endpoint in external libraries. */
   public abstract String name();

--- a/h2o-core/src/main/java/water/api/Route.java
+++ b/h2o-core/src/main/java/water/api/Route.java
@@ -1,16 +1,16 @@
 package water.api;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-
 import water.H2O;
 import water.Iced;
 import water.util.MarkdownBuilder;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
 /**
 * Routing of an http request to a handler method, with path parameter parsing.
 */
-final public class Route extends Iced {
+public final class Route extends Iced {
   static final int MIN_VERSION = 1;
 
   // TODO: handlers are now stateless, so create a single instance and stash it here
@@ -44,7 +44,7 @@ final public class Route extends Iced {
                Class<? extends Handler> handler_class,
                String handler_method,
                HandlerFactory handler_factory) {
-    assert uri != null && handler_class != null && handler_method != null;
+    assert uri != null && handler_class != null;
     assert handler_factory != null : "handler_factory should not be null, caller has to pass it!";
     _uri = uri;
     _http_method = uri.getMethod();
@@ -52,7 +52,7 @@ final public class Route extends Iced {
     _summary = summary;
     _api_name = api_name;
     _handler_class = handler_class;
-    _handler_method = resolveMethod(handler_class, handler_method);
+    _handler_method = resolveMethod(handler_class, handler_method == null? "exec" : handler_method);
     _path_params = uri.getParamsList();
     _handler_factory = handler_factory;
     try {

--- a/h2o-core/src/main/java/water/api/schemas4/SessionIdV4.java
+++ b/h2o-core/src/main/java/water/api/schemas4/SessionIdV4.java
@@ -1,0 +1,11 @@
+package water.api.schemas4;
+
+import water.Iced;
+import water.api.API;
+
+public class SessionIdV4 extends OutputSchemaV4<Iced, SessionIdV4> {
+
+  @API(help="Session ID")
+  public String session_key;
+
+}


### PR DESCRIPTION
The idea is to make an endpoint more discoverable. Thus, instead of writing `registerEndpoint(SomeHandler.class, "methodName")` and forcing the method to be located via reflection later on, I would rather write `registerEndpoint(SomeHandler.SomeMethod.class)`. The latter version allows me to jump to SomeHandler.SomeMethod directly in IntelliJ, and not having to suppress "Unused" warnings all the time (which makes it hard to find out when something is truly unused...)