### PR TITLE
PUBDEV-3703: Documentation for GLM Parameters

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/distribution.rst
+++ b/h2o-docs/src/product/data-science/algo-params/distribution.rst
@@ -72,8 +72,8 @@ Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
 - `huber_alpha <huber_alpha.html>`__
-- `quantile_alpha <quantile_alpha.html>`__
 - `offset_column <offset_column.html>`__
+- `quantile_alpha <quantile_alpha.html>`__
 - `tweedie_power <tweedie_power.html>`__
 - `y <y.html>`__
 

--- a/h2o-docs/src/product/data-science/algo-params/family.rst
+++ b/h2o-docs/src/product/data-science/algo-params/family.rst
@@ -1,0 +1,101 @@
+``family``
+----------
+
+- Available in: GLM
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+GLM problems consist of three main components:
+
+- A random component :math:`f` for the dependent variable :math:`y`: The density function :math:`f(y;\theta,\phi)` has a probability distribution from the exponential family parametrized by :math:`\theta` and :math:`\phi`. This removes the restriction on the distribution of the error and allows for non-homogeneity of the variance with respect to the mean vector. 
+- A systematic component (linear model) :math:`\eta`: :math:`\eta = X\beta`, where :math:`X` is the matrix of all observation vectors :math:`x_i`.
+- A link function :math:`g`: :math:`E(y) = \mu = {g^-1}(\eta)` relates the expected value of the response :math:`\mu` to the linear component :math:`\eta`. The link function can be any monotonic differentiable function. This relaxes the constraints on the additivity of the covariates, and it allows the response to belong to a restricted range of values depending on the chosen transformation :math:`g`. 
+
+Accordingly, in order to specify a GLM problem, you must choose a family function :math:`f`, link function :math:`g`, and any parameters needed to train the model.
+
+You can specify one of the following ``family`` options based on the response column type:
+
+- ``gaussian``: The data must be numeric (Real or Int). This is the default family.
+- ``binomial``: The data must be categorical 2 levels/classes or binary (Enum or Int).
+- ``quasibinomial``: The data must be numeric.
+- ``multinomial``: The data can be categorical with more than two levels/classes (Enum).
+- ``poisson``: The data must be numeric and non-negative (Int).
+- ``gamma``: The data must be numeric and continuous and positive (Real or Int).
+- ``tweedie``: The data must be numeric and continuous (Real) and non-negative.
+
+Refer to the `Families <../glm.html#families>`__ section for detailed information about each family option. 
+
+**Note**: If your response column is binomial, then you must convert that column to a categorical (``.asfactor()`` in Python and ``as.factor()`` in R) and set ``family = binomial``. The following configurations can lead to unexpected results. 
+
+ - If you DO convert the response column to categorical and DO NOT to set ``family=binomial``, then you will receive an error message.
+ - If you DO NOT convert response column to categorical and DO NOT set the family, then GLM will assume the 0s and 1s are numbers and will provide a Gaussian solution to a regression problem.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `link <link.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the cars dataset:
+	# this dataset is used to classify whether or not a car is economical based on
+	# the car's displacement, power, weight, and acceleration, and the year it was made
+	cars <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+
+	# convert response column to a factor
+	cars["economy_20mpg"] <- as.factor(cars["economy_20mpg"])
+
+	# set the predictor names and the response column name
+	predictors <- c("displacement","power","weight","acceleration","year")
+	response <- "economy_20mpg"
+
+	# split into train and validation
+	cars.splits <- h2o.splitFrame(data = cars, ratios = .8, seed = 1234)
+	train <- cars.splits[[1]]
+	valid <- cars.splits[[2]]
+
+	# try using the `family` parameter:
+	car_glm <- h2o.glm(x = predictors, y = response, family = 'binomial', training_frame = train, 
+	                   validation_frame = valid, seed = 1234)
+
+	# print the auc for your validation data
+	print(h2o.auc(car_glm, valid = TRUE))
+   
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+	h2o.init()
+
+	# import the cars dataset:
+	# this dataset is used to classify whether or not a car is economical based on
+	# the car's displacement, power, weight, and acceleration, and the year it was made
+	cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+
+	# convert response column to a factor
+	cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
+
+	# set the predictor names and the response column name
+	predictors = ["displacement","power","weight","acceleration","year"]
+	response = "economy_20mpg"
+
+	# split into train and validation sets
+	train, valid = cars.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `family` parameter:
+	# Initialize and train a GLM
+	cars_glm = H2OGeneralizedLinearEstimator(family = 'binomial', seed = 1234)
+	cars_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the auc for the validation data
+	cars_glm.auc(valid = True)
+

--- a/h2o-docs/src/product/data-science/algo-params/family.rst
+++ b/h2o-docs/src/product/data-science/algo-params/family.rst
@@ -59,13 +59,13 @@ Example
 	response <- "economy_20mpg"
 
 	# split into train and validation
-	cars.splits <- h2o.splitFrame(data = cars, ratios = .8, seed = 1234)
+	cars.splits <- h2o.splitFrame(data = cars, ratios = .8)
 	train <- cars.splits[[1]]
 	valid <- cars.splits[[2]]
 
 	# try using the `family` parameter:
 	car_glm <- h2o.glm(x = predictors, y = response, family = 'binomial', training_frame = train, 
-	                   validation_frame = valid, seed = 1234)
+	                   validation_frame = valid)
 
 	# print the auc for your validation data
 	print(h2o.auc(car_glm, valid = TRUE))
@@ -89,11 +89,11 @@ Example
 	response = "economy_20mpg"
 
 	# split into train and validation sets
-	train, valid = cars.split_frame(ratios = [.8], seed = 1234)
+	train, valid = cars.split_frame(ratios = [.8])
 
 	# try using the `family` parameter:
 	# Initialize and train a GLM
-	cars_glm = H2OGeneralizedLinearEstimator(family = 'binomial', seed = 1234)
+	cars_glm = H2OGeneralizedLinearEstimator(family = 'binomial')
 	cars_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the auc for the validation data

--- a/h2o-docs/src/product/data-science/algo-params/gradient_epsilon.rst
+++ b/h2o-docs/src/product/data-science/algo-params/gradient_epsilon.rst
@@ -9,7 +9,7 @@ Description
 
 GLM includes three criteria outside of ``max_iterations`` that define and check for convergence during logistic regression:
 
-- ``beta_epsilon``: Converge if the beta change is less than this value (or if beta stops changing). This is used with by solvers.
+- ``beta_epsilon``: Converge if the beta change is less than this value (or if beta stops changing). This is used by solvers.
 - ``gradient_epsilon``: Converge if the gradient value change is less than this value (using L-infinity norm). This is used when ``solver=L-BFGS``.
 - ``objective_epsilon``: Converge if the relative objective value changes (for example, (old_val - new_val)/old_val). This is used by all solvers. 
 

--- a/h2o-docs/src/product/data-science/algo-params/interactions.rst
+++ b/h2o-docs/src/product/data-science/algo-params/interactions.rst
@@ -46,7 +46,7 @@ Examples
 	boston["chas"] <- as.factor(boston["chas"])
 
 	# split into train and validation sets
-	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8)
 	train <- boston.splits[[1]]
 	valid <- boston.splits[[2]]
 
@@ -57,8 +57,7 @@ Examples
 	interactions_list = c('crim', 'dis')
 	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
 	                      interactions = interactions_list,
-	                      validation_frame = valid,
-	                      seed = 1234)
+	                      validation_frame = valid)
 
 	# print the mse for validation set
 	print(h2o.mse(boston_glm, valid=TRUE))
@@ -83,7 +82,7 @@ Examples
 	boston['chas'] = boston['chas'].asfactor()
 
 	# split into train and validation sets
-	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
+	train, valid = boston.split_frame(ratios = [.8])
 
 	# take a look at the boston columns:
 	print(boston.columns)
@@ -93,7 +92,7 @@ Examples
 	# the weighted distances to five Boston employment centres)
 	# initialize the estimator then train the model
 	interactions_list = ['crim', 'dis']
-	boston_glm = H2OGeneralizedLinearEstimator(interactions = interactions_list, seed = 1234)
+	boston_glm = H2OGeneralizedLinearEstimator(interactions = interactions_list)
 	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the mse for the validation data

--- a/h2o-docs/src/product/data-science/algo-params/interactions.rst
+++ b/h2o-docs/src/product/data-science/algo-params/interactions.rst
@@ -1,0 +1,100 @@
+``interactions``
+----------------
+
+- Available in: GLM
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+By default, interactions between predictor columns are expanded and computed on the fly as GLM iterates over dataset. The ``interactions`` option allows you to enter a list of predictor column indices that should interact. Note that adding a list of interactions to a model changes the interpretation of all of the coefficients. 
+
+For example, a typical predictor has the form ‘response ~ terms’ where ‘response’ is the (numeric) response vector, and ‘terms’ is a series of terms that specify a linear predictor for ‘response’. For ‘binomial’ and ‘quasibinomial’ families, the response can also be specified as a ‘factor’ (when the first level denotes failure and all other levels denote success) or as a two-column matrix with the columns giving the numbers of successes and failures. 
+
+An ``interactions`` specification of the form ‘first + second’ computes all of the terms in ‘first’ together with all the terms in ‘second’ with any duplicates removed.
+
+An ``interactions`` specification of the form ‘first:second’ indicates the the set of terms obtained by taking the interactions of all terms in ‘first’ with all terms in ‘second’. 
+
+An ``interactions`` specification ‘first*second’ indicates the cross of ‘first’ and ‘second’. This is the same as ‘first + second + first:second’. The terms in the formula will be re-ordered so that main effects come first followed by the interactions, then all second-order, all third-order and so on.
+
+Interactions can be specified between two categorical columns, between two numeric columns, or between a mix of categorical and numerical columns. When entered, all pairwise combinations of predictor column indices will be computed for that list. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Examples
+~~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+	# import the boston dataset:
+	# this dataset looks at features of the boston suburbs and predicts median housing prices
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Housing
+	boston <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/BostonHousing.csv")
+
+	# set the predictor names and the response column name
+	predictors <- colnames(boston)[1:13]
+	# set the response column to "medv", the median value of owner-occupied homes in $1000's
+	response <- "medv"
+
+	# convert the chas column to a factor (chas = Charles River dummy variable (= 1 if tract bounds river; 0 otherwise))
+	boston["chas"] <- as.factor(boston["chas"])
+
+	# split into train and validation sets
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
+	train <- boston.splits[[1]]
+	valid <- boston.splits[[2]]
+
+	# try using the `interactions` parameter:
+	# add the interaction terms between 'crim' and 'dis' (per capita crime rate by town and 
+	# the weighted distances to five Boston employment centres)
+	# initialize the estimator then train the model
+	interactions_list = c('crim', 'dis')
+	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
+	                      interactions = interactions_list,
+	                      validation_frame = valid,
+	                      seed = 1234)
+
+	# print the mse for validation set
+	print(h2o.mse(boston_glm, valid=TRUE))
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+	h2o.init()
+
+	# import the boston dataset:
+	# this dataset looks at features of the boston suburbs and predicts median housing prices
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Housing
+	boston = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/BostonHousing.csv")
+
+	# set the predictor names and the response column name
+	predictors = boston.columns[:-1]
+	# set the response column to "medv", the median value of owner-occupied homes in $1000's
+	response = "medv"
+
+	# convert the chas column to a factor (chas = Charles River dummy variable (= 1 if tract bounds river; 0 otherwise))
+	boston['chas'] = boston['chas'].asfactor()
+
+	# split into train and validation sets
+	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
+
+	# take a look at the boston columns:
+	print(boston.columns)
+
+	# try using the `interactions` parameter:
+	# add the interaction terms between 'crim' and 'dis' (per capita crime rate by town and 
+	# the weighted distances to five Boston employment centres)
+	# initialize the estimator then train the model
+	interactions_list = ['crim', 'dis']
+	boston_glm = H2OGeneralizedLinearEstimator(interactions = interactions_list, seed = 1234)
+	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the mse for the validation data
+	print(boston_glm.mse(valid=True))

--- a/h2o-docs/src/product/data-science/algo-params/intercept.rst
+++ b/h2o-docs/src/product/data-science/algo-params/intercept.rst
@@ -41,13 +41,13 @@ Example
 	response <- 'class'
 
 	# split into train and validation
-	iris.splits <- h2o.splitFrame(data = iris, ratios = .8, seed = 1234)
+	iris.splits <- h2o.splitFrame(data = iris, ratios = .8)
 	train <- iris.splits[[1]]
 	valid <- iris.splits[[2]]
 
 	# try using the `intercept` parameter:
 	iris_glm <- h2o.glm(x = predictors, y = response, family = 'multinomial', 
-	                    intercept = TRUE, training_frame = train, validation_frame = valid, seed = 1234)
+	                    intercept = TRUE, training_frame = train, validation_frame = valid)
 
 	# print the logloss for the validation data
 	print(h2o.logloss(iris_glm, valid = TRUE))
@@ -71,11 +71,11 @@ Example
 	response = 'class'
 
 	# split into train and validation sets
-	train, valid = iris.split_frame(ratios = [.8], seed = 1234)
+	train, valid = iris.split_frame(ratios = [.8])
 
 	# try using the `intercept` parameter:
 	# Initialize and train a GLM
-	iris_glm = H2OGeneralizedLinearEstimator(family = 'multinomial', intercept = True, seed = 1234)
+	iris_glm = H2OGeneralizedLinearEstimator(family = 'multinomial', intercept = True)
 	iris_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the logloss for the validation data

--- a/h2o-docs/src/product/data-science/algo-params/intercept.rst
+++ b/h2o-docs/src/product/data-science/algo-params/intercept.rst
@@ -1,0 +1,82 @@
+``intercept``
+-------------
+
+- Available in: GLM
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+The ``intercept`` command allows you to specify whether a single constant term should to be included in the model. By including a constant term (i.e., an "intercept" or "bias"), we ensure that the model is to be unbiased--i.e., the mean of the residuals will be exactly zero. 
+
+The intercept term adjusts all predictions up or down by a constant amount, i.e. it is the predicted value when all inputs are exactly 0. It can be excluded (forced to equal 0) by setting ``intercept=FALSE``. 
+
+In GLM, the inverse of the link function is applied to obtain the final predictions (targets in regression and probabilities in classification). Excluding the intercept term can negatively impact measured model quality, but it is appropriate when a given linear model should definitely predict 0 when all inputs are 0 (before the application of the inverse of the link function to obtain the final predictions). You may also want to exclude the intercept term to choose a simpler model when appropriate and move away from overfitting. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `family <family.html>`__
+- `link <link.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris <- h2o.importFile("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] <- as.factor(iris['class'])
+
+	# set the predictor names and the response column name
+	predictors <- colnames(iris)[-length(iris)]
+	response <- 'class'
+
+	# split into train and validation
+	iris.splits <- h2o.splitFrame(data = iris, ratios = .8, seed = 1234)
+	train <- iris.splits[[1]]
+	valid <- iris.splits[[2]]
+
+	# try using the `intercept` parameter:
+	iris_glm <- h2o.glm(x = predictors, y = response, family = 'multinomial', 
+	                    intercept = TRUE, training_frame = train, validation_frame = valid, seed = 1234)
+
+	# print the logloss for the validation data
+	print(h2o.logloss(iris_glm, valid = TRUE))
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] = iris['class'].asfactor()
+
+	# set the predictor names and the response column name
+	predictors = iris.columns[:-1]
+	response = 'class'
+
+	# split into train and validation sets
+	train, valid = iris.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `intercept` parameter:
+	# Initialize and train a GLM
+	iris_glm = H2OGeneralizedLinearEstimator(family = 'multinomial', intercept = True, seed = 1234)
+	iris_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the logloss for the validation data
+	iris_glm.logloss(valid = True)

--- a/h2o-docs/src/product/data-science/algo-params/lambda_search.rst
+++ b/h2o-docs/src/product/data-science/algo-params/lambda_search.rst
@@ -7,7 +7,9 @@
 Description
 ~~~~~~~~~~~
 
-Setting ``lambda_search`` to TRUE enables efficient and automatic search for the optimal value of the ``lambda`` parameter. When enabled, GLM will first fit a model with maximum regularization (highest lambda value) and then keep decreasing it at each step until it reaches the minimum lambda or until overfitting occurs. (Note that GLM will automatically calculate the minimum lambda value unless a value for ``lambda`` is specified. In that case, the specified ``lambda`` value becomes the minimum lambda value.) The resulting model is based on the best lambda value. 
+Setting ``lambda_search`` to TRUE enables efficient and automatic search for the optimal value of the ``lambda`` parameter. When enabled, GLM will first fit a model with maximum regularization (highest lambda value) and then keep decreasing it at each step until it reaches the minimum lambda or until overfitting occurs. The resulting model is based on the best lambda value. 
+
+Note that GLM will automatically calculate the minimum lambda value unless a value for ``lambda_min_ratio`` is specified. In that case, the specified value becomes the minimum lambda value. If you enter one or more values for ``lambda``, then the lambda search is performed over only those provided lambdas. 
 
 When looking for a sparse solution (``alpha`` > 0), lambda search can also be used to efficiently handle very wide datasets because it can filter out inactive predictors (noise) and only build models for a small subset of predictors. A possible use case for lambda search is to run it on a dataset with many predictors but limit the number of active predictors to a relatively small value. 
 

--- a/h2o-docs/src/product/data-science/algo-params/lambda_search.rst
+++ b/h2o-docs/src/product/data-science/algo-params/lambda_search.rst
@@ -7,7 +7,7 @@
 Description
 ~~~~~~~~~~~
 
-Setting ``lambda_search`` to TRUE enables efficient and automatic search for the optimal value of the ``lambda`` parameter. When enabled, GLM will first fit a model with maximum regularization (highest lambda value) and then keep decreasing it at each step until it reaches the minimum lambda or until overfitting occurs. The resulting model is based on the best lambda value. 
+Setting ``lambda_search`` to TRUE enables efficient and automatic search for the optimal value of the ``lambda`` parameter. When enabled, GLM will first fit a model with maximum regularization (highest lambda value) and then keep decreasing it at each step until it reaches the minimum lambda or until overfitting occurs. (Note that GLM will automatically calculate the minimum lambda value unless a value for ``lambda`` is specified. In that case, the specified ``lambda`` value becomes the minimum lambda value.) The resulting model is based on the best lambda value. 
 
 When looking for a sparse solution (``alpha`` > 0), lambda search can also be used to efficiently handle very wide datasets because it can filter out inactive predictors (noise) and only build models for a small subset of predictors. A possible use case for lambda search is to run it on a dataset with many predictors but limit the number of active predictors to a relatively small value. 
 

--- a/h2o-docs/src/product/data-science/algo-params/link.rst
+++ b/h2o-docs/src/product/data-science/algo-params/link.rst
@@ -68,13 +68,13 @@ Example
 	response <- 'class'
 
 	# split into train and validation
-	iris.splits <- h2o.splitFrame(data = iris, ratios = .8, seed = 1234)
+	iris.splits <- h2o.splitFrame(data = iris, ratios = .8)
 	train <- iris.splits[[1]]
 	valid <- iris.splits[[2]]
 
 	# try using the `link` parameter:
 	iris_glm <- h2o.glm(x = predictors, y = response, family = 'multinomial', link = 'family_default',
-	                   training_frame = train, validation_frame = valid, seed = 1234)
+	                   training_frame = train, validation_frame = valid)
 
 	# print the logloss for the validation data
 	print(h2o.logloss(iris_glm, valid = TRUE))
@@ -98,11 +98,11 @@ Example
 	response = 'class'
 
 	# split into train and validation sets
-	train, valid = iris.split_frame(ratios = [.8], seed = 1234)
+	train, valid = iris.split_frame(ratios = [.8])
 
 	# try using the `link` parameter:
 	# Initialize and train a GLM
-	iris_glm = H2OGeneralizedLinearEstimator(family = 'multinomial', link = 'family_default', seed = 1234)
+	iris_glm = H2OGeneralizedLinearEstimator(family = 'multinomial', link = 'family_default')
 	iris_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the logloss for the validation data

--- a/h2o-docs/src/product/data-science/algo-params/link.rst
+++ b/h2o-docs/src/product/data-science/algo-params/link.rst
@@ -1,0 +1,109 @@
+``link``
+--------
+
+- Available in: GLM
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+GLM problems consist of three main components:
+
+- A random component :math:`f` for the dependent variable :math:`y`: The density function :math:`f(y;\theta,\phi)` has a probability distribution from the exponential family parametrized by :math:`\theta` and :math:`\phi`. This removes the restriction on the distribution of the error and allows for non-homogeneity of the variance with respect to the mean vector. 
+- A systematic component (linear model) :math:`\eta`: :math:`\eta = X\beta`, where :math:`X` is the matrix of all observation vectors :math:`x_i`.
+- A link function :math:`g`: :math:`E(y) = \mu = {g^-1}(\eta)` relates the expected value of the response :math:`\mu` to the linear component :math:`\eta`. The link function can be any monotonic differentiable function. This relaxes the constraints on the additivity of the covariates, and it allows the response to belong to a restricted range of values depending on the chosen transformation :math:`g`. 
+
+Accordingly, in order to specify a GLM problem, you must choose a family function :math:`f`, link function :math:`g`, and any parameters needed to train the model. 
+
+H2O's GLM supports the following link functions: Family_Default, Identity, Logit, Log, Inverse, and Tweedie.
+
+The following table describes the allowed Family/Link combinations.
+
++----------------+-------------------------------------------------------------+
+| **Family**     | **Link Function**                                           |
++----------------+----------------+----------+-------+-----+---------+---------+
+|                | Family_Default | Identity | Logit | Log | Inverse | Tweedie |
++----------------+----------------+----------+-------+-----+---------+---------+
+| Binomial       | X              |          | X     |     |         |         |
++----------------+----------------+----------+-------+-----+---------+---------+
+| Quasibinomial  | X              |          | X     |     |         |         |
++----------------+----------------+----------+-------+-----+---------+---------+
+| Multinomial    | X              |          |       |     |         |         |
++----------------+----------------+----------+-------+-----+---------+---------+
+| Gaussian       | X              | X        |       | X   | X       |         |
++----------------+----------------+----------+-------+-----+---------+---------+
+| Poisson        | X              | X        |       | X   |         |         |
++----------------+----------------+----------+-------+-----+---------+---------+
+| Gamma          | X              | X        |       | X   | X       |         |
++----------------+----------------+----------+-------+-----+---------+---------+
+| Tweedie        | X              |          |       |     |         | X       |
++----------------+----------------+----------+-------+-----+---------+---------+
+
+Refer to the `Links <../glm.html#links>`__ section for more information. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `family <family.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris <- h2o.importFile("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] <- as.factor(iris['class'])
+
+	# set the predictor names and the response column name
+	predictors <- colnames(iris)[-length(iris)]
+	response <- 'class'
+
+	# split into train and validation
+	iris.splits <- h2o.splitFrame(data = iris, ratios = .8, seed = 1234)
+	train <- iris.splits[[1]]
+	valid <- iris.splits[[2]]
+
+	# try using the `link` parameter:
+	iris_glm <- h2o.glm(x = predictors, y = response, family = 'multinomial', link = 'family_default',
+	                   training_frame = train, validation_frame = valid, seed = 1234)
+
+	# print the logloss for the validation data
+	print(h2o.logloss(iris_glm, valid = TRUE))
+   
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] = iris['class'].asfactor()
+
+	# set the predictor names and the response column name
+	predictors = iris.columns[:-1]
+	response = 'class'
+
+	# split into train and validation sets
+	train, valid = iris.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `link` parameter:
+	# Initialize and train a GLM
+	iris_glm = H2OGeneralizedLinearEstimator(family = 'multinomial', link = 'family_default', seed = 1234)
+	iris_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the logloss for the validation data
+	iris_glm.logloss(valid = True)

--- a/h2o-docs/src/product/data-science/algo-params/missing_values_handling.rst
+++ b/h2o-docs/src/product/data-science/algo-params/missing_values_handling.rst
@@ -41,12 +41,12 @@ Example
 	boston["chas"] <- as.factor(boston["chas"])
 
 	# split into train and validation sets
-	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8)
 	train <- boston.splits[[1]]
 	valid <- boston.splits[[2]]
 
 	# insert missing values at random (this method happens inplace)
-	h2o.insertMissingValues(boston, seed =1234)
+	h2o.insertMissingValues(boston)
 
 	# check the number of missing values
 	print(paste("missing:", sum(is.na(boston)), sep = ", "))
@@ -54,8 +54,7 @@ Example
 	# try using the `missing_values_handling` parameter:
 	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
 	                      missing_values_handling = "Skip",
-	                      validation_frame = valid,
-	                      seed = 1234)
+	                      validation_frame = valid)
 
 	# print the mse for the validation data
 	print(h2o.mse(boston_glm, valid=TRUE))
@@ -71,7 +70,7 @@ Example
 	# build grid search with previously made GLM and hyperparameters
 	grid <- h2o.grid(x = predictors, y = response, training_frame = train, validation_frame = valid,
 	                 algorithm = "glm", grid_id = "boston_grid", hyper_params = hyper_params,
-	                 search_criteria = list(strategy = "Cartesian"), seed = 1234)
+	                 search_criteria = list(strategy = "Cartesian"))
 
 	# Sort the grid models by mse
 	sortedGrid <- h2o.getGrid("boston_grid", sort_by = "mse", decreasing = FALSE)
@@ -97,17 +96,17 @@ Example
 	boston['chas'] = boston['chas'].asfactor()
 
 	# insert missing values at random (this method happens inplace)
-	boston.insert_missing_values(seed = 1234)
+	boston.insert_missing_values()
 
 	# check the number of missing values
 	print('missing:', boston.isna().sum())
 
 	# split into train and validation sets
-	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
+	train, valid = boston.split_frame(ratios = [.8])
 
 	# try using the `missing_values_handling` parameter:
 	# initialize the estimator then train the model
-	boston_glm = H2OGeneralizedLinearEstimator(missing_values_handling = "skip", seed = 1234)
+	boston_glm = H2OGeneralizedLinearEstimator(missing_values_handling = "skip")
 	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the mse for the validation data
@@ -124,7 +123,7 @@ Example
 	# and we want to see the performance of all models. For a larger search space use
 	# random grid search instead: {'strategy': "RandomDiscrete"}
 	# initialize the GLM estimator
-	boston_glm_2 = H2OGeneralizedLinearEstimator(seed = 1234)
+	boston_glm_2 = H2OGeneralizedLinearEstimator()
 
 	# build grid search with previously made GLM and hyperparameters
 	grid = H2OGridSearch(model = boston_glm_2, hyper_params = hyper_params,

--- a/h2o-docs/src/product/data-science/algo-params/missing_values_handling.rst
+++ b/h2o-docs/src/product/data-science/algo-params/missing_values_handling.rst
@@ -1,0 +1,139 @@
+``missing_values_handling``
+---------------------------
+
+- Available in: Deep Learning, GLM
+- Hyperparameter: yes
+
+Description
+~~~~~~~~~~~
+
+This option is used to specify the way that the algorithm will treat missing values. In H2O, the Deep Learning and GLM algorithms will either skip or mean-impute rows with NA values. This option defaults to MeanImputation. Note that categorical variables are imputed by adding an extra “missing” level. Optionally, the algorithm can skip all rows with any missing values.
+ 
+The fewer the NA values in your training data, the better. Always check degrees of freedom in the output model. Degrees of freedom is the number of observations used to train the model minus the size of the model (i.e., the number of features). If this number is much smaller than expected, it is likely that too many rows have been excluded due to missing values:
+
+- If you have few columns with many NAs, you might accidentally be losing all your rows, so its better to exclude (skip) them.
+- If you have many columns with a small fraction of uniformly distributed missing values, every row will likely have at least one missing value. In this case, impute the NAs (e.g., substitute the NAs with mean values) before modeling. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+	# import the boston dataset:
+	# this dataset looks at features of the boston suburbs and predicts median housing prices
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Housing
+	boston <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/BostonHousing.csv")
+
+	# set the predictor names and the response column name
+	predictors <- colnames(boston)[1:13]
+	# set the response column to "medv", the median value of owner-occupied homes in $1000's
+	response <- "medv"
+
+	# convert the chas column to a factor (chas = Charles River dummy variable (= 1 if tract bounds river; 0 otherwise))
+	boston["chas"] <- as.factor(boston["chas"])
+
+	# split into train and validation sets
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
+	train <- boston.splits[[1]]
+	valid <- boston.splits[[2]]
+
+	# insert missing values at random (this method happens inplace)
+	h2o.insertMissingValues(boston, seed =1234)
+
+	# check the number of missing values
+	print(paste("missing:", sum(is.na(boston)), sep = ", "))
+
+	# try using the `missing_values_handling` parameter:
+	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
+	                      missing_values_handling = "Skip",
+	                      validation_frame = valid,
+	                      seed = 1234)
+
+	# print the mse for the validation data
+	print(h2o.mse(boston_glm, valid=TRUE))
+
+	# grid over `missing_values_handling`
+	# select the values for `missing_values_handling` to grid over
+	hyper_params <- list( missing_values_handling = c("Skip", "MeanImputation") )
+
+	# this example uses cartesian grid search because the search space is small
+	# and we want to see the performance of all models. For a larger search space use
+	# random grid search instead: {'strategy': "RandomDiscrete"}
+
+	# build grid search with previously made GLM and hyperparameters
+	grid <- h2o.grid(x = predictors, y = response, training_frame = train, validation_frame = valid,
+	                 algorithm = "glm", grid_id = "boston_grid", hyper_params = hyper_params,
+	                 search_criteria = list(strategy = "Cartesian"), seed = 1234)
+
+	# Sort the grid models by mse
+	sortedGrid <- h2o.getGrid("boston_grid", sort_by = "mse", decreasing = FALSE)
+	sortedGrid
+   
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+	h2o.init()
+
+	# import the boston dataset:
+	# this dataset looks at features of the boston suburbs and predicts median housing prices
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Housing
+	boston = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/BostonHousing.csv")
+
+	# set the predictor names and the response column name
+	predictors = boston.columns[:-1]
+	# set the response column to "medv", the median value of owner-occupied homes in $1000's
+	response = "medv"
+
+	# convert the chas column to a factor (chas = Charles River dummy variable (= 1 if tract bounds river; 0 otherwise))
+	boston['chas'] = boston['chas'].asfactor()
+
+	# insert missing values at random (this method happens inplace)
+	boston.insert_missing_values(seed = 1234)
+
+	# check the number of missing values
+	print('missing:', boston.isna().sum())
+
+	# split into train and validation sets
+	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `missing_values_handling` parameter:
+	# initialize the estimator then train the model
+	boston_glm = H2OGeneralizedLinearEstimator(missing_values_handling = "skip", seed = 1234)
+	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the mse for the validation data
+	print(boston_glm.mse(valid=True))
+
+	# grid over `missing_values_handling`
+	# import Grid Search
+	from h2o.grid.grid_search import H2OGridSearch
+
+	# select the values for `missing_values_handling` to grid over
+	hyper_params = {'missing_values_handling': ["skip", "mean_imputation"]}
+
+	# this example uses cartesian grid search because the search space is small
+	# and we want to see the performance of all models. For a larger search space use
+	# random grid search instead: {'strategy': "RandomDiscrete"}
+	# initialize the GLM estimator
+	boston_glm_2 = H2OGeneralizedLinearEstimator(seed = 1234)
+
+	# build grid search with previously made GLM and hyperparameters
+	grid = H2OGridSearch(model = boston_glm_2, hyper_params = hyper_params,
+	                     search_criteria = {'strategy': "Cartesian"})
+
+	# train using the grid
+	grid.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+
+	# sort the grid models by mse
+	sorted_grid = grid.get_grid(sort_by='mse', decreasing=False)
+	print(sorted_grid)

--- a/h2o-docs/src/product/data-science/algo-params/nlambdas.rst
+++ b/h2o-docs/src/product/data-science/algo-params/nlambdas.rst
@@ -11,7 +11,7 @@ This option specifies the number of lambdas to use during a lambda search. As su
 
 ``nlambdas`` works in conjunction with ``lambda_min_ratio``. The sequence of the :math:`\lambda` values is automatically generated as an exponentially decreasing sequence. It ranges from :math:`\lambda_{max}` (the smallest :math:`\lambda` so that the solution is a model with all 0s) to :math:`\lambda_{min} =` ``lambda_min_ratio`` :math:`\times` :math:`\lambda_{max}`.
 
-H2O computes :math:`\lambda` models sequentially and in decreasing order, warm-starting the model (using the previous solutin as the initial prediction) for :math:`\lambda_k` with the solution for :math:`\lambda_{k-1}`. By warm-starting the models, we get better performance. Typically models for subsequent :math:`\lambda` values are close to each other, so only a few iterations per :math:`\lambda` are needed (two or three). This also achieves greater numerical stability because models with a higher penalty are easier to compute. This method starts with an easy problem and then continues to make small adjustments. 
+H2O computes :math:`\lambda` models sequentially and in decreasing order, warm-starting the model (using the previous solution as the initial prediction) for :math:`\lambda_k` with the solution for :math:`\lambda_{k-1}`. By warm-starting the models, we get better performance. Typically models for subsequent :math:`\lambda` values are close to each other, so only a few iterations per :math:`\lambda` are needed (two or three). This also achieves greater numerical stability because models with a higher penalty are easier to compute. This method starts with an easy problem and then continues to make small adjustments. 
 
 **Notes**: 
 

--- a/h2o-docs/src/product/data-science/algo-params/objective_epsilon.rst
+++ b/h2o-docs/src/product/data-science/algo-params/objective_epsilon.rst
@@ -9,7 +9,7 @@ Description
 
 GLM includes three criteria outside of ``max_iterations`` that define and check for convergence during logistic regression:
 
-- ``beta_epsilon``: Converge if the beta change is less than this value (or if beta stops changing). This is used with by solvers.
+- ``beta_epsilon``: Converge if the beta change is less than this value (or if beta stops changing). This is used by solvers.
 - ``gradient_epsilon``: Converge if the gradient value change is less than this value (using L-infinity norm). This is used when ``solver=L-BFGS``.
 - ``objective_epsilon``: Converge if the relative objective value changes (for example, (old_val - new_val)/old_val). This is used by all solvers. 
 

--- a/h2o-docs/src/product/data-science/algo-params/remove_collinear_columns.rst
+++ b/h2o-docs/src/product/data-science/algo-params/remove_collinear_columns.rst
@@ -41,15 +41,14 @@ Example
 	response <- "IsDepDelayed"
 
 	# split into train and validation
-	airlines.splits <- h2o.splitFrame(data =  airlines, ratios = .8, seed = 1234)
+	airlines.splits <- h2o.splitFrame(data =  airlines, ratios = .8)
 	train <- airlines.splits[[1]]
 	valid <- airlines.splits[[2]]
 
 	# try using the `remove_collinear_columns` parameter:
 	# must be used with lambda = 0
 	airlines.glm <- h2o.glm(family = 'binomial', x = predictors, y = response, training_frame = train,
-	                        validation_frame = valid, remove_collinear_columns = TRUE, lambda = 0,
-	                        seed = 1234)
+	                        validation_frame = valid, remove_collinear_columns = TRUE, lambda = 0)
 
 	# print the auc for the validation data
 	print(h2o.auc(airlines.glm, valid = TRUE))
@@ -78,13 +77,13 @@ Example
 	response = "IsDepDelayed"
 
 	# split into train and validation sets
-	train, valid= airlines.split_frame(ratios = [.8], seed = 1234)
+	train, valid= airlines.split_frame(ratios = [.8])
 
 	# try using the `remove_collinear_columns` parameter:
 	# must be used with lambda_ = 0
 	# initialize your estimator
 	airlines_glm = H2OGeneralizedLinearEstimator(family = 'binomial', lambda_ = 0, 
-	                                             remove_collinear_columns = True, seed =1234)
+	                                             remove_collinear_columns = True)
 
 	# then train your model
 	airlines_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)

--- a/h2o-docs/src/product/data-science/algo-params/remove_collinear_columns.rst
+++ b/h2o-docs/src/product/data-science/algo-params/remove_collinear_columns.rst
@@ -1,0 +1,93 @@
+``remove_collinear_columns``
+----------------------------
+
+- Available in: GLM
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+Collinear columns can cause problems during model fitting. The preferred way to deal with collinearity (and the default H2O behavior) is to add regularization. (See the `Regularization <../glm.html#regularization>`__ topic for more information.) However, if you want a non-regularized solution, you can choose to automatically remove collinear columns by enabling the ``remove_collinear_columns`` option. 
+
+This option can only be used when ``solver=IRLSM`` and with no regularization (``lambda=0``). If enabled, H2O will automatically remove columns when it detects collinearlity. The columns that are removed depend on the order of the columns in the vector of coefficients (intercepts first, then categorical variables ordered by cardinality from largest to smallest, and then numbers).
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `solver <solver.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+	# import the airlines dataset:
+	# This dataset is used to classify whether a flight will be delayed 'YES' or not "NO"
+	# original data can be found at http://www.transtats.bts.gov/
+	airlines <-  h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
+
+	# convert columns to factors
+	airlines["Year"] <- as.factor(airlines["Year"])
+	airlines["Month"] <- as.factor(airlines["Month"])
+	airlines["DayOfWeek"] <- as.factor(airlines["DayOfWeek"])
+	airlines["Cancelled"] <- as.factor(airlines["Cancelled"])
+	airlines['FlightNum'] <- as.factor(airlines['FlightNum'])
+
+	# set the predictor names and the response column name
+	predictors <- c("Origin", "Dest", "Year", "UniqueCarrier", "DayOfWeek", "Month", "Distance", "FlightNum")
+	response <- "IsDepDelayed"
+
+	# split into train and validation
+	airlines.splits <- h2o.splitFrame(data =  airlines, ratios = .8, seed = 1234)
+	train <- airlines.splits[[1]]
+	valid <- airlines.splits[[2]]
+
+	# try using the `remove_collinear_columns` parameter:
+	# must be used with lambda = 0
+	airlines.glm <- h2o.glm(family = 'binomial', x = predictors, y = response, training_frame = train,
+	                        validation_frame = valid, remove_collinear_columns = TRUE, lambda = 0,
+	                        seed = 1234)
+
+	# print the auc for the validation data
+	print(h2o.auc(airlines.glm, valid = TRUE))
+
+   
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+	h2o.init()
+
+	# import the airlines dataset:
+	# This dataset is used to classify whether a flight will be delayed 'YES' or not "NO"
+	# original data can be found at http://www.transtats.bts.gov/
+	airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
+
+	# convert columns to factors
+	airlines["Year"]= airlines["Year"].asfactor()
+	airlines["Month"]= airlines["Month"].asfactor()
+	airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
+	airlines["Cancelled"] = airlines["Cancelled"].asfactor()
+	airlines['FlightNum'] = airlines['FlightNum'].asfactor()
+
+	# set the predictor names and the response column name
+	predictors = ["Origin", "Dest", "Year", "UniqueCarrier", "DayOfWeek", "Month", "Distance", "FlightNum"]
+	response = "IsDepDelayed"
+
+	# split into train and validation sets
+	train, valid= airlines.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `remove_collinear_columns` parameter:
+	# must be used with lambda_ = 0
+	# initialize your estimator
+	airlines_glm = H2OGeneralizedLinearEstimator(family = 'binomial', lambda_ = 0, 
+	                                             remove_collinear_columns = True, seed =1234)
+
+	# then train your model
+	airlines_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the auc for the validation data
+	print(airlines_glm.auc(valid=True))

--- a/h2o-docs/src/product/data-science/algo-params/solver.rst
+++ b/h2o-docs/src/product/data-science/algo-params/solver.rst
@@ -11,9 +11,9 @@ The ``solver`` option allows you to specify the solver method to use in GLM. Whe
 
 In GLM, you can specify one of the following solvers:
 
-- IRLSM: Iteratively Reweighted Least Squares Method (default)
+- IRLSM: Iteratively Reweighted Least Squares Method
 - L_BFGS: Limited-memory Broyden-Fletcher-Goldfarb-Shanno algorithm
-- AUTO: Sets the solver based on given data and parameters.
+- AUTO: Sets the solver based on given data and parameters (default)
 - COORDINATE_DESCENT: Coordinate Decent
 - COORDINATE_DESCENT_NAIVE: Coordinate Decent Naive
 

--- a/h2o-docs/src/product/data-science/algo-params/solver.rst
+++ b/h2o-docs/src/product/data-science/algo-params/solver.rst
@@ -48,15 +48,14 @@ Example
 	boston["chas"] <- as.factor(boston["chas"])
 
 	# split into train and validation sets
-	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8)
 	train <- boston.splits[[1]]
 	valid <- boston.splits[[2]]
 
 	# try using the `solver` parameter:
 	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
 	                      validation_frame = valid,
-	                      solver = 'IRLSM',
-	                      seed = 1234)
+	                      solver = 'IRLSM')
 
 	# print the mse for the validation data
 	print(h2o.mse(boston_glm, valid=TRUE))
@@ -81,11 +80,11 @@ Example
 	boston['chas'] = boston['chas'].asfactor()
 
 	# split into train and validation sets
-	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
+	train, valid = boston.split_frame(ratios = [.8])
 
 	# try using the `solver` parameter:
 	# initialize the estimator then train the model
-	boston_glm = H2OGeneralizedLinearEstimator(solver = 'irlsm' , seed = 1234)
+	boston_glm = H2OGeneralizedLinearEstimator(solver = 'irlsm')
 	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the mse for the validation data

--- a/h2o-docs/src/product/data-science/algo-params/solver.rst
+++ b/h2o-docs/src/product/data-science/algo-params/solver.rst
@@ -1,5 +1,5 @@
-``beta_epsilon``
-----------------
+``solver``
+----------
 
 - Available in: GLM
 - Hyperparameter: no
@@ -7,25 +7,24 @@
 Description
 ~~~~~~~~~~~
 
-GLM includes three criteria outside of ``max_iterations`` that define and check for convergence during logistic regression:
+The ``solver`` option allows you to specify the solver method to use in GLM. When specifying a solver, the optimal solver depends on the data properties and prior information regarding the variables (if available). In general, the data are considered sparse if the ratio of zeros to non-zeros in the input matrix is greater than 10. The solution is sparse when only a subset of the original set of variables is intended to be kept in the model. In a dense solution, all predictors have non-zero coefficients in the final model.
 
-- ``beta_epsilon``: Converge if the beta change is less than this value (or if beta stops changing). This is used by solvers.
-- ``gradient_epsilon``: Converge if the gradient value change is less than this value (using L-infinity norm). This is used when ``solver=L-BFGS``.
-- ``objective_epsilon``: Converge if the relative objective value changes (for example, (old_val - new_val)/old_val). This is used by all solvers. 
+In GLM, you can specify one of the following solvers:
 
-The default for these options is based on a heurisitic:
+- IRLSM: Iteratively Reweighted Least Squares Method (default)
+- L_BFGS: Limited-memory Broyden-Fletcher-Goldfarb-Shanno algorithm
+- AUTO: Sets the solver based on given data and parameters.
+- COORDINATE_DESCENT: Coordinate Decent
+- COORDINATE_DESCENT_NAIVE: Coordinate Decent Naive
 
-- The default for ``beta_epsilon`` is 1e-4.
-- The default for ``gradient_epsilon`` is 1e-6 if there is no regularization (``lambda=0``) or you are running with lambda search; 1e-4 otherwise.
-- The default for ``objective_epsilon`` is 1e-6 if ``lambda=0``; 1e-4 otherwise.
+Detailed information about each of these optiosn is available in the `Solvers <../glm.html#solvers>`__ section.
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
-- `gradient_epsilon <gradient_epsilon.html>`__
-- `max_iterations <max_iterations.html>`__
-- `objective_epsilon <objective_epsilon.html>`__
-- `solver <solver.html>`__
+- `alpha <alpha.html>`__
+- `lambda <lambda.html>`__
+- `lambda_search <lambda_search.html>`__
 
 Example
 ~~~~~~~
@@ -35,7 +34,6 @@ Example
 
 	library(h2o)
 	h2o.init()
-
 	# import the boston dataset:
 	# this dataset looks at features of the boston suburbs and predicts median housing prices
 	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Housing
@@ -50,19 +48,19 @@ Example
 	boston["chas"] <- as.factor(boston["chas"])
 
 	# split into train and validation sets
-	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8)
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
 	train <- boston.splits[[1]]
 	valid <- boston.splits[[2]]
 
-	# try using the `beta_epsilon` parameter:
-	# train your model, where you specify beta_epsilon
+	# try using the `solver` parameter:
 	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
 	                      validation_frame = valid,
-	                      beta_epsilon = 1e-3)
+	                      solver = 'IRLSM',
+	                      seed = 1234)
 
 	# print the mse for the validation data
 	print(h2o.mse(boston_glm, valid=TRUE))
-
+   
    .. code-block:: python
 
 	import h2o
@@ -83,12 +81,13 @@ Example
 	boston['chas'] = boston['chas'].asfactor()
 
 	# split into train and validation sets
-	train, valid = boston.split_frame(ratios = [.8])
+	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
 
-	# try using the `beta_epsilon` parameter:
+	# try using the `solver` parameter:
 	# initialize the estimator then train the model
-	boston_glm = H2OGeneralizedLinearEstimator(beta_epsilon = 1e-3)
+	boston_glm = H2OGeneralizedLinearEstimator(solver = 'irlsm' , seed = 1234)
 	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the mse for the validation data
 	print(boston_glm.mse(valid=True))
+

--- a/h2o-docs/src/product/data-science/algo-params/standardize.rst
+++ b/h2o-docs/src/product/data-science/algo-params/standardize.rst
@@ -38,15 +38,14 @@ Example
 	boston["chas"] <- as.factor(boston["chas"])
 
 	# split into train and validation sets
-	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8)
 	train <- boston.splits[[1]]
 	valid <- boston.splits[[2]]
 
 	# try using the `standardize` parameter:
 	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
 	                      validation_frame = valid,
-	                      standardize = TRUE,
-	                      seed = 1234)
+	                      standardize = TRUE)
 
 	# print the mse for the validation data
 	print(h2o.mse(boston_glm, valid=TRUE))
@@ -71,11 +70,11 @@ Example
 	boston['chas'] = boston['chas'].asfactor()
 
 	# split into train and validation sets
-	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
+	train, valid = boston.split_frame(ratios = [.8])
 
 	# try using the `standardize` parameter:
 	# initialize the estimator then train the model
-	boston_glm = H2OGeneralizedLinearEstimator(standardize = True , seed = 1234)
+	boston_glm = H2OGeneralizedLinearEstimator(standardize = True)
 	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the mse for the validation data

--- a/h2o-docs/src/product/data-science/algo-params/standardize.rst
+++ b/h2o-docs/src/product/data-science/algo-params/standardize.rst
@@ -1,31 +1,20 @@
-``beta_epsilon``
-----------------
+``standardize``
+---------------
 
-- Available in: GLM
+- Available in: Deep Learning, GLM
 - Hyperparameter: no
 
 Description
 ~~~~~~~~~~~
 
-GLM includes three criteria outside of ``max_iterations`` that define and check for convergence during logistic regression:
+This option specifies whether to standardizes numeric columns to have zero mean and unit variance. Enabling this option produces standardized coefficient magnitudes in the model output. 
 
-- ``beta_epsilon``: Converge if the beta change is less than this value (or if beta stops changing). This is used by solvers.
-- ``gradient_epsilon``: Converge if the gradient value change is less than this value (using L-infinity norm). This is used when ``solver=L-BFGS``.
-- ``objective_epsilon``: Converge if the relative objective value changes (for example, (old_val - new_val)/old_val). This is used by all solvers. 
-
-The default for these options is based on a heurisitic:
-
-- The default for ``beta_epsilon`` is 1e-4.
-- The default for ``gradient_epsilon`` is 1e-6 if there is no regularization (``lambda=0``) or you are running with lambda search; 1e-4 otherwise.
-- The default for ``objective_epsilon`` is 1e-6 if ``lambda=0``; 1e-4 otherwise.
+Standardization is highly recommended. As such, this option is enabled by default. If you do not use standardization, the results can include components that are dominated by variables that appear to have larger variances relative to other attributes as a matter of scale, rather than true contribution. Only advanced users should disable this option. 
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
-- `gradient_epsilon <gradient_epsilon.html>`__
-- `max_iterations <max_iterations.html>`__
-- `objective_epsilon <objective_epsilon.html>`__
-- `solver <solver.html>`__
+- None
 
 Example
 ~~~~~~~
@@ -35,7 +24,6 @@ Example
 
 	library(h2o)
 	h2o.init()
-
 	# import the boston dataset:
 	# this dataset looks at features of the boston suburbs and predicts median housing prices
 	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Housing
@@ -50,19 +38,19 @@ Example
 	boston["chas"] <- as.factor(boston["chas"])
 
 	# split into train and validation sets
-	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8)
+	boston.splits <- h2o.splitFrame(data =  boston, ratios = .8, seed = 1234)
 	train <- boston.splits[[1]]
 	valid <- boston.splits[[2]]
 
-	# try using the `beta_epsilon` parameter:
-	# train your model, where you specify beta_epsilon
+	# try using the `standardize` parameter:
 	boston_glm <- h2o.glm(x = predictors, y = response, training_frame = train,
 	                      validation_frame = valid,
-	                      beta_epsilon = 1e-3)
+	                      standardize = TRUE,
+	                      seed = 1234)
 
 	# print the mse for the validation data
 	print(h2o.mse(boston_glm, valid=TRUE))
-
+	   
    .. code-block:: python
 
 	import h2o
@@ -83,11 +71,11 @@ Example
 	boston['chas'] = boston['chas'].asfactor()
 
 	# split into train and validation sets
-	train, valid = boston.split_frame(ratios = [.8])
+	train, valid = boston.split_frame(ratios = [.8], seed = 1234)
 
-	# try using the `beta_epsilon` parameter:
+	# try using the `standardize` parameter:
 	# initialize the estimator then train the model
-	boston_glm = H2OGeneralizedLinearEstimator(beta_epsilon = 1e-3)
+	boston_glm = H2OGeneralizedLinearEstimator(standardize = True , seed = 1234)
 	boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
 
 	# print the mse for the validation data

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -103,7 +103,7 @@ Defining a GLM Model
 
 -  `lambda <algo-params/lambda.html>`__: Specify the regularization strength.
 
--  `lambda_search <algo-params/lambda_search.html>`__: Specify whether to enable lambda search, starting with lambda max. The given lambda is then interpreted as lambda min. 
+-  `lambda_search <algo-params/lambda_search.html>`__: Specify whether to enable lambda search, starting with lambda max. If you also specify a value for ``lambda``, then this value is interpreted as lambda min. If you do not specify a value for ``lambda``, then GLM will calculate the minimum lambda. 
 
 -  `early_stopping <algo-params/early_stopping.html>`__: Specify whether to stop early when there is no more relative improvement on the training  or validation set.
    
@@ -139,13 +139,13 @@ Defining a GLM Model
    -  If the family is **Multinomial**, then only **Family_Default** is supported. (This defaults to ``multinomial``.)
    -  If the family is **Quasibinomial**, then only **Logit** is supported.
 
--  `prior <algo-params/prior.html>`__: Specify prior probability for p(y==1). Use this parameter for logistic regression if the data has been sampled and the mean of response does not reflect reality. 
+-  prior: Specify prior probability for p(y==1). Use this parameter for logistic regression if the data has been sampled and the mean of response does not reflect reality. 
    
      **Note**: This is a simple method affecting only the intercept. You may want to use weights and offset for a better fit.
 
 -  `lambda_min_ratio <algo-params/lambda_min_ratio.html>`__: Specify the minimum lambda to use for lambda search (specified as a ratio of **lambda\_max**).
 
--  `beta_constraints <algo-params/beta_constraints.html>`__: Specify a dataset to use beta constraints. The selected frame is used to constraint the coefficient vector to provide upper and lower bounds. The dataset must contain a names column with valid coefficient names.
+-  beta_constraints: Specify a dataset to use beta constraints. The selected frame is used to constraint the coefficient vector to provide upper and lower bounds. The dataset must contain a names column with valid coefficient names.
 
 -  `max_active_predictors <algo-params/max_active_predictors.html>`__: Specify the maximum number of active
    predictors during computation. This value is used as a stopping
@@ -432,9 +432,9 @@ The recommended way to find optimal regularization settings on H2O is to do a gr
 Lambda Search
 '''''''''''''
 
-If the ``lambda_search`` option is set, GLM will compute models for full regularization path similar to glmnet (see glmnet paper). Regularziation path starts at lambda max (highest lambda values which makes sense - i.e. lowest value driving all coefficients to zero) and goes down to lambda min on log scale, decreasing regularization strength at each step. The returned model will have coefficients corresponding to the “optimal” lambda value as decided during training.
+If the ``lambda_search`` option is set, GLM will compute models for full regularization path similar to glmnet (see glmnet paper). Regularization path starts at lambda max (highest lambda values which makes sense - i.e. lowest value driving all coefficients to zero) and goes down to lambda min on log scale, decreasing regularization strength at each step. The returned model will have coefficients corresponding to the “optimal” lambda value as decided during training.
 
-When looking for a sparse solution (``alpha`` > 0), lambda search can also be used to effeciently handle very wide datasets because it can filter out inactive predictors (noise) and only build models for a small subset of predictors. A common use of lambda search is to run it on a dataset with many predictors but limit the number of active predictors to a relatively small value. 
+When looking for a sparse solution (``alpha`` > 0), lambda search can also be used to efficiently handle very wide datasets because it can filter out inactive predictors (noise) and only build models for a small subset of predictors. A common use of lambda search is to run it on a dataset with many predictors but limit the number of active predictors to a relatively small value. 
 
 Lambda search can be configured along with the following arguments:
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -103,7 +103,7 @@ Defining a GLM Model
 
 -  `lambda <algo-params/lambda.html>`__: Specify the regularization strength.
 
--  `lambda_search <algo-params/lambda_search.html>`__: Specify whether to enable lambda search, starting with lambda max. If you also specify a value for ``lambda``, then this value is interpreted as lambda min. If you do not specify a value for ``lambda``, then GLM will calculate the minimum lambda. 
+-  `lambda_search <algo-params/lambda_search.html>`__: Specify whether to enable lambda search, starting with lambda max. If you also specify a value for ``lambda_min_ratio``, then this value is interpreted as lambda min. If you do not specify a value for ``lambda_min_ratio``, then GLM will calculate the minimum lambda. 
 
 -  `early_stopping <algo-params/early_stopping.html>`__: Specify whether to stop early when there is no more relative improvement on the training  or validation set.
    
@@ -432,9 +432,9 @@ The recommended way to find optimal regularization settings on H2O is to do a gr
 Lambda Search
 '''''''''''''
 
-If the ``lambda_search`` option is set, GLM will compute models for full regularization path similar to glmnet (see glmnet paper). Regularization path starts at lambda max (highest lambda values which makes sense - i.e. lowest value driving all coefficients to zero) and goes down to lambda min on log scale, decreasing regularization strength at each step. The returned model will have coefficients corresponding to the “optimal” lambda value as decided during training.
+If the ``lambda_search`` option is set, GLM will compute models for full regularization path similar to glmnet. (See the `glmnet paper <https://core.ac.uk/download/pdf/6287975.pdf>`__.) Regularization path starts at lambda max (highest lambda values which makes sense - i.e. lowest value driving all coefficients to zero) and goes down to lambda min on log scale, decreasing regularization strength at each step. The returned model will have coefficients corresponding to the “optimal” lambda value as decided during training.
 
-When looking for a sparse solution (``alpha`` > 0), lambda search can also be used to efficiently handle very wide datasets because it can filter out inactive predictors (noise) and only build models for a small subset of predictors. A common use of lambda search is to run it on a dataset with many predictors but limit the number of active predictors to a relatively small value. 
+When looking for a sparse solution (``alpha`` > 0), lambda search can also be used to efficiently handle very wide datasets because it can filter out inactive predictors (noise) and only build models for a small subset of predictors. A possible use case for lambda search is to run it on a dataset with many predictors but limit the number of active predictors to a relatively small value. 
 
 Lambda search can be configured along with the following arguments:
 

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -12,7 +12,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
 
 .. toctree::
    :maxdepth: 2
-   
+
    data-science/algo-params/alpha
    data-science/algo-params/balance_classes
    data-science/algo-params/beta_epsilon
@@ -27,6 +27,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/compute_p_values
    data-science/algo-params/distribution
    data-science/algo-params/early_stopping
+   data-science/algo-params/family
    data-science/algo-params/fold_assignment
    data-science/algo-params/fold_column
    data-science/algo-params/gradient_epsilon
@@ -34,6 +35,8 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/huber_alpha
    data-science/algo-params/ignore_const_cols
    data-science/algo-params/ignored_columns
+   data-science/algo-params/interactions
+   data-science/algo-params/intercept
    data-science/algo-params/keep_cross_validation_fold_assignment
    data-science/algo-params/keep_cross_validation_predictions
    data-science/algo-params/lambda
@@ -41,6 +44,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/lambda_search
    data-science/algo-params/learn_rate
    data-science/algo-params/learn_rate_annealing
+   data-science/algo-params/link
    data-science/algo-params/max_abs_leafnode_pred
    data-science/algo-params/max_active_predictors
    data-science/algo-params/max_after_balance_size
@@ -50,6 +54,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/max_runtime_secs
    data-science/algo-params/min_rows
    data-science/algo-params/min_split_improvement
+   data-science/algo-params/missing_values_handling
    data-science/algo-params/model_id
    data-science/algo-params/mtries
    data-science/algo-params/nbins
@@ -63,11 +68,14 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/offset_column
    data-science/algo-params/pred_noise_bandwidth
    data-science/algo-params/quantile_alpha
+   data-science/algo-params/remove_collinear_columns
    data-science/algo-params/sample_rate
    data-science/algo-params/sample_rate_per_class
    data-science/algo-params/score_each_iteration
    data-science/algo-params/score_tree_interval
    data-science/algo-params/seed
+   data-science/algo-params/solver
+   data-science/algo-params/standardize
    data-science/algo-params/stopping_metric
    data-science/algo-params/stopping_rounds
    data-science/algo-params/stopping_tolerance


### PR DESCRIPTION
Added detailed descriptions and examples of the remaining GLM parameters for the Appendix section.
Driveby fixes: Fixed typos in glm.rst file and the in “epsilon” and nlambdas parameters. Added a note in the lambda_search parameter that GLM will calculate the minimum lambda value unless a lambda is specified. Fixed alphabetized list for the distribution parameter.