### PR TITLE
new whitelist items in R check validation in py, related to PUBDEV-3302

### DIFF
--- a/scripts/validate_r_cmd_check_output.py
+++ b/scripts/validate_r_cmd_check_output.py
@@ -80,6 +80,13 @@ class Check:
 
             r"^The Date field is over a month old.*",
             r"^Checking URLs requires 'libcurl' support in the R build",
+            # relation to optional data.table package
+            r"^\* checking package dependencies ... NOTE",
+            r"^Package suggested but not available for checking*",
+            r"^\* checking Rd cross-references ... NOTE",
+            r"^Package unavailable to check Rd xrefs*",
+            r"^Status: 3 NOTEs",
+            r"^Status: 4 NOTEs"
             ]
 
         s = f.readline()


### PR DESCRIPTION
validation was disabled for a while, and recently enabled again, thus require minor update