### PR TITLE
PUBDEV-2276: Adding support for file name globbing

### DIFF
--- a/h2o-bindings/src/main/java/water/bindings/examples/Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/Example.java
@@ -90,7 +90,7 @@ public class Example {
 
         try {
             // STEP 1: import raw file
-            ImportFilesV3 importBody = importService.importFiles("http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz", null).execute().body();
+            ImportFilesV3 importBody = importService.importFiles("http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz", "", null).execute().body();
             System.out.println("import: " + importBody);
 
             // STEP 2: parse setup

--- a/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
@@ -20,7 +20,7 @@ public class GBM_Example {
 
         // STEP 1: import raw file
         ImportFilesV3 importBody = h2o.importFiles(
-            "http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz"
+            "http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz", ""
           );
         System.out.println("import: " + importBody);
 

--- a/h2o-bindings/src/main/java/water/bindings/examples/retrofit/Merge_Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/retrofit/Merge_Example.java
@@ -26,7 +26,7 @@ public class Merge_Example {
 
         // import and parse files
         { // tourism
-          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/tourism.csv");
+          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/tourism.csv", "");
           ParseSetupV3 parseSetupParams = new ParseSetupV3();
           parseSetupParams.sourceFrames = H2oApi.stringArrayToKeyArray(importBody.destinationFrames, FrameKeyV3.class);
           parseSetupParams.checkHeader = 1;
@@ -40,7 +40,7 @@ public class Merge_Example {
         }
 
         { // heart
-          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/heart.csv");
+          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/heart.csv", "");
           ParseSetupV3 parseSetupParams = new ParseSetupV3();
           parseSetupParams.sourceFrames = H2oApi.stringArrayToKeyArray(importBody.destinationFrames, FrameKeyV3.class);
           parseSetupParams.checkHeader = 1;

--- a/h2o-core/src/main/java/water/api/ImportFilesHandler.java
+++ b/h2o-core/src/main/java/water/api/ImportFilesHandler.java
@@ -21,7 +21,7 @@ public class ImportFilesHandler extends Handler {
     ArrayList<String> fails = new ArrayList();
     ArrayList<String> dels = new ArrayList();
 
-    H2O.getPM().importFiles(importFiles.path, files, keys, fails, dels);
+    H2O.getPM().importFiles(importFiles.path, importFiles.pattern, files, keys, fails, dels);
 
     importFiles.files = files.toArray(new String[files.size()]);
     importFiles.destination_frames = keys.toArray(new String[keys.size()]);

--- a/h2o-core/src/main/java/water/api/schemas3/ImportFilesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportFilesV3.java
@@ -7,6 +7,7 @@ public class ImportFilesV3 extends RequestSchemaV3<ImportFilesV3.ImportFiles, Im
 
   public final static class ImportFiles extends Iced {
     public String path;
+    public String pattern;
     public String files[];
     public String destination_frames[];
     public String fails[];
@@ -16,6 +17,9 @@ public class ImportFilesV3 extends RequestSchemaV3<ImportFilesV3.ImportFiles, Im
   // Input fields
   @API(help = "path", required = true)
   public String path;
+
+  @API(help = "pattern", direction = API.Direction.INPUT)
+  public String pattern;
 
   // Output fields
   @API(help = "files", direction = API.Direction.OUTPUT)

--- a/h2o-core/src/main/java/water/persist/Persist.java
+++ b/h2o-core/src/main/java/water/persist/Persist.java
@@ -49,7 +49,7 @@ public abstract class Persist {
    */
   abstract public List<String> calcTypeaheadMatches(String filter, int limit);
 
-  abstract public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels);
+  abstract public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels);
 
   // The filename can be either byte encoded if it starts with % followed by
   // a number, or is a normal key name with special characters encoded in

--- a/h2o-core/src/main/java/water/persist/PersistFS.java
+++ b/h2o-core/src/main/java/water/persist/PersistFS.java
@@ -99,7 +99,7 @@ final class PersistFS extends Persist {
   }
 
   @Override
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
     assert false;
   }
 

--- a/h2o-core/src/main/java/water/persist/PersistNFS.java
+++ b/h2o-core/src/main/java/water/persist/PersistNFS.java
@@ -130,7 +130,7 @@ public final class PersistNFS extends Persist {
   }
 
   @Override
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
     File f = new File(path);
     if( !f.exists() ) throw new H2ONotFoundArgumentException("File " + path + " does not exist");
     FileIntegrityChecker.check(f).syncDirectory(files,keys,fails,dels);

--- a/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
@@ -390,7 +390,7 @@ public final class PersistHdfs extends Persist {
   }
 
   @Override
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
 //    path = convertS3toS3N(path);
 
     // Fix for S3 kind of URL

--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -142,7 +142,7 @@ public final class PersistS3 extends Persist {
       }
     }
   }
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
     Log.info("ImportS3 processing (" + path + ")");
     // List of processed files
     AmazonS3 s3 = getClient();

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -311,10 +311,10 @@ class H2OFrame(object):
 
 
 
-    def _import_parse(self, path, destination_frame, header, separator, column_names, column_types, na_strings):
+    def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings):
         if is_type(path, str) and "://" not in path:
             path = os.path.abspath(path)
-        rawkey = h2o.lazy_import(path)
+        rawkey = h2o.lazy_import(path, pattern)
         self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings)
         return self
 

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -87,14 +87,14 @@ h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse =
     destFrames <- c()
     fails <- c()
     for(path2 in path){
-      res <-.h2o.__remoteSend(.h2o.__IMPORT, path=path2)
+      res <-.h2o.__remoteSend(.h2o.__IMPORT, path=path2,pattern=pattern)
       destFrames <- c(destFrames, res$destination_frames)
       fails <- c(fails, res$fails)
     }
     res$destination_frames <- destFrames
     res$fails <- fails
   } else {
-    res <- .h2o.__remoteSend(.h2o.__IMPORT, path=path)
+    res <- .h2o.__remoteSend(.h2o.__IMPORT, path=path,pattern=pattern)
   }
 
   if(length(res$fails) > 0L) {
@@ -103,16 +103,11 @@ h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse =
   }
   # Return only the files that successfully imported
   if(length(res$files) <= 0L) stop("all files failed to import")
-  if(parse) {
-    if(pattern=="") {srcKey <- res$destination_frames
-    } else {srcKey  <- res$destination_frames[grepl(pattern,res$destination_frames)]}
-    if(length(srcKey)>0){
-      return( h2o.parseRaw(data=.newH2OFrame(op="ImportFolder",id=srcKey,-1,-1), destination_frame=destination_frame,
-                           header=header, sep=sep, col.names=col.names, col.types=col.types, na.strings=na.strings) )
-    }else{
-      stop("all files failed to import - No file has this `pattern` ")
-    }
-  }
+if(parse) {
+    srcKey <- res$destination_frames
+    return( h2o.parseRaw(data=.newH2OFrame(op="ImportFolder",id=srcKey,-1,-1),pattern=pattern, destination_frame=destination_frame,
+            header=header, sep=sep, col.names=col.names, col.types=col.types, na.strings=na.strings) )
+}
   myData <- lapply(res$destination_frames, function(x) .newH2OFrame( op="ImportFolder", id=x,-1,-1))  # do not gc, H2O handles these nfs:// vecs
   if(length(res$destination_frames) == 1L)
     return( myData[[1L]] )

--- a/h2o-r/h2o-package/R/parse.R
+++ b/h2o-r/h2o-package/R/parse.R
@@ -6,6 +6,8 @@
 #' Parse the Raw Data produced by the import phase.
 #'
 #' @param data An H2OFrame object to be parsed.
+#' @param pattern (Optional) Character string containing a regular expression to match file(s) in
+#'        the folder.
 #' @param destination_frame (Optional) The hex key assigned to the parsed file.
 #' @param header (Optional) A logical value indicating whether the first row is
 #'        the column header. If missing, H2O will automatically try to detect
@@ -26,9 +28,9 @@
 #' @param chunk_size size of chunk of (input) data in bytes
 #' @seealso \link{h2o.importFile}, \link{h2o.parseSetup}
 #' @export
-h2o.parseRaw <- function(data, destination_frame = "", header=NA, sep = "", col.names=NULL,
+h2o.parseRaw <- function(data, pattern="", destination_frame = "", header=NA, sep = "", col.names=NULL,
                          col.types=NULL, na.strings=NULL, blocking=FALSE, parse_type = NULL, chunk_size = NULL) {
-  parse.params <- h2o.parseSetup(data, destination_frame, header, sep, col.names, col.types,
+  parse.params <- h2o.parseSetup(data, pattern="", destination_frame, header, sep, col.names, col.types,
                                  na.strings = na.strings, parse_type = parse_type, chunk_size = chunk_size)
   for(w in parse.params$warnings){
     cat('WARNING:',w,'\n')
@@ -116,7 +118,7 @@ h2o.parseRaw <- function(data, destination_frame = "", header=NA, sep = "", col.
 #' @inheritParams h2o.parseRaw
 #' @seealso \link{h2o.parseRaw}
 #' @export
-h2o.parseSetup <- function(data, destination_frame = "", header = NA, sep = "", col.names = NULL, col.types = NULL,
+h2o.parseSetup <- function(data, pattern="", destination_frame = "", header = NA, sep = "", col.names = NULL, col.types = NULL,
                            na.strings = NULL, parse_type = NULL, chunk_size = NULL) {
 
   # Allow single frame or list of frames; turn singleton into a list


### PR DESCRIPTION
* This PR adds support for file name globbing during import of datasets in H2O. 
* Some examples of this are: 

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="/A/.*/iris_.*")` -> Import all files that have the pattern `/A/.*/iris_.*` in the directory`test/`

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="/A/iris_.*")`  -> Import all files that have the pattern `/A/iris_.*` in the directory `test/`

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="/A/B/iris_.*")` -> Import all files that have the pattern `/A/B/iris_.*` in the directory `test/`

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="iris_.*")` -> Import all files that have the pattern `iris_.*` in the directory `test/`
