### PR TITLE
Changed the signal sent to end a cluster from a SIGKILL to a SIGTERM …

### DIFF
--- a/h2o-algos/testMultiNode.sh
+++ b/h2o-algos/testMultiNode.sh
@@ -24,9 +24,9 @@ rm -fr $OUTDIR
 $MKDIR -p $OUTDIR
 
 function cleanup () {
-  kill -9 ${PID_11} ${PID_21} ${PID_31} ${PID_41} ${PID_51} 1> /dev/null 2>&1
-  kill -9 ${PID_12} ${PID_22} ${PID_32} ${PID_42} ${PID_52} 1> /dev/null 2>&1
-  kill -9 ${PID_13} ${PID_23} ${PID_33} ${PID_43} ${PID_53} 1> /dev/null 2>&1
+  kill -15 ${PID_11} ${PID_21} ${PID_31} ${PID_41} ${PID_51} 1> /dev/null 2>&1
+  kill -15 ${PID_12} ${PID_22} ${PID_32} ${PID_42} ${PID_52} 1> /dev/null 2>&1
+  kill -15 ${PID_13} ${PID_23} ${PID_33} ${PID_43} ${PID_53} 1> /dev/null 2>&1
   wait 1> /dev/null 2>&1
   RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
   if [ "$RC" != "00000" ]; then

--- a/h2o-core/testMultiNode.sh
+++ b/h2o-core/testMultiNode.sh
@@ -23,7 +23,7 @@ esac
 
 # Run cleanup on interrupt or exit
 function cleanup () {
-  kill -9 ${PID_1} ${PID_2} ${PID_3} ${PID_4} 1> /dev/null 2>&1
+  kill -15 ${PID_1} ${PID_2} ${PID_3} ${PID_4} 1> /dev/null 2>&1
   wait 1> /dev/null 2>&1
   RC=`cat $OUTDIR/status.0`
   if [ $RC -ne 0 ]; then


### PR DESCRIPTION
…in {h2o-core,h2o-algos}/testMultiNode.sh

a SIGKILL prevents JaCoCo from dumping coverage data from that cluster when the JVM is terminated.