### PR TITLE
PUBDEV-3818: fix line wrap issue for url

### DIFF
--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -63,7 +63,10 @@ def gen_module(schema, algo, module):
     if help_details:
         yield "#' @details %s" % bi.wrap(help_details, indent=("#'          "), indent_first=False)
     if help_return:
-        yield "#' @return %s" % bi.wrap(help_return, indent=("#'         "), indent_first=False)
+        lines = help_return.split("\n")
+        for line in lines:
+            yield "%s" % line.lstrip()
+        # yield "#' @return %s" % bi.wrap(help_return, indent=("#'         "), indent_first=False)
     if help_epilogue:
         yield "#' @seealso %s" % bi.wrap(help_epilogue, indent=("#'          "), indent_first=False)
     if help_references:
@@ -279,24 +282,25 @@ def help_details_for(algo):
 
 def help_return_for(algo):
     if algo == "drf":
-        return "Creates a \linkS4class{H2OModel} object of the right type."
+        return "#' @return Creates a \linkS4class{H2OModel} object of the right type."
     if algo == "glm":
-        return """A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
-        learning task at hand (if it's binomial classification, then an \code{\linkS4class{H2OBinomialModel}} is
-        returned, if it's regression then a \code{\linkS4class{H2ORegressionModel}} is returned). The default print-
-        out of the models is shown, but further GLM-specifc information can be queried out of the object. To access
-        these various items, please refer to the seealso section below. Upon completion of the GLM, the resulting
-        object has coefficients, normalized coefficients, residual/null deviance, aic, and a host of model metrics
-        including MSE, AUC (for logistic regression), degrees of freedom, and confusion matrices. Please refer to the
-        more in-depth GLM documentation available here: \\url{http://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
+        return """#' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
+        #'         learning task at hand (if it's binomial classification, then an \code{\linkS4class{H2OBinomialModel}} is
+        #'         returned, if it's regression then a \code{\linkS4class{H2ORegressionModel}} is returned). The default print-
+        #'         out of the models is shown, but further GLM-specifc information can be queried out of the object. To access
+        #'         these various items, please refer to the seealso section below. Upon completion of the GLM, the resulting
+        #'         object has coefficients, normalized coefficients, residual/null deviance, aic, and a host of model metrics
+        #'         including MSE, AUC (for logistic regression), degrees of freedom, and confusion matrices. Please refer to the
+        #'         more in-depth GLM documentation available here:
+        #'         \\url{http://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
         """
     if algo == "kmeans":
-        return "Returns an object of class \linkS4class{H2OClusteringModel}."
+        return "#' @return Returns an object of class \linkS4class{H2OClusteringModel}."
     if algo == "naivebayes":
-        return """Returns an object of class \linkS4class{H2OBinomialModel} if the response has two categorical levels,
-         and \linkS4class{H2OMultinomialModel} otherwise."""
+        return """#' @return Returns an object of class \linkS4class{H2OBinomialModel} if the response has two categorical levels,
+        #'         and \linkS4class{H2OMultinomialModel} otherwise."""
     if algo in ["glrm", "pca", "svd"]:
-        return "Returns an object of class \linkS4class{H2ODimReductionModel}."
+        return "#' @return Returns an object of class \linkS4class{H2ODimReductionModel}."
 
 def help_epilogue_for(algo):
     if algo == "glm":

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -292,7 +292,7 @@ def help_return_for(algo):
         #'         object has coefficients, normalized coefficients, residual/null deviance, aic, and a host of model metrics
         #'         including MSE, AUC (for logistic regression), degrees of freedom, and confusion matrices. Please refer to the
         #'         more in-depth GLM documentation available here:
-        #'         \\url{http://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
+        #'         \\url{https://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
         """
     if algo == "kmeans":
         return "#' @return Returns an object of class \linkS4class{H2OClusteringModel}."

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -50,7 +50,7 @@
 #'        values can lead to more overfitting. Defaults to 1024.
 #' @param r2_stopping r2_stopping is no longer supported and will be ignored if set - please use stopping_rounds, stopping_metric
 #'        and stopping_tolerance instead. Previous version of H2O would stop making trees when the R^2 metric equals or
-#'        exceeds this Defaults to 1.7976931348623157e+308.
+#'        exceeds this Defaults to 1.79769313486e+308.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
@@ -80,7 +80,7 @@
 #' @param min_split_improvement Minimum relative improvement in squared error reduction for a split to happen Defaults to 1e-05.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
 #'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
-#' @param max_abs_leafnode_pred Maximum absolute value of a leaf node prediction Defaults to 1.7976931348623157e+308.
+#' @param max_abs_leafnode_pred Maximum absolute value of a leaf node prediction Defaults to 1.79769313486e+308.
 #' @param pred_noise_bandwidth Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions Defaults to 0.0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen". Defaults to AUTO.
@@ -123,7 +123,7 @@ h2o.gbm <- function(x, y, training_frame,
                     nbins = 20,
                     nbins_top_level = 1024,
                     nbins_cats = 1024,
-                    r2_stopping = 1.7976931348623157e+308,
+                    r2_stopping = 1.79769313486e+308,
                     stopping_rounds = 0,
                     stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
                     stopping_tolerance = 0.001,
@@ -144,7 +144,7 @@ h2o.gbm <- function(x, y, training_frame,
                     col_sample_rate_per_tree = 1.0,
                     min_split_improvement = 1e-05,
                     histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
-                    max_abs_leafnode_pred = 1.7976931348623157e+308,
+                    max_abs_leafnode_pred = 1.79769313486e+308,
                     pred_noise_bandwidth = 0.0,
                     categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen")
                     ) 

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -95,8 +95,9 @@
 #'         these various items, please refer to the seealso section below. Upon completion of the GLM, the resulting
 #'         object has coefficients, normalized coefficients, residual/null deviance, aic, and a host of model metrics
 #'         including MSE, AUC (for logistic regression), degrees of freedom, and confusion matrices. Please refer to the
-#'         more in-depth GLM documentation available here: \url{http://h2o-release.s3.amazonaws.com/h2o-dev/rel-
-#'         shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
+#'         more in-depth GLM documentation available here:
+#'         \url{http://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
+
 #' @seealso \code{\link{predict.H2OModel}} for prediction, \code{\link{h2o.mse}}, \code{\link{h2o.auc}},
 #'          \code{\link{h2o.confusionMatrix}}, \code{\link{h2o.performance}}, \code{\link{h2o.giniCoef}},
 #'          \code{\link{h2o.logloss}}, \code{\link{h2o.varimp}}, \code{\link{h2o.scoreHistory}}

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -96,7 +96,7 @@
 #'         object has coefficients, normalized coefficients, residual/null deviance, aic, and a host of model metrics
 #'         including MSE, AUC (for logistic regression), degrees of freedom, and confusion matrices. Please refer to the
 #'         more in-depth GLM documentation available here:
-#'         \url{http://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
+#'         \url{https://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-docs/index.html#Data+Science+Algorithms-GLM}
 
 #' @seealso \code{\link{predict.H2OModel}} for prediction, \code{\link{h2o.mse}}, \code{\link{h2o.auc}},
 #'          \code{\link{h2o.confusionMatrix}}, \code{\link{h2o.performance}}, \code{\link{h2o.giniCoef}},

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -46,7 +46,7 @@
 #'        values can lead to more overfitting. Defaults to 1024.
 #' @param r2_stopping r2_stopping is no longer supported and will be ignored if set - please use stopping_rounds, stopping_metric
 #'        and stopping_tolerance instead. Previous version of H2O would stop making trees when the R^2 metric equals or
-#'        exceeds this Defaults to 1.7976931348623157e+308.
+#'        exceeds this Defaults to 1.79769313486e+308.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
@@ -61,7 +61,7 @@
 #'        Defaults to False.
 #' @param mtries Number of variables randomly sampled as candidates at each split. If set to -1, defaults to sqrt{p} for
 #'        classification and p/3 for regression (where p is the # of predictors Defaults to -1.
-#' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 0.6320000290870667.
+#' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 0.632000029087.
 #' @param sample_rate_per_class Row sample rate per tree per class (from 0.0 to 1.0)
 #' @param binomial_double_trees \code{Logical}. For binary classification: Build 2x as many trees (one per class) - can lead to higher
 #'        accuracy. Defaults to False.
@@ -99,7 +99,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              nbins = 20,
                              nbins_top_level = 1024,
                              nbins_cats = 1024,
-                             r2_stopping = 1.7976931348623157e+308,
+                             r2_stopping = 1.79769313486e+308,
                              stopping_rounds = 0,
                              stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
                              stopping_tolerance = 0.001,
@@ -107,7 +107,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              seed = -1,
                              build_tree_one_node = FALSE,
                              mtries = -1,
-                             sample_rate = 0.6320000290870667,
+                             sample_rate = 0.632000029087,
                              sample_rate_per_class = NULL,
                              binomial_double_trees = FALSE,
                              checkpoint = NULL,


### PR DESCRIPTION
In-built line wrap function currently splits line after 120 characters which resulted in malformed URL. Using manual split instead of line wrap for '@return' docs in R API auto-gen code.