### PR TITLE
Create .h2o.getBinary() method to extract binary data from H2O (MOJOs)

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -40,11 +40,100 @@
     sprintf("%s://%s:%s/%s/%s", scheme, conn@ip, as.character(conn@port), h2oRestApiVersion, urlSuffix)
 }
 
-.h2o.doRawREST <- function(conn, h2oRestApiVersion, urlSuffix, parms, method, fileUploadInfo, getBinary = FALSE, ...) {
+.h2o.getBinary <- function(h2oRestApiVersion, urlSuffix, parms, ...){
+
+  #Get H2O connection
+  conn <- h2o.getConnection()
+
+  #Initial timeout secs
+  timeout_secs <- 0
+
+  #Some type checks
+  stopifnot(is(conn, "H2OConnection"))
+  stopifnot(is.character(urlSuffix))
+  if (missing(parms))
+    parms = list()
+  else {
+    stopifnot(is.list(parms))
+  }
+
+  if( length(list(...)) != 0 ) {
+    l <- list(...)
+  if( !is.null(l$timeout) )
+    timeout_secs <- l$timeout
+    print(timeout_secs)
+  }
+
+  #Set up curlOptions() where applicable
+  opts = curlOptions()
+  if (!is.na(conn@username)) {
+    userpwd = sprintf("%s:%s", conn@username, conn@password)
+    basicAuth = 1L
+    opts = curlOptions(userpwd = userpwd, httpauth = basicAuth, .opts = opts)
+  }
+  if (conn@https) {
+    if (conn@insecure) {
+    opts = curlOptions(ssl.verifypeer = 0L, ssl.verifyhost=0L, .opts = opts)
+   }
+  }
+  if (!is.na(conn@proxy)) {
+    opts = curlOptions(proxy = conn@proxy, .opts = opts)
+  }
+
+  #Initialize status codes/messages/payload
+  httpStatusCode = -1L
+  httpStatusMessage = ""
+  payload = ""
+
+  #Capture logging information if desired
+  if (.h2o.isLogging()) {
+    .h2o.logRest("------------------------------------------------------------")
+  .h2o.logRest("")
+  .h2o.logRest(sprintf("Time:     %s", as.character(format(Sys.time(), "%Y-%m-%d %H:%M:%OS3"))))
+  .h2o.logRest("")
+  .h2o.logRest(sprintf("%-9s %s", "GET", urlSuffix))
+  }
+
+  beginTimeSeconds = as.numeric(proc.time())[3L]
+
+  #Check for cluster_id, cookies, and finally get binary data
+  tmp <- NULL
+  header <- c('Connection' = 'close')
+  if (!is.na(conn@cluster_id)) {
+    header['X-Cluster'] = conn@cluster_id
+  }
+
+  if(!is.na(conn@cookies)) {
+    header['Cookie'] = paste0(conn@cookies, collapse=';')
+  }
+
+  h <- basicHeaderGatherer()
+  t <- basicTextGatherer(.mapUnicode = FALSE)
+  tmp <- getBinaryURL(url = urlSuffix,
+                                #Identify curl options in .opts
+                                .opts = curlOptions(customrequest = "GET",
+                                writefunction = t$update,
+                                headerfunction = h$update,
+                                useragent=R.version.string,
+                                httpheader = header,
+                                verbose = FALSE,
+                                timeout = timeout_secs,
+                                .opts = opts))
+
+  #If status !=200, then throw exception to client
+  httpStatusCode = as.numeric(h$value()["status"])
+  httpStatusMessage = h$value()["statusMessage"]
+  if (httpStatusCode != "200") {
+      stop(paste0(httpStatusMessage," -> Status: ", httpStatusCode))
+  }else{
+    return(tmp) #Return binary data if status is 200
+  }
+}
+
+.h2o.doRawREST <- function(conn, h2oRestApiVersion, urlSuffix, parms, method, fileUploadInfo, ...) {
   timeout_secs <- 0
   stopifnot(is(conn, "H2OConnection"))
   stopifnot(is.character(urlSuffix))
-  stopifnot(is.logical(getBinary))
   if (missing(parms))
     parms = list()
   else {
@@ -138,20 +227,15 @@
   if ((method == "GET") || (method == "DELETE")) {
     h <- basicHeaderGatherer()
     t <- basicTextGatherer(.mapUnicode = FALSE)
-    curlFxn <- curlPerform
-    if(getBinary){
-      curlFxn <- getBinaryURL
-    }
-    tmp <- tryCatch(curlFxn(url = url,
-                                   #Identify curl options in .opts
-                                   .opts = curlOptions(customrequest = method,
-                                                       writefunction = t$update,
-                                                       headerfunction = h$update,
-                                                       useragent=R.version.string,
-                                                       httpheader = header,
-                                                       verbose = FALSE,
-                                                       timeout = timeout_secs,
-                                                       .opts = opts)),
+    tmp <- tryCatch(curlPerform(url = url,
+                                customrequest = method,
+                                writefunction = t$update,
+                                headerfunction = h$update,
+                                useragent=R.version.string,
+                                httpheader = header,
+                                verbose = FALSE,
+                                timeout = timeout_secs,
+                                .opts = opts),
     error = function(x) { .__curlError <<- TRUE; .__curlErrorMessage <<- x$message })
     if (! .__curlError) {
       httpStatusCode = as.numeric(h$value()["status"])

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -51,9 +51,9 @@
   #Some type checks
   stopifnot(is(conn, "H2OConnection"))
   stopifnot(is.character(urlSuffix))
-  if (missing(parms))
+  if (missing(parms)){
     parms = list()
-  else {
+  }else {
     stopifnot(is.list(parms))
   }
 
@@ -73,8 +73,8 @@
   }
   if (conn@https) {
     if (conn@insecure) {
-    opts = curlOptions(ssl.verifypeer = 0L, ssl.verifyhost=0L, .opts = opts)
-   }
+      opts = curlOptions(ssl.verifypeer = 0L, ssl.verifyhost=0L, .opts = opts)
+    }
   }
   if (!is.na(conn@proxy)) {
     opts = curlOptions(proxy = conn@proxy, .opts = opts)
@@ -124,7 +124,7 @@
   httpStatusCode = as.numeric(h$value()["status"])
   httpStatusMessage = h$value()["statusMessage"]
   if (httpStatusCode != "200") {
-      stop(paste0(httpStatusMessage," -> Status: ", httpStatusCode))
+    stop(paste0(httpStatusMessage," -> Status: ", httpStatusCode))
   }else{
     return(tmp) #Return binary data if status is 200
   }

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -88,10 +88,10 @@
   #Capture logging information if desired
   if (.h2o.isLogging()) {
     .h2o.logRest("------------------------------------------------------------")
-  .h2o.logRest("")
-  .h2o.logRest(sprintf("Time:     %s", as.character(format(Sys.time(), "%Y-%m-%d %H:%M:%OS3"))))
-  .h2o.logRest("")
-  .h2o.logRest(sprintf("%-9s %s", "GET", urlSuffix))
+    .h2o.logRest("")
+    .h2o.logRest(sprintf("Time:     %s", as.character(format(Sys.time(), "%Y-%m-%d %H:%M:%OS3"))))
+    .h2o.logRest("")
+    .h2o.logRest(sprintf("%-9s %s", "GET", urlSuffix))
   }
 
   beginTimeSeconds = as.numeric(proc.time())[3L]
@@ -112,13 +112,13 @@
   tmp <- getBinaryURL(url = urlSuffix,
                                 #Identify curl options in .opts
                                 .opts = curlOptions(customrequest = "GET",
-                                writefunction = t$update,
-                                headerfunction = h$update,
-                                useragent=R.version.string,
-                                httpheader = header,
-                                verbose = FALSE,
-                                timeout = timeout_secs,
-                                .opts = opts))
+                                                    writefunction = t$update,
+                                                    headerfunction = h$update,
+                                                    useragent=R.version.string,
+                                                    httpheader = header,
+                                                    verbose = FALSE,
+                                                    timeout = timeout_secs,
+                                                    .opts = opts))
 
   #If status !=200, then throw exception to client
   httpStatusCode = as.numeric(h$value()["status"])

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -268,12 +268,12 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
         getjar = NULL
     }
     if (get_jar) {
-      urlSuffix = "h2o-genmodel.jar"
       #Build genmodel.jar file path
+      urlSuffix = .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = "h2o-genmodel.jar")
       jar.path <- paste0(path, "/h2o-genmodel.jar")
       #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
       #and write to jar.path.
-      writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, getBinary=TRUE), jar.path, useBytes = TRUE)
+      writeBin(.h2o.getBinary(urlSuffix = urlSuffix), jar.path, useBytes = TRUE)
     }
     return(paste0(pojoname,".java"))
   }
@@ -317,20 +317,21 @@ h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE) {
   model_id <- model@model_id
 
   #Build URL for MOJO
-  urlSuffix <- paste0(.h2o.__MODELS,"/",URLencode(model_id),"/mojo")
+  urlSuffix <- .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = paste0(.h2o.__MODELS,"/",model_id,"/mojo"))
 
   #Build MOJO file path and download MOJO file & perform a safe (i.e. error-checked)
   #HTTP GET request to an H2O cluster with MOJO URL
   mojo.path <- paste0(path,"/",model_id,".zip")
-  writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, getBinary=TRUE), mojo.path, useBytes = TRUE)
+  writeBin(.h2o.getBinary(urlSuffix = urlSuffix), mojo.path, useBytes = TRUE)
 
   if (get_genmodel_jar) {
-    urlSuffix = "h2o-genmodel.jar"
+    #Build URL for genmodel jar
+    urlSuffix = .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = "h2o-genmodel.jar")
     #Build genmodel.jar file path
     jar.path <- paste0(path, "/h2o-genmodel.jar")
     #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
     #and write to jar.path.
-    writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, getBinary=TRUE), jar.path, useBytes = TRUE)
+    writeBin(.h2o.getBinary(urlSuffix = urlSuffix), jar.path, useBytes = TRUE)
   }
   return(paste0(model_id,".zip"))
 }

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -255,12 +255,12 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
   pojoname = gsub("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]","_",model_id,perl=T)
 
   #Path to save POJO, if `path` is provided
-  file.path <- paste0(path, "/", pojoname, ".java")
+  file_path <- file.path(path, paste0(pojoname, ".java"))
 
   if( is.null(path) ){
     cat(java) #Pretty print POJO
   } else {
-    write(java, file=file.path) #Write POJO to specified path
+    write(java, file=file_path) #Write POJO to specified path
     # getjar is now deprecated and the new arg name is get_jar
     if (!is.null(getjar)) {
         warning("The `getjar` argument is DEPRECATED; use `get_jar` instead as `getjar` will eventually be removed")
@@ -270,7 +270,7 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
     if (get_jar) {
       #Build genmodel.jar file path
       urlSuffix = .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = "h2o-genmodel.jar")
-      jar.path <- paste0(path, "/h2o-genmodel.jar")
+      jar.path <- file.path(path, "h2o-genmodel.jar")
       #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
       #and write to jar.path.
       writeBin(.h2o.getBinary(urlSuffix = urlSuffix), jar.path, useBytes = TRUE)
@@ -321,14 +321,14 @@ h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE) {
 
   #Build MOJO file path and download MOJO file & perform a safe (i.e. error-checked)
   #HTTP GET request to an H2O cluster with MOJO URL
-  mojo.path <- paste0(path,"/",model_id,".zip")
+  mojo.path <- file.path(path, paste0(model_id,".zip"))
   writeBin(.h2o.getBinary(urlSuffix = urlSuffix), mojo.path, useBytes = TRUE)
 
   if (get_genmodel_jar) {
     #Build URL for genmodel jar
     urlSuffix = .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = "h2o-genmodel.jar")
     #Build genmodel.jar file path
-    jar.path <- paste0(path, "/h2o-genmodel.jar")
+    jar.path <- file.path(path,"h2o-genmodel.jar")
     #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
     #and write to jar.path.
     writeBin(.h2o.getBinary(urlSuffix = urlSuffix), jar.path, useBytes = TRUE)

--- a/h2o-r/tests/testdir_misc/runit_h2oconfig.R
+++ b/h2o-r/tests/testdir_misc/runit_h2oconfig.R
@@ -4,7 +4,8 @@ source("../../scripts/h2o-r-test-setup.R")
 test.config <- function() {
 
     #Set up testing framework
-    dir <- sandbox()
+    dir <- paste0(sandbox(),"/configresults")
+    dir.create(dir)
     h2oconfig_filename <- paste0(dir,"/.h2oconfig")
     fileConn <- file(h2oconfig_filename)
 

--- a/h2o-r/tests/testdir_misc/runit_mojo.R
+++ b/h2o-r/tests/testdir_misc/runit_mojo.R
@@ -2,9 +2,18 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
 
 test.mojo <- function() {
+	dir <- paste0(sandbox(),"/mojoresults")
+	dir.create(dir)
 	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
 	hh <- h2o.gbm(x=c(1,2,3,4),y=5,training_frame=iris.hex)
-	h2o.download_mojo(hh) #check mojo
-	h2o.download_mojo(hh,get_genmodel_jar=TRUE) #Check genmodel.jar
+	h2o.download_mojo(hh,path=dir) #check mojo
+	h2o.download_mojo(hh,get_genmodel_jar=TRUE,path=dir) #Check genmodel.jar
+
+	#Get MOJO and check size is adequate (> 1 byte)
+	mojo <- unzip(paste0(dir,"/",hh@model_id,".zip"), exdir = dir)
+	expect_true(object.size(mojo) > 1)
+
+	#Delete direcory on exit
+	on.exit(unlink(dir,recursive=TRUE))
 }
 doTest("Test MOJO", test.mojo)

--- a/h2o-r/tests/testdir_misc/runit_mojo.R
+++ b/h2o-r/tests/testdir_misc/runit_mojo.R
@@ -11,7 +11,7 @@ test.mojo <- function() {
 
 	#Get MOJO and check size is adequate (> 1 byte)
 	mojo <- unzip(paste0(dir,"/",hh@model_id,".zip"), exdir = dir)
-	expect_true(object.size(mojo) > 1)
+	expect_true(object.size(mojo) > 1) # Check for PUBDEV-3819: R h2o.download_mojo broken - writes a 1 byte file
 
 	#Delete direcory on exit
 	on.exit(unlink(dir,recursive=TRUE))


### PR DESCRIPTION
* This PR creates a method .h2o.getBinary(), which will conduct a safe GET call to an H2O server in regards to getting binary data. This is useful for getting MOJOs.
* Also, this PR include updating the MOJO/h2oconfig test.