### PR TITLE
PUBDEV-3864: Import files by pattern

### DIFF
--- a/h2o-bindings/src/main/java/water/bindings/examples/Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/Example.java
@@ -90,7 +90,7 @@ public class Example {
 
         try {
             // STEP 1: import raw file
-            ImportFilesV3 importBody = importService.importFiles("http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz", null).execute().body();
+            ImportFilesV3 importBody = importService.importFiles("http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz", null, null).execute().body();
             System.out.println("import: " + importBody);
 
             // STEP 2: parse setup

--- a/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
@@ -20,7 +20,7 @@ public class GBM_Example {
 
         // STEP 1: import raw file
         ImportFilesV3 importBody = h2o.importFiles(
-            "http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz"
+            "http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz", null
           );
         System.out.println("import: " + importBody);
 

--- a/h2o-bindings/src/main/java/water/bindings/examples/retrofit/ImportPatternExample.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/retrofit/ImportPatternExample.java
@@ -1,0 +1,120 @@
+package water.bindings.examples.retrofit;
+
+import water.bindings.H2oApi;
+import water.bindings.pojos.*;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ImportPatternExample {
+
+    public static void importPatternExample(String url) throws IOException {
+        H2oApi h2o = url != null ? new H2oApi(url) : new H2oApi();
+
+        //Set url
+        if (url != null) {
+            h2o.setUrl(url);
+        }
+
+        //Util var
+        JobV3 job = null;
+
+        //Init h2o session
+        String sessionId = h2o.newSession().sessionKey;
+
+
+        //Import and parse files based on regex pattern
+        { //prostate dataset (Single file)
+            String pattern = "prostate_0.*"; //Regex pattern of file to import
+            ImportFilesV3 importBody = h2o.importFiles("../smalldata/junit/parse_folder", pattern);
+            ParseSetupV3 parseSetupParams = new ParseSetupV3();
+            parseSetupParams.sourceFrames = H2oApi.stringArrayToKeyArray(importBody.destinationFrames, FrameKeyV3.class);
+            parseSetupParams.checkHeader = 1;
+            ParseSetupV3 parseSetupBody = h2o.guessParseSetup(parseSetupParams);
+
+            ParseV3 parseParms = new ParseV3();
+            H2oApi.copyFields(parseParms, parseSetupBody);
+            parseParms.destinationFrame = H2oApi.stringToFrameKey("prostate");
+            parseParms.blocking = true;
+            ParseV3 parseBody = h2o.parse(parseParms);
+
+            assert importBody.files.length == 1;
+            String[] parsedFiles = new String[importBody.files.length];
+            for(int i = 0; i < importBody.files.length; i ++){
+                parsedFiles[i] = importBody.files[i].substring(importBody.files[0].lastIndexOf("/")+1);
+            }
+            String[] result = {"prostate_0.csv"};
+            assert parseBody.numberColumns == 9;
+            assert parseBody.rows == 10;
+            String[] colNames = {"ID", "CAPSULE", "AGE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON"};
+            assert Arrays.equals(parseBody.columnNames,colNames);
+        }
+
+        { //iris dataset (Single file)
+            String pattern = "iris_.*_correct.*"; //Regex pattern of file to import
+            ImportFilesV3 importBody = h2o.importFiles("../smalldata/iris", pattern);
+            ParseSetupV3 parseSetupParams = new ParseSetupV3();
+            parseSetupParams.sourceFrames = H2oApi.stringArrayToKeyArray(importBody.destinationFrames, FrameKeyV3.class);
+            parseSetupParams.checkHeader = 1;
+            ParseSetupV3 parseSetupBody = h2o.guessParseSetup(parseSetupParams);
+
+            ParseV3 parseParms = new ParseV3();
+            H2oApi.copyFields(parseParms, parseSetupBody);
+            parseParms.destinationFrame = H2oApi.stringToFrameKey("iris");
+            parseParms.blocking = true;
+            ParseV3 parseBody = h2o.parse(parseParms);
+
+            assert importBody.files.length == 1;
+            String[] parsedFiles = new String[importBody.files.length];
+            for(int i = 0; i < importBody.files.length; i ++){
+                parsedFiles[i] = importBody.files[i].substring(importBody.files[i].lastIndexOf("/")+1);
+            }
+            String[] result = {"iris_wheader_correct.csv"};
+            assert Arrays.equals(parsedFiles,result);
+            assert parseBody.numberColumns == 5;
+            assert parseBody.rows == 150;
+            String[] colNames = {"sepal_length", "sepal_width", "petal_length", "petal_width", "species"};
+            assert Arrays.equals(parseBody.columnNames,colNames);
+        }
+
+        { //GBM datasets (Multiple files)
+            String pattern = "50_.*"; //Regex pattern of files to import
+            ImportFilesV3 importBody = h2o.importFiles("../smalldata/gbm_test", pattern);
+            ParseSetupV3 parseSetupParams = new ParseSetupV3();
+            parseSetupParams.sourceFrames = H2oApi.stringArrayToKeyArray(importBody.destinationFrames, FrameKeyV3.class);
+            parseSetupParams.checkHeader = 1;
+            ParseSetupV3 parseSetupBody = h2o.guessParseSetup(parseSetupParams);
+
+            ParseV3 parseParms = new ParseV3();
+            H2oApi.copyFields(parseParms, parseSetupBody);
+            parseParms.destinationFrame = H2oApi.stringToFrameKey("50cat");
+            parseParms.blocking = true;
+            ParseV3 parseBody = h2o.parse(parseParms);
+
+            assert importBody.files.length == 2;
+            String[] parsedFiles = new String[importBody.files.length];
+            for(int i = 0; i < importBody.files.length; i ++){
+                parsedFiles[i] = importBody.files[i].substring(importBody.files[i].lastIndexOf("/")+1);
+            }
+            String[] result = {"50_cattest_train.csv","50_cattest_test.csv"};
+            Arrays.sort(result);
+            Arrays.sort(parsedFiles);
+            assert Arrays.equals(parsedFiles,result);
+            assert parseBody.numberColumns == 3;
+            assert parseBody.rows == 5000;
+            String[] colNames = {"x1","x2","y"};
+            assert Arrays.equals(parseBody.columnNames,colNames);
+        }
+
+        // STEP 99: end the session
+        h2o.endSession();
+    }
+
+    public static void importPatternExample() throws IOException {
+        importPatternExample(null);
+    }
+
+    public static void main (String[] args) throws IOException {
+        importPatternExample();
+    }
+}
+

--- a/h2o-bindings/src/main/java/water/bindings/examples/retrofit/Merge_Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/retrofit/Merge_Example.java
@@ -26,7 +26,7 @@ public class Merge_Example {
 
         // import and parse files
         { // tourism
-          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/tourism.csv");
+          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/tourism.csv", null);
           ParseSetupV3 parseSetupParams = new ParseSetupV3();
           parseSetupParams.sourceFrames = H2oApi.stringArrayToKeyArray(importBody.destinationFrames, FrameKeyV3.class);
           parseSetupParams.checkHeader = 1;
@@ -40,7 +40,7 @@ public class Merge_Example {
         }
 
         { // heart
-          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/heart.csv");
+          ImportFilesV3 importBody = h2o.importFiles("../smalldata/merge/heart.csv", null);
           ParseSetupV3 parseSetupParams = new ParseSetupV3();
           parseSetupParams.sourceFrames = H2oApi.stringArrayToKeyArray(importBody.destinationFrames, FrameKeyV3.class);
           parseSetupParams.checkHeader = 1;

--- a/h2o-bindings/src/test/java/water/bindings/examples/retrofit/ImportPatternExampleTest.java
+++ b/h2o-bindings/src/test/java/water/bindings/examples/retrofit/ImportPatternExampleTest.java
@@ -1,0 +1,13 @@
+package water.bindings.examples.retrofit;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ImportPatternExampleTest extends ExampleTestFixture {
+
+    @Test
+    public void testRun() throws IOException {
+        ImportPatternExample.importPatternExample(getH2OUrl());
+    }
+}

--- a/h2o-core/src/main/java/water/api/ImportFilesHandler.java
+++ b/h2o-core/src/main/java/water/api/ImportFilesHandler.java
@@ -21,7 +21,7 @@ public class ImportFilesHandler extends Handler {
     ArrayList<String> fails = new ArrayList();
     ArrayList<String> dels = new ArrayList();
 
-    H2O.getPM().importFiles(importFiles.path, files, keys, fails, dels);
+    H2O.getPM().importFiles(importFiles.path, importFiles.pattern, files, keys, fails, dels);
 
     importFiles.files = files.toArray(new String[files.size()]);
     importFiles.destination_frames = keys.toArray(new String[keys.size()]);

--- a/h2o-core/src/main/java/water/api/schemas3/ImportFilesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportFilesV3.java
@@ -7,6 +7,7 @@ public class ImportFilesV3 extends RequestSchemaV3<ImportFilesV3.ImportFiles, Im
 
   public final static class ImportFiles extends Iced {
     public String path;
+    public String pattern;
     public String files[];
     public String destination_frames[];
     public String fails[];
@@ -16,6 +17,9 @@ public class ImportFilesV3 extends RequestSchemaV3<ImportFilesV3.ImportFiles, Im
   // Input fields
   @API(help = "path", required = true)
   public String path;
+
+  @API(help = "pattern", direction = API.Direction.INPUT)
+  public String pattern;
 
   // Output fields
   @API(help = "files", direction = API.Direction.OUTPUT)

--- a/h2o-core/src/main/java/water/persist/Persist.java
+++ b/h2o-core/src/main/java/water/persist/Persist.java
@@ -49,7 +49,7 @@ public abstract class Persist {
    */
   abstract public List<String> calcTypeaheadMatches(String filter, int limit);
 
-  abstract public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels);
+  abstract public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels);
 
   // The filename can be either byte encoded if it starts with % followed by
   // a number, or is a normal key name with special characters encoded in

--- a/h2o-core/src/main/java/water/persist/PersistFS.java
+++ b/h2o-core/src/main/java/water/persist/PersistFS.java
@@ -99,7 +99,7 @@ final class PersistFS extends Persist {
   }
 
   @Override
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
     assert false;
   }
 

--- a/h2o-core/src/main/java/water/persist/PersistManager.java
+++ b/h2o-core/src/main/java/water/persist/PersistManager.java
@@ -16,7 +16,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 /**
  * One true persistence manager which hides the implementations from H2O.
  * In particular, HDFS support or S3 support may or may not exist depending
@@ -239,12 +240,13 @@ public class PersistManager {
    * importFiles(importFiles.path, files, keys, fails, dels);
    *
    * @param path  (Input) Path to import data from
+   * @param pattern (Input) Regex pattern to match files by
    * @param files (Output) List of files found
    * @param keys  (Output) List of keys corresponding to files
    * @param fails (Output) List of failed files which mismatch among nodes
    * @param dels  (Output) I don't know what this is
    */
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
     String s = path.toLowerCase(); // path must not be null
     if( s.startsWith("http:") || s.startsWith("https:") ) {
       try {
@@ -258,24 +260,33 @@ public class PersistManager {
       } catch( Throwable e) {
         fails.add(path); // Fails for e.g. broken sockets silently swallow exceptions and just record the failed path
       }
-      return;
     }
-
-    if(s.startsWith("s3:")) {
+    else if(s.startsWith("s3:")) {
       if (I[Value.S3] == null) throw new H2OIllegalArgumentException("S3 support is not configured");
-      I[Value.S3].importFiles(path, files, keys, fails, dels);
-      return;
+      I[Value.S3].importFiles(path, pattern, files, keys, fails, dels);
     }
-    if( s.startsWith("hdfs:") ||
+    else if( s.startsWith("hdfs:") ||
         s.startsWith("s3n:") || 
         s.startsWith("s3a:") || 
         s.startsWith("maprfs:")) {
       if (I[Value.HDFS] == null) throw new H2OIllegalArgumentException("HDFS, S3N, and S3A support is not configured");
-      I[Value.HDFS].importFiles(path, files, keys, fails, dels);
-      return;
+      I[Value.HDFS].importFiles(path, pattern, files, keys, fails, dels);
     }
-    // Attempt NFS import instead
-    I[Value.NFS].importFiles(path, files, keys, fails, dels);
+    else {
+      // Attempt NFS import instead
+      I[Value.NFS].importFiles(path, pattern, files, keys, fails, dels);
+    }
+
+    if(pattern != null && !pattern.isEmpty()) {
+      files.retainAll(matchPattern(path,files,pattern)); //New files ArrayList after matching pattern of choice
+      keys.retainAll(matchPattern(path,keys,pattern)); //New keys ArrayList after matching pattern of choice
+      //New fails ArrayList after matching pattern of choice. Only show failures that match pattern
+      if(!fails.isEmpty()) {
+        fails.retainAll(matchPattern(path, fails, pattern));
+      }
+    }
+
+    return;
   }
 
 
@@ -479,7 +490,7 @@ public class PersistManager {
       return I[Value.ICE];
     }
 
-    if (scheme != null ) {
+    if (scheme != null) {
       switch (scheme) {
         case Schemes.FILE:
           return I[Value.ICE]; // Local FS
@@ -496,4 +507,45 @@ public class PersistManager {
       return I[Value.ICE];
     }
   }
+
+  /**
+   * Finds all entries in the list that matches the regex
+   * @param prefix The substring to extract before pattern matching
+   * @param fileList The list of strings to check
+   * @param matchStr The regular expression to use on the string after prefix
+   * @return list containing the matching entries
+   */
+  public ArrayList<String> matchPattern(String prefix, ArrayList<String> fileList, String matchStr){
+    ArrayList<String> result = new ArrayList<String>();
+    Pattern pattern = Pattern.compile(matchStr);
+    if (matchStr != null) {
+      for(String s : fileList){
+        Matcher matcher = pattern.matcher(afterPrefix(s,prefix));
+        if (matcher.find()) {
+          result.add(s);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns the part of the string that occurs after the first index of the substring
+   * @param wholeString A string that needs to be subsetted
+   * @param substring The substring to extract
+   * @return string after substring
+   */
+  private static String afterPrefix(String wholeString , String substring) {
+    // Returns a substring containing all characters after a string.
+    int posSubstring = wholeString.lastIndexOf(substring);
+    if (posSubstring == -1) {
+      return "";
+    }
+    int adjustedPosSubstring = posSubstring + substring.length();
+    if (adjustedPosSubstring >= wholeString.length()) {
+      return "";
+    }
+    return wholeString.substring(adjustedPosSubstring);
+  }
+
 }

--- a/h2o-core/src/main/java/water/persist/PersistNFS.java
+++ b/h2o-core/src/main/java/water/persist/PersistNFS.java
@@ -130,7 +130,7 @@ public final class PersistNFS extends Persist {
   }
 
   @Override
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
     File f = new File(path);
     if( !f.exists() ) throw new H2ONotFoundArgumentException("File " + path + " does not exist");
     FileIntegrityChecker.check(f).syncDirectory(files,keys,fails,dels);

--- a/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
@@ -390,7 +390,7 @@ public final class PersistHdfs extends Persist {
   }
 
   @Override
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
 //    path = convertS3toS3N(path);
 
     // Fix for S3 kind of URL

--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -142,7 +142,7 @@ public final class PersistS3 extends Persist {
       }
     }
   }
-  public void importFiles(String path, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
+  public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
     Log.info("ImportS3 processing (" + path + ")");
     // List of processed files
     AmazonS3 s3 = getClient();

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -311,10 +311,10 @@ class H2OFrame(object):
 
 
 
-    def _import_parse(self, path, destination_frame, header, separator, column_names, column_types, na_strings):
+    def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings):
         if is_type(path, str) and "://" not in path:
             path = os.path.abspath(path)
-        rawkey = h2o.lazy_import(path)
+        rawkey = h2o.lazy_import(path, pattern)
         self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings)
         return self
 

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -61,6 +61,14 @@
 #' prostate.hex = h2o.importFile(path = prosPath, destination_frame = "prostate.hex")
 #' class(prostate.hex)
 #' summary(prostate.hex)
+#'
+#' #Import files with a certain regex pattern by utilizing h2o.importFolder()
+#' #In this example we import all .csv files in the directory prostate_folder
+#' prosPath = system.file("extdata", "prostate_folder", package = "h2o")
+#' prostate_pattern.hex = h2o.importFolder(path = prosPath, pattern = ".*.csv",
+#'                         destination_frame = "prostate.hex")
+#' class(prostate_pattern.hex)
+#' summary(prostate_pattern.hex)
 #' }
 
 
@@ -87,14 +95,14 @@ h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse =
     destFrames <- c()
     fails <- c()
     for(path2 in path){
-      res <-.h2o.__remoteSend(.h2o.__IMPORT, path=path2)
+      res <-.h2o.__remoteSend(.h2o.__IMPORT, path=path2,pattern=pattern)
       destFrames <- c(destFrames, res$destination_frames)
       fails <- c(fails, res$fails)
     }
     res$destination_frames <- destFrames
     res$fails <- fails
   } else {
-    res <- .h2o.__remoteSend(.h2o.__IMPORT, path=path)
+    res <- .h2o.__remoteSend(.h2o.__IMPORT, path=path,pattern=pattern)
   }
 
   if(length(res$fails) > 0L) {
@@ -103,16 +111,11 @@ h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse =
   }
   # Return only the files that successfully imported
   if(length(res$files) <= 0L) stop("all files failed to import")
-  if(parse) {
-    if(pattern=="") {srcKey <- res$destination_frames
-    } else {srcKey  <- res$destination_frames[grepl(pattern,res$destination_frames)]}
-    if(length(srcKey)>0){
-      return( h2o.parseRaw(data=.newH2OFrame(op="ImportFolder",id=srcKey,-1,-1), destination_frame=destination_frame,
-                           header=header, sep=sep, col.names=col.names, col.types=col.types, na.strings=na.strings) )
-    }else{
-      stop("all files failed to import - No file has this `pattern` ")
-    }
-  }
+if(parse) {
+    srcKey <- res$destination_frames
+    return( h2o.parseRaw(data=.newH2OFrame(op="ImportFolder",id=srcKey,-1,-1),pattern=pattern, destination_frame=destination_frame,
+            header=header, sep=sep, col.names=col.names, col.types=col.types, na.strings=na.strings) )
+}
   myData <- lapply(res$destination_frames, function(x) .newH2OFrame( op="ImportFolder", id=x,-1,-1))  # do not gc, H2O handles these nfs:// vecs
   if(length(res$destination_frames) == 1L)
     return( myData[[1L]] )

--- a/h2o-r/h2o-package/R/parse.R
+++ b/h2o-r/h2o-package/R/parse.R
@@ -6,6 +6,8 @@
 #' Parse the Raw Data produced by the import phase.
 #'
 #' @param data An H2OFrame object to be parsed.
+#' @param pattern (Optional) Character string containing a regular expression to match file(s) in
+#'        the folder.
 #' @param destination_frame (Optional) The hex key assigned to the parsed file.
 #' @param header (Optional) A logical value indicating whether the first row is
 #'        the column header. If missing, H2O will automatically try to detect
@@ -26,9 +28,9 @@
 #' @param chunk_size size of chunk of (input) data in bytes
 #' @seealso \link{h2o.importFile}, \link{h2o.parseSetup}
 #' @export
-h2o.parseRaw <- function(data, destination_frame = "", header=NA, sep = "", col.names=NULL,
+h2o.parseRaw <- function(data, pattern="", destination_frame = "", header=NA, sep = "", col.names=NULL,
                          col.types=NULL, na.strings=NULL, blocking=FALSE, parse_type = NULL, chunk_size = NULL) {
-  parse.params <- h2o.parseSetup(data, destination_frame, header, sep, col.names, col.types,
+  parse.params <- h2o.parseSetup(data, pattern="", destination_frame, header, sep, col.names, col.types,
                                  na.strings = na.strings, parse_type = parse_type, chunk_size = chunk_size)
   for(w in parse.params$warnings){
     cat('WARNING:',w,'\n')
@@ -76,19 +78,10 @@ h2o.parseRaw <- function(data, destination_frame = "", header=NA, sep = "", col.
   if(!is.character(path) || is.na(path) || !nzchar(path)) stop("`path` must be a non-empty character string")
   if(!is.character(pattern) || length(pattern) != 1L || is.na(pattern)) stop("`pattern` must be a character string")
   .key.validate(destination_frame)
-  if(length(path) > 1L) {
-    destFrames <- c()
-    fails <- c()
-    for(path2 in path){
-      res <-.h2o.__remoteSend(.h2o.__IMPORT, path=path2)
-      destFrames <- c(destFrames, res$destination_frames)
-      fails <- c(fails, res$fails)
-    }
-    res$destination_frames <- destFrames
-    res$fails <- fails
-  } else {
-    res <- .h2o.__remoteSend(.h2o.__IMPORT, path=path)
-  }
+  res <-.h2o.__remoteSend(.h2o.__IMPORT, path=path, pattern=pattern)
+  destFrame <- res$destination_frames
+  fails <- res$fails
+
   if(length(res$fails) > 0L) {
     for(i in seq_len(length(res$fails)))
       cat(res$fails[[i]], "failed to import")
@@ -116,7 +109,7 @@ h2o.parseRaw <- function(data, destination_frame = "", header=NA, sep = "", col.
 #' @inheritParams h2o.parseRaw
 #' @seealso \link{h2o.parseRaw}
 #' @export
-h2o.parseSetup <- function(data, destination_frame = "", header = NA, sep = "", col.names = NULL, col.types = NULL,
+h2o.parseSetup <- function(data, pattern="", destination_frame = "", header = NA, sep = "", col.names = NULL, col.types = NULL,
                            na.strings = NULL, parse_type = NULL, chunk_size = NULL) {
 
   # Allow single frame or list of frames; turn singleton into a list


### PR DESCRIPTION
* This PR adds support for importing files by supplying a pattern argument
* Some examples of this are: 

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="/A/.*/iris_.*")` -> Import all files that have the pattern `/A/.*/iris_.*` in the directory`test/`

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="/A/iris_.*")`  -> Import all files that have the pattern `/A/iris_.*` in the directory `test/`

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="/A/B/iris_.*")` -> Import all files that have the pattern `/A/B/iris_.*` in the directory `test/`

- `h2o.importFolder(paste0(getwd(),"/test"),pattern="iris_.*")` -> Import all files that have the pattern `iris_.*` in the directory `test/`