### PR TITLE
speed-up as.h2o by fixing colnames, part of PUBDEV-3821

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1406,7 +1406,16 @@ names.H2OFrame <- function(x) .Primitive("names")(.fetch.data(x,1L))
 #' @param prefix for created names.
 #' @export
 colnames <- function(x, do.NULL=TRUE, prefix = "col") {
-  if( !is.H2OFrame(x) ) return(base::colnames(x,do.NULL,prefix))
+  if (is.data.frame(x)) {
+    # PUBDEV-3821 workaround for slow do.NULL=F
+    nm <- names(x)
+    if (do.NULL || !is.null(nm))
+      return(nm)
+    else
+      return(paste0(prefix, seq_along(x)))
+  }
+  if (!is.H2OFrame(x))
+    return(base::colnames(x,do.NULL=do.NULL,prefix=prefix))
   return(names.H2OFrame(x))
 }
 


### PR DESCRIPTION
Further improvements to as.h2o after PUBDEV-2844. Timings below includes `data.table::fwrite` improvement and `colnames` improvement. It is important to note that this speedup highly depends on data. On numerical columns only `colnames` fix does not make difference.
```r
library(h2o)
h2o.init(nthreads=-1)
h2o.no_progress()
N=1e7; K=100
set.seed(1)
DF <- data.frame(
  id1 = sample(sprintf("id%03d",1:K), N, TRUE),      # large groups (char)
  id2 = sample(sprintf("id%03d",1:K), N, TRUE),      # large groups (char)
  id3 = sample(sprintf("id%010d",1:(N/K)), N, TRUE), # small groups (char)
  id4 = sample(K, N, TRUE),                          # large groups (int)
  id5 = sample(K, N, TRUE),                          # large groups (int)
  id6 = sample(N/K, N, TRUE),                        # small groups (int)
  v1 =  sample(5, N, TRUE),                          # int in range [1,5]
  v2 =  sample(5, N, TRUE),                          # int in range [1,5]
  v3 =  sample(round(runif(100,max=100),4), N, TRUE) # numeric e.g. 23.5749
)
cat("GB =", round(sum(gc()[,2])/1024, 3), "\n")
#GB = 0.404

### restart R session between each timing below

# no data.table, base::colnames
options("h2o.use.data.table"=FALSE)
system.time(hf1 <- as.h2o(DF))
#   user  system elapsed 
# 72.931   3.094  80.518 

# use data.table, base::colnames
options("h2o.use.data.table"=TRUE)
system.time(hf2 <- as.h2o(DF))
#   user  system elapsed 
# 28.193   2.095  18.292

## install branch from PUBDEV-3821

# no data.table, fixed colnames
options("h2o.use.data.table"=FALSE)
system.time(hf3 <- as.h2o(DF))
#   user  system elapsed 
# 54.750   2.319  62.227

# use data.table, fixed colnames
options("h2o.use.data.table"=TRUE)
system.time(hf4 <- as.h2o(DF))
#   user  system elapsed 
# 17.233   1.801   7.462 
```
Fixed `colnames` and `data.table::fwrite` were able to reduce time from 80s to 7s for this dataset - we use it in _grouping_ benchmarks.