### PR TITLE
Generate consistent float values for R API

### DIFF
--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -58,7 +58,7 @@ def gen_module(schema, algo, module):
         if param["values"]:
             phelp += " Must be one of: %s." % ", ".join('"%s"' % p for p in param["values"])
         if param["default_value"] is not None:
-            phelp += " Defaults to %s." % param["default_value"]
+            phelp += " Defaults to %s." % normalize_value(param, True)
         yield "#' @param %s %s" % (param["name"], bi.wrap(phelp, indent=("#'        "), indent_first=False))
     if help_details:
         yield "#' @details %s" % bi.wrap(help_details, indent=("#'          "), indent_first=False)
@@ -836,18 +836,20 @@ def algo_to_modelname(algo):
 def indent(string, n):
     return " " * n + string
 
-def normalize_value(param):
-    if param["type"][:4] == "enum":
+def normalize_value(param, is_help = False):
+    if not(is_help) and param["type"][:4] == "enum":
         return "c(%s)" % ", ".join('"%s"' % p for p in param["values"])
     if param["default_value"] is None:
         if param["type"] in ["short", "int", "long", "double"]:
             return 0
         else:
             return "NULL"
-    if "[]" in param["type"]:
+    if not(is_help) and "[]" in param["type"]:
         return "c(%s)" % ", ".join('%s' % p for p in param["default_value"])
     if param["type"] == "boolean":
         return str(param["default_value"]).upper()
+    if param["type"] == "double":
+        return '%.10g' % param["default_value"]
     return param["default_value"]
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -15,20 +15,20 @@
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
 #' @param nfolds Number of folds for N-fold cross-validation (0 to disable or >= 2). Defaults to 0.
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to False.
-#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to False.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to FALSE.
+#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to FALSE.
 #' @param fold_assignment Cross-validation fold assignment scheme, if fold_column is not specified. The 'Stratified' option will
 #'        stratify the folds based on the response variable, for classification problems. Must be one of: "AUTO",
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative
 #'        weights are not allowed.
 #' @param offset_column Offset column. This will be added to the combination of columns before applying the link function.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        False.
+#'        FALSE.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
 #'        be automatically computed to obtain class balance during training. Requires balance_classes.
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
@@ -38,42 +38,42 @@
 #' @param checkpoint Model checkpoint to resume training with.
 #' @param pretrained_autoencoder Pretrained autoencoder model to initialize this model with.
 #' @param overwrite_with_best_model \code{Logical}. If enabled, override the final model with the best model found during training. Defaults to
-#'        True.
+#'        TRUE.
 #' @param use_all_factor_levels \code{Logical}. Use all factor levels of categorical variables. Otherwise, the first factor level is omitted
 #'        (without loss of accuracy). Useful for variable importances and auto-enabled for autoencoder. Defaults to
-#'        True.
+#'        TRUE.
 #' @param standardize \code{Logical}. If enabled, automatically standardize the data. If disabled, the user must provide properly
-#'        scaled input data. Defaults to True.
+#'        scaled input data. Defaults to TRUE.
 #' @param activation Activation function. Must be one of: "Tanh", "TanhWithDropout", "Rectifier", "RectifierWithDropout", "Maxout",
 #'        "MaxoutWithDropout". Defaults to Rectifier.
 #' @param hidden Hidden layer sizes (e.g. [100, 100]). Defaults to [200, 200].
-#' @param epochs How many times the dataset should be iterated (streamed), can be fractional. Defaults to 10.0.
+#' @param epochs How many times the dataset should be iterated (streamed), can be fractional. Defaults to 10.
 #' @param train_samples_per_iteration Number of training samples (globally) per MapReduce iteration. Special values are 0: one epoch, -1: all
 #'        available data (e.g., replicated training data), -2: automatic. Defaults to -2.
 #' @param target_ratio_comm_to_comp Target ratio of communication overhead to computation. Only for multi-node operation and
 #'        train_samples_per_iteration = -2 (auto-tuning). Defaults to 0.05.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
-#' @param adaptive_rate \code{Logical}. Adaptive learning rate. Defaults to True.
+#' @param adaptive_rate \code{Logical}. Adaptive learning rate. Defaults to TRUE.
 #' @param rho Adaptive learning rate time decay factor (similarity to prior updates). Defaults to 0.99.
 #' @param epsilon Adaptive learning rate smoothing factor (to avoid divisions by zero and allow progress). Defaults to 1e-08.
 #' @param rate Learning rate (higher => less stable, lower => slower convergence). Defaults to 0.005.
 #' @param rate_annealing Learning rate annealing: rate / (1 + rate_annealing * samples). Defaults to 1e-06.
-#' @param rate_decay Learning rate decay factor between layers (N-th layer: rate * rate_decay ^ (n - 1). Defaults to 1.0.
-#' @param momentum_start Initial momentum at the beginning of training (try 0.5). Defaults to 0.0.
-#' @param momentum_ramp Number of training samples for which momentum increases. Defaults to 1000000.0.
-#' @param momentum_stable Final momentum after the ramp is over (try 0.99). Defaults to 0.0.
-#' @param nesterov_accelerated_gradient \code{Logical}. Use Nesterov accelerated gradient (recommended). Defaults to True.
-#' @param input_dropout_ratio Input layer dropout ratio (can improve generalization, try 0.1 or 0.2). Defaults to 0.0.
+#' @param rate_decay Learning rate decay factor between layers (N-th layer: rate * rate_decay ^ (n - 1). Defaults to 1.
+#' @param momentum_start Initial momentum at the beginning of training (try 0.5). Defaults to 0.
+#' @param momentum_ramp Number of training samples for which momentum increases. Defaults to 1000000.
+#' @param momentum_stable Final momentum after the ramp is over (try 0.99). Defaults to 0.
+#' @param nesterov_accelerated_gradient \code{Logical}. Use Nesterov accelerated gradient (recommended). Defaults to TRUE.
+#' @param input_dropout_ratio Input layer dropout ratio (can improve generalization, try 0.1 or 0.2). Defaults to 0.
 #' @param hidden_dropout_ratios Hidden layer dropout ratios (can improve generalization), specify one value per hidden layer, defaults to 0.5.
 #' @param l1 L1 regularization (can add stability and improve generalization, causes many weights to become 0). Defaults to
-#'        0.0.
+#'        0.
 #' @param l2 L2 regularization (can add stability and improve generalization, causes many weights to be small. Defaults to
-#'        0.0.
+#'        0.
 #' @param max_w2 Constraint for squared sum of incoming weights per unit (e.g. for Rectifier). Defaults to 3.4028235e+38.
 #' @param initial_weight_distribution Initial weight distribution. Must be one of: "UniformAdaptive", "Uniform", "Normal". Defaults to
 #'        UniformAdaptive.
-#' @param initial_weight_scale Uniform: -value...value, Normal: stddev. Defaults to 1.0.
+#' @param initial_weight_scale Uniform: -value...value, Normal: stddev. Defaults to 1.
 #' @param initial_weights A list of H2OFrame ids to initialize the weight matrices of this model with.
 #' @param initial_biases A list of H2OFrame ids to initialize the bias vectors of this model with.
 #' @param loss Loss function. Must be one of: "Automatic", "CrossEntropy", "Quadratic", "Huber", "Absolute", "Quantile".
@@ -84,11 +84,11 @@
 #' @param tweedie_power Tweedie power for Tweedie regression, must be between 1 and 2. Defaults to 1.5.
 #' @param huber_alpha Desired quantile for Huber/M-regression (threshold between quadratic and linear loss, must be between 0 and
 #'        1). Defaults to 0.9.
-#' @param score_interval Shortest time interval (in seconds) between model scoring. Defaults to 5.0.
+#' @param score_interval Shortest time interval (in seconds) between model scoring. Defaults to 5.
 #' @param score_training_samples Number of training set samples for scoring (0 for all). Defaults to 10000.
 #' @param score_validation_samples Number of validation set samples for scoring (0 for all). Defaults to 0.
 #' @param score_duty_cycle Maximum duty cycle fraction for scoring (lower: more training, higher: more scoring). Defaults to 0.1.
-#' @param classification_stop Stopping criterion for classification error fraction on training data (-1 to disable). Defaults to 0.0.
+#' @param classification_stop Stopping criterion for classification error fraction on training data (-1 to disable). Defaults to 0.
 #' @param regression_stop Stopping criterion for regression error (MSE) on training data (-1 to disable). Defaults to 1e-06.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 5.
@@ -96,38 +96,38 @@
 #'        "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
 #'        "mean_per_class_error". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
-#'        much) Defaults to 0.0.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#'        much) Defaults to 0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param score_validation_sampling Method used to sample validation dataset for scoring. Must be one of: "Uniform", "Stratified". Defaults to
 #'        Uniform.
-#' @param diagnostics \code{Logical}. Enable diagnostics for hidden layers. Defaults to True.
-#' @param fast_mode \code{Logical}. Enable fast mode (minor approximation in back-propagation). Defaults to True.
+#' @param diagnostics \code{Logical}. Enable diagnostics for hidden layers. Defaults to TRUE.
+#' @param fast_mode \code{Logical}. Enable fast mode (minor approximation in back-propagation). Defaults to TRUE.
 #' @param force_load_balance \code{Logical}. Force extra load balancing to increase training speed for small datasets (to keep all cores
-#'        busy). Defaults to True.
+#'        busy). Defaults to TRUE.
 #' @param variable_importances \code{Logical}. Compute variable importances for input features (Gedeon method) - can be slow for large
-#'        networks. Defaults to False.
+#'        networks. Defaults to FALSE.
 #' @param replicate_training_data \code{Logical}. Replicate the entire training dataset onto every node for faster training on small datasets.
-#'        Defaults to True.
-#' @param single_node_mode \code{Logical}. Run on a single node for fine-tuning of model parameters. Defaults to False.
+#'        Defaults to TRUE.
+#' @param single_node_mode \code{Logical}. Run on a single node for fine-tuning of model parameters. Defaults to FALSE.
 #' @param shuffle_training_data \code{Logical}. Enable shuffling of training data (recommended if training data is replicated and
-#'        train_samples_per_iteration is close to #nodes x #rows, of if using balance_classes). Defaults to False.
+#'        train_samples_per_iteration is close to #nodes x #rows, of if using balance_classes). Defaults to FALSE.
 #' @param missing_values_handling Handling of missing values. Either MeanImputation or Skip. Must be one of: "MeanImputation", "Skip". Defaults
 #'        to MeanImputation.
-#' @param quiet_mode \code{Logical}. Enable quiet mode for less output to standard output. Defaults to False.
-#' @param autoencoder \code{Logical}. Auto-Encoder. Defaults to False.
-#' @param sparse \code{Logical}. Sparse data handling (more efficient for data with lots of 0 values). Defaults to False.
+#' @param quiet_mode \code{Logical}. Enable quiet mode for less output to standard output. Defaults to FALSE.
+#' @param autoencoder \code{Logical}. Auto-Encoder. Defaults to FALSE.
+#' @param sparse \code{Logical}. Sparse data handling (more efficient for data with lots of 0 values). Defaults to FALSE.
 #' @param col_major \code{Logical}. #DEPRECATED Use a column major weight matrix for input layer. Can speed up forward
-#'        propagation, but might slow down backpropagation. Defaults to False.
-#' @param average_activation Average activation for sparse auto-encoder. #Experimental Defaults to 0.0.
-#' @param sparsity_beta Sparsity regularization. #Experimental Defaults to 0.0.
+#'        propagation, but might slow down backpropagation. Defaults to FALSE.
+#' @param average_activation Average activation for sparse auto-encoder. #Experimental Defaults to 0.
+#' @param sparsity_beta Sparsity regularization. #Experimental Defaults to 0.
 #' @param max_categorical_features Max. number of categorical features, enforced via hashing. #Experimental Defaults to 2147483647.
-#' @param reproducible \code{Logical}. Force reproducibility on small data (will be slow - only uses 1 thread). Defaults to False.
-#' @param export_weights_and_biases \code{Logical}. Whether to export Neural Network weights and biases to H2O Frames. Defaults to False.
+#' @param reproducible \code{Logical}. Force reproducibility on small data (will be slow - only uses 1 thread). Defaults to FALSE.
+#' @param export_weights_and_biases \code{Logical}. Whether to export Neural Network weights and biases to H2O Frames. Defaults to FALSE.
 #' @param mini_batch_size Mini-batch size (smaller leads to better fit, larger can speed up and generalize better). Defaults to 1.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen". Defaults to AUTO.
 #' @param elastic_averaging \code{Logical}. Elastic averaging between compute nodes can improve distributed model convergence.
-#'        #Experimental Defaults to False.
+#'        #Experimental Defaults to FALSE.
 #' @param elastic_averaging_moving_rate Elastic averaging moving rate (only if elastic averaging is enabled). Defaults to 0.9.
 #' @param elastic_averaging_regularization Elastic averaging regularization strength (only if elastic averaging is enabled). Defaults to 0.001.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
@@ -165,7 +165,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              standardize = TRUE,
                              activation = c("Tanh", "TanhWithDropout", "Rectifier", "RectifierWithDropout", "Maxout", "MaxoutWithDropout"),
                              hidden = c(200, 200),
-                             epochs = 10.0,
+                             epochs = 10,
                              train_samples_per_iteration = -2,
                              target_ratio_comm_to_comp = 0.05,
                              seed = -1,
@@ -174,18 +174,18 @@ h2o.deeplearning <- function(x, y, training_frame,
                              epsilon = 1e-08,
                              rate = 0.005,
                              rate_annealing = 1e-06,
-                             rate_decay = 1.0,
-                             momentum_start = 0.0,
-                             momentum_ramp = 1000000.0,
-                             momentum_stable = 0.0,
+                             rate_decay = 1,
+                             momentum_start = 0,
+                             momentum_ramp = 1000000,
+                             momentum_stable = 0,
                              nesterov_accelerated_gradient = TRUE,
-                             input_dropout_ratio = 0.0,
+                             input_dropout_ratio = 0,
                              hidden_dropout_ratios = NULL,
-                             l1 = 0.0,
-                             l2 = 0.0,
+                             l1 = 0,
+                             l2 = 0,
                              max_w2 = 3.4028235e+38,
                              initial_weight_distribution = c("UniformAdaptive", "Uniform", "Normal"),
-                             initial_weight_scale = 1.0,
+                             initial_weight_scale = 1,
                              initial_weights = NULL,
                              initial_biases = NULL,
                              loss = c("Automatic", "CrossEntropy", "Quadratic", "Huber", "Absolute", "Quantile"),
@@ -193,16 +193,16 @@ h2o.deeplearning <- function(x, y, training_frame,
                              quantile_alpha = 0.5,
                              tweedie_power = 1.5,
                              huber_alpha = 0.9,
-                             score_interval = 5.0,
+                             score_interval = 5,
                              score_training_samples = 10000,
                              score_validation_samples = 0,
                              score_duty_cycle = 0.1,
-                             classification_stop = 0.0,
+                             classification_stop = 0,
                              regression_stop = 1e-06,
                              stopping_rounds = 5,
                              stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
-                             stopping_tolerance = 0.0,
-                             max_runtime_secs = 0.0,
+                             stopping_tolerance = 0,
+                             max_runtime_secs = 0,
                              score_validation_sampling = c("Uniform", "Stratified"),
                              diagnostics = TRUE,
                              fast_mode = TRUE,
@@ -216,8 +216,8 @@ h2o.deeplearning <- function(x, y, training_frame,
                              autoencoder = FALSE,
                              sparse = FALSE,
                              col_major = FALSE,
-                             average_activation = 0.0,
-                             sparsity_beta = 0.0,
+                             average_activation = 0,
+                             sparsity_beta = 0,
                              max_categorical_features = 2147483647,
                              reproducible = FALSE,
                              export_weights_and_biases = FALSE,

--- a/h2o-r/h2o-package/R/deepwater.R
+++ b/h2o-r/h2o-package/R/deepwater.R
@@ -13,18 +13,18 @@
 #'        categorical variable).
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param checkpoint Model checkpoint to resume training with.
-#' @param autoencoder \code{Logical}. Auto-Encoder. Defaults to False.
+#' @param autoencoder \code{Logical}. Auto-Encoder. Defaults to FALSE.
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
 #' @param nfolds Number of folds for N-fold cross-validation (0 to disable or >= 2). Defaults to 0.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        False.
+#'        FALSE.
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
 #'        balance_classes. Defaults to 5.0.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
 #'        be automatically computed to obtain class balance during training. Requires balance_classes.
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to False.
-#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to False.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to FALSE.
+#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to FALSE.
 #' @param fold_assignment Cross-validation fold assignment scheme, if fold_column is not specified. The 'Stratified' option will
 #'        stratify the folds based on the response variable, for classification problems. Must be one of: "AUTO",
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
@@ -33,12 +33,12 @@
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative
 #'        weights are not allowed.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen". Defaults to AUTO.
 #' @param overwrite_with_best_model \code{Logical}. If enabled, override the final model with the best model found during training. Defaults to
-#'        True.
-#' @param epochs How many times the dataset should be iterated (streamed), can be fractional. Defaults to 10.0.
+#'        TRUE.
+#' @param epochs How many times the dataset should be iterated (streamed), can be fractional. Defaults to 10.
 #' @param train_samples_per_iteration Number of training samples (globally) per MapReduce iteration. Special values are 0: one epoch, -1: all
 #'        available data (e.g., replicated training data), -2: automatic. Defaults to -2.
 #' @param target_ratio_comm_to_comp Target ratio of communication overhead to computation. Only for multi-node operation and
@@ -46,39 +46,39 @@
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
 #' @param standardize \code{Logical}. If enabled, automatically standardize the data. If disabled, the user must provide properly
-#'        scaled input data. Defaults to True.
+#'        scaled input data. Defaults to TRUE.
 #' @param learning_rate Learning rate (higher => less stable, lower => slower convergence). Defaults to 0.005.
 #' @param learning_rate_annealing Learning rate annealing: rate / (1 + rate_annealing * samples). Defaults to 1e-06.
 #' @param momentum_start Initial momentum at the beginning of training (try 0.5). Defaults to 0.9.
-#' @param momentum_ramp Number of training samples for which momentum increases. Defaults to 10000.0.
+#' @param momentum_ramp Number of training samples for which momentum increases. Defaults to 10000.
 #' @param momentum_stable Final momentum after the ramp is over (try 0.99). Defaults to 0.99.
 #' @param distribution Distribution function Must be one of: "AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma",
 #'        "tweedie", "laplace", "quantile", "huber". Defaults to AUTO.
-#' @param score_interval Shortest time interval (in seconds) between model scoring. Defaults to 5.0.
+#' @param score_interval Shortest time interval (in seconds) between model scoring. Defaults to 5.
 #' @param score_training_samples Number of training set samples for scoring (0 for all). Defaults to 10000.
 #' @param score_validation_samples Number of validation set samples for scoring (0 for all). Defaults to 0.
 #' @param score_duty_cycle Maximum duty cycle fraction for scoring (lower: more training, higher: more scoring). Defaults to 0.1.
-#' @param classification_stop Stopping criterion for classification error fraction on training data (-1 to disable). Defaults to 0.0.
-#' @param regression_stop Stopping criterion for regression error (MSE) on training data (-1 to disable). Defaults to 0.0.
+#' @param classification_stop Stopping criterion for classification error fraction on training data (-1 to disable). Defaults to 0.
+#' @param regression_stop Stopping criterion for regression error (MSE) on training data (-1 to disable). Defaults to 0.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 5.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 #'        "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
 #'        "mean_per_class_error". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
-#'        much) Defaults to 0.0.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param shuffle_training_data \code{Logical}. Enable global shuffling of training data. Defaults to True.
+#'        much) Defaults to 0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param shuffle_training_data \code{Logical}. Enable global shuffling of training data. Defaults to TRUE.
 #' @param mini_batch_size Mini-batch size (smaller leads to better fit, larger can speed up and generalize better). Defaults to 32.
-#' @param clip_gradient Clip gradients once their absolute value is larger than this value. Defaults to 10.0.
+#' @param clip_gradient Clip gradients once their absolute value is larger than this value. Defaults to 10.
 #' @param network Network architecture. Must be one of: "auto", "user", "lenet", "alexnet", "vgg", "googlenet", "inception_bn",
 #'        "resnet". Defaults to auto.
 #' @param backend Deep Learning Backend. Must be one of: "auto", "mxnet", "caffe", "tensorflow". Defaults to mxnet.
 #' @param image_shape Width and height of image. Defaults to [0, 0].
 #' @param channels Number of (color) channels. Defaults to 3.
-#' @param sparse \code{Logical}. Sparse data handling (more efficient for data with lots of 0 values). Defaults to False.
-#' @param gpu \code{Logical}. Whether to use a GPU (if available). Defaults to True.
+#' @param sparse \code{Logical}. Sparse data handling (more efficient for data with lots of 0 values). Defaults to FALSE.
+#' @param gpu \code{Logical}. Whether to use a GPU (if available). Defaults to TRUE.
 #' @param device_id Device IDs (which GPUs to use). Defaults to [0].
 #' @param network_definition_file Path of file containing network definition (graph, architecture).
 #' @param network_parameters_file Path of file containing network (initial) parameters (weights, biases).
@@ -88,7 +88,7 @@
 #'        problem_type=dataset. Must be one of: "Rectifier", "Tanh".
 #' @param hidden Hidden layer sizes (e.g. [200, 200]). Only used if no user-defined network architecture file is provided, and
 #'        only for problem_type=dataset.
-#' @param input_dropout_ratio Input layer dropout ratio (can improve generalization, try 0.1 or 0.2). Defaults to 0.0.
+#' @param input_dropout_ratio Input layer dropout ratio (can improve generalization, try 0.1 or 0.2). Defaults to 0.
 #' @param hidden_dropout_ratios Hidden layer dropout ratios (can improve generalization), specify one value per hidden layer, defaults to 0.5.
 #' @param problem_type Problem type, auto-detected by default. If set to image, the H2OFrame must contain a string column containing
 #'        the path (URI or URL) to the images in the first column. If set to text, the H2OFrame must contain a string
@@ -114,7 +114,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           score_each_iteration = FALSE,
                           categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen"),
                           overwrite_with_best_model = TRUE,
-                          epochs = 10.0,
+                          epochs = 10,
                           train_samples_per_iteration = -2,
                           target_ratio_comm_to_comp = 0.05,
                           seed = -1,
@@ -122,23 +122,23 @@ h2o.deepwater <- function(x, y, training_frame,
                           learning_rate = 0.005,
                           learning_rate_annealing = 1e-06,
                           momentum_start = 0.9,
-                          momentum_ramp = 10000.0,
+                          momentum_ramp = 10000,
                           momentum_stable = 0.99,
                           distribution = c("AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"),
-                          score_interval = 5.0,
+                          score_interval = 5,
                           score_training_samples = 10000,
                           score_validation_samples = 0,
                           score_duty_cycle = 0.1,
-                          classification_stop = 0.0,
-                          regression_stop = 0.0,
+                          classification_stop = 0,
+                          regression_stop = 0,
                           stopping_rounds = 5,
                           stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
-                          stopping_tolerance = 0.0,
-                          max_runtime_secs = 0.0,
+                          stopping_tolerance = 0,
+                          max_runtime_secs = 0,
                           ignore_const_cols = TRUE,
                           shuffle_training_data = TRUE,
                           mini_batch_size = 32,
-                          clip_gradient = 10.0,
+                          clip_gradient = 10,
                           network = c("auto", "user", "lenet", "alexnet", "vgg", "googlenet", "inception_bn", "resnet"),
                           backend = c("auto", "mxnet", "caffe", "tensorflow"),
                           image_shape = c(0, 0),
@@ -152,7 +152,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           export_native_parameters_prefix = NULL,
                           activation = c("Rectifier", "Tanh"),
                           hidden = NULL,
-                          input_dropout_ratio = 0.0,
+                          input_dropout_ratio = 0,
                           hidden_dropout_ratios = NULL,
                           problem_type = c("auto", "image", "text", "dataset")
                           ) 

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -18,21 +18,21 @@
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
 #' @param nfolds Number of folds for N-fold cross-validation (0 to disable or >= 2). Defaults to 0.
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to False.
-#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to False.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to FALSE.
+#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to FALSE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param score_tree_interval Score the model after every so many trees. Disabled if set to 0. Defaults to 0.
 #' @param fold_assignment Cross-validation fold assignment scheme, if fold_column is not specified. The 'Stratified' option will
 #'        stratify the folds based on the response variable, for classification problems. Must be one of: "AUTO",
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
 #' @param offset_column Offset column. This will be added to the combination of columns before applying the link function.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative
 #'        weights are not allowed.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        False.
+#'        FALSE.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
 #'        be automatically computed to obtain class balance during training. Requires balance_classes.
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
@@ -41,7 +41,7 @@
 #'        Defaults to 0.
 #' @param ntrees Number of trees. Defaults to 50.
 #' @param max_depth Maximum tree depth. Defaults to 5.
-#' @param min_rows Fewest allowed (weighted) observations in a leaf. Defaults to 10.0.
+#' @param min_rows Fewest allowed (weighted) observations in a leaf. Defaults to 10.
 #' @param nbins For numerical columns (real/int), build a histogram of (at least) this many bins, then split at the best point
 #'        Defaults to 20.
 #' @param nbins_top_level For numerical columns (real/int), build a histogram of (at most) this many bins at the root level, then
@@ -50,7 +50,7 @@
 #'        values can lead to more overfitting. Defaults to 1024.
 #' @param r2_stopping r2_stopping is no longer supported and will be ignored if set - please use stopping_rounds, stopping_metric
 #'        and stopping_tolerance instead. Previous version of H2O would stop making trees when the R^2 metric equals or
-#'        exceeds this Defaults to 1.7976931348623157e+308.
+#'        exceeds this Defaults to 1.797693135e+308.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
@@ -58,13 +58,13 @@
 #'        "mean_per_class_error". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
 #' @param build_tree_one_node \code{Logical}. Run on one node only; no network overhead but fewer cpus used.  Suitable for small datasets.
-#'        Defaults to False.
+#'        Defaults to FALSE.
 #' @param learn_rate Learning rate (from 0.0 to 1.0) Defaults to 0.1.
-#' @param learn_rate_annealing Scale the learning rate by this factor after each tree (e.g., 0.99 or 0.999)  Defaults to 1.0.
+#' @param learn_rate_annealing Scale the learning rate by this factor after each tree (e.g., 0.99 or 0.999)  Defaults to 1.
 #' @param distribution Distribution function Must be one of: "AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma",
 #'        "tweedie", "laplace", "quantile", "huber". Defaults to AUTO.
 #' @param quantile_alpha Desired quantile for Quantile regression, must be between 0 and 1. Defaults to 0.5.
@@ -72,16 +72,16 @@
 #' @param huber_alpha Desired quantile for Huber/M-regression (threshold between quadratic and linear loss, must be between 0 and
 #'        1). Defaults to 0.9.
 #' @param checkpoint Model checkpoint to resume training with.
-#' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 1.0.
+#' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param sample_rate_per_class Row sample rate per tree per class (from 0.0 to 1.0)
-#' @param col_sample_rate Column sample rate (from 0.0 to 1.0) Defaults to 1.0.
-#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.0.
-#' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.0.
+#' @param col_sample_rate Column sample rate (from 0.0 to 1.0) Defaults to 1.
+#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.
+#' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param min_split_improvement Minimum relative improvement in squared error reduction for a split to happen Defaults to 1e-05.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
 #'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
-#' @param max_abs_leafnode_pred Maximum absolute value of a leaf node prediction Defaults to 1.7976931348623157e+308.
-#' @param pred_noise_bandwidth Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions Defaults to 0.0.
+#' @param max_abs_leafnode_pred Maximum absolute value of a leaf node prediction Defaults to 1.797693135e+308.
+#' @param pred_noise_bandwidth Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen". Defaults to AUTO.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
@@ -119,33 +119,33 @@ h2o.gbm <- function(x, y, training_frame,
                     max_hit_ratio_k = 0,
                     ntrees = 50,
                     max_depth = 5,
-                    min_rows = 10.0,
+                    min_rows = 10,
                     nbins = 20,
                     nbins_top_level = 1024,
                     nbins_cats = 1024,
-                    r2_stopping = 1.7976931348623157e+308,
+                    r2_stopping = 1.797693135e+308,
                     stopping_rounds = 0,
                     stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
                     stopping_tolerance = 0.001,
-                    max_runtime_secs = 0.0,
+                    max_runtime_secs = 0,
                     seed = -1,
                     build_tree_one_node = FALSE,
                     learn_rate = 0.1,
-                    learn_rate_annealing = 1.0,
+                    learn_rate_annealing = 1,
                     distribution = c("AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"),
                     quantile_alpha = 0.5,
                     tweedie_power = 1.5,
                     huber_alpha = 0.9,
                     checkpoint = NULL,
-                    sample_rate = 1.0,
+                    sample_rate = 1,
                     sample_rate_per_class = NULL,
-                    col_sample_rate = 1.0,
-                    col_sample_rate_change_per_level = 1.0,
-                    col_sample_rate_per_tree = 1.0,
+                    col_sample_rate = 1,
+                    col_sample_rate_change_per_level = 1,
+                    col_sample_rate_per_tree = 1,
                     min_split_improvement = 1e-05,
                     histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
-                    max_abs_leafnode_pred = 1.7976931348623157e+308,
-                    pred_noise_bandwidth = 0.0,
+                    max_abs_leafnode_pred = 1.797693135e+308,
+                    pred_noise_bandwidth = 0,
                     categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen")
                     ) 
 {

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -17,14 +17,14 @@
 #' @param nfolds Number of folds for N-fold cross-validation (0 to disable or >= 2). Defaults to 0.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to False.
-#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to False.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to FALSE.
+#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to FALSE.
 #' @param fold_assignment Cross-validation fold assignment scheme, if fold_column is not specified. The 'Stratified' option will
 #'        stratify the folds based on the response variable, for classification problems. Must be one of: "AUTO",
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param offset_column Offset column. This will be added to the combination of columns before applying the link function.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative
@@ -32,8 +32,8 @@
 #' @param family Family. Use binomial for classification with logistic regression, others are for regression problems. Must be
 #'        one of: "gaussian", "binomial", "quasibinomial", "multinomial", "poisson", "gamma", "tweedie". Defaults to
 #'        gaussian.
-#' @param tweedie_variance_power Tweedie variance power Defaults to 0.0.
-#' @param tweedie_link_power Tweedie link power Defaults to 1.0.
+#' @param tweedie_variance_power Tweedie variance power Defaults to 0.
+#' @param tweedie_link_power Tweedie link power Defaults to 1.
 #' @param solver AUTO will set the solver based on given data and the other parameters. IRLSM is fast on on problems with small
 #'        number of predictors and for lambda-search with L1 penalty, L_BFGS scales better for datasets with many
 #'        columns. Coordinate descent is experimental (beta). Must be one of: "AUTO", "IRLSM", "L_BFGS",
@@ -42,52 +42,52 @@
 #'        otherwise
 #' @param lambda regularization strength
 #' @param lambda_search \code{Logical}. use lambda search starting at lambda max, given lambda is then interpreted as lambda min
-#'        Defaults to False.
+#'        Defaults to FALSE.
 #' @param early_stopping \code{Logical}. stop early when there is no more relative improvement on train or validation (if provided)
-#'        Defaults to True.
+#'        Defaults to TRUE.
 #' @param nlambdas Number of lambdas to be used in a search. Default indicates: If alpha is zero, with lambda search set to True,
 #'        the value of nlamdas is set to 30 (fewer lambdas are needed for ridge regression) otherwise it is set to 100.
 #'        Defaults to -1.
-#' @param standardize \code{Logical}. Standardize numeric columns to have zero mean and unit variance Defaults to True.
+#' @param standardize \code{Logical}. Standardize numeric columns to have zero mean and unit variance Defaults to TRUE.
 #' @param missing_values_handling Handling of missing values. Either MeanImputation or Skip. Must be one of: "MeanImputation", "Skip". Defaults
 #'        to MeanImputation.
 #' @param compute_p_values \code{Logical}. request p-values computation, p-values work only with IRLSM solver and no regularization
-#'        Defaults to False.
-#' @param remove_collinear_columns \code{Logical}. in case of linearly dependent columns remove some of the dependent columns Defaults to False.
-#' @param intercept \code{Logical}. include constant term in the model Defaults to True.
-#' @param non_negative \code{Logical}. Restrict coefficients (not intercept) to be non-negative Defaults to False.
+#'        Defaults to FALSE.
+#' @param remove_collinear_columns \code{Logical}. in case of linearly dependent columns remove some of the dependent columns Defaults to FALSE.
+#' @param intercept \code{Logical}. include constant term in the model Defaults to TRUE.
+#' @param non_negative \code{Logical}. Restrict coefficients (not intercept) to be non-negative Defaults to FALSE.
 #' @param max_iterations Maximum number of iterations Defaults to -1.
 #' @param objective_epsilon Converge if  objective value changes less than this. Default indicates: If lambda_search is set to True the
 #'        value of objective_epsilon is set to .0001. If the lambda_search is set to False and lambda is equal to zero,
 #'        the value of objective_epsilon is set to .000001, for any other value of lambda the default value of
-#'        objective_epsilon is set to .0001. Defaults to -1.0.
+#'        objective_epsilon is set to .0001. Defaults to -1.
 #' @param beta_epsilon converge if  beta changes less (using L-infinity norm) than beta esilon, ONLY applies to IRLSM solver
 #'        Defaults to 0.0001.
 #' @param gradient_epsilon Converge if  objective changes less (using L-infinity norm) than this, ONLY applies to L-BFGS solver. Default
 #'        indicates: If lambda_search is set to False and lambda is equal to zero, the default value of gradient_epsilon
 #'        is equal to .000001, otherwise the default value is .0001. If lambda_search is set to True, the conditional
-#'        values above are 1E-8 and 1E-6 respectively. Defaults to -1.0.
+#'        values above are 1E-8 and 1E-6 respectively. Defaults to -1.
 #' @param link  Must be one of: "family_default", "identity", "logit", "log", "inverse", "tweedie". Defaults to
 #'        family_default.
 #' @param prior prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
-#'        of response does not reflect reality. Defaults to -1.0.
+#'        of response does not reflect reality. Defaults to -1.
 #' @param lambda_min_ratio Min lambda used in lambda search, specified as a ratio of lambda_max. Default indicates: if the number of
 #'        observations is greater than the number of variables then lambda_min_ratio is set to 0.0001; if the number of
-#'        observations is less than the number of variables then lambda_min_ratio is set to 0.01. Defaults to -1.0.
+#'        observations is less than the number of variables then lambda_min_ratio is set to 0.01. Defaults to -1.
 #' @param beta_constraints beta constraints
 #' @param max_active_predictors Maximum number of active predictors during computation. Use as a stopping criterion to prevent expensive model
 #'        building with many predictors. Default indicates: If the IRLSM solver is used, the value of
 #'        max_active_predictors is set to 7000 otherwise it is set to 100000000. Defaults to -1.
 #' @param interactions A list of predictor column indices to interact. All pairwise combinations will be computed for the list.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        False.
+#'        FALSE.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
 #'        be automatically computed to obtain class balance during training. Requires balance_classes.
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
 #'        balance_classes. Defaults to 5.0.
 #' @param max_hit_ratio_k Max. number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)
 #'        Defaults to 0.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine
 #'         learning task at hand (if it's binomial classification, then an \code{\linkS4class{H2OBinomialModel}} is
 #'         returned, if it's regression then a \code{\linkS4class{H2ORegressionModel}} is returned). The default print-
@@ -142,8 +142,8 @@ h2o.glm <- function(x, y, training_frame,
                     offset_column = NULL,
                     weights_column = NULL,
                     family = c("gaussian", "binomial", "quasibinomial", "multinomial", "poisson", "gamma", "tweedie"),
-                    tweedie_variance_power = 0.0,
-                    tweedie_link_power = 1.0,
+                    tweedie_variance_power = 0,
+                    tweedie_link_power = 1,
                     solver = c("AUTO", "IRLSM", "L_BFGS", "COORDINATE_DESCENT_NAIVE", "COORDINATE_DESCENT"),
                     alpha = NULL,
                     lambda = NULL,
@@ -157,12 +157,12 @@ h2o.glm <- function(x, y, training_frame,
                     intercept = TRUE,
                     non_negative = FALSE,
                     max_iterations = -1,
-                    objective_epsilon = -1.0,
+                    objective_epsilon = -1,
                     beta_epsilon = 0.0001,
-                    gradient_epsilon = -1.0,
+                    gradient_epsilon = -1,
                     link = c("family_default", "identity", "logit", "log", "inverse", "tweedie"),
-                    prior = -1.0,
-                    lambda_min_ratio = -1.0,
+                    prior = -1,
+                    lambda_min_ratio = -1,
                     beta_constraints = NULL,
                     max_active_predictors = -1,
                     interactions = NULL,
@@ -170,7 +170,7 @@ h2o.glm <- function(x, y, training_frame,
                     class_sampling_factors = NULL,
                     max_after_balance_size = 5.0,
                     max_hit_ratio_k = 0,
-                    max_runtime_secs = 0.0
+                    max_runtime_secs = 0
                     ) 
 {
   #If x is missing, then assume user wants to use all columns as features.

--- a/h2o-r/h2o-package/R/glrm.R
+++ b/h2o-r/h2o-package/R/glrm.R
@@ -9,8 +9,8 @@
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param loading_name Frame key to save resulting X
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
@@ -26,11 +26,11 @@
 #'        "OneSparse", "UnitOneSparse", "Simplex". Defaults to None.
 #' @param regularization_y Regularization function for Y matrix Must be one of: "None", "Quadratic", "L2", "L1", "NonNegative",
 #'        "OneSparse", "UnitOneSparse", "Simplex". Defaults to None.
-#' @param gamma_x Regularization weight on X matrix Defaults to 0.0.
-#' @param gamma_y Regularization weight on Y matrix Defaults to 0.0.
+#' @param gamma_x Regularization weight on X matrix Defaults to 0.
+#' @param gamma_y Regularization weight on Y matrix Defaults to 0.
 #' @param max_iterations Maximum number of iterations Defaults to 1000.
 #' @param max_updates Maximum number of updates, defaults to 2*max_iterations Defaults to 2000.
-#' @param init_step_size Initial step size Defaults to 1.0.
+#' @param init_step_size Initial step size Defaults to 1.
 #' @param min_step_size Minimum step size Defaults to 0.0001.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
@@ -39,10 +39,10 @@
 #'        unstable) Must be one of: "GramSVD", "Power", "Randomized". Defaults to Randomized.
 #' @param user_y User-specified initial Y
 #' @param user_x User-specified initial X
-#' @param expand_user_y \code{Logical}. Expand categorical columns in user-specified initial Y Defaults to True.
-#' @param impute_original \code{Logical}. Reconstruct original training data by reversing transform Defaults to False.
-#' @param recover_svd \code{Logical}. Recover singular values and eigenvectors of XY Defaults to False.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param expand_user_y \code{Logical}. Expand categorical columns in user-specified initial Y Defaults to TRUE.
+#' @param impute_original \code{Logical}. Reconstruct original training data by reversing transform Defaults to FALSE.
+#' @param recover_svd \code{Logical}. Recover singular values and eigenvectors of XY Defaults to FALSE.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @return Returns an object of class \linkS4class{H2ODimReductionModel}.
 #' @seealso \code{\link{h2o.kmeans}, \link{h2o.svd}}, \code{\link{h2o.prcomp}}
 #' @references M. Udell, C. Horn, R. Zadeh, S. Boyd (2014). {Generalized Low Rank Models}[http://arxiv.org/abs/1410.0342]. Unpublished manuscript, Stanford Electrical Engineering Department
@@ -72,11 +72,11 @@ h2o.glrm <- function(training_frame, cols = NULL,
                      period = 1,
                      regularization_x = c("None", "Quadratic", "L2", "L1", "NonNegative", "OneSparse", "UnitOneSparse", "Simplex"),
                      regularization_y = c("None", "Quadratic", "L2", "L1", "NonNegative", "OneSparse", "UnitOneSparse", "Simplex"),
-                     gamma_x = 0.0,
-                     gamma_y = 0.0,
+                     gamma_x = 0,
+                     gamma_y = 0,
                      max_iterations = 1000,
                      max_updates = 2000,
-                     init_step_size = 1.0,
+                     init_step_size = 1,
                      min_step_size = 0.0001,
                      seed = -1,
                      init = c("Random", "SVD", "PlusPlus", "User"),
@@ -86,7 +86,7 @@ h2o.glrm <- function(training_frame, cols = NULL,
                      expand_user_y = TRUE,
                      impute_original = FALSE,
                      recover_svd = FALSE,
-                     max_runtime_secs = 0.0
+                     max_runtime_secs = 0
                      ) 
 {
 

--- a/h2o-r/h2o-package/R/kmeans.R
+++ b/h2o-r/h2o-package/R/kmeans.R
@@ -10,26 +10,26 @@
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
 #' @param nfolds Number of folds for N-fold cross-validation (0 to disable or >= 2). Defaults to 0.
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to False.
-#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to False.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to FALSE.
+#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to FALSE.
 #' @param fold_assignment Cross-validation fold assignment scheme, if fold_column is not specified. The 'Stratified' option will
 #'        stratify the folds based on the response variable, for classification problems. Must be one of: "AUTO",
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param k The max. number of clusters. If estimate_k is disabled, the model will find k centroids, otherwise it will
 #'        find up to k centroids. Defaults to 1.
 #' @param estimate_k \code{Logical}. Whether to estimate the number of clusters (<=k) iteratively and deterministically. Defaults
-#'        to False.
+#'        to FALSE.
 #' @param user_points User-specified points
 #' @param max_iterations Maximum training iterations (if estimate_k is enabled, then this is for each inner Lloyds iteration) Defaults
 #'        to 10.
-#' @param standardize \code{Logical}. Standardize columns before computing distances Defaults to True.
+#' @param standardize \code{Logical}. Standardize columns before computing distances Defaults to TRUE.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
 #' @param init Initialization mode Must be one of: "Random", "PlusPlus", "Furthest", "User". Defaults to Furthest.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen". Defaults to AUTO.
 #' @return Returns an object of class \linkS4class{H2OClusteringModel}.
@@ -62,7 +62,7 @@ h2o.kmeans <- function(training_frame, x,
                        standardize = TRUE,
                        seed = -1,
                        init = c("Random", "PlusPlus", "Furthest", "User"),
-                       max_runtime_secs = 0.0,
+                       max_runtime_secs = 0,
                        categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen")
                        ) 
 {

--- a/h2o-r/h2o-package/R/naivebayes.R
+++ b/h2o-r/h2o-package/R/naivebayes.R
@@ -25,26 +25,26 @@
 #'        stratify the folds based on the response variable, for classification problems. Must be one of: "AUTO",
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to False.
-#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to False.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to FALSE.
+#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to FALSE.
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        False.
+#'        FALSE.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
 #'        be automatically computed to obtain class balance during training. Requires balance_classes.
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
 #'        balance_classes. Defaults to 5.0.
 #' @param max_hit_ratio_k Max. number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)
 #'        Defaults to 0.
-#' @param laplace Laplace smoothing parameter Defaults to 0.0.
+#' @param laplace Laplace smoothing parameter Defaults to 0.
 #' @param threshold The minimum standard deviation to use for observations without enough data. 
 #'                  Must be at least 1e-10.
 #' @param eps A threshold cutoff to deal with numeric instability, must be positive.
-#' @param compute_metrics \code{Logical}. Compute metrics on training data Defaults to True.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param compute_metrics \code{Logical}. Compute metrics on training data Defaults to TRUE.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @details The naive Bayes classifier assumes independence between predictor variables conditional         on the
 #'          response, and a Gaussian distribution of numeric predictors with mean and standard         deviation
 #'          computed from the training dataset. When building a naive Bayes classifier,         every row in the
@@ -75,11 +75,11 @@ h2o.naiveBayes <- function(x, y, training_frame,
                            class_sampling_factors = NULL,
                            max_after_balance_size = 5.0,
                            max_hit_ratio_k = 0,
-                           laplace = 0.0,
+                           laplace = 0,
                            threshold = 0.001,
-                           eps = 0.0,
+                           eps = 0,
                            compute_metrics = TRUE,
-                           max_runtime_secs = 0.0
+                           max_runtime_secs = 0
                            ) 
 {
   #If x is missing, then assume user wants to use all columns as features.

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -10,20 +10,20 @@
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
 #' @param pca_method Method for computing PCA (Caution: Power and GLRM are currently experimental and unstable) Must be one of:
 #'        "GramSVD", "Power", "Randomized", "GLRM". Defaults to GramSVD.
 #' @param k Rank of matrix approximation Defaults to 1.
 #' @param max_iterations Maximum training iterations Defaults to 1000.
-#' @param use_all_factor_levels \code{Logical}. Whether first factor level is included in each categorical expansion Defaults to False.
-#' @param compute_metrics \code{Logical}. Whether to compute metrics on the training data Defaults to True.
-#' @param impute_missing \code{Logical}. Whether to impute missing entries with the column mean Defaults to False.
+#' @param use_all_factor_levels \code{Logical}. Whether first factor level is included in each categorical expansion Defaults to FALSE.
+#' @param compute_metrics \code{Logical}. Whether to compute metrics on the training data Defaults to TRUE.
+#' @param impute_missing \code{Logical}. Whether to impute missing entries with the column mean Defaults to FALSE.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @return Returns an object of class \linkS4class{H2ODimReductionModel}.
 #' @seealso \code{\link{h2o.svd}}, \code{\link{h2o.glrm}}
 #' @references N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
@@ -49,7 +49,7 @@ h2o.prcomp <- function(training_frame, x,
                        compute_metrics = TRUE,
                        impute_missing = FALSE,
                        seed = -1,
-                       max_runtime_secs = 0.0
+                       max_runtime_secs = 0
                        ) 
 {
 

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -14,21 +14,21 @@
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
 #' @param nfolds Number of folds for N-fold cross-validation (0 to disable or >= 2). Defaults to 0.
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to False.
-#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to False.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation models. Defaults to FALSE.
+#' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep the cross-validation fold assignment. Defaults to FALSE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param score_tree_interval Score the model after every so many trees. Disabled if set to 0. Defaults to 0.
 #' @param fold_assignment Cross-validation fold assignment scheme, if fold_column is not specified. The 'Stratified' option will
 #'        stratify the folds based on the response variable, for classification problems. Must be one of: "AUTO",
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
 #' @param offset_column Offset column. This will be added to the combination of columns before applying the link function.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative
 #'        weights are not allowed.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
-#'        False.
+#'        FALSE.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
 #'        be automatically computed to obtain class balance during training. Requires balance_classes.
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
@@ -37,7 +37,7 @@
 #'        Defaults to 0.
 #' @param ntrees Number of trees. Defaults to 50.
 #' @param max_depth Maximum tree depth. Defaults to 20.
-#' @param min_rows Fewest allowed (weighted) observations in a leaf. Defaults to 1.0.
+#' @param min_rows Fewest allowed (weighted) observations in a leaf. Defaults to 1.
 #' @param nbins For numerical columns (real/int), build a histogram of (at least) this many bins, then split at the best point
 #'        Defaults to 20.
 #' @param nbins_top_level For numerical columns (real/int), build a histogram of (at most) this many bins at the root level, then
@@ -46,7 +46,7 @@
 #'        values can lead to more overfitting. Defaults to 1024.
 #' @param r2_stopping r2_stopping is no longer supported and will be ignored if set - please use stopping_rounds, stopping_metric
 #'        and stopping_tolerance instead. Previous version of H2O would stop making trees when the R^2 metric equals or
-#'        exceeds this Defaults to 1.7976931348623157e+308.
+#'        exceeds this Defaults to 1.797693135e+308.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
@@ -54,20 +54,20 @@
 #'        "mean_per_class_error". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
 #' @param build_tree_one_node \code{Logical}. Run on one node only; no network overhead but fewer cpus used.  Suitable for small datasets.
-#'        Defaults to False.
+#'        Defaults to FALSE.
 #' @param mtries Number of variables randomly sampled as candidates at each split. If set to -1, defaults to sqrt{p} for
 #'        classification and p/3 for regression (where p is the # of predictors Defaults to -1.
-#' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 0.6320000290870667.
+#' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 0.6320000291.
 #' @param sample_rate_per_class Row sample rate per tree per class (from 0.0 to 1.0)
 #' @param binomial_double_trees \code{Logical}. For binary classification: Build 2x as many trees (one per class) - can lead to higher
-#'        accuracy. Defaults to False.
+#'        accuracy. Defaults to FALSE.
 #' @param checkpoint Model checkpoint to resume training with.
-#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.0.
-#' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.0.
+#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.
+#' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param min_split_improvement Minimum relative improvement in squared error reduction for a split to happen Defaults to 1e-05.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
 #'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
@@ -95,24 +95,24 @@ h2o.randomForest <- function(x, y, training_frame,
                              max_hit_ratio_k = 0,
                              ntrees = 50,
                              max_depth = 20,
-                             min_rows = 1.0,
+                             min_rows = 1,
                              nbins = 20,
                              nbins_top_level = 1024,
                              nbins_cats = 1024,
-                             r2_stopping = 1.7976931348623157e+308,
+                             r2_stopping = 1.797693135e+308,
                              stopping_rounds = 0,
                              stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
                              stopping_tolerance = 0.001,
-                             max_runtime_secs = 0.0,
+                             max_runtime_secs = 0,
                              seed = -1,
                              build_tree_one_node = FALSE,
                              mtries = -1,
-                             sample_rate = 0.6320000290870667,
+                             sample_rate = 0.6320000291,
                              sample_rate_per_class = NULL,
                              binomial_double_trees = FALSE,
                              checkpoint = NULL,
-                             col_sample_rate_change_per_level = 1.0,
-                             col_sample_rate_per_tree = 1.0,
+                             col_sample_rate_change_per_level = 1,
+                             col_sample_rate_per_tree = 1,
                              min_split_improvement = 1e-05,
                              histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
                              categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen")

--- a/h2o-r/h2o-package/R/svd.R
+++ b/h2o-r/h2o-package/R/svd.R
@@ -11,8 +11,8 @@
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
-#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to True.
-#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to False.
+#' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
 #' @param svd_method Method for computing SVD (Caution: Power and Randomized are currently experimental and unstable) Must be one
@@ -21,10 +21,10 @@
 #' @param max_iterations Maximum iterations Defaults to 1000.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Note: only reproducible when running single threaded. Defaults to -1 (time-based random number).
-#' @param keep_u \code{Logical}. Save left singular vectors? Defaults to True.
+#' @param keep_u \code{Logical}. Save left singular vectors? Defaults to TRUE.
 #' @param u_name Frame key to save left singular vectors
-#' @param use_all_factor_levels \code{Logical}. Whether first factor level is included in each categorical expansion Defaults to True.
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.0.
+#' @param use_all_factor_levels \code{Logical}. Whether first factor level is included in each categorical expansion Defaults to TRUE.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @return Returns an object of class \linkS4class{H2ODimReductionModel}.
 #' @references N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
 #' @examples
@@ -49,7 +49,7 @@ h2o.svd <- function(training_frame, x, destination_key,
                     keep_u = TRUE,
                     u_name = NULL,
                     use_all_factor_levels = TRUE,
-                    max_runtime_secs = 0.0
+                    max_runtime_secs = 0
                     ) 
 {
 


### PR DESCRIPTION
When we run `./gradlew build`, it auto-generates R API but based on the machine architecture, the precision of float values (especially, Math.MAX_VALUE) is different. This was discussed [here](https://h2oai.slack.com/archives/dev/p1482018838000511). In order to make it consistent, we will be restricting upto a precision of 10. This is also consistent with Python API [change](https://github.com/h2oai/h2o-3/pull/490/files)