### PR TITLE
PUBDEV-3826: Document support for HDP 2.5 in UG

### DIFF
--- a/h2o-docs/src/product/hadoop.rst
+++ b/h2o-docs/src/product/hadoop.rst
@@ -16,6 +16,7 @@ Currently supported versions:
 -  HDP 2.2
 -  HDP 2.3
 -  HDP 2.4
+-  HDP 2.5
 -  MapR 3.1
 -  MapR 4.0
 -  MapR 5.0


### PR DESCRIPTION
Added HDP 2.5 as a supported Hadoop platform.