### PR TITLE
Extract binary data from H2O (MOJOs)

### DIFF
--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -255,12 +255,12 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
   pojoname = gsub("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]","_",model_id,perl=T)
 
   #Path to save POJO, if `path` is provided
-  file.path <- paste0(path, "/", pojoname, ".java")
+  file_path <- file.path(path, paste0(pojoname, ".java"))
 
   if( is.null(path) ){
     cat(java) #Pretty print POJO
   } else {
-    write(java, file=file.path) #Write POJO to specified path
+    write(java, file=file_path) #Write POJO to specified path
     # getjar is now deprecated and the new arg name is get_jar
     if (!is.null(getjar)) {
         warning("The `getjar` argument is DEPRECATED; use `get_jar` instead as `getjar` will eventually be removed")
@@ -270,7 +270,7 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
     if (get_jar) {
       urlSuffix = "h2o-genmodel.jar"
       #Build genmodel.jar file path
-      jar.path <- paste0(path, "/h2o-genmodel.jar")
+      jar.path <- file.path(path, "h2o-genmodel.jar")
       #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
       #and write to jar.path.
       writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, getBinary=TRUE), jar.path, useBytes = TRUE)
@@ -321,13 +321,13 @@ h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE) {
 
   #Build MOJO file path and download MOJO file & perform a safe (i.e. error-checked)
   #HTTP GET request to an H2O cluster with MOJO URL
-  mojo.path <- paste0(path,"/",model_id,".zip")
+  mojo.path <- file.path(path, paste0(model_id,".zip"))
   writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, getBinary=TRUE), mojo.path, useBytes = TRUE)
 
   if (get_genmodel_jar) {
     urlSuffix = "h2o-genmodel.jar"
     #Build genmodel.jar file path
-    jar.path <- paste0(path, "/h2o-genmodel.jar")
+    jar.path <- file.path(path,"h2o-genmodel.jar")
     #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
     #and write to jar.path.
     writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, getBinary=TRUE), jar.path, useBytes = TRUE)


### PR DESCRIPTION
* This PR adds the functionality of downloading binary data from H2O via `.h2o.doSafeGET()`. This is done by adding a simple check called `getBinary`. If this flag is true, then the REST call is executed with the `getBinaryURL` function, which produces the binary data payload.
* Also, this PR changes `paste0()` -> `file.path()` in `h2o.download_pojo` & `h2o.download_mojo` to ensure platform independence when making path/dir names.