### PR TITLE
PUBDEV-3828: Document in addl places how to get smalldata

### DIFF
--- a/h2o-docs/src/product/data-munging.rst
+++ b/h2o-docs/src/product/data-munging.rst
@@ -6,6 +6,12 @@ Data Manipulation
 
 This section provides examples of common tasks performed when preparing data for machine learning. These examples are run on a local cluster.
 
+**Note**: The examples in this section include datasets that are pulled from GitHub and S3. Alternatively, you can run the following command from within the H2O repository on your local machine to retrieve all datasets in the smalldata folder:
+
+ ::
+  
+  ./gradlew syncSmalldata
+
 .. toctree::
    :maxdepth: 1
 

--- a/h2o-docs/src/product/data-science/algo-params/seed.rst
+++ b/h2o-docs/src/product/data-science/algo-params/seed.rst
@@ -1,7 +1,7 @@
 ``seed``
 --------
 
-- Available in: GBM, DRF, GLM, PCA, GLRM, Naïve-Bayes, K-Means
+- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/weights_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/weights_column.rst
@@ -16,10 +16,10 @@ For scoring, all computed metrics will take the observation weights into account
 - Weights can be specified as integers or as non-integers.
 - You do not have to specify a weight when calling ``model.predict()``. New test data will have the weights column with the same column name. 
 - The weights column cannot be the same as the `fold_column <fold_column.html>`__. 
-- Example unit test scripts are available on github:
+- Example unit test scripts are available on GitHub:
+
   - https://github.com/h2oai/h2o-3/blob/master/h2o-py/tests/testdir_algos/gbm/pyunit_weights_gbm.py
   - https://github.com/h2oai/h2o-3/blob/master/h2o-py/tests/testdir_algos/gbm/pyunit_weights_gamma_gbm.py
-
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/y.rst
+++ b/h2o-docs/src/product/data-science/algo-params/y.rst
@@ -9,6 +9,8 @@ Description
 
 Use this option to specify a response column (y-axis). The response column is the column that you are attempting to predict. For example, based on a set of parameters in a training dataset, will a new customber be more or less likely to purchase a product? Or based on some known variables, what is the likelihood that a flight will be delayed? In both cases, a model can be applied to a training frame and to a validation frame to predict the likely response.  
 
+**Response Columns with DL and GBM Distribution**
+
 Response columns can be numeric or categorical, and they can be binomial or multiomial. If you are specifying a distribution type in DL or GBM, however, then keep in mind the following when defining a response column:
 
 - If the distribution is ``bernoulli``, the the response column must be 2-class categorical
@@ -21,19 +23,30 @@ Response columns can be numeric or categorical, and they can be binomial or mult
 - If the distribution is ``gamma``, the response column must be numeric.
 - If the distribution is ``quantile``, the response column must be numeric.
 
+**Response Columns with GLM Family**
+
+In GLM, you can specify one of the following family options based on the response column type:
+
+- ``gaussian``: The data must be numeric (Real or Int). This is the default family.
+- ``binomial``: The data must be categorical 2 levels/classes or binary (Enum or Int).
+- ``quasibinomial``: The data must be numeric.
+- ``multinomial``: The data can be categorical with more than two levels/classes (Enum).
+- ``poisson``: The data must be numeric and non-negative (Int).
+- ``gamma``: The data must be numeric and continuous and positive (Real or Int).
+- ``tweedie``: The data must be numeric and continuous (Real) and non-negative.
+
 **Notes**: 
 
 - The response column cannot be the same as the `fold_column <fold_column.html>`__. 
 - For supervised learning, the response column cannot be the same as the `weights_column <weights_column.html>`__, and the response column must exist in both the training frame and in the validation frame. 
 
-
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
 - `distribution <distribution.html>`__
+- `family <family.html>`__
 - `offset_column <offset_column.html>`__
 - `weights_column <weights_column.html>`__
-
 
 Example
 ~~~~~~~

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -8,7 +8,12 @@ This Appendix provides detailed descriptions of parameters that can be specified
 **Notes**:
 
 - This Appendix is a work in progress.
-- For parameters that are supported in multiple algorithms, the included example uses the GBM algorithm. 
+- For parameters that are supported in multiple algorithms, the included example uses the GBM or GLM algorithm.
+- The examples in this section include datasets that are pulled from GitHub and S3. Alternatively, you can run the following command from within the H2O repository on your local machine to retrieve all datasets in the smalldata folder:
+
+ ::
+  
+  ./gradlew syncSmalldata
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Added info on how to get the smalldata folder to the Data Manipulation and Parameter sections.
Driveby fixes for parameters:
- seed: added Deep Learning to the list of “available in”
- weights_column: Fix the second-level bulleted list in the Notes section. All items were in a single paragraph.
- y: Currently shows required response column type for GBM and DL distribution. Added a similar section for GLM family. Also, add a
Related Parameter for family.