### PR TITLE
Remove h2o-core's dependency on external regex library

### DIFF
--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -18,8 +18,6 @@ dependencies {
   compile "org.eclipse.jetty:jetty-server:8.1.17.v20150415"
   compile "org.eclipse.jetty:jetty-plus:8.1.17.v20150415"
   compile ("com.github.rwl:jtransforms:2.4.0") { exclude module: "junit" }
-  // For Java6 we need named groups in regexp to have nice user API
-  compile "com.github.tony19:named-regexp:0.2.3"
 
   compile("log4j:log4j:1.2.15") { 
     exclude module: "activation" 

--- a/h2o-core/src/main/java/water/api/RequestUri.java
+++ b/h2o-core/src/main/java/water/api/RequestUri.java
@@ -1,19 +1,18 @@
 package water.api;
 
-import com.google.code.regexp.Pattern;
-
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  *
  */
 public class RequestUri {
 
-  private static Pattern version_pattern = Pattern.compile("^/(?i)(\\d+|EXPERIMENTAL|LATEST)/(.*)");
+  private static Pattern version_pattern = Pattern.compile("^/(?:\\d+|EXPERIMENTAL|LATEST)/.*", Pattern.CASE_INSENSITIVE);
   private static Set<String> http_methods = new HashSet<>(Arrays.asList("HEAD", "GET", "POST", "DELETE"));
 
   private String method;


### PR DESCRIPTION
Remove package `com.google.code.regexp` from the list of dependencies, in order to reduce the size of h2o jar.