### PR TITLE
Do not report timing for gradle tasks that take less than 1 s

### DIFF
--- a/gradle/timing.gradle
+++ b/gradle/timing.gradle
@@ -26,7 +26,9 @@ class TimingsListener implements TaskExecutionListener, BuildListener {
         def secs = (double)(clock.timeInMs / 1000.0)
         def timing = new Timing(secs, task.path)
         timings.add(timing)
-        task.project.logger.warn "${task.path} took ${secs} secs"
+        if (secs >= 1) {
+            task.project.logger.warn "${task.path} took ${secs} secs"
+        }
     }
 
     @Override


### PR DESCRIPTION
This reduces the amount of noise in the gradlew build output