### PR TITLE
Safe GET calls for POJO/MOJO/genmodel. 

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -40,10 +40,14 @@
     sprintf("%s://%s:%s/%s/%s", scheme, conn@ip, as.character(conn@port), h2oRestApiVersion, urlSuffix)
 }
 
-.h2o.doRawREST <- function(conn, h2oRestApiVersion, urlSuffix, parms, method, fileUploadInfo, ...) {
+.h2o.doRawREST <- function(conn, h2oRestApiVersion, urlSuffix, parms, method, fileUploadInfo, binary=FALSE, ...) {
   timeout_secs <- 0
   stopifnot(is(conn, "H2OConnection"))
   stopifnot(is.character(urlSuffix))
+  stopifnot(is.logical(binary))
+  if(binary != FALSE && method != "GET"){
+    stop("binary data is only supported with HTTP GET responses")
+  }
   if (missing(parms))
     parms = list()
   else {
@@ -136,21 +140,36 @@
 
   if ((method == "GET") || (method == "DELETE")) {
     h <- basicHeaderGatherer()
-    t <- basicTextGatherer(.mapUnicode = FALSE)
+    #Internal C-level data structure for collecting binary data.
+    buf <- binaryBuffer()
+    #C routine that puts the binary data in memory as its being processed. Here we are only interested in its
+    #address in memory and will pass it into curlPerform() as the writefunction
+    write <- getNativeSymbolInfo("R_curl_write_binary_data")$address
+    #Note: binaryBuffer() is a constructor function for creating an internal data structure that is used when reading binary
+    #data from an HTTP request via RCurl. It is used with the native routine R_curl_write_binary_data
+    #for collecting the response from the HTTP query into a buffer that stores the bytes. The contents
+    #can then be brought back into R as a raw vector and then used in different ways, e.g. uncompressed
+    #with the Rcompression package, or written to a file via writeBin. We can also convert the raw vector to of type
+    #character.
     tmp <- tryCatch(curlPerform(url = url,
-                                customrequest = method,
-                                writefunction = t$update,
-                                headerfunction = h$update,
-                                useragent=R.version.string,
-                                httpheader = header,
-                                verbose = FALSE,
-                                timeout = timeout_secs,
-                                .opts = opts),
-                    error = function(x) { .__curlError <<- TRUE; .__curlErrorMessage <<- x$message })
+                                  customrequest = method,
+                                  writefunction = write,
+                                  headerfunction = h$update,
+                                  useragent=R.version.string,
+                                  httpheader = header,
+                                  verbose = FALSE,
+                                  timeout = timeout_secs,
+                                  file = buf@ref, #Always get binary data
+                                  .opts = opts),
+                      error = function(x) { .__curlError <<- TRUE; .__curlErrorMessage <<- x$message })
     if (! .__curlError) {
-      httpStatusCode = as.numeric(h$value()["status"])
-      httpStatusMessage = h$value()["statusMessage"]
-      payload = t$value()
+        httpStatusCode = as.numeric(h$value()["status"])
+        httpStatusMessage = h$value()["statusMessage"]
+        if(binary){
+          payload = as(buf, "raw") #Return binary payload as is for output such as MOJOs and genmodel.jar
+        }else{
+          payload = rawToChar(as(buf, "raw")) #convert binary payload to text for other REST calls as they expect text responses
+        }
     }
   } else if (! missing(fileUploadInfo)) {
     stopifnot(method == "POST")
@@ -321,7 +340,9 @@
     cat(sprintf("ERROR: Unexpected HTTP Status code: %d %s (url = %s)\n", rv$httpStatusCode, rv$httpStatusMessage, rv$url))
     cat("\n")
 
-    jsonObject = jsonlite::fromJSON(rv$payload, simplifyDataFrame=FALSE)
+    #Check if payload is a raw vector(binary data) and convert to character for error printing. Otherwise return
+    #normal payload
+    jsonObject = jsonlite::fromJSON(ifelse(is.raw(rv$payload),rawToChar(rv$payload),rv$payload), simplifyDataFrame=FALSE)
 
     exceptionType = jsonObject$exception_type
     if (! is.null(exceptionType)) {

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -342,7 +342,11 @@
 
     #Check if payload is a raw vector(binary data) and convert to character for error printing. Otherwise return
     #normal payload
-    jsonObject = jsonlite::fromJSON(ifelse(is.raw(rv$payload),rawToChar(rv$payload),rv$payload), simplifyDataFrame=FALSE)
+    if(is.raw(rv$payload)){
+      jsonObject = jsonlite::fromJSON(rawToChar(rv$payload), simplifyDataFrame=FALSE)
+    }else{
+      jsonObject = jsonlite::fromJSON(rv$payload, simplifyDataFrame=FALSE)
+    }
 
     exceptionType = jsonObject$exception_type
     if (! is.null(exceptionType)) {

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -225,7 +225,7 @@ h2o.getModel <- function(model_id) {
 #' my_model <- h2o.gbm(x=1:4, y=5, training_frame=fr)
 #'
 #' h2o.download_pojo(my_model)  # print the model to screen
-#' # h2o.download_pojo(my_model, getwd())  # save the POJO and jar file to the current working 
+#' # h2o.download_pojo(my_model, getwd())  # save the POJO and jar file to the current working
 #' #                                         directory, NOT RUN
 #' # h2o.download_pojo(my_model, getwd(), get_jar = FALSE )  # save only the POJO to the current
 #' #                                                           working directory, NOT RUN
@@ -244,37 +244,38 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
     stop(paste0("'path',",path,", to save pojo cannot be found."))
   }
 
+  #Get model id
   model_id <- model@model_id
-  java <- .h2o.__remoteSend(method = "GET", paste0(.h2o.__MODELS, ".java/", model_id), raw=TRUE)
+
+  #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with POJO URL
+  java <- .h2o.doSafeGET(urlSuffix = paste0(.h2o.__MODELS, ".java/", model_id))
 
   # HACK: munge model._id so that it conforms to Java class name. For example, change K-means to K_means.
   # TODO: clients should extract Java class name from header.
   pojoname = gsub("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]","_",model_id,perl=T)
 
-  file.path <- paste0(path, "/", pojoname, ".java")
+  #Path to save POJO, if `path` is provided
+  file_path <- file.path(path, paste0(pojoname, ".java"))
+
   if( is.null(path) ){
-    cat(java)
+    cat(java) #Pretty print POJO
   } else {
-    write(java, file=file.path)
-      # getjar is now deprecated and the new arg name is get_jar
-      if (!is.null(getjar)) {
-        warning("The `getjar` argument is DEPRECATED; use `get_jar` instead as `getjar` will eventually be removed")
-        get_jar = getjar
-        getjar = NULL
-      }
-    if (get_jar) {
-      .__curlError = FALSE
-      .__curlErrorMessage = ""
-      url = .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = "h2o-genmodel.jar")
-      tmp = tryCatch(getBinaryURL(url = url,
-                          useragent = R.version.string),
-                   error = function(x) { .__curlError <<- TRUE; .__curlErrorMessage <<- x$message })
-      if (! .__curlError) {
-        jar.path <- paste0(path, "/h2o-genmodel.jar")
-        writeBin(tmp, jar.path, useBytes = TRUE)
-      }
-    }
-    return(paste0(pojoname,".java"))
+    write(java, file=file_path) #Write POJO to specified path
+  # getjar is now deprecated and the new arg name is get_jar
+  if (!is.null(getjar)) {
+    warning("The `getjar` argument is DEPRECATED; use `get_jar` instead as `getjar` will eventually be removed")
+    get_jar = getjar
+    getjar = NULL
+  }
+  if (get_jar) {
+    urlSuffix = "h2o-genmodel.jar"
+    #Build genmodel.jar file path
+    jar.path <- file.path(path, "h2o-genmodel.jar")
+    #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
+    #and write to jar.path.
+    writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, binary = TRUE), jar.path, useBytes = TRUE)
+  }
+  return(paste0(pojoname,".java"))
   }
 }
 
@@ -312,27 +313,24 @@ h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE) {
     stop(paste0("'path',",path,", to save MOJO file cannot be found."))
   }
 
+  #Get model id
   model_id <- model@model_id
-  .__curlError = FALSE
-  .__curlErrorMessage = ""
 
-  url = .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = paste0(.h2o.__MODELS,"/",model_id,"/mojo"))
-  tmp = tryCatch(getBinaryURL(url = url,
-                      useragent = R.version.string),
-               error = function(x) { .__curlError <<- TRUE; .__curlErrorMessage <<- x$message })
-  if (! .__curlError) {
-     mojo.path <- paste0(path,"/",model_id,".zip")
-     writeBin(tmp, mojo.path, useBytes = TRUE)
-  }
+  #Build URL for MOJO
+  urlSuffix <- paste0(.h2o.__MODELS,"/",URLencode(model_id),"/mojo")
+
+  #Build MOJO file path and download MOJO file & perform a safe (i.e. error-checked)
+  #HTTP GET request to an H2O cluster with MOJO URL
+  mojo.path <- file.path(path, paste0(model_id,".zip"))
+  writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, binary = TRUE), mojo.path, useBytes = TRUE)
+
   if (get_genmodel_jar) {
-    url = .h2o.calcBaseURL(h2oRestApiVersion = .h2o.__REST_API_VERSION, urlSuffix = "h2o-genmodel.jar")
-    tmp = tryCatch(getBinaryURL(url = url,
-                        useragent = R.version.string),
-                 error = function(x) { .__curlError <<- TRUE; .__curlErrorMessage <<- x$message })
-    if (! .__curlError) {
-      jar.path <- paste0(path, "/h2o-genmodel.jar")
-      writeBin(tmp, jar.path, useBytes = TRUE)
-    }
+    urlSuffix = "h2o-genmodel.jar"
+    #Build genmodel.jar file path
+    jar.path <- file.path(path,"h2o-genmodel.jar")
+    #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
+    #and write to jar.path.
+    writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, binary = TRUE), jar.path, useBytes = TRUE)
   }
   return(paste0(model_id,".zip"))
 }

--- a/h2o-r/tests/testdir_misc/runit_mojo.R
+++ b/h2o-r/tests/testdir_misc/runit_mojo.R
@@ -2,9 +2,29 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
 
 test.mojo <- function() {
+	#Set up tmp directory to write MOJO
+	dir <- dir.create(file.path(sandbox(),"mojos"))
+	#Set up path as dir.create() just sets up the directory and returns a logical based on if if failed or not
+	path <- file.path(sandbox(),"mojos")
+
+	#Build GBM model
 	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
 	hh <- h2o.gbm(x=c(1,2,3,4),y=5,training_frame=iris.hex)
-	h2o.download_mojo(hh) #check mojo
-	h2o.download_mojo(hh,get_genmodel_jar=TRUE) #Check genmodel.jar
+
+	#Download MOJO
+	print(sprintf("Dowloading MOJO..."))
+	start_time <- Sys.time()
+	mojo_file <- h2o.download_mojo(hh,path=path) #check mojo
+	end_time <- Sys.time()
+	print(sprintf("MOJO file is %s bytes", object.size(mojo_file)))
+	#Just a check for MOJO size (PUBDEV 3819)
+	expect(object.size(mojo_file) > 1, "MOJO file should be greater than 1 byte!")
+	print(sprintf("Time taken to dowloand MOJO: %s",end_time - start_time))
+
+	#Download genmodel
+	h2o.download_mojo(hh,path=path,get_genmodel_jar=TRUE) #Check genmodel.jar
+
+	#Delete tmp directory
+	on.exit(unlink(path,recursive=TRUE))
 }
 doTest("Test MOJO", test.mojo)

--- a/h2o-r/tests/testdir_misc/runit_mojo.R
+++ b/h2o-r/tests/testdir_misc/runit_mojo.R
@@ -2,10 +2,11 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
 
 test.mojo <- function() {
-	#Set up tmp directory to write MOJO
-	dir <- dir.create(file.path(sandbox(),"mojos"))
 	#Set up path as dir.create() just sets up the directory and returns a logical based on if if failed or not
 	path <- file.path(sandbox(),"mojos")
+
+	#Set up tmp directory to write MOJO
+	dir <- dir.create(path)
 
 	#Build GBM model
 	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
@@ -13,13 +14,13 @@ test.mojo <- function() {
 
 	#Download MOJO
 	print(sprintf("Dowloading MOJO..."))
-	start_time <- Sys.time()
+	start_time <- proc.time()[[3]]
 	mojo_file <- h2o.download_mojo(hh,path=path) #check mojo
-	end_time <- Sys.time()
-	print(sprintf("MOJO file is %s bytes", object.size(mojo_file)))
+	end_time <- proc.time()[[3]]
+	cat(sprintf("MOJO file is %.2f bytes", object.size(mojo_file)),"\n")
 	#Just a check for MOJO size (PUBDEV 3819)
-	expect(object.size(mojo_file) > 1, "MOJO file should be greater than 1 byte!")
-	print(sprintf("Time taken to dowloand MOJO: %s",end_time - start_time))
+	expect_that(object.size(mojo_file), is_more_than(1))
+	cat(sprintf("Time taken to dowloand MOJO: %.2f",end_time - start_time))
 
 	#Download genmodel
 	h2o.download_mojo(hh,path=path,get_genmodel_jar=TRUE) #Check genmodel.jar

--- a/h2o-r/tests/testdir_misc/runit_pojo.R
+++ b/h2o-r/tests/testdir_misc/runit_pojo.R
@@ -2,10 +2,11 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
 
 test.pojo <- function() {
-	#Set up tmp directory to write POJO
-	dir <- dir.create(file.path(sandbox(),"pojos"))
 	#Set up path as dir.create() just sets up the directory and returns a logical based on if if failed or not
 	path <- file.path(sandbox(),"pojos")
+
+	#Set up tmp directory to write POJO
+	dir <- dir.create(path)
 
 	#Build GBM model
 	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
@@ -13,11 +14,11 @@ test.pojo <- function() {
 
 	#Download POJO
 	print(sprintf("Dowloading POJO..."))
-	start_time <- Sys.time()
+	start_time <- proc.time()[[3]]
 	pojo_file <- h2o.download_pojo(hh,path=path) #check pojo
-	end_time <- Sys.time()
-	print(sprintf("POJO file is %s bytes", object.size(pojo_file)))
-	print(sprintf("Time taken to dowloand POJO: %s",end_time - start_time))
+	end_time <- proc.time()[[3]]
+	cat(sprintf("POJO file is %.2f bytes", object.size(pojo_file)),"\n")
+	cat(sprintf("Time taken to dowloand POJO: %.2f",end_time - start_time))
 
 	#Download genmodel
 	h2o.download_pojo(hh,path=path,get_jar=TRUE) #Check genmodel.jar

--- a/h2o-r/tests/testdir_misc/runit_pojo.R
+++ b/h2o-r/tests/testdir_misc/runit_pojo.R
@@ -1,12 +1,28 @@
 setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
-#----------------------------------------------------------------------
-# Purpose:  This test is a sanity check for a pojo download
-#----------------------------------------------------------------------
+
 test.pojo <- function() {
+	#Set up tmp directory to write POJO
+	dir <- dir.create(file.path(sandbox(),"pojos"))
+	#Set up path as dir.create() just sets up the directory and returns a logical based on if if failed or not
+	path <- file.path(sandbox(),"pojos")
+
+	#Build GBM model
 	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
 	hh <- h2o.gbm(x=c(1,2,3,4),y=5,training_frame=iris.hex)
-	h2o.download_pojo(hh) #check pojo
-	h2o.download_pojo(hh,get_jar=TRUE) #Check genmodel.jar
+
+	#Download POJO
+	print(sprintf("Dowloading POJO..."))
+	start_time <- Sys.time()
+	pojo_file <- h2o.download_pojo(hh,path=path) #check pojo
+	end_time <- Sys.time()
+	print(sprintf("POJO file is %s bytes", object.size(pojo_file)))
+	print(sprintf("Time taken to dowloand POJO: %s",end_time - start_time))
+
+	#Download genmodel
+	h2o.download_pojo(hh,path=path,get_jar=TRUE) #Check genmodel.jar
+
+	#Delete tmp directory
+	on.exit(unlink(path,recursive=TRUE))
 }
 doTest("Test POJO", test.pojo)


### PR DESCRIPTION
### This PR does the following

- Safe GET calls for POJO/MOJO/genmodel
- Always return binary data when doing a REST call in R API
- Convert raw vector of output from curlPerfom() to character if non-binary payload is desired (default behavior). If MOJOs/genmodel are called upon, then a raw vector is returned
- If a HTTP exception is raised (status !=200), then ensure payload is of type character. Otherwise a conversion to JSON cannot happen with a raw vector, which is produced when payload is binary data