### PR TITLE
H2O Ensemble - weights_column

### DIFF
--- a/h2o-r/ensemble/h2oEnsemble-package/R/performance.R
+++ b/h2o-r/ensemble/h2oEnsemble-package/R/performance.R
@@ -25,13 +25,14 @@ h2o.ensemble_performance <- function(object, newdata, score_base_models = TRUE) 
   }
   names(newdata_levelone) <- names(object$basefits)
   newdata_levelone$y <- newdata[,object$y]  #cbind the response column to calculate metrics
+  newdata_levelone$weights <- newdata[,object$weights]  #cbind the weight column to calculate metrics
   newdata_metrics <- h2o.performance(model = object$metafit, newdata = newdata_levelone)
   if (score_base_models) {
     newdata_base_metrics <- sapply(object$basefits, function(ll) h2o.performance(model = ll, newdata = newdata))
   } else {
     newdata_base_metrics <- NULL
   }
-
+  
   out <- list(ensemble = newdata_metrics, base = newdata_base_metrics)
   class(out) <- "h2o.ensemble_performance"
   return(out)

--- a/h2o-r/ensemble/h2oEnsemble-package/R/wrappers.R
+++ b/h2o-r/ensemble/h2oEnsemble-package/R/wrappers.R
@@ -51,7 +51,7 @@ h2o.glm.wrapper <- function(x, y, training_frame, model_id = NULL,
                             max_runtime_secs = 0,
                             missing_values_handling = c("MeanImputation", "Skip"), ...) {
   
-  # Also, offset_column, weights_column, intercept not implemented at the moment due to similar bug as beta_constraints
+  # Also, offset_column, intercept not implemented at the moment due to similar bug as beta_constraints
   h2o.glm(x = x, y = y, training_frame = training_frame, model_id = model_id, 
           validation_frame = validation_frame, 
           ignore_const_cols = ignore_const_cols,
@@ -75,7 +75,7 @@ h2o.glm.wrapper <- function(x, y, training_frame, model_id = NULL,
           keep_cross_validation_predictions = keep_cross_validation_predictions, 
           #beta_constraints = beta_constraints,
           #offset_column = offset_column, 
-          #weights_column = weights_column, 
+          weights_column = weights_column, 
           #intercept = intercept, 
           max_active_predictors = max_active_predictors, 
           objective_epsilon = objective_epsilon,


### PR DESCRIPTION
The changes modify some of the functions within H2O's ensemble code to allow for models and metrics to utilize weights. All learners will inherit the weights_column value defined in the ensemble model. The metalearner must be defined separately to include the weights:

h2o.glm.meta <- function(...) h2o.glm.wrapper(..., weights_columns = '_FREQ_')
metalearner <- "h2o.glm.meta"