### PR TITLE
GBM efficiency improvements

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -312,7 +312,7 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
     }
 
     // Abstract classes implemented by the tree builders
-    abstract protected M makeModel( Key modelKey, P parms);
+    abstract protected M makeModel(Key<M> modelKey, P parms);
     abstract protected boolean doOOBScoring();
     abstract protected boolean buildNextKTrees();
     abstract protected void initializeModelSpecifics();
@@ -535,6 +535,27 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
   protected final Vec vec_work( Frame fr, int c) { return fr.vecs()[idx_work(c)]; }
   protected final Vec vec_nids( Frame fr, int c) { return fr.vecs()[idx_nids(c)]; }
   protected final Vec vec_oobt( Frame fr       ) { return fr.vecs()[idx_oobt()]; }
+
+  protected static class FrameMap extends Iced<FrameMap> {
+    public int responseIndex;
+    public int offsetIndex;
+    public int weightIndex;
+    public int tree0Index;
+    public int work0Index;
+    public int nids0Index;
+    public int oobtIndex;
+
+    public FrameMap() {}  // For Externalizable interface
+    public FrameMap(SharedTree t) {
+      responseIndex = t.idx_resp();
+      offsetIndex = t.idx_offset();
+      weightIndex = t.idx_weight();
+      tree0Index = t.idx_tree(0);
+      work0Index = t.idx_work(0);
+      nids0Index = t.idx_nids(0);
+      oobtIndex = t.idx_oobt();
+    }
+  }
 
   protected double[] data_row( Chunk chks[], int row, double[] data) {
     assert data.length == _ncols;

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -588,12 +588,15 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       init = d;
     }
 
-    @Override public boolean modifiesVolatileVecs() { return true; }
+    @Override
+    protected boolean modifiesVolatileVecs() {
+      return true;
+    }
 
     @Override
     public void map(Chunk tree) {
       if (tree instanceof C8DVolatileChunk) {
-        Arrays.fill(((C8DVolatileChunk)tree).getValues(), init);
+        Arrays.fill(((C8DVolatileChunk) tree).getValues(), init);
       } else {
         for (int i = 0; i < tree._len; i++)
           tree.set(i, init);
@@ -609,7 +612,8 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       fm = frameMap;
     }
 
-    @Override public void map(Chunk[] chks, NewChunk[] nc) {
+    @Override
+    public void map(Chunk[] chks, NewChunk[] nc) {
       final Chunk resp = chks[fm.responseIndex];
       final Chunk offset = chks[fm.offsetIndex];
       for (int i = 0; i < chks[0]._len; ++i)
@@ -647,7 +651,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
     public void map(Chunk[] chks) {
       Chunk ys = chks[fm.responseIndex];
       Chunk offset = chks[fm.offsetIndex];
-      Chunk weight = fm.weightIndex >= 0? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
+      Chunk weight = fm.weightIndex >= 0 ? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
       for (int row = 0; row < ys._len; row++) {
         double w = weight.atd(row);
         if (w == 0) continue;
@@ -689,10 +693,10 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
     @Override
     public void map(Chunk[] chks) {
       Chunk ys = chks[fm.responseIndex];
-      Chunk offset = fm.offsetIndex >= 0? chks[fm.offsetIndex] : new C0DChunk(0, chks[0]._len);
+      Chunk offset = fm.offsetIndex >= 0 ? chks[fm.offsetIndex] : new C0DChunk(0, chks[0]._len);
       Chunk preds = chks[fm.tree0Index];  // Prior tree sums
       C8DVolatileChunk wk = (C8DVolatileChunk) chks[fm.work0Index]; // Place to store residuals
-      Chunk weights = fm.weightIndex >= 0? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
+      Chunk weights = fm.weightIndex >= 0 ? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
       double[] fs = nclass > 1 ? new double[nclass + 1] : null;
       for (int row = 0; row < wk._len; row++) {
         double weight = weights.atd(row);
@@ -738,7 +742,8 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       _totalNumNodes = totalNumNodes;
     }
 
-    @Override public void map(Chunk[] chks) {
+    @Override
+    public void map(Chunk[] chks) {
       int len = _totalNumNodes - firstLeafIdx;  // number of leaves
       _mins = new float[len];
       _maxs = new float[len];
@@ -746,17 +751,17 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       Arrays.fill(_maxs, -Float.MAX_VALUE);
 
       Chunk ys = chks[fm.responseIndex];
-      Chunk offset = fm.offsetIndex >= 0? chks[fm.offsetIndex] : new C0DChunk(0, chks[0]._len);
+      Chunk offset = fm.offsetIndex >= 0 ? chks[fm.offsetIndex] : new C0DChunk(0, chks[0]._len);
       Chunk preds = chks[fm.tree0Index]; // Prior tree sums
       Chunk nids = chks[fm.nids0Index];
-      Chunk weights = fm.weightIndex >= 0? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
-      for( int row = 0; row < preds._len; row++) {
-        if( ys.isNA(row) ) continue;
-        if (weights.atd(row)==0) continue;
-        int nid = (int)nids.at8(row);
-        assert(nid!=ScoreBuildHistogram.UNDECIDED_CHILD_NODE_ID);
+      Chunk weights = fm.weightIndex >= 0 ? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
+      for (int row = 0; row < preds._len; row++) {
+        if (ys.isNA(row)) continue;
+        if (weights.atd(row) == 0) continue;
+        int nid = (int) nids.at8(row);
+        assert (nid != ScoreBuildHistogram.UNDECIDED_CHILD_NODE_ID);
         if (nid < 0) continue; //skip OOB and otherwise skipped rows
-        float f = (float)(preds.atd(row) + offset.atd(row));
+        float f = (float) (preds.atd(row) + offset.atd(row));
         int idx = nid - firstLeafIdx;
         _mins[idx] = Math.min(_mins[idx], f);
         _maxs[idx] = Math.max(_maxs[idx], f);
@@ -856,7 +861,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       Log.info("Computing Huber math for (up to) " + nstrata + " different strata.");
       _huberGamma = new double[nstrata];
       _wcounts = new double[nstrata];
-      Chunk weights = fm.weightIndex >= 0? cs[fm.weightIndex] : new C0DChunk(1, cs[0]._len);
+      Chunk weights = fm.weightIndex >= 0 ? cs[fm.weightIndex] : new C0DChunk(1, cs[0]._len);
       Chunk stratum = cs[fm.nids0Index];
       Chunk diffMinusMedianDiff = cs[cs.length - 1];
       for (int row = 0; row < cs[0]._len; ++row) {
@@ -918,11 +923,11 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
    * ESL2, page 387.  Step 2b iii.
    * Nids <== f(Nids)
    * For classification (bernoulli):
-   *    gamma_i = sum (w_i * res_i) / sum (w_i*p_i*(1 - p_i)) where p_i = y_i - res_i
+   * <pre>{@code    gamma_i = sum (w_i * res_i) / sum (w_i*p_i*(1 - p_i)) where p_i = y_i - res_i}</pre>
    * For classification (multinomial):
-   *    gamma_i_k = (nclass-1)/nclass * (sum res_i / sum (|res_i|*(1-|res_i|)))
+   * <pre>{@code    gamma_i_k = (nclass-1)/nclass * (sum res_i / sum (|res_i|*(1-|res_i|)))}</pre>
    * For regression (gaussian):
-   *    gamma_i = sum res_i / count(res_i)
+   * <pre>{@code    gamma_i = sum res_i / count(res_i)}</pre>
    */
   private static class GammaPass extends MRTask<GammaPass> {
     private final FrameMap fm;
@@ -978,9 +983,9 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         final C4VolatileChunk nids = (C4VolatileChunk) chks[fm.nids0Index + k]; // Node-ids  for this tree/class
         int[] nids_vals = nids.getValues();
         final Chunk ress = chks[fm.work0Index + k];  // Residuals for this tree/class
-        final Chunk offset = fm.offsetIndex >= 0? chks[fm.offsetIndex] : new C0DChunk(0, chks[0]._len);
+        final Chunk offset = fm.offsetIndex >= 0 ? chks[fm.offsetIndex] : new C0DChunk(0, chks[0]._len);
         final Chunk preds = chks[fm.tree0Index + k];
-        final Chunk weights = fm.weightIndex >= 0? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
+        final Chunk weights = fm.weightIndex >= 0 ? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
 
         // If we have all constant responses, then we do not split even the
         // root and the residuals should be zero.
@@ -1075,7 +1080,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         final C8DVolatileChunk ct = (C8DVolatileChunk) chks[fm.tree0Index + k];
         double[] ct_vals = ct.getValues();
         final Chunk y = chks[fm.responseIndex];
-        final Chunk weights = fm.weightIndex >= 0? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
+        final Chunk weights = fm.weightIndex >= 0 ? chks[fm.weightIndex] : new C0DChunk(1, chks[0]._len);
         long baseseed = (0xDECAF + _seed) * (0xFAAAAAAB + k * _ntrees1 + _ntrees2);
         for (int row = 0; row < nids._len; row++) {
           int nid = nids_vals[row];

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -176,8 +176,8 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
 
       // Set the initial prediction into the tree column 0
       if (_initialPrediction != 0.0) {
-        MRTask t = new MakeConstantVecTask(_initialPrediction);
-        t.doAll(vec_tree(_train, 0), _parms._build_tree_one_node);  // Only setting tree-column 0
+        new FillVecWithConstant(_initialPrediction)
+          .doAll(vec_tree(_train, 0), _parms._build_tree_one_node);  // Only setting tree-column 0
       }
     }
 
@@ -869,10 +869,10 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
   }
 
 
-  private static class MakeConstantVecTask extends MRTask<MakeConstantVecTask> {
+  private static class FillVecWithConstant extends MRTask<FillVecWithConstant> {
     private double init;
 
-    public MakeConstantVecTask(double d) {
+    public FillVecWithConstant(double d) {
       init = d;
     }
 

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -234,10 +234,8 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       int N = 1; //one step is enough - same as R
 
       double init = 0; //start with initial value of 0 for convergence
-      NewtonRaphson nrtask = new NewtonRaphson(frameMap, new Distribution(_parms));
       do {
-        nrtask.setValue(init);
-        double newInit = nrtask.doAll(train).value();
+        double newInit = new NewtonRaphson(frameMap, new Distribution(_parms), init).doAll(train).value();
         delta = Math.abs(init - newInit);
         init = newInit;
         Log.info("Iteration " + (++count) + ": initial value: " + init);
@@ -632,12 +630,9 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
     private double _numerator;
     private double _denominator;
 
-    public NewtonRaphson(FrameMap frameMap, Distribution distribution) {
+    public NewtonRaphson(FrameMap frameMap, Distribution distribution, double initialValue) {
       fm = frameMap;
       dist = distribution;
-    }
-
-    public void setValue(double initialValue) {
       _init = initialValue;
       _numerator = 0;
       _denominator = 0;

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -631,7 +631,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
     private double _denominator;
 
     public NewtonRaphson(FrameMap frameMap, Distribution distribution, double initialValue) {
-      assert fm != null;
+      assert frameMap != null && distribution != null;
       fm = frameMap;
       dist = distribution;
       _init = initialValue;

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -158,6 +158,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
 
     @Override protected boolean doOOBScoring() { return false; }
     @Override protected void initializeModelSpecifics() {
+      frameMap = new FrameMap(GBM.this);
       _mtry_per_tree = Math.max(1, (int)(_parms._col_sample_rate_per_tree * _ncols)); //per-tree
       if (!(1 <= _mtry_per_tree && _mtry_per_tree <= _ncols)) throw new IllegalArgumentException("Computed mtry_per_tree should be in interval <1,"+_ncols+"> but it is " + _mtry_per_tree);
       _mtry = Math.max(1, (int)(_parms._col_sample_rate * _parms._col_sample_rate_per_tree * _ncols)); //per-split
@@ -175,7 +176,6 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         _initialPrediction = getInitialValueQuantile(_parms._quantile_alpha);
       }
       _model._output._init_f = _initialPrediction; //always write the initial value here (not just for Bernoulli)
-      frameMap = new FrameMap(GBM.this);
 
       // Set the initial prediction into the tree column 0
       if (_initialPrediction != 0.0) {
@@ -631,6 +631,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
     private double _denominator;
 
     public NewtonRaphson(FrameMap frameMap, Distribution distribution, double initialValue) {
+      assert fm != null;
       fm = frameMap;
       dist = distribution;
       _init = initialValue;


### PR DESCRIPTION
This PR converts all MRTasks used within the GBM class into static classes. The problem with the non-static classes is that they pull the entire model class into their serialization, which can be quite large and expensive to pass around the nodes. Making every MRTask static and passing only minimal required information avoids this overhead, which should result in faster GBM training times.