### PR TITLE
PUBDEV-3855: Update copyright year in documentation

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -689,7 +689,7 @@
         </div>
     <div class="row">
         <div class="col-12">
-    <p class="copyright">Copyright &copy;2016 H2O.ai. All rights reserved.</p>
+    <p class="copyright">Copyright &copy;2016-2017 H2O.ai. All rights reserved.</p>
          </div>
     </div>
     </footer>

--- a/h2o-docs/src/product/conf.py
+++ b/h2o-docs/src/product/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'H2O'
-copyright = u'2016 H2O, Inc'
+copyright = u'2016-2017 H2O.ai'
 author = u'h2o'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/h2o-py/docs/conf.py
+++ b/h2o-py/docs/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'H2O'
-copyright = u'2015-2016, H2O.ai'
+copyright = u'2015-2017 H2O.ai'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Added “2017” to the copyright year in the footer of the H2O UG and H2O Python docs. Also updated the footer in the docs.h2o.ai site.