### PR TITLE
[PUBDEV-3863] add a parameter in EasyPredictModelWrapper to not throw…

### DIFF
--- a/h2o-genmodel/src/main/java/overview.html
+++ b/h2o-genmodel/src/main/java/overview.html
@@ -116,12 +116,15 @@ public class main {
     EasyPredictModelWrapper model = new EasyPredictModelWrapper(rawModel);
     //
     // By default, unknown categorical levels throw PredictUnknownCategoricalLevelException.
-    // Optionally configure the wrapper to treat unknown categorical levels as N/A instead:
+    // Optionally configure the wrapper to treat unknown categorical levels as N/A instead
+    // and strings that cannot be converted to numbers also to N/As:
     //
     //     EasyPredictModelWrapper model = new EasyPredictModelWrapper(
-    //                                         new EasyPredictModelWrapper.Config()
-    //                                             .setModel(rawModel)
-    //                                             .setConvertUnknownCategoricalLevelsToNa(true));
+    //         new EasyPredictModelWrapper.Config()
+    //             .setModel(rawModel)
+    //             .setConvertUnknownCategoricalLevelsToNa(true)
+    //             .setConvertInvalidNumbersToNa(true)
+    //     );
 
     RowData row = new RowData();
      row.put("Year", "1987");

--- a/h2o-genmodel/src/test/java/hex/genmodel/easy/EasyPredictModelWrapperTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/easy/EasyPredictModelWrapperTest.java
@@ -102,7 +102,8 @@ public class EasyPredictModelWrapperTest {
 
     m = new EasyPredictModelWrapper(new EasyPredictModelWrapper.Config()
             .setModel(rawModel)
-            .setConvertUnknownCategoricalLevelsToNa(true));
+            .setConvertUnknownCategoricalLevelsToNa(true)
+            .setConvertInvalidNumbersToNa(true));
 
     {
       RowData row0 = new RowData();


### PR DESCRIPTION
… exceptions on strings that are not parseable as numbers (and treat them as NAs instead)
