### PR TITLE
Fixed h2o.get_grid().  model.full_parameters[parm][actual_value] some…

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -695,7 +695,11 @@ def get_grid(grid_id):
     hyper_params = {param: set() for param in gs.hyper_names}
     for param in gs.hyper_names:
         for model in models:
-            hyper_params[param].add(model.full_parameters[param]["actual_value"][0])
+            if isinstance(model.full_parameters[param]["actual_value"], list):
+                hyper_params[param].add(model.full_parameters[param]["actual_value"][0])
+            else:
+                hyper_params[param].add(model.full_parameters[param]["actual_value"])
+
     hyper_params = {str(param): list(vals) for param, vals in hyper_params.items()}
     gs.hyper_params = hyper_params
     gs.model = model.__class__()

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
@@ -31,9 +31,13 @@ def airline_gbm_random_grid():
 
   air_grid = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_parameters, search_criteria=search_crit)
   air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, distribution="bernoulli")
-
   assert(len(air_grid.get_grid())==5)
   print(air_grid.get_grid("logloss"))
+
+  # added this part to check h2o.get_grid is working properly
+  fetch_grid = h2o.get_grid(str(air_grid.grid_id))
+  assert len(air_grid.get_grid())==len(fetch_grid.get_grid())
+
 
 if __name__ == "__main__":
   pyunit_utils.standalone_test(airline_gbm_random_grid)


### PR DESCRIPTION
Model parameters are sometimes returned as a list but other times as a single element.  In h2o.get_grid(), it is assumed to be a list.  I fix it so that h2o.get_grid() will work in both cases. 

Please find the pyunit test in pyunit_gbm_random_grid.py