### PR TITLE
[PUBDEV-3876][HOTFIX] :fire: Handle windows path correctly.

### DIFF
--- a/h2o-core/src/main/java/water/persist/PersistManager.java
+++ b/h2o-core/src/main/java/water/persist/PersistManager.java
@@ -6,6 +6,7 @@ import water.MRTask;
 import water.Value;
 import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.UploadFileVec;
+import water.util.FileUtils;
 import water.util.Log;
 import water.persist.Persist.PersistEntry;
 
@@ -264,7 +265,7 @@ public class PersistManager {
    * @param dels  (Output) I don't know what this is
    */
   public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
-    URI uri = URI.create(path);
+    URI uri = FileUtils.getURI(path);
     String scheme = uri.getScheme();
     if (scheme == null || "file".equals(scheme)) {
       I[Value.NFS].importFiles(path, pattern, files, keys, fails, dels);


### PR DESCRIPTION
The `URI.create()` call does not accept windows URI and it needs to be handled via `File` API.