### PR TITLE
DONLY and IGNORE flags for junit runner reimplemented.

### DIFF
--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -136,15 +136,34 @@ public class TestUtil extends Iced {
   @Rule transient public TestRule runRule = new TestRule() {
     @Override public Statement apply(Statement base, Description description) {
       String testName = description.getClassName() + "#" + description.getMethodName();
-      if ((ignoreTestsNames != null && Arrays.asList(ignoreTestsNames).contains(testName)) ||
-          (doonlyTestsNames != null && !Arrays.asList(doonlyTestsNames).contains(testName))) {
+      boolean ignored = false;
+      if (ignoreTestsNames != null && ignoreTestsNames.length > 0) {
+        for (String tn : ignoreTestsNames) {
+          if (testName.startsWith(tn)) {
+            ignored = true;
+            break;
+          }
+        }
+      }
+      if (doonlyTestsNames != null && doonlyTestsNames.length > 0) {
+        ignored = true;
+        for (String tn : doonlyTestsNames) {
+          if (testName.startsWith(tn)) {
+            ignored = false;
+            break;
+          }
+        }
+      }
+      if (ignored) {
         // Ignored tests trump do-only tests
         Log.info("#### TEST " + testName + " IGNORED");
         return new Statement() {
           @Override
           public void evaluate() throws Throwable {}
         };
-      } else { return base; }
+      } else {
+        return base;
+      }
     }
   };
 


### PR DESCRIPTION
Right now, DOONLY/IGNORE flags can contain only prefix name instead of full test name.