### PR TITLE
[PUBDEV-3894] [PUBDEV-3895] Fix binary comparisons on time columns

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/operators/AstBinOp.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/operators/AstBinOp.java
@@ -336,7 +336,7 @@ abstract public class AstBinOp extends AstPrimitive {
   private ValFrame frame_op_row(Frame lf, Frame row) {
     final double[] rawRow = new double[row.numCols()];
     for (int i = 0; i < rawRow.length; ++i)
-      rawRow[i] = row.vec(i).isNumeric() ? row.vec(i).at(0) : Double.NaN; // is numeric, if not then NaN
+      rawRow[i] = row.vec(i).isNumeric() || row.vec(i).isTime() ? row.vec(i).at(0) : Double.NaN; // is numberlike, if not then NaN
     Frame res = new MRTask() {
       @Override
       public void map(Chunk[] chks, NewChunk[] cress) {

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -36,7 +36,7 @@ from h2o.utils.shared_utils import (_handle_numpy_array, _handle_pandas_data_fra
                                     _handle_python_lists, _is_list, _is_str_list, _py_tmp_key, _quoted,
                                     can_use_pandas, quote, normalize_slice, slice_is_normalized, check_frame_id)
 from h2o.utils.typechecks import (assert_is_type, assert_satisfies, Enum, I, is_type, numeric, numpy_ndarray,
-                                  pandas_dataframe, scipy_sparse, U)
+                                  numpy_datetime, pandas_dataframe, pandas_timestamp, scipy_sparse, U)
 
 __all__ = ("H2OFrame", )
 
@@ -2873,8 +2873,8 @@ class H2OFrame(object):
 #-----------------------------------------------------------------------------------------------------------------------
 
 def _binop(lhs, op, rhs):
-    assert_is_type(lhs, str, numeric, datetime.date, H2OFrame)
-    assert_is_type(rhs, str, numeric, datetime.date, H2OFrame)
+    assert_is_type(lhs, str, numeric, datetime.date, pandas_timestamp, numpy_datetime, H2OFrame)
+    assert_is_type(rhs, str, numeric, datetime.date, pandas_timestamp, numpy_datetime, H2OFrame)
     if isinstance(lhs, H2OFrame) and isinstance(rhs, H2OFrame):
         lrows, lcols = lhs.shape
         rrows, rcols = rhs.shape
@@ -2889,10 +2889,20 @@ def _binop(lhs, op, rhs):
         if not compatible:
             raise H2OValueError("Attempting to operate on incompatible frames: (%d x %d) and (%d x %d)"
                                 % (lrows, lcols, rrows, rcols))
+
     if isinstance(lhs, datetime.date):
         lhs = H2OFrame.moment(date=lhs)
+    elif is_type(lhs, pandas_timestamp):
+        lhs = H2OFrame.moment(date=lhs.to_pydatetime())
+    elif is_type(lhs, numpy_datetime):
+        lhs = H2OFrame.moment(date=datetime.utcfromtimestamp(lhs.astype(int) / 1e9))
+
     if isinstance(rhs, datetime.date):
         rhs = H2OFrame.moment(date=rhs)
+    elif is_type(rhs, pandas_timestamp):
+        rhs = H2OFrame.moment(date=rhs.to_pydatetime())
+    elif is_type(rhs, numpy_datetime):
+        rhs = H2OFrame.moment(date=datetime.utcfromtimestamp(rhs.astype(int) / 1e9))
 
     cache = lhs._ex._cache if isinstance(lhs, H2OFrame) else rhs._ex._cache
     return H2OFrame._expr(expr=ExprNode(op, lhs, rhs), cache=cache)

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2895,14 +2895,14 @@ def _binop(lhs, op, rhs):
     elif is_type(lhs, pandas_timestamp):
         lhs = H2OFrame.moment(date=lhs.to_pydatetime())
     elif is_type(lhs, numpy_datetime):
-        lhs = H2OFrame.moment(date=datetime.utcfromtimestamp(lhs.astype(int) / 1e9))
+        lhs = H2OFrame.moment(date=datetime.datetime.utcfromtimestamp(lhs.astype(int) / 1e9))
 
     if isinstance(rhs, datetime.date):
         rhs = H2OFrame.moment(date=rhs)
     elif is_type(rhs, pandas_timestamp):
         rhs = H2OFrame.moment(date=rhs.to_pydatetime())
     elif is_type(rhs, numpy_datetime):
-        rhs = H2OFrame.moment(date=datetime.utcfromtimestamp(rhs.astype(int) / 1e9))
+        rhs = H2OFrame.moment(date=datetime.datetime.utcfromtimestamp(rhs.astype(int) / 1e9))
 
     cache = lhs._ex._cache if isinstance(lhs, H2OFrame) else rhs._ex._cache
     return H2OFrame._expr(expr=ExprNode(op, lhs, rhs), cache=cache)

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -72,6 +72,7 @@ def connect(server=None, url=None, ip=None, port=None, https=None, verify_ssl_ce
     h2oconn = H2OConnection.open(server=server, url=url, ip=ip, port=port, https=https, auth=auth,
                                  verify_ssl_certificates=verify_ssl_certificates, proxy=proxy,
                                  cluster_id=cluster_id, cookies=cookies, verbose=verbose)
+    h2oconn.cluster.timezone = "UTC"
     if verbose:
         h2oconn.cluster.show_status()
     return h2oconn
@@ -245,6 +246,7 @@ def init(url=None, ip=None, port=None, https=None, insecure=None, username=None,
                                      auth=auth, proxy=proxy, cluster_id=cluster_id, cookies=cookies, verbose=True)
     if check_version:
         version_check()
+    h2oconn.cluster.timezone = "UTC"
     h2oconn.cluster.show_status()
 
 

--- a/h2o-py/h2o/utils/typechecks.py
+++ b/h2o-py/h2o/utils/typechecks.py
@@ -416,7 +416,9 @@ numeric = U(int, float)
 
 h2oframe = _LazyClass("h2o", "H2OFrame")
 pandas_dataframe = _LazyClass("pandas", "DataFrame")
+pandas_timestamp = _LazyClass("pandas", "Timestamp")
 numpy_ndarray = _LazyClass("numpy", "ndarray")
+numpy_datetime = _LazyClass("numpy", "datetime64")
 scipy_sparse = _LazyClass("scipy.sparse", "issparse", lambda value, t: t(value))
 
 

--- a/h2o-py/tests/testdir_misc/pyunit_time_comparisons.py
+++ b/h2o-py/tests/testdir_misc/pyunit_time_comparisons.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import h2o
+import pandas as pd
+import numpy as np
+from tests import pyunit_utils
+
+
+def test_date_comparisons():
+    dfpd = pd.DataFrame({"date": pd.date_range("1/1/2011", periods=10), "value": range(10)})
+    dfh2o = h2o.H2OFrame(dfpd)
+    z1 = dfpd["date"].min()
+    z2 = dfpd["date"].values[2]
+    assert isinstance(z1, pd.Timestamp)
+    assert isinstance(z2, np.datetime64)
+
+    test1pd = dfpd["date"] > z1
+    test1h2o = dfh2o["date"] > z1
+    assert test1pd.sum() == 9, "Incorrect Pandas comparison result:\n%r" % test1pd
+    assert test1h2o.sum().flatten() == 9, "Incorrect H2O comparison result:\n%r" % test1h2o
+
+    test2pd = dfpd["date"] > z2
+    test2h2o = dfh2o["date"] > z2
+    assert test2pd.sum() == 7, "Incorrect Pandas comparison result:\n%r" % test2pd
+    assert test2h2o.sum().flatten() == 7, "Incorrect H2O comparison result:\n%r" % test2h2o
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_date_comparisons)
+else:
+    test_date_comparisons()

--- a/h2o-py/tests/testdir_munging/pyunit_count_temps.py
+++ b/h2o-py/tests/testdir_munging/pyunit_count_temps.py
@@ -10,6 +10,7 @@ def date_munge():
     # crimes_path = "smalldata/chicago/chicagoCrimes10k.csv.zip"
 
     hc = h2o.connection()
+    assert hc.session_id  # Make sure the `POST /4/session` call has happened
     tmps0 = pyunit_utils.temp_ctr()
 
     # GET /3/ImportFiles
@@ -38,7 +39,6 @@ def date_munge():
     crimes = crimes.drop("Date")
     print("# of REST calls used: %d" % (hc.requests_count - rest1))
 
-    # POST /4/sessions
     # POST /99/Rapids  {ast:(tmp= py8 (cols (append
     #                        (tmp= py7 (append
     #                         (tmp= py6 (append
@@ -65,7 +65,7 @@ def date_munge():
     print("Number of temps used: %d" % ntmps)
     print("Number of RESTs used: %d" % nrest)
     assert ntmps == 8
-    assert nrest == 3
+    assert nrest == 2
 
 
 


### PR DESCRIPTION
This actually fixes 2 separate issues (but reported simultaneously):
1) binary comparisons did not work properly with time columns.
2) python module understood only native python `datetime` types, but not Pandas / numpy datetime objects. By supporting those we improve interoperability between our h2o module and pandas (numpy)