### PR TITLE
PUBDEV-3838: Documentation for K-Means parameters

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/col_sample_rate_change_per_level.rst
+++ b/h2o-docs/src/product/data-science/algo-params/col_sample_rate_change_per_level.rst
@@ -14,7 +14,7 @@ This option specifies the relative change of the column sampling rate for every 
 - level 2: ``col_sample_rate`` * factor^2
 - level 3: ``col_sample_rate`` * factor^3
 
-*where factor is the ``col_sample_rate_change_per_level``
+where factor is the ``col_sample_rate_change_per_level``
 
 As indicated above, this option is multiplicative with ``col_sample_rate``. The effective sampling rate at a given level is:
 

--- a/h2o-docs/src/product/data-science/algo-params/estimate_k.rst
+++ b/h2o-docs/src/product/data-science/algo-params/estimate_k.rst
@@ -1,0 +1,91 @@
+``estimate_k``
+--------------
+
+- Available in: K-Means
+- Hyperparameter: yes
+
+Description
+~~~~~~~~~~~
+
+This option is used to specify whether to estimate the number of clusters (:math:`<=k`) iteratively (independent of the seed) and deterministically (beginning with :math:`k=1,2,3...`). If enabled, for each :math:`k` the estimate will go up to ``max_iterations``. 
+
+**Notes**: 
+
+- This option requires that at least one column includes numeric data. You will receive an error if your data has no numeric columns. 
+- If this option is enabled and a ``seed`` is provided, the ``seed`` will be ignored unless you are performing cross validation. 
+- This option cannot be used with ``user_points``. You will receive an error during model training if you enable this option and specify ``user_points``. 
+
+This option is disabled by default.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `k <k.html>`__
+- `max_iterations <max_iterations.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris <-h2o.importFile("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] <-as.factor(iris['class'])
+
+	# set the predictor names 
+	predictors <-colnames(iris)[-length(iris)]
+
+	# split into train and validation
+	iris_splits <- h2o.splitFrame(data = iris, ratios = .8, seed = 1234)
+	train <- iris_splits[[1]]
+	valid <- iris_splits[[2]]
+
+	# try using the `estimate_k` parameter:
+	# set k to the upper limit of classes you'd like to consider
+	# set standardize to False as well since the scales for each feature are very close
+	iris_kmeans <- h2o.kmeans(x = predictors, k = 10, estimate_k = T, standardize = F, 
+	                          training_frame = train, validation_frame=valid, seed = 1234)
+
+	# print the model summary to see the number of clusters chosen
+	summary(iris_kmeans)
+
+
+	
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.kmeans import H2OKMeansEstimator
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] = iris['class'].asfactor()
+
+	# set the predictor names 
+	predictors = iris.columns[:-1]
+
+	# split into train and validation sets
+	train, valid = iris.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `estimate_k` parameter:
+	# set k to the upper limit of classes you'd like to consider
+	# set standardize to False as well since the scales for each feature are very close
+	# initialize the estimator then train the model
+	iris_kmeans = H2OKMeansEstimator(k = 10, estimate_k = True, standardize = False, seed = 1234)
+	iris_kmeans.train(x = predictors, training_frame = train, validation_frame=valid)
+
+	# print the model summary to see the number of clusters chosen
+	iris_kmeans.summary()
+

--- a/h2o-docs/src/product/data-science/algo-params/init.rst
+++ b/h2o-docs/src/product/data-science/algo-params/init.rst
@@ -1,0 +1,151 @@
+``init``
+--------
+
+- Available in: GLRM, K-means
+- Hyperparameter: yes
+
+Description
+~~~~~~~~~~~
+
+This option specifies the initialization mode used in K-Means. The options are Random, Furthest, PlusPlus, and User.
+
+- **Random**: Choose :math:`K` clusters from the set of :math:`N` observations at random so that each observation has an equal chance of being chosen.
+
+- **Furthest** (Default): 
+
+  a. Choose one center :math:`m_{1}` at random.
+
+  b. Calculate the difference between :math:`m_{1}` and each of the remaining :math:`N-1` observations :math:`x_{i}`. :math:`d(x_{i}, m_{1}) = ||(x_{i}-m_{1})||^2`
+
+  c. Choose :math:`m_{2}` to be the :math:`x_{i}` that maximizes :math:`d(x_{i}, m_{1})`.
+
+  d. Repeat until :math:`K` centers have been chosen.
+
+- **PlusPlus**: 
+
+  a. Choose one center :math:`m_{1}` at random.
+
+  b. Calculate the difference between :math:`m_{1}` and each of the remaining :math:`N-1` observations :math:`x_{i}`. :math:`d(x_{i}, m_{1}) = \|(x_{i}-m_{1})\|^2`
+
+  c. Let :math:`P(i)` be the probability of choosing :math:`x_{i}` as :math:`m_{2}`. Weight :math:`P(i)` by :math:`d(x_{i}, m_{1})` so that those :math:`x_{i}` furthest from :math:`m_{2}` have a higher probability of being selected than those :math:`x_{i}` close to :math:`m_{1}`.
+
+  d. Choose the next center :math:`m_{2}` by drawing at random according to the weighted probability distribution.
+   
+  e. Repeat until :math:`K` centers have been chosen. 
+
+- **User** initialization allows you to specify a file (using the ``user_points`` parameter) that includes a vector of initial cluster centers. 
+
+**Notes**: 
+
+- The user-specified points dataset must have the same number of columns as the training observations.
+- This option is ignored when ``estimate_k`` is enabled. In this case, the algorithm is deterministic. 
+- If this option is not specified but a user-points file is specified, then this value will default to ``user``.
+
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `estimate_k <estimate_k.html>`__
+- `user_points <user_points.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the seeds dataset:
+	# this dataset looks at three different types of wheat varieties
+	# the original dataset can be found at http://archive.ics.uci.edu/ml/datasets/seeds
+	seeds <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/seeds_dataset.txt")
+
+	# set the predictor names 
+	# ignore the 8th column which has the prior known clusters for this dataset
+	predictors <-colnames(seeds)[-length(seeds)]
+
+	# split into train and validation
+	seeds_splits <- h2o.splitFrame(data = seeds, ratios = .8, seed = 1234)
+	train <- seeds_splits[[1]]
+	valid <- seeds_splits[[2]]
+
+	# try using the `init` parameter:
+	# build the model with three clusters
+	seeds_kmeans <- h2o.kmeans(x = predictors, k = 3, init='Furthest', training_frame = train, validation_frame = valid, seed = 1234)
+
+	# print the total within cluster sum-of-square error for the validation dataset
+	print(paste0("Total sum-of-square error for valid dataset: ", h2o.tot_withinss(object = seeds_kmeans, valid = T)))
+
+
+	# select the values for `init` to grid over:
+	# Note: this dataset is too small to see significant differences between these options
+	# the purpose of the example is to show how to use grid search with `init` if desired
+	hyper_params <- list( init = c("PlusPlus", "Furthest", "Random")  )
+
+	# this example uses cartesian grid search because the search space is small
+	# and we want to see the performance of all models. For a larger search space use
+	# random grid search instead: list(strategy = "RandomDiscrete")
+	grid <- h2o.grid(x = predictors, k = 3, training_frame = train, validation_frame = valid,
+	                 algorithm = "kmeans", grid_id = "seeds_grid", hyper_params = hyper_params,
+	                 search_criteria = list(strategy = "Cartesian"), seed = 1234)
+
+	## Sort the grid models by TotSS
+	sortedGrid <- h2o.getGrid("seeds_grid", sort_by  = "tot_withinss", decreasing = F)
+	sortedGrid
+
+
+	
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.kmeans import H2OKMeansEstimator
+	h2o.init()
+
+	# import the seeds dataset:
+	# this dataset looks at three different types of wheat varieties
+	# the original dataset can be found at http://archive.ics.uci.edu/ml/datasets/seeds
+	seeds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/seeds_dataset.txt")
+
+	# set the predictor names 
+	# ignore the 8th column which has the prior known clusters for this dataset
+	predictors = seeds.columns[0:7]
+
+	# split into train and validation sets
+	train, valid = seeds.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `init` parameter:
+	# initialize the estimator then train the model
+	seeds_kmeans = H2OKMeansEstimator(k = 3, init='Furthest', seed = 1234)
+	seeds_kmeans.train(x = predictors, training_frame = train, validation_frame= valid)
+
+	# print the total within cluster sum-of-square error for the validation dataset
+	print("sum-of-square error for valid:",seeds_kmeans.tot_withinss(valid = True))
+
+
+	# grid over `init`
+	# import Grid Search
+	from h2o.grid.grid_search import H2OGridSearch
+
+	# select the values for `init` to grid over
+	# Note: this dataset is too small to see significant differences between these options
+	# the purpose of the example is to show how to use grid search with `init` if desired
+	hyper_params = {'init': ["PlusPlus", "Furthest", "Random"]}
+
+	# this example uses cartesian grid search because the search space is small
+	# and we want to see the performance of all models. For a larger search space use
+	# random grid search instead: {'strategy': "RandomDiscrete"}
+	# initialize the estimator
+	seeds_kmeans = H2OKMeansEstimator(k = 3, seed = 1234)
+
+	# build grid search with previously made Kmeans and hyperparameters
+	grid = H2OGridSearch(model = seeds_kmeans, hyper_params = hyper_params,
+	                     search_criteria = {'strategy': "Cartesian"})
+
+	# train using the grid
+	grid.train(x = predictors, training_frame = train, validation_frame = valid)
+
+	# sort the grid models by total within cluster sum-of-square error.
+	sorted_grid = grid.get_grid(sort_by='tot_withinss', decreasing= False)
+	print(sorted_grid)

--- a/h2o-docs/src/product/data-science/algo-params/k.rst
+++ b/h2o-docs/src/product/data-science/algo-params/k.rst
@@ -1,0 +1,117 @@
+``k``
+-----
+
+- Available in: K-Means
+- Hyperparameter: yes
+
+Description
+~~~~~~~~~~~
+
+In K-Means, a "cluster" refers to groups of data in a dataset that are similar to one another. The K-Means algorithm finds clusters and cluster centers in a set of unlabled data.  
+
+This option specifies the maximum number of clusters that K-Means will form.  If ``estimate_k`` is disabled, the model will find :math:`k` centroids, otherwise it will find up to :math:`k` centroids. This value defaults to 1. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `estimate_k <estimate_k.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the seeds dataset:
+	# this dataset looks at three different types of wheat varieties
+	# the original dataset can be found at http://archive.ics.uci.edu/ml/datasets/seeds
+	seeds <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/seeds_dataset.txt")
+
+	# set the predictor names 
+	# ignore the 8th column which has the prior known clusters for this dataset
+	predictors <-colnames(seeds)[-length(seeds)]
+
+	# split into train and validation
+	seeds_splits <- h2o.splitFrame(data = seeds, ratios = .8, seed = 1234)
+	train <- seeds_splits[[1]]
+	valid <- seeds_splits[[2]]
+
+	# try using the `k` parameter:
+	# build the model with three clusters
+	seeds_kmeans <- h2o.kmeans(x = predictors, k = 3, training_frame = train, validation_frame = valid, seed = 1234)
+
+	# print the total within cluster sum-of-square error for the validation dataset
+	print(paste0("Total sum-of-square error for valid dataset: ", h2o.tot_withinss(object = seeds_kmeans, valid = T)))
+
+
+	# select the values for `k` to grid over:
+	# Note: this dataset is too small to see significant differences between these options
+	# the purpose of the example is to show how to use grid search with `k` if desired
+	hyper_params <- list( k = c(2,3,7)  )
+
+	# this example uses cartesian grid search because the search space is small
+	# and we want to see the performance of all models. For a larger search space use
+	# random grid search instead: list(strategy = "RandomDiscrete")
+	grid <- h2o.grid(x = predictors, training_frame = train, validation_frame = valid,
+	                 algorithm = "kmeans", grid_id = "seeds_grid", hyper_params = hyper_params,
+	                 search_criteria = list(strategy = "Cartesian"), seed = 1234)
+
+	## Sort the grid models by TotSS
+	sortedGrid <- h2o.getGrid("seeds_grid", sort_by  = "tot_withinss", decreasing = F)
+	sortedGrid
+	
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.kmeans import H2OKMeansEstimator
+	h2o.init()
+
+	# import the seeds dataset:
+	# this dataset looks at three different types of wheat varieties
+	# the original dataset can be found at http://archive.ics.uci.edu/ml/datasets/seeds
+	seeds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/seeds_dataset.txt")
+
+	# set the predictor names 
+	# ignore the 8th column which has the prior known clusters for this dataset
+	predictors = seeds.columns[0:7]
+
+	# split into train and validation sets
+	train, valid = seeds.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `k` parameter:
+	# build the model with three clusters
+	# initialize the estimator then train the model
+	seeds_kmeans = H2OKMeansEstimator(k = 3, seed = 1234)
+	seeds_kmeans.train(x = predictors, training_frame = train, validation_frame=valid)
+
+	# print the total within cluster sum-of-square error for the validation dataset
+	print("Total sum-of-square error for valid dataset:",seeds_kmeans.tot_withinss(valid = True))
+
+	# grid over `k`
+	# import Grid Search
+	from h2o.grid.grid_search import H2OGridSearch
+
+	# select the values for `k` to grid over
+	# Note: this dataset is too small to see significant differences between these options
+	# the purpose of the example is to show how to use grid search with `k` if desired
+	hyper_params = {'k': [2,3,7]}
+
+	# this example uses cartesian grid search because the search space is small
+	# and we want to see the performance of all models. For a larger search space use
+	# random grid search instead: {'strategy': "RandomDiscrete"}
+	# initialize the estimator
+	seeds_kmeans = H2OKMeansEstimator(seed = 1234)
+
+	# build grid search with previously made Kmeans and hyperparameters
+	grid = H2OGridSearch(model = seeds_kmeans, hyper_params = hyper_params,
+	                     search_criteria = {'strategy': "Cartesian"})
+
+	# train using the grid
+	grid.train(x = predictors, training_frame = train, validation_frame = valid)
+
+	# sort the grid models by total within cluster sum-of-square error.
+	sorted_grid = grid.get_grid(sort_by='tot_withinss', decreasing=False)
+	print(sorted_grid)

--- a/h2o-docs/src/product/data-science/algo-params/user_points.rst
+++ b/h2o-docs/src/product/data-science/algo-params/user_points.rst
@@ -1,0 +1,102 @@
+``user_points``
+---------------
+
+- Available in: K-Means
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+This option allows you to specify a dataframe,  where each row represents an initial cluster center. 
+**Notes**:
+
+- The user-specified points must have the same number of columns as the training observations. 
+- The number of rows must equal the number of clusters. 
+- ``init=furthest`` by default. However, if a user-points file is specified and a value for ``init`` is not, then ``init`` will automatically change to ``user``. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `init <init.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris <-h2o.importFile("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] <-as.factor(iris['class'])
+
+	# set the predictor names 
+	predictors <-colnames(iris)[-length(iris)]
+
+	# split into train and validation
+	iris_splits <- h2o.splitFrame(data = iris, ratios = .8, seed = 1234)
+	train <- iris_splits[[1]]
+	valid <- iris_splits[[2]]
+
+	# specify your points
+	point1 <- c(4.9,3.0,1.4,0.2)
+	point2 <- c(5.6,2.5,3.9,1.1)
+	point3 <- c(6.5,3.0,5.2,2.0)
+
+	# create an H2OFrame with your points
+	points <- as.h2o(t(data.frame(point1, point2, point3)))
+
+	# take a look at the H2OFrame
+	print(points)
+
+	# try using the `user_points` parameter:
+	iris_kmeans <- h2o.kmeans(x = predictors, k = 3, user_points =  points, training_frame = train, validation_frame = valid, seed = 1234)
+
+	# print the total within cluster sum-of-square error for the validation dataset
+	print(paste0("Total sum-of-square error for valid dataset: ", h2o.tot_withinss(object = iris_kmeans, valid = T)))
+
+	
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.kmeans import H2OKMeansEstimator
+	h2o.init()
+
+	# import the iris dataset:
+	# this dataset is used to classify the type of iris plant
+	# the original dataset can be found at https://archive.ics.uci.edu/ml/datasets/Iris
+	iris = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
+
+	# convert response column to a factor
+	iris['class'] = iris['class'].asfactor()
+
+	# set the predictor names and the response column name
+	predictors = iris.columns[:-1]
+
+	# split into train and validation sets
+	train, valid = iris.split_frame(ratios = [.8], seed = 1234)
+
+	# specify your points
+	point1 = [4.9,3.0,1.4,0.2]
+	point2 = [5.6,2.5,3.9,1.1]
+	point3 = [6.5,3.0,5.2,2.0]
+
+	# create an H2OFrame with your points
+	points = h2o.H2OFrame([point1, point2, point3])
+
+	# take a look at the H2OFrame
+	print(points)
+
+	# try using the `user_points` parameter:
+	# initialize the estimator then train the model
+	iris_kmeans = H2OKMeansEstimator(k = 3, user_points = points, seed = 1234)
+	iris_kmeans.train(x=predictors, training_frame=iris, validation_frame=valid)
+
+	# print the total within cluster sum-of-square error for the validation dataset
+	print("sum-of-square error for valid:", iris_kmeans.tot_withinss(valid = True))

--- a/h2o-docs/src/product/data-science/k-means.rst
+++ b/h2o-docs/src/product/data-science/k-means.rst
@@ -145,25 +145,31 @@ The number of clusters :math:`K` is user-defined and is determined a priori.
 1. Choose :math:`K` initial cluster centers :math:`m_{k}` according to one of the
    following:
 
-   -  **Randomization**: Choose :math:`K` clusters from the set of :math:`N` observations at random so that each observation has an equal chance of being chosen.
+    - **Random**: Choose :math:`K` clusters from the set of :math:`N` observations at random so that each observation has an equal chance of being chosen.
 
-   -  **Plus Plus**: Choose one center :math:`m_{1}` at random.
+    - **Furthest** (Default): 
 
-    a. Calculate the difference between :math:`m_{1}` and each of the remaining :math:`N-1` observations :math:`x_{i}`. :math:`d(x_{i}, m_{1}) = \|(x_{i}-m_{1})\|^2`
+      a. Choose one center :math:`m_{1}` at random.
 
-    b. Let :math:`P(i)` be the probability of choosing :math:`x_{i}` as :math:`m_{2}`. Weight :math:`P(i)` by :math:`d(x_{i}, m_{1})` so that those :math:`x_{i}` furthest from :math:`m_{2}` have a higher probability of being selected than those :math:`x_{i}` close to :math:`m_{1}`.
+      b. Calculate the difference between :math:`m_{1}` and each of the remaining :math:`N-1` observations :math:`x_{i}`. :math:`d(x_{i}, m_{1}) = ||(x_{i}-m_{1})||^2`
 
-    c. Choose the next center :math:`m_{2}` by drawing at random according to the weighted probability distribution.
-   
-    d. Repeat until :math:`K` centers have been chosen.
+      c. Choose :math:`m_{2}` to be the :math:`x_{i}` that maximizes :math:`d(x_{i}, m_{1})`.
 
-   -  **Furthest**: Choose one center :math:`m_{1}` at random.
+      d. Repeat until :math:`K` centers have been chosen.
 
-    a. Calculate the difference between :math:`m_{1}` and each of the remaining :math:`N-1` observations :math:`x_{i}`. :math:`d(x_{i}, m_{1}) = ||(x_{i}-m_{1})||^2`
+    - **PlusPlus**: 
 
-    b. Choose :math:`m_{2}` to be the :math:`x_{i}` that maximizes :math:`d(x_{i}, m_{1})`.
+      a. Choose one center :math:`m_{1}` at random.
 
-    c. Repeat until :math:`K` centers have been chosen.
+      b. Calculate the difference between :math:`m_{1}` and each of the remaining :math:`N-1` observations :math:`x_{i}`. :math:`d(x_{i}, m_{1}) = \|(x_{i}-m_{1})\|^2`
+
+      c. Let :math:`P(i)` be the probability of choosing :math:`x_{i}` as :math:`m_{2}`. Weight :math:`P(i)` by :math:`d(x_{i}, m_{1})` so that those :math:`x_{i}` furthest from :math:`m_{2}` have a higher probability of being selected than those :math:`x_{i}` close to :math:`m_{1}`.
+
+      d. Choose the next center :math:`m_{2}` by drawing at random according to the weighted probability distribution.
+       
+      e. Repeat until :math:`K` centers have been chosen. 
+
+    - **User** initialization allows you to specify a file (using the ``user_points`` parameter) that includes a vector of initial cluster centers. 
 
 2. Once :math:`K` initial centers have been chosen calculate the difference
    between each observation :math:`x_{i}` and each of the centers

--- a/h2o-docs/src/product/grid-search.rst
+++ b/h2o-docs/src/product/grid-search.rst
@@ -68,6 +68,7 @@ K-Means Hyperparameters
 -  ``seed``
 -  ``init``
 -  ``estimate_k``
+-  ``k``
 -  ``categorical_encoding``
 
 GLM Hyperparameters

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -32,6 +32,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/compute_p_values
    data-science/algo-params/distribution
    data-science/algo-params/early_stopping
+   data-science/algo-params/estimate_k
    data-science/algo-params/family
    data-science/algo-params/fold_assignment
    data-science/algo-params/fold_column
@@ -40,8 +41,10 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/huber_alpha
    data-science/algo-params/ignore_const_cols
    data-science/algo-params/ignored_columns
+   data-science/algo-params/init
    data-science/algo-params/interactions
    data-science/algo-params/intercept
+   data-science/algo-params/k
    data-science/algo-params/keep_cross_validation_fold_assignment
    data-science/algo-params/keep_cross_validation_predictions
    data-science/algo-params/lambda
@@ -88,6 +91,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/tweedie_link_power
    data-science/algo-params/tweedie_power
    data-science/algo-params/tweedie_variance_power
+   data-science/algo-params/user_points
    data-science/algo-params/validation_frame
    data-science/algo-params/weights_column
    data-science/algo-params/y


### PR DESCRIPTION
- Added documentation or 4 unique K-Means parameters.
- Updated parameters.rst file to include links to these parameter descriptions.
- Fixed the K-Means algorithm section in the K-Means topic to match the list of init options. (User was missing, and numbering was off.)
- Added k to list of grid search ;arameters.
- Driveby fix: Removed hanging “*” from col_sample_rate_change_per_level topic.