### PR TITLE
PUBDEV-3891: Documentation - handling of numerical missing values

### DIFF
--- a/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
@@ -1,6 +1,8 @@
 Missing Values (Categorical/Factors)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+**Note** Unlike in GLM, in GBM numerical values are handled the same way as categorical values. Missing values are not imputed with the mean, as is done by default in GLM.
+
 - **How does the algorithm handle missing values during training?**
 
  Missing values are interpreted as containing information (i.e., missing for a reason), rather than missing at random. During tree building, split decisions for every node are found by minimizing the loss function and treating missing values as a separate category that can go either left or right. 


### PR DESCRIPTION
Added a note indicating that GBM does not treat missing numerical values in the same way as GLM.