### PR TITLE
PUBDEV-3890: Documentation for GLM Solver

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/solver.rst
+++ b/h2o-docs/src/product/data-science/algo-params/solver.rst
@@ -13,11 +13,25 @@ In GLM, you can specify one of the following solvers:
 
 - IRLSM: Iteratively Reweighted Least Squares Method
 - L_BFGS: Limited-memory Broyden-Fletcher-Goldfarb-Shanno algorithm
-- AUTO: Sets the solver based on given data and parameters (default)
 - COORDINATE_DESCENT: Coordinate Decent
 - COORDINATE_DESCENT_NAIVE: Coordinate Decent Naive
+- AUTO: Sets the solver based on given data and parameters (default)
 
-Detailed information about each of these optiosn is available in the `Solvers <../glm.html#solvers>`__ section.
+Detailed information about each of these options is available in the `Solvers <../glm.html#solvers>`__ section. The bullets below describe GLM chooses the solver when ``solver=AUTO``:
+
+-  If there are more than 5k active predictors, GLM uses L_BFGS.
+-  If ``family=multinomial`` and ``alpha=0`` (ridge or no penalty), GLM uses L_BFGS.
+-  If lambda search is enabled, GLM uses COORDINATE_DESCENT.
+-  If your data has upper/lower bounds and no proximal penlaty, GLM uses COORDINATE_DESCENT.
+-  If none above is true, then GLM defaults to IRLSM. This is because COORDINATE_DESCENT works much better with lambda search.
+
+Below are some general guidelines to follow when specifying a solver.  
+
+- L_BFGS works much better for L2-only multininomial and if you have too many active predictors. 
+- You must use IRLSM if you have p-values. 
+- IRLSM and COORDINATE_DESCENT share the same path (i.e., they both compute the same gram matrix), they just solve it differently.
+- Use COORDINATE_DESCENT if you have less than 5000 predictors and L1 penalty.
+- COORDINATE_DESCENT performs better when ``lambda_search`` is enabled. Also with bounds, it tends to get a higher accuracy.
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -485,7 +485,7 @@ IRLSM (the default) uses a `Gram Matrix <https://en.wikipedia.org/wiki/Gramian_m
 
 - For a sparse solution with a dense dataset, use IRLSM with ``lambda_search=TRUE`` if fewer than 500 active predictors in the solution are expected; otherwise, use L-BFGS. Set ``alpha`` to be greater than 0 to add in an :math:`\ell_1` penalty to the elastic net regularization, which induces sparsity in the estimated coefficients.
 
-- For a sparse solution with a sparse dataset, use IRLSM with ``lambda_search=TRUE`` if you expect less than 5000 active predictors in the solution; otherwise, use L-BGGS. Set ``alpha`` to be greater than 0.
+- For a sparse solution with a sparse dataset, use IRLSM with ``lambda_search=TRUE`` if you expect less than 5000 active predictors in the solution; otherwise, use L-BFGS. Set ``alpha`` to be greater than 0.
 
 If you are unsure whether the solution should be sparse or dense, try both along with a grid of alpha values. The optimal model can be picked based on its performance on the validation data (or alternatively, based on the performance in cross-validation when not enough data is available to have a separate validation dataset).
 
@@ -498,6 +498,7 @@ In addition to IRLSM and L-BFGS, H2O's GLM includes options for specifying Coord
 
 - Coordinate Descent is IRLSM with the covariance updates version of cyclical coordinate descent in the innermost loop. This version is faster when :math:`N > p` and :math:`p` ~ :math:`500`.
 - Coordinate Descent Naive is IRLSM with the naive updates version of cyclical coordinate descent in the innermost loop.
+- Coordinate Descent provides much better results if lambda search is enabled. Also, with bounds, it tends to get higher accuracy.
 
 Both of the above method are explained in the `glmnet paper <https://core.ac.uk/download/pdf/6287975.pdf>`__. 
 


### PR DESCRIPTION
- Added more info describing how GLM selects the solver when
solver=AUTO.
- Fixed typo in Solver subtopic, and added a bullet about COD providing
better results when lambda_search is enabled.