### PR TITLE
[PUBDEV-3137] declutter output of ./gradlew build by redirecting output of some noisy tasks to log files

### DIFF
--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -28,7 +28,7 @@ ext {
 
 task setProjectVersion << {
     File INIT = new File([T, "h2o", "__init__.py"].join(File.separator))
-    print INIT.path
+    println "    INIT.path = " + INIT.path
     def txt=""
     txt = INIT.text
     txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION)
@@ -37,7 +37,7 @@ task setProjectVersion << {
 
 task resetProjectVersion << {
     File INIT = new File([T, "h2o", "__init__.py"].join(File.separator))
-    print INIT.path
+    println "    INIT.path = " + INIT.path
     def txt=""
     txt = INIT.text
     txt = txt.replaceAll(PROJECT_VERSION, "SUBST_PROJECT_VERSION")
@@ -53,6 +53,7 @@ task upgradeOrInstallWheel(type: Exec) {
 }
 
 task buildDist(type: Exec) {
+    standardOutput = new FileOutputStream("build/tmp/h2o-py_buildDist.out")
     commandLine getOsSpecificCommandLine(["python", "setup.py", "bdist_wheel"])
 }
 

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -53,7 +53,7 @@ task upgradeOrInstallWheel(type: Exec) {
 }
 
 task buildDist(type: Exec) {
-    standardOutput = new FileOutputStream("build/tmp/h2o-py_buildDist.out")
+    standardOutput = new FileOutputStream("build/h2o-py_buildDist.out")
     commandLine getOsSpecificCommandLine(["python", "setup.py", "bdist_wheel"])
 }
 

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -1,3 +1,4 @@
+import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.tools.ant.taskdefs.condition.Os
 import java.nio.file.FileSystems
 import java.nio.file.Files
@@ -26,6 +27,10 @@ ext {
     T               = getProjectDir().toString()
 }
 
+task makeOutputDir(type: Exec) {
+    commandLine getOsSpecificCommandLine(['mkdir', '-p', 'build/tmp'])
+}
+
 task setProjectVersion << {
     File INIT = new File([T, "h2o", "__init__.py"].join(File.separator))
     println "    INIT.path = " + INIT.path
@@ -52,8 +57,10 @@ task upgradeOrInstallWheel(type: Exec) {
     commandLine getOsSpecificCommandLine(["pip", "install", "wheel", "--user", "--upgrade", "--ignore-installed"])
 }
 
-task buildDist(type: Exec) {
-    standardOutput = new FileOutputStream("build/h2o-py_buildDist.out")
+task buildDist(type: Exec, dependsOn: makeOutputDir) {
+    doFirst {
+        standardOutput = new FileOutputStream("build/tmp/h2o-py_buildDist.out")
+    }
     commandLine getOsSpecificCommandLine(["python", "setup.py", "bdist_wheel"])
 }
 

--- a/h2o-r/build.gradle
+++ b/h2o-r/build.gradle
@@ -90,9 +90,9 @@ task setProperties << {
     project.ext.BUILD_BRANCH = BUILD_BRANCH
     project.ext.R_VERSION    = getRVersion.output()
     project.ext.PDF_LATEX    = (pdflatex.output()).toLowerCase().contains("pdflatex") ? pdflatex.output() : ""
-    println "Git Branch: " + BUILD_BRANCH
-    println "R Version: " + R_VERSION
-    println "PDF LATEX: " + PDF_LATEX
+    println "    Git Branch: " + BUILD_BRANCH
+    println "    R Version: " + R_VERSION
+    println "    PDF LATEX: " + PDF_LATEX
 }
 
 task setDevPackageFiles << {
@@ -128,14 +128,17 @@ task setPackageFiles << {
 }
 
 task buildPackageDocumentation(type: Exec) {
+    standardOutput = new FileOutputStream("build/tmp/h2o-r_buildPackageDocumentation.out")
+    errorOutput = new FileOutputStream("build/tmp/h2o-r_buildPackageDocumentation.err")
     commandLine getOsSpecificCommandLine(['R', "-q", "-e", "library(devtools); document('h2o-package');"])
 }
 
 task genPDF(type: Exec) {
+    standardOutput = new FileOutputStream("build/tmp/h2o-r_genPDF.out")
+    errorOutput = new FileOutputStream("build/tmp/h2o-r_genPDF.err")
     ignoreExitValue=true
     if (SYS_OS == "windows") commandLine 'cmd', '/c', 'R', 'CMD', "Rd2pdf", "--force", "--output=h2o_package.pdf", "--title=\"h2o\"", "--no-preview", "h2o-package\\man"
     else commandLine 'R', "CMD", "Rd2pdf", "--force", "--output=h2o_package.pdf", "--title=\"h2o\"", "--no-preview", "h2o-package/man"
-    standardOutput = new ByteArrayOutputStream() // > /dev/null
 }
 
 genPDF.onlyIf { PDF_LATEX != "" && SYS_OS != "windows" }
@@ -155,7 +158,11 @@ task cpH2OAppJar << {
     copyFile([T,"..", "build", "h2o.jar"],[T, "h2o-package", "inst", "java", "h2o.jar"])
 }
 
-task buildPKG(type: Exec) { commandLine getOsSpecificCommandLine(['R', 'CMD', 'build', 'h2o-package']) }
+task buildPKG(type: Exec) {
+    standardOutput = new FileOutputStream("build/tmp/h2o-r_buildPKG.out")
+    commandLine getOsSpecificCommandLine(['R', 'CMD', 'build', 'h2o-package'])
+}
+
 task cpToR << {
     new File([T, "R", "src", "contrib"].join(File.separator)).mkdirs()
     copyFile([T, "README.md"], [T, "R", "README.md"])
@@ -178,7 +185,6 @@ task cleanUp << {
 }
 
 task cleaner << {
-    println "Cleaning..."
     new File([T, "h2o_package.pdf"].join(File.separator)).delete()
     new File([T, "h2o"].join(File.separator)).deleteDir()
     new File([T, "PACKAGES"].join(File.separator)).delete()

--- a/h2o-r/build.gradle
+++ b/h2o-r/build.gradle
@@ -128,14 +128,14 @@ task setPackageFiles << {
 }
 
 task buildPackageDocumentation(type: Exec) {
-    standardOutput = new FileOutputStream("build/tmp/h2o-r_buildPackageDocumentation.out")
-    errorOutput = new FileOutputStream("build/tmp/h2o-r_buildPackageDocumentation.err")
+    standardOutput = new FileOutputStream("build/h2o-r_buildPackageDocumentation.out")
+    errorOutput = new FileOutputStream("build/h2o-r_buildPackageDocumentation.err")
     commandLine getOsSpecificCommandLine(['R', "-q", "-e", "library(devtools); document('h2o-package');"])
 }
 
 task genPDF(type: Exec) {
-    standardOutput = new FileOutputStream("build/tmp/h2o-r_genPDF.out")
-    errorOutput = new FileOutputStream("build/tmp/h2o-r_genPDF.err")
+    standardOutput = new FileOutputStream("build/h2o-r_genPDF.out")
+    errorOutput = new FileOutputStream("build/h2o-r_genPDF.err")
     ignoreExitValue=true
     if (SYS_OS == "windows") commandLine 'cmd', '/c', 'R', 'CMD', "Rd2pdf", "--force", "--output=h2o_package.pdf", "--title=\"h2o\"", "--no-preview", "h2o-package\\man"
     else commandLine 'R', "CMD", "Rd2pdf", "--force", "--output=h2o_package.pdf", "--title=\"h2o\"", "--no-preview", "h2o-package/man"
@@ -159,7 +159,7 @@ task cpH2OAppJar << {
 }
 
 task buildPKG(type: Exec) {
-    standardOutput = new FileOutputStream("build/tmp/h2o-r_buildPKG.out")
+    standardOutput = new FileOutputStream("build/h2o-r_buildPKG.out")
     commandLine getOsSpecificCommandLine(['R', 'CMD', 'build', 'h2o-package'])
 }
 

--- a/h2o-r/build.gradle
+++ b/h2o-r/build.gradle
@@ -128,14 +128,18 @@ task setPackageFiles << {
 }
 
 task buildPackageDocumentation(type: Exec) {
-    standardOutput = new FileOutputStream("build/h2o-r_buildPackageDocumentation.out")
-    errorOutput = new FileOutputStream("build/h2o-r_buildPackageDocumentation.err")
+    doFirst {
+        standardOutput = new FileOutputStream("build/tmp/h2o-r_buildPackageDocumentation.out")
+        errorOutput = new FileOutputStream("build/tmp/h2o-r_buildPackageDocumentation.err")
+    }
     commandLine getOsSpecificCommandLine(['R', "-q", "-e", "library(devtools); document('h2o-package');"])
 }
 
 task genPDF(type: Exec) {
-    standardOutput = new FileOutputStream("build/h2o-r_genPDF.out")
-    errorOutput = new FileOutputStream("build/h2o-r_genPDF.err")
+    doFirst {
+        standardOutput = new FileOutputStream("build/tmp/h2o-r_genPDF.out")
+        errorOutput = new FileOutputStream("build/tmp/h2o-r_genPDF.err")
+    }
     ignoreExitValue=true
     if (SYS_OS == "windows") commandLine 'cmd', '/c', 'R', 'CMD', "Rd2pdf", "--force", "--output=h2o_package.pdf", "--title=\"h2o\"", "--no-preview", "h2o-package\\man"
     else commandLine 'R', "CMD", "Rd2pdf", "--force", "--output=h2o_package.pdf", "--title=\"h2o\"", "--no-preview", "h2o-package/man"
@@ -159,7 +163,9 @@ task cpH2OAppJar << {
 }
 
 task buildPKG(type: Exec) {
-    standardOutput = new FileOutputStream("build/h2o-r_buildPKG.out")
+    doFirst {
+        standardOutput = new FileOutputStream("build/tmp/h2o-r_buildPKG.out")
+    }
     commandLine getOsSpecificCommandLine(['R', 'CMD', 'build', 'h2o-package'])
 }
 

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -167,6 +167,7 @@ task cleanUpSmokeTest << {
 }
 
 task compileAndInstallDocFiles(type: Exec) {
+    standardOutput = new FileOutputStream("build/tmp/h2o-web_compileAndInstallDocFiles.out")
     H2OBuildVersion bv = new H2OBuildVersion(rootDir, version);
     def projectVersion = bv.getProjectVersion()
     def branchName = bv.getBranch()

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -167,7 +167,9 @@ task cleanUpSmokeTest << {
 }
 
 task compileAndInstallDocFiles(type: Exec) {
-    standardOutput = new FileOutputStream("build/h2o-web_compileAndInstallDocFiles.out")
+    doFirst {
+        standardOutput = new FileOutputStream("build/tmp/h2o-web_compileAndInstallDocFiles.out")
+    }
     H2OBuildVersion bv = new H2OBuildVersion(rootDir, version);
     def projectVersion = bv.getProjectVersion()
     def branchName = bv.getBranch()

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -167,7 +167,7 @@ task cleanUpSmokeTest << {
 }
 
 task compileAndInstallDocFiles(type: Exec) {
-    standardOutput = new FileOutputStream("build/tmp/h2o-web_compileAndInstallDocFiles.out")
+    standardOutput = new FileOutputStream("build/h2o-web_compileAndInstallDocFiles.out")
     H2OBuildVersion bv = new H2OBuildVersion(rootDir, version);
     def projectVersion = bv.getProjectVersion()
     def branchName = bv.getBranch()


### PR DESCRIPTION
The most serious offender was the `:h2o-r:genPDF`, which generates >2000 lines of complaints (they may be useful, but they will be more useful in a separate file). This change makes it somewhat easier to read Jenkins log files.