### PR TITLE
PUBDEV-3942 - Updated and fixed the GBM Missing Values FAQ

### DIFF
--- a/h2o-docs/src/product/data-science/gbm-faq/about_the_data.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/about_the_data.rst
@@ -30,6 +30,10 @@ About the Data
  - Quantile: the response column must be numeric
  - Huber: the response column must be numeric
 
+ Refer to the `distribution <../algo-params/distribution.html>`__ parameter in the Appendix for more information about the ``distribution`` options. 
+
+.. _lossfunction:
+
 - **What loss function is automatically chosen for each of these distributions?**
 
  By default, the residual deviance is minimized, which is the natural loss for Poisson, Gamma, Tweedie, Huber, etc. For Laplace, the residual deviance is the same as absolute error. For Gaussian, it's the same as squared error.

--- a/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
@@ -1,13 +1,21 @@
-Missing Values (Categorical/Factors)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Missing Values 
+^^^^^^^^^^^^^^
 
 **Note** Unlike in GLM, in GBM numerical values are handled the same way as categorical values. Missing values are not imputed with the mean, as is done by default in GLM.
+
+**Brief Overview of Missing Values Handling**
+
+In GBM, the optimal direction for every feature value (numeric and categorical) is stored, including NAs, for future use.
+
+For scoring, NAs have an optimal direction that is determined from the training data. This means that missing numeric, categorical, or unseen categorical values are turned into NAs and then follow that direction.
+
+Specifically, if there are no NAs in the training data, then NAs in the test data follow the majority direction (the direction with the most observations). If there are NAs in the training data, then NAs in the test data follow the direction that is optimal for the NAs of the training data. 
 
 - **How does the algorithm handle missing values during training?**
 
  Missing values are interpreted as containing information (i.e., missing for a reason), rather than missing at random. During tree building, split decisions for every node are found by minimizing the loss function and treating missing values as a separate category that can go either left or right. 
 
- So how does the algorithm determine what goes left or right? The algo decides which feature and level/number value to split on its decision to make things go left or right is purely based on value (i.e. everything less than the split point value goes left and everything greater and equal goes right). This means that missing values can go left or right, in the same way as any other categorical, since Nas are now seen as a new categorical.
+ So how does the algorithm determine what goes left or right? The algo decides which feature and level/number value to split on its decision to make things go left or right is purely based on value (i.e. everything less than the split point value goes left, and everything greater and equal goes right). This means that missing values can go left or right in the same way as any other categorical because NAs are now seen as a new categorical.
 
  A note on ``nbins_cats``: This parameter specifies the number of bins to use for non-Na categoricals, it does not bin missing values. Regardless of the number of bins a user chooses for ``nbins_cats``, an additional bin will be created specifically for the missing values. 
 
@@ -16,6 +24,10 @@ Missing Values (Categorical/Factors)
  During scoring, missing values follow the optimal path that was determined for them during training (minimized loss function).
 
 - **What loss function was used?**
+
+ The loss function is automatically chosen based on the distribution parameter selection. Refer to the :ref:`What loss function is automatically chosen for each of these distributions? <lossfunction>` question in the `About the Data <about_the_data.html>`__ section.
+
+- **How does the algorithm handle missing values during testing?**
 
  During scoring, missing values follow the optimal path that was determined for them during training (minimized loss function). Note that test-NAs follow the majority direction - the direction through which the most observations flow - if there were no NAs in training.
 


### PR DESCRIPTION
- Changed the title of this topic
- Add a sub-section that provides a summary/overview of missing values
handling
- Fixed the “What loss function was used” question. Also added links to
the about_the_data file (and added a reference tag in that file).
Driveby change: Added a link to the `distribution` parameter in the
about_the_data file.