### PR TITLE
Minor tweaks. a4c0391 for Jacoco; 868270d, 6d525da for AutoML

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -53,6 +53,11 @@ public final class DHistogram extends Iced {
   public double wY(int i){ return _vals[3*i+1];}
   public double wYY(int i){return _vals[3*i+2];}
 
+  public void addAtomic(int id, double y, double wy, double wyy) {
+    AtomicUtils.DoubleArray.add(_vals,3*id+0,y);
+    AtomicUtils.DoubleArray.add(_vals,3*id+1,wy);
+    AtomicUtils.DoubleArray.add(_vals,3*id+2,wyy);
+  }
 
   public void addNasAtomic(double y, double wy, double wyy) {
     AtomicUtils.DoubleArray.add(_vals,3*_nbin+0,y);

--- a/h2o-algos/testMultiNode.sh
+++ b/h2o-algos/testMultiNode.sh
@@ -24,9 +24,9 @@ rm -fr $OUTDIR
 $MKDIR -p $OUTDIR
 
 function cleanup () {
-  kill -9 ${PID_11} ${PID_21} ${PID_31} ${PID_41} ${PID_51} 1> /dev/null 2>&1
-  kill -9 ${PID_12} ${PID_22} ${PID_32} ${PID_42} ${PID_52} 1> /dev/null 2>&1
-  kill -9 ${PID_13} ${PID_23} ${PID_33} ${PID_43} ${PID_53} 1> /dev/null 2>&1
+  kill -15 ${PID_11} ${PID_21} ${PID_31} ${PID_41} ${PID_51} 1> /dev/null 2>&1
+  kill -15 ${PID_12} ${PID_22} ${PID_32} ${PID_42} ${PID_52} 1> /dev/null 2>&1
+  kill -15 ${PID_13} ${PID_23} ${PID_33} ${PID_43} ${PID_53} 1> /dev/null 2>&1
   wait 1> /dev/null 2>&1
   RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
   if [ "$RC" != "00000" ]; then

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1046,7 +1046,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
 
   // Remove temp keys.  TODO: Really should use Scope but Scope does not
   // currently allow nested-key-keepers.
-  static protected void cleanup_adapt( Frame adaptFr, Frame fr ) {
+  static public void cleanup_adapt( Frame adaptFr, Frame fr ) {
     Key[] keys = adaptFr.keys();
     for( int i=0; i<keys.length; i++ )
       if( fr.find(keys[i]) == -1 ) //only delete vecs that aren't shared

--- a/h2o-core/testMultiNode.sh
+++ b/h2o-core/testMultiNode.sh
@@ -23,7 +23,7 @@ esac
 
 # Run cleanup on interrupt or exit
 function cleanup () {
-  kill -9 ${PID_1} ${PID_2} ${PID_3} ${PID_4} 1> /dev/null 2>&1
+  kill -15 ${PID_1} ${PID_2} ${PID_3} ${PID_4} 1> /dev/null 2>&1
   wait 1> /dev/null 2>&1
   RC=`cat $OUTDIR/status.0`
   if [ $RC -ne 0 ]; then


### PR DESCRIPTION
`kill -9` prevents the process from dumping execution data, resulting in lost coverage.
`cleanup_adapt` is changed to public and `addAtomic` was created so that they can be used in AutoML
