### PR TITLE
PUBDEV-3949: Fix scrolling issue in Python docs

### DIFF
--- a/h2o-docs-theme/sphinx_rtd_theme/static/css/theme.css
+++ b/h2o-docs-theme/sphinx_rtd_theme/static/css/theme.css
@@ -3864,8 +3864,9 @@ div[class^='highlight'] pre {
   top: 0;
   left: 0;
   width: 330px;
-  overflow: hidden;
-  min-height: 100%;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  height: 100%;
   background: #343131;
   z-index: 200;
 }


### PR DESCRIPTION
On the Sphinx RTD theme, changed the .wy-nav-side div to scroll on the Y axis upon overflow.