### PR TITLE
[SW-316] Encryption for external cluster communication

### DIFF
--- a/h2o-core/src/main/java/water/ExternalFrameHandler.java
+++ b/h2o-core/src/main/java/water/ExternalFrameHandler.java
@@ -2,6 +2,7 @@ package water;
 
 
 import java.io.IOException;
+import java.nio.channels.ByteChannel;
 import java.nio.channels.SocketChannel;
 
 /**
@@ -70,7 +71,7 @@ final class ExternalFrameHandler {
     /**
      * Method which receives the {@link SocketChannel} and {@link AutoBuffer} and dispatches the request for further processing
      */
-    void process(SocketChannel sock, AutoBuffer ab) throws IOException {
+    void process(ByteChannel sock, AutoBuffer ab) throws IOException {
         int requestType = ab.get1();
         switch (requestType) {
             case CREATE_FRAME:

--- a/h2o-core/src/main/java/water/ExternalFrameHandler.java
+++ b/h2o-core/src/main/java/water/ExternalFrameHandler.java
@@ -69,7 +69,7 @@ final class ExternalFrameHandler {
     static final byte DOWNLOAD_FRAME = 1;
 
     /**
-     * Method which receives the {@link SocketChannel} and {@link AutoBuffer} and dispatches the request for further processing
+     * Method which receives the {@link ByteChannel} and {@link AutoBuffer} and dispatches the request for further processing
      */
     void process(ByteChannel sock, AutoBuffer ab) throws IOException {
         int requestType = ab.get1();

--- a/h2o-core/src/main/java/water/ExternalFrameHandlerThread.java
+++ b/h2o-core/src/main/java/water/ExternalFrameHandlerThread.java
@@ -1,6 +1,7 @@
 package water;
 
 import java.io.IOException;
+import java.nio.channels.ByteChannel;
 import java.nio.channels.SocketChannel;
 
 /**
@@ -14,10 +15,10 @@ import java.nio.channels.SocketChannel;
  * that new bunch of requests or data is coming.</p>
  */
 class ExternalFrameHandlerThread extends Thread {
-    private SocketChannel _sock;
+    private ByteChannel _sock;
     private AutoBuffer _ab;
 
-    ExternalFrameHandlerThread(SocketChannel sock, AutoBuffer ab) {
+    ExternalFrameHandlerThread(ByteChannel sock, AutoBuffer ab) {
         super("TCP-"+sock);
         _sock = sock;
         _ab = ab;

--- a/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
@@ -6,7 +6,7 @@ import water.fvec.Frame;
 import water.parser.BufferedString;
 
 import java.io.IOException;
-import java.nio.channels.SocketChannel;
+import java.nio.channels.ByteChannel;
 import java.util.UUID;
 
 import static water.ExternalFrameUtils.*;
@@ -21,7 +21,7 @@ final class ExternalFrameReaderBackend {
      * @param channel socket channel originating from non-h2o node
      * @param initAb {@link AutoBuffer} containing information necessary for preparing backend for reading
      */
-    static void handleReadingFromChunk(SocketChannel channel, AutoBuffer initAb) throws IOException {
+    static void handleReadingFromChunk(ByteChannel channel, AutoBuffer initAb) throws IOException {
         // receive required information
         String frameKey = initAb.getStr();
         int chunkIdx = initAb.getInt();

--- a/h2o-core/src/main/java/water/ExternalFrameUtils.java
+++ b/h2o-core/src/main/java/water/ExternalFrameUtils.java
@@ -1,6 +1,7 @@
 package water;
 
 import water.fvec.Vec;
+import water.network.SocketChannelFactory;
 
 import javax.print.DocFlavor;
 import java.io.IOException;
@@ -36,8 +37,8 @@ public class ExternalFrameUtils {
      * frames or write to H2O frames from non-H2O environment, such as Spark executor.
      */
     public static ByteChannel getConnection(String h2oNodeHostname, int h2oNodeApiPort) throws IOException{
-        return H2ONode.openChan(TCPReceiverThread.TCP_EXTERNAL, null, h2oNodeHostname, h2oNodeApiPort +1);
-
+        SocketChannelFactory socketFactory = SocketChannelFactory.instance(H2OSecurityManager.instance());
+        return H2ONode.openChan(TCPReceiverThread.TCP_EXTERNAL, socketFactory, h2oNodeHostname, h2oNodeApiPort +1);
     }
 
     public static ByteChannel getConnection(String ipPort) throws IOException{

--- a/h2o-core/src/main/java/water/ExternalFrameWriterBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterBackend.java
@@ -4,7 +4,7 @@ import water.fvec.ChunkUtils;
 import water.fvec.NewChunk;
 
 import java.io.IOException;
-import java.nio.channels.SocketChannel;
+import java.nio.channels.ByteChannel;
 
 import static water.ExternalFrameUtils.*;
 
@@ -17,7 +17,7 @@ final class ExternalFrameWriterBackend {
      * @param sock socket channel originating from non-h2o node
      * @param ab {@link AutoBuffer} containing information necessary for preparing backend for writing
      */
-    static void handleWriteToChunk(SocketChannel sock, AutoBuffer ab) throws IOException {
+    static void handleWriteToChunk(ByteChannel sock, AutoBuffer ab) throws IOException {
         String frameKey = ab.getStr();
         byte[] expectedTypes = ab.getA1();
         assert expectedTypes != null;

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -124,8 +124,8 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     _last_heard_from = System.currentTimeMillis();
     _heartbeat = new HeartBeat();
 
-    _security = new H2OSecurityManager();
-    _socketFactory = new SocketChannelFactory(_security);
+    _security = H2OSecurityManager.instance();
+    _socketFactory = SocketChannelFactory.instance(_security);
   }
 
   // ---------------
@@ -322,12 +322,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     ByteBuffer bb = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder());
     bb.put(tcpType).putChar((char) H2O.H2O_PORT).put((byte) 0xef).flip();
 
-    ByteChannel wrappedSocket;
-    if(socketFactory != null){
-      wrappedSocket = socketFactory.clientChannel(sock, isa.getHostName(), isa.getPort());
-    }else{
-      wrappedSocket = sock;
-    }
+    ByteChannel wrappedSocket = socketFactory.clientChannel(sock, isa.getHostName(), isa.getPort());
 
     while (bb.hasRemaining()) {  // Write out magic startup sequence
       wrappedSocket.write(bb);

--- a/h2o-core/src/main/java/water/H2OSecurityManager.java
+++ b/h2o-core/src/main/java/water/H2OSecurityManager.java
@@ -52,6 +52,9 @@ public class H2OSecurityManager {
             if (null != H2O.ARGS.internal_security_conf) {
                 this.sslSocketChannelFactory = new SSLSocketChannelFactory();
                 this.securityEnabled = true;
+                Log.info("H2O node running in encrypted mode using config file [" + H2O.ARGS.internal_security_conf + "]");
+            } else {
+                Log.info("H2O node running in unencrypted mode.");
             }
         } catch (SSLContextException e) {
             Log.err("Node initialized with SSL enabled but failed to create SSLContext. " +

--- a/h2o-core/src/main/java/water/H2OSecurityManager.java
+++ b/h2o-core/src/main/java/water/H2OSecurityManager.java
@@ -42,10 +42,12 @@ import java.nio.channels.SocketChannel;
  */
 public class H2OSecurityManager {
 
+    private volatile static H2OSecurityManager INSTANCE = null;
+
     public boolean securityEnabled = false;
     private SSLSocketChannelFactory sslSocketChannelFactory;
 
-    H2OSecurityManager() {
+    private H2OSecurityManager() {
         try {
             if (null != H2O.ARGS.internal_security_conf) {
                 this.sslSocketChannelFactory = new SSLSocketChannelFactory();
@@ -65,5 +67,16 @@ public class H2OSecurityManager {
 
     public ByteChannel wrapClientChannel(SocketChannel channel, String host, int port) throws IOException {
         return sslSocketChannelFactory.wrapClientChannel(channel, host, port);
+    }
+
+    public static H2OSecurityManager instance() {
+        if(null == INSTANCE) {
+            synchronized (H2OSecurityManager.class) {
+                if (null == INSTANCE) {
+                    INSTANCE = new H2OSecurityManager();
+                }
+            }
+        }
+        return INSTANCE;
     }
 }

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -108,7 +108,7 @@ public class TCPReceiverThread extends Thread {
           new TCPReaderThread(wrappedSocket, new AutoBuffer(wrappedSocket, inetAddress), inetAddress).start();
           break;
         case TCP_EXTERNAL:
-          new ExternalFrameHandlerThread(sock, new AutoBuffer(sock, null)).start();
+          new ExternalFrameHandlerThread(wrappedSocket, new AutoBuffer(wrappedSocket, null)).start();
           break;
         default:
           throw H2O.fail("unexpected channel type " + chanType + ", only know 1 - Small, 2 - Big and 3 - ExternalFrameHandling");

--- a/h2o-core/src/main/java/water/network/SocketChannelFactory.java
+++ b/h2o-core/src/main/java/water/network/SocketChannelFactory.java
@@ -13,26 +13,39 @@ import java.nio.channels.SocketChannel;
  */
 public class SocketChannelFactory {
 
+    private volatile static SocketChannelFactory INSTANCE;
+
     private H2OSecurityManager sm;
 
-    public SocketChannelFactory(H2OSecurityManager sm) {
+    private SocketChannelFactory(H2OSecurityManager sm) {
         this.sm = sm;
     }
 
     public ByteChannel serverChannel(ByteChannel channel) throws IOException {
-        if(sm.securityEnabled && !(channel instanceof SSLSocketChannel)) {
-            return sm.wrapServerChannel((SocketChannel)channel);
+        if (sm.securityEnabled && !(channel instanceof SSLSocketChannel)) {
+            return sm.wrapServerChannel((SocketChannel) channel);
         } else {
             return channel;
         }
     }
 
     public ByteChannel clientChannel(ByteChannel channel, String host, int port) throws IOException {
-        if(sm.securityEnabled && !(channel instanceof SSLSocketChannel)) {
-            return sm.wrapClientChannel((SocketChannel)channel, host, port);
+        if (sm.securityEnabled && !(channel instanceof SSLSocketChannel)) {
+            return sm.wrapClientChannel((SocketChannel) channel, host, port);
         } else {
             return channel;
         }
+    }
+
+    public static SocketChannelFactory instance(H2OSecurityManager sm) {
+        if (null == INSTANCE) {
+            synchronized (SocketChannelFactory.class) {
+                if (null == INSTANCE) {
+                    INSTANCE = new SocketChannelFactory(sm);
+                }
+            }
+        }
+        return INSTANCE;
     }
 
 }


### PR DESCRIPTION
The external cluster communication was using unencrypted sockets even if the internal security parameter was passed. This PR fixes this problem. More changes might be necessary depending on the state of the SW communication.