### PR TITLE
:fire: [HOTFIX] Change command line path in h2o-py/build.gradle if Windows OS

### DIFF
--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -28,7 +28,11 @@ ext {
 }
 
 task makeOutputDir(type: Exec) {
-    commandLine getOsSpecificCommandLine(['mkdir', '-p', 'build/tmp'])
+    if(Os.isFamily(Os.FAMILY_WINDOWS)){
+        commandLine getOsSpecificCommandLine(['mkdir', 'build\\tmp'])
+    } else {
+        commandLine getOsSpecificCommandLine(['mkdir', '-p', 'build/tmp'])
+    }
 }
 
 task setProjectVersion << {


### PR DESCRIPTION
* This PR adds a check for a Windows OS in the gradle task `makeOutputDir`. 
* Previously, this was causing build failures for various Windows unit test suites as it was not creating a valid output directory.