### PR TITLE
Pubdev 3916 pca hangs car c

### DIFF
--- a/h2o-algos/src/main/java/hex/gram/Gram.java
+++ b/h2o-algos/src/main/java/hex/gram/Gram.java
@@ -863,16 +863,21 @@ public final class Gram extends Iced<Gram> {
     }
     @Override public void chunkDone(){
       if(_std) {
-        double r = 1.0 / _nobs;
-        _gram.mul(r);
+        if (_nobs > 0) {  // removing NA rows may produce _nobs=0
+          double r = 1.0 / _nobs;
+          _gram.mul(r);
+        }
       }
     }
     @Override public void reduce(GramTask gt){
       if(_std) {
-        double r1 = (double) _nobs / (_nobs + gt._nobs);
-        _gram.mul(r1);
-        double r2 = (double) gt._nobs / (_nobs + gt._nobs);
-        gt._gram.mul(r2);
+        if ((_nobs > 0) && (gt._nobs > 0)) {  // removing NA rows may produce _nobs=0
+          double r1 = (double) _nobs / (_nobs + gt._nobs);
+          _gram.mul(r1);
+
+          double r2 = (double) gt._nobs / (_nobs + gt._nobs);
+          gt._gram.mul(r2);
+        }
       }
       _gram.add(gt._gram);
       _nobs += gt._nobs;

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_3916_pca_hangs.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_3916_pca_hangs.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.transforms.decomposition import H2OPCA
+
+
+
+def pca_car():
+  num_runs = 10
+  run_time_c = []
+
+  car = h2o.import_file(path=pyunit_utils.locate("smalldata/pca_test/car.arff.txt"))  # Nidhi: import may not work
+  for run_index in range(num_runs):  # multiple runs to get an idea of run time info
+    carPCA = H2OPCA(k=car.ncols, transform="STANDARDIZE")
+    carPCA.train(x=list(range(0, car.ncols)), training_frame=car)
+    run_time_c.append(carPCA._model_json['output']['end_time']-carPCA._model_json['output']['start_time'])
+    print("PCA model training time with car.arff.txt data in ms is {0}".format(run_time_c[run_index]))
+
+    h2o.remove(carPCA)
+
+  assert (max(run_time_c)) < 1000, "PCA runs for car.arff.txt take too much time!"
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(pca_car)
+else:
+  pca_car()

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_3916_pca_hangs.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_3916_pca_hangs.R
@@ -1,0 +1,30 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# Test PCA on car.arff.txt
+test.pca.car <- function() {
+  run_time_c = c()
+  run_time_c2 = c()
+  num_run = 10
+
+  Log.info("Importing car.arff.txt data...\n")
+  data=h2o.importFile(locate("smalldata/pca_test/car.arff.txt"))
+  for (runIndex in 1:num_run) {
+    mm = h2o.prcomp(data,transform = "STANDARDIZE",k=ncol(data))
+    print("PCA run time with car.arff.txt data in ms is ")
+    print(mm@model$run_time)
+    run_time_c = c(run_time_c,mm@model$run_time)
+    print("average run time in ms for data.arff.txt is: ")
+    print(mean(run_time_c))
+    print("maximum run time in ms for data.arff.txt is: ")
+    print(max(run_time_c))
+    print("minimum run time in ms for data.arff.txt is: ")
+    print(min(run_time_c))
+
+    h2o.rm(mm)
+  }
+  # check to make sure PCA is not taking too long to run
+  expect_true(max(run_time_c) < 1000)
+}
+
+doTest("PCA Test: USArrests Data", test.pca.car)


### PR DESCRIPTION
Added Pyunit and RUNIT test to make sure PCA runs the car.arff.txt data fast and not hanged as reported in JIRA-PUBDEV-3916.

Added one more check to make sure that user parameter k is lower than the number of rows in dataset after removing NAs.