### PR TITLE
[HOTFIX] :fire: Remove gradle caches.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ gradle/buildnumber.properties
 # Doc stuff
 .Rapp.history
 *.synctex.gz
+
+# Ignore gradle home files
+caches
+wrapper
+


### PR DESCRIPTION
On Jenkins machine: If GRADLE_HOME is configured to point to the directory with source code, Jenkins CI is complaining about additional files. This fix puts gradle caches into Git ignore list.