### PR TITLE
[PUBDEV-3941] Make EasyModelPredictWrapper work for AutoEncoders

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
@@ -153,8 +153,7 @@ public abstract class GenModel implements IGenModel, IGeneratedModel, Serializab
   }
 
   public int getPredsSize(ModelCategory mc) {
-    return (mc == ModelCategory.DimReduction)? nclasses() :
-           (mc == ModelCategory.AutoEncoder)? nfeatures() : getPredsSize();
+    return (mc == ModelCategory.DimReduction)? nclasses() : getPredsSize();
   }
 
   public static String createAuxKey(String k) {

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -3,7 +3,6 @@ package hex.genmodel.easy;
 import hex.ModelCategory;
 import hex.genmodel.GenModel;
 import hex.genmodel.algos.deepwater.DeepwaterMojoModel;
-import hex.genmodel.algos.word2vec.Word2VecMojoModel;
 import hex.genmodel.algos.word2vec.WordEmbeddingModel;
 import hex.genmodel.easy.exception.PredictException;
 import hex.genmodel.easy.exception.PredictNumberFormatException;
@@ -239,7 +238,6 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
   }
 
   /**
-   * Note: this method is not yet implemented.
    * Make a prediction on a new data point using an AutoEncoder model.
    * @param data A new data point.
    * @return The prediction.
@@ -262,6 +260,12 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
     return p;
   }
 
+  /**
+   * Creates a 1-hot encoded representation of the input data.
+   * @param data raw input as seen by the score0 function
+   * @param size target size of the output array
+   * @return 1-hot encoded data
+   */
   private double[] expandRawData(double[] data, int size) {
     double[] expanded = new double[size];
     int pos = 0;
@@ -278,6 +282,12 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
     return expanded;
   }
 
+  /**
+   * Converts output of AutoEncoder to a RowData structure. Categorical fields are represented by
+   * a map of domain values -> reconstructed values, missing domain value is represented by a 'null' key
+   * @param reconstructed raw output of AutoEncoder
+   * @return reconstructed RowData structure
+   */
   private RowData reconstructedToRowData(double[] reconstructed) {
     RowData rd = new RowData();
     int pos = 0;

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
@@ -1,8 +1,9 @@
 package hex.genmodel.easy.prediction;
 
-/**
- * TODO
- */
+import hex.genmodel.easy.RowData;
+
 public class AutoEncoderModelPrediction extends AbstractPrediction {
-  // ? not sure what this should be.
+  public double[] original;
+  public double[] reconstructed;
+  public RowData reconstructedRowData;
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
@@ -2,8 +2,26 @@ package hex.genmodel.easy.prediction;
 
 import hex.genmodel.easy.RowData;
 
+/**
+ * Data reconstructed by the AutoEncoder model based on a given input.
+ */
 public class AutoEncoderModelPrediction extends AbstractPrediction {
+  /**
+   * Representation of the original input the way AutoEncoder model sees it (1-hot encoded categorical values)
+   */
   public double[] original;
+
+  /**
+   * Reconstructed data, the array has same length as the original input. The user can use the original input
+   * and reconstructed output to easily calculate eg. the reconstruction error.
+   */
   public double[] reconstructed;
+
+  /**
+   * Reconstructed data represented in RowData structure. The structure will copy the structure of the RowData input
+   * with the exception of categorical values. Categorical fields will be represented as a map of the domain values
+   * to the reconstructed values.
+   * Example: input RowData([sex: "Male", ..]) will produce output RowData([sex: [Male: 0.9, Female: 0.1], ..]
+   */
   public RowData reconstructedRowData;
 }

--- a/h2o-genmodel/src/test/java/hex/genmodel/easy/EasyPredictModelWrapperTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/easy/EasyPredictModelWrapperTest.java
@@ -5,15 +5,11 @@ import hex.genmodel.GenModel;
 import hex.genmodel.MojoModel;
 import hex.genmodel.algos.word2vec.WordEmbeddingModel;
 import hex.genmodel.easy.exception.PredictUnknownCategoricalLevelException;
-import hex.genmodel.easy.prediction.BinomialModelPrediction;
-import hex.genmodel.easy.prediction.SortedClassProbability;
-import hex.genmodel.easy.prediction.Word2VecPrediction;
+import hex.genmodel.easy.prediction.*;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -214,6 +210,76 @@ public class EasyPredictModelWrapperTest {
     @Override
     public ModelCategory getModelCategory() {
       return ModelCategory.WordEmbedding;
+    }
+  }
+
+  @Test
+  public void testAutoEncoderModel() throws Exception {
+    MyAutoEncoderModel rawModel = new MyAutoEncoderModel();
+    EasyPredictModelWrapper m = new EasyPredictModelWrapper(rawModel);
+
+    RowData row = new RowData();
+    row.put("Species", "versicolor");
+    row.put("Sepal.Length", 7.0);
+    row.put("Sepal.Width", 3.2);
+    row.put("Petal.Length", 4.7);
+    row.put("Petal.Width", 1.4);
+
+    AbstractPrediction p = m.predict(row);
+    Assert.assertTrue(p instanceof AutoEncoderModelPrediction);
+    AutoEncoderModelPrediction aep = (AutoEncoderModelPrediction) p;
+    Assert.assertArrayEquals(new double[]{0.0, 1.0, 0.0, 0.0, 7.0, 3.2, 4.7, 1.4}, aep.original, 0.01);
+    Assert.assertArrayEquals(new double[]{0.0, 1.3124, 0.4864, 0.0, 6.1729, 3.0573, 17.8372, 1.1993}, aep.reconstructed, 0.001);
+    Map<String, Object> expected = new HashMap<String, Object>() {{
+      put("Petal.Length", 17.8372);
+      put("Petal.Width", 1.1993);
+      put("Sepal.Width", 3.0573);
+      put("Sepal.Length", 6.1729);
+      put("Species", new HashMap<String, Object>() {{
+        put(null, 0.0);
+        put("setosa", 0.0);
+        put("virginica", 0.4864);
+        put("versicolor", 1.3124);
+       }});
+    }};
+    Assert.assertEquals(expected, aep.reconstructedRowData);
+  }
+
+  private static class MyAutoEncoderModel extends GenModel {
+
+    private static final String[][] DOMAINS = new String[][] {
+      /* Species */ new String[]{"setosa", "versicolor", "virginica"},
+      /* Sepal.Length */ null,
+      /* Sepal.Width */ null,
+      /* Petal.Length */ null,
+      /* Petal.Width */ null
+    };
+
+    private MyAutoEncoderModel() {
+      super(new String[] {"Species", "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"}, DOMAINS);
+    }
+
+    @Override
+    public ModelCategory getModelCategory() { return ModelCategory.AutoEncoder; }
+    @Override
+    public boolean isSupervised() { return false; }
+    @Override
+    public int nfeatures() { return 5; }
+    @Override
+    public int nclasses() { return 8; }
+    @Override
+    public String getUUID() { return null; }
+    @Override
+    public int getPredsSize() { return nclasses(); }
+
+    @Override
+    public double[] score0(double[] row, double[] preds) {
+      // 7.0,3.2,4.7,1.4,"versicolor"
+      final double[] result = {0,1.3124,0.4864,0,6.1729,3.0573,17.8372,1.1993};
+      Assert.assertArrayEquals(new double[]{1.0,7.0,3.2,4.7,1.4}, row, 0.0001);
+      Assert.assertEquals(result.length, preds.length);
+      System.arraycopy(result, 0, preds, 0, result.length);
+      return result;
     }
   }
 


### PR DESCRIPTION
This is a proposal of a barebones interface of AutoEncoderPrediction.

What is missing:
 - documentation,
 - interface doesn't provide reconstruction error - this is currently hard to do because error is calculated on normalized values and there is no natural way how to get the normalization coefficients from the current GenModel for AutoEncoder