### PR TITLE
PUBDEV-3784 - Document default values for categorical_encoding

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/categorical_encoding.rst
+++ b/h2o-docs/src/product/data-science/algo-params/categorical_encoding.rst
@@ -9,20 +9,22 @@ Description
 
 This option specifies the encoding scheme to use for handling categorical features. Available schemes include the following:
 
-**GBM/DRF**
+**GBM/DRF/K-Means**
 
-  - ``auto`` or ``AUTO``: Allow the algorithm to decide (default)
-  - ``enum`` or ``Enum``: 1 column per categorical feature
+  - ``auto`` or ``AUTO``: Allow the algorithm to decide (default). For GBM, DRF, and K-Means, the algorithm will perform Enum encoding when ``auto`` option is specified. 
+  - ``enum`` or ``Enum``: Leave the dataset as is, internally map the strings to integers, and use these integers to make splits - either via ordinal nature when ``nbins_cats`` is too small to resolve all levels or via bitsets that do a perfect group split.
   - ``one_hot_explicit`` or ``OneHotExplicit`` : N+1 new columns for categorical features with N levels
   - ``binary`` or ``Binary``: No more than 32 columns per categorical feature
   - ``eigen`` or ``Eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
 
-**Deep Learning/K-Means**
+**Deep Learning**
 
-  - ``auto`` or ``AUTO``:  Allow the algorithm to decide
-  - ``one_hot_internal`` or ``OneHotInternal``: On the fly N+1 new cols for categorical features with N levels (default)
+  - ``auto`` or ``AUTO``:  Allow the algorithm to decide. For Deep Learning, the algorithm will perform One Hot Internal encoding when ``auto`` is specified.
+  - ``one_hot_internal`` or ``OneHotInternal``: Leave the dataset as is. This internally expands each row via one-hot encoding on the fly. (default)
   - ``binary`` or ``Binary``: No more than 32 columns per categorical feature
   - ``eigen`` or ``Eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
+
+  **Note**: For Deep Learning, this value defaults to ``one_hot_internal``. Similarly, if ``auto`` is specified, then the algorithm performs ``one_hot_internal`` encoding. 
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/distribution.rst
+++ b/h2o-docs/src/product/data-science/algo-params/distribution.rst
@@ -28,7 +28,7 @@ The following general guidelines apply when selecting a distribution:
  - A Bernoulli distribution is used for binary outcomes.
  - A Multinomial distribution can handle multiple discrete outcomes.
 
- For Regression Problems:
+ For Regression problems:
 
  - A Gaussian distribution is the function for continuous targets.
  - A Poisson distribution is used for estimating counts.

--- a/h2o-docs/src/product/data-science/algo-params/max_depth.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_depth.rst
@@ -7,9 +7,18 @@
 Description
 ~~~~~~~~~~~
 
-This specifies the maximum depth to which each tree will be built. In general, deeper trees can seem to provide better accuracy on a training set because deeper trees can overfit your model to your data. Also, the deeper the algorithm goes, the more computing time is required. This is especially true at depths greater than 10. At depth 4, 8 nodes, for example, you need ``8 * 100 * 20`` trials to complete this splitting for the layer.
+This specifies the maximum depth to which each tree will be built. A single tree will stop splitting when there are no more splits that satisfy the ``min_rows`` parameter, if it reaches ``max_depth``, or if there are no splits that satisfy this ``min_split_improvement`` parameter.
+
+In general, deeper trees can seem to provide better accuracy on a training set because deeper trees can overfit your model to your data. Also, the deeper the algorithm goes, the more computing time is required. This is especially true at depths greater than 10. At depth 4, 8 nodes, for example, you need ``8 * 100 * 20`` trials to complete this splitting for the layer.
 
 One way to determine an appropriate value for ``max_depth`` is to run a quick Cartesian grid search. Each model in the grid search will use early stopping to tune the number of trees using the validation set AUC, as before. The examples below are also available in the `GBM Tuning Tutorials <https://github.com/h2oai/h2o-3/tree/master/h2o-docs/src/product/tutorials/gbm>`__  folder on GitHub.
+
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `min_rows <min_rows.html>`__
+- `min_split_improvement <min_split_improvement.html>`__
 
 Example
 ~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/nfolds.rst
+++ b/h2o-docs/src/product/data-science/algo-params/nfolds.rst
@@ -52,7 +52,7 @@ Example
 
 	# set the number of folds for you n-fold cross validation:
 	folds <- 5
-	# folds <- 10
+	# folds <- 5
 
 	# train a gbm using the nfolds parameter:
 	cars_gbm <- h2o.gbm(x = predictors, y = response, training_frame = cars,
@@ -82,7 +82,7 @@ Example
 
 	# set the number of folds for you n-fold cross validation:
 	folds = 5
-	# folds = 10
+	# folds = 5
 
 	# initialize the estimator then train the model
 	cars_gbm = H2OGradientBoostingEstimator(nfolds = folds, seed = 1234)
@@ -90,3 +90,4 @@ Example
 
 	# print the auc for the cross-validated data
 	cars_gbm.auc(xval=True)
+	

--- a/h2o-docs/src/product/data-science/algo-params/standardize.rst
+++ b/h2o-docs/src/product/data-science/algo-params/standardize.rst
@@ -2,7 +2,7 @@
 ---------------
 
 - Available in: Deep Learning, GLM, K-Means
-- Hyperparameter: no
+- Hyperparameter: yes
 
 Description
 ~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/user_points.rst
+++ b/h2o-docs/src/product/data-science/algo-params/user_points.rst
@@ -8,6 +8,7 @@ Description
 ~~~~~~~~~~~
 
 This option allows you to specify a dataframe,  where each row represents an initial cluster center. 
+
 **Notes**:
 
 - The user-specified points must have the same number of columns as the training observations. 

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -150,10 +150,12 @@ recommended, as model performance can vary greatly.
 
 -  **categorical_encoding**: Specify one of the following encoding schemes for handling categorical features:
 
-  - ``auto``: Allow the algorithm to decide
+  - ``auto``: Allow the algorithm to decide. In Deep Learning, the algorithm will perform ``one_hot_internal`` encoding if ``auto`` is specified. 
   - ``one_hot_internal``: On the fly N+1 new cols for categorical features with N levels (default)
   - ``binary``: No more than 32 columns per categorical feature
   - ``eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
+
+  **Note**: This value defaults to ``one_hot_internal``. Similarly, if ``auto`` is specified, then the algorithm performs ``one_hot_internal`` encoding. 
 
 -  **l1**: Specify the L1 regularization to add stability and improve
    generalization; sets the value of many weights to 0.

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -202,8 +202,8 @@ Defining a DRF Model
    This option is disabled by default.
 
 -  `checkpoint <algo-params/checkpoint.html>`__: Enter a model key associated with a
-   previously-trained model. Use this option to build a new model as a
-   continuation of a previously-generated model.
+   previously trained model. Use this option to build a new model as a
+   continuation of a previously generated model.
 
 -  `col_sample_rate_change_per_level <algo-params/col_sample_rate_change_per_level.html>`__: This option specifies to change the column sampling rate as a function of the depth in the tree. For example:
 
@@ -233,7 +233,7 @@ Defining a DRF Model
 
 - `categorical_encoding <algo-params/categorical_encoding.html>`__: Specify one of the following encoding schemes for handling categorical features:
 
-  - ``auto``: Allow the algorithm to decide (default)
+  - ``auto``: Allow the algorithm to decide (default). In DRF, the algorithm will automatically perform ``enum`` encoding.
   - ``enum``: 1 column per categorical feature
   - ``one_hot_explicit``: N+1 new columns for categorical features with N levels
   - ``binary``: No more than 32 columns per categorical feature

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -140,7 +140,7 @@ Defining a GBM Model
 
 - `categorical_encoding <algo-params/categorical_encoding.html>`__: Specify one of the following encoding schemes for handling categorical features:
 
-  - ``auto``: Allow the algorithm to decide (default)
+  - ``auto``: Allow the algorithm to decide (default). In GBM, the algorithm will automatically perform ``enum`` encoding.
   - ``enum``: 1 column per categorical feature
   - ``one_hot_explicit``: N+1 new columns for categorical features with N levels
   - ``binary``: No more than 32 columns per categorical feature
@@ -246,8 +246,8 @@ Defining a GBM Model
 -  `huber_alpha <algo-params/huber_alpha.html>`__: Specify the desired quantile for Huber/M-regression (the threshold between quadratic and linear loss). This value must be between 0 and 1.
 
 -  `checkpoint <algo-params/checkpoint.html>`__: Enter a model key associated with a
-   previously-trained model. Use this option to build a new model as a
-   continuation of a previously-generated model.
+   previously trained model. Use this option to build a new model as a
+   continuation of a previously generated model.
 
 -  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Enable this option to keep the
    cross-validation predictions.

--- a/h2o-docs/src/product/data-science/k-means.rst
+++ b/h2o-docs/src/product/data-science/k-means.rst
@@ -39,11 +39,11 @@ Defining a K-Means Model
 
 -  `score_each_iteration <algo-params/score_each_iteration.html>`__: (Optional) Specify whether to score during each iteration of the model training.
 
--  `k <algo-params/k.html>`__: Specify the number of clusters.
+-  `k <algo-params/k.html>`__: Specify the number of clusters (groups of data) in a dataset that are similar to one another.
 
 -  `estimate_k <algo-params/estimate_k.html>`__: Specify whether to estimate the number of clusters (<=k) iteratively (independent of the seed) and deterministically (beginning with ``k=1,2,3...``). If enabled, for each **k** that, the estimate will go up to **max_iteration**. This option is disabled by default.
 
--  `user_points <algo-params/user_points.html>`__: Specify a vector of initial cluster centers. The user-specified points must have the same number of columns as the training observations. The number of rows must equal the number of clusters.
+-  `user_points <algo-params/user_points.html>`__: Specify a dataframe, where each row represents an initial cluster center.
 
 -  `max_iterations <algo-params/max_iterations.html>`__: Specify the maximum number of training iterations. The range is 0 to 1e6.
 
@@ -66,8 +66,9 @@ Defining a K-Means Model
 
 - `categorical_encoding <algo-params/categorical_encoding.html>`__: Specify one of the following encoding schemes for handling categorical features:
 
-  - ``auto``: Allow the algorithm to decide (default)
-  - ``one_hot_internal``: On the fly N+1 new cols for categorical features with N levels (default)
+  - ``auto``: Allow the algorithm to decide (default). In K-Means, the algorithm will automatically perform ``enum`` encoding.
+  - ``enum``: 1 column per categorical feature
+  - ``one_hot_explicit``: N+1 new columns for categorical features with N levels
   - ``binary``: No more than 32 columns per categorical feature
   - ``eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
 

--- a/h2o-docs/src/product/grid-search.rst
+++ b/h2o-docs/src/product/grid-search.rst
@@ -80,6 +80,7 @@ GLM Hyperparameters
 -  ``alpha``
 -  ``lambda``
 -  ``missing_values_handling``
+-  ``standardize``
 
 GLRM Hyperparameters
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Added clarification for categorical_encoding default values and what happens when user selects categorical_encoding=auto.
Also some driveway fixes:
- Updated descriptions for k and user_points in K-Means section.
- Parameter for distribution: Make headings consistent: “For Regression
problems” and “For Classification Problems”
- Parameters for nfolds: The python example has comment folds=10, but
the example shows folds=5
- Parameters for standardize: gridable=true for K-means and Deep
Learning. gridable value is absent for GLM, but specify this as “yes”.
Also add “standardize” to list of GLM hyper parameters in the grid
search topic.
- in GBM/DRF description for checkpoint, removed the hyphens in
“previously trained” and “previously generated”.
- In the max_depth parameter (appendix), added related parameters for min_split_improvement and min_rows. Also added the following line: "a single tree will stop splitting when there are no more splits that
satisfy the ``min_rows`` parameter, if it reaches ``max_depth``, or if there are no splits that satisfy this ``min_split_improvement`` parameter."