### PR TITLE
[HOTFIX][StackedEnsemble] :fire: Do not show StackedEnsemble model builder in Flow UI

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -40,6 +40,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     };
   }
 
+  @Override public BuilderVisibility builderVisibility() { return BuilderVisibility.Experimental; }
+
   @Override protected StackedEnsembleDriver trainModelImpl() { return _driver = new StackedEnsembleDriver(); }
 
   public static void addModelPredictionsToLevelOneFrame(Model aModel, Frame aModelsPredictions, Frame levelOneFrame) {


### PR DESCRIPTION
This fix is for rel-tverberg release and need to be cherry-picked into master.