### PR TITLE
Add support for `coef(h2o_model)` in R

### DIFF
--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -358,6 +358,12 @@ res = .h2o.__remoteSend(method="GET", .h2o.__ComputeGram, X=h2o.getId(X),W=weigh
 h2o.getFrame(res$destination_frame$name)
 }
 
+#' S3 method to support \code{coef(model)} vis-a-vis other linear models in R
+#' @export
+coef.H2ORegressionModel <- function(h2o_model) {
+  h2o.coef(h2o_model)
+}
+
 ##' Start an H2O Generalized Linear Model Job
 ##'
 ##' Creates a background H2O GLM job.


### PR DESCRIPTION
Hey.

This is a convenience. Most other linear modelling libraries in R support `coef(model)` rather than having to remember a bespoke method or index i.e. `h2o.coef(model)`.

I'm not sure where to update the namespace.