### PR TITLE
PUBDEV-3827: fix PCA scoring history and importance.  Added Runit tes…

### DIFF
--- a/h2o-algos/src/main/java/hex/pca/PCAModel.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAModel.java
@@ -4,7 +4,10 @@ import hex.DataInfo;
 import hex.Model;
 import hex.ModelCategory;
 import hex.ModelMetrics;
-import water.*;
+import water.DKV;
+import water.Job;
+import water.Key;
+import water.MRTask;
 import water.codegen.CodeGenerator;
 import water.codegen.CodeGeneratorPipeline;
 import water.exceptions.JCodeSB;
@@ -13,6 +16,8 @@ import water.fvec.Frame;
 import water.util.JCodeGen;
 import water.util.SBPrintStream;
 import water.util.TwoDimTable;
+
+import java.util.ArrayList;
 
 public class PCAModel extends Model<PCAModel,PCAModel.PCAParameters,PCAModel.PCAOutput> {
 
@@ -71,6 +76,11 @@ public class PCAModel extends Model<PCAModel,PCAModel.PCAParameters,PCAModel.PCA
 
     // Permutation matrix mapping training col indices to adaptedFrame
     public int[] _permutation;
+
+    // the following fields are added for scoring history which can different fields depending on the PCA Method
+    // here are the common fields for all PCA methods
+    public ArrayList<Long> _training_time_ms = new ArrayList<>();
+
 
     public PCAOutput(PCA b) { super(b); }
 

--- a/h2o-algos/src/main/java/hex/svd/SVDModel.java
+++ b/h2o-algos/src/main/java/hex/svd/SVDModel.java
@@ -1,16 +1,14 @@
 package hex.svd;
 
-import hex.DataInfo;
-import hex.Model;
-import hex.ModelCategory;
-import hex.ModelMetrics;
-import hex.ModelMetricsUnsupervised;
+import hex.*;
 import water.*;
 import water.codegen.CodeGeneratorPipeline;
 import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.util.JCodeGen;
 import water.util.SBPrintStream;
+
+import java.util.ArrayList;
 
 public class SVDModel extends Model<SVDModel, SVDModel.SVDParameters, SVDModel.SVDOutput> {
 
@@ -83,6 +81,12 @@ public class SVDModel extends Model<SVDModel, SVDModel.SVDParameters, SVDModel.S
 
     // Expanded column names of adapted training frame
     public String[] _names_expanded;
+
+    // variables for building up a scoring history
+    public ArrayList<Double> _history_average_SEE = new ArrayList<>();  // for randomized SVD
+    public ArrayList<Double> _history_err = new ArrayList<>();          // for power SVD method
+    public ArrayList<Double> _history_eigenVectorIndex = new ArrayList<>();     // store which eigenvector we are working on
+    public ArrayList<Long> _training_time_ms = new ArrayList<>();
 
     public SVDOutput(SVD b) { super(b); }
 

--- a/h2o-algos/src/main/java/hex/util/DimensionReductionUtils.java
+++ b/h2o-algos/src/main/java/hex/util/DimensionReductionUtils.java
@@ -1,0 +1,96 @@
+package hex.util;
+
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import water.util.PrettyPrint;
+import water.util.TwoDimTable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+
+/**
+ * Created by wendycwong on 2/9/17.
+ */
+public class DimensionReductionUtils {
+    /**
+     * This method will calculate the importance of principal components for PCA/GLRM methods.
+     *
+     * @param std_deviation: array of singular values
+     * @param totVar: sum of squared singular values
+     * @param vars: array of singular values squared
+     * @param prop_var: var[i]/totVar for each i
+     * @param cum_var: cumulative sum of var[i]/totVar from index 0 to index i.
+     */
+    public static void generateIPC(double[] std_deviation, double totVar, double[] vars, double[] prop_var,
+                                   double[] cum_var) {
+        int arrayLen = std_deviation.length;
+
+        if (totVar > 0) {
+            for (int i = 0; i < arrayLen; i++) {
+                vars[i] = std_deviation[i] * std_deviation[i];
+                prop_var[i] = vars[i] / totVar;
+                cum_var[i] = i == 0 ? prop_var[0] : cum_var[i-1] + prop_var[i];
+            }
+        }
+    }
+
+    /**
+     * Create the scoring history for dimension reduction algorithms like PCA/SVD.  We do make the following assumptions
+     * about your scoring_history.  First we assume that you will always have the following field:
+     * 1. Timestamp: long denoting the time in ms;
+     * 2. All other fields are double.
+     *
+     * The following field will be generated for you automatically: Duration and Iteration.
+     *
+     * @param scoreTable: HashMap containing column headers and arraylist containing the history of values collected.
+     * @param tableName: title/name of your scoring table
+     * @param startTime:  time your model building job was first started.
+     * @return: TwoDimTable containing the scoring history.
+     */
+    public static TwoDimTable createScoringHistoryTableDR(LinkedHashMap<String, ArrayList> scoreTable, String tableName,
+                                                          long startTime) {
+        List<String> colHeaders = new ArrayList<>();
+        List<String> colTypes = new ArrayList<>();
+        List<String> colFormat = new ArrayList<>();
+        ArrayList<String> otherTableEntries = new ArrayList<String>();
+
+        for (String fieldName:scoreTable.keySet()) {
+            if (fieldName.equals("Timestamp")) {
+                colHeaders.add("Timestamp"); colTypes.add("string"); colFormat.add("%s");
+                colHeaders.add("Duration"); colTypes.add("string"); colFormat.add("%s");
+                colHeaders.add("Iteration"); colTypes.add("long"); colFormat.add("%d");
+            } else {
+                otherTableEntries.add(fieldName); colHeaders.add(fieldName); colTypes.add("double"); colFormat.add("%.5f");
+            }
+        }
+
+        int rows = scoreTable.get("Timestamp").size(); // number of entries of training history
+
+        TwoDimTable table = new TwoDimTable(
+                tableName, null,
+                new String[rows],
+                colHeaders.toArray(new String[0]),
+                colTypes.toArray(new String[0]),
+                colFormat.toArray(new String[0]),
+                "");
+
+        assert (rows <= table.getRowDim());
+
+        for (int row = 0; row < rows; row++) {
+            int col = 0;
+            // take care of Timestamp, Duration, Iteration.
+            DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
+            table.set(row, col++, fmt.print((long) scoreTable.get("Timestamp").get(row)));
+            table.set(row, col++, PrettyPrint.msecs((long) scoreTable.get("Timestamp").get(row) - startTime, true));
+            table.set(row, col++, row);
+
+            // take care of the extra field
+            for (int remaining_cols = 0; remaining_cols < otherTableEntries.size(); remaining_cols++) {
+                table.set(row, col++, (double) scoreTable.get(otherTableEntries.get(remaining_cols)).get(row));
+            }
+        }
+        return table;
+    }
+}

--- a/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
@@ -4,7 +4,6 @@ import hex.Model;
 import hex.ModelCategory;
 import water.Weaver;
 import water.api.API;
-import water.util.IcedHashMap;
 import water.util.IcedHashMapGeneric;
 import water.util.Log;
 

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -1,7 +1,10 @@
 package water.util;
 
 import water.*;
-import water.fvec.*;
+import water.fvec.AppendableVec;
+import water.fvec.Frame;
+import water.fvec.NewChunk;
+import water.fvec.Vec;
 
 import java.text.DecimalFormat;
 import java.util.*;
@@ -1637,8 +1640,8 @@ public class ArrayUtils {
   }
 
   public static boolean isSorted(int[] vals) {
-    for(int i = 1; i < vals.length; ++i)
-      if(vals[i-1] > vals[i]) return false;
+    for (int i = 1; i < vals.length; ++i)
+      if (vals[i - 1] > vals[i]) return false;
     return true;
   }
 }

--- a/h2o-core/src/main/java/water/util/TwoDimTable.java
+++ b/h2o-core/src/main/java/water/util/TwoDimTable.java
@@ -219,6 +219,17 @@ public class TwoDimTable extends Iced {
   public int getColDim() { return colHeaders.length; }
 
   /**
+   * Need to change table header when we are calling GLRM from PCA.
+   *
+   * @param newHeader: String containing new table header.
+   */
+  public void setTableHeader(String newHeader) {
+    if (!StringUtils.isNullOrEmpty(newHeader)) {
+      this.tableHeader = newHeader;
+    }
+  }
+
+  /**
    * Setter for table cells
    * @param row a row index
    * @param col a column index

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -1,4 +1,6 @@
 from ..estimators.estimator_base import H2OEstimator
+from h2o.utils.typechecks import Enum
+from h2o.utils.typechecks import assert_is_type
 
 
 class H2OPCA(H2OEstimator):
@@ -8,11 +10,12 @@ class H2OPCA(H2OEstimator):
     algo = "pca"
 
     def __init__(self, model_id=None, k=None, max_iterations=None, seed=None,
-                 transform=("NONE", "DEMEAN", "DESCALE", "STANDARDIZE", "NORMALIZE"),
+                 transform="NONE",
                  use_all_factor_levels=False,
-                 pca_method=("GramSVD", "Power", "GLRM"),
+                 pca_method="GramSVD",
                  ignore_const_cols=True,
-                 impute_missing=False):
+                 impute_missing=False,
+                 compute_metrics=True):
         """
         Principal Components Analysis
 
@@ -41,15 +44,23 @@ class H2OPCA(H2OEstimator):
             - ``"Power"``: computation of the SVD using the power iteration method,
             - ``"GLRM"``: fit a generalized low rank model with an l2 loss function (no regularization) and solve for
               the SVD using local matrix algebra.
+            - ``"Randomized"``: computation of the SVD using the randomized method from thesis of Nathan P. Halko,
+                Randomized methods for computing low-rank approximation of matrices,
+        :param bool ignore_const_cols: If true, will ignore constant columns.  Default is True.
+        :param bool impute_missing:  whether to impute NA/missing values.
+        :param bool compute_metrics: whether to compute metrics on training data.  Default to True
 
         :returns: A new instance of H2OPCA.
+
         """
         super(H2OPCA, self).__init__()
         self._parms = locals()
         self._parms = {k: v for k, v in self._parms.items() if k != "self"}
-        self._parms["pca_method"] = "GramSVD" if isinstance(pca_method, tuple) else pca_method
-        self._parms["transform"] = "NONE" if isinstance(transform, tuple) else transform
 
+        assert_is_type(pca_method, Enum("GramSVD", "Power", "GLRM", "Randomized"))
+        self._parms["pca_method"]=pca_method
+        assert_is_type(transform, Enum("NONE", "DEMEAN", "DESCALE", "STANDARDIZE", "NORMALIZE"))
+        self._parms["transform"]=transform
 
     def fit(self, X, y=None, **params):
         return super(H2OPCA, self).fit(X)
@@ -67,15 +78,12 @@ class H2OPCA(H2OEstimator):
         """
         return self.predict(X)
 
-
-
-
 class H2OSVD(H2OEstimator):
     """Singular Value Decomposition"""
     algo = "svd"
 
     def __init__(self, nv=None, max_iterations=None, transform=None, seed=None,
-                 use_all_factor_levels=None, svd_method=None):
+                 use_all_factor_levels=None, svd_method="GramSVD"):
         """
         Singular value decomposition of an H2OFrame.
 
@@ -109,8 +117,11 @@ class H2OSVD(H2OEstimator):
         super(H2OSVD, self).__init__()
         self._parms = locals()
         self._parms = {k: v for k, v in self._parms.items() if k != "self"}
-        self._parms["svd_method"] = "GramSVD" if isinstance(svd_method, tuple) else svd_method
-        self._parms["transform"] = "NONE" if isinstance(transform, tuple) else transform
+
+        assert_is_type(svd_method, Enum("GramSVD", "Power", "GLRM", "Randomized"))
+        self._parms["svd_method"] = svd_method
+        assert_is_type(transform, Enum("NONE", "DEMEAN", "DESCALE", "STANDARDIZE", "NORMALIZE"))
+        self._parms["transform"]=transform
         self._parms['_rest_version'] = 99
 
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_3827_scoringHistory_importance.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_3827_scoringHistory_importance.py
@@ -1,0 +1,98 @@
+from __future__ import print_function
+from builtins import range
+from random import randint
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.transforms.decomposition import H2OPCA
+
+def pca_scoring_history_importance():
+    """
+    This test aims to check and make sure PCA returns the scoring history and importance which are
+    reported missing for certain PCA mode.  Apart from changing the PCA mode, I throw in the transform
+    type to test as well randomly.
+    """
+    transform_types = ["NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"]
+    transformN = transform_types[randint(0, len(transform_types)-1)]
+
+    print("Importing australia.csv data...\n")
+    australia = h2o.upload_file(pyunit_utils.locate("smalldata/extdata/australia.csv"))
+    col_indices = list(range(0, australia.ncol))
+
+    print("transform is {0}.\n".format(transformN))
+    # checking out PCA with GramSVD
+    print("@@@@@@  Building PCA with GramSVD...\n")
+    gramSVD = H2OPCA(k=3, transform=transformN)
+    gramSVD.train(x=col_indices, training_frame=australia)
+
+    # check PCA with PCA set to Randomized
+    print("@@@@@@  Building PCA with Randomized...\n")
+    randomizedPCA = H2OPCA(k=3, transform=transformN, pca_method="Randomized", compute_metrics=True,
+                         use_all_factor_levels=True)
+    randomizedPCA.train(x=col_indices, training_frame=australia)
+
+    # compare singular values and stuff with GramSVD
+    print("@@@@@@  Comparing eigenvalues between GramSVD and Randomized...\n")
+    pyunit_utils.assert_H2OTwoDimTable_equal(gramSVD._model_json["output"]["importance"],
+                                           randomizedPCA._model_json["output"]["importance"],
+                                           ["Standard deviation", "Cumulative Proportion", "Cumulative Proportion"],
+                                           tolerance=1e-3)
+    print("@@@@@@  Comparing eigenvectors between GramSVD and Randomized...\n")
+    # compare singular vectors
+    pyunit_utils.assert_H2OTwoDimTable_equal(gramSVD._model_json["output"]["eigenvectors"],
+                                           randomizedPCA._model_json["output"]["eigenvectors"],
+                                           randomizedPCA._model_json["output"]["names"], tolerance=1e-2,
+                                           check_sign=True)
+
+    # check PCA with PCA set to Power
+    print("@@@@@@  Building PCA with Power...\n")
+    powerPCA = H2OPCA(k=3, transform=transformN, pca_method="Power", compute_metrics=True, use_all_factor_levels=True)
+    powerPCA.train(x=col_indices, training_frame=australia)
+
+    # compare singular values and stuff with GramSVD
+    print("@@@@@@  Comparing eigenvalues between GramSVD and Power...\n")
+    pyunit_utils.assert_H2OTwoDimTable_equal(gramSVD._model_json["output"]["importance"],
+                                           powerPCA._model_json["output"]["importance"],
+                                           ["Standard deviation", "Cumulative Proportion", "Cumulative Proportion"])
+    print("@@@@@@  Comparing eigenvectors between GramSVD and Power...\n")
+    # compare singular vectors
+    pyunit_utils.assert_H2OTwoDimTable_equal(gramSVD._model_json["output"]["eigenvectors"],
+                                           powerPCA._model_json["output"]["eigenvectors"],
+                                           powerPCA._model_json["output"]["names"], tolerance=1e-5, check_sign=True)
+
+    # check PCA with PCA set to GLRM
+    print("@@@@@@  Building PCA with GLRM...\n")
+    glrmPCA = H2OPCA(k=3, transform=transformN, pca_method="GLRM", compute_metrics=True, use_all_factor_levels=True)
+    glrmPCA.train(x=col_indices, training_frame=australia)
+
+    # compare singular values and stuff with GramSVD
+    print("@@@@@@  Comparing eigenvalues between GramSVD and GLRM...\n")
+    pyunit_utils.assert_H2OTwoDimTable_equal(gramSVD._model_json["output"]["importance"],
+                                           glrmPCA._model_json["output"]["importance"],
+                                           ["Standard deviation", "Cumulative Proportion", "Cumulative Proportion"],
+                                           tolerance=1e-2)
+    print("@@@@@@  Comparing eigenvectors between GramSVD and GLRM...\n")
+    # compare singular vectors
+    pyunit_utils.assert_H2OTwoDimTable_equal(gramSVD._model_json["output"]["eigenvectors"],
+                                           glrmPCA._model_json["output"]["eigenvectors"],
+                                           glrmPCA._model_json["output"]["names"], tolerance=1e-1,check_sign=True)
+
+    # make sure we find the scoring history and it is not empty for all the PCA modes
+    # just check and make sure the cell_values exceed 0
+    assert len(gramSVD._model_json["output"]["scoring_history"].cell_values) > 0, "PCA Scoring history setting " \
+                                                                                "pca_method to GramSVD is empty."
+    assert len(powerPCA._model_json["output"]["scoring_history"].cell_values) > 0, "PCA Scoring history setting " \
+                                                                                 "pca_method to using is empty."
+    assert len(randomizedPCA._model_json["output"]["scoring_history"].cell_values) > 0, "PCA Scoring history setting " \
+                                                                                      "pca_method to Randomized is " \
+                                                                                      "empty."
+    assert len(glrmPCA._model_json["output"]["scoring_history"].cell_values) > 0, "PCA Scoring history setting " \
+                                                                                  "pca_method to GLRM is empty."
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pca_scoring_history_importance)
+else:
+    pca_scoring_history_importance()

--- a/h2o-r/tests/testdir_algos/pca/runit_PUBDEV_3827_scoringHistory_importance.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_PUBDEV_3827_scoringHistory_importance.R
@@ -1,0 +1,89 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# In this test, I want to make sure importance and scoring history for PCA models built using
+# all PCA methods are generated correctly.  In addition, I check and make sure that PCA
+# models are built correctly and agree with each other when different transform is used.  When
+# the transform is STANDARDIZE, we will compare our PCA models with R PCA model since  R only
+# support STANDARDIZE transform.
+test.pca.pubdev3827 <- function() {
+  Log.info("Importing australia.csv data...\n")
+  australia.hex <- h2o.uploadFile(locate("smalldata/extdata/australia.csv"))
+  australia.hex <- na.omit(australia.hex) # remove na rows
+  aus = as.data.frame(australia.hex)
+
+  transform_types = c("NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE")
+  transformN = transform_types[sample(1:4,1,replace=F)]
+  Log.info(paste("transform is set to ", transformN, sep=" "))
+
+  ranks = 3
+  if (transformN == "STANDARDIZE") {    # check result with R PCA for standardize
+    Log.info("Building PCA model using R...")
+    pcaR = prcomp(aus, center=TRUE, scale.=TRUE, rank.=ranks)
+  }
+  
+  Log.info("Building PCA model with GramSVD...")
+  gramSVD.pca <- h2o.prcomp(training_frame = australia.hex, transform=transformN, k=ranks)
+  print(gramSVD.pca@model$scoring_history)
+  print(gramSVD.pca@model$importance)
+
+  Log.info("Building PCA model with Randomized...") 
+  randomized.pca <- h2o.prcomp(training_frame = australia.hex, transform=transformN, k=ranks,
+  pca_method="Randomized", compute_metrics=TRUE)
+  print(randomized.pca@model$scoring_history)
+  print(randomized.pca@model$importance)
+
+  Log.info("Building PCA model with Power...") 
+  power.pca <- h2o.prcomp(training_frame = australia.hex, transform=transformN, k=ranks,
+                               pca_method="Power", compute_metrics=TRUE)
+  print(power.pca@model$scoring_history)
+  print(power.pca@model$importance)
+
+  Log.info("Building PCA model with GLRM...")
+  glrm.pca <- h2o.prcomp(training_frame = australia.hex, transform=transformN, k=ranks,
+                               pca_method="GLRM", compute_metrics=TRUE, use_all_factor_levels=TRUE)
+  print(glrm.pca@model$scoring_history)
+  print(glrm.pca@model$importance)
+
+  if (transformN == "STANDARDIZE") {  # just compare R and H2O PCA models with GramSVD
+  Log.info("****** Comparing R PCA model and GramSVD PCA model...")
+  isFlipped1 <- checkPCAModel(gramSVD.pca, pcaR, tolerance=3e-2, compare_all_importance=TRUE)
+  }
+
+  isFlipped1 <- checkPCAModelWork(ranks, gramSVD.pca@model$importance, randomized.pca@model$importance,
+  gramSVD.pca@model$eigenvectors, randomized.pca@model$eigenvectors,
+  "Compare importance between PCA GramSVD and PCA Randomized",
+  "PCA GramSVD Importance of Components:",
+  "PCA Randomized Importance of Components:", tolerance=2e-2,
+  compare_all_importance=TRUE)
+
+  Log.info("****** Comparing GramSVD PCA model and Power PCA model...")
+  isFlipped1 <- checkPCAModelWork(ranks, gramSVD.pca@model$importance, power.pca@model$importance,
+  gramSVD.pca@model$eigenvectors, power.pca@model$eigenvectors,
+  "Compare importance between PCA GramSVD and PCA Power",
+  "PCA GramSVD Importance of Components:",
+  "PCA Power Importance of Components:", tolerance=2e-6,
+  compare_all_importance=TRUE)
+
+  Log.info("****** Comparing GramSVD PCA model and GLRM PCA model...")
+  isFlipped1 <- checkPCAModelWork(ranks, gramSVD.pca@model$importance, glrm.pca@model$importance, 
+                              gramSVD.pca@model$eigenvectors, glrm.pca@model$eigenvectors, 
+                              "Compare importance between PCA GramSVD and PCA GLRM", 
+                              "PCA GramSVD Importance of Components:", 
+                              "PCA GLRM Importance of Components:", tolerance=2e-1,
+                              compare_all_importance=TRUE)
+
+  Log.info("Checking scoring history from all PCA methods")
+  expect_true(length(gramSVD.pca@model$scoring_history) > 0) # make sure we have a valid scoring history
+  expect_true(length(randomized.pca@model$scoring_history) > 0) # make sure we have a valid scoring history
+  expect_true(length(power.pca@model$scoring_history) > 0) # make sure we have a valid scoring history
+  expect_true(length(glrm.pca@model$scoring_history) > 0) # make sure we have a valid scoring history
+
+  Log.info("Checking importance from all PCA methods")
+  expect_true(length(gramSVD.pca@model$importance) > 0) # make sure we have a valid importance
+  expect_true(length(randomized.pca@model$importance) > 0) # ake sure we have a valid importance
+  expect_true(length(power.pca@model$importance) > 0) # ake sure we have a valid importance
+  expect_true(length(glrm.pca@model$importance) > 0) # ake sure we have a valid importance
+}
+
+doTest("PCA Test: PUBDEV-3827: Scoring history and importance of components", test.pca.pubdev3827)

--- a/h2o-r/tests/testdir_algos/pca/runit_pca_pubdev_3694_Rotterdam_large.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pca_pubdev_3694_Rotterdam_large.R
@@ -21,8 +21,8 @@ check.pca.widedata.gramSVD <- function() {
     pcaR <- prcomp(dfR, center = TRUE, scale. = TRUE, rank.=ranks)      # train R PCA
     h2o_pca <- h2o.prcomp(df, k = ranks, x = x, transform = 'STANDARDIZE', seed=12345)      # train H2O PCA
 
-    # the eigenvectors and eigvalues calculated from R and H2O are close but not equal
-    isFlipped1 <- checkPCAModel(h2o_pca, pcaR, tolerance=1)
+    # the eigenvectors and eigvalues calculated from R and H2O are close but not equal, R use random methods too.
+    isFlipped1 <- checkPCAModel(h2o_pca, pcaR, tolerance=2e-1, compare_all_importance=FALSE)
 
     Log.info("Compare Projections into PC space")
     predR <- predict(pcaR, dfR)


### PR DESCRIPTION
…t derived from Angela JIRA.

PUBDEV-3797: Fix PCA scoring history and importance.  Fixed Python interface to add PCA method Randomized.

PUBDEV-3827: fix PCA scoring history and importance.  Add compute_metrics to legal list of parameters for PCA in Python.

PUBDEV-3827: fix PCA scoring history and importance.  Added pyunit test to check scoring history and importance for every PCA mode.

PUBDEV-3827: Fix PCA scoring history and importance.  Fixed bug in java.  Parameters total_variance was not calculated.  Improved pyunit test to check out all transform mode and all PCA_methods.

PUBDEV-3827. Fix PCA scoring history and importance.  Correct calculation of total_variance.

PUBDEV-3827: fix pca scoring history and importance.  Fix total_variance calculation when PCA method is glrm.

PUBDEV-3827: fix PCA scoring history importance.  Fixed tolerance level.  Generate more printing for debugging.

PUBDEV-3827: fix PCA scoring history and importance.  Added Runit test and cleaning up.

PUBDFEV-3827: PCA scoring history and importance.  Clean up code to calculate importance in one spot for PCA/GLRM.  Fixed bugs in calculating importance for all PCA modes.

PUBDEV-3827: add scoring history and importance to PCA.  Fixed Runit test and now it is just like the Pyunit test except that we can compare R PCA result with H2O PCA results when transform is STANDARDIZE.