### PR TITLE
PUBDEV-3983: GBM FAQ updates

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/distribution.rst
+++ b/h2o-docs/src/product/data-science/algo-params/distribution.rst
@@ -9,9 +9,11 @@ Description
 
 Unlike in GLM, where users specify both a distribution ``family`` and a ``link`` for the loss function, in GBM and Deep Learning, distributions and loss functions are tightly coupled. In these algorithms, a loss function is specified using the ``distribution`` parameter. When specifying the distribution, the loss function is automatically selected as well. For exponential families (such as Poisson, Gamma, and Tweedie), the canonical logarithmic link function is used.
 
-By default, the GBM/Deep Learning loss function method performs AUTO distribution. In this case, the algorithm will guess the model type based on the response column type (specified using ``y``). Certain cases can exist, however, in which the median starting value for this loss function can lead to poor results (for example, if the median is the lowest or highest value in a tree node). The ``distribution`` option allows you to specify a different method. Available methods include AUTO, bernoulli, multinomial, gaussian, poisson, gamma, laplace, quantile, huber, and tweedie.
+By default, the GBM/Deep Learning loss function method performs AUTO distribution. In this case, the algorithm will guess the model type based on the response column type (specified using ``y``). More specifically, if the response column type is numeric, AUTO defaults to "gaussian"; if categorical, AUTO defaults to bernoulli or multinomial depending on the number of response categories.
 
-- If the distribution is ``bernoulli``, the the response column must be 2-class categorical
+Certain cases can exist, however, in which the median starting value for this loss function can lead to poor results (for example, if the median is the lowest or highest value in a tree node). The ``distribution`` option allows you to specify a different method. Available methods include AUTO, bernoulli, multinomial, gaussian, poisson, gamma, laplace, quantile, huber, and tweedie.
+
+- If the distribution is ``bernoulli``, the response column must be 2-class categorical
 - If the distribution is ``multinomial``, the response column must be categorical.
 - If the distribution is ``gaussian``, the response column must be numeric.
 - If the distribution is ``poisson``, the response column must be numeric.

--- a/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
@@ -35,4 +35,4 @@ Specifically, if there are no NAs in the training data, then NAs in the test dat
 
 - **What happens when you try to predict on a categorical level not seen during training?**
 
- Unseen categorical levels follow the majority path for each node. The tree structure remembers for each split whether the left or right side had more observations going down that path during training.
+Unseen categorical levels are turned into NAs, and thus follow the same behavior as an NA. If there are no NAs in the training data, then unseen categorical levels in the test data follow the majority direction (the direction with the most observations). If there are NAs in the training data, then unseen categorical levels in the test data follow the direction that is optimal for the NAs of the training data.


### PR DESCRIPTION
- Updated GBM Missing Values faqs for “What happens when you try to predict on a categorical level not seen during training?”
- Driveby fix: In the distribution option, added clarification describing the method that the algorithm performs when the distribution is AUTO.