### PR TITLE
PUBDEV-3938: orc timestamp offset.  Force python to use local time wh…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ doIncludeOrc=false
 #
 orcDefaultHadoopClientVersion=2.6.0-cdh5.4.0
 orcDefaultHiveExecVersion=1.1.0-cdh5.4.0
+
 #
 # Default hadoop client version
 #

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -673,11 +673,18 @@ public class TestUtil extends Iced {
           } else if (c0 instanceof CStrChunk && c1 instanceof CStrChunk) {
             if (!(c0.isNA(rows) && c1.isNA(rows))) {
               BufferedString s0 = new BufferedString(), s1 = new BufferedString();
-              c0.atStr(s0, rows); c1.atStr(s1, rows);
+              c0.atStr(s0, rows);
+              c1.atStr(s1, rows);
               if (s0.compareTo(s1) != 0) {
                 _unequal = true;
                 return;
               }
+            }
+          } else if((c0 instanceof C8Chunk) && (c1 instanceof C8Chunk)) {
+            long d0 = c0.at8(rows), d1 = c1.at8(rows);
+            if (d0 != d1) {
+              _unequal = true;
+              return;
             }
           }else {
             double d0 = c0.atd(rows), d1 = c1.atd(rows);

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
@@ -35,7 +35,7 @@ public class ParseTestMultiFileOrc extends TestUtil {
     }
 
     @BeforeClass
-    static public void setup() { TestUtil.stall_till_cloudsize(5); }
+    static public void setup() { TestUtil.stall_till_cloudsize(1); }
 
     @Test
     public void testParseMultiFileOrcs() {

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
@@ -3,14 +3,13 @@ package water.parser;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import water.TestUtil;
+import water.util.Log;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
 import java.util.TreeSet;
-
-import water.TestUtil;
-import water.util.Log;
 
 import static org.junit.Assert.assertEquals;
 import static water.parser.OrcTestUtils.compareOrcAndH2OFrame;
@@ -66,7 +65,7 @@ public class ParseTestOrc extends TestUtil {
     };
 
     @BeforeClass
-    static public void setup() { TestUtil.stall_till_cloudsize(5); }
+    static public void setup() { TestUtil.stall_till_cloudsize(1); }
 
     @BeforeClass
     static public void _preconditionJavaVersion() { // NOTE: the `_` force execution of this check after setup

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2630,7 +2630,7 @@ def compareOneStringColumn(frame1, frame2, col_ind, rows, numElements):
     else:
         numElements = rows
 
-    for ele_ind in range(numElements):
+    for ele_ind in range(min(rows, numElements)):
         row_ind = row_indices[ele_ind]
 
         val1 = frame1[row_ind, col_ind]
@@ -2653,15 +2653,14 @@ def compareOneNumericColumn(frame1, frame2, col_ind, rows, tolerance, numElement
     :return: None.  Will throw exceptions if comparison failed.
     """
 
-    row_indices = []
+    row_indices = list(range(rows))
     if numElements > 0:
-        row_indices = random.sample(xrange(rows), numElements)
+        random.shuffle(row_indices)
     else:
-        numElements = rows  # Compare all elements
-        row_indices = list(range(rows))
+        numElements = rows
 
 
-    for ele_ind in range(numElements):
+    for ele_ind in range(min(rows, numElements)):
         row_ind = row_indices[ele_ind]
 
         val1 = frame1[row_ind, col_ind]
@@ -2677,8 +2676,6 @@ def compareOneNumericColumn(frame1, frame2, col_ind, rows, tolerance, numElement
         else:   # something is wrong, one frame got a missing value while the other is fine.
             assert 1 == 2,  "failed frame values check! frame1 value {0}, frame2 value {1} at row {2}, " \
                             "column {3}".format(val1, val2, row_ind, col_ind)
-
-import warnings
 
 def expect_warnings(filewithpath, warn_phrase="warn", warn_string_of_interest="warn", number_of_times=1, in_hdfs=False):
     """

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_list_timezones.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_list_timezones.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2olist_timezones():
+    """
+    Python API test: h2o.cluster().list_timezones()
+    """
+    try:
+        timezones = h2o.cluster().list_timezones()
+        assert_is_type(timezones, H2OFrame)
+
+        # change the assert nrow from == to >= in case more timezones are introduced in the future.
+        assert timezones.nrow>=460, "h2o.cluster().list_timezones() returns frame with wrong row number."
+        assert timezones.ncol==1, "h2o.cluster().list_timezones() returns frame with wrong column number."
+    except Exception as e:
+        assert False, "h2o.cluster().list_timezones() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2olist_timezones)
+else:
+    h2olist_timezones()

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_network_test.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_network_test.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2onetwork_test():
+    """
+    Python API test: h2o.cluster().network_test()
+    """
+    try:
+        h2o.cluster().network_test()    # no return type
+    except Exception as e:
+        assert False, "h2o.cluster().network_test() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2onetwork_test)
+else:
+    h2onetwork_test()

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_show_status.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_show_status.py
@@ -1,0 +1,22 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2ocluster_status():
+    """
+    Python API test: h2o.cluster().show_status(True) and h2o.cluster().show_status()
+
+    """
+    try:
+        h2o.cluster().show_status(True)    # no return type
+        h2o.cluster().show_status()
+    except Exception as e:
+        assert False, "h2o.cluster().show_status() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2ocluster_status)
+else:
+    h2ocluster_status()

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_timezone.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_timezone.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2oget_timezone():
+    """
+    Python API test: h2o.cluster().timezone() to get the time zone, h2o.cluster().timezone="UTC" to
+    test setting the time zone.
+
+    Copy from pyunit_get_set_list_timezones.py
+    """
+    try:
+        origTZ = h2o.cluster().timezone
+        print("Original timezone: {0}".format(origTZ))
+
+        newZone = 'America/Los_Angeles'
+        h2o.cluster().timezone = newZone
+        assert str(h2o.cluster().timezone)==newZone, "Time zone was not set correctly."
+        h2o.cluster().timezone=origTZ   # reset timezone back to original one
+    except Exception as e:
+        assert False, "h2o.cluster().timezone command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2oget_timezone)
+else:
+    h2oget_timezone()

--- a/h2o-py/tests/testdir_hdfs/index.list
+++ b/h2o-py/tests/testdir_hdfs/index.list
@@ -1,3 +1,4 @@
+pyunit_INTERNAL_HDFS_timestamp_date_orc.py
 pyunit_INTERNAL_HDFS_pubdev_3359_import_1000s_file.py
 pyunit_INTERNAL_HDFS_basic.py
 pyunit_INTERNAL_HDFS_import_export.py

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_timestamp_date_orc.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_timestamp_date_orc.py
@@ -31,6 +31,9 @@ def hdfs_orc_parser():
                   "skipped.".format("pyunit_INTERNAL_HDFS_timestamp_date_orc.py"))
             pass
         else:
+            origTZ = h2o.cluster().timezone
+            newZone = 'America/Los_Angeles'
+            h2o.cluster().timezone = newZone
             tol_time = 200              # comparing in ms or ns
             tol_numeric = 1e-5          # tolerance for comparing other numeric fields
             numElements2Compare = 100   # choose number of elements per column to compare.  Save test time.
@@ -52,6 +55,8 @@ def hdfs_orc_parser():
                 # compare the two frames
                 assert pyunit_utils.compare_frames(h2oOrc, h2oCsv, numElements2Compare, tol_time, tol_numeric), \
                     "H2O frame parsed from orc and csv files are different!"
+                
+            h2o.cluster().timezone=origTZ
     else:
         raise EnvironmentError
 

--- a/h2o-py/tests/testdir_parser/pyunit_orc_NOFEATURE_parser_timestamp_date.py
+++ b/h2o-py/tests/testdir_parser/pyunit_orc_NOFEATURE_parser_timestamp_date.py
@@ -19,6 +19,9 @@ def orc_parser_timestamp_date():
 
     :return: None
     """
+    origTZ = h2o.cluster().timezone
+    newZone = 'America/Los_Angeles'
+    h2o.cluster().timezone = newZone
 
     tol_time = 200              # comparing in ms or ns
     tol_numeric = 1e-5          # tolerance for comparing other numeric fields
@@ -41,7 +44,7 @@ def orc_parser_timestamp_date():
         assert pyunit_utils.compare_frames(h2oOrc, h2oCsv, numElements2Compare, tol_time, tol_numeric), \
             "H2O frame parsed from orc and csv files are different!"
 
-
+    h2o.cluster().timezone=origTZ
 if __name__ == "__main__":
     pyunit_utils.standalone_test(orc_parser_timestamp_date)
 else:


### PR DESCRIPTION
After h2o python client force the timezone to UTC, orc parser timestamp test failed due to orc parser uses local time.  To remove this problem, I set the time zone to local time run the test and revert time zone back to UTC.  This should not affect other tests.

In addition, I forget to test the following APIs:
h2o.cluster().timezone
h2o.cluster().list_timezones()
h2o.cluster().show_status()
h2o.cluster().network_test().

Thanks!
