### PR TITLE
README changes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,7 +23,7 @@
 <h4>        Bug
 </h4>
 <ul>
-<li> Hotfix: remove StackedEnsemble from Flow UI - right now only supported from Python and R interfaces
+<li> Hotfix: Remove StackedEnsemble from Flow UI. Training is only supported from Python and R interfaces. Viewing is supported in the Flow UI.
 </li>
 </ul>
 


### PR DESCRIPTION
Indicated that 3.10.2.3 hotfix did not completely remove stacked
ensembles from Flow. Users can train SE models in Python and R, and then view the SE models in Flow.