### PR TITLE
use drift flow.js bundle to add new top-level Plot menu to Flow

### DIFF
--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -102,7 +102,7 @@ task deleteLegacyFlowBundleFromWebRoot(type: Delete) {
 
 task copyFlowBundleFromDrift() << {
   def f = new File('h2o-web/lib/h2o-flow/build/js/flow.js')
-  new URL('http://raw.githubusercontent.com/micahstubbs/drift/e143439d23aa49a6bf2717f73f60275cf60f6fc6/build/flow.js').withInputStream{ i -> f.withOutputStream{ it << i }}
+  new URL('http://raw.githubusercontent.com/h2oai/drift/3ff2bf747eb348385f23ccddf520156e42cb45b5/build/flow.js').withInputStream{ i -> f.withOutputStream{ it << i }}
 }
 
 task copyFlowToWebRoot(type: Copy) {

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -96,9 +96,13 @@ task installBowerPackages(type: Exec) {
   }
 }
 
+task deleteLegacyFlowBundleFromWebRoot(type: Delete) {
+  delete 'lib/h2o-flow/build/js/flow.js'
+}
+
 task copyFlowBundleFromDrift() << {
   def f = new File('h2o-web/lib/h2o-flow/build/js/flow.js')
-  new URL('https://raw.githubusercontent.com/micahstubbs/drift/master/build/flow.js').withInputStream{ i -> f.withOutputStream{ it << i }}
+  new URL('https://raw.githubusercontent.com/micahstubbs/drift/e143439d23aa49a6bf2717f73f60275cf60f6fc6/build/flow.js').withInputStream{ i -> f.withOutputStream{ it << i }}
 }
 
 task copyFlowToWebRoot(type: Copy) {
@@ -194,7 +198,8 @@ task deleteDocFiles(type: Delete) {
 
 installNpmPackages.dependsOn checkClientPrerequisites
 installBowerPackages.dependsOn installNpmPackages
-copyFlowBundleFromDrift.dependsOn installBowerPackages
+deleteLegacyFlowBundleFromWebRoot.dependsOn installBowerPackages
+copyFlowBundleFromDrift.dependsOn deleteLegacyFlowBundleFromWebRoot
 copyFlowToWebRoot.dependsOn copyFlowBundleFromDrift
 
 compileHelpFiles.dependsOn installNpmPackages

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -102,7 +102,7 @@ task deleteLegacyFlowBundleFromWebRoot(type: Delete) {
 
 task copyFlowBundleFromDrift() << {
   def f = new File('h2o-web/lib/h2o-flow/build/js/flow.js')
-  new URL('https://raw.githubusercontent.com/micahstubbs/drift/e143439d23aa49a6bf2717f73f60275cf60f6fc6/build/flow.js').withInputStream{ i -> f.withOutputStream{ it << i }}
+  new URL('http://raw.githubusercontent.com/micahstubbs/drift/e143439d23aa49a6bf2717f73f60275cf60f6fc6/build/flow.js').withInputStream{ i -> f.withOutputStream{ it << i }}
 }
 
 task copyFlowToWebRoot(type: Copy) {

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -96,6 +96,11 @@ task installBowerPackages(type: Exec) {
   }
 }
 
+task copyFlowBundleFromDrift() << {
+  def f = new File('h2o-web/lib/h2o-flow/build/js/flow.js')
+  new URL('https://raw.githubusercontent.com/micahstubbs/drift/master/build/flow.js').withInputStream{ i -> f.withOutputStream{ it << i }}
+}
+
 task copyFlowToWebRoot(type: Copy) {
   from 'lib/h2o-flow/build'
   into 'src/main/resources/www/flow'
@@ -189,7 +194,8 @@ task deleteDocFiles(type: Delete) {
 
 installNpmPackages.dependsOn checkClientPrerequisites
 installBowerPackages.dependsOn installNpmPackages
-copyFlowToWebRoot.dependsOn installBowerPackages
+copyFlowBundleFromDrift.dependsOn installBowerPackages
+copyFlowToWebRoot.dependsOn copyFlowBundleFromDrift
 
 compileHelpFiles.dependsOn installNpmPackages
 


### PR DESCRIPTION
This PR uses the [drift](https://github.com/micahstubbs/drift) flow.js bundle to add a new top-level Plot menu to Flow

![screen shot 2017-02-06 at 10 06 44 pm](https://cloud.githubusercontent.com/assets/2119400/22679714/053af62c-ecb9-11e6-9dc2-58c1e5c40d8d.png)
