### PR TITLE
PUBDEV-4006: Doc site updates for Stacked Ensembles

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -283,10 +283,10 @@
               <td>Tuning</td>
             </tr>
             <tr>
-              <td>Ensembles (Stacking)</td>
-              <td><a href="http://docs.h2o.ai/h2o-tutorials/latest-stable/tutorials/ensembles-stacking/index.html">Tutorial</a></td>
+              <td>Stacked Ensembles</td>
+              <td>Tutorial</td>
               <td>Booklet</td>
-              <td><a href="https://github.com/h2oai/h2o-3/blob/master/h2o-r/ensemble/README.md">Reference</a></td>
+              <td><a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html">Reference</a></td>
               <td>Tuning</td>
             </tr>
             </tbody>
@@ -337,7 +337,7 @@
               <a href="h2o-docs/booklets/RBooklet.pdf">R Booklet</a>
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/demos">Examples and Demos</a>
               <a href="h2o-docs/faq.html#r">R FAQ</a>
-              <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/ensemble/README.md">Ensemble R Package Readme</a>
+              <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/ensemble/README.md">h2oEnsemble R Package Readme</a>
               <a href="https://github.com/h2oai/rsparkling/blob/master/README.md">RSparkling Readme</a>
               <a href="h2o-docs/migrating.html">Migrating from H2O-2</a>
           </div>


### PR DESCRIPTION
- Changed Ensembles (Stacking) to Stacked Ensembles
- Removed Tutorials link
- Updated “Reference” link. This now points to the Stacked Ensembles section in the User Guide.
- Changed “Ensemble R Package Readme” to “h2oEnsemble R Package Readme”
Note: Did not change “Readme” to “Homepage.” Let if for now for consistency with other readme files on the site.