### PR TITLE
[PUBDEV-4017][HOTFIX] :fire: Fix the build dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,16 +10,16 @@ buildscript {
     //noinspection GroovyAssignabilityCheck
     dependencies {
         classpath 'org.ow2.asm:asm:5.1'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
         classpath 'com.github.townsfolk:gradle-release:1.2'
-        classpath 'de.undercouch:gradle-download-task:2.1.0'
-        classpath 'joda-time:joda-time:2.3'
         classpath 'com.adaptc.gradle:nexus-workflow:0.6'
         classpath 'org.testng:testng:6.8'
         classpath "be.insaneprogramming.gradle:animalsniffer-gradle-plugin:+"
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.3.1'
-        classpath 'ca.cutterslade.gradle:gradle-dependency-analyze:1.1.0'
+        // Note: Analyze unused/undefined dependencies for each module - good for debugging
+        // However, later it should be enabled by default
+        //classpath 'ca.cutterslade.gradle:gradle-dependency-analyze:1.1.0'
     }
 }
 
@@ -131,8 +131,11 @@ ext {
 //
 allprojects {
     group = 'ai.h2o'
+    // By default inject debugging support
     apply plugin: 'project-report'
+    apply from: "$rootDir/gradle/debug.gradle"
 
+    // Support different IDEs
     apply plugin: 'idea'
     apply plugin: 'eclipse'
     apply from: "$rootDir/gradle/artifacts.gradle"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,8 @@ repositories {
 }
 
 dependencies {
-    compile 'io.minio:minio:2.0.4'
+    compile 'io.minio:minio:3.0.3'
+    // Upgrade http client since the old version was colliding with other plugins
+    compile 'org.apache.httpcomponents:httpclient:4.5.2'
 }
 

--- a/gradle/debug.gradle
+++ b/gradle/debug.gradle
@@ -1,0 +1,5 @@
+// Show build script dependencies
+task buildScriptDependencies(type: org.gradle.api.tasks.diagnostics.DependencyReportTask) {
+        configurations = project.buildscript.configurations
+}
+

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -9,6 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'de.undercouch:gradle-download-task:3.2.0'
+        classpath 'joda-time:joda-time:2.3'
     }
 }
 

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -1,24 +1,23 @@
 //
 // Supports dataset synchronization with S3
 //
-import org.apache.tools.ant.taskdefs.condition.Os
+
 
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
     }
-    dependencies { //Gradle seems to require these dependencies be listed in build.gradle AND here
-        classpath 'de.undercouch:gradle-download-task:2.1.0'
-        classpath 'joda-time:joda-time:2.2'
+    dependencies {
+        classpath 'de.undercouch:gradle-download-task:3.2.0'
     }
 }
 
 // Shows download progress, nice for large file downloads
-apply plugin: 'de.undercouch.download'
-import de.undercouch.gradle.tasks.download.Download
+// We need to reference plugin class directly here: http://mrhaki.blogspot.com/2015/10/gradle-goodness-apply-external-script.html
+apply plugin: de.undercouch.gradle.tasks.download.DownloadTaskPlugin
 
-// Amazon timestamps are only easily read by Joda
+import org.apache.tools.ant.taskdefs.condition.Os
+import de.undercouch.gradle.tasks.download.Download
 import org.joda.time.format.ISODateTimeFormat
 
 import java.util.regex.Matcher

--- a/gradle/scala.gradle
+++ b/gradle/scala.gradle
@@ -21,9 +21,9 @@ sourceSets {
 
 // Activate Zinc compiler and configure scalac
 tasks.withType(ScalaCompile) {
-//    scalaCompileOptions.useCompileDaemon = false
-//    scalaCompileOptions.useAnt = false
-//    scalaCompileOptions.additionalParameters = ['-target:jvm-1.6']
+	configure(scalaCompileOptions.forkOptions) {
+        jvmArgs = ['-XX:MaxPermSize=256m']
+    }
 }
 
 // Create jar


### PR DESCRIPTION
Wrong version of Download Task Plugin was used for new gradle version causing
```
java.lang.NoClassDefFoundError: Lorg/gradle/logging/ProgressLogger
```

The fix:
  - upgrade version of download-task-plugin
  - fix collision of buildscript dependencies by updating minio version and forcing http-client version to 4.5.2
  - minor update in `gradle/s3sync.gradle` script to include dependencies directly in the script instead of top-level script