### PR TITLE
PUBDEV-3964: StepOutOfRangeException when building GBM model

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -159,8 +159,8 @@ public final class DHistogram extends Iced {
 
   static class StepOutOfRangeException extends RuntimeException {
 
-    public StepOutOfRangeException(double step, int xbins, double maxEx, double min) {
-      super("step=" + step + ", xbins = " + xbins + ", maxEx = " + maxEx + ", min = " + min);
+    public StepOutOfRangeException(String name, double step, int xbins, double maxEx, double min) {
+      super("column=" + name + " leads to invalid histogram(check numeric range) -> [max=" + maxEx + ", min = " + min + "], step= " + step + ", xbin= " + xbins);
     }
   }
   public DHistogram(String name, final int nbins, int nbins_cats, byte isInt, double min, double maxEx,
@@ -195,7 +195,7 @@ public final class DHistogram extends Iced {
     } else {
       _step = xbins / (maxEx - min);              // Step size for linear interpolation, using mul instead of div
       if(_step <= 0 || Double.isInfinite(_step) || Double.isNaN(_step))
-        throw new StepOutOfRangeException(_step, xbins, maxEx, min);
+        throw new StepOutOfRangeException(name,_step, xbins, maxEx, min);
     }
     _nbin = (char) xbins;
     assert(_nbin>0);


### PR DESCRIPTION
* This PR fixes the `StepOutOfRange` exception in tree models.
* The main issue is a float point overload due to a column that has a very high max value. To remedy this, I propose to ignore such columns for a couple reasons:

1. These columns would be ignored in the tree building process, anyways.
2. An exception should not be thrown if these values are encountered. Rather, we should gracefully tell the user of such columns after building the model.

Note, I have also modified the exception message to be a bit more clear just in case this exception is hit.