### PR TITLE
Add a title to the documentation page

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -4,6 +4,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>H2O.ai Documentation</title>
         <link rel="shortcut icon" href="assets/images/favicon.ico">
         <link rel='stylesheet' id='megamenu-css' href='assets/maxmegamenu/maxmegamenu_style.css?ver=5b6e52' type='text/css' media='all' />
         <link rel='stylesheet' href='assets/vendor/bootstrap.min.css' type='text/css' />


### PR DESCRIPTION
H2O.ai doc site now has a title.