### PR TITLE
Updated cloud to cluster in h2o.clusterInfo() printout

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -381,9 +381,9 @@ h2o.clusterStatus <- function() {
   res <- .h2o.fromJSON(jsonlite::fromJSON(.h2o.doSafeGET(urlSuffix = .h2o.__CLOUD), simplifyDataFrame=FALSE))
 
   cat("Version:", res$version, "\n")
-  cat("Cloud name:", res$cloud_name, "\n")
-  cat("Cloud size:", res$cloud_size, "\n")
-  if(res$locked) cat("Cloud is locked\n\n") else cat("Accepting new members\n\n")
+  cat("Cluster name:", res$cloud_name, "\n")
+  cat("Cluster size:", res$cloud_size, "\n")
+  if(res$locked) cat("Cluster is locked\n\n") else cat("Accepting new members\n\n")
   if(is.null(res$nodes) || length(res$nodes) == 0L) stop("No nodes found")
 
   # Calculate how many seconds ago we last contacted cloud


### PR DESCRIPTION
`h2o.clusterInfo()` in R used to print:

```
Version: 3.11.0.99999 
Cloud name: H2O_started_from_R_me_jox289 
Cloud size: 1 
Cloud is locked
```
But this PR changes it to:

```
Version: 3.11.0.99999 
Cluster name: H2O_started_from_R_me_jox289 
Cluster size: 1 
Cluster is locked
```
This should have been updated a long time ago when we stopped using the term "cloud" and started using the term "cluster."