### PR TITLE
Improved error message regarding the continuity of time

### DIFF
--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
@@ -99,7 +99,9 @@ public class DeepLearningCheckpointReporting extends TestUtil {
           durationBefore = durationBefore.substring(0, durationBefore.length()-4);
           String durationAfter = (String)table.get((int)(p._epochs+1),1);
           durationAfter = durationAfter.substring(0, durationAfter.length()-4);
-          Assert.assertTrue("Duration must be smooth", Double.parseDouble(durationAfter) - Double.parseDouble(durationBefore) < sleepTime+1);
+          double diff = Double.parseDouble(durationAfter) - Double.parseDouble(durationBefore);
+          
+          Assert.assertTrue("Duration must be smooth; actual " + diff + ", expected at most " + sleepTime + " (before=" + durationBefore + ", after=" + durationAfter + ")", diff < sleepTime+1);
 
           // Check that time stamp does see the sleep
           String timeStampBefore = (String)table.get((int)(p._epochs),0);


### PR DESCRIPTION
 In DeepLearningCheckpointReporting:

1) run(hex.deeplearning.DeepLearningCheckpointReporting)
java.lang.AssertionError: Duration must be smooth