### PR TITLE
PUBDEV-4039 revert flow to version 0.5.2

### DIFF
--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "h2oai/h2o-flow#d1fd4b8538f156f3cbb668eef049856ae6bc8e79"
+    "h2o-flow": "0.5.2"
   },
   "devDependencies": {}
 }

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -198,9 +198,10 @@ task deleteDocFiles(type: Delete) {
 
 installNpmPackages.dependsOn checkClientPrerequisites
 installBowerPackages.dependsOn installNpmPackages
-deleteLegacyFlowBundleFromWebRoot.dependsOn installBowerPackages
-copyFlowBundleFromDrift.dependsOn deleteLegacyFlowBundleFromWebRoot
-copyFlowToWebRoot.dependsOn copyFlowBundleFromDrift
+// deleteLegacyFlowBundleFromWebRoot.dependsOn installBowerPackages
+// copyFlowBundleFromDrift.dependsOn deleteLegacyFlowBundleFromWebRoot
+// copyFlowToWebRoot.dependsOn copyFlowBundleFromDrift
+copyFlowToWebRoot.dependsOn installBowerPackages
 
 compileHelpFiles.dependsOn installNpmPackages
 


### PR DESCRIPTION
This PR reverts the version of Flow shipped with `h2o-3` to version `0.5.2` to resolve regressions with: 
 
- passing null pointer exception errors from backend `h2o-3` to the user in Flow
- viewing model output for for Word2Vec and custom algos not specified in `_schemaHacks`

