### PR TITLE
PUBDEV-4003: add api tests for python data manipulation module. Add a…

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -38,8 +38,6 @@ from h2o.utils.typechecks import (assert_is_type, assert_satisfies, Enum, I, is_
 __all__ = ("H2OFrame", )
 
 
-
-
 class H2OFrame(object):
     """
     Primary data store for H2O.
@@ -422,7 +420,7 @@ class H2OFrame(object):
                 IPython.display.display_html(self._ex._cache._tabulate("html", False), raw=True)
         else:
             if use_pandas and can_use_pandas():
-                print(self.head().as_data_frame(fill_cache=True))
+                print(self.head().as_data_frame(True))  # no keyword fill_cache
             else:
                 s = self.__unicode__()
                 stk = traceback.extract_stack()
@@ -1059,8 +1057,8 @@ class H2OFrame(object):
         """
         Convert the frame (containing strings / categoricals) into the ``date`` format.
 
-        :param str format: the format string (e.g. "YYYY-mm-dd")
-        :returns: new H2OFrame with "date" column types
+        :param str format: the format string (e.g. "%Y-%m-%d")
+        :returns: new H2OFrame with "int" column types
         """
         fr = H2OFrame._expr(expr=ExprNode("as.Date", self, format), cache=self._ex._cache)
         if fr._ex._cache.types_valid():
@@ -1110,7 +1108,8 @@ class H2OFrame(object):
 
     def prod(self, na_rm=False):
         """
-        Compute the product of all values in the frame.
+        Compute the product of all values across all rows in a single column H2O frame.  If you apply
+        this command on a multi-column H2O frame, the answer may not be correct.
 
         :param bool na_rm: If True then NAs will be ignored during the computation.
         :returns: product of all values in the frame (a float)
@@ -1917,7 +1916,7 @@ class H2OFrame(object):
 
     def relevel(self, y):
         """
-        Reorder levels of an H2O factor.
+        Reorder levels of an H2O factor for one single column of a H2O frame
 
         The levels of a factor are reordered such that the reference level is at level 0, all remaining levels are
         moved down as needed.
@@ -2293,7 +2292,8 @@ class H2OFrame(object):
 
     def countmatches(self, pattern):
         """
-        For each string in the frame, count the occurrences of the provided pattern.
+        For each string in the frame, count the occurrences of the provided pattern.  If countmathces is applied to
+        a frame, all columns of the frame must be type string, otherwise, the returned frame will contain errors.
 
         The pattern here is a plain string, not a regular expression. We will search for the occurrences of the
         pattern as a substring in element of the frame. This function is applicable to frames containing only
@@ -2348,7 +2348,7 @@ class H2OFrame(object):
         The set argument is a string specifying the set of characters to be removed.
         If omitted, the set argument defaults to removing whitespace.
 
-        :param str set: The set of characters to lstrip from strings in column
+        :param character set: The set of characters to lstrip from strings in column.
         :returns: a new H2OFrame with the same shape as the original frame and having all its values
             trimmed from the left (equivalent of Python's ``str.lstrip()``).
         """
@@ -2368,7 +2368,7 @@ class H2OFrame(object):
         The set argument is a string specifying the set of characters to be removed.
         If omitted, the set argument defaults to removing whitespace.
 
-        :param str set: The set of characters to rstrip from strings in column
+        :param character set: The set of characters to rstrip from strings in column
         :returns: a new H2OFrame with the same shape as the original frame and having all its values
             trimmed from the right (equivalent of Python's ``str.rstrip()``).
         """
@@ -2751,6 +2751,10 @@ class H2OFrame(object):
         :returns: an H2OFrame where each element is equal to the corresponding element in the source
             frame minus the previous-row element in the same frame.
         """
+        if self.ncols > 1:
+            raise H2OValueError("Only single-column frames supported")
+        if self.types[self.columns[0]] not in {"real", "int", "bool"}:
+            raise H2OValueError("Numeric column expected")
         fr = H2OFrame._expr(expr=ExprNode("difflag1", self), cache=self._ex._cache)
         return fr
 

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame():
+    """
+    Python API test: h2o.frame.H2OFrame(python_obj=None, destination_frame=None, header=0, separator=', ',
+    column_names=None, column_types=None, na_strings=None)
+    """
+    python_lists = [[1,4,"a",1], [2,5,"b",0], [3,6,"c",1]]
+    col_names=["num1","num2","str1","enum1"]
+    dest_frame="newFrame"
+    heads=-1
+    sep=','
+    col_types=['numeric', 'numeric', 'string', 'enum']
+    na_str=['NA']
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, destination_frame=dest_frame, header=heads, separator=sep,
+                            column_names=col_names, column_types=col_types, na_strings=na_str)
+    assert_is_type(h2oframe, H2OFrame)
+    assert h2oframe.nrows==len(python_lists) and h2oframe.ncols==len(python_lists[0]), "h2o.H2OFrame() command is " \
+                                                                                 "not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame())
+else:
+    h2o_H2OFrame()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_all_any_anyfactor_isfactor.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_all_any_anyfactor_isfactor.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from tests import pyunit_utils
+
+def h2o_H2OFrame_all():
+    """
+    Python API test: h2o.frame.H2OFrame.all(), h2o.frame.H2OFrame.any(), h2o.frame.H2OFrame.anyfactor(),
+    h2o.frame.H2OFrame.isfactor()
+    """
+    python_lists=[[True, False], [False, True], [True, True], [True, 'NA']]
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, na_strings=['NA']) # contains true and false
+    assert not(h2oframe.all()), "h2o.H2OFrame.all() command is not working." # all elements are true or NA
+    assert h2oframe.any(), "h2o.H2OFrame.any() command is not working." # all elements are true or NA
+    assert h2oframe.anyfactor(), "h2o.H2OFrame.anyfactor() command is not working." # all columns are factors
+
+    clist = h2oframe.isfactor()
+    assert_is_type(clist, list)     # check return type
+    assert sum(clist)==h2oframe.ncol, "h2o.H2OFrame.isfactor() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_all())
+else:
+    h2o_H2OFrame_all()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_any_na_rm.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_any_na_rm.py
@@ -1,0 +1,18 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_any_rm_na():
+    """
+    Python API test: h2o.frame.H2OFrame.any_na_rm()
+    """
+    python_lists = [['NA',1,'NA','NA'], ['NA','NA','NA','NA']]
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, na_strings=['NA'])
+    assert h2oframe.any_na_rm(), "h2o.H2OFrame.any_rm_na() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_any_rm_na())
+else:
+    h2o_H2OFrame_any_rm_na()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_apply.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_apply.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_apply():
+    """
+    Python API test: h2o.frame.H2OFrame.apply(fun=None, axis=0)
+    """
+    python_lists = [[1,2,3,4], [1,2,3,4]]
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, na_strings=['NA'])
+    colMean = h2oframe.apply(lambda x: x.mean(), axis=0)
+    rowMean = h2oframe.apply(lambda x: x.mean(), axis=1)
+    assert_is_type(colMean, H2OFrame)
+    assert_is_type(rowMean, H2OFrame)
+    assert rowMean[0,0]==rowMean[1,0] and (rowMean[0,0]-2.5)<1e-10, "h2o.H2OFrame.apply() command is not working."
+    assert (colMean[0,0]==h2oframe[0,0]) and (colMean[0,1]==h2oframe[0,1]) and (colMean[0,2]==h2oframe[0,2]) and \
+           (colMean[0,3]==h2oframe[0,3]), "h2o.H2OFrame.apply() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_apply())
+else:
+    h2o_H2OFrame_apply()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_as_data_frame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_as_data_frame.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from pandas import DataFrame
+
+def h2o_H2OFrame_as_data_frame():
+    """
+    Python API test: h2o.frame.H2OFrame.as_data_frame(use_pandas=True, header=True)
+
+    Copied from pyunit_as_data_frame.py
+    """
+    smallbike = h2o.import_file(pyunit_utils.locate("smalldata/jira/citibike_head.csv"))
+    smallbike_noheader = smallbike.as_data_frame(use_pandas=True, header=False)
+    assert_is_type(smallbike_noheader, DataFrame)
+    assert len(smallbike_noheader) == smallbike.nrow
+
+    head_small_bike = smallbike.head(rows=5, cols=2)
+    tail_small_bike = smallbike.tail(rows=5, cols=2)
+    assert len(head_small_bike[0])==len(tail_small_bike[0])==5, "h2o.H2OFrame.as_data_frame() command is " \
+                                                                "not working."
+    assert len(head_small_bike)==len(tail_small_bike)==5, "h2o.H2OFrame.as_data_frame() command is not working."
+
+    ##use_pandas = True
+    small_bike_pandas = smallbike.as_data_frame(use_pandas=True, header=True)
+    assert_is_type(small_bike_pandas, DataFrame)
+    assert small_bike_pandas.shape == (smallbike.nrow, smallbike.ncol)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_as_data_frame())
+else:
+    h2o_H2OFrame_as_data_frame()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_as_date.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_as_date.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+import time
+import datetime
+from random import randrange
+
+
+def h2o_H2OFrame_as_date():
+    """
+    Python API test: h2o.frame.H2OFrame.as_date(format)
+
+    Copied from pyunit_as_date.py
+    """
+    hdf = h2o.import_file(path=pyunit_utils.locate("smalldata/jira/v-11-eurodate.csv"))
+    temp = hdf['ds5'].as_date("%d.%m.%y %H:%M")
+    assert_is_type(temp, H2OFrame)
+
+    # choose one element from new timestamp frame and compare it with conversion by python.  Should equal.
+    row_ind = randrange(0, temp.nrows)
+    s = hdf[row_ind,'ds5']
+
+    tz = h2o.cluster().timezone     # set python timezone to be the same as H2O timezone
+    os.environ['TZ']=tz
+    time.tzset()
+    pythonTime = (time.mktime(datetime.datetime.strptime(s, "%d.%m.%y %H:%M").timetuple()))*1000.0
+
+    assert abs(pythonTime-temp[row_ind,0]) < 1e-10, "h2o.H2OFrame.as_date() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_as_date())
+else:
+    h2o_H2OFrame_as_date()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_ascharacter.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_ascharacter.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_ascharacter():
+    """
+    Python API test: h2o.frame.H2OFrame.ascharacter()
+
+    Copied from pyunit_ascharacter.py
+    """
+    h2oframe =  h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars.csv"))
+    newFrame = h2oframe['cylinders'].ascharacter()
+
+    assert_is_type(newFrame, H2OFrame)
+    assert newFrame.isstring()[0], "h2o.H2OFrame.ascharacter() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_ascharacter())
+else:
+    h2o_H2OFrame_ascharacter()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_asfactor.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_asfactor.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_asfactor():
+    """
+    Python API test: h2o.frame.H2OFrame.asfactor()
+
+    Copied from pyunit_ascharacter.py
+    """
+    h2oframe =  h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars.csv"))
+    newFrame = h2oframe['cylinders'].asfactor()
+
+    assert_is_type(newFrame, H2OFrame)
+    assert newFrame.isfactor()[0], "h2o.H2OFrame.asfactor() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_asfactor())
+else:
+    h2o_H2OFrame_asfactor()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_asnumeric.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_asnumeric.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_asnumeric():
+    """
+    Python API test: h2o.frame.H2OFrame.asnumeric()
+
+    Copied from pyunit_glrm_PUBDEV_3728_binary_numeric.py
+    """
+    prostateF = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    newFrame = prostateF[[0,4]].asfactor()
+
+    assert_is_type(newFrame, H2OFrame)
+    assert newFrame.isfactor()[0] and newFrame.isfactor()[newFrame.ncols-1], \
+        "h2o.H2OFrame.asfactor() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_asnumeric())
+else:
+    h2o_H2OFrame_asnumeric()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_categories.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_categories.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_categories():
+    """
+    Python API test: h2o.frame.H2OFrame.categories()
+    """
+    python_lists = np.random.randint(4, size=(10,1))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, column_types=['enum'])
+    alllevels = h2oframe.categories()
+    alllevels = [int(i) for i in alllevels]     # convert string into integers for comparison
+    truelevels = np.unique(python_lists).tolist()   # categorical levels calculated from Python
+    assert alllevels==truelevels, "h2o.H2OFrame.categories() command is not working."
+    pyunit_utils.equal_two_arrays(alllevels, truelevels, 1e-10, 0)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_categories())
+else:
+    h2o_H2OFrame_categories()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cbind.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cbind.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_cbind():
+    """
+    Python API test: h2o.frame.H2OFrame.cbind(data)
+
+    Copied from pyunit_cbind.py
+    """
+    hdf = h2o.import_file(path=pyunit_utils.locate('smalldata/jira/pub-180.csv'))
+    hdfrows, hdfcols = hdf.shape
+
+    hdf2 = hdf.cbind(hdf)
+    assert_is_type(hdf2, H2OFrame)  # check new frame data type
+    assert hdf2.shape==(hdfrows, 2*hdfcols), "h2o.H2OFrame.cbind() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_cbind())
+else:
+    h2o_H2OFrame_cbind()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_col_names_columns.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_col_names_columns.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_col_names():
+    """
+    Python API test: h2o.frame.H2OFrame.col_names(), h2o.frame.H2OFrame.columns()
+
+    Copied from pyunit_colnames.py
+    """
+    iris_wheader = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    expected_names = ["sepal_len", "sepal_wid", "petal_len", "petal_wid", "class"]
+    assert iris_wheader.col_names == expected_names == iris_wheader.columns, \
+        "Expected {0} for column names but got {1}".format(expected_names, iris_wheader.col_names)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_col_names())
+else:
+    h2o_H2OFrame_col_names()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_columns_by_type.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_columns_by_type.py
@@ -1,0 +1,41 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+
+def h2o_H2OFrame_columns_by_type():
+    """
+    Python API test: h2o.frame.H2OFrame.columns_by_type(coltype='numeric')
+
+    Copied from pyunit_colnames_by_type.py
+    """
+    fr = h2o.import_file(pyunit_utils.locate("smalldata/jira/filter_type.csv"))
+
+    #Positive case. Look for all coltypes
+    num_type = fr.columns_by_type() #numeric by default
+    cat_type = fr.columns_by_type(coltype="categorical")
+    str_type = fr.columns_by_type(coltype="string")
+    time_type = fr.columns_by_type(coltype="time")
+    uuid_type = fr.columns_by_type(coltype="uuid")
+    bad_type = fr.columns_by_type(coltype="bad")
+
+    assert_is_type(num_type, list)  # check for correct return type
+    assert_is_type(cat_type, list)
+    assert_is_type(str_type, list)
+    assert_is_type(time_type, list)
+    assert_is_type(uuid_type, list)
+    assert_is_type(bad_type, list)
+
+    # check for correct grouping
+    assert 2.0 in bad_type, "h2o.H2OFrame.columns_by_type command is not working."
+    assert (0.0 in num_type) and (2.0 in num_type), "h2o.H2OFrame.columns_by_type command is not working."
+    assert (1.0 in str_type) and (4.0 in str_type), "h2o.H2OFrame.columns_by_type command is not working."
+    assert 3.0 in time_type, "h2o.H2OFrame.columns_by_type command is not working."
+    assert 5.0 in uuid_type, "h2o.H2OFrame.columns_by_type command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_columns_by_type())
+else:
+    h2o_H2OFrame_columns_by_type()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_concat.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_concat.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_concat():
+    """
+    Python API test: h2o.frame.H2OFrame.concat(frames, axis=1)
+
+    Copied from pyunit_concat.py
+    """
+    df1 = h2o.create_frame(integer_fraction=1,binary_fraction=0,categorical_fraction=0,seed=1)
+    df2 = h2o.create_frame(integer_fraction=1,binary_fraction=0,categorical_fraction=0,seed=2)
+    df3 = h2o.create_frame(integer_fraction=1,binary_fraction=0,categorical_fraction=0,seed=3)
+
+    # frame to frame concat (column-wise)
+    df123 = df1.concat([df2,df3])
+    assert_is_type(df123, H2OFrame)     # check return type
+    assert df123.shape==(df1.nrows, df1.ncols+df2.ncols+df3.ncols), "h2o.H2OFrame.concat command is not working."#
+
+    #Frame to Frame concat (row wise)
+    df123_row = df1.concat([df2,df3], axis = 0)
+    assert_is_type(df123_row, H2OFrame)     # check return type
+    assert df123_row.shape==(df1.nrows+df2.nrows+df3.nrows, df1.ncols), \
+        "h2o.H2OFrame.concat command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_concat())
+else:
+    h2o_H2OFrame_concat()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cor.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cor.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+import numpy as np
+
+def h2o_H2OFrame_cor():
+    """
+    Python API test: h2o.frame.H2OFrame.cor(y=None, na_rm=False, use=None)
+    """
+    python_lists = np.random.uniform(-1,1, (10,2))
+    python_lists2 = 0.5*python_lists[:,0]-0.3*python_lists[:,1]
+    python_list3 = python_lists[:,0]
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    h2oframe2 = h2o.H2OFrame(python_obj=python_lists2)
+    h2oframe3 = h2o.H2OFrame(python_obj=python_list3)
+
+    corframe = h2oframe.cor(h2oframe2, na_rm=True, use=None)
+    corval = h2oframe2.cor(h2oframe3, na_rm=False, use=None)
+
+    assert_is_type(corframe, H2OFrame)
+    assert corframe.shape==(2,1), "h2o.H2OFrame.cor() command is not working."
+    assert_is_type(corval, float)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_cor())
+else:
+    h2o_H2OFrame_cor()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_countmatches.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_countmatches.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_countmatches():
+    """
+    Python API test: h2o.frame.H2OFrame.countmatches(pattern)
+
+    Copied from pyunit_countmatches.py
+    """
+    python_lists = [["what","is"], ["going", "on"], ["When", "are"], ["MeetingMeetingon", "gone"]]
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    matches = h2oframe.countmatches(['Wh', 'ing', 'on'])
+    assert_is_type(matches, H2OFrame)
+    assert matches.shape == h2oframe.shape, "h2o.H2OFrame.countmatches() command is not working."
+    assert matches.any_na_rm(), "h2o.H2OFrame.countmatches() command is not working."
+    nomatches = h2oframe.countmatches(['rain','pluck'])
+    assert not(nomatches.any_na_rm()), "h2o.H2OFrame.countmatches() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_countmatches())
+else:
+    h2o_H2OFrame_countmatches()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cummax_cummin_cumprod_cumsum_large.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cummax_cummin_cumprod_cumsum_large.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+import operator
+
+
+def h2o_H2OFrame_cummax():
+    """
+    Python API test: h2o.frame.H2OFrame.cummax(axis=0), h2o.frame.H2OFrame.cummin(axis=0),
+    h2o.frame.H2OFrame.cumprod(axis=0), h2o.frame.H2OFrame.cumsum(axis=0)
+
+    Copied from pyunit_cumsum_cumprod_cummin_cummax.py
+    """
+    python_object=[list(range(1,10)), list(range(9,0,-1))]
+    python_object_transpose = np.transpose(python_object)
+    foo = h2o.H2OFrame(python_obj=python_object_transpose)
+
+    cummax_col = foo.cummax(axis=0)
+    cummin_col = foo.cummin(axis=0)
+    cumprod_col = foo.cumprod(axis=0)
+    cumsum_col = foo.cumsum(axis=0)
+
+    # check return types
+    assert_is_type(cummax_col, H2OFrame)
+    assert_is_type(cummin_col, H2OFrame)
+    assert_is_type(cumprod_col, H2OFrame)
+    assert_is_type(cumsum_col, H2OFrame)
+
+    # compare results of cum operations
+    checkOpsCorrect(foo, cummax_col, max)   # cummax
+    checkOpsCorrect(foo, cummin_col, min)   # cummin
+    checkOpsCorrect(foo, cumprod_col, operator.mul) # cumprod
+    checkOpsCorrect(foo, cumsum_col, operator.add)  # cumsum
+
+def checkOpsCorrect(sourceFrame, resultFrame, op):
+    f0 = pyunit_utils.cumop(sourceFrame, op, 0)
+    tempFrame = h2o.H2OFrame(python_obj=np.transpose(f0))
+    f1 = pyunit_utils.cumop(sourceFrame, op, 1)
+    tempFrame=tempFrame.cbind(h2o.H2OFrame(python_obj=np.transpose(f1)))
+    pyunit_utils.compare_frames(resultFrame, tempFrame, numElements=9)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_cummax())
+else:
+    h2o_H2OFrame_cummax()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cut.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_cut.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_cut():
+    """
+    Python API test: h2o.frame.H2OFrame.cut(breaks, labels=None, include_lowest=False, right=True, dig_lab=3)[source]
+    """
+    python_lists = np.random.uniform(-2,2, (100,1))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    breaks = [-2, 1, 0, 1, 2]
+    newframe = h2oframe.cut(breaks, labels=None, include_lowest=False, right=True, dig_lab=3)
+    assert_is_type(newframe, H2OFrame)  # check return type as H2OFrame
+    # check returned frame content is correct
+    assert newframe.types["C1"]=="enum", "h2o.H2OFrame.cut() command is not working."
+    assert len(newframe.levels()) <= len(breaks), "h2o.H2OFrame.cut() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_cut())
+else:
+    h2o_H2OFrame_cut()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_day_dayOfWeek_hour_minute_month_second_week_year_moment_mktime_DEP.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_day_dayOfWeek_hour_minute_month_second_week_year_moment_mktime_DEP.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_day():
+    """
+    Python API test: h2o.frame.H2OFrame.day(), h2o.frame.H2OFrame.dayOfWeek(), h2o.frame.H2OFrame.hour(),
+    h2o.frame.H2OFrame.minute(), h2o.frame.H2OFrame.month(), h2o.frame.H2OFrame.second(), h2o.frame.H2OFrame.week(),
+    h2o.frame.H2OFrame.year(), h2o.frame.H2OFrame.moment(), h2o.frame.H2OFrame.mktime(),
+
+    Copied from pyunit_count_temps.py
+    """
+    datetime = h2o.import_file(path=pyunit_utils.locate("smalldata/parser/orc/orc2csv/TestOrcFile.testDate2038.csv"))
+    datetime_day = datetime[0].day()
+    checkday = datetime_day==5
+    assert_is_type(datetime_day, H2OFrame)    # check return type, should be H2OFrame
+    assert checkday.sum().flatten() == datetime.nrows, "h2o.H2OFrame.day() command is not working."
+
+    datetime_dow = datetime[0].dayOfWeek()
+    checkdow = datetime_dow == 'Wed'
+    assert_is_type(datetime_dow, H2OFrame)    # check return type, should be H2OFrame
+    assert checkdow.any(), "h2o.H2OFrame.dayOfWeek() command is not working."
+
+    datetime_hour = datetime[0].hour()
+    checkhour = datetime_hour == 12
+    assert_is_type(datetime_hour, H2OFrame)    # check return type, should be H2OFrame
+    assert checkhour.sum().flatten() == datetime.nrows, "h2o.H2OFrame.hour() command is not working."
+
+    datetime_minute = datetime[0].minute()
+    checkminute = datetime_minute == 34.0
+    assert_is_type(datetime_minute, H2OFrame)    # check return type, should be H2OFrame
+    assert checkminute.sum().flatten() == datetime.nrows, "h2o.H2OFrame.minute() command is not working."
+
+    datetime_month = datetime[0].month()
+    checkmonth = datetime_month == 5.0
+    assert_is_type(datetime_month, H2OFrame)    # check return type, should be H2OFrame
+    assert checkmonth.sum().flatten() == datetime.nrows, "h2o.H2OFrame.hour() command is not working."
+
+    datetime_second = datetime[0].second()
+    checksecond = datetime_second == 56.0
+    assert_is_type(datetime_second, H2OFrame)    # check return type, should be H2OFrame
+    assert checksecond.sum().flatten() == datetime.nrows, "h2o.H2OFrame.second() command is not working."
+
+    datetime_week = datetime[0].week()
+    checkweek = datetime_week == 18.0
+    assert_is_type(datetime_week, H2OFrame)    # check return type, should be H2OFrame
+    assert checkweek.any(), "h2o.H2OFrame.week() command is not working."
+
+    datetime_year = datetime[0].year()
+    checkyear= datetime_year == 2038
+    assert_is_type(datetime_year, H2OFrame)    # check return type, should be H2OFrame
+    assert checkyear.any(), "h2o.H2OFrame.year() command is not working."
+
+    datetimeF=datetime[0]
+    mktime_datetime = h2o.H2OFrame.moment(year=datetimeF.year(), month=datetimeF.month(), day=datetimeF.day(),
+                                      hour=datetimeF.hour(), minute=datetimeF.minute(), second=datetimeF.second(),
+                                      msec=0, date=None, time=None)
+    assert_is_type(mktime_datetime, H2OFrame)
+
+    datetimeF=datetime[0]
+    mktime_datetime = h2o.H2OFrame.mktime(year=datetimeF.year(), month=datetimeF.month(), day=datetimeF.day(),
+                                          hour=datetimeF.hour(), minute=datetimeF.minute(),
+                                          second=datetimeF.second(), msec=0)
+    diff = 2789999999.0
+    assert_is_type(mktime_datetime, H2OFrame)
+    assert abs(datetime[0,0]+diff-mktime_datetime[0,0]) < 1e-6, "h2o.H2OFrame.mktime() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_day())
+else:
+    h2o_H2OFrame_day()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_describe.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_describe.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_describe():
+    """
+    Python API test: h2o.frame.H2OFrame.describe(chunk_summary=False))
+    """
+    python_lists = [[1,2,3],[4,5,6],["a","b","c"], [1,0,1]]
+    col_names=["num1","num2","str1","enum1"]
+    dest_frame="newFrame"
+    heads=-1
+    sep=','
+    col_types=['numeric', 'numeric', 'string', 'enum']
+    na_str=['NA']
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, destination_frame=dest_frame, header=heads, separator=sep,
+                            column_names=col_names, column_types=col_types, na_strings=na_str)
+    h2oframe.describe(chunk_summary=True)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_describe())
+else:
+    h2o_H2OFrame_describe()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_difflag1.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_difflag1.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_difflag1():
+    """
+    Python API test: h2o.frame.H2OFrame.difflag1()
+    """
+    python_object=[list(range(10)), list(range(10))]
+    foo = h2o.H2OFrame(python_obj=np.transpose(python_object))
+
+    diffs = foo[0].difflag1()   # default
+    results = diffs==1.0
+    # check correct return type
+    assert_is_type(diffs, H2OFrame)
+    assert results.sum().flatten()==foo.nrow-1, "h2o.H2OFrame.difflag1() command is not working."
+    # To-do: check correct result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_difflag1())
+else:
+    h2o_H2OFrame_difflag1()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_drop.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_drop.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_dim():
+    """
+    Python API test: h2o.frame.H2OFrame.drop(index, axis=1)
+
+    copied from pyunit_drop.py
+    """
+    pros = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate.csv"))
+    nc = pros.ncol
+    nr = pros.nrow
+
+    h2oframe1 = pros.drop([pros.names[0]])
+    assert h2oframe1.dim==[nr, nc-1], "h2o.H2OFrame.drop() command is not working."
+    h2oframe2=h2oframe1.drop([0], axis=0)
+    assert h2oframe2.dim==[nr-1, nc-1], "h2o.H2OFrame.drop() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_dim())
+else:
+    h2o_H2OFrame_dim()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_entropy.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_entropy.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_entropy():
+    """
+    Python API test: h2o.frame.H2OFrame.entropy()
+
+    copied from pyunit_entropy.py
+    """
+    frame = h2o.H2OFrame.from_python(["redrum"])
+    g = frame.entropy()
+    assert_is_type(g, H2OFrame)
+    assert abs(g[0,0] - 2.25162916739) < 1e-6, "h2o.H2OFrame.entropy() command is not working."
+
+    # #test empty strings
+    strings = h2o.H2OFrame.from_python([''], column_types=['string'])
+    assert_is_type(strings, H2OFrame)
+    assert strings.entropy()[0,0] == 0, "h2o.H2OFrame.entropy() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_entropy())
+else:
+    h2o_H2OFrame_entropy()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_filter_na_cols.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_filter_na_cols.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+
+def h2o_H2OFrame_filter_na_cols():
+    """
+    Python API test: h2o.frame.H2OFrame.filter_na_cols(frac=0.2)
+
+    copied from pyunit_filter_nacols.py
+    """
+    fr = h2o.import_file(pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    include_cols = fr.filter_na_cols()  # should be all columns
+    assert_is_type(include_cols, list)
+    assert include_cols==list(range(fr.ncol)), "h2o.H2OFrame.filter_na_cols() command is not working."
+
+    fr[1,1] = None  # make a value None, filter out the second column
+
+    include_cols = fr.filter_na_cols(0.001)
+    assert_is_type(include_cols, list)
+    assert (1 not in include_cols) and (len(include_cols)==(fr.ncol-1)), \
+        "h2o.H2OFrame.filter_na_cols() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_filter_na_cols())
+else:
+    h2o_H2OFrame_filter_na_cols()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_flatten.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_flatten.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_flatten():
+    """
+    Python API test: h2o.frame.H2OFrame.flatten()
+
+    copied from pyunit_entropy.py
+    """
+    frame = h2o.H2OFrame.from_python(["redrum"])
+    g = frame.flatten()
+    assert g=="redrum", "h2o.H2OFrame.flatten() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_flatten())
+else:
+    h2o_H2OFrame_flatten()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_frame_id.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_frame_id.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+
+def h2o_H2OFrame_frame_id():
+    """
+    Python API test: h2o.frame.H2OFrame.frame_id
+    """
+    python_lists = np.random.uniform(-1,1, (3,4))
+    frameName = "randomlyGeneratedFrame."
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, destination_frame=frameName)
+    assert frameName==h2oframe.frame_id, "h2o.H2OFrame.frame_id command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_frame_id())
+else:
+    h2o_H2OFrame_frame_id()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_get_frame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_get_frame.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_get_frame():
+    """
+    Python API test: h2o.frame.H2OFrame.get_frame()
+    """
+    frame1 = h2o.import_file(pyunit_utils.locate("smalldata/jira/hexdev_29.csv"))
+    frame2 = h2o.get_frame(frame1.frame_id)
+    assert_is_type(frame2, H2OFrame)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_get_frame())
+else:
+    h2o_H2OFrame_get_frame()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_get_frame_data.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_get_frame_data.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+import random
+
+def h2o_H2OFrame_get_frame_data():
+    """
+    Python API test: h2o.frame.H2OFrame.get_frame_data()
+    """
+    h2o_iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    temp = h2o_iris.get_frame_data()
+    assert_is_type(temp, str)       # check return type
+    # randomly check last column and make sure they are included in the string generated from get_frame_data()
+    assert h2o_iris[random.randrange(0, h2o_iris.nrow), "class"] in temp, "h2o.H2OFrame.get_frame_data()" \
+                                                                          " command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_get_frame_data())
+else:
+    h2o_H2OFrame_get_frame_data()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_getrow.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_getrow.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+import numpy as np
+from random import randrange
+from h2o.utils.typechecks import assert_is_type
+
+
+def h2o_H2OFrame_getrow():
+    """
+    Python API test: h2o.frame.H2OFrame.getrow()
+    """
+    numRow = 1
+    numCol = randrange(1,3)
+    python_lists = np.random.uniform(-1,1, (numRow, numCol))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    onerow = h2oframe.getrow()
+    assert_is_type(onerow, list)    # check return type
+    # check and make sure random picked elements agree
+    colInd = randrange(0, h2oframe.ncol)
+    assert abs(h2oframe[0, colInd]-onerow[colInd]) < 1e-6, "h2o.H2OFrame.getrow() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_getrow())
+else:
+    h2o_H2OFrame_getrow()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_group_by.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_group_by.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.group_by import GroupBy
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+
+
+def h2o_H2OFrame_group_by():
+    """
+    Python API test: h2o.frame.H2OFrame.group_by(by)
+
+    Copied from pyunit_groupby.py
+    """
+    h2o_iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    grouped = h2o_iris.group_by(["class"])      # set by as a list
+    assert_is_type(grouped, GroupBy)
+
+    grouped = h2o_iris.group_by("class")        # set by as a str
+    assert_is_type(grouped, GroupBy)
+
+    grouped = h2o_iris.group_by(4)        # set by as an int
+    assert_is_type(grouped, GroupBy)
+
+    grouped = h2o_iris.group_by([4])        # set by as an int list
+    assert_is_type(grouped, GroupBy)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_group_by())
+else:
+    h2o_H2OFrame_group_by()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_gsub.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_gsub.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_gsub():
+    """
+    Python API test: h2o.frame.H2OFrame.gsub(pattern, replacement, ignore_case=False)
+
+    Copied from pyunit_sub_gsub.py
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"),
+                            col_types=["numeric","numeric","numeric","numeric","string"])
+
+    frame["C5"] = frame["C5"].gsub("s", "z", ignore_case=False)
+    assert frame[0,4] == "Iriz-zetoza", "Expected 'Iriz-zetoza', but got {0}".format(frame[0,4])
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_gsub())
+else:
+    h2o_H2OFrame_gsub()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_head.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_head.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from random import randrange
+from h2o.frame import H2OFrame
+from h2o.utils.typechecks import assert_is_type
+
+
+def h2o_H2OFrame_head():
+    """
+    Python API test: h2o.frame.H2OFrame.head(rows=10, cols=200)
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"),
+                            col_types=["numeric","numeric","numeric","numeric","string"])
+    rowNum = randrange(1, frame.nrow)
+    colNum = randrange(1, frame.ncol)
+    newFrame = frame.head(rows=rowNum, cols=colNum)
+
+    assert_is_type(newFrame, H2OFrame)  # check return type
+    assert newFrame.dim==[rowNum, colNum], "h2o.H2OFrame.head() command is not working."    # check frame size
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_head())
+else:
+    h2o_H2OFrame_head()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_hist.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_hist.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+from h2o.utils.typechecks import assert_is_type
+
+
+def h2o_H2OFrame_hist():
+    """
+    Python API test: h2o.frame.H2OFrame.hist(breaks='sturges', plot=True, **kwargs)
+
+    Copied from pyunit_hist.py
+    """
+    df = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris.csv"))
+    df.describe()
+
+    h = df[0].hist(breaks=5,plot=False)
+    assert_is_type(h, H2OFrame)  # check return type
+    assert h.nrow == 5, "h2o.H2OFrame.hist() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_hist())
+else:
+    h2o_H2OFrame_hist()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_ifelse.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_ifelse.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from random import randrange
+from h2o.frame import H2OFrame
+from h2o.utils.typechecks import assert_is_type
+import numpy as np
+
+
+def h2o_H2OFrame_ifelse():
+    """
+    Python API test: h2o.frame.H2OFrame.ifelse(yes, no)
+
+    Copied from pyunit_ifelse.py
+    """
+    python_lists = np.random.uniform(-1,1, (5,5))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+
+    newFrame = (h2oframe>0).ifelse(1, -1)
+    assert_is_type(h2oframe, H2OFrame)  # check return type
+    # randomly check one entry
+    rowInd = randrange(0, h2oframe.nrow)
+    colInd = randrange(0, h2oframe.ncol)
+    assert newFrame[rowInd, colInd]==np.sign(h2oframe[rowInd, colInd]), "h2o.H2OFrame.ifelse() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_ifelse())
+else:
+    h2o_H2OFrame_ifelse()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_impute.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_impute.py
@@ -1,0 +1,83 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from random import randrange
+import numpy as np
+from scipy.stats import mode
+
+
+def h2o_H2OFrame_impute():
+    """
+    Python API test: h2o.frame.H2OFrame.impute(column=-1, method='mean', combine_method='interpolate', by=None,
+    group_by_frame=None, values=None)
+    """
+    python_lists = np.random.randint(-5,5, (100,3))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, column_types=["int", "int", "enum"])
+    row_ind_mean = randrange(0,h2oframe.nrow)       # row and col index that we want to set to NA and impute with mean
+    row_ind_median = randrange(0,h2oframe.nrow)      # row and col index that we want to set to NA and impute with median
+    row_ind_mode = randrange(0,h2oframe.nrow)       # row and col index that we want to set to NA and impute with mode
+
+    col0 = list(python_lists[:,0])
+    col1 = list(python_lists[:,1])
+    col2 = list(python_lists[:,2])
+
+    print(col0)
+    print(col1)
+    print(col2)
+
+    del col0[row_ind_mean]
+    impute_mean = np.mean(col0)
+    del col1[row_ind_median]
+    impute_median = np.median(col1)
+    del col2[row_ind_mode]
+    impute_mode = mode(col2).__getitem__(0)[0]
+    modeNum = findModeNumber(col2)
+
+    print("first column NA row is {0}, second column NA row is {1}, third column NA row "
+          "is {2}".format(row_ind_mean, row_ind_median, row_ind_mode))
+    sys.stdout.flush()
+    h2oframe[row_ind_mean, 0]=float("nan")      # insert nans into frame
+    h2oframe[row_ind_median, 1]=float("nan")
+    h2oframe[row_ind_mode, 2]=float("nan")
+
+    h2oframe.impute(column=0, method='mean', by=None, group_by_frame=None, values=None)
+    h2oframe.impute(column=1, method='median', combine_method='average', group_by_frame=None, values=None)
+    h2oframe.impute(column=2, method='mode')
+
+    # check to make sure correct methods are imputed
+    assert abs(h2oframe[row_ind_mean, 0]-impute_mean) < 1e-6, "h2o.H2OFrame.impute() command is not working and " \
+                                                              "the difference is {0}".format(abs(h2oframe[row_ind_mean, 0]-impute_mean))
+    assert abs(h2oframe[row_ind_median, 1]-impute_median) < 1e-6, "h2o.H2OFrame.impute() command is not working and " \
+                                                                  "the difference is {0}.".format(abs(h2oframe[row_ind_median, 1]-impute_median))
+    if modeNum == 1:    # python and h2o provide different numbers when there is more than 1 mode
+        assert abs(int(h2oframe[row_ind_mode, 2])-impute_mode) < 1e-6, "h2o.H2OFrame.impute() command is not working and " \
+                                                                   "the difference is {0}.".format(abs(int(h2oframe[row_ind_mode, 2])-impute_mode))
+    else:
+        print("impute with mode is not tested here because there are more than one mode found.")
+
+def findModeNumber(python_list):
+    countVal = dict()
+
+    for ele in python_list:
+        if (ele in countVal.keys()):
+            countVal[ele] += 1
+        else:
+            countVal[ele] = 1
+
+    presentNum = countVal.values()
+    maxVal = max(presentNum)
+    maxNum = 0;
+
+    for ele in presentNum:
+        if ele == maxVal:
+            maxNum += 1
+
+    return maxNum
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_impute())
+else:
+    h2o_H2OFrame_impute()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_insert_mssing_values.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_insert_mssing_values.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from random import randrange
+from h2o.frame import H2OFrame
+from h2o.utils.typechecks import assert_is_type
+import numpy as np
+import random
+
+
+def h2o_H2OFrame_insert_missing_values():
+    """
+    Python API test: h2o.frame.H2OFrame.insert_missing_values(fraction=0.1, seed=None)
+    """
+    python_lists = np.random.uniform(-1,1, (10000, 10))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+
+    fraction = random.uniform(0,1)
+    h2oframe.insert_missing_values(fraction=fraction, seed=None)
+    fract_NAs = sum(h2oframe.nacnt())/(h2oframe.ncol*h2oframe.nrow)
+    assert abs(fraction-fract_NAs) < 1e-2, "h2o.H2OFrame.insert_missing_values() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_insert_missing_values())
+else:
+    h2o_H2OFrame_insert_missing_values()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_interaction.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_interaction.py
@@ -1,0 +1,51 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+from h2o.utils.typechecks import assert_is_type
+
+
+def h2o_H2OFrame_interaction():
+    """
+    Python API test: h2o.frame.H2OFrame.interaction(factors, pairwise, max_factors, min_occurrence,
+    destination_frame=None)[source]
+
+    copied from pyunit_h2ointeraction.py
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+
+    # add a couple of factor columns to iris
+    iris = iris.cbind(iris[4] == "Iris-setosa")
+    iris[5] = iris[5].asfactor()
+    iris.set_name(5,"C6")
+
+    iris = iris.cbind(iris[4] == "Iris-virginica")
+    iris[6] = iris[6].asfactor()
+    iris.set_name(6, name="C7")
+
+    # create a frame of the two-way interactions
+    two_way_interactions = iris.interaction(factors=[4,5,6], pairwise=True, max_factors=10000,
+                                           min_occurrence=1, destination_frame=None)
+    assert_is_type(two_way_interactions, H2OFrame)
+    assert two_way_interactions.nrow == 150 and two_way_interactions.ncol == 3, \
+        "Expected 150 rows and 3 columns, but got {0} rows and {1} " \
+        "columns".format(two_way_interactions.nrow, two_way_interactions.ncol)
+    levels1 = two_way_interactions.levels()[0]
+    levels2 = two_way_interactions.levels()[1]
+    levels3 = two_way_interactions.levels()[2]
+
+    assert levels1 == ["Iris-setosa_1", "Iris-versicolor_0", "Iris-virginica_0"], \
+        "Expected the following levels {0}, but got {1}".format(["Iris-setosa_1", "Iris-versicolor_0", "Iris-virginica_0"],
+                                                                levels1)
+    assert levels2 == ["Iris-setosa_0", "Iris-versicolor_0", "Iris-virginica_1"], \
+        "Expected the following levels {0}, but got {1}".format(["Iris-setosa_0", "Iris-versicolor_0", "Iris-virginica_1"],
+                                                                levels2)
+    assert levels3 == ["0_0", "1_0", "0_1"], "Expected the following levels {0}, but got {1}".format(["0_0", "1_0", "0_1"],
+                                                                                                     levels3)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_interaction())
+else:
+    h2o_H2OFrame_interaction()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isax.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isax.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+from h2o.utils.typechecks import assert_is_type
+
+def h2o_H2OFrame_isax():
+    """
+    Python API test: h2o.frame.H2OFrame.isax(num_words, max_cardinality, optimize_card=False)
+
+    copied from pyunit_isax.py
+    """
+    df = h2o.create_frame(rows=1,cols=256,real_fraction=1.0,missing_fraction=0.0,seed=123)
+    df2 = df.cumsum(axis=1)
+    res = df2.isax(num_words=10,max_cardinality=10, optimize_card=False)
+    res.show()
+    answer = "0^10_0^10_0^10_0^10_5^10_7^10_8^10_9^10_9^10_8^10"
+
+    assert_is_type(res, H2OFrame)       # check return type
+    assert answer == res[0,0], "expected isax index to be " + answer + " but got" + res[0,0] + " instead."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_isax())
+else:
+    h2o_H2OFrame_isax()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isin.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isin.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_isin():
+    """
+    Python API test: h2o.frame.H2OFrame.isin(item)
+
+    Copied from pyunit_isin.py
+    """
+    cars = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
+
+    assert_is_type(cars.isin("AMC Gremlin"), H2OFrame)   # check return type
+    assert (cars[0].isin("AMC Gremlin") == (cars[0] == "AMC Gremlin")).all()
+    assert (cars[2].isin(6) == (cars[2] == 6)).all()
+    assert not (cars.isin(["AMC Gremlin","AMC Concord DL"]) == cars.isin("AMC Gremlin")).all()
+    assert (cars.isin(["AMC Gremlin","AMC Concord DL",6]) == cars.isin("AMC Gremlin") + cars.isin("AMC Concord DL")
+        + cars.isin(6)).all()
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_isin())
+else:
+    h2o_H2OFrame_isin()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isna.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isna.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_isna():
+    """
+    Python API test: h2o.frame.H2OFrame.isna()
+
+    Copied from pyunit_isin.py
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    temp = iris.isna()  # contains no NAs
+    assert_is_type(temp, H2OFrame)   # check return type
+    assert not(temp.all()), "h2o.H2OFrame.isna() command is not working."
+
+    iris_NA = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader_NA.csv"))
+    temp_NA = iris_NA.isna()
+    assert_is_type(temp_NA, H2OFrame)   # check return type
+    assert temp_NA.any(), "h2o.H2OFrame.isna() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_isna())
+else:
+    h2o_H2OFrame_isna()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isnumeric.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isnumeric.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+
+
+def h2o_H2OFrame_isnumeric():
+    """
+    Python API test: h2o.frame.H2OFrame.isnumeric()
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    clist = h2oframe.isnumeric()
+
+    assert_is_type(clist, list)     # check return type
+    assert sum(clist)==col_num, "h2o.H2OFrame.isnumeric() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_isnumeric())
+else:
+    h2o_H2OFrame_isnumeric()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isstring_ischaracter_DEP.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_isstring_ischaracter_DEP.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+
+
+def h2o_H2OFrame_isstring():
+    """
+    Python API test: h2o.frame.H2OFrame.isstring(), h2o.frame.H2OFrame.ischaracter() [DEPRECATED] Use frame.isstring()
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newFrame = h2oframe.asfactor().ascharacter()
+    clist = newFrame.isstring()
+    assert_is_type(clist, list)     # check return type
+    assert sum(clist)==col_num, "h2o.H2OFrame.isstring() command is not working."  # check return result
+
+    clist2 = newFrame.ischaracter()
+    assert_is_type(clist2, list)     # check return type
+    assert sum(clist2)==col_num, "h2o.H2OFrame.ischaracter() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_isstring())
+else:
+    h2o_H2OFrame_isstring()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_kfold_column.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_kfold_column.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_kfold_column():
+    """
+    Python API test: h2o.frame.H2OFrame.kfold_column(n_folds=3, seed=-1)
+    """
+    python_lists = np.random.randint(-5,5, (1000, 2))
+    k = randrange(2,10)
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    clist = h2oframe.kfold_column(n_folds=k, seed=12345)
+
+    assert_is_type(clist, H2OFrame)     # check return type
+    assert clist.asfactor().nlevels()[0]==k, "h2o.H2OFrame.kfold_column() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_kfold_column())
+else:
+    h2o_H2OFrame_kfold_column()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_kurtosis.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_kurtosis.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.utils.typechecks import assert_is_type
+import numpy as np
+from tests import pyunit_utils
+
+
+def h2o_H2OFrame_kurtosis():
+    """
+    Python API test: h2o.frame.H2OFrame.kurtosis(na_rm=False)
+    """
+    python_lists = np.random.normal(0,1, (10000, 1))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    clist = h2oframe.kurtosis(na_rm=True)
+
+    assert_is_type(clist, list)     # check return type
+    assert abs(clist[0]-3.0) < 1e-1, "h2o.H2OFrame.kurtosis() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_kurtosis())
+else:
+    h2o_H2OFrame_kurtosis()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_levels.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_levels.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+
+
+def h2o_H2OFrame_levels():
+    """
+    Python API test: h2o.frame.H2OFrame.levels()
+    """
+    python_lists = np.random.randint(-2,2, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, column_types=['enum', 'enum'])
+    clist = h2oframe.levels()
+
+    assert_is_type(clist, list)     # check return type
+    assert len(clist)==2, "h2o.H2OFrame.levels() command is not working."  # check list length
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_levels())
+else:
+    h2o_H2OFrame_levels()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_logical_negation.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_logical_negation.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_logical_negation():
+    """
+    Python API test: h2o.frame.H2OFrame.logical_negation()
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    python_lists = np.zeros((row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    clist = h2oframe.logical_negation()
+
+    assert_is_type(clist, H2OFrame)     # check return type
+    assert clist.all(), "h2o.H2OFrame.logical_negation() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_logical_negation())
+else:
+    h2o_H2OFrame_logical_negation()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_lstrip.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_lstrip.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+
+
+def h2o_H2OFrame_lstrip():
+    """
+    Python API test: h2o.frame.H2OFrame.lstrip(set='')
+
+    Copied from runit_lstrip.R
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    iris["C5"] = iris["C5"].lstrip("Iris-")
+    newNames = iris["C5"].levels()[0]
+    newStrip = ["etosa", "versicolor", "virginica"]
+
+    assert newNames==newStrip, "h2o.H2OFrame.lstrip() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_lstrip())
+else:
+    h2o_H2OFrame_lstrip()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_match.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+from random import randrange
+import numpy as np
+
+
+def h2o_H2OFrame_match():
+    """
+    Python API test: h2o.frame.H2OFrame.match(table, nomatch=0)
+
+    Copied from runit_lstrip.R
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    matchFrame = iris["C5"].match(['Iris-setosa'])
+    assert_is_type(matchFrame, H2OFrame)    # check return type
+    assert matchFrame.sum()[0,0]==50.0, "h2o.H2OFrame.match() command is not working."  # check return result
+
+    matchFrame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor'])
+    assert_is_type(matchFrame, H2OFrame)    # check return type
+    assert matchFrame.sum()[0,0]==100.0, "h2o.H2OFrame.match() command is not working."  # check return result
+
+    matchFrame = iris["C5"].match(['Iris-setosa', 'Iris-versicolor', 'Iris-virginica'])
+    assert_is_type(matchFrame, H2OFrame)    # check return type
+    assert matchFrame.sum()[0,0]==150.0, "h2o.H2OFrame.match() command is not working."  # check return result
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_match())
+else:
+    h2o_H2OFrame_match()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_max_mean_median_min_large.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_max_mean_median_min_large.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_stats():
+    """
+    Python API test: h2o.frame.H2OFrame.max(), h2o.frame.H2OFrame.mean(), h2o.frame.H2OFrame.median(),
+    h2o.frame.H2OFrame.min(),
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    assert abs(h2oframe.max()-np.ndarray.max(python_lists)) < 1e-12, "h2o.H2OFrame.max() command is not working."
+    assert abs(h2oframe.min()-np.ndarray.min(python_lists)) < 1e-12, "h2o.H2OFrame.min() command is not working."
+
+    h2oMean = h2oframe.mean(skipna=False, axis=0)
+    assert_is_type(h2oMean, H2OFrame)
+    numpmean = list(np.mean(python_lists, axis=0))
+    h2omean = h2oMean.as_data_frame(use_pandas=True, header=False)
+    pyunit_utils.equal_two_arrays(numpmean, h2omean.values.tolist()[0], 1e-12, 1e-6)
+
+    h2oMedian = h2oframe.median(na_rm=True)
+    assert_is_type(h2oMedian, list)
+    numpmedian = list(np.median(python_lists, axis=0))
+    pyunit_utils.equal_two_arrays(numpmedian, h2oMedian, 1e-12, 1e-6)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_stats())
+else:
+    h2o_H2OFrame_stats()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_merge.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_merge.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_merge():
+    """
+    Python API test: h2o.frame.H2OFrame.merge(other, all_x=False, all_y=False, by_x=None, by_y=None, method='auto')
+
+    Copied from pyunit_pubdev_1443.py
+    """
+    col = 10000* [0, 0, 1, 1, 2, 3, 0]
+    fr = h2o.H2OFrame(list(zip(*[col])))
+    fr.set_names(['rank'])
+
+    mapping = h2o.H2OFrame(list(zip(*[[0,1,2,3],[6,7,8,9]])))
+    mapping.set_names(['rank', 'outcome'])
+
+    merged = fr.merge(mapping,all_x=True,all_y=False, by_x=None, by_y=None, method='auto')
+
+    rows, cols = merged.dim
+    assert rows == 70000 and cols == 2, "Expected 70000 rows and 2 cols, but got {0} rows and {1} " \
+                                        "cols".format(rows, cols)
+
+    threes = merged[merged['rank'] == 3].nrow
+    assert threes == 10000, "Expected 10000 3's, but got {0}".format(threes)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_merge())
+else:
+    h2o_H2OFrame_merge()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_modulo_kfold_column.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_modulo_kfold_column.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_modulo_kfold_column():
+    """
+    Python API test: h2o.frame.H2OFrame.modulo_kfold_column(n_folds=3)
+    """
+    python_lists = np.random.randint(-5,5, (1000, 2))
+    k = randrange(2,10)
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    clist = h2oframe.kfold_column(n_folds=k)
+
+    assert_is_type(clist, H2OFrame)     # check return type
+    assert clist.asfactor().nlevels()[0]==k, "h2o.H2OFrame.modulo_kfold_column() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_modulo_kfold_column())
+else:
+    h2o_H2OFrame_modulo_kfold_column()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_mult.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_mult.py
@@ -1,0 +1,38 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+import random
+
+def h2o_H2OFrame_mult():
+    """
+    Python API test: h2o.frame.H2OFrame.mult(matrix)
+
+    Copied from pyunit_mmult.py
+    """
+    data = [[random.uniform(-10000,10000)] for c in range(100)]
+    h2o_data = h2o.H2OFrame(data)
+    np_data = np.array(data)
+
+    h2o_mm = h2o_data.mult(h2o_data.transpose())
+    np_mm = np.dot(np_data, np.transpose(np_data))
+
+    assert_is_type(h2o_mm, H2OFrame)
+
+    for x in range(10):
+        for y in range(10):
+            r = random.randint(0,99)
+            c = random.randint(0,99)
+            h2o_val = h2o_mm[r,c]
+            np_val = np_mm[r][c]
+            assert abs(h2o_val - np_val) < 1e-06, "check unsuccessful! h2o computed {0} and numpy computed {1}. expected " \
+                                                  "equal quantile values between h2o and numpy".format(h2o_val,np_val)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_mult())
+else:
+    h2o_H2OFrame_mult()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_na_omit.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_na_omit.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_na_omit():
+    """
+    Python API test: h2o.frame.H2OFrame.na_omit()
+
+    Copied from runit_lstrip.R
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader_NA_2.csv"))
+    newframe=iris.na_omit()
+    assert_is_type(newframe, H2OFrame)
+    assert newframe.nrow==iris.nrow-10, "h2o.H2OFrame.na_omit() command is not working."  # check return result
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_na_omit())
+else:
+    h2o_H2OFrame_na_omit()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nacnt.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nacnt.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_na_omit():
+    """
+    Python API test: h2o.frame.H2OFrame.na_omit()
+
+    Copied from runit_lstrip.R
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader_NA_2.csv"))
+    newframe=iris.nacnt()
+    assert_is_type(newframe, list)
+    assert sum(newframe)==17,  "h2o.H2OFrame.nacnt() command is not working."  # check return result
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_na_omit())
+else:
+    h2o_H2OFrame_na_omit()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_names.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_names.py
@@ -1,0 +1,22 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+
+def h2o_H2OFrame_names():
+    """
+    Python API test: h2o.frame.H2OFrame.names
+
+    Copied from runit_lstrip.R
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader_NA_2.csv"))
+    newframe=iris.names
+    assert_is_type(newframe, list)
+    assert len(newframe)==iris.ncol,  "h2o.H2OFrame.names command is not working."  # check return result
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_names())
+else:
+    h2o_H2OFrame_names()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nchar.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nchar.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_nchar():
+    """
+    Python API test: h2o.frame.H2OFrame.nchar()
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader_NA_2.csv"))
+    newframe=iris[4].nchar()
+    assert_is_type(newframe, H2OFrame)
+    assert abs(newframe.sum().flatten()-(11+14+15)*50)< 1e-6, "h2o.H2OFrame.nchar() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_nchar())
+else:
+    h2o_H2OFrame_nchar()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nlevels.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nlevels.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+import numpy as np
+
+
+def h2o_H2OFrame_nlevels():
+    """
+    Python API test: h2o.frame.H2OFrame.nlevels()
+    """
+    python_lists = np.random.randint(-2,2, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, column_types=['enum', 'enum'])
+    clist = h2oframe.nlevels()
+
+    assert_is_type(clist, list)     # check return type
+    assert len(clist)==2 and max(clist)==min(clist)==4, "h2o.H2OFrame.nlevels() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_nlevels())
+else:
+    h2o_H2OFrame_nlevels()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nrow_nrows_ncol_ncols_dim_shape.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_nrow_nrows_ncol_ncols_dim_shape.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_nrow():
+    """
+    Python API test: h2o.frame.H2OFrame.nrow, h2o.frame.H2OFrame.nrows, h2o.frame.H2OFrame.ncol,
+    h2o.frame.H2OFrame.ncols, h2o.frame.H2OFrame.dim
+    """
+    ncol=5
+    nrow=150
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader_NA_2.csv"))
+    assert iris.nrow==nrow, "h2o.H2OFrame.nrow command is not working."
+    assert iris.nrows==nrow, "h2o.H2OFrame.nrows command is not working."
+    assert iris.ncol==ncol, "h2o.H2OFrame.ncol command is not working."
+    assert iris.ncols==ncol, "h2o.H2OFrame.ncols command is not working."
+    assert iris.dim==[nrow,ncol], "h2o.H2OFrame.dim command is not working."
+    assert iris.shape==(nrow, ncol), "h2o.H2OFrame.shape command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_nrow())
+else:
+    h2o_H2OFrame_nrow()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_num_valid_substrings.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_num_valid_substrings.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+import inspect
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_num_valid_substrings():
+    """
+    Python API test: h2o.frame.H2OFrame.num_valid_substrings(i)
+    """
+    try:
+        # generate files to write to
+        results_dir = pyunit_utils.locate("results")    # real test when result directory is there
+        full_path = os.path.join(results_dir, "test_num_valid_substrings.txt")
+        with open(full_path, "w") as text_file:
+            text_file.write("setosa")
+            text_file.write('\n')
+            text_file.write("virginica")
+        iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader_NA_2.csv"))
+        temp = iris[4].num_valid_substrings(path_to_words=full_path)
+        assert_is_type(temp, H2OFrame)
+        assert temp.sum().flatten()==100, "h2o.H2OFrame.num_valid_substrings command is not working."
+    except Exception as e:
+        if 'File not found' in e.args[0]:
+            print("Directory is not writable.  h2o.H2OFrame.num_valid_substrings is tested for number of argument "
+                  "and argument name only.")
+            allargs = inspect.getargspec(h2o.H2OFrame.num_valid_substrings)
+            assert len(allargs.args)==2 and allargs.args[1]=='path_to_words', \
+                "h2o.H2OFrame.num_valid_substrings() contains only one argument, path_to_words!"
+        else:
+            assert False, "h2o.H2OFrame.num_valid_substrings() contains only one argument, path_to_words!"
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_num_valid_substrings())
+else:
+    h2o_H2OFrame_num_valid_substrings()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_pop.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_pop.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_pop():
+    """
+    Python API test: h2o.frame.H2OFrame.pop(i)
+
+    Copied from pyunit_pop.py
+    """
+    pros = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate.csv"))
+    nc = pros.ncol
+
+    popped_col = pros.pop(pros.names[0])    # pop with string column name
+    assert_is_type(popped_col, H2OFrame)
+    assert popped_col.ncol==1, "h2o.H2OFrame.pop() command is not working."
+    assert pros.ncol==nc-1, "h2o.H2OFrame.pop()command is not working."
+
+    popped_col = pros.pop(0)    # pop with integer index
+    assert_is_type(popped_col, H2OFrame)
+    assert popped_col.ncol==1, "h2o.H2OFrame.pop() command is not working."
+    assert pros.ncol==nc-2, "h2o.H2OFrame.pop()command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_pop())
+else:
+    h2o_H2OFrame_pop()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_prod.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_prod.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+import random
+
+
+def h2o_H2OFrame_prod():
+    """
+    Python API test: h2o.frame.H2OFrame.prod(na_rm=False)
+
+    Copied from pyunit_prod.py
+    """
+    data = [[random.uniform(1,10)] for c in range(10)]
+    h2o_data = h2o.H2OFrame(data)
+    np_data = np.array(data)
+
+    h2o_prod = h2o_data.prod(na_rm=True)
+    np_prod = np.prod(np_data)
+
+    assert abs(h2o_prod - np_prod) < 1e-06, "check unsuccessful! h2o computed {0} and numpy computed {1}. expected " \
+                                            "equal quantile values between h2o and numpy".format(h2o_prod,np_prod)
+
+    h2o.remove(h2o_data)
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_prod())
+else:
+    h2o_H2OFrame_prod()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_quantile.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_quantile.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+import random
+
+
+def h2o_H2OFrame_quantile():
+    """
+    Python API test: h2o.frame.H2OFrame.quantile(prob=None, combine_method='interpolate', weights_column=None)
+
+    Copied from pyunit_quantile.py
+    """
+    data = [[random.uniform(-10000,10000)] for c in range(1000)]
+    h2o_data = h2o.H2OFrame(data)
+    np_data = np.array(data)
+    h2o_quants = h2o_data.quantile(prob=None, combine_method='interpolate', weights_column=None)
+    assert_is_type(h2o_quants, H2OFrame)
+
+    np_quants = np.percentile(np_data,[1, 10, 25, 33.3, 50, 66.7, 75, 90, 99],axis=0)
+
+    for e in range(9):
+        h2o_val = h2o_quants[e,1]
+        np_val = np_quants[e][0]
+        assert abs(h2o_val - np_val) < 1e-06, \
+            "check unsuccessful! h2o computed {0} and numpy computed {1}. expected equal quantile values between h2o " \
+            "and numpy".format(h2o_val,np_val)
+
+    h2o.remove(h2o_data)
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_quantile())
+else:
+    h2o_H2OFrame_quantile()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_rbind.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_rbind.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_rbind():
+    """
+    Python API test: h2o.frame.H2OFrame.rbind(data)
+
+    Copied from pyunit_cbind.py
+    """
+    hdf = h2o.import_file(path=pyunit_utils.locate('smalldata/jira/pub-180.csv'))
+    hdfrows, hdfcols = hdf.shape
+
+    hdf2 = hdf.rbind(hdf)
+    assert_is_type(hdf2, H2OFrame)  # check new frame data type
+    assert hdf2.shape==(2*hdfrows, hdfcols), "h2o.H2OFrame.rbind() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_rbind())
+else:
+    h2o_H2OFrame_rbind()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_refresh.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_refresh.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_refresh():
+    """
+    Python API test: h2o.frame.H2OFrame.refresh()
+
+    Copied from pyunit_uniop_colname_domain.py
+    """
+    dataframe = {'A': [1,0,3,4], 'B': [5,6,-6, -1], 'C':[-4, -6, -7, 8]}
+    frame = h2o.H2OFrame(dataframe)
+    frame_asin = frame.asin()
+
+    #Check colnames of original frame remain untouched.
+    assert set(frame.names) == {"A", "B", "C"}, "Expected original colnames to remain the same after uniop operation"
+    #Check new colnames for modified frame are of the convention `op(colname)`
+    assert ["asin(%s)" % (name) for name in frame.names] == frame_asin.names,"Expected equal col names after" \
+                                                                             " uniop operation"
+
+    #Check again after a refresh to the frame
+    frame_asin.refresh()
+    #Check new colnames for modified frame are of the convention `op(colname)`
+    assert ["asin(%s)" % (name) for name in frame.names] == frame_asin.names,"Expected equal col names after " \
+                                                                             "uniop operation"
+    #Check types are maintained
+    assert frame_asin.types == {"asin(A)": "real", "asin(B)": "real", "asin(C)": "int"}, "Expect equal col types " \
+                                                                                         "after uniop operation"
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_refresh())
+else:
+    h2o_H2OFrame_refresh()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_relevel.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_relevel.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+import numpy as np
+
+
+def h2o_H2OFrame_relevel():
+    """
+    Python API test: h2o.frame.H2OFrame.relevel(y)
+    """
+    python_lists = np.random.randint(-5,5, (100, 2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newFrame = h2oframe.asfactor()
+    allLevels = newFrame.levels()
+    lastLevels = len(allLevels[0])-1
+    newZeroLevel = allLevels[0][lastLevels]
+    newFrame[0] = newFrame[0].relevel(newZeroLevel)    # set last level as 0
+    newLevels = newFrame.levels()
+
+    assert allLevels != newLevels, "h2o.H2OFrame.relevel() command is not working." # should not equal
+    assert newLevels[0][0]==allLevels[0][lastLevels], "h2o.H2OFrame.relevel() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_relevel())
+else:
+    h2o_H2OFrame_relevel()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_rep_len.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_rep_len.py
@@ -1,0 +1,38 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+from random import randrange
+import numpy as np
+import math
+
+
+def h2o_H2OFrame_rep_len():
+    """
+    Python API test: h2o.frame.H2OFrame.rep_len(length_out)
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    length_out_r = math.ceil(0.78*row_num)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+
+    one_column = h2oframe[0].rep_len(length_out=(length_out_r+row_num))       # one column, duplicate row
+    assert_is_type(one_column, H2OFrame)    # check return type
+        # check shape
+    assert one_column.shape == (length_out_r+row_num, 1), "h2o.H2OFrame.rep_len() command is not working."
+
+    # check values
+    repeat_row_start = row_num
+    repeat_row_end = row_num+length_out_r
+    pyunit_utils.compare_frames(h2oframe[0:length_out_r,0], one_column[repeat_row_start:repeat_row_end, 0],
+                                length_out_r, tol_time=0, tol_numeric=1e-6, strict=False, compare_NA=True)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_rep_len())
+else:
+    h2o_H2OFrame_rep_len()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_rstrip.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_rstrip.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_rstrip():
+    """
+    Python API test: h2o.frame.H2OFrame.rstrip(set='')
+
+    Copied from runit_lstrip.R
+    """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    iris["C5"] = iris["C5"].rstrip("color")
+    newNames = iris["C5"].levels()[0]
+    newStrip = ['Iris-setosa', 'Iris-versi', 'Iris-virginica']
+
+    assert newNames==newStrip, "h2o.H2OFrame.rstrip() command is not working."  # check return result
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_rstrip())
+else:
+    h2o_H2OFrame_rstrip()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_runif.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_runif.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+import numpy as np
+
+
+def h2o_H2OFrame_runif():
+    """
+    Python API test: h2o.frame.H2OFrame.runif(seed=None)
+    """
+    python_lists = np.random.uniform(0,1, 10000)
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    h2oRunif = h2oframe.runif(seed=None)
+
+    # check mean and std
+    assert abs(h2oframe.mean().flatten()-h2oRunif.mean()) < 1e-2, "h2o.H2OFrame.runif() command is not working."
+    assert abs(h2oframe.sd()[0]-h2oRunif.sd()[0]) < 1e-2, "h2o.H2OFrame.runif() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_runif())
+else:
+    h2o_H2OFrame_runif()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_scale.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_scale.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+import numpy as np
+
+
+def h2o_H2OFrame_scale():
+    """
+    Python API test: h2o.frame.H2OFrame.scale(center=True, scale=True)
+    """
+    python_lists = np.random.uniform(1, 10, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newframe = h2oframe.scale(center=True, scale=True)
+    frameMean = newframe.mean()
+    framesd = newframe.sd()
+
+    assert_is_type(newframe, H2OFrame)
+    assert (abs(frameMean[0,0]) < 1e-3) and (abs(frameMean[0,1]) < 1e-3), \
+        "h2o.H2OFrame.scale() command is not working."
+    assert (abs(framesd[0]-1) < 1e-3) and (abs(framesd[1]-1))<1e-3, "h2o.H2OFrame.scale() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_scale())
+else:
+    h2o_H2OFrame_scale()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sd.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sd.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+import numpy as np
+
+def h2o_H2OFrame_sd():
+    """
+    Python API test: h2o.frame.H2OFrame.sd(na_rm=False)
+    """
+    python_lists = np.random.uniform(1, 10, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newframe = h2oframe.scale(center=True, scale=True)
+    framesd = newframe.sd()
+    assert (abs(framesd[0]-1) < 1e-3) and (abs(framesd[1]-1))<1e-3, "h2o.H2OFrame.sd() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_sd())
+else:
+    h2o_H2OFrame_sd()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_set_level_set_levels.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_set_level_set_levels.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+import random
+
+def h2o_H2OFrame_set_level():
+    """
+    Python API test: h2o.frame.H2OFrame.set_level(level), h2o.frame.H2OFrame.set_levels(levels)
+    """
+    python_lists = np.random.randint(-5,5, (10000, 2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newFrame = h2oframe.asfactor()
+    allLevels = newFrame.levels()
+
+    newLevel0 = random.sample(allLevels[0], len(allLevels[0]))
+    newLevel1 = random.sample(allLevels[1], len(allLevels[1]))
+
+    newFrame[0] = newFrame[0].set_levels(levels=newLevel0)
+    newFrame[1] = newFrame[1].set_levels(levels=newLevel1)
+
+    assert newFrame[0].levels()[0]==newLevel0, "h2o.H2OFrame.set_levels() command is not working."
+    assert newFrame[1].levels()[0]==newLevel1, "h2o.H2OFrame.set_levels() command is not working."
+
+    allLevels = newFrame.levels()
+    lastLevel = allLevels[0][len(allLevels[0])-1]
+    firstLevel = allLevels[1][0]
+
+    newFrame[0] = newFrame[0].set_level(level=lastLevel)
+    newFrame[1] = newFrame[1].set_level(level=firstLevel)
+
+    assert (newFrame[0]==lastLevel).all(), "h2o.H2OFrame.set_level() command is not working."
+    assert (newFrame[1]==firstLevel).all, "h2o.H2OFrame.set_level() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_set_level())
+else:
+    h2o_H2OFrame_set_level()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_set_name_set_names.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_set_name_set_names.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+import random
+
+def h2o_H2OFrame_set_name():
+    """
+    Python API test: h2o.frame.H2OFrame.set_name(col=None, name=None), h2o.frame.H2OFrame.set_names(names)
+    """
+    row_num = random.randrange(1,10)
+    col_num = random.randrange(1,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+
+    newNames = random.sample(h2oframe.names, col_num)
+    h2oframe.set_names(names=newNames)
+    assert h2oframe.names==newNames, "h2o.H2OFrame.set_names() command is not working."
+
+    newName = "Dolphine"
+    h2oframe.set_name(col=0, name=newName)
+    assert h2oframe.names[0]==newName, "h2o.H2OFrame.set_name() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_set_name())
+else:
+    h2o_H2OFrame_set_name()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_show.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_show.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from random import randrange
+
+
+def h2o_H2OFrame_show():
+    """
+    Python API test: h2o.frame.H2OFrame.show(use_pandas=False)
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+
+    h2oframe.show(use_pandas=True)
+    h2oframe.show(use_pandas=False)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_show())
+else:
+    h2o_H2OFrame_show()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_skewness.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_skewness.py
@@ -1,0 +1,22 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+
+def h2o_H2OFrame_skewness():
+    """
+    Python API test: h2o.frame.H2OFrame.skewness(na_rm=False)
+    """
+    python_lists = np.random.uniform(-1,1, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newframe = h2oframe.skewness()
+    assert_is_type(newframe, list)
+    assert len(newframe)==2, "h2o.H2OFrame.skewness() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_skewness())
+else:
+    h2o_H2OFrame_skewness()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_split_frame.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_split_frame.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_split_frame():
+    """
+    Python API test: h2o.frame.H2OFrame.split_frame(ratios=None, destination_frames=None, seed=None)
+    """
+    python_lists = np.random.uniform(-1,1, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newframe = h2oframe.split_frame(ratios=[0.5, 0.25], destination_frames=["f1", "f2", "f3"], seed=None)
+    assert_is_type(newframe, list)
+    assert_is_type(newframe[0], H2OFrame)
+    assert len(newframe)==3, "h2o.H2OFrame.split_frame() command is not working."
+    assert h2oframe.nrow==(newframe[0].nrow+newframe[1].nrow+newframe[2].nrow), "h2o.H2OFrame.split_frame() command " \
+                                                                                "is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_split_frame())
+else:
+    h2o_H2OFrame_split_frame()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_stratified_kfold_column.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_stratified_kfold_column.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_stratified_kfold_column():
+    """
+    Python API test: h2o.frame.H2OFrame.stratified_kfold_column(n_folds=3, seed=-1)
+    """
+    python_lists = np.random.randint(-3,3, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists).asfactor()
+    newframe = h2oframe[1].stratified_kfold_column(n_folds=3, seed=-1)
+    assert_is_type(newframe, H2OFrame)
+    assert ((newframe==0).sum()+(newframe==1).sum()+(newframe==2).sum())==h2oframe.nrow, \
+        "h2o.H2OFrame.stratified_kfold_column() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_stratified_kfold_column())
+else:
+    h2o_H2OFrame_stratified_kfold_column()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_stratified_split.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_stratified_split.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_strafified_split():
+    """
+    Python API test: h2o.frame.H2OFrame.stratified_split(test_frac=0.2, seed=-1)
+    """
+    python_lists = np.random.randint(-3,3, (10000,2))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists).asfactor()
+    newframe = h2oframe[1].stratified_split(test_frac=0.2, seed=-1)
+    assert_is_type(newframe, H2OFrame)
+    assert ((newframe=='train').sum()+(newframe=='test').sum())==h2oframe.nrow, \
+        "h2o.H2OFrame.stratified_kfold_column() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_strafified_split())
+else:
+    h2o_H2OFrame_strafified_split()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_strsplit.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_strsplit.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_strsplit():
+    """
+    Python API test: h2o.frame.H2OFrame.strsplit(pattern)
+
+    Copied from pyunit_strsplit.py
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    result = frame["C5"].strsplit("-")
+    assert_is_type(result, H2OFrame)
+    assert result.nrow == 150 and result.ncol == 2
+    assert result[0,0] == "Iris" and result[0,1] == "setosa", "Expected 'Iris' and 'setosa', but got {0} and " \
+                                                              "{1}".format(result[0,0], result[0,1])
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_strsplit())
+else:
+    h2o_H2OFrame_strsplit()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_structure.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_structure.py
@@ -1,0 +1,17 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_structure():
+    """
+    Python API test: h2o.frame.H2OFrame.structure()
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    frame.structure()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_structure())
+else:
+    h2o_H2OFrame_structure()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sub.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sub.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_sub():
+    """
+    Python API test: h2o.frame.H2OFrame.sub(pattern, replacement, ignore_case=False)
+
+    Copied from pyunit_substring.py
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    frame["C5"] = frame["C5"].sub('s','z', ignore_case=False)
+    assert frame[1,4] == "Iriz-setosa", "Expected 'Iriz-setosa', but got {0}".format(frame[1,4])
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_sub())
+else:
+    h2o_H2OFrame_sub()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_substring.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_substring.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_substring():
+    """
+    Python API test: h2o.frame.H2OFrame.substring(start_index, end_index=None)
+
+    Copied from pyunit_sub_gsub.py
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    frame["C5"]= frame["C5"].substring(0,5)
+
+    assert (frame["C5"]=='Iris-').sum() == frame.nrow, \
+        "h2o.H2OFrame.substring() command is not working."
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_substring())
+else:
+    h2o_H2OFrame_substring()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sum.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sum.py
@@ -1,0 +1,37 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+from random import randrange
+import numpy as np
+
+def h2o_H2OFrame_sum():
+    """
+    Python API test: h2o.frame.H2OFrame.meansum(skipna=True, axis=0, **kwargs)
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+
+    # axis = 0
+    h2oSum = h2oframe.sum(skipna=False, axis=0)
+    assert_is_type(h2oSum, H2OFrame)
+    numpsum = list(np.sum(python_lists, axis=0))
+    h2omean = h2oSum.as_data_frame(use_pandas=True, header=False)
+    pyunit_utils.equal_two_arrays(numpsum, h2omean.values.tolist()[0], 1e-12, 1e-6)
+
+    # axis = 1
+    h2oSum = h2oframe.sum(skipna=False, axis=1)
+    assert_is_type(h2oSum, H2OFrame)
+    numpsum = list(np.sum(python_lists, axis=1))
+    h2omean = h2oSum.as_data_frame(use_pandas=True, header=False)
+    pyunit_utils.equal_two_arrays(numpsum, h2omean.values.T.tolist()[0], 1e-12, 1e-6)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_sum())
+else:
+    h2o_H2OFrame_sum()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_summary.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_summary.py
@@ -1,0 +1,17 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_summary():
+    """
+    Python API test: h2o.frame.H2OFrame.summary()
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    frame.summary()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_summary())
+else:
+    h2o_H2OFrame_summary()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_table.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_table.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_table():
+    """
+    Python API test: h2o.frame.H2OFrame.table(data2=None, dense=True)
+
+    Copied from pyunit_table.py
+    """
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    tableFrame = df[['DPROS','RACE']].table(data2=None, dense=True)
+
+    assert_is_type(tableFrame, H2OFrame)
+    assert tableFrame.sum(axis=0).sum(axis=1).flatten()==df.nrow, \
+        "h2o.H2OFrame.table() command is not working."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_table())
+else:
+    h2o_H2OFrame_table()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_tail.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_tail.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_tail():
+    """
+    Python API test: h2o.frame.H2OFrame.tail(rows=10, cols=200)
+    """
+    row_num = randrange(2,10)
+    col_num = randrange(2,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    new_row = randrange(1, row_num)
+    new_col = randrange(1, col_num)
+    newFrame = h2oframe.tail(rows=new_row, cols=new_col)
+
+    assert_is_type(newFrame, H2OFrame)     # check return type
+    assert newFrame.shape==(new_row, new_col), "h2o.H2OFrame.tail() command is not working."  # check return result
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_tail())
+else:
+    h2o_H2OFrame_tail()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_tolower.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_tolower.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+
+
+def h2o_H2OFrame_tolower():
+    """
+    Python API test: h2o.frame.H2OFrame.tolower()
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    frame["C5"]= frame["C5"].tolower()
+
+    assert (frame["C5"]=='iris-setosa').sum() == 50, \
+        "h2o.H2OFrame.tolower() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_tolower())
+else:
+    h2o_H2OFrame_tolower()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_toupper.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_toupper.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+
+
+def h2o_H2OFrame_toupper():
+    """
+    Python API test: h2o.frame.H2OFrame.toupper()
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    frame["C5"]= frame["C5"].toupper()
+
+    assert (frame["C5"]=='IRIS-SETOSA').sum() == 50, \
+        "h2o.H2OFrame.toupper() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_toupper())
+else:
+    h2o_H2OFrame_toupper()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_transpose.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_transpose.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from random import randrange
+import numpy as np
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_transpose():
+    """
+    Python API test: h2o.frame.H2OFrame.transpose()
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newFrame = h2oframe.transpose()
+
+    assert_is_type(newFrame, H2OFrame)     # check return type
+    # check shape
+    assert newFrame.shape==(h2oframe.ncol, h2oframe.nrow), "h2o.H2OFrame.transpose() command is not working."
+    # check content
+    pyunit_utils.compare_frames(h2oframe, newFrame.transpose(), h2oframe.nrow, tol_time=0, tol_numeric=1e-6)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_transpose())
+else:
+    h2o_H2OFrame_transpose()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_trim.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_trim.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_trim():
+    """
+    Python API test: h2o.frame.H2OFrame.trim()
+
+    Copied frm pyunit_trim.py
+    """
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_trim.csv"),
+                            col_types=["string","numeric","numeric","numeric","numeric","numeric","numeric","numeric"])
+
+    # single column (frame)
+    trimmed_frame = frame["name"].trim()
+    assert trimmed_frame[0,0] == "AMC Ambassador Brougham", "Expected 'AMC Ambassador Brougham', " \
+                                                            "but got {}".format(trimmed_frame[0,0])
+    assert trimmed_frame[1,0] == "AMC Ambassador DPL", "Expected 'AMC Ambassador DPL', " \
+                                                       "but got {}".format(trimmed_frame[1,0])
+    assert trimmed_frame[2,0] == "AMC Ambassador SST", "Expected 'AMC Ambassador SST', " \
+                                                       "but got {}".format(trimmed_frame[2,0])
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_trim())
+else:
+    h2o_H2OFrame_trim()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_trunc.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_trunc.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+from random import randrange
+import numpy as np
+import math
+
+
+def h2o_H2OFrame_trunc():
+    """
+    Python API test: h2o.frame.H2OFrame.trunc()
+    """
+    row_num = randrange(1,10)
+    col_num = randrange(1,10)
+    length_out_r = math.ceil(0.78*row_num)
+    length_out_c = math.ceil(col_num*0.4)
+    python_lists = np.random.randint(-5,5, (row_num, col_num))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+
+    allframe = h2oframe.trunc()
+    assert_is_type(allframe, H2OFrame)      # check return type
+        # check values
+    pyunit_utils.assert_correct_frame_operation(h2oframe, allframe, "floor")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_trunc())
+else:
+    h2o_H2OFrame_trunc()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_types_type.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_types_type.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+
+def h2o_H2OFrame_types():
+    """
+    Python API test: h2o.frame.H2OFrame.types
+
+    Copied frm pyunit_trim.py
+    """
+    column_types = ["string","numeric","numeric","numeric","numeric","numeric","numeric","numeric"]
+    frame = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_trim.csv"), col_types=column_types)
+    frameTypes = frame.types
+
+    index = 0
+    for cnames in frame.names:
+        assert frameTypes[cnames]==frame.type(cnames), "h2o.H2OFrame.types command is not working."
+        assert frame.type(index)==column_types[index] or frame.type(index)=="int" or frame.type(index)=="real", \
+            "h2o.H2OFrame.type() command is not working."
+        index+=1
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_types())
+else:
+    h2o_H2OFrame_types()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_unique.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_unique.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+import numpy as np
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_unique():
+    """
+    Python API test: h2o.frame.H2OFrame.unique()
+    """
+    python_lists = np.random.randint(-5,5, (100, 1))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newFrame = h2oframe.unique()
+    allLevels = h2oframe.asfactor().levels()[0]
+    assert_is_type(newFrame, H2OFrame)     # check return type
+    assert len(allLevels)==newFrame.nrow, "h2o.H2OFrame.unique command is not working." # check shape
+    newFrame = newFrame.asfactor()    # change to enum to make sure elements are string type
+
+    for rowIndex in range(newFrame.nrow):   # check values
+        assert newFrame[rowIndex, 0] in allLevels, "h2o.H2OFrame.unique command is not working." # check shape
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_unique())
+else:
+    h2o_H2OFrame_unique()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_var.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_var.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+import numpy as np
+from h2o.frame import H2OFrame
+
+
+def h2o_H2OFrame_var():
+    """
+    Python API test: h2o.frame.H2OFrame.var(y=None, na_rm=False, use=None)
+
+    Copied from pyunit_var.py
+    """
+    iris_h2o = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    iris_np = np.genfromtxt(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"),
+                            delimiter=',',
+                            skip_header=1,
+                            usecols=(0, 1, 2, 3))
+
+    var_np = np.var(iris_np, axis=0, ddof=1)
+    for i in range(4):
+        var_h2o = iris_h2o.var(y=iris_h2o[i], na_rm=True, use=None)
+        assert_is_type(var_h2o, H2OFrame)
+        assert abs(var_np[i] - var_h2o[i,0]) < 1e-10, "h2o.H2OFrame.var() command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_var())
+else:
+    h2o_H2OFrame_var()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_which.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_which.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+import numpy as np
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrame_which():
+    """
+    Python API test: h2o.frame.H2OFrame.which()
+    """
+    python_lists = np.random.randint(1,5, (100,1))
+    h2oframe = h2o.H2OFrame(python_obj=python_lists)
+    newFrame = h2oframe.which()     # first row contains index 0.
+
+    assert_is_type(newFrame, H2OFrame)     # check return type
+    assert newFrame[1:h2oframe.nrow,0].all(), "h2o.H2OFrame.which() command is not working."  # check return result
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_which())
+else:
+    h2o_H2OFrame_which()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2o_math_ops_large.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2o_math_ops_large.py
@@ -1,0 +1,76 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+import numpy as np
+from h2o.utils.typechecks import assert_is_type
+from h2o.frame import H2OFrame
+
+def h2o_H2OFrameAsin():
+    """
+    Python API tests for: h2o.frame.H2OFrame.abs(), h2o.frame.H2OFrame.acos(), h2o.frame.H2OFrame.acosh(),
+    h2o.frame.H2OFrame.asin(), h2o.frame.H2OFrame.asinh(), h2o.frame.H2OFrame.atan(), h2o.frame.H2OFrame.atanh(),
+    h2o.frame.H2OFrame.ceil(), h2o.frame.H2OFrame.cos(), h2o.frame.H2OFrame.cosh(), h2o.frame.H2OFrame.cospi(),
+    h2o.frame.H2OFrame.digamma(), h2o.frame.H2OFrame.exp(), h2o.frame.H2OFrame.expm1(), h2o.frame.H2OFrame.floor(),
+    h2o.frame.H2OFrame.gamma(), h2o.frame.H2OFrame.lgamma(), h2o.frame.H2OFrame.log(), h2o.frame.H2OFrame.log(),
+    h2o.frame.H2OFrame.log1p(), h2o.frame.H2OFrame.log2(), h2o.frame.H2OFrame.round(), h2o.frame.H2OFrame.sign(),
+    h2o.frame.H2OFrame.signif(), h2o.frame.H2OFrame.sin(), h2o.frame.H2OFrame.sinh(), h2o.frame.H2OFrame.sinpi(),
+    h2o.frame.H2OFrame.sqrt(), h2o.frame.H2OFrame.tan(), h2o.frame.H2OFrame.tanh(), h2o.frame.H2OFrame.tanpi()
+    """
+    h2oframe = genData(-1,1,3,4)    # verify H2OFrame.abs()
+    compareEvalOps(h2oframe, h2oframe.abs(), H2OFrame, "abs")   # verify H2OFrame.abs()
+    compareEvalOps(h2oframe, h2oframe.acos(), H2OFrame, "acos") # verify H2OFrame.acos()
+    compareEvalOps(h2oframe, h2oframe.asin(), H2OFrame, "asin") # verify H2OFrame.asin()
+    compareEvalOps(h2oframe, h2oframe.asinh(), H2OFrame, "asinh") # verify H2OFrame.asinh()
+    compareEvalOps(h2oframe, h2oframe.atan(), H2OFrame, "atan") # verify H2OFrame.atan()
+    compareEvalOps(h2oframe, h2oframe.cos(), H2OFrame, "cos") # verify H2OFrame.cos()
+    compareEvalOps(h2oframe, h2oframe.cosh(), H2OFrame, "cosh") # verify H2OFrame.cosh()
+    compareEvalOps(h2oframe, h2oframe.cospi(), H2OFrame, "cospi") # verify H2OFrame.cospi()
+    compareEvalOps(h2oframe, h2oframe.exp(), H2OFrame, "exp") # verify H2OFrame.exp()
+    compareEvalOps(h2oframe, h2oframe.expm1(), H2OFrame, "expm1") # verify H2OFrame.expm1()
+    compareEvalOps(h2oframe, h2oframe.sin(), H2OFrame, "sin") # verify H2OFrame.sin()
+    compareEvalOps(h2oframe, h2oframe.sinh(), H2OFrame, "sinh") # verify H2OFrame.sinh()
+    compareEvalOps(h2oframe, h2oframe.sinpi(), H2OFrame, "sinpi") # verify H2OFrame.sinpi()
+    compareEvalOps(h2oframe, h2oframe.tan(), H2OFrame, "tan") # verify H2OFrame.tan()
+    compareEvalOps(h2oframe, h2oframe.tanh(), H2OFrame, "tanh") # verify H2OFrame.tanh()
+    compareEvalOps(h2oframe, h2oframe.tanpi(), H2OFrame, "tanpi") # verify H2OFrame.tanpi()
+    h2o.remove(h2oframe)
+    h2oframe = genData(1,3,3,4)
+    compareEvalOps(h2oframe, h2oframe.acosh(), H2OFrame, "acosh")   # verify H2OFrame.acos()
+    compareEvalOps(h2oframe, h2oframe.digamma(), H2OFrame, "digamma")   # verify H2OFrame.digamma()
+    h2o.remove(h2oframe)
+    h2oframe = genData(-0.9,0.9,3,4)
+    compareEvalOps(h2oframe, h2oframe.atanh(), H2OFrame, "atanh")   # verify H2OFrame.atanh()
+    h2o.remove(h2oframe)
+    h2oframe = genData(-10,10,3,4)
+    compareEvalOps(h2oframe, h2oframe.ceil(), H2OFrame, "ceil")   # verify H2OFrame.ceil()
+    compareEvalOps(h2oframe, h2oframe.floor(), H2OFrame, "floor")   # verify H2OFrame.floor()
+    compareEvalOps(h2oframe, h2oframe.round(digits=0), H2OFrame, "round")   # verify H2OFrame.round()
+    compareEvalOps(h2oframe, h2oframe.sign(), H2OFrame, "sign")   # verify H2OFrame.sign()
+    compareEvalOps(h2oframe, h2oframe.signif(digits=7), H2OFrame, "signif")   # verify H2OFrame.signif()
+    h2o.remove(h2oframe)
+    h2oframe = genData(1,10,5,5)
+    compareEvalOps(h2oframe, h2oframe.log(), H2OFrame, "log") # verify H2OFrame.log()
+    compareEvalOps(h2oframe, h2oframe.log10(), H2OFrame, "log10") # verify H2OFrame.log10()
+    compareEvalOps(h2oframe, h2oframe.log1p(), H2OFrame, "log1p") # verify H2OFrame.log1p()
+    compareEvalOps(h2oframe, h2oframe.log2(), H2OFrame, "log2") # verify H2OFrame.log2()
+    compareEvalOps(h2oframe, h2oframe.lgamma(), H2OFrame, "lgamma") # verify H2OFrame.lgamma()
+    compareEvalOps(h2oframe, h2oframe.sqrt(), H2OFrame, "sqrt") # verify H2OFrame.sqrt()
+    compareEvalOps(h2oframe, h2oframe.trigamma(), H2OFrame, "trigamma") # verify H2OFrame.trigamma()
+    compareEvalOps(h2oframe, h2oframe.gamma(), H2OFrame, "gamma")   # verify H2OFrame.gamma()
+
+
+
+def genData(lowBound, upBound, rowN, colN):
+    python_lists = np.random.uniform(lowBound, upBound, (rowN, colN))
+    return h2o.H2OFrame(python_obj=python_lists)
+
+def compareEvalOps(origFrame, newFrame, objType, operString):
+    assert_is_type(newFrame, objType)
+    pyunit_utils.assert_correct_frame_operation(origFrame, newFrame, operString)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrameAsin())
+else:
+    h2o_H2OFrameAsin()

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2ogroup_by_GroupBy_count_frame_get_frame_max_mean_min_mode_sd_ss_sum_var_large.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2ogroup_by_GroupBy_count_frame_get_frame_max_mean_min_mode_sd_ss_sum_var_large.py
@@ -1,0 +1,76 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+import h2o
+from h2o.utils.typechecks import assert_is_type
+from h2o.group_by import GroupBy
+from h2o.frame import H2OFrame
+
+def h2ogroup_by_GroupBy_AllOps():
+    """
+    Python API test: h2o.group_by.GroupBy(fr, by), h2o.group_by.GroupBy.count(na='all'), h2o.group_by.GroupBy.frame,
+    h2o.group_by.GroupBy.count, h2o.group_by.GroupBy.mode, h2o.group_by.GroupBy.max, h2o.group_by.GroupBy.mean,
+    h2o.group_by.GroupBy.min, h2o.group_by.GroupBy.sd, h2o.group_by.GroupBy.ss, h2o.group_by.GroupBy.sum,
+    h2o.group_by.GroupBy.var
+
+    Copied from pyunit_groupby_allOps.py
+    """
+    h2o_prostate = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    by=["CAPSULE", "RACE"]
+    groupbyObj = GroupBy(fr=h2o_prostate, by=by)
+    assert_is_type(groupbyObj, GroupBy)     # verify GroupBy
+
+    counts = groupbyObj.count(na='all')     #verify count
+    assert_is_type(counts, GroupBy)     # check return type
+    countsInfo = counts.get_frame()     # look into group by result
+    assert_is_type(countsInfo, H2OFrame)    # verify get_frame
+    assert countsInfo.shape == ((h2o_prostate["CAPSULE"].nlevels()[0]*h2o_prostate["RACE"].nlevels()[0]), len(by)+1), \
+        "h2o.group_by.GroupBy.count() command is not working."
+
+    assert_is_type(counts.frame, H2OFrame)  # verify frame
+
+    verifyOps(GroupBy(fr=h2o_prostate, by=by).mode(col=["DPROS"], na='rm'),
+              ((h2o_prostate["CAPSULE"].nlevels()[0]*h2o_prostate["RACE"].nlevels()[0]), len(by)+1),
+              [2], [1.0], "h2o.group_by.GroupBy.mode()")
+
+    h2o_iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    groupbyObj = GroupBy(fr=h2o_iris, by="class")
+
+    verifyOps(GroupBy(fr=h2o_iris, by="class").max(col=None, na='all'), (3,5),
+              ["max_sepal_len", "max_sepal_wid", "max_petal_wid"], [5.8, 3.4, 2.5], "h2o.group_by.GroupBy.max()")
+    verifyOps(GroupBy(fr=h2o_iris, by="class").mean(col=None, na='all'), (3,5),
+              ["mean_sepal_len", "mean_sepal_wid", "mean_petal_wid"],
+              [5.006, 2.77, 2.026], "h2o.group_by.GroupBy.mean()")
+    verifyOps(GroupBy(fr=h2o_iris, by="class").min(col=None, na='all'), (3,5),
+              ["min_sepal_len", "min_sepal_wid", "min_petal_wid"], [4.3, 2.0, 1.4], "h2o.group_by.GroupBy.min()")
+    verifyOps(GroupBy(fr=h2o_iris, by="class").sd(col=None, na='all'), (3,5),
+              ["sdev_sepal_len", "sdev_sepal_wid", "sdev_petal_wid"],
+              [0.352489687213, 0.313798323378, 0.274650055637], "h2o.group_by.GroupBy.sd()")
+    verifyOps(GroupBy(fr=h2o_iris, by="class").ss(col=None, na='all'), (3,5),
+              ["sumSquares_sepal_len", "sumSquares_sepal_wid", "sumSquares_petal_wid"],
+              [1259.09, 388.47, 208.93], "h2o.group_by.GroupBy.ss()")
+    verifyOps(GroupBy(fr=h2o_iris, by="class").sum(col=None, na='all'), (3,5),
+              ["sum_sepal_len", "sum_sepal_wid", "sum_petal_wid"],
+              [250.3, 138.5, 101.3], "h2o.group_by.GroupBy.sum()")
+    verifyOps(GroupBy(fr=h2o_iris, by="class").var(col=None, na='all'), (3,5),
+              ["var_sepal_len", "var_sepal_wid", "var_petal_wid"],
+              [0.352489687213*0.352489687213, 0.313798323378*0.313798323378, 0.274650055637*0.274650055637],
+              "h2o.group_by.GroupBy.var()")
+
+
+def verifyOps(opers, shapeS, threshold_name, threshold_val, groupByCommand):
+    assert_is_type(opers, GroupBy)
+    operInfo = opers.get_frame()
+    assert_is_type(operInfo, H2OFrame)
+
+    assert operInfo.shape == shapeS, "{0} command is not working.".format(groupByCommand)
+
+    for index in range(len(threshold_val)):
+        assert abs(operInfo[index, threshold_name[index]] - threshold_val[index]) < 1e-6, \
+            "{0} command is not working.".format(groupByCommand)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2ogroup_by_GroupBy_AllOps())
+else:
+    h2ogroup_by_GroupBy_AllOps()

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oapi.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oapi.py
@@ -11,27 +11,24 @@ def h2oapi():
     """
     Python API test: h2o.api(endpoint, data=None, json=None, filename=None, save_to=None)
     """
-    try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        Y = 3
-        X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
 
-        model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
-        model.train(x=X, y=Y, training_frame=training_data)
-        frame_api = h2o.api("GET /3/Frames/%s/summary" % training_data.frame_id)
-        assert_is_type(frame_api, H2OResponse)
-        hf_col_summary = h2o.api("GET /3/Frames/%s/summary" % training_data.frame_id)["frames"][0]
-        # test h2o.api() getting frame information
-        assert hf_col_summary["row_count"]==100, "row count is incorrect.  Fix h2o.api()."
-        assert hf_col_summary["column_count"]==14, "column count is incorrect.  Fix h2o.api()."
+    model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
+    model.train(x=X, y=Y, training_frame=training_data)
+    frame_api = h2o.api("GET /3/Frames/%s/summary" % training_data.frame_id)
+    assert_is_type(frame_api, H2OResponse)
+    hf_col_summary = h2o.api("GET /3/Frames/%s/summary" % training_data.frame_id)["frames"][0]
+    # test h2o.api() getting frame information
+    assert hf_col_summary["row_count"]==100, "row count is incorrect.  Fix h2o.api()."
+    assert hf_col_summary["column_count"]==14, "column count is incorrect.  Fix h2o.api()."
 
-        # test h2o.api() getting model information
-        model_api = h2o.api("GET /3/GetGLMRegPath", data={"model": model._model_json["model_id"]["name"]})
-        assert_is_type(model_api, H2OResponse)
-        model_coefficients = model_api["coefficients"][0]
-        assert len(model_coefficients)==11, "Number of coefficients is wrong.  h2o.api() command is not working."
-    except Exception as e:
-        assert False, "h2o.api() command not is working."
+    # test h2o.api() getting model information
+    model_api = h2o.api("GET /3/GetGLMRegPath", data={"model": model._model_json["model_id"]["name"]})
+    assert_is_type(model_api, H2OResponse)
+    model_coefficients = model_api["coefficients"][0]
+    assert len(model_coefficients)==11, "Number of coefficients is wrong.  h2o.api() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oapi)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oas_list.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oas_list.py
@@ -10,16 +10,14 @@ def h2oas_list():
     Python API test: h2o.as_list(data, use_pandas=True, header=True)
     Copied from pyunit_frame_as_list.py
     """
-    try:
-        iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
 
-        res1 = h2o.as_list(iris, use_pandas=False)
-        assert_is_type(res1, list)
-        res1 = list(zip(*res1))
-        assert abs(float(res1[0][9]) - 4.4) < 1e-10 and abs(float(res1[1][9]) - 2.9) < 1e-10 and \
-           abs(float(res1[2][9]) - 1.4) < 1e-10, "incorrect values"
-    except Exception as e:
-        assert False, "h2o.as_list() command not is working."
+    res1 = h2o.as_list(iris, use_pandas=False)
+    assert_is_type(res1, list)
+    res1 = list(zip(*res1))
+    assert abs(float(res1[0][9]) - 4.4) < 1e-10 and abs(float(res1[1][9]) - 2.9) < 1e-10 and \
+       abs(float(res1[2][9]) - 1.4) < 1e-10, "incorrect values"
+
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oas_list)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oassign.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oassign.py
@@ -10,16 +10,13 @@ def h2oassign():
     """
     Python API test: h2o.assign(data, xid)
     """
-    try:
-        old_name = "benign.csv"
-        new_name = "newBenign.csv"
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"), destination_frame=old_name)
-        assert training_data.frame_id==old_name, "h2o.import_file() is not working.  Wrong frame_id is assigned."
-        temp=h2o.assign(training_data, new_name)
-        assert_is_type(temp, H2OFrame)
-        assert training_data.frame_id==new_name, "h2o.assign() is not working.  New frame_id is not assigned."
-    except Exception as e:
-        assert False, "h2o.assign() command is not working."
+    old_name = "benign.csv"
+    new_name = "newBenign.csv"
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"), destination_frame=old_name)
+    assert training_data.frame_id==old_name, "h2o.import_file() is not working.  Wrong frame_id is assigned."
+    temp=h2o.assign(training_data, new_name)
+    assert_is_type(temp, H2OFrame)
+    assert training_data.frame_id==new_name, "h2o.assign() is not working.  New frame_id is not assigned."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oassign)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster.py
@@ -3,16 +3,15 @@ import sys
 sys.path.insert(1,"../../../")
 from tests import pyunit_utils
 import h2o
+from h2o.backend.cluster import H2OCluster
+from h2o.utils.typechecks import assert_is_type
 
 def h2ocluster():
     """
     Python API test: h2o.cluster()
     """
-
-    try:
-        h2o.cluster()
-    except Exception as e:
-        assert False, "h2o.cluster() command not is working."
+    ret = h2o.cluster()
+    assert_is_type(ret, H2OCluster)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2ocluster)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_info_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_info_DEPRECATED.py
@@ -9,11 +9,8 @@ def h2ocluster_info():
     Python API test: h2o.cluster_info()
     Deprecated, use h2o.cluster().show_status().
     """
-    try:
-        h2o.cluster_info()    # no return type
-    except Exception as e:
-        assert False, "h2o.cluster_info() command is not working."
-
+    ret = h2o.cluster_info()    # no return type
+    assert ret is None
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2ocluster_info)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_shutdown.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_shutdown.py
@@ -21,13 +21,11 @@ def h2ocluster_shutdown():
         assert_is_type(e, TypeError)
         assert "badparam" in e.args[0], "h2o.shutdown() command is not working."
 
-    try:
-        thread = threading.Thread(target=call_shutdown)
-        thread.daemon =True
-        thread.start()
-        thread.join(1.0)
-    except Exception as e:
-        assert False, "h2o.cluster().shutdown() command is not working."
+
+    thread = threading.Thread(target=call_shutdown)
+    thread.daemon =True
+    thread.start()
+    thread.join(1.0)
 
 def call_shutdown():
     h2o.cluster().shutdown(prompt=True)   # call shutdown but do not actually shut anything down.

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_status_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocluster_status_DEPRECATED.py
@@ -9,11 +9,8 @@ def h2ocluster_status():
     Python API test: h2o.cluster_status()
     Deprecated, use h2o.cluster().show_status(True)
     """
-    try:
-        h2o.cluster_status()    # no return type
-    except Exception as e:
-        assert False, "h2o.cluster_status() command is not working."
-
+    ret = h2o.cluster_status()    # no return type
+    assert ret is None
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2ocluster_status)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oconnection.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oconnection.py
@@ -11,11 +11,8 @@ def h2oconnection():
     Python API test: h2o.connection()
     """
     # call with no arguments
-    try:
-        temp = h2o.connection()
-        assert_is_type(temp, H2OConnection)
-    except Exception as e:
-        assert False, "h2o.connection() command is not working."
+    temp = h2o.connection()
+    assert_is_type(temp, H2OConnection)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oconnection)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocreate_frame.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ocreate_frame.py
@@ -17,40 +17,36 @@ def h2ocreate_frame():
 
     Copied from pyunit_NOPASS_javapredict_dynamic_data_paramsDL.py
     """
-
-    try:
-        # Generate random dataset
-        dataset_params = {}
-        dataset_params['rows'] = random.sample(list(range(50,150)),1)[0]
-        dataset_params['cols'] = random.sample(list(range(3,6)),1)[0]
-        dataset_params['categorical_fraction'] = round(random.random(),1)
-        left_over = (1 - dataset_params['categorical_fraction'])
-        dataset_params['integer_fraction'] = round(left_over - round(random.uniform(0,left_over),1),1)
-        if dataset_params['integer_fraction'] + dataset_params['categorical_fraction'] == 1:
-            if dataset_params['integer_fraction'] > dataset_params['categorical_fraction']:
-                dataset_params['integer_fraction'] = dataset_params['integer_fraction'] - 0.1
-            else:
-                dataset_params['categorical_fraction'] = dataset_params['categorical_fraction'] - 0.1
-        dataset_params['missing_fraction'] = random.uniform(0,0.5)
-        dataset_params['has_response'] = False
-        dataset_params['randomize'] = True
-        dataset_params['factors'] = random.randint(2,5)
-        print("Dataset parameters: {0}".format(dataset_params))
-
-        distribution = random.sample(['bernoulli','multinomial','gaussian','poisson','gamma'], 1)[0]
-        if   distribution == 'bernoulli': dataset_params['response_factors'] = 2
-        elif distribution == 'gaussian':  dataset_params['response_factors'] = 1
-        elif distribution == 'multinomial': dataset_params['response_factors'] = random.randint(3,5)
+    # Generate random dataset
+    dataset_params = {}
+    dataset_params['rows'] = random.sample(list(range(50,150)),1)[0]
+    dataset_params['cols'] = random.sample(list(range(3,6)),1)[0]
+    dataset_params['categorical_fraction'] = round(random.random(),1)
+    left_over = (1 - dataset_params['categorical_fraction'])
+    dataset_params['integer_fraction'] = round(left_over - round(random.uniform(0,left_over),1),1)
+    if dataset_params['integer_fraction'] + dataset_params['categorical_fraction'] == 1:
+        if dataset_params['integer_fraction'] > dataset_params['categorical_fraction']:
+            dataset_params['integer_fraction'] = dataset_params['integer_fraction'] - 0.1
         else:
-            dataset_params['has_response'] = False
-        print("Distribution: {0}".format(distribution))
+            dataset_params['categorical_fraction'] = dataset_params['categorical_fraction'] - 0.1
+    dataset_params['missing_fraction'] = random.uniform(0,0.5)
+    dataset_params['has_response'] = False
+    dataset_params['randomize'] = True
+    dataset_params['factors'] = random.randint(2,5)
+    print("Dataset parameters: {0}".format(dataset_params))
 
-        train = h2o.create_frame(**dataset_params)
-        assert_is_type(train, H2OFrame)
-        assert train.ncol==dataset_params['cols'], "h2o.create_frame() create frame with wrong column number."
-        assert train.nrow==dataset_params['rows'], "h2o.create_frame() create frame with wrong row number."
-    except Exception as e:
-        assert False, "h2o.create_frame() command not is working."
+    distribution = random.sample(['bernoulli','multinomial','gaussian','poisson','gamma'], 1)[0]
+    if   distribution == 'bernoulli': dataset_params['response_factors'] = 2
+    elif distribution == 'gaussian':  dataset_params['response_factors'] = 1
+    elif distribution == 'multinomial': dataset_params['response_factors'] = random.randint(3,5)
+    else:
+        dataset_params['has_response'] = False
+    print("Distribution: {0}".format(distribution))
+
+    train = h2o.create_frame(**dataset_params)
+    assert_is_type(train, H2OFrame)
+    assert train.ncol==dataset_params['cols'], "h2o.create_frame() create frame with wrong column number."
+    assert train.nrow==dataset_params['rows'], "h2o.create_frame() create frame with wrong row number."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2ocreate_frame)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odeep_copy.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odeep_copy.py
@@ -10,18 +10,14 @@ def h2odeep_copy():
     """
     Python API test: h2o.deep_copy(data, xid)
     """
-    try:
-        new_name = "new_frame"
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        training_copy = h2o.deep_copy(training_data, new_name)
-        assert_is_type(training_data, H2OFrame)
-        assert_is_type(training_copy, H2OFrame)
-        assert training_data.nacnt()==training_copy.nacnt(), "h2o.deep_copy() command is not working."
-        training_copy.insert_missing_values(fraction=0.9)   # randomly added missing values with high probability
-        assert not(training_data.nacnt()==training_copy.nacnt()), "h2o.deep_copy() command is not working."
-    except Exception as e:
-        assert False, "h2o.deep_copy() command is not working."
-
+    new_name = "new_frame"
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    training_copy = h2o.deep_copy(training_data, new_name)
+    assert_is_type(training_data, H2OFrame)
+    assert_is_type(training_copy, H2OFrame)
+    assert training_data.nacnt()==training_copy.nacnt(), "h2o.deep_copy() command is not working."
+    training_copy.insert_missing_values(fraction=0.9)   # randomly added missing values with high probability
+    assert not(training_data.nacnt()==training_copy.nacnt()), "h2o.deep_copy() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2odeep_copy)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odemo.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odemo.py
@@ -10,11 +10,8 @@ def h2odemo():
 
     Copied from pyunit_glm_demo.py
     """
-
-    try:
-        h2o.demo(funcname="glm", interactive=False, echo=True, test=True)
-    except Exception as e:
-        assert False, "h2o.demo() command not is working."
+    ret = h2o.demo(funcname="glm", interactive=False, echo=True, test=True)
+    assert ret is None
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2odemo)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odownload_all_logs.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odownload_all_logs.py
@@ -9,27 +9,24 @@ def h2odownload_all_logs():
     """
     Python API test: h2o.download_all_logs(dirname=u'.', filename=None)
     """
-    try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        Y = 3
-        X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
 
-        model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
-        model.train(x=X, y=Y, training_frame=training_data)
-        try:
-            results_dir = pyunit_utils.locate("results")    # find directory path to results folder
-            filename = "logs.csv"
-            dir_path = h2o.download_all_logs(results_dir, filename)       # save logs csv
-            full_path_filename = os.path.join(results_dir, filename)
-            assert dir_path == full_path_filename, "h2o.download_all_logs() command is not working."
-            assert os.path.isfile(full_path_filename), "h2o.download_all_logs() command is not working."
-        except Exception as e:
-            if 'File not found' in e.args[0]:
-                print("Directory is not writable.  h2o.download_all_logs() command is not tested.")
-            else:
-                assert False, "h2o.download_all_logs() command is not working."
+    model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
+    model.train(x=X, y=Y, training_frame=training_data)
+    try:
+        results_dir = pyunit_utils.locate("results")    # find directory path to results folder
+        filename = "logs.csv"
+        dir_path = h2o.download_all_logs(results_dir, filename)       # save logs csv
+        full_path_filename = os.path.join(results_dir, filename)
+        assert dir_path == full_path_filename, "h2o.download_all_logs() command is not working."
+        assert os.path.isfile(full_path_filename), "h2o.download_all_logs() command is not working."
     except Exception as e:
-        assert False, "h2o.download_all_logs() command is not working."
+        if 'File not found' in e.args[0]:
+            print("Directory is not writable.  h2o.download_all_logs() command is not tested.")
+        else:
+            assert False, "h2o.download_all_logs() command is not working."
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odownload_csv.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odownload_csv.py
@@ -8,21 +8,17 @@ def h2odownload_csv():
     """
     Python API test: h2o.download_csv(data, filename)
     """
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
     try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        try:
-            results_dir = pyunit_utils.locate("results")    # find directory path to results folder
-            filename = os.path.join(results_dir, "benign.csv")
-            h2o.download_csv(training_data, filename)       # save csv
-            assert os.path.isfile(filename), "h2o.download_csv() command is not working."
-        except Exception as e:
-            if 'File not found' in e.args[0]:
-                print("Directory is not writable.  h2o.download_csv() command is not tested.")
-            else:
-                assert False, "h2o.download_csvresult() command is not working."
+        results_dir = pyunit_utils.locate("results")    # find directory path to results folder
+        filename = os.path.join(results_dir, "benign.csv")
+        h2o.download_csv(training_data, filename)       # save csv
+        assert os.path.isfile(filename), "h2o.download_csv() command is not working."
     except Exception as e:
-        assert False, "h2o.download_csv() command is not working."
-
+        if 'File not found' in e.args[0]:
+            print("Directory is not writable.  h2o.download_csv() command is not tested.")
+        else:
+            assert False, "h2o.download_csvresult() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2odownload_csv)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odownload_pojo.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2odownload_pojo.py
@@ -11,20 +11,17 @@ def h2odownload_pojo():
 
     Copied from glm_download_pojo.py
     """
+    h2o_df = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate.csv"))
+    h2o_df['CAPSULE'] = h2o_df['CAPSULE'].asfactor()
+    binomial_fit = H2OGeneralizedLinearEstimator(family = "binomial")
+    binomial_fit.train(y = "CAPSULE", x = ["AGE", "RACE", "PSA", "GLEASON"], training_frame = h2o_df)
     try:
-        h2o_df = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate.csv"))
-        h2o_df['CAPSULE'] = h2o_df['CAPSULE'].asfactor()
-        binomial_fit = H2OGeneralizedLinearEstimator(family = "binomial")
-        binomial_fit.train(y = "CAPSULE", x = ["AGE", "RACE", "PSA", "GLEASON"], training_frame = h2o_df)
-        try:
-            results_dir = pyunit_utils.locate("results")    # find directory path to results folder
-            h2o.download_pojo(binomial_fit,path=results_dir)
-            assert os.path.isfile(os.path.join(results_dir, "h2o-genmodel.jar")), "h2o.download_pojo() " \
-                                                                                  "command is not working."
-        except:
-            h2o.download_pojo(binomial_fit)     # just print pojo to screen if directory does not exists
-    except Exception as e:
-        assert False, "h2o.download_pojo() command is not working."
+        results_dir = pyunit_utils.locate("results")    # find directory path to results folder
+        h2o.download_pojo(binomial_fit,path=results_dir)
+        assert os.path.isfile(os.path.join(results_dir, "h2o-genmodel.jar")), "h2o.download_pojo() " \
+                                                                              "command is not working."
+    except:
+        h2o.download_pojo(binomial_fit)     # just print pojo to screen if directory does not exists
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oexport_file.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oexport_file.py
@@ -9,27 +9,24 @@ def h2oexport_file():
     Python API test: h2o.export_file(frame, path, force=False, parts=1).  Note taht force=True is only honored if
     parts=1.  Otherwise, an error will be thrown.
     """
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
     try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        try:
-            results_dir = pyunit_utils.locate("results")    # find directory path to results folder
-            final_path = os.path.join(results_dir, 'frameData')
-            h2o.export_file(training_data, final_path, force=True, parts=1)       # save data
-            assert os.path.isfile(final_path), "h2o.export_file() command is not working."
-            final_dir_path = os.path.join(results_dir, 'multiFrame')
-            h2o.export_file(training_data, final_dir_path, force=True, parts=-1)
-            assert len(os.listdir(final_dir_path))>0, "h2o.export_file() command is not working."
-        except Exception as e:
-            if e.__class__.__name__=='ValueError' and 'File not found' in e.args[0]:
-                print("Directory is not writable.  h2o.export_file() command is not tested.")
-            else :
-                assert e.__class__.__name__=='H2OResponseError' and \
-                       'exportFrame: Cannot use path' in e.args[0]._props['dev_msg'], \
-                    "h2o.export_file() command is not working."
-                print("Directory: {0} is not empty.  Delete or empy it before re-run.  h2o.export_file() "
-                      "is not tested with multi-part export.".format(final_dir_path))
+        results_dir = pyunit_utils.locate("results")    # find directory path to results folder
+        final_path = os.path.join(results_dir, 'frameData')
+        h2o.export_file(training_data, final_path, force=True, parts=1)       # save data
+        assert os.path.isfile(final_path), "h2o.export_file() command is not working."
+        final_dir_path = os.path.join(results_dir, 'multiFrame')
+        h2o.export_file(training_data, final_dir_path, force=True, parts=-1)
+        assert len(os.listdir(final_dir_path))>0, "h2o.export_file() command is not working."
     except Exception as e:
-        assert False, "h2o.export_file() command is not working."
+        if e.__class__.__name__=='ValueError' and 'File not found' in e.args[0]:
+            print("Directory is not writable.  h2o.export_file() command is not tested.")
+        else :
+            assert e.__class__.__name__=='H2OResponseError' and \
+                   'exportFrame: Cannot use path' in e.args[0]._props['dev_msg'], \
+                "h2o.export_file() command is not working."
+            print("Directory: {0} is not empty.  Delete or empy it before re-run.  h2o.export_file() "
+                  "is not tested with multi-part export.".format(final_dir_path))
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oframe.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oframe.py
@@ -10,15 +10,11 @@ def h2oframe():
     """
     Python API test: h2o.frame(frame_id)
     """
-    try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        frame_summary = h2o.frame(training_data.frame_id)
-        assert_is_type(frame_summary, H2OResponse)
-        assert frame_summary["frames"][0]['rows']==training_data.nrow, "h2o.frame() command is not working."
-        assert frame_summary["frames"][0]['column_count']==training_data.ncol, "h2o.frame() command is not working."
-    except Exception as e:
-        assert False, "h2o.frame() command is not working."
-
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    frame_summary = h2o.frame(training_data.frame_id)
+    assert_is_type(frame_summary, H2OResponse)
+    assert frame_summary["frames"][0]['rows']==training_data.nrow, "h2o.frame() command is not working."
+    assert frame_summary["frames"][0]['column_count']==training_data.ncol, "h2o.frame() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oframe)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oframes.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oframes.py
@@ -10,27 +10,23 @@ def h2oframes():
     """
     Python API test: h2o.frames()
     """
-    try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
-        prostate = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
-        all_frames_summary = h2o.frames()
-        assert_is_type(all_frames_summary, H2OResponse)
-        assert len(all_frames_summary['frames'])>=3, "h2o.frames() command is not working.  It did not fetch all 3 " \
-                                                     "frame summaries."
-        total_columns = training_data.ncol+arrestsH2O.ncol+prostate.ncol
-        summary_total_columns = all_frames_summary['frames'][0]['columns']+all_frames_summary['frames'][1]['columns']\
-                                +all_frames_summary['frames'][2]['columns']
-        assert total_columns==summary_total_columns, "Wrong frame columns are returned in frame summary.  " \
-                                                     "h2o.frames() command is not working."
-        total_rows = training_data.nrow+arrestsH2O.nrow+prostate.nrow
-        summary_total_rows = all_frames_summary['frames'][0]['rows']+all_frames_summary['frames'][1]['rows'] \
-                                +all_frames_summary['frames'][2]['rows']
-        assert total_rows==summary_total_rows, "Wrong frame rows are returned in frame summary.  " \
-                                               "h2o.frames() command is not working."
-    except Exception as e:
-        assert False, "h2o.frames() command is not working."
-
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
+    prostate = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    all_frames_summary = h2o.frames()
+    assert_is_type(all_frames_summary, H2OResponse)
+    assert len(all_frames_summary['frames'])>=3, "h2o.frames() command is not working.  It did not fetch all 3 " \
+                                                 "frame summaries."
+    total_columns = training_data.ncol+arrestsH2O.ncol+prostate.ncol
+    summary_total_columns = all_frames_summary['frames'][0]['columns']+all_frames_summary['frames'][1]['columns']\
+                            +all_frames_summary['frames'][2]['columns']
+    assert total_columns==summary_total_columns, "Wrong frame columns are returned in frame summary.  " \
+                                                 "h2o.frames() command is not working."
+    total_rows = training_data.nrow+arrestsH2O.nrow+prostate.nrow
+    summary_total_rows = all_frames_summary['frames'][0]['rows']+all_frames_summary['frames'][1]['rows'] \
+                            +all_frames_summary['frames'][2]['rows']
+    assert total_rows==summary_total_rows, "Wrong frame rows are returned in frame summary.  " \
+                                           "h2o.frames() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oframes)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_frame.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_frame.py
@@ -10,13 +10,9 @@ def h2oget_frame():
     """
     Python API test: h2o.get_frame(frame_id)
     """
-    try:
-        frame1 = h2o.import_file(pyunit_utils.locate("smalldata/jira/hexdev_29.csv"))
-        frame2 = h2o.get_frame(frame1.frame_id)
-        assert_is_type(frame2, H2OFrame)
-    except Exception as e:
-        assert False, "h2o.get_frame() command is not working."
-
+    frame1 = h2o.import_file(pyunit_utils.locate("smalldata/jira/hexdev_29.csv"))
+    frame2 = h2o.get_frame(frame1.frame_id)
+    assert_is_type(frame2, H2OFrame)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oget_frame)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_grid.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_grid.py
@@ -14,35 +14,31 @@ def h2oget_grid():
 
     Copy from pyunit_gbm_random_grid.py
     """
-    try:
-        air_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip"), destination_frame="air.hex")
-        myX = ["DayofMonth","DayOfWeek"]
+    air_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip"), destination_frame="air.hex")
+    myX = ["DayofMonth","DayOfWeek"]
 
-        hyper_parameters = {
-            'learn_rate':[0.1,0.2],
-            'max_depth':[2,3],
-            'ntrees':[5,10]
-        }
+    hyper_parameters = {
+        'learn_rate':[0.1,0.2],
+        'max_depth':[2,3],
+        'ntrees':[5,10]
+    }
 
-        search_crit = {'strategy': "RandomDiscrete",
-                       'max_models': 5,
-                       'seed' : 1234,
-                       'stopping_rounds' : 3,
-                       'stopping_metric' : "AUTO",
-                       'stopping_tolerance': 1e-2
-                       }
+    search_crit = {'strategy': "RandomDiscrete",
+                   'max_models': 5,
+                   'seed' : 1234,
+                   'stopping_rounds' : 3,
+                   'stopping_metric' : "AUTO",
+                   'stopping_tolerance': 1e-2
+                   }
 
-        air_grid = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_parameters, search_criteria=search_crit)
-        air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, distribution="bernoulli")
+    air_grid = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_parameters, search_criteria=search_crit)
+    air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, distribution="bernoulli")
 
-        fetched_grid = h2o.get_grid(str(air_grid.grid_id))
-        assert_is_type(fetched_grid, H2OGridSearch)
-        assert len(air_grid.get_grid())==5, "h2o.get_grid() is command not working.  " \
-                                            "It returned the wrong number of models."
-        assert len(air_grid.get_grid())==len(fetched_grid.get_grid()), "h2o.get_grid() is command not working."
-    except Exception as e:
-        assert False, "h2o.get_grid() command is not working."
-
+    fetched_grid = h2o.get_grid(str(air_grid.grid_id))
+    assert_is_type(fetched_grid, H2OGridSearch)
+    assert len(air_grid.get_grid())==5, "h2o.get_grid() is command not working.  " \
+                                        "It returned the wrong number of models."
+    assert len(air_grid.get_grid())==len(fetched_grid.get_grid()), "h2o.get_grid() is command not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oget_grid)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_model.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_model.py
@@ -10,22 +10,17 @@ def h2oget_model():
     """
     Python API test: h2o.get_model(model_id)
     """
-    try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        Y = 3
-        X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
 
-        model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
-        model.train(x=X, y=Y, training_frame=training_data)
-        model2 = h2o.get_model(model.model_id)
-        assert_is_type( model, H2OGeneralizedLinearEstimator)
-        assert_is_type(model2, H2OGeneralizedLinearEstimator)
-        assert (model._model_json['output']['model_category']==model2._model_json['output']['model_category']) and \
-               (model2._model_json['output']['model_category']=='Binomial'), "h2o.get_model() command is not working"
-
-    except Exception as e:
-        assert False, "h2o.get_model() command is not working"
-
+    model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
+    model.train(x=X, y=Y, training_frame=training_data)
+    model2 = h2o.get_model(model.model_id)
+    assert_is_type( model, H2OGeneralizedLinearEstimator)
+    assert_is_type(model2, H2OGeneralizedLinearEstimator)
+    assert (model._model_json['output']['model_category']==model2._model_json['output']['model_category']) and \
+           (model2._model_json['output']['model_category']=='Binomial'), "h2o.get_model() command is not working"
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oget_model)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_timezone_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_timezone_DEPRECATED.py
@@ -13,17 +13,13 @@ def h2oget_timezone():
 
     Copy from pyunit_get_set_list_timezones.py
     """
-    try:
-        origTZ = h2o.get_timezone()
-        print("Original timezone: {0}".format(origTZ))
+    origTZ = h2o.get_timezone()
+    print("Original timezone: {0}".format(origTZ))
 
-        timezones = h2o.list_timezones()
-        assert_is_type(timezones, H2OFrame)
-        assert timezones.nrow==460, "h2o.get_timezone() returns frame with wrong row number."
-        assert timezones.ncol==1, "h2o.get_timezone() returns frame with wrong column number."
-    except Exception as e:
-        assert False, "h2o.get_timezone() command is not working."
-
+    timezones = h2o.list_timezones()
+    assert_is_type(timezones, H2OFrame)
+    assert timezones.nrow==460, "h2o.get_timezone() returns frame with wrong row number."
+    assert timezones.ncol==1, "h2o.get_timezone() returns frame with wrong column number."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oget_timezone)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oimport_file.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oimport_file.py
@@ -11,25 +11,20 @@ def h2oimport_file():
     Python API test: h2o.import_file(path=None, destination_frame=None, parse=True, header=0, sep=None,
     col_names=None, col_types=None, na_strings=None)
     """
-    try:
-        col_types=['enum','numeric','enum','enum','enum','numeric','numeric','numeric']
-        col_headers = ["CAPSULE","AGE","RACE","DPROS","DCAPS","PSA","VOL","GLEASON"]
-        hex_key = "training_data.hex"
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"),
-                                        destination_frame=hex_key, header=1, sep = ',',
-                                        col_names=col_headers, col_types=col_types, na_strings=["NA"])
-        assert_is_type(training_data, H2OFrame)
-        assert training_data.frame_id == hex_key, "frame_id was not assigned correctly.  h2o.import_file() is not" \
-                                                  " working."
-        assert len(set(training_data.col_names) & set(col_headers))==len(col_headers), "column names are incorrect.  " \
-                                                                                       "h2o.import_file() not working."
-        assert training_data.nrow==380, "number of rows is incorrect.  h2o.import_file() is not working."
-        assert training_data.ncol==8, "number of columns is incorrect.  h2o.import_file() is not working."
-        assert sum(training_data.nacnt())==3, "NA count is incorrect.  h2o.import_file() is not working."
-
-    except Exception as e:
-        assert False, "h2o.import_file() command is not working."
-
+    col_types=['enum','numeric','enum','enum','enum','numeric','numeric','numeric']
+    col_headers = ["CAPSULE","AGE","RACE","DPROS","DCAPS","PSA","VOL","GLEASON"]
+    hex_key = "training_data.hex"
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"),
+                                    destination_frame=hex_key, header=1, sep = ',',
+                                    col_names=col_headers, col_types=col_types, na_strings=["NA"])
+    assert_is_type(training_data, H2OFrame)
+    assert training_data.frame_id == hex_key, "frame_id was not assigned correctly.  h2o.import_file() is not" \
+                                              " working."
+    assert len(set(training_data.col_names) & set(col_headers))==len(col_headers), "column names are incorrect.  " \
+                                                                                   "h2o.import_file() not working."
+    assert training_data.nrow==380, "number of rows is incorrect.  h2o.import_file() is not working."
+    assert training_data.ncol==8, "number of columns is incorrect.  h2o.import_file() is not working."
+    assert sum(training_data.nacnt())==3, "NA count is incorrect.  h2o.import_file() is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oimport_file)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oimport_sql_select.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oimport_sql_select.py
@@ -11,12 +11,9 @@ def h2oimport_sql_select():
     Not a real test, just make sure arguments are not changed.
     """
     command_list = ['connection_url', 'select_query', 'username', 'password', 'optimize']
-    try:
-        allargs = inspect.getargspec(h2o.import_sql_select)
-        for arg_name in command_list:
-            assert arg_name in allargs.args, "argument "+arg_name+" is missing from h2o.import_sql_select() command"
-    except Exception as e:
-        assert False, "h2o.import_sql_select() command is not working."
+    allargs = inspect.getargspec(h2o.import_sql_select)
+    for arg_name in command_list:
+        assert arg_name in allargs.args, "argument "+arg_name+" is missing from h2o.import_sql_select() command"
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oimport_sql_select)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oimport_sql_table.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oimport_sql_table.py
@@ -12,12 +12,9 @@ def h2oimport_sql_table():
     """
 
     command_list = ['connection_url', 'table', 'username', 'password', 'columns', 'optimize']
-    try:
-        allargs = inspect.getargspec(h2o.import_sql_table)
-        for arg_name in command_list:
-            assert arg_name in allargs.args, "argument "+arg_name+" is missing from h2o.import_sql_table() command"
-    except Exception as e:
-        assert False, "h2o.import_sql_table() command is not working."
+    allargs = inspect.getargspec(h2o.import_sql_table)
+    for arg_name in command_list:
+        assert arg_name in allargs.args, "argument "+arg_name+" is missing from h2o.import_sql_table() command"
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oimport_sql_table)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ointeraction.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ointeraction.py
@@ -12,40 +12,36 @@ def h2ointeraction():
 
     Copied from pyunit_interaction.py
     """
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
 
-    try:
-        iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    # add a couple of factor columns to iris
+    iris = iris.cbind(iris[4] == "Iris-setosa")
+    iris[5] = iris[5].asfactor()
+    iris.set_name(5,"C6")
 
-        # add a couple of factor columns to iris
-        iris = iris.cbind(iris[4] == "Iris-setosa")
-        iris[5] = iris[5].asfactor()
-        iris.set_name(5,"C6")
+    iris = iris.cbind(iris[4] == "Iris-virginica")
+    iris[6] = iris[6].asfactor()
+    iris.set_name(6, name="C7")
 
-        iris = iris.cbind(iris[4] == "Iris-virginica")
-        iris[6] = iris[6].asfactor()
-        iris.set_name(6, name="C7")
+    # create a frame of the two-way interactions
+    two_way_interactions = h2o.interaction(iris, factors=[4,5,6], pairwise=True, max_factors=10000,
+                                           min_occurrence=1)
+    assert_is_type(two_way_interactions, H2OFrame)
+    assert two_way_interactions.nrow == 150 and two_way_interactions.ncol == 3, \
+        "Expected 150 rows and 3 columns, but got {0} rows and {1} " \
+        "columns".format(two_way_interactions.nrow, two_way_interactions.ncol)
+    levels1 = two_way_interactions.levels()[0]
+    levels2 = two_way_interactions.levels()[1]
+    levels3 = two_way_interactions.levels()[2]
 
-        # create a frame of the two-way interactions
-        two_way_interactions = h2o.interaction(iris, factors=[4,5,6], pairwise=True, max_factors=10000,
-                                               min_occurrence=1)
-        assert_is_type(two_way_interactions, H2OFrame)
-        assert two_way_interactions.nrow == 150 and two_way_interactions.ncol == 3, \
-            "Expected 150 rows and 3 columns, but got {0} rows and {1} " \
-            "columns".format(two_way_interactions.nrow, two_way_interactions.ncol)
-        levels1 = two_way_interactions.levels()[0]
-        levels2 = two_way_interactions.levels()[1]
-        levels3 = two_way_interactions.levels()[2]
-
-        assert levels1 == ["Iris-setosa_1", "Iris-versicolor_0", "Iris-virginica_0"], \
-            "Expected the following levels {0}, but got {1}".format(["Iris-setosa_1", "Iris-versicolor_0", "Iris-virginica_0"],
-                                                                    levels1)
-        assert levels2 == ["Iris-setosa_0", "Iris-versicolor_0", "Iris-virginica_1"], \
-            "Expected the following levels {0}, but got {1}".format(["Iris-setosa_0", "Iris-versicolor_0", "Iris-virginica_1"],
-                                                                    levels2)
-        assert levels3 == ["0_0", "1_0", "0_1"], "Expected the following levels {0}, but got {1}".format(["0_0", "1_0", "0_1"],
-                                                                                                         levels3)
-    except:
-        assert False, "h2o.interaction() command not is working."
+    assert levels1 == ["Iris-setosa_1", "Iris-versicolor_0", "Iris-virginica_0"], \
+        "Expected the following levels {0}, but got {1}".format(["Iris-setosa_1", "Iris-versicolor_0", "Iris-virginica_0"],
+                                                                levels1)
+    assert levels2 == ["Iris-setosa_0", "Iris-versicolor_0", "Iris-virginica_1"], \
+        "Expected the following levels {0}, but got {1}".format(["Iris-setosa_0", "Iris-versicolor_0", "Iris-virginica_1"],
+                                                                levels2)
+    assert levels3 == ["0_0", "1_0", "0_1"], "Expected the following levels {0}, but got {1}".format(["0_0", "1_0", "0_1"],
+                                                                                                     levels3)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2ointeraction)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olazy_import.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olazy_import.py
@@ -3,16 +3,15 @@ import sys
 sys.path.insert(1,"../../../")
 from tests import pyunit_utils
 import h2o
+from h2o.utils.typechecks import assert_is_type
+
 
 def h2olazy_import():
     """
     Python API test: h2o.lazy_import(path)
     """
-    try:
-        training_data = h2o.lazy_import(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
-    except Exception as e:
-        assert False, "h2o.lazy_import() command is not working."
-
+    training_data = h2o.lazy_import(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    assert_is_type(training_data, list)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2olazy_import)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olist_timezones_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olist_timezones_DEPRECATED.py
@@ -11,14 +11,10 @@ def h2olist_timezones():
     Python API test: h2o.list_timezones()
     Deprecated, use h2o.cluster().list_timezones().
     """
-    try:
-        timezones = h2o.list_timezones()
-        assert_is_type(timezones, H2OFrame)
-        assert timezones.nrow==460, "h2o.get_timezone() returns frame with wrong row number."
-        assert timezones.ncol==1, "h2o.get_timezone() returns frame with wrong column number."
-    except Exception as e:
-        assert False, "h2o.list_timezones() command is not working."
-
+    timezones = h2o.list_timezones()
+    assert_is_type(timezones, H2OFrame)
+    assert timezones.nrow==460, "h2o.get_timezone() returns frame with wrong row number."
+    assert timezones.ncol==1, "h2o.get_timezone() returns frame with wrong column number."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2olist_timezones)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oload_dataset.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oload_dataset.py
@@ -10,12 +10,8 @@ def h2oload_dataset():
     """
     Python API test: h2o.load_dataset(relative_path)
     """
-
-    try:
-        prostate = h2o.load_dataset("prostate")
-        assert_is_type(prostate, H2OFrame)
-    except Exception as e:
-        assert False, "h2o.load_dataset() command not is working."
+    prostate = h2o.load_dataset("prostate")
+    assert_is_type(prostate, H2OFrame)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oload_dataset)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oload_model.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oload_model.py
@@ -10,30 +10,26 @@ def h2oapi():
     """
     Python API test: h2o.load_model(path)
     """
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+
+    model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
+    model.train(x=X, y=Y, training_frame=training_data)
     try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        Y = 3
-        X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+        results_dir = pyunit_utils.locate("results")    # find directory path to results folder
+        h2o.save_model(model, path=results_dir, force=True)       # save model
+        full_path_filename = os.path.join(results_dir, model._id)
+        assert os.path.isfile(full_path_filename), "h2o.save_model() command is not working."
+        model_reloaded = h2o.load_model(full_path_filename)
+        assert_is_type(model, H2OGeneralizedLinearEstimator)
+        assert_is_type(model_reloaded, H2OGeneralizedLinearEstimator)
 
-        model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
-        model.train(x=X, y=Y, training_frame=training_data)
-        try:
-            results_dir = pyunit_utils.locate("results")    # find directory path to results folder
-            h2o.save_model(model, path=results_dir, force=True)       # save model
-            full_path_filename = os.path.join(results_dir, model._id)
-            assert os.path.isfile(full_path_filename), "h2o.save_model() command is not working."
-            model_reloaded = h2o.load_model(full_path_filename)
-            assert_is_type(model, H2OGeneralizedLinearEstimator)
-            assert_is_type(model_reloaded, H2OGeneralizedLinearEstimator)
-
-        except Exception as e:
-            if 'File not found' in e.args[0]:
-                print("Directory is not writable.  h2o.load_model() command is not tested.")
-            else:
-                assert False, "h2o.load_model() command is not working."
     except Exception as e:
-        assert False, "h2o.load_model() command is not working."
-
+        if 'File not found' in e.args[0]:
+            print("Directory is not writable.  h2o.load_model() command is not tested.")
+        else:
+            assert False, "h2o.load_model() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oapi)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olog_and_echo.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2olog_and_echo.py
@@ -8,11 +8,8 @@ def h2olog_and_echo():
     """
     Python API test: h2o.log_and_echo(message=u'')
     """
-    try:
-        h2o.log_and_echo("Testing h2o.log_and_echo")
-    except Exception as e:
-        assert False, "h2o.log_and_echo() command is not working."
-
+    ret = h2o.log_and_echo("Testing h2o.log_and_echo")
+    assert ret is None
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2olog_and_echo)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ols.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2ols.py
@@ -11,16 +11,13 @@ def h2ols():
     """
     Python API test: h2o.ls()
     """
-    try:
-        iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
-        lsObject = h2o.ls()
-        # check return type as DataFrame
-        assert_is_type(lsObject, DataFrame)
-        # check that our frame info was included in the lsObject
-        assert lsObject.values[0][0] == str(iris.frame_id), \
-            "Frame info iris.hex should have been found but h2o.ls() command failed."
-    except Exception as e:
-        assert False, "h2o.ls() command is not working."
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    lsObject = h2o.ls()
+    # check return type as DataFrame
+    assert_is_type(lsObject, DataFrame)
+    # check that our frame info was included in the lsObject
+    assert lsObject.values[0][0] == str(iris.frame_id), \
+        "Frame info iris.hex should have been found but h2o.ls() command failed."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2ols)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2omake_metrics.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2omake_metrics.py
@@ -13,35 +13,32 @@ def h2omake_metrics():
 
     Copied from pyunit_make_metrics.py
     """
-    try:
-        fr = h2o.import_file(pyunit_utils.locate("smalldata/logreg/prostate.csv"))
-        fr["CAPSULE"] = fr["CAPSULE"].asfactor()
-        fr["RACE"] = fr["RACE"].asfactor()
+    fr = h2o.import_file(pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    fr["CAPSULE"] = fr["CAPSULE"].asfactor()
+    fr["RACE"] = fr["RACE"].asfactor()
 
-        response = "RACE"
-        predictors = list(set(fr.names) - {"ID", response})
-        model = H2OGradientBoostingEstimator(distribution="multinomial", ntrees=2, max_depth=3, min_rows=1,
-                                             learn_rate=0.01, nbins=20)
-        model.train(x=predictors, y=response, training_frame=fr)
-        predicted = h2o.assign(model.predict(fr)[1:], "pred")
-        actual = h2o.assign(fr[response].asfactor(), "act")
-        domain = fr[response].levels()[0]
+    response = "RACE"
+    predictors = list(set(fr.names) - {"ID", response})
+    model = H2OGradientBoostingEstimator(distribution="multinomial", ntrees=2, max_depth=3, min_rows=1,
+                                         learn_rate=0.01, nbins=20)
+    model.train(x=predictors, y=response, training_frame=fr)
+    predicted = h2o.assign(model.predict(fr)[1:], "pred")
+    actual = h2o.assign(fr[response].asfactor(), "act")
+    domain = fr[response].levels()[0]
 
-        m0 = model.model_performance(train=True)
-        m1 = h2o.make_metrics(predicted, actual, domain=domain)
-        m2 = h2o.make_metrics(predicted, actual)
-        assert_is_type(m1, H2OMultinomialModelMetrics)
-        assert_is_type(m2, H2OMultinomialModelMetrics)
-        assert abs(m0.mse() - m1.mse()) < 1e-5
-        assert abs(m0.rmse() - m1.rmse()) < 1e-5
-        assert abs(m0.logloss() - m1.logloss()) < 1e-5
-        assert abs(m0.mean_per_class_error() - m1.mean_per_class_error()) < 1e-5
-        assert abs(m2.mse() - m1.mse()) < 1e-5
-        assert abs(m2.rmse() - m1.rmse()) < 1e-5
-        assert abs(m2.logloss() - m1.logloss()) < 1e-5
-        assert abs(m2.mean_per_class_error() - m1.mean_per_class_error()) < 1e-5
-    except Exception as e:
-        assert False, "h2o.make_metrics() command not is working."
+    m0 = model.model_performance(train=True)
+    m1 = h2o.make_metrics(predicted, actual, domain=domain)
+    m2 = h2o.make_metrics(predicted, actual)
+    assert_is_type(m1, H2OMultinomialModelMetrics)
+    assert_is_type(m2, H2OMultinomialModelMetrics)
+    assert abs(m0.mse() - m1.mse()) < 1e-5
+    assert abs(m0.rmse() - m1.rmse()) < 1e-5
+    assert abs(m0.logloss() - m1.logloss()) < 1e-5
+    assert abs(m0.mean_per_class_error() - m1.mean_per_class_error()) < 1e-5
+    assert abs(m2.mse() - m1.mse()) < 1e-5
+    assert abs(m2.rmse() - m1.rmse()) < 1e-5
+    assert abs(m2.logloss() - m1.logloss()) < 1e-5
+    assert abs(m2.mean_per_class_error() - m1.mean_per_class_error()) < 1e-5
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2omake_metrics)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2onetwork_test_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2onetwork_test_DEPRECATED.py
@@ -9,11 +9,8 @@ def h2onetwork_test():
     Python API test: h2o.network_test()
     Deprecated, use h2o.cluster().network_test().
     """
-    try:
-        h2o.network_test()    # no return type
-    except Exception as e:
-        assert False, "h2o.network_test() command is not working."
-
+    ret = h2o.network_test()    # no return type
+    assert ret is None
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2onetwork_test)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oparse_raw.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oparse_raw.py
@@ -12,16 +12,12 @@ def h2oparse_raw():
 
     copied from pyunit_hexdev_29_parse_false.py
     """
-    try:
-        fraw = h2o.import_file(pyunit_utils.locate("smalldata/jira/hexdev_29.csv"), parse=False)
-        assert isinstance(fraw, list)
+    fraw = h2o.import_file(pyunit_utils.locate("smalldata/jira/hexdev_29.csv"), parse=False)
+    assert isinstance(fraw, list)
 
-        fhex = h2o.parse_raw(h2o.parse_setup(fraw), id='hexdev_29.hex', first_line_is_header=0)
-        fhex.summary()
-        assert_is_type(fhex, H2OFrame)
-    except Exception as e:
-        assert False, "h2o.parse_raw() command is not working."
-
+    fhex = h2o.parse_raw(h2o.parse_setup(fraw), id='hexdev_29.hex', first_line_is_header=0)
+    fhex.summary()
+    assert_is_type(fhex, H2OFrame)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oparse_raw)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oparse_setup.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oparse_setup.py
@@ -11,19 +11,15 @@ def h2oparse_setup():
     Python API test: h2o.parse_setup(raw_frames, destination_frame=None, header=0, separator=None, column_names=None,
      column_types=None, na_strings=None)
     """
-    try:
-        col_types=['enum','numeric','enum','enum','enum','numeric','numeric','numeric']
-        col_headers = ["CAPSULE","AGE","RACE","DPROS","DCAPS","PSA","VOL","GLEASON"]
-        hex_key = "training_data.hex"
+    col_types=['enum','numeric','enum','enum','enum','numeric','numeric','numeric']
+    col_headers = ["CAPSULE","AGE","RACE","DPROS","DCAPS","PSA","VOL","GLEASON"]
+    hex_key = "training_data.hex"
 
-        fraw = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"), parse=False)
-        setup = h2o.parse_setup(fraw, destination_frame=hex_key, header=1, separator=',', column_names=col_headers,
-                                column_types=col_types, na_strings=["NA"])
-        assert_is_type(setup, H2OResponse)
-        assert setup["number_columns"]==len(col_headers), "h2o.parse_setup() command is not working."
-    except Exception as e:
-        assert False, "h2o.parse_setup() command is not working."
-
+    fraw = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"), parse=False)
+    setup = h2o.parse_setup(fraw, destination_frame=hex_key, header=1, separator=',', column_names=col_headers,
+                            column_types=col_types, na_strings=["NA"])
+    assert_is_type(setup, H2OResponse)
+    assert setup["number_columns"]==len(col_headers), "h2o.parse_setup() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oparse_setup)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2orapids.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2orapids.py
@@ -9,12 +9,8 @@ def h2orapids():
     """
     Python API test: h2o.rapids(expr)
     """
-    try:
-        rapidTime = h2o.rapids("(getTimeZone)")["string"]
-        print(str(rapidTime))
-    except Exception as e:
-        assert False, "h2o.rapids() command is not working."
-
+    rapidTime = h2o.rapids("(getTimeZone)")["string"]
+    print(str(rapidTime))
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2orapids)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oremove_all.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oremove_all.py
@@ -13,12 +13,8 @@ def h2oremove_all():
     by just checking the argument list which should be empty.
     """
     # call with no arguments
-    try:
-        allargs = inspect.getargspec(h2o.remove_all)
-        assert len(allargs.args)==0, "h2o.remove_all() should have no arguments!"
-    except Exception as e:
-        assert False, "h2o.remove_all() command is not working."
-
+    allargs = inspect.getargspec(h2o.remove_all)
+    assert len(allargs.args)==0, "h2o.remove_all() should have no arguments!"
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oremove_all)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2osave_model.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2osave_model.py
@@ -9,25 +9,21 @@ def h2osave_model():
     """
     Python API test: h2o.save_model(model, path=u'', force=False)
     """
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+
+    model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
+    model.train(x=X, y=Y, training_frame=training_data)
     try:
-        training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
-        Y = 3
-        X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
-
-        model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
-        model.train(x=X, y=Y, training_frame=training_data)
-        try:
-            results_dir = pyunit_utils.locate("results")    # find directory path to results folder
-            h2o.save_model(model, path=results_dir, force=True)       # save model
-            assert os.path.isfile(os.path.join(results_dir, model._id)), "h2o.save_model() command is not working."
-        except Exception as e:
-            if 'File not found' in e.args[0]:
-                print("Directory is not writable.  h2o.save_model() command is not tested.")
-            else:
-                assert False, "h2o.save_model() command is not working."
+        results_dir = pyunit_utils.locate("results")    # find directory path to results folder
+        h2o.save_model(model, path=results_dir, force=True)       # save model
+        assert os.path.isfile(os.path.join(results_dir, model._id)), "h2o.save_model() command is not working."
     except Exception as e:
-        assert False, "h2o.save_model() command is not working."
-
+        if 'File not found' in e.args[0]:
+            print("Directory is not writable.  h2o.save_model() command is not tested.")
+        else:
+            assert False, "h2o.save_model() command is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2osave_model)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oset_timezone_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oset_timezone_DEPRECATED.py
@@ -12,25 +12,21 @@ def h2oset_timezone():
 
     Copy from pyunit_get_set_list_timezones.py
     """
-    try:
-        origTZ = h2o.get_timezone()
-        print("Original timezone: {0}".format(origTZ))
+    origTZ = h2o.get_timezone()
+    print("Original timezone: {0}".format(origTZ))
 
-        timezones = h2o.list_timezones()
-        # don't use the first one..it's a header for the table
-        print("timezones[0]:", timezones[0])
-        zone = timezones[random.randint(1,timezones.nrow-1),0].split(" ")[1].split(",")[0]
-        print("Setting the timezone: {0}".format(zone))
-        h2o.set_timezone(zone)
+    timezones = h2o.list_timezones()
+    # don't use the first one..it's a header for the table
+    print("timezones[0]:", timezones[0])
+    zone = timezones[random.randint(1,timezones.nrow-1),0].split(" ")[1].split(",")[0]
+    print("Setting the timezone: {0}".format(zone))
+    h2o.set_timezone(zone)
 
-        newTZ = h2o.get_timezone()
-        assert newTZ == zone, "Expected new timezone to be {0}, but got {01}".format(zone, newTZ)
+    newTZ = h2o.get_timezone()
+    assert newTZ == zone, "Expected new timezone to be {0}, but got {01}".format(zone, newTZ)
 
-        print("Setting the timezone back to original: {0}".format(origTZ))
-        h2o.set_timezone(origTZ)
-    except Exception as e:
-        assert False, "h2o.set_timezone() command is not working."
-
+    print("Setting the timezone back to original: {0}".format(origTZ))
+    h2o.set_timezone(origTZ)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oset_timezone)

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oshutdown_DEPRECATED.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oshutdown_DEPRECATED.py
@@ -23,13 +23,10 @@ def h2oshutdown():
         assert_is_type(e, TypeError)
         assert "badparam" in e.args[0], "h2o.shutdown() command is not working."
 
-    try:
-        thread = threading.Thread(target=call_shutdown)
-        thread.daemon =True
-        thread.start()
-        thread.join(1.0)
-    except Exception as e:
-        assert False, "h2o.shutdown() command is not working."
+    thread = threading.Thread(target=call_shutdown)
+    thread.daemon =True
+    thread.start()
+    thread.join(1.0)
 
 def call_shutdown():
     h2o.shutdown(prompt=True)   # call shutdown but do not actually shut anything down.

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oupload_file.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oupload_file.py
@@ -16,24 +16,20 @@ def h2oupload_file():
     in the file will result reading in the column names as data.  Since the column names may not be the right column
     type, it will be counted as NAs.
     """
-    try:
-        col_types=['enum','numeric','enum','enum','enum','numeric','numeric','numeric']
-        col_headers = ["CAPSULE","AGE","RACE","DPROS","DCAPS","PSA","VOL","GLEASON"]
-        hex_key = "training_data.hex"
-        training_data = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"),
-                                        destination_frame=hex_key, header=1, sep = ',',
-                                        col_names=col_headers, col_types=col_types, na_strings=["NA"])
-        assert_is_type(training_data, H2OFrame)
-        assert training_data.frame_id == hex_key, "frame_id was not assigned correctly.  h2o.upload_file() is not" \
-                                                  " working."
-        assert len(set(training_data.col_names) & set(col_headers))==len(col_headers), "column names are incorrect.  " \
-                                                             "h2o.upload_file() not working."
-        assert training_data.nrow==380, "number of rows is incorrect.  h2o.upload_file() is not working."
-        assert training_data.ncol==8, "number of columns is incorrect.  h2o.upload_file() is not working."
-        assert sum(training_data.nacnt())==3, "NA count is incorrect.  h2o.upload_file() is not working."
-
-    except Exception as e:
-        assert False, "h2o.upload_file() command is not working."
+    col_types=['enum','numeric','enum','enum','enum','numeric','numeric','numeric']
+    col_headers = ["CAPSULE","AGE","RACE","DPROS","DCAPS","PSA","VOL","GLEASON"]
+    hex_key = "training_data.hex"
+    training_data = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"),
+                                    destination_frame=hex_key, header=1, sep = ',',
+                                    col_names=col_headers, col_types=col_types, na_strings=["NA"])
+    assert_is_type(training_data, H2OFrame)
+    assert training_data.frame_id == hex_key, "frame_id was not assigned correctly.  h2o.upload_file() is not" \
+                                              " working."
+    assert len(set(training_data.col_names) & set(col_headers))==len(col_headers), "column names are incorrect.  " \
+                                                         "h2o.upload_file() not working."
+    assert training_data.nrow==380, "number of rows is incorrect.  h2o.upload_file() is not working."
+    assert training_data.ncol==8, "number of columns is incorrect.  h2o.upload_file() is not working."
+    assert sum(training_data.nacnt())==3, "NA count is incorrect.  h2o.upload_file() is not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oupload_file)

--- a/h2o-py/tests/testdir_jira/pyunit_hexdev_295_show.py
+++ b/h2o-py/tests/testdir_jira/pyunit_hexdev_295_show.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 sys.path.insert(1,"../../")
 import h2o

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3676,7 +3676,6 @@ h2o.merge <- function(x, y, by=intersect(names(x), names(y)), by.x=by, by.y=by, 
 #' @export
 h2o.arrange <- function(x, ...) {
   by <- as.character(substitute(list(...))[-1])
-  browser()
   ascend <- as.character(substitute(list(...))[-1]) # initialize to same length as by
   if (!length(by)) stop("Please provide at least one column to sort by")
   for (index in c(1:length(by))) {


### PR DESCRIPTION
1. Added python api tests for python commands found in  module Data Manipulation.

2. Changed API tests for cluster and removed the try/except unless we are interested in examining the error message.

3. Changed python documentation on data manipulation commands.  Some of them will give an error if applied to multi-column frames.  However, you only hit the error if you want to return the return H2O Frame.  Otherwise, everything will be fine even though you are getting junk.