### PR TITLE
Parser Hotfix, do not use stream parse for Parquet, it doens't support it

### DIFF
--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -818,7 +818,8 @@ public final class ParseDataset {
       try {
         switch( cpr ) {
         case NONE:
-          boolean disableParallelParse = (_keys.length > TOO_MANY_KEYS_COUNT) && (vec.nChunks() <= SMALL_FILE_NCHUNKS);
+          boolean disableParallelParse = (_keys.length > TOO_MANY_KEYS_COUNT) &&
+                  (vec.nChunks() <= SMALL_FILE_NCHUNKS) && _parseSetup._parse_type.isStreamParseSupported();
           if( _parseSetup._parse_type.isParallelParseSupported() && (! disableParallelParse)) {
             new DistributedParse(_vg, localSetup, _vecIdStart, chunkStartIdx, this, key, vec.nChunks()).dfork(vec).getResult(false);
             for( int i = 0; i < vec.nChunks(); ++i )

--- a/h2o-core/src/main/java/water/parser/ParserInfo.java
+++ b/h2o-core/src/main/java/water/parser/ParserInfo.java
@@ -12,14 +12,22 @@ public class ParserInfo extends Iced<ParserInfo> {
   final int prior;
   /** Does this parser support parallel parse. */
   final boolean isParallelParseSupported;
+  /** Does this parser support stream parse. */
+  final boolean isStreamParseSupported;
   /** Does this parser need post update of vector categoricals. */
   final boolean isDomainProvided;
 
-  public ParserInfo(String name, int prior, boolean isParallelParseSupported, boolean isDomainProvided) {
+
+  public ParserInfo(String name, int prior, boolean isParallelParseSupported, boolean isStreamParseSupported,
+                    boolean isDomainProvided) {
     this.name = name;
     this.prior = prior;
     this.isParallelParseSupported = isParallelParseSupported;
+    this.isStreamParseSupported = isStreamParseSupported;
     this.isDomainProvided = isDomainProvided;
+  }
+  public ParserInfo(String name, int prior, boolean isParallelParseSupported, boolean isDomainProvided) {
+    this(name, prior, isParallelParseSupported, true, isDomainProvided);
   }
   public ParserInfo(String name, int prior, boolean isParallelParseSupported) {
     this(name, prior, isParallelParseSupported, false);
@@ -38,6 +46,11 @@ public class ParserInfo extends Iced<ParserInfo> {
   /** Does the parser support parallel parse? */
   public boolean isParallelParseSupported() {
     return isParallelParseSupported;
+  }
+
+  /** Does the parser support stream parse? */
+  public boolean isStreamParseSupported() {
+    return isStreamParseSupported;
   }
 
   @Override

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Field;
 public class ParquetParserProvider extends ParserProvider {
 
   /* Setup for this parser */
-  static ParserInfo PARQUET_INFO = new ParserInfo("PARQUET", DefaultParserProviders.MAX_CORE_PRIO + 30, true, false);
+  static ParserInfo PARQUET_INFO = new ParserInfo("PARQUET", DefaultParserProviders.MAX_CORE_PRIO + 30, true, false, false);
 
   @Override
   public ParserInfo info() {


### PR DESCRIPTION
Parquet Parser doesn't support stream parsing (it relies on random seeks in a file). H2O's parse switches to stream parse if the parsed files are too small and there is too many of them. This causes an issue to the parquet parser.