### PR TITLE
 PUBDEV-3915-h2o-assembly-confusion-matrices-docs-api-tests: added do…

### DIFF
--- a/h2o-py/h2o/assembly.py
+++ b/h2o-py/h2o/assembly.py
@@ -9,15 +9,54 @@ from h2o.transforms.transform_base import H2OTransformer
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.shared_utils import urlopen, quoted
 from h2o.utils.typechecks import assert_is_type
+import os
 
 
 class H2OAssembly(object):
     """
+    H2OAssembly class can be used to specify multiple frame operations in one place.
+
+    Sample usage:
+
+    >>> iris = h2o.load_dataset("iris")
+    >>> assembly = H2OAssembly(steps=[
+    ... ("col_select",       H2OColSelect(["Sepal.Length", "Petal.Length", "Species"])),
+    ... ("cos_Sepal.Length", H2OColOp(op=H2OFrame.cos, col="Sepal.Length", inplace=True)),
+    ... ("str_cnt_Species",  H2OColOp(op=H2OFrame.countmatches, col="Species",
+    ...                               inplace=False, pattern="s"))
+    ... ])
+    >>> result = assembly.fit(iris)  # fit the assembly and perform the munging operations
+
+    In this example, we first load the iris frame.  Next, the following data munging operations are performed on the
+    iris frame
+
+        1. only select three columns out of the five columns;
+        2. take the cosine of the column Sepal.Length and replace the original column with the cosine of the column;
+        3. want to count the number of rows with the letter s in the class column.  Since inplace is set to
+           False, a new column is generated to hold the result.
+
     Extension class of Pipeline implementing additional methods:
 
-      - to_pojo: Exports the assembly to a self-contained Java POJO used in a per-row, high-throughput environment.
-      - union: Combine two H2OAssembly objects, the resulting row from each H2OAssembly are joined with simple
-        concatenation.
+       - to_pojo: Exports the assembly to a self-contained Java POJO used in a per-row, high-throughput environment.
+
+    In addition, H2OAssembly provides a few static methods that perform element to element operations between
+    two frames. They all are called as
+
+    >>> H2OAssembly.op(frame1, frame2)
+
+    while frame1, frame2 are H2OFrame of the same size and same column types.  It will return a H2OFrame
+    containing the element-wise result of operation op.  The following operations are currently supported
+
+        - divide
+        - plus
+        - multiply
+        - minus
+        - less_than
+        - less_than_equal
+        - equal_equal
+        - not_equal
+        - greater_than
+        - greater_than_equal
     """
 
     # static properties pointing to H2OFrame methods
@@ -37,9 +76,8 @@ class H2OAssembly(object):
         """
         Build a new H2OAssembly.
 
-        :param steps: A list of steps that sequentially transforms the input
-            data. Each step is a tuple ``(name, operation)``, where each
-            ``operation`` is an instance of an ``H2OTransformer`` class.
+        :param steps: A list of steps that sequentially transforms the input data. Each step is a
+            tuple ``(name, operation)``, where each ``operation`` is an instance of an ``H2OTransformer`` class.
         """
         assert_is_type(steps, [(str, H2OTransformer)])
         self.id = None
@@ -55,6 +93,14 @@ class H2OAssembly(object):
 
 
     def to_pojo(self, pojo_name="", path="", get_jar=True):
+        """
+        Convert the munging operations performed on H2OFrame into a POJO.
+
+        :param pojo_name:  (str) Name of POJO
+        :param path:  (str) path of POJO.
+        :param get_jar: (bool) Whether to also download the h2o-genmodel.jar file needed to compile the POJO
+        :return: None
+        """
         assert_is_type(pojo_name, str)
         assert_is_type(path, str)
         assert_is_type(get_jar, bool)
@@ -68,12 +114,7 @@ class H2OAssembly(object):
             with open(file_path, 'w', encoding="utf-8") as f:
                 f.write(java)  # this had better be utf-8 ?
         if get_jar and path != "":
-            url = h2o.connection().make_url("h2o-genmodel.jar")
-            filename = path + "/" + "h2o-genmodel.jar"
-            response = urlopen()(url)
-            with open(filename, "wb") as f:
-                f.write(response.read())
-
+            h2o.api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, "h2o-genmodel.jar"))
 
     # def union(self, assemblies):
     #   # fuse the assemblies onto this one, each is added to the end going left -> right
@@ -88,9 +129,14 @@ class H2OAssembly(object):
 
 
     def fit(self, fr):
+        """
+        To perform the munging operations on a frame specified in steps on the frame fr.
+
+        :param fr: H2OFrame where munging operations are to be performed on.
+        :return: H2OFrame after munging operations are completed.
+        """
         assert_is_type(fr, H2OFrame)
         steps = "[%s]" % ",".join(quoted(step[1].to_rest(step[0]).replace('"', "'")) for step in self.steps)
         j = h2o.api("POST /99/Assembly", data={"steps": steps, "frame": fr.frame_id})
         self.id = j["assembly"]["name"]
         return H2OFrame.get_frame(j["result"]["name"])
-

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -301,8 +301,6 @@ class H2OFrame(object):
         raise H2OValueError("Column '%r' does not exist in the frame" % col)
 
 
-
-
     def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings):
         if is_type(path, str) and "://" not in path:
             path = os.path.abspath(path)
@@ -2497,7 +2495,7 @@ class H2OFrame(object):
         Conduct a diff-1 transform on a numeric frame column.
 
         :returns: an H2OFrame where each element is equal to the corresponding element in the source
-        frame minus the previous-row element in the same frame.
+            frame minus the previous-row element in the same frame.
         """
         fr = H2OFrame._expr(expr=ExprNode("difflag1", self), cache=self._ex._cache)
         return fr

--- a/h2o-py/h2o/group_by.py
+++ b/h2o-py/h2o/group_by.py
@@ -25,23 +25,24 @@ class GroupBy(object):
 
     Sample usage:
 
-       >>> my_frame = ...  # some existing H2OFrame
-       >>> grouped = my_frame.group_by(by=["C1", "C2"])
-       >>> grouped.sum(col="X1", na="all").mean(col="X5", na="all").max()
-       >>> grouped.get_frame()
+    >>> my_frame = ...  # some existing H2OFrame
+    >>> grouped = my_frame.group_by(by=["C1", "C2"])
+    >>> grouped.sum(col="X1", na="all").mean(col="X5", na="all").max()
+    >>> grouped.get_frame()
 
-    Any number of aggregations may be chained together in this manner.  Note that once the aggregation
-    operations are complete, calling the GroupBy object with a new set of aggregations will yield no
-    effect.  You must generate a new GroupBy object in order to apply a new aggregation on it.  In addition,
-    certain aggregations are only defined for numerical or categorical columns.  An error will be thrown for
-    calling aggregation on the wrong data types.
 
-    If no arguments are given to the aggregation (e.g. "max" in the above example),
-    then it is assumed that the aggregation should apply to all columns but the
-    group by columns.
+    Any number of aggregations may be chained together in this manner.  Note that once the aggregation operations
+    are complete, calling the GroupBy object with a new set of aggregations will yield no effect.  You must generate
+    a new GroupBy object in order to apply a new aggregation on it.  In addition, certain aggregations are only
+    defined for numerical or categorical columns.  An error will be thrown for calling aggregation on the wrong
+    data types.
+
+    If no arguments are given to the aggregation (e.g. "max" in the above example), then it is assumed that the
+    aggregation should apply to all columns but the group by columns.
 
     All GroupBy aggregations take parameter na, which controls treatment of NA values during the calculation.
     It can be one of:
+
         - "all" (default) -- any NAs are used in the calculation as-is; which usually results in the final result
           being NA too.
         - "ignore" -- NA entries are not included in calculations, but the total number of entries is taken as the
@@ -52,11 +53,12 @@ class GroupBy(object):
     Variance (var) and standard deviation (sd) are the sample (not population) statistics.
     """
 
+
     def __init__(self, fr, by):
         """
         Return a new ``GroupBy`` object using the H2OFrame specified in fr and the desired grouping columns
-        specified in by.  The original H2O frame will be stored as member _fr.  Information on the new
-        grouping of the original frame is described in a new H2OFrame in member frame.
+        specified in by.  The original H2O frame will be stored as member _fr.  Information on the new grouping
+        of the original frame is described in a new H2OFrame in member frame.
 
         The returned groups are sorted by the natural group-by column sort.
 
@@ -79,12 +81,11 @@ class GroupBy(object):
 
     def min(self, col=None, na="all"):
         """
-        Calculate the minimum of each column specified in col for each group of a GroupBy object.  If no col is given,
-        compute the minimum among all numeric columns other than those being grouped on.
+        Calculate the minimum of each column specified in col for each group of a GroupBy object.  If no col is
+        given, compute the minimum among all numeric columns other than those being grouped on.
 
         :param col: col can be None (default), a column name (str) or an index (int) of a single column,  or a
-            list for multiple columns
-        denoting the set of columns to group by.
+            list for multiple columns denoting the set of columns to group by.
         :param str na:  one of 'rm', 'ignore' or 'all' (default).
         :return: the original GroupBy object (self), for ease of constructing chained operations.
 
@@ -94,8 +95,8 @@ class GroupBy(object):
 
     def max(self, col=None, na="all"):
         """
-        Calculate the maximum of each column specified in col for each group of a GroupBy object.  If no col is given,
-        compute the maximum among all numeric columns other than those being grouped on.
+        Calculate the maximum of each column specified in col for each group of a GroupBy object.  If no col is
+        given, compute the maximum among all numeric columns other than those being grouped on.
 
         :param col: col can be None (default), a column name (str) or an index (int) of a single column,  or a
             list for multiple columns
@@ -107,8 +108,8 @@ class GroupBy(object):
 
     def mean(self, col=None, na="all"):
         """
-        Calculate the mean of each column specified in col for each group of a GroupBy object.  If no col is given,
-        compute the mean among all numeric columns other than those being grouped on.
+        Calculate the mean of each column specified in col for each group of a GroupBy object.  If no col is
+        given, compute the mean among all numeric columns other than those being grouped on.
 
         :param col: col can be None (default), a column name (str) or an index (int) of a single column,  or a
             list for multiple columns
@@ -143,8 +144,8 @@ class GroupBy(object):
 
     def sd(self, col=None, na="all"):
         """
-        Calculate the standard deviation of each column specified in col for each group of a GroupBy object.
-        If no col is given, compute the standard deviation among all numeric columns other than those being grouped on.
+        Calculate the standard deviation of each column specified in col for each group of a GroupBy object. If no
+        col is given, compute the standard deviation among all numeric columns other than those being grouped on.
 
         :param col: col can be None (default), a column name (str) or an index (int) of a single column,  or a
             list for multiple columns
@@ -156,8 +157,8 @@ class GroupBy(object):
 
     def var(self, col=None, na="all"):
         """
-        Calculate the variance of each column specified in col for each group of a GroupBy object.  If no col is given,
-        compute the variance among all numeric columns other than those being grouped on.
+        Calculate the variance of each column specified in col for each group of a GroupBy object.  If no col is
+        given, compute the variance among all numeric columns other than those being grouped on.
 
         :param col: col can be None (default), a column name (str) or an index (int) of a single column,  or a
             list for multiple columns
@@ -210,8 +211,8 @@ class GroupBy(object):
         The number of columns depend on the number of aggregations performed, the number of columns specified in
         the col parameter.  Generally, expect the number of columns to be
 
-        (len(col) of aggregation 0 + len(col) of aggregation 1 +...+ len(col) of aggregation n) x (number of groups of the GroupBy object)
-        +1 (for group-by group names).
+        (len(col) of aggregation 0 + len(col) of aggregation 1 +...+ len(col) of aggregation n) x
+        (number of groups of the GroupBy object) +1 (for group-by group names).
 
         Note:
             - the count aggregation only generates one column;

--- a/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_3827_scoringHistory_importance.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_3827_scoringHistory_importance.py
@@ -42,7 +42,7 @@ def pca_scoring_history_importance():
     # compare singular vectors
     pyunit_utils.assert_H2OTwoDimTable_equal(gramSVD._model_json["output"]["eigenvectors"],
                                            randomizedPCA._model_json["output"]["eigenvectors"],
-                                           randomizedPCA._model_json["output"]["names"], tolerance=1e-2,
+                                           randomizedPCA._model_json["output"]["names"], tolerance=5e-2,
                                            check_sign=True)
 
     # check PCA with PCA set to Power

--- a/h2o-py/tests/testdir_apis/H2OAssembly/pyunit_h2oassembly_fit.py
+++ b/h2o-py/tests/testdir_apis/H2OAssembly/pyunit_h2oassembly_fit.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.assembly import *
+from h2o.transforms.preprocessing import *
+
+def h2oassembly_fit():
+    """
+    Python API test: H2OAssembly.fit(fr)
+
+    Copied from pyunit_assembly_demo.py
+    """
+
+    fr = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"),
+                       col_types=["numeric","numeric","numeric","numeric","string"])  # import data
+    assembly = H2OAssembly(steps=[("col_select",      H2OColSelect(["sepal_len", "petal_len", "class"])),
+                                ("cos_sep_len",     H2OColOp(op=H2OFrame.cos, col="sepal_len", inplace=True)),
+                                ("str_cnt_species", H2OColOp(op=H2OFrame.countmatches, col="class", inplace=False,
+                                                             pattern="s"))])     # string operation
+
+    assert_is_type(assembly, H2OAssembly)
+    result = assembly.fit(fr)  # fit the assembly, which performs column select
+    assert_is_type(result, H2OFrame)
+    assert result.ncol==4, "H2OAssembly.fit() command is not working" # selects 3 columns, added one from countmatches.
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2oassembly_fit)
+else:
+    h2oassembly_fit()

--- a/h2o-py/tests/testdir_apis/H2OAssembly/pyunit_h2oassembly_static_methods.py
+++ b/h2o-py/tests/testdir_apis/H2OAssembly/pyunit_h2oassembly_static_methods.py
@@ -1,0 +1,59 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+from tests import pyunit_utils
+from h2o.assembly import *
+from h2o.utils.typechecks import assert_is_type
+
+def h2oassembly_divide():
+    """
+    Python API test: test all H2OAssembly static methods and they are:
+    H2OAssembly.divide(frame1, frame2)
+    H2OAssembly.plus(frame1, frame2)
+    H2OAssembly.multiply(frame1, frame2)
+    H2OAssembly.minus(frame1, frame2)
+    H2OAssembly.less_than(frame1, frame2)
+    H2OAssembly.less_than_equal(frame1, frame2)
+    H2OAssembly.equal_equal(frame1, frame2)
+    H2OAssembly.not_equal(frame1, frame2)
+    H2OAssembly.greater_than(frame1, frame2)
+    H2OAssembly.greater_than_equal(frame1, frame2)
+    """
+    python_list1 = [[4,4,4,4],[4,4,4,4]]
+    python_list2 = [[2,2,2,2], [2,2,2,2]]
+    frame1 = h2o.H2OFrame(python_obj=python_list1)
+    frame2 = h2o.H2OFrame(python_obj=python_list2)
+
+    verify_results(H2OAssembly.divide(frame1, frame2), 2, "H2OAssembly.divide()")   #  test H2OAssembly.divide()
+    verify_results(H2OAssembly.plus(frame1, frame2), 6, "H2OAssembly.plus()")       #  test H2OAssembly.plus()
+    verify_results(H2OAssembly.multiply(frame1, frame2), 8, "H2OAssembly.multiply()")   #  test H2OAssembly.multiply()
+    verify_results(H2OAssembly.minus(frame1, frame2), 2, "H2OAssembly.minus()")     #  test H2OAssembly.minus()
+        # test H2OAssembly.less_than()
+    verify_results(H2OAssembly.less_than(frame2, frame1), 1.0, "H2OAssembly.less_than()")
+    verify_results(H2OAssembly.less_than(frame2, frame2), 0.0, "H2OAssembly.less_than()")
+        # test H2OAssembly.less_than_equal()
+    verify_results(H2OAssembly.less_than_equal(frame2, frame1), 1.0, "H2OAssembly.less_than_equal()")
+    verify_results(H2OAssembly.less_than_equal(frame2, frame2), 1.0, "H2OAssembly.less_than_equal()")
+        # test H2OAssembly.equal_equal()
+    verify_results(H2OAssembly.equal_equal(frame2, frame1), 0.0, "H2OAssembly.equal_equal()")
+    verify_results(H2OAssembly.equal_equal(frame2, frame2), 1.0, "H2OAssembly.equal_equal()")
+        # test H2OAssembly.not_equal()
+    verify_results(H2OAssembly.not_equal(frame2, frame1), 1.0, "H2OAssembly.not_equal()")
+    verify_results(H2OAssembly.not_equal(frame2, frame2), 0.0, "H2OAssembly.not_equal()")
+        # test H2OAssembly.greater_than()
+    verify_results(H2OAssembly.greater_than(frame1, frame2), 1.0, "H2OAssembly.greater_than()")
+    verify_results(H2OAssembly.greater_than(frame2, frame2), 0.0, "H2OAssembly.greater_than()")
+    # test H2OAssembly.greater_than_equal()
+    verify_results(H2OAssembly.greater_than_equal(frame1, frame2), 1.0, "H2OAssembly.greater_than_equal()")
+    verify_results(H2OAssembly.greater_than_equal(frame2, frame2), 1.0, "H2OAssembly.greater_than_equal()")
+
+
+def verify_results(resultFrame, matchValue, commandName):
+    assert_is_type(resultFrame, H2OFrame)
+    assert (resultFrame==matchValue).all(), commandName+" command is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2oassembly_divide)
+else:
+    h2oassembly_divide()

--- a/h2o-py/tests/testdir_apis/H2OAssembly/pyunit_h2oassembly_to_pojo.py
+++ b/h2o-py/tests/testdir_apis/H2OAssembly/pyunit_h2oassembly_to_pojo.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.utils.typechecks import assert_is_type
+from h2o.assembly import *
+from h2o.transforms.preprocessing import *
+import os
+
+def h2oassembly_to_pojo():
+    """
+    Python API test: H2OAssembly.to_pojo(pojo_name=u'', path=u'', get_jar=True)
+
+    Copied from pyunit_assembly_demo.py
+    """
+
+    fr = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"),
+                       col_types=["numeric","numeric","numeric","numeric","string"])
+    assembly = H2OAssembly(steps=[("col_select",      H2OColSelect(["sepal_len", "petal_len", "class"])),
+                                ("cos_sep_len",     H2OColOp(op=H2OFrame.cos, col="sepal_len", inplace=True)),
+                                ("str_cnt_species",
+                                 H2OColOp(op=H2OFrame.countmatches, col="class", inplace=False, pattern="s"))])
+
+    result = assembly.fit(fr)  # fit the assembly
+    assert_is_type(result, H2OFrame)
+
+    results_dir = os.path.join(os.getcwd(), "results")
+    if os.path.isdir(results_dir):
+        assembly.to_pojo(pojo_name="iris_munge", path=results_dir, get_jar=True)
+        assert os.path.isfile(os.path.join(results_dir, "h2o-genmodel.jar")), "H2OAssembly.to_pojo() " \
+                                                                          "command is not working."
+    else:
+        assembly.to_pojo(pojo_name="iris_munge", path='', get_jar=False)  # just print pojo to screen
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2oassembly_to_pojo)
+else:
+    h2oassembly_to_pojo()


### PR DESCRIPTION
PUBDEV-3915: add docs to assembly module, confusion matrices.  Add API tests for assembly module.

1.  Added documentation to assembly.py
2. Added API tests to assembly.py
3. Did not add docs to confusion matrix as it is pretty clear to me at this point.