### PR TITLE
PUBDEV-4065-pyunit_gbm_random_grid_large_fix.  Change the assert mode…

### DIFF
--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid_large.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid_large.py
@@ -42,7 +42,9 @@ def airline_gbm_random_grid():
   
   air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, nfolds=5, fold_assignment='Modulo', keep_cross_validation_predictions=True, distribution="bernoulli", seed=1234)
 
-  assert(len(air_grid.get_grid())==5)
+    # under rare circumstances, GBM may not build enough model (5 in this case) within 600 seconds to return
+    # hence, switch the compare from == to <= should fix the intermittent problem.
+  assert len(air_grid.get_grid())<=5, "Grid search has returned more models than allowed."
   print(air_grid.get_grid("logloss"))
 
   stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all", base_models=air_grid.model_ids)


### PR DESCRIPTION
Changed 
   assert len(air_grid.get_grid())==5
to
  assert len(air_grid.get_grid())<=5

due to

 search_criteria_tune = {'strategy': "RandomDiscrete",
                   'max_runtime_secs': 600,  ## limit the runtime to 10 minutes
                   'max_models': 5,  ## build no more than 5 models
                   'seed' : 1234,
                   'stopping_rounds' : 5,
                   'stopping_metric' : "AUC",
                   'stopping_tolerance': 1e-3
                   }

Very rarely, there may not be enough time (600 sec) to build all 5 models.  Hence, the assert == will throw an error.