### PR TITLE
Updating R docs for h2o.getGrid

### DIFF
--- a/h2o-r/h2o-package/R/grid.R
+++ b/h2o-r/h2o-package/R/grid.R
@@ -123,7 +123,9 @@ h2o.grid <- function(algorithm,
   h2o.getGrid(grid_id = grid_id)
 }
 
-#' Get a grid object from H2O distributed K/V store. Note that if neither cross-validation nor a 
+#' Get a grid object from H2O distributed K/V store. 
+#' 
+#' Note that if neither cross-validation nor a 
 #' validation frame is used in the grid search, then the training metrics will display in the 
 #' "get grid" output. If a validation frame is passed to the grid, and nfolds = 0, then the 
 #' validation metrics will display. However, if nfolds > 1, then cross-validation metrics will 


### PR DESCRIPTION
The description and title in the R docs for `h2o.getGrid` were joined and duplicated due to a missing linebreak in the `grid.R` file.
