### PR TITLE
Add SortByResponse and LabelEncoding categorical_encoding schemes.

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GBMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GBMV3.java
@@ -59,7 +59,7 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
       "histogram_type",
       "max_abs_leafnode_pred",
       "pred_noise_bandwidth",
-      "categorical_encoding",
+      "categorical_encoding"
 //      "use_new_histo_tsk",
 //      "col_block_sz",
 //      "min_threads",

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -27,6 +27,10 @@ import java.util.List;
 import java.util.Random;
 
 public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends SharedTreeModel.SharedTreeParameters, O extends SharedTreeModel.SharedTreeOutput> extends ModelBuilder<M,P,O> {
+  public boolean shouldReorder(Vec v) {
+    return _parms._categorical_encoding == Model.Parameters.CategoricalEncodingScheme.SortByResponse
+           && v.cardinality() > _parms._nbins_cats;  // no need to sort categoricals with fewer than nbins_cats - they will be sorted in every leaf anyway
+  }
   final protected static boolean DEV_DEBUG = false;
   protected int _mtry;
   protected int _mtry_per_tree;

--- a/h2o-algos/src/test/java/hex/kmeans/KMeansRandomTest.java
+++ b/h2o-algos/src/test/java/hex/kmeans/KMeansRandomTest.java
@@ -41,6 +41,7 @@ public class KMeansRandomTest extends TestUtil {
                           KMeans.Initialization.Furthest,
                           KMeans.Initialization.PlusPlus,
                   }) {
+                    if (catEncoding == Model.Parameters.CategoricalEncodingScheme.SortByResponse) continue;
 
                     count++;
 

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -129,7 +129,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       AUTO, Random, Modulo, Stratified
     }
     public enum CategoricalEncodingScheme {
-      AUTO, OneHotInternal, OneHotExplicit, Enum, Binary, Eigen, Integer, SortByResponse
+      AUTO, OneHotInternal, OneHotExplicit, Enum, Binary, Eigen, LabelEncoder, SortByResponse
     }
     public long _seed = -1;
     public long getOrMakeRealSeed(){
@@ -940,9 +940,9 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
             vec = evec;
           }
         } else if(vec.isCategorical()) {
-          if (parms._categorical_encoding == Parameters.CategoricalEncodingScheme.Integer) {
+          if (parms._categorical_encoding == Parameters.CategoricalEncodingScheme.LabelEncoder) {
             Vec evec = vec.toNumericVec();
-            toDelete.put(evec._key, "categorically encoded vec");
+            toDelete.put(evec._key, "label encoded vec");
             vec = evec;
           } else {
             throw new IllegalArgumentException("Test/Validation dataset has categorical column '" + names[i] + "' which is real-valued in the training data");

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -129,7 +129,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       AUTO, Random, Modulo, Stratified
     }
     public enum CategoricalEncodingScheme {
-      AUTO, OneHotInternal, OneHotExplicit, Enum, Binary, Eigen
+      AUTO, OneHotInternal, OneHotExplicit, Enum, Binary, Eigen, Integer, SortByResponse
     }
     public long _seed = -1;
     public long getOrMakeRealSeed(){
@@ -939,8 +939,14 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
               msgs.add("Test/Validation dataset column '" + names[i] + "' has levels not trained on: " + Arrays.toString(Arrays.copyOfRange(ds, domains[i].length, ds.length)));
             vec = evec;
           }
-        } else if( vec.isCategorical() ) {
-          throw new IllegalArgumentException("Test/Validation dataset has categorical column '" + names[i] + "' which is real-valued in the training data");
+        } else if(vec.isCategorical()) {
+          if (parms._categorical_encoding == Parameters.CategoricalEncodingScheme.Integer) {
+            Vec evec = vec.toNumericVec();
+            toDelete.put(evec._key, "categorically encoded vec");
+            vec = evec;
+          } else {
+            throw new IllegalArgumentException("Test/Validation dataset has categorical column '" + names[i] + "' which is real-valued in the training data");
+          }
         }
         good++;      // Assumed compatible; not checking e.g. Strings vs UUID
       }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -129,7 +129,10 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       AUTO, Random, Modulo, Stratified
     }
     public enum CategoricalEncodingScheme {
-      AUTO, OneHotInternal, OneHotExplicit, Enum, Binary, Eigen, LabelEncoder, SortByResponse
+      AUTO(false), OneHotInternal(false), OneHotExplicit(false), Enum(false), Binary(false), Eigen(false), LabelEncoder(false), SortByResponse(true);
+      CategoricalEncodingScheme(boolean needResponse) { _needResponse = needResponse; }
+      final boolean _needResponse;
+      boolean needsResponse() { return _needResponse; }
     }
     public long _seed = -1;
     public long getOrMakeRealSeed(){

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -17,6 +17,7 @@ import java.util.*;
 abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Parameters, O extends Model.Output> extends Iced {
 
   public ToEigenVec getToEigenVec() { return null; }
+  public boolean shouldReorder(Vec v) { return _parms._categorical_encoding == Model.Parameters.CategoricalEncodingScheme.SortByResponse; }
 
   transient private IcedHashMap<Key,String> _toDelete = new IcedHashMap<>();
   void cleanUp() { FrameUtils.cleanUp(_toDelete); }
@@ -959,7 +960,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       String[] skipCols = new String[]{_parms._weights_column, _parms._offset_column, _parms._fold_column, _parms._response_column};
       Frame newtrain = FrameUtils.categoricalEncoder(_train, skipCols, _parms._categorical_encoding, getToEigenVec());
       if (newtrain!=_train) {
-        assert(newtrain._key!=null);
+        assert (newtrain._key != null);
         _origNames = _train.names();
         _origDomains = _train.domains();
         _train = newtrain;
@@ -981,6 +982,36 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
           _vresponse = _valid.vec(_parms._response_column);
         }
       }
+      Vec[] vecs = _train.vecs();
+      for (int j = 0; j < vecs.length; ++j) {
+        Vec v = vecs[j];
+        if (v == _response || v == _fold) continue;
+        if (v.isCategorical() && shouldReorder(v)) {
+          final int len = v.domain().length;
+          Log.info("Reordering categorical column " + _train.name(j) + " (" + len + " levels) based on the mean (weighted) response per level.");
+          VecUtils.MeanResponsePerLevelTask mrplt = new VecUtils.MeanResponsePerLevelTask(len).doAll(v,
+                  _parms._weights_column != null ? _train.vec(_parms._weights_column) : v.makeCon(1.0),
+                  _train.vec(_parms._response_column));
+          double[] meanWeightedResponse  = mrplt.meanWeightedResponse;
+//          for (int i=0;i<len;++i)
+//            Log.info(v.domain()[i] + " -> " + meanWeightedResponse[i]);
+
+          // Option 1: Order the categorical column by response to make better splits
+          int[] idx=new int[len];
+          for (int i=0;i<len;++i) idx[i] = i;
+          ArrayUtils.sort(idx, meanWeightedResponse);
+          int[] invIdx=new int[len];
+          for (int i=0;i<len;++i) invIdx[idx[i]] = i;
+          Vec vNew = new VecUtils.ReorderTask(invIdx).doAll(1, Vec.T_NUM, new Frame(v)).outputFrame().anyVec();
+          String[] newDomain = new String[len];
+          for (int i = 0; i < len; ++i) newDomain[i] = v.domain()[idx[i]];
+          vNew.setDomain(newDomain);
+//          for (int i=0;i<len;++i)
+//            Log.info(vNew.domain()[i] + " -> " + meanWeightedResponse[idx[i]]);
+          vecs[j] = vNew;
+        }
+      }
+      _train.restructure(_train.names(), vecs);
     }
     assert (!expensive || _valid==null || Arrays.equals(_train._names, _valid._names) || _parms._categorical_encoding == Model.Parameters.CategoricalEncodingScheme.Binary);
     if (_valid!=null && !Arrays.equals(_train._names, _valid._names) && _parms._categorical_encoding == Model.Parameters.CategoricalEncodingScheme.Binary) {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -982,6 +982,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
           _vresponse = _valid.vec(_parms._response_column);
         }
       }
+      boolean restructured = false;
       Vec[] vecs = _train.vecs();
       for (int j = 0; j < vecs.length; ++j) {
         Vec v = vecs[j];
@@ -1009,9 +1010,11 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
 //          for (int i=0;i<len;++i)
 //            Log.info(vNew.domain()[i] + " -> " + meanWeightedResponse[idx[i]]);
           vecs[j] = vNew;
+          restructured = true;
         }
       }
-      _train.restructure(_train.names(), vecs);
+      if (restructured)
+        _train.restructure(_train.names(), vecs);
     }
     assert (!expensive || _valid==null || Arrays.equals(_train._names, _valid._names) || _parms._categorical_encoding == Model.Parameters.CategoricalEncodingScheme.Binary);
     if (_valid!=null && !Arrays.equals(_train._names, _valid._names) && _parms._categorical_encoding == Model.Parameters.CategoricalEncodingScheme.Binary) {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -17,7 +17,7 @@ import java.util.*;
 abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Parameters, O extends Model.Output> extends Iced {
 
   public ToEigenVec getToEigenVec() { return null; }
-  public boolean shouldReorder(Vec v) { return _parms._categorical_encoding == Model.Parameters.CategoricalEncodingScheme.SortByResponse; }
+  public boolean shouldReorder(Vec v) { return _parms._categorical_encoding.needsResponse() && isSupervised(); }
 
   transient private IcedHashMap<Key,String> _toDelete = new IcedHashMap<>();
   void cleanUp() { FrameUtils.cleanUp(_toDelete); }
@@ -800,6 +800,10 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     _train = new Frame(null /* not putting this into KV */, tr._names.clone(), tr.vecs().clone());
     if (expensive) {
       _parms.getOrMakeRealSeed();
+    }
+    if (_parms._categorical_encoding.needsResponse() && !isSupervised()) {
+      error("_categorical_encoding", "Categorical encoding scheme cannot be "
+          + _parms._categorical_encoding.toString() + " - no response column available.");
     }
     if (_parms._nfolds < 0 || _parms._nfolds == 1) {
       error("_nfolds", "nfolds must be either 0 or >1.");

--- a/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
@@ -110,7 +110,7 @@ public class ModelParametersSchemaV3<P extends Model.Parameters, S extends Model
   public Model.Parameters.FoldAssignmentScheme fold_assignment;
 
   @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
-          values = {"AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen"},
+          values = {"AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse"},
           help = "Encoding scheme for categorical features")
   public Model.Parameters.CategoricalEncodingScheme categorical_encoding;
 

--- a/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
@@ -110,7 +110,7 @@ public class ModelParametersSchemaV3<P extends Model.Parameters, S extends Model
   public Model.Parameters.FoldAssignmentScheme fold_assignment;
 
   @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
-          values = {"AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse"},
+          values = {"AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse"},
           help = "Encoding scheme for categorical features")
   public Model.Parameters.CategoricalEncodingScheme categorical_encoding;
 

--- a/h2o-core/src/main/java/water/util/FrameUtils.java
+++ b/h2o-core/src/main/java/water/util/FrameUtils.java
@@ -84,8 +84,8 @@ public class FrameUtils {
         return new CategoricalBinaryEncoder(dataset, skipCols).exec().get();
       case Eigen:
         return new CategoricalEigenEncoder(tev, dataset, skipCols).exec().get();
-      case Integer:
-        return new CategoricalIntegerEncoder(dataset, skipCols).exec().get();
+      case LabelEncoder:
+        return new CategoricalLabelEncoder(dataset, skipCols).exec().get();
       default:
         throw H2O.unimpl();
     }
@@ -553,24 +553,24 @@ public class FrameUtils {
     }
   }
 
-  public static class CategoricalIntegerEncoder extends Iced {
+  public static class CategoricalLabelEncoder extends Iced {
     final Frame _frame;
     Job<Frame> _job;
     final String[] _skipCols;
 
-    public CategoricalIntegerEncoder(Frame dataset, String[] skipCols) {
+    public CategoricalLabelEncoder(Frame dataset, String[] skipCols) {
       _frame = dataset;
       _skipCols = skipCols;
     }
 
     /**
-     * Driver for CategoricalIntegerEncoder
+     * Driver for CategoricalLabelEncoder
      */
-    class CategoricalIntegerEncoderDriver extends H2O.H2OCountedCompleter {
+    class CategoricalLabelEncoderDriver extends H2O.H2OCountedCompleter {
       final Frame _frame;
       final Key<Frame> _destKey;
       final String[] _skipCols;
-      CategoricalIntegerEncoderDriver(Frame frame, Key<Frame> destKey, String[] skipCols) { _frame = frame; _destKey = destKey; _skipCols = skipCols; }
+      CategoricalLabelEncoderDriver(Frame frame, Key<Frame> destKey, String[] skipCols) { _frame = frame; _destKey = destKey; _skipCols = skipCols; }
 
       @Override public void compute2() {
         Vec[] frameVecs = _frame.vecs();
@@ -605,9 +605,9 @@ public class FrameUtils {
       if (_frame == null)
         throw new IllegalArgumentException("Frame doesn't exist.");
       Key<Frame> destKey = Key.makeSystem(Key.make().toString());
-      _job = new Job<>(destKey, Frame.class.getName(), "CategoricalIntegerEncoder");
+      _job = new Job<>(destKey, Frame.class.getName(), "CategoricalLabelEncoder");
       int workAmount = _frame.lastVec().nChunks();
-      return _job.start(new CategoricalIntegerEncoderDriver(_frame, destKey, _skipCols), workAmount);
+      return _job.start(new CategoricalLabelEncoderDriver(_frame, destKey, _skipCols), workAmount);
     }
   }
   /**

--- a/h2o-py/h2o/estimators/aggregator.py
+++ b/h2o-py/h2o/estimators/aggregator.py
@@ -146,14 +146,14 @@ class H2OAggregatorEstimator(H2OEstimator):
         """
         Encoding scheme for categorical features
 
-        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``
-        (default: ``"auto"``).
+        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
+        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/aggregator.py
+++ b/h2o-py/h2o/estimators/aggregator.py
@@ -147,13 +147,13 @@ class H2OAggregatorEstimator(H2OEstimator):
         Encoding scheme for categorical features
 
         One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
-        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
+        ``"label_encoder"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1318,14 +1318,14 @@ class H2ODeepLearningEstimator(H2OEstimator):
         """
         Encoding scheme for categorical features
 
-        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``
-        (default: ``"auto"``).
+        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
+        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1319,13 +1319,13 @@ class H2ODeepLearningEstimator(H2OEstimator):
         Encoding scheme for categorical features
 
         One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
-        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
+        ``"label_encoder"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -316,14 +316,14 @@ class H2ODeepWaterEstimator(H2OEstimator):
         """
         Encoding scheme for categorical features
 
-        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``
-        (default: ``"auto"``).
+        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
+        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -317,13 +317,13 @@ class H2ODeepWaterEstimator(H2OEstimator):
         Encoding scheme for categorical features
 
         One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
-        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
+        ``"label_encoder"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -787,14 +787,14 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         """
         Encoding scheme for categorical features
 
-        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``
-        (default: ``"auto"``).
+        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
+        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -788,13 +788,13 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         Encoding scheme for categorical features
 
         One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
-        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
+        ``"label_encoder"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/kmeans.py
+++ b/h2o-py/h2o/estimators/kmeans.py
@@ -318,14 +318,14 @@ class H2OKMeansEstimator(H2OEstimator):
         """
         Encoding scheme for categorical features
 
-        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``
-        (default: ``"auto"``).
+        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
+        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/kmeans.py
+++ b/h2o-py/h2o/estimators/kmeans.py
@@ -319,13 +319,13 @@ class H2OKMeansEstimator(H2OEstimator):
         Encoding scheme for categorical features
 
         One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
-        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
+        ``"label_encoder"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -677,14 +677,14 @@ class H2ORandomForestEstimator(H2OEstimator):
         """
         Encoding scheme for categorical features
 
-        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``
-        (default: ``"auto"``).
+        One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
+        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -678,13 +678,13 @@ class H2ORandomForestEstimator(H2OEstimator):
         Encoding scheme for categorical features
 
         One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
-        ``"integer"``, ``"sort_by_response"``  (default: ``"auto"``).
+        ``"label_encoder"``, ``"sort_by_response"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 
     @categorical_encoding.setter
     def categorical_encoding(self, categorical_encoding):
-        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "integer", "sort_by_response"))
+        assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
 
 

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -126,7 +126,7 @@
 #' @param export_weights_and_biases \code{Logical}. Whether to export Neural Network weights and biases to H2O Frames. Defaults to FALSE.
 #' @param mini_batch_size Mini-batch size (smaller leads to better fit, larger can speed up and generalize better). Defaults to 1.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen". Defaults to AUTO.
+#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
 #' @param elastic_averaging \code{Logical}. Elastic averaging between compute nodes can improve distributed model convergence.
 #'        #Experimental Defaults to FALSE.
 #' @param elastic_averaging_moving_rate Elastic averaging moving rate (only if elastic averaging is enabled). Defaults to 0.9.
@@ -223,7 +223,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              reproducible = FALSE,
                              export_weights_and_biases = FALSE,
                              mini_batch_size = 1,
-                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen"),
+                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse"),
                              elastic_averaging = FALSE,
                              elastic_averaging_moving_rate = 0.9,
                              elastic_averaging_regularization = 0.001

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -126,7 +126,7 @@
 #' @param export_weights_and_biases \code{Logical}. Whether to export Neural Network weights and biases to H2O Frames. Defaults to FALSE.
 #' @param mini_batch_size Mini-batch size (smaller leads to better fit, larger can speed up and generalize better). Defaults to 1.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
+#'        "Binary", "Eigen", "LabelEncoder", "SortByResponse". Defaults to AUTO.
 #' @param elastic_averaging \code{Logical}. Elastic averaging between compute nodes can improve distributed model convergence.
 #'        #Experimental Defaults to FALSE.
 #' @param elastic_averaging_moving_rate Elastic averaging moving rate (only if elastic averaging is enabled). Defaults to 0.9.
@@ -223,7 +223,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              reproducible = FALSE,
                              export_weights_and_biases = FALSE,
                              mini_batch_size = 1,
-                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse"),
+                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse"),
                              elastic_averaging = FALSE,
                              elastic_averaging_moving_rate = 0.9,
                              elastic_averaging_regularization = 0.001

--- a/h2o-r/h2o-package/R/deepwater.R
+++ b/h2o-r/h2o-package/R/deepwater.R
@@ -35,7 +35,7 @@
 #'        weights are not allowed.
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen". Defaults to AUTO.
+#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
 #' @param overwrite_with_best_model \code{Logical}. If enabled, override the final model with the best model found during training. Defaults to
 #'        TRUE.
 #' @param epochs How many times the dataset should be iterated (streamed), can be fractional. Defaults to 10.
@@ -113,7 +113,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           offset_column = NULL,
                           weights_column = NULL,
                           score_each_iteration = FALSE,
-                          categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen"),
+                          categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse"),
                           overwrite_with_best_model = TRUE,
                           epochs = 10,
                           train_samples_per_iteration = -2,

--- a/h2o-r/h2o-package/R/deepwater.R
+++ b/h2o-r/h2o-package/R/deepwater.R
@@ -35,7 +35,7 @@
 #'        weights are not allowed.
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
+#'        "Binary", "Eigen", "LabelEncoder", "SortByResponse". Defaults to AUTO.
 #' @param overwrite_with_best_model \code{Logical}. If enabled, override the final model with the best model found during training. Defaults to
 #'        TRUE.
 #' @param epochs How many times the dataset should be iterated (streamed), can be fractional. Defaults to 10.
@@ -113,7 +113,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           offset_column = NULL,
                           weights_column = NULL,
                           score_each_iteration = FALSE,
-                          categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse"),
+                          categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse"),
                           overwrite_with_best_model = TRUE,
                           epochs = 10,
                           train_samples_per_iteration = -2,

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -83,7 +83,7 @@
 #' @param max_abs_leafnode_pred Maximum absolute value of a leaf node prediction Defaults to 1.797693135e+308.
 #' @param pred_noise_bandwidth Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen". Defaults to AUTO.
+#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
 #' \donttest{
@@ -146,7 +146,7 @@ h2o.gbm <- function(x, y, training_frame,
                     histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
                     max_abs_leafnode_pred = 1.797693135e+308,
                     pred_noise_bandwidth = 0,
-                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen")
+                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse")
                     ) 
 {
   #If x is missing, then assume user wants to use all columns as features.

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -83,7 +83,7 @@
 #' @param max_abs_leafnode_pred Maximum absolute value of a leaf node prediction Defaults to 1.797693135e+308.
 #' @param pred_noise_bandwidth Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
+#'        "Binary", "Eigen", "LabelEncoder", "SortByResponse". Defaults to AUTO.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
 #' \donttest{
@@ -146,7 +146,7 @@ h2o.gbm <- function(x, y, training_frame,
                     histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
                     max_abs_leafnode_pred = 1.797693135e+308,
                     pred_noise_bandwidth = 0,
-                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse")
+                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse")
                     ) 
 {
   #If x is missing, then assume user wants to use all columns as features.

--- a/h2o-r/h2o-package/R/kmeans.R
+++ b/h2o-r/h2o-package/R/kmeans.R
@@ -33,7 +33,7 @@
 #' @param init Initialization mode Must be one of: "Random", "PlusPlus", "Furthest", "User". Defaults to Furthest.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen". Defaults to AUTO.
+#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
 #' @return Returns an object of class \linkS4class{H2OClusteringModel}.
 #' @seealso \code{\link{h2o.cluster_sizes}}, \code{\link{h2o.totss}}, \code{\link{h2o.num_iterations}},
 #'          \code{\link{h2o.betweenss}}, \code{\link{h2o.tot_withinss}}, \code{\link{h2o.withinss}},
@@ -65,7 +65,7 @@ h2o.kmeans <- function(training_frame, x,
                        seed = -1,
                        init = c("Random", "PlusPlus", "Furthest", "User"),
                        max_runtime_secs = 0,
-                       categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen")
+                       categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse")
                        ) 
 {
 

--- a/h2o-r/h2o-package/R/kmeans.R
+++ b/h2o-r/h2o-package/R/kmeans.R
@@ -33,7 +33,7 @@
 #' @param init Initialization mode Must be one of: "Random", "PlusPlus", "Furthest", "User". Defaults to Furthest.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
+#'        "Binary", "Eigen", "LabelEncoder", "SortByResponse". Defaults to AUTO.
 #' @return Returns an object of class \linkS4class{H2OClusteringModel}.
 #' @seealso \code{\link{h2o.cluster_sizes}}, \code{\link{h2o.totss}}, \code{\link{h2o.num_iterations}},
 #'          \code{\link{h2o.betweenss}}, \code{\link{h2o.tot_withinss}}, \code{\link{h2o.withinss}},
@@ -65,7 +65,7 @@ h2o.kmeans <- function(training_frame, x,
                        seed = -1,
                        init = c("Random", "PlusPlus", "Furthest", "User"),
                        max_runtime_secs = 0,
-                       categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse")
+                       categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse")
                        ) 
 {
 

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -72,7 +72,7 @@
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
 #'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen". Defaults to AUTO.
+#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @export
@@ -115,7 +115,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              col_sample_rate_per_tree = 1,
                              min_split_improvement = 1e-05,
                              histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
-                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen")
+                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse")
                              ) 
 {
   #If x is missing, then assume user wants to use all columns as features.

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -72,7 +72,7 @@
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",
 #'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen", "Integer", "SortByResponse". Defaults to AUTO.
+#'        "Binary", "Eigen", "LabelEncoder", "SortByResponse". Defaults to AUTO.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @export
@@ -115,7 +115,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              col_sample_rate_per_tree = 1,
                              min_split_improvement = 1e-05,
                              histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
-                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "Integer", "SortByResponse")
+                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse")
                              ) 
 {
   #If x is missing, then assume user wants to use all columns as features.


### PR DESCRIPTION
For DRF/GBM, we now sort all categorical columns with more than nbins_cats factors, to allow the <= split to be useful and to reduce the effective number of factors in the child nodes. Otherwise, it would quite likely never split on this feature, and the bitset magic would never occur. Now, we get higher (over)fitting ability.