### PR TITLE
Pubdev 4065 fix random grid search and pyunit_gbm_random_grid_large.py

### DIFF
--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -254,38 +254,8 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
             throw new H2OIllegalArgumentException("Grid search model parameter '" + key + "' is set in both the model parameters and in the hyperparameters map.  This is ambiguous; set it in one place or the other, not both.");
         }
       } // for all keys
-
-      // do the same check for search criteria for max_runtime_secs only!
-      if (search_criteria != null && search_criteria.strategy() == HyperSpaceSearchCriteria.Strategy.RandomDiscrete) {
-        // _max_runtime_secs
-        if (setSearchCriterToParams(defaults, "_max_runtime_secs", params, search_criteria,
-                ((HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria) search_criteria).max_runtime_secs())) {
-          params._max_runtime_secs =
-                  ((HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria) search_criteria).max_runtime_secs();
-        }
-      }
     } // BaseWalker()
 
-    public boolean setSearchCriterToParams(MP defaults, String fieldname, MP params, C search_criteria,
-                                        Object searchCriteriaVal) {
-      Object defaultVal = PojoUtils.getFieldValue(defaults, fieldname, PojoUtils.FieldNaming.CONSISTENT);
-      Object actualVal = PojoUtils.getFieldValue(params, fieldname, PojoUtils.FieldNaming.CONSISTENT);
-
-      if ((defaultVal !=null) && actualVal != null && searchCriteriaVal != null) {
-        if (!defaultVal.equals(actualVal) && !defaultVal.equals(searchCriteriaVal)) { // both values are not default
-          if (!actualVal.equals(searchCriteriaVal)) { // parameter is set both in model and search_criteria, not allowed
-            throw new H2OIllegalArgumentException("Grid search model parameter '" + fieldname +
-                    "' is set in both the model parameters and in the search_criteria.  This is ambiguous; " +
-                    "set it in one place or the other, not both.");
-          }
-        }
-      }
-
-      if ((searchCriteriaVal != null) && (defaultVal != null) && (!defaultVal.equals(searchCriteriaVal))) {
-        return true;
-      }
-      return false;
-    }
     @Override
     public String[] getHyperParamNames() {
       return _hyperParamNames;
@@ -381,8 +351,13 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
             MP params = getModelParams(commonModelParams, hypers);
             // add max_runtime_secs in search criteria into params if applicable
             if (_search_criteria != null && _search_criteria.strategy() == HyperSpaceSearchCriteria.Strategy.RandomDiscrete) {
-              if (this.time_remaining_secs() > 0)  {
-                params._max_runtime_secs = (long) floor(min(params._max_runtime_secs, this.time_remaining_secs()));
+              double timeleft = this.time_remaining_secs();
+              if (timeleft > 0)  {
+                if (params._max_runtime_secs > 0) {
+                  params._max_runtime_secs = (long) floor(min(params._max_runtime_secs, timeleft));
+                } else {
+                  params._max_runtime_secs = (long) floor(timeleft);
+                }
               }
             }
             // We have another model parameters

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2885,3 +2885,23 @@ def cannaryHDFSTest(hdfs_name_node, file_name):
             return True
         else:       # exception is caused by other reasons.
             return False
+
+def extract_scoring_history_field(aModel, fieldOfInterest):
+    """
+    Given a fieldOfInterest that are found in the model scoring history, this function will extract the list
+    of field values for you from the model.
+
+    :param aModel: H2O model where you want to extract a list of fields from the scoring history
+    :param fieldOfInterest: string representing a field of interest.
+    :return: List of field values or None if it cannot be found
+    """
+
+    allFields = aModel._model_json["output"]["scoring_history"]._col_header
+    if fieldOfInterest in allFields:
+        cellValues = []
+        fieldIndex = allFields.index(fieldOfInterest)
+        for eachCell in aModel._model_json["output"]["scoring_history"].cell_values:
+            cellValues.append(eachCell[fieldIndex])
+        return cellValues
+    else:
+        return None

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid_large.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid_large.py
@@ -1,58 +1,78 @@
 from __future__ import print_function
-from builtins import map
-from builtins import str
 from builtins import range
-from collections import OrderedDict
 import math
 import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-import itertools
 from h2o.grid.grid_search import H2OGridSearch
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+import time
+
 
 def airline_gbm_random_grid():
-  air_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip"), destination_frame="air.hex")
-  myX = ["Year","Month","CRSDepTime","UniqueCarrier","Origin","Dest"]
+    air_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip"), destination_frame="air.hex")
+    myX = ["Year","Month","CRSDepTime","UniqueCarrier","Origin","Dest"]
 
-  # create hyperameter and search criteria lists (ranges are inclusive..exclusive))
-  hyper_params_tune = {'max_depth' : list(range(1,10+1,1)),
-                'sample_rate': [x/100. for x in range(20,101)],
-                'col_sample_rate' : [x/100. for x in range(20,101)],
-                'col_sample_rate_per_tree': [x/100. for x in range(20,101)],
-                'col_sample_rate_change_per_level': [x/100. for x in range(90,111)],
-                'min_rows': [2**x for x in range(0,int(math.log(air_hex.nrow,2)-1)+1)],
-                'nbins': [2**x for x in range(4,11)],
-                'nbins_cats': [2**x for x in range(4,13)],
-                'min_split_improvement': [0,1e-8,1e-6,1e-4],
-                'histogram_type': ["UniformAdaptive","QuantilesGlobal","RoundRobin"]}
+    # create hyperameter and search criteria lists (ranges are inclusive..exclusive))
+    hyper_params_tune = {'max_depth' : list(range(1,10+1,1)),
+                         'sample_rate': [x/100. for x in range(20,101)],
+                         'col_sample_rate' : [x/100. for x in range(20,101)],
+                         'col_sample_rate_per_tree': [x/100. for x in range(20,101)],
+                         'col_sample_rate_change_per_level': [x/100. for x in range(90,111)],
+                         'min_rows': [2**x for x in range(0,int(math.log(air_hex.nrow,2)-1)+1)],
+                         'nbins': [2**x for x in range(4,11)],
+                         'nbins_cats': [2**x for x in range(4,13)],
+                         'min_split_improvement': [0,1e-8,1e-6,1e-4],
+                         'histogram_type': ["UniformAdaptive","QuantilesGlobal","RoundRobin"]}
+    # search_criteria directs how to do grid search.
+    # 1). grid search can stop early if the early stopping conditions specified by
+    #   stopping_metric/stopping_tolerance/stopping_rounds
+    # 2). grid search will stop if it takes longer than max_runtime_secs
+    # 3). grid search will stop if it has collected max_models in its array.
+    #
+    # grid search stops correctly if any of the three conditions are satisfied
+    search_criteria_tune = {'strategy': "RandomDiscrete",
+                            'max_runtime_secs': 600,   # limit the runtime to 10 minutes to hit more stopping conditions
+                            'max_models': 5,            # build no more than 5 models
+                            'seed' : 1234,
+                            'stopping_rounds' : 5,
+                            'stopping_metric' : "AUC",
+                            'stopping_tolerance': 1e-3
+                            }
 
-  search_criteria_tune = {'strategy': "RandomDiscrete",
-                   'max_runtime_secs': 600,  ## limit the runtime to 10 minutes
-                   'max_models': 5,  ## build no more than 5 models
-                   'seed' : 1234,
-                   'stopping_rounds' : 5,
-                   'stopping_metric' : "AUC",
-                   'stopping_tolerance': 1e-3
-                   }
 
-  air_grid = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_params_tune, search_criteria=search_criteria_tune)
-  
-  air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, nfolds=5, fold_assignment='Modulo', keep_cross_validation_predictions=True, distribution="bernoulli", seed=1234)
+    air_grid = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_params_tune, search_criteria=search_criteria_tune)
+    starttime = time.time()
+    air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, nfolds=5, fold_assignment='Modulo', keep_cross_validation_predictions=True, distribution="bernoulli", seed=1234)
+    runtime = time.time()-starttime
 
-    # under rare circumstances, GBM may not build enough model (5 in this case) within 600 seconds to return
-    # hence, switch the compare from == to <= should fix the intermittent problem.
-  assert len(air_grid.get_grid())<=5, "Grid search has returned more models than allowed."
-  print(air_grid.get_grid("logloss"))
+    # check stopping condition 3), max_models
+    correct_stopping_condition = len(air_grid.get_grid()) == search_criteria_tune["max_models"]
 
-  stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all", base_models=air_grid.model_ids)
-  stacker.train(model_id="my_ensemble", y="IsDepDelayed", training_frame=air_hex)
-  predictions = stacker.predict(air_hex)  # training data
-  print("preditions for ensemble are in: " + predictions.frame_id)
+    # if false, check stopping condition 2), max_runtime_secs
+    if not(correct_stopping_condition):
+        correct_stopping_condition = runtime >= search_criteria_tune["max_runtime_secs"]
+
+    # if false, check stopping condition 1), early stopping has occurred.
+    if not(correct_stopping_condition):
+        for eachModel in air_grid.models:
+            metric_list = pyunit_utils.extract_scoring_history_field(eachModel, "training_auc")
+            if pyunit_utils.evaluate_early_stopping(metric_list, search_criteria_tune["stopping_rounds"],
+                                                    search_criteria_tune["stopping_tolerance"], True):
+                correct_stopping_condition=True
+                break
+
+    assert correct_stopping_condition, "Grid search did not find a model that fits the search_criteria_tune."
+    print(air_grid.get_grid("logloss"))
+
+    stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all", base_models=air_grid.model_ids)
+    stacker.train(model_id="my_ensemble", y="IsDepDelayed", training_frame=air_hex)
+    predictions = stacker.predict(air_hex)  # training data
+    print("preditions for ensemble are in: " + predictions.frame_id)
 
 if __name__ == "__main__":
-  pyunit_utils.standalone_test(airline_gbm_random_grid)
+    pyunit_utils.standalone_test(airline_gbm_random_grid)
 else:
-  airline_gbm_random_grid()
+    airline_gbm_random_grid()


### PR DESCRIPTION
1. fix random grid search backend so that we will copy over the parameters in search_criteria into model params when appropriate.

2. fixed pyunit_gbm_random_grid_large.py to check and verify stopping conditions are met properly.  Changed the assertion from len(air_grid)==5 into 3 stopping condition checks:
    search_criteria directs how to do grid search.
    1). grid search can stop early if the early stopping conditions specified by
       stopping_metric/stopping_tolerance/stopping_rounds
    2). grid search will stop if it takes longer than max_runtime_secs
    3). grid search will stop if it has collected max_models in its array.
    
    grid search stops correctly if any of the three conditions are satisfied