### PR TITLE
PUBDEV-4041: Fixing python docstring for stackedensemble

### DIFF
--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -301,15 +301,16 @@ def help_epilogue_for(algo):
                          >>> from h2o.estimators.gbm import H2OGradientBoostingEstimator
                          >>> from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
                          >>> col_types = ["numeric", "numeric", "numeric", "enum", "enum", "numeric", "numeric", "numeric", "numeric"]
-                         >>> dat = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/prostate/prostate.csv", destination_frame="prostate_hex", col_types= col_types)
-                         >>> train, test = dat.split_frame(ratios=[.8], seed=1)
+                         >>> data = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/prostate/prostate.csv", col_types=col_types)
+                         >>> train, test = data.split_frame(ratios=[.8], seed=1)
                          >>> x = ["CAPSULE","GLEASON","RACE","DPROS","DCAPS","PSA","VOL"]
                          >>> y = "AGE"
-                         >>> my_gbm = H2OGradientBoostingEstimator()
+                         >>> nfolds = 5
+                         >>> my_gbm = H2OGradientBoostingEstimator(nfolds=nfolds, fold_assignment="Modulo", keep_cross_validation_predictions=True)
                          >>> my_gbm.train(x=x, y=y, training_frame=train)
-                         >>> my_rf = H2ORandomForestEstimator()
+                         >>> my_rf = H2ORandomForestEstimator(nfolds=nfolds, fold_assignment="Modulo", keep_cross_validation_predictions=True)
                          >>> my_rf.train(x=x, y=y, training_frame=train)
-                         >>> stack = H2OStackedEnsembleEstimator(model_id="my_ensemble_guassian", training_frame=train, validation_frame=test, base_models=[my_gbm.model_id,  my_rf.model_id], selection_strategy="choose_all")
+                         >>> stack = H2OStackedEnsembleEstimator(model_id="my_ensemble", training_frame=train, validation_frame=test, base_models=[my_gbm.model_id, my_rf.model_id])
                          >>> stack.train(x=x, y=y, training_frame=train, validation_frame=test)
                          >>> stack.model_performance()"""
     if algo == "glm":

--- a/h2o-py/docs/modeling.rst
+++ b/h2o-py/docs/modeling.rst
@@ -42,6 +42,12 @@ Supervised
     :show-inheritance:
     :members:
 
+:mod:`H2OStackedEnsembleEstimator`
+----------------------------------
+.. autoclass:: h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
+    :show-inheritance:
+    :members:
+
 
 Unsupervised
 ++++++++++++
@@ -76,11 +82,6 @@ Unsupervised
     :show-inheritance:
     :members:
 
-:mod:`H2OStackedEnsembleEstimator`
-----------------------------------
-.. autoclass:: h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
-    :show-inheritance:
-    :members:
 
 
 Miscellaneous

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -19,9 +19,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     Builds a stacked ensemble (aka "super learner") machine learning method that uses two
     or more H2O learning algorithms to improve predictive performance. It is a loss-based
     supervised learning method that finds the optimal combination of a collection of prediction
-    algorithms. This method supports regression and binary classification.
-
-    Docs: http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html
+    algorithms.This method supports regression and binary classification.
 
     Examples
     --------


### PR DESCRIPTION
This fixes a [previous merged PR](https://github.com/h2oai/h2o-3/pull/866) which didn't properly fix the docstring.  The docstring for Stacked Ensemble in Python is now properly edited in the `./h2o-bindings/bin/gen_python.py`.  It also moves Stacked Ensemble from the "unsupervised" to "supervised" section of the Python module docs.