### PR TITLE
Removing a blank line in the h2o-py/docs/modeling.rst file

### DIFF
--- a/h2o-py/docs/modeling.rst
+++ b/h2o-py/docs/modeling.rst
@@ -83,7 +83,6 @@ Unsupervised
     :members:
 
 
-
 Miscellaneous
 +++++++++++++
 


### PR DESCRIPTION
This extra line might have been breaking the python docs build.