### PR TITLE
Reverted changes in modeling.rst back to H2O 3.10.3.3 version

### DIFF
--- a/h2o-py/docs/modeling.rst
+++ b/h2o-py/docs/modeling.rst
@@ -42,12 +42,6 @@ Supervised
     :show-inheritance:
     :members:
 
-:mod:`H2OStackedEnsembleEstimator`
-----------------------------------
-.. autoclass:: h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
-    :show-inheritance:
-    :members:
-
 
 Unsupervised
 ++++++++++++
@@ -79,6 +73,12 @@ Unsupervised
 :mod:`H2OPrincipalComponentAnalysisEstimator`
 ---------------------------------------------
 .. autoclass:: h2o.estimators.pca.H2OPrincipalComponentAnalysisEstimator
+    :show-inheritance:
+    :members:
+
+:mod:`H2OStackedEnsembleEstimator`
+----------------------------------
+.. autoclass:: h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
     :show-inheritance:
     :members:
 


### PR DESCRIPTION
For an unknown reason, there are build failures due to a change made in the `./h2o-py/docs/modeling.rst` file.  This PR reverts the file back to the H2O 3.10.3.3 version (which was working correctly).  Once the build is working again, a new attempt to modify the file will be made, but right now, we just want to get the master build working again.