### PR TITLE
PUBDEV-4090 enable random seed gridsearch

### DIFF
--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -158,6 +158,9 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
      * Hyper space description - in this case only dimension and possible values.
      */
     final protected Map<String, Object[]> _hyperParams;
+
+    protected boolean _set_model_seed_from_search_seed = false;  // true if model parameter seed is set to default value and false otherwise
+    long model_number = 0l;   // denote model number
     /**
      * Cached names of used hyper parameters.
      */
@@ -254,6 +257,20 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
             throw new H2OIllegalArgumentException("Grid search model parameter '" + key + "' is set in both the model parameters and in the hyperparameters map.  This is ambiguous; set it in one place or the other, not both.");
         }
       } // for all keys
+
+      // check model parameter seed value and determine if it is set to default value for random gridsearch
+      if ((search_criteria != null) &&
+              (search_criteria.strategy() == HyperSpaceSearchCriteria.Strategy.RandomDiscrete)) {
+        Object defaultSeedVal = PojoUtils.getFieldValue(defaults, "_seed", PojoUtils.FieldNaming.CONSISTENT);
+        Object actualSeedVal = PojoUtils.getFieldValue(params, "_seed", PojoUtils.FieldNaming.CONSISTENT);
+        long gridSeed = ((HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria) search_criteria).seed();
+
+        if ((defaultSeedVal != null) && (actualSeedVal != null)) {
+          if (defaultSeedVal.equals(actualSeedVal) && !defaultSeedVal.equals(gridSeed)) { // param seed = default, gridSeed != default
+            _set_model_seed_from_search_seed = true;
+          }
+        }
+      }
     } // BaseWalker()
 
     @Override
@@ -349,18 +366,7 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
             MP commonModelParams = (MP) _params.clone();
             // Fill model parameters
             MP params = getModelParams(commonModelParams, hypers);
-            // add max_runtime_secs in search criteria into params if applicable
-            if (_search_criteria != null && _search_criteria.strategy() == HyperSpaceSearchCriteria.Strategy.RandomDiscrete) {
-              double timeleft = this.time_remaining_secs();
-              if (timeleft > 0)  {
-                if (params._max_runtime_secs > 0) {
-                  params._max_runtime_secs = (long) floor(min(params._max_runtime_secs, timeleft));
-                } else {
-                  params._max_runtime_secs = (long) floor(timeleft);
-                }
-              }
-            }
-            // We have another model parameters
+
             return params;
           } else {
             throw new NoSuchElementException("No more elements to explore in hyper-space!");
@@ -496,6 +502,27 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
             MP commonModelParams = (MP) _params.clone();
             // Fill model parameters
             MP params = getModelParams(commonModelParams, hypers);
+
+            // add max_runtime_secs in search criteria into params if applicable
+            if (_search_criteria != null && _search_criteria.strategy() == HyperSpaceSearchCriteria.Strategy.RandomDiscrete) {
+              // ToDo: model seed setting will be different for parallel model building.
+              // ToDo: This implementation only works for sequential model building.
+              if (_set_model_seed_from_search_seed) {
+                // set model seed = search_criteria.seed+(0, 1, 2,..., model number)
+                params._seed=((HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria) _search_criteria).seed()+
+                        (model_number++);
+              }
+
+              // set max_runtime_secs
+              double timeleft = this.time_remaining_secs();
+              if (timeleft > 0)  {
+                if (params._max_runtime_secs > 0) {
+                  params._max_runtime_secs = (long) floor(min(params._max_runtime_secs, timeleft));
+                } else {
+                  params._max_runtime_secs = (long) floor(timeleft);
+                }
+              }
+            }
             return params;
           } else {
             throw new NoSuchElementException("No more elements to explore in hyper-space!");

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -1424,7 +1424,7 @@ def generate_sign_vec(table1, table2):
 
     return sign_vec
 
-def equal_two_arrays(array1, array2, eps, tolerance):
+def equal_two_arrays(array1, array2, eps, tolerance, throwError=True):
     """
     This function will compare the values of two python tuples.  First, if the values are below
     eps which denotes the significance level that we care, no comparison is performed.  Next,
@@ -1453,7 +1453,10 @@ def equal_two_arrays(array1, array2, eps, tolerance):
 
         return True                                     # return True, elements of two arrays are close enough
     else:
-        assert False, "The two arrays are of different size!"
+        if throwError:
+            assert False, "The two arrays are of different size!"
+        else:
+            return False
 
 def equal_2D_tables(table1, table2, tolerance=1e-6):
     """
@@ -1484,6 +1487,7 @@ def equal_2D_tables(table1, table2, tolerance=1e-6):
 
     else:
         assert False, "The two arrays are of different size!"
+
 
 def compare_two_arrays(array1, array2, eps, tolerance, comparison_string, array1_string, array2_string, error_string,
                        success_string, template_is_better, just_print=False):
@@ -2911,7 +2915,6 @@ def model_run_time_sorted_by_time(model_list):
     """
     This function is written to sort the metrics that we care in the order of when the model was built.  The
     oldest model metric will be the first element.
-
     :param model_list: list of models built sequentially that contains metric of interest among other fields
     :return: model run time in secs sorted by order of building
     """
@@ -2927,3 +2930,27 @@ def model_run_time_sorted_by_time(model_list):
             (model_list[index]._model_json["output"]["run_time"]/1000.0)
 
     return model_runtime_sec_list
+
+
+def model_seed_sorted_by_time(model_list):
+    """
+    This function is written to find the seed used by each model in the order of when the model was built.  The
+    oldest model metric will be the first element.
+    :param model_list: list of models built sequentially that contains metric of interest among other fields
+    :return: model seed sorted by order of building
+    """
+
+    model_num = len(model_list)
+
+    model_seed_list = [None] * model_num
+
+
+    for index in range(model_num):
+        model_index = int(model_list[index]._id.split('_')[-1])
+
+        for pIndex in range(len(model_list.models[0]._model_json["parameters"])):
+            if model_list.models[index]._model_json["parameters"][pIndex]["name"]=="seed":
+                model_seed_list[model_index]=model_list.models[index]._model_json["parameters"][pIndex]["actual_value"]
+                break
+
+    return model_seed_list

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
@@ -1,0 +1,87 @@
+from __future__ import print_function
+from builtins import range
+import math
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.grid.grid_search import H2OGridSearch
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+def random_grid_model_seeds_PUBDEV_4090():
+    '''
+    This test is written to verify that I have implemented the model seed determination properly when
+    random grid search is enabled.  Basically, there are three cases:
+    1. Both the model and search_criteria did not set the seed value.  The seed values are either not set or
+      set to default values.  In this case, random grid search and model will be using random seeds for itself
+      independent of each other;
+    2. Both the model and search_criteria set their seeds to be non-default values.  Random grid search will use
+      the seed set in search_critera and model will be built using the seed set in its model parameter.
+    3. The search_criteria seed is set to a non-default value while the model parameter seed is default value,
+      Random grid search will use the search_criteria seed while the models will be built using the following
+      sequence of seeds:
+      - model 0: search_criteria seed;
+      - model 1: search_criteria seed+1;
+      -....
+      - model n: search_criteria seed+n;
+      ...
+    4. Model parameter seed is set but search seed is set to default.  In this case, gridsearch will use random
+      seed while models are built using the one seed.
+
+    Current code already support cases 1/2/4.  The code changes were made to enable case 3 and this is the
+    case that will be tested here.
+    '''
+    air_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip"),
+                              destination_frame="air.hex")
+    myX = ["Year","Month","CRSDepTime","UniqueCarrier","Origin","Dest"]
+    grid_max_runtime_secs = 20
+    # create hyperameter and search criteria lists (ranges are inclusive..exclusive))
+    hyper_params_tune = {'max_depth' : list(range(1,10+1,1)),
+                         'sample_rate': [x/100. for x in range(20,101)],
+                         'col_sample_rate' : [x/100. for x in range(20,101)],
+                         'col_sample_rate_per_tree': [x/100. for x in range(20,101)],
+                         'col_sample_rate_change_per_level': [x/100. for x in range(90,111)],
+                         'min_rows': [2**x for x in range(0,int(math.log(air_hex.nrow,2)-1)+1)],
+                         'nbins': [2**x for x in range(4,11)],
+                         'nbins_cats': [2**x for x in range(4,13)],
+                         'min_split_improvement': [0,1e-8,1e-6,1e-4],
+                         'histogram_type': ["UniformAdaptive","QuantilesGlobal","RoundRobin"]}
+
+
+    search_criteria_tune1 = {'strategy': "RandomDiscrete",
+                             'max_runtime_secs': grid_max_runtime_secs ,   # limit the runtime
+                             'seed' : 1234,
+                             }
+    search_criteria_tune2 = {'strategy': "RandomDiscrete",
+                             'max_runtime_secs': grid_max_runtime_secs ,   # limit the runtime
+                             'seed' : 1234,
+                             }
+
+    # case 3, search criteria seed is set but model parameter seed is not:
+    air_grid1 = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_params_tune,
+                              search_criteria=search_criteria_tune1)
+    air_grid2 = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_params_tune,
+                              search_criteria=search_criteria_tune2)
+    air_grid1.train(x=myX, y="IsDepDelayed", training_frame=air_hex, distribution="bernoulli")
+    air_grid2.train(x=myX, y="IsDepDelayed", training_frame=air_hex, distribution="bernoulli")
+
+    # expect both models to render the same metrics as they use the same model seed, search criteria seed
+    model_seeds1 = pyunit_utils.model_seed_sorted_by_time(air_grid1)
+    model_seeds2 = pyunit_utils.model_seed_sorted_by_time(air_grid2)
+    # check model seeds are set as gridseed+model number where model number = 0, 1, ..., ...
+    model_len = min(len(air_grid1), len(air_grid2))
+    correct_model_seeds = list(range(search_criteria_tune1["seed"], search_criteria_tune1["seed"]+model_len))
+    assert model_seeds1[0:model_len]==model_seeds2[0:model_len], "Random gridsearch seed is not set correctly as model seeds..."
+    assert model_seeds1==correct_model_seeds, "Random gridsearch seed is not "
+
+    # compare training_rmse from scoring history
+    metric_list1 = pyunit_utils.extract_scoring_history_field(air_grid1.models[0], "training_rmse")
+    metric_list2 = pyunit_utils.extract_scoring_history_field(air_grid2.models[0], "training_rmse")
+    assert pyunit_utils.equal_two_arrays(metric_list1[0:model_len], metric_list2[0:model_len], 1e-5, 1e-6, False), \
+        "Random gridsearch seed is not set correctly as model seeds..."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(random_grid_model_seeds_PUBDEV_4090)
+else:
+    random_grid_model_seeds_PUBDEV_4090()


### PR DESCRIPTION
1. Added code in HyperSpaceWalker.java to enable the following parameter seed setup:

If the user sets a search seed, and the user hasn’t set the base model seed parameter to a non -1 value, then the random search sets the model seed to the search seed + the model number (0, 1, 2) for this search.

2.  Add h2o-3/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py to verify that grid search building repeatability implemented in 1.