### PR TITLE
Moved out all "string to bytes" transformations

### DIFF
--- a/h2o-core/src/main/java/hex/DMatrix.java
+++ b/h2o-core/src/main/java/hex/DMatrix.java
@@ -11,6 +11,7 @@ import water.fvec.NewChunk.Value;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
 import water.util.Log;
+import water.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Iterator;

--- a/h2o-core/src/main/java/hex/ModelMojoWriter.java
+++ b/h2o-core/src/main/java/hex/ModelMojoWriter.java
@@ -6,6 +6,7 @@ import water.H2O;
 import water.api.SchemaServer;
 import water.api.StreamWriter;
 import water.api.schemas3.ModelSchemaV3;
+import water.util.StringUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -133,7 +134,7 @@ public abstract class ModelMojoWriter<M extends Model<M, P, O>, P extends Model.
   /** Finish writing a text file. */
   protected final void finishWritingTextFile() throws IOException {
     assert tmpfile != null : "No text file is currently being written";
-    writeblob(tmpname, tmpfile.toString().getBytes(Charset.forName("UTF-8")));
+    writeblob(tmpname, StringUtils.toBytes(tmpfile));
     tmpfile = null;
   }
 

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -10,6 +10,7 @@ import java.util.Random;
 
 import water.network.SocketChannelUtils;
 import water.util.Log;
+import water.util.StringUtils;
 import water.util.TwoDimTable;
 
 /** A ByteBuffer backed mixed Input/Output streaming class, using Iced serialization.
@@ -1466,7 +1467,7 @@ public final class AutoBuffer {
   // Put a String as bytes (not chars!)
   public AutoBuffer putStr( String s ) {
     if( s==null ) return putInt(-1);
-    return putA1(s.getBytes(UTF_8));
+    return putA1(StringUtils.bytesOf(s));
   }
 
   @SuppressWarnings("unused")  public AutoBuffer putEnum( Enum x ) {
@@ -1594,7 +1595,7 @@ public final class AutoBuffer {
   public AutoBuffer putJNULL( ) { return put1('n').put1('u').put1('l').put1('l'); }
   // Escaped JSON string
   private AutoBuffer putJStr( String s ) {
-    byte[] b = s.getBytes();
+    byte[] b = StringUtils.bytesOf(s);
     int off=0;
     for( int i=0; i<b.length; i++ ) {
       if( b[i] == '\\' || b[i] == '"') { // Double up backslashes, escape quotes
@@ -1707,7 +1708,7 @@ public final class AutoBuffer {
 
   // Most simple integers
   private AutoBuffer putJInt( int i ) {
-    byte b[] = Integer.toString(i).getBytes();
+    byte b[] = StringUtils.toBytes(i);
     return putA1(b,b.length);
   }
 

--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -24,6 +24,7 @@ import water.exceptions.H2OAbstractRuntimeException;
 import water.exceptions.H2OFailException;
 import water.util.HttpResponseStatus;
 import water.util.Log;
+import water.util.StringUtils;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -392,7 +393,7 @@ public class JettyHTTPD {
     }
 
     boundaryString = ct.substring(idx + "boundary=".length());
-    byte[] boundary = boundaryString.getBytes();
+    byte[] boundary = StringUtils.bytesOf(boundaryString);
 
     // Consume headers of the mime part.
     InputStream is = request.getInputStream();
@@ -405,7 +406,7 @@ public class JettyHTTPD {
   }
 
   public static boolean validKeyName(String name) {
-    byte[] arr = name.getBytes();
+    byte[] arr = StringUtils.bytesOf(name);
     for (byte b : arr) {
       if (b == '"') return false;
       if (b == '\\') return false;

--- a/h2o-core/src/main/java/water/Key.java
+++ b/h2o-core/src/main/java/water/Key.java
@@ -1,6 +1,7 @@
 package water;
 
 import water.util.ReflectionUtils;
+import water.util.StringUtils;
 import water.util.UnsafeUtils;
 import water.fvec.*;
 
@@ -457,7 +458,7 @@ final public class Key<T extends Keyed> extends Iced<Key<T>> implements Comparab
         l -= Character.isDigit(l) ? '0' : ('a' - 10);
         res[r++] = (byte)(h << 4 | l);
       }
-      System.arraycopy(tail.getBytes(), 0, res, r, tail.length());
+      System.arraycopy(StringUtils.bytesOf(tail), 0, res, r, tail.length());
       return res;
     } else {
       byte[] res = new byte[what.length()];

--- a/h2o-core/src/main/java/water/Value.java
+++ b/h2o-core/src/main/java/water/Value.java
@@ -7,6 +7,7 @@ import jsr166y.ForkJoinPool;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.Log;
+import water.util.StringUtils;
 
 /** The core Value stored in the distributed K/V store, used to cache Plain Old
  *  Java Objects, and maintain coherency around the cluster.  It contains an
@@ -308,7 +309,7 @@ public final class Value extends Iced implements ForkJoinPool.ManagedBlocker {
     _replicas = null;
   }
   Value(Key k, byte[] mem ) { this(k, mem.length, mem, TypeMap.PRIM_B, ICE); }
-  Value(Key k, String s ) { this(k, s.getBytes()); }
+  Value(Key k, String s ) { this(k, StringUtils.bytesOf(s)); }
   Value(Key k, Iced pojo ) { this(k,pojo,ICE); }
   Value(Key k, Iced pojo, byte be ) {
     _key = k;

--- a/h2o-core/src/main/java/water/api/NanoResponse.java
+++ b/h2o-core/src/main/java/water/api/NanoResponse.java
@@ -2,6 +2,7 @@ package water.api;
 
 import water.util.FileUtils;
 import water.util.Log;
+import water.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -36,12 +37,7 @@ public class NanoResponse {
   public NanoResponse(String status, String mimeType, String txt) {
     this.status = status;
     this.mimeType = mimeType;
-    try {
-      this.data = new ByteArrayInputStream(txt.getBytes("UTF-8"));
-    }
-    catch (java.io.UnsupportedEncodingException e) {
-      Log.err(e);
-    }
+    this.data = new ByteArrayInputStream(StringUtils.bytesOf(txt));
   }
 
   public void writeTo(OutputStream os) {

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -741,11 +741,11 @@ public class RequestServer extends HttpServlet {
           g.doIt();
           bytes = g.bytes;
         } else {
-          bytes = "Node not healthy".getBytes();
+          bytes = StringUtils.bytesOf("Node not healthy");
         }
       }
       catch (Exception e) {
-        bytes = e.toString().getBytes();
+        bytes = StringUtils.toBytes(e);
       }
       perNodeZipByteArray[i] = bytes;
     }
@@ -759,7 +759,7 @@ public class RequestServer extends HttpServlet {
         bytes = g.bytes;
       }
       catch (Exception e) {
-        bytes = e.toString().getBytes();
+        bytes = StringUtils.toBytes(e);
       }
       clientNodeByteArray = bytes;
     }
@@ -770,7 +770,7 @@ public class RequestServer extends HttpServlet {
       finalZipByteArray = zipLogs(perNodeZipByteArray, clientNodeByteArray, outputFileStem);
     }
     catch (Exception e) {
-      finalZipByteArray = e.toString().getBytes();
+      finalZipByteArray = StringUtils.toBytes(e);
     }
 
     NanoResponse res = new NanoResponse(HTTP_OK, MIME_DEFAULT_BINARY, new ByteArrayInputStream(finalZipByteArray));

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1474,7 +1474,7 @@ public class Frame extends Lockable<Frame> {
           sb.append(',').append('"').append(names[i]).append('"');
         sb.append('\n');
       }
-      _line = sb.toString().getBytes();
+      _line = StringUtils.bytesOf(sb);
       _chkRow = -1; // first process the header line
       _curChks = chks;
     }
@@ -1513,7 +1513,7 @@ public class Frame extends Lockable<Frame> {
         }
       }
       sb.append('\n');
-      return sb.toString().getBytes();
+      return StringUtils.bytesOf(sb);
     }
 
     @Override public int available() throws IOException {

--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -7,6 +7,7 @@ import water.H2O;
 import water.MemoryManager;
 import water.parser.BufferedString;
 import water.util.PrettyPrint;
+import water.util.StringUtils;
 import water.util.UnsafeUtils;
 
 import java.util.*;
@@ -576,7 +577,7 @@ public class NewChunk extends Chunk {
   }
 
   private void append_ss(String str) {
-    byte[] bytes = str == null ? new byte[0] : str.getBytes(Charsets.UTF_8);
+    byte[] bytes = str == null ? new byte[0] : StringUtils.bytesOf(str);
 
     // Allocate memory if necessary
     if (_ss == null)

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -6,6 +6,7 @@ import water.JettyHTTPD;
 import water.util.Log;
 import water.util.NetworkUtils;
 import water.util.OSUtils;
+import water.util.StringUtils;
 
 import java.io.*;
 import java.net.*;
@@ -629,7 +630,7 @@ public class NetworkInit {
 
   static HashSet<H2ONode> parseFlatFileFromString( String s ) {
     HashSet<H2ONode> h2os = new HashSet<>();
-    InputStream is = new ByteArrayInputStream(s.getBytes());
+    InputStream is = new ByteArrayInputStream(StringUtils.bytesOf(s));
     List<FlatFileEntry> list = parseFlatFile(is);
     for(FlatFileEntry entry : list)
       h2os.add(H2ONode.intern(entry.inet, entry.port+1));// use the UDP port here

--- a/h2o-core/src/main/java/water/init/NodePersistentStorage.java
+++ b/h2o-core/src/main/java/water/init/NodePersistentStorage.java
@@ -6,6 +6,7 @@ import water.persist.Persist.PersistEntry;
 import water.persist.PersistManager;
 import water.util.FileUtils;
 import water.util.Log;
+import water.util.StringUtils;
 
 import java.io.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -183,7 +184,7 @@ public class NodePersistentStorage {
     validateCategoryName(categoryName);
     validateKeyName(keyName);
 
-    InputStream is = new ByteArrayInputStream(value.getBytes());
+    InputStream is = new ByteArrayInputStream(StringUtils.bytesOf(value));
     put(categoryName, keyName, is);
   }
 

--- a/h2o-core/src/main/java/water/parser/BufferedString.java
+++ b/h2o-core/src/main/java/water/parser/BufferedString.java
@@ -3,6 +3,7 @@ package water.parser;
 import com.google.common.base.Charsets;
 import water.AutoBuffer;
 import water.Iced;
+import water.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.Formatter;
@@ -28,7 +29,7 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
      this(Arrays.copyOfRange(from._buf,from._off,from._off+from._len));
    }
 
-   public BufferedString(String from) { this(from.getBytes(Charsets.UTF_8)); }
+   public BufferedString(String from) { this(StringUtils.bytesOf(from)); }
    // Used to make a temp recycling BufferedString in hot loops
    public BufferedString() { }
 
@@ -136,7 +137,7 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
   }
 
   public final BufferedString set(String s) {
-    return set(s.getBytes(Charsets.UTF_8));
+    return set(StringUtils.bytesOf(s));
   }
 
   public void setOff(int off) {

--- a/h2o-core/src/main/java/water/parser/Categorical.java
+++ b/h2o-core/src/main/java/water/parser/Categorical.java
@@ -61,6 +61,7 @@ public final class Categorical extends Iced {
   }
 
   public static final int MAX_EXAMPLES = 10;
+  // TODO(Vlad): either make sure it works, or just get rid of it
   public void convertToUTF8(int col){
     int hexConvCnt = 0;
     BufferedString[] bStrs = _map.keySet().toArray(new BufferedString[_map.size()]);

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -5,6 +5,8 @@ import org.apache.http.ParseException;
 import water.fvec.Vec;
 import water.fvec.FileVec;
 import water.Key;
+import water.util.StringUtils;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -495,7 +497,7 @@ MAIN_LOOP:
   /** Dermines the number of separators in given line.  Correctly handles quoted tokens. */
   private static int[] determineSeparatorCounts(String from, byte singleQuote) {
     int[] result = new int[separators.length];
-    byte[] bits = from.getBytes();
+    byte[] bits = StringUtils.bytesOf(from);
     boolean inQuote = false;
     for( byte c : bits ) {
       if( (c == singleQuote) || (c == CsvParser.CHAR_DOUBLE_QUOTE) )
@@ -517,7 +519,7 @@ MAIN_LOOP:
   }
   public static String[] determineTokens(String from, byte separator, byte singleQuote) {
     ArrayList<String> tokens = new ArrayList<>();
-    byte[] bits = from.getBytes();
+    byte[] bits = StringUtils.bytesOf(from);
     int offset = 0;
     int quotes = 0;
     while (offset < bits.length) {

--- a/h2o-core/src/main/java/water/parser/ParseTime.java
+++ b/h2o-core/src/main/java/water/parser/ParseTime.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import static water.util.StringUtils.*;
 
 public abstract class ParseTime {
   // Deduce if we are looking at a Date/Time value, or not.
@@ -29,18 +30,18 @@ public abstract class ParseTime {
   }
 
   private static final byte MMS[][][] = new byte[][][] {
-    {"jan".getBytes(),"january"  .getBytes()},
-    {"feb".getBytes(),"february" .getBytes()},
-    {"mar".getBytes(),"march"    .getBytes()},
-    {"apr".getBytes(),"april"    .getBytes()},
-    {"may".getBytes(),"may"      .getBytes()},
-    {"jun".getBytes(),"june"     .getBytes()},
-    {"jul".getBytes(),"july"     .getBytes()},
-    {"aug".getBytes(),"august"   .getBytes()},
-    {"sep".getBytes(),"september".getBytes()},
-    {"oct".getBytes(),"october"  .getBytes()},
-    {"nov".getBytes(),"november" .getBytes()},
-    {"dec".getBytes(),"december" .getBytes()}
+    {bytesOf("jan"),bytesOf("january")},
+    {bytesOf("feb"),bytesOf("february")},
+    {bytesOf("mar"),bytesOf("march")},
+    {bytesOf("apr"),bytesOf("april")},
+    {bytesOf("may"),bytesOf("may")},
+    {bytesOf("jun"),bytesOf("june")},
+    {bytesOf("jul"),bytesOf("july")},
+    {bytesOf("aug"),bytesOf("august")},
+    {bytesOf("sep"),bytesOf("september")},
+    {bytesOf("oct"),bytesOf("october")},
+    {bytesOf("nov"),bytesOf("november")},
+    {bytesOf("dec"),bytesOf("december")}
   };
 
   public static long attemptTimeParse( BufferedString str ) {

--- a/h2o-core/src/main/java/water/util/GetLogsFromNode.java
+++ b/h2o-core/src/main/java/water/util/GetLogsFromNode.java
@@ -65,7 +65,7 @@ public class GetLogsFromNode extends Iced {
         _bytes = baos.toByteArray();
       }
       catch (Exception e) {
-        _bytes = e.toString().getBytes();
+        _bytes = StringUtils.toBytes(e);
       }
     }
 

--- a/h2o-core/src/main/java/water/util/StringUtils.java
+++ b/h2o-core/src/main/java/water/util/StringUtils.java
@@ -1,9 +1,11 @@
 package water.util;
 
+import com.google.common.base.Charsets;
 import water.parser.BufferedString;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.*;
 
 /**
@@ -187,5 +189,13 @@ public class StringUtils {
       res = (res << 4) + hexCode.get(c);
     }
     return res;
+  }
+
+  public static byte[] bytesOf(CharSequence str) {
+    return str.toString().getBytes(Charsets.UTF_8);
+  }
+
+  public static byte[] toBytes(Object value) {
+    return bytesOf(String.valueOf(value));
   }
 }

--- a/h2o-core/src/test/java/water/KeyToString.java
+++ b/h2o-core/src/test/java/water/KeyToString.java
@@ -2,12 +2,13 @@ package water;
 
 import static org.junit.Assert.*;
 import org.junit.*;
+import water.util.StringUtils;
 
 import java.util.Arrays;
 
 public class KeyToString extends TestUtil {
   @Test public void testKeyToString() {
-    byte[] b = "XXXHelloAll".getBytes();
+    byte[] b = StringUtils.bytesOf("XXXHelloAll");
     assertTrue(Key.make(b).toString().equals("XXXHelloAll"));
     assertTrue(Arrays.equals(Key.make(b)._kb,b));
     b[0] = 16;

--- a/h2o-core/src/test/java/water/fvec/FVecTest.java
+++ b/h2o-core/src/test/java/water/fvec/FVecTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import water.*;
 import water.util.ArrayUtils;
 import water.util.FileUtils;
+import water.util.StringUtils;
 
 import java.io.File;
 
@@ -21,7 +22,7 @@ public class FVecTest extends TestUtil {
     byte [][] chunks = new byte[data.length][];
     long [] espc = new long[data.length+1];
     for(int i = 0; i < chunks.length; ++i){
-      chunks[i] = data[i].getBytes();
+      chunks[i] = StringUtils.bytesOf(data[i]);
       espc[i+1] = espc[i] + data[i].length();
     }
     Futures fs = new Futures();

--- a/h2o-core/src/test/java/water/network/SSLSocketChannelFactoryTest.java
+++ b/h2o-core/src/test/java/water/network/SSLSocketChannelFactoryTest.java
@@ -2,6 +2,7 @@ package water.network;
 
 import org.junit.Test;
 import water.util.FileUtils;
+import water.util.StringUtils;
 
 import javax.net.ssl.SSLException;
 import java.io.IOException;
@@ -168,7 +169,7 @@ public class SSLSocketChannelFactoryTest {
 
                 // FIRST TEST: SSL -> SSL SMALL COMMUNICATION
                 ByteBuffer write = ByteBuffer.allocate(1024);
-                write.put("hello, world".getBytes("UTF-8"));
+                write.put(StringUtils.bytesOf("hello, world"));
                 write.flip();
                 wrappedChannel.write(write);
 
@@ -180,8 +181,7 @@ public class SSLSocketChannelFactoryTest {
                     toWriteBig.clear();
                     while (toWriteBig.hasRemaining()) {
                         toWriteBig.put(
-                                ("hello, world" + ((i * 64 * 1024 + toWriteBig.position()) % 9) + "!!!")
-                                        .getBytes("UTF-8")
+                            StringUtils.bytesOf("hello, world" + ((i * 64 * 1024 + toWriteBig.position()) % 9) + "!!!")
                         );
                     }
                     toWriteBig.flip();
@@ -192,7 +192,7 @@ public class SSLSocketChannelFactoryTest {
 
                 // THIRD TEST: NON-SSL -> SSL COMMUNICATION
                 write.clear();
-                write.put("hello, world".getBytes("UTF-8"));
+                write.put(StringUtils.bytesOf("hello, world"));
                 write.flip();
                 sock.write(write);
 
@@ -200,8 +200,7 @@ public class SSLSocketChannelFactoryTest {
 
                 // FOURTH TEST: SSL -> NON-SSL COMMUNICATION
                 write.clear();
-                write.put("hello, world".getBytes("UTF-8"));
-                write.flip();
+                write.put(StringUtils.bytesOf("hello, world"));
                 wrappedChannel.write(write);
 
             } catch (IOException | InterruptedException | BrokenBarrierException e) {

--- a/h2o-core/src/test/java/water/parser/ParserTest.java
+++ b/h2o-core/src/test/java/water/parser/ParserTest.java
@@ -11,6 +11,7 @@ import water.api.schemas3.ParseSetupV3;
 import water.fvec.*;
 import water.util.FileUtils;
 import water.util.Log;
+import water.util.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,7 +35,7 @@ public class ParserTest extends TestUtil {
     DKV.put(k,bv,fs);
     for( int i = 0; i < data.length; ++i ) {
       Key ck = bv.chunkKey(i);
-      DKV.put(ck, new Value(ck,new C1NChunk(data[i].getBytes())),fs);
+      DKV.put(ck, new Value(ck,new C1NChunk(StringUtils.bytesOf(data[i]))),fs);
     }
     fs.blockForPending();
     return k;

--- a/h2o-core/src/test/java/water/parser/ParserTest2.java
+++ b/h2o-core/src/test/java/water/parser/ParserTest2.java
@@ -9,6 +9,7 @@ import water.TestUtil;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.PrettyPrint;
+import water.util.StringUtils;
 
 import java.util.Random;
 import java.util.UUID;
@@ -80,7 +81,7 @@ public class ParserTest2 extends TestUtil {
                                               ar("'Tomas''s","test2'","test2",null),
                                               ar("last","'line''s","trailing","piece'") };
     Key k = ParserTest.makeByteVec(data);
-    ParseSetup gSetupF = ParseSetup.guessSetup(null, data[0].getBytes(), CSV_INFO, (byte)',', 4, false/*single quote*/, ParseSetup.NO_HEADER, null, null, null, null);
+    ParseSetup gSetupF = ParseSetup.guessSetup(null, StringUtils.bytesOf(data[0]), CSV_INFO, (byte)',', 4, false/*single quote*/, ParseSetup.NO_HEADER, null, null, null, null);
     gSetupF._column_types = ParseSetup.strToColumnTypes(new String[]{"Enum", "Enum", "Enum", "Enum"});
     Frame frF = ParseDataset.parse(Key.make(), new Key[]{k}, false, gSetupF);
     testParsed(frF,expectFalse);
@@ -88,7 +89,7 @@ public class ParserTest2 extends TestUtil {
     String[][] expectTrue = new String[][] { ar("Tomass,test,first,line", null),
                                              ar("Tomas''stest2","test2"),
                                              ar("last", "lines trailing piece") };
-    ParseSetup gSetupT = ParseSetup.guessSetup(null, data[0].getBytes(), CSV_INFO, (byte)',', 2, true/*single quote*/, ParseSetup.NO_HEADER, null, null, null, null);
+    ParseSetup gSetupT = ParseSetup.guessSetup(null, StringUtils.bytesOf(data[0]), CSV_INFO, (byte)',', 2, true/*single quote*/, ParseSetup.NO_HEADER, null, null, null, null);
     gSetupT._column_types = ParseSetup.strToColumnTypes(new String[]{"Enum", "Enum", "Enum", "Enum"});
     Frame frT = ParseDataset.parse(Key.make(), new Key[]{k}, true, gSetupT);
     //testParsed(frT,expectTrue);  // not currently passing
@@ -255,7 +256,7 @@ public class ParserTest2 extends TestUtil {
     long startTime = System.currentTimeMillis();
     for (int i = 0; i < numOfIterations; i++) {
       int idx = random.nextInt(numOfUniqueCats);
-      bs.set(values[idx].getBytes());
+      bs.set(StringUtils.bytesOf(values[idx]));
       cat.addKey(bs);
       if (i % 10000000 == 0) System.out.println("Iterations: " + i);
     }

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/AbstractMessage.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/AbstractMessage.java
@@ -1,5 +1,7 @@
 package water.hadoop;
 
+import water.util.StringUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -97,7 +99,7 @@ class AbstractMessage {
   }
 
   protected void writeString(Socket s, String str) throws Exception {
-    byte b[] = str.getBytes("UTF-8");
+    byte b[] = StringUtils.bytesOf(str);
     writeInt(s, b.length);
     writeBytes(s, b);
   }

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -11,6 +11,7 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import water.network.SecurityUtils;
+import water.util.StringUtils;
 
 import java.io.*;
 import java.net.*;
@@ -1250,11 +1251,11 @@ public class h2odriver extends Configured implements Tool {
       addMapperConf(conf, "-login_conf", "login.conf", loginConfFileName);
     } else if (kerberosLogin) {
       // Use default Kerberos configuration file
-      final byte[] krbConfData = (
+      final byte[] krbConfData = StringUtils.bytesOf(
               "krb5loginmodule {\n" +
               "     com.sun.security.auth.module.Krb5LoginModule required;\n" +
               "};"
-      ).getBytes();
+      );
       addMapperConf(conf, "-login_conf", "login.conf", krbConfData);
     }
 

--- a/h2o-parsers/h2o-avro-parser/src/test/java/water/parser/ParseTestAvro.java
+++ b/h2o-parsers/h2o-avro-parser/src/test/java/water/parser/ParseTestAvro.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 import water.TestUtil;
 import water.fvec.Frame;
 import water.fvec.Vec;
+import water.util.StringUtils;
 
 /**
  * Test suite for Avro parser.
@@ -187,7 +188,7 @@ class AvroFileGenerator {
       for (int i = 0; i < nrows; i++) {
         GenericRecord gr = new GenericData.Record(schema);
         gr.put("CString", String.valueOf(i));
-        gr.put("CBytes", ByteBuffer.wrap(String.valueOf(i).getBytes()));
+        gr.put("CBytes", ByteBuffer.wrap(StringUtils.toBytes(i)));
         gr.put("CInt", i);
         gr.put("CLong", Long.valueOf(i));
         gr.put("CFloat", Float.valueOf(i));
@@ -230,7 +231,7 @@ class AvroFileGenerator {
       for (int i = 0; i < nrows; i++) {
         GenericRecord gr = new GenericData.Record(schema);
         gr.put("CUString", i == 0 ? null : String.valueOf(i));
-        gr.put("CUBytes", i == 0 ? null : ByteBuffer.wrap(String.valueOf(i).getBytes()));
+        gr.put("CUBytes", i == 0 ? null : ByteBuffer.wrap(StringUtils.toBytes(i)));
         gr.put("CUInt", i == 0 ? null : i);
         gr.put("CULong", i == 0 ? null : Long.valueOf(i));
         gr.put("CUFloat", i == 0 ? null : Float.valueOf(i));

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
@@ -15,6 +15,7 @@ import water.Key;
 import water.fvec.Vec;
 import water.parser.*;
 import water.util.ArrayUtils;
+import water.util.StringUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -306,14 +307,14 @@ public class OrcParser extends Parser {
         HashMap<Number,byte[]> map = _toStringMaps.get(colId);
         BufferedString bs = new BufferedString();
         if(vec.isRepeating) {
-          bs.set(Double.toString(oneColumn[0]).getBytes());
+          bs.set(StringUtils.toBytes(oneColumn[0]));
           for (int i = 0; i < rowNumber; ++i)
             dout.addStrCol(colId, bs);
         } else  if (vec.noNulls) {
           for (int i = 0; i < rowNumber; i++) {
             double d = oneColumn[i];
             if(map.get(d) == null) // TODO probably more effficient if moved to the data output
-              map.put(d, Double.toString(d).getBytes());
+              map.put(d, StringUtils.toBytes(d));
             dout.addStrCol(colId, bs.set(map.get(d)));
           }
         } else {
@@ -324,7 +325,7 @@ public class OrcParser extends Parser {
             else {
               double d = oneColumn[i];
               if(map.get(d) == null)
-                map.put(d,Double.toString(d).getBytes());
+                map.put(d,StringUtils.toBytes(d));
               dout.addStrCol(colId, bs.set(map.get(d)));
             }
           }
@@ -367,14 +368,14 @@ public class OrcParser extends Parser {
         HashMap<Number,byte[]> map = _toStringMaps.get(colId);
         BufferedString bs = new BufferedString();
         if(vec.isRepeating) {
-          bs.set(Long.toString(oneColumn[0]).getBytes());
+          bs.set(StringUtils.toBytes(oneColumn[0]));
           for (int i = 0; i < rowNumber; ++i)
             dout.addStrCol(colId, bs);
         } else  if (vec.noNulls) {
           for (int i = 0; i < rowNumber; i++) {
             long l = oneColumn[i];
             if(map.get(l) == null)
-              map.put(l,Long.toString(l).getBytes());
+              map.put(l,StringUtils.toBytes(l));
             dout.addStrCol(colId, bs.set(map.get(l)));
           }
         } else {
@@ -385,7 +386,7 @@ public class OrcParser extends Parser {
             else {
               long l = oneColumn[i];
               if(map.get(l) == null)
-                map.put(l,Long.toString(l).getBytes());
+                map.put(l,StringUtils.toBytes(l));
               dout.addStrCol(colId, bs.set(map.get(l)));
             }
           }

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkConverter.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkConverter.java
@@ -12,6 +12,7 @@ import org.apache.parquet.schema.Type;
 import water.fvec.Vec;
 import water.parser.BufferedString;
 import water.parser.ParseWriter;
+import water.util.StringUtils;
 
 /**
  * Implementation of Parquet's GroupConverter for H2O's chunks.
@@ -98,7 +99,7 @@ class ChunkConverter extends GroupConverter {
 
     @Override
     public void addBinary(Binary value) {
-      _bs.set(value.toStringUsingUTF8().getBytes());
+      _bs.set(StringUtils.bytesOf(value.toStringUsingUTF8()));
       _writer.addStrCol(_colIdx, _bs);
     }
 
@@ -117,7 +118,7 @@ class ChunkConverter extends GroupConverter {
 
     @Override
     public void addValueFromDictionary(int dictionaryId) {
-      _bs.set(_dict[dictionaryId].getBytes());
+      _bs.set(StringUtils.bytesOf(_dict[dictionaryId]));
       _writer.addStrCol(_colIdx, _bs);
     }
   }
@@ -160,7 +161,7 @@ class ChunkConverter extends GroupConverter {
 
     @Override
     public void addBinary(Binary value) {
-      _bs.set(value.toStringUsingUTF8().getBytes());
+      _bs.set(StringUtils.bytesOf(value.toStringUsingUTF8()));
       _writer.addStrCol(_colIdx, _bs);
     }
   }


### PR DESCRIPTION
Moved them into a `StringUtils` method.
The thing is, repeating "udf, udf" everywhere looks kind of too repetitive.
Using default encoding means we depend on whatever settings a server has,
and the server can be something in Japan (and another in Russia, and yet another in China), so we can't seriously rely on everything being UTF-8.

So there.

A method `toBytes()` is added to apply to whatever object comes up.
Tests passed on my machine.