### PR TITLE
[PUBDEV-4102] Bully client mode & client disconnect support

### DIFF
--- a/h2o-core/src/main/java/water/ClientHeartBeatCheckThread.java
+++ b/h2o-core/src/main/java/water/ClientHeartBeatCheckThread.java
@@ -1,0 +1,52 @@
+package water;
+
+import water.util.Log;
+
+/**
+ * This thread checks whether the heartbeat from the bully client has been seen before the timeout and if not, it kills
+ * the whole h2o cloud
+ */
+public class ClientHeartBeatCheckThread extends Thread {
+    public ClientHeartBeatCheckThread() {
+        super("ClientHeartbeatCheckThread");
+        setDaemon(true);
+    }
+
+    @Override
+    public void run(){
+        while(true) {
+            if(H2O.SELF._last_heard_from_bully_client != 0){
+                // we need to make sure that rest of the nodes agree with our decision that the bully client is not
+                // available anymore and the cloud should be stooped.
+                if(H2O.SELF._last_heard_from_bully_client + H2O.ARGS.bully_client_timeout >= System.currentTimeMillis()) {
+                    Log.warn("Bully client seems not to be available!");
+                    BullyClientCheckMRTask tsk = new BullyClientCheckMRTask();
+                    Log.warn("Asking the rest of the nodes if bully client is really gone.");
+                    if(((BullyClientCheckMRTask)tsk.doAllNodes()).consensus) {
+                        // we suspect that the client is gone, but we need to check with the rest of the nodes in the cluster
+                        // if all nodes in the cluster agree on the fact that the client is not a available, stop the cluster
+                        Log.fatal("Stopping H2O cloud since bully client hasn't seen heartbeat in specified timeout");
+                        H2O.shutdown(0);
+                    }
+                }
+            }
+            // wait for the duration of timeout
+            try {
+                sleep(H2O.ARGS.bully_client_timeout);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static class BullyClientCheckMRTask extends MRTask {
+        public boolean consensus = true;
+
+        @Override
+        public void reduce(MRTask mrt) {
+            if(((BullyClientCheckMRTask)mrt).consensus) { // don't change the value in case negative consensus
+                consensus = H2O.SELF._last_heard_from_bully_client + H2O.ARGS.bully_client_timeout >= System.currentTimeMillis();
+            }
+        }
+    }
+}

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -36,6 +36,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   transient short _unique_idx; // Dense integer index, skipping 0.  NOT cloud-wide unique.
   transient boolean _announcedLostContact;  // True if heartbeat published a no-contact msg
   transient public long _last_heard_from; // Time in msec since we last heard from this Node
+  transient public long _last_heard_from_bully_client; // Last known client of this cluster known to this node
   transient public volatile HeartBeat _heartbeat;  // My health info.  Changes 1/sec.
   transient public int _tcp_readers;               // Count of started TCP reader threads
 

--- a/h2o-core/src/main/java/water/HeartBeat.java
+++ b/h2o-core/src/main/java/water/HeartBeat.java
@@ -17,6 +17,7 @@ public class HeartBeat extends Iced<HeartBeat> {
   byte[] _jar_md5;              // JAR file digest
 
   public boolean _client;       // This is a client node: no keys homed here
+  public boolean _bully_client; // Special client mode - kill cluster when client disappears
 
   public int _pid;              // Process ID
 

--- a/h2o-core/src/main/java/water/UDPClientEvent.java
+++ b/h2o-core/src/main/java/water/UDPClientEvent.java
@@ -1,24 +1,47 @@
 package water;
 
+import water.util.Log;
+
 /**
  * A simple message which informs cluster about a new client
- * which was connected. The event is used only in flatfile mode
- * to allow client to connect to a single node, which will
- * inform a cluster about the client.
- * Hence, the rest of nodes will start ping client with heartbeat, and
- * vice versa.
+ * which was connected or about existing client who wants to disconnect.
+ * The event is used only in flatfile mode where in case of connecting, it
+ * it allows the client to connect to a single node, which will
+ * inform a cluster about the client. Hence, the rest of nodes will
+ * start ping client with heartbeat, and vice versa.
  */
 public class UDPClientEvent extends UDP {
 
   @Override
   AutoBuffer call(AutoBuffer ab) {
     // Handle only by non-client nodes
-    if (ab._h2o != H2O.SELF
-        && !H2O.ARGS.client
-        && H2O.isFlatfileEnabled()) {
+    if (ab._h2o != H2O.SELF && !H2O.ARGS.client) {
       ClientEvent ce = new ClientEvent().read(ab);
-      if (ce.type == ClientEvent.Type.CONNECT) {
-        H2O.addNodeToFlatfile(ce.clientNode);
+      switch(ce.type){
+        // Connect event is not sent in multicast mode
+        case CONNECT:
+          if(H2O.isFlatfileEnabled()) {
+            H2O.addNodeToFlatfile(ce.clientNode);
+          }
+          break;
+        // Regular disconnect event also doesn't have any effect in multicast mode. The client can come and go as many
+        // as it wants. However we need to catch the bully disconnect event in both multicast and flatfile mode.
+        case DISCONNECT:
+          // in both multicast and flatfile mode, reset the known bully client
+
+          if(H2O.isFlatfileEnabled()) {
+            Log.info("Client: " + ce.clientNode + " has been disconnected on: " + ab._h2o);
+            H2O.removeNodeFromFlatfile(ce.clientNode);
+          }
+          if(ce.clientNode._heartbeat._bully_client){
+            Log.info("Stopping H2O cloud because bully client is disconnecting from the cloud.");
+            // client is sending disconnect message on purpose, we can stop the cloud even without asking
+            // the rest of the nodes for consensus on this
+            H2O.shutdown(0);
+          }
+        break;
+        default:
+          throw new RuntimeException("Unsupported Client event: " + ce.type);
       }
     }
 

--- a/h2o-core/src/main/java/water/UDPHeartbeat.java
+++ b/h2o-core/src/main/java/water/UDPHeartbeat.java
@@ -13,6 +13,10 @@ class UDPHeartbeat extends UDP {
       // and if we update it here we risk dropping an update.
       ab._h2o._heartbeat = new HeartBeat().read(ab);
       Paxos.doHeartbeat(ab._h2o);
+
+      if(ab._h2o._heartbeat._bully_client){
+        H2O.SELF._last_heard_from_bully_client = ab._h2o._last_heard_from;
+      }
     }
     return ab;
   }

--- a/h2o-core/src/test/java/water/ClientTest.java
+++ b/h2o-core/src/test/java/water/ClientTest.java
@@ -7,7 +7,6 @@ import water.fvec.Frame;
 
 public class ClientTest extends TestUtil {
   @BeforeClass static public void setup() { stall_till_cloudsize(3); }
-  
   // ---
   // Run some basic tests.  Create a key, test that it does not exist, insert a
   // value for it, get the value for it, delete it.


### PR DESCRIPTION
In Sparkling Water external cluster we need to be able to close H2O cluster when the Spark application with H2O client in it has been killed.

This can be done be reusing current heartbeat class in 2 scenarios.

We can trigger shutdown action of the cloud after successful finish of all the tasks in the sparkling water app using special disconnect message.

If h2o client is killed and this message couldn't be sent, h2o nodes will check if they are running in the special dependant mode and kill themselves when they haven't received heartbeat from the client for specific amount of time.

**Changes to the code:**
 - Add new configuration property called **-bully_client**. When set, this ensures the client is running in special bully(cluster lifecycle manager mode) in which the cloud is killed when this client is stopped/inaccessible
 - Add new configuration called **-bully_client_timeout** with default value of 10000 milliseconds. When node doesn't hear from bully client for this amount of time, the shutdown of cloud is triggered. 
- Support for regular client disconnection.
- Support for client disconnection in bully mode in which the cluster is stopped as well
- Support for disconnection in case bully client has been killed/ is not accessible. The cluster is stopped in this mode as well.

**TODO:**
- test regular client disconenction in multicast and flatfile mode
- test bully client disconnection in multicast and flatfile mode
- test the case when bully client stops sending heartbeats in regular and flatfile mode