### PR TITLE
Added port and ip details to the error logs for h2o cloud

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1415,7 +1415,7 @@ class TestRunner(object):
             if self._h2o_exists_and_healthy(c.get_ip(), c.get_port()):
                 print("Node {} healthy.".format(c))
             else:
-                print("Node %r NOT HEALTHY" % c)
+                print("Node with IP {} and port {} NOT HEALTHY" .format(c.get_ip(),c.get_port()))
                 # should an exception be thrown?
 
     def stop_clouds(self):


### PR DESCRIPTION
The current error log reports the following message for a Non healthy cluster:

10:30:00 Node <__main__.H2OCloud object at 0x26ebc50> NOT HEALTHY

Made changes to the log to report the actual node IP and port.