### PR TITLE
Pubdev 2535 Pivot v2

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -242,6 +242,7 @@ public class Env extends Iced {
     init(new AstScale());
     init(new AstSetDomain());
     init(new AstSetLevel());
+    init(new AstPivot());
 
     // Assignment; all of these lean heavily on Copy-On-Write optimizations.
     init(new AstAppend());      // Add a column

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -1,15 +1,14 @@
 package water.rapids.ast.prims.mungers;
 
+import org.apache.commons.lang.ArrayUtils;
 import water.*;
 import water.fvec.*;
-import water.rapids.Rapids;
 import water.rapids.Env;
 import water.rapids.vals.ValFrame;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
-import water.H2O;
 import water.util.VecUtils;
-import java.util.ArrayList;
+
 public class AstPivot extends AstPrimitive {
   @Override
   public String[] args() {
@@ -28,66 +27,121 @@ public class AstPivot extends AstPrimitive {
 
   @Override
   public ValFrame apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
+    // Distributed parallelized mrtask pivot
+    // Limitations: a single index value cant have more than chunk size * chunk size number of rows
+    //  or if all rows of a single index value cant fit on a single node (due to the sort call)
     Frame fr = stk.track(asts[1].exec(env)).getFrame();
     String index = stk.track(asts[2].exec(env)).getStr();
     String column = stk.track(asts[3].exec(env)).getStr();
     String value = stk.track(asts[4].exec(env)).getStr();
-    Key k1 = Key.<Frame>make();
-    fr._key = k1;
-    DKV.put(fr);
     int indexIdx = fr.find(index);
-    int valueIdx = fr.find(value);
     int colIdx = fr.find(column);
-    // decide if we slice and merge repeatedly or if we sort and mrtask
-    if (fr.vec(column).domain().length < H2O.CLOUD.size()) {
-      // This is the slice and merge method. Good for when keys of a label cannot fit on one node
+    // This is the sort then MRTask method.
+    // Create the target Frame
+    // Now sort on the index key, result is that unique keys will be localized
+    fr = fr.sort(new int[]{0});
+    final long[] classes = new VecUtils.CollectDomain().doAll(fr.vec(colIdx)).domain();
+    final int nClass = fr.vec(colIdx).isNumeric() ? classes.length : fr.vec(colIdx).domain().length;
+    String[] header = (String[]) ArrayUtils.addAll(new String[]{index}, fr.vec(colIdx).domain());
+    Frame initialPass = new pivotTask(fr,index,column,value).doAll(nClass+1, Vec.T_NUM, fr).outputFrame(null, header, null);
+    initialPass = initialPass.sort(new int[]{0});
+    // Fix up when a run of the same index crosses over chunk boundaries
+    Frame secondPass = new pivotCleanup().doAll(nClass+1,Vec.T_NUM,initialPass).outputFrame(Key.<Frame>make(),header,null);
+    Vec origTypeVec = secondPass.vec(0).makeCopy(null,fr.vec(indexIdx).get_type());
+    secondPass.replace(0,origTypeVec);
+    initialPass.delete();
+    return new ValFrame(secondPass);
+  }
 
-      String[] column_set = fr.vec(column).domain();
-      Frame indexSetFr = Rapids.exec("(sort (unique (cols " + fr._key + " " + indexIdx + ")) 0)").getFrame();
-      indexSetFr._key = Key.<Frame>make();
-      Frame res = new Frame(Key.<Frame>make());
-      res.add(indexSetFr);
-      DKV.put(indexSetFr);
-      try {
-        for (String c : column_set) {
-          String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + colIdx + ") '" + c + "')) [%d, %d])",
-            indexIdx,
-            valueIdx);
-          Frame frTmp = Rapids.exec(rapidsString1).getFrame();
-          frTmp._key = Key.<Frame>make();
-          DKV.put(frTmp);
-          String rapidsString2 = String.format("(cols (merge " + indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
-          Frame joinedOnAllIdx = Rapids.exec(rapidsString2).getFrame();
-          joinedOnAllIdx.setNames(new String[]{c});
-          res.add(joinedOnAllIdx);
-          frTmp.delete();
+  protected class pivotCleanup extends MRTask<AstPivot.pivotCleanup>{
+    pivotCleanup() {}
+    @Override
+    public void map(Chunk[] cs, NewChunk[] nc) {
+      // skip past the first set of indexes if we know that the previous chunk will run in here
+      long firstIdx =  cs[0].at8(0);
+      long globalIdx = cs[0].start();
+      int start = 0;
+      if (globalIdx > 0 && cs[0].vec().at8(globalIdx-1)==firstIdx){
+        while(firstIdx == cs[0].at8(start)) start++;
+      }
+      for (int i=start; i<cs[0]._len; i++) {
+        long currentIdx = cs[0].at8(i);
+        if (currentIdx != cs[0].at8(i+1)) {
+          nc[0].addNum(cs[0].at8(i));
+          for (int j=1;j<nc.length;j++) nc[j].addNum(cs[j].atd(i));
+          continue;
         }
-      } finally {
-        DKV.remove(indexSetFr._key);
-        DKV.remove(k1);
+        int count = 1;
+        double[] newRow = new double[nc.length-1];
+        for (int j = 0; j < nc.length-1; j++) newRow[j] = cs[j+1].atd(i);
+        while(currentIdx ==  cs[0].at8(i+count) && count+i < cs[0]._len) {
+          // merge the forward row, the newRow and the existing row
+          // here would be a good place to apply aggregating function
+          // for now we are aggregating by "first"
+          for (int j=0;j<nc.length-1;j++) {
+            if(Double.isNaN(newRow[j]) && !Double.isNaN(cs[j+1].atd(i+count))) {
+              newRow[j] = cs[j+1].atd(i+count);
+            }
+          }
+          // need to look if we need to go to next chunk
+          if (i+count == cs[0]._len-1) {
+            Chunk nextChunk = cs[0].nextChunk();
+            if (nextChunk != null && currentIdx == nextChunk.at8(0)) {
+              Chunk[] nextChunkArr = new Chunk[]{};
+              for (int j=0;j<nc.length-1;j++) {
+                nextChunkArr[j] = cs[j+1].nextChunk();
+              }
+              int countNC = 0;
+              while(currentIdx == nextChunk.at8(countNC)) {
+                for (int j=0;j<nc.length-1;j++) {
+                  if(Double.isNaN(newRow[j]) && !Double.isNaN(nextChunkArr[j].atd(countNC))) {
+                    newRow[j] = nextChunkArr[j].atd(countNC);
+                  }
+                }
+                countNC++;
+              }
+            }
+          }
+          count++;
+        }
+        nc[0].addNum(currentIdx);
+        for (int j = 1; j < nc.length; j++) {
+          nc[j].addNum(newRow[j-1]);
+        }
+        i+=count;
       }
-      return new ValFrame(res);
     }
-    else {
-
-      // This is the sort then MRTask method.
-      fr.sort(new int[]{colIdx,indexIdx});
-      // Create the target Frame
-      Frame indexSetFr = Rapids.exec("(sort (unique (cols " + fr._key + " " + indexIdx + ")) 0)").getFrame();
-      indexSetFr._key = Key.<Frame>make();
-      Frame res = new Frame(Key.<Frame>make());
-      res.add(indexSetFr);
-      for (String d: fr.vec(column).domain()) {
-        res.add(d,indexSetFr.vec(0).makeCon(Double.NaN));
-      }
-      // This MRTask will set each row in the Frame
-      ArrayList<Vec.Writer> vws  = new ArrayList<>();
-      for (Vec v: res.vecs()) {
-        vws.add(v.open());
-      }
-
-
-      return new ValFrame(fr);
+  }
+  protected class pivotTask extends MRTask<AstPivot.pivotTask> {
+    int _indexColIdx;
+    int _colColIdx;
+    int _valColIdx;
+    pivotTask(Frame fr, String index, String column, String value ) {
+      _indexColIdx = fr.find(index); _colColIdx = fr.find(column); _valColIdx = fr.find(value);
     }
+    @Override
+    public void map(Chunk[] cs, NewChunk[] nc) {
+      for (int i = 0; i < cs[0]._len; i++) {
+        // consolidate locally. we know its sorted by index
+        // i will be jumping forward
+        long currentIdx = cs[_indexColIdx].at8(i); // the row label
+        int count = 0; // the secondary chunk row counter
+        double[] newRow = new double[nc.length-1];   // the pivot accumulator
+        for (int j = 0; j < nc.length-1; j++) newRow[j] = Double.NaN;
+        while (i+count < cs[0]._len && currentIdx == cs[_indexColIdx].at8(i+count)) {
+          newRow[(int) cs[_colColIdx].at8(i+count)] = cs[_valColIdx].atd(i+count);
+          count++;
+        }
+        i+=(count-1);
+        // load the data into newChunk
+        nc[0].addNum(currentIdx);
+        for (int j = 1; j < nc.length; j++) {
+          nc[j].addNum(newRow[j-1]);
+        }
+
+
+      }
+    }
+
   }
 }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -3,13 +3,14 @@ package water.rapids.ast.prims.mungers;
 import org.apache.commons.lang.ArrayUtils;
 import water.*;
 import water.fvec.*;
-import water.rapids.Env;
+import water.rapids.Val;
+import water.rapids.ast.AstBuiltin;
 import water.rapids.vals.ValFrame;
-import water.rapids.ast.AstPrimitive;
-import water.rapids.ast.AstRoot;
 import water.util.VecUtils;
 
-public class AstPivot extends AstPrimitive {
+import java.util.Arrays;
+
+public class AstPivot extends AstBuiltin<AstPivot> {
   @Override
   public String[] args() {
     return new String[]{"ary", "index", "column", "value"}; //the array and name of columns
@@ -26,16 +27,20 @@ public class AstPivot extends AstPrimitive {
   }
 
   @Override
-  public ValFrame apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
+  public ValFrame exec(Val[] args) {
     // Distributed parallelized mrtask pivot
     // Limitations: a single index value cant have more than chunk size * chunk size number of rows
     //  or if all rows of a single index value cant fit on a single node (due to the sort call)
-    Frame fr = stk.track(asts[1].exec(env)).getFrame();
-    String index = stk.track(asts[2].exec(env)).getStr();
-    String column = stk.track(asts[3].exec(env)).getStr();
-    String value = stk.track(asts[4].exec(env)).getStr();
+    Frame fr = args[1].getFrame();
+    String index = args[2].getStr();
+    String column = args[3].getStr();
+    String value = args[4].getStr();
     int indexIdx = fr.find(index);
     int colIdx = fr.find(column);
+    if(fr.vec(column).isConst())
+      throw new IllegalArgumentException("Column: '" + column + "'is constant. Perhaps use transpose?" );
+    if(fr.vec(index).naCnt() > 0)
+      throw new IllegalArgumentException("Index column '" + index + "' has > 0 NAs");
     // This is the sort then MRTask method.
     // Create the target Frame
     // Now sort on the index key, result is that unique keys will be localized
@@ -43,10 +48,14 @@ public class AstPivot extends AstPrimitive {
     final long[] classes = new VecUtils.CollectDomain().doAll(fr.vec(colIdx)).domain();
     final int nClass = fr.vec(colIdx).isNumeric() ? classes.length : fr.vec(colIdx).domain().length;
     String[] header = (String[]) ArrayUtils.addAll(new String[]{index}, fr.vec(colIdx).domain());
-    Frame initialPass = new pivotTask(fr,index,column,value).doAll(nClass+1, Vec.T_NUM, fr).outputFrame(null, header, null);
+    Frame initialPass = new pivotTask(fr,index,column,value)
+      .doAll(nClass+1, Vec.T_NUM, fr)
+      .outputFrame(null, header, null);
     initialPass = initialPass.sort(new int[]{0});
     // Collapse identical index rows even when index crosses over chunk boundaries
-    Frame secondPass = new pivotCleanup().doAll(nClass+1,Vec.T_NUM,initialPass).outputFrame(null,header,null);
+    Frame secondPass = new pivotCleanup()
+      .doAll(nClass+1,Vec.T_NUM,initialPass)
+      .outputFrame(null,header,null);
     Frame result = new Frame(secondPass.vec(0).makeCopy(null,fr.vec(indexIdx).get_type()));
     result._key = Key.<Frame>make();
     result.setNames(new String[]{index});
@@ -56,7 +65,7 @@ public class AstPivot extends AstPrimitive {
     return new ValFrame(result);
   }
 
-  protected class pivotCleanup extends MRTask<AstPivot.pivotCleanup>{
+  private class pivotCleanup extends MRTask<AstPivot.pivotCleanup>{
     pivotCleanup() {}
     @Override
     public void map(Chunk[] cs, NewChunk[] nc) {
@@ -65,7 +74,7 @@ public class AstPivot extends AstPrimitive {
       long globalIdx = cs[0].start();
       int start = 0;
       if (globalIdx > 0 && cs[0].vec().at8(globalIdx-1)==firstIdx){
-        while(firstIdx == cs[0].at8(start)) start++;
+        while(start < cs[0].len() && firstIdx == cs[0].at8(start)) start++;
       }
       for (int i=start; i<cs[0]._len; i++) {
         long currentIdx = cs[0].at8(i);
@@ -90,26 +99,32 @@ public class AstPivot extends AstPrimitive {
               newRow[j] = cs[j + 1].atd(i + count);
             }
           }
-          // need to look if we need to go to next chunk
-          if (i + count == cs[0]._len - 1) {
-            Chunk nextChunk = cs[0].nextChunk();
-            if (nextChunk != null && currentIdx == nextChunk.at8(0)) {
-              Chunk[] nextChunkArr = new Chunk[]{};
-              for (int j = 0; j < nc.length - 1; j++) {
-                nextChunkArr[j] = cs[j + 1].nextChunk();
-              }
-              int countNC = 0;
-              while (currentIdx == nextChunk.at8(countNC)) {
-                for (int j = 0; j < nc.length - 1; j++) {
-                  if (Double.isNaN(newRow[j]) && !Double.isNaN(nextChunkArr[j].atd(countNC))) {
-                    newRow[j] = nextChunkArr[j].atd(countNC);
-                  }
-                }
-                countNC++;
+          count++;
+        }
+        // need to look if we need to go to next chunk
+        if (i + count == cs[0]._len && cs[0].nextChunk() != null) {
+          Chunk nextChunk = cs[0].nextChunk(); // for the index
+          Chunk[] nextChunkArr = new Chunk[nc.length - 1]; // for the rest of the columns
+          for (int j = 0; j < nc.length - 1; j++) {
+            nextChunkArr[j] = cs[j + 1].nextChunk();
+          }
+          int countNC = 0;
+          // If we reach the end of the chunk, we'll update nextChunk and nextChunkArr
+          while (nextChunk != null && countNC < nextChunk._len && currentIdx == nextChunk.at8(countNC)) {
+            for (int j = 0; j < nc.length - 1; j++) {
+              if (Double.isNaN(newRow[j]) && !Double.isNaN(nextChunkArr[j].atd(countNC))) {
+                newRow[j] = nextChunkArr[j].atd(countNC);
               }
             }
+            countNC++;
+            if (countNC == nextChunk._len) { // go to the next chunk again
+              nextChunk = nextChunk.nextChunk();
+              for (int j = 0; j < nc.length - 1; j++) {
+                nextChunkArr[j] = nextChunkArr[j].nextChunk();
+              }
+              countNC = 0;
+            }
           }
-          count++;
         }
         nc[0].addNum(currentIdx);
         for (int j = 1; j < nc.length; j++) {
@@ -119,7 +134,7 @@ public class AstPivot extends AstPrimitive {
       }
     }
   }
-  protected class pivotTask extends MRTask<AstPivot.pivotTask> {
+  private class pivotTask extends MRTask<AstPivot.pivotTask> {
     int _indexColIdx;
     int _colColIdx;
     int _valColIdx;
@@ -134,7 +149,7 @@ public class AstPivot extends AstPrimitive {
         long currentIdx = cs[_indexColIdx].at8(i); // the row label
         int count = 0; // the secondary chunk row counter
         double[] newRow = new double[nc.length-1];   // the pivot accumulator
-        for (int j = 0; j < nc.length-1; j++) newRow[j] = Double.NaN;
+        Arrays.fill(newRow,Double.NaN);
         while (i+count < cs[0]._len && currentIdx == cs[_indexColIdx].at8(i+count)) {
           newRow[(int) cs[_colColIdx].at8(i+count)] = cs[_valColIdx].atd(i+count);
           count++;

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -1,0 +1,79 @@
+package water.rapids.ast.prims.mungers;
+
+import water.*;
+import water.fvec.*;
+import water.rapids.Rapids;
+import water.rapids.Env;
+import water.rapids.vals.ValFrame;
+import water.rapids.ast.AstPrimitive;
+import water.rapids.ast.AstRoot;
+import water.util.VecUtils;
+
+public class AstPivot extends AstPrimitive {
+  @Override
+  public String[] args() {
+    return new String[]{"ary", "index", "column", "value"}; //the array and name of columns
+  }
+
+  @Override
+  public int nargs() {
+    return 1 + 4;
+  } // (pivot ary index column value)
+
+  @Override
+  public String str() {
+    return "pivot";
+  }
+
+  @Override
+  public ValFrame apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
+    Frame origfr = stk.track(asts[1].exec(env)).getFrame();
+    String _index = stk.track(asts[2].exec(env)).getStr();
+    String _column = stk.track(asts[3].exec(env)).getStr();
+    String _value = stk.track(asts[4].exec(env)).getStr();
+    Key k1 = Key.<Frame>make();
+    Frame fr = origfr.subframe(new String[]{_index,_column,_value}).deepCopy(k1.toString());
+    DKV.put(fr);
+    int _index_colidx = fr.find(_index);
+    int _value_colidx = fr.find(_value);
+    int _col_colidx = fr.find(_column);
+
+    String[] _column_set = fr.vec(_column).domain();
+    long[] _indexSet = new VecUtils.CollectDomain().doAll(fr.vec(_index)).domain();
+    byte vecType = fr.vec(_index_colidx).get_type();
+    Frame _indexSetFr = new Frame(Key.<Frame>make(),new String[]{_index},new Vec[]{UniqueVec(vecType,_indexSet)});
+    Frame res = new Frame(Key.<Frame>make());
+    res.add(_indexSetFr.deepCopy(_indexSetFr._key.toString()));
+    DKV.put(_indexSetFr);
+    for (String _c: _column_set) {
+      String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + _col_colidx + ") '" + _c + "')) [%d, %d])",
+              _index_colidx,
+              _value_colidx);
+      Frame frTmp = Rapids.exec(rapidsString1).getFrame();
+      frTmp._key = Key.<Frame>make();
+      DKV.put(frTmp);
+      String rapidsString2 = String.format("(cols (merge " + _indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
+      Frame joinedOnAllIdx = Rapids.exec(rapidsString2).getFrame();
+      joinedOnAllIdx.setNames(new String[]{_c});
+      res.add(joinedOnAllIdx);
+      frTmp.delete();
+
+    }
+    _indexSetFr.delete();
+    fr.delete();
+    return new ValFrame(res);
+
+  }
+  public static Vec UniqueVec(byte vecType,long ...rows) {
+    Key<Vec> k = Vec.VectorGroup.VG_LEN1.addVec();
+    Futures fs = new Futures();
+    AppendableVec avec = new AppendableVec(k,vecType);
+    avec.setDomain(null);
+    NewChunk chunk = new NewChunk(avec, 0);
+    for( long r : rows ) chunk.addNum(r);
+    chunk.close(0, fs);
+    Vec vec = avec.layout_and_close(fs);
+    fs.blockForPending();
+    return vec;
+  }
+}

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -44,23 +44,24 @@ public class AstPivot extends AstPrimitive {
     Frame res = new Frame(Key.<Frame>make());
     res.add(indexSetFr);
     DKV.put(indexSetFr);
-    for (String c: column_set) {
-      String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + colIdx + ") '" + c + "')) [%d, %d])",
-              indexIdx,
-              valueIdx);
-      Frame frTmp = Rapids.exec(rapidsString1).getFrame();
-      frTmp._key = Key.<Frame>make();
-      DKV.put(frTmp);
-      String rapidsString2 = String.format("(cols (merge " + indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
-      Frame joinedOnAllIdx = Rapids.exec(rapidsString2).getFrame();
-      joinedOnAllIdx.setNames(new String[]{c});
-      res.add(joinedOnAllIdx);
-      frTmp.delete();
-
+    try {
+      for (String c: column_set) {
+        String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + colIdx + ") '" + c + "')) [%d, %d])",
+          indexIdx,
+          valueIdx);
+        Frame frTmp = Rapids.exec(rapidsString1).getFrame();
+        frTmp._key = Key.<Frame>make();
+        DKV.put(frTmp);
+        String rapidsString2 = String.format("(cols (merge " + indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
+        Frame joinedOnAllIdx = Rapids.exec(rapidsString2).getFrame();
+        joinedOnAllIdx.setNames(new String[]{c});
+        res.add(joinedOnAllIdx);
+        frTmp.delete();
+      }
+    } finally {
+      DKV.remove(indexSetFr._key);
+      DKV.remove(k1);
     }
-    DKV.remove(indexSetFr._key);
-    DKV.remove(k1);
-
     return new ValFrame(res);
 
   }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -7,8 +7,9 @@ import water.rapids.Env;
 import water.rapids.vals.ValFrame;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
+import water.H2O;
 import water.util.VecUtils;
-
+import java.util.ArrayList;
 public class AstPivot extends AstPrimitive {
   @Override
   public String[] args() {
@@ -37,32 +38,56 @@ public class AstPivot extends AstPrimitive {
     int indexIdx = fr.find(index);
     int valueIdx = fr.find(value);
     int colIdx = fr.find(column);
+    // decide if we slice and merge repeatedly or if we sort and mrtask
+    if (fr.vec(column).domain().length < H2O.CLOUD.size()) {
+      // This is the slice and merge method. Good for when keys of a label cannot fit on one node
 
-    String[] column_set = fr.vec(column).domain();
-    Frame indexSetFr = Rapids.exec("(sort (unique (cols " + fr._key + " " + indexIdx + ")) 0)").getFrame();
-    indexSetFr._key = Key.<Frame>make();
-    Frame res = new Frame(Key.<Frame>make());
-    res.add(indexSetFr);
-    DKV.put(indexSetFr);
-    try {
-      for (String c: column_set) {
-        String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + colIdx + ") '" + c + "')) [%d, %d])",
-          indexIdx,
-          valueIdx);
-        Frame frTmp = Rapids.exec(rapidsString1).getFrame();
-        frTmp._key = Key.<Frame>make();
-        DKV.put(frTmp);
-        String rapidsString2 = String.format("(cols (merge " + indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
-        Frame joinedOnAllIdx = Rapids.exec(rapidsString2).getFrame();
-        joinedOnAllIdx.setNames(new String[]{c});
-        res.add(joinedOnAllIdx);
-        frTmp.delete();
+      String[] column_set = fr.vec(column).domain();
+      Frame indexSetFr = Rapids.exec("(sort (unique (cols " + fr._key + " " + indexIdx + ")) 0)").getFrame();
+      indexSetFr._key = Key.<Frame>make();
+      Frame res = new Frame(Key.<Frame>make());
+      res.add(indexSetFr);
+      DKV.put(indexSetFr);
+      try {
+        for (String c : column_set) {
+          String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + colIdx + ") '" + c + "')) [%d, %d])",
+            indexIdx,
+            valueIdx);
+          Frame frTmp = Rapids.exec(rapidsString1).getFrame();
+          frTmp._key = Key.<Frame>make();
+          DKV.put(frTmp);
+          String rapidsString2 = String.format("(cols (merge " + indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
+          Frame joinedOnAllIdx = Rapids.exec(rapidsString2).getFrame();
+          joinedOnAllIdx.setNames(new String[]{c});
+          res.add(joinedOnAllIdx);
+          frTmp.delete();
+        }
+      } finally {
+        DKV.remove(indexSetFr._key);
+        DKV.remove(k1);
       }
-    } finally {
-      DKV.remove(indexSetFr._key);
-      DKV.remove(k1);
+      return new ValFrame(res);
     }
-    return new ValFrame(res);
+    else {
 
+      // This is the sort then MRTask method.
+      fr.sort(new int[]{colIdx,indexIdx});
+      // Create the target Frame
+      Frame indexSetFr = Rapids.exec("(sort (unique (cols " + fr._key + " " + indexIdx + ")) 0)").getFrame();
+      indexSetFr._key = Key.<Frame>make();
+      Frame res = new Frame(Key.<Frame>make());
+      res.add(indexSetFr);
+      for (String d: fr.vec(column).domain()) {
+        res.add(d,indexSetFr.vec(0).makeCon(Double.NaN));
+      }
+      // This MRTask will set each row in the Frame
+      ArrayList<Vec.Writer> vws  = new ArrayList<>();
+      for (Vec v: res.vecs()) {
+        vws.add(v.open());
+      }
+
+
+      return new ValFrame(fr);
+    }
   }
 }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -46,11 +46,14 @@ public class AstPivot extends AstPrimitive {
     Frame initialPass = new pivotTask(fr,index,column,value).doAll(nClass+1, Vec.T_NUM, fr).outputFrame(null, header, null);
     initialPass = initialPass.sort(new int[]{0});
     // Collapse identical index rows even when index crosses over chunk boundaries
-    Frame secondPass = new pivotCleanup().doAll(nClass+1,Vec.T_NUM,initialPass).outputFrame(Key.<Frame>make(),header,null);
-    Vec origTypeVec = secondPass.vec(0).makeCopy(null,fr.vec(indexIdx).get_type());
-    secondPass.replace(0,origTypeVec);
+    Frame secondPass = new pivotCleanup().doAll(nClass+1,Vec.T_NUM,initialPass).outputFrame(null,header,null);
+    Frame result = new Frame(secondPass.vec(0).makeCopy(null,fr.vec(indexIdx).get_type()));
+    result._key = Key.<Frame>make();
+    result.setNames(new String[]{index});
+    secondPass.remove(0);
+    result.add(secondPass);
     initialPass.delete();
-    return new ValFrame(secondPass);
+    return new ValFrame(result);
   }
 
   protected class pivotCleanup extends MRTask<AstPivot.pivotCleanup>{

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -27,53 +27,41 @@ public class AstPivot extends AstPrimitive {
 
   @Override
   public ValFrame apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
-    Frame origfr = stk.track(asts[1].exec(env)).getFrame();
-    String _index = stk.track(asts[2].exec(env)).getStr();
-    String _column = stk.track(asts[3].exec(env)).getStr();
-    String _value = stk.track(asts[4].exec(env)).getStr();
+    Frame fr = stk.track(asts[1].exec(env)).getFrame();
+    String index = stk.track(asts[2].exec(env)).getStr();
+    String column = stk.track(asts[3].exec(env)).getStr();
+    String value = stk.track(asts[4].exec(env)).getStr();
     Key k1 = Key.<Frame>make();
-    Frame fr = origfr.subframe(new String[]{_index,_column,_value}).deepCopy(k1.toString());
+    fr._key = k1;
     DKV.put(fr);
-    int _index_colidx = fr.find(_index);
-    int _value_colidx = fr.find(_value);
-    int _col_colidx = fr.find(_column);
+    int indexIdx = fr.find(index);
+    int valueIdx = fr.find(value);
+    int colIdx = fr.find(column);
 
-    String[] _column_set = fr.vec(_column).domain();
-    long[] _indexSet = new VecUtils.CollectDomain().doAll(fr.vec(_index)).domain();
-    byte vecType = fr.vec(_index_colidx).get_type();
-    Frame _indexSetFr = new Frame(Key.<Frame>make(),new String[]{_index},new Vec[]{UniqueVec(vecType,_indexSet)});
+    String[] column_set = fr.vec(column).domain();
+    Frame indexSetFr = Rapids.exec("(sort (unique (cols " + fr._key + " " + indexIdx + ")) 0)").getFrame();
+    indexSetFr._key = Key.<Frame>make();
     Frame res = new Frame(Key.<Frame>make());
-    res.add(_indexSetFr.deepCopy(_indexSetFr._key.toString()));
-    DKV.put(_indexSetFr);
-    for (String _c: _column_set) {
-      String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + _col_colidx + ") '" + _c + "')) [%d, %d])",
-              _index_colidx,
-              _value_colidx);
+    res.add(indexSetFr);
+    DKV.put(indexSetFr);
+    for (String c: column_set) {
+      String rapidsString1 = String.format("(cols (rows " + fr._key + " (== (cols " + fr._key + " " + colIdx + ") '" + c + "')) [%d, %d])",
+              indexIdx,
+              valueIdx);
       Frame frTmp = Rapids.exec(rapidsString1).getFrame();
       frTmp._key = Key.<Frame>make();
       DKV.put(frTmp);
-      String rapidsString2 = String.format("(cols (merge " + _indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
+      String rapidsString2 = String.format("(cols (merge " + indexSetFr._key + " " + frTmp._key + " True False [0] [0] 'auto') 1)");
       Frame joinedOnAllIdx = Rapids.exec(rapidsString2).getFrame();
-      joinedOnAllIdx.setNames(new String[]{_c});
+      joinedOnAllIdx.setNames(new String[]{c});
       res.add(joinedOnAllIdx);
       frTmp.delete();
 
     }
-    _indexSetFr.delete();
-    fr.delete();
+    DKV.remove(indexSetFr._key);
+    DKV.remove(k1);
+
     return new ValFrame(res);
 
-  }
-  public static Vec UniqueVec(byte vecType,long ...rows) {
-    Key<Vec> k = Vec.VectorGroup.VG_LEN1.addVec();
-    Futures fs = new Futures();
-    AppendableVec avec = new AppendableVec(k,vecType);
-    avec.setDomain(null);
-    NewChunk chunk = new NewChunk(avec, 0);
-    for( long r : rows ) chunk.addNum(r);
-    chunk.close(0, fs);
-    Vec vec = avec.layout_and_close(fs);
-    fs.blockForPending();
-    return vec;
   }
 }

--- a/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstPivotTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstPivotTest.java
@@ -1,0 +1,48 @@
+package water.rapids.ast.prims.mungers;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import water.rapids.Rapids;
+import water.rapids.Val;
+import water.rapids.vals.ValFrame;
+import water.util.ArrayUtils;
+import water.rapids.Session;
+public class AstPivotTest  extends TestUtil {
+    @BeforeClass
+    static public void setup() { stall_till_cloudsize(1); }
+
+    @Test public void TestPivot() {
+        Scope.enter();
+        try {
+            Session sess = new Session();
+            Frame fr = new TestFrameBuilder()
+                    .withName("$fr", sess)
+                    .withColNames("index", "col", "value")
+                    .withVecTypes(Vec.T_NUM,Vec.T_CAT,Vec.T_NUM)
+                    .withDataForCol(0, ar(1, 2, 3, 4, 2, 4))
+                    .withDataForCol(1, ar("a", "a", "a", "a", "b", "b"))
+                    .withDataForCol(2, ard(10.1, 10.2, 10.3, 10.4, 20.1, 22.2))
+                    .build();
+            Val val = Rapids.exec("(pivot $fr 'index' 'col' 'value')", sess);
+            Assert.assertTrue(val instanceof ValFrame);
+            Frame res = Scope.track(val.getFrame());
+            // check the first column. should be all unique indexes in order
+            assertVecEquals(res.vec(0),dvec(1.0,2.0,3.0,4.0), 0.0);
+            // next column is "a" values in correct order
+            assertVecEquals(res.vec(1),dvec(10.1,10.2,10.3,10.4), 0.0);
+            // last column is "b" values
+            assertVecEquals(res.vec(2),dvec(Double.NaN, 20.1, Double.NaN,22.2), 0.0);
+        } finally {
+            Scope.exit();
+        }
+
+
+
+    }
+}

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2355,11 +2355,15 @@ class H2OFrame(object):
         :param value:
         :return:
         """
-        if index not in self.names:
+        assert_is_type(index, str)
+        assert_is_type(column, str)
+        assert_is_type(value, str)
+        col_names = self.names
+        if index not in col_names:
             raise H2OValueError("Index not in H2OFrame")
-        if column not in self.names:
+        if column not in col_names:
             raise H2OValueError("Column not in H2OFrame")
-        if value not in self.names:
+        if value not in col_names:
             raise H2OValueError("Value column not in H2OFrame")
         if self.type(column) not in ["enum","time","int"]:
             raise H2OValueError("'column' argument is not type enum, time or int")

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2343,6 +2343,27 @@ class H2OFrame(object):
         if max_cardinality <= 0: raise H2OValueError("max_cardinality must be greater than 0")
         return H2OFrame._expr(expr=ExprNode("isax", self, num_words, max_cardinality, optimize_card))
 
+    def pivot(self, index, column, value):
+        """
+        Pivot the frame designated by the three columns: index, column, and value
+        Index is a column that will be the row label
+        Column is a column that contains categorical levels which will each be turned into a column
+        Value is a column associated with an index and column
+
+        :param index:
+        :param column:
+        :param value:
+        :return:
+        """
+        if index not in self.names:
+            raise H2OValueError("Index not in H2OFrame")
+        if column not in self.names:
+            raise H2OValueError("Column not in H2OFrame")
+        if value not in self.names:
+            raise H2OValueError("Value column not in H2OFrame")
+        if self.type(column) not in ["enum","time","int"]:
+            raise H2OValueError("'column' argument is not type enum, time or int")
+        return H2OFrame._expr(expr=ExprNode("pivot",self,index,column,value))
 
     def sub(self, pattern, replacement, ignore_case=False):
         """

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2345,14 +2345,12 @@ class H2OFrame(object):
 
     def pivot(self, index, column, value):
         """
-        Pivot the frame designated by the three columns: index, column, and value
-        Index is a column that will be the row label
-        Column is a column that contains categorical levels which will each be turned into a column
-        Value is a column associated with an index and column
+        Pivot the frame designated by the three columns: index, column, and value. Index and column should be
+        of type enum, int, or time.
 
-        :param index:
-        :param column:
-        :param value:
+        :param index: Index is a column that will be the row label
+        :param column: The labels for the columns in the pivoted Frame
+        :param value: The column of values for the given index and column label
         :return:
         """
         assert_is_type(index, str)
@@ -2367,6 +2365,8 @@ class H2OFrame(object):
             raise H2OValueError("Value column not in H2OFrame")
         if self.type(column) not in ["enum","time","int"]:
             raise H2OValueError("'column' argument is not type enum, time or int")
+        if self.type(index) not in ["enum","time","int"]:
+            raise H2OValueError("'index' argument is not type enum, time or int")
         return H2OFrame._expr(expr=ExprNode("pivot",self,index,column,value))
 
     def sub(self, pattern, replacement, ignore_case=False):

--- a/h2o-py/tests/testdir_misc/pyunit_pivot_medium.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pivot_medium.py
@@ -19,9 +19,8 @@ def pivot():
     df2.show()
     df3 = df2.pivot(index="time", column="C2", value="C3")
     df3.show()
-    assert len(df3) == 18250
-    assert len(df3.columns) == 11
-    h2o.remove_all()
+    assert len(df3) == 18250, "Wrong number of rows. Should be 18250 days of data"
+    assert len(df3.columns) == 11, "Wrong number of columns"
     print("Testing size: ")
     for s in [100,200,300,400,500,1000,2000,4211,100000]:
         print(str(s))
@@ -31,10 +30,19 @@ def pivot():
         dfall = df1.rbind(df2)
         dfall = dfall.rbind(df3)
         res = dfall.pivot(index="index", column="column", value="value")
-        assert res["a"].sum()[0,0] == 1*s
-        assert res["b"].sum()[0,0] == 2*s
-        assert res["c"].sum()[0,0] == 3*s
-        h2o.remove_all() 
+        assert res["a"].sum()[0,0] == 1*s, "Wrong sum of 'a' column"
+        assert res["b"].sum()[0,0] == 2*s, "Wrong sum of 'b' column"
+        assert res["c"].sum()[0,0] == 3*s, "Wrong sum of 'c' column"
+    # See if it can find the last label
+    df = h2o.create_frame(rows=1000001,randomize=False,integer_fraction=0.0,categorical_fraction=0.0,time_fraction=0.0,cols=2,value=1.0,missing_fraction=0.0)
+    df2 = h2o.create_frame(rows=1000000,integer_fraction=0.0,categorical_fraction=1.0,time_fraction=0.0,cols=1,factors=2,missing_fraction=0.0)
+    df2b = df2.rbind(h2o.H2OFrame({"C1":"b"}))
+    df2b.set_names(["C3"])
+    dft = df.cbind(df2b)
+    p = dft.pivot(index="C1",value="C2",column="C3")
+    assert len(p.columns) == 4, "Wrong number of columns for last label test"
+    assert len(p) == 1, "Wrong number of rows for last label test"
+
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(pivot)

--- a/h2o-py/tests/testdir_misc/pyunit_pivot_medium.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pivot_medium.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+def pivot():
+    df = h2o.create_frame(rows=1000000,
+                          cols=3,
+                          factors=10,
+                          categorical_fraction=1.0/3,
+                          time_fraction=1.0/3,
+                          real_fraction=1.0/3,
+                          real_range=100,
+                          missing_fraction=0.0,
+                          seed=123)
+    dcol = df.moment(year=df["C1"].year(),month=df["C1"].month(),day=df["C1"].day())
+    df2 = df.cbind(dcol)
+    df2.show()
+    df3 = df2.pivot(index="time", column="C2", value="C3")
+    df3.show()
+    assert len(df3) == 18250
+    assert len(df3.columns) == 11
+    h2o.remove(df)
+    h2o.remove(df2)
+    h2o.remove(df3)
+    h2o.remove(dcol)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pivot)
+else:
+    pivot()

--- a/h2o-py/tests/testdir_misc/pyunit_pivot_medium.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pivot_medium.py
@@ -21,11 +21,20 @@ def pivot():
     df3.show()
     assert len(df3) == 18250
     assert len(df3.columns) == 11
-    h2o.remove(df)
-    h2o.remove(df2)
-    h2o.remove(df3)
-    h2o.remove(dcol)
-
+    h2o.remove_all()
+    print("Testing size: ")
+    for s in [100,200,300,400,500,1000,2000,4211,100000]:
+        print(str(s))
+        df1 = h2o.H2OFrame({"index":range(1,s+1),"column":["a"]*s,"value":[1]*s})
+        df2 = h2o.H2OFrame({"index":range(1,s+1),"column":["b"]*s,"value":[2]*s})
+        df3 = h2o.H2OFrame({"index":range(1,s+1),"column":["c"]*s,"value":[3]*s})
+        dfall = df1.rbind(df2)
+        dfall = dfall.rbind(df3)
+        res = dfall.pivot(index="index", column="column", value="value")
+        assert res["a"].sum()[0,0] == 1*s
+        assert res["b"].sum()[0,0] == 2*s
+        assert res["c"].sum()[0,0] == 3*s
+        h2o.remove_all() 
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(pivot)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1094,6 +1094,27 @@ h2o.impute <- function(data, column=0, method=c("mean","median","mode"), # TODO:
 #' @param na.rm ignore missing values
 #' @export
 range.H2OFrame <- function(...,na.rm = TRUE) c(min(...,na.rm=na.rm), max(...,na.rm=na.rm))
+
+#' Pivot the frame designated by the three columns: index, column, and value
+#' Index is a column that will be the row label
+#' Column is a column that contains categorical levels which will each be turned into a column
+#' Value is a column associated with an index and column
+#'
+#' @param x an H2OFrame
+#' @param index the column where pivoted rows should be aligned on
+#' @param column the column to pivot
+#' @param value values of the pivoted table
+#' @return An H2OFrame with columns from the columns arg, aligned on the index arg, with values from values arg
+#' @export
+h2o.pivot <- function(x, index, column, value){
+  if(! index %in% colnames(x)) stop("index column not found in dataframe")
+  if(! column %in% colnames(x)) stop("column column not found in dataframe")
+  if(! value %in% colnames(x)) stop("value column not found in dataframe")
+  if( ! h2o.getTypes(x)[grep(index,colnames(x))] %in% c("enum","time","int")) {
+    stop("index must be enum, time or int")
+  }
+  .newExpr("pivot", x, .quote(index), .quote(column), .quote(value))
+}
 #-----------------------------------------------------------------------------------------------------------------------
 # Time & Date
 #-----------------------------------------------------------------------------------------------------------------------
@@ -3815,6 +3836,7 @@ h2o.isax <- function(x, num_words, max_cardinality, optimize_card = FALSE){
   }
   .newExpr("isax", x, num_words, max_cardinality, optimize_card)
 }
+
 
 #-----------------------------------------------------------------------------------------------------------------------
 # String Operations

--- a/h2o-r/tests/testdir_munging/runit_pivot.R
+++ b/h2o-r/tests/testdir_munging/runit_pivot.R
@@ -11,9 +11,7 @@ test.pivot <- function(){
                          missing_fraction=0.0,
                          seed=123)
     df$C3 = h2o.abs(df$C3)
-    head(df)
     df2 = h2o.pivot(df,index="C3",column="C2",value="C1")
-    head(df2)
     expect_equal(nrow(df2),101)
     expect_equal(ncol(df2),11)
 }

--- a/h2o-r/tests/testdir_munging/runit_pivot.R
+++ b/h2o-r/tests/testdir_munging/runit_pivot.R
@@ -1,0 +1,21 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.pivot <- function(){
+    print("step1")
+    df = h2o.createFrame(rows = 1000,
+                         cols=3,
+                         factors=10,
+                         integer_fraction=1.0/3,
+                         categorical_fraction=1.0/3,
+                         missing_fraction=0.0,
+                         seed=123)
+    df$C3 = h2o.abs(df$C3)
+    head(df)
+    df2 = h2o.pivot(df,index="C3",column="C2",value="C1")
+    head(df2)
+    expect_equal(nrow(df2),101)
+    expect_equal(ncol(df2),11)
+}
+
+doTest("Test pivot", test.pivot)


### PR DESCRIPTION
This is a much improved version of Pivot.  First does a sort by index.  Then pivots locally within Chunks, collapsing rows sequentially as the index is ordered.

The cleanup mrtask then merges identical indexes and crosses Chunk boundaries.  Checks to see if the current Chunk has a run that continues from the previous Chunk.

This method scales with column cardinality much better than the previous method.

Limitation is that all rows of a single index value needs to fit on one node 
and max rows for a single index value and column label is Chunk size * Chunk size

Todo: More thorough checking on the pyunit.  Clean up some comments in AstPivot.java