### PR TITLE
[PUBDEV-4125] - Automatic radius selection for Aggregator - add target_num_exemplars parameter, remove radius_scale

### DIFF
--- a/h2o-algos/src/main/java/hex/aggregator/Aggregator.java
+++ b/h2o-algos/src/main/java/hex/aggregator/Aggregator.java
@@ -108,6 +108,9 @@ public class Aggregator extends ModelBuilder<AggregatorModel,AggregatorModel.Agg
     if (_parms._target_num_exemplars <= 0) {
       error("_target_num_exemplars", "target_num_exemplars must be > 0.");
     }
+    if (_parms._rel_tol_num_exemplars <= 0 || _parms._rel_tol_num_exemplars>=1) {
+      error("_rel_tol_num_exemplars", "rel_tol_num_exemplars must be inside 0...1.");
+    }
     super.init(expensive);
     if (expensive) {
       byte[] types = _train.types();
@@ -154,7 +157,7 @@ public class Aggregator extends ModelBuilder<AggregatorModel,AggregatorModel.Agg
         double hi = 256;
         double mid = 8; //starting point of radius_scale
 
-        double tol = 0.5; // +/- 50% off target number of exemplars is ok
+        double tol = _parms._rel_tol_num_exemplars;
         int upperLimit = (int)((1.+tol)*targetNumExemplars);
         int lowerLimit = (int)((1.-tol)*targetNumExemplars);
 

--- a/h2o-algos/src/main/java/hex/aggregator/AggregatorModel.java
+++ b/h2o-algos/src/main/java/hex/aggregator/AggregatorModel.java
@@ -25,11 +25,12 @@ public class AggregatorModel extends Model<AggregatorModel,AggregatorModel.Aggre
     public String javaName() { return AggregatorModel.class.getName(); }
     @Override public long progressUnits() { return 5 + 2*train().anyVec().nChunks() - 1; } // nChunks maps and nChunks-1 reduces, multiply by two for main job overhead
 
-    public double _radius_scale=1.0;
+    //public double _radius_scale=1.0;
+//    public int _max_iterations = 1000;     // Max iterations for SVD
     public DataInfo.TransformType _transform = DataInfo.TransformType.NORMALIZE; // Data transformation
     public PCAModel.PCAParameters.Method _pca_method = PCAModel.PCAParameters.Method.Power;   // Method for dimensionality reduction
     public int _k = 1;                     // Number of principal components
-    public int _max_iterations = 1000;     // Max iterations for SVD
+    public int _target_num_exemplars = 5000;
     public boolean _use_all_factor_levels = false;   // When expanding categoricals, should first level be kept or dropped?
   }
 

--- a/h2o-algos/src/main/java/hex/aggregator/AggregatorModel.java
+++ b/h2o-algos/src/main/java/hex/aggregator/AggregatorModel.java
@@ -31,6 +31,7 @@ public class AggregatorModel extends Model<AggregatorModel,AggregatorModel.Aggre
     public PCAModel.PCAParameters.Method _pca_method = PCAModel.PCAParameters.Method.Power;   // Method for dimensionality reduction
     public int _k = 1;                     // Number of principal components
     public int _target_num_exemplars = 5000;
+    public double _rel_tol_num_exemplars = 0.5;
     public boolean _use_all_factor_levels = false;   // When expanding categoricals, should first level be kept or dropped?
   }
 

--- a/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
@@ -17,6 +17,7 @@ public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,A
             "ignored_columns",
             "ignore_const_cols",
             "target_num_exemplars",
+            "rel_tol_num_exemplars",
 //            "radius_scale",
             "transform",
             "categorical_encoding",
@@ -44,6 +45,9 @@ public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,A
 
     @API(help = "Targeted number of exemplars", direction = API.Direction.INOUT, gridable = true, level= API.Level.secondary)
     public int target_num_exemplars;
+
+    @API(help = "Relative tolerance for number of exemplars (e.g, 0.5 is +/- 50%)", direction = API.Direction.INOUT, gridable = true, level= API.Level.secondary)
+    public double rel_tol_num_exemplars;
 
     @API(help = "RNG seed for initialization", direction = API.Direction.INOUT, level= API.Level.secondary)
     public long seed;

--- a/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
@@ -42,7 +42,7 @@ public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,A
     @API(help = "Maximum number of iterations for PCA", direction = API.Direction.INOUT, gridable = true, level= API.Level.expert)
     public int max_iterations;
 
-    @API(help = "Target number of exemplars", direction = API.Direction.INOUT, gridable = true, level= API.Level.secondary)
+    @API(help = "Targeted number of exemplars", direction = API.Direction.INOUT, gridable = true, level= API.Level.secondary)
     public int target_num_exemplars;
 
     @API(help = "RNG seed for initialization", direction = API.Direction.INOUT, level= API.Level.secondary)

--- a/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
@@ -16,7 +16,8 @@ public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,A
             "response_column",
             "ignored_columns",
             "ignore_const_cols",
-            "radius_scale",
+            "target_num_exemplars",
+//            "radius_scale",
             "transform",
             "categorical_encoding",
 //            "pca_method",
@@ -26,8 +27,8 @@ public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,A
 //            "use_all_factor_levels",
 //            "max_runtime_secs"
     };
-    @API(help = "Radius scaling", gridable = true)
-    public double radius_scale;
+//    @API(help = "Radius scaling", gridable = true)
+//    public double radius_scale;
 
     @API(help = "Transformation of training data", values = { "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE" }, gridable = true, level= API.Level.expert)  // TODO: pull out of categorical class
     public DataInfo.TransformType transform;
@@ -40,6 +41,9 @@ public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,A
 
     @API(help = "Maximum number of iterations for PCA", direction = API.Direction.INOUT, gridable = true, level= API.Level.expert)
     public int max_iterations;
+
+    @API(help = "Target number of exemplars", direction = API.Direction.INOUT, gridable = true, level= API.Level.secondary)
+    public int target_num_exemplars;
 
     @API(help = "RNG seed for initialization", direction = API.Direction.INOUT, level= API.Level.secondary)
     public long seed;

--- a/h2o-algos/src/test/java/hex/util/AggregatorTest.java
+++ b/h2o-algos/src/test/java/hex/util/AggregatorTest.java
@@ -17,8 +17,12 @@ import water.util.Log;
 
 public class AggregatorTest extends TestUtil {
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+  @Test public void testAggregator100() { testAggregator(100); }
+  @Test public void testAggregator1k() { testAggregator(1000); }
+  @Test public void testAggregator13() { testAggregator(13); }
+  @Test public void testAggregator10k() { testAggregator(10000); }
 
-  @Test public void testAggregator() {
+  public void testAggregator(int max) {
     CreateFrame cf = new CreateFrame();
     cf.rows = 100000;
     cf.cols = 2;
@@ -31,16 +35,16 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 1.0;
+    parms._target_num_exemplars = max;
     long start = System.currentTimeMillis();
-    AggregatorModel agg = new Aggregator(parms).trainModel().get();  // 0.905
+    AggregatorModel agg = new Aggregator(parms).trainModel().get();
     System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");
     agg.checkConsistency();
     Frame output = agg._output._output_frame.get();
     System.out.println(output.toTwoDimTable(0,10));
     frame.delete();
     Log.info("Number of exemplars: " + agg._exemplars.length);
-//    Assert.assertTrue(agg._exemplars.length==649);
+    Assert.assertTrue(Math.abs(agg._exemplars.length-max)<0.25*max);
     output.remove();
     agg.remove();
   }
@@ -61,7 +65,6 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 1.0;
     parms._categorical_encoding = Model.Parameters.CategoricalEncodingScheme.Eigen;
     long start = System.currentTimeMillis();
     AggregatorModel agg = new Aggregator(parms).trainModel().get();  // 0.905
@@ -70,7 +73,6 @@ public class AggregatorTest extends TestUtil {
     Frame output = agg._output._output_frame.get();
     System.out.println(output.toTwoDimTable(0,10));
     Log.info("Number of exemplars: " + agg._exemplars.length);
-//    Assert.assertTrue(agg._exemplars.length==649);
     output.remove();
     frame.remove();
     agg.remove();
@@ -92,7 +94,6 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 1.0;
     parms._transform = DataInfo.TransformType.NORMALIZE;
     parms._categorical_encoding = Model.Parameters.CategoricalEncodingScheme.Binary;
     long start = System.currentTimeMillis();
@@ -102,7 +103,7 @@ public class AggregatorTest extends TestUtil {
     Frame output = agg._output._output_frame.get();
     System.out.println(output.toTwoDimTable(0,10));
     Log.info("Number of exemplars: " + agg._exemplars.length);
-//    Assert.assertTrue(agg._exemplars.length==649);
+    Assert.assertTrue(agg._exemplars.length==1000);
     output.remove();
     frame.remove();
     agg.remove();
@@ -125,7 +126,7 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 1.0;
+    parms._target_num_exemplars = 278;
     parms._transform = DataInfo.TransformType.NORMALIZE;
     parms._categorical_encoding = Model.Parameters.CategoricalEncodingScheme.OneHotExplicit;
     long start = System.currentTimeMillis();
@@ -135,7 +136,7 @@ public class AggregatorTest extends TestUtil {
     Frame output = agg._output._output_frame.get();
     System.out.println(output.toTwoDimTable(0,10));
     Log.info("Number of exemplars: " + agg._exemplars.length);
-//    Assert.assertTrue(agg._exemplars.length==649);
+    Assert.assertTrue(agg._exemplars.length<=278);
     output.remove();
     frame.remove();
     agg.remove();
@@ -147,7 +148,7 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 5.0;
+    parms._target_num_exemplars = 500;
     long start = System.currentTimeMillis();
     AggregatorModel agg = new Aggregator(parms).trainModel().get();  // 0.179
     System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");    agg.checkConsistency();
@@ -156,7 +157,7 @@ public class AggregatorTest extends TestUtil {
     Log.info("Exemplars: " + output.toString());
     output.remove();
     Log.info("Number of exemplars: " + agg._exemplars.length);
-//    Assert.assertTrue(agg._exemplars.length==615);
+    Assert.assertTrue(agg._exemplars.length<=500*1.05);
     agg.remove();
   }
 
@@ -165,7 +166,7 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 3.0;
+    parms._target_num_exemplars = 137;
     long start = System.currentTimeMillis();
     AggregatorModel agg = new Aggregator(parms).trainModel().get();  // 0.418
     System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");    agg.checkConsistency();
@@ -184,13 +185,13 @@ public class AggregatorTest extends TestUtil {
 
       parms = new AggregatorModel.AggregatorParameters();
       parms._train = frame._key;
-      parms._radius_scale = 3.0;
+      parms._target_num_exemplars = 137;
       start = System.currentTimeMillis();
       AggregatorModel agg2 = new Aggregator(parms).trainModel().get();  // 0.373 0.504 0.357 0.454 0.368 0.355
       System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");      agg2.checkConsistency();
       Log.info("Number of exemplars for " + i + " chunks: " + agg2._exemplars.length);
       rebalanced.delete();
-      Assert.assertTrue(Math.abs(agg._exemplars.length - agg2._exemplars.length) == 0); //< agg._exemplars.length*0);
+      Assert.assertTrue(Math.abs(agg._exemplars.length - agg2._exemplars.length) == 0);
       output = agg2._output._output_frame.get();
       output.remove();
       agg2.remove();
@@ -204,7 +205,7 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 5.0;
+    parms._target_num_exemplars = 117;
     long start = System.currentTimeMillis();
     AggregatorModel agg = new Aggregator(parms).trainModel().get();   // 1.489
     System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");    agg.checkConsistency();
@@ -225,7 +226,7 @@ public class AggregatorTest extends TestUtil {
     Frame output = agg._output._output_frame.get();
     output.remove();
     Log.info("Number of exemplars: " + agg._exemplars.length);
-//    Assert.assertTrue(agg._exemplars.length==615);
+    Assert.assertTrue(agg._exemplars.length<=117);
     frame.delete();
     agg.remove();
   }
@@ -242,10 +243,10 @@ public class AggregatorTest extends TestUtil {
     DKV.put(frame);
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 10;
+    parms._target_num_exemplars = 17;
     AggregatorModel agg = new Aggregator(parms).trainModel().get();
     Frame output = agg._output._output_frame.get();
-    Assert.assertTrue(output.numRows() < 0.5*frame.numRows());
+    Assert.assertTrue(output.numRows() <= 17);
     boolean same = true;
     for (int i=0;i<frame.numCols();++i) {
       if (frame.vec(i).isCategorical()) {
@@ -265,7 +266,6 @@ public class AggregatorTest extends TestUtil {
 
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
-    parms._radius_scale = 100.0;
     long start = System.currentTimeMillis();
     AggregatorModel agg = new Aggregator(parms).trainModel().get();
     System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");    agg.checkConsistency();

--- a/h2o-algos/src/test/java/hex/util/AggregatorTest.java
+++ b/h2o-algos/src/test/java/hex/util/AggregatorTest.java
@@ -44,7 +44,7 @@ public class AggregatorTest extends TestUtil {
     System.out.println(output.toTwoDimTable(0,10));
     frame.delete();
     Log.info("Number of exemplars: " + agg._exemplars.length);
-    Assert.assertTrue(Math.abs(agg._exemplars.length-max)<0.25*max);
+    Assert.assertTrue(Math.abs(agg._exemplars.length-max)<=0.5*max);
     output.remove();
     agg.remove();
   }

--- a/h2o-algos/src/test/java/hex/util/AggregatorTest.java
+++ b/h2o-algos/src/test/java/hex/util/AggregatorTest.java
@@ -43,8 +43,7 @@ public class AggregatorTest extends TestUtil {
     Frame output = agg._output._output_frame.get();
     System.out.println(output.toTwoDimTable(0,10));
     frame.delete();
-    Log.info("Number of exemplars: " + agg._exemplars.length);
-    Assert.assertTrue(Math.abs(agg._exemplars.length-max)<=0.5*max);
+    checkNumExemplars(agg);
     output.remove();
     agg.remove();
   }
@@ -135,12 +134,28 @@ public class AggregatorTest extends TestUtil {
     agg.checkConsistency();
     Frame output = agg._output._output_frame.get();
     System.out.println(output.toTwoDimTable(0,10));
-    Log.info("Number of exemplars: " + agg._exemplars.length);
-    Assert.assertTrue(agg._exemplars.length<=278);
+    checkNumExemplars(agg);
     output.remove();
     frame.remove();
     agg.remove();
     Scope.exit();
+  }
+
+  @Ignore
+  @Test public void testAirlines() {
+    Frame frame = parse_test_file("smalldata/airlines/allyears2k_headers.zip");
+    AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
+    parms._train = frame._key;
+    parms._target_num_exemplars = 500;
+    parms._rel_tol_num_exemplars = 0.05;
+    long start = System.currentTimeMillis();
+    AggregatorModel agg = new Aggregator(parms).trainModel().get();  // 0.179
+    System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");    agg.checkConsistency();
+    frame.delete();
+    Frame output = agg._output._output_frame.get();
+    output.remove();
+    checkNumExemplars(agg);
+    agg.remove();
   }
 
   @Test public void testCovtype() {
@@ -149,6 +164,7 @@ public class AggregatorTest extends TestUtil {
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
     parms._target_num_exemplars = 500;
+    parms._rel_tol_num_exemplars = 0.05;
     long start = System.currentTimeMillis();
     AggregatorModel agg = new Aggregator(parms).trainModel().get();  // 0.179
     System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");    agg.checkConsistency();
@@ -156,9 +172,14 @@ public class AggregatorTest extends TestUtil {
     Frame output = agg._output._output_frame.get();
     Log.info("Exemplars: " + output.toString());
     output.remove();
-    Log.info("Number of exemplars: " + agg._exemplars.length);
-    Assert.assertTrue(agg._exemplars.length<=500*1.05);
+    checkNumExemplars(agg);
     agg.remove();
+  }
+
+  public void checkNumExemplars(AggregatorModel m) {
+    Log.info("Number of exemplars: " + m._exemplars.length);
+    Assert.assertTrue(m._exemplars.length >= (1.-m._parms._rel_tol_num_exemplars)*m._parms._target_num_exemplars);
+    Assert.assertTrue(m._exemplars.length <= (1.+m._parms._rel_tol_num_exemplars)*m._parms._target_num_exemplars);
   }
 
   @Test public void testChunks() {
@@ -167,12 +188,12 @@ public class AggregatorTest extends TestUtil {
     AggregatorModel.AggregatorParameters parms = new AggregatorModel.AggregatorParameters();
     parms._train = frame._key;
     parms._target_num_exemplars = 137;
+    parms._rel_tol_num_exemplars = 0.05;
     long start = System.currentTimeMillis();
     AggregatorModel agg = new Aggregator(parms).trainModel().get();  // 0.418
     System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");    agg.checkConsistency();
     Frame output = agg._output._output_frame.get();
-    Log.info("Number of exemplars: " + agg._exemplars.length);
-//    Assert.assertTrue(agg._exemplars.length==1993);
+    checkNumExemplars(agg);
     output.remove();
     agg.remove();
 
@@ -186,6 +207,7 @@ public class AggregatorTest extends TestUtil {
       parms = new AggregatorModel.AggregatorParameters();
       parms._train = frame._key;
       parms._target_num_exemplars = 137;
+      parms._rel_tol_num_exemplars = 0.05;
       start = System.currentTimeMillis();
       AggregatorModel agg2 = new Aggregator(parms).trainModel().get();  // 0.373 0.504 0.357 0.454 0.368 0.355
       System.out.println("AggregatorModel finished in: " + (System.currentTimeMillis() - start)/1000. + " seconds");      agg2.checkConsistency();
@@ -194,6 +216,7 @@ public class AggregatorTest extends TestUtil {
       Assert.assertTrue(Math.abs(agg._exemplars.length - agg2._exemplars.length) == 0);
       output = agg2._output._output_frame.get();
       output.remove();
+      checkNumExemplars(agg);
       agg2.remove();
     }
     frame.delete();
@@ -225,8 +248,7 @@ public class AggregatorTest extends TestUtil {
 
     Frame output = agg._output._output_frame.get();
     output.remove();
-    Log.info("Number of exemplars: " + agg._exemplars.length);
-    Assert.assertTrue(agg._exemplars.length<=117);
+    checkNumExemplars(agg);
     frame.delete();
     agg.remove();
   }
@@ -274,6 +296,7 @@ public class AggregatorTest extends TestUtil {
 //    Log.info("Exemplars: " + output);
     output.remove();
     Log.info("Number of exemplars: " + agg._exemplars.length);
+    checkNumExemplars(agg);
     agg.remove();
   }
 }


### PR DESCRIPTION
added target_num_exemplars parameter (defaults to 5000), removed radius_scale

returns a frame with a number of exemplars that is within 50% of the target value (50%-150%).

takes about 1 min to aggregate 116M rows (airline) to 5000 exemplars on my laptop.

NOTE: we could make the 50% a parameter for more or less "picky" users, but maybe we don't need to do that just yet - ideas/thoughts?