### PR TITLE
fix pyunit_4090_grid_model_seeds.py.  Caused by length of grid models…

### DIFF
--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
@@ -71,14 +71,21 @@ def random_grid_model_seeds_PUBDEV_4090():
     # check model seeds are set as gridseed+model number where model number = 0, 1, ..., ...
     model_len = min(len(air_grid1), len(air_grid2))
     correct_model_seeds = list(range(search_criteria_tune1["seed"], search_criteria_tune1["seed"]+model_len))
-    assert model_seeds1[0:model_len]==model_seeds2[0:model_len], "Random gridsearch seed is not set correctly as model seeds..."
-    assert model_seeds1==correct_model_seeds, "Random gridsearch seed is not "
+
+    expectedSeeds = ','.join(str(x) for x in correct_model_seeds)
+    model1Seeds = ','.join(str(x) for x in model_seeds1[0:model_len])
+    model2Seeds = ','.join(str(x) for x in model_seeds2[0:model_len])
+    assert model_seeds1[0:model_len]==correct_model_seeds, "Model seeds are not set correctly: expected %s; " \
+                                                           "got %s" % (expectedSeeds, model1Seeds)
+    assert model_seeds2[0:model_len]==correct_model_seeds, "Model seeds are not set correctly: expected %s; " \
+                                                           "got %s" % (expectedSeeds, model2Seeds)
 
     # compare training_rmse from scoring history
     metric_list1 = pyunit_utils.extract_scoring_history_field(air_grid1.models[0], "training_rmse")
     metric_list2 = pyunit_utils.extract_scoring_history_field(air_grid2.models[0], "training_rmse")
     assert pyunit_utils.equal_two_arrays(metric_list1[0:model_len], metric_list2[0:model_len], 1e-5, 1e-6, False), \
-        "Random gridsearch seed is not set correctly as model seeds..."
+        "Training_rmse are different between the two grid search models.  Tests are supposed to be repeatable in " \
+        "this case.  Make sure model seeds are actually set correctly in the Java backend."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix pyunit_4090_grid_model_seeds.py.  The grid search model length changes depending on how much time it runs and is random.