### PR TITLE
PUBDEV-4266: Adds support for converting word2vec model to a Frame

### DIFF
--- a/h2o-algos/src/main/java/hex/api/RegisterAlgos.java
+++ b/h2o-algos/src/main/java/hex/api/RegisterAlgos.java
@@ -1,6 +1,5 @@
 package hex.api;
 
-import hex.word2vec.Word2VecModel;
 import water.H2O;
 import hex.ModelBuilder;
 import water.api.GridSearchHandler;

--- a/h2o-algos/src/main/java/hex/word2vec/Word2VecModel.java
+++ b/h2o-algos/src/main/java/hex/word2vec/Word2VecModel.java
@@ -63,8 +63,11 @@ public class Word2VecModel extends Model<Word2VecModel, Word2VecParameters, Word
   }
 
   private static class ConvertToFrameTask extends MRTask<ConvertToFrameTask> {
-    private Word2VecModel _model;
-    public ConvertToFrameTask(Word2VecModel model) { _model = model; }
+    private Key<Word2VecModel> _modelKey;
+    private transient Word2VecModel _model;
+    public ConvertToFrameTask(Word2VecModel model) { _modelKey = model._key; }
+    @Override
+    protected void setupLocal() { _model = DKV.getGet(_modelKey); }
     @Override
     public void map(Chunk[] cs, NewChunk[] ncs) {
       assert cs.length == 1;

--- a/h2o-algos/src/main/java/hex/word2vec/Word2VecModel.java
+++ b/h2o-algos/src/main/java/hex/word2vec/Word2VecModel.java
@@ -41,6 +41,46 @@ public class Word2VecModel extends Model<Word2VecModel, Word2VecParameters, Word
   }
 
   /**
+   * Converts this word2vec model to a Frame.
+   * @return Frame made of columns: Word, V1, .., Vn. Word column holds the vocabulary associated
+   * with this word2vec model, and columns V1, .., Vn represent the embeddings in the n-dimensional space.
+   */
+  public Frame toFrame() {
+    Vec zeroVec = null;
+    try {
+      zeroVec = Vec.makeZero(_output._words.length);
+      byte[] types = new byte[1 + _output._vecSize];
+      Arrays.fill(types, Vec.T_NUM);
+      types[0] = Vec.T_STR;
+      String[] colNames = new String[types.length];
+      colNames[0] = "Word";
+      for (int i = 1; i < colNames.length; i++)
+        colNames[i] = "V" + i;
+      return new ConvertToFrameTask(this).doAll(types, zeroVec).outputFrame(colNames, null);
+    } finally {
+      if (zeroVec != null) zeroVec.remove();
+    }
+  }
+
+  private static class ConvertToFrameTask extends MRTask<ConvertToFrameTask> {
+    private Word2VecModel _model;
+    public ConvertToFrameTask(Word2VecModel model) { _model = model; }
+    @Override
+    public void map(Chunk[] cs, NewChunk[] ncs) {
+      assert cs.length == 1;
+      assert ncs.length == _model._output._vecSize + 1;
+      Chunk chk = cs[0];
+      int wordOffset = (int) chk.start();
+      int vecPos = _model._output._vecSize * wordOffset;
+      for (int i = 0; i < chk._len; i++) {
+        ncs[0].addStr(_model._output._words[wordOffset + i]);
+        for (int j = 1; j < ncs.length; j++)
+          ncs[j].addNum(_model._output._vecs[vecPos++]);
+      }
+    }
+  }
+
+  /**
    * Takes an input string can return the word vector for that word.
    *
    * @param target - String of desired word

--- a/h2o-algos/src/main/java/water/rapids/prims/word2vec/AstWord2VecToFrame.java
+++ b/h2o-algos/src/main/java/water/rapids/prims/word2vec/AstWord2VecToFrame.java
@@ -1,0 +1,35 @@
+package water.rapids.prims.word2vec;
+
+import hex.word2vec.Word2VecModel;
+import water.rapids.Env;
+import water.rapids.ast.AstPrimitive;
+import water.rapids.ast.AstRoot;
+import water.rapids.vals.ValFrame;
+
+/**
+ * Converts a word2vec model to a Frame
+ */
+public class AstWord2VecToFrame extends AstPrimitive {
+
+  @Override
+  public String[] args() {
+    return new String[]{"model"};
+  }
+
+  @Override
+  public int nargs() {
+    return 1 + 1;
+  } // (word2vec.to.frame model)
+
+  @Override
+  public String str() {
+    return "word2vec.to.frame";
+  }
+
+  @Override
+  public ValFrame apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
+    Word2VecModel model = (Word2VecModel) stk.track(asts[1].exec(env)).getModel();
+    return new ValFrame(model.toFrame());
+  }
+
+}

--- a/h2o-algos/src/main/resources/META-INF/services/water.rapids.ast.AstPrimitive
+++ b/h2o-algos/src/main/resources/META-INF/services/water.rapids.ast.AstPrimitive
@@ -1,0 +1,1 @@
+water.rapids.prims.word2vec.AstWord2VecToFrame

--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -1,5 +1,6 @@
 package water.rapids;
 
+import hex.Model;
 import water.*;
 import water.fvec.Frame;
 import water.rapids.ast.*;
@@ -19,6 +20,7 @@ import water.rapids.ast.prims.time.*;
 import water.rapids.ast.prims.timeseries.*;
 import water.rapids.vals.ValFrame;
 import water.rapids.vals.ValFun;
+import water.rapids.vals.ValModel;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -288,6 +290,9 @@ public class Env extends Iced {
     init(new AstSeq());
     init(new AstSeqLen());
 
+    // Custom (eg. algo-specific)
+    for (AstPrimitive prim : PrimsService.INSTANCE.getAllPrims())
+      init(prim);
   }
 
 
@@ -380,8 +385,10 @@ public class Env extends Iced {
     if (value != null) {
       if (value.isFrame())
         return addGlobals((Frame) value.get());
+      if (value.isModel())
+        return new ValModel((Model) value.get());
       // Only understand Frames right now
-      throw new IllegalArgumentException("DKV name lookup of " + id + " yielded an instance of type " + value.className() + ", but only Frame is supported");
+      throw new IllegalArgumentException("DKV name lookup of " + id + " yielded an instance of type " + value.className() + ", but only Frame & Model are supported");
     }
 
     // Now the built-ins

--- a/h2o-core/src/main/java/water/rapids/PrimsService.java
+++ b/h2o-core/src/main/java/water/rapids/PrimsService.java
@@ -1,0 +1,33 @@
+package water.rapids;
+
+import water.rapids.ast.AstPrimitive;
+
+import java.util.*;
+
+/**
+ * PrimService manages access to non-core Rapid primitives.
+ * This includes algorithm specific rapids & 3rd party rapids.
+ */
+class PrimsService {
+
+  static PrimsService INSTANCE = new PrimsService();
+
+  private final ServiceLoader<AstPrimitive> _loader;
+
+  private PrimsService() {
+    _loader = ServiceLoader.load(AstPrimitive.class);
+  }
+
+  /**
+   * Locates all available non-core primitives of the Rapid language.
+   * @return list of Rapid primitives
+   */
+  synchronized List<AstPrimitive> getAllPrims() {
+    List<AstPrimitive> prims = new ArrayList<>();
+    for (AstPrimitive prim : _loader) {
+      prims.add(prim);
+    }
+    return prims;
+  }
+
+}

--- a/h2o-core/src/main/java/water/rapids/Val.java
+++ b/h2o-core/src/main/java/water/rapids/Val.java
@@ -1,5 +1,6 @@
 package water.rapids;
 
+import hex.Model;
 import water.fvec.Frame;
 import water.Iced;
 import water.rapids.ast.AstPrimitive;
@@ -17,6 +18,7 @@ abstract public class Val extends Iced {
   final public static int FRM = 5;     // Frame, not a Vec.  Can be a Frame of 1 Vec
   final public static int ROW = 6;     // Row of data; limited to a single array of doubles
   final public static int FUN = 7;     // Function
+  final public static int MOD = 8;     // Model
 
   abstract public int type();
 
@@ -28,6 +30,7 @@ abstract public class Val extends Iced {
   public boolean isFrame() { return false; }
   public boolean isRow()   { return false; }
   public boolean isFun()   { return false; }
+  public boolean isModel() { return false; }
 
   // One of these methods is overridden in each subclass
   public double   getNum()   { throw badValue("number"); }
@@ -37,6 +40,7 @@ abstract public class Val extends Iced {
   public Frame    getFrame() { throw badValue("Frame"); }
   public double[] getRow()   { throw badValue("Row"); }
   public AstPrimitive getFun() { throw badValue("function"); }
+  public Model    getModel() { throw badValue("Model"); }
 
   private IllegalArgumentException badValue(String expectedType) {
     return new IllegalArgumentException("Expected a " + expectedType + " but found a " + getClass());

--- a/h2o-core/src/main/java/water/rapids/vals/ValModel.java
+++ b/h2o-core/src/main/java/water/rapids/vals/ValModel.java
@@ -1,0 +1,19 @@
+package water.rapids.vals;
+
+import hex.Model;
+import water.rapids.Val;
+
+public class ValModel extends Val {
+  private final Model _m;
+
+  public ValModel(Model m) {
+    assert m != null : "Cannot construct a Model from null";
+    _m = m;
+  }
+
+  @Override public int type() { return MOD; }
+  @Override public boolean isModel() { return true; }
+  @Override public Model getModel() { return _m; }
+  @Override public String toString() { return _m.toString(); }
+
+}

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -21,6 +21,7 @@ from h2o.backend.connection import H2OConnectionError
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.compatibility import repr2, viewitems, viewvalues
 from h2o.utils.shared_utils import _is_fr, _py_tmp_key
+from h2o.model.model_base import ModelBase
 
 
 class ExprNode(object):
@@ -151,6 +152,8 @@ class ExprNode(object):
                 return "[%d:%s]" % (start, str(stop - start))
             else:
                 return "[%d:%s:%d]" % (start, str((stop - start + step - 1) // step), step)
+        if isinstance(arg, ModelBase):
+            return arg.model_id
         return repr2(arg)
 
     def __del__(self):

--- a/h2o-py/h2o/model/word_embedding.py
+++ b/h2o-py/h2o/model/word_embedding.py
@@ -6,6 +6,7 @@ from h2o.utils.compatibility import *  # NOQA
 from .model_base import ModelBase
 from .metrics_base import *  # NOQA
 import h2o
+from h2o.expr import ExprNode
 
 
 class H2OWordEmbeddingModel(ModelBase):
@@ -40,3 +41,11 @@ class H2OWordEmbeddingModel(ModelBase):
         """
         j = h2o.api("GET /3/Word2VecTransform", data={'model': self.model_id, 'words_frame': words.frame_id, 'aggregate_method': aggregate_method})
         return h2o.get_frame(j["vectors_frame"]["name"])
+
+    def to_frame(self):
+        """
+        Converts a given word2vec model into H2OFrame.
+
+        :returns: a frame representing learned word embeddings.
+        """
+        return h2o.H2OFrame._expr(expr=ExprNode("word2vec.to.frame", self))

--- a/h2o-py/tests/testdir_algos/word2vec/pyunit_word2vec_to_frame.py
+++ b/h2o-py/tests/testdir_algos/word2vec/pyunit_word2vec_to_frame.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.word2vec import H2OWord2vecEstimator
+
+
+def word2vec_to_frame():
+    print("Test converting a word2vec model to a Frame")
+
+    words = h2o.create_frame(rows=1000,cols=1,string_fraction=1.0,missing_fraction=0.0)
+    embeddings = h2o.create_frame(rows=1000,cols=100,real_fraction=1.0,missing_fraction=0.0)
+    word_embeddings = words.cbind(embeddings)
+
+    w2v_model = H2OWord2vecEstimator(pre_trained=word_embeddings)
+    w2v_model.train(training_frame=word_embeddings)
+
+    w2v_frame = w2v_model.to_frame()
+
+    word_embeddings.names = w2v_frame.names
+    assert word_embeddings.as_data_frame().equals(word_embeddings.as_data_frame()), "Source and generated embeddings match"
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(word2vec_to_frame)
+else:
+    word2vec_to_frame()

--- a/h2o-r/h2o-package/R/w2vutils.R
+++ b/h2o-r/h2o-package/R/w2vutils.R
@@ -57,3 +57,25 @@ h2o.transform <- function(word2vec, words, aggregate_method = c("NONE", "AVERAGE
     key <- res$vectors_frame$name
     h2o.getFrame(key)
 }
+
+#'
+#' Converts a given word2vec model into H2OFrame. The frame represents learned word embeddings
+#'
+#' @param word2vec A word2vec model.
+#' @examples
+#' \donttest{
+#' h2o.init()
+#'
+#' # Build a dummy word2vec model
+#' data <- as.character(as.h2o(c("a", "b", "a")))
+#' w2v.model <- h2o.word2vec(data, sent_sample_rate = 0, min_word_freq = 0, epochs = 1, vec_size = 2)
+#'
+#' # Transform words to vectors and return average vector for each sentence
+#' h2o.toFrame(w2v.model) # -> Frame made of 2 rows and 2 columns
+#' }
+#' @export
+h2o.toFrame <- function(word2vec) {
+    if (!is(word2vec, "H2OModel")) stop("`word2vec` must be a word2vec model")
+
+    .newExpr("word2vec.to.frame", word2vec@model_id)
+}

--- a/h2o-r/tests/testdir_algos/word2vec/runit_word2vec_to_frame.R
+++ b/h2o-r/tests/testdir_algos/word2vec/runit_word2vec_to_frame.R
@@ -1,0 +1,23 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+
+test.word2vec.toFrame <- function() {
+    pretrained.frame <- as.h2o(data.frame(
+        Word = c("a", "b"), V1 = c(0, 1), V2 = c(1, 0), V3 = c(0.2, 0.8),
+        stringsAsFactors = FALSE
+    ))
+
+    # convert to an H2O word2vec model
+    pretrained.w2v <- h2o.word2vec(pre_trained = pretrained.frame, vec_size = 3)
+
+    # conver back to a Frame
+    result <- h2o.toFrame(pretrained.w2v)
+    result.local <- as.data.frame(result)
+
+    expect_equal(result, expected = pretrained.frame)
+}
+
+doTest("Test converting a word2vec model to a frame", test.word2vec.toFrame)


### PR DESCRIPTION
This PR introduces support for converting word2vec model into a Frame.

It uses algo-specific rapids and introduces a new rapids discovery mechanism. Rapids now support working with models

eg.:

    fr <- .newExpr("word2vec.to.frame", w2v.model@model_id)
 
would convert a word2vec model to an H2O frame