### PR TITLE
PUBDEV-4164: offset_column updates

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/distribution.rst
+++ b/h2o-docs/src/product/data-science/algo-params/distribution.rst
@@ -46,7 +46,7 @@ When ``quantile`` is specified, then users can also specify a ``quantile_alpha``
 
 When ``huber`` is specified, then users can also specify a ``huber_alpha`` value. This indicates the top percentile of error that should be considered as outliers. 
 
-For all distributions except ``multinomial``, you can specify an ``offset_column``. Offsets are per-row “bias values” that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. If the distribution is Bernoulli, then the value for the ``offset_column`` must be less than 1.
+For all distributions except ``multinomial``, you can specify an ``offset_column``. Offsets are per-row “bias values” that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. 
 
 Some examples of response distributions are provided below.
 

--- a/h2o-docs/src/product/data-science/algo-params/offset_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/offset_column.rst
@@ -8,7 +8,9 @@
 Description
 ~~~~~~~~~~~
 
-An offset is a per-row “bias value” that is used during model training. For Gaussian distributions, offsets can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. If the distribution is Bernoulli, the value must be less than one. This option is not applicable for multinomial distributions.
+An offset is a per-row “bias value” that is used during model training. For Gaussian distributions, offsets can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. This option is not applicable for multinomial distributions.
+
+Because the ``offset_column`` is hard to create, it may be useful to pass in a column of predicted results from a previous model. (In the link function space, for example if working with a binary response, use the predicted logit values.) For example, this previous model could contain features not present in your current training set. 
 
 **Note**: 
 
@@ -20,6 +22,8 @@ Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
 - `distribution <distribution.html>`__
+- `family <family.html>`__
+- `link <link.html>`__
 - `weights_column <weights_column.html>`__
 - `y <y.html>`__
 

--- a/h2o-docs/src/product/data-science/algo-params/offset_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/offset_column.rst
@@ -8,15 +8,15 @@
 Description
 ~~~~~~~~~~~
 
-An offset is a per-row “bias value” that is used during model training. For Gaussian distributions, offsets can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. This option is not applicable for multinomial distributions.
+An offset is a per-row “bias value” that is used during model training. For Gaussian distributions, offsets can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. 
 
-Because the ``offset_column`` is hard to create, it may be useful to pass in a column of predicted results from a previous model. (In the link function space, for example if working with a binary response, use the predicted logit values.) For example, this previous model could contain features not present in your current training set. 
+When used with GBM, Deep Learning, or GLM distributions/family-link functions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For example, you may have fitted some other (logistic) regression using other variables (and data), and now you want to see if the present variables can add anything. So you use the predicted logit from the other model as an offset in. To get the logit from a predicted probability in H2O, you can use this expression: :math:`\text{logit} = \text{log}\big(\frac{prob}{(1-prob)}\big)`.
 
 **Note**: 
 
-- The ``offset_column`` can only be used for regression problems.
+- An offset column can only be used for regression problems.
+- This option is not applicable for multinomial distributions
 - The offset column cannot be the same as the `fold_column <fold_column.html>`__. 
-
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -174,7 +174,7 @@ Defining a GBM Model
 -  `offset_column <algo-params/offset_column.html>`__: (Not applicable if the **distribution** is
    **multinomial**) Specify a column to use as the offset.
    
-	 **Note**: Offsets are per-row "bias values" that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. If the **distribution** is **Bernoulli**, the value must be less than one.
+	 **Note**: Offsets are per-row "bias values" that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__. 
 
 -  `weights_column <algo-params/weights_column.html>`__: Specify a column to use for the observation
    weights, which are used for bias correction. The specified


### PR DESCRIPTION
- Removed (in 3 locations) documentation that stated offset_column must be less than 1 for bernoulli distributions. Note that the bernoulli case was not documented in the GBM booklet, so there was nothing to change.
- Added tip to pass in a column of predicted values when specifying an offset_column.