### PR TITLE
[PUBDEV-4171] Check for empty system property

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1752,7 +1752,7 @@ final public class H2O {
       if( s.startsWith("ai.h2o.") ) {
         args2.add("-" + s.substring(7));
         // hack: Junits expect properties, throw out dummy prop for ga_opt_out
-        if (!s.substring(7).equals("ga_opt_out"))
+        if (!s.substring(7).equals("ga_opt_out") && !System.getProperty(s).isEmpty())
           args2.add(System.getProperty(s));
       }
     }


### PR DESCRIPTION
Prevents adding a value to the array of arguments if the intended syntax is the existence of a flag.