### PR TITLE
PUBDEV-4167: PCA OOM with user data.  Changed to PCA.jav and SVD.java…

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -1407,7 +1407,7 @@ def assert_H2OTwoDimTable_equal(table1, table2, col_header_list, tolerance=1e-6,
                         val1 = table1.cell_values[name_ind1][indC]
                         val2 = table2.cell_values[name_ind2][indC]*flip_sign_vec[indC]
 
-                        if (type(val1) == float) and (type(val2) == float):
+                        if isinstance(val1, float) and isinstance(val2, float):
                             compare_val_ratio = abs(val1-val2)/max(1, abs(val1), abs(val2))
                             if compare_val_ratio > tolerance:
                                 print("Table entry difference is {0}".format(compare_val_ratio))
@@ -1434,11 +1434,15 @@ def generate_for_indices(list_size, check_all, num_per_dim, start_val):
 
 def generate_sign_vec(table1, table2):
     sign_vec = [1]*len(table1.cell_values[0])
-    for indC in range(1, len(table2.cell_values[0])):
-        if (np.sign(table1.cell_values[0][indC])!=np.sign(table2.cell_values[0][indC])):
-            sign_vec[indC] = -1
-        else:
-            sign_vec[indC] = 1
+    for indC in range(1, len(table2.cell_values[0])):   # may need to look at other elements since some may be zero
+        for indR in range(0, len(table2.cell_values)):
+            if (abs(table1.cell_values[indR][indC]) > 0) and (abs(table2.cell_values[indR][indC]) > 0):
+                sign_vec[indC] = int(np.sign(table1.cell_values[indR][indC]) * np.sign(table2.cell_values[indR][indC]))
+                # if (np.sign(table1.cell_values[indR][indC])!=np.sign(table2.cell_values[indR][indC])):
+                #     sign_vec[indC] = -1
+                # else:
+                #     sign_vec[indC] = 1
+                break       # found what we need.  Goto next column
 
     return sign_vec
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4167_pca_NOPASS_OOM.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4167_pca_NOPASS_OOM.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from random import randint
+from h2o.transforms.decomposition import H2OPCA
+
+def pca_pubdev_4167_OOM():
+  """
+  This pyunit is written to make sure PCA works with customer data.  It is mainly used by customer to verify
+  PCA operations and not to be used as a regular test since I do not want to expose customer data.
+  """
+  h2o.remove_all()
+  transform_types = ["NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"]   # make sure we check all tranforms
+  transformN = transform_types[randint(0, len(transform_types)-1)]
+  print("transform used on dataset is {0}.\n".format(transformN))
+
+  training_data = h2o.import_file(path=pyunit_utils.locate("/Users/wendycwong/gitBackup/SDatasets/pubdev_4167_Avkash/m120K.tar"))  # Nidhi: import may not work
+
+  gramSVDPCA = H2OPCA(k=training_data.ncols, transform=transformN)
+  gramSVDPCA.train(x=list(range(0, training_data.ncols)), training_frame=training_data)
+
+  powerSVDPCA = H2OPCA(k=training_data.ncols, transform=transformN, pca_method="Power")
+  powerSVDPCA.train(x=list(range(0, training_data.ncols)), training_frame=training_data)
+
+  # compare singular values and stuff between power and GramSVD methods
+  print("@@@@@@  Comparing eigenvalues between GramSVD and Power...\n")
+  pyunit_utils.assert_H2OTwoDimTable_equal(gramSVDPCA._model_json["output"]["importance"],
+                                           powerSVDPCA._model_json["output"]["importance"],
+                                           ["Standard deviation", "Cumulative Proportion", "Cumulative Proportion"],
+                                           tolerance=1e-5, check_all=False)
+  print("@@@@@@  Comparing eigenvectors between GramSVD and Power...\n")
+  # compare singular vectors
+  pyunit_utils.assert_H2OTwoDimTable_equal(gramSVDPCA._model_json["output"]["eigenvectors"],
+                                           powerSVDPCA._model_json["output"]["eigenvectors"],
+                                           powerSVDPCA._model_json["output"]["names"], tolerance=1e-1,
+                                           check_sign=True)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(pca_pubdev_4167_OOM)
+else:
+  pca_pubdev_4167_OOM()


### PR DESCRIPTION
Three things:

1. Changed PCA.java and SVD.java to choose the format (normal or widedataset) that is most memory efficient.  

2. Changed utilsPY.py to prepare for eigenvectors are contain lots of zeros when checking the sign.

3. Added Pyunit test pyunit_pubdev_4167_NOPASS_OOM.py to test my fix.  However, since customer would like to keep dataset private, set the test to NOPASS and mainly used as an example for customer to checkout my fix.