### PR TITLE
[PUBDEV-4168] Enable cors option for debugging

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -308,6 +308,9 @@ final public class H2O {
     /** -no_latest_check Do not attempt to retrieve latest H2O version from S3 on startup */
     public boolean noLatestCheck = false;
 
+    /** If true, adds Access-Control-Allow-Origin: * header to all REST endpoint responses **/
+    public boolean cors = false;
+
     @Override public String toString() {
       StringBuilder result = new StringBuilder();
 
@@ -359,6 +362,7 @@ final public class H2O {
     }
     public boolean matches(String s) {
       _lastMatchedFor = s;
+      System.out.println("matches: " + _s + "\t" + s + "\t" + _s.equals("-"  + s));
       if (_s.equals("-"  + s)) return true;
       if (_s.equals("--" + s)) return true;
       return false;
@@ -387,7 +391,6 @@ final public class H2O {
     for (AbstractH2OExtension e : H2O.getExtensions()) {
       args = e.parseArguments(args);
     }
-
     for (int i = 0; i < args.length; i++) {
       OptString s = new OptString(args[i]);
       if (s.matches("h") || s.matches("help")) {
@@ -531,6 +534,9 @@ final public class H2O {
       }
       else if (s.matches("no_latest_check")) {
         ARGS.noLatestCheck = true;
+      }
+      else if (s.matches("debug.cors")) {
+        ARGS.cors = true;
       }
       else {
         parseFailed("Unknown argument (" + s + ")");

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -308,9 +308,6 @@ final public class H2O {
     /** -no_latest_check Do not attempt to retrieve latest H2O version from S3 on startup */
     public boolean noLatestCheck = false;
 
-    /** If true, adds Access-Control-Allow-Origin: * header to all REST endpoint responses **/
-    public boolean cors = false;
-
     @Override public String toString() {
       StringBuilder result = new StringBuilder();
 
@@ -390,6 +387,7 @@ final public class H2O {
     for (AbstractH2OExtension e : H2O.getExtensions()) {
       args = e.parseArguments(args);
     }
+
     for (int i = 0; i < args.length; i++) {
       OptString s = new OptString(args[i]);
       if (s.matches("h") || s.matches("help")) {
@@ -533,9 +531,6 @@ final public class H2O {
       }
       else if (s.matches("no_latest_check")) {
         ARGS.noLatestCheck = true;
-      }
-      else if (s.matches("debug.cors")) {
-        ARGS.cors = true;
       }
       else {
         parseFailed("Unknown argument (" + s + ")");

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -362,7 +362,6 @@ final public class H2O {
     }
     public boolean matches(String s) {
       _lastMatchedFor = s;
-      System.out.println("matches: " + _s + "\t" + s + "\t" + _s.equals("-"  + s));
       if (_s.equals("-"  + s)) return true;
       if (_s.equals("--" + s)) return true;
       return false;

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -10,6 +10,7 @@ import water.nbhm.NonBlockingHashMap;
 import water.rapids.Assembly;
 import water.util.*;
 
+import javax.servlet.*;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -244,6 +245,9 @@ public class RequestServer extends HttpServlet {
       final String contentType = request.getContentType();
       Properties parms = new Properties();
       String postBody = null;
+      if (H2O.ARGS.cors) {
+        response.setHeader("Access-Control-Allow-Origin", "*");
+      }
 
       if ("application/json".equals(contentType)) {
         StringBuffer jb = new StringBuffer();

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -244,7 +244,7 @@ public class RequestServer extends HttpServlet {
       final String contentType = request.getContentType();
       Properties parms = new Properties();
       String postBody = null;
-      if (H2O.ARGS.cors) {
+      if (System.getProperty(H2O.OptArgs.SYSTEM_PROP_PREFIX + "debug.cors") != null) {
         response.setHeader("Access-Control-Allow-Origin", "*");
       }
 

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -10,7 +10,6 @@ import water.nbhm.NonBlockingHashMap;
 import water.rapids.Assembly;
 import water.util.*;
 
-import javax.servlet.*;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;


### PR DESCRIPTION
Adds `Access-Control-Allow-Origin: *` header behind a dev parameter of `debug.cors`. This allows the frontend and backend to be decoupled - easing development of Flow.