### PR TITLE
Fix typo in docker image building command

### DIFF
--- a/h2o-docs/src/product/docker.rst
+++ b/h2o-docs/src/product/docker.rst
@@ -79,7 +79,7 @@ From the **/data/h2o-{{branch\_name}}** directory, run:
 
 ::
 
-    docker build -t "h2oai/{{branch_name}}:v5" .
+    docker build -t "h2o.ai/{{branch_name}}:v5" .
 
     **Note**: ``v5`` represents the current version number.
 


### PR DESCRIPTION
Dot in image name was missing and was expected in next steps.