### PR TITLE
PUBDEV-4181 use valid spdx license expression for h2o-web package.json

### DIFF
--- a/h2o-web/package.json
+++ b/h2o-web/package.json
@@ -16,7 +16,7 @@
     "Machine Learning"
   ],
   "author": "Prithvi Prabhu <prithvi@0xdata.com>",
-  "license": "Apache License Version 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/h2oai/h2o-dev/issues"
   },


### PR DESCRIPTION
This PR resolves the NPM warning:

`npm WARN h2o-web@0.0.0 license should be a valid SPDX license expression`

that currently prints every time someone builds **h2o-3**

more signal, less noise 😄 

[JIRA PUBDEDV-4181](https://0xdata.atlassian.net/browse/PUBDEV-4181)