### PR TITLE
Added the first example of style check in H2O-3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,9 +213,9 @@ subprojects {
         if (applyFindbugsPlugin) {
             apply from: "$rootDir/gradle/findbugs.gradle"
         }
-        if (project.hasProperty("doCheckStyle")) {
-            apply from: "$rootDir/gradle/checkstyle.gradle"
-        }
+
+        apply from: "$rootDir/gradle/checkstyle.gradle"
+
         if (project.hasProperty("doAnimalSniffer") && project.doAnimalSniffer == "true") {
             apply from: "$rootDir/gradle/animalSniffer.gradle"
         }

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'checkstyle'
 
 checkstyle {
-  configFile = new File(rootDir, "gradle/config/checkstyle/google_checks.xml")
+  configFile = new File(rootDir, "gradle/config/checkstyle/h2o_checks.xml")
   ignoreFailures = true
   showViolations = true
   //toolVersion = "6.8.1"

--- a/gradle/config/checkstyle/google_checks.xml
+++ b/gradle/config/checkstyle/google_checks.xml
@@ -201,5 +201,10 @@
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>
         </module>
+        <module name="Regexp">
+            <!-- . matches any character, so we need to escape it and use \. to match dots. -->
+            <property name="format" value="System\.out\.println"/>
+            <property name="illegalPattern" value="true"/>
+        </module>
     </module>
 </module>

--- a/gradle/config/checkstyle/h2o_checks.xml
+++ b/gradle/config/checkstyle/h2o_checks.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+
+    Checkstyle configuration that checks the Google coding conventions from:
+    
+    -  Google Java Style
+       https://google-styleguide.googlecode.com/svn-history/r130/trunk/javaguide.html
+       
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    Most Checks are configurable, be sure to consult the documentation.
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+    
+    This file is specific for H2O.ai. We plan to grow it gradually.
+ -->
+
+<module name = "Checker">
+  <module name="TreeWalker">
+    <module name="Regexp">
+        <property name="format" value="[^)]\.getBytes\("/>
+        <property name="illegalPattern" value="true"/>
+    </module>
+  </module>
+</module>

--- a/h2o-algos/src/main/java/hex/grep/Grep.java
+++ b/h2o-algos/src/main/java/hex/grep/Grep.java
@@ -80,7 +80,7 @@ public class Grep extends ModelBuilder<GrepModel,GrepModel.GrepParameters,GrepMo
   private class ByteSeq implements CharSequence {
     private final byte _bs0[];
     private final byte _bs1[];
-    ByteSeq( Chunk chk0, Chunk chk1 ) { _bs0 = chk0.getBytes(); _bs1 = chk1==null ? null : chk1.getBytes(); }
+    ByteSeq( Chunk chk0, Chunk chk1 ) { _bs0 = chk0.bytes(); _bs1 = chk1==null ? null : chk1.bytes(); }
 
     @Override public char charAt(int idx ) {
       return (char)(idx < _bs0.length ? _bs0[idx] : _bs1[idx-_bs0.length]);

--- a/h2o-core/src/main/java/hex/DMatrix.java
+++ b/h2o-core/src/main/java/hex/DMatrix.java
@@ -7,14 +7,11 @@ import water.H2O.H2OCountedCompleter;
 import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.fvec.NewChunk;
-import water.fvec.NewChunk.Value;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
 import water.util.Log;
-import water.util.StringUtils;
 
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -259,7 +256,7 @@ public class DMatrix  {
       }
       Chunk modChunk = new NewChunk(res).setSparseRatio(2).compress();
       if(_progressKey != null)
-        new UpdateProgress(modChunk.getBytes().length,modChunk.frozenType()).fork(_progressKey);
+        new UpdateProgress(modChunk.bytes().length,modChunk.frozenType()).fork(_progressKey);
       DKV.put(zChunk.vec().chunkKey(zChunk.cidx()),modChunk,_fs);
     }
     @Override public void closeLocal(){

--- a/h2o-core/src/main/java/water/fvec/Chunk.java
+++ b/h2o-core/src/main/java/water/fvec/Chunk.java
@@ -166,7 +166,7 @@ public abstract class Chunk extends Iced<Chunk> implements Vec.Holder {
   /** Short-cut to the embedded big-data memory.  Generally not useful for
    *  public consumption, since the data remains compressed and holding on to a
    *  pointer to this array defeats the user-mode spill-to-disk. */
-  public byte[] getBytes() { return _mem; }
+  public byte[] bytes() { return _mem; }
 
   public void setBytes(byte[] mem) { _mem = mem; }
 

--- a/h2o-core/src/main/java/water/parser/FVecParseReader.java
+++ b/h2o-core/src/main/java/water/parser/FVecParseReader.java
@@ -25,7 +25,7 @@ public class FVecParseReader implements ParseReader {
     if(_chk == null)
       return null;
     _goffset = _chk.start();
-    return _chk.getBytes();
+    return _chk.bytes();
   }
   @Override public int  getChunkDataStart(int cidx) { return -1; }
   @Override public void setChunkDataStart(int cidx, int offset) { }

--- a/h2o-core/src/main/java/water/util/SetOfBytes.java
+++ b/h2o-core/src/main/java/water/util/SetOfBytes.java
@@ -15,7 +15,7 @@ public class SetOfBytes {
   }
   
   public SetOfBytes(String s) {
-    this(s.getBytes());
+    this(StringUtils.bytesOf(s));
   }
   
   public boolean contains(int b) { return b < 256 && b > -129 && bits[0xff&b];}
@@ -35,7 +35,7 @@ public class SetOfBytes {
     return n;
   }
   
-  public byte[] getBytes() {
+  public byte[] bytes() {
     byte[] out = new byte[size()];
     int i = 0;
     for (int b = 0; b < 256; b++) if (bits[b]) out[i++] = (byte)b;
@@ -44,6 +44,6 @@ public class SetOfBytes {
   }
   
   @Override public String toString() {
-    return "SetOfBytes(" + Arrays.toString(getBytes()) + ")";
+    return "SetOfBytes(" + Arrays.toString(bytes()) + ")";
   }
 }

--- a/h2o-core/src/test/java/water/KVTest.java
+++ b/h2o-core/src/test/java/water/KVTest.java
@@ -145,7 +145,7 @@ public class KVTest extends TestUtil {
     // Count occurrences of bytes
     @Override public void map( Chunk chk ) {
       _x = new int[256];        // One-time set histogram array
-      byte[] bits = chk.getBytes(); // Raw file bytes
+      byte[] bits = chk.bytes(); // Raw file bytes
       for( byte b : bits ) // Compute local histogram
         _x[b&0xFF]++;
     }

--- a/h2o-core/src/test/java/water/MRThrow.java
+++ b/h2o-core/src/test/java/water/MRThrow.java
@@ -87,7 +87,7 @@ public class MRThrow extends TestUtil {
     // Count occurrences of bytes
     @Override public void map( Chunk chk ) {
       _x = new int[256];            // One-time set histogram array
-      byte[] bits = chk.getBytes(); // Raw file bytes
+      byte[] bits = chk.bytes(); // Raw file bytes
       for( byte b : bits )          // Compute local histogram
         _x[b&0xFF]++;
       if( H2O.SELF.equals(_throwAt) )

--- a/h2o-core/src/test/java/water/parser/BufferedStringTest.java
+++ b/h2o-core/src/test/java/water/parser/BufferedStringTest.java
@@ -1,16 +1,12 @@
 package water.parser;
 
+import org.eclipse.jetty.util.StringUtil;
 import org.junit.Ignore;
 import org.junit.Test;
 import water.AutoBuffer;
-import water.Paxos;
-import water.TestUtil;
-
 import java.util.Arrays;
-
-import static java.util.Arrays.*;
-
 import static org.junit.Assert.*;
+import static water.util.StringUtils.*;
 
 /**
  * This is mostly a skeleton of the tests, feel free to implement the cases
@@ -22,7 +18,7 @@ public class BufferedStringTest {
   public void testWrite_impl() throws Exception {
     final String source = "this is not a string";
     BufferedString sut = new BufferedString(source);
-    assertArrayEquals(source.getBytes(), sut.getBuffer());
+    assertArrayEquals(bytesOf(source), sut.getBuffer());
     AutoBuffer ab = new AutoBuffer();
     sut.write_impl(ab);
     final byte[] expected = ("\u0015" + source).getBytes();
@@ -69,8 +65,8 @@ public class BufferedStringTest {
     // TODO(vlad): fix it; we don't need the cloud
 //    Paxos._commonKnowledge = true; // this is totally stupid; thank you Cliff for the fun
 // TODO(vlad): fix the crash in the next line    
-//    byte[] bytes = sut1.asBytes();
-//    assertArrayEquals(source.getBytes(), bytes);
+//    byte[] bytes = sut1.bytes();
+//    assertArrayEquals(bytesOf(source), bytes);
   }
 
   @Test @Ignore // this is a stub
@@ -175,7 +171,7 @@ public class BufferedStringTest {
   public void testGetBuffer() throws Exception {
     final String source = "not a string\u00f0";
     BufferedString sut = new BufferedString(source);
-    final byte[] expected = source.getBytes("UTF8");
+    final byte[] expected = bytesOf(source);
     final byte[] actual = sut.getBuffer();
     assertArrayEquals("Failed. expected " + Arrays.toString(expected) + 
                       ", got " + Arrays.toString(actual), 

--- a/h2o-core/src/test/java/water/util/SetOfBytesTest.java
+++ b/h2o-core/src/test/java/water/util/SetOfBytesTest.java
@@ -50,7 +50,7 @@ public class SetOfBytesTest {
   @Test
   public void testAsBytes() throws Exception {
     SetOfBytes sut = new SetOfBytes("Hello World!");
-    assertEquals(sut, new SetOfBytes(sut.getBytes()));
-    assertArrayEquals(" !HWdelor".getBytes(), sut.getBytes());
+    assertEquals(sut, new SetOfBytes(sut.bytes()));
+    assertArrayEquals(StringUtils.bytesOf(" !HWdelor"), sut.bytes());
   }
 }

--- a/h2o-genmodel/build.gradle
+++ b/h2o-genmodel/build.gradle
@@ -24,6 +24,7 @@ javadoc {
 //
 
 dependencies {
+  testCompile project(":h2o-core")
   testCompile "junit:junit:${junitVersion}"
   compile "net.sf.opencsv:opencsv:2.3"
   compile "ai.h2o:deepwater-backend-api:1.0.2"

--- a/h2o-genmodel/src/test/java/hex/genmodel/InMemoryMojoReaderBackendTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/InMemoryMojoReaderBackendTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.util.HashMap;
 import java.util.Map;
+import water.util.StringUtils;
 
 import static org.junit.Assert.*;
 
@@ -16,7 +17,7 @@ public class InMemoryMojoReaderBackendTest {
   @Before
   public void setup() {
     Map<String, byte[]> content = new HashMap<>();
-    content.put("text-file", "line1\nline2\n".getBytes());
+    content.put("text-file", StringUtils.bytesOf("line1\nline2\n"));
     content.put("binary-file", new byte[]{0, 1, 2});
     readerBackend = new InMemoryMojoReaderBackend(content);
   }


### PR DESCRIPTION
We can introduce Google's style guide gradually, case by case, and fix it.
Chunk.getBytes() renamed to Chunk.bytes() (you can check out Josh Bloch's opinion on the issue of "getters").