### PR TITLE
PUBDEV-4192: clean up INTERNAL test failures.  Added tryCatch in 4 ru…

### DIFF
--- a/h2o-r/tests/testdir_algos/glm/runit_INTERNAL_GLM_bc_categoricals.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_INTERNAL_GLM_bc_categoricals.R
@@ -5,8 +5,16 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 test <- function() {
   ## Import data
-  h2oData <- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
-  betaConstraints <- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+  results = tryCatch({  
+    h2oData <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
+    betaConstraints <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+    runTest<<-TRUE},
+    error = function(e) {
+      print("runit_INTERNAL_GLM_bc_categoricals.Rtest is not conducted because the datasets are not accessible.")
+      runTest<<-FALSE
+    })
+
+  if (runTest) {
   betaConstraints <- betaConstraints[1:(nrow(betaConstraints)-1),] # remove intercept
   bc <- as.data.frame(betaConstraints)
 
@@ -75,6 +83,7 @@ test <- function() {
   print(paste0("GLMNET'S AUC : ", glmnet_auc))
 
   checkGLMModel2(model.h2o, model.r)
+  }
 }
 
 doTest("GLM Test: GLM w/ Beta Constraints", test)

--- a/h2o-r/tests/testdir_algos/glm/runit_INTERNAL_GLM_bc_illegal_input.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_INTERNAL_GLM_bc_illegal_input.R
@@ -6,8 +6,17 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 test <- function() {
   ## Import data
-  h2oData <- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
-  betaConstraints <- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+  results = tryCatch({
+    h2oData <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
+    betaConstraints <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+    runTest<<-TRUE
+  },
+  error=function(e) {
+    print("**** WARNING: runit_INTERNAL_GLM_bc_illegal_input.R test is not conducted because the datasets are not accessible.")
+    runTest<<-FALSE
+  })
+
+  if (runTest) {
   betaConstraints <- betaConstraints[1:(nrow(betaConstraints)-1),] # remove intercept
   bc <- as.data.frame(betaConstraints)
 
@@ -42,6 +51,7 @@ test <- function() {
   c <- bc
   names(c) <- gsub("lower_bounds", replacement = "lowerbounds", x = names(bc))
   checkException(run_glm(c), "Did not detect beta constraint column name typo.", silent = T)
+  }
 }
 
 doTest("GLM Test: Beta Constraints Illegal Argument Exceptions", test)

--- a/h2o-r/tests/testdir_algos/glm/runit_INTERNAL_GLM_bc_unordered_input.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_INTERNAL_GLM_bc_unordered_input.R
@@ -8,8 +8,17 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 test <- function() {
   ## Import data
-  h2oData <- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
-  bc <- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+  
+  result = tryCatch({
+    h2oData <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
+    bc <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+    runTest<<-TRUE
+  }, error = function(e) {
+    print("**** WARNING: runit_INTERNAL_GLM_bc_unordered_input.R test is not conducted because the datasets are not accessible.")
+    runTest<<-FALSE
+  })
+
+  if (runTest) {
   bc <- bc[1:(nrow(bc)-1),] # remove intercept
   bc <- as.data.frame(bc)
 
@@ -42,6 +51,7 @@ test <- function() {
 
   checkEqualsNumeric(h2o.coef(a), h2o.coef(b))
   checkEqualsNumeric(h2o.coef(b), h2o.coef(c))
+  }
 }
 
 doTest("GLM Test: Beta Constraints with Priors", test)

--- a/h2o-r/tests/testdir_jira/runit_INTERNAL_hex_2025_priors.R
+++ b/h2o-r/tests/testdir_jira/runit_INTERNAL_hex_2025_priors.R
@@ -5,8 +5,16 @@ source("../../scripts/h2o-r-test-setup.R")
 
 test <- function(){
   ## Import data
-  h2oData <- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
-  betaConstraints <- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+  result = tryCatch({
+    h2oData <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/data.csv")
+    betaConstraints <<- h2o.importFile("/mnt/0xcustomer-datasets/c27/constraints_indices.csv")
+    runTest=TRUE},
+    error=function(e) {
+      print("**** WARNING: runit_INTERNAL_hex_2025_priors.R test is not conducted because the datasets are not accessible.")
+      runTest<<-FALSE
+    })
+
+  if (runTest) {
   betaConstraints <- betaConstraints[1:(nrow(betaConstraints)-1),] # remove intercept
   betaConstraints <- as.data.frame(betaConstraints)
 
@@ -49,6 +57,7 @@ test <- function(){
   intercept2adj <- intercept1-adjustment
   checkEqualsNumeric(coeff1, coeff2, tolerance = 0)
   checkEqualsNumeric(intercept2, intercept2adj, tolerance = 1E-10)
+  }
 }
 
 doTest("GLM Test: Beta Constraints with Priors", test)


### PR DESCRIPTION
Clean up the following tests so that they won't fail when INTERNAL datasets are not available per Jeff G request:

testdir_algos_glm_runit_INTERNAL_GLM_bc_unordered_input.R.out.txt
testdir_algos_glm_runit_INTERNAL_GLM_bc_categoricals.R.out.txt   testdir_jira_runit_INTERNAL_hex_2025_priors.R.out.txt
testdir_algos_glm_runit_INTERNAL_GLM_bc_illegal_input.R.out.txt