### PR TITLE
PUBDEV-4045: Doc site - Make H2O User Guide more prominent

### DIFF
--- a/h2o-docs/src/front/assets/stylesheets/style.css
+++ b/h2o-docs/src/front/assets/stylesheets/style.css
@@ -35,7 +35,7 @@ html {
 body {
 	font-family: 'Heebo', sans-serif;
 	font-weight: 300;
-    font-size: 1em;
+    font-size: .94em;
 /*
     -webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;

--- a/h2o-docs/src/front/assets/vendor/bootstrap.min.css
+++ b/h2o-docs/src/front/assets/vendor/bootstrap.min.css
@@ -4608,7 +4608,7 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:hover,a.list-gro
 	border-radius:6px
 }
 .well-sm {
-	padding:9px;
+	padding:4px;
 	border-radius:0px;
 	border: 1px solid #424242;
 }

--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -116,11 +116,11 @@
       <div class="row">
         <div class="col-md-12">
           <ul class="nav navbar-nav navbar-left">
-          <li style="margin-top: 7px; margin-bottom: 14.6667px; margin-left: 0px; margin-right: 0px; font-size: 1.1em; font-weight: 400;"><a href="#gettingstarted">Getting Started</a></li>
-          <li style="font-size: 1.1em; font-weight: 400;"><a href="#algorithms">Data Science Algorithms</a></li>
+          <li style="margin-top: 7px; margin-bottom: 14.6667px; margin-left: 0px; margin-right: 0px; font-size: 1.1em; font-weight: 400;"><a href="#gettingstarted">Getting Started &amp; User Guides</a></li>
+          <li style="font-size: 1.1em; font-weight: 400;"><a href="#algorithms">Algorithms</a></li>
           <li style="font-size: 1.1em; font-weight: 400;"><a href="#languages">Languages</a></li>
           <li style="font-size: 1.1em; font-weight: 400;"><a href="#tutorials">Tutorials, Examples, &amp; Presentations</a></li>
-          <li style="font-size: 1.1em; font-weight: 400;"><a href="#fordevelopers">For Developers</a></li>
+          <li style="font-size: 1.1em; font-weight: 400;"><a href="#fordevelopers">API &amp; Developer Docs</a></li>
           <li style="font-size: 1.1em; font-weight: 400;"><a href="#forenterprise">For the Enterprise</a></li>
           </ul>
         </div>
@@ -131,7 +131,7 @@
 
     <div class="row">
       <div class="col-md-12">
-          <h3 class="txt-cntr"><a name="gettingstarted"></a>Getting Started</h3>
+          <h3 class="txt-cntr"><a name="gettingstarted"></a>Getting Started &amp; User Guides</h3>
       </div>
     </div>
 
@@ -141,7 +141,7 @@
           <h4>H<sub>2</sub>O</h4>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 10px;">
               <a href="h2o-docs/welcome.html">What is H2O?</a>
-              <p style="margin: 0pt; font-weight: 500;"><a href="h2o-docs/index.html">H2O USER GUIDE</a> <- MAIN H2O DOC!</p>
+              <p style="margin: 0pt;"><a href="h2o-docs/index.html" style="font-weight: 500; font-size: 1.1em;">H2O User Guide</a> <style="font-color:black; font-size:0.9em;>(Main docs)</style="font-color:black;></p>
               <a href="http://shop.oreilly.com/product/0636920053170.do">H2O Book (O'Reilly)</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/Changes.md">Recent Changes</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/LICENSE">Open Source License (Apache V2)</a>
@@ -238,7 +238,7 @@
 
     <div class="row">
       <div class="col-md-12">
-        <h3 class="txt-cntr"><a name="algorithms"></a>Data Science Algorithms</h3>
+        <h3 class="txt-cntr"><a name="algorithms"></a>Algorithms</h3>
       </div>
     </div>
 
@@ -491,7 +491,7 @@
 
     <div class="row">
       <div class="col-md-12">
-        <h3 class="txt-cntr"><a name="fordevelopers"></a>For Developers</h3>
+        <h3 class="txt-cntr"><a name="fordevelopers"></a>API & Developer Docs</h3>
       </div>
     </div>
 

--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -141,7 +141,7 @@
           <h4>H<sub>2</sub>O</h4>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 10px;">
               <a href="h2o-docs/welcome.html">What is H2O?</a>
-              <a href="h2o-docs/index.html">H2O User Guide</a>
+              <p style="margin: 0pt; font-weight: 500;"><a href="h2o-docs/index.html">H2O USER GUIDE</a> <- MAIN H2O DOC!</p>
               <a href="http://shop.oreilly.com/product/0636920053170.do">H2O Book (O'Reilly)</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/Changes.md">Recent Changes</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/LICENSE">Open Source License (Apache V2)</a>


### PR DESCRIPTION
- Increased the weight of the H2O User Guide link.
- That entry is a "p" style so that I could add text after the link without wrapping. (The "a" tag adds a return at it’s closing "a".)
- To avoid line wrapping, changed the box padding to 4px. (6px worked in Chrome and Firefox, but not Safari.) Also changed main font size from 1em to .94em.