### PR TITLE
PUBDEV-4105: Add which.max, which.min support for R H2OFrame & PUBDEV-4104: Add support for idxmax, idxmin in Python H2OFrame

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -280,6 +280,8 @@ public class Env extends Iced {
     // Search
     init(new AstMatch());
     init(new AstWhich());
+    init(new AstWhichMax());
+    init(new AstWhichMin());
 
     // Repeaters
     init(new AstRepLen());

--- a/h2o-core/src/main/java/water/rapids/ast/prims/search/AstWhichFunc.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/search/AstWhichFunc.java
@@ -1,0 +1,225 @@
+package water.rapids.ast.prims.search;
+
+import water.H2O;
+import water.Key;
+import water.MRTask;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.fvec.NewChunk;
+import water.rapids.Env;
+import water.rapids.Val;
+import water.rapids.ast.AstBuiltin;
+import water.fvec.Vec;
+import water.rapids.ast.AstRoot;
+import water.rapids.vals.ValFrame;
+import water.rapids.vals.ValRow;
+
+public abstract class AstWhichFunc extends AstBuiltin<AstWhichFunc> {
+    @Override
+    public String[] args() {
+        return new String[]{"frame", "na_rm", "axis"};
+    }
+
+    @Override
+    public int nargs() {
+        return 1 + 1;
+    }
+
+    @Override
+    public String str() {
+        throw H2O.unimpl();
+    }
+
+    public abstract double op(Vec l); //Operation to perform in colWiseWhichVal() -> Vec.max() or Vec.min().
+
+    public abstract String searchVal(); //String indicating what we are searching for across rows in rowWiseWhichVal() -> max or min.
+
+    public abstract double init();
+
+    @Override
+    public Val apply(Env env, Env.StackHelp stk, AstRoot[] asts) {
+        Val val1 = asts[1].exec(env);
+        if (val1 instanceof ValFrame) {
+            Frame fr = stk.track(val1).getFrame();
+            boolean na_rm = asts[2].exec(env).getNum() == 1;
+            boolean axis = asts.length == 4 && (asts[3].exec(env).getNum() == 1);
+            return axis ? rowwiseWhichVal(fr, na_rm) : colwiseWhichVal(fr, na_rm);
+        }
+        else if (val1 instanceof ValRow) {
+            // This may be called from AstApply when doing per-row computations.
+            double[] row = val1.getRow();
+            boolean na_rm = asts[2].exec(env).getNum() == 1;
+            double val = Double.NEGATIVE_INFINITY;
+            double valIndex = 0;
+            if(searchVal() == "max") { //Looking for the max?
+                for (int i = 0; i < row.length; i++) {
+                    if (Double.isNaN(row[i])) {
+                        if (!na_rm)
+                            return new ValRow(new double[]{Double.NaN}, null);
+                    } else {
+                        if (row[i] > val) {
+                            val = row[i];
+                            valIndex = i;
+                        }
+                    }
+                }
+            }else if(searchVal() == "min"){ //Looking for the min?
+                for (int i = 0; i < row.length; i++) {
+                    if (Double.isNaN(row[i])) {
+                        if (!na_rm)
+                            return new ValRow(new double[]{Double.NaN}, null);
+                    } else {
+                        if (row[i] < val) {
+                            val = row[i];
+                            valIndex = i;
+                        }
+                    }
+                }
+            }
+            else{
+                throw new IllegalArgumentException("Incorrect argument: expected to search for max() or min(), received " + searchVal());
+            }
+            return new ValRow(new double[]{valIndex}, null);
+        } else
+            throw new IllegalArgumentException("Incorrect argument: expected a frame or a row, received " + val1.getClass());
+    }
+
+
+    /**
+     * Compute row-wise, and return a frame consisting of a single Vec of value indexes in each row.
+     */
+    private ValFrame rowwiseWhichVal(Frame fr, final boolean na_rm) {
+        String[] newnames = {"which." + searchVal()};
+        Key<Frame> newkey = Key.make();
+
+        // Determine how many columns of different types we have
+        int n_numeric = 0, n_time = 0;
+        for (Vec vec : fr.vecs()) {
+            if (vec.isNumeric()) n_numeric++;
+            if (vec.isTime()) n_time++;
+        }
+        // Compute the type of the resulting column: if all columns are TIME then the result is also time; otherwise
+        // if at least one column is numeric then the result is also numeric.
+        byte resType = n_numeric > 0 ? Vec.T_NUM : Vec.T_TIME;
+
+        // Construct the frame over which the val index should be computed
+        Frame compFrame = new Frame();
+        for (int i = 0; i < fr.numCols(); i++) {
+            Vec vec = fr.vec(i);
+            if (n_numeric > 0? vec.isNumeric() : vec.isTime())
+                compFrame.add(fr.name(i), vec);
+        }
+        Vec anyvec = compFrame.anyVec();
+
+        // Take into account certain corner cases
+        if (anyvec == null) {
+            Frame res = new Frame(newkey);
+            anyvec = fr.anyVec();
+            if (anyvec != null) {
+                // All columns in the original frame are non-numeric -> return a vec of NAs
+                res.add("which." + searchVal(), anyvec.makeCon(Double.NaN));
+            } // else the original frame is empty, in which case we return an empty frame too
+            return new ValFrame(res);
+        }
+        if (!na_rm && n_numeric < fr.numCols() && n_time < fr.numCols()) {
+            // If some of the columns are non-numeric and na_rm==false, then the result is a vec of NAs
+            Frame res = new Frame(newkey, newnames, new Vec[]{anyvec.makeCon(Double.NaN)});
+            return new ValFrame(res);
+        }
+
+        // Compute over all rows
+        final int numCols = compFrame.numCols();
+        Frame res = new MRTask() {
+            @Override
+            public void map(Chunk[] cs, NewChunk nc) {
+                for (int i = 0; i < cs[0]._len; i++) {
+                    int numNaColumns = 0;
+                    double value = Double.NEGATIVE_INFINITY;
+                    int valueIndex = 0;
+                    if (searchVal() == "max") { //Looking for the max?
+                        for (int j = 0; j < numCols; j++) {
+                            double val = cs[j].atd(i);
+                            if (Double.isNaN(val)) {
+                                numNaColumns++;
+                            } else if (val > value) { //Return the first occurrence of the val
+                                value = val;
+                                valueIndex = j;
+                            }
+                        }
+                    }else if(searchVal()=="min"){ //Looking for the min?
+                        for (int j = 0; j < numCols; j++) {
+                            double val = cs[j].atd(i);
+                            if (Double.isNaN(val)) {
+                                numNaColumns++;
+                            }
+                            else if(val <  value) { //Return the first occurrence of the min index
+                                value = val;
+                                valueIndex = j;
+                            }
+                        }
+                    }else{
+                        throw new IllegalArgumentException("Incorrect argument: expected to search for max() or min(), received " + searchVal());
+                    }
+                    if (na_rm ? numNaColumns < numCols : numNaColumns == 0)
+                        nc.addNum(valueIndex);
+                    else
+                        nc.addNum(Double.NaN);
+                }
+            }
+        }.doAll(1, resType, compFrame)
+                .outputFrame(newkey, newnames, null);
+
+        // Return the result
+        return new ValFrame(res);
+    }
+
+
+    /**
+     * Compute column-wise (i.e.value index of each column), and return a frame having a single row.
+     */
+    private ValFrame colwiseWhichVal(Frame fr, final boolean na_rm) {
+        Frame res = new Frame();
+
+        Vec vec1 = Vec.makeCon(null, 0);
+        assert vec1.length() == 1;
+
+        for (int i = 0; i < fr.numCols(); i++) {
+            Vec v = fr.vec(i);
+            double searchValue = op(v);
+            boolean valid = (v.isNumeric() || v.isTime() || v.isBinary()) && v.length() > 0 && (na_rm || v.naCnt() == 0);
+            FindIndexCol findIndexCol = new FindIndexCol(searchValue).doAll(new byte[]{Vec.T_NUM}, v);
+            Vec newvec = vec1.makeCon(valid ? findIndexCol._valIndex : Double.NaN, v.isTime()? Vec.T_TIME : Vec.T_NUM);
+            res.add(fr.name(i), newvec);
+        }
+
+        vec1.remove();
+        return new ValFrame(res);
+    }
+
+    private static class FindIndexCol extends MRTask<AstWhichFunc.FindIndexCol>{
+        double _val;
+        double _valIndex;
+
+
+        FindIndexCol(double val) {
+            _val = val;
+            _valIndex = Double.POSITIVE_INFINITY;
+        }
+
+        @Override
+        public void map(Chunk c, NewChunk nc) {
+            long start = c.start();
+            for (int i = 0; i < c._len; ++i) {
+                if (c.atd(i) == _val) {
+                    _valIndex = start + i;
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void reduce(AstWhichFunc.FindIndexCol mic) {
+            _valIndex = Math.min(_valIndex, mic._valIndex); //Return the first occurrence of the val index
+        }
+    }
+}

--- a/h2o-core/src/main/java/water/rapids/ast/prims/search/AstWhichMax.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/search/AstWhichMax.java
@@ -1,0 +1,28 @@
+package water.rapids.ast.prims.search;
+
+import water.fvec.Vec;
+
+public class AstWhichMax extends AstWhichFunc {
+    @Override
+    public int nargs() { return 1 + 3; } // "frame", "na_rm", "axis"
+
+    @Override
+    public String str() {
+        return "which.max";
+    }
+
+    @Override
+    public double op(Vec l) {
+        return l.max();
+    }
+
+    @Override
+    public String searchVal(){
+        return "max";
+    }
+
+    @Override
+    public double init() {
+        return 0;
+    }
+}

--- a/h2o-core/src/main/java/water/rapids/ast/prims/search/AstWhichMin.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/search/AstWhichMin.java
@@ -1,0 +1,28 @@
+package water.rapids.ast.prims.search;
+
+import water.fvec.Vec;
+
+public class AstWhichMin extends AstWhichFunc {
+    @Override
+    public int nargs() { return 1 + 3; } // "frame", "na_rm", "axis"
+
+    @Override
+    public String str() {
+        return "which.min";
+    }
+
+    @Override
+    public double op(Vec l) {
+        return l.min();
+    }
+
+    @Override
+    public String searchVal(){
+        return "min";
+    }
+
+    @Override
+    public double init() {
+        return 0;
+    }
+}

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2801,7 +2801,7 @@ class H2OFrame(object):
         """
         return H2OFrame._expr(expr=ExprNode("which", self))
 
-    def idxmax(self,skipna=False, axis=0):
+    def idxmax(self,skipna=True, axis=0):
         """
         Get the index of the max value in a column or row
 
@@ -2815,7 +2815,7 @@ class H2OFrame(object):
         """
         return H2OFrame._expr(expr=ExprNode("which.max", self, skipna, axis))
 
-    def idxmin(self,skipna=False, axis=0):
+    def idxmin(self,skipna=True, axis=0):
         """
         Get the index of the min value in a column or row
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2801,6 +2801,34 @@ class H2OFrame(object):
         """
         return H2OFrame._expr(expr=ExprNode("which", self))
 
+    def idxmax(self,skipna=False, axis=0):
+        """
+        Get the index of the max value in a column or row
+
+        :param bool skipna: If True (default), then NAs are ignored during the search. Otherwise presence
+            of NAs renders the entire result NA.
+        :param int axis: Direction of finding the max index. If 0 (default), then the max index is searched columnwise, and the
+            result is a frame with 1 row and number of columns as in the original frame. If 1, then the max index is searched
+            rowwise and the result is a frame with 1 column, and number of rows equal to the number of rows in the original frame.
+        :returns: either a list of max index values per-column or an H2OFrame containing max index values
+                  per-row from the original frame.
+        """
+        return H2OFrame._expr(expr=ExprNode("which.max", self, skipna, axis))
+
+    def idxmin(self,skipna=False, axis=0):
+        """
+        Get the index of the min value in a column or row
+
+        :param bool skipna: If True (default), then NAs are ignored during the search. Otherwise presence
+            of NAs renders the entire result NA.
+        :param int axis: Direction of finding the min index. If 0 (default), then the min index is searched columnwise, and the
+            result is a frame with 1 row and number of columns as in the original frame. If 1, then the min index is searched
+            rowwise and the result is a frame with 1 column, and number of rows equal to the number of rows in the original frame.
+        :returns: either a list of min index values per-column or an H2OFrame containing min index values
+                  per-row from the original frame.
+        """
+        return H2OFrame._expr(expr=ExprNode("which.min", self, skipna, axis))
+
 
     def ifelse(self, yes, no):
         """

--- a/h2o-py/tests/testdir_munging/pyunit_whichmaxmin.py
+++ b/h2o-py/tests/testdir_munging/pyunit_whichmaxmin.py
@@ -1,0 +1,66 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+import pandas as pd
+
+def whichmaxmin():
+
+    #Make H2O frame
+    f1 = h2o.create_frame(rows = 10000, cols = 100, categorical_fraction = 0, missing_fraction = 0,seed=1234)
+
+    #Make comparable pandas frame
+    f2 = f1.as_data_frame(use_pandas=True)
+
+    #############################################################
+    #Col wise max
+    which_max_col = f1.idxmax()
+    which_max_col = which_max_col.transpose()
+
+    which_max_col_pd = f2.idxmax(axis=0)
+    which_max_col_pd = h2o.H2OFrame(pd.DataFrame(which_max_col_pd,columns=["C1"]))
+
+    diff_max_col_idx = which_max_col - which_max_col_pd
+
+    assert diff_max_col_idx.sum() == 0
+
+    #Col wise min
+    which_min_col = f1.idxmin()
+    which_min_col = which_min_col.transpose()
+
+    which_min_col_pd = f2.idxmin(axis=0)
+    which_min_col_pd = h2o.H2OFrame(pd.DataFrame(which_min_col_pd,columns=["C1"]))
+
+    diff_min_col_idx = which_min_col - which_min_col_pd
+
+    assert diff_min_col_idx.sum() == 0
+
+    #############################################################
+    #Row wise max
+    which_max_row = f1.idxmax(axis=1)
+
+    which_max_row_pd = f2.idxmax(axis=1)
+    which_max_row_pd = h2o.H2OFrame(pd.DataFrame(which_max_row_pd,columns=["C1"]))
+    which_max_row_pd = which_max_row_pd.ascharacter().lstrip("C").asnumeric() - 1 #Had to clean up before comparison (indexing was +1)
+
+    diff_max_row_idx = which_max_row - which_max_row_pd
+
+    assert diff_max_row_idx.sum() == 0
+
+    #Row wise min
+    which_min_row = f1.idxmin(axis=1)
+
+    which_min_row_pd = f2.idxmin(axis=1)
+    which_min_row_pd = h2o.H2OFrame(pd.DataFrame(which_min_row_pd,columns=["C1"]))
+    which_min_row_pd = which_min_row_pd.ascharacter().lstrip("C").asnumeric() - 1 #Had to clean up before comparison (indexing was +1)
+
+    diff_min_row_idx = which_min_row - which_min_row_pd
+
+    assert diff_min_row_idx.sum() == 0
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(whichmaxmin)
+else:
+    whichmaxmin()

--- a/h2o-r/h2o-package/R/constants.R
+++ b/h2o-r/h2o-package/R/constants.R
@@ -26,7 +26,7 @@ assign("LOG_FILE_NAME", NULL,  .pkg.env)
   "cos", "sin", "acos", "cosh", "tan", "tanh", "exp", "log", "sqrt", 
   "abs", "ceiling", "floor", 
   "mean", "sd", "sum", "prod", "all", "any", "min", "max", 
-  "is.factor", "nrow", "ncol", "length" 
+  "is.factor", "nrow", "ncol", "length" , "which.max", "which.min"
 )
 
 

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1576,7 +1576,7 @@ h2o.which <- function(x) {
 #' @return Returns an H2OFrame object.
 #' @seealso \code{\link[base]{which.max}} for the base R method.
 #' @export
-h2o.which_max <- function(x,na.rm = FALSE,axis = 0, ...) {
+h2o.which_max <- function(x,na.rm = FALSE,axis = 0) {
   if( !is.H2OFrame(x) ){
     stop("must be an H2OFrame")
   }
@@ -1597,7 +1597,7 @@ which.max.H2OFrame <- h2o.which_max
 #' @return Returns an H2OFrame object.
 #' @seealso \code{\link[base]{which.min}} for the base R method.
 #' @export
-h2o.which_min <- function(x,na.rm = FALSE,axis = 0, ...) {
+h2o.which_min <- function(x,na.rm = FALSE,axis = 0) {
   if( !is.H2OFrame(x) ) stop("must be an H2OFrame")
   else .newExpr("which.min",x,na.rm,axis) + 1
 }

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1576,7 +1576,7 @@ h2o.which <- function(x) {
 #' @return Returns an H2OFrame object.
 #' @seealso \code{\link[base]{which.max}} for the base R method.
 #' @export
-h2o.which_max <- function(x,na.rm = FALSE,axis = 0) {
+h2o.which_max <- function(x,na.rm = TRUE,axis = 0) {
   if( !is.H2OFrame(x) ){
     stop("must be an H2OFrame")
   }
@@ -1597,7 +1597,7 @@ which.max.H2OFrame <- h2o.which_max
 #' @return Returns an H2OFrame object.
 #' @seealso \code{\link[base]{which.min}} for the base R method.
 #' @export
-h2o.which_min <- function(x,na.rm = FALSE,axis = 0) {
+h2o.which_min <- function(x,na.rm = TRUE,axis = 0) {
   if( !is.H2OFrame(x) ) stop("must be an H2OFrame")
   else .newExpr("which.min",x,na.rm,axis) + 1
 }

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1566,6 +1566,46 @@ h2o.which <- function(x) {
   else .newExpr("which",x) + 1
 }
 
+#' Which indice contains the max value?
+#'
+#' Get the index of the max value in a column or row
+#'
+#' @param x An H2OFrame object.
+#' @param na.rm \code{logical}. Indicate whether missing values should be removed.
+#' @param axis \code{integer}. Indicate whether to calculate the mean down a column (0) or across a row (1).
+#' @return Returns an H2OFrame object.
+#' @seealso \code{\link[base]{which.max}} for the base R method.
+#' @export
+h2o.which_max <- function(x,na.rm = FALSE,axis = 0, ...) {
+  if( !is.H2OFrame(x) ){
+    stop("must be an H2OFrame")
+  }
+  .newExpr("which.max", chk.H2OFrame(x), na.rm, axis) + 1
+}
+
+#' @rdname h2o.which_max
+#' @export
+which.max.H2OFrame <- h2o.which_max
+
+#' Which index contains the min value?
+#'
+#' Get the index of the min value in a column or row
+#'
+#' @param x An H2OFrame object.
+#' @param na.rm \code{logical}. Indicate whether missing values should be removed.
+#' @param axis \code{integer}. Indicate whether to calculate the mean down a column (0) or across a row (1).
+#' @return Returns an H2OFrame object.
+#' @seealso \code{\link[base]{which.min}} for the base R method.
+#' @export
+h2o.which_min <- function(x,na.rm = FALSE,axis = 0, ...) {
+  if( !is.H2OFrame(x) ) stop("must be an H2OFrame")
+  else .newExpr("which.min",x,na.rm,axis) + 1
+}
+
+#' @rdname h2o.which_max
+#' @export
+which.min.H2OFrame <- h2o.which_min
+
 #' Count of NAs per column
 #'
 #' Gives the count of NAs per column.
@@ -3776,6 +3816,10 @@ apply <- function(X, MARGIN, FUN, ...) {
     if( nargs > 0 ) extra_args <- c(extra_args,tail(args,nargs))
     fcn <- if( length(extra_args)==0 ) fname
            else paste0("{ COL . (",fname," COL ",paste(extra_args,collapse=" "),")}")
+
+    if(fname == "which.max" || fname == "which.min"){
+      return(.newExpr("apply",X,MARGIN,fcn) + 1)
+    }
     return(.newExpr("apply",X,MARGIN,fcn))
   }
 

--- a/h2o-r/tests/testdir_munging/exec/runit_whichmaxmin.R
+++ b/h2o-r/tests/testdir_munging/exec/runit_whichmaxmin.R
@@ -1,0 +1,70 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.whichmaxmin <- function(){
+    #Create H2O Frame
+    hf <- h2o.createFrame(rows = 10000, cols = 100, categorical_fraction = 0, missing_fraction = 0,seed=1234)
+
+    #Cast as R Data Frame for comparison
+    df <- as.data.frame(hf)
+
+    #Col wise max
+    which_max_col <- h2o.which_max(hf,axis=0)
+    which_max_col_app <- apply(hf,2,which.max)
+
+    #Apply and original which_max should match
+    expect_equal(sum(which_max_col_app == which_max_col),100)
+    expect_equal(which_max_col_app,which_max_col)
+
+    #H2O which_max should match R
+    which_max_col_app_r <- apply(df,2,which.max)
+
+    expect_equal(which_max_col, as.h2o(which_max_col_app_r))
+    expect_equal(which_max_col_app, as.h2o(which_max_col_app_r))
+
+    #Col wise min
+    which_min_col <- h2o.which_min(hf,axis=0)
+    which_min_col_app <- apply(hf,2,which.min)
+
+    #Apply and original which_max should match
+    expect_equal(sum(which_min_col_app == which_min_col),100)
+    expect_equal(which_min_col_app,which_min_col)
+
+    #H2O which_max should match R
+    which_min_col_app_r <- apply(df,2,which.min)
+
+    expect_equal(which_min_col, as.h2o(which_min_col_app_r))
+    expect_equal(which_min_col_app, as.h2o(which_min_col_app_r))
+
+    #############################################################
+    #Row wise max
+    which_max_row <- h2o.which_max(hf,axis=1)
+    which_max_row_app <- apply(hf,1,which.max)
+
+    #Apply and original which_max should match
+    expect_equal(sum(which_max_row_app == which_max_row),10000)
+    expect_equal(which_max_row_app,which_max_col)
+
+    #H2O which_max should match R
+    which_max_row_app_r <- apply(df,1,which.max)
+
+    expect_equal(which_max_row, as.h2o(which_max_row_app_r))
+    expect_equal(which_max_row_app, as.h2o(which_max_row_app_r))
+
+    #Row wise min
+    which_min_row <- h2o.which_min(hf,axis=1)
+    which_min_row_app <- apply(hf,1,which.min)
+
+    #Apply and original which_max should match
+    expect_equal(sum(which_min_row_app == which_min_row),10000)
+    expect_equal(which_min_row_app,which_min_row)
+
+    #H2O which_max should match R
+    which_min_row_app_r <- apply(df,1,which.min)
+
+    expect_equal(which_min_row, as.h2o(which_min_row_app_r))
+    expect_equal(which_min_row_app, as.h2o(which_min_row_app_r))
+
+}
+
+doTest("Check which_max/min ", test.whichmaxmin)


### PR DESCRIPTION
* This PR adds `which.max` & `which.min` to the R API and `idxmax()` & `idxmin()` to the Python API through Rapids.
* The main use of these functions are finding the index of the maximum/minimum value in a column/row.