### PR TITLE
PUBDEV-4072: Supporting h2o-genmodel.jar name change into download_pojo function

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -848,13 +848,14 @@ def frames():
     return api("GET /3/Frames")
 
 
-def download_pojo(model, path="", get_jar=True):
+def download_pojo(model, path="", get_jar=True, jar_name=""):
     """
     Download the POJO for this model to the directory specified by path; if path is "", then dump to screen.
 
     :param model: the model whose scoring POJO should be retrieved.
     :param path: an absolute path to the directory where POJO should be saved.
     :param get_jar: retrieve the h2o-genmodel.jar also (will be saved to the same folder ``path``).
+    :param jar_name: Custom name of genmodel jar.
     :returns: location of the downloaded POJO file.
     """
     assert_is_type(model, ModelBase)
@@ -868,7 +869,10 @@ def download_pojo(model, path="", get_jar=True):
     else:
         filename = api("GET /3/Models.java/%s" % model.model_id, save_to=path)
         if get_jar:
-            api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, "h2o-genmodel.jar"))
+            if jar_name == "":
+                api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, "h2o-genmodel.jar"))
+            else:
+                api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, jar_name))
         return filename
 
 

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -703,12 +703,13 @@ class ModelBase(backwards_compatible()):
         return h2o.download_pojo(self, path, get_jar=get_genmodel_jar)
 
 
-    def download_mojo(self, path=".", get_genmodel_jar=False):
+    def download_mojo(self, path=".", get_genmodel_jar=False, genmodel_name=""):
         """
         Download the model in MOJO format.
 
         :param path: the path where MOJO file should be saved.
         :param get_genmodel_jar: if True, then also download h2o-genmodel.jar and store it in folder ``path``.
+        :param genmodel_name Custom name of genmodel jar
         :returns: name of the MOJO file written.
         """
         assert_is_type(path, str)
@@ -717,7 +718,10 @@ class ModelBase(backwards_compatible()):
             raise H2OValueError("MOJOs are currently supported for Distributed Random Forest, "
                                 "Gradient Boosting Machine, Deep Water, GLM, GLRM and word2vec models only.")
         if get_genmodel_jar:
-            h2o.api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, "h2o-genmodel.jar"))
+            if genmodel_name == "":
+                h2o.api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, "h2o-genmodel.jar"))
+            else:
+                h2o.api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, genmodel_name))
         return h2o.api("GET /3/Models/%s/mojo" % self.model_id, save_to=path)
 
     def save_mojo(self, path="", force=False):

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -687,7 +687,7 @@ class ModelBase(backwards_compatible()):
         print("No metalearner for this model")
 
 
-    def download_pojo(self, path="", get_genmodel_jar=False):
+    def download_pojo(self, path="", get_genmodel_jar=False, genmodel_name=""):
         """
         Download the POJO for this model to the directory specified by path.
 
@@ -695,12 +695,13 @@ class ModelBase(backwards_compatible()):
 
         :param path:  An absolute path to the directory where POJO should be saved.
         :param get_genmodel_jar: if True, then also download h2o-genmodel.jar and store it in folder ``path``.
+        :param genmodel_name Custom name of genmodel jar
         :returns: name of the POJO file written.
         """
         assert_is_type(path, str)
         assert_is_type(get_genmodel_jar, bool)
         path = path.rstrip("/")
-        return h2o.download_pojo(self, path, get_jar=get_genmodel_jar)
+        return h2o.download_pojo(self, path, get_jar=get_genmodel_jar, jar_name=genmodel_name)
 
 
     def download_mojo(self, path=".", get_genmodel_jar=False, genmodel_name=""):

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -215,6 +215,7 @@ h2o.getModel <- function(model_id) {
 #'             to console. The file name will be a compilable java file name.
 #' @param get_jar Whether to also download the h2o-genmodel.jar file needed to compile the POJO
 #' @param getjar (DEPRECATED) Whether to also download the h2o-genmodel.jar file needed to compile the POJO. This argument is now called `get_jar`.
+#' @param jar_name Custom name of genmodel jar.
 #' @return If path is NULL, then pretty print the POJO to the console.
 #'         Otherwise save it to the specified directory and return POJO file name.
 #' @examples
@@ -232,7 +233,7 @@ h2o.getModel <- function(model_id) {
 #' h2o.download_pojo(my_model, getwd())  # save to the current working directory
 #' }
 #' @export
-h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
+h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE, jar_name="") {
 
   if(!is.null(path) && !(is.character(path))){
     stop("The 'path' variable should be of type character")
@@ -270,7 +271,11 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
   if (get_jar) {
     urlSuffix = "h2o-genmodel.jar"
     #Build genmodel.jar file path
-    jar.path <- file.path(path, "h2o-genmodel.jar")
+    if(jar_name==""){
+      jar.path <- file.path(path, "h2o-genmodel.jar")
+    }else{
+      jar.path <- file.path(path, jar_name)
+    }
     #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
     #and write to jar.path.
     writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, binary = TRUE), jar.path, useBytes = TRUE)
@@ -285,6 +290,7 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
 #' @param model An H2OModel
 #' @param path The path where MOJO file should be saved. Saved to current directory by default.
 #' @param get_genmodel_jar If TRUE, then also download h2o-genmodel.jar and store it in folder ``path``.
+#' @param genmodel_name Custom name of genmodel jar.
 #' @return Name of the MOJO file written to the path.
 #'
 #' @examples
@@ -296,7 +302,7 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE) {
 #' h2o.download_mojo(my_model)  # save to the current working directory
 #' }
 #' @export
-h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE) {
+h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE, genmodel_name="") {
 
   if(!(is.character(path))){
     stop("The 'path' variable should be of type character")
@@ -327,7 +333,11 @@ h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE) {
   if (get_genmodel_jar) {
     urlSuffix = "h2o-genmodel.jar"
     #Build genmodel.jar file path
-    jar.path <- file.path(path,"h2o-genmodel.jar")
+    if(genmodel_name==""){
+      jar.path <- file.path(path, "h2o-genmodel.jar")
+    }else{
+      jar.path <- file.path(path, genmodel_name)
+    }
     #Perform a safe (i.e. error-checked) HTTP GET request to an H2O cluster with genmodel.jar URL
     #and write to jar.path.
     writeBin(.h2o.doSafeGET(urlSuffix = urlSuffix, binary = TRUE), jar.path, useBytes = TRUE)


### PR DESCRIPTION
* This PR adds a new parameter to `download_pojo`/`download_mojo` functions that will allow a custom name for the `genmodel.jar`.