### PR TITLE
PUBDEV-4143: Improve the Python group_by option count column name

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
@@ -294,8 +294,13 @@ public class AstGroup extends AstPrimitive {
 
     // Build the output!
     String[] fcnames = new String[aggs.length];
-    for (int i = 0; i < aggs.length; i++)
-      fcnames[i] = aggs[i]._fcn.toString() + "_" + fr.name(aggs[i]._col);
+    for (int i = 0; i < aggs.length; i++) {
+      if(aggs[i]._fcn.toString() != "nrow") {
+        fcnames[i] = aggs[i]._fcn.toString() + "_" + fr.name(aggs[i]._col);
+      }else{
+        fcnames[i] = aggs[i]._fcn.toString();
+      }
+    }
 
     MRTask mrfill = new MRTask() {
       @Override

--- a/h2o-docs/src/booklets/v2_2015/source/R_Vignette_code_examples/r_glm_demo.R
+++ b/h2o-docs/src/booklets/v2_2015/source/R_Vignette_code_examples/r_glm_demo.R
@@ -21,7 +21,7 @@ flightsByMonth.R = as.data.frame(flightsByMonth)
 # Find months with the highest cancellation ratio
 which(colnames(airlines.hex)=="Cancelled")
 cancellationsByMonth = h2o.group_by(data = airlines.hex, by = "Month", sum("Cancelled"),gb.control=list(na.methods="rm"))
-cancellation_rate = cancellationsByMonth$sum_Cancelled/flightsByMonth$nrow_Month
+cancellation_rate = cancellationsByMonth$sum_Cancelled/flightsByMonth$nrow
 rates_table = h2o.cbind(flightsByMonth$Month, cancellation_rate)
 rates_table.R = as.data.frame(rates_table)
 


### PR DESCRIPTION
* `nrow` operation in GroupBy does not need a column name appended since its only a count of rows per group.