### PR TITLE
PUBDEV-3711: h2o.coef in R not functional for multinomial models

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -999,8 +999,12 @@ h2o.giniCoef <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 h2o.coef <- function(object) {
   if( is(object, "H2OModel") ) {
     if( is.null(object@model$coefficients_table) ) stop("Can only extract coefficeints from GLMs")
-    coefs <- object@model$coefficients_table$coefficients
-    names(coefs) <- object@model$coefficients_table$names
+    if(object@parameters$family != "multinomial"){
+      coefs <- object@model$coefficients_table$coefficients
+      names(coefs) <- object@model$coefficients_table$names
+    }else{
+      coefs <- object@model$coefficients_table
+    }
     return(coefs)
   } else stop("Can only extract coefficients from GLMs")
 }
@@ -1013,8 +1017,12 @@ h2o.coef <- function(object) {
 h2o.coef_norm <- function(object) {
   if( is(object, "H2OModel") ) {
     if( is.null(object@model$coefficients_table) ) stop("Can only extract coefficeints from GLMs")
-    coefs <- object@model$coefficients_table$standardized_coefficients
-    names(coefs) <- object@model$coefficients_table$names
+    if(object@parameters$family != "multinomial"){
+      coefs <- object@model$coefficients_table$standardized_coefficients
+      names(coefs) <- object@model$coefficients_table$names
+    }else{
+      coefs <- object@model$coefficients_table
+    }
     return(coefs)
   } else stop("Can only extract coefficients from GLMs")
 }

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -997,16 +997,18 @@ h2o.giniCoef <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' @param object an \linkS4class{H2OModel} object.
 #' @export
 h2o.coef <- function(object) {
-  if( is(object, "H2OModel") ) {
-    if( is.null(object@model$coefficients_table) ) stop("Can only extract coefficeints from GLMs")
-    if(object@parameters$family != "multinomial"){
+  if (is(object, "H2OModel")) {
+    if (is.null(object@model$coefficients_table)) stop("Can only extract coefficeints from GLMs")
+    if (object@parameters$family != "multinomial") {
       coefs <- object@model$coefficients_table$coefficients
       names(coefs) <- object@model$coefficients_table$names
-    }else{
+    } else {
       coefs <- object@model$coefficients_table
     }
     return(coefs)
-  } else stop("Can only extract coefficients from GLMs")
+  } else {
+    stop("Can only extract coefficients from GLMs")
+  }  
 }
 
 #'
@@ -1015,16 +1017,18 @@ h2o.coef <- function(object) {
 #' @param object an \linkS4class{H2OModel} object.
 #' @export
 h2o.coef_norm <- function(object) {
-  if( is(object, "H2OModel") ) {
-    if( is.null(object@model$coefficients_table) ) stop("Can only extract coefficeints from GLMs")
-    if(object@parameters$family != "multinomial"){
+  if (is(object, "H2OModel")) {
+    if (is.null(object@model$coefficients_table)) stop("Can only extract coefficeints from GLMs")
+    if (object@parameters$family != "multinomial") {
       coefs <- object@model$coefficients_table$standardized_coefficients
       names(coefs) <- object@model$coefficients_table$names
-    }else{
+    } else {
       coefs <- object@model$coefficients_table
     }
     return(coefs)
-  } else stop("Can only extract coefficients from GLMs")
+  } else {
+    stop("Can only extract coefficients from GLMs")
+  }
 }
 
 #' Retrieves Mean Squared Error Value


### PR DESCRIPTION
This PR fixes a [bug](https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-3711) in `h2o.coef` & `h2o.coef_norm` in the R API when dealing with multinomial GLM. 
