### PR TITLE
Optimize build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,20 +20,18 @@ RUN \
   apt-get update -q -y && \
   apt-get dist-upgrade -y && \
   apt-get clean && \
-  rm -rf /var/cache/apt/* 
+  rm -rf /var/cache/apt/* && \
 
 # Install Oracle Java 7
-RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip python-pip python-sklearn python-pandas python-numpy python-matplotlib software-properties-common python-software-properties && \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update -q && \
   echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
   echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y oracle-java7-installer && \
-  apt-get clean 
+  apt-get clean && \
 
 # Fetch h2o latest_stable
-RUN \
   wget http://h2o-release.s3.amazonaws.com/h2o/latest_stable -O latest && \
   wget --no-check-certificate -i latest -O /opt/h2o.zip && \
   unzip -d /opt /opt/h2o.zip && \
@@ -42,10 +40,9 @@ RUN \
   cd `find . -name 'h2o.jar' | sed 's/.\///;s/\/h2o.jar//g'` && \ 
   cp h2o.jar /opt && \
   /usr/bin/pip install `find . -name "*.whl"` && \
-  wget https://raw.githubusercontent.com/h2oai/h2o-3/master/docker/start-h2o-docker.sh
+  wget https://raw.githubusercontent.com/h2oai/h2o-3/master/docker/start-h2o-docker.sh && \
 
 # Get Content
-RUN \
   wget http://s3.amazonaws.com/h2o-training/mnist/train.csv.gz && \
   gunzip train.csv.gz && \ 
   wget https://raw.githubusercontent.com/laurendiperna/Churn_Scripts/master/Extraction_Script.py  && \


### PR DESCRIPTION
It is considered a best practice to combine multiple `RUN` commands when possible. There are no functional changes to this file beside this. These small changes to the Dockerfile will produce a Docker image that is about 410MB smaller (1.55 GB vs 1.59 GB)  

https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run