### PR TITLE
PUBDEV-4147: Expose word2vec in Python API

### DIFF
--- a/h2o-py/demos/word2vec_craigslistjobtitles.ipynb
+++ b/h2o-py/demos/word2vec_craigslistjobtitles.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import h2o\n",
+    "h2o.init()\n",
+    "from h2o.estimators.word2vec import H2OWord2vecEstimator\n",
+    "from h2o.estimators.gbm import H2OGradientBoostingEstimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "job_titles_path = \"https://raw.githubusercontent.com/h2oai/sparkling-water/rel-1.6/examples/smalldata/craigslistJobTitles.csv\"\n",
+    "job_titles = h2o.import_file(job_titles_path, destination_frame = \"jobtitles\",\n",
+    "                             col_names = [\"category\", \"jobtitle\"], col_types = [\"enum\", \"string\"], header = 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "STOP_WORDS = [\"ax\",\"i\",\"you\",\"edu\",\"s\",\"t\",\"m\",\"subject\",\"can\",\"lines\",\"re\",\"what\",\n",
+    "               \"there\",\"all\",\"we\",\"one\",\"the\",\"a\",\"an\",\"of\",\"or\",\"in\",\"for\",\"by\",\"on\",\n",
+    "               \"but\",\"is\",\"in\",\"a\",\"not\",\"with\",\"as\",\"was\",\"if\",\"they\",\"are\",\"this\",\"and\",\"it\",\"have\",\n",
+    "               \"from\",\"at\",\"my\",\"be\",\"by\",\"not\",\"that\",\"to\",\"from\",\"com\",\"org\",\"like\",\"likes\",\"so\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def tokenize(sentences, stop_word = STOP_WORDS):\n",
+    "    tokenized = sentences.tokenize(\"\\\\W+\")\n",
+    "    tokenized_lower = tokenized.tolower()\n",
+    "    tokenized_filtered = tokenized_lower[(tokenized_lower.nchar() >= 2) | (tokenized_lower.isna()),:]\n",
+    "    tokenized_words = tokenized_filtered[tokenized_filtered.grep(\"[0-9]\",invert=True,output_logical=True),:]\n",
+    "    tokenized_words = tokenized_words[(tokenized_words.isna()) | (~ tokenized_words.isin(STOP_WORDS)),:]\n",
+    "    return tokenized_words"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def predict(job_title,w2v, gbm):\n",
+    "    words = tokenize(h2o.H2OFrame(job_title).ascharacter())\n",
+    "    job_title_vec = w2v.transform(words, aggregate_method=\"AVERAGE\")\n",
+    "    print(gbm.predict(test_data=job_title_vec))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Break job titles into sequence of words\")\n",
+    "words = tokenize(job_titles[\"jobtitle\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Build word2vec model\")\n",
+    "w2v_model = H2OWord2vecEstimator(sent_sample_rate = 0.0, epochs = 10)\n",
+    "w2v_model.train(training_frame=words)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Sanity check - find synonyms for the word 'teacher'\")\n",
+    "w2v_model.find_synonyms(\"teacher\", count = 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Calculate a vector for each job title\")\n",
+    "job_title_vecs = w2v_model.transform(words, aggregate_method = \"AVERAGE\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Prepare training&validation data (keep only job titles made of known words)\")\n",
+    "valid_job_titles = ~ job_title_vecs[\"C1\"].isna()\n",
+    "data = job_titles[valid_job_titles,:].cbind(job_title_vecs[valid_job_titles,:])\n",
+    "data_split = data.split_frame(ratios=[0.8])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Build a basic GBM model\")\n",
+    "gbm_model = H2OGradientBoostingEstimator()\n",
+    "gbm_model.train(x = job_title_vecs.names,\n",
+    "                y=\"category\", \n",
+    "                training_frame = data_split[0], \n",
+    "                validation_frame = data_split[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(\"Predict!\")\n",
+    "print(predict([\"school teacher having holidays every month\"], w2v_model, gbm_model))\n",
+    "print(predict([\"developer with 3+ Java experience, jumping\"], w2v_model, gbm_model))\n",
+    "print(predict([\"Financial accountant CPA preferred\"], w2v_model, gbm_model))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2207,6 +2207,18 @@ class H2OFrame(object):
         fr._ex._cache.nrows = self.nrow
         return fr
 
+    def tokenize(self, split):
+        """
+        Tokenize String
+
+        tokenize() is similar to strsplit(), the difference between them is that tokenize() will store the tokenized
+        text into a single column making it easier for additional processing (filtering stop words, word2vec algo, ...).
+
+        :param str split The regular expression to split on.
+        @return An H2OFrame with a single column representing the tokenized Strings. Original rows of the input DF are separated by NA.
+        """
+        fr = H2OFrame._expr(expr=ExprNode("tokenize", self, split))
+        return fr
 
     def countmatches(self, pattern):
         """
@@ -2497,6 +2509,22 @@ class H2OFrame(object):
         """
         return H2OFrame._expr(expr=ExprNode("toupper", self), cache=self._ex._cache)
 
+    def grep(self,pattern, ignore_case = False, invert = False, output_logical = False):
+        """
+        Searches for matches to argument `pattern` within each element
+        of a string column.
+
+        Default behavior is to return indices of the elements matching the pattern. Parameter
+        `output_logical` can be used to return a logical vector indicating if the element matches
+        the pattern (1) or not (0).
+
+        :param str pattern: A character string containing a regular expression.
+        :param bool ignore_case: If True, then case is ignored during matching.
+        :param bool invert:  If True, then identify elements that do not match the pattern.
+        :param bool output_logical: If True, then return logical vector of indicators instead of list of matching positions
+        :return: H2OFrame holding the matching positions or a logical list if `output_logical` is enabled.
+        """
+        return H2OFrame._expr(expr=ExprNode("grep", self, pattern, ignore_case, invert, output_logical))
 
     def tolower(self):
         """

--- a/h2o-py/h2o/model/word_embedding.py
+++ b/h2o-py/h2o/model/word_embedding.py
@@ -24,3 +24,19 @@ class H2OWordEmbeddingModel(ModelBase):
         """
         j = h2o.api("GET /3/Word2VecSynonyms", data={'model': self.model_id, 'word': word, 'count': count})
         return OrderedDict(sorted(zip(j['synonyms'], j['scores']), key=lambda t: t[1], reverse=True))
+
+    def transform(self, words, aggregate_method):
+        """
+        Transform words (or sequences of words) to vectors using a word2vec model.
+
+        :param str words: An H2OFrame made of a single column containing source words.
+        :param str aggregate_method: Specifies how to aggregate sequences of words. If method is `NONE`
+               then no aggregation is performed and each input word is mapped to a single word-vector.
+               If method is 'AVERAGE' then input is treated as sequences of words delimited by NA.
+               Each word of a sequences is internally mapped to a vector and vectors belonging to
+               the same sentence are averaged and returned in the result.
+
+        :returns: the approximate reconstruction of the training data.
+        """
+        j = h2o.api("GET /3/Word2VecTransform", data={'model': self.model_id, 'words_frame': words.frame_id, 'aggregate_method': aggregate_method})
+        return h2o.get_frame(j["vectors_frame"]["name"])


### PR DESCRIPTION
* This PR adds the following word2vec utility functions:  `h2o.tokenize`, `h2o.grep`, & `h2o.transform`.
* Also, a  word2vec demo to show an end-end example of word2vec in Python.