### PR TITLE
PUBDEV-4081: Sparse matrix cannot be converted to H2O

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3151,11 +3151,7 @@ as.h2o.Matrix <- function(x, destination_frame="", ...) {
   
   if( destination_frame=="")
     destination_frame <- deparse(substitute(x))
-  
-  sparse <- .h2o.is.sparse.matrix(x)
-  if(!sparse)
-    return(as.h2o.default(x, destination_frame=destination_frame, ...))
-  
+
   destination_frame <- destination_frame.guess(destination_frame) # filter out invalid i.e. "abc::fun()"
   .key.validate(destination_frame)
   if ( destination_frame=="" ) # .h2o.readSVMLight wont handle ""
@@ -3168,16 +3164,15 @@ as.h2o.Matrix <- function(x, destination_frame="", ...) {
   h2f
 }
 
-.h2o.is.sparse.matrix <- function(x) (attr(class(x), "package") == "Matrix") && inherits(x, "Matrix")
-
 .h2o.write.matrix.svmlight <- function(matrix, file) {
   on.exit(sink())
   sink(file)
-  apply(matrix, 1, function(r) {
+  sapply(1:nrow(matrix), function(i) {
+    r <- matrix[i, ]
     val.indices <- which(r != 0)
     val.indices <- val.indices[val.indices > 1]
     target <- r[1]
-    features <- paste(val.indices - 1, r[val.indices], collapse = " ", sep = ":")
+    features <- paste(sprintf("%d", val.indices - 1), r[val.indices], collapse = " ", sep = ":")
     line <- sprintf("%s %s\n", target, features)
     cat(line)
   })

--- a/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
+++ b/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
@@ -17,7 +17,7 @@ test.as.h2o.sparse <- function() {
     Log.info("Check that data.frame in H2O has the same content as the local matrix")
     expect_equal(h2o.small.df, as.data.frame(as.matrix(m.small)))
 
-    # 2. large sparse matrix (46341 x 46343), too big for as.matrix in R (Cholmod error 'problem too large')
+    # 2. large sparse matrix (46341 x 46343): too big for as.matrix in R (Cholmod error 'problem too large')
     i <- c(1, 3:8, 46341)
     j <- c(2, 9, 6:10, 46343)
     x <- pi * (1:8)

--- a/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
+++ b/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
@@ -22,6 +22,7 @@ test.as.h2o.sparse <- function() {
     j <- c(2, 9, 6:10, 46343)
     x <- pi * (1:8)
     m.large <- Matrix::sparseMatrix(i, j, x = x)
+    expect_error(as.matrix(m.large), "Cholmod error 'problem too large'")
 
     Log.info("Loading a large sparse matrix into H2O")
     h2o.large <- as.h2o(m.large, "large_matrix")

--- a/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
+++ b/h2o-r/tests/testdir_misc/runit_as.h2o_sparse.R
@@ -2,19 +2,37 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
 
 test.as.h2o.sparse <- function() {
+    # 1. small matrix
     data <- rep(0, 100)
     data[(1:10)^2] <- 1:10 * pi
-    m <- matrix(data, ncol = 20, byrow = TRUE)
-    m <- Matrix::Matrix(m, sparse = TRUE)
-    
+    m.dense.small <- matrix(data, ncol = 20, byrow = TRUE)
+    m.small <- Matrix::Matrix(m.dense.small, sparse = TRUE)
+
     Log.info("Loading a sparse matrix into H2O")
-    h2o.matrix <- as.h2o(m, "sparse_matrix")
+    h2o.small <- as.h2o(m.small, "small_matrix")
 
-    h2o.df <- as.data.frame(h2o.matrix)
-    colnames(h2o.df) <- sprintf("V%s", 1:20)
+    h2o.small.df <- as.data.frame(h2o.small)
+    colnames(h2o.small.df) <- sprintf("V%s", 1:20)
 
-    Log.info("Expect that number of rows in as.data.frame is same as the original file")
-    expect_equal(h2o.df, as.data.frame(as.matrix(m)))
+    Log.info("Check that data.frame in H2O has the same content as the local matrix")
+    expect_equal(h2o.small.df, as.data.frame(as.matrix(m.small)))
+
+    # 2. large sparse matrix (46341 x 46343), too big for as.matrix in R (Cholmod error 'problem too large')
+    i <- c(1, 3:8, 46341)
+    j <- c(2, 9, 6:10, 46343)
+    x <- pi * (1:8)
+    m.large <- Matrix::sparseMatrix(i, j, x = x)
+
+    Log.info("Loading a large sparse matrix into H2O")
+    h2o.large <- as.h2o(m.large, "large_matrix")
+
+    Log.info("Check that the large matrix has correct size in H2O")
+    expect_equal(c(46341, 46343), dim(h2o.large))
+
+    # 3. show index numbers are correctly formatted (scientific notation, eg. 1e5 is written as 100000)
+    m.simple <- Matrix::sparseMatrix(1, 1e5 + 1, x = pi) # +1 because indices are 0-based in SVMLight
+    h2o.simple <- as.h2o(m.simple, "simple_matrix")
+    expect_equal(c(1, 100001), dim(h2o.simple))
 }
 
 doTest("Test as.h2o for sparse matrix", test.as.h2o.sparse)


### PR DESCRIPTION
This fix is needed for release 3.10.4.4.