### PR TITLE
[PUBDEV-4249] Allow users to override default Python binary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,9 +158,8 @@ ext {
     h2oRESTApiVersion = '3'
 
     getOsSpecificCommandLine = { List<GString> args ->
-        return Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] + args : args
+        return Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] + args : ['/usr/bin/env'] + args
     }
-
 }
 
 //

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -2,13 +2,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 description = "H2O Python Package"
 
-String pythonexe = "python"
-String pipexe = "pip"
-if (System.env.VIRTUAL_ENV) {
-    pythonexe = "${System.env.VIRTUAL_ENV}/bin/python".toString()
-    pipexe = "${System.env.VIRTUAL_ENV}/bin/pip".toString()
-}
-
 dependencies {
     compile project(":h2o-assemblies:main")
 }
@@ -17,27 +10,23 @@ def buildVersion = new H2OBuildVersion(rootDir, version)
 
 ext {
     PROJECT_VERSION = buildVersion.getProjectVersion()
+    pythonexe       = findProperty("pythonExec") ?: "python"
+    pipexe          = findProperty("pipExec") ?: "pip"
+    if (System.env.VIRTUAL_ENV) {
+        pythonexe = "${System.env.VIRTUAL_ENV}/bin/python".toString()
+        pipexe = "${System.env.VIRTUAL_ENV}/bin/pip".toString()
+    }
+    testsPath        = file("tests")
 }
 
+task setProjectVersion << {
+    File INIT = new File([T, "h2o", "__init__.py"].join(File.separator))
+    println "    INIT.path = " + INIT.path
+    def txt = INIT.text
+    txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION)
+            .replaceAll("SUBST_PROJECT_BUILDINFO", bv.toString())
 
-task makeOutputDir(type: Exec) {
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine getOsSpecificCommandLine(['if not exist "build\\tmp" mkdir', 'build\\tmp'])
-    } else {
-        commandLine getOsSpecificCommandLine(['mkdir', '-p', 'build/tmp'])
-    }
-}
-
-
-task setProjectVersion {
-    doLast {
-        File INIT = file("${getProjectDir()}/h2o/__init__.py")
-        println "    INIT.path =" + INIT.path
-        def txt = INIT.text
-        txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION)
-                .replaceAll("SUBST_PROJECT_BUILDINFO", buildVersion.toString())
-        INIT.write(txt)
-    }
+    INIT.write(txt)
 }
 
 task resetProjectVersion {
@@ -57,14 +46,17 @@ task verifyDependencies(type: Exec) {
     ])
 }
 
-task buildDist(type: Exec, dependsOn: [verifyDependencies, setProjectVersion, makeOutputDir]) {
+task buildDist(type: Exec) {
+    dependsOn verifyDependencies
+    dependsOn setProjectVersion
+
     doFirst {
-        standardOutput = new FileOutputStream("build/tmp/h2o-py_buildDist.out")
+        file("${buildDir}/tmp").mkdirs()
+        standardOutput = new FileOutputStream(file("${buildDir}/tmp/h2o-py_buildDist.out"))
     }
     commandLine getOsSpecificCommandLine([pythonexe, "setup.py", "bdist_wheel"])
 }
 
-def testsPath = file("./tests")
 task smokeTest(type: Exec) {
     dependsOn build
     workingDir testsPath
@@ -72,16 +64,23 @@ task smokeTest(type: Exec) {
     if (project.hasProperty("jacocoCoverage")) {
         args << '--jacoco'
     }
-    commandLine args
+    commandLine getOsSpecificCommandLine(args)
 }
-
 
 //
 // Cleanup tasks
 //
 
+task pythonVersion(type: Exec) {
+    doFirst {
+        println(System.env.VIRTUAL_ENV)
+        println(environment)
+    }
+    commandLine getOsSpecificCommandLine([pythonexe, "--version"])
+}
+
 task cleanUpSmokeTest(type: Delete) {
-    delete file("${getProjectDir()}/results")
+    delete file("tests/results")
 }
 
 task cleanCoverageData(type: Delete) {
@@ -89,10 +88,13 @@ task cleanCoverageData(type: Delete) {
 }
 
 task cleaner(type: Delete) {
-    delete file("${getProjectDir()}/dist")
-    delete file("${getProjectDir()}/h2o.egg-info")
-    delete file("${getProjectDir()}/build")
-    delete fileTree(dir: "$projectDir/h2o", include: '**/*.pyc')
+    doFirst {
+        println "Cleaning..."
+    }
+    delete file("dist/")
+    delete file("h2o.egg-info/")
+    delete file("build/")
+    delete fileTree(dir: "$projectDir/h2o" , include: '**/*.pyc')
 }
 
 //

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-
 description = "H2O Python Package"
 
 dependencies {
@@ -20,11 +18,11 @@ ext {
 }
 
 task setProjectVersion << {
-    File INIT = new File([T, "h2o", "__init__.py"].join(File.separator))
+    File INIT = file("${getProjectDir()}/h2o/__init__.py")
     println "    INIT.path = " + INIT.path
     def txt = INIT.text
     txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION)
-            .replaceAll("SUBST_PROJECT_BUILDINFO", bv.toString())
+            .replaceAll("SUBST_PROJECT_BUILDINFO", buildVersion.toString())
 
     INIT.write(txt)
 }

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -16,12 +16,8 @@ dependencies {
     publishedJars project(path: ':h2o-assemblies:genmodel', configuration: 'shadow')
 }
 
-static def getOsSpecificCommandLine(args) {
-  return Os.isFamily(Os.FAMILY_WINDOWS) ? [ 'cmd', '/c' ] + args : args
-}
-
 static def checkPrerequisite(name) {
-  def prefix = Os.isFamily(Os.FAMILY_WINDOWS) ? 'cmd /c ' : ''
+  def prefix = Os.isFamily(Os.FAMILY_WINDOWS) ? 'cmd /c ' : '/usr/bin/env '
   def command = prefix + name + ' -v'
   def proc
   try {
@@ -40,7 +36,7 @@ static def checkPrerequisite(name) {
 
 task checkClientPrerequisites {
     doLast {
-    def nodeInstallationInstruction = """\
+        def nodeInstallationInstruction = """\
 
 To install node.js, try one of these:
 
@@ -57,29 +53,18 @@ Use the official installer at http://nodejs.org/download/
 
 """
 
-    def nodeFailureMessage = "Could not detect a node.js installation on this system.\nInstall node.js and try again.\n" + nodeInstallationInstruction
+        def nodeFailureMessage = "Could not detect a node.js installation on this system.\nInstall node.js and try again.\n" + nodeInstallationInstruction
 
-    if (checkPrerequisite('node') != 0) {
-        if (Os.isFamily(Os.FAMILY_MAC)) {
-            if (checkPrerequisite('/usr/local/bin/node') != 0) {
+        if (checkPrerequisite('node') != 0) {
+            if (Os.isFamily(Os.FAMILY_MAC)) {
+                if (checkPrerequisite('/usr/local/bin/node') != 0) {
+                    throw new StopExecutionException(nodeFailureMessage)
+                }
+            } else {
                 throw new StopExecutionException(nodeFailureMessage)
             }
-        } else {
-            throw new StopExecutionException(nodeFailureMessage)
         }
     }
-
-//  def npmFailureMessage = "Could not find command 'npm'.\nRe-install node.js and try again.\n" + nodeInstallationInstruction
-//  if (checkPrerequisite('npm') != 0) {
-//    if (Os.isFamily(Os.FAMILY_MAC)) {
-//      if (checkPrerequisite('/usr/local/bin/npm') != 0) {
-//        throw new StopExecutionException(npmFailureMessage)
-//      }
-//    } else {
-//      throw new StopExecutionException(npmFailureMessage)
-//    }
-//  }
-}
 }
 
 task installNpmPackages(type: Exec) {
@@ -169,14 +154,6 @@ task copyHelpImages(type: Copy) {
   from "$rootDir/h2o-docs/src/product/flow/images"
   into "$rootDir/h2o-web/src/main/resources/www/flow/help/images"
 }
-
-// CNC: Turn off phantomjs smokeTest until flow changes hit master
-//task smokeTest(type: Exec) {
-//    dependsOn build
-//    println "phantom.js (Flow) smoke test (../scripts/run.py --wipeall --test ./lib/h2o-flow/build/js/headless-test.js)..."
-//    workingDir new File(".")
-//    commandLine '../scripts/run.py', '--wipeall', '--test', './lib/h2o-flow/build/js/headless-test.js'
-//}
 
 task cleanUpSmokeTest {
     doLast {


### PR DESCRIPTION
In some environment build fails on using wrong python version.
This patch allows users to override default names for Python and Pip.