### PR TITLE
PUBDEV-4248: Add a parameter that ignores the config file reader when h2o.init() is called

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -161,7 +161,7 @@ def init(url=None, ip=None, port=None, https=None, insecure=None, username=None,
     :param max_mem_size: Maximum memory to use for the new h2o server.
     :param min_mem_size: Minimum memory to use for the new h2o server.
     :param strict_version_check: If True, an error will be raised if the client and server versions don't match.
-    :param ignore_config: Indicates whether a search for a .h2oconfig file should be conducted or not. Default value is False.
+    :param ignore_config: Indicates whether a processing of a .h2oconfig file should be conducted or not. Default value is False.
     :param kwargs: (all other deprecated attributes)
     """
     global h2oconn

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -141,7 +141,7 @@ def version_check():
 
 def init(url=None, ip=None, port=None, https=None, insecure=None, username=None, password=None,
          cookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None, enable_assertions=True,
-         max_mem_size=None, min_mem_size=None, strict_version_check=None,ignore_config=False, **kwargs):
+         max_mem_size=None, min_mem_size=None, strict_version_check=None, ignore_config=False, **kwargs):
     """
     Attempt to connect to a local server, or if not successful start a new server and connect to it.
 
@@ -214,26 +214,26 @@ def init(url=None, ip=None, port=None, https=None, insecure=None, username=None,
     # Apply the config file if ignore_config=False
     if not ignore_config:
         config = H2OConfigReader.get_config()
-    if not ignore_config and url is None and ip is None and port is None and https is None and "init.url" in config:
-        url = config["init.url"]
-    if not ignore_config and proxy is None and "init.proxy" in config:
-        proxy = config["init.proxy"]
-    if not ignore_config and cookies is None and "init.cookies" in config:
-        cookies = config["init.cookies"].split(";")
-    if not ignore_config and auth is None and "init.username" in config and "init.password" in config:
-        auth = (config["init.username"], config["init.password"])
-    if not ignore_config and strict_version_check is None:
-        if "init.check_version" in config:
-            check_version = config["init.check_version"].lower() != "false"
-        elif os.environ.get("H2O_DISABLE_STRICT_VERSION_CHECK"):
-            check_version = False
-    else:
-        check_version = strict_version_check
-    if insecure is None:
-        if not ignore_config and "init.verify_ssl_certificates" in config:
-            verify_ssl_certificates = config["init.verify_ssl_certificates"].lower() != "false"
-    else:
-        verify_ssl_certificates = not insecure
+        if url is None and ip is None and port is None and https is None and "init.url" in config:
+            url = config["init.url"]
+        if proxy is None and "init.proxy" in config:
+            proxy = config["init.proxy"]
+        if cookies is None and "init.cookies" in config:
+            cookies = config["init.cookies"].split(";")
+        if auth is None and "init.username" in config and "init.password" in config:
+            auth = (config["init.username"], config["init.password"])
+        if strict_version_check is None:
+            if "init.check_version" in config:
+                check_version = config["init.check_version"].lower() != "false"
+            elif os.environ.get("H2O_DISABLE_STRICT_VERSION_CHECK"):
+                check_version = False
+            else:
+                check_version = strict_version_check
+        if insecure is None:
+            if "init.verify_ssl_certificates" in config:
+                verify_ssl_certificates = config["init.verify_ssl_certificates"].lower() != "false"
+            else:
+                verify_ssl_certificates = not insecure
 
     if not start_h2o:
         print("Warning: if you don't want to start local H2O server, then use of `h2o.connect()` is preferred.")

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -141,7 +141,7 @@ def version_check():
 
 def init(url=None, ip=None, port=None, https=None, insecure=None, username=None, password=None,
          cookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None, enable_assertions=True,
-         max_mem_size=None, min_mem_size=None, strict_version_check=None, **kwargs):
+         max_mem_size=None, min_mem_size=None, strict_version_check=None,ignore_config=False, **kwargs):
     """
     Attempt to connect to a local server, or if not successful start a new server and connect to it.
 
@@ -161,6 +161,7 @@ def init(url=None, ip=None, port=None, https=None, insecure=None, username=None,
     :param max_mem_size: Maximum memory to use for the new h2o server.
     :param min_mem_size: Minimum memory to use for the new h2o server.
     :param strict_version_check: If True, an error will be raised if the client and server versions don't match.
+    :param ignore_config: Indicates whether a search for a .h2oconfig file should be conducted or not. Default value is FALSE.
     :param kwargs: (all other deprecated attributes)
     """
     global h2oconn
@@ -210,17 +211,18 @@ def init(url=None, ip=None, port=None, https=None, insecure=None, username=None,
     check_version = True
     verify_ssl_certificates = True
 
-    # Apply the config file
-    config = H2OConfigReader.get_config()
-    if url is None and ip is None and port is None and https is None and "init.url" in config:
+    # Apply the config file if ignore_config=False
+    if not ignore_config:
+        config = H2OConfigReader.get_config()
+    if not ignore_config and url is None and ip is None and port is None and https is None and "init.url" in config:
         url = config["init.url"]
-    if proxy is None and "init.proxy" in config:
+    if not ignore_config and proxy is None and "init.proxy" in config:
         proxy = config["init.proxy"]
-    if cookies is None and "init.cookies" in config:
+    if not ignore_config and cookies is None and "init.cookies" in config:
         cookies = config["init.cookies"].split(";")
-    if auth is None and "init.username" in config and "init.password" in config:
+    if not ignore_config and auth is None and "init.username" in config and "init.password" in config:
         auth = (config["init.username"], config["init.password"])
-    if strict_version_check is None:
+    if not ignore_config and strict_version_check is None:
         if "init.check_version" in config:
             check_version = config["init.check_version"].lower() != "false"
         elif os.environ.get("H2O_DISABLE_STRICT_VERSION_CHECK"):
@@ -228,7 +230,7 @@ def init(url=None, ip=None, port=None, https=None, insecure=None, username=None,
     else:
         check_version = strict_version_check
     if insecure is None:
-        if "init.verify_ssl_certificates" in config:
+        if not ignore_config and "init.verify_ssl_certificates" in config:
             verify_ssl_certificates = config["init.verify_ssl_certificates"].lower() != "false"
     else:
         verify_ssl_certificates = not insecure

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -161,7 +161,7 @@ def init(url=None, ip=None, port=None, https=None, insecure=None, username=None,
     :param max_mem_size: Maximum memory to use for the new h2o server.
     :param min_mem_size: Minimum memory to use for the new h2o server.
     :param strict_version_check: If True, an error will be raised if the client and server versions don't match.
-    :param ignore_config: Indicates whether a search for a .h2oconfig file should be conducted or not. Default value is FALSE.
+    :param ignore_config: Indicates whether a search for a .h2oconfig file should be conducted or not. Default value is False.
     :param kwargs: (all other deprecated attributes)
     """
     global h2oconn

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -27,6 +27,7 @@
 #' @param password (Optional) Password to login with.
 #' @param cookies (Optional) Vector(or list) of cookies to add to request.
 #' @param context_path (Optional) The last part of connection URL: http://<ip>:<port>/<context_path>
+#' @param ignore_config (Optional) A \code{logical} value indicating whether a search for a .h2oconfig file should be concucted or not.
 #' @return this method will load it and return a \code{H2OConnection} object containing the IP address and port number of the H2O server.
 #' @note Users may wish to manually upgrade their package (rather than waiting until being prompted), which requires
 #' that they fully uninstall and reinstall the H2O package, and the H2O client package. You must unload packages running

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -56,38 +56,40 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
                      max_mem_size = NULL, min_mem_size = NULL,
                      ice_root = tempdir(), strict_version_check = TRUE, proxy = NA_character_,
                      https = FALSE, insecure = FALSE, username = NA_character_, password = NA_character_,
-                     cookies = NA_character_, context_path = NA_character_) {
+                     cookies = NA_character_, context_path = NA_character_, ignore_config = FALSE) {
 
-    # Check for .h2oconfig file
-    # Find .h2oconfig file starting from currenting directory and going
-    # up all parent directories until it reaches the root directory.
-    config_path <- .find.config()
+    if(!(ignore_config)){
+      # Check for .h2oconfig file
+      # Find .h2oconfig file starting from currenting directory and going
+      # up all parent directories until it reaches the root directory.
+      config_path <- .find.config()
 
-    #Read in config if available
-    if(!(is.null(config_path))){
+      #Read in config if available
+      if(!(is.null(config_path))){
 
-      h2oconfig = .parse.h2oconfig(config_path,print_path=TRUE)
+        h2oconfig = .parse.h2oconfig(config_path,print_path=TRUE)
 
-      #Check for each `allowed_config_keys` in the config file and set to counterparts in `h2o.init()`
-      if(strict_version_check == TRUE && "init.check_version" %in% colnames(h2oconfig)){
-        strict_version_check = as.logical(trimws(toupper(as.character(h2oconfig$init.check_version))))
+        #Check for each `allowed_config_keys` in the config file and set to counterparts in `h2o.init()`
+        if(strict_version_check == TRUE && "init.check_version" %in% colnames(h2oconfig)){
+          strict_version_check = as.logical(trimws(toupper(as.character(h2oconfig$init.check_version))))
+        }
+        if(is.na(proxy) && "init.proxy" %in% colnames(h2oconfig)){
+          proxy = trimws(as.character(h2oconfig$init.proxy))
+        }
+        if(insecure == FALSE && "init.verify_ssl_certificates" %in% colnames(h2oconfig)){
+          insecure = as.logical(trimws(toupper(as.character(h2oconfig$init.verify_ssl_certificates))))
+        }
+        if(is.na(cookies) && "init.cookies" %in% colnames(h2oconfig)){
+          cookies = as.vector(trimws(strsplit(as.character(h2oconfig$init.cookies),";")[[1]]))
+        }
+        if(is.na(username) && "init.username" %in% colnames(h2oconfig)){
+          username = trimws(as.character(h2oconfig$init.username))
+        }
+        if(is.na(password) && "init.password" %in% colnames(h2oconfig)){
+          password = trimws(as.character(h2oconfig$init.password))
+        }
       }
-      if(is.na(proxy) && "init.proxy" %in% colnames(h2oconfig)){
-        proxy = trimws(as.character(h2oconfig$init.proxy))
-      }
-      if(insecure == FALSE && "init.verify_ssl_certificates" %in% colnames(h2oconfig)){
-        insecure = as.logical(trimws(toupper(as.character(h2oconfig$init.verify_ssl_certificates))))
-      }
-      if(is.na(cookies) && "init.cookies" %in% colnames(h2oconfig)){
-        cookies = as.vector(trimws(strsplit(as.character(h2oconfig$init.cookies),";")[[1]]))
-      }
-      if(is.na(username) && "init.username" %in% colnames(h2oconfig)){
-        username = trimws(as.character(h2oconfig$init.username))
-      }
-      if(is.na(password) && "init.password" %in% colnames(h2oconfig)){
-        password = trimws(as.character(h2oconfig$init.password))
-      }
-  }
+    }
 
   if(!is.character(ip) || length(ip) != 1L || is.na(ip) || !nzchar(ip))
     stop("`ip` must be a non-empty character string")

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -27,7 +27,7 @@
 #' @param password (Optional) Password to login with.
 #' @param cookies (Optional) Vector(or list) of cookies to add to request.
 #' @param context_path (Optional) The last part of connection URL: http://<ip>:<port>/<context_path>
-#' @param ignore_config (Optional) A \code{logical} value indicating whether a search for a .h2oconfig file should be concucted or not.
+#' @param ignore_config (Optional) A \code{logical} value indicating whether a search for a .h2oconfig file should be conducted or not. Default value is FALSE.
 #' @return this method will load it and return a \code{H2OConnection} object containing the IP address and port number of the H2O server.
 #' @note Users may wish to manually upgrade their package (rather than waiting until being prompted), which requires
 #' that they fully uninstall and reinstall the H2O package, and the H2O client package. You must unload packages running


### PR DESCRIPTION
* Please see JIRA for description