### PR TITLE
PUBDEV-4246: proportional of variance.

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -60,7 +60,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     public DataInfo.TransformType _transform = DataInfo.TransformType.NONE;
     public int _k = 1;                       // Rank of resulting XY matrix
     public GlrmInitialization _init = GlrmInitialization.PlusPlus;  // Initialization of Y matrix
-    public SVDParameters.Method _svd_method = SVDParameters.Method.Randomized;  // SVD initialization method (for _init = SVD)
+    public SVDParameters.Method _svd_method = SVDParameters.Method.Power;  // SVD initialization method (for _init = SVD)
     public Key<Frame> _user_y;               // User-specified Y matrix (for _init = User)
     public Key<Frame> _user_x;               // User-specified X matrix (for _init = User)
     public boolean _expand_user_y = true;    // Should categorical columns in _user_y be expanded via one-hot encoding? (for _init = User)

--- a/h2o-algos/src/main/java/hex/pca/PCA.java
+++ b/h2o-algos/src/main/java/hex/pca/PCA.java
@@ -183,12 +183,18 @@ public class PCA extends ModelBuilder<PCAModel,PCAModel.PCAParameters,PCAModel.P
       double dfcorr = 1.0 / Math.sqrt(_train.numRows() - 1.0);
       pca._output._std_deviation = new double[_parms._k];
       pca._output._eigenvectors_raw = glrm._output._eigenvectors_raw;
-      for(int i = 0; i < glrm._output._singular_vals.length; i++) {
-        pca._output._std_deviation[i] = dfcorr * glrm._output._singular_vals[i];
-      }
       pca._output._nobs = _train.numRows();
-      // Since gram = X'X/n, but variance requires n-1 in denominator
-      pca._output._total_variance = gram.diagSum()*pca._output._nobs/(pca._output._nobs-1.0);
+
+      if (gram._diagN == 0) { // no categorical columns
+        for (int i = 0; i < glrm._output._singular_vals.length; i++) {
+          pca._output._std_deviation[i] = dfcorr * glrm._output._singular_vals[i];
+        }
+        // Since gram = X'X/n, but variance requires n-1 in denominator
+        pca._output._total_variance = gram.diagSum() * pca._output._nobs / (pca._output._nobs - 1.0);
+      } else {  // no change to eigen values for categoricals
+        pca._output._std_deviation = glrm._output._std_deviation;
+        pca._output._total_variance = glrm._output._total_variance;
+      }
       buildTables(pca, glrm._output._names_expanded);
     }
 
@@ -394,7 +400,10 @@ public class PCA extends ModelBuilder<PCAModel,PCAModel.PCAParameters,PCAModel.P
           parms._gamma_x = parms._gamma_y = 0;
           parms._regularization_x = GlrmRegularizer.None;
           parms._regularization_y = GlrmRegularizer.None;
-          parms._init = GlrmInitialization.SVD; // changed from PlusPlus to SVD.  Seems to give better result
+          if (dinfo._cats > 0)
+            parms._init = GlrmInitialization.PlusPlus;
+          else
+            parms._init = GlrmInitialization.SVD; // changed from PlusPlus to SVD.  Seems to give better result
 
           // Build an SVD model
           // Hack: we have to resort to unsafe type casts because _job is of Job<PCAModel> type, whereas a GLRM

--- a/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/AggregatorV99.java
@@ -3,9 +3,10 @@ package hex.schemas;
 import hex.DataInfo;
 import hex.aggregator.Aggregator;
 import hex.aggregator.AggregatorModel;
-import static hex.pca.PCAModel.*;
 import water.api.API;
 import water.api.schemas3.ModelParametersSchemaV3;
+
+import static hex.pca.PCAModel.PCAParameters;
 
 public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,AggregatorV99.AggregatorParametersV99> {
 
@@ -34,7 +35,7 @@ public class AggregatorV99 extends ModelBuilderSchema<Aggregator,AggregatorV99,A
     @API(help = "Transformation of training data", values = { "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE" }, gridable = true, level= API.Level.expert)  // TODO: pull out of categorical class
     public DataInfo.TransformType transform;
 
-    @API(help = "Method for computing PCA (Caution: Power and GLRM are currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized", "GLRM" }, gridable = true, level= API.Level.expert)
+    @API(help = "Method for computing PCA (Caution: GLRM is currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized", "GLRM" }, gridable = true, level= API.Level.expert)
     public PCAParameters.Method pca_method;
 
     @API(help = "Rank of matrix approximation", direction = API.Direction.INOUT, gridable = true, level= API.Level.secondary)

--- a/h2o-algos/src/main/java/hex/schemas/GLRMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLRMV3.java
@@ -99,7 +99,7 @@ public class GLRMV3 extends ModelBuilderSchema<GLRM, GLRMV3, GLRMV3.GLRMParamete
     @API(help = "Initialization mode", values = { "Random", "SVD", "PlusPlus", "User" }, gridable = true) // TODO: pull out of categorical class
     public GlrmInitialization init;
 
-    @API(help = "Method for computing SVD during initialization (Caution: Power and Randomized are currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized" }, gridable = true)   // TODO: pull out of enum class
+    @API(help = "Method for computing SVD during initialization (Caution: Randomized is currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized" }, gridable = true)   // TODO: pull out of enum class
     public SVDParameters.Method svd_method;
 
     @API(help = "User-specified initial Y")

--- a/h2o-algos/src/main/java/hex/schemas/PCAV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/PCAV3.java
@@ -30,7 +30,7 @@ public class PCAV3 extends ModelBuilderSchema<PCA,PCAV3,PCAV3.PCAParametersV3> {
     @API(help = "Transformation of training data", values = { "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE" }, gridable = true)  // TODO: pull out of categorical class
     public DataInfo.TransformType transform;
 
-    @API(help = "Method for computing PCA (Caution: Power and GLRM are currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized", "GLRM" })   // TODO: pull out of categorical class
+    @API(help = "Method for computing PCA (Caution: GLRM is currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized", "GLRM" })   // TODO: pull out of categorical class
     public PCAParameters.Method pca_method;
 
     @API(help = "Rank of matrix approximation", required = true, direction = API.Direction.INOUT, gridable = true)

--- a/h2o-algos/src/main/java/hex/schemas/SVDV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/SVDV99.java
@@ -30,7 +30,7 @@ public class SVDV99 extends ModelBuilderSchema<SVD,SVDV99,SVDV99.SVDParametersV9
     @API(help = "Transformation of training data", values = { "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE" })  // TODO: pull out of categorical class
     public DataInfo.TransformType transform;
 
-    @API(help = "Method for computing SVD (Caution: Power and Randomized are currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized" })   // TODO: pull out of enum class
+    @API(help = "Method for computing SVD (Caution: Randomized is currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized" })   // TODO: pull out of enum class
     public SVDParameters.Method svd_method;
 
     @API(help = "Number of right singular vectors")

--- a/h2o-docs/src/product/data-science/glrm.rst
+++ b/h2o-docs/src/product/data-science/glrm.rst
@@ -116,7 +116,7 @@ Defining a GLRM Model
 -  **svd\_method**: Specify the method for computing SVD during
    initialization: GramSVD, Power, Randomized.
 
-       **Caution**: Power and Randomized are currently experimental.
+       **Caution**: Randomized is currently experimental.
 
 -  **user\_y**: (Optional) Specify the initial Y value.
 

--- a/h2o-py/h2o/estimators/glrm.py
+++ b/h2o-py/h2o/estimators/glrm.py
@@ -394,10 +394,9 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
     @property
     def svd_method(self):
         """
-        Method for computing SVD during initialization (Caution: Randomized is currently experimental and
-        unstable)
+        Method for computing SVD during initialization (Caution: Randomized is currently experimental and unstable)
 
-        One of: ``"gram_s_v_d"``, ``"power"``, ``"randomized"``  (default: ``"randomized"``).
+        One of: ``"gram_s_v_d"``, ``"power"``, ``"randomized"``  (default: ``"power"``).
         """
         return self._parms.get("svd_method")
 

--- a/h2o-py/h2o/estimators/glrm.py
+++ b/h2o-py/h2o/estimators/glrm.py
@@ -394,7 +394,7 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
     @property
     def svd_method(self):
         """
-        Method for computing SVD during initialization (Caution: Power and Randomized are currently experimental and
+        Method for computing SVD during initialization (Caution: Randomized is currently experimental and
         unstable)
 
         One of: ``"gram_s_v_d"``, ``"power"``, ``"randomized"``  (default: ``"randomized"``).

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -130,7 +130,7 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     @property
     def pca_method(self):
         """
-        Method for computing PCA (Caution: Power and GLRM are currently experimental and unstable)
+        Method for computing PCA (Caution: GLRM is currently experimental and unstable)
 
         One of: ``"gram_s_v_d"``, ``"power"``, ``"randomized"``, ``"glrm"``  (default: ``"gram_s_v_d"``).
         """

--- a/h2o-py/h2o/estimators/svd.py
+++ b/h2o-py/h2o/estimators/svd.py
@@ -130,7 +130,7 @@ class H2OSingularValueDecompositionEstimator(H2OEstimator):
     @property
     def svd_method(self):
         """
-        Method for computing SVD (Caution: Power and Randomized are currently experimental and unstable)
+        Method for computing SVD (Caution: Randomized is currently experimental and unstable)
 
         One of: ``"gram_s_v_d"``, ``"power"``, ``"randomized"``  (default: ``"gram_s_v_d"``).
         """

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_4246_pro_var.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_4246_pro_var.py
@@ -1,0 +1,46 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+from h2o.transforms.decomposition import H2OPCA
+
+# This unit test makes sure that GLRM will not return proportional of variance with values exceeding 1 when
+# categorical columns exist.  However, when there are categorical columns, if the sole purpose is to perform
+# PCA, I will not recommend using GLRM.  The reason is due to GLRM will optimize the categorical columns
+# using a categorical loss and not the quadratic loss as in PCA algos.  The eigenvalues obtained from PCA
+# and GLRM differs in this case.
+def glrm_iris():
+  print("Importing iris.csv data...")
+  irisH2O = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris.csv"))
+  irisH2O.describe()
+
+  print("@@@@@@  Building PCA with GramSVD...\n")
+  glrmPCA = H2OPCA(k=5, transform="STANDARDIZE", pca_method="GLRM", use_all_factor_levels=True, seed=21)
+  glrmPCA.train(x=irisH2O.names, training_frame=irisH2O)
+
+  glrm_h2o = H2OGeneralizedLowRankEstimator(k=5, loss="Quadratic",transform="STANDARDIZE", recover_svd=True,  seed=21)
+  glrm_h2o.train(x=irisH2O.names, training_frame=irisH2O)
+
+  # compare singular values and stuff with GramSVD
+  print("@@@@@@  Comparing eigenvalues between GramSVD and GLRM...\n")
+  pyunit_utils.assert_H2OTwoDimTable_equal(glrmPCA._model_json["output"]["importance"],
+                                           glrm_h2o._model_json["output"]["importance"],
+                                           ["Standard deviation", "Cumulative Proportion", "Cumulative Proportion"],
+                                           tolerance=1e-6)
+  print("@@@@@@  Comparing eigenvectors between GramSVD and GLRM...\n")
+
+  # compare singular vectors
+  pyunit_utils.assert_H2OTwoDimTable_equal(glrmPCA._model_json["output"]["eigenvectors"],
+                                           glrm_h2o._model_json["output"]["eigenvectors"],
+                                           glrm_h2o._model_json["output"]["names"], tolerance=1e-6,check_sign=True)
+
+  # check to make sure maximum proportional variance <= 1
+  assert glrmPCA._model_json["output"]["importance"].cell_values[1][1] <= 1, \
+    "Expected value <= 1.0 but received {0}".format(glrmPCA._model_json["output"]["importance"].cell_values[1][1])
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(glrm_iris)
+else:
+  glrm_iris()

--- a/h2o-r/h2o-package/R/glrm.R
+++ b/h2o-r/h2o-package/R/glrm.R
@@ -35,8 +35,8 @@
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Defaults to -1 (time-based random number).
 #' @param init Initialization mode Must be one of: "Random", "SVD", "PlusPlus", "User". Defaults to PlusPlus.
-#' @param svd_method Method for computing SVD during initialization (Caution: Power and Randomized are currently experimental and
-#'        unstable) Must be one of: "GramSVD", "Power", "Randomized". Defaults to Randomized.
+#' @param svd_method Method for computing SVD during initialization (Caution: Randomized is currently experimental and
+#'        unstable) Must be one of: "GramSVD", "Power", "Randomized". Defaults to Power.
 #' @param user_y User-specified initial Y
 #' @param user_x User-specified initial X
 #' @param expand_user_y \code{Logical}. Expand categorical columns in user-specified initial Y Defaults to TRUE.

--- a/h2o-r/h2o-package/R/glrm.R
+++ b/h2o-r/h2o-package/R/glrm.R
@@ -35,8 +35,8 @@
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)
 #'        Defaults to -1 (time-based random number).
 #' @param init Initialization mode Must be one of: "Random", "SVD", "PlusPlus", "User". Defaults to PlusPlus.
-#' @param svd_method Method for computing SVD during initialization (Caution: Randomized is currently experimental and
-#'        unstable) Must be one of: "GramSVD", "Power", "Randomized". Defaults to Power.
+#' @param svd_method Method for computing SVD during initialization (Caution: Randomized is currently experimental and unstable)
+#'        Must be one of: "GramSVD", "Power", "Randomized". Defaults to Power.
 #' @param user_y User-specified initial Y
 #' @param user_x User-specified initial X
 #' @param expand_user_y \code{Logical}. Expand categorical columns in user-specified initial Y Defaults to TRUE.

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -14,8 +14,8 @@
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
-#' @param pca_method Method for computing PCA (Caution: GLRM is currently experimental and unstable) Must be one of:
-#'        "GramSVD", "Power", "Randomized", "GLRM". Defaults to GramSVD.
+#' @param pca_method Method for computing PCA (Caution: GLRM is currently experimental and unstable) Must be one of: "GramSVD",
+#'        "Power", "Randomized", "GLRM". Defaults to GramSVD.
 #' @param k Rank of matrix approximation Defaults to 1.
 #' @param max_iterations Maximum training iterations Defaults to 1000.
 #' @param use_all_factor_levels \code{Logical}. Whether first factor level is included in each categorical expansion Defaults to FALSE.

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -14,7 +14,7 @@
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
-#' @param pca_method Method for computing PCA (Caution: Power and GLRM are currently experimental and unstable) Must be one of:
+#' @param pca_method Method for computing PCA (Caution: GLRM is currently experimental and unstable) Must be one of:
 #'        "GramSVD", "Power", "Randomized", "GLRM". Defaults to GramSVD.
 #' @param k Rank of matrix approximation Defaults to 1.
 #' @param max_iterations Maximum training iterations Defaults to 1000.

--- a/h2o-r/h2o-package/R/svd.R
+++ b/h2o-r/h2o-package/R/svd.R
@@ -15,8 +15,8 @@
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
-#' @param svd_method Method for computing SVD (Caution: Randomized is currently experimental and unstable) Must be one
-#'        of: "GramSVD", "Power", "Randomized". Defaults to GramSVD.
+#' @param svd_method Method for computing SVD (Caution: Randomized is currently experimental and unstable) Must be one of:
+#'        "GramSVD", "Power", "Randomized". Defaults to GramSVD.
 #' @param nv Number of right singular vectors Defaults to 1.
 #' @param max_iterations Maximum iterations Defaults to 1000.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default)

--- a/h2o-r/h2o-package/R/svd.R
+++ b/h2o-r/h2o-package/R/svd.R
@@ -15,7 +15,7 @@
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
-#' @param svd_method Method for computing SVD (Caution: Power and Randomized are currently experimental and unstable) Must be one
+#' @param svd_method Method for computing SVD (Caution: Randomized is currently experimental and unstable) Must be one
 #'        of: "GramSVD", "Power", "Randomized". Defaults to GramSVD.
 #' @param nv Number of right singular vectors Defaults to 1.
 #' @param max_iterations Maximum iterations Defaults to 1000.


### PR DESCRIPTION
	1. Fixed code to make sure proportional variances do not exceed 1.
	2. Added pyunit test to check and make sure 
           - that the eigenvalues generated from PCA specifying GLRM as the PCA method and that from 
            calling GLRM directly are the same.
         - maximum proportional variance (first element) does not exceed 1.