### PR TITLE
PUBDEV-4267: Change default nthreads to -1 in R API h2o.init()

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -15,7 +15,7 @@
 #' @param forceDL (Optional) A \code{logical} value indicating whether to force download of the H2O executable. Defaults to FALSE, so the executable will only be downloaded if it does not already exist in the h2o R library resources directory \code{h2o/java/h2o.jar}.  This value is only used when R starts H2O.
 #' @param enable_assertions (Optional) A \code{logical} value indicating whether H2O should be launched with assertions enabled. Used mainly for error checking and debugging purposes.  This value is only used when R starts H2O.
 #' @param license (Optional) A \code{character} string value specifying the full path of the license file.  This value is only used when R starts H2O.
-#' @param nthreads (Optional) Number of threads in the thread pool.  This relates very closely to the number of CPUs used.  -2 means use the CRAN default of 2 CPUs.  -1 means use all CPUs on the host.  A positive integer specifies the number of CPUs directly.  This value is only used when R starts H2O.
+#' @param nthreads (Optional) Number of threads in the thread pool.  This relates very closely to the number of CPUs used. -1 means use all CPUs on the host (Default).  A positive integer specifies the number of CPUs directly.  This value is only used when R starts H2O.
 #' @param max_mem_size (Optional) A \code{character} string specifying the maximum size, in bytes, of the memory allocation pool to H2O. This value must a multiple of 1024 greater than 2MB. Append the letter m or M to indicate megabytes, or g or G to indicate gigabytes.  This value is only used when R starts H2O.
 #' @param min_mem_size (Optional) A \code{character} string specifying the minimum size, in bytes, of the memory allocation pool to H2O. This value must a multiple of 1024 greater than 2MB. Append the letter m or M to indicate megabytes, or g or G to indicate gigabytes.  This value is only used when R starts H2O.
 #' @param ice_root (Optional) A directory to handle object spillage. The defaul varies by OS.
@@ -52,7 +52,7 @@
 #' }
 #' @export
 h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = FALSE,
-                     enable_assertions = TRUE, license = NULL, nthreads = -2,
+                     enable_assertions = TRUE, license = NULL, nthreads = -1,
                      max_mem_size = NULL, min_mem_size = NULL,
                      ice_root = tempdir(), strict_version_check = TRUE, proxy = NA_character_,
                      https = FALSE, insecure = FALSE, username = NA_character_, password = NA_character_,

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -221,7 +221,7 @@ h2o.getModel <- function(model_id) {
 #' @examples
 #' \donttest{
 #' library(h2o)
-#' h <- h2o.init(nthreads=-1)
+#' h <- h2o.init()
 #' fr <- as.h2o(iris)
 #' my_model <- h2o.gbm(x=1:4, y=5, training_frame=fr)
 #'
@@ -296,7 +296,7 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE, jar_n
 #' @examples
 #' \donttest{
 #' library(h2o)
-#' h <- h2o.init(nthreads=-1)
+#' h <- h2o.init()
 #' fr <- as.h2o(iris)
 #' my_model <- h2o.gbm(x=1:4, y=5, training_frame=fr)
 #' h2o.download_mojo(my_model)  # save to the current working directory

--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -5,7 +5,7 @@
 #'if(Sys.info()['sysname'] == "Darwin" && Sys.info()['release'] == '13.4.0'){
 #'  quit(save="no")
 #'}else{
-#'  h2o.init()
+#'  h2o.init(nthreads=-2)
 #'}
 NULL
 

--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -5,7 +5,7 @@
 #'if(Sys.info()['sysname'] == "Darwin" && Sys.info()['release'] == '13.4.0'){
 #'  quit(save="no")
 #'}else{
-#'  h2o.init(nthreads=-2)
+#'  h2o.init(nthreads = 2)
 #'}
 NULL
 

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2876,12 +2876,12 @@ h2o.cross_validation_predictions <- function(object) {
 #' @examples
 #' \donttest{
 #' library(h2o)
-#' h2o.init(nthreads = -1)
-#' prostate.path = system.file("extdata", "prostate.csv", package="h2o")
-#' prostate.hex = h2o.uploadFile(path = prostate.path, destination_frame = "prostate.hex")
+#' h2o.init()
+#' prostate.path <- system.file("extdata", "prostate.csv", package="h2o")
+#' prostate.hex <- h2o.uploadFile(path = prostate.path, destination_frame = "prostate.hex")
 #' prostate.hex[, "CAPSULE"] <- as.factor(prostate.hex[, "CAPSULE"] )
 #' prostate.hex[, "RACE"] <- as.factor(prostate.hex[,"RACE"] )
-#' prostate.gbm = h2o.gbm(x = c("AGE","RACE"),
+#' prostate.gbm <- h2o.gbm(x = c("AGE","RACE"),
 #'                        y = "CAPSULE",
 #'                        training_frame = prostate.hex,
 #'                        ntrees = 10,


### PR DESCRIPTION
* This PR will set `nthreads` in `h2o.init()` to `-1` by default and set `nthreads` in `h2o.init()` to `-2` for R examples to comply with CRAN.