### PR TITLE
PUBDEV-4253: Documentation - HDP 2.6

### DIFF
--- a/h2o-docs/src/product/hadoop.rst
+++ b/h2o-docs/src/product/hadoop.rst
@@ -17,6 +17,7 @@ Currently supported versions:
 -  HDP 2.3
 -  HDP 2.4
 -  HDP 2.5
+-  HDP 2.6
 -  MapR 3.1
 -  MapR 4.0
 -  MapR 5.0


### PR DESCRIPTION
Added HDP 2.6 to list of supported Hadoop versions.