### PR TITLE
PUBDEV-4268: Documentation for nthreads

### DIFF
--- a/h2o-docs/src/product/data-munging/combining-columns.rst
+++ b/h2o-docs/src/product/data-munging/combining-columns.rst
@@ -7,7 +7,7 @@ The ``cbind`` function allows you to combine datasets by adding columns from one
    .. code-block:: r
 	
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	
 	# Create two simple, two-column R data frames by inputting values, ensuring that both have a common column (in this case, "fruit").
 	> left <- data.frame(fruit = c('apple','orange','banana','lemon','strawberry','blueberry'), color = c('red','orange','yellow','yellow','red','blue'))

--- a/h2o-docs/src/product/data-munging/combining-rows.rst
+++ b/h2o-docs/src/product/data-munging/combining-rows.rst
@@ -9,7 +9,7 @@ Note that when using ``rbind``, the two datasets must have the same set of colum
    .. code-block:: r
    
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	
 	# Import an existing training dataset
 	> ecg1Path <- "http://h2o-public-test-data.s3.amazonaws.com/smalldata/anomaly/ecg_discord_train.csv"

--- a/h2o-docs/src/product/data-munging/groupby.rst
+++ b/h2o-docs/src/product/data-munging/groupby.rst
@@ -56,7 +56,7 @@ Note that once the aggregation operations are complete, calling the GroupBy obje
    .. code-block:: r
 
     > library(h2o)
-    > h2o.init(nthreads=-1)
+    > h2o.init()
 
     # Import the airlines data set and display a summary.
     > airlinesURL <- "https://s3.amazonaws.com/h2o-airlines-unpacked/allyears2k.csv"

--- a/h2o-docs/src/product/data-munging/importing-data.rst
+++ b/h2o-docs/src/product/data-munging/importing-data.rst
@@ -8,7 +8,7 @@ Unlike the `upload <uploading-data.html>`__ function, which is a push from the c
 	
 	# To import small iris data file from H2O’s package:
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	> irisPath <- "https://s3.amazonaws.com/h2o-airlines-unpacked/allyears2k.csv" 
 	> iris.hex <- h2o.importFile(path = irisPath, destination_frame = "iris.hex")
 	  

--- a/h2o-docs/src/product/data-munging/importing-files.rst
+++ b/h2o-docs/src/product/data-munging/importing-files.rst
@@ -23,7 +23,7 @@ The ``importFolder`` (R)/``import_file`` (Python) function can be used to import
 	
 	# To import all .csv files from the prostate_folder directory:
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	> prosPath <- system.file("extdata", "prostate_folder", package = "h2o")
 	> prostate_pattern.hex <- h2o.importFolder(path = prosPath, pattern = ".*.csv", destination_frame = "prostate.hex")
 	> class(prostate_pattern.hex)

--- a/h2o-docs/src/product/data-munging/imputing-data.rst
+++ b/h2o-docs/src/product/data-munging/imputing-data.rst
@@ -17,7 +17,7 @@ The ``impute`` function accepts the following arguments:
    .. code-block:: r
 
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 
    	#Upload the Airlines dataset
    	> filePath <- "https://s3.amazonaws.com/h2o-airlines-unpacked/allyears2k.csv"

--- a/h2o-docs/src/product/data-munging/merging-data.rst
+++ b/h2o-docs/src/product/data-munging/merging-data.rst
@@ -11,7 +11,7 @@ Note that in order for a merge to work in multinode clusters, one of the dataset
    
 	# Currently, this function only supports `all.x = TRUE`. All other permutations will fail.
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	
 	# Create two simple, two-column R data frames by inputting values, ensuring that both have a common column (in this case, "fruit").
 	> left <- data.frame(fruit = c('apple','orange','banana','lemon','strawberry','blueberry'), color = c('red','orange','yellow','yellow','red','blue'))

--- a/h2o-docs/src/product/data-munging/replacing-values.rst
+++ b/h2o-docs/src/product/data-munging/replacing-values.rst
@@ -7,7 +7,7 @@ This example shows how to replace numeric values in a frame of data. Note that i
    .. code-block:: r
 
     > library(h2o)
-    > h2o.init(nthreads=-1)
+    > h2o.init()
 
     #Upload the iris dataset
     > path <- "http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv""

--- a/h2o-docs/src/product/data-munging/slicing-columns.rst
+++ b/h2o-docs/src/product/data-munging/slicing-columns.rst
@@ -7,7 +7,7 @@ H2O lazily slices out columns of data and will only materialize a shared copy up
    .. code-block:: r
 	
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	> path <- "http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv"
 	> df <- h2o.importFile(path)
 	> print(df)

--- a/h2o-docs/src/product/data-munging/slicing-rows.rst
+++ b/h2o-docs/src/product/data-munging/slicing-rows.rst
@@ -7,7 +7,7 @@ H2O lazily slices out rows of data and will only materialize a shared copy upon 
    .. code-block:: r
    
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	> path <- "http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv"
     > df <- h2o.importFile(path)
 

--- a/h2o-docs/src/product/data-munging/splitting-datasets.rst
+++ b/h2o-docs/src/product/data-munging/splitting-datasets.rst
@@ -9,7 +9,7 @@ Note that when splitting frames, H2O does not give an exact split. It's designed
    .. code-block:: r
    
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	
 	# Import the prostate dataset
 	> prostate.hex <- h2o.importFile(path = "https://raw.github.com/h2oai/h2o/master/smalldata/logreg/prostate.csv", destination_frame = "prostate.hex")

--- a/h2o-docs/src/product/data-munging/uploading-data.rst
+++ b/h2o-docs/src/product/data-munging/uploading-data.rst
@@ -9,7 +9,7 @@ Run the following command to load data that resides on the same machine that is 
    .. code-block:: r
 	
 	> library(h2o)
-	> h2o.init(nthreads=-1)
+	> h2o.init()
 	> irisPath <- "../smalldata/iris/iris_wheader.csv"
 	> iris.hex <- h2o.uploadFile(path = irisPath, destination_frame = "iris.hex")
 	  

--- a/h2o-docs/src/product/data-science/algo-params/eps_prob.rst
+++ b/h2o-docs/src/product/data-science/algo-params/eps_prob.rst
@@ -22,47 +22,47 @@ Example
 .. example-code::
    .. code-block:: r
 
-	library(h2o)
-	h2o.init()
+    library(h2o)
+    h2o.init()
 
-	# import the cars dataset:
-	cars <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+    # import the cars dataset
+    cars <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
 
-	# Specify model-building exercise (1:binomial, 2:multinomial)
-	problem <- sample(1:2,1)
+    # Specify model-building exercise (1:binomial, 2:multinomial)
+    problem <- sample(1:2,1)
 
-	# Specify response column based on predictor value and problem type
-	predictors <- c("displacement","power","weight","acceleration","year")
-	if ( problem == 1 ) { response_col <- "economy_20mpg"} else { response_col <- "cylinders" }
+    # Specify response column based on predictor value and problem type
+    predictors <- c("displacement","power","weight","acceleration","year")
+    if ( problem == 1 ) { response_col <- "economy_20mpg"} else { response_col <- "cylinders" }
 
-	# Convert the response column to a factor
-	cars[,response_col] <- as.factor(cars[,response_col])
+    # Convert the response column to a factor
+    cars[,response_col] <- as.factor(cars[,response_col])
 
-	# Specify model parameters
-	laplace <- c(1)
-	min_prob <- c(0.1)
-	eps_prob <- c(0.5)
+    # Specify model parameters
+    laplace <- c(1)
+    min_prob <- c(0.1)
+    eps_prob <- c(0.5)
 
     # Build the model 
     cars_naivebayes <- h2o.naiveBayes(x=predictors, y=response_col, training_frame=cars, 
                                       eps_prob=eps_prob, min_prob=min_prob, laplace=laplace)
     print(cars_naivebayes)
 
-	# Predict on training data
-	cars_naivebayes.pred <- predict(cars_naivebayes, cars)
-	print(head(cars_naivebayes.pred))
+    # Predict on training data
+    cars_naivebayes.pred <- predict(cars_naivebayes, cars)
+    print(head(cars_naivebayes.pred))
 
-	# Specify grid search parameters
-	grid_space <- list()
-	grid_space$laplace <- c(1,2)
-	grid_space$min_prob <- c(0.1,0.2)
-	grid_space$eps_prob <- c(0.5,0.6)
+    # Specify grid search parameters
+    grid_space <- list()
+    grid_space$laplace <- c(1,2)
+    grid_space$min_prob <- c(0.1,0.2)
+    grid_space$eps_prob <- c(0.5,0.6)
 
-	# Construct the grid of naive bayes models
-	cars_naivebayes_grid <- h2o.grid(x=predictors, y=response_col, training_frame=cars, 
+    # Construct the grid of naive bayes models
+    cars_naivebayes_grid <- h2o.grid(x=predictors, y=response_col, training_frame=cars, 
                                      algorithm="naivebayes", grid_id="naiveBayes_grid_cars_test", 
                                      hyper_params=grid_space)
-	print(cars_naivebayes_grid)
+    print(cars_naivebayes_grid)
 
    .. code-block:: python
 

--- a/h2o-docs/src/product/data-science/algo-params/min_prob.rst
+++ b/h2o-docs/src/product/data-science/algo-params/min_prob.rst
@@ -22,26 +22,26 @@ Example
 .. example-code::
    .. code-block:: r
 
-	library(h2o)
-	h2o.init()
+    library(h2o)
+    h2o.init()
 
-	# import the cars dataset:
-	cars <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+    # import the cars dataset
+    cars <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
 
-	# Specify model-building exercise (1:binomial, 2:multinomial)
-	problem <- sample(1:2,1)
+    # Specify model-building exercise (1:binomial, 2:multinomial)
+    problem <- sample(1:2,1)
 
-	# Specify response column based on predictor value and problem type
-	predictors <- c("displacement","power","weight","acceleration","year")
-	if ( problem == 1 ) { response_col <- "economy_20mpg"} else { response_col <- "cylinders" }
+    # Specify response column based on predictor value and problem type
+    predictors <- c("displacement","power","weight","acceleration","year")
+    if ( problem == 1 ) { response_col <- "economy_20mpg"} else { response_col <- "cylinders" }
 
-	# Convert the response column to a factor
-	cars[,response_col] <- as.factor(cars[,response_col])
+    # Convert the response column to a factor
+    cars[,response_col] <- as.factor(cars[,response_col])
 
-	# Specify model parameters
-	laplace <- c(1)
-	min_prob <- c(0.1)
-	eps_prob <- c(0.5)
+    # Specify model parameters
+    laplace <- c(1)
+    min_prob <- c(0.1)
+    eps_prob <- c(0.5)
 
     # Build the model 
     cars_naivebayes <- h2o.naiveBayes(x=predictors, y=response_col, training_frame=cars, 
@@ -62,7 +62,7 @@ Example
     cars_naivebayes_grid <- h2o.grid(x=predictors, y=response_col, training_frame=cars, 
                                     algorithm="naivebayes", grid_id="naiveBayes_grid_cars_test", 
                                     hyper_params=grid_space)
-	print(cars_naivebayes_grid)
+    print(cars_naivebayes_grid)
 
    .. code-block:: python
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -530,7 +530,7 @@ Example
    .. code-block:: r
 
     library(h2o)
-    h2o.init(nthreads=-1)
+    h2o.init()
 
     df <- h2o.importFile("https://h2o-public-test-data.s3.amazonaws.com/smalldata/prostate/prostate.csv")
     df$CAPSULE <- as.factor(df$CAPSULE)

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -74,7 +74,7 @@ Example
    .. code-block:: r
 
     library(h2o)
-    h2o.init(nthreads = -1)
+    h2o.init()
 
     # Import a sample binary outcome train/test set into H2O
     train <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
@@ -91,15 +91,12 @@ Example
     # Number of CV folds (to generate level-one data for stacking)
     nfolds <- 5
 
-
-
     # There are a few ways to assemble a list of models to stack toegether:
     # 1. Train individual models and put them in a list
     # 2. Train a grid of models
     # 3. Train several grids of models
     # Note: All base models must have the same cross-validation folds and 
     # the cross-validated predicted values must be kept.
-
 
 
     # 1. Generate a 2-model ensemble (GBM + RF)
@@ -148,7 +145,6 @@ Example
 
     # Generate predictions on a test set (if neccessary)
     pred <- h2o.predict(ensemble, newdata = test)
-
 
 
     # 2. Generate a random grid of models and stack them together
@@ -210,9 +206,7 @@ Example
     from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
     from h2o.grid.grid_search import H2OGridSearch
     from __future__ import print_function
-    
-
-    h2o.init(nthreads=-1)
+    h2o.init()
 
     # Import a sample binary outcome train/test set into H2O
     train = h2o.import_file("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
@@ -230,15 +224,12 @@ Example
     # Number of CV folds (to generate level-one data for stacking)
     nfolds = 5 
 
-
-
-    # There are a few ways to assemble a list of models to stack toegether:
+    # There are a few ways to assemble a list of models to stack together:
     # 1. Train individual models and put them in a list
     # 2. Train a grid of models
     # 3. Train several grids of models
     # Note: All base models must have the same cross-validation folds and 
     # the cross-validated predicted values must be kept.
-
 
 
     # 1. Generate a 2-model ensemble (GBM + RF)
@@ -285,7 +276,6 @@ Example
     pred = ensemble.predict(test)
     
     
-
     # 2. Generate a random grid of models and stack them together
 
     # Specify GBM hyperparameters for the grid
@@ -322,8 +312,6 @@ Example
 
     # Generate predictions on a test set (if neccessary)
     pred = ensemble.predict(test)
-
-
 
 FAQ
 ~~~

--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -58,7 +58,7 @@ Perform the following steps in R to install H2O. Copy and paste these commands o
  ::
 
 	library(h2o)
-	localH2O = h2o.init(nthreads=-1) 
+	localH2O = h2o.init() 
 	demo(h2o.kmeans) 
 
 Installing H2O's R Package from CRAN

--- a/h2o-docs/src/product/faq/r.rst
+++ b/h2o-docs/src/product/faq/r.rst
@@ -137,16 +137,15 @@ Make sure to install the dependencies for the H2O R package as well:
     if (! ("tools" %in% rownames(installed.packages()))) { install.packages("tools") }
     if (! ("utils" %in% rownames(installed.packages()))) { install.packages("utils") }
 
-Finally, install the latest version of the H2O package for R:
+Finally, install the latest stable version of the H2O package for R:
 
 ::
 
-    install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/<branch_name>/<build_number>/R")))
+    install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/latest_stable_R)))
     library(h2o)
-    localH2O = h2o.init(nthreads=-1)
+    localH2O = h2o.init()
 
-If your R version is older than the H2O R package, upgrade your R
-version using ``update.packages(checkBuilt=TRUE, ask=FALSE)``.
+If your R version is older than the H2O R package, upgrade your R version using ``update.packages(checkBuilt=TRUE, ask=FALSE)``.
 
 --------------
 

--- a/h2o-docs/src/product/grid-search.rst
+++ b/h2o-docs/src/product/grid-search.rst
@@ -306,7 +306,7 @@ Random Hyper-Parameter Grid Search Example
 
 
     library(h2o)
-    h2o.init(nthreads=-1)
+    h2o.init()
     train <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/arrhythmia.csv.gz")
     dim(train)
     response <- 1

--- a/h2o-docs/src/product/starting-h2o.rst
+++ b/h2o-docs/src/product/starting-h2o.rst
@@ -6,9 +6,9 @@ There are a variety of ways to start H2O, depending on which client you would li
 From R
 ------
 
-Use the ``h2o.init()`` method to initialize H2O. This method accepts the following options. Note that in most cases, simply using ``h2o.init(nthreads=-1)`` is all that a user is required to do.
+Use the ``h2o.init()`` method to initialize H2O. This method accepts the following options. Note that in most cases, simply using ``h2o.init()`` is all that a user is required to do.
 
-- ``nthreads``: This launches H2O using all available CPUs and is only applicable if you launch H2O locally using R. If you start H2O locally outside of R or start H2O on Hadoop, the nthreads = -1 parameter is not applicable.
+- ``nthreads``: This launches H2O using all available CPUs and is only applicable if you launch H2O locally using R. If you start H2O locally outside of R or start H2O on Hadoop, the nthreads parameter is not applicable.
 - ``ip``: The IP address of the server where H2O is running.
 - ``port``: The port number of the H2O server.
 - ``startH2O``: (Optional) A logical value indicating whether to try to start H2O from R if no connection with H2O is detected. This is only possible if ``ip = "localhost"`` or ``ip = "127.0.0.1"``. If an existing connection is detected, R does not start H2O.
@@ -41,7 +41,7 @@ Example
 ::
 
   library h2o
-  h2o.init(nthreads=-1)
+  h2o.init()
 
   H2O is not running yet, starting it now...
 
@@ -262,11 +262,8 @@ H2O Options
 
 -	``-ice_root <fileSystemPath>``: Specify a directory for H2O to spill temporary data to disk (where ``<fileSystemPath>`` is the file path).
 -  ``-flow_dir <server-side or HDFS directory>``: Specify a directory for saved flows. The default is ``/Users/h2o-<H2OUserName>/h2oflows``(where ``<H2OUserName>`` is your user name).
--  ``-nthreads <#ofThreads>``: Specify the maximum number of threads in
-   the low-priority batch work queue (where ``<#ofThreads>`` is the
-   number of threads). The default is 99.
--  ``-client``: Launch H2O node in client mode. This is used mostly for
-   running Sparkling Water.
+-  ``-nthreads <#ofThreads>``: Specify the maximum number of threads in the low-priority batch work queue (where ``<#ofThreads>`` is the number of threads). 
+-  ``-client``: Launch H2O node in client mode. This is used mostly for running Sparkling Water.
 
 H2O Internal Communication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -136,7 +136,7 @@ At this point, determine whether you want to complete this quick start in either
     > library(h2o)
 
     # Run the following command to initialize H2O on your local machine (single-node cluster) using all available CPUs.
-    > h2o.init(nthreads=-1)
+    > h2o.init()
  
     # Import the Iris (with headers) dataset.
     > path <- "smalldata/iris/iris_wheader.csv"
@@ -522,7 +522,7 @@ Hadoop Launch Parameters
 -  ``-mapperXmx <per mapper Java Xmx heap size>``: Specify the amount of memory to allocate to H2O (at least 6g).
 -  ``-extramempercent <0-20>``: Specify the extra memory for internal JVM use outside of the Java heap. This is a percentage of ``mapperXmx``.
 -  ``-n | -nodes <number of H2O nodes>``: Specify the number of nodes.
--  ``-nthreads <maximum number of CPUs>``: Specify the number of CPUs to use. Enter ``-1`` to use all CPUs on the host, or enter a positive integer.
+-  ``-nthreads <maximum number of CPUs>``: Specify the number of CPUs to use. This defaults to using all CPUs on the host, or you can enter a positive integer.
 -  ``-baseport <initialization port for H2O nodes>``: Specify the initialization port for the H2O nodes. The default is ``54321``.
 -  ``-ea``: Enable assertions to verify boolean expressions for error detection.
 -  ``-verbose:gc``: Include heap and garbage collection information in the logs.


### PR DESCRIPTION
Remove nthreads=-1 from examples in the User Guide. This is now the default value, so it is not required.
Driveby fix: Fixed formatting for R examples in the min_prob and eps_prob parameter topics.