### PR TITLE
PUBDEV-4290: New Hadoop launch parameters in 3.10.5.1 documentation

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -507,6 +507,7 @@ Hadoop Launch Parameters
 
 -  ``-h | -help``: Display help
 -  ``-jobname <JobName>``: Specify a job name for the Jobtracker to use; the default is ``H2O_nnnnn`` (where n is chosen randomly)
+-  ``-principal <kerberos principal> -keytab <keytab path> | -run_as_user <hadoop username>``: Optionally specify a Kerberos principal and keytab or specify the ``run_as_user`` parameter to start clusters on behalf of the user/principal. Note that using ``run_as_user`` implies that the Hadoop cluster does not have Kerberos. 
 -  ``-driverif <IP address of mapper -> driver callback interface>``: Specify the IP address for callback messages from the mapper to the driver.
 -  ``-driverport <port of mapper -> callback interface>``: Specify the port number for callback messages from the mapper to the driver.
 -  ``-driverportrange <range portX-portY of mapper-> callback interface>``: Specify the allowed port range of the driver callback interface, eg. 50000-55000.


### PR DESCRIPTION
Added information about the new -principal and -run_as_user Hadoop launch parameters. This was added to the hadoop.rst file for 3.10.4.4. In 3.10.5.1, this topic is moved to the welcome.rst file.