### PR TITLE
PUBDEV-4211: Documentation clarification for downloading logs

### DIFF
--- a/h2o-docs/src/product/logs.rst
+++ b/h2o-docs/src/product/logs.rst
@@ -80,7 +80,10 @@ If you are not using Hadoop and the job is still running:
 
 --------------
 
--  To view the REST API logs from R:
+Logging in R
+~~~~~~~~~~~~
+
+To view the REST API logs from R:
 
  1. In R, enter ``h2o.startLogging()``. The output displays the location of the REST API logs:
 
@@ -111,11 +114,17 @@ If you are not using Hadoop and the job is still running:
             {"__meta":{"schema_version":    1,"schema_name":"CloudV1","schema_type":"Iced"},"version":"0.1.17.1009","cloud_name":...[truncated]}
             -------------------------------------------------------------
 
---------------
 
--  Download the logs using R. 
+To download the logs using R:
 
-   In R, enter the command ``h2o.downloadAllLogs(filename = "logs.zip")`` (where ``filename`` is the specified filename for the logs).
+   In R, enter the command ``h2o.downloadAllLogs(filename = "logs.zip")``, where ``filename`` is the specified filename for the logs. Note that you must include the .zip extension.
+
+Logging in Python
+~~~~~~~~~~~~~~~~~
+
+To download the logs using Python:
+  
+   In Python, enter the command ``h2o.download_all_logs(dirname='./your_directory_name/', filename = 'autoh2o_log.zip')``, where ``autoh2o_log.zip`` will download to a folder that is one down from where you are currently working into a directory called ``your_directory_name``. Please note that ``your_directory_name`` should be replaced with the name of a directory that you've created and that already exists.
 
 --------------
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -900,9 +900,14 @@ def download_all_logs(dirname=".", filename=None):
     Download H2O log files to disk.
 
     :param dirname: a character string indicating the directory that the log file should be saved in.
-    :param filename: a string indicating the name that the CSV file should be.
+    :param filename: a string indicating the name that the CSV file should be. Note that the saved format is .zip, so the file name must include the .zip extension.
 
-    :returns: path of logs written.
+    :returns: path of logs written in a zip file.
+
+    :examples: The following code will save the zip file `'autoh2o_log.zip'` in a directory that is one down from where you are currently working into a directory called `your_directory_name`. (Please note that `your_directory_name` should be replaced with the name of the directory that you've created and that already exists.)
+
+        >>> h2o.download_all_logs(dirname='./your_directory_name/', filename = 'autoh2o_log.zip')
+
     """
     assert_is_type(dirname, str)
     assert_is_type(filename, str, None)

--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -171,10 +171,14 @@ h2o.logAndEcho <- function(message) {
 
 #' Download H2O Log Files to Disk
 #'
-#' \code{h2o.downloadAllLogs} downloads all H2O log files to local disk. Generally used for debugging purposes.
+#' \code{h2o.downloadAllLogs} downloads all H2O log files to local disk in .zip format. Generally used for debugging purposes.
 #'
 #' @param dirname (Optional) A character string indicating the directory that the log file should be saved in.
-#' @param filename (Optional) A character string indicating the name that the log file should be saved to.
+#' @param filename (Optional) A character string indicating the name that the log file should be saved to. Note that the saved format is .zip, so the file name must include the .zip extension.
+#' @examples
+#' \donttest{
+#' h2o.downloadAllLogs(dirname='./your_directory_name/', filename = 'autoh2o_log.zip')
+#' }
 #' @export
 h2o.downloadAllLogs <- function(dirname = ".", filename = NULL) {
   if(!is.character(dirname) || length(dirname) != 1L || is.na(dirname) || !nzchar(dirname))


### PR DESCRIPTION
R, Python, and User Guide now all remind customers that the file name for downloading logs must include the .zip extension.