### PR TITLE
PUBDEV-4308 Fix in Rollupstats. Do not throw can not clean up rollups…

### DIFF
--- a/h2o-core/src/main/java/water/fvec/RollupStats.java
+++ b/h2o-core/src/main/java/water/fvec/RollupStats.java
@@ -467,11 +467,8 @@ final class RollupStats extends Iced {
               break;
             } catch (Exception e) {
               Log.err(e);
-              if (cleanupStats(nnn))
-                throw e;
-              else
-                throw new IllegalStateException("Unable to clean up RollupStats after an exception (see cause). " +
-                      "This could cause a key leakage, key=" + _rsKey, e);
+              cleanupStats(nnn);
+              throw e;
             }
           } // else someone else is modifying the rollups => try again
         }


### PR DESCRIPTION
… exception, throw the original cause instead even if rollups cleanup was not successful.