### PR TITLE
PUBDEV-4194: Added "word2vec" to list of algorithms on doc site

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -53,7 +53,7 @@
                 <div class="textwidget">
                   <a style="color:#ffffff;" href="http://www.h2o.ai/sparkling-water/"><img src="assets/images/sparkling-water.png" /><p>Sparkling Water allows users to combine the fast, scalable machine learning algorithms of H2O with the capabilities of Spark.</p></a>
                 </div>
-          </li>
+              </li>
               <li class='mega-menu-item mega-menu-item-type-widget widget_text mega-menu-columns-1-of-4 mega-menu-item-text-8' id='mega-menu-item-text-8'>
                 <div class="textwidget">
                   <a style="color:#ffffff;" href="http://www.h2o.ai/steam/"><img src="assets/images/steam.svg" /><p>Steam is an end-to-end platform that streamlines the entire process of building and deploying smart applications.</p></a>
@@ -81,7 +81,7 @@
                 <div class="textwidget">
                   <a style="color:#ffffff;" href="http://www.h2o.ai/insurance/"><img src="assets/images/insurance-icon.svg" /><h4>Insurance</h4><p>H2O AI automates insurance product recommendations and improves customer intelligence</p></a>
                 </div>
-          </li>
+              </li>
               <li class='mega-menu-item mega-menu-item-type-widget widget_text mega-menu-columns-1-of-3 mega-menu-item-text-5' id='mega-menu-item-text-5'>
                 <div class="textwidget">
                   <a style="color:#ffffff;" href="http://www.h2o.ai/healthcare/"><img src="assets/images/healthcare-icon.svg" /><h4>Healthcare</h4><p>H2O AI prescribes personalized medicine, saves patient lives and reduces cancer fatalities</p></a>
@@ -141,7 +141,7 @@
           <h4>H<sub>2</sub>O</h4>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 10px;">
               <a href="h2o-docs/welcome.html">What is H2O?</a>
-              <p style="margin: 0pt;"><a href="h2o-docs/index.html" style="font-weight: 500; font-size: 1.1em;">H2O User Guide</a> <style="font-color:black; font-size:0.9em;>(Main docs)</style="font-color:black;></p>
+              <p style="margin: 0pt;"><a href="h2o-docs/index.html" style="font-weight: 500; font-size: 1.1em;">H2O User Guide</a> <style="font-color:black; font-size:0.9em;">(Main docs)</style="font-color:black;"></p>
               <a href="http://shop.oreilly.com/product/0636920053170.do">H2O Book (O'Reilly)</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/Changes.md">Recent Changes</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/LICENSE">Open Source License (Apache V2)</a>
@@ -218,11 +218,10 @@
           <h4>Q &amp; A</h4>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 6px;">
             <a href="h2o-docs/faq.html">FAQ</a>
-            <a href="https://community.h2o.ai/index.html">Community Forum</a>
-            <a style="line-height: 1.3em"; href="https://groups.google.com/forum/#!forum/h2ostream">h2ostream Google Group</a>
             <a href="http://jira.h2o.ai">Issue Tracking (JIRA)</a>
-            <a href="https://gitter.im/h2oai/h2o-3">Gitter</a>
             <a href="http://stackoverflow.com/questions/tagged/h2o">Stack Overflow</a>
+            <a style="line-height: 1.3em"; href="https://groups.google.com/forum/#!forum/h2ostream">h2ostream Google Group</a>
+            <a href="https://gitter.im/h2oai/h2o-3">Gitter</a>
             <a href="http://stats.stackexchange.com/search?q=h2o">Cross Validated</a>
           </div>
           <hr>
@@ -243,7 +242,7 @@
     </div>
 
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-5">
         <div class="well well-sm">
           <h4>Supervised Learning</h4>
           <table class="table">
@@ -295,7 +294,7 @@
         </div>
       </div>
 
-      <div class="col-md-6">
+      <div class="col-md-4">
         <div class="well well-sm">
           <h4>Unsupervised Learning</h4>
           <table class="table">
@@ -319,7 +318,24 @@
           </table>
         </div>
       </div>
+        <div class="col-md-3">
+        <div class="well well-sm">
+          <h4>Miscellaneous</h4>
+          <table class="table">
+            <tbody class="lt-gry-bg1">
+            <tr>
+              <td style="width: 80%">Word2vec</td>
+              <td>Tutorial</td>
+              <td><a href="h2o-docs/data-science/word2vec.html">Reference</a></td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
+    </div>
+    
+
 
     <hr>
 


### PR DESCRIPTION
Adding word2vec to also list on the docs.h2o.ai site. Added this as a separate block with a Miscellaneous heading.
Driveby fix: removed “Community” link from list of resources.