### PR TITLE
PUBDEV-4283: performance measure on parsing categorical data.  Added …

### DIFF
--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
@@ -1,0 +1,61 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import time
+from tests import pyunit_utils
+import numpy
+#----------------------------------------------------------------------
+# This test is carried out to find out how the speed of parsing changes with
+# code from Vlad.
+#----------------------------------------------------------------------
+
+
+def hdfs_import_bigCat():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        numTimes = 10
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+        allFiles = ["/datasets/bigCatFiles/tenThousandCat10C.csv", "/datasets/bigCatFiles/hundredThousandCat10C.csv",
+                    "/datasets/bigCatFiles/oneMillionCat10C.csv", "/datasets/bigCatFiles/tenThousandCat100C.csv",
+                    "/datasets/bigCatFiles/hundredThousandCat100C.csv", "/datasets/bigCatFiles/oneMillionCat100C.csv",
+                    "/datasets/bigCatFiles/tenThousandCat1000C.csv",
+                    "/datasets/bigCatFiles/hundredThousandCat1000C.csv", "/datasets/bigCatFiles/oneMillionCat1000C.csv"]
+        reps = [10, 10, 10, 100, 100, 100, 1000, 1000, 1000]
+
+        for ind in range(0,len(allFiles)):  # run tests for 3 different sizes per Tomas request
+            print("*******  Parsing file {0} ********".format(allFiles[ind]))
+            runPerformance("hdfs://{0}{1}".format(hdfs_name_node, allFiles[ind]), numTimes, reps[ind])
+
+    else:
+        raise EnvironmentError
+
+
+def runPerformance(url_csv, numTimes, numRepeats):
+    columntypes = ["enum"]*numRepeats
+    runtimes = []
+
+    for ind in range(0, numTimes):
+        startcsv = time.time()
+        multi_file_csv = h2o.import_file(url_csv, na_strings=['\\N'], col_types=columntypes)
+        endcsv = time.time()
+
+        runtimes.append(endcsv-startcsv)
+        h2o.remove(multi_file_csv)  # remove file to save space
+
+    # write out summary run results
+    print("*******************************")
+    print("All run times {0}".format(runtimes))
+    arr = numpy.array(runtimes)
+    print(" Maximum run time is {0}, minimum run time is {1}".format(max(runtimes), min(runtimes)))
+    print("Mean run time is {0}, std is {1}".format(numpy.mean(arr, axis=0), numpy.std(arr, axis=0)))
+    print("*******************************")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_import_bigCat)
+else:
+    hdfs_import_bigCat()

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
@@ -22,10 +22,8 @@ def hdfs_import_bigCat():
         hdfs_name_node = pyunit_utils.hadoop_namenode()
         allFiles = ["/datasets/bigCatFiles/tenThousandCat10C.csv", "/datasets/bigCatFiles/hundredThousandCat10C.csv",
                     "/datasets/bigCatFiles/oneMillionCat10C.csv", "/datasets/bigCatFiles/tenThousandCat100C.csv",
-                    "/datasets/bigCatFiles/hundredThousandCat100C.csv", "/datasets/bigCatFiles/oneMillionCat100C.csv",
-                    "/datasets/bigCatFiles/tenThousandCat1000C.csv",
-                    "/datasets/bigCatFiles/hundredThousandCat1000C.csv", "/datasets/bigCatFiles/oneMillionCat1000C.csv"]
-        reps = [10, 10, 10, 100, 100, 100, 1000, 1000, 1000]
+                    "/datasets/bigCatFiles/hundredThousandCat100C.csv", "/datasets/bigCatFiles/oneMillionCat100C.csv"]
+        reps = [10, 10, 10, 100, 100, 100]
 
         for ind in range(0,len(allFiles)):  # run tests for 3 different sizes per Tomas request
             print("*******  Parsing file {0} ********".format(allFiles[ind]))

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
@@ -45,6 +45,7 @@ def runPerformance(url_csv, numTimes, numRepeats):
         endcsv = time.time()
 
         runtimes.append(endcsv-startcsv)
+        print("All run times {0}".format(runtimes))
         h2o.remove(multi_file_csv)  # remove file to save space
 
     # write out summary run results

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
@@ -22,10 +22,10 @@ def hdfs_import_bigCat():
         hdfs_name_node = pyunit_utils.hadoop_namenode()
         allFiles = ["/datasets/bigCatFiles/tenThousandCat10C.csv", "/datasets/bigCatFiles/hundredThousandCat10C.csv",
                     "/datasets/bigCatFiles/oneMillionCat10C.csv", "/datasets/bigCatFiles/tenThousandCat50C.csv",
-                    "/datasets/bigCatFiles/hundredThousandCat50C.csv",
-                    "/datasets/bigCatFiles/oneMillionCat50C.csv","/datasets/bigCatFiles/tenThousandCat100C.csv",
-                    "/datasets/bigCatFiles/hundredThousandCat100C.csv"]
-        reps = [10, 10, 10, 50, 50, 50, 100, 100]
+                    "/datasets/bigCatFiles/hundredThousandCat50C.csv","/datasets/bigCatFiles/tenThousandCat100C.csv",
+                    "/datasets/bigCatFiles/hundredThousandCat100C.csv",
+                    "/datasets/bigCatFiles/oneMillionCat50C.csv"]
+        reps = [10, 10, 10, 50, 50,  100, 100,50]
 
         for ind in range(0,len(allFiles)):  # run tests for 3 different sizes per Tomas request
             print("*******  Parsing file {0} ********".format(allFiles[ind]))

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py
@@ -21,9 +21,11 @@ def hdfs_import_bigCat():
         numTimes = 10
         hdfs_name_node = pyunit_utils.hadoop_namenode()
         allFiles = ["/datasets/bigCatFiles/tenThousandCat10C.csv", "/datasets/bigCatFiles/hundredThousandCat10C.csv",
-                    "/datasets/bigCatFiles/oneMillionCat10C.csv", "/datasets/bigCatFiles/tenThousandCat100C.csv",
-                    "/datasets/bigCatFiles/hundredThousandCat100C.csv", "/datasets/bigCatFiles/oneMillionCat100C.csv"]
-        reps = [10, 10, 10, 100, 100, 100]
+                    "/datasets/bigCatFiles/oneMillionCat10C.csv", "/datasets/bigCatFiles/tenThousandCat50C.csv",
+                    "/datasets/bigCatFiles/hundredThousandCat50C.csv",
+                    "/datasets/bigCatFiles/oneMillionCat50C.csv","/datasets/bigCatFiles/tenThousandCat100C.csv",
+                    "/datasets/bigCatFiles/hundredThousandCat100C.csv"]
+        reps = [10, 10, 10, 50, 50, 50, 100, 100]
 
         for ind in range(0,len(allFiles)):  # run tests for 3 different sizes per Tomas request
             print("*******  Parsing file {0} ********".format(allFiles[ind]))


### PR DESCRIPTION
added pyunit_INTERNAL_HDFS_import_bigCat_hdp2p2.py to test parser speed for categorical data.  This test only run on hdp2.2 mr-0xd cluster machines.

The actual test for this one is carried out here: http://mr-0xc1:8080/view/QE/job/hdp2.2_vlad_4222_performance_test/