### PR TITLE
Add Leave One Covariate Out (LOCO)

### DIFF
--- a/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
+++ b/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
@@ -19,26 +19,26 @@ public class LeaveOneCovarOutHandler extends Handler {
 
         final Frame frame = FramesHandler.getFromDKV("frame", args.frame.key());
         final Model model= ModelsHandler.getFromDKV("model",args.model.key());
-        String loco_frame_id = args.loco_frame_id;
-        final String replace_val = args.replace_val;
         assert model.isSupervised() : "Model " + model._key + " is not supervised.";
+        String locoFrameId = args.loco_frame_id;
+        final String replaceVal = args.replace_val;
 
-        if(loco_frame_id == null){
-            loco_frame_id = "loco_"+frame._key.toString() + "_" + model._key.toString();
+        if(locoFrameId == null){
+            locoFrameId = "loco_"+frame._key.toString() + "_" + model._key.toString();
         }
 
-        final Job<Frame> j = new Job(Key.make(loco_frame_id), Frame.class.getName(), "loco_prediction");
-        final String dest_frame_id = loco_frame_id;
+        final Job<Frame> job = new Job(Key.make(locoFrameId), Frame.class.getName(), "Conduct Leave One Covariate Out for each column in the frame");
+        final String dest_frame_id = locoFrameId;
         H2O.H2OCountedCompleter work = new H2O.H2OCountedCompleter() {
                 @Override
                 public void compute2() {
-                    LeaveOneCovarOut.leaveOneCovarOut(model,frame,j,replace_val,Key.make(dest_frame_id));
+                    LeaveOneCovarOut.leaveOneCovarOut(model,frame,job,replaceVal,Key.make(dest_frame_id));
                     tryComplete();
                 }
             };
 
-        j.start(work, model._output._names.length);
-        return new JobV3().fillFromImpl(j);
+        job.start(work, model._output._names.length);
+        return new JobV3().fillFromImpl(job);
     }
 
 }

--- a/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
+++ b/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
@@ -1,0 +1,46 @@
+package hex.api;
+
+import hex.mli.loco.LeaveOneCovarOut;
+import hex.schemas.LeaveOneCovarOutV3;
+import water.H2O;
+import water.Job;
+import water.api.FramesHandler;
+import hex.Model;
+import water.api.schemas3.JobV3;
+import water.fvec.Frame;
+import water.api.Handler;
+import water.api.ModelsHandler;
+import water.Key;
+import water.DKV;
+
+public class LeaveOneCovarOutHandler extends Handler {
+
+    public JobV3 getLoco(int version, final LeaveOneCovarOutV3 args) {
+
+        final Frame frame = FramesHandler.getFromDKV("frame", args.frame.key());
+        final Model model= ModelsHandler.getFromDKV("model",args.model.key());
+        String loco_frame_id = args.loco_frame_id;
+        final String replace_val = args.replace_val;
+        assert model.isSupervised() : "Model " + model._key + " is not supervised.";
+
+        if(loco_frame_id == null){
+            loco_frame_id = "loco_"+frame._key.toString() + "_" + model._key.toString();
+        }
+
+        final Job<Frame> j = new Job(Key.make(loco_frame_id), Frame.class.getName(), "loco_prediction");
+        final String dest_frame_id = loco_frame_id;
+        H2O.H2OCountedCompleter work = new H2O.H2OCountedCompleter() {
+                @Override
+                public void compute2() {
+                    Frame sensitivityAnalysisFrame = LeaveOneCovarOut.leaveOneCovarOut(model,frame,j,replace_val);
+                    sensitivityAnalysisFrame._key = Key.make(dest_frame_id);
+                    DKV.put(sensitivityAnalysisFrame._key,sensitivityAnalysisFrame);
+                    tryComplete();
+                }
+            };
+
+        j.start(work, model._output._names.length);
+        return new JobV3().fillFromImpl(j);
+    }
+
+}

--- a/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
+++ b/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
@@ -32,9 +32,7 @@ public class LeaveOneCovarOutHandler extends Handler {
         H2O.H2OCountedCompleter work = new H2O.H2OCountedCompleter() {
                 @Override
                 public void compute2() {
-                    Frame sensitivityAnalysisFrame = LeaveOneCovarOut.leaveOneCovarOut(model,frame,j,replace_val);
-                    sensitivityAnalysisFrame._key = Key.make(dest_frame_id);
-                    DKV.put(sensitivityAnalysisFrame._key,sensitivityAnalysisFrame);
+                    LeaveOneCovarOut.leaveOneCovarOut(model,frame,j,replace_val,Key.make(dest_frame_id));
                     tryComplete();
                 }
             };

--- a/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
+++ b/h2o-algos/src/main/java/hex/api/LeaveOneCovarOutHandler.java
@@ -11,7 +11,6 @@ import water.fvec.Frame;
 import water.api.Handler;
 import water.api.ModelsHandler;
 import water.Key;
-import water.DKV;
 
 public class LeaveOneCovarOutHandler extends Handler {
 

--- a/h2o-algos/src/main/java/hex/api/RegisterAlgos.java
+++ b/h2o-algos/src/main/java/hex/api/RegisterAlgos.java
@@ -67,5 +67,8 @@ public class RegisterAlgos extends water.api.AbstractRegister {
 
     H2O.register("POST /3/DataInfoFrame",MakeGLMModelHandler.class, "getDataInfoFrame", "glm_datainfo_frame",
         "Test only");
+
+    H2O.register("POST /3/LeaveOneCovarOut", LeaveOneCovarOutHandler.class, "getLoco","loco",
+            "Conduct Leave One Covariate Out (LOCO) Analysis");
   }
 }

--- a/h2o-algos/src/main/java/hex/mli/loco/LeaveOneCovarOut.java
+++ b/h2o-algos/src/main/java/hex/mli/loco/LeaveOneCovarOut.java
@@ -1,0 +1,236 @@
+package hex.mli.loco;
+
+import hex.Model;
+import hex.ModelCategory;
+import water.MRTask;
+import water.ParallelizationTask;
+import water.exceptions.H2OIllegalArgumentException;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.fvec.NewChunk;
+import water.fvec.Vec;
+import water.DKV;
+import water.H2O;
+import water.util.Log;
+import water.Iced;
+import water.Job;
+import water.rapids.ast.prims.reducers.AstMedian;
+import hex.quantile.QuantileModel.CombineMethod;
+
+/**
+ * Leave One Covariate Out (LOCO)
+ *
+ * Calculates row-wise variable importance's by re-scoring a trained supervised model and measuring the impact of setting
+ * each variable to missing or it’s most central value(mean or median & mode for categorical's)
+ *
+ */
+public class LeaveOneCovarOut extends Iced {
+
+    /**
+     * Conduct Leave One Covariate Out (LOCO) given a model, frame, job, and replacement value
+     * @param m Supervised H2O model
+     * @param fr H2O Frame to score
+     * @param job Job to keep track of in terms of progress
+     * @param replaceVal Value to replace column by when conducting LOCO ("mean" or "median"). Default is null
+     * @return  An H2OFrame displaying the base prediction (model scored with all predictors) and the difference in predictions
+     *          when variables are dropped/replaced. The difference displayed is the base prediction substracted from
+     *          the new prediction (when a variable is dropped/replaced with mean/median/mode) for binomial classification
+     *          and regression problems. For multinomial problems, the sum of the absolute value of differences across classes
+     *          is calculated per column dropped/replaced.
+     */
+    public static Frame leaveOneCovarOut(Model m, Frame fr, Job job, String replaceVal){
+
+        Frame locoAnalysisFrame = new Frame();
+        if(m._output.getModelCategory() != ModelCategory.Multinomial) {
+            locoAnalysisFrame.add("base_pred", getBasepredictions(m, fr)[0]);
+        } else {
+            locoAnalysisFrame.add(new Frame(getBasepredictions(m, fr)));
+            locoAnalysisFrame._names[0] = "base_pred";
+        }
+
+        String[] predictors = m._output._names;
+
+        LeaveOneCovariateOutDriver[] tasks = new LeaveOneCovariateOutDriver[predictors.length-1];
+
+        for(int i = 0; i < tasks.length; i++){
+            tasks[i] = new LeaveOneCovariateOutDriver(locoAnalysisFrame,fr,m,predictors[i],replaceVal);
+        }
+
+        ParallelizationTask locoCollector = new ParallelizationTask<>(tasks, job);
+        long start = System.currentTimeMillis();
+        Log.info("Starting Leave One Covariate Out (LOCO) analysis for model " + m._key + " and frame " + fr._key);
+        H2O.submitTask(locoCollector).join();
+
+        if(m._output.getModelCategory() == ModelCategory.Multinomial){
+            int[] colsToRemove = new int[locoAnalysisFrame.numCols()-1];
+            for(int i =0; i<colsToRemove.length; i++){
+                colsToRemove[i] = i+1;
+            }
+            locoAnalysisFrame.remove(colsToRemove);
+        }
+
+        for (int i = 0; i < tasks.length; i++) {
+            locoAnalysisFrame.add("rc_" + tasks[i]._predictor, tasks[i]._result[0]);
+        }
+        Log.info("Finished Leave One Covariate Out (LOCO) analysis for model " + m._key + " and frame " + fr._key +
+                " in " + (System.currentTimeMillis()-start)/1000. + " seconds for " + (predictors.length-1) + " columns");
+
+        return locoAnalysisFrame;
+
+    }
+
+    private static class LeaveOneCovariateOutDriver extends H2O.H2OCountedCompleter<LeaveOneCovariateOutDriver>{
+
+        private final Frame _locoFrame;
+        private final Frame _frame;
+        private final Model _model;
+        private final String _predictor;
+        private final String _replaceVal;
+        Vec[] _result;
+
+        public LeaveOneCovariateOutDriver(Frame locoFrame, Frame fr, Model m, String predictor, String replaceVal){
+            _locoFrame = locoFrame;
+            _frame = fr;
+            _model = m;
+            _predictor = predictor;
+            _replaceVal = replaceVal;
+        }
+
+        @Override
+        public void compute2() {
+            if(_model._output.getModelCategory() == ModelCategory.Multinomial){
+                Vec[] predTmp = getNewPredictions(_model,_frame,_predictor,_replaceVal);
+                Frame tmpFrame = new Frame().add(_locoFrame).add(new Frame(predTmp));
+                _result = new MultiDiffTask(_model._output.nclasses()).doAll(Vec.T_NUM, tmpFrame).outputFrame().vecs();
+                for (Vec v : predTmp) v.remove();
+            } else {
+                _result = getNewPredictions(_model, _frame, _predictor,_replaceVal);
+                new DiffTask().doAll(_locoFrame.vec(0), _result[0]);
+            }
+            Log.info("Completed Leave One Covariate Out (LOCO) Analysis for column: " + _predictor);
+            tryComplete();
+        }
+
+    }
+
+    /**
+     * Get base predictions given a model and frame. "Base predictions" are predictions based on all features in the
+     * model
+     * @param m An H2O supervised model
+     * @param fr A Frame to score on
+     * @return An array of Vecs containing predictions
+     */
+    private static Vec[] getBasepredictions(Model m, Frame fr){
+
+        Frame basePredsFr = m.score(fr,null,null,false);
+
+        if(m._output.getModelCategory() == ModelCategory.Binomial) {
+            Vec basePreds = basePredsFr.remove(2);
+            basePredsFr.delete();
+            return new Vec[] {basePreds};
+        }else if(m._output.getModelCategory() == ModelCategory.Multinomial){
+            Vec[] basePredsVecs = basePredsFr.vecs();
+            DKV.remove(basePredsFr._key);
+            return basePredsVecs;
+        } else {
+            Vec basePreds = basePredsFr.remove(0);
+            basePredsFr.delete();
+            return new Vec[] {basePreds};
+        }
+
+    }
+
+    /**
+     * Get new predictions based on dropping/replacing a column with mean, median, or mode
+     * @param m An H2O supervised model
+     * @param fr A Frame to score on
+     * @param colToDrop Column to modify/drop before prediction
+     * @param valToReplace Value to replace colToDrop by (Default is null)
+     * @return
+     */
+    private static Vec[] getNewPredictions(Model m, Frame fr, String colToDrop, String valToReplace) {
+        Frame workerFrame = new Frame(fr);
+        Vec vecToReplace = fr.vec(colToDrop);
+        Vec replacementVec = null;
+        if(valToReplace == null){
+            replacementVec = vecToReplace.makeCon(Double.NaN);
+        } else if(valToReplace.equals("mean")){
+            if(vecToReplace.isCategorical()){
+                Vec tmpVec = vecToReplace.makeCon(vecToReplace.mode());
+                replacementVec = tmpVec.toCategoricalVec(); //Can only get mode for categoricals
+                tmpVec.remove();
+            } else {
+                replacementVec = vecToReplace.makeCon(vecToReplace.mean());
+            }
+        } else if(valToReplace.equals("median")){
+            if(vecToReplace.isCategorical()){
+                Vec tmpVec = vecToReplace.makeCon(vecToReplace.mode());
+                replacementVec = tmpVec.toCategoricalVec();  //Can only get mode for categoricals
+                tmpVec.remove();
+            } else {
+                Frame tmpFr = new Frame(vecToReplace);
+                double median = AstMedian.median(tmpFr, CombineMethod.AVERAGE);
+                replacementVec = vecToReplace.makeCon(median);
+            }
+        } else {
+            throw new H2OIllegalArgumentException("Invalid value to replace columns in LOCO. Got " + valToReplace);
+        }
+        int vecToDropIdx = fr.find(colToDrop);
+        workerFrame.replace(vecToDropIdx,replacementVec);
+        DKV.put(workerFrame);
+        Frame modifiedPredictionsFr = m.score(workerFrame,null,null,false);
+        try {
+            if (m._output.getModelCategory() == ModelCategory.Binomial) {
+                Vec modifiedPrediction = modifiedPredictionsFr.remove(2);
+                modifiedPredictionsFr.delete();
+                return new Vec[] {modifiedPrediction};
+            } else if(m._output.getModelCategory() == ModelCategory.Multinomial){
+                Vec[] vecs = modifiedPredictionsFr.vecs();
+                DKV.remove(modifiedPredictionsFr._key);
+                return vecs;
+            } else {
+                Vec modifiedPrediction = modifiedPredictionsFr.remove(0);
+                modifiedPredictionsFr.delete();
+                return new Vec[] {modifiedPrediction};
+            }
+        } finally{
+            DKV.remove(workerFrame._key);
+            replacementVec.remove();
+        }
+
+    }
+
+    private static class DiffTask extends MRTask<DiffTask>{
+        @Override public void map(Chunk[] c) {
+            Chunk _basePred = c[0];
+            for(int chnk = 1; chnk < c.length; chnk++){
+                for(int row = 0; row < c[0]._len; row++){
+                    c[chnk].set(row, c[chnk].atd(row) - _basePred.atd(row));
+                }
+            }
+        }
+    }
+
+    private static class MultiDiffTask extends MRTask<MultiDiffTask>{
+
+        private final int _numClasses;
+
+        public MultiDiffTask(int numClasses){
+            _numClasses = numClasses;
+        }
+
+        @Override
+        public void map(Chunk[] cs, NewChunk nc) {
+            for (int i = 0; i < cs[0]._len; i++) {
+                double d = 0;
+                for (int j = 1; j < _numClasses+1; j++) {
+                    double val = cs[j + _numClasses+1].atd(i) - cs[j].atd(i);
+                    d += Math.abs(val);
+                }
+                nc.addNum(d);
+            }
+        }
+    }
+}
+
+

--- a/h2o-algos/src/main/java/hex/schemas/LeaveOneCovarOutV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/LeaveOneCovarOutV3.java
@@ -1,0 +1,22 @@
+package hex.schemas;
+
+import water.Iced;
+import water.api.API;
+import water.api.schemas3.KeyV3;
+import water.api.schemas3.SchemaV3;
+
+public class LeaveOneCovarOutV3 extends SchemaV3<Iced, LeaveOneCovarOutV3> {
+
+    @API(help="input supervised model", required = true, direction = API.Direction.INPUT)
+    public KeyV3.ModelKeyV3 model;
+
+    @API(help="input frame",required = true, direction = API.Direction.INPUT)
+    public KeyV3.FrameKeyV3 frame;
+
+    @API(help="Value to replace columns in LOCO analysis",required = false, direction = API.Direction.INPUT)
+    public String replace_val;
+
+    @API(help="Destination id for this LOCO job; auto-generated if not specified.", direction = API.Direction.INOUT, required = false)
+    public String loco_frame_id;
+
+}

--- a/h2o-algos/src/test/java/hex/mli/LeaveOneCovarOutTest.java
+++ b/h2o-algos/src/test/java/hex/mli/LeaveOneCovarOutTest.java
@@ -3,6 +3,7 @@ package hex.mli;
 import hex.genmodel.utils.DistributionFamily;
 import hex.mli.loco.LeaveOneCovarOut;
 import hex.tree.gbm.GBM;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import water.DKV;
@@ -110,11 +111,14 @@ public class LeaveOneCovarOutTest extends TestUtil {
             gbm = job.trainModel().get();
 
             if(method == null) {
-                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, null);
+                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, null,null);
+                assert DKV.get(loco._key) != null : "LOCO frame with default transform is not in DKV!";
             } else if(method == "mean"){
-                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, "mean");
+                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, "mean",null);
+                assert DKV.get(loco._key) != null : "LOCO frame with mean transform is not in DKV!";
             } else{
-                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, "median");
+                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, "median",null);
+                assert DKV.get(loco._key) != null : "LOCO frame with median transform is not in DKV!";
             }
             return loco;
 

--- a/h2o-algos/src/test/java/hex/mli/LeaveOneCovarOutTest.java
+++ b/h2o-algos/src/test/java/hex/mli/LeaveOneCovarOutTest.java
@@ -1,0 +1,129 @@
+package hex.mli;
+
+import hex.genmodel.utils.DistributionFamily;
+import hex.mli.loco.LeaveOneCovarOut;
+import hex.tree.gbm.GBM;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.DKV;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import hex.tree.gbm.GBMModel;
+import static hex.genmodel.utils.DistributionFamily.gaussian;
+import static hex.genmodel.utils.DistributionFamily.multinomial;
+import static hex.genmodel.utils.DistributionFamily.bernoulli;
+
+/**
+ * This Junit is mainly used to detect leaks in Leave One Covariate Out (LOCO)
+ */
+public class LeaveOneCovarOutTest extends TestUtil {
+
+    @BeforeClass()
+    public static void setup() { stall_till_cloudsize(1); }
+
+    @Test
+    public void testLocoRegressionDefault() {
+        //Regression case
+        locoRun("./smalldata/junit/cars.csv", "economy (mpg)", gaussian,null);
+    }
+
+    @Test
+    public void testLocoBernoulliDefault() {
+        //Bernoulli case
+        locoRun("./smalldata/logreg/prostate.csv", "CAPSULE", bernoulli,null);
+
+    }
+
+    @Test
+    public void testLocoMultinomialDefault(){
+        //Multinomial case
+        locoRun("./smalldata/junit/cars.csv", "cylinders", multinomial,null);
+    }
+
+    @Test
+    public void testLocoRegressionMean() {
+        //Regression case
+        locoRun("./smalldata/junit/cars.csv", "economy (mpg)", gaussian,"mean");
+    }
+
+    @Test
+    public void testLocoBernoulliMean() {
+        //Bernoulli case
+        locoRun("./smalldata/logreg/prostate.csv", "CAPSULE", bernoulli,"mean");
+
+    }
+
+    @Test
+    public void testLocoMultinomialMean(){
+        //Multinomial case
+        locoRun("./smalldata/junit/cars.csv", "cylinders", multinomial,"mean");
+    }
+
+    @Test
+    public void testLocoRegressionMedian() {
+        //Regression case
+        locoRun("./smalldata/junit/cars.csv", "economy (mpg)", gaussian,"median");
+    }
+
+    @Test
+    public void testLocoBernoulliMedian() {
+        //Bernoulli case
+        locoRun("./smalldata/logreg/prostate.csv", "CAPSULE", bernoulli,"median");
+
+    }
+
+    @Test
+    public void testLocoMultinomialMedian(){
+        //Multinomial case
+        locoRun("./smalldata/junit/cars.csv", "cylinders", multinomial,"median");
+    }
+
+    public Frame locoRun(String fname, String response, DistributionFamily family, String method) {
+        GBMModel gbm = null;
+        Frame fr = null;
+        Frame loco=null;
+        try {
+            Scope.enter();
+            fr = parse_test_file(fname);
+            int idx = fr.find(response);
+            if (family == DistributionFamily.bernoulli || family == DistributionFamily.multinomial || family == DistributionFamily.modified_huber) {
+                if (!fr.vecs()[idx].isCategorical()) {
+                    Scope.track(fr.replace(idx, fr.vecs()[idx].toCategoricalVec()));
+                }
+            }
+            DKV.put(fr);             // Update frame after hacking it
+
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            if( idx < 0 ) idx = ~idx;
+            parms._train = fr._key;
+            parms._response_column = fr._names[idx];
+            parms._ntrees = 5;
+            parms._distribution = family;
+            parms._max_depth = 4;
+            parms._min_rows = 1;
+            parms._nbins = 50;
+            parms._learn_rate = .2f;
+            parms._score_each_iteration = true;
+
+            GBM job = new GBM(parms);
+            gbm = job.trainModel().get();
+
+            if(method == null) {
+                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, null);
+            } else if(method == "mean"){
+                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, "mean");
+            } else{
+                loco = LeaveOneCovarOut.leaveOneCovarOut(gbm, fr, job._job, "median");
+            }
+            return loco;
+
+        } finally {
+            if( fr  != null ) fr.remove();
+            if( gbm != null ) gbm.delete();
+            if( loco != null ) loco.remove();
+            Scope.exit();
+        }
+    }
+
+}

--- a/h2o-algos/src/test/java/hex/mli/LeaveOneCovarOutTest.java
+++ b/h2o-algos/src/test/java/hex/mli/LeaveOneCovarOutTest.java
@@ -3,7 +3,6 @@ package hex.mli;
 import hex.genmodel.utils.DistributionFamily;
 import hex.mli.loco.LeaveOneCovarOut;
 import hex.tree.gbm.GBM;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import water.DKV;

--- a/h2o-core/src/main/java/water/ParallelizationTask.java
+++ b/h2o-core/src/main/java/water/ParallelizationTask.java
@@ -1,7 +1,5 @@
 package water;
 
-import jsr166y.CountedCompleter;
-
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ParallelizationTask<T extends H2O.H2OCountedCompleter<T>> extends H2O.H2OCountedCompleter {
@@ -42,12 +40,6 @@ public class ParallelizationTask<T extends H2O.H2OCountedCompleter<T>> extends H
             int i = _ctr.incrementAndGet();
             if (i < _tasks.length)
                 asyncVecTask(i);
-        }
-
-        @Override
-        public boolean onExceptionalCompletion(Throwable ex, CountedCompleter caller) {
-            ex.printStackTrace();
-            return super.onExceptionalCompletion(ex, caller);
         }
     }
 }

--- a/h2o-core/src/main/java/water/ParallelizationTask.java
+++ b/h2o-core/src/main/java/water/ParallelizationTask.java
@@ -1,0 +1,53 @@
+package water;
+
+import jsr166y.CountedCompleter;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ParallelizationTask<T extends H2O.H2OCountedCompleter<T>> extends H2O.H2OCountedCompleter {
+    private final AtomicInteger _ctr; // Concurrency control
+    private static int DEFAULT_MAX_PARALLEL_TASKS = -1;
+    private final T[] _tasks; // Task holder
+    private final Job _j; //Keep track of job progress
+    transient private int _maxParallelTasks;
+
+    public ParallelizationTask(T[] tasks, Job j) {
+        this(tasks, DEFAULT_MAX_PARALLEL_TASKS, j);
+    }
+
+    public ParallelizationTask(T[] tasks, int maxParallelTasks, Job j) {
+        _maxParallelTasks = maxParallelTasks > 0 ? maxParallelTasks : H2O.SELF._heartbeat._num_cpus;
+        _ctr = new AtomicInteger(_maxParallelTasks - 1);
+        _tasks = tasks;
+        _j = j;
+    }
+
+    @Override public void compute2() {
+        final int nTasks = _tasks.length;
+        addToPendingCount(nTasks-1);
+        for (int i=0; i < Math.min(_maxParallelTasks, nTasks); ++i) asyncVecTask(i);
+    }
+
+    private void asyncVecTask(final int task) {
+        _tasks[task].setCompleter(new Callback());
+        _tasks[task].fork();
+    }
+
+    private class Callback extends H2O.H2OCallback{
+        public Callback(){super(ParallelizationTask.this);}
+        @Override public void callback(H2O.H2OCountedCompleter cc) {
+            if(_j != null) {
+                _j.update(1);
+            }
+            int i = _ctr.incrementAndGet();
+            if (i < _tasks.length)
+                asyncVecTask(i);
+        }
+
+        @Override
+        public boolean onExceptionalCompletion(Throwable ex, CountedCompleter caller) {
+            ex.printStackTrace();
+            return super.onExceptionalCompletion(ex, caller);
+        }
+    }
+}

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -201,7 +201,7 @@ class ModelBase(backwards_compatible()):
           >>>
           >>> iris_h2o = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
           >>> g = h2o.h2o.H2OGradientBoostingEstimator()
-          >>> g.train(x=range(1,5),y="species",training_frame=fr)
+          >>> g.train(x=list(range(0,4)),y="C5",training_frame=iris_h2o)
           >>> g.loco(fr)
           >>> g.loco(fr, replace_val="mean")
           >>> g.loco(fr,replace_val="median")

--- a/h2o-py/tests/testdir_algos/loco/pyunit_loco_binomial.py
+++ b/h2o-py/tests/testdir_algos/loco/pyunit_loco_binomial.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def loco_binomial():
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+
+    # Remove ID from training frame
+    train = df.drop("ID")
+
+    # For VOL & GLEASON, a zero really means "missing"
+    vol = train['VOL']
+    vol[vol == 0] = None
+    gle = train['GLEASON']
+    gle[gle == 0] = None
+
+    # Convert CAPSULE to a logical factor
+    train['CAPSULE'] = train['CAPSULE'].asfactor()
+    g = h2o.h2o.H2OGradientBoostingEstimator()
+    g.train(x=list(range(1, train.ncol)), y="CAPSULE",training_frame=train)
+
+    #Run LOCO
+    g.loco(df)
+    g.loco(df, replace_val="mean")
+    g.loco(df, replace_val="median")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(loco_binomial)
+else:
+    loco_binomial()

--- a/h2o-py/tests/testdir_algos/loco/pyunit_loco_multinomial.py
+++ b/h2o-py/tests/testdir_algos/loco/pyunit_loco_multinomial.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def loco_multinomial():
+    iris_h2o = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+    g = h2o.h2o.H2OGradientBoostingEstimator()
+    g.train(x=list(range(0,4)),y="C5",training_frame=iris_h2o)
+
+    #Run LOCO
+    g.loco(iris_h2o)
+    g.loco(iris_h2o, replace_val="mean")
+    g.loco(iris_h2o, replace_val="median")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(loco_multinomial)
+else:
+    loco_multinomial()

--- a/h2o-py/tests/testdir_algos/loco/pyunit_loco_regression.py
+++ b/h2o-py/tests/testdir_algos/loco/pyunit_loco_regression.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def loco_regression():
+   iris_h2o = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+   g = h2o.h2o.H2OGradientBoostingEstimator()
+   g.train(x=list(range(0,3)),y="C4",training_frame=iris_h2o)
+
+   #Run LOCO
+   g.loco(iris_h2o)
+   g.loco(iris_h2o, replace_val="mean")
+   g.loco(iris_h2o, replace_val="median")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(loco_regression)
+else:
+    loco_regression()

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3027,9 +3027,12 @@ h2o.deepfeatures <- function(object, data, layer) {
 #' h2o.init()
 #' fr <- as.h2o(iris)
 #' g <- h2o.gbm(1:3,4,fr)
-#' h2o.loco(g,fr) #Dropping each column iteratively and score.
-#' h2o.loco(g,fr,replace_val = "mean") #Replace each column by its mean (mode for categoricals) iteratively and score.
-#' h2o.loco(g,fr,replace_val = "median") #Replace each column by its median (mode for categoricals) iteratively and score.
+#' #Dropping each column iteratively and score.
+#' h2o.loco(g,fr)
+#' #Replace each column by its mean (mode for categoricals) iteratively and score.
+#' h2o.loco(g,fr,replace_val = "mean")
+#' #Replace each column by its median (mode for categoricals) iteratively and score.
+#' h2o.loco(g,fr,replace_val = "median")
 #' }
 #' @export
 h2o.loco <- function(model, frame, loco_frame_id, replace_val){

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3011,7 +3011,7 @@ h2o.deepfeatures <- function(object, data, layer) {
 #' Leave One Covariate Out (LOCO)
 #'
 #' Calculates row-wise variable importance's by re-scoring a trained supervised model and measuring the impact of setting
-#' each variable to missing or it’s most central value(mean or median & mode for categorical's)
+#' each variable to missing or it's most central value(mean or median & mode for categorical's)
 #' @param model A supervised H2O model
 #' @param frame An H2OFrame to score
 #' @param loco_frame_id Destination id for this job; auto-generated if not specified.

--- a/h2o-r/scripts/h2o-r-test-setup.R
+++ b/h2o-r/scripts/h2o-r-test-setup.R
@@ -157,7 +157,7 @@ function() {
 
         # source h2o-r/tests/runitUtils
         to_src <- c("utilsR.R", "pcaR.R", "deeplearningR.R", "glmR.R", "glrmR.R", "gbmR.R", "kmeansR.R",
-                    "naivebayesR.R", "gridR.R", "shared_javapredict.R")
+                    "naivebayesR.R", "gridR.R", "shared_javapredict.R","locoR.R")
         src_path <- paste(h2oRDir,"tests","runitUtils",sep=.Platform$file.sep)
         invisible(lapply(to_src,function(x){source(paste(src_path, x, sep = .Platform$file.sep))}))
 

--- a/h2o-r/tests/runitUtils/locoR.R
+++ b/h2o-r/tests/runitUtils/locoR.R
@@ -1,0 +1,95 @@
+r.loco <- function(model, record, replace_val=NULL,regression=TRUE) {
+
+    # Get Features
+    features <- model@parameters$x
+
+    # Get Prediction
+    if(regression){
+        base_prediction <- as.matrix(h2o.predict(model, record)$predict)
+    }else{
+        base_prediction <- as.matrix(h2o.predict(model, record)$p1)
+    }
+
+    # Get Predictions in each feature was replaced with NA
+    predictions <- NULL
+
+    for(i in features){
+        altered_record <- record
+        altered_record[i] <- NA
+
+        if(regression){
+            new_prediction <- as.matrix(h2o.predict(model, altered_record)$predict)[, 1]
+        }else{
+            new_prediction <- as.matrix(h2o.predict(model, altered_record)$p1)[, 1]
+        }
+
+        new_prediction <- data.frame('VariableRemoved' = i,
+        'BaseProbability' = base_prediction[1,],
+        'NewProbability' = new_prediction,
+        stringsAsFactors = FALSE)
+        predictions <- rbind(predictions, new_prediction)
+    }
+
+    rownames(predictions) <- NULL
+
+
+    # Get Effect of each feature on the prediction
+    predictions$EffectOnProbability <- predictions$NewProbability - base_prediction
+    loco_predictions <- t(predictions$EffectOnProbability)
+    loco_predictions <- cbind(base_prediction[1,],loco_predictions)
+    colnames(loco_predictions) = c("base_pred",paste0("rc_",predictions$VariableRemoved))
+    rownames(loco_predictions) <- NULL
+    loco_predictions <- as.data.frame(loco_predictions)
+    return(loco_predictions)
+}
+
+r.loco.multinomial <-function(model,record){
+    preds = h2o.predict(model,record)
+
+    preds_prob = preds[,2:4]
+    preds_prob <- as.matrix(preds_prob)
+    # Get Features
+    features <- model@parameters$x
+    predictions <- NULL
+    for(i in features){
+        altered_record <- record
+        altered_record[i] <- NA
+        new_prediction <- as.matrix(as.numeric(h2o.predict(model, altered_record)))
+        new_prediction <- new_prediction[,2:4]
+        diff = sum(abs(new_prediction-preds_prob[1,]))
+        new_prediction <- data.frame('VariableRemoved' = i,
+        'diff' = diff,
+        stringsAsFactors = FALSE)
+        predictions <- rbind(predictions, new_prediction)
+    }
+    loco_predictions <- t(predictions$diff)
+    loco_predictions <- cbind(as.data.frame(preds["predict"]),loco_predictions)
+    colnames(loco_predictions) = c("base_pred",paste0("rc_",predictions$VariableRemoved))
+    rownames(loco_predictions) <- NULL
+    loco_predictions <- as.data.frame(loco_predictions)
+    return(loco_predictions)
+}
+
+run_loco_r <- function(model, df, regression=TRUE){
+    for(i in (1:nrow(df))){
+        if(i == 1){
+            pred = r.loco(model,df[i, ],regression=regression)
+        }else{
+            pred = rbind(pred,r.loco(model, df[i, ],regression=regression))
+        }
+
+    }
+    return(pred)
+}
+
+run_loco_r_mult <- function(model, df){
+    for(i in (1:nrow(df))){
+        if(i == 1){
+            pred = r.loco.multinomial(model,df[i, ])
+        }else{
+            pred = rbind(pred,r.loco.multinomial(model,df[i, ]))
+        }
+
+    }
+    return(pred)
+}

--- a/h2o-r/tests/testdir_algos/loco/runit_loco_binomial.R
+++ b/h2o-r/tests/testdir_algos/loco/runit_loco_binomial.R
@@ -19,6 +19,11 @@ test.loco.binomial <- function(){
 
     expect_equal(as.data.frame(h2o_loco),r_loco)
 
+    #Run LOCO with replace_val set to "mean" and "median"
+    h2o_loco_mean <- h2o.loco(gbm, pros.hex,replace_val="mean")
+    h2o_loco_median <- h2o.loco(gbm, pros.hex,replace_val="median")
+
+
 }
 
 doTest("LOCO Test", test.loco.binomial)

--- a/h2o-r/tests/testdir_algos/loco/runit_loco_binomial.R
+++ b/h2o-r/tests/testdir_algos/loco/runit_loco_binomial.R
@@ -1,0 +1,24 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.loco.binomial <- function(){
+    pros.hex <- h2o.uploadFile(locate("smalldata/prostate/prostate.csv.zip"))
+
+    #Sample data
+    pros.hex = pros.hex[1:150,]
+    pros.hex[,2] = as.factor(pros.hex[,2])
+
+    #Build GBM (Binomial)
+    gbm <- h2o.gbm(3:9,2,pros.hex)
+
+    #GBM LOCO (Binomial)
+    h2o_loco <- h2o.loco(gbm,pros.hex)
+
+    #R version of LOCO
+    r_loco <- run_loco_r(gbm,pros.hex,regression=FALSE)
+
+    expect_equal(as.data.frame(h2o_loco),r_loco)
+
+}
+
+doTest("LOCO Test", test.loco.binomial)

--- a/h2o-r/tests/testdir_algos/loco/runit_loco_multinomial.R
+++ b/h2o-r/tests/testdir_algos/loco/runit_loco_multinomial.R
@@ -14,6 +14,10 @@ test.loco.multinomial <- function(){
     r_loco <- run_loco_r_mult(gbm,iris.hex)
     expect_equal(as.data.frame(h2o_loco),r_loco)
 
+    #Run LOCO with replace_val set to "mean" and "median"
+    h2o_loco_mean <- h2o.loco(gbm, iris.hex,replace_val="mean")
+    h2o_loco_median <- h2o.loco(gbm, iris.hex,replace_val="median")
+
 }
 
 doTest("LOCO Test", test.loco.multinomial)

--- a/h2o-r/tests/testdir_algos/loco/runit_loco_multinomial.R
+++ b/h2o-r/tests/testdir_algos/loco/runit_loco_multinomial.R
@@ -1,0 +1,19 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.loco.multinomial <- function(){
+    iris.hex <- as.h2o(iris)
+
+    #Build GBM (Multinomial)
+    gbm <- h2o.gbm(1:4,5,iris.hex)
+
+    #GBM LOCO (Multinomial)
+    h2o_loco <- h2o.loco(gbm,iris.hex)
+
+    #R version of LOCO
+    r_loco <- run_loco_r_mult(gbm,iris.hex)
+    expect_equal(as.data.frame(h2o_loco),r_loco)
+
+}
+
+doTest("LOCO Test", test.loco.multinomial)

--- a/h2o-r/tests/testdir_algos/loco/runit_loco_regression.R
+++ b/h2o-r/tests/testdir_algos/loco/runit_loco_regression.R
@@ -16,6 +16,10 @@ test.loco.regression <- function(){
 
     expect_equal(as.data.frame(h2o_loco),r_loco)
 
+    #Run LOCO with replace_val set to "mean" and "median"
+    h2o_loco_mean <- h2o.loco(gbm, iris.hex,replace_val="mean")
+    h2o_loco_median <- h2o.loco(gbm, iris.hex,replace_val="median")
+
 
 }
 

--- a/h2o-r/tests/testdir_algos/loco/runit_loco_regression.R
+++ b/h2o-r/tests/testdir_algos/loco/runit_loco_regression.R
@@ -1,0 +1,22 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.loco.regression <- function(){
+    iris.hex <- as.h2o(iris)
+    iris.hex[,5] = as.factor(iris.hex[,5])
+
+    #Build GBM (Regression)
+    gbm <- h2o.gbm(c(1:3,5),4,iris.hex)
+
+    #GBM LOCO (Regression)
+    h2o_loco <- h2o.loco(gbm,iris.hex)
+
+    #R version of LOCO
+    r_loco <- run_loco_r(gbm,iris.hex)
+
+    expect_equal(as.data.frame(h2o_loco),r_loco)
+
+
+}
+
+doTest("LOCO Test", test.loco.regression)


### PR DESCRIPTION
Leave One Covariate Out (LOCO):
Calculates row-wise variable importance's by re-scoring a trained supervised model and measuring the impact of setting each variable to missing or it’s most central value(mean or median & mode for categorical's)

What will be returned from LOCO?
An H2OFrame displaying the base prediction (model scored with all predictors) and the difference in predictions when variables are dropped/replaced. The difference displayed is the base prediction substracted from the new prediction (when a variable is dropped/replaced with mean/median/mode) for binomial classification and regression problems. For multinomial problems, the sum of the absolute value of differences across classes is calculated per column dropped/replaced.