### PR TITLE
PUBDEV-4339 GLM fix. 

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -1172,7 +1172,6 @@ public class DataInfo extends Keyed<DataInfo> {
         row.response[i-1] = rChunk.atd(r);
         if(Double.isNaN(row.response[i-1])) {
           row.response_bad = true;
-          break;
         }
         if (_normRespMul != null) {
           row.response[i-1] = (row.response[i-1] - _normRespSub[i-1]) * _normRespMul[i-1];

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
@@ -102,7 +102,7 @@ public class DeepLearning extends ModelBuilder<DeepLearningModel,DeepLearningMod
     // Checks and adjustments:
     // 1) observation weights (adjust mean/sigmas for predictors and response)
     // 2) NAs (check that there's enough rows left)
-    GLMTask.YMUTask ymt = new GLMTask.YMUTask(dinfo, nClasses,!parms._autoencoder && nClasses == 1, parms._missing_values_handling == MissingValuesHandling.Skip, !parms._autoencoder).doAll(dinfo._adaptedFrame);
+    GLMTask.YMUTask ymt = new GLMTask.YMUTask(dinfo, nClasses,!parms._autoencoder && nClasses == 1, parms._missing_values_handling == MissingValuesHandling.Skip, !parms._autoencoder,true).doAll(dinfo._adaptedFrame);
     if (ymt.wsum() == 0 && parms._missing_values_handling == DeepLearningParameters.MissingValuesHandling.Skip)
       throw new H2OIllegalArgumentException("No rows left in the dataset after filtering out rows with missing values. Ignore columns with many NAs or set missing_values_handling to 'MeanImputation'.");
     if (parms._weights_column != null && parms._offset_column != null) {

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -426,7 +426,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           _dinfo.setWeights(_generatedWeights = "__glm_gen_weights", wc);
         }
 
-        YMUTask ymt = new YMUTask(_dinfo, _parms._family == Family.multinomial?nclasses():1, setWeights, skippingRows,true).doAll(_dinfo._adaptedFrame);
+        YMUTask ymt = new YMUTask(_dinfo, _parms._family == Family.multinomial?nclasses():1, setWeights, skippingRows,true,false).doAll(_dinfo._adaptedFrame);
         if (ymt.wsum() == 0)
           throw new IllegalArgumentException("No rows left in the dataset after filtering out rows with missing values. Ignore columns with many NAs or impute your missing values prior to calling glm.");
         Log.info(LogMsg("using " + ymt.nobs() + " nobs out of " + _dinfo._adaptedFrame.numRows() + " total"));
@@ -439,7 +439,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         if (_parms._family == Family.multinomial) {
           _state._ymu = MemoryManager.malloc8d(_nclass);
           for (int i = 0; i < _state._ymu.length; ++i)
-            _state._ymu[i] = _priorClassDist[i];
+            _state._ymu[i] = _priorClassDist[i];//ymt.responseMeans()[i];
         } else
         _state._ymu = _parms._intercept?ymt._yMu:new double[]{_parms.linkInv(0)};
       } else {

--- a/h2o-algos/src/main/java/hex/glm/GLMScore.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMScore.java
@@ -102,10 +102,6 @@ public class GLMScore extends MRTask<GLMScore> {
 
   private void processRow(DataInfo.Row r, float [] res, double [] ps, NewChunk [] preds, int ncols) {
     if(_dinfo._responses != 0)res[0] = (float) r.response[0];
-    if(r.rid == 20 || r.rid == 30)
-      System.out.println("rid = " + r.rid + ", response = " + r.response(0)  + ", isBad = " + r.response_bad);
-    if(r.response_bad)
-      System.out.println("response at " + r.rid + " is bad!");
     if (r.predictors_bad) {
       Arrays.fill(ps,Double.NaN);
     } else if(r.weight == 0) {
@@ -150,10 +146,6 @@ public class GLMScore extends MRTask<GLMScore> {
       DataInfo.Row r = _dinfo.newDenseRow();
       for (int rid = 0; rid < chks[0]._len; ++rid) {
         _dinfo.extractDenseRow(chks, rid, r);
-        if(r.rid == 20) {
-          System.out.println("haha");
-          _dinfo.extractDenseRow(chks, rid, r);
-        }
         processRow(r,res,ps,preds,ncols);
       }
     }

--- a/h2o-algos/src/main/java/hex/glm/GLMScore.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMScore.java
@@ -102,6 +102,10 @@ public class GLMScore extends MRTask<GLMScore> {
 
   private void processRow(DataInfo.Row r, float [] res, double [] ps, NewChunk [] preds, int ncols) {
     if(_dinfo._responses != 0)res[0] = (float) r.response[0];
+    if(r.rid == 20 || r.rid == 30)
+      System.out.println("rid = " + r.rid + ", response = " + r.response(0)  + ", isBad = " + r.response_bad);
+    if(r.response_bad)
+      System.out.println("response at " + r.rid + " is bad!");
     if (r.predictors_bad) {
       Arrays.fill(ps,Double.NaN);
     } else if(r.weight == 0) {
@@ -146,6 +150,10 @@ public class GLMScore extends MRTask<GLMScore> {
       DataInfo.Row r = _dinfo.newDenseRow();
       for (int rid = 0; rid < chks[0]._len; ++rid) {
         _dinfo.extractDenseRow(chks, rid, r);
+        if(r.rid == 20) {
+          System.out.println("haha");
+          _dinfo.extractDenseRow(chks, rid, r);
+        }
         processRow(r,res,ps,preds,ncols);
       }
     }

--- a/h2o-algos/src/main/java/hex/glm/GLMTask.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMTask.java
@@ -188,6 +188,7 @@ public abstract class GLMTask  {
 
 
    private double [] _predictorSDs;
+   private final boolean _expandedResponse; // true iff family == multinomial and response has been maually expanded into binary columns
 
    public double [] predictorMeans(){return _basicStats.mean();}
    public double [] predictorSDs(){
@@ -200,7 +201,7 @@ public abstract class GLMTask  {
      return _basicStatsResponse.sigma();
    }
 
-   public YMUTask(DataInfo dinfo, int nclasses, boolean computeWeightedMeanSigmaResponse, boolean skipNAs, boolean haveResponse) {
+   public YMUTask(DataInfo dinfo, int nclasses, boolean computeWeightedMeanSigmaResponse, boolean skipNAs, boolean haveResponse, boolean expandedResponse) {
      _nums = dinfo._nums;
      _numOff = dinfo._cats;
      _responseId = haveResponse ? dinfo.responseChunkId(0) : -1;
@@ -209,6 +210,7 @@ public abstract class GLMTask  {
      _nClasses = nclasses;
      _computeWeightedMeanSigmaResponse = computeWeightedMeanSigmaResponse;
      _skipNAs = skipNAs;
+     _expandedResponse = _nClasses > 1 && expandedResponse;
    }
 
    @Override public void setupLocal(){}
@@ -273,8 +275,17 @@ public abstract class GLMTask  {
          continue;
        if(_computeWeightedMeanSigmaResponse) {
          //FIXME: Add support for subtracting offset from response
-         for(int i = 0; i < _nClasses; ++i)
-           numsResponse[i] = chunks[chunks.length-_nClasses+i].atd(r);
+         if(_expandedResponse) {
+           for (int i = 0; i < _nClasses; ++i)
+             numsResponse[i] = chunks[chunks.length - _nClasses + i].atd(r);
+         } else {
+           Arrays.fill(numsResponse,0);
+           double d = response.atd(r);
+           if(Double.isNaN(d))
+             Arrays.fill(numsResponse,Double.NaN);
+           else
+             numsResponse[(int)d] = 1;
+         }
          _basicStatsResponse.add(numsResponse,w);
        }
        double d = response.atd(r);

--- a/h2o-algos/src/main/java/hex/glm/GLMTask.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMTask.java
@@ -210,7 +210,7 @@ public abstract class GLMTask  {
      _nClasses = nclasses;
      _computeWeightedMeanSigmaResponse = computeWeightedMeanSigmaResponse;
      _skipNAs = skipNAs;
-     _expandedResponse = _nClasses > 1 && expandedResponse;
+     _expandedResponse = _nClasses == 1 || expandedResponse;
    }
 
    @Override public void setupLocal(){}


### PR DESCRIPTION
YMUTask shared with deep learning was expecting response to be expanded into #classes binary vectors in multinomial case, but glm does not do that => caused AIIOB in case YMUTask was computing response mean/sigma (either got weights or missing value handling == skip) and there were more classes than predictor columns (unexpanded).

Added a flag to state whether response is expanded (true for DL, false for GLM).