### PR TITLE
PUBDEV-4265: Problem with h2o.uploadFile on Windows

### DIFF
--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -495,16 +495,6 @@ public class JettyHTTPD {
     return new InputStreamWrapper(is, boundary);
   }
 
-  public static boolean validKeyName(String name) {
-    byte[] arr = StringUtils.bytesOf(name);
-    for (byte b : arr) {
-      if (b == '"') return false;
-      if (b == '\\') return false;
-    }
-
-    return true;
-  }
-
   public static void sendErrorResponse(HttpServletResponse response, Exception e, String uri) {
     if (e instanceof H2OFailException) {
       H2OFailException ee = (H2OFailException) e;

--- a/h2o-core/src/main/java/water/api/PostFileServlet.java
+++ b/h2o-core/src/main/java/water/api/PostFileServlet.java
@@ -22,11 +22,6 @@ public class PostFileServlet extends HttpServlet {
       if (destination_frame == null) {
         destination_frame = "upload" + Key.rand();
       }
-      if (!JettyHTTPD.validKeyName(destination_frame)) {
-        JettyHTTPD.setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
-        response.getWriter().write("Invalid key name, contains illegal characters");
-        return;
-      }
 
       //
       // Here is an example of how to upload a file from the command line.


### PR DESCRIPTION
This PR removes `validKeyName()` from `JettyHTTPD.java` and `PostFileServlet.java` as it put a constraint on destination frame id, which causes issues for `h2o.uploadFile` (see referenced JIRA).