### PR TITLE
PUBDEV-4319 Fix in unseen categorical levels handling in GLM scoring.

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -944,18 +944,18 @@ public class DataInfo extends Keyed<DataInfo> {
   public final int getCategoricalId(int cid, int val) {
     boolean isIWV = isInteractionVec(cid);
     if(val == -1) { // NA
-      if(_skipMissing) return val;
       val = _catNAFill[cid];
     } else if( !_useAllFactorLevels && !isIWV )  // categorical interaction vecs drop reference level in a special way
       val -= 1;
+    if(val < 0) return -1; // column si to be skipped
     int [] offs = fullCatOffsets();
     int expandedVal = val + offs[cid];
     if(expandedVal >= offs[cid+1]) {  // previously unseen level
       assert _valid:"Categorical value out of bounds, got " + val + ", next cat starts at " + fullCatOffsets()[cid+1];
-      if(_skipMissing) return -1;
+      if(_skipMissing)
+        return -1;
       val = _catNAFill[cid];
     }
-    if(val < 0) return -1; // column si to be skipped
     if (_catMap != null && _catMap[cid] != null) {  // some levels are ignored?
       val = _catMap[cid][val];
       assert _useAllFactorLevels;

--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -59,8 +59,11 @@ public class DataInfo extends Keyed<DataInfo> {
   }
 
   public int[] catNAFill() {return _catNAFill;}
-
   public int catNAFill(int cid) {return _catNAFill[cid];}
+
+  public void setCatNAFill(int[] catNAFill) {
+    _catNAFill = catNAFill;
+  }
 
   public enum TransformType {
     NONE, STANDARDIZE, NORMALIZE, DEMEAN, DESCALE;
@@ -99,7 +102,7 @@ public class DataInfo extends Keyed<DataInfo> {
   public int _cats;  // "raw" number of categorical columns as they exist in the frame
   public int [] _catOffsets;   // offset column indices for the 1-hot expanded values (includes enum-enum interaction)
   public boolean [] _catMissing;  // bucket for missing levels
-  public int [] _catNAFill;    // majority class of each categorical col (or last bucket if _catMissing[i] is true)
+  private int [] _catNAFill;    // majority class of each categorical col (or last bucket if _catMissing[i] is true)
   public int [] _permutation; // permutation matrix mapping input col indices to adaptedFrame
   public double [] _normMul;  // scale the predictor column by this value
   public double [] _normSub;  // subtract from the predictor this value
@@ -694,7 +697,7 @@ public class DataInfo extends Keyed<DataInfo> {
           continue;
         res[k++] = _adaptedFrame._names[i] + "." + vecs[i].domain()[j];
       }
-      if (_catMissing[i] && getCategoricalId(i, _catNAFill[i]) >=0)
+      if (_catMissing[i] && getCategoricalId(i, -1) >=0)
         res[k++] = _adaptedFrame._names[i] + ".missing(NA)";
       if( vecs[i] instanceof InteractionWrappedVec ) {
         InteractionWrappedVec iwv = (InteractionWrappedVec)vecs[i];
@@ -927,7 +930,7 @@ public class DataInfo extends Keyed<DataInfo> {
 
 
   public final int getCategoricalId(int cid, double val) {
-    if(Double.isNaN(val)) return getCategoricalId(cid, _catNAFill[cid]);
+    if(Double.isNaN(val)) return getCategoricalId(cid, -1);
     int ival = (int)val;
     if(ival != val) throw new IllegalArgumentException("Categorical id must be an integer or NA (missing).");
     return getCategoricalId(cid,ival);
@@ -940,14 +943,19 @@ public class DataInfo extends Keyed<DataInfo> {
    */
   public final int getCategoricalId(int cid, int val) {
     boolean isIWV = isInteractionVec(cid);
-    if( !_useAllFactorLevels && !isIWV )  // categorical interaction vecs drop reference level in a special way
+    if(val == -1) { // NA
+      if(_skipMissing) return val;
+      val = _catNAFill[cid];
+    } else if( !_useAllFactorLevels && !isIWV )  // categorical interaction vecs drop reference level in a special way
       val -= 1;
     int [] offs = fullCatOffsets();
     int expandedVal = val + offs[cid];
     if(expandedVal >= offs[cid+1]) {  // previously unseen level
       assert _valid:"Categorical value out of bounds, got " + val + ", next cat starts at " + fullCatOffsets()[cid+1];
+      if(_skipMissing) return -1;
       val = _catNAFill[cid];
     }
+    if(val < 0) return -1; // column si to be skipped
     if (_catMap != null && _catMap[cid] != null) {  // some levels are ignored?
       val = _catMap[cid][val];
       assert _useAllFactorLevels;
@@ -1115,7 +1123,7 @@ public class DataInfo extends Keyed<DataInfo> {
           row.predictors_bad = true;
           continue;
         }         
-        int cid = getCategoricalId(i,isMissing? _catNAFill[i]:(int)chunks[i].at8(r));
+        int cid = getCategoricalId(i,isMissing? -1:(int)chunks[i].at8(r));
         if(cid >=0)
           row.binIds[row.nBins++] = cid;
       }

--- a/h2o-algos/src/main/java/hex/glm/GLMTask.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMTask.java
@@ -487,13 +487,13 @@ public abstract class GLMTask  {
       for(int cid = 0; cid < _dinfo._cats; ++cid){
         Chunk c = chks[cid];
         if(c.isSparseZero()) {
-          int nvals = c.getSparseDoubles(vals,ids,_dinfo.catNAFill(cid));
+          int nvals = c.getSparseDoubles(vals,ids,-1);
           for(int i = 0; i < nvals; ++i){
             int id = _dinfo.getCategoricalId(cid,(int)vals[i]);
             if(id >=0) etas[ids[i]] += _beta[id];
           }
         } else {
-          c.getIntegers(ids, 0, c._len,_dinfo.catNAFill(cid));
+          c.getIntegers(ids, 0, c._len,-1);
           for(int i = 0; i < ids.length; ++i){
             int id = _dinfo.getCategoricalId(cid,ids[i]);
             if(id >=0) etas[i] += _beta[id];
@@ -507,15 +507,15 @@ public abstract class GLMTask  {
       for(int cid = 0; cid < _dinfo._cats; ++cid){
         Chunk c = chks[cid];
         if(c.isSparseZero()) {
-          int nvals = c.getSparseDoubles(vals,ids,_dinfo.catNAFill(cid));
+          int nvals = c.getSparseDoubles(vals,ids,-1);
           for(int i = 0; i < nvals; ++i){
             int id = _dinfo.getCategoricalId(cid,(int)vals[i]);
             if(id >=0) _gradient[id] += etas[ids[i]];
           }
         } else {
-          c.getIntegers(ids, 0, c._len,_dinfo.catNAFill(cid));
+          c.getIntegers(ids, 0, c._len,-1);
           for(int i = 0; i < ids.length; ++i){
-            int id = _dinfo.getCategoricalId(cid,(int)ids[i]);
+            int id = _dinfo.getCategoricalId(cid,ids[i]);
             if(id >=0) _gradient[id] += etas[i];
           }
         }
@@ -772,13 +772,13 @@ public abstract class GLMTask  {
       for(int cid = 0; cid < _dinfo._cats; ++cid){
         Chunk c = chks[cid];
         if(c.isSparseZero()) {
-          int nvals = c.getSparseDoubles(vals,ids,_dinfo.catNAFill(cid));
+          int nvals = c.getSparseDoubles(vals,ids,-1);
           for(int i = 0; i < nvals; ++i){
             int id = _dinfo.getCategoricalId(cid,(int)vals[i]);
             if(id >=0)ArrayUtils.add(etas[ids[i]],_beta[id]);
           }
         } else {
-          c.getIntegers(ids, 0, c._len,_dinfo.catNAFill(cid));
+          c.getIntegers(ids, 0, c._len,-1);
           for(int i = 0; i < ids.length; ++i){
             int id = _dinfo.getCategoricalId(cid,ids[i]);
             if(id >=0) ArrayUtils.add(etas[i],_beta[id]);
@@ -792,13 +792,13 @@ public abstract class GLMTask  {
       for(int cid = 0; cid < _dinfo._cats; ++cid){
         Chunk c = chks[cid];
         if(c.isSparseZero()) {
-          int nvals = c.getSparseDoubles(vals,ids,_dinfo.catNAFill(cid));
+          int nvals = c.getSparseDoubles(vals,ids,-1);
           for(int i = 0; i < nvals; ++i){
             int id = _dinfo.getCategoricalId(cid,(int)vals[i]);
             if(id >=0) ArrayUtils.add(_gradient[id],etas[ids[i]]);
           }
         } else {
-          c.getIntegers(ids, 0, c._len,_dinfo.catNAFill(cid));
+          c.getIntegers(ids, 0, c._len,-1);
           for(int i = 0; i < ids.length; ++i){
             int id = _dinfo.getCategoricalId(cid,ids[i]);
             if(id >=0) ArrayUtils.add(_gradient[id],etas[i]);

--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -931,7 +931,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
           if (!(_binaryColumnIndices.contains(tinfo._permutation[colIndex]))) {
             permutationTemp[newColIndex] = tinfo._permutation[colIndex];
             catMissingTemp[newColIndex] = tinfo._catMissing[colIndex];
-            catNAFillTemp[newColIndex] = tinfo._catNAFill[colIndex];
+            catNAFillTemp[newColIndex] = tinfo.catNAFill(colIndex);
             currentCardinality[newColIndex] = cardinalities[colIndex];
             catOffsetsTemp[newColIndex+1] = catOffsetsTemp[newColIndex]+currentCardinality[newColIndex];
 
@@ -969,7 +969,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
         // copy the changed arrays back to tinfo information
         tinfo._catOffsets = Arrays.copyOf(catOffsetsTemp, catOffsetsTemp.length);
         tinfo._catMissing = Arrays.copyOf(catMissingTemp, tinfo._cats);
-        tinfo._catNAFill = Arrays.copyOf(catNAFillTemp, tinfo._cats);
+        tinfo.setCatNAFill(Arrays.copyOf(catNAFillTemp, tinfo._cats));
         tinfo._permutation = Arrays.copyOf(permutationTemp, tinfo._permutation.length);
         tinfo._numOffsets = Arrays.copyOf(numOffsetsTemp, tinfo._nums);
         if (tinfo._normMul != null) {


### PR DESCRIPTION
Filled in value was off by 1 if the missing value handling was set on skip.