### PR TITLE
PUBDEV-4350: Update R/Py docs about sample_rate_per_class

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -73,7 +73,7 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     @API(help = "Row sample rate per tree (from 0.0 to 1.0)", gridable = true)
     public double sample_rate;
 
-    @API(help = "Row sample rate per tree per class (from 0.0 to 1.0)", level = API.Level.expert, gridable = true)
+    @API(help = "A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)", level = API.Level.expert, gridable = true)
     public double[] sample_rate_per_class;
 
     @API(help = "Column sample rate per tree (from 0.0 to 1.0)", level = API.Level.secondary, gridable = true)

--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -73,7 +73,7 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     @API(help = "Row sample rate per tree (from 0.0 to 1.0)", gridable = true)
     public double sample_rate;
 
-    @API(help = "A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)", level = API.Level.expert, gridable = true)
+    @API(help = "A list of row sample rates per class (relative fraction for each class, from 0.0 to 1.0), for each tree", level = API.Level.expert, gridable = true)
     public double[] sample_rate_per_class;
 
     @API(help = "Column sample rate per tree (from 0.0 to 1.0)", level = API.Level.secondary, gridable = true)

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -664,7 +664,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @property
     def sample_rate_per_class(self):
         """
-        Row sample rate per tree per class (from 0.0 to 1.0)
+        A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
 
         Type: ``List[float]``.
         """

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -664,7 +664,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @property
     def sample_rate_per_class(self):
         """
-        A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
+        A list of row sample rates per class (relative fraction for each class, from 0.0 to 1.0), for each tree
 
         Type: ``List[float]``.
         """

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -569,7 +569,7 @@ class H2ORandomForestEstimator(H2OEstimator):
     @property
     def sample_rate_per_class(self):
         """
-        Row sample rate per tree per class (from 0.0 to 1.0)
+        A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
 
         Type: ``List[float]``.
         """

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -569,7 +569,7 @@ class H2ORandomForestEstimator(H2OEstimator):
     @property
     def sample_rate_per_class(self):
         """
-        A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
+        A list of row sample rates per class (relative fraction for each class, from 0.0 to 1.0), for each tree
 
         Type: ``List[float]``.
         """

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -73,7 +73,7 @@
 #'        1). Defaults to 0.9.
 #' @param checkpoint Model checkpoint to resume training with.
 #' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 1.
-#' @param sample_rate_per_class Row sample rate per tree per class (from 0.0 to 1.0)
+#' @param sample_rate_per_class A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
 #' @param col_sample_rate Column sample rate (from 0.0 to 1.0) Defaults to 1.
 #' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -73,7 +73,7 @@
 #'        1). Defaults to 0.9.
 #' @param checkpoint Model checkpoint to resume training with.
 #' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 1.
-#' @param sample_rate_per_class A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
+#' @param sample_rate_per_class A list of row sample rates per class (relative fraction for each class, from 0.0 to 1.0), for each tree
 #' @param col_sample_rate Column sample rate (from 0.0 to 1.0) Defaults to 1.
 #' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -62,7 +62,7 @@
 #' @param mtries Number of variables randomly sampled as candidates at each split. If set to -1, defaults to sqrt{p} for
 #'        classification and p/3 for regression (where p is the # of predictors Defaults to -1.
 #' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 0.6320000291.
-#' @param sample_rate_per_class Row sample rate per tree per class (from 0.0 to 1.0)
+#' @param sample_rate_per_class A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
 #' @param binomial_double_trees \code{Logical}. For binary classification: Build 2x as many trees (one per class) - can lead to higher
 #'        accuracy. Defaults to FALSE.
 #' @param checkpoint Model checkpoint to resume training with.

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -62,7 +62,7 @@
 #' @param mtries Number of variables randomly sampled as candidates at each split. If set to -1, defaults to sqrt{p} for
 #'        classification and p/3 for regression (where p is the # of predictors Defaults to -1.
 #' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 0.6320000291.
-#' @param sample_rate_per_class A list/vector of the fraction of rows to sample for each tree, per class (from 0.0 to 1.0)
+#' @param sample_rate_per_class A list of row sample rates per class (relative fraction for each class, from 0.0 to 1.0), for each tree
 #' @param binomial_double_trees \code{Logical}. For binary classification: Build 2x as many trees (one per class) - can lead to higher
 #'        accuracy. Defaults to FALSE.
 #' @param checkpoint Model checkpoint to resume training with.


### PR DESCRIPTION
`sample_rate_per_class` does not currently have a clear definition. This PR clarifies any potential confusion (see JIRA: https://0xdata.atlassian.net/browse/PUBDEV-4350?filter=-1)