### PR TITLE
PUBDEV-4360: Add links for SW 2.1 docs on documentation site

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -165,7 +165,7 @@
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 6px;">
               <a href="h2o-docs/faq.html#sparkling-water">What is Sparkling Water?</a>
               <a href="h2o-docs/booklets/SparklingWaterBooklet.pdf">Sparkling Water Booklet</a>
-              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-1.6/py/README.rst">1.6</a></p>
+              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/py/README.rst">2.1</a></p>
               <a href="https://github.com/h2oai/rsparkling/blob/master/README.md">RSparkling Readme</a>
               <a href="https://github.com/h2oai/sparkling-water/blob/master/LICENSE">Open Source License (Apache V2)</a>
            </div>
@@ -369,7 +369,7 @@
               <a href="h2o-docs/booklets/PythonBooklet.pdf">Python Booklet</a>
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-py/demos">Examples and Demos</a>
               <a href="h2o-docs/faq.html#python">Python FAQ</a>
-              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-1.6/py/README.rst">1.6</a></p>
+              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/py/README.rst">2.1</a></p>
               <a href="https://tgsmith61591.github.io/skutil/">skutil Docs</a>
           </div>
         </div>
@@ -394,12 +394,12 @@
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 0pt;">Sparkling Water API</td>
               <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/DEVEL.md">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-1.6/DEVEL.md">1.6</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/DEVEL.md">2.1</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparkling Water Scaladoc</td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/0/scaladoc/index.html#package">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-1.6/1/scaladoc/index.html">1.6</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/1/scaladoc/index.html">2.1</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">H2O Scaladoc</td>
@@ -536,7 +536,7 @@
                   <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/DEVEL.md">2.0</a>
                 </td>
                 <td style="padding-bottom: 0pt; padding-top: 0pt;">
-                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-1.6/DEVEL.md">1.6</a>
+                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/DEVEL.md">2.1</a>
                 </td>
               </td>
             </tr>
@@ -599,7 +599,7 @@
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparkling Water Readme</td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/README.md">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-1.6/README.md">1.6</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/README.md">2.1</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparking Water Scaladoc</td>
@@ -607,7 +607,7 @@
                 <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/0/scaladoc/index.html#package">2.0</a>
               </td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-1.6/1/scaladoc/index.html">1.6</a>
+                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/1/scaladoc/index.html">2.1</a>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
On the docs.h2o.ai site, replaced SW 1.6 documentation links with SW 2.1. This now matches the SW download page, which only includes 2.0 and 2.1.