### PR TITLE
PUBDEV-4315

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMTask.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMTask.java
@@ -1339,6 +1339,7 @@ public abstract class GLMTask  {
         double mu = r.response(1);
         double eta = r.response(2);
         double d = mu*(1-mu);
+        if(d == 0) d = 1e-10;
         wz = r.weight * (eta * d + (y-mu));
         w  = r.weight * d;
       } else if(_beta != null) {

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -1830,6 +1830,26 @@ public class GLMTest  extends TestUtil {
   }
 
   @Test
+  public void testZeroedColumn(){
+    Vec x = Vec.makeCon(Vec.newKey(),1,2,3,4,5);
+    Vec y = Vec.makeCon(x.group().addVec(),0,1,0,1,0);
+    Vec z = Vec.makeCon(Vec.newKey(),1,2,3,4,5);
+    Vec w = Vec.makeCon(x.group().addVec(),1,0,1,0,1);
+    Frame fr = new Frame(Key.<Frame>make("test"),new String[]{"x","y","z","w"},new Vec[]{x,y,z,w});
+    DKV.put(fr);
+    GLMParameters parms = new GLMParameters(Family.gaussian);
+    parms._train = fr._key;
+    parms._lambda = new double[]{0};
+    parms._alpha = new double[]{0};
+    parms._compute_p_values = true;
+    parms._response_column = "z";
+    parms._weights_column = "w";
+    GLMModel m = new GLM(parms).trainModel().get();
+    System.out.println(m.coefficients());
+    m.delete();
+    fr.delete();
+  }
+  @Test
   public void testDeviances() {
     for (Family fam : Family.values()) {
       if(fam == Family.quasibinomial) continue;


### PR DESCRIPTION
Even though zero columns should be filtered up front before the algorithm is even run, they can happen due to e.g. categorical level never occurring in the given fold. When this happens, coefficient should be removed on the fly and set to 0. However, this does not quite work for multinomial - there is too much complexity in working with subset of coefficients at a given time. Since multinomial is currently only implemented via coordinate descent over classes, it should be run with regularization and so zeroed predictors are not a problem.

Fix: 1) do not remove zeroed predictors if family==multinomial.
       2) refined zeroed column detection - require both XtX and XtY to be zeroes for the given column. Zero XtX can happen in case of e.g. running binomial and given predictor turning prediction to 1 whenever non-zero. Zero XtY trivial occurs if response is zero for every non-zero predictor value. In both cases, predictor should be left in.