### PR TITLE
PUBDEV-4363 Made C0DChunk with NaN con work with strings.

### DIFF
--- a/h2o-core/src/main/java/water/fvec/C0DChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C0DChunk.java
@@ -1,5 +1,6 @@
 package water.fvec;
 
+import water.parser.BufferedString;
 import water.util.UnsafeUtils;
 
 import java.util.UUID;
@@ -33,6 +34,10 @@ public class C0DChunk extends Chunk {
   @Override double min() { return _con; }
   @Override double max() { return _con; }
 
+  BufferedString atStr_impl(BufferedString bStr, int idx) {
+    if(Double.isNaN(_con)) return null; // speciall all missing case
+    return super.atStr_impl(bStr,idx);
+  }
   // 3.3333333e33
 //  public int pformat_len0() { return 22; }
 //  public String pformat0() { return "% 21.15e"; }

--- a/h2o-core/src/test/java/water/fvec/NewChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import water.DKV;
 import water.Futures;
 import water.TestUtil;
+import water.parser.BufferedString;
 
 import java.util.Arrays;
 import java.util.Random;
@@ -39,6 +40,7 @@ public class NewChunkTest extends TestUtil {
     cc.close(0, new Futures()).blockForPending();
   }
   void remove() {if(vec != null)vec.remove();}
+
 
   @Test public void testSparseDoubles(){
     NewChunk nc = new NewChunk(new double[]{Math.PI});
@@ -282,7 +284,11 @@ public class NewChunkTest extends TestUtil {
       for (int k = 0; k < K; ++k) nc.addNA();
       assertEquals(K, nc._len);
       post();
-      for (int k = 0; k < K; ++k) Assert.assertTrue(cc.isNA(k));
+      BufferedString bs = new BufferedString();
+      for (int k = 0; k < K; ++k) {
+        Assert.assertTrue(cc.isNA(k));
+        Assert.assertEquals(null,cc.atStr(bs,k));
+      }
       Assert.assertTrue(cc instanceof C0DChunk);
     } finally { remove(); }
   }


### PR DESCRIPTION
C0DChunk with con==NaN should behave as all NA chunk, even for strings.
E.g. following should work, but it throws "Not a String" exception in master right now.

NewChunk nc = new NewChunk(...);
nc.addNa();
Chunk c = nc.compress();
assert c.atStr(new BufferedString(),0) == null; // instead get a "Not a String" Exception here.
