### PR TITLE
HEXDEV-561: Documentation for JDBC Databases

### DIFF
--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -32,6 +32,7 @@ Default Data Sources
 - local file system
 - S3 
 - HDFS
+- JDBC
 
 HDFS-like Data Sources
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -165,3 +166,93 @@ core-site.xml must be configured for at least the following properties (class, p
                 <value>mybucket</value>
         </property>
     </configuration>
+
+JDBC Databases
+~~~~~~~~~~~~~~
+
+Relational databases that include a JDBC (Java database connectivity) driver can be used as the source of data for machine learning in H2O. Currently supported SQL databases are MySQL, PostgreSQL, and MariaDB. Data from these SQL databases can be pulled into H2O using the ``import_sql_table`` and ``import_sql_select`` functions.
+
+Refer to the following articles for examples about using JDBC data sources with H2O.
+
+- `Setup postgresql database on OSX <https://aichamp.wordpress.com/2017/03/20/setup-postgresql-database-on-osx/>`__
+- `Restoring DVD rental database into postgresql <https://aichamp.wordpress.com/2017/03/20/restoring-dvd-rental-database-into-postgresql/>`__
+- `Building H2O GLM model using Postgresql database and JDBC driver <https://aichamp.wordpress.com/2017/03/20/building-h2o-glm-model-using-postgresql-database-and-jdbc-driver/>`__
+
+``import_sql_table``
+''''''''''''''''''''
+
+This function imports a SQL table to H2OFrame in memory. This function assumes that the SQL table is not being updated and is stable. Users can run multiple SELECT SQL queries concurrently for parallel ingestion.
+
+**Note**: Be sure to start the h2o.jar in the terminal with your downloaded JDBC driver in the classpath:
+
+::
+  
+      java -cp <path_to_h2o_jar>:<path_to_jdbc_driver_jar> water.H2OApp
+
+The ``import_sql_table`` function accepts the following parameters:
+
+- ``connection_url``: The URL of the SQL database connection as specified by the Java Database Connectivity (JDBC) Driver. For example, "jdbc:mysql://localhost:3306/menagerie?&useSSL=false"
+- ``table``: The name of the SQL table
+- ``columns``: A list of column names to import from SQL table. Default is to import all columns.
+- ``username``: The username for SQL server
+- ``password``: The password for SQL server
+- ``optimize``: Specifies to optimize the import of SQL table for faster imports. Note that this option is experimental.
+
+.. example-code::
+   .. code-block:: r
+
+    connection_url <- "jdbc:mysql://172.16.2.178:3306/ingestSQL?&useSSL=false"
+    table <- "citibike20k"
+    username <- "root"
+    password <- "abc123"
+    my_citibike_data <- h2o.import_sql_table(connection_url, table, username, password)
+
+   .. code-block:: python
+
+    connection_url = "jdbc:mysql://172.16.2.178:3306/ingestSQL?&useSSL=false"
+    table = "citibike20k"
+    username = "root"
+    password = "abc123"
+    my_citibike_data = h2o.import_sql_table(connection_url, table, username, password)
+
+
+``import_sql_select``
+'''''''''''''''''''''
+
+This function imports the SQL table that is the result of the specified SQL query to H2OFrame in memory. It creates a temporary SQL table from the specified sql_query. Users can run multiple SELECT SQL queries on the temporary table concurrently for parallel ingestion, and then drop the table.
+    
+**Note**: Be sure to start the h2o.jar in the terminal with your downloaded JDBC driver in the classpath:
+
+::
+  
+      java -cp <path_to_h2o_jar>:<path_to_jdbc_driver_jar> water.H2OApp
+
+The ``import_sql_select`` function accepts the following parameters:
+
+- ``connection_url``: URL of the SQL database connection as specified by the Java Database Connectivity (JDBC) Driver. For example, "jdbc:mysql://localhost:3306/menagerie?&useSSL=false"
+- ``select_query``: SQL query starting with `SELECT` that returns rows from one or more database tables.
+- ``username``: The username for the SQL server
+- ``password``: The password for the SQL server
+- ``optimize``: Specifies to optimize import of SQL table for faster imports. Note that this option is experimental.
+
+
+.. example-code::
+   .. code-block:: r
+
+    connection_url <- "jdbc:mysql://172.16.2.178:3306/ingestSQL?&useSSL=false"
+    select_query <-  "SELECT  bikeid  from  citibike20k"
+    username <- "root"
+    password <- "abc123"
+    my_citibike_data <- h2o.import_sql_select(connection_url, select_query, username, password)
+
+
+   .. code-block:: python
+
+    connection_url = "jdbc:mysql://172.16.2.178:3306/ingestSQL?&useSSL=false"
+    select_query = "SELECT bikeid from citibike20k"
+    username = "root"
+    password = "abc123"
+    my_citibike_data = h2o.import_sql_select(connection_url, select_query, username, password)
+
+
+


### PR DESCRIPTION
Added a section about using a JDBC driver to import data into H2O. This section also describes the import_sql_table and import_sql_select functions, with R and Python examples.