### PR TITLE
PUBDEV-1616: glrm gramSVD mismatch.  Fixed runit test for a better co…

### DIFF
--- a/h2o-algos/src/main/java/hex/util/DimensionReductionUtils.java
+++ b/h2o-algos/src/main/java/hex/util/DimensionReductionUtils.java
@@ -4,6 +4,7 @@ import hex.DataInfo;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import water.fvec.Frame;
+import water.util.ArrayUtils;
 import water.util.PrettyPrint;
 import water.util.TwoDimTable;
 
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import static java.lang.Math.sqrt;
 import static water.util.ArrayUtils.*;
 
 
@@ -37,6 +39,14 @@ public class DimensionReductionUtils {
                 prop_var[i] = vars[i] / totVar;
                 cum_var[i] = i == 0 ? prop_var[0] : cum_var[i-1] + prop_var[i];
             }
+        }
+        double lastCum = cum_var[arrayLen-1];
+        if (lastCum > 1) {  // GLRM sometimes screw up the matrix estimation pretty bad
+            double multF = 1/lastCum;
+            ArrayUtils.mult(prop_var, multF);
+            ArrayUtils.mult(cum_var, multF);
+            ArrayUtils.mult(vars, multF);
+            ArrayUtils.mult(std_deviation, sqrt(multF));
         }
     }
 

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3501_variance_metrics.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_PUBDEV_3501_variance_metrics.R
@@ -6,9 +6,6 @@ test.glrm.pubdev_3501.variance.metrics <- function() {
 #  ausPath <- system.file("extdata", "australia.csv", package="h2o")
 #  australia.hex = h2o.importFile(path = ausPath, destination_frame="australia.hex")
   arrestsH2O <- h2o.uploadFile(locate("smalldata/pca_test/USArrests.csv"), destination_frame = "arrestsH2O")
-
-  browser()
-  
   pca_model = h2o.prcomp(training_frame = arrestsH2O, k = 4, transform = "STANDARDIZE")
   print(pca_model)
   glrm_model = h2o.glrm(training_frame = arrestsH2O, k = 4, loss = "Quadratic", gamma_x = 0,

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_1616_glrm_GramSVD.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_1616_glrm_GramSVD.R
@@ -1,0 +1,37 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# Nidhi reports that GLRM and GramSVD produce different singular values with the birds.csv
+test.pca.glrm_GramSVD <- function() {
+  ranks = 5
+  df <- h2o.importFile(locate("smalldata/pca_test/birds.csv"), destination_frame="df")
+  pcaGLRM <- h2o.prcomp(df, k=ranks, use_all_factor_levels=TRUE, pca_method="GLRM", transform="STANDARDIZE")
+  pcaGramSVD <- h2o.prcomp(df, k=ranks, use_all_factor_levels=TRUE, pca_method="GramSVD", transform="STANDARDIZE")
+
+  t = pcaGLRM@model$importance
+  glrmSVals = c(t$pc1[1], t$pc2[1], t$pc3[1], t$pc4[1], t$pc5[1])
+  t = pcaGramSVD@model$importance
+  gramSVDSVals = c(t$pc1[1], t$pc2[1], t$pc3[1], t$pc4[1], t$pc5[1])
+  maxDiff = max(abs(glrmSVals-gramSVDSVals))
+  if (maxDiff > 1e-6) {
+    print("Eigenvalues/Eigenvectors returned by GLRM and GramSVD differ due to different enum column handling
+    and NA rows handling.")
+    print("Maximum difference is ")
+    print(maxDiff)
+  }
+  # compare GLRM and GramSVD with numerical dataset.  Should be close.
+  df = h2o.createFrame(rows=1000, cols=10, real_range=100,string_fraction=0, categorical_fraction = 0,
+  integer_fraction = 0, binary_fraction=0, missing_fraction=0, has_response=FALSE, seed=12345)
+  pcaGLRM <- h2o.prcomp(df, k=ranks, use_all_factor_levels=TRUE, pca_method="GLRM", transform="STANDARDIZE")
+  pcaGramSVD <- h2o.prcomp(df, k=ranks, use_all_factor_levels=TRUE, pca_method="GramSVD", transform="STANDARDIZE")
+  # compare results from GLRM and GramSVD for all numerical data.  Should be the same.
+  isFlipped1 <- checkPCAModelWork(ranks, pcaGLRM@model$importance, pcaGramSVD@model$importance,
+  pcaGLRM@model$eigenvectors, pcaGramSVD@model$eigenvectors,
+  "Compare importance between PCA GLRM and PCA GramSVD",
+  "PCA GLRM Importance of Components:",
+  "PCA GramSVD Importance of Components:", tolerance=1e-6,
+  compare_all_importance=TRUE)
+
+}
+
+doTest("PCA Test: compare SVD from GLRM and GramSVD", test.pca.glrm_GramSVD)


### PR DESCRIPTION
two changes:

1. When GLRM failed to approximate well data matrix with numerical columns converted from enum columns, the total_variances may not equal the trace of gram matrix.  Fixed this case to avoid proportional_variance exceeding 1 again.

2. Added Runit test to prove that GLRM, GramSVD generate different eigenvalues/eigenvectors with datasets with enum columns and NA rows.  However, when dataset is numerical, both method generate the same eigenvector/eigenvalues.