### PR TITLE
PUBDEV-3840: Implements Platt Scaling to GBM and DRF (binomial models)

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/DRFV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DRFV3.java
@@ -51,8 +51,8 @@ public class DRFV3 extends SharedTreeV3<DRF,DRFV3, DRFV3.DRFParametersV3> {
         "min_split_improvement",
         "histogram_type",
         "categorical_encoding",
-			"calibrate_model",
-			"calibration_frame"
+		"calibrate_model",
+		"calibration_frame"
     };
 
     // Input fields

--- a/h2o-algos/src/main/java/hex/schemas/DRFV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DRFV3.java
@@ -50,7 +50,9 @@ public class DRFV3 extends SharedTreeV3<DRF,DRFV3, DRFV3.DRFParametersV3> {
         "col_sample_rate_per_tree",
         "min_split_improvement",
         "histogram_type",
-        "categorical_encoding"
+        "categorical_encoding",
+			"calibrate_model",
+			"calibration_frame"
     };
 
     // Input fields

--- a/h2o-algos/src/main/java/hex/schemas/GBMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GBMV3.java
@@ -59,7 +59,9 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
       "histogram_type",
       "max_abs_leafnode_pred",
       "pred_noise_bandwidth",
-      "categorical_encoding"
+      "categorical_encoding",
+      "calibrate_model",
+      "calibration_frame"
 //      "use_new_histo_tsk",
 //      "col_block_sz",
 //      "min_threads",

--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -93,10 +93,10 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     @API(help="What type of histogram to use for finding optimal split points", values = { "AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"}, level = API.Level.secondary, gridable = true)
     public SharedTreeParameters.HistogramType histogram_type;
 
-    @API(help="Use Platt's Scaling to do model calibration. Ie you would like the classifcation prediction to represent posterior probabilities.", level = API.Level.expert, gridable = false)
+    @API(help="Use Platt Scaling to do model calibration. Transforms the outputs of a classification model into a probability distribution over classes", level = API.Level.expert)
     public boolean calibrate_model;
 
-    @API(help="Calibration frame for Platt's scaling", level = API.Level.expert, direction = API.Direction.INOUT, gridable=false)
+    @API(help="Calibration frame for Platt Scaling", level = API.Level.expert, direction = API.Direction.INOUT)
     public FrameKeyV3 calibration_frame;
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -3,7 +3,9 @@ package hex.schemas;
 import hex.tree.SharedTree;
 import hex.tree.SharedTreeModel.SharedTreeParameters;
 import water.api.API;
+import water.api.schemas3.KeyV3.FrameKeyV3;
 import water.api.schemas3.ModelParametersSchemaV3;
+
 
 public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P extends SharedTreeV3.SharedTreeParametersV3> extends ModelBuilderSchema<B,S,P> {
 
@@ -90,5 +92,11 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
 
     @API(help="What type of histogram to use for finding optimal split points", values = { "AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"}, level = API.Level.secondary, gridable = true)
     public SharedTreeParameters.HistogramType histogram_type;
+
+    @API(help="Use Platt's Scaling to do model calibration. Ie you would like the classifcation prediction to represent posterior probabilities.", level = API.Level.expert, gridable = false)
+    public boolean calibrate_model;
+
+    @API(help="Calibration frame for Platt's scaling", level = API.Level.expert, direction = API.Direction.INOUT, gridable=false)
+    public FrameKeyV3 calibration_frame;
   }
 }

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -70,6 +70,9 @@ public abstract class SharedTreeModel<
 
     public double[] _sample_rate_per_class; //fraction of rows to sample for each tree, per class
 
+    public boolean _calibrate_model = false; // Use Platt's Scaling
+    public Key<Frame> _calibration_frame;
+
     @Override public long progressUnits() { return _ntrees + (_histogram_type==HistogramType.QuantilesGlobal || _histogram_type==HistogramType.RoundRobin ? 1 : 0); }
 
     public double _col_sample_rate_change_per_level = 1.0f; //relative change of the column sampling rate for every level

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -296,12 +296,14 @@ public class GBMTest extends TestUtil {
     try {
       Frame train = parse_test_file("smalldata/gbm_test/ecology_model.csv");
       Frame calib = parse_test_file("smalldata/gbm_test/ecology_eval.csv");
+
       // Fix training set
       train.remove("Site").remove();     // Remove unique ID
       Scope.track(train.vec("Angaus"));
       train.replace(train.find("Angaus"), train.vecs()[train.find("Angaus")].toCategoricalVec());
       Scope.track(train);
       DKV.put(train); // Update frame after hacking it
+
       // Fix calibration set (the same way as training)
       Scope.track(calib.vec("Angaus"));
       calib.replace(calib.find("Angaus"), calib.vecs()[calib.find("Angaus")].toCategoricalVec());

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static hex.genmodel.utils.DistributionFamily.*;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static water.fvec.FVecTest.makeByteVec;
@@ -283,6 +284,49 @@ public class GBMTest extends TestUtil {
       if( gbm  != null ) gbm .delete();
       if( pred != null ) pred.remove();
       if( res  != null ) res .remove();
+      Scope.exit();
+    }
+  }
+
+  // Scoring should output original probabilities and probabilities calibrated by Platt Scaling
+  @Test public void testGBMPredictWithCalibration() {
+    GBMModel gbm = null;
+    GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+    Scope.enter();
+    try {
+      Frame train = parse_test_file("smalldata/gbm_test/ecology_model.csv");
+      Frame calib = parse_test_file("smalldata/gbm_test/ecology_eval.csv");
+      // Fix training set
+      train.remove("Site").remove();     // Remove unique ID
+      Scope.track(train.vec("Angaus"));
+      train.replace(train.find("Angaus"), train.vecs()[train.find("Angaus")].toCategoricalVec());
+      Scope.track(train);
+      DKV.put(train); // Update frame after hacking it
+      // Fix calibration set (the same way as training)
+      Scope.track(calib.vec("Angaus"));
+      calib.replace(calib.find("Angaus"), calib.vecs()[calib.find("Angaus")].toCategoricalVec());
+      Scope.track(calib);
+      DKV.put(calib); // Update frame after hacking it
+
+      parms._train = train._key;
+      parms._calibrate_model = true;
+      parms._calibration_frame = calib._key;
+      parms._response_column = "Angaus"; // Train on the outcome
+      parms._distribution = DistributionFamily.multinomial;
+
+      gbm = new GBM(parms).trainModel().get();
+
+      Frame pred = parse_test_file("smalldata/gbm_test/ecology_eval.csv");
+      pred.remove("Angaus").remove();    // No response column during scoring
+      Scope.track(pred);
+      Frame res = Scope.track(gbm.score(pred));
+
+      assertArrayEquals(new String[]{"predict", "p0", "p1", "cal_p0", "cal_p1"}, res._names);
+      assertEquals(res.vec("cal_p0").mean(), 0.7860, 1e-4);
+      assertEquals(res.vec("cal_p1").mean(), 0.2139, 1e-4);
+    } finally {
+      if (gbm != null)
+        gbm.remove();
       Scope.exit();
     }
   }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1192,9 +1192,14 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
 
     if (computeMetrics)
       bs._mb.makeModelMetrics(this, fr, adaptFrm, bs.outputFrame());
-    return bs.outputFrame(Key.<Frame>make(destination_key), names, domains);
+    Frame predictFr = bs.outputFrame(Key.<Frame>make(destination_key), names, domains);
+    return postProcessPredictions(predictFr);
   }
 
+  protected Frame postProcessPredictions(Frame predictFr) {
+    // nothing by default
+    return predictFr;
+  }
 
   /** Score an already adapted frame.  Returns a MetricBuilder that can be used to make a model metrics.
    * @param adaptFrm Already adapted frame

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1103,15 +1103,15 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     return adapted;
   }
 
-  private Frame encodeFrameCategoricals(Frame fr, boolean scopeTrack) {
+  private Frame encodeFrameCategoricals(Frame fr, boolean scopeTrackOrig) {
     String[] skipCols = new String[]{_parms._weights_column, _parms._offset_column, _parms._fold_column, _parms._response_column};
     Frame encoded = FrameUtils.categoricalEncoder(fr, skipCols, _parms._categorical_encoding, getToEigenVec());
     if (encoded != fr) {
       assert encoded._key != null;
-      if (scopeTrack)
-        Scope.track(encoded);
+      if (scopeTrackOrig)
+        Scope.track(fr);
       else
-        _toDelete.put(encoded._key, Arrays.toString(Thread.currentThread().getStackTrace()));
+        _toDelete.put(fr._key, Arrays.toString(Thread.currentThread().getStackTrace()));
     }
     return encoded;
   }

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1087,8 +1087,8 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     if (fr.numRows()==0) error(field, frDesc + " must have > 0 rows.");
     Frame adapted = new Frame(null /* not putting this into KV */, fr._names.clone(), fr.vecs().clone());
     try {
-      String[] msgs = Model.adaptTestForTrain(_valid, null, null, _train._names, _train.domains(), _parms, expensive, true, null, getToEigenVec(), _toDelete, false);
-      Vec response = fr.vec(_parms._response_column);
+      String[] msgs = Model.adaptTestForTrain(adapted, null, null, _train._names, _train.domains(), _parms, expensive, true, null, getToEigenVec(), _toDelete, false);
+      Vec response = adapted.vec(_parms._response_column);
       if (response == null && _parms._response_column != null)
         error(field, frDesc + " must have a response column '" + _parms._response_column + "'.");
       if (expensive) {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1065,6 +1065,24 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   }
 
   /**
+   * Adapts a given frame to the same schema as the training frame.
+   * This includes encoding of categorical variables (if expensive is enabled).
+   *
+   * Note: This method should only be used during ModelBuilder initialization - it should be called in init(..) method.
+   *
+   * @param fr input frame
+   * @param frDesc frame description, eg. "Validation Frame" - will be shown in validation error messages
+   * @param field name of a field for validation errors
+   * @param expensive indicates full ("expensive") processing
+   * @return adapted frame
+   */
+  protected Frame init_adaptFrameToTrain(Frame fr, String frDesc, String field, boolean expensive) {
+    Frame adapted = adaptFrameToTrain(fr, frDesc, field, expensive);
+    if (expensive)
+      adapted = encodeFrameCategoricals(adapted, true);
+    return adapted;
+  }
+
   private Frame adaptFrameToTrain(Frame fr, String frDesc, String field, boolean expensive) {
     if (fr.numRows()==0) error(field, frDesc + " must have > 0 rows.");
     Frame adapted = new Frame(null /* not putting this into KV */, fr._names.clone(), fr.vecs().clone());

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1103,15 +1103,15 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     return adapted;
   }
 
-  private Frame encodeFrameCategoricals(Frame fr, boolean scopeTrackOrig) {
+  private Frame encodeFrameCategoricals(Frame fr, boolean scopeTrack) {
     String[] skipCols = new String[]{_parms._weights_column, _parms._offset_column, _parms._fold_column, _parms._response_column};
     Frame encoded = FrameUtils.categoricalEncoder(fr, skipCols, _parms._categorical_encoding, getToEigenVec());
     if (encoded != fr) {
       assert encoded._key != null;
-      if (scopeTrackOrig)
-        Scope.track(fr);
+      if (scopeTrack)
+        Scope.track(encoded);
       else
-        _toDelete.put(fr._key, Arrays.toString(Thread.currentThread().getStackTrace()));
+        _toDelete.put(encoded._key, Arrays.toString(Thread.currentThread().getStackTrace()));
     }
     return encoded;
   }

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -37,7 +37,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
                       "learn_rate", "learn_rate_annealing", "distribution", "quantile_alpha", "tweedie_power",
                       "huber_alpha", "checkpoint", "sample_rate", "sample_rate_per_class", "col_sample_rate",
                       "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
-                      "histogram_type", "max_abs_leafnode_pred", "pred_noise_bandwidth", "categorical_encoding"}
+                      "histogram_type", "max_abs_leafnode_pred", "pred_noise_bandwidth", "categorical_encoding",
+                      "calibrate_model", "calibration_frame"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -796,5 +797,36 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     def categorical_encoding(self, categorical_encoding):
         assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
+
+
+    @property
+    def calibrate_model(self):
+        """
+        Use Platt Scaling to do model calibration. Transforms the outputs of a classification model into a probability
+        distribution over classes
+
+        Type: ``bool``  (default: ``False``).
+        """
+        return self._parms.get("calibrate_model")
+
+    @calibrate_model.setter
+    def calibrate_model(self, calibrate_model):
+        assert_is_type(calibrate_model, None, bool)
+        self._parms["calibrate_model"] = calibrate_model
+
+
+    @property
+    def calibration_frame(self):
+        """
+        Calibration frame for Platt Scaling
+
+        Type: ``H2OFrame``.
+        """
+        return self._parms.get("calibration_frame")
+
+    @calibration_frame.setter
+    def calibration_frame(self, calibration_frame):
+        assert_is_type(calibration_frame, None, H2OFrame)
+        self._parms["calibration_frame"] = calibration_frame
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -32,7 +32,7 @@ class H2ORandomForestEstimator(H2OEstimator):
                       "stopping_metric", "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node",
                       "mtries", "sample_rate", "sample_rate_per_class", "binomial_double_trees", "checkpoint",
                       "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
-                      "histogram_type", "categorical_encoding"}
+                      "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -686,5 +686,36 @@ class H2ORandomForestEstimator(H2OEstimator):
     def categorical_encoding(self, categorical_encoding):
         assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response"))
         self._parms["categorical_encoding"] = categorical_encoding
+
+
+    @property
+    def calibrate_model(self):
+        """
+        Use Platt Scaling to do model calibration. Transforms the outputs of a classification model into a probability
+        distribution over classes
+
+        Type: ``bool``  (default: ``False``).
+        """
+        return self._parms.get("calibrate_model")
+
+    @calibrate_model.setter
+    def calibrate_model(self, calibrate_model):
+        assert_is_type(calibrate_model, None, bool)
+        self._parms["calibrate_model"] = calibrate_model
+
+
+    @property
+    def calibration_frame(self):
+        """
+        Calibration frame for Platt Scaling
+
+        Type: ``H2OFrame``.
+        """
+        return self._parms.get("calibration_frame")
+
+    @calibration_frame.setter
+    def calibration_frame(self, calibration_frame):
+        assert_is_type(calibration_frame, None, H2OFrame)
+        self._parms["calibration_frame"] = calibration_frame
 
 

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -84,6 +84,9 @@
 #' @param pred_noise_bandwidth Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions Defaults to 0.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen", "LabelEncoder", "SortByResponse". Defaults to AUTO.
+#' @param calibrate_model \code{Logical}. Use Platt Scaling to do model calibration. Transforms the outputs of a classification model
+#'        into a probability distribution over classes Defaults to FALSE.
+#' @param calibration_frame Calibration frame for Platt Scaling
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
 #' \donttest{
@@ -146,7 +149,9 @@ h2o.gbm <- function(x, y, training_frame,
                     histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
                     max_abs_leafnode_pred = 1.797693135e+308,
                     pred_noise_bandwidth = 0,
-                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse")
+                    categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse"),
+                    calibrate_model = FALSE,
+                    calibration_frame = NULL
                     ) 
 {
   #If x is missing, then assume user wants to use all columns as features.
@@ -279,6 +284,10 @@ h2o.gbm <- function(x, y, training_frame,
     parms$pred_noise_bandwidth <- pred_noise_bandwidth
   if (!missing(categorical_encoding))
     parms$categorical_encoding <- categorical_encoding
+  if (!missing(calibrate_model))
+    parms$calibrate_model <- calibrate_model
+  if (!missing(calibration_frame))
+    parms$calibration_frame <- calibration_frame
   # Error check and build model
   .h2o.modelJob('gbm', parms, h2oRestApiVersion=3) 
 }

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -73,6 +73,9 @@
 #'        "Random", "QuantilesGlobal", "RoundRobin". Defaults to AUTO.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen", "LabelEncoder", "SortByResponse". Defaults to AUTO.
+#' @param calibrate_model \code{Logical}. Use Platt Scaling to do model calibration. Transforms the outputs of a classification model
+#'        into a probability distribution over classes Defaults to FALSE.
+#' @param calibration_frame Calibration frame for Platt Scaling
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @export
@@ -115,7 +118,9 @@ h2o.randomForest <- function(x, y, training_frame,
                              col_sample_rate_per_tree = 1,
                              min_split_improvement = 1e-05,
                              histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
-                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse")
+                             categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse"),
+                             calibrate_model = FALSE,
+                             calibration_frame = NULL
                              ) 
 {
   #If x is missing, then assume user wants to use all columns as features.
@@ -231,6 +236,10 @@ h2o.randomForest <- function(x, y, training_frame,
     parms$histogram_type <- histogram_type
   if (!missing(categorical_encoding))
     parms$categorical_encoding <- categorical_encoding
+  if (!missing(calibrate_model))
+    parms$calibrate_model <- calibrate_model
+  if (!missing(calibration_frame))
+    parms$calibration_frame <- calibration_frame
   # Error check and build model
   .h2o.modelJob('drf', parms, h2oRestApiVersion=3) 
 }

--- a/h2o-r/tests/testdir_algos/gbm/runit_GBM_calibration_binomial.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBM_calibration_binomial.R
@@ -1,0 +1,51 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+test.GBM.calibration.binomial <- function() {
+
+    ecology.hex <- h2o.importFile(locate("smalldata/gbm_test/ecology_model.csv"))
+    ecology.hex$Angaus <- as.factor(ecology.hex$Angaus)
+
+    ecology.split <- h2o.splitFrame(ecology.hex, seed = 12354)
+    ecology.train <- ecology.split[[1]]
+    ecology.calib <- ecology.split[[2]]
+
+    # introduce a weight column (artificial non-constant) ONLY to the train set (NOT the calibration one)
+    weights <- c(0, rep(1, nrow(ecology.train) - 1))
+    ecology.train$weight <- as.h2o(weights)
+
+    # Train H2O GBM Model with Calibration
+    ecology.model <- h2o.gbm(x = 3:13, y = "Angaus", training_frame = ecology.train,
+                             ntrees = 10,
+                             max_depth = 5,
+                             min_rows = 10,
+                             learn_rate = 0.1,
+                             distribution = "multinomial",
+                             weights_column = "weight",
+                             calibrate_model = TRUE,
+                             calibration_frame = ecology.calib
+    )
+
+    predicted <- h2o.predict(ecology.model, ecology.calib)
+
+    # Check that calibrated probabilities were appended to the output frame
+    expect_equal(colnames(predicted), c("predict", "p0", "p1", "cal_p0", "cal_p1"))
+
+    # Manually scale the probabilities using GLM in R
+    manual.calib.input <- cbind(as.data.frame(predicted$p1), as.data.frame(ecology.calib$Angaus))
+    colnames(manual.calib.input) <- c("x", "y")
+    manual.calib.model <- glm(y ~ x, manual.calib.input, family = binomial)
+    manual.calib.predicted <- predict(manual.calib.model, newdata = manual.calib.input, type = "response")
+
+    # Check that manually calculated probabilities match output from H2O
+    expect_equal(
+      as.data.frame(predicted$cal_p1),
+      data.frame(cal_p1 = manual.calib.predicted, row.names = NULL),
+      tolerance = 1e-4, scale = 1
+    )
+}
+
+doTest("GBM: Test Binomial Model Calibration (Platt Scaling)", test.GBM.calibration.binomial)
+


### PR DESCRIPTION
GBM/DRF: Support for calibrating output probabilities using Platt Scaling.

Platt Scaling tutorial: http://danielnee.com/tag/platt-scaling/

Implemented as a post-processing step in the SharedTree[Model]. Calibrated probabilities are appended to the frame with original prediction. This is done in a separate scoring task. Combining tree scoring & glm scoring into the same task is challenging because the tree scoring logic doesn't expect the extra columns reserved for calibrated probabilities. This is the main reason why it is implemented in post-processing.