### PR TITLE
[PUBDEV-4392] Verify cluster name also in flat-file cloud-up mode

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1477,6 +1477,7 @@ final public class H2O {
     // Create the starter Cloud with 1 member
     SELF._heartbeat._jar_md5 = JarHash.JARHASH;
     SELF._heartbeat._client = ARGS.client;
+    SELF._heartbeat._cloud_name_hash = ARGS.name.hashCode();
   }
 
   /** Starts the worker threads, receiver threads, heartbeats and all other

--- a/h2o-core/src/main/java/water/HeartBeat.java
+++ b/h2o-core/src/main/java/water/HeartBeat.java
@@ -10,6 +10,7 @@ import water.init.JarHash;
 public class HeartBeat extends Iced<HeartBeat> {
   char _hb_version;             // Incrementing counter for sorting timelines better.
   int _cloud_hash;              // Cloud-membership hash
+  int _cloud_name_hash;         // Hash of this cloud's name
   boolean _common_knowledge;    // Cloud shares common knowledge
   char _cloud_size;             // Cloud-size this guy is reporting
   long _jvm_boot_msec;          // Boot time of JVM

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -47,6 +47,12 @@ public abstract class Paxos {
       }
       return 0;
     }
+    
+    if(H2O.isFlatfileEnabled() && h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash){
+      // ignore requests from this node as they are coming from different cluster
+      // it's fine to check for this only in flat file mode as it is already handled in the multi-cast mode
+      return 0;
+    }
 
     // I am not client but received client heartbeat in flatfile mode.
     // Means that somebody is trying to connect to this cloud.

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -48,9 +48,8 @@ public abstract class Paxos {
       return 0;
     }
     
-    if(H2O.isFlatfileEnabled() && h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash){
+    if(h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash){
       // ignore requests from this node as they are coming from different cluster
-      // it's fine to check for this only in flat file mode as it is already handled in the multi-cast mode
       return 0;
     }
 


### PR DESCRIPTION
This simple change ensures that when multiple nodes from different clusters are started on the same physical node they don't collide. 

Any comments welcome!