### PR TITLE
Add support for requesting Spot instances

### DIFF
--- a/ec2/README.md
+++ b/ec2/README.md
@@ -17,7 +17,7 @@ export AWS_SSH_PRIVATE_KEY_FILE="/path/to/private_key.pem"
 source ~/.bash_profile
 ```
 
-STEP 2:  Install python and boto, if necessary
+STEP 2:  Install python 2 and boto, if necessary
 -----------------------------------------
 
 - Boto: http://boto.readthedocs.org/en/latest/
@@ -34,9 +34,13 @@ numInstancesToLaunch = 4
 instanceType = 'm3.2xlarge'
 instanceNameRoot = 'h2o-instance'
 ```
+- You can also specify a [maximum Spot request bid](https://aws.amazon.com/ec2/spot/pricing/) if running on Spot is desired:
+```
+spotBid = '1.35'
+```
 **Note:** After following steps 1-3 (where you set up your environment) you can run the scripts within the repo using the following command: `./run-all.sh` or you can do it manually by following steps 4-5.
 
-**Note:** If you fail to initialize a cluster instance, then you should `Terminate` the instance before re-trying to prevent a refusal of connection. 
+**Note:** If you fail to initialize a cluster instance, then you should `Terminate` the instance before re-trying to prevent a refusal of connection.
 
 STEP 4:  Start H2O Cluster
 -------------------------------------------------
@@ -45,6 +49,8 @@ STEP 4:  Start H2O Cluster
 ```
 ./h2o-cluster-launch-instances.py
 ```
+
+**Note:** If using Spot requests and your spot bid is too low, the entire request will be automatically cancelled for you.
 
 - Below will distribute the `h2o.jar` file to all the worker nodes, along with your AWS credentials and then start the H2O cluster. Note, the `h2o.jar` is reflective of the latest stable build from H2O.
 ```

--- a/ec2/h2o-cluster-launch-instances.py
+++ b/ec2/h2o-cluster-launch-instances.py
@@ -42,7 +42,7 @@ instanceType = 'm3.2xlarge'
 instanceNameRoot = 'h2o-instance'
 # set to a string USD amount if you'd like to request spot instances
 # read more about spot here: https://aws.amazon.com/ec2/spot/
-spotBid = '0.01'
+spotBid = None
 
 
 # Options to help debugging.

--- a/ec2/h2o-cluster-launch-instances.py
+++ b/ec2/h2o-cluster-launch-instances.py
@@ -40,6 +40,9 @@ securityGroupName = 'SecurityDisabled'
 numInstancesToLaunch = 2
 instanceType = 'm3.2xlarge'
 instanceNameRoot = 'h2o-instance'
+# set to a string USD amount if you'd like to request spot instances
+# read more about spot here: https://aws.amazon.com/ec2/spot/
+spotBid = '0.01'
 
 
 # Options to help debugging.
@@ -105,20 +108,71 @@ ec2 = boto.ec2.connect_to_region(regionName, debug=debug)
 
 print 'Launching', numInstancesToLaunch, 'instances.'
 
-reservation = ec2.run_instances(
-    image_id=amiId,
-    min_count=numInstancesToLaunch,
-    max_count=numInstancesToLaunch,
-    key_name=keyName,
-    instance_type=instanceType,
-    security_groups=[securityGroupName],
-    instance_profile_arn=iam_profile_resource_name,
-    instance_profile_name=iam_profile_name,
-    dry_run=dryRun
-)
+if spotBid is None:
+    reservation = ec2.run_instances(
+        image_id=amiID,
+        min_count=numInstancesToLaunch,
+        max_count=numInstancesToLaunch,
+        key_name=keyName,
+        instance_type=instanceType,
+        security_groups=[securityGroupName],
+        instance_profile_arn=iam_profile_resource_name,
+        instance_profile_name=iam_profile_name,
+        dry_run=dryRun
+    )
+else:
+    spotRequests = ec2.request_spot_instances(
+        price=spotBid,
+        image_id=amiID,
+        count=numInstancesToLaunch,
+        key_name=keyName,
+        instance_type=instanceType,
+        security_groups=[securityGroupName],
+        instance_profile_arn=iam_profile_resource_name,
+        instance_profile_name=iam_profile_name,
+        dry_run=dryRun,
+    )
 
-for i in range(numInstancesToLaunch):
-    instance = reservation.instances[i]
+    requestIDs = [request.id for request in spotRequests]
+    fulfilled = []
+
+    while requestIDs:
+        requests = ec2.get_all_spot_instance_requests(
+            request_ids=requestIDs,
+        )
+
+        for request in requests:
+            if request.instance_id:
+                requestIDs.remove(request.id)
+                fulfilled.append(request.instance_id)
+
+            # unrecoverable error without increasing the spot bid
+            elif request.status.code == u'price-too-low':
+                print request.status.message
+                print 'Cancelling Spot requests...'
+                # get original request ids since some requests may have already been fulfilled
+                ec2.cancel_spot_instance_requests(
+                    request_ids=[request.id for request in spotRequests],
+                )
+
+                print 'Exiting...'
+                sys.exit(1)
+
+            print request.id, request.status.message
+
+        print '%s/%s requests fulfilled' % (len(fulfilled), numInstancesToLaunch)
+
+        if requestIDs:
+            print 'Waiting for remaining requests to be fulfilled...'
+            time.sleep(5)
+
+    reservation = ec2.get_all_instances(
+        instance_ids=fulfilled,
+    )
+
+instances = reservation[0].instances
+
+for i, instance in enumerate(instances):
     print 'Waiting for instance', i+1, 'of', numInstancesToLaunch, '...'
     instance.update()
     while instance.state != 'running':
@@ -133,11 +187,9 @@ print
 print 'Creating output files: ', publicFileName, privateFileName
 print
 
-for i in range(numInstancesToLaunch):
-    instance = reservation.instances[i]
-    instanceName = ''
-    if 'Name' in instance.tags:
-        instanceName = instance.tags['Name'];
+for i, instance in enumerate(instances):
+    instanceName = instance.tags.get('Name', '')
+
     print 'Instance', i+1, 'of', numInstancesToLaunch
     print '    Name:   ', instanceName
     print '    PUBLIC: ', instance.public_dns_name


### PR DESCRIPTION
This PR modifies the ec2 helper scripts to allow requesting Spot instances, which can significantly lower the cost of large, long-running clusters.

In particular, this adds a new `spotBid` variable that, if set to anything other than `None`, will request that the desired instances be spun up through Spot. For more background on Spot, [see AWS](https://aws.amazon.com/ec2/spot/).

I needed Spot support for work, so I figured I might as well try to get up merged upstream.