### PR TITLE
PUBDEV-4314: python varimp for PCA.  Added varimp() for PCA.  Added a…

### DIFF
--- a/h2o-py/h2o/model/dim_reduction.py
+++ b/h2o-py/h2o/model/dim_reduction.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
+from h2o.utils.shared_utils import can_use_pandas
 from h2o.utils.compatibility import *  # NOQA
 
 from .model_base import ModelBase
@@ -11,6 +12,25 @@ class H2ODimReductionModel(ModelBase):
     """
     Dimension reduction model, such as PCA or GLRM.
     """
+
+
+    def varimp(self, use_pandas=False):
+        """
+        Return the Importance of components associcated with a pca model
+
+        Type: ``bool``  (default: ``True``).
+        """
+        model = self._model_json["output"]
+        if "importance" in list(model.keys()) and model["importance"]:
+            vals = model["importance"].cell_values
+            header = model["importance"].col_header
+            if use_pandas and can_use_pandas():
+                import pandas
+                return pandas.DataFrame(vals, columns=header)
+            else:
+                return vals
+        else:
+            print("Warning: This model doesn't have importances of components.")
 
     def num_iterations(self):
         """Get the number of iterations that it took to converge or reach max iterations."""

--- a/h2o-py/h2o/model/dim_reduction.py
+++ b/h2o-py/h2o/model/dim_reduction.py
@@ -16,9 +16,9 @@ class H2ODimReductionModel(ModelBase):
 
     def varimp(self, use_pandas=False):
         """
-        Return the Importance of components associcated with a pca model
+        Return the Importance of components associcated with a pca model.
 
-        Type: ``bool``  (default: ``True``).
+        use_pandas: ``bool``  (default: ``False``).
         """
         model = self._model_json["output"]
         if "importance" in list(model.keys()) and model["importance"]:

--- a/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_4314_varimp.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_4314_varimp.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.transforms.decomposition import H2OPCA
+from h2o.utils.typechecks import assert_is_type
+from pandas import DataFrame
+
+
+# This test aims to test that our PCA works with wide datasets for the following PCA methods:
+# 1. GramSVD: PUBDEV-3694;
+# 2. Power: PUBDEV-3858
+#
+# It will compare the eigenvalues and eigenvectors obtained with the various methods and they should agree
+# to within certain tolerance.
+
+def pca_pubdev_4314():
+    print("Importing prostate_cat.csv data...\n")
+    prostate = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    prostate.describe()
+    print("PCA with k = 3, retx = FALSE, transform = 'STANDARDIZE'")
+    fitPCA = H2OPCA(k=3, transform="StANDARDIZE", pca_method="GramSVD")
+    fitPCA.train(x=list(range(0,8)), training_frame=prostate)
+    print(fitPCA.summary())
+    varimpPandas = fitPCA.varimp(use_pandas=True)
+    assert_is_type(varimpPandas, DataFrame)
+    varimpList = fitPCA.varimp()
+    print(varimpList)
+    assert_is_type(varimpList, list)
+    sys.stdout.flush()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pca_pubdev_4314())
+else:
+    pca_pubdev_4314()


### PR DESCRIPTION
Two things:
1. Added varimp() to get to the importance of components output from PCA for Python.
2.  Added a pyunit test to make sure we are getting the correct return types.