### PR TITLE
PUBDEV-4389: k-LIME misinterprets order of categorical columns

### DIFF
--- a/h2o-r/tests/testdir_algos/klime/runit_klime_titanic.R
+++ b/h2o-r/tests/testdir_algos/klime/runit_klime_titanic.R
@@ -11,9 +11,13 @@ test.klime.titanic <- function() {
   titanic_expected = h2o.importFile(path = locate("smalldata/klime_test/titanic_3_expected.csv"),
                                     col.types = c("real","real","real","real","real","real","real","real","real"))
 
+  titanic_age <- titanic_input$Age
+  titanic_input$Age <- NULL
+  titanic_input <- h2o.cbind(titanic_age, titanic_input)
+
   # Train a k-LIME model
   klime = h2o.klime(training_frame = titanic_input,
-                    x = c("Pclass", "Sex", "Age", "SibSp", "Parch"), y = "p1",
+                    x = c("Age", "Pclass", "Sex", "SibSp", "Parch"), y = "p1",
                     max_k = 3, estimate_k = FALSE,
                     seed = 12345)
 


### PR DESCRIPTION
k-LIME ignored order of columns imposed by GLM. GLM internally reorders columns to have categorical columns first, this was not affected in k-LIME which preserved the original order of columns.

The idea of the fix is to first compute the global GLM and use its order of columns for both k-means clustering and cluster-local GLMs.