### PR TITLE
More lenient image type check for MOJO predictions

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -523,7 +523,7 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
           }
         } else if (o instanceof Double) {
           value = (Double) o;
-        } else if (o instanceof byte[] && isImage) {
+        } else if (o instanceof byte[]) {
           // Read the image from raw bytes
           InputStream is = new ByteArrayInputStream((byte[]) o);
           try {
@@ -536,7 +536,7 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
                   "Unexpected object type " + o.getClass().getName() + " for numeric column " + dataColumnName);
         }
 
-        if (isImage && img != null) {
+        if (img != null) {
           DeepwaterMojoModel dwm = (DeepwaterMojoModel) m;
           int W = dwm._width;
           int H = dwm._height;


### PR DESCRIPTION
Treat all byte[] as images during predictions so we can predict images in byte[] format even using models trained using dataset format.