### PR TITLE
PUBDEV-4414: Change get_leaderboard() and get_leader() in Py API to Python properties

### DIFF
--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -166,7 +166,8 @@ class H2OAutoML(object):
         if self.project_name is None:
             self.project_name = "automl_" + training_frame.frame_id
 
-    def get_leader(self):
+    @property
+    def leader(self):
         """
         Retrieve the top model from an H2OAutoML object
 
@@ -184,12 +185,12 @@ class H2OAutoML(object):
         >>> # Launch H2OAutoML
         >>> aml.train(y=y, training_frame=training_frame)
         >>> # Get the top model
-        >>> aml.get_leader()
+        >>> aml.leader
         """
-        leader = h2o.get_model(self._leader_id)
-        return leader
+        return h2o.get_model(self._leader_id)
 
-    def get_leaderboard(self):
+    @property
+    def leaderboard(self):
         """
         Retrieve the leaderboard from an H2OAutoML object
 
@@ -208,10 +209,9 @@ class H2OAutoML(object):
         >>> # Launch H2OAutoML
         >>> aml.train(y=y, training_frame=training_frame)
         >>> # Get the leaderboard
-        >>> aml.get_leaderboard()
+        >>> aml.leaderboard
         """
-        res = h2o.api("GET /99/AutoML/" + self._automl_key)
-        return res["leaderboard_table"]
+        return self._leaderboard
 
     def predict(self, test_data):
         """
@@ -233,7 +233,7 @@ class H2OAutoML(object):
         >>> # Launch H2OAutoML
         >>> aml.train(y=y, training_frame=training_frame)
         >>> #Predict with #1 model from H2OAutoML leaderboard
-        >>> aml.predict()
+        >>> aml.predict(test_data)
 
         """
         if self._fetch():
@@ -246,12 +246,13 @@ class H2OAutoML(object):
     #-------------------------------------------------------------------------------------------------------------------
     def _fetch(self):
         res = h2o.api("GET /99/AutoML/" + self._automl_key)
-        self._leaderboard = [key["name"] for key in res['leaderboard']['models']]
+        leaderboard_list = [key["name"] for key in res['leaderboard']['models']]
 
-        if self._leaderboard is not None and len(self._leaderboard) > 0:
-            self._leader_id = self._leaderboard[0]
+        if leaderboard_list is not None and len(leaderboard_list) > 0:
+            self._leader_id = leaderboard_list[0]
         else:
             self._leader_id = None
+        self._leaderboard = res["leaderboard_table"]
         return self._leader_id is not None
 
     def _get_params(self):

--- a/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
+++ b/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
@@ -32,7 +32,9 @@ def prostate_automl():
 
     print("AutoML (Binomial) run with x not provided with train, valid, and test")
     aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, test_frame=test)
-    assert set(aml.get_leaderboard().col_header) == set(["","model_id","auc","logloss"])
+    print(aml.leader)
+    print(aml.leaderboard)
+    assert set(aml.leaderboard.col_header) == set(["","model_id","auc","logloss"])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(prostate_automl)

--- a/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
+++ b/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
@@ -28,7 +28,9 @@ def iris_automl():
 
     print("AutoML (Multinomial) run with x not provided with train, valid, and test")
     aml.train(y="class", training_frame=train,validation_frame=valid, test_frame=test)
-    assert set(aml.get_leaderboard().col_header) == set(["","model_id","mean_per_class_error"])
+    print(aml.leader)
+    print(aml.leaderboard)
+    assert set(aml.leaderboard.col_header) == set(["","model_id","mean_per_class_error"])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(iris_automl)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -67,9 +67,9 @@ def prostate_automl():
     build_control["project"] = "Project6"
     aml.train(y="CAPSULE", training_frame=train)
     print("Check leader")
-    aml.get_leader()
+    aml.leader
     print("Check leaderboard")
-    aml.get_leaderboard()
+    aml.leaderboard
     print("Check predictions")
     aml.predict(train)
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
@@ -35,23 +35,23 @@ def prostate_automl():
     y = "CAPSULE"
     names = train.names
     aml.train(x=x,y=y, training_frame=train,validation_frame=valid, test_frame=test)
-    models = aml.get_leaderboard()["model_id"]
+    models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 
     print("AutoML with x and y as col indexes, train, valid, and test")
     aml.train(x=[2,3,4],y=1, training_frame=train,validation_frame=valid, test_frame=test)
-    models = aml.get_leaderboard()["model_id"]
+    models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 
 
     print("AutoML with x as a str list, y as a col index, train, valid, and test")
     aml.train(x=x,y=1, training_frame=train,validation_frame=valid, test_frame=test)
-    models = aml.get_leaderboard()["model_id"]
+    models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 
     print("AutoML with x as col indexes, y as a str, train, valid, and test")
     aml.train(x=[2,3,4],y=y, training_frame=train,validation_frame=valid, test_frame=test)
-    models = aml.get_leaderboard()["model_id"]
+    models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
+++ b/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
@@ -28,7 +28,9 @@ def australia_automl():
 
     print("AutoML (Regression) run with x not provided with train, valid, and test")
     aml.train(y="runoffnew", training_frame=train,validation_frame=valid, test_frame=test)
-    assert set(aml.get_leaderboard().col_header) == set(["","model_id", "mean_residual_deviance","rmse", "mae", "rmsle"])
+    print(aml.leader)
+    print(aml.leaderboard)
+    assert set(aml.leaderboard.col_header) == set(["","model_id", "mean_residual_deviance","rmse", "mae", "rmsle"])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(australia_automl)


### PR DESCRIPTION
* Change `get_leaderboard()` and `get_leader()`in `H2OAutoML` methods to properties called `.leader` and `.leaderboard`.