### PR TITLE
PUBDEV-6732: Fix model export via java-rest-bindings

### DIFF
--- a/h2o-bindings/bin/gen_java.py
+++ b/h2o-bindings/bin/gen_java.py
@@ -251,7 +251,13 @@ def generate_proxy(classname, endpoints):
         required_param_strs = []
         for field in e["input_params"]:
             fname = field["name"]
-            ftype = "Path" if field["is_path_param"] else "Field"
+            if field["is_path_param"]:
+                ftype = "Path"
+            else:
+                if e["http_method"] == "POST":
+                    ftype = "Field"
+                else:
+                    ftype = "Query"
             ptype = translate_type(field["type"], field["schema_name"])
             if ptype.endswith("KeyV3") or ptype == "ColSpecifierV3": ptype = "String"
             if ptype.endswith("KeyV3[]"): ptype = "String[]"

--- a/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
@@ -1,5 +1,6 @@
 package water.bindings.examples.retrofit;
 
+import java.io.File;
 import water.bindings.H2oApi;
 import water.bindings.pojos.*;
 
@@ -98,6 +99,17 @@ public class GBM_Example {
 
         ModelMetricsListSchemaV3 predictions = h2o.predict(predict_params);
         System.out.println("predictions: " + predictions);
+        
+        // STEP 9 (optional): export model as binary
+        // Fails...
+        ModelExportV3 model_export = new ModelExportV3();
+        model_export.modelId = model_key;
+        
+        File f = File.createTempFile("model", ".h2o");
+        model_export.dir = File.createTempFile("model", ".h2o").getPath();
+        f.deleteOnExit();
+        
+        h2o.exportModel(model_export);
 
         // STEP 99: end the session
         h2o.endSession();


### PR DESCRIPTION
https://github.com/dietzc/h2o-3/commit/dbd30f49d5e4deb43460327ebf61857874ece07d adds a model export to the `GBM` example, which results in a failing test. https://github.com/dietzc/h2o-3/commit/9d561c97da9cd517a4c45cb7c869343fa775dcde fixes the problem by using `@Query` for non-`POST` methods.

I hope this helps.