### PR TITLE
k-LIME, report metrics for cluster-local models

### DIFF
--- a/h2o-algos/src/main/java/hex/klime/KLime.java
+++ b/h2o-algos/src/main/java/hex/klime/KLime.java
@@ -94,6 +94,16 @@ public class KLime extends ModelBuilder<KLimeModel, KLimeModel.KLimeParameters, 
         Frame clusterLabels = Scope.track(clusteringModel.score(clusteringTrain));
 
         final int K = clusteringModel._output._k[clusteringModel._output._k.length - 1];
+
+        model._output._clustering = clusteringModel;
+        model._output._globalRegressionModel = globalRegressionModel;
+        model._output._regressionModels = new GLMModel[K];
+        model.update(_job);
+
+        // this calculates R2 on each cluster using a global model
+        model.score(_parms.train()).delete(); // This scores on the training data and appends a ModelMetrics
+        model._output._training_metrics = ModelMetrics.getFromDKV(model, _parms.train());
+
         String[] clusterNames = new String[K];
         for (int i = 0; i < K; i++)
           clusterNames[i] = "cluster" + i;
@@ -154,9 +164,6 @@ public class KLime extends ModelBuilder<KLimeModel, KLimeModel.KLimeParameters, 
           } else
             _job.update(1); // model won't be built
         }
-
-        model._output._clustering = clusteringModel;
-        model._output._globalRegressionModel = globalRegressionModel;
         model._output._regressionModels = regressionModels;
 
         model.score(_parms.train()).delete(); // This scores on the training data and appends a ModelMetrics

--- a/h2o-algos/src/main/java/hex/klime/KLimeModel.java
+++ b/h2o-algos/src/main/java/hex/klime/KLimeModel.java
@@ -190,6 +190,14 @@ public class KLimeModel extends Model<KLimeModel, KLimeParameters, KLimeOutput> 
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public void reduce(KLimeMetricBuilder mb) {
+      for (int i = 0; i < _clusterMBs.length; i++)
+        _clusterMBs[i].reduce(mb._clusterMBs[i]);
+      super.reduce(mb);
+    }
+
+    @Override
     public ModelMetrics makeModelMetrics(Model m, Frame f, Frame adaptedFrame, Frame preds) {
       ModelMetricsRegression globalMetrics = (ModelMetricsRegression) super.makeModelMetrics(null, f, null, null);
       ModelMetricsRegression[] clusterMetrics = new ModelMetricsRegression[_clusterMBs.length];

--- a/h2o-algos/src/main/java/water/api/ModelMetricsKLimeV3.java
+++ b/h2o-algos/src/main/java/water/api/ModelMetricsKLimeV3.java
@@ -1,0 +1,39 @@
+package water.api;
+
+import hex.klime.KLimeModel;
+import water.api.schemas3.ModelMetricsRegressionV3;
+import water.api.schemas3.TwoDimTableV3;
+import water.util.TwoDimTable;
+
+public class ModelMetricsKLimeV3<I extends KLimeModel.ModelMetricsKLime, S extends ModelMetricsKLimeV3<I, S>> extends ModelMetricsRegressionV3<I, S> {
+
+  @API(help="Number of clusters.", direction=API.Direction.OUTPUT)
+  public int k;
+
+  @API(help="Local metrics calculated for each cluster.", direction=API.Direction.OUTPUT)
+  public TwoDimTableV3 cluster_metrics;
+
+  @Override
+  public S fillFromImpl(I modelMetrics) {
+    super.fillFromImpl(modelMetrics);
+    k = modelMetrics._clusterMetrics.length;
+    String[] clusterNames = new String[k];
+    for (int i = 0; i < k; i++)
+      clusterNames[i] = Integer.toString(i);
+    TwoDimTable cm = new TwoDimTable("Cluster Metrics", "Metrics calculated from cluster-local observations",
+            clusterNames,
+            new String[]{"Uses Global Model", "r2", "MSE", "RMSE", "nobs"},
+            new String[]{"string", "double", "double", "double", "int"},
+            null,
+            "Cluster");
+    for (int i = 0; i < k; i++) {
+      cm.set(i, 0, Boolean.toString(modelMetrics._usesGlobalModel[i]));
+      cm.set(i, 1, modelMetrics._clusterMetrics[i].r2());
+      cm.set(i, 2, modelMetrics._clusterMetrics[i].mse());
+      cm.set(i, 3, modelMetrics._clusterMetrics[i].rmse());
+      cm.set(i, 4, modelMetrics._clusterMetrics[i]._nobs);
+    }
+    cluster_metrics = new TwoDimTableV3().fillFromImpl(cm);
+    return (S) this;
+  }
+}

--- a/h2o-algos/src/test/java/hex/klime/KLimeTest.java
+++ b/h2o-algos/src/test/java/hex/klime/KLimeTest.java
@@ -9,6 +9,8 @@ import water.Scope;
 import water.TestUtil;
 import water.fvec.Frame;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 public class KLimeTest extends TestUtil {
@@ -50,6 +52,11 @@ public class KLimeTest extends TestUtil {
           sum += scored.vec(j).at(i);
         assertEquals("Reason codes are correct for row " + i, scored.vec(0).at(i), sum + intercept, 0.0001);
       }
+
+      assertTrue(klm._output._training_metrics instanceof KLimeModel.ModelMetricsKLime);
+      KLimeModel.ModelMetricsKLime tm = (KLimeModel.ModelMetricsKLime) klm._output._training_metrics;
+      assertArrayEquals(new boolean[]{false, true, true}, tm._usesGlobalModel);
+      assertEquals(3, tm._clusterMetrics.length);
     } finally {
       Scope.exit();
     }

--- a/h2o-core/src/main/java/hex/ModelMetricsRegression.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsRegression.java
@@ -105,7 +105,7 @@ public class ModelMetricsRegression extends ModelMetricsSupervised {
       _dist=dist;
     }
 
-    // ds[0] has the prediction and ds[1] is ignored
+    // ds[0] has the prediction and ds[1,..,N] is ignored
     @Override public double[] perRow(double ds[], float[] yact, Model m) {return perRow(ds, yact, 1, 0, m);}
     @Override public double[] perRow(double ds[], float[] yact, double w, double o,  Model m) {
       if( Float.isNaN(yact[0]) ) return ds; // No errors if   actual   is missing

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -69,9 +69,9 @@ class MetricsBase(backwards_compatible()):
         types_w_clustering = ['ModelMetricsClustering']
         types_w_mult = ['ModelMetricsMultinomial']
         types_w_bin = ['ModelMetricsBinomial', 'ModelMetricsBinomialGLM']
-        types_w_r2 = ['ModelMetricsRegressionGLM']
-        types_w_mean_residual_deviance = ['ModelMetricsRegressionGLM', 'ModelMetricsRegression']
-        types_w_mean_absolute_error = ['ModelMetricsRegressionGLM', 'ModelMetricsRegression']
+        types_w_r2 = ['ModelMetricsRegressionGLM', 'ModelMetricsKLime']
+        types_w_mean_residual_deviance = ['ModelMetricsRegressionGLM', 'ModelMetricsRegression', 'ModelMetricsKLime']
+        types_w_mean_absolute_error = ['ModelMetricsRegressionGLM', 'ModelMetricsRegression', 'ModelMetricsKLime']
         types_w_logloss = types_w_bin + types_w_mult
         types_w_dim = ["ModelMetricsGLRM"]
 

--- a/h2o-r/tests/testdir_algos/klime/runit_klime_titanic.R
+++ b/h2o-r/tests/testdir_algos/klime/runit_klime_titanic.R
@@ -6,17 +6,17 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 test.klime.titanic <- function() {
   # Load Titanic dataset (with predictions of 'Survived' made by GBM)
-  titanic_input = h2o.importFile(path = locate("smalldata/klime_test/titanic_input.csv"),
-                                   col.types = c("enum","enum","real","real","real","enum","real","real","real","real"))
-  titanic_expected = h2o.importFile(path = locate("smalldata/klime_test/titanic_3_expected.csv"),
-                                    col.types = c("real","real","real","real","real","real","real","real","real"))
+  titanic_input <- h2o.importFile(path = locate("smalldata/klime_test/titanic_input.csv"),
+                                  col.types = c("enum","enum","real","real","real","enum","real","real","real","real"))
+  titanic_expected <- h2o.importFile(path = locate("smalldata/klime_test/titanic_3_expected.csv"),
+                                     col.types = c("real","real","real","real","real","real","real","real","real"))
 
   titanic_age <- titanic_input$Age
   titanic_input$Age <- NULL
   titanic_input <- h2o.cbind(titanic_age, titanic_input)
 
   # Train a k-LIME model
-  klime = h2o.klime(training_frame = titanic_input,
+  klime <- h2o.klime(training_frame = titanic_input,
                     x = c("Age", "Pclass", "Sex", "SibSp", "Parch"), y = "p1",
                     max_k = 3, estimate_k = FALSE,
                     seed = 12345)


### PR DESCRIPTION
Improvement of k-LIME: model performance metrics are reported for each cluster.

It also lays groundwork for improving overall k-LIME performance, in next PR we will compare R2 of GLM on a cluster with R2 of global GLM calculated from only the data that belong to the cluster.