### PR TITLE
[PUBDEV-4292][WIP] Non-recursive creation of Rapid expressions in Python

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -74,7 +74,7 @@ class ExprNode(object):
 
     # Magical count-of-5:   (get 2 more when looking at it in debug mode)
     #  2 for _get_ast_str frame, 2 for _get_ast_str local dictionary list, 1 for parent
-    MAGIC_REF_COUNT = 4 if sys.gettrace() is None else 6  # M = debug ? 6 : 4
+    MAGIC_REF_COUNT = 3 if sys.gettrace() is None else 5  # M = debug ? 6 : 4
 
     # Flag to control application of local expression tree optimizations
     __ENABLE_EXPR_OPTIMIZATIONS__ = True
@@ -154,23 +154,23 @@ class ExprNode(object):
                     if (top and head == self) or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
                         head._cache._id = _py_tmp_key(append=h2o.connection().session_id)
                         s = "(tmp= {} {}".format(head._cache._id, s)
-                        stack.append('^@^')
-                    stack.append('^@^')
+                        stack.append('@')
+                    stack.append('@')
                     stack.extend(reversed(head._children))
-            elif head == '^@^':
+            elif head == '@':
                 s = ')'
             else:
-                s = ExprNode._arg_to_expr(head)
+                s = ExprNode._primitive_expr_to_string(head)
             # Append
             r.append(s)
 
         return " ".join(r)
 
     @staticmethod
-    def _arg_to_expr(arg):
+    def _primitive_expr_to_string(arg):
         """
         Return string representation of primitive expression.
-        It does not accept instance of Expr!
+        It does not support instance of Expr!
         """
         if arg is None:
             return "[]"  # empty list

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -24,6 +24,7 @@ from h2o.utils.shared_utils import _is_fr, _py_tmp_key
 from h2o.model.model_base import ModelBase
 from h2o.expr_optimizer import optimize
 
+
 class ExprNode(object):
     """
     Composable Expressions: This module contains code for the lazy expression DAG.
@@ -73,7 +74,7 @@ class ExprNode(object):
 
     # Magical count-of-5:   (get 2 more when looking at it in debug mode)
     #  2 for _get_ast_str frame, 2 for _get_ast_str local dictionary list, 1 for parent
-    MAGIC_REF_COUNT = 5 if sys.gettrace() is None else 7  # M = debug ? 7 : 5
+    MAGIC_REF_COUNT = 4 if sys.gettrace() is None else 6  # M = debug ? 6 : 4
 
     # Flag to control application of local expression tree optimizations
     __ENABLE_EXPR_OPTIMIZATIONS__ = True
@@ -135,24 +136,45 @@ class ExprNode(object):
     # the timezone change, so cannot be lazy.
     #
     def _get_ast_str(self, top):
-        if not self._cache.is_empty():  # Data already computed and cached; could a "false-like" cached value
-            return str(self._cache._data) if self._cache.is_scalar() else self._cache._id
-        if self._cache._id is not None:
-            return self._cache._id  # Data already computed under ID, but not cached
-        # assert isinstance(self._children,tuple)
-        exec_str = "({} {})".format(self._op, " ".join([ExprNode._arg_to_expr(ast) for ast in self._children]))
-        gc_ref_cnt = len(gc.get_referrers(self))
-        if top or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
-            self._cache._id = _py_tmp_key(append=h2o.connection().session_id)
-            exec_str = "(tmp= {} {})".format(self._cache._id, exec_str)
-        return exec_str
+        stack = collections.deque()
+        # Append self and evaluate
+        stack.append(self)
+        r = collections.deque()
+        while len(stack) > 0:
+            head = stack.pop()
+            #print("\n{}: {}\n".format(len(stack), r))
+            s = None
+            if isinstance(head, ExprNode):
+                if not head._cache.is_empty():  # Data already computed and cached; could a "false-like" cached value
+                    s = str(head._cache._data) if head._cache.is_scalar() else head._cache._id
+                elif head._cache._id is not None:
+                    s = head._cache._id  # Data already computed under ID, but not cached
+                else:
+                    s = "({}".format(head._op)
+                    gc_ref_cnt = len(gc.get_referrers(head))
+                    if head == self or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
+                        head._cache._id = _py_tmp_key(append=h2o.connection().session_id)
+                        s = "(tmp= {} {}".format(head._cache._id, s)
+                        stack.append('^@^')
+                    stack.append('^@^')
+                    stack.extend(reversed(head._children))
+            elif head == '^@^':
+                s = ')'
+            else:
+                s = ExprNode._arg_to_expr(head)
+            # Append
+            r.append(s)
+
+        return " ".join(r)
 
     @staticmethod
     def _arg_to_expr(arg):
+        """
+        Return string representation of primitive expression.
+        It does not accept instance of Expr!
+        """
         if arg is None:
             return "[]"  # empty list
-        if isinstance(arg, ExprNode):
-            return arg._get_ast_str(False)
         if isinstance(arg, ASTId):
             return str(arg)
         if isinstance(arg, (list, tuple, range)):

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -142,7 +142,6 @@ class ExprNode(object):
         r = collections.deque()
         while len(stack) > 0:
             head = stack.pop()
-            #print("\n{}: {}\n".format(len(stack), r))
             s = None
             if isinstance(head, ExprNode):
                 if not head._cache.is_empty():  # Data already computed and cached; could a "false-like" cached value

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -74,7 +74,7 @@ class ExprNode(object):
 
     # Magical count-of-5:   (get 2 more when looking at it in debug mode)
     #  2 for _get_ast_str frame, 2 for _get_ast_str local dictionary list, 1 for parent
-    MAGIC_REF_COUNT = 3 if sys.gettrace() is None else 5  # M = debug ? 6 : 4
+    MAGIC_REF_COUNT = 4 if sys.gettrace() is None else 6  # M = debug ? 6 : 4
 
     # Flag to control application of local expression tree optimizations
     __ENABLE_EXPR_OPTIMIZATIONS__ = True
@@ -151,7 +151,8 @@ class ExprNode(object):
                 else:
                     s = "({}".format(head._op)
                     gc_ref_cnt = len(gc.get_referrers(head))
-                    if (top and head == self) or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
+                    print(gc.get_referrers(head))
+                    if (top and head is self) or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
                         head._cache._id = _py_tmp_key(append=h2o.connection().session_id)
                         s = "(tmp= {} {}".format(head._cache._id, s)
                         stack.append('@')
@@ -215,7 +216,7 @@ class ExprNode(object):
         return "".join(self._2_string(sb=[])) if pprint else ExprNode._collapse_sb(self._2_string(sb=[]))
 
     def _to_string(self):
-        return ' '.join(["(" + self._op] + [ExprNode._arg_to_expr(a) for a in self._children] + [")"])
+        return self._get_ast_str(False)
 
     def _2_string(self, depth=0, sb=None):
         sb += ['\n', " " * depth, "(" + self._op, " "]

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -152,7 +152,7 @@ class ExprNode(object):
                 else:
                     s = "({}".format(head._op)
                     gc_ref_cnt = len(gc.get_referrers(head))
-                    if head == self or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
+                    if (top and head == self) or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
                         head._cache._id = _py_tmp_key(append=h2o.connection().session_id)
                         s = "(tmp= {} {}".format(head._cache._id, s)
                         stack.append('^@^')

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_weights_gamma_gbm.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_weights_gamma_gbm.py
@@ -29,6 +29,7 @@ def weights_gamma():
 
 
 if __name__ == "__main__":
+  h2o.enable_expr_optimizations(False)
   pyunit_utils.standalone_test(weights_gamma)
 else:
   weights_gamma()


### PR DESCRIPTION
The fix includes:
  - switch from recursive preparation of Rapids expresion to explicit stack-based preparation
  - optimized string concatenation (based on http://blog.mclemon.io/ironpython-efficient-string-concatenation)

TODO: backend is still failing to StackOverflow