### PR TITLE
k-LIME, compare R2 of global model to cluster model on cluster-local data

### DIFF
--- a/h2o-algos/src/main/java/hex/klime/KLime.java
+++ b/h2o-algos/src/main/java/hex/klime/KLime.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static hex.kmeans.KMeansModel.KMeansParameters;
+import static hex.klime.KLimeModel.ModelMetricsKLime;
 
 public class KLime extends ModelBuilder<KLimeModel, KLimeModel.KLimeParameters, KLimeModel.KLimeOutput> {
 
@@ -151,11 +152,11 @@ public class KLime extends ModelBuilder<KLimeModel, KLimeModel.KLimeParameters, 
 
         bulkBuildModels(_job, allBuilders, 1);
 
-        double global_r2 = ((ModelMetricsSupervised) globalRegressionModel._output._training_metrics).r2();
         GLMModel[] regressionModels = new GLMModel[K];
         for (int i = 0; i < localBuilders.length; i++) {
           if (localBuilders[i] != null) {
             GLMModel localModel = DKV.getGet(localBuilders[i]._job._result);
+            double global_r2 = ((ModelMetricsKLime) model._output._training_metrics)._clusterMetrics[i].r2();
             double local_r2 = ((ModelMetricsSupervised) localModel._output._training_metrics).r2();
             if (local_r2 > global_r2)
               regressionModels[i] = localModel; // local model is better, keep it

--- a/h2o-py/tests/testdir_algos/klime/pyunit_titanic_kLIME.py
+++ b/h2o-py/tests/testdir_algos/klime/pyunit_titanic_kLIME.py
@@ -28,13 +28,14 @@ def kLIMEtitanic():
     predicted_p1 = titanic_predicted["predict_klime"]
     mse_manual = ((titanic_input["p1"] - predicted_p1) * (titanic_input["p1"] - predicted_p1)).mean()[0,0]
     assert abs(klime.mse() - mse_manual) < 1e-6
-    assert abs(klime.mse() - 0.00937167549983) < 1e-6
+    assert abs(klime.mse() - 0.00447654691449) < 1e-6
 
     # Clusters are the same
     assert (abs(titanic_predicted["cluster_klime"] - titanic_expected["cluster_klime"])).sum()[0,0] == 0
 
-    # K-Lime prediction are almost the same as expected predictions
-    assert (abs(titanic_predicted["predict_klime"] - titanic_expected["predict_klime"]) > 0.005).sum()[0,0] == 0
+    # K-Lime prediction are almost the same as expected predictions (on cluster = 0)
+    assert (abs(titanic_predicted[titanic_predicted["cluster_klime"] == 0, "predict_klime"] -
+                titanic_expected[titanic_expected["cluster_klime"] == 0, "predict_klime"]) > 0.005).sum()[0,0] == 0
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(kLIMEtitanic)

--- a/h2o-r/tests/testdir_algos/klime/runit_klime_titanic.R
+++ b/h2o-r/tests/testdir_algos/klime/runit_klime_titanic.R
@@ -24,9 +24,15 @@ test.klime.titanic <- function() {
   # Use as a regular regression model to predict
   titanic_predicted <- h2o.predict(klime, titanic_input)
 
-  # Check predictions
-  expect_equal(as.data.frame(titanic_predicted$predict_klime)[1],
-               expected = as.data.frame(titanic_expected$predict_klime)[1], tolerance = 0.005)
+  titanic_predicted_loc <- as.data.frame(titanic_predicted)
+  titanic_expected_loc <- as.data.frame(titanic_expected)
+
+  # Check clustering
+  expect_equal(titanic_predicted_loc$cluster_klime, expected = titanic_expected_loc$cluster_klime)
+
+  # Check prediction on cluster = 0
+  expect_equal(titanic_predicted_loc[titanic_predicted_loc$cluster_klime == 0, "predict_klime"],
+               expected = titanic_expected_loc[titanic_expected_loc$cluster_klime == 0, "predict_klime"], tolerance = 0.005)
 }
 
 doTest("Test k-LIME on Titanic dataset with k=3", test.klime.titanic)


### PR DESCRIPTION
This PR improves accuracy of k-LIME model. In previous implementation we used the global model if its R2 was better than R2 of the cluster model. This comparison is flawed because the R2 of the global model is calculated on all data. It doesn't really say anything about the performance of the global model on the cluster data.

This PR compares R2 of the global model calculated on on cluster-local datapoints to R2 of the cluster model. This leads to improved accuracy of k-LIME, cluster-local models are used more often.