### PR TITLE
PUBDEV-4403: Documentation for saving and loading flows

### DIFF
--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -222,12 +222,9 @@ currently used in your flow; essentially, a command history.
 Saving Flows
 ^^^^^^^^^^^^
 
-You can save your flow for later reuse. To save your flow as a notebook,
-click the "Save" button (the first button in the row of buttons below
-the flow name), or click the drop-down "Flow" menu and select "Save
-Flow." To enter a custom name for the flow, click the default flow name
-("Untitled Flow") and type the desired flow name. A pencil icon
-indicates where to enter the desired name.
+You can save your flow for later reuse. After a Flow is saved, you can load it by clicking on the **Flows** tab in the right sidebar. Then in the pop-up confirmation window that appears, select **Load Notebook**. Refer to `Loading Flows <flow.html#loading-flows>`__ for more information. 
+
+To save your flow as a notebook, click the "Save" button (the first button in the row of buttons below the flow name), or click the drop-down "Flow" menu and select "Save Flow." To enter a custom name for the flow, click the default flow name ("Untitled Flow") and type the desired flow name. A pencil icon indicates where to enter the desired name.
 
 .. figure:: images/Flow_rename.png
    :alt: Renaming Flows
@@ -244,7 +241,6 @@ right of the flow name.
 
 .. figure:: images/Flow_flows.png
    :alt: Flows
-
 
 Finding Saved Flows on Your Disk
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -1,28 +1,7 @@
 Saving and Loading a Model
 ==========================
 
-This section describes how to save and load models using Flow, R, and Python. 
-
-In Flow
--------
-
-There are a number of ways you can save your model in Flow. 
-
-- In the web UI, click the **Flow** menu, then click **Save Flow**. Your flow is saved to the *Flows* tab in the **Help** sidebar on the right.
-- In the web UI, click the **Flow** menu, then click **Download this Flow...**. Depending on your browser and configuration, your flow is saved to the "Downloads" folder (by default) or to the location you specify in the pop-up **Save As** window if it appears.
-- For DRF, GBM, and DL models only: Use model checkpointing to resume training a model. Copy the ``model_id`` number from a built model and paste it into the *checkpoint* field in the ``buildModel`` cell.
-
- **Note**: When you are running H2O on Hadoop, H2O tries to determine the home HDFS directory so it can use that as the download location. If the default home HDFS directory is not found, manually set the download location from the command line using the ``-flow_dir`` parameter. For example, 
-
- ::
-
-	hadoop jar h2odriver.jar <...> -flow_dir hdfs:///user/yourname/yourflowdir). 
-
- You can view the default download directory in the logs by clicking **Admin > View logs...** and looking for the line that begins with ``Flow dir:``.
-
-After a Flow is saved, you can load it by clicking on the **Flows** tab in the right sidebar. Then in the pop-up confirmation window that appears, select **Load Notebook**. Refer to `Loading Flows <flow.html#loading-flows>`__ for more information. 
-
-In Flow, you can also import specific models rather than entire Flows. Refer to `Exporting and Importing Models <flow.html#exporting-and-importing-models>`__ for more information. 
+This section describes how to save and load models using R, Python, and Flow. 
 
 In R and Python
 ---------------
@@ -84,3 +63,8 @@ In R and Python, you can save a model locally or to HDFS using the ``h2o.saveMod
 	hdfs_name_node = "node-1"
 	hdfs_model_path = sprintf("hdfs://%s%s", hdfs_name_node, hdfs_tmp_dir)
 	new_model_path = h2o.save_model(h2o_glm, "hdfs://" + hdfs_name_node + "/" + hdfs_model_path)
+
+In Flow
+-------
+
+The steps for saving and loading models in Flow are described in the **Using Flow - H2O's Web UI** section. Specifically, refer to `Exporting and Importing Models <flow.html#exporting-and-importing-models>`__ for information about loading models into Flow. 


### PR DESCRIPTION
The “Saving and Loading a Model” section for Flows now points to this topic in the Flow section. Previously, this included steps for saving and loading Flows rather than models. Additionally, all of the information about saving flows from that topic is duplicated in the Flow section.