### PR TITLE
PUBDEV-4335: PCA documentation - add links to Parameters

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/compute_metrics.rst
+++ b/h2o-docs/src/product/data-science/algo-params/compute_metrics.rst
@@ -1,7 +1,7 @@
 ``compute_metrics``
 --------------------
 
-- Available in: Naïve-Bayes
+- Available in: Naïve-Bayes, PCA
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/k.rst
+++ b/h2o-docs/src/product/data-science/algo-params/k.rst
@@ -1,18 +1,29 @@
 ``k``
 -----
 
-- Available in: K-Means
+- Available in: K-Means, PCA
 - Hyperparameter: yes
 
 Description
 ~~~~~~~~~~~
 
+K-Means
+'''''''
+
 In K-Means, a "cluster" refers to groups of data in a dataset that are similar to one another. The K-Means algorithm finds clusters and cluster centers in a set of unlabled data.  
 
 This option specifies the maximum number of clusters that K-Means will form.  If ``estimate_k`` is disabled, the model will find :math:`k` centroids, otherwise it will find up to :math:`k` centroids. This parameter is required and has no default value. 
 
+PCA
+'''
+
+In PCA, 
+
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
+
+K-Means
+'''''''
 
 - `estimate_k <estimate_k.html>`__
 

--- a/h2o-docs/src/product/data-science/pca.rst
+++ b/h2o-docs/src/product/data-science/pca.rst
@@ -17,68 +17,38 @@ since PCA guarantees that all dimensions of a manifold are orthogonal.
 Defining a PCA Model
 ~~~~~~~~~~~~~~~~~~~~
 
--  **model\_id**: (Optional) Specify a custom name for the model to use as
-   a reference. By default, H2O automatically generates a destination
-   key.
+-  `model_id <algo-params/model_id.html>`__: (Optional) Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
 
--  **training\_frame**: (Required) Specify the dataset used to build the
-   model. **NOTE**: In Flow, if you click the **Build a model** button from the ``Parse`` cell, the training frame is entered automatically.
+-  `training_frame <algo-params/training_frame.html>`__: (Required) Specify the dataset used to build the model. **NOTE**: In Flow, if you click the **Build a model** button from the ``Parse`` cell, the training frame is entered automatically.
 
--  **validation\_frame**: (Optional) Specify the dataset used to evaluate
-   the accuracy of the model.
+-  `validation_frame <algo-params/validation_frame.html>`__: (Optional) Specify the dataset used to evaluate the accuracy of the model.
 
--  **ignored\_columns**: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column
-   name to add it to the list of columns excluded from the model. To add
-   all columns, click the **All** button. To remove a column from the
-   list of ignored columns, click the X next to the column name. To
-   remove all columns from the list of ignored columns, click the
-   **None** button. To search for a specific column, type the column
-   name in the **Search** field above the column list. To only show
-   columns with a specific percentage of missing values, specify the
-   percentage in the **Only show columns with more than 0% missing
-   values** field. To change the selections for the hidden columns, use
-   the **Select Visible** or **Deselect Visible** buttons.
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
--  **ignore\_const\_cols**: Specify whether to ignore constant
-   training columns, since no information can be gained from them. This
-   option is enabled by default.
+-  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Specify whether to ignore constant training columns, since no information can be gained from them. This option is enabled by default.
 
--  **transform**: Specify the transformation method for the training
-   data: None, Standardize, Normalize, Demean, or Descale. The default
-   is None.
+-  `transform <algo-params/transform.html>`__: Specify the transformation method for the training data: None, Standardize, Normalize, Demean, or Descale. The default is None.
 
--  **pca\_method**: Specify the algorithm to use for computing the principal components:
+-  `pca_method <algo-params/pca_method>`__: Specify the algorithm to use for computing the principal components:
 
    -  **GramSVD**: Uses a distributed computation of the Gram matrix, followed by a local SVD using the JAMA package
    -  **Power**: Computes the SVD using the power iteration method (experimental)
    -  **Randomized**: Uses randomized subspace iteration method
    -  **GLRM**: Fits a generalized low-rank model with L2 loss function and no regularization and solves for the SVD using local matrix algebra (experimental)
 
--  **k**\ \*: Specify the rank of matrix approximation. The default is 1.
+-  `k <algo-params/k.html>`__: Specify the rank of matrix approximation. The default is 1.
 
--  **max\_iterations**: Specify the number of training iterations. The
-   value must be between 1 and 1e6 and the default is 1000.
+-  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations. The value must be between 1 and 1e6 and the default is 1000.
 
--  **seed**: Specify the random number generator (RNG) seed for
-   algorithm components dependent on randomization. The seed is
-   consistent for each H2O instance so that you can create models with
-   the same starting conditions in alternative configurations.
+-  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations.
 
--  **use\_all\_factor\_levels**: Specify whether to use all factor
-   levels in the possible set of predictors; if you enable this option,
-   sufficient regularization is required. By default, the first factor
-   level is skipped. For PCA models, this option ignores the first
-   factor level of each categorical column when expanding into indicator
-   columns.
+-  `use_all_factor_levels <algo-params/use_all_factor_levels.html>`__: Specify whether to use all factor levels in the possible set of predictors; if you enable this option, sufficient regularization is required. By default, the first factor level is skipped. For PCA models, this option ignores the first  factor level of each categorical column when expanding into indicator columns.
 
--  **compute\_metrics**: Enable metrics computations on the training
-   data.
+-  `compute_metrics <algo-params/compute_metrics.html>`__: Enable metrics computations on the training  data.
 
--  **score\_each\_iteration**: (Optional) Specify whether to score
-   during each iteration of the model training.
+-  `score_each_iteration <algo-params/score_each_iteration.html>`__: (Optional) Specify whether to score during each iteration of the model training.
 
--  **max\_runtime\_secs**: Maximum allowed runtime in seconds for model
-   training. Use 0 to disable.
+-  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. Use 0 to disable.
 
 Interpreting a PCA Model
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adding links from PCA parameters to the Parameters appendix. Added PCA to “Available in” section for k and compute_metrics parameters.