### PR TITLE
PUBDEV-4422: Change argument name test_frame to leaderboard_frame in AutoML

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -229,13 +229,13 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private void handleDatafileParameters(AutoMLBuildSpec buildSpec) {
     this.origTrainingFrame = DKV.getGet(buildSpec.input_spec.training_frame);
     this.validationFrame = DKV.getGet(buildSpec.input_spec.validation_frame);
-    this.testFrame = DKV.getGet(buildSpec.input_spec.test_frame);
+    this.testFrame = DKV.getGet(buildSpec.input_spec.leaderboard_frame);
 
     if (null == buildSpec.input_spec.training_frame && null != buildSpec.input_spec.training_path)
       this.origTrainingFrame = importParseFrame(buildSpec.input_spec.training_path, buildSpec.input_spec.parse_setup);
     if (null == buildSpec.input_spec.validation_frame && null != buildSpec.input_spec.validation_path)
       this.validationFrame = importParseFrame(buildSpec.input_spec.validation_path, buildSpec.input_spec.parse_setup);
-    if (null == buildSpec.input_spec.test_frame && null != buildSpec.input_spec.test_path)
+    if (null == buildSpec.input_spec.leaderboard_frame && null != buildSpec.input_spec.test_path)
       this.testFrame = importParseFrame(buildSpec.input_spec.test_path, buildSpec.input_spec.parse_setup);
 
     if (null == this.origTrainingFrame)
@@ -251,7 +251,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     optionallySplitDatasets();
 
     if (null == this.trainingFrame) {
-      // we didn't need to split off the validation_frame or test_frame ourselves
+      // we didn't need to split off the validation_frame or leaderboard_frame ourselves
       this.trainingFrame = new Frame(origTrainingFrame);
       DKV.put(this.trainingFrame);
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -69,7 +69,7 @@ public class AutoMLBuildSpec extends Iced {
 
     public Key<Frame> training_frame;
     public Key<Frame> validation_frame;
-    public Key<Frame> test_frame;
+    public Key<Frame> leaderboard_frame;
 
     public String response_column;
     public String[] ignored_columns;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -60,7 +60,7 @@ public class AutoMLBuildSpec extends Iced {
   static final public class AutoMLInput extends Iced {
     public ImportFilesV3.ImportFiles training_path;
     public ImportFilesV3.ImportFiles validation_path;
-    public ImportFilesV3.ImportFiles test_path;
+    public ImportFilesV3.ImportFiles leaderboard_path;
 
     public ParseSetup parse_setup;
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -53,8 +53,8 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help = "Path of validation data to import and parse, in any form that H2O accepts, including local files or directories, s3, hdfs, etc.", direction=API.Direction.INPUT)
     public ImportFilesV3 validation_path;
 
-    @API(help = "Path of test data to import and parse, in any form that H2O accepts, including local files or directories, s3, hdfs, etc.", direction=API.Direction.INPUT)
-    public ImportFilesV3 test_path;
+    @API(help = "Path of test data (to create the leaderboard) to import and parse, in any form that H2O accepts, including local files or directories, s3, hdfs, etc.", direction=API.Direction.INPUT)
+    public ImportFilesV3 leaderboard_path;
 
     @API(help = "Used to override default settings for training and test data parsing.", direction=API.Direction.INPUT)
     public ParseSetupV3 parse_setup;
@@ -68,7 +68,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help = "ID of the validation data frame.", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 validation_frame;
 
-    @API(help = "ID of the test data frame.", direction=API.Direction.INPUT)
+    @API(help = "ID of the leaderboard/test data frame.", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 leaderboard_frame;
 
     @API(help = "Response column",

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -69,11 +69,11 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     public KeyV3.FrameKeyV3 validation_frame;
 
     @API(help = "ID of the test data frame.", direction=API.Direction.INPUT)
-    public KeyV3.FrameKeyV3 test_frame;
+    public KeyV3.FrameKeyV3 leaderboard_frame;
 
     @API(help = "Response column",
          direction=API.Direction.INPUT,
-         is_member_of_frames = {"training_frame", "validation_frame", "test_frame"},
+         is_member_of_frames = {"training_frame", "validation_frame", "leaderboard_frame"},
          is_mutually_exclusive_with = {"ignored_columns"},
          required = false
       )
@@ -81,7 +81,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
 
     @API(help = "Names of columns to ignore for training",
          direction=API.Direction.INPUT,
-         is_member_of_frames = {"training_frame", "validation_frame", "test_frame"},
+         is_member_of_frames = {"training_frame", "validation_frame", "leaderboard_frame"},
          required = false
       )
     public String[] ignored_columns;

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -70,7 +70,7 @@ class H2OAutoML(object):
         self._leader_id = None
         self._leaderboard = None
 
-    def train(self, x=None, y=None, training_frame=None, validation_frame=None, test_frame=None):
+    def train(self, x=None, y=None, training_frame=None, validation_frame=None, leaderboard_frame=None):
         """
         Begins the automl task, which is a background task that incrementally improves
         over time. At any point, the user may use the "predict"/"performance"
@@ -81,7 +81,7 @@ class H2OAutoML(object):
         :param training_frame: The H2OFrame having the columns indicated by x and y (as well as any
             additional columns specified by fold, offset, and weights).
         :param validation_frame: H2OFrame with validation data to be scored on while training.
-        :param test_frame: H2OFrame with test data to be scored on in the leaderboard.
+        :param leaderboard_frame: H2OFrame with test data to be scored on in the leaderboard.
 
         :returns: An H2OAutoML object.
 
@@ -126,9 +126,9 @@ class H2OAutoML(object):
             assert_is_type(training_frame, H2OFrame)
             input_spec['validation_frame'] = validation_frame.frame_id
 
-        if test_frame is not None:
+        if leaderboard_frame is not None:
             assert_is_type(training_frame, H2OFrame)
-            input_spec['test_frame'] = test_frame.frame_id
+            input_spec['leaderboard_frame'] = leaderboard_frame.frame_id
 
         if x is not None:
             assert_is_type(x,list)

--- a/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
+++ b/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
@@ -31,7 +31,7 @@ def prostate_automl():
     test["CAPSULE"] = test["CAPSULE"].asfactor()
 
     print("AutoML (Binomial) run with x not provided with train, valid, and test")
-    aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     print(aml.leader)
     print(aml.leaderboard)
     assert set(aml.leaderboard.col_header) == set(["","model_id","auc","logloss"])

--- a/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
+++ b/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
@@ -27,7 +27,7 @@ def iris_automl():
     aml = H2OAutoML(max_runtime_secs = 30,build_control=build_control)
 
     print("AutoML (Multinomial) run with x not provided with train, valid, and test")
-    aml.train(y="class", training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(y="class", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     print(aml.leader)
     print(aml.leaderboard)
     assert set(aml.leaderboard.col_header) == set(["","model_id","mean_per_class_error"])

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -49,17 +49,17 @@ def prostate_automl():
 
     print("AutoML run with x not provided with train and test")
     build_control["project"] = "Project3"
-    aml.train(y="CAPSULE", training_frame=train,test_frame=test)
+    aml.train(y="CAPSULE", training_frame=train,leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("AutoML run with x not provided with train, valid, and test")
     build_control["project"] = "Project4"
-    aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("AutoML run with x not provided and y as col idx with train, valid, and test")
     build_control["project"] = "Project5"
-    aml.train(y=1, training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(y=1, training_frame=train,validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("Check predict, leader, and leaderboard")

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
@@ -34,23 +34,23 @@ def prostate_automl():
     x = ["AGE","RACE","DPROS"]
     y = "CAPSULE"
     names = train.names
-    aml.train(x=x,y=y, training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(x=x,y=y, training_frame=train,validation_frame=valid, leaderboard_frame=test)
     models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 
     print("AutoML with x and y as col indexes, train, valid, and test")
-    aml.train(x=[2,3,4],y=1, training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(x=[2,3,4],y=1, training_frame=train,validation_frame=valid, leaderboard_frame=test)
     models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 
 
     print("AutoML with x as a str list, y as a col index, train, valid, and test")
-    aml.train(x=x,y=1, training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(x=x,y=1, training_frame=train,validation_frame=valid, leaderboard_frame=test)
     models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 
     print("AutoML with x as col indexes, y as a str, train, valid, and test")
-    aml.train(x=[2,3,4],y=y, training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(x=[2,3,4],y=y, training_frame=train,validation_frame=valid, leaderboard_frame=test)
     models = aml.leaderboard["model_id"]
     pyunit_utils.check_ignore_cols_automl(models,names,x,y)
 

--- a/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
+++ b/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
@@ -27,7 +27,7 @@ def australia_automl():
     aml = H2OAutoML(max_runtime_secs = 30,build_control=build_control)
 
     print("AutoML (Regression) run with x not provided with train, valid, and test")
-    aml.train(y="runoffnew", training_frame=train,validation_frame=valid, test_frame=test)
+    aml.train(y="runoffnew", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     print(aml.leader)
     print(aml.leaderboard)
     assert set(aml.leaderboard.col_header) == set(["","model_id", "mean_residual_deviance","rmse", "mae", "rmsle"])

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -12,7 +12,7 @@
 #'        categorical variable).
 #' @param training_frame Training data frame (or ID).
 #' @param validation_frame Validation data frame (or ID); Optional.
-#' @param test_frame Test data frame (or ID).  The Leaderboard will be scored using this test data set. Optional.
+#' @param leaderboard_frame Leaderboard data frame (or ID).  The Leaderboard will be scored using this data set. Optional.
 #' @param build_control List of custom build parameters. Optional. 
 #' @param max_runtime_secs Maximum allowed runtime in seconds for the entire model training process.  Use 0 to disable. Defaults to 600 secs (10 min).
 #' @details AutoML finds the best model, given a training frame and response, and returns an H2OAutoML object,
@@ -30,7 +30,7 @@
 #' @export
 h2o.automl <- function(x, y, training_frame,
                        validation_frame = NULL,
-                       test_frame = NULL,
+                       leaderboard_frame = NULL,
                        build_control = NULL,
                        max_runtime_secs = 600)
 {
@@ -61,9 +61,9 @@ h2o.automl <- function(x, y, training_frame,
   }
 
   # Test frame must be a key or an H2OFrame object
-  test_frame_id <- NULL
-  if (!is.null(test_frame)) {
-    test_frame_id <- h2o.getId(test_frame)
+  leaderboard_frame_id <- NULL
+  if (!is.null(leaderboard_frame)) {
+    leaderboard_frame_id <- h2o.getId(leaderboard_frame)
   }
 
   # Input/data parameters to send to the AutoML backend
@@ -71,7 +71,7 @@ h2o.automl <- function(x, y, training_frame,
   input_spec$response_column <- ifelse(is.numeric(y),names(training_frame[y]),y)
   input_spec$training_frame <- training_frame_id
   input_spec$validation_frame <- validation_frame_id
-  input_spec$test_frame <- test_frame_id
+  input_spec$leaderboard_frame <- leaderboard_frame_id
 
   # If x is specified, set ignored_columns; otherwise do not send ignored_columns in the POST
   if (!missing(x)) {

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_binomial_leaderboard_higgs.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_binomial_leaderboard_higgs.R
@@ -16,10 +16,10 @@ automl.leaderboard.test <- function() {
   train[,y] <- as.factor(train[,y])
   test[,y] <- as.factor(test[,y])
 
-  # Train AutoML with just a training_frame & test_frame
+  # Train AutoML with just a training_frame & leaderboard_frame
   aml <- h2o.automl(y = y,
                     training_frame = train,
-                    test_frame = test,
+                    leaderboard_frame = test,
                     max_runtime_secs = 30)
 
   # Get test set AUC from leaderboard vs h2o.performance() and check that it matches


### PR DESCRIPTION
After feedback from the team, we decided it's probably best to change the name `test_frame` to `leaderboard_frame`.

Notes: `test_frame` should be called `leaderboard_frame` (or similar), because people didn’t like the idea of evaluating models on a “test set” and then choosing the best model from that. It really should be referred to as a validation/holdout set rather than a “test set”, but we already used the `validation_frame` to tune individual models via early stopping, so to be clear that this is used only for creating the leaderboard, we will change the name to `leaderboard_frame`.  This frame will only be used to generate the leaderboard metrics. Someone also mentioned that they'd prefer to use the `validation_frame` for the leaderboard metrics because they doesn’t want to split their data too many times, which right now you can do at the user level by passing a validation frame twice -- just use the same frame name for `validation_frame` and `leaderboard_frame` and AutoML will be none the wiser.