### PR TITLE
PUBDEV-4452: AutoML regression task gives error related to mean_residual_deviance

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -616,7 +616,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
         setCommonModelBuilderParams(glmParameters);
 
     glmParameters._lambda_search = true;
-    glmParameters._family = getResponseColumn().isBinary() ? GLMModel.GLMParameters.Family.binomial :
+    glmParameters._family = getResponseColumn().isBinary() && !(getResponseColumn().isNumeric()) ? GLMModel.GLMParameters.Family.binomial :
             getResponseColumn().isCategorical() ? GLMModel.GLMParameters.Family.multinomial :
                     GLMModel.GLMParameters.Family.gaussian;  // TODO: other continuous distributions!
 


### PR DESCRIPTION
* This PR changes the logic in GLM grid in AutoML. Currently, if the outcome is 0/1, the GLM grid will assume it is a classification problem. However, other algorithms in AutoML will read this as a regression, which will cause a collision. 
* The solution is to ensure the outcome is binary and NOT numeric for classification in GLM grid.