### PR TITLE
PUBDEV-4459: AutoML: Move the rest of build_control args to top-level in Python API

### DIFF
--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -250,13 +250,7 @@ class H2OAutoML(object):
 
         :examples:
         >>> #Set up an H2OAutoML object
-        >>> build_control = {
-        >>>              'stopping_criteria': {
-        >>>              'stopping_rounds': 3,
-        >>>              'stopping_tolerance': 0.001
-        >>>            }
-        >>>        }
-        >>> aml = H2OAutoML(max_runtime_secs=30, build_control=build_control)
+        >>> aml = H2OAutoML(max_runtime_secs=30)
         >>> # Launch H2OAutoML
         >>> aml.train(y=y, training_frame=training_frame)
         >>> #Predict with #1 model from H2OAutoML leaderboard

--- a/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
+++ b/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
@@ -17,14 +17,7 @@ def prostate_automl():
     valid = fr[1]
     test = fr[2]
 
-    #Make build control for automl
-    build_control = {
-        'stopping_criteria': {
-            'stopping_rounds': 3,
-            'stopping_tolerance': 0.001
-        }
-    }
-    aml = H2OAutoML(max_runtime_secs = 30,build_control=build_control)
+    aml = H2OAutoML(max_runtime_secs = 30,stopping_rounds=3,stopping_tolerance=0.001)
 
     train["CAPSULE"] = train["CAPSULE"].asfactor()
     valid["CAPSULE"] = valid["CAPSULE"].asfactor()

--- a/h2o-py/tests/testdir_algos/automl/features/pyunit_automl_fold_assignment.py
+++ b/h2o-py/tests/testdir_algos/automl/features/pyunit_automl_fold_assignment.py
@@ -9,14 +9,7 @@ def test_fold_column():
 
     train = h2o.import_file(path=pyunit_utils.locate("smalldata/census_income/adult_data.csv"))
 
-    build_control = {
-        'stopping_criteria': {
-            'seed': 42,
-            'stopping_rounds': 3,
-            'stopping_tolerance': 0.05
-        }
-    }
-    aml = H2OAutoML(max_runtime_secs = 420, build_control = build_control)
+    aml = H2OAutoML(max_runtime_secs = 420, stopping_rounds=3,stopping_tolerance=0.05,seed=42)
     aml.train(y='income', training_frame=train, fold_column = 'education-num')
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
+++ b/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
@@ -17,14 +17,7 @@ def iris_automl():
     valid = fr[1]
     test = fr[2]
 
-    #Make build control for automl
-    build_control = {
-        'stopping_criteria': {
-            'stopping_rounds': 3,
-            'stopping_tolerance': 0.001
-        }
-    }
-    aml = H2OAutoML(max_runtime_secs = 30,build_control=build_control)
+    aml = H2OAutoML(max_runtime_secs = 3,stopping_rounds=3,stopping_tolerance=0.001)
 
     print("AutoML (Multinomial) run with x not provided with train, valid, and test")
     aml.train(y="class", training_frame=train,validation_frame=valid, leaderboard_frame=test)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -17,54 +17,44 @@ def prostate_automl():
     valid = fr[1]
     test = fr[2]
 
-    #Make build control for automl
-    build_control = {
-        'stopping_criteria': {
-            'stopping_rounds': 3,
-            'stopping_tolerance': 0.001
-        }
-    }
-    aml = H2OAutoML(max_runtime_secs = 10,build_control=build_control)
-
     train["CAPSULE"] = train["CAPSULE"].asfactor()
     valid["CAPSULE"] = valid["CAPSULE"].asfactor()
     test["CAPSULE"] = test["CAPSULE"].asfactor()
 
     print("Check arguments to H2OAutoML class")
-    aml2 = H2OAutoML(max_runtime_secs = 10,project_name="aml2",build_control=build_control)
-    aml2.train(y="CAPSULE", training_frame=train)
-    assert aml2.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
-    assert aml2.project_name == "aml2", "Project name is not set"
-    assert aml2.build_control == build_control, "build_control is not correctly set"
+    aml = H2OAutoML(max_runtime_secs = 10,project_name="aml",stopping_rounds=3,stopping_tolerance=0.001)
+    aml.train(y="CAPSULE", training_frame=train)
+    assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
+    assert aml.project_name == "aml", "Project name is not set"
 
     print("AutoML run with x not provided and train set only")
-    build_control["project"] = "Project1"
+    aml.build_control["project"] = "Project1"
     aml.train(y="CAPSULE", training_frame=train)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("AutoML run with x not provided with train and valid")
-    build_control["project"] = "Project2"
+    aml.build_control["project"] = "Project2"
     aml.train(y="CAPSULE", training_frame=train,validation_frame=valid)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("AutoML run with x not provided with train and test")
-    build_control["project"] = "Project3"
+    aml.build_control["project"] = "Project3"
     aml.train(y="CAPSULE", training_frame=train,leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("AutoML run with x not provided with train, valid, and test")
-    build_control["project"] = "Project4"
+    aml.build_control["project"] = "Project4"
     aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("AutoML run with x not provided and y as col idx with train, valid, and test")
-    build_control["project"] = "Project5"
+    aml.build_control["project"] = "Project5"
     aml.train(y=1, training_frame=train,validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
 
     print("Check predict, leader, and leaderboard")
     print("AutoML run with x not provided and train set only")
-    build_control["project"] = "Project6"
+    aml.build_control["project"] = "Project6"
     aml.train(y="CAPSULE", training_frame=train)
     print("Check leader")
     aml.leader

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -5,6 +5,9 @@ import h2o
 from tests import pyunit_utils
 from h2o.automl import H2OAutoML
 
+"""
+This test is used to check arguments passed into H2OAutoML along with different ways of using `.train()`
+"""
 def prostate_automl():
 
     df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
@@ -22,46 +25,82 @@ def prostate_automl():
     test["CAPSULE"] = test["CAPSULE"].asfactor()
 
     print("Check arguments to H2OAutoML class")
-    aml = H2OAutoML(max_runtime_secs = 10,project_name="aml",stopping_rounds=3,stopping_tolerance=0.001)
+    aml = H2OAutoML(max_runtime_secs = 10,project_name="aml",stopping_rounds=3,stopping_tolerance=0.001,stopping_metric="AUC",max_models=10,seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "aml", "Project name is not set"
+    assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
+    assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
+    assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
+    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.seed == 1234, "seed is not set to `1234`"
 
     print("AutoML run with x not provided and train set only")
-    aml.build_control["project"] = "Project1"
+    aml.project_name = "Project1"
     aml.train(y="CAPSULE", training_frame=train)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
+    assert aml.project_name == "Project1", "Project name is not set"
+    assert aml.project_name == "Project1", "Project name is not set"
+    assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
+    assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
+    assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
+    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.seed == 1234, "seed is not set to `1234`"
 
     print("AutoML run with x not provided with train and valid")
-    aml.build_control["project"] = "Project2"
+    aml.project_name = "Project2"
     aml.train(y="CAPSULE", training_frame=train,validation_frame=valid)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
+    assert aml.project_name == "Project2", "Project name is not set"
+    assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
+    assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
+    assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
+    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.seed == 1234, "seed is not set to `1234`"
 
     print("AutoML run with x not provided with train and test")
-    aml.build_control["project"] = "Project3"
+    aml.project_name = "Project3"
     aml.train(y="CAPSULE", training_frame=train,leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
+    assert aml.project_name == "Project3", "Project name is not set"
+    assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
+    assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
+    assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
+    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.seed == 1234, "seed is not set to `1234`"
 
     print("AutoML run with x not provided with train, valid, and test")
-    aml.build_control["project"] = "Project4"
+    aml.project_name = "Project4"
     aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
+    assert aml.project_name == "Project4", "Project name is not set"
+    assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
+    assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
+    assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
+    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.seed == 1234, "seed is not set to `1234`"
 
     print("AutoML run with x not provided and y as col idx with train, valid, and test")
-    aml.build_control["project"] = "Project5"
+    aml.project_name = "Project5"
     aml.train(y=1, training_frame=train,validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
+    assert aml.project_name == "Project5", "Project name is not set"
+    assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
+    assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
+    assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
+    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.seed == 1234, "seed is not set to `1234`"
 
     print("Check predict, leader, and leaderboard")
     print("AutoML run with x not provided and train set only")
-    aml.build_control["project"] = "Project6"
+    aml.project_name = "Project6"
     aml.train(y="CAPSULE", training_frame=train)
     print("Check leader")
-    aml.leader
+    print(aml.leader)
     print("Check leaderboard")
-    aml.leaderboard
+    print(aml.leaderboard)
     print("Check predictions")
-    aml.predict(train)
+    print(aml.predict(train))
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(prostate_automl)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
@@ -17,14 +17,7 @@ def prostate_automl():
     valid = fr[1]
     test = fr[2]
 
-    #Make build control for automl
-    build_control = {
-        'stopping_criteria': {
-            'stopping_rounds': 3,
-            'stopping_tolerance': 0.001
-        }
-    }
-    aml = H2OAutoML(max_runtime_secs = 30,build_control=build_control)
+    aml = H2OAutoML(max_runtime_secs = 30,stopping_rounds=3,stopping_tolerance=0.001)
 
     train["CAPSULE"] = train["CAPSULE"].asfactor()
     valid["CAPSULE"] = valid["CAPSULE"].asfactor()

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
@@ -5,6 +5,9 @@ import h2o
 from tests import pyunit_utils
 from h2o.automl import H2OAutoML
 
+"""
+This test is used to check different variants of `ignored_columns` in `.train()`
+"""
 def prostate_automl():
 
     df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))

--- a/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
+++ b/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
@@ -17,14 +17,7 @@ def australia_automl():
     valid = fr[1]
     test = fr[2]
 
-    #Make build control for automl
-    build_control = {
-        'stopping_criteria': {
-            'stopping_rounds': 3,
-            'stopping_tolerance': 0.001
-        }
-    }
-    aml = H2OAutoML(max_runtime_secs = 30,build_control=build_control)
+    aml = H2OAutoML(max_runtime_secs = 30,stopping_rounds=3,stopping_tolerance=0.001)
 
     print("AutoML (Regression) run with x not provided with train, valid, and test")
     aml.train(y="runoffnew", training_frame=train,validation_frame=valid, leaderboard_frame=test)


### PR DESCRIPTION
* Moved the remainder of the build_control args to the top-level user API in Python, so that they are properly documented and more accessible and easy to use.
* `build_control` params moved to top-level:
      1. max_runtime_secs
      2. max_models
      3. stopping_metric
      4. stopping_tolerance
      5. stopping_rounds
      6. seed
* Updated tests to account for new parameters