### PR TITLE
PUBDEV-4364 - Support for DL models without hidden layers (and always compute varimp)

### DIFF
--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
@@ -128,17 +128,22 @@ public class DeepLearning extends ModelBuilder<DeepLearningModel,DeepLearningMod
     }
 //    assert(makeDataInfo(_train, _valid, _parms).fullN() == p);
     long output = _parms._autoencoder ? p : Math.abs(_train.lastVec().cardinality());
-    // weights
-    long model_size = p * _parms._hidden[0];
-    int layer=1;
-    for (; layer < _parms._hidden.length; ++layer)
-      model_size += _parms._hidden[layer-1] * _parms._hidden[layer];
-    model_size += _parms._hidden[layer-1] * output;
+    long model_size = 0;
+    if (_parms._hidden.length==0) {
+      model_size += p * output;
+    } else {
+      // weights
+      model_size += p * _parms._hidden[0];
+      int layer = 1;
+      for (; layer < _parms._hidden.length; ++layer)
+        model_size += _parms._hidden[layer - 1] * _parms._hidden[layer];
+      model_size += _parms._hidden[layer - 1] * output;
 
-    // biases
-    for (layer=0; layer < _parms._hidden.length; ++layer)
-      model_size += _parms._hidden[layer];
-    model_size += output;
+      // biases
+      for (layer = 0; layer < _parms._hidden.length; ++layer)
+        model_size += _parms._hidden[layer];
+      model_size += output;
+    }
 
     if (model_size > 1e8) {
       String msg = "Model is too large: " + model_size + " parameters. Try reducing the number of neurons in the hidden layers (or reduce the number of categorical factors).";

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -1734,7 +1734,8 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
     void validate(DeepLearning dl, boolean expensive) {
       boolean classification = expensive || dl.nclasses() != 0 ? dl.isClassifier() : _loss == CrossEntropy || _loss == ModifiedHuber;
       if (_loss == ModifiedHuber) dl.error("_loss", "ModifiedHuber loss function is not supported yet.");
-      if (_hidden == null || _hidden.length == 0) dl.error("_hidden", "There must be at least one hidden layer.");
+//      if (_hidden == null || _hidden.length == 0) dl.error("_hidden", "There must be at least one hidden layer.");
+      if (_hidden == null) _hidden = new int[0];
       for (int h : _hidden) if (h <= 0) dl.error("_hidden", "Hidden layer size must be positive.");
       if (_mini_batch_size < 1)
         dl.error("_mini_batch_size", "Mini-batch size must be >= 1");

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -1634,7 +1634,7 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
      * The implemented method (by Gedeon) considers the weights connecting the
      * input features to the first two hidden layers.
      */
-    public boolean _variable_importances = false;
+    public boolean _variable_importances = true;
 
     /**
      * Enable fast mode (minor approximation in back-propagation), should not affect results significantly.

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModelInfo.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModelInfo.java
@@ -587,45 +587,56 @@ final public class DeepLearningModelInfo extends Iced<DeepLearningModelInfo> {
     float[] vi = new float[units[0]];
     Arrays.fill(vi, 0f);
 
-    float[][] Qik = new float[units[0]][units[2]]; //importance of input i on output k
-    float[] sum_wj = new float[units[1]]; //sum of incoming weights into first hidden layer
-    float[] sum_wk = new float[units[2]]; //sum of incoming weights into output layer (or second hidden layer)
-    for (float[] Qi : Qik) Arrays.fill(Qi, 0f);
-    Arrays.fill(sum_wj, 0f);
-    Arrays.fill(sum_wk, 0f);
-
-    // compute sum of absolute incoming weights
-    for (int j = 0; j < units[1]; j++) {
+    if (units.length==2) {
+      // no hidden layers
       for (int i = 0; i < units[0]; i++) {
-        float wij = get_weights(0).get(j, i);
-        sum_wj[j] += Math.abs(wij);
-      }
-    }
-    for (int k = 0; k < units[2]; k++) {
-      for (int j = 0; j < units[1]; j++) {
-        float wjk = get_weights(1).get(k, j);
-        sum_wk[k] += Math.abs(wjk);
-      }
-    }
-    // compute importance of input i on output k as product of connecting weights going through j
-    for (int i = 0; i < units[0]; i++) {
-      for (int k = 0; k < units[2]; k++) {
+        // sum up abs weights going out from each input neuron
         for (int j = 0; j < units[1]; j++) {
           float wij = get_weights(0).get(j, i);
-          float wjk = get_weights(1).get(k, j);
-          //Qik[i][k] += Math.abs(wij)/sum_wj[j] * wjk; //Wong,Gedeon,Taggart '95
-          Qik[i][k] += Math.abs(wij) / sum_wj[j] * Math.abs(wjk) / sum_wk[k]; //Gedeon '97
+          vi[i] += Math.abs(wij);
         }
       }
+    } else {
+      float[][] Qik = new float[units[0]][units[2]]; //importance of input i on output k
+      float[] sum_wj = new float[units[1]]; //sum of incoming weights into first hidden layer
+      float[] sum_wk = new float[units[2]]; //sum of incoming weights into output layer (or second hidden layer)
+      for (float[] Qi : Qik) Arrays.fill(Qi, 0f);
+      Arrays.fill(sum_wj, 0f);
+      Arrays.fill(sum_wk, 0f);
+
+      // compute sum of absolute incoming weights
+      for (int j = 0; j < units[1]; j++) {
+        for (int i = 0; i < units[0]; i++) {
+          float wij = get_weights(0).get(j, i);
+          sum_wj[j] += Math.abs(wij);
+        }
+      }
+      for (int k = 0; k < units[2]; k++) {
+        for (int j = 0; j < units[1]; j++) {
+          float wjk = get_weights(1).get(k, j);
+          sum_wk[k] += Math.abs(wjk);
+        }
+      }
+      // compute importance of input i on output k as product of connecting weights going through j
+      for (int i = 0; i < units[0]; i++) {
+        for (int k = 0; k < units[2]; k++) {
+          for (int j = 0; j < units[1]; j++) {
+            float wij = get_weights(0).get(j, i);
+            float wjk = get_weights(1).get(k, j);
+            //Qik[i][k] += Math.abs(wij)/sum_wj[j] * wjk; //Wong,Gedeon,Taggart '95
+            Qik[i][k] += Math.abs(wij) / sum_wj[j] * Math.abs(wjk) / sum_wk[k]; //Gedeon '97
+          }
+        }
+      }
+      // normalize Qik over all outputs k
+      for (int k = 0; k < units[2]; k++) {
+        float sumQk = 0;
+        for (int i = 0; i < units[0]; i++) sumQk += Qik[i][k];
+        for (int i = 0; i < units[0]; i++) Qik[i][k] /= sumQk;
+      }
+      // importance for feature i is the sum over k of i->k importances
+      for (int i = 0; i < units[0]; i++) vi[i] = ArrayUtils.sum(Qik[i]);
     }
-    // normalize Qik over all outputs k
-    for (int k = 0; k < units[2]; k++) {
-      float sumQk = 0;
-      for (int i = 0; i < units[0]; i++) sumQk += Qik[i][k];
-      for (int i = 0; i < units[0]; i++) Qik[i][k] /= sumQk;
-    }
-    // importance for feature i is the sum over k of i->k importances
-    for (int i = 0; i < units[0]; i++) vi[i] = ArrayUtils.sum(Qik[i]);
 
     //normalize importances such that max(vi) = 1
     ArrayUtils.div(vi, ArrayUtils.maxValue(vi));

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningTest.java
@@ -1443,6 +1443,62 @@ public class DeepLearningTest extends TestUtil {
     }
   }
 
+  @Test
+  public void testNoHiddenLayerRegression() {
+    Frame tfr = null;
+    DeepLearningModel dl = null;
+    DeepLearningModel dl2 = null;
+
+    try {
+      tfr = parse_test_file("./smalldata/logreg/prostate.csv");
+      DeepLearningParameters parms = new DeepLearningParameters();
+      parms._train = tfr._key;
+      parms._epochs = 1000;
+      parms._response_column = "AGE";
+      parms._hidden = new int[]{};
+      dl = new DeepLearning(parms).trainModel().get();
+      Frame res = dl.score(tfr);
+      assertTrue(dl.testJavaScoring(tfr, res, 1e-5));
+      res.remove();
+    } finally {
+      if (tfr != null) tfr.delete();
+      if (dl != null) dl.delete();
+      if (dl2 != null) dl2.delete();
+    }
+  }
+
+  @Test
+  public void testNoHiddenLayerClassification() {
+    Frame tfr = null;
+    DeepLearningModel dl = null;
+    DeepLearningModel dl2 = null;
+
+    try {
+      tfr = parse_test_file("./smalldata/logreg/prostate.csv");
+      for (String s : new String[]{
+          "CAPSULE"
+      }) {
+        Vec resp = tfr.vec(s).toCategoricalVec();
+        tfr.remove(s).remove();
+        tfr.add(s, resp);
+        DKV.put(tfr);
+      }
+      DeepLearningParameters parms = new DeepLearningParameters();
+      parms._train = tfr._key;
+      parms._epochs = 1000;
+      parms._response_column = "CAPSULE";
+      parms._hidden = null; // that works too, not just empty array
+      dl = new DeepLearning(parms).trainModel().get();
+      Frame res = dl.score(tfr);
+      assertTrue(dl.testJavaScoring(tfr, res, 1e-5));
+      res.remove();
+    } finally {
+      if (tfr != null) tfr.delete();
+      if (dl != null) dl.delete();
+      if (dl2 != null) dl2.delete();
+    }
+  }
+
   @Ignore
   public void testConvergenceAUC_ModifiedHuber() {
     Frame tfr = null;

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1091,7 +1091,7 @@ class H2ODeepLearningEstimator(H2OEstimator):
         """
         Compute variable importances for input features (Gedeon method) - can be slow for large networks.
 
-        Type: ``bool``  (default: ``False``).
+        Type: ``bool``  (default: ``True``).
         """
         return self._parms.get("variable_importances")
 

--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_iris_no_hidden.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_iris_no_hidden.py
@@ -9,11 +9,11 @@ def deeplearning_no_hidden():
   iris_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
 
   hh = H2ODeepLearningEstimator(hidden=[], loss="CrossEntropy", export_weights_and_biases=True)
-  hh.train(x=list(range(3)), y=4, training_frame=iris_hex)
+  hh.train(x=list(range(4)), y=4, training_frame=iris_hex)
   hh.show()
   weights1 = hh.weights(0)
   assert weights1.shape[0] == 3
-  assert weights1.shape[1] == 3
+  assert weights1.shape[1] == 4
 
 if __name__ == "__main__":
   pyunit_utils.standalone_test(deeplearning_no_hidden)

--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_iris_no_hidden.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_iris_no_hidden.py
@@ -1,0 +1,24 @@
+from builtins import range
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.deeplearning import H2ODeepLearningEstimator
+
+def deeplearning_no_hidden():
+
+
+
+  iris_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+  hh = H2ODeepLearningEstimator(hidden=None, loss="CrossEntropy")
+  hh.train(x=list(range(3)), y=4, training_frame=iris_hex)
+  hh.show()
+
+  hh = H2ODeepLearningEstimator(hidden=[], loss="CrossEntropy")
+  hh.train(x=list(range(3)), y=4, training_frame=iris_hex)
+  hh.show()
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(deeplearning_no_hidden)
+else:
+  deeplearning_no_hidden()

--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_iris_no_hidden.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_iris_no_hidden.py
@@ -6,17 +6,14 @@ from tests import pyunit_utils
 from h2o.estimators.deeplearning import H2ODeepLearningEstimator
 
 def deeplearning_no_hidden():
-
-
-
   iris_hex = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
-  hh = H2ODeepLearningEstimator(hidden=None, loss="CrossEntropy")
-  hh.train(x=list(range(3)), y=4, training_frame=iris_hex)
-  hh.show()
 
-  hh = H2ODeepLearningEstimator(hidden=[], loss="CrossEntropy")
+  hh = H2ODeepLearningEstimator(hidden=[], loss="CrossEntropy", export_weights_and_biases=True)
   hh.train(x=list(range(3)), y=4, training_frame=iris_hex)
   hh.show()
+  weights1 = hh.weights(0)
+  assert weights1.shape[0] == 3
+  assert weights1.shape[1] == 3
 
 if __name__ == "__main__":
   pyunit_utils.standalone_test(deeplearning_no_hidden)

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -106,7 +106,7 @@
 #' @param force_load_balance \code{Logical}. Force extra load balancing to increase training speed for small datasets (to keep all cores
 #'        busy). Defaults to TRUE.
 #' @param variable_importances \code{Logical}. Compute variable importances for input features (Gedeon method) - can be slow for large
-#'        networks. Defaults to FALSE.
+#'        networks. Defaults to TRUE.
 #' @param replicate_training_data \code{Logical}. Replicate the entire training dataset onto every node for faster training on small datasets.
 #'        Defaults to TRUE.
 #' @param single_node_mode \code{Logical}. Run on a single node for fine-tuning of model parameters. Defaults to FALSE.
@@ -208,7 +208,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              diagnostics = TRUE,
                              fast_mode = TRUE,
                              force_load_balance = TRUE,
-                             variable_importances = FALSE,
+                             variable_importances = TRUE,
                              replicate_training_data = TRUE,
                              single_node_mode = FALSE,
                              shuffle_training_data = FALSE,

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -161,7 +161,9 @@ h2o.getModel <- function(model_id) {
       type    <- mapping[1L, 1L]
       scalar  <- mapping[1L, 2L]
 
-      if (type == "numeric" && value == "Infinity")
+      if(type == "numeric" && class(value) == "list" && length(value) == 0) #Special case when using deep learning with 0 hidden units
+        value <- 0
+      else if (type == "numeric" && value == "Infinity")
         value <- Inf
       else if (type == "numeric" && value == "-Infinity")
         value <- -Inf

--- a/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
+++ b/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
@@ -1,14 +1,12 @@
 setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
-
-
 check.deeplearning_no_hidden <- function() {
 	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
-	hh <- h2o.deeplearning(x=c(1,2,3,4),y=5,hidden=NULL,training_frame=iris.hex)
-	hh <- h2o.deeplearning(x=c(1,2,3,4),y=5,hidden=c(),training_frame=iris.hex)
+	hh <- h2o.deeplearning(x=c(1,2,3,4),y=5,hidden=numeric(),training_frame=iris.hex,export_weights_and_biases=TRUE)
 	print(hh)
-  
+  w3 = h2o.weights(object = hh,1)
+  print(dim(w3))
 }
 
 doTest("Deep Learning Test: Iris", check.deeplearning_no_hidden)

--- a/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
+++ b/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
@@ -6,7 +6,7 @@ check.deeplearning_no_hidden <- function() {
 	hh <- h2o.deeplearning(x=c(1,2,3,4),y=5,hidden=numeric(),training_frame=iris.hex,export_weights_and_biases=TRUE)
 	print(hh)
   w3 = h2o.weights(object = hh,1)
-  print(dim(w3))
+  expect_equals(dim(w3) == c(4,3))
 }
 
 doTest("Deep Learning Test: Iris", check.deeplearning_no_hidden)

--- a/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
+++ b/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
@@ -1,0 +1,14 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+check.deeplearning_no_hidden <- function() {
+	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
+	hh <- h2o.deeplearning(x=c(1,2,3,4),y=5,hidden=NULL,training_frame=iris.hex)
+	hh <- h2o.deeplearning(x=c(1,2,3,4),y=5,hidden=c(),training_frame=iris.hex)
+	print(hh)
+  
+}
+
+doTest("Deep Learning Test: Iris", check.deeplearning_no_hidden)

--- a/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
+++ b/h2o-r/tests/testdir_algos/deeplearning/runit_deeplearning_no_hidden.R
@@ -2,11 +2,13 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
 check.deeplearning_no_hidden <- function() {
+	print("Reading in iris")
 	iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
+	print("Building Deep Learning model with no hidden units")
 	hh <- h2o.deeplearning(x=c(1,2,3,4),y=5,hidden=numeric(),training_frame=iris.hex,export_weights_and_biases=TRUE)
-	print(hh)
-  w3 = h2o.weights(object = hh,1)
-  expect_equals(dim(w3) == c(4,3))
+    print(hh)
+    w3 = h2o.weights(object = hh,1)
+    expect_equal(dim(w3), c(3,4))
 }
 
 doTest("Deep Learning Test: Iris", check.deeplearning_no_hidden)


### PR DESCRIPTION
Allow training of deeplearning models without a hidden layer.

TODO:
* DONE Add workaround everywhere where hidden[i] is accessed. (e.g., variable importances)
* DONE Check that POJO works
* DONE (was there already) Add support for a single bias term ("intercept")
* DONE Test classification and regression, should compare to GLM
* DONE Add R/Py/JUnits
* DONE Check Flow
* Update docs