### PR TITLE
PUBDEV-4470: Added Partners to top banner

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -104,6 +104,8 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
           <li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-55' id='mega-menu-item-55'>
             <a class="mega-menu-link" href="http://www.h2o.ai/community/" tabindex="0">Community</a>
           </li>
+          <li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-current-menu-item mega-page_item mega-page-item-382 mega-current_page_item mega-align-bottom-left mega-menu-flyout mega-menu-item-717' id='mega-menu-item-717'><a class="mega-menu-link" href="https://www.h2o.ai/partners/" tabindex="0">Partners</a>
+          </li>
           <li class='mega-menu-item mega-menu-item-type-custom mega-menu-item-object-custom mega-align-bottom-left mega-menu-flyout mega-menu-item-90' id='mega-menu-item-90'>
           <a class="mega-menu-link" href="http://h2o.ai/download?page_id=176" tabindex="0">Download</a>
           </li>
@@ -150,7 +152,7 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
           <h4>H<sub>2</sub>O</h4>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 10px;">
               <a href="h2o-docs/welcome.html">What is H2O?</a>
-              <p style="margin: 0pt;"><a href="h2o-docs/index.html" style="font-weight: 500; font-size: 1.1em;">H2O User Guide</a> <style="font-color:black; font-size:0.9em;">(Main docs)</style="font-color:black;"></p>
+              <p style="margin: 0pt;"><a href="h2o-docs/index.html" style="font-weight: 500; font-size: 1.1em;">H2O User Guide</a> (Main docs)</p>
               <a href="http://shop.oreilly.com/product/0636920053170.do">H2O Book (O'Reilly)</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/Changes.md">Recent Changes</a>
               <a href="https://github.com/h2oai/h2o-3/blob/master/LICENSE">Open Source License (Apache V2)</a>


### PR DESCRIPTION
“Partners” is now available on main doc site, making this more consistent with the h2o.ai site.
Driveby fix: Removed unnecessary “style” tag that was mid-line. Font shows up correctly in all tested browsers.