### PR TITLE
PUBDEV-4416 - fix ORC stream parse

### DIFF
--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestBinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestBinomial.java
@@ -1253,6 +1253,10 @@ public class GLMBasicTestBinomial extends TestUtil {
     _abcd = parse_test_file("smalldata/glm_test/abcd.csv");
     Frame _airlines = parse_test_file("smalldata/airlines/AirlinesTrain.csv.zip");
     _airlines.remove("IsDepDelayed_REC").remove();
+    Key k  = Key.make("airliens_rebalanced");
+    H2O.submitTask(new RebalanceDataSet(_airlines,k,1)).join(); // need this to match the random split from R
+    _airlines.delete();
+    _airlines = DKV.getGet(k);
     String [] names = new String[]{"Origin", "Dest", "fDayofMonth", "fYear", "UniqueCarrier", "fDayOfWeek", "fMonth", "DepTime", "ArrTime", "Distance", "IsDepDelayed"};
     _airlines.restructure(names,_airlines.vecs(names));
     _airlinesTrain = new MRTask(){

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -43,6 +43,7 @@ public class ParseSetup extends Iced {
   String[][] _data;           // First few rows of parsed/tokenized data
 
   String [] _fileNames = new String[]{"unknown"};
+  public  boolean disableParallelParse;
 
   public void setFileName(String name) {_fileNames[0] = name;}
 
@@ -354,7 +355,7 @@ public class ParseSetup extends Iced {
         try {
           _gblSetup = guessSetup(bv, bits, _userSetup);
           for(ParseWriter.ParseErr e:_gblSetup._errs) {
-            e._byteOffset += e._cidx*Parser.StreamData.bufSz;
+//            e._byteOffset += e._cidx*Parser.StreamData.bufSz;
             e._cidx = 0;
             e._file = _file;
           }
@@ -622,25 +623,17 @@ public class ParseSetup extends Iced {
    * @param bytes Array of bytes (containing 0 or more newlines)
    * @return The longest line length in the given bytes
    */
-  private static final long maxLineLength(byte[] bytes) {
-    if (bytes.length >= 2) {
-      String st = new String(bytes);
-      StringReader sr = new StringReader(st);
-      BufferedReader br = new BufferedReader(sr);
-      String line;
-      long maxLineLength=0;
-      try {
-        while(true) {
-          line = br.readLine();
-          if (line == null) break;
-          maxLineLength = Math.max(line.length(), maxLineLength);
-        }
-      } catch (IOException e) {
-        return -1;
+  private static final int maxLineLength(byte[] bytes) {
+    int start = bytes.length;
+    int max = -1;
+    for(int i = 0; i < bytes.length; ++i){
+      if(CsvParser.isEOL(bytes[i])){
+        int delta = i-start+1;
+        max = Math.max(max,delta);
+        start = i+1;
       }
-      return maxLineLength;
     }
-    return -1;
+    return Math.max(max,bytes.length-start+1);
   }
 
   /**

--- a/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
@@ -1,5 +1,7 @@
 package water.parser;
 
+import water.Futures;
+import water.H2O;
 import water.Iced;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
@@ -8,7 +10,7 @@ import water.util.IcedHashMap;
 /** Class implementing ParseWriter, on behalf ParseSetup
  * to examine the contents of a file for guess the column types.
  */
-public class PreviewParseWriter extends Iced implements ParseWriter {
+public class PreviewParseWriter extends Iced implements StreamParseWriter {
   protected final static int MAX_PREVIEW_COLS  = 100;
   protected final static int MAX_PREVIEW_LINES = 10;
   protected int _nlines;
@@ -271,4 +273,16 @@ public class PreviewParseWriter extends Iced implements ParseWriter {
 
   @Override
   public long lineNum() {return _nlines;}
+
+  @Override
+  public StreamParseWriter nextChunk() {throw H2O.unimpl();}
+
+  @Override
+  public StreamParseWriter reduce(StreamParseWriter dout) {throw H2O.unimpl();}
+
+  @Override
+  public StreamParseWriter close() {return this;}
+
+  @Override
+  public StreamParseWriter close(Futures fs) {return this;}
 }

--- a/h2o-core/src/main/java/water/parser/SVMLightParser.java
+++ b/h2o-core/src/main/java/water/parser/SVMLightParser.java
@@ -25,18 +25,15 @@ class SVMLightParser extends Parser {
   /** Try to parse the bytes as svm light format, return a ParseSetupHandler with type 
    *  SVMLight if the input is in svm light format, throw an exception otherwise.
    */
-  public static ParseSetup guessSetup(byte [] bytes) {
-    // find the last eof
-    int i = bytes.length-1;
-    while(i > 0 && bytes[i] != '\n') --i;
-    assert i >= 0;
-    InputStream is = new ByteArrayInputStream(Arrays.copyOf(bytes,i));
+  public static ParseSetup guessSetup(byte [] bits) {
+    int lastNewline = bits.length-1;
+    while(lastNewline > 0 && !CsvParser.isEOL(bits[lastNewline]))lastNewline--;
+    if(lastNewline > 0) bits = Arrays.copyOf(bits,lastNewline+1);
     SVMLightParser p = new SVMLightParser(new ParseSetup(SVMLight_INFO,
             ParseSetup.GUESS_SEP, false,ParseSetup.GUESS_HEADER,ParseSetup.GUESS_COL_CNT,
             null,null,null,null,null), null);
     SVMLightInspectParseWriter dout = new SVMLightInspectParseWriter();
-    try{ p.streamParse(is, dout);
-    } catch(IOException e) { throw new RuntimeException(e); }
+    p.parseChunk(0,new ByteAryData(bits,0), dout);
     if (dout._ncols > 0 && dout._nlines > 0 && dout._nlines > dout._invalidLines)
       return new ParseSetup(SVMLight_INFO, ParseSetup.GUESS_SEP,
             false,ParseSetup.NO_HEADER,dout._ncols,null,dout.guessTypes(),null,null,dout._data, dout.removeErrors());

--- a/h2o-core/src/main/java/water/parser/StreamParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/StreamParseWriter.java
@@ -2,7 +2,7 @@ package water.parser;
 
 import water.Futures;
 
-interface StreamParseWriter extends ParseWriter {
+public interface StreamParseWriter extends ParseWriter {
   StreamParseWriter nextChunk();
   StreamParseWriter reduce(StreamParseWriter dout);
   StreamParseWriter close();

--- a/h2o-core/src/main/java/water/parser/XlsParser.java
+++ b/h2o-core/src/main/java/water/parser/XlsParser.java
@@ -143,7 +143,7 @@ class XlsParser extends Parser {
   }
   private Props _wrkbook, _rootentry;
 
-  @Override public ParseWriter streamParse( final InputStream is, final ParseWriter dout) throws IOException {
+  @Override public ParseWriter streamParse( final InputStream is, final StreamParseWriter dout) throws IOException {
     _is = is;
     // Check for magic first
     readAtLeast(IDENTIFIER_OLE.length);

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -338,7 +338,7 @@ public class TestUtil extends Iced {
    * @param na_string string for NA in a column
    * @return
    */
-  protected static Frame parse_test_folder( String fname, String na_string, int check_header, byte[] column_types ) {
+  protected static Frame parse_test_folder( String fname, String na_string, int check_header, byte[] column_types, boolean disableParallelParse) {
     File folder = FileUtils.locateFile(fname);
     File[] files = contentsOf(fname, folder);
     Arrays.sort(files);
@@ -370,7 +370,7 @@ public class TestUtil extends Iced {
 
     if (column_types != null)
       p.setColumnTypes(column_types);
-
+    p.disableParallelParse = disableParallelParse;
     return ParseDataset.parse(Key.make(), res, true, p);
 
   }
@@ -752,7 +752,7 @@ public class TestUtil extends Iced {
         File f = generatedFile = prepareFile();
         System.out.println("File generated into: " + f.getCanonicalPath());
         if (f.isDirectory()) {
-          return parse_test_folder(f.getCanonicalPath(), null, ParseSetup.HAS_HEADER, null);
+          return parse_test_folder(f.getCanonicalPath(), null, ParseSetup.HAS_HEADER, null, false);
         } else {
           return parse_test_file(f.getCanonicalPath());
         }

--- a/h2o-core/src/test/java/water/parser/ParserTestARFF.java
+++ b/h2o-core/src/test/java/water/parser/ParserTestARFF.java
@@ -18,7 +18,7 @@ import static water.parser.ParserTest.makeByteVec;
 import java.util.Arrays;
 
 public class ParserTestARFF extends TestUtil {
-  @BeforeClass static public void setup() { stall_till_cloudsize(5); }
+  @BeforeClass static public void setup() { stall_till_cloudsize(1); }
 
   /**
    * Helper to check parsed column types

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
@@ -35,26 +35,28 @@ public class ParseTestMultiFileOrc extends TestUtil {
     }
 
     @BeforeClass
-    static public void setup() { TestUtil.stall_till_cloudsize(5); }
+    static public void setup() { TestUtil.stall_till_cloudsize(1); }
 
     @Test
     public void testParseMultiFileOrcs() {
 
-        for (int f_index = 0; f_index < csvDirectories.length; f_index++) {
-            Frame csv_frame = parse_test_folder(csvDirectories[f_index], "\\N", 0, null);
+        for(boolean disableParallelParse:new boolean[]{false,true}) {
+            for (int f_index = 0; f_index < csvDirectories.length; f_index++) {
+                Frame csv_frame = parse_test_folder(csvDirectories[f_index], "\\N", 0, null,disableParallelParse);
 
-            byte[] types = csv_frame.types();
+                byte[] types = csv_frame.types();
 
-            for (int index = 0; index < types.length; index++) {
-                if (types[index] == 0)
-                    types[index] = 4;
+                for (int index = 0; index < types.length; index++) {
+                    if (types[index] == 0)
+                        types[index] = 4;
+                }
+
+                Frame orc_frame = parse_test_folder(orcDirectories[f_index], null, 0, types,disableParallelParse);
+                assertTrue(TestUtil.isIdenticalUpToRelTolerance(csv_frame, orc_frame, 1e-5));
+
+                csv_frame.delete();
+                orc_frame.delete();
             }
-
-            Frame orc_frame = parse_test_folder(orcDirectories[f_index], null, 0, types);
-            assertTrue(TestUtil.isIdenticalUpToRelTolerance(csv_frame, orc_frame, 1e-5));
-
-            csv_frame.delete();
-            orc_frame.delete();
         }
     }
 }

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import water.TestUtil;
+import water.fvec.Frame;
 import water.util.FileUtils;
 import water.util.Log;
 


### PR DESCRIPTION
  1. Parser.setupLocal was not called when doing stream parse
  2. Orc does not read from passed input stream, it reads data via ORC libraries -> needs its own streamParse loop
  3. There was a strange behavior in h2o where streamParse did something different from streamParseZip and in fact streamParseZip was being used for actual parsing even fro non-zipped data.