### PR TITLE
PUBDEV-4250: Updated confusion matrix header to be more clear

### DIFF
--- a/h2o-core/src/main/java/hex/ConfusionMatrix.java
+++ b/h2o-core/src/main/java/hex/ConfusionMatrix.java
@@ -305,7 +305,7 @@ public class ConfusionMatrix extends Iced {
     // set format width
     colFormat[colFormat.length-1] = "= %" + width + "s";
 
-    TwoDimTable table = new TwoDimTable("Confusion Matrix", "vertical: actual; across: predicted", rowHeader, colHeader, colType, colFormat, null);
+    TwoDimTable table = new TwoDimTable("Confusion Matrix", "Row labels: Actual class; Column labels: Predicted class", rowHeader, colHeader, colType, colFormat, null);
 
     // Main CM Body
     for (int a = 0; a < _cm.length; a++) {


### PR DESCRIPTION
The confusion matrix header now reads:

```
> h2o.confusionMatrix(model)
Confusion Matrix: Row labels: Actual class; Column labels: Predicted class
           setosa versicolor virginica  Error      Rate
setosa         50          0         0 0.0000 =  0 / 50
versicolor      0         48         2 0.0400 =  2 / 50
virginica       0          1        49 0.0200 =  1 / 50
Totals         50         49        51 0.0200 = 3 / 150
```