### PR TITLE
 PUBDEV-4484 - Make quasibinomial glm model behave like binomial.

### DIFF
--- a/h2o-algos/src/main/java/hex/coxph/CoxPH.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPH.java
@@ -158,7 +158,7 @@ public class CoxPH extends ModelBuilder<CoxPHModel,CoxPHModel.CoxPHParameters,Co
               (long) start_column.min() + 1;
       o.max_time = (long) stop_column.max();
 
-      final int n_time = new VecUtils.CollectDomain().doAll(stop_column).domain().length;
+      final int n_time = new VecUtils.CollectIntegerDomain().doAll(stop_column).domain().length;
       o.time         = MemoryManager.malloc8(n_time);
       o.n_risk       = MemoryManager.malloc8d(n_time);
       o.n_event      = MemoryManager.malloc8d(n_time);

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -318,7 +318,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   public int nclasses() {
     if (_parms._family == Family.multinomial)
       return _nclass;
-    if (_parms._family == Family.binomial)
+    if (_parms._family == Family.binomial || _parms._family == Family.quasibinomial)
       return 2;
     return 1;
   }

--- a/h2o-algos/src/main/java/hex/glm/GLMMetricBuilder.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMMetricBuilder.java
@@ -43,6 +43,7 @@ public class GLMMetricBuilder extends MetricBuilderSupervised<GLMMetricBuilder> 
     if(_computeMetrics) {
       switch(_glmf._family){
         case binomial:
+        case quasibinomial:
           _metricBuilder = new MetricBuilderBinomial(domain);
           break;
         case multinomial:
@@ -71,7 +72,7 @@ public class GLMMetricBuilder extends MetricBuilderSupervised<GLMMetricBuilder> 
     if(!ArrayUtils.hasNaNsOrInfs(ds) && !ArrayUtils.hasNaNsOrInfs(yact)) {
       if(_glmf._family == Family.multinomial)
         add2(yact[0], ds, weight, offset);
-      else if (_glmf._family == Family.binomial)
+      else if (_glmf._family == Family.binomial || _glmf._family == Family.quasibinomial)
         add2(yact[0], ds[2], weight, offset);
       else
         add2(yact[0], ds[0], weight, offset);
@@ -106,7 +107,7 @@ public class GLMMetricBuilder extends MetricBuilderSupervised<GLMMetricBuilder> 
   public void add(double yreal, double ymodel, double weight, double offset) {
     if(weight == 0)return;
     _yact[0] = (float) yreal;
-    if(_glmf._family == Family.binomial) {
+    if(_glmf._family == Family.binomial || _glmf._family == Family.quasibinomial) {
       _ds[1] = 1 - ymodel;
       _ds[2] = ymodel;
     } else {
@@ -160,6 +161,7 @@ public class GLMMetricBuilder extends MetricBuilderSupervised<GLMMetricBuilder> 
       case gaussian:
         _aic =  _nobs * (Math.log(residual_deviance / _nobs * 2 * Math.PI) + 1) + 2;
         break;
+      case quasibinomial:
       case binomial:
         _aic = residual_deviance;
         break;
@@ -169,7 +171,6 @@ public class GLMMetricBuilder extends MetricBuilderSupervised<GLMMetricBuilder> 
       case gamma:
         _aic = Double.NaN;
         break;
-      case quasibinomial:
       case tweedie:
       case multinomial:
         _aic = Double.NaN;
@@ -184,7 +185,7 @@ public class GLMMetricBuilder extends MetricBuilderSupervised<GLMMetricBuilder> 
     GLMModel gm = (GLMModel)m;
     computeAIC();
     ModelMetrics metrics = _metricBuilder.makeModelMetrics(gm, f, null, null);
-    if (_glmf._family == Family.binomial) {
+    if (_glmf._family == Family.binomial || _glmf._family == Family.quasibinomial) {
       ModelMetricsBinomial metricsBinommial = (ModelMetricsBinomial) metrics;
       GainsLift gl = null;
       if (preds!=null) {

--- a/h2o-algos/src/main/java/hex/glm/GLMScore.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMScore.java
@@ -90,7 +90,7 @@ public class GLMScore extends MRTask<GLMScore> {
       preds[0] = ArrayUtils.maxIndex(eta);
     } else {
       double mu = _m._parms.linkInv(r.innerProduct(_beta) + o);
-      if (_m._parms._family == GLMModel.GLMParameters.Family.binomial) { // threshold for prediction
+      if (_m._parms._family == GLMModel.GLMParameters.Family.binomial || _m._parms._family == GLMModel.GLMParameters.Family.quasibinomial) { // threshold for prediction
         preds[0] = mu >= _defaultThreshold?1:0;
         preds[1] = 1.0 - mu; // class 0
         preds[2] = mu; // class 1

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -1321,7 +1321,7 @@ public class GLMTest  extends TestUtil {
 
 
   public static double residualDeviance(GLMModel m) {
-    if (m._parms._family == Family.binomial) {
+    if (m._parms._family == Family.binomial || m._parms._family == Family.quasibinomial) {
       ModelMetricsBinomialGLM metrics = (ModelMetricsBinomialGLM) m._output._training_metrics;
       return metrics._resDev;
     } else {
@@ -1368,7 +1368,7 @@ public class GLMTest  extends TestUtil {
   }
 
   public static double resDOF(GLMModel m) {
-    if (m._parms._family == Family.binomial) {
+    if (m._parms._family == Family.binomial || m._parms._family == Family.quasibinomial) {
       ModelMetricsBinomialGLM metrics = (ModelMetricsBinomialGLM) m._output._training_metrics;
       return metrics._residualDegressOfFreedom;
     } else {
@@ -1397,7 +1397,7 @@ public class GLMTest  extends TestUtil {
   }
 
   public static double nullDeviance(GLMModel m) {
-    if (m._parms._family == Family.binomial) {
+    if (m._parms._family == Family.binomial || m._parms._family == Family.quasibinomial) {
       ModelMetricsBinomialGLM metrics = (ModelMetricsBinomialGLM) m._output._training_metrics;
       return metrics._nullDev;
     } else {

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -964,7 +964,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
           if (vec.isString())
             vec = VecUtils.stringToCategorical(vec); //turn a String column into a categorical column (we don't delete the original vec here)
           if( expensive && vec.domain() != domains[i] && !Arrays.equals(vec.domain(),domains[i]) ) { // Result needs to be the same categorical
-            CategoricalWrappedVec evec;
+            Vec evec;
             try {
               evec = vec.adaptTo(domains[i]); // Convert to categorical or throw IAE
               toDelete.put(evec._key, "categorically adapted vec");

--- a/h2o-core/src/main/java/water/fvec/CategoricalWrappedVec.java
+++ b/h2o-core/src/main/java/water/fvec/CategoricalWrappedVec.java
@@ -78,7 +78,7 @@ public class CategoricalWrappedVec extends WrappedVec {
     // The source Vec does not have a domain, hence is an integer column.  The
     // to[] mapping has the set of unique numbers, we need to map from those
     // numbers to the index to the numbers.
-    if( from==null ) {
+    if( from==null) {
       setDomain(to);
       if( fromIsBad ) { _map = new int[0]; return; }
       int min = Integer.valueOf(to[0]);

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -1347,9 +1347,58 @@ public class Vec extends Keyed<Vec> {
 
   /** Make a Vec adapting this cal vector to the 'to' categorical Vec.  The adapted
    *  CategoricalWrappedVec has 'this' as it's masterVec, but returns results in the 'to'
-   *  domain (or just past it, if 'this' has elements not appearing in the 'to'
-   *  domain). */
-  public CategoricalWrappedVec adaptTo( String[] domain ) {
+   *  newDomain (or just past it, if 'this' has elements not appearing in the 'to'
+   *  newDomain). */
+  public Vec adaptTo( String[] domain ) {
+    if(!isBad() && isNumeric() && !ArrayUtils.isInt(domain)) { // try to adapt double domain
+      // treat double domain here - return full vector copy instead of mapping double to ints on the fly in a WrappedVec
+      final int oldDomainLen = domain.length;
+      int nan_cnt = 0;
+        int j = 0;
+        double [] double_domain = MemoryManager.malloc8d(domain.length);
+        for (int i = 0; i < double_domain.length; ++i)
+        try {
+          double_domain[j] = Double.parseDouble(domain[i]);
+          j++;
+        } catch(NumberFormatException ex){nan_cnt++;}
+        if (j < double_domain.length)
+          double_domain = Arrays.copyOf(double_domain, j);
+        double[] new_double_domain = new VecUtils.CollectDoubleDomain(double_domain, 100000).doAll(this).domain();
+        if (new_double_domain.length > 0) {
+          int n = domain.length;
+          domain = Arrays.copyOf(domain, domain.length + new_double_domain.length);
+          for (int i = 0; i < new_double_domain.length; ++i)
+            domain[n + i] = String.valueOf(new_double_domain[i]);
+        }
+        Vec res = makeZero(domain);
+        double_domain = MemoryManager.malloc8d(domain.length - nan_cnt);
+        j = 0;
+        final int[] indeces = MemoryManager.malloc4(domain.length - nan_cnt);
+        for (int i = 0; i < domain.length; ++i) {
+          try {
+            double_domain[j] = Double.parseDouble(domain[i]);
+            indeces[j] = i;
+            j++;
+          } catch (NumberFormatException ex) {/*ignore*/}
+        }
+        if (!ArrayUtils.isSorted(double_domain))
+          ArrayUtils.sort(indeces, double_domain);
+        final double[] sorted_domain_vals = ArrayUtils.select(double_domain, indeces);
+        new MRTask() {
+          @Override
+          public void map(Chunk c0, Chunk c1) {
+            for (int i = 0; i < c0._len; ++i) {
+              double d = c0.atd(i);
+              if (Double.isNaN(d))
+                c1.setNA(i);
+              else {
+                c1.set(i, indeces[Arrays.binarySearch(sorted_domain_vals, d)]);
+              }
+            }
+          }
+        }.doAll(new Vec[]{this, res});
+        return res;
+    }
     return new CategoricalWrappedVec(group().addVec(),_rowLayout,domain,this._key);
   }
 

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -1361,43 +1361,47 @@ public class Vec extends Keyed<Vec> {
           double_domain[j] = Double.parseDouble(domain[i]);
           j++;
         } catch(NumberFormatException ex){nan_cnt++;}
-        if (j < double_domain.length)
-          double_domain = Arrays.copyOf(double_domain, j);
-        double[] new_double_domain = new VecUtils.CollectDoubleDomain(double_domain, 100000).doAll(this).domain();
-        if (new_double_domain.length > 0) {
-          int n = domain.length;
-          domain = Arrays.copyOf(domain, domain.length + new_double_domain.length);
-          for (int i = 0; i < new_double_domain.length; ++i)
-            domain[n + i] = String.valueOf(new_double_domain[i]);
-        }
-        Vec res = makeZero(domain);
-        double_domain = MemoryManager.malloc8d(domain.length - nan_cnt);
-        j = 0;
-        final int[] indeces = MemoryManager.malloc4(domain.length - nan_cnt);
-        for (int i = 0; i < domain.length; ++i) {
-          try {
-            double_domain[j] = Double.parseDouble(domain[i]);
-            indeces[j] = i;
-            j++;
-          } catch (NumberFormatException ex) {/*ignore*/}
-        }
-        if (!ArrayUtils.isSorted(double_domain))
-          ArrayUtils.sort(indeces, double_domain);
-        final double[] sorted_domain_vals = ArrayUtils.select(double_domain, indeces);
-        new MRTask() {
-          @Override
-          public void map(Chunk c0, Chunk c1) {
-            for (int i = 0; i < c0._len; ++i) {
-              double d = c0.atd(i);
-              if (Double.isNaN(d))
-                c1.setNA(i);
-              else {
-                c1.set(i, indeces[Arrays.binarySearch(sorted_domain_vals, d)]);
+        if(j == double_domain.length) { // only atempt to adapt if we have fully double domain,  (to preserve current behavior for ints, could relax this later)
+          if (j < double_domain.length)
+            double_domain = Arrays.copyOf(double_domain, j);
+          double[] new_double_domain = new VecUtils.CollectDoubleDomain(double_domain, 100000).doAll(this).domain();
+          if (new_double_domain.length > 0) {
+            int n = domain.length;
+            domain = Arrays.copyOf(domain, domain.length + new_double_domain.length);
+            for (int i = 0; i < new_double_domain.length; ++i)
+              domain[n + i] = String.valueOf(new_double_domain[i]);
+          }
+          Vec res = makeZero(domain);
+          double_domain = MemoryManager.malloc8d(domain.length - nan_cnt);
+          j = 0;
+          final int[] indeces = MemoryManager.malloc4(domain.length - nan_cnt);
+          int[] order_indeces = ArrayUtils.seq(0, indeces.length);
+          for (int i = 0; i < domain.length; ++i) {
+            try {
+              double_domain[j] = Double.parseDouble(domain[i]);
+              indeces[j] = i;
+              j++;
+            } catch (NumberFormatException ex) {/*ignore*/}
+          }
+          if (!ArrayUtils.isSorted(double_domain))
+            ArrayUtils.sort(order_indeces, double_domain);
+          final double[] sorted_domain_vals = ArrayUtils.select(double_domain, order_indeces);
+          final int[] sorted_indeces = ArrayUtils.select(indeces, order_indeces);
+          new MRTask() {
+            @Override
+            public void map(Chunk c0, Chunk c1) {
+              for (int i = 0; i < c0._len; ++i) {
+                double d = c0.atd(i);
+                if (Double.isNaN(d))
+                  c1.setNA(i);
+                else {
+                  c1.set(i, sorted_indeces[Arrays.binarySearch(sorted_domain_vals, d)]);
+                }
               }
             }
-          }
-        }.doAll(new Vec[]{this, res});
-        return res;
+          }.doAll(new Vec[]{this, res});
+          return res;
+        }
     }
     return new CategoricalWrappedVec(group().addVec(),_rowLayout,domain,this._key);
   }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstKFold.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstKFold.java
@@ -61,7 +61,7 @@ public class AstKFold extends AstPrimitive {
     // therefore, have a seed per class to be used by the map call
     if (!(y.isCategorical() || (y.isNumeric() && y.isInt())))
       throw new IllegalArgumentException("stratification only applies to integer and categorical columns. Got: " + y.get_type_str());
-    final long[] classes = new VecUtils.CollectDomain().doAll(y).domain();
+    final long[] classes = new VecUtils.CollectIntegerDomain().doAll(y).domain();
     final int nClass = y.isNumeric() ? classes.length : y.domain().length;
     final long[] seeds = new long[nClass]; // seed for each regular fold column (one per class)
     for (int i = 0; i < nClass; ++i)

--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstStratifiedSplit.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstStratifiedSplit.java
@@ -55,7 +55,7 @@ public class AstStratifiedSplit extends AstPrimitive {
     checkIfCanStratifyBy(stratifyingColumn);
     randomizationSeed = randomizationSeed == -1 ? new Random().nextLong() : randomizationSeed;
     // Collect input vector domain
-    final long[] classes = new VecUtils.CollectDomain().doAll(stratifyingColumn).domain();
+    final long[] classes = new VecUtils.CollectIntegerDomain().doAll(stratifyingColumn).domain();
     // Number of output classes
     final int numClasses = stratifyingColumn.isNumeric() ? classes.length : stratifyingColumn.domain().length;
     

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstPivot.java
@@ -46,7 +46,7 @@ public class AstPivot extends AstBuiltin<AstPivot> {
     // Create the target Frame
     // Now sort on the index key, result is that unique keys will be localized
     Frame fr2 = fr.sort(new int[]{indexIdx});
-    final long[] classes = new VecUtils.CollectDomain().doAll(fr.vec(colIdx)).domain();
+    final long[] classes = new VecUtils.CollectIntegerDomain().doAll(fr.vec(colIdx)).domain();
     final int nClass = (fr.vec(colIdx).isNumeric() || fr.vec(colIdx).isTime()) ? classes.length : fr.vec(colIdx).domain().length;
     String[] header = null;
     if (fr.vec(colIdx).isNumeric()) {

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -890,10 +890,12 @@ public class ArrayUtils {
     return cnt;
   }
 
-  public static boolean isInt(String s) {
-    if (s == null || s.isEmpty()) return false;
-    int i = s.charAt(0)=='-' ? 1 : 0;
-    for(; i<s.length();i++) if (!Character.isDigit(s.charAt(i))) return false;
+  public static boolean isInt(String... ary) {
+    for(String s:ary) {
+      if (s == null || s.isEmpty()) return false;
+      int i = s.charAt(0) == '-' ? 1 : 0;
+      for (; i < s.length(); i++) if (!Character.isDigit(s.charAt(i))) return false;
+    }
     return true;
   }
 
@@ -1197,6 +1199,17 @@ public class ArrayUtils {
 
   public static int [] sortedMerge(int[] a, int [] b) {
     int [] c = MemoryManager.malloc4(a.length + b.length);
+    int i = 0, j = 0;
+    for(int k = 0; k < c.length; ++k){
+      if(i == a.length) c[k] = b[j++];
+      else if(j == b.length)c[k] = a[i++];
+      else if(b[j] < a[i]) c[k] = b[j++];
+      else c[k] = a[i++];
+    }
+    return c;
+  }
+  public static double [] sortedMerge(double[] a, double [] b) {
+    double [] c = MemoryManager.malloc8d(a.length + b.length);
     int i = 0, j = 0;
     for(int k = 0; k < c.length; ++k){
       if(i == a.length) c[k] = b[j++];
@@ -1786,6 +1799,11 @@ public class ArrayUtils {
   }
 
   public static boolean isSorted(int[] vals) {
+    for (int i = 1; i < vals.length; ++i)
+      if (vals[i - 1] > vals[i]) return false;
+    return true;
+  }
+  public static boolean isSorted(double[] vals) {
     for (int i = 1; i < vals.length; ++i)
       if (vals[i - 1] > vals[i]) return false;
     return true;

--- a/h2o-core/src/main/java/water/util/FrameUtils.java
+++ b/h2o-core/src/main/java/water/util/FrameUtils.java
@@ -879,7 +879,7 @@ public class FrameUtils {
   static public void shrinkDomainsToObservedSubset(Frame frameToModifyInPlace) {
     for (Vec v : frameToModifyInPlace.vecs()) {
       if (v.isCategorical()) {
-        long[] uniques = (v.min() >= 0 && v.max() < Integer.MAX_VALUE - 4) ? new VecUtils.CollectDomainFast((int)v.max()).doAll(v).domain() : new VecUtils.CollectDomain().doAll(v).domain();
+        long[] uniques = (v.min() >= 0 && v.max() < Integer.MAX_VALUE - 4) ? new VecUtils.CollectDomainFast((int)v.max()).doAll(v).domain() : new VecUtils.CollectIntegerDomain().doAll(v).domain();
         String[] newDomain = new String[uniques.length];
         final int[] fromTo = new int[(int)ArrayUtils.maxValue(uniques)+1];
         for (int i=0;i<newDomain.length;++i) {

--- a/h2o-core/src/main/java/water/util/IcedDouble.java
+++ b/h2o-core/src/main/java/water/util/IcedDouble.java
@@ -8,6 +8,14 @@ public class IcedDouble extends Iced {
   @Override public boolean equals( Object o ) {
     return o instanceof IcedDouble && ((IcedDouble) o)._val == _val;
   }
-  @Override public int hashCode() { return new Double(_val).hashCode(); }
+  @Override public int hashCode() {
+    long bits = Double.doubleToLongBits(_val);
+    return (int)(bits ^ (bits >>> 32));
+  }
   @Override public String toString() { return Double.toString(_val); }
+
+  public IcedDouble setVal(double atd) {
+    _val = atd;
+    return this;
+  }
 }

--- a/h2o-core/src/main/java/water/util/IcedLong.java
+++ b/h2o-core/src/main/java/water/util/IcedLong.java
@@ -8,7 +8,9 @@ public class IcedLong extends Iced {
   @Override public boolean equals( Object o ) {
     return o instanceof IcedLong && ((IcedLong) o)._val == _val;
   }
-  @Override public int hashCode() { return new Long(_val).hashCode(); }
+  @Override public int hashCode() {
+    return (int)(_val ^ (_val >>> 32));
+  }
   @Override public String toString() { return Long.toString(_val); }
 
   public static IcedLong valueOf(long value) {

--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -412,7 +412,7 @@ public class VecUtils {
     public CollectDoubleDomain(double [] knownDomain, int maxDomainSize) {
       _maxDomain = maxDomainSize;
       _sortedKnownDomain = knownDomain == null?null:knownDomain.clone();
-      if(!ArrayUtils.isSorted(knownDomain))
+      if(_sortedKnownDomain != null && !ArrayUtils.isSorted(knownDomain))
         Arrays.sort(_sortedKnownDomain);
     }
 

--- a/h2o-core/src/test/java/water/fvec/CategoricalWrappedVecTest.java
+++ b/h2o-core/src/test/java/water/fvec/CategoricalWrappedVecTest.java
@@ -13,6 +13,19 @@ import java.util.Random;
 public class CategoricalWrappedVecTest extends TestUtil {
   @BeforeClass static public void setup() {  stall_till_cloudsize(1); }
 
+  @Test public void testAdaptToDoubleDomain(){
+    Vec v0 = Vec.makeCon(Vec.newKey(),3.14,2.7,0.33333,-123.456,1.65e9,-500.50);
+    Vec v1 = v0.adaptTo(new String[]{"0.270e1","-123.456"});
+    Assert.assertArrayEquals(new String[]{"0.270e1","-123.456","-500.5","0.33333","3.14","1.65E9"},v1.domain());
+    Assert.assertEquals(v1.at8(0),4);
+    Assert.assertEquals(v1.at8(1),0);
+    Assert.assertEquals(v1.at8(2),3);
+    Assert.assertEquals(v1.at8(3),1);
+    Assert.assertEquals(v1.at8(4),5);
+    Assert.assertEquals(v1.at8(5),2);
+    v0.remove();
+    v1.remove();
+  }
   // Need to move test files over
   @Test public void testAdaptTo() {
     Scope.enter();
@@ -20,7 +33,7 @@ public class CategoricalWrappedVecTest extends TestUtil {
     try {
       v1 = parse_test_file("smalldata/junit/mixcat_train.csv");
       v2 = parse_test_file("smalldata/junit/mixcat_test.csv");
-      CategoricalWrappedVec vv = v2.vecs()[0].adaptTo(v1.vecs()[0].domain());
+      CategoricalWrappedVec vv = (CategoricalWrappedVec) v2.vecs()[0].adaptTo(v1.vecs()[0].domain());
       Assert.assertArrayEquals("Mapping differs",new int[]{0,1,3},vv._map);
       Assert.assertArrayEquals("Mapping differs",new String[]{"A","B","C","D"},vv.domain());
       vv.remove();


### PR DESCRIPTION
1. When training on data in {lb,ub}, set {str(lb),str(ub)} as domain but use actual numeric values during training.
    (this means all metrics are calculated with binary response!)
2. Mark quasibinomial model as binomial.
3. Had to fix Vec.adapt and Vec.toCategorical to work with double domain.