### PR TITLE
[PUBDEV-4481] Removed deprecated h2o.importURL function from R API

### DIFF
--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -25,8 +25,7 @@
 #' will be relative to the start location of the H2O instance. The default
 #' behavior is to pass-through to the parse phase automatically.
 #'
-#' \code{h2o.importURL} and \code{h2o.importHDFS} are both deprecated functions. Instead, use
-#' \code{h2o.importFile}
+#' \code{h2o.importHDFS} is deprecated. Instead, use \code{h2o.importFile}.
 #'
 #' @param path The complete URL or normalized file path of the file to be
 #'        imported. Each row of data appears as one line of the file.
@@ -121,13 +120,6 @@ if(parse) {
     return( myData[[1L]] )
   else
     return( myData )
-}
-
-
-#' @rdname h2o.importFile
-#' @export
-h2o.importURL <- function(path, destination_frame = "", parse = TRUE, header = NA, sep = "", col.names = NULL, na.strings=NULL) {
-  .Deprecated("h2o.importFile")
 }
 
 

--- a/h2o-r/tests/testdir_algos/kmeans/runit_kmeans_getModel.R
+++ b/h2o-r/tests/testdir_algos/kmeans/runit_kmeans_getModel.R
@@ -6,7 +6,6 @@ source("../../../scripts/h2o-r-test-setup.R")
 # Test k-means clustering on benign.csv
 test.km.benign <- function() {
   Log.info("Importing benign.csv data...\n")
-  # benign.hex = h2o.importURL( "https..//raw.github.com/0xdata/h2o/master/smalldata/logreg/benign.csv")
   # benign.hex = h2o.importFile( normalizePath("../../../smalldata/logreg/benign.csv"))
   benign.hex <- h2o.importFile( locate("smalldata/logreg/benign.csv"))
   benign.sum <- summary(benign.hex)

--- a/h2o-r/tests/testdir_algos/kmeans/runit_kmeans_prostate.R
+++ b/h2o-r/tests/testdir_algos/kmeans/runit_kmeans_prostate.R
@@ -6,7 +6,6 @@ source("../../../scripts/h2o-r-test-setup.R")
 # Test k-means clustering on prostate.csv
 test.km.prostate <- function() {
   Log.info("Importing prostate.csv data...\n")
-  # prostate.hex = h2o.importURL( "https..//raw.github.com/0xdata/h2o/master/smalldata/logreg/prostate.csv", "prostate.hex")
   # prostate.hex = h2o.importFile( normalizePath("../../../smalldata/logreg/prostate.csv"))
   prostate.hex <- h2o.uploadFile( locate("smalldata/logreg/prostate.csv"))
   prostate.sum <- summary(prostate.hex)


### PR DESCRIPTION
- Removed h2o.importURL deprecated function from import.R
- Removed commented references from runit_kmeans tests
- JIRA here: https://0xdata.atlassian.net/browse/PUBDEV-4481