### PR TITLE
PUBDEV-4499: Export h2o.deepwater.available function in R API

### DIFF
--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -626,17 +626,21 @@ def help_afterword_for(algo):
     if algo == "deepwater":
         return """
             #' Ask the H2O server whether a Deep Water model can be built (depends on availability of native backends)
-            #' Returns True if a deep water model can be built, or False otherwise.
-            #' @param h2oRestApiVersion (Optional) Specific version of the REST API to use
-            #'
+            #' Returns TRUE if a Deep Water model can be built, or FALSE otherwise.
+            #' @param h2oRestApiVersion (Optional) Specific version of the REST API to use.
+            #' @export
             h2o.deepwater.available <- function(h2oRestApiVersion = .h2o.__REST_API_VERSION) {
-                visibility = .h2o.__remoteSend(method = "GET", h2oRestApiVersion = h2oRestApiVersion, .h2o.__MODEL_BUILDERS("deepwater"))$model_builders[["deepwater"]][["visibility"]]
+                res <- .h2o.__remoteSend(method = "GET", 
+                                         h2oRestApiVersion = h2oRestApiVersion, 
+                                         page = .h2o.__MODEL_BUILDERS("deepwater"))
+                visibility <- res$model_builders[["deepwater"]][["visibility"]]
                 if (visibility == "Experimental") {
                     print("Cannot build a Deep Water model - no backend found.")
-                    return(FALSE)
+                    available <- FALSE
                 } else {
-                   return(TRUE)
+                   available <- TRUE
                 }
+                return(available)
             }
         """
     if algo == "glm":


### PR DESCRIPTION
This was never functional in the R API because it was not properly exported to the namespace.

Now it will say:
```r
> h2o.deepwater.available()
[1] "Cannot build a Deep Water model - no backend found."
[1] FALSE
```
It still needs to be tested against a system with a valid Deep Water backend.