### PR TITLE
PUBDEV-4494: Saving and Loading Ensemble Binary Models

### DIFF
--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -318,8 +318,7 @@ FAQ
 
 -  **How do I save ensemble models?**
 
-  Currently, there is no support for saving ensembles, but this will be addressed in the next release.  `Binary save/load <https://0xdata.atlassian.net/browse/PUBDEV-3970>`__ as as well as `MOJO support <https://0xdata.atlassian.net/browse/PUBDEV-3877>`__ is planned for Stacked Ensemble models.  (More accurately, you can currently save an ensemble as a binary model, but there may be issues when loading it back in.)
-
+  H2O now supports saving and loading ensemble models. (Refer to `PUBDEV-3970 <https://0xdata.atlassian.net/browse/PUBDEV-3970>`__ for more information.) The steps are the same as those described in the `Saving and Loading a Model <../save-and-load-model.html>`__ section. Note that MOJO support is planned for Stacked Ensemble models in a future release. (See `PUBDEV-3877 <https://0xdata.atlassian.net/browse/PUBDEV-3877>`__.)
 
 -  **Will an stacked ensemble always perform better than a single model?**
   
@@ -329,7 +328,6 @@ FAQ
 -  **How do I improve the performance of an ensemble?**
   
   If you find that your ensemble is not performing better than the best base learner, then you can try a few different things.  First, look to see if there are base learners that are performing much worse than the other base learners (for example, a GLM).  If so, remove them from the ensemble and try again.  Second, you can try adding more models to the ensemble, especially models that add diversity to your set of base models.  Once `custom metalearner support <https://0xdata.atlassian.net/browse/PUBDEV-3743>`__ is added, you can try out different metalearners as well.
-
 
 -  **How does the algorithm handle missing values during training?**
 
@@ -351,7 +349,6 @@ FAQ
    column?**
 
   In the base learners, specify ``balance_classes``, ``class_sampling_factors`` and ``max_after_balance_size`` to control over/under-sampling.
-
 
 
 Additional Information

--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -44,14 +44,14 @@ In R and Python, you can save a model locally or to HDFS using the ``h2o.saveMod
 .. example-code::
    .. code-block:: r
 
-	# build the model
-	model <- h2o.glm(model params)
+    # build the model
+    model <- h2o.glm(model params)
 
-	# save the model to HDFS
-	hdfs_name_node <- "node-1"
-	hdfs_tmp_dir <- "/tmp/runit”
-	model_path <- sprintf("hdfs://%s%s", hdfs_name_node, hdfs_tmp_dir)
-	h2o.saveModel(model, dir=model_path, name="mymodel")
+    # save the model to HDFS
+    hdfs_name_node <- "node-1"
+    hdfs_tmp_dir <- "/tmp/runit"
+    model_path <- sprintf("hdfs://%s%s", hdfs_name_node, hdfs_tmp_dir)
+    h2o.saveModel(model, dir=model_path, name="mymodel")
 
    .. code-block:: python
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -938,13 +938,16 @@ def download_all_logs(dirname=".", filename=None):
 
 def save_model(model, path="", force=False):
     """
-    Save an H2O Model object to disk.
+    Save an H2O Model object to disk. (Note that ensemble binary models can now be saved using this method.)
 
     :param model: The model object to save.
     :param path: a path to save the model at (hdfs, s3, local)
     :param force: if True overwrite destination directory in case it exists, or throw exception if set to False.
 
     :returns: the path of the saved model
+
+    :examples:
+        >>> path = h2o.save_model(my_model, dir=my_path)
     """
     assert_is_type(model, ModelBase)
     assert_is_type(path, str)
@@ -955,7 +958,7 @@ def save_model(model, path="", force=False):
 
 def load_model(path):
     """
-    Load a saved H2O model from disk.
+    Load a saved H2O model from disk. (Note that ensemble binary models can now be loaded using this method.)
 
     :param path: the full path of the H2O Model to be imported.
 

--- a/h2o-r/h2o-package/R/export.R
+++ b/h2o-r/h2o-package/R/export.R
@@ -121,7 +121,8 @@ h2o.downloadCSV <- function(data, filename) {
 #'
 #' Save an H2O Model Object to Disk
 #'
-#' Save an \linkS4class{H2OModel} to disk.
+#' Save an \linkS4class{H2OModel} to disk. (Note that ensemble binary models 
+#' can be saved.)
 #'
 #' In the case of existing files \code{force = TRUE} will overwrite the file.
 #' Otherwise, the operation will fail.

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -253,7 +253,8 @@ h2o.import_sql_select<- function(connection_url, select_query, username, passwor
 #'
 #' Load H2O Model from HDFS or Local Disk
 #'
-#' Load a saved H2O model from disk.
+#' Load a saved H2O model from disk. (Note that ensemble binary models 
+#' can now be loaded using this method.)
 #'
 #' @param path The path of the H2O Model to be imported.
 #'        and port of the server running H2O.


### PR DESCRIPTION
- In User Guide, updated the FAQ that previously indicated users could save and load stacked ensemble models
- In R docs, added a note to loadModel and saveModel indicating that users can save and load ensemble binary models
- In Python docs, added a note to load_model and save_model indicating that users can save and load ensemble binary models
- Driveby fix: Fixed the R example in Saving and Loading a model. Highlighting is no longer skipped.