### PR TITLE
PUBDEV-4496: Change project to project_name in AutoML backend

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -115,7 +115,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     Date startTime = new Date();
 
-    userFeedback = new UserFeedback(this); // Don't use until we set this.project
+    userFeedback = new UserFeedback(this); // Don't use until we set this.project_name
 
     this.buildSpec = buildSpec;
 
@@ -141,8 +141,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       }
     }
 
-    userFeedback.info(Stage.Workflow, "Project: " + project());
-    leaderboard = new Leaderboard(project(), userFeedback, this.leaderboardFrame);
+    userFeedback.info(Stage.Workflow, "Project: " + projectName());
+    leaderboard = new Leaderboard(projectName(), userFeedback, this.leaderboardFrame);
 
     /*
     TODO
@@ -943,17 +943,17 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     Log.info(userFeedback.toString("User Feedback for AutoML Run " + this._key));
     Log.info();
 
-    Leaderboard trainingLeaderboard = new Leaderboard(project() + "_training", userFeedback, this.trainingFrame);
+    Leaderboard trainingLeaderboard = new Leaderboard(projectName() + "_training", userFeedback, this.trainingFrame);
     trainingLeaderboard.addModels(this.leaderboard().getModelKeys());
-    Log.info(trainingLeaderboard.toTwoDimTable("TRAINING FRAME Leaderboard for project " + project(), true).toString());
+    Log.info(trainingLeaderboard.toTwoDimTable("TRAINING FRAME Leaderboard for project " + projectName(), true).toString());
     Log.info();
 
-    Leaderboard validationLeaderboard = new Leaderboard(project() + "_validation", userFeedback, this.validationFrame);
+    Leaderboard validationLeaderboard = new Leaderboard(projectName() + "_validation", userFeedback, this.validationFrame);
     validationLeaderboard.addModels(this.leaderboard().getModelKeys());
-    Log.info(validationLeaderboard.toTwoDimTable("VALIDATION FRAME Leaderboard for project " + project(), true).toString());
+    Log.info(validationLeaderboard.toTwoDimTable("VALIDATION FRAME Leaderboard for project " + projectName(), true).toString());
     Log.info();
 
-    Log.info(leaderboard().toTwoDimTable("Leaderboard for project " + project(), true).toString());
+    Log.info(leaderboard().toTwoDimTable("Leaderboard for project " + projectName(), true).toString());
 
     possiblyVerifyImmutability();
 
@@ -1053,7 +1053,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
   public UserFeedback userFeedback() { return userFeedback == null ? null : userFeedback._key.get(); }
 
-  public String project() {
+  public String projectName() {
     return buildSpec == null ? null : buildSpec.project();
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -46,7 +46,7 @@ public class AutoMLBuildSpec extends Iced {
      * (e.g., "airlines" and "iris").  If the user doesn't set it we use the basename
      * of the training file name.
      */
-    public String project = null;
+    public String project_name = null;
     public String loss = "AUTO";  // TODO: plumb through
     public HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria stopping_criteria;
   }
@@ -113,8 +113,8 @@ public class AutoMLBuildSpec extends Iced {
       return project_cached;
 
     // allow the user to override:
-    if (null != build_control.project) {
-      project_cached = build_control.project;
+    if (null != build_control.project_name) {
+      project_cached = build_control.project_name;
       return project_cached;
     }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/EckoClient.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/EckoClient.java
@@ -124,10 +124,10 @@ public class EckoClient {
 
     if (eckoEnabled) {
       AutoML autoML = event.getAutoML();
-      String project = autoML.project();
+      String project = autoML.projectName();
       initializeProjectPage(project);
 
-      ProjectStatus status = statuses.get(statuses.get(event.getAutoML().project()));
+      ProjectStatus status = statuses.get(statuses.get(event.getAutoML().projectName()));
       status.lastEvent = event;
 
       int httpStatus = -1;
@@ -214,7 +214,7 @@ public class EckoClient {
   } // updateLeaderboard
 
   public static final void updateProgress(AutoML autoML) {
-    ProjectStatus status = statuses.get(autoML.project());
+    ProjectStatus status = statuses.get(autoML.projectName());
     double progress = (autoML.job() == null ? 0.0 : autoML.job().progress());
     status.progress = progress;
     updateHomePage(status);

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -20,7 +20,7 @@ import static water.Key.make;
 /**
  * Utility to track all the models built for a given dataset type.
  * <p>
- * Note that if a new Leaderboard is made for the same project it'll
+ * Note that if a new Leaderboard is made for the same project_name it'll
  * keep using the old model list, which allows us to run AutoML multiple
  * times and keep adding to the leaderboard.
  * <p>
@@ -35,7 +35,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
    * Identifier for models that should be grouped together in the leaderboard
    * (e.g., "airlines" and "iris").
    */
-  private final String project;
+  private final String project_name;
 
   /**
    * List of models for this leaderboard, sorted by metric so that the best is first,
@@ -104,8 +104,8 @@ public class Leaderboard extends Keyed<Leaderboard> {
   /**
    *
    */
-  public Leaderboard(String project, UserFeedback userFeedback, Frame leaderboardFrame) {
-    this._key = make(idForProject(project));
+  public Leaderboard(String project_name, UserFeedback userFeedback, Frame leaderboardFrame) {
+    this._key = make(idForProject(project_name));
     Leaderboard old = DKV.getGet(this._key);
 
     if (null != old) {
@@ -115,7 +115,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
       this.leaderboard_set_metrics = old.leaderboard_set_metrics;
       this.sort_metrics = old.sort_metrics;
     }
-    this.project = project;
+    this.project_name = project_name;
     this.userFeedback = userFeedback;
     this.leaderboardFrame = leaderboardFrame;
     DKV.put(this);
@@ -131,10 +131,10 @@ public class Leaderboard extends Keyed<Leaderboard> {
     }
   }
 
-  public static String idForProject(String project) { return "AutoML_Leaderboard_" + project; }
+  public static String idForProject(String project_name) { return "AutoML_Leaderboard_" + project_name; }
 
   public String getProject() {
-    return project;
+    return project_name;
   }
 
   public void setMetricAndDirection(String metric,String[] otherMetrics, boolean sortDecreasing){
@@ -562,7 +562,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
   }
 
   public TwoDimTable toTwoDimTable() {
-    return toTwoDimTable("Leaderboard for project: " + project, false);
+    return toTwoDimTable("Leaderboard for project_name: " + project_name, false);
   }
 
   public TwoDimTable toTwoDimTable(String tableHeader, boolean leftJustifyModelIds) {
@@ -600,12 +600,12 @@ public class Leaderboard extends Keyed<Leaderboard> {
 
   //private static final SimpleDateFormat timestampFormat = new SimpleDateFormat("HH:mm:ss.SSS");
 
-  //public static String toString(String project, Model[] models, String fieldSeparator, String lineSeparator, boolean includeTitle, boolean includeHeader, boolean includeTimestamp) {
-  public static String toString(String project, Model[] models, String fieldSeparator, String lineSeparator, boolean includeTitle, boolean includeHeader) {
+  //public static String toString(String project_name, Model[] models, String fieldSeparator, String lineSeparator, boolean includeTitle, boolean includeHeader, boolean includeTimestamp) {
+  public static String toString(String project_name, Model[] models, String fieldSeparator, String lineSeparator, boolean includeTitle, boolean includeHeader) {
     StringBuilder sb = new StringBuilder();
     if (includeTitle) {
-      sb.append("Leaderboard for project \"")
-              .append(project)
+      sb.append("Leaderboard for project_name \"")
+              .append(project_name)
               .append("\": ");
 
       if (models.length == 0) {
@@ -652,8 +652,8 @@ public class Leaderboard extends Keyed<Leaderboard> {
   }
 
   public String toString(String fieldSeparator, String lineSeparator) {
-    //return toString(project, getModels(), fieldSeparator, lineSeparator, true, true, false);
-    return toString(project, getModels(), fieldSeparator, lineSeparator, true, true);
+    //return toString(project_name, getModels(), fieldSeparator, lineSeparator, true, true, false);
+    return toString(project_name, getModels(), fieldSeparator, lineSeparator, true, true);
   }
 
   @Override

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -184,7 +184,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
     new TAtomic<Leaderboard>() {
       @Override
       final public Leaderboard atomic(Leaderboard old) {
-        if (old == null) old = new Leaderboard(project, userFeedback, leaderboardFrame);
+        if (old == null) old = new Leaderboard(project_name, userFeedback, leaderboardFrame);
 
         final Key<Model>[] oldModels = old.models;
         final Key<Model> oldLeader = (oldModels == null || 0 == oldModels.length) ? null : oldModels[0];

--- a/h2o-automl/src/main/java/water/automl/RegisterRestApi.java
+++ b/h2o-automl/src/main/java/water/automl/RegisterRestApi.java
@@ -26,7 +26,7 @@ public class RegisterRestApi extends AbstractRegister {
             "Return all the AutoML leaderboards.");
 
     RequestServer.registerEndpoint("leaderboard",
-            "GET /99/Leaderboards/{project}", LeaderboardsHandler.class, "fetch",
+            "GET /99/Leaderboards/{project_name}", LeaderboardsHandler.class, "fetch",
             "Return the AutoML leaderboard for the given project.");
   }
 

--- a/h2o-automl/src/main/java/water/automl/api/LeaderboardsHandler.java
+++ b/h2o-automl/src/main/java/water/automl/api/LeaderboardsHandler.java
@@ -43,10 +43,10 @@ public class LeaderboardsHandler extends Handler {
 
   @SuppressWarnings("unused") // called through reflection by RequestServer
   public LeaderboardV99 fetch(int version, LeaderboardsV99 s) {
-    if (null == s.project)
-      throw new H2OKeyNotFoundArgumentException("Client must specify a project.");
+    if (null == s.project_name)
+      throw new H2OKeyNotFoundArgumentException("Client must specify a project_name.");
 
-      return new LeaderboardV99().fillFromImpl(getFromDKV("project", Leaderboard.idForProject(s.project)));
+      return new LeaderboardV99().fillFromImpl(getFromDKV("project_name", Leaderboard.idForProject(s.project_name)));
   }
 
   // TODO: almost identical to ModelsHandler; refactor

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -26,7 +26,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     }
 
     @API(help="optional project name used to group models from multiple runs into a leaderboard; derived from the training data name if not specified")
-    public String project;
+    public String project_name;
 
     @API(help="loss function", direction=API.Direction.INPUT)
     public String loss;

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
@@ -26,7 +26,7 @@ public class AutoMLV99 extends SchemaV3<AutoML,AutoMLV99> {
    * (e.g., "airlines" and "iris").
    */
   @API(help="Identifier for models that should be grouped together in the same leaderboard", direction=API.Direction.INOUT)
-  public String project = "<default>";
+  public String project_name = "<default>";
 
   @API(help="The leaderboard for this project, potentially including models from other AutoML runs", direction=API.Direction.OUTPUT)
   public LeaderboardV99   leaderboard;
@@ -45,7 +45,7 @@ public class AutoMLV99 extends SchemaV3<AutoML,AutoMLV99> {
 
     if (null == autoML) return this;
 
-    this.project = autoML.project();
+    this.project_name = autoML.projectName();
 
     if (null != autoML._key) {
       this.automl_id = new AutoML.AutoMLKeyV3(autoML._key);

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLsV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLsV99.java
@@ -8,7 +8,7 @@ public class AutoMLsV99 extends RequestSchemaV3<AutoMLHandler.AutoMLs, AutoMLsV9
 
   // Input fields
   @API(help="Name of project of interest", json=false)
-  public String project;
+  public String project_name;
 
   // Output fields
   @API(help="AutoMLs", direction=API.Direction.OUTPUT)

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardV99.java
@@ -11,7 +11,7 @@ public class LeaderboardV99 extends Schema<Leaderboard, LeaderboardV99> {
    * (e.g., "airlines" and "iris").
    */
   @API(help="Identifier for models that should be grouped together in the leaderboard", direction=API.Direction.INOUT)
-  public final String project = "<default>";
+  public final String project_name = "<default>";
 
   /**
    * List of models for this leaderboard, sorted by metric so that the best is first

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardsV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardsV99.java
@@ -8,7 +8,7 @@ public class LeaderboardsV99 extends RequestSchemaV3<LeaderboardsHandler.Leaderb
 
   // Input fields
   @API(help="Name of project of interest", json=false)
-  public String project;
+  public String project_name;
 
   // Output fields
   @API(help="Leaderboards", direction=API.Direction.OUTPUT)

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -81,7 +81,7 @@ class H2OAutoML(object):
         #Set project name if provided. If None, then we set in .train() to "automl_" + training_frame.frame_id
         if project_name is not None:
             assert_is_type(project_name,str)
-            self.build_control["project"] = project_name
+            self.build_control["project_name"] = project_name
             self.project_name = project_name
         else:
             self.project_name = None

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -109,9 +109,9 @@ h2o.automl <- function(x, y, training_frame,
 
   # If project_name is NULL, auto-gen based on training_frame ID
   if (is.null(project_name)) {
-    build_control$project <- paste0("automl_", training_frame_id)
+    build_control$project_name <- paste0("automl_", training_frame_id)
   } else {
-    build_control$project <- project_name
+    build_control$project_name <- project_name
   }
   
   # Create the parameter list to POST to the AutoMLBuilder 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -130,7 +130,7 @@ h2o.automl <- function(x, y, training_frame,
 
   # Make AutoML object
   new("H2OAutoML",
-      project_name = build_control$project,
+      project_name = build_control$project_name,
       leader = leader,
       leaderboard = leaderboard
   )


### PR DESCRIPTION
* We use project_name in the AutoML R/Py APIs, so we should change the name on the backend (Java) as well for consistency. The R and Python APIs will also need a small change – they send project_name to the build_control$project / build_control['project'] , so that will require a small edit.