### PR TITLE
PUBDEV-4511: Remove selection_strategy argument from Stacked Ensemble

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -49,11 +49,13 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     public String javaName() { return StackedEnsembleModel.class.getName(); }
     @Override public long progressUnits() { return 1; }  // TODO
 
+    /*
     public static enum SelectionStrategy { choose_all }
 
     // TODO: make _selection_strategy an object:
-    /** How do we choose which models to stack? */
+    // How do we choose which models to stack?
     public SelectionStrategy _selection_strategy;
+    */
 
     /** Which models can we choose from? */
     public Key<Model> _base_models[] = new Key[0];

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -17,13 +17,18 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "response_column",
       "validation_frame",
       "base_models",
-      "selection_strategy",
+      //"selection_strategy",
     };
 
+    /*
     @API(help = "Strategy for choosing which models to stack.", values = { "choose_all" }, gridable = false)
     public StackedEnsembleModel.StackedEnsembleParameters.SelectionStrategy selection_strategy;
 
     @API(help = "List of model ids which we can stack together.  Which ones are chosen depends on the selection_strategy (currently, all models will be used since selection_strategy can only be set to choose_all).  Models must have been cross-validated using nfolds > 1, fold_assignment equal to Modulo, and keep_cross_validation_folds must be set to True.", required = true)
+    public KeyV3.ModelKeyV3 base_models[];
+    */
+
+    @API(help = "List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
     public KeyV3.ModelKeyV3 base_models[];
   }
 }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -791,7 +791,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleModel.StackedEnsembleParameters();
     stackedEnsembleParameters._base_models = allModelKeys.toArray(new Key[0]);
-    stackedEnsembleParameters._selection_strategy = StackedEnsembleModel.StackedEnsembleParameters.SelectionStrategy.choose_all;
+    //stackedEnsembleParameters._selection_strategy = StackedEnsembleModel.StackedEnsembleParameters.SelectionStrategy.choose_all;
     Job ensembleJob = trainModel(null, "stackedensemble", stackedEnsembleParameters);
     return ensembleJob;
   }

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -55,11 +55,9 @@ Defining an H2O Stacked Ensemble Model
 
 -  **validation_frame**: Specify the dataset used to evaluate the accuracy of the model.
 
--  **selection_strategy**: Specify the strategy for choosing which models to stack. Note that **choose_all** is currently the only selection strategy implemented. 
-
 -  **base_models**: Specify a list of model IDs that can be stacked together. Models must have been cross-validated using ``nfolds`` > 1, they all must use the same cross-validation folds and ``keep_cross_validation_folds`` must be set to True.  
 
-Regarding the base models: One way to guarantee identical folds across base models is to set **fold_assignment** = "Modulo" in all the base models.  Currently, using base models that were all trained with **fold_assignment** = "Modulo" is a strict requirement, but this will be `relaxed <https://0xdata.atlassian.net/browse/PUBDEV-3973>`__ in the next release to allow for identical user-specified folds or random folds that were generated with the same seed.
+Regarding the base models: One way to guarantee identical folds across base models is to set ``fold_assignment = "Modulo"`` in all the base models.  It is also possible to get identical folds by setting ``fold_assignment = "Random"`` when the same seed is used in all base models.
 
 Also in a `future release <https://0xdata.atlassian.net/browse/PUBDEV-3743>`__, there will be an additional **metalearner** parameter which allows for the user to specify the metalearning algorithm used.  Currently, the metalearner is fixed as a default H2O GLM with non-negative weights.
 

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -48,8 +48,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def __init__(self, **kwargs):
         super(H2OStackedEnsembleEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models",
-                      "selection_strategy"}
+        names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -110,10 +109,8 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def base_models(self):
         """
-        List of model ids which we can stack together.  Which ones are chosen depends on the selection_strategy
-        (currently, all models will be used since selection_strategy can only be set to choose_all).  Models must have
-        been cross-validated using nfolds > 1, fold_assignment equal to Modulo, and keep_cross_validation_folds must be
-        set to True.
+        List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and folds
+        must be identical across models.
 
         Type: ``List[str]``  (default: ``[]``).
         """
@@ -123,20 +120,5 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def base_models(self, base_models):
         assert_is_type(base_models, None, [str])
         self._parms["base_models"] = base_models
-
-
-    @property
-    def selection_strategy(self):
-        """
-        Strategy for choosing which models to stack.
-
-        One of: ``"choose_all"``.
-        """
-        return self._parms.get("selection_strategy")
-
-    @selection_strategy.setter
-    def selection_strategy(self, selection_strategy):
-        assert_is_type(selection_strategy, None, Enum("choose_all"))
-        self._parms["selection_strategy"] = selection_strategy
 
 

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
@@ -37,7 +37,7 @@ def airline_gbm_random_grid():
 
 
 
-    stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all", base_models=air_grid.model_ids)
+    stacker = H2OStackedEnsembleEstimator(base_models=air_grid.model_ids)
     print("created H2OStackedEnsembleEstimator")
     stacker.train(model_id="my_ensemble", y="IsDepDelayed", training_frame=air_hex)
     print("trained H2OStackedEnsembleEstimator")

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid_large.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid_large.py
@@ -67,7 +67,7 @@ def airline_gbm_random_grid():
     assert correct_stopping_condition, "Grid search did not find a model that fits the search_criteria_tune."
     print(air_grid.get_grid("logloss"))
 
-    stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all", base_models=air_grid.model_ids)
+    stacker = H2OStackedEnsembleEstimator(base_models=air_grid.model_ids)
     stacker.train(model_id="my_ensemble", y="IsDepDelayed", training_frame=air_hex)
     predictions = stacker.predict(air_hex)  # training data
     print("preditions for ensemble are in: " + predictions.frame_id)

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_binomial.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_binomial.py
@@ -81,8 +81,7 @@ def stackedensemble_binomial_test():
 
     # Train a stacked ensemble using the GBM and GLM above
     stack = H2OStackedEnsembleEstimator(model_id="my_ensemble_binomial",
-                                        base_models=[my_gbm.model_id,  my_rf.model_id],
-                                        selection_strategy="choose_all")
+                                        base_models=[my_gbm.model_id,  my_rf.model_id])
 
     stack.train(x=x, y=y, training_frame=train, validation_frame=test)  # also test that validation_frame is working
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_gaussian.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_gaussian.py
@@ -92,8 +92,7 @@ def stackedensemble_guassian_test():
 
     # Train a stacked ensemble using the GBM and GLM above
     stack = H2OStackedEnsembleEstimator(model_id="my_ensemble_guassian",
-                                        base_models=[my_gbm.model_id,  my_rf.model_id, my_xrf.model_id],
-                                        selection_strategy="choose_all")
+                                        base_models=[my_gbm.model_id,  my_rf.model_id, my_xrf.model_id])
 
     stack.train(x=x, y=y, training_frame=train, validation_frame=test)  # also test that validation_frame is working
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_grid_binomial.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_grid_binomial.py
@@ -59,7 +59,6 @@ def stackedensemble_grid_binomial():
 
     # Train a stacked ensemble using the GBM grid
     stack = H2OStackedEnsembleEstimator(model_id="my_ensemble_gbm_grid_binomial", 
-                                        selection_strategy="choose_all", 
                                         base_models=grid.model_ids)
     stack.train(x=x, y=y, training_frame=train, validation_frame=test)
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_grid_gaussian.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_grid_gaussian.py
@@ -56,7 +56,6 @@ def stackedensemble_grid_gaussian():
 
     # Train a stacked ensemble using the GBM grid
     stack = H2OStackedEnsembleEstimator(model_id="my_ensemble_gbm_grid_guassian",
-                                        selection_strategy="choose_all", 
                                         base_models=grid.model_ids)
     stack.train(x=x, y=y, training_frame=train, validation_frame=test)
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_regression.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_regression.py
@@ -51,8 +51,7 @@ def stackedensemble_gaussian():
     my_glm.model_performance(australia_hex).show()
 
 
-    stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all",
-                                          base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
+    stacker = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
     stacker.train(model_id="my_ensemble", x=myX, y="runoffnew", training_frame=australia_hex)
     # test ignore_columns parameter checking
     # stacker.train(model_id="my_ensemble", y="runoffnew", training_frame=australia_hex, ignored_columns=["premax"])
@@ -94,7 +93,7 @@ def stackedensemble_gaussian():
     my_glm.model_performance(ecology_train).show()
 
 
-    stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all", base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
+    stacker = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
     print("created H2OStackedEnsembleEstimator: " + str(stacker))
     stacker.train(model_id="my_ensemble", y="Angaus", training_frame=ecology_train)
     print("trained H2OStackedEnsembleEstimator: " + str(stacker))
@@ -140,7 +139,7 @@ def stackedensemble_gaussian():
     my_glm.model_performance(insurance_train).show()
 
 
-    stacker = H2OStackedEnsembleEstimator(selection_strategy="choose_all", base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
+    stacker = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
     print("created H2OStackedEnsembleEstimator: " + str(stacker))
     stacker.train(model_id="my_ensemble", y="Claims", training_frame=insurance_train)
     print("trained H2OStackedEnsembleEstimator: " + str(stacker))

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_regression.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_regression.py
@@ -51,11 +51,11 @@ def stackedensemble_gaussian():
     my_glm.model_performance(australia_hex).show()
 
 
-    stacker = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
-    stacker.train(model_id="my_ensemble", x=myX, y="runoffnew", training_frame=australia_hex)
+    stack = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
+    stack.train(model_id="my_ensemble", x=myX, y="runoffnew", training_frame=australia_hex)
     # test ignore_columns parameter checking
-    # stacker.train(model_id="my_ensemble", y="runoffnew", training_frame=australia_hex, ignored_columns=["premax"])
-    predictions = stacker.predict(australia_hex)  # training data
+    # stack.train(model_id="my_ensemble", y="runoffnew", training_frame=australia_hex, ignored_columns=["premax"])
+    predictions = stack.predict(australia_hex)  # training data
     print("Predictions for australia ensemble are in: " + predictions.frame_id)
 
 
@@ -93,13 +93,13 @@ def stackedensemble_gaussian():
     my_glm.model_performance(ecology_train).show()
 
 
-    stacker = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
-    print("created H2OStackedEnsembleEstimator: " + str(stacker))
-    stacker.train(model_id="my_ensemble", y="Angaus", training_frame=ecology_train)
-    print("trained H2OStackedEnsembleEstimator: " + str(stacker))
+    stack = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
+    print("created H2OStackedEnsembleEstimator: " + str(stack))
+    stack.train(model_id="my_ensemble", y="Angaus", training_frame=ecology_train)
+    print("trained H2OStackedEnsembleEstimator: " + str(stack))
     print("trained H2OStackedEnsembleEstimator via get_model: " + str(h2o.get_model("my_ensemble")))
 
-    predictions = stacker.predict(ecology_train)  # training data
+    predictions = stack.predict(ecology_train)  # training data
     print("predictions for ensemble are in: " + predictions.frame_id)
 
 
@@ -139,15 +139,15 @@ def stackedensemble_gaussian():
     my_glm.model_performance(insurance_train).show()
 
 
-    stacker = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
-    print("created H2OStackedEnsembleEstimator: " + str(stacker))
-    stacker.train(model_id="my_ensemble", y="Claims", training_frame=insurance_train)
-    print("trained H2OStackedEnsembleEstimator: " + str(stacker))
+    stack = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
+    print("created H2OStackedEnsembleEstimator: " + str(stack))
+    stack.train(model_id="my_ensemble", y="Claims", training_frame=insurance_train)
+    print("trained H2OStackedEnsembleEstimator: " + str(stack))
 
     print("metalearner: ")
-    print(h2o.get_model(stacker.metalearner()['name']))
+    print(h2o.get_model(stack.metalearner()['name']))
 
-    predictions = stacker.predict(insurance_train)  # training data
+    predictions = stack.predict(insurance_train)  # training data
     print("preditions for ensemble are in: " + predictions.frame_id)
 
 if __name__ == "__main__":

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -14,11 +14,8 @@
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param training_frame Id of the training data frame (Not required, to allow initial validation of model parameters).
 #' @param validation_frame Id of the validation data frame.
-#' @param base_models List of model ids which we can stack together.  Which ones are chosen depends on the selection_strategy
-#'        (currently, all models will be used since selection_strategy can only be set to choose_all).  Models must have
-#'        been cross-validated using nfolds > 1, fold_assignment equal to Modulo, and keep_cross_validation_folds must
-#'        be set to True. Defaults to [].
-#' @param selection_strategy Strategy for choosing which models to stack. Must be one of: "choose_all".
+#' @param base_models List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and
+#'        folds must be identical across models. Defaults to [].
 #' @examples
 #' 
 #' # See example R code here: 
@@ -28,8 +25,7 @@
 h2o.stackedEnsemble <- function(x, y, training_frame,
                                 model_id = NULL,
                                 validation_frame = NULL,
-                                base_models = list(),
-                                selection_strategy = c("choose_all")
+                                base_models = list()
                                 ) 
 {
   #If x is missing, then assume user wants to use all columns as features.
@@ -63,8 +59,6 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$validation_frame <- validation_frame
   if (!missing(base_models))
     parms$base_models <- base_models
-  if (!missing(selection_strategy))
-    parms$selection_strategy <- selection_strategy
   # Error check and build model
   .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion=99) 
 }

--- a/h2o-r/tests/testdir_algos/gbm/runit_GBMGrid_airlines.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBMGrid_airlines.R
@@ -59,10 +59,9 @@ gbm.grid.test <- function() {
     # stacker.grid <- h2o.grid("stackedensemble", y = "IsDepDelayed", x = myX,
     #                         training_frame = air.hex,
     #                         model_id = "my_ensemble",
-    #                         selection_strategy = "choose_all",
     #                         base_models = air.grid@model_ids)
     stacker <- h2o.stackedEnsemble(x = myX, y = "IsDepDelayed", training_frame = air.hex,
-                                   model_id = "my_ensemble", selection_strategy = "choose_all",
+                                   model_id = "my_ensemble",
                                    base_models = air.grid@model_ids)
 
     predictions = h2o.predict(stacker, air.hex) # training data

--- a/h2o-r/tests/testdir_algos/gbm/runit_GBMRandomGrid_airlines_large.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBMRandomGrid_airlines_large.R
@@ -70,8 +70,9 @@ gbm.random.grid.test <- function() {
     print(air.grid)
     expect_that(length(air.grid@model_ids) == 5, is_true())
 
-    stacker <- h2o.stackedEnsemble(x = myX, y = "IsDepDelayed", training_frame = air.hex,
-                                   model_id = "my_ensemble", selection_strategy = "choose_all",
+    stacker <- h2o.stackedEnsemble(x = myX, y = "IsDepDelayed", 
+                                   training_frame = air.hex,
+                                   model_id = "my_ensemble",
                                    base_models = air.grid@model_ids)
 
     predictions = h2o.predict(stacker, air.hex)  # training data

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_binomial.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_binomial.R
@@ -70,7 +70,6 @@ stackedensemble.binomial.test <- function() {
                                training_frame = train,
                                validation_frame = test,  #also test that validation_frame is working
                                model_id = "my_ensemble_binomial", 
-                               selection_strategy = "choose_all",
                                base_models = list(my_gbm@model_id, my_rf@model_id))
   
   # Check that prediction works

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_gaussian.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_gaussian.R
@@ -92,7 +92,6 @@ stackedensemble.gaussian.test <- function() {
                                training_frame = train,
                                validation_frame = test,  #also test that validation_frame is working
                                model_id = "my_ensemble_gaussian", 
-                               selection_strategy = "choose_all",
                                base_models = list(my_gbm@model_id, my_rf@model_id, my_xrf@model_id))
   
   # Check that prediction works
@@ -120,7 +119,6 @@ stackedensemble.gaussian.test <- function() {
                                training_frame = train,
                                validation_frame = test,  #also test that validation_frame is working
                                model_id = "my_ensemble_gaussian", 
-                               selection_strategy = "choose_all",
                                base_models = list(my_gbm@model_id, my_rf@model_id, my_xrf@model_id))
   
   pred <- h2o.predict(stack, newdata = test)

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_grid_binomial.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_grid_binomial.R
@@ -58,7 +58,6 @@ stackedensemble.binomial.grid.test <- function() {
                                training_frame = train,
                                validation_frame = test,
                                model_id = "my_ensemble_gbm_grid_binomial",
-                               selection_strategy = c("choose_all"), 
                                base_models = gbm_grid@model_ids)
   
   # Check that prediction works

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_grid_gaussian.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_grid_gaussian.R
@@ -57,7 +57,6 @@ stackedensemble.gaussian.grid.test <- function() {
                                training_frame = train,
                                validation_frame = test,
                                model_id = "my_ensemble_gbm_grid_gaussian",
-                               selection_strategy = c("choose_all"), 
                                base_models = gbm_grid@model_ids)
   
   # Check that prediction works


### PR DESCRIPTION
- Since the `selection_strategy` parameter doesn't do anything, it should be removed. I think it's a bad idea to have a parameter that's not being used in the API.  We also don't have concrete plans for how we might use it in the immediate future, so for now we can keep it out of the API.
- The code has not been removed, it's been commented out so that if we ever decide to implement it in the future, it will be easy to add back in. Since our R and Python APIs are auto-generated, it's best comment it out from the Java code.  Removing it from the backend also automagically removes it from Flow.
- JIRA: https://0xdata.atlassian.net/browse/PUBDEV-4511

Now is our best chance to drop this parameter from the API since it's a major release (3.12). 