### PR TITLE
PUBDEV-4509: AutoML fails when fold_column or weights_column and x are both specified in Python

### DIFF
--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -214,9 +214,10 @@ class H2OAutoML(object):
                     xset.add(xi)
             x = list(xset)
             ignored_columns = set(names) - {y} - set(x)
-            if fold_column is not None: ignored_columns = ignored_columns - set(fold_column)
-            if weights_column is not None: ignored_columns = ignored_columns - set(weights_column)
-            input_spec['ignored_columns'] = list(ignored_columns)
+            if fold_column is not None: ignored_columns = ignored_columns.remove(fold_column)
+            if weights_column is not None: ignored_columns = ignored_columns.remove(weights_column)
+            if ignored_columns is not None:
+                input_spec['ignored_columns'] = list(ignored_columns)
 
         automl_build_params = dict(input_spec = input_spec)
 


### PR DESCRIPTION
* Currently, fold_column and weights_column only work if we don't include an `x` argument. If `x` is specified, it throws an error. This can be fixed on the client side. The cause of this is how we calculate the `ignored_columns` arg from the difference between all columns and (x, y). 