### PR TITLE
PUBDEV-4336: Documenting PCA parameters

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/impute_missing.rst
+++ b/h2o-docs/src/product/data-science/algo-params/impute_missing.rst
@@ -1,0 +1,171 @@
+``impute_missing``
+------------------
+
+- Available in: PCA
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+In some cases, dataset used can contain a fewer number of rows due to the removal of rows with NA/missing values. If this is not the desired behavior, then you can use the ``impute_missing`` option to impute missing entries in each column with the column mean value. 
+
+This value defaults to False.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+    library(h2o)
+    h2o.init()
+
+    # Load the Birds dataset
+    birds.hex <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train with impute_missing enabled
+    birds.pca <- h2o.prcomp(training_frame = birds.hex, transform = "STANDARDIZE",
+                            k = 3, pca_method="Power", use_all_factor_levels=TRUE, 
+                            impute_missing=TRUE)
+
+    # View the importance of components
+    birds.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     1.496991 1.351000 1.014182
+    Proportion of Variance 0.289987 0.236184 0.133098
+    Cumulative Proportion  0.289987 0.526171 0.659269
+
+    # View the eigenvectors
+    birds.pca@model$eigenvectors
+    Rotation: 
+                      pc1      pc2       pc3
+    patch.Ref1a  0.007207 0.007449  0.001161
+    patch.Ref1b -0.003090 0.011257 -0.001066
+    patch.Ref1c  0.002962 0.008850 -0.000264
+    patch.Ref1d -0.001295 0.011003  0.000501
+    patch.Ref1e  0.006559 0.006904 -0.001206
+
+    ---
+                    pc1       pc2       pc3
+    S          0.463591 -0.053410  0.184799
+    year      -0.055934  0.009691 -0.968635
+    area       0.533375 -0.289381 -0.130338
+    log.area.  0.583966 -0.262287 -0.089582
+    ENN       -0.270615 -0.573900  0.038835
+    log.ENN.  -0.231368 -0.640231  0.026325
+
+    # Train again without imputing missing values
+    birds2.pca <- h2o.prcomp(training_frame = birds.hex, transform = "STANDARDIZE",
+                             k = 3, pca_method="Power", use_all_factor_levels=TRUE, 
+                             impute_missing=FALSE)
+
+    Warning message:
+    In doTryCatch(return(expr), name, parentenv, handler) :
+      _train: Dataset used may contain fewer number of rows due to removal of rows 
+      with NA/missing values. If this is not desirable, set impute_missing argument 
+      in pca call to TRUE/True/true/... depending on the client language.
+
+    # View the importance of components
+    birds2.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     1.546397 1.348276 1.055239
+    Proportion of Variance 0.300269 0.228258 0.139820
+    Cumulative Proportion  0.300269 0.528527 0.668347
+
+    # View the eigenvectors
+    birds2.pca@model$eigenvectors
+    Rotation: 
+                      pc1       pc2       pc3
+    patch.Ref1a  0.009848 -0.005947 -0.001061
+    patch.Ref1b -0.001628 -0.014739 -0.001007
+    patch.Ref1c  0.004994 -0.009486 -0.000523
+    patch.Ref1d  0.000117 -0.004400 -0.004917
+    patch.Ref1e  0.003627 -0.001467 -0.004268
+
+    ---
+                    pc1       pc2       pc3
+    S          0.515048  0.226915 -0.123136
+    year      -0.066269 -0.069526  0.971250
+    area       0.414050  0.344332  0.149339
+    log.area.  0.497313  0.363609  0.131261
+    ENN       -0.390235  0.545631 -0.007944
+    log.ENN.  -0.345665  0.562834 -0.002092
+
+   .. code-block:: python
+
+    import(h2o)
+    h2o.init()
+    from h2o.transforms.decomposition import H2OPCA
+
+    # Load the Birds dataset
+    birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train with impute_missing enabled
+    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+                       use_all_factor_levels=True, impute_missing=True)
+    birds.pca.train(x=list(range(4)), training_frame=birds)
+
+    # View the importance of components
+    birds.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 1.0505993078459912, 0.8950182545325247, 0.5587566783073901), 
+    (u'Proportion of Variance', 0.28699613488673914, 0.20828865401845226, 0.08117966990084355), 
+    (u'Cumulative Proportion', 0.28699613488673914, 0.4952847889051914, 0.5764644588060349)]
+
+    # View the eigenvectors
+    birds.pca.rotation()
+    Rotation: 
+                       pc1                 pc2                pc3
+    -----------------  ------------------  -----------------  ----------------
+    patch.Ref1a        0.00732398141913    -0.0141576160836   0.0294419461081
+    patch.Ref1b        -0.00482860843905   0.00867426840498   0.0330778190153
+    patch.Ref1c        0.00124768649004    -0.00274167383932  0.0312598825617
+    patch.Ref1d        -0.000370181920761  0.000297923901103  0.0317439245635
+    patch.Ref1e        0.00223394447742    -0.00459462277502  0.0309648089406
+    ---                ---                 ---                ---
+    landscape.Bauxite  -0.0638494513759    0.136728811833     0.118858152002
+    landscape.Forest   0.0378085502606     -0.0833578672691   0.969316569884
+    landscape.Urban    -0.0545759062856    0.111309410422     0.0354475756223
+    S                  0.564501605704      -0.767095710638    -0.0466832766991
+    year               -0.814596906726     -0.577331674836    -0.0101626722479
+
+    See the whole table with table.as_data_frame()
+
+    # Train again without imputing missing values
+    birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+    birds2.pca = H2OPCA(k = 3, transform = "STANDARDIZE", 
+                        pca_method="Power", use_all_factor_levels=True, 
+                        impute_missing=False)
+    birds2.pca.train(x=list(range(4)), training_frame=birds2)
+
+    # View the importance of components
+    birds2.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 1.1238486420242524, 0.949554306091356, 0.534896629598228), 
+    (u'Proportion of Variance', 0.3080623966646966, 0.21991895069672512, 0.06978510918460899), 
+    (u'Cumulative Proportion', 0.3080623966646966, 0.5279813473614217, 0.5977664565460307)]
+
+    # View the eigenvectors
+    birds2.pca.rotation()
+    Rotation: 
+                       pc1                pc2                pc3
+    -----------------  -----------------  -----------------  -----------------
+    patch.Ref1a        0.00898674970716   0.0133755203176    0.0386887315027
+    patch.Ref1b        -0.00583910665399  -0.00850852817775  0.0403921679996
+    patch.Ref1c        0.00157382152659   0.00243349606991   0.0395404497512
+    patch.Ref1d        0.00205431391489   -0.00464763108225  0.0130225730145
+    patch.Ref1e        0.00521157104675   9.98792622547e-07  0.0126676559841
+    ---                ---                ---                ---
+    landscape.Bauxite  -0.0927064158093   -0.0985077050027   0.312254932996
+    landscape.Forest   0.049803344754     0.0606680349608    0.928822693132
+    landscape.Urban    -0.0671561320808   -0.108679950396    0.033639706807
+    S                  0.661206203315     0.69412159594      -0.0166591571667
+    year               -0.727793152951    0.684904477663     -0.00409291536614
+
+    See the whole table with table.as_data_frame()
+

--- a/h2o-docs/src/product/data-science/algo-params/k.rst
+++ b/h2o-docs/src/product/data-science/algo-params/k.rst
@@ -17,7 +17,7 @@ This option specifies the maximum number of clusters that K-Means will form.  If
 PCA
 '''
 
-In PCA, 
+In PCA, ``k`` specifies the rank of matrix approximation. This can be a value from 1 to 9 and defaults to 1.
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/pca_method.rst
+++ b/h2o-docs/src/product/data-science/algo-params/pca_method.rst
@@ -1,0 +1,175 @@
+``pca_method``
+--------------
+
+- Available in: PCA
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+Use the ``pca_method`` parameter to specify the algorithm to use for computing the principal components. Available options include:
+
+   -  **GramSVD**: Uses a distributed computation of the Gram matrix, followed by a local SVD using the JAMA package
+   -  **Power**: Computes the SVD using the power iteration method (experimental)
+   -  **Randomized**: Uses randomized subspace iteration method
+   -  **GLRM**: Fits a generalized low-rank model with L2 loss function and no regularization and solves for the SVD using local matrix algebra (experimental)
+
+**Note**: For ``pca_method = Randomized``, the algorithm must deal with matrices of size *m* by *k* and *n* by *k*, where
+
+   - *m* is number of rows,
+   - *n* is expanded column size and
+   - *k* is the number of eigenvectors desired.
+
+As a result, there is no advantage to be gained by trying to find the eigenvectors of the matrix transpose. In other words, when using PCA with wide datasets, users should not choose Randomize method.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+    library(h2o)
+    h2o.init()
+
+    # Load the Birds dataset
+    birds.hex <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train using the Power pca_method
+    birds.pca <- h2o.prcomp(training_frame = birds.hex, transform = "STANDARDIZE",
+                            k = 3, pca_method="Power", use_all_factor_levels=TRUE, 
+                            impute_missing=TRUE)
+
+    # View the importance of components
+    birds.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     1.496991 1.351000 1.014182
+    Proportion of Variance 0.289987 0.236184 0.133098
+    Cumulative Proportion  0.289987 0.526171 0.659269
+
+    # View the eigenvectors
+    birds.pca@model$eigenvectors
+    Rotation: 
+                      pc1      pc2       pc3
+    patch.Ref1a  0.007207 0.007449  0.001161
+    patch.Ref1b -0.003090 0.011257 -0.001066
+    patch.Ref1c  0.002962 0.008850 -0.000264
+    patch.Ref1d -0.001295 0.011003  0.000501
+    patch.Ref1e  0.006559 0.006904 -0.001206
+
+    ---
+                    pc1       pc2       pc3
+    S          0.463591 -0.053410  0.184799
+    year      -0.055934  0.009691 -0.968635
+    area       0.533375 -0.289381 -0.130338
+    log.area.  0.583966 -0.262287 -0.089582
+    ENN       -0.270615 -0.573900  0.038835
+    log.ENN.  -0.231368 -0.640231  0.026325
+
+    # Train again using GLRM pca_method
+    birds2.pca <- h2o.prcomp(training_frame = birds.hex, transform = "STANDARDIZE",
+                             k = 3, pca_method="GLRM", use_all_factor_levels=TRUE, 
+                             impute_missing=TRUE)
+
+    # View the importance of components
+    birds2.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     2.659459 0.700971 0.404706
+    Proportion of Variance 0.915223 0.063583 0.021194
+    Cumulative Proportion  0.915223 0.978806 1.000000
+
+    # View the eigenvectors
+    birds2.pca@model$eigenvectors
+    Rotation: 
+                      pc1      pc2       pc3
+    patch.Ref1a -0.092008 0.030110 -0.018916
+    patch.Ref1b -0.107461 0.040519  0.076546
+    patch.Ref1c -0.103785 0.059700  0.016164
+    patch.Ref1d -0.105764 0.044823  0.062234
+    patch.Ref1e -0.102115 0.058994 -0.037536
+
+    ---
+                   pc1       pc2       pc3
+    S         0.003558  0.111264 -0.422437
+    year      0.000008 -0.004418  0.032813
+    area      0.004551  0.049496 -0.444745
+    log.area. 0.002756  0.066183 -0.453866
+    ENN       0.013259 -0.274711 -0.053960
+    log.ENN.  0.009517 -0.282830 -0.107461
+
+   .. code-block:: python
+
+    import(h2o)
+    h2o.init()
+    from h2o.transforms.decomposition import H2OPCA
+
+    # Load the Birds dataset
+    birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train with the Power pca_method
+    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+                       use_all_factor_levels=True, impute_missing=True)
+    birds.pca.train(x=list(range(4)), training_frame=birds)
+
+    # View the importance of components
+    birds.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 1.0505993078459912, 0.8950182545325247, 0.5587566783073901), 
+    (u'Proportion of Variance', 0.28699613488673914, 0.20828865401845226, 0.08117966990084355), 
+    (u'Cumulative Proportion', 0.28699613488673914, 0.4952847889051914, 0.5764644588060349)]
+
+    # View the eigenvectors
+    birds.pca.rotation()
+    Rotation: 
+                       pc1                 pc2                pc3
+    -----------------  ------------------  -----------------  ----------------
+    patch.Ref1a        0.00732398141913    -0.0141576160836   0.0294419461081
+    patch.Ref1b        -0.00482860843905   0.00867426840498   0.0330778190153
+    patch.Ref1c        0.00124768649004    -0.00274167383932  0.0312598825617
+    patch.Ref1d        -0.000370181920761  0.000297923901103  0.0317439245635
+    patch.Ref1e        0.00223394447742    -0.00459462277502  0.0309648089406
+    ---                ---                 ---                ---
+    landscape.Bauxite  -0.0638494513759    0.136728811833     0.118858152002
+    landscape.Forest   0.0378085502606     -0.0833578672691   0.969316569884
+    landscape.Urban    -0.0545759062856    0.111309410422     0.0354475756223
+    S                  0.564501605704      -0.767095710638    -0.0466832766991
+    year               -0.814596906726     -0.577331674836    -0.0101626722479
+
+    See the whole table with table.as_data_frame()
+
+    # Train again with the GLRM pca_method
+    birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+    birds2.pca = H2OPCA(k = 3, transform = "STANDARDIZE", 
+                        pca_method="GLRM", use_all_factor_levels=True, 
+                        impute_missing=True)
+    birds2.pca.train(x=list(range(4)), training_frame=birds2)
+
+    # View the importance of components
+    birds2.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 1.9286830840160667, 0.2896650415698226, 0.2053712844270903), 
+    (u'Proportion of Variance', 0.9672162180423401, 0.021816948059531167, 0.01096683389812861), 
+    (u'Cumulative Proportion', 0.9672162180423401, 0.9890331661018713, 0.9999999999999999)]
+
+    # View the eigenvectors
+    birds2.pca.rotation()
+    Rotation: 
+                       pc1                pc2                pc3
+    -----------------  -----------------  -----------------  -----------------
+    patch.Ref1a        -0.0973454860413    0.0233748845619   -0.0407839669099
+    patch.Ref1b        -0.0979880717715    -0.0167446302072  -0.0162149496631
+    patch.Ref1c        -0.0971529563124    0.00536661170128  -0.0177009628488
+    patch.Ref1d        -0.100657197505     0.00754923938494  -0.018364320893
+    patch.Ref1e        -0.0982933822825    0.0158116058361   -0.0193764027317
+    ---                ---                 ---               ---
+    landscape.Bauxite  -0.0248166745792    -0.504864083913   0.074374750806
+    landscape.Forest   -0.0296555294277    0.232678445269    -0.537738667852
+    landscape.Urban    -0.0733909967344    -0.112998988851   0.0347355699687
+    S                  0.00878461186804    0.649068763107    -0.130282514102
+    year               -0.000583301909773  -0.0765116904321  -0.69416666169
+
+    See the whole table with table.as_data_frame()

--- a/h2o-docs/src/product/data-science/algo-params/transform.rst
+++ b/h2o-docs/src/product/data-science/algo-params/transform.rst
@@ -2,7 +2,7 @@
 -------------
 
 - Available in: PCA
-- Hyperparameter: no
+- Hyperparameter: yes
 
 Description
 ~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/transform.rst
+++ b/h2o-docs/src/product/data-science/algo-params/transform.rst
@@ -1,0 +1,168 @@
+``transform``
+-------------
+
+- Available in: PCA
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+Use the ``transform`` parameter to specify the transformation method used for the training data. Available options include:
+
+- None (default): Do not perform any transformations on the data. 
+- Standardize: Standardizing subtracts the mean and then divides each variable by its standard deviation.
+- Normalize: Scales all numeric variables in the range [0,1]. 
+- Demean: The mean for each variable is subtracting from each observation resulting in mean zero.  Note that it is not always advisable to demean the data if the Moving Average parameter is of primary interest to estimate.
+- Descale: Divides by the standard deviation of each column.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+    library(h2o)
+    h2o.init()
+
+    # Load the Birds dataset
+    birds.hex <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train using Standardized transform
+    birds.pca <- h2o.prcomp(training_frame = birds.hex, transform = "STANDARDIZE",
+                            k = 3, pca_method="Power", use_all_factor_levels=TRUE, 
+                            impute_missing=TRUE)
+
+    # View the importance of components
+    birds.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     1.496991 1.351000 1.014182
+    Proportion of Variance 0.289987 0.236184 0.133098
+    Cumulative Proportion  0.289987 0.526171 0.659269
+
+    # View the eigenvectors
+    birds.pca@model$eigenvectors
+    Rotation: 
+                      pc1      pc2       pc3
+    patch.Ref1a  0.007207 0.007449  0.001161
+    patch.Ref1b -0.003090 0.011257 -0.001066
+    patch.Ref1c  0.002962 0.008850 -0.000264
+    patch.Ref1d -0.001295 0.011003  0.000501
+    patch.Ref1e  0.006559 0.006904 -0.001206
+
+    ---
+                    pc1       pc2       pc3
+    S          0.463591 -0.053410  0.184799
+    year      -0.055934  0.009691 -0.968635
+    area       0.533375 -0.289381 -0.130338
+    log.area.  0.583966 -0.262287 -0.089582
+    ENN       -0.270615 -0.573900  0.038835
+    log.ENN.  -0.231368 -0.640231  0.026325
+
+    # Train again using Normalize transform
+    birds2.pca <- h2o.prcomp(training_frame = birds.hex, transform = "NORMALIZE",
+                             k = 3, pca_method="Power", use_all_factor_levels=TRUE, 
+                             impute_missing=TRUE)
+
+    # View the importance of components
+    birds2.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     0.632015 0.531616 0.517096
+    Proportion of Variance 0.166444 0.117764 0.111418
+    Cumulative Proportion  0.166444 0.284208 0.395626
+
+    # View the eigenvectors
+    birds2.pca@model$eigenvectors
+    Rotation: 
+                    pc1       pc2       pc3
+    patch.Ref1a 0.026631 -0.006839 0.008674
+    patch.Ref1b 0.025825 -0.010199 0.004386
+    patch.Ref1c 0.026240 -0.008322 0.006759
+    patch.Ref1d 0.026106 -0.009375 0.005472
+    patch.Ref1e 0.026313 -0.007510 0.007769
+
+    ---
+                    pc1       pc2       pc3
+    S          0.055295  0.113531  0.141168
+    year      -0.003343 -0.013812 -0.019785
+    area      -0.011008  0.064146  0.087213
+    log.area.  0.007378  0.080143  0.086986
+    ENN       -0.151652 -0.026572 -0.013064
+    log.ENN.  -0.463210 -0.046953  0.086169
+
+   .. code-block:: python
+
+    import(h2o)
+    h2o.init()
+    from h2o.transforms.decomposition import H2OPCA
+
+    # Load the Birds dataset
+    birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train with the Power pca_method
+    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+                       use_all_factor_levels=True, impute_missing=True)
+    birds.pca.train(x=list(range(4)), training_frame=birds)
+
+    # View the importance of components
+    birds.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 1.0505993078459912, 0.8950182545325247, 0.5587566783073901), 
+    (u'Proportion of Variance', 0.28699613488673914, 0.20828865401845226, 0.08117966990084355), 
+    (u'Cumulative Proportion', 0.28699613488673914, 0.4952847889051914, 0.5764644588060349)]
+
+    # View the eigenvectors
+    birds.pca.rotation()
+    Rotation: 
+                       pc1                 pc2                pc3
+    -----------------  ------------------  -----------------  ----------------
+    patch.Ref1a        0.00732398141913    -0.0141576160836   0.0294419461081
+    patch.Ref1b        -0.00482860843905   0.00867426840498   0.0330778190153
+    patch.Ref1c        0.00124768649004    -0.00274167383932  0.0312598825617
+    patch.Ref1d        -0.000370181920761  0.000297923901103  0.0317439245635
+    patch.Ref1e        0.00223394447742    -0.00459462277502  0.0309648089406
+    ---                ---                 ---                ---
+    landscape.Bauxite  -0.0638494513759    0.136728811833     0.118858152002
+    landscape.Forest   0.0378085502606     -0.0833578672691   0.969316569884
+    landscape.Urban    -0.0545759062856    0.111309410422     0.0354475756223
+    S                  0.564501605704      -0.767095710638    -0.0466832766991
+    year               -0.814596906726     -0.577331674836    -0.0101626722479
+
+    See the whole table with table.as_data_frame()
+
+    # Train again using Normalize transform
+    birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+    birds2.pca = H2OPCA(k = 3, transform = "NORMALIZE", pca_method="Power", 
+                        use_all_factor_levels=True, impute_missing=True)
+    birds2.pca.train(x=list(range(4)), training_frame=birds2)
+
+    # View the importance of components
+    birds2.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 0.5615959368803389, 0.527199563812311, 0.5094397597133178), 
+    (u'Proportion of Variance', 0.14220176282406302, 0.12531618081504411, 0.11701532412044723), 
+    (u'Cumulative Proportion', 0.14220176282406302, 0.26751794363910714, 0.3845332677595544)]
+
+    # View the eigenvectors
+    birds2.pca.rotation()
+    Rotation: 
+                       pc1                pc2                pc3
+    -----------------  -----------------  -----------------  -----------------
+    patch.Ref1a        0.0321402336467    -5.67047495074e-05  0.000466136314122 
+    patch.Ref1b        0.0312293374798    -0.00233972080607   -0.00219708018283
+    patch.Ref1c        0.0316847855632    -0.00119821277779   -0.000865471934357
+    patch.Ref1d        0.0315635183971    -0.00150214960133   -0.00122002465866
+    patch.Ref1e        0.0317587104328    -0.00101293187492   -0.000649335409312
+    ---                ---                ---                 ---
+    landscape.Bauxite  -0.0276965008223   -0.962683908867     0.166590998707
+    landscape.Forest   0.982163161865     -0.0373079859488    -0.0270202298116
+    landscape.Urban    -0.00873355942469  -0.0280626855484    -0.0394249459161
+    S                  0.0515403663478    0.113344870593      0.123141154399
+    year               -0.00488342003667  -0.0143717060558    -0.0187277019153
+
+    See the whole table with table.as_data_frame()
+

--- a/h2o-docs/src/product/data-science/algo-params/use_all_factor_levels.rst
+++ b/h2o-docs/src/product/data-science/algo-params/use_all_factor_levels.rst
@@ -1,0 +1,156 @@
+``use_all_factor_levels``
+-------------------------
+
+- Available in: PCA
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+This option allows you to specify whether to use all factor levels in the possible set of predictors. This option is disabled by default, so the first factor level is skipped. If you enable this option, then the PCA model ignores the first factor level of each categorical column when expanding into indicator columns. Note also that if you enable this option, then sufficient regularization is required. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+    # Load the Birds dataset
+    birds.hex <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train using all factor levels
+    birds.pca <- h2o.prcomp(training_frame = birds.hex, transform = "STANDARDIZE",
+                            k = 3, pca_method="Power", use_all_factor_levels=TRUE)
+
+    # View the importance of components
+    birds.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     1.546397 1.348276 1.055239
+    Proportion of Variance 0.300269 0.228258 0.139820
+    Cumulative Proportion  0.300269 0.528527 0.668347
+
+    # View the eigenvectors
+    birds.pca@model$eigenvectors
+    Rotation: 
+                      pc1      pc2       pc3
+    patch.Ref1a  0.009848 -0.005947 0.001061
+    patch.Ref1b -0.001628 -0.014739 0.001007
+    patch.Ref1c  0.004994 -0.009486 0.000523
+    patch.Ref1d  0.000117 -0.004400 0.004917
+    patch.Ref1e  0.003627 -0.001467 0.004268
+
+    ---
+                    pc1       pc2       pc3
+    S          0.515048  0.226915  0.123136
+    year      -0.066269 -0.069526 -0.971250
+    area       0.414050  0.344332 -0.149339
+    log.area.  0.497313  0.363609 -0.131261
+    ENN       -0.390235  0.545631  0.007944
+    log.ENN.  -0.345665  0.562834  0.002092
+
+    # Train again without using all factor levels
+    birds2.pca <- h2o.prcomp(training_frame = birds.hex, transform = "STANDARDIZE",
+                             k = 3, pca_method="Power", use_all_factor_levels=FALSE)
+
+    # View the importance of components
+    birds2.pca@model$importance
+    Importance of components: 
+                                pc1      pc2      pc3
+    Standard deviation     1.544463 1.342094 1.054848
+    Proportion of Variance 0.309387 0.233622 0.144320
+    Cumulative Proportion  0.309387 0.543008 0.687328
+
+    # View the eigenvectors
+    birds2.pca@model$eigenvectors
+    Rotation: 
+                      pc1      pc2       pc3
+    patch.Ref1b -0.001469 0.014976  0.000849
+    patch.Ref1c  0.005120 0.009480  0.000457
+    patch.Ref1d  0.000164 0.004468  0.004877
+    patch.Ref1e  0.003656 0.001399  0.004283
+    patch.Ref1g  0.005728 0.002821 -0.003653
+
+    ---
+                    pc1       pc2       pc3
+    S          0.510775 -0.233390  0.123700
+    year      -0.064706  0.068396 -0.973014
+    area       0.409889 -0.355035 -0.145441
+    log.area.  0.494189 -0.379361 -0.125400
+    ENN       -0.397489 -0.543776  0.012354
+    log.ENN.  -0.355681 -0.554631  0.002802
+
+   .. code-block:: python
+
+    import(h2o)
+    h2o.init()
+    from h2o.transforms.decomposition import H2OPCA
+
+    # Load the Birds dataset
+    birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+
+    # Train using all factor levels
+    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+                       use_all_factor_levels=True)
+    birds.pca.train(x=list(range(4)), training_frame=birds)
+
+    # View the importance of components
+    birds.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 1.123848642024252, 0.9495543060913556, 0.5348966295982289), 
+    (u'Proportion of Variance', 0.30806239666469637, 0.21991895069672493, 0.06978510918460921), 
+    (u'Cumulative Proportion', 0.30806239666469637, 0.5279813473614213, 0.5977664565460306)]
+
+    # View the eigenvectors
+    birds.pca.rotation()
+    Rotation: 
+                       pc1                 pc2                pc3
+    -----------------  ------------------  -----------------  ----------------
+    patch.Ref1a        0.00898674959389   -0.0133755203032    -0.0386887320947
+    patch.Ref1b        -0.00583910658193  0.0085085283222     -0.0403921689887
+    patch.Ref1c        0.00157382150598   -0.0024334959905    -0.0395404505417
+    patch.Ref1d        0.00205431395425   0.00464763109547    -0.0130225732894
+    patch.Ref1e        0.00521157104674   -9.98807074937e-07  -0.0126676561766
+    ---                ---                ---                 ---
+    landscape.Bauxite  -0.092706414975    0.0985077063774     -0.312254873011
+    landscape.Forest   0.0498033442402    -0.0606680332043    -0.928822711491
+    landscape.Urban    -0.0671561311604   0.108679950954      -0.0336397179284
+    S                  0.661206197437     -0.694121601584     0.0166591597288
+    year               -0.727793158751    -0.684904471511     0.00409291352783
+
+    See the whole table with table.as_data_frame()
+
+    # Train again without using all factor levels
+    birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
+    birds2.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+                        use_all_factor_levels=False) 
+    birds2.pca.train(x=list(range(4)), training_frame=birds2)
+
+    # View the importance of components
+    birds2.pca.varimp(use_pandas=False)
+    [(u'Standard deviation', 1.1172889937645427, 0.9428301355878612, 0.5343711223812785), 
+    (u'Proportion of Variance', 0.3239196034161728, 0.2306604322634375, 0.07409555444280075), 
+    (u'Cumulative Proportion', 0.3239196034161728, 0.5545800356796103, 0.628675590122411)]
+
+    # View the eigenvectors
+    birds2.pca.rotation()
+    Rotation: 
+                       pc1                pc2                pc3
+    -----------------  -----------------  -----------------  -----------------
+    patch.Ref1b        0.00573715248567   0.00905029823292   0.0397305412063
+    patch.Ref1c        -0.00155941141753  -0.00262429190783  0.0388265166788
+    patch.Ref1d        -0.00220082271557  0.00460340227135   0.0127992097357
+    patch.Ref1e        -0.00530828965991  -0.00035582622718  0.0124225177099
+    patch.Ref1g        0.00398590526959   0.00628351783691   0.0261357246393
+    ---                ---                ---                ---
+    landscape.Bauxite  0.0926709193464    0.108265715468     0.368430097989
+    landscape.Forest   -0.049531997119    -0.0658907199023   0.910420643338
+    landscape.Urban    0.0662724833811    0.116520039037     0.0360237860344
+    S                  -0.643180719366    -0.730003524026    -0.0176460246561
+    year               0.753676017614     -0.65628159817     -0.00410087043089
+
+    See the whole table with table.as_data_frame()

--- a/h2o-docs/src/product/data-science/pca.rst
+++ b/h2o-docs/src/product/data-science/pca.rst
@@ -29,14 +29,14 @@ Defining a PCA Model
 
 -  `transform <algo-params/transform.html>`__: Specify the transformation method for the training data: None, Standardize, Normalize, Demean, or Descale. The default is None.
 
--  `pca_method <algo-params/pca_method>`__: Specify the algorithm to use for computing the principal components:
+-  `pca_method <algo-params/pca_method.html>`__: Specify the algorithm to use for computing the principal components:
 
    -  **GramSVD**: Uses a distributed computation of the Gram matrix, followed by a local SVD using the JAMA package
    -  **Power**: Computes the SVD using the power iteration method (experimental)
    -  **Randomized**: Uses randomized subspace iteration method
    -  **GLRM**: Fits a generalized low-rank model with L2 loss function and no regularization and solves for the SVD using local matrix algebra (experimental)
 
--  `k <algo-params/k.html>`__: Specify the rank of matrix approximation. The default is 1.
+-  `k <algo-params/k.html>`__: Specify the rank of matrix approximation. This can be a value from 1 to 9 and defaults to 1.
 
 -  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations. The value must be between 1 and 1e6 and the default is 1000.
 
@@ -49,6 +49,9 @@ Defining a PCA Model
 -  `score_each_iteration <algo-params/score_each_iteration.html>`__: (Optional) Specify whether to score during each iteration of the model training.
 
 -  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. Use 0 to disable.
+
+-  `impute_missing <algo-params/impute_missing.html>`__: Specifies whether to impute missing entries with the column mean value. This value defaults to False.
+
 
 Interpreting a PCA Model
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -97,14 +100,13 @@ FAQ
 
 -  **What if there are a large number of categorical factor levels?**
 
-  Each factor level (with the exception of the first, depending on whether **use\_all\_factor\_levels** is enabled) is assigned an indicator column. The indicator column is 1 if the observation corresponds to a particular factor; otherwise, it is 0. As a result, many factor levels result in a large Gram matrix and slower computation of the SVD.
+  Each factor level (with the exception of the first, depending on whether ``use_all_factor_levels`` is enabled) is assigned an indicator column. The indicator column is 1 if the observation corresponds to a particular factor; otherwise, it is 0. As a result, many factor levels result in a large Gram matrix and slower computation of the SVD.
 
 -  **How are categorical columns handled during model building?**
 
   If the GramSVD or Power methods are used, the categorical columns are expanded into 0/1 indicator columns for each factor level. The algorithm is then performed on this expanded training frame. For GLRM, the multidimensional loss function for categorical columns is discussed in Section 6.1 of `"Generalized Low Rank Models" <https://web.stanford.edu/~boyd/papers/pdf/glrm.pdf>`__ by Boyd et al.
 
--  **When running PCA, is it better to create a cluster that uses many
-   smaller nodes or fewer larger nodes?**
+-  **When running PCA, is it better to create a cluster that uses many smaller nodes or fewer larger nodes?**
 
   For PCA, this is dependent on the specified ``pca_method`` parameter:
 
@@ -113,10 +115,13 @@ FAQ
   -  For **GLRM**, the number of nodes depends on whether the dataset contains many categorical columns with many levels. If this is the case, we recommend using fewer larger nodes, since computing the loss function for categoricals is an intensive task. If the majority of the data is numeric and the categorical columns have only a small number of levels (~10-20), we recommend using many small nodes in the cluster.
   -  For **Power**, we recommend using fewer larger nodes because the intensive calculations are single-threaded. However, this method is only recommended for obtaining principal component values (such as ``k << ncol(train))`` because the other methods are far more efficient.
 
--  **I ran PCA on my dataset - how do I input the new parameters into a
-   model?**
+-  **I ran PCA on my dataset - how do I input the new parameters into a model?**
 
   After the PCA model has been built using ``h2o.prcomp``, use ``h2o.predict`` on the original data frame and the PCA model to produce the dimensionality-reduced representation. Use ``cbind`` to add the predictor column from the original data frame to the data frame produced by the output of ``h2o.predict``. At this point, you can build supervised learning models on the new data frame.
+
+- **How can I evaluate and choose the appropriate set of target dimensions for data?** 
+
+  The set of target dimensions can be chosen by inspecting the cumulative proportion of variance explained. (For example, select the number of components that explain 95% variance in data.) This information can be displayed using ``pca_model.summary()``. You can also view the variable importances using ``@model$importance`` in R or ``varimp()`` in Python
 
 PCA Algorithm
 ~~~~~~~~~~~~~

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -39,6 +39,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/huber_alpha
    data-science/algo-params/ignore_const_cols
    data-science/algo-params/ignored_columns
+   data-science/algo-params/impute_missing
    data-science/algo-params/init
    data-science/algo-params/interactions
    data-science/algo-params/intercept
@@ -75,6 +76,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/ntrees
    data-science/algo-params/objective_epsilon
    data-science/algo-params/offset_column
+   data-science/algo-params/pca_method
    data-science/algo-params/pred_noise_bandwidth
    data-science/algo-params/quantile_alpha
    data-science/algo-params/remove_collinear_columns
@@ -89,9 +91,11 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/stopping_rounds
    data-science/algo-params/stopping_tolerance
    data-science/algo-params/training_frame
+   data-science/algo-params/transform
    data-science/algo-params/tweedie_link_power
    data-science/algo-params/tweedie_power
    data-science/algo-params/tweedie_variance_power
+   data-science/algo-params/use_all_factor_levels
    data-science/algo-params/user_points
    data-science/algo-params/validation_frame
    data-science/algo-params/weights_column


### PR DESCRIPTION
- Added impute_missing, transform, pca_method, and use_all_factor_levels to Parameters appendix. Updated the index to include these parameters.
- Added a PCA-specific description for the k parameter.
- Added impute_missing to the list of parameters in the PCA section (where it was missing).