### PR TITLE
HEXDEV-692: prediction difference between H2O model and Pojo predicti…

### DIFF
--- a/h2o-py/tests/testdir_javapredict/pyunit_hexdev_692_dum_NOPASS.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_hexdev_692_dum_NOPASS.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+from builtins import zip
+from builtins import range
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+# Used to test out customer dataset to make sure h2o model predict and pojo predict generate
+# the same answers.  However, customer dataset is not to be made public and hence this test
+# is a NOPASS.
+def javapredict_gbm_hexdev_692():
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/Training_Data.csv"))
+    test = h2o.upload_file(pyunit_utils.locate("smalldata/Training_Data.csv"))
+    params = {'ntrees':100, 'max_depth':7,  'seed':42, 'training_frame':train } # 651MB pojo
+    print("Parameter list:")
+    for k,v in zip(list(params.keys()), list(params.values())): print("{0}, {1}".format(k,v))
+
+    x = list(range(0,14))
+    y = "Label"
+
+    pyunit_utils.javapredict("gbm", "class", train, test, x, y, **params)
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(javapredict_gbm_hexdev_692)
+else:
+    javapredict_gbm_hexdev_692()

--- a/h2o-r/tests/runitUtils/shared_javapredict.R
+++ b/h2o-r/tests/runitUtils/shared_javapredict.R
@@ -40,8 +40,10 @@ doJavapredictTest <- function(model,test_file,test_frame,params) {
   cmd <- sprintf(   "%s/out_h2o.csv", tmpdir_name)
   write.csv(prediction1, cmd, quote=FALSE, row.names=FALSE)
 
-  print("Setting up for Java POJO")
+  print("Setting up for Java POJO") 
+  # for missing column names, H2O use C1, C2,...  R uses X, Y,...
   test_with_response <- read.csv(test_file, header=T)
+  names(test_with_response) = names(test_frame) # replace R column names with H2O column names
   test_without_response <- test_with_response[,params$x]
   if(is.null(ncol(test_without_response))) {
     test_without_response <- data.frame(test_without_response)

--- a/h2o-r/tests/testdir_javapredict/runit_hexdev_692_NOPASS_dum.R
+++ b/h2o-r/tests/testdir_javapredict/runit_hexdev_692_NOPASS_dum.R
@@ -1,0 +1,36 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+#----------------------------------------------------------------------
+# Used to test out customer dataset to make sure h2o model predict and pojo predict generate
+# the same answers.  However, customer dataset is not to be made public and hence this test
+# is a NOPASS.
+#----------------------------------------------------------------------
+test <-
+  function() {
+    #----------------------------------------------------------------------
+    # Parameters for the test.
+    #----------------------------------------------------------------------
+    
+    # Story:
+    # The objective of the test is to verify java code generation
+    # for big models containing huge amount of trees.
+    # This case verify multi-classifiers.
+    training_file <- test_file <- locate("smalldata/Training_Data.csv")
+    #training_file <- test_file <- locate("smalldata/dd.csv")
+    
+    training_frame <- h2o.importFile(training_file)
+    test_frame <- h2o.importFile(test_file)
+    browser()
+    params                 <- list()
+    params$ntrees          <- 100
+    params$max_depth       <- 7
+    params$x               <- 1:14
+    params$y               <- "Label"
+    params$training_frame  <- training_frame
+    params$seed            <- 42
+    
+    doJavapredictTest("gbm",test_file,test_frame,params)
+  }
+
+doTest("gbm test", test)


### PR DESCRIPTION
Customer dataset contains a null column name.  For datasets with null column names, R uses X, Y,... as stand ins.  However, H2O uses C1, C2 as arbitrary column name assignments.  

Before calling the Pojo prediction, we load the dataset for POJO using R.  The column name is set to be X instead of C1.  Hence, in R, basically, the Pojo is making prediction using one less column.  Hence the difference.  

I make sure the column names (in shared_javapredict.R) are the same for h2o model predict and pojo predict and this solves the problem.  Added Pyunit and Runit tests to verify my fix works.  You can verify it if you have the proper dataset.