### PR TITLE
PUBDEV-4529: Added new parameters to AutoML topic

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -20,6 +20,8 @@ In both the R and Python API, AutoML uses the same data-related arguments, ``x``
 - `training_frame <data-science/algo-params/training_frame.html>`__: Specifies the training set. This argument is required.
 - `validation_frame <data-science/algo-params/validation_frame.html>`__: This argument is optional and will be used for early stopping within the training process of the individual models in the AutoML run.  
 - **leaderboard_frame**: This argument allows the user to specify a particular data frame to rank the models on the leaderboard. This frame will not be used for anything besides creating the leaderboard.
+- `fold_column <data-science/algo-params/fold_column.html>`__: Specifies a column with cross-validation fold index assignment per observation. This is used to override the default, randomized, 5-fold cross-validation scheme for individual models in the AutoML run.
+- `weights_column <data-science/algo-params/weights_column.html>`__: Specifies a column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative weights are not allowed.
 - `max_runtime_secs <data-science/algo-params/max_runtime_secs.html>`__: This argument controls how long the AutoML run will execute. This defaults to 3600 seconds.
 - **project_name**: Specify a string that identifies an AutoML project. This value defaults to NULL, which means a project name will be auto-generated based on the training frame ID.
 - **max_models**: Specify the maximum number of models to build in an AutoML run. (Does not include Stacked Ensembles.) 
@@ -176,7 +178,7 @@ Here’s an example showing basic usage of the ``h2o.automl()`` function in *R* 
 AutoML Output
 -------------
 
-The AutoML object includes a "leaderboard" of models that were trained in the process, ranked by a default metric based on the problem type (the second column of the leaderboard).  In binary classification problems, that metric is AUC, and in multiclass classification problems, the metric is mean per-class error.  In regression problems, the default sort metric is root mean squared error (RMSE).  Some additional metrics are also provided, for convenience.
+The AutoML object includes a "leaderboard" of models that were trained in the process, ranked by a default metric based on the problem type (the second column of the leaderboard). In binary classification problems, that metric is AUC, and in multiclass classification problems, the metric is mean per-class error. In regression problems, the default sort metric is deviance.  Some additional metrics are also provided, for convenience.
 
 Here is an example leaderboard for a binary classification task:
 

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -11,25 +11,23 @@ H2O's AutoML can be used for automating the machine learning workflow, which inc
 AutoML Interface
 ----------------
 
-The AutoML interface is designed to have as few parameters as possible so that all the user needs to do is point to their dataset, identify the response column and optionally specify a time constraint, a maximum number of models constraint, and early stopping parameters. 
+The H2O AutoML interface is designed to have as few parameters as possible so that all the user needs to do is point to their dataset, identify the response column and optionally specify a time constraint, a maximum number of models constraint, and early stopping parameters. 
 
-In both the R and Python API, AutoML uses the same data-related arguments, ``x``, ``y``, ``training_frame``, ``validation_frame``, as the other H2O algorithms. Below is a list of all available AutoML options. 
+In both the R and Python API, AutoML uses the same data-related arguments, ``x``, ``y``, ``training_frame``, ``validation_frame``, as the other H2O algorithms.  Most of the time, all you'll need to do is specify the data arguments, set one of ``max_runtime_secs`` or ``max_models``, and you're ready to go!  The early stopping arguments can be left at their defaults, unless you want fine-grained control of the AutoML process.  Below is a list of all available AutoML arguments.  
 
-- **x**: The **x** argument only needs to be specified if the user wants to exclude predictor columns from their data frame.  If all columns (other than the response) should be used in prediction, this can be left blank/unspecified.
+- **x**: A list/vector of predictor column names or indexes.  This argument is optional and only needs to be specified if the user wants to exclude columns from the set of predictors.  If all columns (other than the response) should be used in prediction, then this does not need to be set.
 - `y <data-science/algo-params/y.html>`__: This argument is the name (or index) of the response column. This argument is required.
 - `training_frame <data-science/algo-params/training_frame.html>`__: Specifies the training set. This argument is required.
 - `validation_frame <data-science/algo-params/validation_frame.html>`__: This argument is optional and will be used for early stopping within the training process of the individual models in the AutoML run.  
 - **leaderboard_frame**: This argument allows the user to specify a particular data frame to rank the models on the leaderboard. This frame will not be used for anything besides creating the leaderboard.
 - `fold_column <data-science/algo-params/fold_column.html>`__: Specifies a column with cross-validation fold index assignment per observation. This is used to override the default, randomized, 5-fold cross-validation scheme for individual models in the AutoML run.
 - `weights_column <data-science/algo-params/weights_column.html>`__: Specifies a column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative weights are not allowed.
-- `max_runtime_secs <data-science/algo-params/max_runtime_secs.html>`__: This argument controls how long the AutoML run will execute. This defaults to 3600 seconds.
-- **project_name**: Specify a string that identifies an AutoML project. This value defaults to NULL, which means a project name will be auto-generated based on the training frame ID.
-- **max_models**: Specify the maximum number of models to build in an AutoML run. (Does not include Stacked Ensembles.) 
-- `stopping_rounds <data-science/algo-params/stopping_rounds.html>`__: This argument stops training when the option selected for **stopping_metric** doesn't improve for the specified number of training rounds, based on a simple moving average. To disable this feature, specify ``0``. The metric is computed on the validation data (if provided); otherwise, training data is used.
+- `max_runtime_secs <data-science/algo-params/max_runtime_secs.html>`__: This argument controls how long the AutoML run will execute. This defaults to 3600 seconds (1 hour).
+- **max_models**: Specify the maximum number of models to build in an AutoML run. (Does not include the Stacked Ensemble model.) 
 
--  `stopping_metric <data-science/algo-params/stopping_metric.html>`__: Specifies the metric to use for early stopping. The available options are:
+-  `stopping_metric <data-science/algo-params/stopping_metric.html>`__: Specifies the metric to use for early stopping. Defaults to ``"AUTO"``.  The available options are:
 
-    - ``auto``: This defaults to ``logloss`` for classification, ``deviance`` for regression
+    - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
     - ``deviance``
     - ``logloss``
     - ``mse``
@@ -41,9 +39,16 @@ In both the R and Python API, AutoML uses the same data-related arguments, ``x``
     - ``misclassification``
     - ``mean_per_class_error``
 
--  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__ option specifies the relative tolerance for the metric-based stopping to stop training if the improvement is less than this value.
+-  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value.  Defaults to 0.001.
 
--  `seed <data-science/algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations.
+- `stopping_rounds <data-science/algo-params/stopping_rounds.html>`__: This argument stops training new models in the AutoML run when the option selected for **stopping_metric** doesn't improve for the specified number of models, based on a simple moving average. Defaults to 3 and must be an non-negative integer.  To disable this feature, set it to 0. 
+
+- `seed <data-science/algo-params/seed.html>`__: Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if max_models or early stopping is used because max_runtime_secs is resource limited, meaning that if the resources are not the same between runs, AutoML may be able to train more models on one run vs another.  Defaults to ``NULL/None``.
+
+- **project_name**: Character string to identify an AutoML project. Defaults to ``NULL/None``, which means a project name will be auto-generated based on the training frame ID.  More models can be trained on an existing AutoML project by specifying the same project name in muliple calls to the AutoML function (as long as the same training frame is used in subsequent runs).
+
+
+**Note:** When multiple options are set to control the stopping of the AutoML run (e.g. ``max_models`` and ``max_runtime_secs``), then whichever happens first will stop the AutoML run.
 
 Auto-Generated Frames
 ~~~~~~~~~~~~~~~~~~~~~
@@ -110,7 +115,7 @@ Here’s an example showing basic usage of the ``h2o.automl()`` function in *R* 
     # predictions directly on the `"H2OAutoML"` object, or on the leader 
     # model object directly
 
-    #pred <- h2o.predict(aml, test)  #Not functional yet: https://0xdata.atlassian.net/browse/PUBDEV-4428
+    pred <- h2o.predict(aml, test)  # predict(aml, test) also works
 
     # or:
     pred <- h2o.predict(aml@leader, test)
@@ -211,7 +216,7 @@ FAQ
 
 -  **How do I save AutoML runs?**
 
-  Rather than saving an AutoML object itself, currently, the best thing to do is to save the models you want to keep, individually.  This will be improved in a future release.
+  Rather than saving an AutoML object itself, currently, the best thing to do is to save the models you want to keep, individually.  A utility for saving all of the models at once will be added in a future release.
 
 
 -  **Why is there no Stacked Ensemble on my Leaderboard?**
@@ -223,6 +228,4 @@ Additional Information
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - AutoML development is tracked `here <https://0xdata.atlassian.net/issues>`__. This page lists all open or in-progress AutoML JIRA tickets.
-- AutoML is currently in experimental mode ("V99" in the REST API).  This means that the API (REST, R, Python or otherwise) may be subject to breaking changes.
-- More background and information will be added to this document prior to the official release of AutoML.
-
+- AutoML is currently in experimental mode ("V99" in the REST API).  This means that, although unlikely, the API (REST, R, Python or otherwise) may be subject to breaking changes.

--- a/h2o-docs/src/product/data-science/algo-params/categorical_encoding.rst
+++ b/h2o-docs/src/product/data-science/algo-params/categorical_encoding.rst
@@ -38,7 +38,7 @@ This option specifies the encoding scheme to use for handling categorical featur
   - ``eigen`` or ``Eigen``: *k* columns per categorical feature, keeping projections of one-hot-encoded matrix onto *k*-dim eigen space only
   - ``label_encoder`` or ``LabelEncoder``: Convert every enum into the integer of its index (for example, level 0 -> 0, level 1 -> 1, etc.). This is useful for keeping the number of columns small for XGBoost or DeepLearning/DeepWater, where the algorithm otherwise perform ExplicitOneHotEncoding. 
   - ``sort_by_response`` or ``SortByResponse``: Reorders the levels by the mean response (for example, the level with lowest response -> 0, the level with second-lowest response -> 1, etc.).
-  - ``enum_limited``: Automatically reduce categorical levels to the most prevalent ones during Aggregator training and only keep the **T** most frequent levels.
+  - ``enum_limited`` or ``EnumLimited``: Automatically reduce categorical levels to the most prevalent ones during Aggregator training and only keep the **T** most frequent levels.
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/fold_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/fold_column.rst
@@ -1,7 +1,7 @@
 ``fold_column``
 ---------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, AutoML
 - Hyperparameter: no
 
 

--- a/h2o-docs/src/product/data-science/algo-params/weights_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/weights_column.rst
@@ -1,7 +1,7 @@
 ``weights_column``
 ------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM
+- Available in: GBM, DRF, Deep Learning, GLM, AutoML
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/faq/general.rst
+++ b/h2o-docs/src/product/faq/general.rst
@@ -40,9 +40,12 @@ To score a simple .CSV file, download the
     mkdir gbm_model_dir
     javac -cp h2o-genmodel.jar -J-Xmx2g -J-XX:MaxPermSize=128m PredictCSV.java gbm_model.java -d gbm_model_dir
 
-Specify the following: - the classpath using ``-cp`` - the model name
-(or class) using ``--model`` - the csv file you want to score using
-``--input`` - the location for the predictions using ``--output``.
+Specify the following: 
+
+- the classpath using ``-cp`` 
+- the model name (or class) using ``--model`` 
+- the csv file you want to score using ``--input`` 
+- the location for the predictions using ``--output``.
 
 You must match the table column names to the order specified in the
 POJO. The output file will be in a .hex format, which is a lossless text


### PR DESCRIPTION
- Added fold_column and weights_column parameters to the AutoML topic.
- Added “AutoML” as a supported algo for each of these parameters in the Appendix.
- Changed the default sort metric for regression problems to be deviance.
Driveby fix: Fixed bulleted list in FAQ > General topic.

Adding @ledell in the case of any additional updates.