### PR TITLE
[PUBDEV-4536] Provides a file which contains a list of licenses for each H2O dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
 
 plugins {
     id "java"
+    id "com.github.hierynomus.license" version "0.14.0"
 }
 
 //

--- a/h2o-assemblies/genmodel/build.gradle
+++ b/h2o-assemblies/genmodel/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
+apply plugin: 'com.github.hierynomus.license'
 
 description = "H2O GenModel Assembly which is embedded into H2O.jar"
 
@@ -39,11 +40,19 @@ shadowJar {
   exclude 'test.properties'
   exclude 'cockpitlite.properties'
   exclude 'devpay_products.properties'
+  transform(com.github.jengelman.gradle.plugins.shadow.transformers.IncludeResourceTransformer.class) {
+    file = file("${buildDir}/reports/license/dependency-license.xml")
+    resource = "META-INF/license/h2o-depenencies-licenses.xml"
+  }
 }
 
 artifacts {
   archives shadowJar
 }
 
+// Disable regular jar since the project is empty
 jar.enabled = false
+// Plug ShadowJar task into execution graph
+shadowJar.dependsOn(project.tasks.getByName('downloadLicenses'))
 build.dependsOn shadowJar
+

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -1,5 +1,4 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'java'
 apply plugin: 'com.github.hierynomus.license'
 
@@ -24,6 +23,8 @@ dependencies {
     }
     compile project(":h2o-parquet-parser")
     compile "org.slf4j:slf4j-log4j12:1.7.5"
+
+    
 }
 
 //
@@ -49,39 +50,31 @@ for (comp in optionalComponents) {
     
 }
 
-task shadowJar(type: ShadowJar) {
-    configurations = [ project.configurations.compile ]
-    mergeServiceFiles()
-    classifier = ''
-    // CDH 5.3.0 provides joda-time v1.6 which is too old, shadow the library instead
-    if (!project.hasProperty("jacocoCoverage")) {
-        relocate 'org.joda.time', 'ai.h2o.org.joda.time'
-    }
-    exclude 'META-INF/*.DSA'
-    exclude 'META-INF/*.SF'
-    exclude 'synchronize.properties'
-    exclude 'uploader.properties'
-    exclude 'test.properties'
-    exclude 'cockpitlite.properties'
-    exclude 'devpay_products.properties'
-    manifest {
-        attributes 'Main-Class': 'water.H2OApp'
-    }
-
-    into("META-INF") {
-        from("${buildDir.absolutePath}/reports/license"){
-            include "dependency-license.xml"
-        }
-    }
-}
-
-configurations{
-    shadow
+shadowJar {
+  mergeServiceFiles()
+  classifier = ''
+  // CDH 5.3.0 provides joda-time v1.6 which is too old, shadow the library instead
+  if (!project.hasProperty("jacocoCoverage")) {
+    relocate 'org.joda.time', 'ai.h2o.org.joda.time'
+  }
+  exclude 'META-INF/*.DSA'
+  exclude 'META-INF/*.SF'
+  exclude 'synchronize.properties'
+  exclude 'uploader.properties'
+  exclude 'test.properties'
+  exclude 'cockpitlite.properties'
+  exclude 'devpay_products.properties'
+  manifest {
+    attributes 'Main-Class': 'water.H2OApp'
+  }
+  transform(com.github.jengelman.gradle.plugins.shadow.transformers.IncludeResourceTransformer.class) {
+    file = file("${buildDir}/reports/license/dependency-license.xml")
+    resource = "META-INF/license/h2o-depenencies-licenses.xml"
+  }
 }
 
 artifacts {
   archives shadowJar
-  shadow shadowJar
 }
 
 //
@@ -100,6 +93,7 @@ task copyJar(type: Copy) {
     rename { it.replace(assembly, allInOne) }
 }
 
+// Include licences
 shadowJar.dependsOn(project.tasks.getByName('downloadLicenses'))
 // Execute always copyJar
 shadowJar.finalizedBy copyJar

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.github.johnrengelman.shadow'
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 apply plugin: 'java'
+apply plugin: 'com.github.hierynomus.license'
 
 description = "H2O Application Assembly"
 // Exclude unwanted dependencies
@@ -47,27 +49,39 @@ for (comp in optionalComponents) {
     
 }
 
-shadowJar {
-  mergeServiceFiles()
-  classifier = ''
-  // CDH 5.3.0 provides joda-time v1.6 which is too old, shadow the library instead
-  if (!project.hasProperty("jacocoCoverage")) {
-    relocate 'org.joda.time', 'ai.h2o.org.joda.time'
-  }
-  exclude 'META-INF/*.DSA'
-  exclude 'META-INF/*.SF'
-  exclude 'synchronize.properties'
-  exclude 'uploader.properties'
-  exclude 'test.properties'
-  exclude 'cockpitlite.properties'
-  exclude 'devpay_products.properties'
-  manifest {
-    attributes 'Main-Class': 'water.H2OApp'
-  }
+task shadowJar(type: ShadowJar) {
+    configurations = [ project.configurations.compile ]
+    mergeServiceFiles()
+    classifier = ''
+    // CDH 5.3.0 provides joda-time v1.6 which is too old, shadow the library instead
+    if (!project.hasProperty("jacocoCoverage")) {
+        relocate 'org.joda.time', 'ai.h2o.org.joda.time'
+    }
+    exclude 'META-INF/*.DSA'
+    exclude 'META-INF/*.SF'
+    exclude 'synchronize.properties'
+    exclude 'uploader.properties'
+    exclude 'test.properties'
+    exclude 'cockpitlite.properties'
+    exclude 'devpay_products.properties'
+    manifest {
+        attributes 'Main-Class': 'water.H2OApp'
+    }
+
+    into("META-INF") {
+        from("${buildDir.absolutePath}/reports/license"){
+            include "dependency-license.xml"
+        }
+    }
+}
+
+configurations{
+    shadow
 }
 
 artifacts {
   archives shadowJar
+  shadow shadowJar
 }
 
 //
@@ -85,6 +99,8 @@ task copyJar(type: Copy) {
     into "${project.parent.parent.buildDir}"
     rename { it.replace(assembly, allInOne) }
 }
+
+shadowJar.dependsOn(project.tasks.getByName('downloadLicenses'))
 // Execute always copyJar
 shadowJar.finalizedBy copyJar
 // Run shadowJar as par of build

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -23,8 +23,6 @@ dependencies {
     }
     compile project(":h2o-parquet-parser")
     compile "org.slf4j:slf4j-log4j12:1.7.5"
-
-    
 }
 
 //


### PR DESCRIPTION
in assembly jar file

Custom ShadowJar task had to be created as it does not have public API to add files from somewhere else. The `append` method is used for a bit different thing, see https://github.com/johnrengelman/shadow/issues/180

However this gives us a better control of what goes into shadow jar and we can specify additional files to go inside easily.

This change downloads licence for each used dependency and put the reported xml file into the META-INF directory of the generated jar as part of the build process