### PR TITLE
[PUBDEV-4542] Fix bug with Log.info method bypassing handling of buffered messages

### DIFF
--- a/h2o-core/src/main/java/water/util/Log.java
+++ b/h2o-core/src/main/java/water/util/Log.java
@@ -81,7 +81,7 @@ abstract public class Log {
     l.info(s);
   }
 
-  public static void info( String s, boolean stdout ) { if( _level >= INFO ) write0(INFO, stdout, s); }
+  public static void info( String s, boolean stdout ) { if( _level >= INFO ) write0(INFO, stdout, new String[]{s}); }
 
   // This call *throws* an unchecked exception and never returns (after logging).
   public static RuntimeException throwErr( Throwable e ) {


### PR DESCRIPTION
Log.info method internally used method which did not do the log initialisation which is against the design of our logging. This PR ensures that we call the correct method which eventually initialise the correct logging