### PR TITLE
[PUBDEV-4546] In logs, we can se PID to be set to wrong value before …

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1062,7 +1062,7 @@ final public class H2O {
 
   // Best-guess process ID
   public static final long PID;
-  static{
+  static {
     PID = getCurrentPID();
   }
 
@@ -2135,7 +2135,7 @@ final public class H2O {
   }
 
   /** Find PID of the current process, use -1 if we can't find the value. */
-  private static long getCurrentPID(){
+  private static long getCurrentPID() {
     try {
       String n = ManagementFactory.getRuntimeMXBean().getName();
       int i = n.indexOf('@');

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1059,9 +1059,12 @@ final public class H2O {
 
   // Used to gate default worker threadpool sizes
   public static final int NUMCPUS = Runtime.getRuntime().availableProcessors();
-  // Best-guess process ID
-  public static long PID = -1L;
 
+  // Best-guess process ID
+  public static final long PID;
+  static{
+    PID = getCurrentPID();
+  }
 
   /**
    * Throw an exception that will cause the request to fail, but the cluster to continue.
@@ -2021,12 +2024,6 @@ final public class H2O {
           Log.POST(11, ste.toString());
       }
     }
-
-    // We need to initialize PID before we initialize SELF_ADDRESS.
-    // Initialization of SELF_ADDRESS triggers buffered logged messages to be logged and PID
-    // is part of the log header. We want to have correct PID in the buffered messages as well.
-    initializePID();
-
     // Epic Hunt for the correct self InetAddress
     long time4 = System.currentTimeMillis();
     Log.info("IPv6 stack selected: " + IS_IPV6);
@@ -2138,13 +2135,18 @@ final public class H2O {
   }
 
   /** Find PID of the current process, use -1 if we can find the value */
-  private static void initializePID(){
-    PID = -1L;
+  private static long getCurrentPID(){
     try {
       String n = ManagementFactory.getRuntimeMXBean().getName();
       int i = n.indexOf('@');
-      if( i != -1 ) PID = Long.parseLong(n.substring(0, i));
-    } catch( Throwable ignore ) { }
+      if(i != -1){
+        return Long.parseLong(n.substring(0, i));
+      }else{
+        return -1L;
+      }
+    } catch(Throwable ignore) {
+      return -1L;
+    }
   }
 
   // Die horribly

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1556,13 +1556,6 @@ final public class H2O {
 
   /** Initializes the local node and the local cloud with itself as the only member. */
   private static void startLocalNode() {
-    PID = -1L;
-    try {
-      String n = ManagementFactory.getRuntimeMXBean().getName();
-      int i = n.indexOf('@');
-      if( i != -1 ) PID = Long.parseLong(n.substring(0, i));
-    } catch( Throwable ignore ) { }
-
     // Figure self out; this is surprisingly hard
     NetworkInit.initializeNetworkSockets();
     // Do not forget to put SELF into the static configuration (to simulate
@@ -2029,6 +2022,11 @@ final public class H2O {
       }
     }
 
+    // We need to initialize PID before we initialize SELF_ADDRESS.
+    // Initialization of SELF_ADDRESS triggers buffered logged messages to be logged and PID
+    // is part of the log header. We want to have correct PID in the buffered messages as well.
+    initializePID();
+
     // Epic Hunt for the correct self InetAddress
     long time4 = System.currentTimeMillis();
     Log.info("IPv6 stack selected: " + IS_IPV6);
@@ -2137,6 +2135,16 @@ final public class H2O {
     Log.debug("    Start network services: " + (time10 - time9) + "ms");
     Log.debug("    Cloud up: " + (time11 - time10) + "ms");
     Log.debug("    Start GA: " + (time12 - time11) + "ms");
+  }
+
+  /** Find PID of the current process, use -1 if we can find the value */
+  private static void initializePID(){
+    PID = -1L;
+    try {
+      String n = ManagementFactory.getRuntimeMXBean().getName();
+      int i = n.indexOf('@');
+      if( i != -1 ) PID = Long.parseLong(n.substring(0, i));
+    } catch( Throwable ignore ) { }
   }
 
   // Die horribly

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2139,9 +2139,9 @@ final public class H2O {
     try {
       String n = ManagementFactory.getRuntimeMXBean().getName();
       int i = n.indexOf('@');
-      if(i != -1){
+      if(i != -1) {
         return Long.parseLong(n.substring(0, i));
-      }else{
+      } else {
         return -1L;
       }
     } catch(Throwable ignore) {

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2134,7 +2134,7 @@ final public class H2O {
     Log.debug("    Start GA: " + (time12 - time11) + "ms");
   }
 
-  /** Find PID of the current process, use -1 if we can find the value */
+  /** Find PID of the current process, use -1 if we can't find the value. */
   private static long getCurrentPID(){
     try {
       String n = ManagementFactory.getRuntimeMXBean().getName();


### PR DESCRIPTION
…it's properly initialized

We need to initialize PID before we initialize SELF_ADDRESS. Initialization of SELF_ADDRESS triggers buffered logged messages to be logged and PID is part of the log header. We want to have correct PID in the buffered messaged as well

This is the last but one issue in the logs I found.