### PR TITLE
[PUBDEV-4541] Create logs into unique directories and refactor out me…

### DIFF
--- a/h2o-core/src/main/java/water/util/FileUtils.java
+++ b/h2o-core/src/main/java/water/util/FileUtils.java
@@ -6,11 +6,40 @@ import water.fvec.NFSFileVec;
 
 import java.io.*;
 import java.net.URI;
+import java.util.UUID;
 
 /**
  * File utilities.
  */
 public class FileUtils {
+  private static int MAX_DIR_CREATION_ATTEMPTS = 10;
+
+  /**
+   * Create a directory inside the given parent directory. The directory is guaranteed to be
+   * newly created, and is not marked for automatic deletion.
+   */
+  public static File createUniqueDirectory(String rootDir, String namePrefix) throws IOException {
+    int attempts = 0;
+    int maxAttempts = MAX_DIR_CREATION_ATTEMPTS;
+    File dir = null;
+    while (dir == null) {
+      attempts += 1;
+      if (attempts > maxAttempts) {
+        throw new IOException("Failed to create a temp directory (under " + rootDir + ") after " +
+                maxAttempts + " attempts!");
+      }
+      try {
+        dir = new File(rootDir, namePrefix + "-" + UUID.randomUUID().toString());
+        if (dir.exists() || !dir.mkdirs()) {
+          dir = null;
+        }
+      } catch(SecurityException e) {
+        dir = null;
+      }
+    }
+    return dir.getCanonicalFile();
+  }
+
   /**
    * Silently close given files.
    *


### PR DESCRIPTION
…thod for default log directory

This is the last bug! When running multiple H2O clusters locally they all log into the same directory. Therefore when we ask for logs we can get logs also from that different cluster. This fixes it by putting the logs into separated unique directory

As we talked with @mmalohlava the refactoring change will go into the next release. So for now, this should be fine. Thanks all for reviewing!