### PR TITLE
PUBDEV-4551: Documentation updates for Deep Water on docs.h2o.ai

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -215,12 +215,13 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
             <a href="https://github.com/h2oai/deepwater/blob/master/README.md">Deep Water Readme</a>
             <a href="h2o-docs/booklets/DeepWaterBooklet.pdf">Deep Water Booklet</a>
             <a href="https://github.com/h2oai/deepwater/blob/master/docs/open-tour-dallas/deep-water-ami.md">Deep Water AMI Guide</a>
+            <a href="https://github.com/h2oai/deepwater#pre-release-docker-image">Deep Water Docker Image</a>
             <a href="https://github.com/h2oai/deepwater/blob/master/LICENSE">Open Source License (Apache V2)</a>
            </div>
            <hr>
           <div class="primary txt-cntr" style="display: block; width: 100%; margin-bottom:10px;">
-            <a href="https://console.aws.amazon.com/ec2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-d32f70c4" style="color: #000000; font-size: 1.1em;">Launch Deep Water AMI</a>
-            <br><p style="color: gray; margin: 0pt;">(choose g2.2xlarge)</p>
+            <a href="https://github.com/h2oai/deepwater#pre-release-amazon-aws-image" style="color: #000000; font-size: 1.1em;">Launch Deep Water AMI</a>
+            <br><p style="color: gray; margin: 0pt;">(choose p2.xlarge)</p>
           </div>
         </div>
 


### PR DESCRIPTION
- Changed “Launch Deep Water AMI” button link to point to https://github.com/h2oai/deepwater#pre-release-amazon-aws-image
- Changed the recommended machine on the launch button to be p2.xlarge
instead of h2.2xlarge.
- Added a link to the docker image at https://github.com/h2oai/deepwater#pre-release-docker-image