### PR TITLE
PUBDEV-4567: speedup topbottomN.  Added dataframe rebalance, use arra…

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstTopN.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstTopN.java
@@ -39,7 +39,7 @@ public class AstTopN extends AstPrimitive {
 		public String description() {
 				return "Return the top N percent rows for a numerical column as a frame with two columns.  The first column " +
 												"will contain the original row indices of the chosen values.  The second column contains the top N row" +
-												"values.  If getBottomN is 1, we will return the bottom N percent.  If getBottomN is 0, we will return" +
+												"values.  If getBottomN is 1, we will return the bottom N percent.  If getBottomN is -1, we will return" +
 												"the top N percent of rows";
 		}
 
@@ -52,7 +52,7 @@ public class AstTopN extends AstPrimitive {
 				long numRows = Math.round(nPercent * 0.01 * frOriginal.numRows()); // number of rows to return
 
 				String[] finalColumnNames = {"Original_Row_Indices", frOriginal.name(colIndex)}; // set output frame names
-				GrabTopNPQ grabTask = new GrabTopNPQ(finalColumnNames, numRows, (getBottomN == 0 ? 1 : -1));
+				GrabTopNPQ grabTask = new GrabTopNPQ(finalColumnNames, numRows, getBottomN);
 				grabTask.doAll(frOriginal.vec(colIndex));
 				return new ValFrame(grabTask._sortedOut);
 		}

--- a/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstTopN.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstTopN.java
@@ -1,7 +1,6 @@
 package water.rapids.ast.prims.reducers;
 
 import water.MRTask;
-import water.fvec.C8Chunk;
 import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.fvec.Vec;
@@ -15,246 +14,245 @@ import java.util.PriorityQueue;
 import static java.lang.StrictMath.min;
 
 public class AstTopN extends AstPrimitive {
-		@Override
-		public String[] args() {
-				return new String[]{"frame", "col", "nPercent", "getBottomN"};
-		}
+  @Override
+  public String[] args() {
+    return new String[]{"frame", "col", "nPercent", "grabTopN"};
+  }
 
-		@Override
-		public String str() {
-				return "topn";
-		}
+  @Override
+  public String str() {
+    return "topn";
+  }
 
-		@Override
-		public int nargs() {
-				return 1 + 4;
-		} // function name plus 4 arguments.
+  @Override
+  public int nargs() {
+    return 1 + 4;
+  } // function name plus 4 arguments.
 
-		@Override
-		public String example() {
-				return "(topn frame col nPercent getBottomN)";
-		}
+  @Override
+  public String example() {
+    return "(topn frame col nPercent getBottomN)";
+  }
 
-		@Override
-		public String description() {
-				return "Return the top N percent rows for a numerical column as a frame with two columns.  The first column " +
-												"will contain the original row indices of the chosen values.  The second column contains the top N row" +
-												"values.  If getBottomN is 1, we will return the bottom N percent.  If getBottomN is -1, we will return" +
-												"the top N percent of rows";
-		}
+  @Override
+  public String description() {
+    return "Return the top N percent rows for a numerical column as a frame with two columns.  The first column " +
+            "will contain the original row indices of the chosen values.  The second column contains the top N row" +
+            "values.  If grabTopN is -1, we will return the bottom N percent.  If grabTopN is 1, we will return" +
+            "the top N percent of rows";
+  }
 
-		@Override
-		public ValFrame apply(Env env, Env.StackHelp stk, AstRoot[] asts) { // implementation with PriorityQueue
-				Frame frOriginal = stk.track(asts[1].exec(env)).getFrame(); // get the 2nd argument and convert it to a Frame
-				int colIndex = (int) stk.track(asts[2].exec(env)).getNum();     // column index of interest
-				double nPercent = stk.track(asts[3].exec(env)).getNum();        //  top or bottom percentage of row to return
-				int getBottomN = (int) stk.track(asts[4].exec(env)).getNum();   // 0, return top, 1 return bottom percentage
-				long numRows = Math.round(nPercent * 0.01 * frOriginal.numRows()); // number of rows to return
+  @Override
+  public ValFrame apply(Env env, Env.StackHelp stk, AstRoot[] asts) { // implementation with PriorityQueue
+    Frame frOriginal = stk.track(asts[1].exec(env)).getFrame(); // get the 2nd argument and convert it to a Frame
+    int colIndex = (int) stk.track(asts[2].exec(env)).getNum();     // column index of interest
+    double nPercent = stk.track(asts[3].exec(env)).getNum();        //  top or bottom percentage of row to return
+    int grabTopN = (int) stk.track(asts[4].exec(env)).getNum();   // 0, return top, 1 return bottom percentage
+    long numRows = Math.round(nPercent * 0.01 * frOriginal.numRows()); // number of rows to return
 
-				String[] finalColumnNames = {"Original_Row_Indices", frOriginal.name(colIndex)}; // set output frame names
-				GrabTopNPQ grabTask = new GrabTopNPQ(finalColumnNames, numRows, getBottomN);
-				grabTask.doAll(frOriginal.vec(colIndex));
-				return new ValFrame(grabTask._sortedOut);
-		}
+    String[] finalColumnNames = {"Original_Row_Indices", frOriginal.name(colIndex)}; // set output frame names
+    GrabTopNPQ grabTask = new GrabTopNPQ(finalColumnNames, numRows, grabTopN, frOriginal.vec(colIndex).isInt());
+    grabTask.doAll(frOriginal.vec(colIndex));
+    return new ValFrame(grabTask._sortedOut);
+  }
 
-		public class GrabTopNPQ<E extends Comparable<E>> extends MRTask<GrabTopNPQ<E>> {
-				final String[] _columnName;   // name of column that we are grabbing top N for
-				PriorityQueue _sortQueue;
-				long[] _rowIndices;  // store original row indices of values that are grabbed
-				long[] _lValues;         // store the grabbed values
-				double[] _dValues;  // store grabbed longs
-				Frame _sortedOut;   // store the final result of sorting
-				final int _rowSize;   // number of top or bottom rows to keep
-				final int _flipSign;   // 1 for top values, -1 for bottom values
-				boolean _csLong = false;      // chunk of interest is long
+  public class GrabTopNPQ<E extends Comparable<E>> extends MRTask<GrabTopNPQ<E>> {
+    final String[] _columnName;   // name of column that we are grabbing top N for
+    PriorityQueue _sortQueue;
+    long[] _rowIndices;  // store original row indices of values that are grabbed
+    long[] _lValues;         // store the grabbed values
+    double[] _dValues;  // store grabbed longs
+    Frame _sortedOut;   // store the final result of sorting
+    final int _rowSize;   // number of top or bottom rows to keep
+    final int _flipSign;   // 1 for top values, -1 for bottom values
+    boolean _csLong = false;      // chunk of interest is long
 
-				private GrabTopNPQ(String[] columnName, long rowSize, int flipSign) {
-						_columnName = columnName;
-						_rowSize = (int) rowSize;
-						_flipSign = flipSign;
-				}
+    private GrabTopNPQ(String[] columnName, long rowSize, int flipSign, boolean isLong) {
+      _columnName = columnName;
+      _rowSize = (int) rowSize;
+      _flipSign = flipSign;
+      _csLong = isLong;
+    }
 
-				@Override
-				public void map(Chunk cs) {
-						_sortQueue = new PriorityQueue<RowValue<E>>(); // instantiate a priority queue
-						_csLong = cs instanceof C8Chunk;
-						long startRow = cs.start();           // absolute row offset
+    @Override
+    public void map(Chunk cs) {
+      _sortQueue = new PriorityQueue<RowValue<E>>(); // instantiate a priority queue
+      long startRow = cs.start();           // absolute row offset
 
-						for (int rowIndex = 0; rowIndex < cs._len; rowIndex++) {  // stuff our chunks into priorityQueue
-								long absRowIndex = rowIndex + startRow;
-								if (!cs.isNA(rowIndex)) { // skip NAN values
-										addOneValue(cs, rowIndex, absRowIndex, _sortQueue);
-								}
-						}
+      for (int rowIndex = 0; rowIndex < cs._len; rowIndex++) {  // stuff our chunks into priorityQueue
+        long absRowIndex = rowIndex + startRow;
+        if (!cs.isNA(rowIndex)) { // skip NAN values
+          addOneValue(cs, rowIndex, absRowIndex, _sortQueue);
+        }
+      }
 
-						// copy the PQ into the corresponding arrays
-						if (_csLong) {
-								_lValues = new long[_sortQueue.size()];
-								copyPQ2ArryL(_sortQueue, _lValues);
-						} else {
-								_dValues = new double[_sortQueue.size()];
-								copyPQ2ArryD(_sortQueue, _dValues);
-						}
-				}
+      // copy the PQ into the corresponding arrays
+      if (_csLong) {
+        _lValues = new long[_sortQueue.size()];
+        copyPQ2ArryL(_sortQueue, _lValues);
+      } else {
+        _dValues = new double[_sortQueue.size()];
+        copyPQ2ArryD(_sortQueue, _dValues);
+      }
+    }
 
-				public void copyPQ2ArryL(PriorityQueue sortQueue, long[] values) {
-						//copy values on PQ into arrays in sorted order
-						int qSize = sortQueue.size();
-						_rowIndices = new long[qSize];
+    public void copyPQ2ArryL(PriorityQueue sortQueue, long[] values) {
+      //copy values on PQ into arrays in sorted order
+      int qSize = sortQueue.size();
+      _rowIndices = new long[qSize];
 
-						for (int index = qSize - 1; index >= 0; index--) {
-								RowValue tempPairs = (RowValue) sortQueue.poll();
-								_rowIndices[index] = tempPairs.getRow();
-								values[index] = (long) tempPairs.getValue();
-						}
-				}
+      for (int index = qSize - 1; index >= 0; index--) {
+        RowValue tempPairs = (RowValue) sortQueue.poll();
+        _rowIndices[index] = tempPairs.getRow();
+        values[index] = (long) tempPairs.getValue();
+      }
+    }
 
-				public <T> void copyPQ2ArryD(PriorityQueue sortQueue, double[] values) {
-						//copy values on PQ into arrays in sorted order
-						int qSize = sortQueue.size();
-						_rowIndices = new long[qSize];
+    public <T> void copyPQ2ArryD(PriorityQueue sortQueue, double[] values) {
+      //copy values on PQ into arrays in sorted order
+      int qSize = sortQueue.size();
+      _rowIndices = new long[qSize];
 
-						for (int index = qSize - 1; index >= 0; index--) {
-								RowValue tempPairs = (RowValue) sortQueue.poll();
-								_rowIndices[index] = tempPairs.getRow();
-								values[index] = (double) tempPairs.getValue();
-						}
-				}
+      for (int index = qSize - 1; index >= 0; index--) {
+        RowValue tempPairs = (RowValue) sortQueue.poll();
+        _rowIndices[index] = tempPairs.getRow();
+        values[index] = (double) tempPairs.getValue();
+      }
+    }
 
-				@Override
-				public void reduce(GrabTopNPQ<E> other) {
-						// do a combine here of two arrays.  Note the value always store values that are increasing
-						if (_csLong)
-								mergeArraysL(other._rowIndices, other._lValues);
-						else
-								mergeArraysD(other._rowIndices, other._dValues);
-				}
+    @Override
+    public void reduce(GrabTopNPQ<E> other) {
+      // do a combine here of two arrays.  Note the value always store values that are increasing
+      if (_csLong)
+        mergeArraysL(other._rowIndices, other._lValues);
+      else
+        mergeArraysD(other._rowIndices, other._dValues);
+    }
 
-				public void mergeArraysL(long[] otherRow, long[] otherValue) {
-						// grab bottom and grab top are slightly different
-						int finalArraySize = min(this._rowSize, this._lValues.length + otherValue.length);
+    public void mergeArraysL(long[] otherRow, long[] otherValue) {
+      // grab bottom and grab top are slightly different
+      int finalArraySize = min(this._rowSize, this._lValues.length + otherValue.length);
 
-						long[] newRow = new long[finalArraySize];
-						long[] newValues = new long[finalArraySize]; // desired values are at start of array
-						int thisRowIndex = 0;
-						int otherRowIndex = 0;
-						for (int index = 0; index < finalArraySize; index++) {
-								if ((thisRowIndex < this._lValues.length) && (otherRowIndex < otherValue.length)) {
-										if ((this._lValues[thisRowIndex] - otherValue[otherRowIndex]) * this._flipSign >= 0) {
-												newRow[index] = this._rowIndices[thisRowIndex];
-												newValues[index] = this._lValues[thisRowIndex++];
-										} else {
-												newRow[index] = otherRow[otherRowIndex];
-												newValues[index] = otherValue[otherRowIndex++];
-										}
-								} else { // one of the array is done!
-										if (thisRowIndex < this._lValues.length) { // otherArray is done
-												newRow[index] = this._rowIndices[thisRowIndex];
-												newValues[index] = this._lValues[thisRowIndex++];
-										} else { // thisArray is done.  Use the other one
-												newRow[index] = otherRow[otherRowIndex];
-												newValues[index] = otherValue[otherRowIndex++];
-										}
-								}
-						}
-						this._rowIndices = newRow;
-						this._lValues = newValues;
-				}
+      long[] newRow = new long[finalArraySize];
+      long[] newValues = new long[finalArraySize]; // desired values are at start of array
+      int thisRowIndex = 0;
+      int otherRowIndex = 0;
+      for (int index = 0; index < finalArraySize; index++) {
+        if ((thisRowIndex < this._lValues.length) && (otherRowIndex < otherValue.length)) {
+          if ((((Long) this._lValues[thisRowIndex]).compareTo(otherValue[otherRowIndex]) * this._flipSign >= 0)) {
+            newRow[index] = this._rowIndices[thisRowIndex];
+            newValues[index] = this._lValues[thisRowIndex++];
+          } else {
+            newRow[index] = otherRow[otherRowIndex];
+            newValues[index] = otherValue[otherRowIndex++];
+          }
+        } else { // one of the array is done!
+          if (thisRowIndex < this._lValues.length) { // otherArray is done
+            newRow[index] = this._rowIndices[thisRowIndex];
+            newValues[index] = this._lValues[thisRowIndex++];
+          } else { // thisArray is done.  Use the other one
+            newRow[index] = otherRow[otherRowIndex];
+            newValues[index] = otherValue[otherRowIndex++];
+          }
+        }
+      }
+      this._rowIndices = newRow;
+      this._lValues = newValues;
+    }
 
+    public void mergeArraysD(long[] otherRow, double[] otherValue) {
+      // grab bottom and grab top are slightly different
+      int finalArraySize = min(this._rowSize, this._rowIndices.length + otherRow.length);
 
-				public void mergeArraysD(long[] otherRow, double[] otherValue) {
-						// grab bottom and grab top are slightly different
-						int finalArraySize = min(this._rowSize, this._rowIndices.length + otherRow.length);
+      long[] newRow = new long[finalArraySize];
+      double[] newValues = new double[finalArraySize]; // desired values are at start of array
+      int thisRowIndex = 0;
+      int otherRowIndex = 0;
+      for (int index = 0; index < finalArraySize; index++) {
+        if ((thisRowIndex < this._dValues.length) && (otherRowIndex < otherValue.length)) {
+          if (((Double) this._dValues[thisRowIndex]).compareTo(otherValue[otherRowIndex]) * this._flipSign >= 0) {
+            newRow[index] = this._rowIndices[thisRowIndex];
+            newValues[index] = this._dValues[thisRowIndex++];
+          } else {
+            newRow[index] = otherRow[otherRowIndex];
+            newValues[index] = otherValue[otherRowIndex++];
+          }
+        } else { // one of the array is done!
+          if (thisRowIndex < this._dValues.length) { // otherArray is done
+            newRow[index] = this._rowIndices[thisRowIndex];
+            newValues[index] = this._dValues[thisRowIndex++];
+          } else { // thisArray is done.  Use the other one
+            newRow[index] = otherRow[otherRowIndex];
+            newValues[index] = otherValue[otherRowIndex++];
+          }
+        }
+      }
+      this._rowIndices = newRow;
+      this._dValues = newValues;
+    }
 
-						long[] newRow = new long[finalArraySize];
-						double[] newValues = new double[finalArraySize]; // desired values are at start of array
-						int thisRowIndex = 0;
-						int otherRowIndex = 0;
-						for (int index = 0; index < finalArraySize; index++) {
-								if ((thisRowIndex < this._dValues.length) && (otherRowIndex < otherValue.length)) {
-										if ((this._dValues[thisRowIndex] - otherValue[otherRowIndex]) * this._flipSign >= 0) {
-												newRow[index] = this._rowIndices[thisRowIndex];
-												newValues[index] = this._dValues[thisRowIndex++];
-										} else {
-												newRow[index] = otherRow[otherRowIndex];
-												newValues[index] = otherValue[otherRowIndex++];
-										}
-								} else { // one of the array is done!
-										if (thisRowIndex < this._dValues.length) { // otherArray is done
-												newRow[index] = this._rowIndices[thisRowIndex];
-												newValues[index] = this._dValues[thisRowIndex++];
-										} else { // thisArray is done.  Use the other one
-												newRow[index] = otherRow[otherRowIndex];
-												newValues[index] = otherValue[otherRowIndex++];
-										}
-								}
-						}
-						this._rowIndices = newRow;
-						this._dValues = newValues;
-				}
+    @Override
+    public void postGlobal() {  // copy the sorted heap into a vector and make a frame out of it.
+      Vec[] xvecs = new Vec[2];   // final output frame will have two chunks, original row index, top/bottom values
+      long actualRowOutput = this._rowIndices.length; // due to NAs, may not have enough rows to return
+      for (int index = 0; index < xvecs.length; index++)
+        xvecs[index] = Vec.makeZero(actualRowOutput);
 
-				@Override
-				public void postGlobal() {  // copy the sorted heap into a vector and make a frame out of it.
-						Vec[] xvecs = new Vec[2];   // final output frame will have two chunks, original row index, top/bottom values
-						long actualRowOutput = this._rowIndices.length; // due to NAs, may not have enough rows to return
-						for (int index = 0; index < xvecs.length; index++)
-								xvecs[index] = Vec.makeZero(actualRowOutput);
+      for (int index = 0; index < actualRowOutput; index++) {
+        xvecs[0].set(index, this._rowIndices[index]);
+        xvecs[1].set(index, _csLong ? this._lValues[index] : this._dValues[index]);
+      }
+      _sortedOut = new Frame(_columnName, xvecs);
+    }
 
-						for (int index = 0; index < actualRowOutput; index++) {
-								xvecs[0].set(index, this._rowIndices[index]);
-								xvecs[1].set(index, _csLong ? this._lValues[index] : this._dValues[index]);
-						}
-						_sortedOut = new Frame(_columnName, xvecs);
-				}
+    /*
+    This function will add one value to the sorted priority queue.
+ */
+    public void addOneValue(Chunk cs, int rowIndex, long absRowIndex, PriorityQueue sortHeap) {
+      RowValue currPair = null;
+      if (_csLong) {  // long chunk
+        long a = cs.at8(rowIndex);
+        currPair = new RowValue(absRowIndex, a, _flipSign);
 
-				/*
-				This function will add one value to the sorted priority queue.
-	*/
-				public void addOneValue(Chunk cs, int rowIndex, long absRowIndex, PriorityQueue sortHeap) {
-						RowValue currPair = null;
-						if (_csLong) {  // long chunk
-								long a = cs.at8(rowIndex);
-								currPair = new RowValue(absRowIndex, a, _flipSign);
+      } else {                      // other numeric chunk
+        double a = cs.atd(rowIndex);
+        currPair = new RowValue(absRowIndex, a, _flipSign);
+      }
+      sortHeap.offer(currPair);   // add pair to PriorityQueue
+      if (sortHeap.size() > _rowSize) {
+        sortHeap.poll();      // remove head if exceeds queue size
+      }
+    }
+  }
 
-						} else {                      // other numeric chunk
-								double a = cs.atd(rowIndex);
-								currPair = new RowValue(absRowIndex, a, _flipSign);
-						}
-						sortHeap.offer(currPair);   // add pair to PriorityQueue
-						if (sortHeap.size() > _rowSize) {
-								sortHeap.poll();      // remove head if exceeds queue size
-						}
-				}
-		}
+  /*
+  Small class to implement priority entry is a key/value pair of original row index and the
+  corresponding value.  Implemented the compareTo function and comparison is performed on
+  the value.
+   */
+  public class RowValue<E extends Comparable<E>> implements Comparable<RowValue<E>> {
+    private long _rowIndex;
+    private E _value;
+    boolean _increasing;  // true if grabbing for top N, false for bottom N
+    int _flipSign;        // 1 to grab top and -1 to grab bottom
 
-		/*
-		Small class to implement priority entry is a key/value pair of original row index and the
-		corresponding value.  Implemented the compareTo function and comparison is performed on
-		the value.
-			*/
-		public class RowValue<E extends Comparable<E>> implements Comparable<RowValue<E>> {
-				private long _rowIndex;
-				private E _value;
-				boolean _increasing;  // true if grabbing for top N, false for bottom N
-				int _flipSign;        // 1 to grab top and -1 to grab bottom
+    public RowValue(long rowIndex, E value, int flipSign) {
+      this._rowIndex = rowIndex;
+      this._value = value;
+      this._flipSign = flipSign;
+    }
 
-				public RowValue(long rowIndex, E value, int flipSign) {
-						this._rowIndex = rowIndex;
-						this._value = value;
-						this._flipSign = flipSign;
-				}
+    public E getValue() {
+      return this._value;
+    }
 
-				public E getValue() {
-						return this._value;
-				}
+    public long getRow() {
+      return this._rowIndex;
+    }
 
-				public long getRow() {
-						return this._rowIndex;
-				}
-
-				@Override
-				public int compareTo(RowValue<E> other) {
-						return (this.getValue().compareTo(other.getValue()) * this._flipSign);
-				}
-		}
+    @Override
+    public int compareTo(RowValue<E> other) {
+      return (this.getValue().compareTo(other.getValue()) * this._flipSign);
+    }
+  }
 }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstTopN.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstTopN.java
@@ -1,16 +1,15 @@
 package water.rapids.ast.prims.reducers;
 
+import water.DKV;
+import water.H2O;
+import water.Key;
 import water.MRTask;
-import water.fvec.C8Chunk;
-import water.fvec.Chunk;
-import water.fvec.Frame;
-import water.fvec.Vec;
+import water.fvec.*;
 import water.rapids.Env;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
 import water.rapids.vals.ValFrame;
 
-import java.io.Serializable;
 import java.util.PriorityQueue;
 
 import static java.lang.StrictMath.min;
@@ -47,37 +46,48 @@ public class AstTopN extends AstPrimitive {
 		@Override
 		public ValFrame apply(Env env, Env.StackHelp stk, AstRoot[] asts) { // implementation with PriorityQueue
 				Frame frOriginal = stk.track(asts[1].exec(env)).getFrame(); // get the 2nd argument and convert it to a Frame
+				// break into multiple chunks if needed
+				if ((frOriginal.anyVec().nChunks() == 1) && (frOriginal.numRows() > 1000)) {
+						Key rebalancedKey = Key.make();
+						RebalanceDataSet rb = new RebalanceDataSet(frOriginal, rebalancedKey, 4);
+						H2O.submitTask(rb);
+						rb.join();
+						frOriginal = DKV.get(rebalancedKey).get();
+				}
 				int colIndex = (int) stk.track(asts[2].exec(env)).getNum();     // column index of interest
 				double nPercent = stk.track(asts[3].exec(env)).getNum();        //  top or bottom percentage of row to return
 				int getBottomN = (int) stk.track(asts[4].exec(env)).getNum();   // 0, return top, 1 return bottom percentage
-				int totColumns = frOriginal.numCols();
 				long numRows = Math.round(nPercent * 0.01 * frOriginal.numRows()); // number of rows to return
 
 				String[] finalColumnNames = {"Original_Row_Indices", frOriginal.name(colIndex)}; // set output frame names
-				GrabTopNPQ grabTask = new GrabTopNPQ(finalColumnNames, numRows, (getBottomN == 0));
+				GrabTopNPQ grabTask = new GrabTopNPQ(finalColumnNames, numRows, (getBottomN == 0 ? 1 : -1));
 				grabTask.doAll(frOriginal.vec(colIndex));
+				frOriginal.remove();
 				return new ValFrame(grabTask._sortedOut);
 		}
 
 		public class GrabTopNPQ<E extends Comparable<E>> extends MRTask<GrabTopNPQ<E>> {
 				final String[] _columnName;   // name of column that we are grabbing top N for
 				PriorityQueue _sortQueue;
+				long[] _rowIndices;  // store original row indices of values that are grabbed
+				long[] _lValues;         // store the grabbed values
+				double[] _dValues;  // store grabbed longs
 				Frame _sortedOut;   // store the final result of sorting
 				final int _rowSize;   // number of top or bottom rows to keep
-				final boolean _increasing;  // sort with Top values first if true.
+				final int _flipSign;   // 1 for top values, -1 for bottom values
 				boolean _csLong = false;      // chunk of interest is long
 
-				private GrabTopNPQ(String[] columnName, long rowSize, boolean increasing) {
+				private GrabTopNPQ(String[] columnName, long rowSize, int flipSign) {
 						_columnName = columnName;
 						_rowSize = (int) rowSize;
-						_increasing = increasing;
+						_flipSign = flipSign;
 				}
 
 				@Override
 				public void map(Chunk cs) {
 						_sortQueue = new PriorityQueue<RowValue<E>>(); // instantiate a priority queue
 						_csLong = cs instanceof C8Chunk;
-						Long startRow = cs.start();           // absolute row offset
+						long startRow = cs.start();           // absolute row offset
 
 						for (int rowIndex = 0; rowIndex < cs._len; rowIndex++) {  // stuff our chunks into priorityQueue
 								long absRowIndex = rowIndex + startRow;
@@ -85,30 +95,123 @@ public class AstTopN extends AstPrimitive {
 										addOneValue(cs, rowIndex, absRowIndex, _sortQueue);
 								}
 						}
+
+						// copy the PQ into the corresponding arrays
+						if (_csLong) {
+								_lValues = new long[_sortQueue.size()];
+								copyPQ2ArryL(_sortQueue, _lValues);
+						} else {
+								_dValues = new double[_sortQueue.size()];
+								copyPQ2ArryD(_sortQueue, _dValues);
+						}
+				}
+
+				public void copyPQ2ArryL(PriorityQueue sortQueue, long[] values) {
+						//copy values on PQ into arrays in sorted order
+						int qSize = sortQueue.size();
+						_rowIndices = new long[qSize];
+
+						for (int index = qSize - 1; index >= 0; index--) {
+								RowValue tempPairs = (RowValue) sortQueue.poll();
+								_rowIndices[index] = tempPairs.getRow();
+								values[index] = (long) tempPairs.getValue();
+						}
+				}
+
+				public <T> void copyPQ2ArryD(PriorityQueue sortQueue, double[] values) {
+						//copy values on PQ into arrays in sorted order
+						int qSize = sortQueue.size();
+						_rowIndices = new long[qSize];
+
+						for (int index = qSize - 1; index >= 0; index--) {
+								RowValue tempPairs = (RowValue) sortQueue.poll();
+								_rowIndices[index] = tempPairs.getRow();
+								values[index] = (double) tempPairs.getValue();
+						}
 				}
 
 				@Override
 				public void reduce(GrabTopNPQ<E> other) {
-						this._sortQueue.addAll(other._sortQueue);
+						// do a combine here of two arrays.  Note the value always store values that are increasing
+						if (_csLong)
+								mergeArraysL(other._rowIndices, other._lValues);
+						else
+								mergeArraysD(other._rowIndices, other._dValues);
+				}
 
-						int sizesToReduce = this._sortQueue.size() - _rowSize;
-						if (sizesToReduce > 0) {
-								for (int index = 0; index < sizesToReduce; index++)
-										this._sortQueue.poll();
+				public void mergeArraysL(long[] otherRow, long[] otherValue) {
+						// grab bottom and grab top are slightly different
+						int finalArraySize = min(this._rowSize, this._lValues.length+otherValue.length);
+
+						long[] newRow = new long[finalArraySize];
+						long[] newValues = new long[finalArraySize]; // desired values are at start of array
+						int thisRowIndex = 0;
+						int otherRowIndex = 0;
+						for (int index = 0; index < finalArraySize; index++) {
+								if ((thisRowIndex < this._lValues.length) && (otherRowIndex < otherValue.length)) {
+										if ((this._lValues[thisRowIndex] - otherValue[otherRowIndex]) * this._flipSign >= 0) {
+												newRow[index] = this._rowIndices[thisRowIndex];
+												newValues[index] = this._lValues[thisRowIndex++];
+										} else {
+												newRow[index] = otherRow[otherRowIndex];
+												newValues[index] = otherValue[otherRowIndex++];
+										}
+								} else { // one of the array is done!
+										if (thisRowIndex < this._lValues.length) { // otherArray is done
+												newRow[index] = this._rowIndices[thisRowIndex];
+												newValues[index] = this._lValues[thisRowIndex++];
+										} else { // thisArray is done.  Use the other one
+												newRow[index] = otherRow[otherRowIndex];
+												newValues[index] = otherValue[otherRowIndex++];
+										}
+								}
 						}
+						this._rowIndices = newRow;
+						this._lValues = newValues;
+				}
+
+
+				public void mergeArraysD(long[] otherRow, double[] otherValue) {
+						// grab bottom and grab top are slightly different
+						int finalArraySize = min(this._rowSize, this._rowIndices.length+otherRow.length);
+
+						long[] newRow = new long[finalArraySize];
+						double[] newValues = new double[finalArraySize]; // desired values are at start of array
+						int thisRowIndex = 0;
+						int otherRowIndex = 0;
+						for (int index = 0; index < finalArraySize; index++) {
+								if ((thisRowIndex < this._dValues.length) && (otherRowIndex < otherValue.length)) {
+										if ((this._dValues[thisRowIndex] - otherValue[otherRowIndex]) * this._flipSign >= 0) {
+												newRow[index] = this._rowIndices[thisRowIndex];
+												newValues[index] = this._dValues[thisRowIndex++];
+										} else {
+												newRow[index] = otherRow[otherRowIndex];
+												newValues[index] = otherValue[otherRowIndex++];
+										}
+								} else { // one of the array is done!
+										if (thisRowIndex < this._dValues.length) { // otherArray is done
+												newRow[index] = this._rowIndices[thisRowIndex];
+												newValues[index] = this._dValues[thisRowIndex++];
+										} else { // thisArray is done.  Use the other one
+												newRow[index] = otherRow[otherRowIndex];
+												newValues[index] = otherValue[otherRowIndex++];
+										}
+								}
+						}
+						this._rowIndices = newRow;
+						this._dValues = newValues;
 				}
 
 				@Override
 				public void postGlobal() {  // copy the sorted heap into a vector and make a frame out of it.
 						Vec[] xvecs = new Vec[2];   // final output frame will have two chunks, original row index, top/bottom values
-						long actualRowOutput = min(_rowSize, _sortQueue.size()); // due to NAs, may not have enough rows to return
+						long actualRowOutput = this._rowIndices.length; // due to NAs, may not have enough rows to return
 						for (int index = 0; index < xvecs.length; index++)
 								xvecs[index] = Vec.makeZero(actualRowOutput);
 
 						for (int index = 0; index < actualRowOutput; index++) {
-								RowValue transport = (RowValue) this._sortQueue.poll();
-								xvecs[0].set(index, transport.getRow());
-								xvecs[1].set(index, _csLong ? (Long) transport.getValue() : (Double) transport.getValue());
+								xvecs[0].set(index, this._rowIndices[index]);
+								xvecs[1].set(index, _csLong ? this._lValues[index] : this._dValues[index]);
 						}
 						_sortedOut = new Frame(_columnName, xvecs);
 				}
@@ -120,11 +223,11 @@ public class AstTopN extends AstPrimitive {
 						RowValue currPair = null;
 						if (_csLong) {  // long chunk
 								long a = cs.at8(rowIndex);
-								currPair = new RowValue(absRowIndex, a, _increasing);
+								currPair = new RowValue(absRowIndex, a, _flipSign);
 
 						} else {                      // other numeric chunk
 								double a = cs.atd(rowIndex);
-								currPair = new RowValue(absRowIndex, a, _increasing);
+								currPair = new RowValue(absRowIndex, a, _flipSign);
 						}
 						sortHeap.offer(currPair);   // add pair to PriorityQueue
 						if (sortHeap.size() > _rowSize) {
@@ -138,28 +241,29 @@ public class AstTopN extends AstPrimitive {
 		corresponding value.  Implemented the compareTo function and comparison is performed on
 		the value.
 			*/
-		public class RowValue<E extends Comparable<E>> implements Comparable<RowValue<E>>, Serializable {
-				private Long _rowIndex;
+		public class RowValue<E extends Comparable<E>> implements Comparable<RowValue<E>> {
+				private long _rowIndex;
 				private E _value;
 				boolean _increasing;  // true if grabbing for top N, false for bottom N
+				int _flipSign;        // 1 to grab top and -1 to grab bottom
 
-				public RowValue(Long rowIndex, E value, boolean increasing) {
+				public RowValue(long rowIndex, E value, int flipSign) {
 						this._rowIndex = rowIndex;
 						this._value = value;
-						this._increasing = increasing;
+						this._flipSign = flipSign;
 				}
 
 				public E getValue() {
 						return this._value;
 				}
 
-				public Long getRow() {
+				public long getRow() {
 						return this._rowIndex;
 				}
 
 				@Override
 				public int compareTo(RowValue<E> other) {
-						return (this.getValue().compareTo(other.getValue()) * (this._increasing ? 1 : -1));
+						return (this.getValue().compareTo(other.getValue()) * this._flipSign);
 				}
 		}
 }

--- a/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstTopNTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstTopNTest.java
@@ -20,119 +20,119 @@ import java.util.Random;
 import static org.junit.Assert.assertTrue;
 
 /**
-	* Test the AstTopN.java class
-	*/
+ * Test the AstTopN.java class
+ */
 public class AstTopNTest extends TestUtil {
-		static Frame _train;    // store training data
-		double _tolerance = 1e-12;
-		public Random _rand = new Random();
+  static Frame _train;    // store training data
+  double _tolerance = 1e-12;
+  public Random _rand = new Random();
 
-		@BeforeClass
-		public static void setup() {   // randomly generate a frame here.
-				stall_till_cloudsize(1);
-		}
+  @BeforeClass
+  public static void setup() {   // randomly generate a frame here.
+    stall_till_cloudsize(1);
+  }
 
-		//--------------------------------------------------------------------------------------------------------------------
-		// Tests
-		//--------------------------------------------------------------------------------------------------------------------
+  //--------------------------------------------------------------------------------------------------------------------
+  // Tests
+  //--------------------------------------------------------------------------------------------------------------------
 
-		/**
-			* Loading in a dataset containing data from -1000000 to 1000000 multiplied by 1.1 as the float column in column 1.
-			* The other column (column 0) is a long data type with maximum data value at 2^63.
-			*/
-		@Test
-		public void TestTopBottomN() {
-				Scope.enter();
-				double[] checkPercent = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}; //, 11, 12, 13, 14, 15, 17, 19}; // complete test
-				int numRuns = 1;
-				double testPercent = 0;      // store test percentage
-				Frame topLong = null, topFloat = null, bottomLong = null, bottomFloat = null;
+  /**
+   * Loading in a dataset containing data from -1000000 to 1000000 multiplied by 1.1 as the float column in column 1.
+   * The other column (column 0) is a long data type with maximum data value at 2^63.
+   */
+  @Test
+  public void TestTopBottomN() {
+    Scope.enter();
+    double[] checkPercent = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}; //, 11, 12, 13, 14, 15, 17, 19}; // complete test
+    int numRuns = 1;
+    double testPercent = 0;      // store test percentage
+    Frame topLong = null, topFloat = null, bottomLong = null, bottomFloat = null;
 
-				// load in the datasets with the answers
-				_train = parse_test_file(Key.make("topbottom"), "smalldata/jira/TopBottomN.csv.zip");
-				topFloat = parse_test_file(Key.make("top20"), "smalldata/jira/Top20Per.csv.zip");
-				topLong = topFloat.extractFrame(0, 1);
-				bottomFloat = parse_test_file(Key.make("bottom20"), "smalldata/jira/Bottom20Per.csv.zip");
-				bottomLong = bottomFloat.extractFrame(0, 1);
+    // load in the datasets with the answers
+    _train = parse_test_file(Key.make("topbottom"), "smalldata/jira/TopBottomN.csv.zip");
+    topFloat = parse_test_file(Key.make("top20"), "smalldata/jira/Top20Per.csv.zip");
+    topLong = topFloat.extractFrame(0, 1);
+    bottomFloat = parse_test_file(Key.make("bottom20"), "smalldata/jira/Bottom20Per.csv.zip");
+    bottomLong = bottomFloat.extractFrame(0, 1);
 
-				Scope.track(_train);
-				Scope.track(topLong);
-				Scope.track(topFloat);
-				Scope.track(bottomFloat);
-				Scope.track(bottomLong);
+    Scope.track(_train);
+    Scope.track(topLong);
+    Scope.track(topFloat);
+    Scope.track(bottomFloat);
+    Scope.track(bottomLong);
 
-				try {
-						for (int index = 0; index < numRuns; index++) { // randomly choose 4 percentages to test
-								testPercent = checkPercent[_rand.nextInt(checkPercent.length)];
-								int testNo = _rand.nextInt(4);
-								Log.info("Percentage is " + testPercent);
-								if (testNo == 0) {
-										Log.info("Testing top N long.");
-										testTopBottom(topLong, testPercent, -1, "0", _tolerance);
-								}
-								if (testNo == 1) {
-										Log.info("Testing top N float.");
-										testTopBottom(topFloat, testPercent, -1, "1", _tolerance);  // test top % Float
-								}
-								if (testNo == 2) {
-										Log.info("Testing bottom N long.");
-										testTopBottom(bottomLong, testPercent, 1, "0", _tolerance);  // test bottom % Long
-								}
-								if (testNo == 3) {
-										Log.info("Testing bottom N float.");
-										testTopBottom(bottomFloat, testPercent, 1, "1", _tolerance);  // test bottom % Float
-								}
-						}
-				} finally {
-						Scope.exit();
-				}
-		}
+    try {
+      for (int index = 0; index < numRuns; index++) { // randomly choose 4 percentages to test
+        testPercent = checkPercent[_rand.nextInt(checkPercent.length)];
+        int testNo = _rand.nextInt(4);
+        Log.info("Percentage is " + testPercent);
+        if (testNo == 0) {
+          Log.info("Testing top N long.");
+          testTopBottom(topLong, testPercent, 1, "0", _tolerance);
+        }
+        if (testNo == 1) {
+          Log.info("Testing top N float.");
+          testTopBottom(topFloat, testPercent, 1, "1", _tolerance);  // test top % Float
+        }
+        if (testNo == 2) {
+          Log.info("Testing bottom N long.");
+          testTopBottom(bottomLong, testPercent, -1, "0", _tolerance);  // test bottom % Long
+        }
+        if (testNo == 3) {
+          Log.info("Testing bottom N float.");
+          testTopBottom(bottomFloat, testPercent, -1, "1", _tolerance);  // test bottom % Float
+        }
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
 
-		public void testTopBottom(Frame topBottom, double testPercent, int getBottom, String columnIndex,
-																												double tolerance) {
-				Scope.enter();
-				Frame topBN = null, topBL = null;
-				try {
-						long runTime = System.currentTimeMillis();
-						String x = "(topn " + _train._key + " " + columnIndex + " " + testPercent + " " + getBottom + ")";
-						Val res = Rapids.exec(x);         // make the call to grab top/bottom N percent
-						topBN = res.getFrame();            // get frame that contains top N elements
-						runTime = System.currentTimeMillis() - runTime;
-						Log.info("run time in ms is " + runTime);
-						Scope.track(topBN);
-						topBL = topBN.extractFrame(1, 2);
-						Scope.track(topBL);
-						checkTopBottomN(topBottom, topBL, tolerance, getBottom);
-				} finally {
-						Scope.exit();
-				}
-		}
+  public void testTopBottom(Frame topBottom, double testPercent, int grabTopN, String columnIndex,
+                            double tolerance) {
+    Scope.enter();
+    Frame topBN = null, topBL = null;
+    try {
+      long runTime = System.currentTimeMillis();
+      String x = "(topn " + _train._key + " " + columnIndex + " " + testPercent + " " + grabTopN + ")";
+      Val res = Rapids.exec(x);         // make the call to grab top/bottom N percent
+      topBN = res.getFrame();            // get frame that contains top N elements
+      runTime = System.currentTimeMillis() - runTime;
+      Log.info("run time in ms is " + runTime);
+      Scope.track(topBN);
+      topBL = topBN.extractFrame(1, 2);
+      Scope.track(topBL);
+      checkTopBottomN(topBottom, topBL, tolerance, grabTopN);
+    } finally {
+      Scope.exit();
+    }
+  }
 
-		/*
-		Helper function to compare test frame result with correct answer
-			*/
-		public void checkTopBottomN(Frame answerF, Frame grabF, double tolerance, int getBottom) {
-				Scope.enter();
-				try {
-						double nfrac = (getBottom > 0) ? 1.0 * grabF.numRows() / answerF.numRows() : (1 - 1.0 * grabF.numRows() / answerF.numRows());   // translate percentage to actual fraction
+  /*
+  Helper function to compare test frame result with correct answer
+   */
+  public void checkTopBottomN(Frame answerF, Frame grabF, double tolerance, int grabTopN) {
+    Scope.enter();
+    try {
+      double nfrac = (grabTopN < 0) ? 1.0 * grabF.numRows() / answerF.numRows() : (1 - 1.0 * grabF.numRows() / answerF.numRows());   // translate percentage to actual fraction
 
-						SplitFrame sf = new SplitFrame(answerF, new double[]{nfrac, 1 - nfrac}, new Key[]{Key.make("topN.hex"), Key.make("bottomN.hex")});
-						// Invoke the job
-						sf.exec().get();
-						Key[] ksplits = sf._destination_frames;
-						Frame topN = (Frame) ((getBottom > 0) ? DKV.get(ksplits[0]).get() : DKV.get(ksplits[1]).get());
-						double[] bottomN = FrameUtils.asDoubles(grabF.vec(0));
-						Arrays.sort(bottomN);
-						Frame sortedF = new water.util.ArrayUtils().frame(bottomN);
-						Scope.track(sortedF);
-						Frame sortedFT = DMatrix.transpose(sortedF);
-						Scope.track(sortedFT);
-						assertTrue(isIdenticalUpToRelTolerance(topN, sortedFT, tolerance));
-						Scope.track(topN);
-						Scope.track_generic(ksplits[0].get());
-						Scope.track_generic(ksplits[1].get());
-				} finally {
-						Scope.exit();
-				}
-		}
+      SplitFrame sf = new SplitFrame(answerF, new double[]{nfrac, 1 - nfrac}, new Key[]{Key.make("topN.hex"), Key.make("bottomN.hex")});
+      // Invoke the job
+      sf.exec().get();
+      Key[] ksplits = sf._destination_frames;
+      Frame topN = (Frame) ((grabTopN < 0) ? DKV.get(ksplits[0]).get() : DKV.get(ksplits[1]).get());
+      double[] bottomN = FrameUtils.asDoubles(grabF.vec(0));
+      Arrays.sort(bottomN);
+      Frame sortedF = new water.util.ArrayUtils().frame(bottomN);
+      Scope.track(sortedF);
+      Frame sortedFT = DMatrix.transpose(sortedF);
+      Scope.track(sortedFT);
+      assertTrue(isIdenticalUpToRelTolerance(topN, sortedFT, tolerance));
+      Scope.track(topN);
+      Scope.track_generic(ksplits[0].get());
+      Scope.track_generic(ksplits[1].get());
+    } finally {
+      Scope.exit();
+    }
+  }
 }

--- a/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstTopNTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstTopNTest.java
@@ -68,11 +68,11 @@ public class AstTopNTest extends TestUtil {
 								Log.info("Percentage is " + testPercent);
 								if (testNo == 0) {
 										Log.info("Testing top N long.");
-										testTopBottom(topLong, testPercent, 0, "0", _tolerance);
+										testTopBottom(topLong, testPercent, -1, "0", _tolerance);
 								}
 								if (testNo == 1) {
 										Log.info("Testing top N float.");
-										testTopBottom(topFloat, testPercent, 0, "1", _tolerance);  // test top % Float
+										testTopBottom(topFloat, testPercent, -1, "1", _tolerance);  // test top % Float
 								}
 								if (testNo == 2) {
 										Log.info("Testing bottom N long.");

--- a/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstTopNTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/reducers/AstTopNTest.java
@@ -66,19 +66,19 @@ public class AstTopNTest extends TestUtil {
 								testPercent = checkPercent[_rand.nextInt(checkPercent.length)];
 								int testNo = _rand.nextInt(4);
 								Log.info("Percentage is " + testPercent);
-								if (testNo==0) {
+								if (testNo == 0) {
 										Log.info("Testing top N long.");
 										testTopBottom(topLong, testPercent, 0, "0", _tolerance);
 								}
-								if (testNo==1) {
+								if (testNo == 1) {
 										Log.info("Testing top N float.");
 										testTopBottom(topFloat, testPercent, 0, "1", _tolerance);  // test top % Float
 								}
-								if (testNo==2) {
+								if (testNo == 2) {
 										Log.info("Testing bottom N long.");
 										testTopBottom(bottomLong, testPercent, 1, "0", _tolerance);  // test bottom % Long
 								}
-								if (testNo==3) {
+								if (testNo == 3) {
 										Log.info("Testing bottom N float.");
 										testTopBottom(bottomFloat, testPercent, 1, "1", _tolerance);  // test bottom % Float
 								}
@@ -116,8 +116,7 @@ public class AstTopNTest extends TestUtil {
 				try {
 						double nfrac = (getBottom > 0) ? 1.0 * grabF.numRows() / answerF.numRows() : (1 - 1.0 * grabF.numRows() / answerF.numRows());   // translate percentage to actual fraction
 
-						SplitFrame sf = new SplitFrame(answerF, new double[]{nfrac, 1 - nfrac}, new Key[]{
-														Key.make("topN.hex"), Key.make("bottomN.hex")});
+						SplitFrame sf = new SplitFrame(answerF, new double[]{nfrac, 1 - nfrac}, new Key[]{Key.make("topN.hex"), Key.make("bottomN.hex")});
 						// Invoke the job
 						sf.exec().get();
 						Key[] ksplits = sf._destination_frames;

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2509,14 +2509,14 @@ class H2OFrame(object):
             raise H2OValueError("'index' argument is not type enum, time or int")
         return H2OFrame._expr(expr=ExprNode("pivot",self,index,column,value))
 
-    def topNBottomN(self, column=0, nPercent=10, getBottom=0):
+    def topNBottomN(self, column=0, nPercent=10, getBottom=-1):
         """
         Given a column name or one column index, a percent N, this function will return the top or bottom N% of the
          values of the column of a frame.  The column must be a numerical column.
     
         :param column: a string for column name or an integer index
         :param nPercent: a top or bottom percentage of the column values to return
-        :param getBottom: 0 to grab top N percent and 1 to grab bottom N percent
+        :param getBottom: -1 to grab top N percent and 1 to grab bottom N percent
         :returns: a H2OFrame containing two columns.  The first column contains the original row indices where
             the top/bottom values are extracted from.  The second column contains the values.
         """
@@ -2550,7 +2550,7 @@ class H2OFrame(object):
         :returns: a H2OFrame containing two columns.  The first column contains the original row indices where
             the top values are extracted from.  The second column contains the top nPercent values.
         """
-        return self.topNBottomN(column, nPercent, 0)
+        return self.topNBottomN(column, nPercent, -1)
 
     def bottomN(self, column=0, nPercent=10):
         """

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2509,14 +2509,14 @@ class H2OFrame(object):
             raise H2OValueError("'index' argument is not type enum, time or int")
         return H2OFrame._expr(expr=ExprNode("pivot",self,index,column,value))
 
-    def topNBottomN(self, column=0, nPercent=10, getBottom=-1):
+    def topNBottomN(self, column=0, nPercent=10, grabTopN=-1):
         """
         Given a column name or one column index, a percent N, this function will return the top or bottom N% of the
          values of the column of a frame.  The column must be a numerical column.
     
         :param column: a string for column name or an integer index
         :param nPercent: a top or bottom percentage of the column values to return
-        :param getBottom: -1 to grab top N percent and 1 to grab bottom N percent
+        :param grabTopN: -1 to grab bottom N percent and 1 to grab top N percent
         :returns: a H2OFrame containing two columns.  The first column contains the original row indices where
             the top/bottom values are extracted from.  The second column contains the values.
         """
@@ -2538,7 +2538,7 @@ class H2OFrame(object):
         if not(self[colIndex].isnumeric()):
             raise H2OValueError("Wrong column type!  Selected column must be numeric.")
 
-        return H2OFrame._expr(expr=ExprNode("topn",self,colIndex, nPercent, getBottom))
+        return H2OFrame._expr(expr=ExprNode("topn", self, colIndex, nPercent, grabTopN))
 
     def topN(self, column=0, nPercent=10):
         """
@@ -2550,7 +2550,7 @@ class H2OFrame(object):
         :returns: a H2OFrame containing two columns.  The first column contains the original row indices where
             the top values are extracted from.  The second column contains the top nPercent values.
         """
-        return self.topNBottomN(column, nPercent, -1)
+        return self.topNBottomN(column, nPercent, 1)
 
     def bottomN(self, column=0, nPercent=10):
         """
@@ -2562,7 +2562,7 @@ class H2OFrame(object):
         :returns: a H2OFrame containing two columns.  The first column contains the original row indices where
             the bottom values are extracted from.  The second column contains the bottom nPercent values.
         """
-        return self.topNBottomN(column, nPercent, 1)
+        return self.topNBottomN(column, nPercent, -1)
 
     def sub(self, pattern, replacement, ignore_case=False):
         """

--- a/h2o-py/tests/testdir_munging/pyunit_top_bottomN_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_top_bottomN_large.py
@@ -34,7 +34,7 @@ def h2o_H2OFrame_top_bottomN():
         pyunit_utils.compare_frames(newTopFrame, newTopFrameC, nsample, tol_numeric=tolerance)
 
         # compare one of the return frames with known answer
-        compare_rep_frames(topAnswer, newTopFrame, tolerance, colIndex, -1)
+        compare_rep_frames(topAnswer, newTopFrame, tolerance, colIndex, 1)
     else:
         # test bottomN here
         print("For bottomN: Percentage chosen is {0}.  Column index chosen is {1}".format(nP, colIndex))
@@ -44,14 +44,14 @@ def h2o_H2OFrame_top_bottomN():
         # the two return frames should be the same for this case
         pyunit_utils.compare_frames(newBottomFrame, newBottomFrameC, nsample, tol_numeric=tolerance)
         # compare one of the return frames with known answer
-        compare_rep_frames(bottomAnswer, newBottomFrame, tolerance, colIndex, 1)
+        compare_rep_frames(bottomAnswer, newBottomFrame, tolerance, colIndex, -1)
 
 
-def compare_rep_frames(answerF, repFrame, tolerance,  colIndex, getBottom=-1):
+def compare_rep_frames(answerF, repFrame, tolerance, colIndex, grabTopN=-1):
     # actual answer is in second column of repFrame
     highIndex = int(round(repFrame.nrow/4))
     allIndex = range(answerF.nrow-highIndex, answerF.nrow)
-    if getBottom>0:     # get bottom N percent
+    if grabTopN<0:     # get bottom N percent
         allIndex = range(0, highIndex)
     repIndex = 0
     answerArray = np.transpose(answerF[colIndex].as_data_frame(header=False).values)[0]

--- a/h2o-py/tests/testdir_munging/pyunit_top_bottomN_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_top_bottomN_large.py
@@ -34,7 +34,7 @@ def h2o_H2OFrame_top_bottomN():
         pyunit_utils.compare_frames(newTopFrame, newTopFrameC, nsample, tol_numeric=tolerance)
 
         # compare one of the return frames with known answer
-        compare_rep_frames(topAnswer, newTopFrame, tolerance, colIndex, 0)
+        compare_rep_frames(topAnswer, newTopFrame, tolerance, colIndex, -1)
     else:
         # test bottomN here
         print("For bottomN: Percentage chosen is {0}.  Column index chosen is {1}".format(nP, colIndex))
@@ -47,7 +47,7 @@ def h2o_H2OFrame_top_bottomN():
         compare_rep_frames(bottomAnswer, newBottomFrame, tolerance, colIndex, 1)
 
 
-def compare_rep_frames(answerF, repFrame, tolerance,  colIndex, getBottom=0):
+def compare_rep_frames(answerF, repFrame, tolerance,  colIndex, getBottom=-1):
     # actual answer is in second column of repFrame
     highIndex = int(round(repFrame.nrow/4))
     allIndex = range(answerF.nrow-highIndex, answerF.nrow)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1138,9 +1138,9 @@ h2o.pivot <- function(x, index, column, value){
 # @param x an H2OFrame
 # @param column is a column name or column index to grab the top N percent value from
 # @param nPercent a top percentage values to grab
-# @param getBottom if -1 grab top percentage, 1 grab bottom percentage
+# @param grabTopN if -1 grab bottom percentage, 1 grab top percentage
 # @return An H2OFrame with 2 columns: first column is the original row indices, second column contains the values
-h2o.topBottomN <- function(x, column, nPercent, getBottom){
+h2o.topBottomN <- function(x, column, nPercent, grabTopN){
   cnames = names(x)
   colIndex=0
   if (typeof(column)=="character") {  # verify column
@@ -1157,7 +1157,7 @@ h2o.topBottomN <- function(x, column, nPercent, getBottom){
   if (nPercent*0.01*nrow(x) < 1) stop("Increase nPercent.  Current value will result in top 0 row.")
   if (!h2o.isnumeric(x[colIndex+1])) stop("Wrong column type!  Selected column must be numeric.")
 
-  .newExpr("topn", x, colIndex, nPercent,getBottom)
+  .newExpr("topn", x, colIndex, nPercent,grabTopN)
 }
 
 #' H2O topN
@@ -1170,7 +1170,7 @@ h2o.topBottomN <- function(x, column, nPercent, getBottom){
 #' @return An H2OFrame with 2 columns.  The first column is the original row indices, second column contains the topN values
 #' @export
 h2o.topN <- function(x, column, nPercent) {
-  h2o.topBottomN(x, column, nPercent, -1)
+  h2o.topBottomN(x, column, nPercent, 1)
 }
 #' H2O bottomN
 #'
@@ -1183,7 +1183,7 @@ h2o.topN <- function(x, column, nPercent) {
 #' @return An H2OFrame with 2 columns.  The first column is the original row indices, second column contains the bottomN values
 #' @export
 h2o.bottomN <- function(x, column, nPercent) {
-  h2o.topBottomN(x, column, nPercent, 1)
+  h2o.topBottomN(x, column, nPercent, -1)
 }
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1138,7 +1138,7 @@ h2o.pivot <- function(x, index, column, value){
 # @param x an H2OFrame
 # @param column is a column name or column index to grab the top N percent value from
 # @param nPercent a top percentage values to grab
-# @param getBottom if 0 grab top percentage, 1 grab bottom percentage
+# @param getBottom if -1 grab top percentage, 1 grab bottom percentage
 # @return An H2OFrame with 2 columns: first column is the original row indices, second column contains the values
 h2o.topBottomN <- function(x, column, nPercent, getBottom){
   cnames = names(x)
@@ -1170,7 +1170,7 @@ h2o.topBottomN <- function(x, column, nPercent, getBottom){
 #' @return An H2OFrame with 2 columns.  The first column is the original row indices, second column contains the topN values
 #' @export
 h2o.topN <- function(x, column, nPercent) {
-  h2o.topBottomN(x, column, nPercent, 0)
+  h2o.topBottomN(x, column, nPercent, -1)
 }
 #' H2O bottomN
 #'

--- a/h2o-r/tests/testdir_munging/runit_topN_bottomN_large.R
+++ b/h2o-r/tests/testdir_munging/runit_topN_bottomN_large.R
@@ -24,7 +24,7 @@ test.topNbottomN = function() {
 
         # result from column name and column index should be the same
         h2o_and_R_equal(topNf, topNfI)
-        compare_rep_frames(topAnswer, topNf, tolerance, colIndex, -1)
+        compare_rep_frames(topAnswer, topNf, tolerance, colIndex, 1)
     } else {
         # test bottomN with randomly chosen N percent, and with column names and column index
         print(paste("test bottomN: nPercent is", nP, " Column index is ", colIndex))
@@ -32,18 +32,18 @@ test.topNbottomN = function() {
         bottomNfI = h2o.bottomN(dataset, colIndex, nP)              # call with column index
         # result from column name and column index should be the same
         h2o_and_R_equal(bottomNf, bottomNfI)
-        compare_rep_frames(bottomAnswer, bottomNfI, tolerance, colIndex, 1)
+        compare_rep_frames(bottomAnswer, bottomNfI, tolerance, colIndex, -1)
     }
 }
 
-compare_rep_frames = function(answerFrame, actualFrame, tolerance, colIndex, getBottom) {
+compare_rep_frames = function(answerFrame, actualFrame, tolerance, colIndex, grabTopN) {
     answerA = sort(data.matrix(as.data.frame(answerFrame)[colIndex]))
     actualA = sort(data.matrix(as.data.frame(actualFrame)[2]))
     highIndex = nrow(answerFrame)
     distinctValNum = nrow(actualFrame) / 4
     allIndex = c((highIndex - distinctValNum + 1) : highIndex)
     repIndex = 1
-    if (getBottom > 0) {
+    if (grabTopN < 0) {
         allIndex = c(1 : distinctValNum)
     }
     for (index in allIndex) {

--- a/h2o-r/tests/testdir_munging/runit_topN_bottomN_large.R
+++ b/h2o-r/tests/testdir_munging/runit_topN_bottomN_large.R
@@ -24,7 +24,7 @@ test.topNbottomN = function() {
 
         # result from column name and column index should be the same
         h2o_and_R_equal(topNf, topNfI)
-        compare_rep_frames(topAnswer, topNf, tolerance, colIndex, 0)
+        compare_rep_frames(topAnswer, topNf, tolerance, colIndex, -1)
     } else {
         # test bottomN with randomly chosen N percent, and with column names and column index
         print(paste("test bottomN: nPercent is", nP, " Column index is ", colIndex))


### PR DESCRIPTION
Speed up top/bottom N operation by:
- dataset rebalance;
- use arrays that are Iced automatically per suggestion from Michal Kurba
- minor speed up.

Questions to reviewers:
- cannot use Generic arrays and therefore end up writing separate functions for double and long.
- generic arrays will not allow primitive long and double.
- however, will encounter error if use arrays of Long and Double class.
- let me know if you know how to get around this.

Performance comparison of this PR and master are being conducted on personal jenkins.  Will share data once I have the results.