### PR TITLE
Pubdev 4456 rf weights problem

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/drf/DRF.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRF.java
@@ -1,7 +1,7 @@
 package hex.tree.drf;
 
-import hex.genmodel.utils.DistributionFamily;
 import hex.ModelCategory;
+import hex.genmodel.utils.DistributionFamily;
 import hex.tree.*;
 import hex.tree.DTree.DecidedNode;
 import hex.tree.DTree.LeafNode;
@@ -12,6 +12,7 @@ import water.MRTask;
 import water.fvec.C0DChunk;
 import water.fvec.Chunk;
 import water.fvec.Frame;
+
 import java.util.Random;
 
 import static hex.genmodel.GenModel.getPrediction;
@@ -23,7 +24,8 @@ import static hex.tree.drf.TreeMeasuresCollector.asVotes;
  *  Based on "Elements of Statistical Learning, Second Edition, page 387"
  */
 public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel.DRFParameters, hex.tree.drf.DRFModel.DRFOutput> {
-
+  private static final double ONEBOUND=1+1e-12;    // due to fixed precision
+  private static final double ZEROBOUND=-1e-12;    // due to fixed precision
   @Override public ModelCategory[] can_build() {
     return new ModelCategory[]{
       ModelCategory.Regression,
@@ -327,6 +329,10 @@ public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel
     }
     else if (_nclass==2 && _model.binomialOpt()) {
       fs[1] = weight * chk_tree(chks, 0).atd(row) / chk_oobt(chks).atd(row);
+      if (fs[1]>1 && fs[1]<=ONEBOUND)
+        fs[1] = 1.0;
+      else if (fs[1]<0 && fs[1]>=ZEROBOUND)
+        fs[1] = 0.0;
       assert(fs[1] >= 0 && fs[1] <= 1);
       fs[2] = 1. - fs[1];
     }

--- a/h2o-core/src/main/java/water/util/MathUtils.java
+++ b/h2o-core/src/main/java/water/util/MathUtils.java
@@ -16,7 +16,6 @@ import water.fvec.Vec;
 import java.util.Arrays;
 
 public class MathUtils {
-
   public static double weightedSigma(long nobs, double wsum, double xSum, double xxSum) {
     double reg = 1.0/wsum;
     return nobs <= 1? 0 : Math.sqrt(xxSum*reg - (xSum*xSum) * reg * reg);

--- a/h2o-py/tests/testdir_algos/rf/pyunit_PUBDEV_4456_airline_weights_large.py
+++ b/h2o-py/tests/testdir_algos/rf/pyunit_PUBDEV_4456_airline_weights_large.py
@@ -1,0 +1,35 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+
+# This test does not have an assert at the end and it is an okay.  In PUBDEV-4456, Nidhi noticed that when
+# we have a weight column, this test will fail.  This is caused by the assertion error of fs[1]>=0 && fs[1]>=1.
+# This failure manisfested as: When fs[1] is 1, it is read back as 1.0000000000000002. To get around this error,
+# I just added a tolerance at the end of the bound and changed the assertion to:
+#     assert(fs[1]>=-1e-12 && fs[1] <= 1+1e-12.
+# This solves the problem for now.
+#
+# I filed a JIRA PUBDEV-4142 to tackle this problem.  Once this JIRA is completed, I will go in and remove the hack that
+# I put in.
+
+def test_data_with_weights():
+
+  train  = h2o.upload_file(pyunit_utils.locate("smalldata/airlines/modified_airlines.csv"))
+  splits = train.split_frame(ratios=[0.7])
+  train = splits[0]
+  test = splits[1]
+
+  hh1 = H2ORandomForestEstimator(ntrees=1000, seed=1234, score_tree_interval=10, stopping_rounds=20,
+                                 stopping_metric="AUC", stopping_tolerance=0.001, max_runtime_secs=20*60)
+
+
+  hh1.train(x=list(range(10)), y=30, training_frame=train, validation_frame=test, weights_column="weight")
+
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_data_with_weights)
+else:
+  test_data_with_weights()

--- a/h2o-r/tests/testdir_algos/randomforest/runit_PUBDEV_4456_airline_weights_large.R
+++ b/h2o-r/tests/testdir_algos/randomforest/runit_PUBDEV_4456_airline_weights_large.R
@@ -1,0 +1,32 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# This test does not have an assert at the end and it is an okay.  In PUBDEV-4456, Nidhi noticed that when
+# we have a weight column, this test will fail.  This is caused by the assertion error of fs[1]>=0 && fs[1]>=1.
+# This failure manisfested as: When fs[1] is 1, it is read back as 1.0000000000000002. To get around this error,
+# I just added a tolerance at the end of the bound and changed the assertion to:
+#     assert(fs[1]>=-1e-12 && fs[1] <= 1+1e-12.
+# This solves the problem for now.
+#
+# I filed a JIRA PUBDEV-4142 to tackle this problem.  Once this JIRA is completed, I will go in and remove the hack that
+# I put in.
+
+test.rf.dataset.weights<- function() {
+  data1 = h2o.importFile(locate("smalldata/airlines/modified_airlines.csv"))
+  ss = h2o.splitFrame(data1,ratios = c(.7),destination_frames = c("tr","va"),seed = 1)
+
+  rfFit.h2o <- h2o.randomForest(x=1:10,
+  y=31,
+  ntrees = 1000,
+  training_frame=ss[[1]],
+  validation_frame=ss[[2]],
+  seed = 12345,
+  weights_column = "weight", # If weighting applies, include it in training frame and validation frame
+  score_tree_interval = 10,
+  stopping_rounds = 20,
+  stopping_metric = "AUC",
+  stopping_tolerance = 0.001,
+  max_runtime_secs = 20*60)
+}
+
+doTest("rf: dataset with weights", test.rf.dataset.weights)


### PR DESCRIPTION
PUBDEV-4142 causes a numerical issue:

When fs[1] is 1, it is read back as 1.0000000000000002. To get around this error, I just added a tolerance at the end of the bound and changed the assertion to:
                      assert(fs[1]>=-1e-12 && fs[1] <= 1+1e-12. 
This solves the problem for now.

Added Runit/Pyunit tests to check and make sure the current hack is working.