### PR TITLE
Pubdev 4438 one off error

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/params/AstNumList.java
+++ b/h2o-core/src/main/java/water/rapids/ast/params/AstNumList.java
@@ -241,7 +241,7 @@ public class AstNumList extends AstParameter {
    */
   public long index(long v) {
     int bIdx = findBase(v);
-    if (bIdx >= 0) return water.util.ArrayUtils.sum(_cnts, 0, bIdx - 1);
+    if (bIdx >= 0) return water.util.ArrayUtils.sum(_cnts, 0, bIdx);
     bIdx = -bIdx - 2;
     if (bIdx < 0) return -1L;
     assert _bases[bIdx] < v;

--- a/h2o-core/src/test/java/water/rapids/RapidsTest.java
+++ b/h2o-core/src/test/java/water/rapids/RapidsTest.java
@@ -19,6 +19,7 @@ import water.util.Log;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Random;
 
 import static org.junit.Assert.*;
 import static water.rapids.Rapids.IllegalASTException;
@@ -435,6 +436,33 @@ public class RapidsTest extends TestUtil {
       }
     }
     return true;
+  }
+
+  /*
+  This test will generate a random sorted array and test only the index method of AstNumList.java. It will check
+  and make sure every index of the array is returned correctly by the index method.
+   */
+  @Test public void testAstNumListIndex() {
+    Random rand = new Random();
+    int numElement = 2000;
+    int[] array2H2O = new int[numElement];  // store sorted integer array
+    int arrayVal = rand.nextInt(Integer.SIZE-1);
+
+    for (int val = 0; val < numElement; val++) {
+      int randValue = rand.nextInt(100);
+      arrayVal += randValue;
+      if (randValue==0)   // avoid duplicated elements
+        arrayVal++;
+      array2H2O[val]=Math.abs(arrayVal);
+    }
+    AstNumList h2oArray = new AstNumList(array2H2O);
+    h2oArray._isSort=true;  // array is sorted
+    // check to make sure indext returned by method index is correct
+    for (int index=0; index < numElement; index++) {
+      int val = array2H2O[index];
+      int h2oIndex = (int) h2oArray.index(val);
+      assertEquals(index, h2oIndex);
+    }
   }
 
   @Test public void testRowSlice() {

--- a/h2o-r/tests/testdir_jira/runit_PUBDEV_4438_one_off.R
+++ b/h2o-r/tests/testdir_jira/runit_PUBDEV_4438_one_off.R
@@ -1,0 +1,20 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+#----------------------------------------------------------------------
+# Purpose:  This test to make sure we fixed the off-by-one bug in
+# PUBDEV-4438 is fixed.
+#----------------------------------------------------------------------
+
+test <- function() {
+  tolerance=1e-12
+  data(iris)
+  iris<-rbind(iris,iris,iris,iris,iris,iris,iris,iris,iris,iris,iris,iris,iris,iris,iris,iris)
+  iris_h2o<-as.h2o(iris)
+  expect_true(abs(iris[2,1]-iris_h2o[2,1]) < tolerance)
+
+  # assignment and things changed a bit, first column, second row of Sepal.Length changes from 4.9 to 5.1
+  iris_h2o[c(1:1001),"Sepal.Length"]<-iris_h2o[c(1:1001),"Sepal.Length"]
+  expect_true(abs(iris[2,1]-iris_h2o[2,1]) < tolerance)
+}
+
+doTest("Off_by_one_error", test)


### PR DESCRIPTION
Two things:

1. Fixed index problem in method index of AstNumList.java.  Given a list of [0,1,2,3, ...], the returned index for 0 and 1 are both 0 and the return index of 2 or more is one less that it should be.  Easy fix: changed 
                     if (bIdx >= 0) return water.util.ArrayUtils.sum(_cnts, 0, bIdx - 1);
TO
                     if (bIdx >= 0) return water.util.ArrayUtils.sum(_cnts, 0, bIdx );

2. Add Runit test to make sure the assignment error is gone. 

-------------------------
The reason that you only see this problem if you have more than 1000 elements is because for data with less than 1001 elements, different function calls are made!