### PR TITLE
PUBDEV-4579: Updates to booklets

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/DeepWaterBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/DeepWaterBooklet.tex
@@ -466,7 +466,6 @@ localhost:55000/makewar > example.war
 At the time of this writing, we have many exciting upcoming releases and initiatives at H2O.ai.
 	\begin{itemize}
 		\item{\textbf{Machine Learning and GPUs}}: H2O.ai has developed the fastest scalable, distributed in-memory machine learning platform, and we now extend its capabilities to GPUs, aiming to create the fastest artificial intelligence platform on GPUs.  Stay tuned for more of our algorithms exploiting GPU-acceleration.
-		\item{\textbf{XGBoost}}: For many problems, XGBoost is the one of the best gradient boosting machine (GBM) frameworks today.  In other cases, the H2O GBM algorithm comes out on top.  Both implementations will soon be available on the H2O platform, and both will leverage GPU acceleration.
 		\item{\textbf{Automatic Machine Learning}}: H2O AutoML is an automatic machine learning capability that will encapsulate and automate best practices in data cleaning, feature engineering, hyper-parameter search, and ensemble generation.
 		\item{\textbf{Machine Learning Interpretability}}: Often times, especially in regulated industries, model transparency and explanation become just as paramount as predictive performance.  Through visualizations and various techniques, machine learning interpretability functionality will continually make its way to the H2O platform.  For details on the ideas around machine learning interpretability, please visit: {\url{https://www.oreilly.com/ideas/ideas-on-interpreting-machine-learning}}.
 	\end{itemize}

--- a/h2o-docs/src/booklets/v2_2015/source/PythonBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/PythonBooklet.tex
@@ -412,11 +412,13 @@ In addition to loading data from Python objects, H2O can load data directly from
 \item CSV (delimited) files
 \item ORC
 \item SVMLite
+\item Parquet
 \end{itemize} &
 \begin{itemize}
 \item ARFF
 \item XLS
-\item XLST 
+\item XLSX 
+\item AVRO
 \end{itemize}
 \end{tabular}
 \end{frame}
@@ -454,6 +456,7 @@ H2O supports the following models:
   \item Principal Components Analysis (PCA)
   \item K-means
   \item Stacked Ensembles
+  \item XGBoost
 \end{itemize} &
 
 \begin{itemize}
@@ -484,6 +487,8 @@ The list continues to grow, so check \url{www.h2o.ai} to see the latest addition
 {\textbf{Na\"{i}ve Bayes}}: Generates a probabilistic classifier that assumes the value of a particular feature is unrelated to the presence or absence of any other feature, given the class variable. It is often used in text categorization.
 
 {\textbf{Stacked Ensembles}}: Using multiple models built from different algorithms, Stacked Ensembles finds the optimal combination of a collection of prediction algorithms using a process known as "stacking."
+
+{\textbf{XGBoost}}: XGBoost is an optimized gradient boosting library that implements machine learning algorithms under the Gradient Boosting Machine (GBM) framework. For many problems, XGBoost is the one of the best GBM frameworks today.  In other cases, the H2O GBM algorithm comes out on top.  Both implementations are available on the H2O platform.
 
 \subsubsection{Unsupervised Learning}
 {\textbf{K-Means}}: Reveals groups or clusters of data points for segmentation. It clusters observations into $k$-number of points with the nearest mean.

--- a/h2o-docs/src/booklets/v2_2015/source/RBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/RBooklet.tex
@@ -452,6 +452,8 @@ The list is growing quickly, so check \url{www.h2o.ai} to see the latest additio
 
 {\textbf{Stacked Ensembles}}: Using multiple models built from different algorithms, Stacked Ensembles finds the optimal combination of a collection of prediction algorithms using a process known as "stacking."
 
+{\textbf{XGBoost}}: XGBoost is an optimized gradient boosting library that implements machine learning algorithms under the Gradient Boosting Machine (GBM) framework. For many problems, XGBoost is the one of the best GBM frameworks today.  In other cases, the H2O GBM algorithm comes out on top.  Both implementations are available on the H2O platform.
+
 \subsection{Unsupervised Learning}
 
 {\textbf{K-means}}: Reveals groups or clusters of data points for segmentation. It clusters observations into $k$-number of points with the nearest mean.
@@ -483,7 +485,6 @@ The following demo demonstrates how to:
 \item Display the results
 \end{enumerate}
 
-\newpage
 \lstinputlisting[style=R]{R_Vignette_code_examples/r_glm_demo.R}
 
 \newpage
@@ -1238,6 +1239,7 @@ The following section lists some common R commands by function and a brief descr
 {\texttt{h2o.naiveBayes}}: Build gradient boosted classification trees and gradient boosted regression trees on a parsed dataset.
 {\texttt{h2o.prcomp}}: Perform principal components analysis on the given dataset.
 {\texttt{h2o.randomForest}}: Perform random forest classification on a dataset.
+{\texttt{h2o.xgboost}}: Build an extreme gradient boosted model.
 
 \medskip
 \emph{Model Training: Unsupervised Learning}\par
@@ -1329,8 +1331,6 @@ of Hit Ratio tables are returned, where the names are {\texttt{train}}, {\texttt
 \section{Acknowledgments}
 We would like to acknowledge the following individuals for their contributions to this booklet: Spencer Aiello, Eric Eckstrand, Anqi Fu, Patrick Aboyoun, and Jessica Lanford.
 
-
-\newpage
 \section{References}
 
 \bibliographystyle{plainnat}
@@ -1376,6 +1376,8 @@ We would like to acknowledge the following individuals for their contributions t
 \bibentry{h2o_R_package}
 
 \medskip
+
+\newpage
 
 \section{Authors}
 

--- a/h2o-docs/src/booklets/v2_2015/source/sw/sections/apps.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/sw/sections/apps.tex
@@ -6,10 +6,10 @@ This is a simple example project to start coding with Sparkling Water.
 
 \textbf{Dependencies}
 
-This droplet uses Sparkling Water 1.6 which integrates:
+This droplet uses Sparkling Water 2.1 which integrates:
 \begin{itemize}
-\item Spark 1.6
-\item H2O 3.8 Tukey
+\item Spark 2.1
+\item H2O 3.10.5 Vajda
 \end{itemize}
 
 For more details see \texttt{build.gradle}.

--- a/h2o-docs/src/booklets/v2_2015/source/sw/sections/deployment.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/sw/sections/deployment.tex
@@ -28,7 +28,7 @@ An application submission with Sparkling Water Fatjar is using the \texttt{--jar
 \pagebreak
 \begin{lstlisting}[style=Bash]
 $SPARK_HOME/bin/spark-submit \
-  --jars assembly/build/libs/sparkling-water-assembly-1.6.1-all.jar \
+  --jars assembly/build/libs/sparkling-water-assembly-2.1.8-all.jar \
   --class org.apache.spark.examples.h2o.CraigslistJobTitlesStreamingApp \
   /dev/null
 \end{lstlisting}
@@ -37,11 +37,11 @@ $SPARK_HOME/bin/spark-submit \
 
 Sparkling Water is also published as a Spark package. The benefit of using the package is that you can use it directly from your Spark distribution without need to download Sparkling Water.
 
-For example, if you have Spark version 1.6 and would like to use Sparkling Water version 1.6.1 and launch example \texttt{CraigslistJobTitlesStreamingApp}, then you can use the following command:
+For example, if you have Spark version 2.1 and would like to use Sparkling Water version 2.1.8 and launch example \texttt{CraigslistJobTitlesStreamingApp}, then you can use the following command:
 
 \begin{lstlisting}[style=Bash]
 $SPARK_HOME/bin/spark-submit \
-  --packages ai.h2o:sparkling-water-core_2.10:1.6.1,ai.h2o:sparkling-water-examples_2.10:1.6.1 \
+  --packages ai.h2o:sparkling-water-core_2.11:2.1.8,ai.h2o:sparkling-water-examples_2.11:2.1.8 \
   --class org.apache.spark.examples.h2o.CraigslistJobTitlesStreamingApp \
   /dev/null
 \end{lstlisting}
@@ -52,19 +52,12 @@ The similar command works for spark-shell:
 
 \begin{lstlisting}[style=Bash]
 $SPARK_HOME/bin/spark-shell \
- --packages ai.h2o:sparkling-water-core_2.10:1.6.1,ai.h2o:sparkling-water-examples_2.10:1.6.1 
+ --packages ai.h2o:sparkling-water-core_2.11:2.1.8,ai.h2o:sparkling-water-examples_2.11:2.1.8 
 \end{lstlisting}
 
-The same command works for Python programs:
+Note: When you are using Spark packages, you do not need to download Sparkling Water distribution. Spark installation is sufficient.
 
-\begin{lstlisting}[style=Bash]
-$SPARK_HOME/bin/spark-submit \
- --packages ai.h2o:sparkling-water-core_2.10:1.6.1,ai.h2o:sparkling-water-examples_2.10:1.6.1\
-  example.py
-\end{lstlisting}
-
-Note: When you are using Spark packages you do not need to download Sparkling Water distribution! Spark installation is sufficient!
-
+\newpage
 \subsection{Target Deployment Environments}
 Sparkling Water supports deployments to the following Spark cluster types:
 \begin{itemize}
@@ -82,7 +75,7 @@ $SPARK_HOME/bin/spark-submit \
   --conf spark.executor.memory=5g \
   --conf spark.driver.memory=5g \
   --master local[*] \
-  --packages ai.h2o:sparkling-water-examples_2.10:1.6.1 \
+  --packages ai.h2o:sparkling-water-examples_2.11:2.1.8 \
   --class org.apache.spark.examples.h2o.ChicagoCrimeApp \
   /dev/null
 \end{lstlisting}
@@ -97,7 +90,7 @@ $SPARK_HOME/bin/spark-submit \
   --conf spark.executor.memory=5g \
   --conf spark.driver.memory=5g \
   --master spark://machine-foo.bar.com:7077 \
-  --packages ai.h2o:sparkling-water-examples_2.10:1.6.1 \
+  --packages ai.h2o:sparkling-water-examples_2.11:2.1.8 \
   --class org.apache.spark.examples.h2o.ChicagoCrimeApp \
   /dev/null
 \end{lstlisting}
@@ -114,7 +107,7 @@ $SPARK_HOME/bin/spark-submit \
   --conf spark.driver.memory=5g \
   --num-executors 5 \
   --master yarn-client \
-  --packages ai.h2o:sparkling-water-examples_2.10:1.6.1 \
+  --packages ai.h2o:sparkling-water-examples_2.11:2.1.8 \
   --class org.apache.spark.examples.h2o.ChicagoCrimeApp \
   /dev/null
 \end{lstlisting}

--- a/h2o-docs/src/booklets/v2_2015/source/sw/sections/pysparkling.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/sw/sections/pysparkling.tex
@@ -11,7 +11,7 @@ PySparkling Water programs can be launched as an application, or in an interacti
 \begin{enumerate}
 \item Download Spark (if not already installed) from the Spark Downloads Page.
 
-Choose Spark release : 1.6.0
+Choose Spark release : 2.1.0
 
 Choose a package type: Pre-built for Hadoop 2.4 and later
 
@@ -30,8 +30,8 @@ export MASTER="local-cluster[3,2,1024]"
 
 \begin{lstlisting}[style=Bash]
 cd ~/Downloads
-unzip sparkling-water-1.6.1.zip
-cd sparkling-water-1.6.1
+unzip sparkling-water-2.1.8.zip
+cd sparkling-water-2.1.8
 \end{lstlisting}
 
 Start an interactive Python terminal:
@@ -60,8 +60,8 @@ import h2o
 Alternatively, to launch on YARN:
 
 \begin{lstlisting}[style=Bash]
-wget http://h2o-release.s3.amazonaws.com/sparkling-water/rel-1.6/1/sparkling-water-1.6.1.zip
-unzip sparkling-water-1.6.1.zip
+wget http://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/8/sparkling-water-2.1.8.zip
+unzip sparkling-water-2.1.8.zip
  
 export SPARK_HOME="/path/to/spark/installation"
 export HADOOP_CONF_DIR=/etc/hadoop/conf
@@ -78,7 +78,7 @@ import h2o
 
 Or to launch as a Spark Package application:
 \begin{lstlisting}[style=Bash]
-$SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-core_2.10:1.6.1 --py-files $SPARKLING_HOME/py/dist/pySparkling-1.6.1-py2.7.egg
+$SPARK_HOME/bin/spark-submit --packages ai.h2o:sparkling-water-core_2.11:2.1.8 --py-files $SPARKLING_HOME/py/dist/pySparkling-2.1.8-py2.7.egg
 $SPARKLING_HOME/py/examples/scripts/H2OContextDemo.py 
 \end{lstlisting}
 

--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -411,8 +411,8 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparkling Water Scaladoc</td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/0/scaladoc/index.html#package">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/1/scaladoc/index.html">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/9/scaladoc/index.html#package">2.0</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/8/scaladoc/index.html">2.1</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">H2O Scaladoc</td>


### PR DESCRIPTION
- In the Sparkling Water booklet, removed the sentence that reads “The same command works for Python programs” along with the code sample. Also replaced references of 1.6 with 2.1.
- In the Deep Water booklet, removed XGBoost from list of “Coming Soon”
- In the Python and R booklets, added XGBoost under the list of supervised learning algorithms. Also updated the list of accepted data source file formats in Python.
Driveby fix: On the doc site, updated the links for the Sparkling Water scaladoc pages for 2.0 and 2.1.