### PR TITLE
PUBDEV-4531: predictCsv.  Fixed predictCsv.java to accept arbitrary s…

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
@@ -1,12 +1,15 @@
 package hex.genmodel.tools;
 
+import au.com.bytecode.opencsv.CSVReader;
 import hex.ModelCategory;
 import hex.genmodel.GenModel;
 import hex.genmodel.MojoModel;
 import hex.genmodel.easy.EasyPredictModelWrapper;
 import hex.genmodel.easy.RowData;
-import hex.genmodel.easy.prediction.*;
-import au.com.bytecode.opencsv.CSVReader;
+import hex.genmodel.easy.prediction.BinomialModelPrediction;
+import hex.genmodel.easy.prediction.ClusteringModelPrediction;
+import hex.genmodel.easy.prediction.MultinomialModelPrediction;
+import hex.genmodel.easy.prediction.RegressionModelPrediction;
 
 import java.io.BufferedWriter;
 import java.io.FileReader;
@@ -14,21 +17,20 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 /**
- * Simple driver program for reading a CSV file and making predictions.
+ * Simple driver program for reading a CSV file and making predictions.  Added support for separators that are
+ * not commas. User needs to add the --separator separator_string to the input call.  Do not escape
+ * the special Java characters, I will do it for you.
  *
  * This driver program is used as a test harness by several tests in the testdir_javapredict directory.
  * <p></p>
  * See the top-of-tree master version of this file <a href="https://github.com/h2oai/h2o-3/blob/master/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java" target="_blank">here on github</a>.
  */
 public class PredictCsv {
-  private String modelName;
-
   private String inputCSVFileName;
-
   private String outputCSVFileName;
-
   private boolean useDecimalOutput = false;
-
+  public char separator = ',';   // separator used to delimite input datasets
+  public boolean setInvNumNA = false;    // enable .setConvertInvalidNumbersToNa(true)
   // Model instance
   private EasyPredictModelWrapper model;
 
@@ -63,7 +65,6 @@ public class PredictCsv {
         case "N/A":
         case "-":
           continue;
-
         default:
           row.put(columnName, cellData);
       }
@@ -81,8 +82,8 @@ public class PredictCsv {
 
   private void run() throws Exception {
     ModelCategory category = model.getModelCategory();
-
-    CSVReader reader = new CSVReader(new FileReader(inputCSVFileName));
+    CSVReader reader = new CSVReader(new FileReader(inputCSVFileName), separator);
+    String readline;
     BufferedWriter output = new BufferedWriter(new FileWriter(outputCSVFileName));
 
     // Emit outputCSV column names.
@@ -120,18 +121,17 @@ public class PredictCsv {
     //       all the rows to the score function, in which case it can evaluate each tree for each row, avoiding
     //       multiple rounds of fetching each tree from the filesystem.
     //
-    int lineNum = 0;
+    int lineNum=1;    // count number of lines of input dataset file parsed
     try {
       String[] inputColumnNames = null;
       String[] splitLine;
-      while ((splitLine = reader.readNext()) != null) {
-        lineNum++;
+      //Reader in the column names here.
+      if ((splitLine=reader.readNext()) != null)
+        inputColumnNames=splitLine;
+      else  // file empty, throw an error
+        throw new Exception("Input dataset file is empty!");
 
-        // Handle the header.
-        if (lineNum == 1) {
-          inputColumnNames = splitLine;
-          continue;
-        }
+      while ((splitLine = reader.readNext()) != null) {
 
         // Parse the CSV line.  Don't handle quoted commas.  This isn't a parser test.
         RowData row = formatDataRow(splitLine, inputColumnNames);
@@ -188,6 +188,7 @@ public class PredictCsv {
         }
 
         output.write("\n");
+        lineNum++;
       }
     }
     catch (Exception e) {
@@ -195,11 +196,11 @@ public class PredictCsv {
       System.out.println("");
       e.printStackTrace();
       System.exit(1);
+    } finally {
+      // Clean up.
+      output.close();
+      reader.close();
     }
-
-    // Clean up.
-    output.close();
-    reader.close();
   }
 
 
@@ -213,51 +214,63 @@ public class PredictCsv {
 
   private void loadPojo(String className) throws Exception {
     GenModel genModel = (GenModel) Class.forName(className).newInstance();
-    model = new EasyPredictModelWrapper(new EasyPredictModelWrapper.Config().setModel(genModel).setConvertUnknownCategoricalLevelsToNa(true));
+    model = new EasyPredictModelWrapper(new EasyPredictModelWrapper.Config().setModel(genModel).setConvertUnknownCategoricalLevelsToNa(true).setConvertInvalidNumbersToNa(setInvNumNA));
   }
 
   private void loadMojo(String modelName) throws IOException {
     GenModel genModel = MojoModel.load(modelName);
-    model = new EasyPredictModelWrapper(new EasyPredictModelWrapper.Config().setModel(genModel).setConvertUnknownCategoricalLevelsToNa(true));
+    model = new EasyPredictModelWrapper(new EasyPredictModelWrapper.Config().setModel(genModel).setConvertUnknownCategoricalLevelsToNa(true).setConvertInvalidNumbersToNa(setInvNumNA));
   }
 
   private static void usage() {
     System.out.println("");
     System.out.println("Usage:  java [...java args...] hex.genmodel.tools.PredictCsv --mojo mojoName");
-    System.out.println("             --pojo pojoName --input inputFile --output outputFile --decimal");
+    System.out.println("             --pojo pojoName --input inputFile --output outputFile --separator sepStr --decimal --setConvertInvalidNum");
     System.out.println("");
     System.out.println("     --mojo    Name of the zip file containing model's MOJO.");
     System.out.println("     --pojo    Name of the java class containing the model's POJO. Either this ");
     System.out.println("               parameter or --model must be specified.");
-    System.out.println("     --input   CSV file containing the test data set to score.");
+    System.out.println("     --input   text file containing the test data set to score.");
     System.out.println("     --output  Name of the output CSV file with computed predictions.");
+    System.out.println("     --separator Separator to be used in input file containing test data set.");
     System.out.println("     --decimal Use decimal numbers in the output (default is to use hexademical).");
+    System.out.println("     --setConvertInvalidNum Will call .setConvertInvalidNumbersToNa(true) when loading models.");
     System.out.println("");
     System.exit(1);
   }
 
   private void parseArgs(String[] args) {
     try {
+      String pojoMojoModelNames = ""; // store Pojo/Mojo/Model names
+      int loadType = 0; // 0: load pojo, 1: load mojo, 2: load model
       for (int i = 0; i < args.length; i++) {
         String s = args[i];
         if (s.equals("--header")) continue;
         if (s.equals("--decimal"))
           useDecimalOutput = true;
+        else if (s.equals("--setConvertInvalidNum"))
+          setInvNumNA=true;
         else {
           i++;
           if (i >= args.length) usage();
           String sarg = args[i];
           switch (s) {
-            case "--model":  loadModel(sarg); break;
-            case "--mojo":   loadMojo(sarg); break;
-            case "--pojo":   loadPojo(sarg); break;
+            case "--model":  pojoMojoModelNames=sarg; loadType=2; break;//loadModel(sarg); break;
+            case "--mojo":   pojoMojoModelNames=sarg; loadType=1; break;//loadMojo(sarg); break;
+            case "--pojo":   pojoMojoModelNames=sarg; loadType=0; break;//loadPojo(sarg); break;
             case "--input":  inputCSVFileName = sarg; break;
             case "--output": outputCSVFileName = sarg; break;
+            case "--separator": separator=sarg.charAt(sarg.length()-1);; break;
             default:
               System.out.println("ERROR: Unknown command line argument: " + s);
               usage();
           }
         }
+      }
+      switch(loadType) {
+        case 0: loadPojo(pojoMojoModelNames); break;
+        case 1: loadMojo(pojoMojoModelNames); break;
+        case 2: loadModel(pojoMojoModelNames); break;
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -154,7 +154,7 @@ def np_comparison_check(h2o_data, np_data, num_elements):
         assert np.absolute(h2o_val - np_val) < 1e-5, \
             "failed comparison check! h2o computed {0} and numpy computed {1}".format(h2o_val, np_val)
 
-def javapredict(algo, equality, train, test, x, y, compile_only=False, **kwargs):
+def javapredict(algo, equality, train, test, x, y, compile_only=False, separator=",", setInvNumNA=False,**kwargs):
     print("Creating model in H2O")
     if algo == "gbm": model = H2OGradientBoostingEstimator(**kwargs)
     elif algo == "random_forest": model = H2ORandomForestEstimator(**kwargs)
@@ -206,6 +206,7 @@ def javapredict(algo, equality, train, test, x, y, compile_only=False, **kwargs)
         f = open(in_csv, "r+")
         csv = f.read()
         csv = re.sub('\"', "", csv)
+        csv = re.sub(",", separator, csv)       # replace with arbitrary separator for input dataset
         f.seek(0)
         f.write(csv)
         f.truncate()
@@ -218,7 +219,9 @@ def javapredict(algo, equality, train, test, x, y, compile_only=False, **kwargs)
         cp_sep = ";" if sys.platform == "win32" else ":"
         java_cmd = ["java", "-ea", "-cp", h2o_genmodel_jar + cp_sep + tmpdir, "-Xmx12g", "-XX:MaxPermSize=2g",
                     "-XX:ReservedCodeCacheSize=256m", "hex.genmodel.tools.PredictCsv",
-                    "--pojo", pojoname, "--input", in_csv, "--output", out_pojo_csv]
+                    "--pojo", pojoname, "--input", in_csv, "--output", out_pojo_csv, "--separator", separator]
+        if setInvNumNA:
+            java_cmd.append("--setConvertInvalidNum")
         p = subprocess.Popen(java_cmd, stdout=PIPE, stderr=STDOUT)
         o, e = p.communicate()
         print("Java output: {0}".format(o))
@@ -245,7 +248,6 @@ def javapredict(algo, equality, train, test, x, y, compile_only=False, **kwargs)
                 assert hp == pp, "Expected predictions to be the same for row %d, but got %r and %r" % (r, hp, pp)
             else:
                 raise ValueError
-
 
 def javamunge(assembly, pojoname, test, compile_only=False):
     """

--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdex_4531_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdex_4531_large.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+from builtins import zip
+from builtins import range
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+# JIRA PUBDEV_4531.  Allow predictCsv to read user dataset separated by any separator.
+# added parameter to do .setConvertInvalidNumbersToNa(true)
+def javapredict_pubdev_4531():
+    train = h2o.upload_file(pyunit_utils.locate("smalldata/logreg/prostate_train_null_column_name.csv"))
+    test = h2o.upload_file(pyunit_utils.locate("smalldata/logreg/prostate_train_null_column_name.csv"))
+    params = {'ntrees':20, 'max_depth':2,  'seed':42, 'training_frame':train,
+              'learn_rate':0.1, 'min_rows':10, 'distribution':"bernoulli"} # 651MB pojo
+    train["CAPSULE"] = train["CAPSULE"].asfactor()
+    test["CAPSULE"] = test["CAPSULE"].asfactor()
+    print("Parameter list:")
+    for k,v in zip(list(params.keys()), list(params.values())): print("{0}, {1}".format(k,v))
+
+    x = list(range(0,train.ncol))
+    y = "CAPSULE"
+
+    pyunit_utils.javapredict("gbm", "class", train, test, x, y, **params)    # make sure original call run
+    # check a separator that is a special character
+    pyunit_utils.javapredict("gbm", "class", train, test, x, y,separator="|", setInvNumNA=True, **params)
+    pyunit_utils.javapredict("gbm", "class", train, test, x, y,separator="\|", setInvNumNA=True, **params)
+    # test with escape string // already added
+    pyunit_utils.javapredict("gbm", "class", train, test, x, y,separator="\\|", setInvNumNA=True, **params)
+    # check a separator that is not a special character
+    pyunit_utils.javapredict("gbm", "class", train, test, x, y,separator="@", setInvNumNA=True, **params)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(javapredict_pubdev_4531)
+else:
+    javapredict_pubdev_4531()

--- a/h2o-r/tests/runitUtils/shared_javapredict.R
+++ b/h2o-r/tests/runitUtils/shared_javapredict.R
@@ -1,4 +1,4 @@
-doJavapredictTest <- function(model,test_file,test_frame,params) {
+doJavapredictTest <- function(model,test_file,test_frame,params, separator=",", setInvNumNA=FALSE) {
   conn <- h2o.getConnection()
   myIP <- conn@ip
   myPort <- conn@port
@@ -49,7 +49,9 @@ doJavapredictTest <- function(model,test_file,test_frame,params) {
     test_without_response <- data.frame(test_without_response)
     colnames(test_without_response) <- params$x
   }
-  write.csv(test_without_response, file = sprintf("%s/in.csv", tmpdir_name), row.names=F, quote=F)
+  #write.csv(test_without_response, file = sprintf("%s/in.csv", tmpdir_name), row.names=F, quote=F)
+  file = sprintf("%s/in.csv", tmpdir_name)
+  write.table(test_without_response, file, sep=separator, row.names=FALSE, quote=FALSE)
   cmd <- sprintf("curl http://%s:%s/3/h2o-genmodel.jar > %s/h2o-genmodel.jar", myIP, myPort, tmpdir_name)
   if (.Platform$OS.type == "windows") shell(cmd)
   else safeSystem(cmd)
@@ -57,8 +59,12 @@ doJavapredictTest <- function(model,test_file,test_frame,params) {
   safeSystem(cmd)
 
   print("Predicting with Java POJO")
-  if (.Platform$OS.type == "windows") cmd <- sprintf("java -ea -cp %s/h2o-genmodel.jar;%s -Xmx4g -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=256m hex.genmodel.tools.PredictCsv --header --model %s --input %s/in.csv --output %s/out_pojo.csv", tmpdir_name, tmpdir_name, model_key, tmpdir_name, tmpdir_name)
-  else cmd <- sprintf("java -ea -cp %s/h2o-genmodel.jar:%s -Xmx4g -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=256m hex.genmodel.tools.PredictCsv --header --pojo %s --input %s/in.csv --output %s/out_pojo.csv", tmpdir_name, tmpdir_name, model_key, tmpdir_name, tmpdir_name)
+  if (.Platform$OS.type == "windows") cmd <- sprintf("java -ea -cp %s/h2o-genmodel.jar;%s -Xmx4g -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=256m hex.genmodel.tools.PredictCsv --header --model %s --input %s/in.csv --output %s/out_pojo.csv --separator %s", tmpdir_name, tmpdir_name, model_key, tmpdir_name, tmpdir_name, separator)
+  else cmd <- sprintf("java -ea -cp %s/h2o-genmodel.jar:%s -Xmx4g -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=256m hex.genmodel.tools.PredictCsv --header --pojo %s --input %s/in.csv --output %s/out_pojo.csv --separator %s", tmpdir_name, tmpdir_name, model_key, tmpdir_name, tmpdir_name, separator)
+  if (setInvNumNA)
+    cmd <- paste(cmd, " --setConvertInvalidNum")
+
+  
   safeSystem(cmd)
 
   print("Comparing predictions between H2O and Java POJO")

--- a/h2o-r/tests/testdir_javapredict/runit_pubdev_4531_large.R
+++ b/h2o-r/tests/testdir_javapredict/runit_pubdev_4531_large.R
@@ -1,0 +1,56 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+#----------------------------------------------------------------------
+# Used to test out customer dataset to make sure h2o model predict and pojo predict generate
+# the same answers.  However, customer dataset is not to be made public and hence this test
+# is a NOPASS.
+#----------------------------------------------------------------------
+test <-
+  function() {
+    #----------------------------------------------------------------------
+    # Parameters for the test.
+    #----------------------------------------------------------------------
+    
+    # Story:
+    # The objective of the test is to verify java code generation
+    # for big models containing huge amount of trees.
+    # This case verify multi-classifiers.
+    test_file <- locate("smalldata/logreg/prostate_train_null_column_name.csv")
+    test_frame <- h2o.importFile(test_file)
+    params = prepTest()
+    browser()
+    doJavapredictTest("gbm",test_file,test_frame,params)  # make sure original code run
+
+    # check a separator that is not a special character
+    test_file <- locate("smalldata/logreg/prostate_train_null_column_name.csv")
+    test_frame <- h2o.importFile(test_file)
+    params = prepTest()
+    doJavapredictTest("gbm",test_file,test_frame,params,separator="@",setInvNumNA=FALSE)
+
+
+    test_file <- locate("smalldata/logreg/prostate_train_null_column_name.csv")
+    test_frame <- h2o.importFile(test_file)
+    params = prepTest()
+    doJavapredictTest("gbm",test_file,test_frame,params,separator="$",setInvNumNA=TRUE)
+  }
+
+prepTest <- function() {
+  # check a separator that is a special character, R does not all | to be a separator, change it to (
+  training_file <- test_file <- locate("smalldata/logreg/prostate_train_null_column_name.csv")
+  training_frame <- h2o.importFile(training_file)
+
+  params                 <- list()
+  params$ntrees          <- 20
+  params$max_depth       <- 3
+  params$x               <- 2:8
+  params$y               <- "CAPSULE"
+  params$training_frame  <- training_frame
+  params$seed            <- 42
+  params$learn_rate       <-0.1
+  params$min_rows        <-10
+  params$distribution    <-"bernoulli"
+  return(params)
+}
+
+doTest("pubdev-4531: PredictCsv test", test)


### PR DESCRIPTION
Added the following code to satisfy PUBDEV-4531:

- enable PredictCsv.java to accept arbitrary separator characters in the input dataset file if the user includes the optional flag --separator in the input arguments..  If a user enter a special java character as separator, I will add the \\ for them.

- enable PredictCsv.java to do setConvertInvalidNumbersToNa(setInvNumNA)) if the optional flag --setConvertInvalidNum is included in the input arguments;

- changed test harness in R/Python to make sure these new optional parameters are allowed and passed to PredictCsv.java.

- added R/Python unit tests to make sure the javapredict works with different arbitrary separators and with the --setConvertInvalidNum set.