### PR TITLE
PUBDEV-4096-rel-vajda: Updates for Stacked Ensembles docs

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/model_id.rst
+++ b/h2o-docs/src/product/data-science/algo-params/model_id.rst
@@ -1,7 +1,7 @@
 ``model_id``
 ------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, Word2Vec
+- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, Word2Vec, Stacked Ensembles
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/stopping_rounds.rst
+++ b/h2o-docs/src/product/data-science/algo-params/stopping_rounds.rst
@@ -15,6 +15,11 @@ Use this option to stop model training when the option selected for `stopping_me
 
 then the model will stop training after reaching three scoring events in a row in which a model's missclassication value does not improve by **1e-3**. These stopping options are used to increase performance by restricting the number of models that get built. 
 
+The default value for this option varies depending on the algorithm:
+
+- GBM/DRF: ``stopping_rounds`` defaults to 0 (disabled)
+- Deep Learning: ``stopping_rounds`` defaults to 5 
+
 To disable this feature, specify 0. When disabled, the metric is computed on the validation data (if provided); otherwise, training data is used. 
 
 When used with Deep Learning, you can also specify the ``overwrite_with_best_model`` option. When enabled, the final model is the best model generated for the given ``stopping_metric`` option.

--- a/h2o-docs/src/product/data-science/algo-params/training_frame.rst
+++ b/h2o-docs/src/product/data-science/algo-params/training_frame.rst
@@ -1,7 +1,7 @@
 ``training_frame``
 ------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, Word2Vec
+- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, Word2Vec, Stacked Ensembles
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/validation_frame.rst
+++ b/h2o-docs/src/product/data-science/algo-params/validation_frame.rst
@@ -1,7 +1,7 @@
 ``validation_frame``
 --------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means
+- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, Stacked Ensembles
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -49,15 +49,19 @@ The steps below describe the individual tasks involved in training and testing a
 Defining an H2O Stacked Ensemble Model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  **model_id**: Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
+-  `model_id <algo-params/model_id.html>`__: Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
 
--  **training_frame**: Specify the dataset used to build the model. 
+-  `training_frame <algo-params/training_frame.html>`__ Specify the dataset used to build the model. 
 
--  **validation_frame**: Specify the dataset used to evaluate the accuracy of the model.
+-  `validation_frame <algo-params/validation_frame.html>`__: Specify the dataset used to evaluate the accuracy of the model.
 
--  **base_models**: Specify a list of model IDs that can be stacked together. Models must have been cross-validated using ``nfolds`` > 1, they all must use the same cross-validation folds and ``keep_cross_validation_folds`` must be set to True.  
+-  **base_models**: Specify a list of model IDs that can be stacked together. Models must have been cross-validated using ``nfolds`` > 1, they all must use the same cross-validation folds, and ``keep_cross_validation_folds`` must be set to True. 
 
-Regarding the base models: One way to guarantee identical folds across base models is to set ``fold_assignment = "Modulo"`` in all the base models.  It is also possible to get identical folds by setting ``fold_assignment = "Random"`` when the same seed is used in all base models.
+  **Notes regarding** ``base_models``: 
+
+    - One way to guarantee identical folds across base models is to set ``fold_assignment = "Modulo"`` in all the base models.  It is also possible to get identical folds by setting ``fold_assignment = "Random"`` when the same seed is used in all base models.
+
+    - In R, you can specify a list of models in the ``base_models`` parameter. 
 
 Also in a `future release <https://0xdata.atlassian.net/browse/PUBDEV-3743>`__, there will be an additional **metalearner** parameter which allows for the user to specify the metalearning algorithm used.  Currently, the metalearner is fixed as a default H2O GLM with non-negative weights.
 


### PR DESCRIPTION
- In the documentation for Stacked Ensembles, added that in R, you can specify a list of models in the ``base_models`` parameter.
- Added links from the Stacked Ensembles config options to the parameters section (where available)
- Added “Stacked Ensembles” to the parameters in the Appendix where Stacked Ensembles is supported.
Driveby fix: Added default values to the stopping_rounds option.