### PR TITLE
PUBDEV-4583: Updated description for Alpha command in R docs

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -83,16 +83,16 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help = "AUTO will set the solver based on given data and the other parameters. IRLSM is fast on on problems with small number of predictors and for lambda-search with L1 penalty, L_BFGS scales better for datasets with many columns. Coordinate descent is experimental (beta).", values = {"AUTO", "IRLSM", "L_BFGS","COORDINATE_DESCENT_NAIVE", "COORDINATE_DESCENT"}, level = Level.critical)
     public Solver solver;
 
-    @API(help = "distribution of regularization between L1 and L2. Default value of alpha is 0 when SOLVER = 'L-BFGS', 0.5 otherwise", level = Level.critical, gridable = true)
+    @API(help = "Distribution of regularization between the L1 (Lasso) and L2 (Ridge) penalties. A value of 1 for alpha represents Lasso regression, a value of 0 produces Ridge regression, and anything in between specifies the amount of mixing between the two. Default value of alpha is 0 when SOLVER = 'L-BFGS'; 0.5 otherwise.", level = Level.critical, gridable = true)
     public double[] alpha;
 
-    @API(help = "regularization strength", required = false, level = Level.critical, gridable = true)
+    @API(help = "Regularization strength", required = false, level = Level.critical, gridable = true)
     public double[] lambda;
 
-    @API(help = "use lambda search starting at lambda max, given lambda is then interpreted as lambda min", level = Level.critical)
+    @API(help = "Use lambda search starting at lambda max, given lambda is then interpreted as lambda min", level = Level.critical)
     public boolean lambda_search;
 
-    @API(help="stop early when there is no more relative improvement on train or validation (if provided)")
+    @API(help="Stop early when there is no more relative improvement on train or validation (if provided)")
     public boolean early_stopping;
 
     @API(help = "Number of lambdas to be used in a search." +
@@ -113,7 +113,7 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help = "Maximum number of iterations", level = Level.secondary)
     public int max_iterations;
 
-    @API(help = "converge if  beta changes less (using L-infinity norm) than beta esilon, ONLY applies to IRLSM solver ", level = Level.expert)
+    @API(help = "Converge if  beta changes less (using L-infinity norm) than beta esilon, ONLY applies to IRLSM solver ", level = Level.expert)
     public double beta_epsilon;
 
     @API(help = "Converge if  objective value changes less than this."+ " Default indicates: If lambda_search"+
@@ -128,13 +128,13 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     " the conditional values above are 1E-8 and 1E-6 respectively.", level = Level.expert)
     public double gradient_epsilon;
 
-    @API(help="likelihood divider in objective value computation, default is 1/nobs")
+    @API(help="Likelihood divider in objective value computation, default is 1/nobs")
     public double obj_reg;
 
     @API(help = "", level = Level.secondary, values = {"family_default", "identity", "logit", "log", "inverse", "tweedie"})
     public GLMParameters.Link link;
 
-    @API(help="include constant term in the model", level = Level.expert)
+    @API(help="Include constant term in the model", level = Level.expert)
     public boolean intercept;
 
 //    @API(help = "Tweedie variance power", level = Level.secondary)
@@ -143,16 +143,16 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
 //    @API(help = "Tweedie link power", level = Level.secondary)
 //    public double tweedie_link_power;
 
-    @API(help = "prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean of response does not reflect reality.", level = Level.expert)
+    @API(help = "Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean of response does not reflect reality.", level = Level.expert)
     public double prior;
 
-    @API(help = "Min lambda used in lambda search, specified as a ratio of lambda_max." +
+    @API(help = "Minimum lambda used in lambda search, specified as a ratio of lambda_max." +
     " Default indicates: if the number of observations is greater than the number of variables then lambda_min_ratio" +
     " is set to 0.0001; if the number of observations is less than the number of variables then lambda_min_ratio" +
     " is set to 0.01.", level = Level.expert)
     public double lambda_min_ratio;
 
-    @API(help = "beta constraints", direction = API.Direction.INPUT /* Not required, to allow initial params validation: , required=true */)
+    @API(help = "Beta constraints", direction = API.Direction.INPUT /* Not required, to allow initial params validation: , required=true */)
     public FrameKeyV3 beta_constraints;
 
     @API(help="Maximum number of active predictors during computation. Use as a stopping criterion" +
@@ -195,13 +195,13 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     /**
      * The maximum number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)
      */
-    @API(help = "Max. number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)", level = API.Level.secondary, direction=API.Direction.INOUT)
+    @API(help = "Maximum number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)", level = API.Level.secondary, direction=API.Direction.INOUT)
     public int max_hit_ratio_k;
 
-    @API(help="request p-values computation, p-values work only with IRLSM solver and no regularization", level = Level.secondary, direction = Direction.INPUT)
+    @API(help="Request p-values computation, p-values work only with IRLSM solver and no regularization", level = Level.secondary, direction = Direction.INPUT)
     public boolean compute_p_values; // _remove_collinear_columns
 
-    @API(help="in case of linearly dependent columns remove some of the dependent columns", level = Level.secondary, direction = Direction.INPUT)
+    @API(help="In case of linearly dependent columns, remove some of the dependent columns", level = Level.secondary, direction = Direction.INPUT)
     public boolean remove_collinear_columns; // _remove_collinear_columns
 
     /////////////////////

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -334,8 +334,9 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def alpha(self):
         """
-        distribution of regularization between L1 and L2. Default value of alpha is 0 when SOLVER = 'L-BFGS', 0.5
-        otherwise
+        Distribution of regularization between the L1 (Lasso) and L2 (Ridge) penalties. A value of 1 for alpha
+        represents Lasso regression, a value of 0 produces Ridge regression, and anything in between specifies the
+        amount of mixing between the two. Default value of alpha is 0 when SOLVER = 'L-BFGS'; 0.5 otherwise.
 
         Type: ``List[float]``.
         """
@@ -350,7 +351,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def lambda_(self):
         """
-        regularization strength
+        Regularization strength
 
         Type: ``List[float]``.
         """
@@ -365,7 +366,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def lambda_search(self):
         """
-        use lambda search starting at lambda max, given lambda is then interpreted as lambda min
+        Use lambda search starting at lambda max, given lambda is then interpreted as lambda min
 
         Type: ``bool``  (default: ``False``).
         """
@@ -380,7 +381,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def early_stopping(self):
         """
-        stop early when there is no more relative improvement on train or validation (if provided)
+        Stop early when there is no more relative improvement on train or validation (if provided)
 
         Type: ``bool``  (default: ``True``).
         """
@@ -441,7 +442,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def compute_p_values(self):
         """
-        request p-values computation, p-values work only with IRLSM solver and no regularization
+        Request p-values computation, p-values work only with IRLSM solver and no regularization
 
         Type: ``bool``  (default: ``False``).
         """
@@ -456,7 +457,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def remove_collinear_columns(self):
         """
-        in case of linearly dependent columns remove some of the dependent columns
+        In case of linearly dependent columns, remove some of the dependent columns
 
         Type: ``bool``  (default: ``False``).
         """
@@ -471,7 +472,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def intercept(self):
         """
-        include constant term in the model
+        Include constant term in the model
 
         Type: ``bool``  (default: ``True``).
         """
@@ -534,7 +535,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def beta_epsilon(self):
         """
-        converge if  beta changes less (using L-infinity norm) than beta esilon, ONLY applies to IRLSM solver
+        Converge if  beta changes less (using L-infinity norm) than beta esilon, ONLY applies to IRLSM solver
 
         Type: ``float``  (default: ``0.0001``).
         """
@@ -583,7 +584,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def prior(self):
         """
-        prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
+        Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
         of response does not reflect reality.
 
         Type: ``float``  (default: ``-1``).
@@ -599,7 +600,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def lambda_min_ratio(self):
         """
-        Min lambda used in lambda search, specified as a ratio of lambda_max. Default indicates: if the number of
+        Minimum lambda used in lambda search, specified as a ratio of lambda_max. Default indicates: if the number of
         observations is greater than the number of variables then lambda_min_ratio is set to 0.0001; if the number of
         observations is less than the number of variables then lambda_min_ratio is set to 0.01.
 
@@ -616,7 +617,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def beta_constraints(self):
         """
-        beta constraints
+        Beta constraints
 
         Type: ``H2OFrame``.
         """
@@ -725,7 +726,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def max_hit_ratio_k(self):
         """
-        Max. number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)
+        Maximum number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)
 
         Type: ``int``  (default: ``0``).
         """

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -38,12 +38,13 @@
 #'        number of predictors and for lambda-search with L1 penalty, L_BFGS scales better for datasets with many
 #'        columns. Coordinate descent is experimental (beta). Must be one of: "AUTO", "IRLSM", "L_BFGS",
 #'        "COORDINATE_DESCENT_NAIVE", "COORDINATE_DESCENT". Defaults to AUTO.
-#' @param alpha distribution of regularization between L1 and L2. Default value of alpha is 0 when SOLVER = 'L-BFGS', 0.5
-#'        otherwise
-#' @param lambda regularization strength
-#' @param lambda_search \code{Logical}. use lambda search starting at lambda max, given lambda is then interpreted as lambda min
+#' @param alpha Distribution of regularization between the L1 (Lasso) and L2 (Ridge) penalties. A value of 1 for alpha
+#'        represents Lasso regression, a value of 0 produces Ridge regression, and anything in between specifies the
+#'        amount of mixing between the two. Default value of alpha is 0 when SOLVER = 'L-BFGS'; 0.5 otherwise.
+#' @param lambda Regularization strength
+#' @param lambda_search \code{Logical}. Use lambda search starting at lambda max, given lambda is then interpreted as lambda min
 #'        Defaults to FALSE.
-#' @param early_stopping \code{Logical}. stop early when there is no more relative improvement on train or validation (if provided)
+#' @param early_stopping \code{Logical}. Stop early when there is no more relative improvement on train or validation (if provided)
 #'        Defaults to TRUE.
 #' @param nlambdas Number of lambdas to be used in a search. Default indicates: If alpha is zero, with lambda search set to True,
 #'        the value of nlamdas is set to 30 (fewer lambdas are needed for ridge regression) otherwise it is set to 100.
@@ -51,17 +52,17 @@
 #' @param standardize \code{Logical}. Standardize numeric columns to have zero mean and unit variance Defaults to TRUE.
 #' @param missing_values_handling Handling of missing values. Either MeanImputation or Skip. Must be one of: "MeanImputation", "Skip". Defaults
 #'        to MeanImputation.
-#' @param compute_p_values \code{Logical}. request p-values computation, p-values work only with IRLSM solver and no regularization
+#' @param compute_p_values \code{Logical}. Request p-values computation, p-values work only with IRLSM solver and no regularization
 #'        Defaults to FALSE.
-#' @param remove_collinear_columns \code{Logical}. in case of linearly dependent columns remove some of the dependent columns Defaults to FALSE.
-#' @param intercept \code{Logical}. include constant term in the model Defaults to TRUE.
+#' @param remove_collinear_columns \code{Logical}. In case of linearly dependent columns, remove some of the dependent columns Defaults to FALSE.
+#' @param intercept \code{Logical}. Include constant term in the model Defaults to TRUE.
 #' @param non_negative \code{Logical}. Restrict coefficients (not intercept) to be non-negative Defaults to FALSE.
 #' @param max_iterations Maximum number of iterations Defaults to -1.
 #' @param objective_epsilon Converge if  objective value changes less than this. Default indicates: If lambda_search is set to True the
 #'        value of objective_epsilon is set to .0001. If the lambda_search is set to False and lambda is equal to zero,
 #'        the value of objective_epsilon is set to .000001, for any other value of lambda the default value of
 #'        objective_epsilon is set to .0001. Defaults to -1.
-#' @param beta_epsilon converge if  beta changes less (using L-infinity norm) than beta esilon, ONLY applies to IRLSM solver
+#' @param beta_epsilon Converge if  beta changes less (using L-infinity norm) than beta esilon, ONLY applies to IRLSM solver
 #'        Defaults to 0.0001.
 #' @param gradient_epsilon Converge if  objective changes less (using L-infinity norm) than this, ONLY applies to L-BFGS solver. Default
 #'        indicates: If lambda_search is set to False and lambda is equal to zero, the default value of gradient_epsilon
@@ -69,12 +70,12 @@
 #'        values above are 1E-8 and 1E-6 respectively. Defaults to -1.
 #' @param link  Must be one of: "family_default", "identity", "logit", "log", "inverse", "tweedie". Defaults to
 #'        family_default.
-#' @param prior prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
+#' @param prior Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
 #'        of response does not reflect reality. Defaults to -1.
-#' @param lambda_min_ratio Min lambda used in lambda search, specified as a ratio of lambda_max. Default indicates: if the number of
+#' @param lambda_min_ratio Minimum lambda used in lambda search, specified as a ratio of lambda_max. Default indicates: if the number of
 #'        observations is greater than the number of variables then lambda_min_ratio is set to 0.0001; if the number of
 #'        observations is less than the number of variables then lambda_min_ratio is set to 0.01. Defaults to -1.
-#' @param beta_constraints beta constraints
+#' @param beta_constraints Beta constraints
 #' @param max_active_predictors Maximum number of active predictors during computation. Use as a stopping criterion to prevent expensive model
 #'        building with many predictors. Default indicates: If the IRLSM solver is used, the value of
 #'        max_active_predictors is set to 7000 otherwise it is set to 100000000. Defaults to -1.
@@ -85,7 +86,7 @@
 #'        be automatically computed to obtain class balance during training. Requires balance_classes.
 #' @param max_after_balance_size Maximum relative size of the training data after balancing class counts (can be less than 1.0). Requires
 #'        balance_classes. Defaults to 5.0.
-#' @param max_hit_ratio_k Max. number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)
+#' @param max_hit_ratio_k Maximum number (top K) of predictions to use for hit ratio computation (for multi-class only, 0 to disable)
 #'        Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @return A subclass of \code{\linkS4class{H2OModel}} is returned. The specific subclass depends on the machine


### PR DESCRIPTION
Updated the GLMV3.java file with an improved description for the alpha command.
The change to the alpha description has to be made in the GLMV3.java file. Built H2O locally after, and the associated files were also updated. Also, the generated PDF displays the updated description for alpha.
Driveby fix: Fixed capitalization in other GLM parameter descriptions.