### PR TITLE
[PUBDEV-4269] H2O should warn user about the minimal required Coloram…

### DIFF
--- a/h2o-py/h2o/backend/__init__.py
+++ b/h2o-py/h2o/backend/__init__.py
@@ -44,4 +44,14 @@ from .server import H2OLocalServer
 from .connection import H2OConnection
 from .connection import H2OConnectionConf
 
+import colorama
+from distutils.version import StrictVersion
+import sys
+
+if StrictVersion(colorama.__version__) < StrictVersion("0.3.8"):
+    print("[WARNING] H2O requires colorama module of version 0.3.8 or newer. You have version %s.\n"
+          "You can upgrade to the newest version of the module running from the command line\n"
+          "    $ pip%s install --upgrade colorama" % (colorama.__version__, sys.version_info[0]))
+
+
 __all__ = ("H2OCluster", "H2OConnection", "H2OLocalServer", "H2OConnectionConf")

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -91,5 +91,5 @@ setup(
     ]},
 
     # run-time dependencies
-    install_requires=["requests", "tabulate", "future", "colorama"],
+    install_requires=["requests", "tabulate", "future", "colorama>=0.3.8"],
 )


### PR DESCRIPTION
…a version in case of python client (0.3.8)