### PR TITLE
PUBDEV-4595: model error.  Replace / in mode_id with _ and generate a user warning

### DIFF
--- a/h2o-core/src/main/java/water/Job.java
+++ b/h2o-core/src/main/java/water/Job.java
@@ -1,11 +1,12 @@
 package water;
 
 import jsr166y.CountedCompleter;
-import java.util.Arrays;
 import water.H2O.H2OCountedCompleter;
 import water.api.schemas3.KeyV3;
 import water.util.ArrayUtils;
 import water.util.Log;
+
+import java.util.Arrays;
 
 /** Jobs are used to do minimal tracking of long-lifetime user actions,
  *  including progress-bar updates and the ability to review in progress or
@@ -53,6 +54,19 @@ public final class Job<T extends Keyed> extends Keyed<Job> {
     _result = key;              // Result (destination?) key
     _typeid = clz_of_T==null ? 0 : TypeMap.onIce(clz_of_T);
     _description = desc; 
+  }
+
+  /** Create a Job when a warning already exists due to bad model_id
+   *  @param key  Key of the final result
+   *  @param clz_of_T String class of the Keyed result
+   *  @param desc String description
+   *  @param warningStr String contains a warning on model_id*/
+  public Job(Key<T> key, String clz_of_T, String desc, String warningStr) {
+    this(key, clz_of_T, desc);
+    if (warningStr != null) {
+      _warns = new String[] {warningStr};
+    }
+
   }
 
   // Job Keys are pinned to this node (i.e., the node that invoked the

--- a/h2o-core/src/main/java/water/api/ModelBuilderHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelBuilderHandler.java
@@ -9,6 +9,7 @@ import water.Key;
 import water.TypeMap;
 import water.api.schemas3.ModelParametersSchemaV3;
 import water.util.HttpResponseStatus;
+import water.util.Log;
 import water.util.PojoUtils;
 
 import java.util.Properties;
@@ -38,11 +39,21 @@ public class ModelBuilderHandler<B extends ModelBuilder, S extends ModelBuilderS
 
     // User specified key, or make a default?
     String model_id = parms.getProperty("model_id");
+    String warningStr = null;
+    if ((model_id != null) && (model_id.contains("/"))) { // found / in model_id, replace with _ and set warning
+      String tempName = model_id;
+      model_id = model_id.replaceAll("/", "_");
+      warningStr = "Bad model_id: slash (/) found and replaced with _.  " + "Original model_id "+tempName +
+              " is now "+model_id+".";
+      Log.warn("model_id", warningStr);
+    }
     Key<Model> key = doTrain ? (model_id==null ? ModelBuilder.defaultKey(algoName) : Key.<Model>make(model_id)) : null;
     // Default Job for just this training
-    Job job = doTrain ? new Job<>(key,ModelBuilder.javaName(algoURLName),algoName) : null;
+    Job job = doTrain ? (warningStr!=null ? new Job<>(key,ModelBuilder.javaName(algoURLName),algoName, warningStr) :
+            new Job<>(key,ModelBuilder.javaName(algoURLName),algoName)) : null;
     // ModelBuilder
     B builder = ModelBuilder.make(algoURLName,job,key);
+
     schema.parameters.fillFromImpl(builder._parms); // Defaults for this builder into schema
     schema.parameters.fillFromParms(parms);         // Overwrite with user parms
     schema.parameters.fillImpl(builder._parms);     // Merged parms back over Model.Parameter object

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_4959_model_error.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_4959_model_error.py
@@ -1,0 +1,58 @@
+from __future__ import print_function
+from builtins import range
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from tests import pyunit_utils
+
+try:    # redirect python output
+    from StringIO import StringIO  # for python 3
+except ImportError:
+    from io import StringIO  # for python 2
+
+# This method test to make sure when a user enter a bad model id with slashes (/), it will be
+# replaced with _ and a warning message should be generated and passed to the user.
+def test_benign():
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/BostonHousing.csv"))
+    Y = 13
+    X = list(range(13))
+    check_warnings("Wendy Wong and Nidhi Mehta", X, Y, 0, training_data)   # expect no warning here
+
+    check_warnings("Wendy / Wong / and / Nidhi / Mehta", X, Y, 1, training_data)   # bad model_id, expect one warning
+    check_warnings(' test -  june/fifteenth ', X, Y, 1, training_data)   # bad model_id, expect one warning
+
+
+def check_warnings(model_id, X, Y, warnNumber, training_data):
+    buffer = StringIO() # redirect output
+    sys.stderr=buffer
+    model = H2OGeneralizedLinearEstimator(family="Gaussian", nfolds=2, fold_assignment="Modulo",
+                                          keep_cross_validation_predictions=True, model_id=model_id)
+    model.train(x=X, y=Y, training_frame=training_data)
+    warn_phrase = "UserWarning"
+    warn_string_of_interest = "slash (/) found"
+    sys.stderr=sys.__stderr__   # redirect printout back to normal path
+
+    try:        # for python 2.7
+        assert len(buffer.buflist)==warnNumber
+        if len(buffer.buflist) > 0:  # check to make sure we have the right number of warning
+            for index in range(len(buffer.buflist)):
+                print("*** captured warning message: {0}".format(buffer.buflist[index]))
+                assert (warn_phrase in buffer.buflist[index]) and (warn_string_of_interest in buffer.buflist[index])
+    except:     # for python 3.
+        if warnNumber==0:
+            try:
+                warns = buffer.getvalue()
+                assert False, "Warning not expected but received..."
+            except:
+                assert True, "Warning not expected but received..."
+        else:   # may receive more warnings than our own.  Need to filter it out
+            warns = buffer.getvalue()
+            print("*** captured warning message: {0}".format(warns))
+            countWarns = warns.split().count("slash")
+            assert countWarns==warnNumber, "Expected number of warnings: {0}, but received {1}.".format(warnNumber, countWarns)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_benign)
+else:
+    test_benign()

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -159,7 +159,7 @@
     #can then be brought back into R as a raw vector and then used in different ways, e.g. uncompressed
     #with the Rcompression package, or written to a file via writeBin. We can also convert the raw vector to of type
     #character.
-    tmp <- tryCatch(curlPerform(url = url,
+    tmp <- tryCatch(curlPerform(url = URLencode(url),
                                   customrequest = method,
                                   writefunction = write,
                                   headerfunction = h$update,
@@ -184,7 +184,7 @@
     h = basicHeaderGatherer()
     t = basicTextGatherer(.mapUnicode = FALSE)
     header['Expect'] = ''
-    tmp = tryCatch(postForm(uri = url,
+    tmp = tryCatch(postForm(uri = URLencode(url),
                             .params = list(fileUploadInfo = fileUploadInfo),
                             .opts=curlOptions(writefunction = t$update,
                                               headerfunction = h$update,
@@ -207,7 +207,7 @@
     }else{
       header = "Content-Type: application/json"
     }
-    tmp = tryCatch(curlPerform(url = url,
+    tmp = tryCatch(curlPerform(url = URLencode(url),
                                postfields = postBody,
                                writefunction = t$update,
                                headerfunction = h$update,

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_4595_model_error.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_4595_model_error.R
@@ -1,0 +1,37 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# This is a replica of the test used by Nidhi Mehta when she filed JIRA PUBDEV-4595 model error when
+# there are white spaces (for R client only) or when there are /.  I have fixed the backend code to replace
+# / with _ and generate a warning to the user about the change in model_id.  This test is to make sure that
+# the R client does not generate warnings when there are spaces in the model id.  It should generate a warning
+# when the user includes / in the model id.
+glm2Benign <- function() {
+	my_model_id = "Wendy Wong and Nidhi Mehta"	# should raise no warning
+	bhexFV <- h2o.uploadFile(locate("smalldata/logreg/benign.csv"), destination_frame="benignFV.hex")
+	maxX <- 11
+	Y <- 4
+	X   <- 3:maxX
+	X   <- X[ X != Y ]
+
+	Log.info(paste0("The model_id is ", my_model_id))
+	Log.info("Build the model and expect no warning.")
+	mFV <- h2o.glm(model_id = my_model_id, y = Y, x = colnames(bhexFV)[X], training_frame = bhexFV,
+	family = "binomial", nfolds = 5, alpha = 0, lambda = 1e-5)
+
+	my_model_id = "Wendy / Wong / and / Nidhi / Mehta"	# expect warning here
+	Log.info(paste0("The model_id is ", my_model_id))
+	Log.info("Build the model and expect a warning.")
+
+	expect_warning(h2o.glm(model_id = my_model_id, y = Y, x = colnames(bhexFV)[X], training_frame = bhexFV,
+	family = "binomial", nfolds = 5, alpha = 0, lambda = 1e-5))
+
+	my_model_id = ' test -  june/fifteenth ' # expect warning here too.
+	Log.info(paste0("The model_id is ", my_model_id))
+	Log.info("Build the model and expect a warning.")
+
+	expect_warning(h2o.glm(model_id = my_model_id, y = Y, x = colnames(bhexFV)[X], training_frame = bhexFV,
+	family = "binomial", nfolds = 5, alpha = 0, lambda = 1e-5))
+}
+
+doTest("GLM: Benign Data", glm2Benign)


### PR DESCRIPTION
Four things:
- Added code in backend to replace / with _ in model ID.
- Added warning on bad model_id to job warning which is automatically handled by all clients.
- Fixed bug in R client to allow white spaces in model_id.
- Added Pyunit and Runit tests to capture warnings when bad model_ids are used.