### PR TITLE
Tomas/pubdev 4611 - Made Orc Parser use VecFilesystem

### DIFF
--- a/h2o-core/src/main/java/water/parser/FVecParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/FVecParseWriter.java
@@ -98,7 +98,7 @@ public class FVecParseWriter extends Iced implements StreamParseWriter {
   }
 
   @Override
-  public void setInvalidCol(int colIdx, int nrows) {
+  public void addNAs(int colIdx, int nrows) {
     (_nvs[colIdx] = _vecs[colIdx].chunkForChunkIdx(_cidx)).addNAs(nrows);
   }
 

--- a/h2o-core/src/main/java/water/parser/FVecParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/FVecParseWriter.java
@@ -96,6 +96,12 @@ public class FVecParseWriter extends Iced implements StreamParseWriter {
   @Override public final void addInvalidCol(int colIdx) {
     if(colIdx < _nCols) _nvs[_col = colIdx].addNA();
   }
+
+  @Override
+  public void setInvalidCol(int colIdx, int nrows) {
+    (_nvs[colIdx] = _vecs[colIdx].chunkForChunkIdx(_cidx)).addNAs(nrows);
+  }
+
   @Override public boolean isString(int colIdx) { return (colIdx < _nCols) && (_ctypes[colIdx] == Vec.T_CAT || _ctypes[colIdx] == Vec.T_STR);}
 
   @Override public void addStrCol(int colIdx, BufferedString str) {

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -723,7 +723,7 @@ public final class ParseDataset {
         switch( cpr ) {
         case NONE:
           ParserInfo.ParseMethod pm = _parseSetup._parse_type.parseMethod(_keys.length,vec.nChunks());
-          if(pm == ParserInfo.ParseMethod.DistributesParse) {
+          if(pm == ParserInfo.ParseMethod.DistributedParse) {
             new DistributedParse(_vg, localSetup, _vecIdStart, chunkStartIdx, this, key, vec.nChunks()).dfork(vec).getResult(false);
             for( int i = 0; i < vec.nChunks(); ++i )
               _chunk2ParseNodeMap[chunkStartIdx + i] = vec.chunkKey(i).home_node().index();

--- a/h2o-core/src/main/java/water/parser/ParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/ParseWriter.java
@@ -39,7 +39,7 @@ public interface ParseWriter extends Freezable {
   void addNumCol(int colIdx, double d);
   // An an invalid / missing entry
   void addInvalidCol(int colIdx);
-  void setInvalidCol(int colIdx, int nrow);
+  void addNAs(int colIdx, int nrow);
   // Add a String column
   void addStrCol( int colIdx, BufferedString str );
   // Final rolling back of partial line

--- a/h2o-core/src/main/java/water/parser/ParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/ParseWriter.java
@@ -39,6 +39,7 @@ public interface ParseWriter extends Freezable {
   void addNumCol(int colIdx, double d);
   // An an invalid / missing entry
   void addInvalidCol(int colIdx);
+  void setInvalidCol(int colIdx, int nrow);
   // Add a String column
   void addStrCol( int colIdx, BufferedString str );
   // Final rolling back of partial line

--- a/h2o-core/src/main/java/water/parser/ParserInfo.java
+++ b/h2o-core/src/main/java/water/parser/ParserInfo.java
@@ -1,5 +1,6 @@
 package water.parser;
 
+import water.H2O;
 import water.Iced;
 
 /**
@@ -41,6 +42,28 @@ public class ParserInfo extends Iced<ParserInfo> {
   /** Get order priority for this parser. */
   public int priority() {
     return prior;
+  }
+
+  // TOO_MANY_KEYS_COUNT specifies when to disable parallel parse. We want to cover a scenario when
+  // we are working with too many keys made of small files - in this case the distributed parse
+  // doesn't work well because of the way chunks are distributed to nodes. We should switch to a local
+  // parse to make sure the work is uniformly distributed across the whole cluster.
+  public static final int TOO_MANY_KEYS_COUNT = 128;
+  // A file is considered to be small if it can fit into <SMALL_FILE_NCHUNKS> number of chunks.
+  public static final int SMALL_FILE_NCHUNKS = 10;
+
+  public enum ParseMethod {StreamParse,DistributesParse}
+  /*
+  localSetup.disableParallelParse ||
+   */
+  public ParseMethod parseMethod(int nfiles, int nchunks){
+    if(isStreamParseSupported()) {
+      if (!isParallelParseSupported() || (nfiles > TOO_MANY_KEYS_COUNT && (nchunks <= SMALL_FILE_NCHUNKS)))
+        return ParseMethod.StreamParse;
+    }
+    if(isParallelParseSupported())
+      return ParseMethod.DistributesParse;
+    throw H2O.unimpl();
   }
 
   /** Does the parser support parallel parse? */

--- a/h2o-core/src/main/java/water/parser/ParserInfo.java
+++ b/h2o-core/src/main/java/water/parser/ParserInfo.java
@@ -52,7 +52,7 @@ public class ParserInfo extends Iced<ParserInfo> {
   // A file is considered to be small if it can fit into <SMALL_FILE_NCHUNKS> number of chunks.
   public static final int SMALL_FILE_NCHUNKS = 10;
 
-  public enum ParseMethod {StreamParse,DistributesParse}
+  public enum ParseMethod {StreamParse, DistributedParse}
   /*
   localSetup.disableParallelParse ||
    */
@@ -62,7 +62,7 @@ public class ParserInfo extends Iced<ParserInfo> {
         return ParseMethod.StreamParse;
     }
     if(isParallelParseSupported())
-      return ParseMethod.DistributesParse;
+      return ParseMethod.DistributedParse;
     throw H2O.unimpl();
   }
 

--- a/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
@@ -100,7 +100,7 @@ public class PreviewParseWriter extends Iced implements StreamParseWriter {
   }
 
   @Override
-  public void setInvalidCol(int colIdx, int nrow) {
+  public void addNAs(int colIdx, int nrow) {
     throw H2O.unimpl();
   }
 

--- a/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
@@ -98,6 +98,12 @@ public class PreviewParseWriter extends Iced implements StreamParseWriter {
         _data[_nlines][colIdx] = "NA";
     }
   }
+
+  @Override
+  public void setInvalidCol(int colIdx, int nrow) {
+    throw H2O.unimpl();
+  }
+
   @Override public void addStrCol(int colIdx, BufferedString str) {
     if(colIdx < _ncols) {
       // Check for time

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
@@ -132,7 +132,7 @@ public class OrcParser extends Parser {
         int colIndex = 0;
         for (int col = 0; col < batch.numCols; ++col) {  // read one column at a time;
           if (toInclude[col + 1]) { // only write a column if we actually want it
-            if(_setup.getColumnTypes()[col] != Vec.T_BAD)
+            if(_setup.getColumnTypes()[colIndex] != Vec.T_BAD)
               write1column(dataVectors[col], orcTypes[colIndex], colIndex, nrows, dout);
             else dout.addNAs(col,nrows);
             colIndex++;

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
@@ -132,11 +132,17 @@ public class OrcParser extends Parser {
         int colIndex = 0;
         for (int col = 0; col < batch.numCols; ++col) {  // read one column at a time;
           if (toInclude[col + 1]) { // only write a column if we actually want it
-            write1column(dataVectors[col], orcTypes[colIndex], colIndex, nrows, dout);
+            if(_setup.getColumnTypes()[col] != Vec.T_BAD)
+              write1column(dataVectors[col], orcTypes[colIndex], colIndex, nrows, dout);
             colIndex++;
           }
         }
         rows  += currentBatchRow;    // record number of rows of data actually read
+      }
+      byte [] col_types = _setup.getColumnTypes();
+      for(int i = 0; i < col_types.length; ++i){
+        if(col_types[i] == Vec.T_BAD)
+          dout.setInvalidCol(i,(int)rowCount);
       }
       perStripe.close();
     } catch(IOException ioe) {

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParser.java
@@ -134,6 +134,7 @@ public class OrcParser extends Parser {
           if (toInclude[col + 1]) { // only write a column if we actually want it
             if(_setup.getColumnTypes()[col] != Vec.T_BAD)
               write1column(dataVectors[col], orcTypes[colIndex], colIndex, nrows, dout);
+            else dout.addNAs(col,nrows);
             colIndex++;
           }
         }
@@ -142,7 +143,7 @@ public class OrcParser extends Parser {
       byte [] col_types = _setup.getColumnTypes();
       for(int i = 0; i < col_types.length; ++i){
         if(col_types[i] == Vec.T_BAD)
-          dout.setInvalidCol(i,(int)rowCount);
+          dout.addNAs(i,(int)rowCount);
       }
       perStripe.close();
     } catch(IOException ioe) {

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
@@ -116,7 +116,7 @@ public class OrcParserProvider extends ParserProvider {
         byte[] old_columnTypes = stp.getColumnTypes();
         String[] old_columnTypeNames = stp.getColumnTypesString();
         for (int index = 0; index < columnTypes.length; index++) {
-          if (columnTypes[index] == Vec.T_CAT)  // only copy the enum types
+          if (columnTypes[index] == Vec.T_CAT || columnTypes[index] == Vec.T_BAD)  // only copy the enum types
             old_columnTypes[index] = columnTypes[index];
         }
         stp.setColumnTypes(old_columnTypes);

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
@@ -1,7 +1,6 @@
 package water.parser.orc;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.orc.OrcFile;
 import org.apache.hadoop.hive.ql.io.orc.Reader;
@@ -13,7 +12,6 @@ import water.Job;
 import water.Key;
 import water.fvec.*;
 import water.parser.*;
-import water.persist.PersistHdfs;
 import water.persist.VecFileSystem;
 
 import java.io.IOException;
@@ -27,9 +25,9 @@ import static water.fvec.FileVec.getPathForKey;
  */
 public class OrcParserProvider extends ParserProvider {
 
-  public static class OrParserInfo extends ParserInfo {
+  public static class OrcParserInfo extends ParserInfo {
 
-    public OrParserInfo() {
+    public OrcParserInfo() {
       super("ORC", DefaultParserProviders.MAX_CORE_PRIO + 20, true, true, false);
     }
 
@@ -43,7 +41,7 @@ public class OrcParserProvider extends ParserProvider {
     }
   }
   /* Setup for this parser */
-  static ParserInfo ORC_INFO = new OrParserInfo();
+  static ParserInfo ORC_INFO = new OrcParserInfo();
 
   @Override
   public ParserInfo info() {

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
@@ -37,7 +37,7 @@ public class OrcParserProvider extends ParserProvider {
       // ORC stream parse is more efficient
       return
           nfiles >= (ncores_tot >> 1)  // got enough files to keep cluster busy
-              ?ParseMethod.StreamParse:ParseMethod.StreamParse;//ParseMethod.DistributesParse;
+              ?ParseMethod.StreamParse:ParseMethod.StreamParse;//ParseMethod.DistributedParse;
     }
   }
   /* Setup for this parser */

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
@@ -38,9 +38,7 @@ public class OrcParserProvider extends ParserProvider {
       // prefer StreamParse if we have enough files to keep cluster busy
       // ORC stream parse is more efficient
       return
-          nfiles >= ncores_tot // got enough files to keep cluster busy
-              || nchunks <= 4  // there is not much parallelization anyways, better to save unnecessary memory loads
-              || (nfiles >= ncores_tot >> 1) && nchunks <= H2O.NUMCPUS
+          nfiles >= (ncores_tot >> 1)  // got enough files to keep cluster busy
               ?ParseMethod.StreamParse:ParseMethod.StreamParse;//ParseMethod.DistributesParse;
     }
   }

--- a/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
+++ b/h2o-parsers/h2o-orc-parser/src/main/java/water/parser/orc/OrcParserProvider.java
@@ -142,7 +142,6 @@ public class OrcParserProvider extends ParserProvider {
     if(!(v instanceof FileVec)) throw H2O.unimpl("ORC only implemented for HDFS / NFS files");
     try {
       ((OrcParser.OrcParseSetup)setup).setOrcFileReader(getReader((FileVec)v));
-
       return setup;
 
     } catch (IOException e) {throw new RuntimeException(e);}

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
@@ -1,5 +1,6 @@
 package water.parser;
 
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -9,8 +10,12 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.TreeSet;
 
+import water.Key;
 import water.TestUtil;
+import water.api.schemas3.ParseSetupV3;
 import water.fvec.Frame;
+import water.fvec.NFSFileVec;
+import water.fvec.Vec;
 import water.util.FileUtils;
 import water.util.Log;
 
@@ -75,6 +80,18 @@ public class ParseTestOrc extends TestUtil {
     static public void _preconditionJavaVersion() { // NOTE: the `_` force execution of this check after setup
         // Does not run test on Java6 since we are running on Hadoop lib
         Assume.assumeTrue("Java6 is not supported", !System.getProperty("java.version", "NA").startsWith("1.6"));
+    }
+
+    @Test public void testBadColumn(){
+        NFSFileVec nfs = makeNfsFileVec("smalldata/parser/orc/orc_split_elim.orc");
+        Key<Frame> outputKey = Key.make("orc_Test");
+        ParseSetup ps = ParseSetup.guessSetup(new Key[]{nfs._key}, new ParseSetup(new ParseSetupV3()));
+        System.out.println("ParseSetup");
+        System.out.println(ps);
+        ps._column_types[0] = Vec.T_BAD;
+        Frame fr = ParseDataset.parse(outputKey, new Key[]{nfs._key},true,ps);
+        Assert.assertTrue(fr.vec(0).isBad());
+        fr.delete();
     }
 
     @Test

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
@@ -16,6 +16,7 @@ import water.api.schemas3.ParseSetupV3;
 import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.fvec.Vec;
+import water.parser.orc.OrcParserProvider;
 import water.util.FileUtils;
 import water.util.Log;
 
@@ -85,7 +86,10 @@ public class ParseTestOrc extends TestUtil {
     @Test public void testBadColumn(){
         NFSFileVec nfs = makeNfsFileVec("smalldata/parser/orc/orc_split_elim.orc");
         Key<Frame> outputKey = Key.make("orc_Test");
-        ParseSetup ps = ParseSetup.guessSetup(new Key[]{nfs._key}, new ParseSetup(new ParseSetupV3()));
+        ParseSetup pstp = new ParseSetup(new ParseSetupV3());
+        pstp._parse_type = new OrcParserProvider.OrcParserInfo();
+        ParseSetup ps = ParseSetup.guessSetup(new Key[]{nfs._key}, pstp);
+        Assert.assertEquals(ps._parse_type.name(), "ORC");
         System.out.println("ParseSetup");
         System.out.println(ps);
         ps._column_types[0] = Vec.T_BAD;

--- a/h2o-parsers/h2o-orc-parser/testMultiNode.sh
+++ b/h2o-parsers/h2o-orc-parser/testMultiNode.sh
@@ -65,7 +65,7 @@ fi
 #   build/classes/main - Main h2o core classes
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
-JVM="nice $JAVA_CMD -DcloudSize=5 -ea $COVERAGE -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp build/libs/h2o-orc-parser-test.jar${SEP}build/libs/h2o-orc-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../lib/*"
+JVM="nice $JAVA_CMD -DcloudSize=5 -ea $COVERAGE -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp build/libs/h2o-orc-parser-test.jar${SEP}build/libs/h2o-orc-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../h2o-persist-hdfs/build/libs/h2o-persist-hdfs.jar${SEP}../../lib/*"
 
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.

--- a/h2o-parsers/h2o-parquet-parser/build.gradle
+++ b/h2o-parsers/h2o-parquet-parser/build.gradle
@@ -8,6 +8,9 @@ def parquetHadoopVersion = binding.variables.get("hadoopVersion") ?
 
 dependencies {
   compile project(":h2o-core")
+  compile(project(":h2o-persist-hdfs")) {
+    transitive = false
+  }
   // Parquet support
   // Use the same version as Spark 1.5-2.0
   compile("org.apache.parquet:parquet-hadoop:1.7.0")

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/org/apache/parquet/hadoop/VecParquetReader.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/org/apache/parquet/hadoop/VecParquetReader.java
@@ -36,12 +36,13 @@ import org.apache.parquet.schema.MessageType;
 import water.fvec.Vec;
 import water.parser.ParseWriter;
 import water.parser.parquet.ChunkReadSupport;
-import water.parser.parquet.VecDataInputStream;
-import water.parser.parquet.VecFileSystem;
+import water.persist.VecDataInputStream;
 import water.util.Log;
 
 import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
 import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
+
+import water.persist.VecFileSystem;
 
 /**
  * Implementation of Parquet Reader working on H2O's Vecs.

--- a/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/ParseTestParquet.java
+++ b/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/ParseTestParquet.java
@@ -42,7 +42,7 @@ public class ParseTestParquet extends TestUtil {
   private static double EPSILON = 1e-9;
 
   @BeforeClass
-  static public void setup() { TestUtil.stall_till_cloudsize(5); }
+  static public void setup() { TestUtil.stall_till_cloudsize(1); }
 
   @Test
   public void testParseSimple() {

--- a/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/VecDataInputStreamTest.java
+++ b/h2o-parsers/h2o-parquet-parser/src/test/java/water/parser/parquet/VecDataInputStreamTest.java
@@ -7,6 +7,7 @@ import water.Key;
 import water.MRTask;
 import water.TestUtil;
 import water.fvec.*;
+import water.persist.VecDataInputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/h2o-parsers/h2o-parquet-parser/testMultiNode.sh
+++ b/h2o-parsers/h2o-parquet-parser/testMultiNode.sh
@@ -44,7 +44,7 @@ fi
 #   build/classes/main - Main h2o core classes
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
-JVM="nice $JAVA_CMD -DcloudSize=5 -ea -Xmx3g -Xms3g -cp build/libs/h2o-parquet-parser-test.jar${SEP}build/libs/h2o-parquet-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../lib/*"
+JVM="nice $JAVA_CMD -DcloudSize=5 -ea -Xmx3g -Xms3g -cp build/libs/h2o-parquet-parser-test.jar${SEP}build/libs/h2o-parquet-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../h2o-persist-hdfs/build/libs/h2o-persist-hdfs.jar${SEP}../../lib/*"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-persist-hdfs/src/main/java/water/persist/VecDataInputStream.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/VecDataInputStream.java
@@ -1,4 +1,4 @@
-package water.parser.parquet;
+package water.persist;
 
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;

--- a/h2o-persist-hdfs/src/main/java/water/persist/VecFileSystem.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/VecFileSystem.java
@@ -1,4 +1,4 @@
-package water.parser.parquet;
+package water.persist;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;


### PR DESCRIPTION
Make ORC use VecFileSystem from Parquet parser implementation (refactored to h2o-persist-hdfs) instead of native hadoop file system.

Two benefits: 
   a) consistency with the rest of h2o (data read via standard DKV mechanism)
   b) DKV caching

VecFileSystem/VecInputStream refactored to h2o-persist-hdfs
