### PR TITLE
PUBDEV-4608: Allows to disable internal memory checks during training

### DIFF
--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearning.java
@@ -116,7 +116,7 @@ public class DeepLearning extends ModelBuilder<DeepLearningModel,DeepLearningMod
     return dinfo;
   }
 
-  @Override protected void checkMemoryFootPrint() {
+  @Override protected void checkMemoryFootPrint_impl() {
     if (_parms._checkpoint != null) return;
     long p = hex.util.LinearAlgebraUtils.numColsExp(_train,true) - (_parms._autoencoder ? 0 : _train.lastVec().cardinality());
     String[][] dom = _train.domains();

--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -74,7 +74,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
   @Override public boolean havePojo() { return false; }
   @Override public boolean haveMojo() { return true; }
 
-  @Override protected void checkMemoryFootPrint() {
+  @Override protected void checkMemoryFootPrint_impl() {
     HeartBeat hb = H2O.SELF._heartbeat;
     double p = hex.util.LinearAlgebraUtils.numColsExp(_train,true);
     double r = _train.numRows();

--- a/h2o-algos/src/main/java/hex/kmeans/KMeans.java
+++ b/h2o-algos/src/main/java/hex/kmeans/KMeans.java
@@ -42,7 +42,7 @@ public class KMeans extends ClusteringModelBuilder<KMeansModel,KMeansModel.KMean
   public KMeans( KMeansModel.KMeansParameters parms, Job job) { super(parms,job); init(false); }
   public KMeans(boolean startup_once) { super(new KMeansModel.KMeansParameters(),startup_once); }
 
-  @Override protected void checkMemoryFootPrint() {
+  @Override protected void checkMemoryFootPrint_impl() {
     long mem_usage = 8 /*doubles*/ * _parms._k * _train.numCols() * (_parms._standardize ? 2 : 1);
     long max_mem = H2O.SELF._heartbeat.get_free_mem();
     if (mem_usage > max_mem) {

--- a/h2o-algos/src/main/java/hex/naivebayes/NaiveBayes.java
+++ b/h2o-algos/src/main/java/hex/naivebayes/NaiveBayes.java
@@ -32,7 +32,7 @@ public class NaiveBayes extends ModelBuilder<NaiveBayesModel,NaiveBayesParameter
   @Override public boolean haveMojo() { return false; }
 
   @Override
-  protected void checkMemoryFootPrint() {
+  protected void checkMemoryFootPrint_impl() {
     // compute memory usage for pcond matrix
     long mem_usage = (_train.numCols() - 1) * _train.lastVec().cardinality();
     String[][] domains = _train.domains();

--- a/h2o-algos/src/main/java/hex/pca/PCA.java
+++ b/h2o-algos/src/main/java/hex/pca/PCA.java
@@ -51,7 +51,7 @@ public class PCA extends ModelBuilder<PCAModel,PCAModel.PCAParameters,PCAModel.P
   @Override public boolean havePojo() { return true; }
   @Override public boolean haveMojo() { return false; }
 
-  @Override protected void checkMemoryFootPrint() {
+  @Override protected void checkMemoryFootPrint_impl() {
 
     HeartBeat hb = H2O.SELF._heartbeat; // todo: Add to H2O object memory information so we don't have to use heartbeat.
     //   int numCPUs= H2O.NUMCPUS;   // proper way to get number of CPUs.

--- a/h2o-algos/src/main/java/hex/svd/SVD.java
+++ b/h2o-algos/src/main/java/hex/svd/SVD.java
@@ -83,7 +83,7 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
   public SVD(boolean startup_once) { super(new SVDParameters(),startup_once); }
 
   @Override
-  protected void checkMemoryFootPrint() {
+  protected void checkMemoryFootPrint_impl() {
     HeartBeat hb = H2O.SELF._heartbeat;
     double p = LinearAlgebraUtils.numColsExp(_train, true);
     double r = _train.numRows();

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -901,7 +901,7 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
     }
   }
 
-  @Override protected void checkMemoryFootPrint() {
+  @Override protected void checkMemoryFootPrint_impl() {
     if (_model._output._ntrees == 0) return;
     int trees_so_far = _model._output._ntrees; //existing trees
     long model_mem_size = new ComputeModelSize(trees_so_far, _model._output._treeKeys).doAllNodes()._model_mem_size;

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -749,10 +749,21 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   protected void ignoreInvalidColumns(int npredictors, boolean expensive){}
 
   /**
+   * Makes sure the final model will fit in memory.
+   *
+   * Note: This method should not be overridden (override checkMemoryFootPrint_impl instead). It is
+   * not declared 'final' to not to break 3rd party implementations. It might be declared final in the future
+   * if necessary.
+   */
+  protected void checkMemoryFootPrint() {
+    if (Boolean.getBoolean(H2O.OptArgs.SYSTEM_PROP_PREFIX + "debug.noMemoryCheck")) return; // skip check if disabled
+    checkMemoryFootPrint_impl();
+  }
+
+  /**
    * Override this method to call error() if the model is expected to not fit in memory, and say why
    */
-  protected void checkMemoryFootPrint() {}
-
+  protected void checkMemoryFootPrint_impl() {}
 
   transient double [] _distribution;
   transient protected double [] _priorClassDist;


### PR DESCRIPTION
The target audience is internal QA who can disable the check to make sure
that estimates of model sizes are not inflated (and that the modelling
would actually finishes if the memory check was not present).

See jira PUBDEV-4608 for reference.