### PR TITLE
PUBDEV-4445-rel-vajda: prediction warning.  -Passed warning messages from model…

### DIFF
--- a/h2o-algos/src/test/java/hex/pca/PCATest.java
+++ b/h2o-algos/src/test/java/hex/pca/PCATest.java
@@ -289,4 +289,38 @@ public class PCATest extends TestUtil {
       Scope.exit();
     }
   }
+
+  /*
+  This test will make sure that when the test dataset contains columns that are different from
+  the training dataset, a warning should be generated to warn the user.
+   */
+  @Test public void testIrisScoreWarning() throws InterruptedException, ExecutionException {
+    PCAModel model = null;
+    Frame fr = null, fr2= null;
+    Frame tr = null, te= null;
+    Scope.enter();
+
+    try {
+      fr = parse_test_file("smalldata/iris/iris_wheader.csv");
+      tr = parse_test_file("smalldata/iris/iris_wheader_bad_cnames.csv");
+      Scope.track(fr);
+      Scope.track(tr);
+
+      PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
+      parms._train=fr._key;
+ //     parms._valid = tr._key;
+      parms._k = 4;
+      parms._max_iterations = 1000;
+      parms._pca_method = PCAParameters.Method.GramSVD;
+
+      model = new PCA(parms).trainModel().get();
+      Scope.track_generic(model);
+
+      // Done building model; produce a score column with cluster choices
+      fr2 = model.score(tr);
+      Scope.track(fr2);
+    } finally {
+      Scope.exit();
+    }
+  }
 }

--- a/h2o-core/src/main/java/water/api/ModelMetricsHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelMetricsHandler.java
@@ -2,6 +2,7 @@ package water.api;
 
 import hex.*;
 import hex.genmodel.utils.DistributionFamily;
+import org.apache.commons.lang.ArrayUtils;
 import water.*;
 import water.api.schemas3.*;
 import water.exceptions.H2OIllegalArgumentException;
@@ -367,6 +368,10 @@ class ModelMetricsHandler extends Handler {
           Frame predictions = ((Model.DeepFeatures) parms._model).scoreDeepFeatures(parms._frame, s.deep_features_hidden_layer, j);
           predictions = new Frame(Key.<Frame>make(parms._predictions_name), predictions.names(), predictions.vecs());
           DKV.put(predictions._key, predictions);
+        }
+        if ((parms._model._warningsP != null) && (parms._model._warningsP.length > 0)) { // add prediction warning here only
+          String[] allWarnings = (String[]) ArrayUtils.addAll(j.warns(), parms._model._warningsP); // copy both over
+          j.setWarnings(allWarnings);
         }
         tryComplete();
       }

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_covtype_PUBDEV_4445.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_covtype_PUBDEV_4445.py
@@ -1,0 +1,71 @@
+import sys, os
+
+sys.path.insert(1, os.path.join("..", "..", ".."))
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+try:
+    from StringIO import StringIO  # for python 3
+except ImportError:
+    from io import StringIO  # for python 2
+
+
+# A more detailed test on checking the warning messages from scoring/prediction functions.
+def bigcat_gbm():
+    covtype = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    covtype[54] = covtype[54].asfactor()
+    covtypeTest = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    covtypeTest[54] = covtype[54].asfactor()
+
+    regular = H2OGradientBoostingEstimator(ntrees=10, seed=1234)
+    regular.train(x=list(range(54)), y=54, training_frame=covtype)
+
+    # do prediction on original dataset, no warnings
+    check_warnings(regular, 0, covtypeTest)
+    # drop response, no warnings
+    covtypeTest = covtypeTest.drop(54)
+    check_warnings(regular, 0, covtypeTest)
+
+    covtypeTest = covtypeTest.drop(1)
+    covtypeTest=covtypeTest.drop(1)
+    check_warnings(regular, 2, covtypeTest)
+
+    covtypeTest = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    covtypeTest[54] = covtype[54].asfactor()
+    covtypeTest=covtypeTest.drop(3)
+    covtypeTest=covtypeTest.drop(5)
+    covtypeTest=covtypeTest.drop(7)
+    check_warnings(regular, 3, covtypeTest)
+
+def check_warnings(theModel, warnNumber, dataset):
+    buffer = StringIO() # redirect output
+    sys.stderr=buffer
+    pred_h2o = theModel.predict(dataset)
+    warn_phrase = "missing"
+    sys.stderr=sys.__stderr__   # redirect printout back to normal path
+    try:        # for python 2.7
+        assert len(buffer.buflist)==warnNumber
+        if len(buffer.buflist) > 0:  # check to make sure we have the right number of warning
+            for index in range(len(buffer.buflist)):
+                print("*** captured warning message: {0}".format(buffer.buflist[index]))
+                assert (warn_phrase in buffer.buflist[index]), "Wrong warning message is received."
+    except:     # for python 3.
+        if warnNumber==0:
+            try:
+                warns = buffer.getvalue()
+                assert False, "Warning not expected but received..."
+            except:
+                assert True, "Warning not expected but received..."
+        else:
+            warns = buffer.getvalue()
+            print("*** captured warning message: {0}".format(warns))
+            countWarns = warns.split().count(warn_phrase)
+            assert countWarns==warnNumber, "Expected number of warning: {0}.  But received {1}.".format(warnNumber, countWarns)
+
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(bigcat_gbm)
+else:
+    bigcat_gbm()

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_4445_iris_predict_warning.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_4445_iris_predict_warning.py
@@ -1,0 +1,52 @@
+from __future__ import print_function
+from builtins import str
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+
+try:
+    from StringIO import StringIO  # for python 3
+except ImportError:
+    from io import StringIO  # for python 2
+
+
+def glrm_iris():
+    print("Importing iris_wheader.csv data...")
+    irisH2O = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    irisTest = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris_wheader_bad_cnames.csv"))
+
+    rank = 3
+    gx = 0.5
+    gy = 0.5
+    trans = "STANDARDIZE"
+    print("H2O GLRM with rank k = " + str(rank) + ", gamma_x = " + str(gx) + ", gamma_y = " + str(
+        gy) + ", transform = " + trans)
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=rank, loss="Quadratic", gamma_x=gx, gamma_y=gy, transform=trans)
+    glrm_h2o.train(x=irisH2O.names, training_frame=irisH2O)
+
+    print("Impute original data from XY decomposition")  # and expect warnings
+    buffer = StringIO()     # redirect warning messages to string buffer for later analysis
+    sys.stderr = buffer
+
+    h2o_pred = glrm_h2o.predict(irisTest)
+
+    warn_phrase = "UserWarning"
+    warn_string_of_interest = "missing column"
+    sys.stderr = sys.__stderr__     # redirect it back to stdout.
+    try:        # for python 2.7
+        if len(buffer.buflist) > 0:
+            for index in range(len(buffer.buflist)):
+                print("*** captured warning message: {0}".format(buffer.buflist[index]))
+                assert (warn_phrase in buffer.buflist[index]) and (warn_string_of_interest in buffer.buflist[index])
+    except:     # for python 3.
+        warns = buffer.getvalue()
+        print("*** captured warning message: {0}".format(warns))
+        assert (warn_phrase in warns) and (warn_string_of_interest in warns)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glrm_iris)
+else:
+    glrm_iris()

--- a/h2o-r/tests/testdir_algos/glrm/runit_glrm_iris_PUBDEV_4445.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_glrm_iris_PUBDEV_4445.R
@@ -1,0 +1,17 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.glrm.iris <- function() {
+  Log.info("Importing iris_wheader.csv data...") 
+  irisH2O <- h2o.uploadFile(locate("smalldata/iris/iris_wheader.csv"), destination_frame = "irisH2O")
+  irisTest <- h2o.uploadFile(locate("smalldata/iris/iris_wheader_bad_cnames.csv"))
+  
+  num_cols <- colnames(irisH2O)[1:4]   # sepal_len, sepal_wid, petal_len, and petal_wid
+  fitH2O <- h2o.glrm(irisH2O, k = 2, loss = "Quadratic", gamma_x = 0.5, gamma_y = 0.5, transform = "STANDARDIZE",
+    impute_original = FALSE)
+
+  abc = predict(fitH2O, irisTest)
+  expect_warning(predict(fitH2O, irisTest))
+}
+
+doTest("GLRM Test: Iris with Various Transformations", test.glrm.iris)


### PR DESCRIPTION
…… (#1286)

* PUBDEV-4445: pass warning message from prediction to clients with Pyunit/Runit and Junit tests.

* PUBDEV-4445: prediction warning.  Added NPE check.
PUBDEV-4445: prediction warning.  Fixed pyunit test for python 3.
PUBDEV-4445: prediction warning.  Generate warning if response column is removed in adaptTestForTrain.  This warning is used by other tests.  For prediction, I will exclude the warning if response column is missing.

* PUBDEV-4445: prediction warning.  Fixed bug uncovered by Michal K.