### PR TITLE
PUBDEV-4621: Add documentation for missing GLM parameters

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/balance_classes.rst
+++ b/h2o-docs/src/product/data-science/algo-params/balance_classes.rst
@@ -1,7 +1,7 @@
 ``balance_classes``
 -------------------
 
-- Available in: GBM, DRF, Deep Learning, Naïve-Bayes
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/class_sampling_factors.rst
+++ b/h2o-docs/src/product/data-science/algo-params/class_sampling_factors.rst
@@ -1,7 +1,7 @@
 ``class_sampling_factors``
 --------------------------
 
-- Available in: GBM, DRF, Deep Learning, Naïve-Bayes
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/max_after_balance_size.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_after_balance_size.rst
@@ -1,7 +1,7 @@
 ``max_after_balance_size``
 --------------------------
 
-- Available in: GBM, DRF, Deep Learning, Naïve-Bayes
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/max_hit_ratio_k.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_hit_ratio_k.rst
@@ -1,7 +1,7 @@
 ``max_hit_ratio_k``
 -------------------
 
-- Available in: GBM, DRF, Deep Learning, Naïve-Bayes
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -153,6 +153,16 @@ Defining a GLM Model
 
 -  `interactions <algo-params/interactions.html>`__: Specify a list of predictor column indices to interact. All pairwise combinations will be computed for this list. 
 
+-  `balance_classes <algo-params/balance_classes.html>`__: Specify whether to oversample the minority classes to balance the class distribution. This option is not enabled by default and can increase the data frame size. This option is only applicable for classification. Majority classes can be undersampled to satisfy the **max_after_balance_size** parameter.
+
+-  `class_sampling_factors <algo-params/class_sampling_factors.html>`__: Specify the per-class (in lexicographical order) over/under-sampling ratios. By default, these ratios are automatically computed during training to obtain the class balance.
+
+-  `max_after_balance_size <algo-params/max_after_balance_size.html>`__: Specify the maximum relative size of the training data after balancing class counts (**balance_classes** must be enabled). The value can be less than 1.0.
+
+-  `max_hit_ratio_k <algo-params/max_hit_ratio_k.html>`__: Specify the maximum number (top K) of predictions to use for hit ratio computation. Applicable to multi-class only. To disable, enter 0.
+
+-  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Maximum allowed runtime in seconds for model training. Use 0 to disable.
+
 Interpreting a GLM Model
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
In the GLM section of the user guide, added parameters for the following:
- balance_classes
- class_sampling_factors
- max_after_balance_size
- max_hit_ratio_k
- max_runtime_secs
In the Parameters Appendix, added “GLM” to the “Available In” section for these parameters.