### PR TITLE
Fixing Grid endpoint

### DIFF
--- a/h2o-docs/src/product/tutorials/GridSearch.md
+++ b/h2o-docs/src/product/tutorials/GridSearch.md
@@ -8,7 +8,7 @@ The current implementation of the grid search REST API exposes the following end
 
 - `GET /<version>/Grids`: List available grids, with optional parameters to sort the list by model metric such as MSE
 - `GET /<version>/Grids/<grid_id>`: Return specified grid
-- `POST /<version>/Grids/<algo_name>`: Start a new grid search
+- `POST /<version>/Grid/<algo_name>`: Start a new grid search
 	- `<algo_name>`: Supported algorithm values are `{glm, gbm, drf, kmeans, deeplearning}`
 
 Endpoints accept model-specific parameters (e.g., [GBMParametersV3](https://github.com/h2oai/h2o-3/blob/master/h2o-algos/src/main/java/hex/schemas/GBMV3.java) and an additional parameter called `hyper_parameters` which contains a dictionary of the hyper parameters which will be searched. In this dictionary an array of values is specified for each searched hyperparameter.


### PR DESCRIPTION
`Grid` correction seems to have been reverted in https://github.com/h2oai/h2o-3/commit/ed77175a9a2b4e72853270fe7871461b3179b924#diff-deed868a9c728f3ebdc2a862a35ee31b