### PR TITLE
Pubdev 3947 pca slow

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -468,6 +468,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
 
         // Set X and Y appropriately given SVD of A = UDV'
         // a) Set Y = D^(1/2)V'S where S = diag(\sigma)
+        _parms._k = svd._parms._nv;   // parameter k may have been reduced due to rank deficient dataset
         double[] dsqrt = new double[_parms._k];
         for (int i = 0; i < _parms._k; i++) {
           dsqrt[i] = Math.sqrt(svd._output._d[i]);
@@ -2550,7 +2551,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
 
     CholMulTask(CholeskyDecomposition chol, Archetypes yt, int ncolA, int ncolX, int ncats,
                 double[] normSub, double[] normMul) {
-      assert yt != null && yt.rank() == ncolX;
+      assert yt != null && yt.rank() <= ncolX;
       assert ncats <= ncolA;
       _yt = yt;
       _ncolA = ncolA;

--- a/h2o-algos/src/main/java/hex/pca/PCA.java
+++ b/h2o-algos/src/main/java/hex/pca/PCA.java
@@ -78,9 +78,13 @@ public class PCA extends ModelBuilder<PCAModel,PCAModel.PCAParameters,PCAModel.P
 
       error("_train", msg);
     }
-
-    if (mem_usage > mem_usage_w) {  // choose the most memory efficient one
-      _wideDataset = true;   // set to true if wide dataset is detected
+    // _wideDataset is true if original memory does not fit.
+    if (mem_usage > max_mem) {
+      _wideDataset = true;  // have to set _wideDataset in this case
+    } else {  // both ways fit into memory.  Want to choose wideDataset if p is too big.
+      if ((p > 5000) && ( r < 5000)) {
+        _wideDataset = true;
+      }
     }
   }
 
@@ -309,7 +313,7 @@ public class PCA extends ModelBuilder<PCAModel,PCAModel.PCAParameters,PCAModel.P
           GramTask gtsk = null;
 
           if (_wideDataset) {
-            ogtsk = new OuterGramTask(_job._key, dinfo).doAll(dinfo._adaptedFrame);
+            ogtsk = new OuterGramTask(_job._key, dinfo).doAll(dinfo._adaptedFrame); // 30 times slower than gram
             gram = ogtsk._gram;
             model._output._nobs = ogtsk._nobs;
           } else {

--- a/h2o-algos/src/main/java/hex/svd/SVD.java
+++ b/h2o-algos/src/main/java/hex/svd/SVD.java
@@ -105,8 +105,13 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
       error("_train", msg);
     }
 
-    if (mem_usage > mem_usage_w) {  // choose the most memory efficient one
-      _wideDataset = true;   // set to true if wide dataset is detected
+    // _wideDataset is true if original memory does not fit.
+    if (mem_usage > max_mem) {
+      _wideDataset = true;  // have to set _wideDataset in this case
+    } else {  // both ways fit into memory.  Want to choose wideDataset if p is too big.
+      if ((p > 5000) && ( r < 5000)) {
+        _wideDataset = true;
+      }
     }
   }
 

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_3502_pca_hangs_large_NOPASS.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_3502_pca_hangs_large_NOPASS.R
@@ -7,26 +7,31 @@ source("../../../scripts/h2o-r-test-setup.R")
 # the purpose of this test, we are only going to use Power.  You can try GramSVD as well.
 test.pca.la1s <- function() {
   run_time_c = c()
-  num_run = 2
+  num_run = 1
 
   browser()
-  dataR = h2o.importFile("bigdata/laptop/jira/la1s.wc.arff.txt.zip",sep=',',destination_frame = "data",header = T, parse=FALSE)
+  dataR = h2o.importFile(locate("bigdata/laptop/jira/la1s.wc.arff.txt.zip"),sep=',',destination_frame = "data",header = T, parse=FALSE)
   data <- h2o.parseRaw(dataR, destination_frame = "bigParse",
                               parse_type = "CSV", header = T) # chunk_size = 124022500 size will make one chunk.
   data$CLASS_LABEL = NULL
 
   for (runIndex in 1:num_run) {
     # k=1939 is very large and this is going to take a long time.
-    mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1938,max_iterations = 300,pca_method = "Randomized")
-    print("PCA run time with car.arff.txt data in ms is ")
+    mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1938,max_iterations = 10,pca_method = "GramSVD")
+    print("PCA (GramSVD) run time with car.arff.txt data in ms is ")
     print(mm@model$run_time)
-    run_time_c = c(run_time_c,mm@model$run_time)
-    print("average run time in ms for data.arff.txt is: ")
-    print(mean(run_time_c))
-    print("maximum run time in ms for data.arff.txt is: ")
-    print(max(run_time_c))
-    print("minimum run time in ms for data.arff.txt is: ")
-    print(min(run_time_c))
+
+    h2o.rm(mm)
+
+    mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1938,max_iterations = 10,pca_method = "Power")
+    print("PCA (Power) run time with car.arff.txt data in ms is ")
+    print(mm@model$run_time)
+
+    h2o.rm(mm)
+
+    mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1938,max_iterations = 10,pca_method = "Randomized")
+    print("PCA (Randomized) run time with car.arff.txt data in ms is ")
+    print(mm@model$run_time)
 
     h2o.rm(mm)
   }

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_3947_pca_slow_NOPASS_large.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_3947_pca_slow_NOPASS_large.R
@@ -1,0 +1,37 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+# Test PCA on car.arff.txt
+test.pca.slow <- function() {
+  data = h2o.uploadFile(locate("bigdata/laptop/jira/re0.wc.arff.txt.zip"),destination_frame = "data",header = T)
+  data = data[,-2887]
+  data2 = as.data.frame(data)
+
+  print("Running R PCA...")
+  ptm <- proc.time()
+  fitR <- prcomp(data2, center = T, scale. = T)
+  timepassed = proc.time() - ptm
+  print(timepassed)
+
+  print("Running H2O PCA with GramSVD...")
+  ptm <- proc.time()
+  mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1504, pca_method="GramSVD")
+  h2otimepassed = proc.time() - ptm
+  print(h2otimepassed)
+  h2o.rm(mm)
+  ptm <- proc.time()
+
+  print("Running with GLRM...")
+  mmGLRM = h2o.glrm(data, transform="STANDARDIZE", k = 1504, init="Random", max_iterations=3, recover_svd=TRUE, regularization_x="None", regularization_y="None")
+  h2otimepassed = proc.time() - ptm
+  print(h2otimepassed)
+  h2o.rm(mmGLRM)
+
+  print("Running H2O PCA with Randomized...")
+  ptm <- proc.time()
+  mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1504, max_iterations=3, pca_method="Randomized")
+  h2otimepassed = proc.time() - ptm
+  print(h2otimepassed)
+  h2o.rm(mm)
+  h2o.rm(data)
+}
+doTest("PCA Test: rec0.wc.arff.txt", test.pca.slow)


### PR DESCRIPTION
1. Fixed bugs in glrm.java when randomized is used as initialization method.
3. Only enable wide dataset method for PCA if the dataset is very wide.  Discovered that generating the gram matrix is much faster than outergram.
3. Added runit test to time the it takes to build pca models.