### PR TITLE
PUBDEV-4642: AutoML: NPE in leaderboard if there are no models

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -510,7 +510,16 @@ public class Leaderboard extends Keyed<Leaderboard> {
     String[] rowHeaders = new String[length];
     for (int i = 0; i < length; i++) rowHeaders[i] = "" + i;
 
-    if ("mean_per_class_error".equals(sort_metric)){ //Multinomial
+    if (sort_metric == null && length == 0) {
+      // empty TwoDimTable
+      return new TwoDimTable(tableHeader,
+              "no models in this leaderboard",
+              new String[0],
+              new String[0],
+              new String[0],
+              new String[0],
+              "-");
+    } else if ("mean_per_class_error".equals(sort_metric)){ //Multinomial
       return new TwoDimTable(tableHeader,
               "models sorted in order of " + sort_metric + ", best first",
               rowHeaders,


### PR DESCRIPTION
Jenkins was running slowly, built no models, and accidentally tripped over this bug.  I repro'd by temporarily creating an empty leaderboard in AutoML.java.