### PR TITLE
upgrade dockerfile to run Java 8 on Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ########################################################################
-# Dockerfile for Oracle JDK 7 on Ubuntu 14.04
+# Dockerfile for Oracle JDK 8 on Ubuntu 16.04
 ########################################################################
 
 # pull base image
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 # maintainer details
 MAINTAINER h2oai "h2o.ai"
@@ -16,19 +16,19 @@ MAINTAINER h2oai "h2o.ai"
 
 RUN \
   echo 'DPkg::Post-Invoke {"/bin/rm -f /var/cache/apt/archives/*.deb || true";};' | tee /etc/apt/apt.conf.d/no-cache && \
-  echo "deb http://mirror.math.princeton.edu/pub/ubuntu trusty main universe" >> /etc/apt/sources.list && \
+  echo "deb http://mirror.math.princeton.edu/pub/ubuntu xenial main universe" >> /etc/apt/sources.list && \
   apt-get update -q -y && \
   apt-get dist-upgrade -y && \
   apt-get clean && \
   rm -rf /var/cache/apt/* && \
 
-# Install Oracle Java 7
+# Install Oracle Java 8
   DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip python-pip python-sklearn python-pandas python-numpy python-matplotlib software-properties-common python-software-properties && \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update -q && \
   echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
   echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y oracle-java7-installer && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y oracle-java8-installer && \
   apt-get clean && \
 
 # Fetch h2o latest_stable


### PR DESCRIPTION
Java 7 on Ubuntu 14.04 seems to be (at least temporarily) broken.