### PR TITLE
AutoML as a module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,10 @@ ext {
       project(':h2o-ext-xgboost')
     ]
 
+    extensionProjects = [
+      project(':h2o-automl')
+    ]
+
     scalaProjects = [
       project(':h2o-scala_2.10'),
       project(':h2o-scala_2.11'),

--- a/h2o-app/build.gradle
+++ b/h2o-app/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   compile project(":h2o-genmodel")
   compile project(":h2o-core")
   compile project(":h2o-algos")
-  compile project(":h2o-automl")
   // Note: orc parser is included at the assembly level for each
   // Hadoop distribution
 }

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -64,6 +64,7 @@ shadowJar {
   exclude 'devpay_products.properties'
   manifest {
     attributes 'Main-Class': 'water.H2OApp'
+    attributes 'Class-Path': extensionProjects.collect { "h2o-ext/${it.name}.jar" }.join(";")
   }
   transform(com.github.jengelman.gradle.plugins.shadow.transformers.IncludeResourceTransformer.class) {
     file = file("${buildDir}/reports/license/dependency-license.xml")
@@ -87,14 +88,27 @@ task copyJar(type: Copy) {
     from ("${project.buildDir}/libs"){
         include assembly
     }
-    into "${project.parent.parent.buildDir}"
+    into "${rootProject.buildDir}"
     rename { it.replace(assembly, allInOne) }
 }
 
+task copyExtensionJars(type: Copy) {
+    extensionProjects.each { p ->
+        from("${p.buildDir}/libs") {
+            include "${p.project.name}.jar"
+        }
+        into "${rootProject.buildDir}/h2o-ext/"
+        eachFile { f ->
+            logger.info("Copy extension file ${f.relativeSourcePath} to ${f.relativePath}")
+        }
+    }
+}
+
+// Make sure extensions jars are built prior to making the shadow jar
 // Include licences
-shadowJar.dependsOn(project.tasks.getByName('downloadLicenses'))
-// Execute always copyJar
-shadowJar.finalizedBy copyJar
+shadowJar.dependsOn extensionProjects.collect { p -> p.getTasksByName("jar", false) } + [project.tasks.getByName('downloadLicenses')]
+// Execute always copyJar & copyExtensionJars
+shadowJar.finalizedBy copyJar, copyExtensionJars
 // Run shadowJar as par of build
 jar.finalizedBy shadowJar
 

--- a/h2o-bindings/bin/gen_all.py
+++ b/h2o-bindings/bin/gen_all.py
@@ -31,7 +31,6 @@ cloud = run.H2OCloud(
     h2o_jar=os.path.abspath(h2o_jarfile),
     base_port=48000,
     xmx="4g",
-    cp="",
     output_dir=results_dir,
     test_ssl=False
 )

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -62,15 +62,12 @@ class H2OAutoML(object):
                  seed=None,
                  project_name=None):
 
-        #Check if H2O jar contains AutoML
-        try:
-            h2o.api("GET /3/Metadata/schemas/AutoMLV99")
-        except h2o.exceptions.H2OResponseError as e:
-            print(e)
+        # Check if AutoML extension is available
+        if not H2OAutoML.available():
             print("*******************************************************************\n" \
                   "*Please verify that your H2O jar has the proper AutoML extensions.*\n" \
-                  "*******************************************************************\n" \
-                  "\nVerbose Error Message:")
+                  "*******************************************************************\n")
+            raise RuntimeError("AutoML extension is not available")
 
         #If max_runtime_secs is not provided, then it is set to default (600 secs)
         if max_runtime_secs is not 3600:
@@ -134,6 +131,15 @@ class H2OAutoML(object):
         self._automl_key = None
         self._leader_id = None
         self._leaderboard = None
+
+    @staticmethod
+    def available():
+        """
+        Ask the H2O server whether AutoML extension is available.
+
+        :return: True if a AutoML is available, False otherwise
+        """
+        return 'AutoML' in h2o.cluster().list_api_extensions()
 
     #---------------------------------------------------------------------------
     # Basic properties

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -32,9 +32,11 @@
 #' \donttest{
 #' library(h2o)
 #' h2o.init()
-#' votes_path <- system.file("extdata", "housevotes.csv", package="h2o")
-#' votes_hf <- h2o.uploadFile(path = votes_path, header = TRUE)
-#' aml <- h2o.automl(y = "Class", training_frame = votes_hf, max_runtime_secs = 30)
+#' if (h2o.automl.available()) {
+#'   votes_path <- system.file("extdata", "housevotes.csv", package="h2o")
+#'   votes_hf <- h2o.uploadFile(path = votes_path, header = TRUE)
+#'   aml <- h2o.automl(y = "Class", training_frame = votes_hf, max_runtime_secs = 30)
+#' }
 #' }
 #' @export
 h2o.automl <- function(x, y, training_frame,
@@ -50,18 +52,8 @@ h2o.automl <- function(x, y, training_frame,
                        seed = NULL,
                        project_name = NULL)
 {
-
-  tryCatch({
-    .h2o.__remoteSend(h2oRestApiVersion = 3, method="GET", page = "Metadata/schemas/AutoMLV99")
-  },
-  error = function(cond){
-    message("
-         *********************************************************************\n
-         * Please verify that your H2O jar has the proper AutoML extensions. *\n
-         *********************************************************************\n
-         \nVerbose Error Message:")
-    message(cond)
-  })
+  if (! h2o.automl.available())
+    .h2o.automl.na.error()
 
   # Required args: training_frame & response column (y)
   if (missing(training_frame)) stop("argument 'training_frame' is missing")
@@ -210,3 +202,19 @@ predict.H2OAutoML <- function(object, newdata, ...) {
   h2o.getFrame(dest_key)
 }
 
+#' Ask the H2O server whether AutoML extension is available
+#' Returns True if a AutoML is available, False otherwise
+#' @export
+h2o.automl.available <- function() {
+  "AutoML" %in% h2o.list_api_extensions()
+}
+
+.h2o.automl.na.error <- function() {
+  message("
+         ******************************************************************************************\n
+         * Please verify that you have the AutoML extension!                                      *\n
+         * Make sure the h2o-automl.jar is stored in h2o-ext directory (relative to your h2o.jar) *\n
+         ******************************************************************************************\n
+         ")
+  stop("AutoML not available!")
+}


### PR DESCRIPTION
This PR converts AutoML into an H2O extension module and removes it from regular H2O build. User will have to download H2O and AutoML extension separately.

Starting from command line:
1. Download h2o.jar and h2o-automl.jar, put h2o-automl.jar in directory h2o-ext.
2. Run java -jar h2o.jar as usual, extension will be automatically picked up by H2O.

Starting from R/Python:
Put h2o-automl.jar on classpath when running h2o.init().
- in R: h2o.init(extra_classpath="/Users/mkurka/git/h2o/h2o-3/build/h2o-ext/h2o-automl.jar")
- in Python: h2o.init(extra_classpath=['/Users/mkurka/git/h2o/h2o-3/build/h2o-ext/h2o-automl.jar'])

Starting on Hadoop:
hadoop jar h2odriver.jar -libjars /Users/mkurka/git/h2o/h2o-3/build/h2o-ext/h2o-automl.jar -nodes 1 -mapperXmx 4g -output t2

Note: Flow will show a generic error when AutoML is triggered, py/r will should descriptive error.