### PR TITLE
PUBDEV-4446: See OUTPUT - SCORING HISTORY part in Flow in R and Python APIs

### DIFF
--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -69,6 +69,8 @@ def gen_module(schema, algo, module):
         if param["default_value"] is not None:
             phelp += " Defaults to %s." % normalize_value(param, True)
         yield "#' @param %s %s" % (param["name"], bi.wrap(phelp, indent=("#'        "), indent_first=False))
+    if algo in ["deeplearning","drf", "gbm","xgboost"]:
+        yield "#' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE."
     if help_details:
         yield "#' @details %s" % bi.wrap(help_details, indent=("#'          "), indent_first=False)
     if help_return:
@@ -108,6 +110,8 @@ def gen_module(schema, algo, module):
                 list.append(indent("eps_prob = %s" % normalize_value(param), 17 + len(module)))
                 continue
         list.append(indent("%s = %s" % (param["name"], normalize_value(param)), 17 + len(module)))
+    if algo in ["deeplearning","drf", "gbm","xgboost"]:
+        list.append(indent("verbose = FALSE ",17 + len(module)))
     yield ",\n".join(list)
     yield indent(") \n{", 17 + len(module))
     if algo in ["deeplearning", "deepwater", "xgboost", "drf", "gbm", "glm", "naivebayes", "stackedensemble"]:
@@ -251,9 +255,12 @@ def gen_module(schema, algo, module):
         lines = help_extra_checks.split("\n")
         for line in lines:
             yield "%s" % line
-    if algo != "glm":
+    if algo not in ["glm","deeplearning","drf", "gbm","xgboost"]:
         yield "  # Error check and build model"
         yield "  .h2o.modelJob('%s', parms, h2oRestApiVersion = %d) \n}" % (algo, 99 if algo in ["svd", "stackedensemble"] else 3)
+    if algo in ["deeplearning","drf", "gbm","xgboost"]:
+        yield "  # Error check and build model"
+        yield "  .h2o.modelJob('%s', parms, h2oRestApiVersion = %d, verbose=verbose) \n}" % (algo, 99 if algo in ["svd", "stackedensemble"] else 3)
     if help_afterword:
         lines = help_afterword.split("\n")
         for line in lines:

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -86,7 +86,7 @@ class H2OEstimator(ModelBase):
 
     def train(self, x=None, y=None, training_frame=None, offset_column=None, fold_column=None,
               weights_column=None, validation_frame=None, max_runtime_secs=None, ignored_columns=None,
-              model_id=None):
+              model_id=None, verbose=False):
         """
         Train the H2O model.
 
@@ -100,6 +100,7 @@ class H2OEstimator(ModelBase):
         :param weights_column: The name or index of the column in training_frame that holds the per-row weights.
         :param validation_frame: H2OFrame with validation data to be scored on while training.
         :param float max_runtime_secs: Maximum allowed runtime in seconds for model training. Use 0 to disable.
+        :param bool verbose: Print scoring history to stdout. Defaults to False.
         """
         assert_is_type(training_frame, H2OFrame)
         assert_is_type(validation_frame, None, H2OFrame)
@@ -111,7 +112,10 @@ class H2OEstimator(ModelBase):
         assert_is_type(weights_column, None, int, str)
         assert_is_type(max_runtime_secs, None, numeric)
         assert_is_type(model_id, None, str)
+        assert_is_type(verbose,bool)
         algo = self.algo
+        if verbose and algo not in ["drf","gbm","deeplearning","xgboost"]:
+            raise H2OValueError("Verbose should only be set to True for drf, gbm, deeplearning, and xgboost models")
         parms = self._parms.copy()
         if "__class__" in parms:  # FIXME: hackt for PY3
             del parms["__class__"]
@@ -201,7 +205,7 @@ class H2OEstimator(ModelBase):
             self._rest_version = rest_ver
             return
 
-        model.poll()
+        model.poll(verbose_model_scoring_history=verbose)
         model_json = h2o.api("GET /%d/Models/%s" % (rest_ver, model.dest_key))["models"][0]
         self._resolve_model(model.dest_key, model_json)
 

--- a/h2o-py/h2o/job.py
+++ b/h2o-py/h2o/job.py
@@ -53,7 +53,7 @@ class H2OJob(object):
             hidden = not H2OJob.__PROGRESS_BAR__
             pb = ProgressBar(title=self._job_type + " progress", hidden=hidden)
             if verbose_model_scoring_history:
-                pb.execute(self._refresh_job_status, print_verbose_info=lambda x: "False" if x != True else self._print_verbose_info())
+                pb.execute(self._refresh_job_status, print_verbose_info=lambda x: self._print_verbose_info() if int(x * 10) % 5 == 0  else " ")
             else:
                 pb.execute(self._refresh_job_status)
         except StopIteration as e:

--- a/h2o-py/h2o/job.py
+++ b/h2o-py/h2o/job.py
@@ -41,7 +41,7 @@ class H2OJob(object):
         self._poll_count = 10**10
 
 
-    def poll(self):
+    def poll(self, verbose_model_scoring_history = False):
         """
         Wait until the job finishes.
 
@@ -51,7 +51,10 @@ class H2OJob(object):
         try:
             hidden = not H2OJob.__PROGRESS_BAR__
             pb = ProgressBar(title=self._job_type + " progress", hidden=hidden)
-            pb.execute(self._refresh_job_status)
+            if verbose_model_scoring_history:
+                pb.execute(self._refresh_job_status, verbose_model=self.job['dest']['name'])
+            else:
+                pb.execute(self._refresh_job_status)
         except StopIteration as e:
             if str(e) == "cancelled":
                 h2o.api("POST /3/Jobs/%s/cancel" % self.job_key)

--- a/h2o-py/h2o/utils/progressbar.py
+++ b/h2o-py/h2o/utils/progressbar.py
@@ -182,7 +182,7 @@ class ProgressBar(object):
                 if wait_time > 0:
                     time.sleep(wait_time)
                     if print_verbose_info is not None:
-                        print_verbose_info(True)
+                        print_verbose_info(progress)
         except KeyboardInterrupt:
             # If the user presses Ctrl+C, we interrupt the progress bar.
             status = "cancelled"

--- a/h2o-py/h2o/utils/progressbar.py
+++ b/h2o-py/h2o/utils/progressbar.py
@@ -11,13 +11,14 @@ import math
 import os
 import sys
 import time
+from datetime import datetime
+import h2o
 from types import FunctionType, GeneratorType, MethodType
 
 import colorama
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.shared_utils import clamp
 from h2o.utils.typechecks import assert_is_type, is_type, numeric
-
 
 
 class ProgressBar(object):
@@ -122,7 +123,7 @@ class ProgressBar(object):
         self._next_poll_time = None
 
 
-    def execute(self, progress_fn):
+    def execute(self, progress_fn, verbose_model=None):
         """
         Start the progress bar, and return only when the progress reaches 100%.
 
@@ -177,7 +178,13 @@ class ProgressBar(object):
                 time1 = self._get_time_at_progress(result.next_progress)
                 next_render_time = min(time0, time1)
                 self._draw(result.rendered)
-
+                if verbose_model is not None:
+                    time.sleep(1) #To avoid 400 HTTP error
+                    model = h2o.get_model(verbose_model)
+                    print("\nScoring History for Model " + str(model.model_id) + " at " + str(datetime.now()))
+                    print("Model Build is {0:.0f}% done...".format(progress*100))
+                    print(model.scoring_history().tail())
+                    print("\n")
                 # Wait until the next rendering/querying cycle
                 wait_time = min(next_render_time, self._next_poll_time) - now
                 if wait_time > 0:

--- a/h2o-py/h2o/utils/progressbar.py
+++ b/h2o-py/h2o/utils/progressbar.py
@@ -11,8 +11,6 @@ import math
 import os
 import sys
 import time
-from datetime import datetime
-import h2o
 from types import FunctionType, GeneratorType, MethodType
 
 import colorama
@@ -123,7 +121,7 @@ class ProgressBar(object):
         self._next_poll_time = None
 
 
-    def execute(self, progress_fn, verbose_model=None):
+    def execute(self, progress_fn, print_verbose_info=None):
         """
         Start the progress bar, and return only when the progress reaches 100%.
 
@@ -178,17 +176,13 @@ class ProgressBar(object):
                 time1 = self._get_time_at_progress(result.next_progress)
                 next_render_time = min(time0, time1)
                 self._draw(result.rendered)
-                if verbose_model is not None:
-                    time.sleep(1) #To avoid 400 HTTP error
-                    model = h2o.get_model(verbose_model)
-                    print("\nScoring History for Model " + str(model.model_id) + " at " + str(datetime.now()))
-                    print("Model Build is {0:.0f}% done...".format(progress*100))
-                    print(model.scoring_history().tail())
-                    print("\n")
+
                 # Wait until the next rendering/querying cycle
                 wait_time = min(next_render_time, self._next_poll_time) - now
                 if wait_time > 0:
                     time.sleep(wait_time)
+                    if print_verbose_info is not None:
+                        print_verbose_info(True)
         except KeyboardInterrupt:
             # If the user presses Ctrl+C, we interrupt the progress bar.
             status = "cancelled"

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -783,7 +783,7 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
 #   Job Polling
 #-----------------------------------------------------------------------------------------------------------------------
 
-.h2o.__waitOnJob <- function(job_key, pollInterval = 1) {
+.h2o.__waitOnJob <- function(job_key, pollInterval = 1, verboseModelScoringHistory=FALSE) {
   progressBar <- .h2o.is_progress()
   if (progressBar) pb <- txtProgressBar(style = 3L)
   keepRunning <- TRUE
@@ -800,7 +800,12 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
       }
 
       job = jobs[[1]]
-
+      if(verboseModelScoringHistory){
+        Sys.sleep(1) #To avoid 400 HTTP error
+        cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
+        print(paste0("Model Build is ", job$progress*100, "% done..."))
+        print(tail(h2o.getModel(job$dest$name)@model$scoring_history))
+      }
       status = job$status
       stopifnot(is.character(status))
 

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -800,12 +800,6 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
       }
 
       job = jobs[[1]]
-      if(verboseModelScoringHistory){
-        Sys.sleep(1) #To avoid 400 HTTP error
-        cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
-        print(paste0("Model Build is ", job$progress*100, "% done..."))
-        print(tail(h2o.getModel(job$dest$name)@model$scoring_history))
-      }
       status = job$status
       stopifnot(is.character(status))
 
@@ -851,6 +845,11 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
 
       if (keepRunning) {
         Sys.sleep(pollInterval)
+        if(verboseModelScoringHistory){
+          cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
+          print(paste0("Model Build is ", job$progress*100, "% done..."))
+          print(tail(h2o.getModel(job$dest$name)@model$scoring_history))
+        }
       } else {
         if (progressBar) {
           close(pb)

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -131,6 +131,7 @@
 #'        #Experimental Defaults to FALSE.
 #' @param elastic_averaging_moving_rate Elastic averaging moving rate (only if elastic averaging is enabled). Defaults to 0.9.
 #' @param elastic_averaging_regularization Elastic averaging regularization strength (only if elastic averaging is enabled). Defaults to 0.001.
+#' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
 #' \donttest{
@@ -226,7 +227,8 @@ h2o.deeplearning <- function(x, y, training_frame,
                              categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                              elastic_averaging = FALSE,
                              elastic_averaging_moving_rate = 0.9,
-                             elastic_averaging_regularization = 0.001
+                             elastic_averaging_regularization = 0.001,
+                             verbose = FALSE 
                              ) 
 {
   # If x is missing, then assume user wants to use all columns as features.
@@ -436,7 +438,7 @@ h2o.deeplearning <- function(x, y, training_frame,
   if (!missing(elastic_averaging_regularization))
     parms$elastic_averaging_regularization <- elastic_averaging_regularization
   # Error check and build model
-  .h2o.modelJob('deeplearning', parms, h2oRestApiVersion = 3) 
+  .h2o.modelJob('deeplearning', parms, h2oRestApiVersion = 3, verbose=verbose) 
 }
 
 #' Anomaly Detection via H2O Deep Learning Model

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -87,6 +87,7 @@
 #' @param calibrate_model \code{Logical}. Use Platt Scaling to calculate calibrated class probabilities. Calibration can provide more
 #'        accurate estimates of class probabilities. Defaults to FALSE.
 #' @param calibration_frame Calibration frame for Platt Scaling
+#' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
 #' \donttest{
@@ -151,7 +152,8 @@ h2o.gbm <- function(x, y, training_frame,
                     pred_noise_bandwidth = 0,
                     categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                     calibrate_model = FALSE,
-                    calibration_frame = NULL
+                    calibration_frame = NULL,
+                    verbose = FALSE 
                     ) 
 {
   # If x is missing, then assume user wants to use all columns as features.
@@ -289,5 +291,5 @@ h2o.gbm <- function(x, y, training_frame,
   if (!missing(calibration_frame))
     parms$calibration_frame <- calibration_frame
   # Error check and build model
-  .h2o.modelJob('gbm', parms, h2oRestApiVersion = 3) 
+  .h2o.modelJob('gbm', parms, h2oRestApiVersion = 3, verbose=verbose) 
 }

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -159,6 +159,7 @@
 #'
 #' @rdname h2o.getFutureModel
 #' @param object H2OModel
+#' @param verbose Print model progress to console. Default is FALSE
 #' @export
 h2o.getFutureModel <- function(object,verbose=FALSE) {
   .h2o.__waitOnJob(object@job_key,verboseModelScoringHistory=verbose)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -94,13 +94,13 @@
 }
 
 
-.h2o.modelJob <- function( algo, params, h2oRestApiVersion=.h2o.__REST_API_VERSION ) {
+.h2o.modelJob <- function( algo, params, h2oRestApiVersion=.h2o.__REST_API_VERSION, verbose=FALSE) {
   if( !is.null(params$validation_frame) )
     .eval.frame(params$training_frame)
   if( !is.null(params$validation_frame) )
     .eval.frame(params$validation_frame)
   job <- .h2o.startModelJob(algo, params, h2oRestApiVersion)
-  h2o.getFutureModel(job)
+  h2o.getFutureModel(job, verbose = verbose)
 }
 
 .h2o.startModelJob <- function(algo, params, h2oRestApiVersion) {
@@ -160,8 +160,8 @@
 #' @rdname h2o.getFutureModel
 #' @param object H2OModel
 #' @export
-h2o.getFutureModel <- function(object) {
-  .h2o.__waitOnJob(object@job_key)
+h2o.getFutureModel <- function(object,verbose=FALSE) {
+  .h2o.__waitOnJob(object@job_key,verboseModelScoringHistory=verbose)
   h2o.getModel(object@model_id)
 }
 

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -76,6 +76,7 @@
 #' @param calibrate_model \code{Logical}. Use Platt Scaling to calculate calibrated class probabilities. Calibration can provide more
 #'        accurate estimates of class probabilities. Defaults to FALSE.
 #' @param calibration_frame Calibration frame for Platt Scaling
+#' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @export
@@ -120,7 +121,8 @@ h2o.randomForest <- function(x, y, training_frame,
                              histogram_type = c("AUTO", "UniformAdaptive", "Random", "QuantilesGlobal", "RoundRobin"),
                              categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                              calibrate_model = FALSE,
-                             calibration_frame = NULL
+                             calibration_frame = NULL,
+                             verbose = FALSE 
                              ) 
 {
   # If x is missing, then assume user wants to use all columns as features.
@@ -241,5 +243,5 @@ h2o.randomForest <- function(x, y, training_frame,
   if (!missing(calibration_frame))
     parms$calibration_frame <- calibration_frame
   # Error check and build model
-  .h2o.modelJob('drf', parms, h2oRestApiVersion = 3) 
+  .h2o.modelJob('drf', parms, h2oRestApiVersion = 3, verbose=verbose) 
 }

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -72,6 +72,7 @@
 #' @param backend Backend. By default (auto), a GPU is used if available. Must be one of: "auto", "gpu", "cpu". Defaults to
 #'        auto.
 #' @param gpu_id Which GPU to use.  Defaults to 0.
+#' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @export
 h2o.xgboost <- function(x, y, training_frame,
                         model_id = NULL,
@@ -120,7 +121,8 @@ h2o.xgboost <- function(x, y, training_frame,
                         reg_alpha = 0.0,
                         dmatrix_type = c("auto", "dense", "sparse"),
                         backend = c("auto", "gpu", "cpu"),
-                        gpu_id = 0
+                        gpu_id = 0,
+                        verbose = FALSE 
                         ) 
 {
   # If x is missing, then assume user wants to use all columns as features.
@@ -253,7 +255,7 @@ h2o.xgboost <- function(x, y, training_frame,
   if (!missing(gpu_id))
     parms$gpu_id <- gpu_id
   # Error check and build model
-  .h2o.modelJob('xgboost', parms, h2oRestApiVersion = 3) 
+  .h2o.modelJob('xgboost', parms, h2oRestApiVersion = 3, verbose=verbose) 
 }
 
 #' Ask the H2O server whether a XGBoost model can be built (depends on availability of native backend)


### PR DESCRIPTION
* Add verbose option to display scoring histories as model job is running. 
* Will only apply to gbm, drf, xgboost, and deeplearning (iterative supervised algorithms)
* Examples output for R API:
![h2o_verbose_r](https://user-images.githubusercontent.com/10055668/27926338-ed1c03fc-623c-11e7-94fb-3dc62ab58598.gif)
* Example output for Py API: 
![h2o_verbose_py](https://user-images.githubusercontent.com/10055668/27926346-f7efb1ac-623c-11e7-87a0-93bfb7315f4e.gif)
