### PR TITLE
PUBDEV-4690: Removed default stopping_tolerance in AutoML R/Py

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -54,7 +54,7 @@ Metric-based (used as a group):
     - ``misclassification``
     - ``mean_per_class_error``
 
--  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a value determined by the size of the dataset and the ``na`` rate. 1/((nrows * non-na-rate)^2)
+-  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the ``na`` rate.  In that case, the value is computed as 1/((nrows * non-na-rate)^2).
 
 - `stopping_rounds <data-science/algo-params/stopping_rounds.html>`__: This argument stops training new models in the AutoML run when the option selected for **stopping_metric** doesn't improve for the specified number of models, based on a simple moving average. Defaults to 3 and must be an non-negative integer.  To disable this feature, set it to 0. 
 

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -54,7 +54,7 @@ Metric-based (used as a group):
     - ``misclassification``
     - ``mean_per_class_error``
 
--  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001 if the dataset is big enough; otherwise it defaults to a value determined by the size of the dataset and the ``na`` rate. 1/((nrows * non-na-rate)^2)
+-  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a value determined by the size of the dataset and the ``na`` rate. 1/((nrows * non-na-rate)^2)
 
 - `stopping_rounds <data-science/algo-params/stopping_rounds.html>`__: This argument stops training new models in the AutoML run when the option selected for **stopping_metric** doesn't improve for the specified number of models, based on a simple moving average. Defaults to 3 and must be an non-negative integer.  To disable this feature, set it to 0. 
 

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -54,7 +54,7 @@ Metric-based (used as a group):
     - ``misclassification``
     - ``mean_per_class_error``
 
--  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the ``na`` rate.  In that case, the value is computed as 1/((nrows * non-na-rate)^2).
+-  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the non-NA-rate.  In that case, the value is computed as 1/sqrt(nrows * non-NA-rate).
 
 - `stopping_rounds <data-science/algo-params/stopping_rounds.html>`__: This argument stops training new models in the AutoML run when the option selected for **stopping_metric** doesn't improve for the specified number of models, based on a simple moving average. Defaults to 3 and must be an non-negative integer.  To disable this feature, set it to 0. 
 

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -88,30 +88,22 @@ class H2OAutoML(object):
         if max_models is not None:
             assert_is_type(max_models,int)
             self.build_control["stopping_criteria"]["max_models"] = max_models
-            self.max_models = max_models
+        self.max_models = max_models
 
         if stopping_metric is not "AUTO":
             assert_is_type(stopping_metric,str)
-            self.build_control["stopping_criteria"]["stopping_metric"] = stopping_metric
-            self.stopping_metric = stopping_metric
-        else:
-            self.build_control["stopping_criteria"]["stopping_metric"] = stopping_metric
-            self.stopping_metric = stopping_metric
+        self.build_control["stopping_criteria"]["stopping_metric"] = stopping_metric
+        self.stopping_metric = stopping_metric
 
         if stopping_tolerance is not None:
             assert_is_type(stopping_tolerance,float)
             self.build_control["stopping_criteria"]["stopping_tolerance"] = stopping_tolerance
-            self.stopping_tolerence = stopping_tolerance
-        else:
-            self.stopping_tolerence = stopping_tolerance
+        self.stopping_tolerence = stopping_tolerance
 
         if stopping_rounds is not 3:
             assert_is_type(stopping_rounds,int)
-            self.build_control["stopping_criteria"]["stopping_rounds"] = stopping_rounds
-            self.stopping_rounds = stopping_rounds
-        else:
-            self.build_control["stopping_criteria"]["stopping_rounds"] = stopping_rounds
-            self.stopping_rounds = stopping_rounds
+        self.build_control["stopping_criteria"]["stopping_rounds"] = stopping_rounds
+        self.stopping_rounds = stopping_rounds    
 
         if seed is not None:
             assert_is_type(seed,int)

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -23,7 +23,7 @@ class H2OAutoML(object):
     :param float stopping_tolerance: This option specifies the relative tolerance for the metric-based stopping
       to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001
       if the dataset is at least 1 million rows; otherwise it defaults to a value determined by the size of the dataset
-      and the ``na`` rate.  In that case, the value is computed as 1/((nrows * non-na-rate)^2).
+      and the non-NA-rate.  In that case, the value is computed as 1/sqrt(nrows * non-NA-rate).
     :param int stopping_rounds: This argument stops training new models in the AutoML run when the option selected for
       stopping_metric doesn't improve for the specified number of models, based on a simple moving average.
       To disable this feature, set it to 0. Defaults to 3 and must be an non-negative integer.

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -22,8 +22,8 @@ class H2OAutoML(object):
       ``misclassification``, ``mean_per_class_error``.
     :param float stopping_tolerance: This option specifies the relative tolerance for the metric-based stopping
       to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001
-      if the dataset is big enough; otherwise it defaults to a value determined by the size of the dataset
-      and the ``na`` rate. 1/((nrows * non-na-rate)^2)
+      if the dataset is at least 1 million rows; otherwise it defaults to a value determined by the size of the dataset
+      and the ``na`` rate.  In that case, the value is computed as 1/((nrows * non-na-rate)^2).
     :param int stopping_rounds: This argument stops training new models in the AutoML run when the option selected for
       stopping_metric doesn't improve for the specified number of models, based on a simple moving average.
       To disable this feature, set it to 0. Defaults to 3 and must be an non-negative integer.
@@ -57,7 +57,7 @@ class H2OAutoML(object):
                  max_runtime_secs=3600,
                  max_models=None,
                  stopping_metric="AUTO",
-                 stopping_tolerance=0.001,
+                 stopping_tolerance=None,
                  stopping_rounds=3,
                  seed=None,
                  project_name=None):
@@ -101,7 +101,7 @@ class H2OAutoML(object):
             self.build_control["stopping_criteria"]["stopping_metric"] = stopping_metric
             self.stopping_metric = stopping_metric
 
-        if stopping_tolerance is not 0.001:
+        if stopping_tolerance is not None:
             assert_is_type(stopping_tolerance,float)
             self.build_control["stopping_criteria"]["stopping_tolerance"] = stopping_tolerance
             self.stopping_tolerence = stopping_tolerance

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -72,13 +72,10 @@ class H2OAutoML(object):
                   "*******************************************************************\n" \
                   "\nVerbose Error Message:")
 
-        #If max_runtime_secs is not provided, then it is set to default (600 secs)
+        #If max_runtime_secs is not provided, then it is set to default (3600 secs)
         if max_runtime_secs is not 3600:
             assert_is_type(max_runtime_secs,int)
-            max_runtime_secs = max_runtime_secs
-            self.max_runtime_secs = max_runtime_secs
-        else:
-            self.max_runtime_secs = max_runtime_secs
+        self.max_runtime_secs = max_runtime_secs
 
         #Make bare minimum build_control
         self.build_control = {
@@ -106,7 +103,6 @@ class H2OAutoML(object):
             self.build_control["stopping_criteria"]["stopping_tolerance"] = stopping_tolerance
             self.stopping_tolerence = stopping_tolerance
         else:
-            self.build_control["stopping_criteria"]["stopping_tolerance"] = stopping_tolerance
             self.stopping_tolerence = stopping_tolerance
 
         if stopping_rounds is not 3:

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -19,8 +19,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO is logloss for classification, deviance for regression).  
 #'        Must be one of "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much). This value defaults to 0.001 if the 
-#'        dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the NA-rate.  In that case, the value is computed 
-#'        as 1/((nrows * non-na-rate)^2).
+#'        dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the non-NA-rate.  In that case, the value is computed 
+#'        as 1/sqrt(nrows * non-NA-rate).
 #' @param stopping_rounds Integer. Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the stopping_metric 
 #'        does not improve for k (stopping_rounds) scoring events. Defaults to 3 and must be an non-zero integer.  Use 0 to disable early stopping.
 #' @param seed Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if max_models or early stopping is used 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -18,7 +18,9 @@
 #' @param max_models Maximum number of models to build in the AutoML process (does not include Stacked Ensembles). Defaults to NULL.
 #' @param stopping_metric Metric to use for early stopping (AUTO is logloss for classification, deviance for regression).  
 #'        Must be one of "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error". Defaults to AUTO.
-#' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much) Defaults to 0.001.
+#' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much). This value defaults to 0.001 if the 
+#'        dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the NA-rate.  In that case, the value is computed 
+#'        as 1/((nrows * non-na-rate)^2).
 #' @param stopping_rounds Integer. Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the stopping_metric 
 #'        does not improve for k (stopping_rounds) scoring events. Defaults to 3 and must be an non-zero integer.  Use 0 to disable early stopping.
 #' @param seed Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if max_models or early stopping is used 
@@ -45,7 +47,7 @@ h2o.automl <- function(x, y, training_frame,
                        max_runtime_secs = 3600,
                        max_models = NULL,
                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
-                       stopping_tolerance = 0.001,
+                       stopping_tolerance = NULL,
                        stopping_rounds = 3,
                        seed = NULL,
                        project_name = NULL)
@@ -140,7 +142,9 @@ h2o.automl <- function(x, y, training_frame,
     build_control$stopping_criteria$max_models <- max_models
   }
   build_control$stopping_criteria$stopping_metric <- match.arg(stopping_metric)
-  build_control$stopping_criteria$stopping_tolerance <- stopping_tolerance
+  if (!is.null(stopping_tolerance)) {
+    build_control$stopping_criteria$stopping_tolerance <- stopping_tolerance
+  }
   build_control$stopping_criteria$stopping_rounds <- stopping_rounds
   if (!is.null(seed)) {
     build_control$stopping_criteria$seed <- seed


### PR DESCRIPTION
Removed stopping_tolerance default value of 0.001 in AutoML R and Python clients. https://0xdata.atlassian.net/browse/PUBDEV-4690