### PR TITLE
PUBDEV-4604: Added script to install the clients after building H2O

### DIFF
--- a/install-clients.sh
+++ b/install-clients.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# After building H2O with ./gradlew build
+# run this script to install the new R and Python clients.
+
+pip uninstall -y h2o
+pip install h2o-py/dist/h2o-*-py2.py3-none-any.whl
+R CMD REMOVE h2o
+R CMD INSTALL h2o-r/R/src/contrib/h2o*.tar.gz
+

--- a/scripts/install-clients.sh
+++ b/scripts/install-clients.sh
@@ -4,7 +4,6 @@
 # run this script to install the new R and Python clients.
 
 pip uninstall -y h2o
-pip install h2o-py/dist/h2o-*-py2.py3-none-any.whl
+pip install ../h2o-py/dist/h2o-*-py2.py3-none-any.whl
 R CMD REMOVE h2o
-R CMD INSTALL h2o-r/R/src/contrib/h2o*.tar.gz
-
+R CMD INSTALL ../h2o-r/R/src/contrib/h2o*.tar.gz


### PR DESCRIPTION
This is a utility script for H2O developers to use to simplify (re)installing the R and Python clients after running a `./gradlew build`.