### PR TITLE
PUBDEV-4694: Make CompressedTree smaller by storing common metatada elsewhere

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/CompressedForest.java
+++ b/h2o-algos/src/main/java/hex/tree/CompressedForest.java
@@ -1,0 +1,68 @@
+package hex.tree;
+
+import water.DKV;
+import water.Iced;
+import water.Key;
+
+/**
+ * Collection of Compressed Trees
+ * contains:
+ *  - keys to trees
+ *  - metadata shared among all the trees (eg. domain information)
+ *  The purpose of this class is to avoid replicating large common metadata into each Compressed Tree (eg. domains).
+ */
+public class CompressedForest extends Iced<CompressedTree> {
+
+  public final Key<CompressedTree>[/*_ntrees*/][/*_nclass*/] _treeKeys;
+  public final String[][] _domains;
+
+  CompressedForest(Key<CompressedTree>[][] treeKeys, String[][] domains) {
+    _treeKeys = treeKeys;
+    _domains = domains;
+  }
+
+  public final int ntrees() { return _treeKeys.length; }
+
+  /**
+   * Fetches trees from DKV and converts to a node-local structure.
+   * @return fetched trees
+   */
+  public final LocalCompressedForest fetch() {
+    int ntrees = _treeKeys.length;
+    CompressedTree[][] trees = new CompressedTree[ntrees][];
+    for (int t = 0; t < ntrees; t++) {
+      Key[] treek = _treeKeys[t];
+      trees[t] = new CompressedTree[treek.length];
+      for (int i = 0; i < treek.length; i++)
+        if (treek[i] != null)
+          trees[t][i] = DKV.get(treek[i]).get();
+    }
+    return new LocalCompressedForest(trees, _domains);
+  }
+
+  /**
+   * Node-local representation of a collection of trees.
+   * Is not meant to be Serialized/Iced or send over the wire.
+   */
+  public static class LocalCompressedForest {
+    public CompressedTree[][] _trees;
+    public String[][] _domains;
+
+    private LocalCompressedForest(CompressedTree[][] trees, String[][] domains) {
+      _trees = trees;
+      _domains = domains;
+    }
+
+    /** Score given tree on the row of data.
+     *  @param data row of data
+     *  @param preds array to hold resulting prediction
+     *  @param tidx index of a tree (points to a representation of a single regression tree, or multi tree)  */
+    public final void scoreTree(double data[], double preds[], int tidx) {
+      CompressedTree[] ts = _trees[tidx];
+      for( int c=0; c<ts.length; c++ )
+        if( ts[c] != null )
+          preds[ts.length==1?0:c+1] += ts[c].score(data, _domains);
+    }
+  }
+
+}

--- a/h2o-algos/src/main/java/hex/tree/CompressedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/CompressedTree.java
@@ -27,22 +27,20 @@ public class CompressedTree extends Keyed<CompressedTree> {
   final byte [] _bits;
   final int _nclass;     // Number of classes being predicted (for an integer prediction tree)
   final long _seed;
-  final String[][] _domains;
 
-  public CompressedTree(byte[] bits, int nclass, long seed, int tid, int cls, String[][] domains) {
+  public CompressedTree(byte[] bits, int nclass, long seed, int tid, int cls) {
     super(makeTreeKey(tid, cls));
     _bits = bits;
     _nclass = nclass;
     _seed = seed;
-    _domains = domains;
   }
 
-  public double score(final double row[]) {
-    return SharedTreeMojoModel.scoreTree(_bits, row, _nclass, false, _domains);
+  public double score(final double row[], final String[][] domains) {
+    return SharedTreeMojoModel.scoreTree(_bits, row, _nclass, false, domains);
   }
 
-  public String getDecisionPath(final double row[]) {
-    double d = SharedTreeMojoModel.scoreTree(_bits, row, _nclass, true, _domains);
+  public String getDecisionPath(final double row[], final String[][] domains) {
+    double d = SharedTreeMojoModel.scoreTree(_bits, row, _nclass, true, domains);
     return SharedTreeMojoModel.getDecisionPath(d);
   }
 

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -740,7 +740,7 @@ public class DTree extends Iced {
       ab.put1(0).put2((char)65535); // Flag it special so the decompress doesn't look for top-level decision
     root().compress(ab, _abAux);      // Compress whole tree
     assert ab.position() == sz;
-    return new CompressedTree(ab.buf(),_nclass,_seed,tid,cls, domains);
+    return new CompressedTree(ab.buf(),_nclass,_seed,tid,cls);
   }
 
   static Split findBestSplitPoint(DHistogram hs, int col, double min_rows) {

--- a/h2o-algos/src/main/java/hex/tree/DTreeScorer.java
+++ b/h2o-algos/src/main/java/hex/tree/DTreeScorer.java
@@ -6,41 +6,24 @@ public abstract class DTreeScorer<T extends DTreeScorer<T>> extends MRTask<T> {
   protected final int _ncols;
   protected final int _nclass;
   protected final int _skip;
-  protected final Key[][] _treeKeys;
-  protected transient CompressedTree[][] _trees;
+  protected final CompressedForest _cforest;
+  protected transient CompressedForest.LocalCompressedForest _forest;
   protected SharedTree _st;
 
-  public DTreeScorer(int ncols, int nclass, SharedTree st, Key[][] treeKeys) {
+  public DTreeScorer(int ncols, int nclass, SharedTree st, CompressedForest cforest) {
     _ncols = ncols;
     _nclass = nclass;
-    _treeKeys = treeKeys;
+    _cforest = cforest;
     _st = st;
     _skip = _st.numSpecialCols();
   }
-  protected int ntrees() { return _trees.length; }
+
+  protected int ntrees() { return _cforest.ntrees(); }
 
   @Override protected final void setupLocal() {
-    int ntrees = _treeKeys.length;
-    _trees = new CompressedTree[ntrees][];
-    for (int t=0; t<ntrees; t++) {
-      Key[] treek = _treeKeys[t];
-      _trees[t] = new CompressedTree[treek.length];
-      // FIXME remove get by introducing fetch class for all trees
-      for (int i=0; i<treek.length; i++)
-        if (treek[i]!=null)
-          _trees[t][i] = DKV.get(treek[i]).get();
-    }
+    _forest = _cforest.fetch();
   }
 
-  protected void score0(double data[], double preds[], CompressedTree[] ts) { scoreTree(data, preds, ts); }
+  protected void score0(double data[], double preds[], int tidx) { _forest.scoreTree(data, preds, tidx); }
 
-  /** Score given tree on the row of data.
-   *  @param data row of data
-   *  @param preds array to hold resulting prediction
-   *  @param ts a tree representation (single regression tree, or multi tree)  */
-  public static void scoreTree(double data[], double preds[], CompressedTree[] ts) {
-    for( int c=0; c<ts.length; c++ )
-      if( ts[c] != null )
-        preds[ts.length==1?0:c+1] += ts[c].score(data);
-  }
 }

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -373,7 +373,9 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
       // Reconstruct the working tree state from the checkpoint
       Timer t = new Timer();
       int ntreesFromCheckpoint = ((SharedTreeModel.SharedTreeParameters) _parms._checkpoint.<SharedTreeModel>get()._parms)._ntrees;
-      new ReconstructTreeState(_ncols, _nclass, st /*large, but cleaner code this way*/, _parms._sample_rate,_model._output._treeKeys, doOOBScoring()).doAll(_train, _parms._build_tree_one_node);
+      new ReconstructTreeState(_ncols, _nclass, st /*large, but cleaner code this way*/, _parms._sample_rate,
+              new CompressedForest(_model._output._treeKeys, _model._output._domains), doOOBScoring())
+              .doAll(_train, _parms._build_tree_one_node);
       for (int i = 0; i < ntreesFromCheckpoint; i++) _rand.nextLong(); //for determinism
       Log.info("Reconstructing OOB stats from checkpoint took " + t);
       if (DEV_DEBUG) {

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -198,7 +198,7 @@ public abstract class SharedTreeModel<
         DKV.put(keys[i]=ct._key,ct,fs);
         _treeStats.updateBy(trees[i]); // Update tree shape stats
 
-        CompressedTree ctAux = new CompressedTree(trees[i]._abAux.buf(),-1,-1,-1,-1,_domains);
+        CompressedTree ctAux = new CompressedTree(trees[i]._abAux.buf(),-1,-1,-1,-1);
         keysAux[i] = ctAux._key = Key.make(createAuxKey(ct._key.toString()));
         DKV.put(ctAux);
       }
@@ -250,7 +250,7 @@ public abstract class SharedTreeModel<
             Key[] keys = _output._treeKeys[tidx];
             for (Key key : keys) {
               if (key != null) {
-                String pred = DKV.get(key).<CompressedTree>get().getDecisionPath(input);
+                String pred = DKV.get(key).<CompressedTree>get().getDecisionPath(input,_output._domains);
                 output[col++] = pred;
               }
             }
@@ -326,7 +326,7 @@ public abstract class SharedTreeModel<
     Key[] keys = _output._treeKeys[treeIdx];
     for( int c=0; c<keys.length; c++ ) {
       if (keys[c] != null) {
-        double pred = DKV.get(keys[c]).<CompressedTree>get().score(data);
+        double pred = DKV.get(keys[c]).<CompressedTree>get().score(data,_output._domains);
         assert (!Double.isInfinite(pred));
         preds[keys.length == 1 ? 0 : c + 1] += pred;
       }


### PR DESCRIPTION
This object can later store information shared among all Trees, for
now it just holds the keys of the trees