### PR TITLE
PUBDEV-4656: Documentation for Hive format

### DIFF
--- a/h2o-docs/src/product/data-munging/importing-data.rst
+++ b/h2o-docs/src/product/data-munging/importing-data.rst
@@ -3,6 +3,8 @@ Importing a File
 
 Unlike the `upload <uploading-data.html>`__ function, which is a push from the client to the server, the import function is a parallelized reader and pulls information from the server from a location specified by the client. The path is a server-side path. This is a fast, scalable, highly optimized way to read data. H2O pulls the data from a data store and initiates the data transfer as a read operation.
 
+Refer to the `Supported File Formats <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/getting-data-into-h2o.html#supported-file-formats>`__ topic to ensure that you are using a supported file type.
+
 .. example-code::
    .. code-block:: r
 	

--- a/h2o-docs/src/product/data-munging/uploading-data.rst
+++ b/h2o-docs/src/product/data-munging/uploading-data.rst
@@ -3,6 +3,8 @@ Uploading a File
 
 Unlike the import function, which is a parallelized reader, the upload function is a push from the client to the server. The specified path must be a client-side path. This is not scalable and is only intended for smaller data sizes. The client pushes the data from a local filesystem (for example, on your machine where R or Python is running) to H2O. For big-data operations, you don't want the data stored on or flowing through the client.
 
+Refer to the `Supported File Formats <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/getting-data-into-h2o.html#supported-file-formats>`__ topic to ensure that you are using a supported file type.
+
 Run the following command to load data that resides on the same machine that is running H2O. 
 
 .. example-code::

--- a/h2o-docs/src/product/data-science/gbm-faq/scoring.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/scoring.rst
@@ -10,7 +10,7 @@ Scoring
   3. Call the predict endpoint either from R, Python, Flow, or the REST API directly. 
   4. Export the predictions to file or download them from the server.
 
- You can also score models in parallel by downloading a pojo for each model, and then embedding those pojos within a HIVE UDF to score the large dataset stored on Hadoop. A tutorial on this process can be found `here <http://docs.h2o.ai/h2o-tutorials/latest-stable/tutorials/hive_udf_template/index.html>`__.
+ You can also score models in parallel by downloading a POJO or MOJO for each model, and then embedding those within a HIVE UDF to score the large dataset stored on Hadoop. Tutorials on this process can be found `here (POJO) <https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/hive_udf_pojo_template>`__ and `here (MOJO) <https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/hive_udf_mojo_template>`__.
 
 - **Which parameters are used with or for scoring?**
 

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -17,7 +17,11 @@ H2O currently supports the following file types:
 - Avro (without multifile parsing or column type modification)
 - Parquet
 
-Note that ORC is available only if H2O is running as a Hadoop job. 
+**Notes**: 
+ 
+ - ORC is available only if H2O is running as a Hadoop job. 
+ - Users can also import Hive files that are saved in ORC format. 
+
 
 .. _data_sources:
 

--- a/h2o-docs/src/product/pojo-quick-start.rst
+++ b/h2o-docs/src/product/pojo-quick-start.rst
@@ -10,6 +10,9 @@ Users can refer to the following Quick Start files for more information about ge
 - `POJO Quick Start <https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/howto/POJO_QuickStart.md>`__
 - `MOJO Quick Start <https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/howto/MOJO_QuickStart.md>`__
 
-**Note**: MOJOs are supported for GBM, DRF, GLM, and K-Means models only.
+**Notes**: 
+
+- MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, Word2vec, and XGBoost models only.
+- POJOs are not supported for XGBoost.
 
 Developers can refer to the the `POJO and MOJO Model Javadoc <http://docs.h2o.ai/h2o/latest-stable/h2o-genmodel/javadoc/index.html>`__.

--- a/h2o-genmodel/src/main/java/overview.html
+++ b/h2o-genmodel/src/main/java/overview.html
@@ -57,6 +57,10 @@ H2O allows you to convert the models you have built to a
 POJOs allow users to build a model using H2O and then deploy the model to score in real-time.
 
 <p></p>
+
+<b>Note:</b> POJOs are not supported for the XGBoost algorithm.
+
+<p></p>
 <!-- ============================================================ -->
 <!-- ============================================================ -->
 <br>
@@ -302,7 +306,7 @@ A MOJO (Model Object, Optimized) is an alternative to H2O's currently available 
 POJOs, H2O allows you to convert models that you build to MOJOs, which can then be deployed
 for scoring in real time.
 <p></p>
-<b>Note</b>: MOJOs are supported for DRF, GBM, GLM, and K-Means algorithms only.
+<b>Note</b>: MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, Word2vec, and XGBoost algorithms only.
 
 <h3><u>Benefit of MOJOs over POJOs</u></h3>
 <p></p>


### PR DESCRIPTION
Added a note indicating that Hive files can be saved in ORC format and then imported.
Driveby fixes:
- Fixed link to Hive tutorials in the GBM FAQ
- Updated list of POJO and MOJO supported algorithms.