### PR TITLE
PUBDEV-4689: Document that only Avro version 1.8.0 is supported

### DIFF
--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -629,7 +629,7 @@ The read-only **Sources** field shows the file path for the imported data select
  -  AVRO
  -  PARQUET
 
- **Note**: For SVMLight data, the column indices must be >= 1 and the columns must be in ascending order.
+ **Note**: For SVMLight data, the column indices must be >= 1 and the columns must be in ascending order. For AVRO, only version 1.8.0 is supported.
 
 2. If a separator or delimiter is used, select it from the **Separator** list.
 

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -14,10 +14,13 @@ H2O currently supports the following file types:
 - ARFF
 - XLS
 - XLSX
-- Avro (without multifile parsing or column type modification)
+- Avro version 1.8.0 (without multifile parsing or column type modification)
 - Parquet
 
-Note that ORC is available only if H2O is running as a Hadoop job. 
+**Notes**:
+
+- ORC is available only if H2O is running as a Hadoop job. 
+- Users can also import Hive files that are saved in ORC format.
 
 .. _data_sources:
 


### PR DESCRIPTION
For topics that indicate we support Avro formatted data, indicate that only 1.8.0 is supported. This is in response to ticket 90937.