### PR TITLE
PUBDEV-4683: Allows overriding a type of a Str/Cat column in a Parquet file

### DIFF
--- a/h2o-core/src/main/java/water/Job.java
+++ b/h2o-core/src/main/java/water/Job.java
@@ -388,6 +388,7 @@ public final class Job<T extends Keyed> extends Keyed<Job> {
     if(_worked    != remote._worked    ) differ = true;
     if(_msg       != remote._msg       ) differ = true;
     if(_max_runtime_msecs != remote._max_runtime_msecs) differ = true;
+    if(! Arrays.equals(_warns, remote._warns)) differ = true;
     if( differ )
       synchronized(this) { 
         _stop_requested = remote._stop_requested;
@@ -398,6 +399,7 @@ public final class Job<T extends Keyed> extends Keyed<Job> {
         _worked    = remote._worked    ;
         _msg       = remote._msg       ;
         _max_runtime_msecs = remote._max_runtime_msecs;
+        _warns     = remote._warns;
       }
   }
   @Override public Class<KeyV3.JobKeyV3> makeSchema() { return KeyV3.JobKeyV3.class; }

--- a/h2o-core/src/main/java/water/parser/ParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/ParseWriter.java
@@ -9,6 +9,10 @@ public interface ParseWriter extends Freezable {
 
   class ParseErr extends Iced {
     public ParseErr(){}
+    public ParseErr(String file, String err) {
+      this(err, 0, -1, -1);
+      _file = file;
+    }
     public ParseErr(String err, int cidx, long lineNum, long byteOff){
       _err = err;
       _cidx = cidx;
@@ -24,7 +28,7 @@ public interface ParseWriter extends Freezable {
     // filled int he end (when we now the line-counts)
     long _gLineNum = -1;
     public String toString(){
-      return "ParseError at file " + _file + (_gLineNum == -1?"":" at line " + _lineNum + " ( destination line " + _gLineNum + " )") + "  at byte offset " + _byteOffset + "; error = \'" + _err + "\'";
+      return "ParseError at file " + _file + (_gLineNum == -1?"":" at line " + _lineNum + " ( destination line " + _gLineNum + " )") + (_byteOffset == -1 ? "" : "  at byte offset " + _byteOffset) + "; error = \'" + _err + "\'";
     }
   }
 

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
@@ -2,17 +2,16 @@ package water.parser.parquet;
 
 import org.apache.parquet.hadoop.VecParquetReader;
 import org.reflections.ReflectionUtils;
+import water.DKV;
 import water.H2O;
 import water.Job;
 import water.Key;
 import water.fvec.ByteVec;
 import water.fvec.FileVec;
+import water.fvec.Frame;
 import water.fvec.Vec;
-import water.parser.DefaultParserProviders;
-import water.parser.ParseSetup;
-import water.parser.Parser;
-import water.parser.ParserInfo;
-import water.parser.ParserProvider;
+import water.parser.*;
+import water.util.ArrayUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -44,9 +43,21 @@ public class ParquetParserProvider extends ParserProvider {
 
   @Override
   public ParseSetup createParserSetup(Key[] inputs, ParseSetup requestedSetup) {
-    // pass through for now (just convert to an instance of ParquetParseSetup if needed)
-    return requestedSetup instanceof ParquetParser.ParquetParseSetup ?
+    // convert to an instance of ParquetParseSetup if needed
+    ParseSetup setup = requestedSetup instanceof ParquetParser.ParquetParseSetup ?
             requestedSetup : requestedSetup.copyTo(new ParquetParser.ParquetParseSetup());
+    // override incorrect type mappings (using the MessageFormat of the first file)
+    Object frameOrVec = DKV.getGet(inputs[0]);
+    ByteVec vec = (ByteVec) (frameOrVec instanceof Frame ? ((Frame) frameOrVec).vec(0) : frameOrVec);
+    byte[] requestedTypes = setup.getColumnTypes();
+    byte[] types = ParquetParser.correctTypeConversions(vec, requestedTypes);
+    setup.setColumnTypes(types);
+    for (int i = 0; i < types.length; i++)
+      if (types[i] != requestedTypes[i])
+        setup._errs = ArrayUtils.append(setup._errs, new ParseWriter.ParseErr(inputs[0].toString(),
+                "Unsupported type override (" + Vec.TYPE_STR[types[i]] + " -> " + Vec.TYPE_STR[requestedTypes[i]] + "). Column " +
+                setup.getColumnNames()[i] + " will be parsed as " + Vec.TYPE_STR[types[i]]));
+    return setup;
   }
 
   @Override


### PR DESCRIPTION
This will solve PUBDEV-4683 (user overrides type of a Numeric column and forces it to be a String) - this will not be allowed anymore.

It will allow workaround for PUBDEV-4685 - user will be able to specify a String column instead of a Categorical column (unification on the categorical column causes issues).