### PR TITLE
PUBDEV-4653: Grid Search not working with the new H2OXGBoostEstimator() & PUBDEV-4704: h2o xgboost: grid in h2o python gives error

### DIFF
--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -261,6 +261,7 @@ class H2OEstimator(ModelBase):
         if name == "H2OKMeansEstimator": return "kmeans"
         if name == "H2ONaiveBayesEstimator": return "naivebayes"
         if name == "H2ORandomForestEstimator": return "drf"
+        if name == "H2OXGBoostEstimator": return "xgboost"
         if name == "H2OPCA": return "pca"
         if name == "H2OSVD": return "svd"
 


### PR DESCRIPTION
* Add `xgboost` algo to Python grid search