### PR TITLE
Fixes NPE in gridsearch when there are models in a "weird" state

### DIFF
--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -290,7 +290,12 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     final Key<Model>[] modelKeys = KeySnapshot.globalSnapshot().filter(new KeySnapshot.KVFilter() {
       @Override
       public boolean filter(KeySnapshot.KeyInfo k) {
-        return Value.isSubclassOf(k._type, Model.class) && ((Model)k._key.get())._parms.checksum() == checksum;
+        if (! Value.isSubclassOf(k._type, Model.class))
+          return false;
+        Model m = ((Model)k._key.get());
+        if ((m == null) || (m._parms == null))
+          return false;
+        return m._parms.checksum() == checksum;
       }
     }).keys();
 


### PR DESCRIPTION
There also was a race condition, the model could get deleted between two DKV calls.