### PR TITLE
PUBDEV-4522: Update list of required Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,24 +219,7 @@ open target/docs-website/h2o-docs/index.html
 
 ### 4.2. Setup on all Platforms
 
-> **Note**: The following instructions assume you have installed the latest version of [**pip**](https://pip.pypa.io/en/latest/installing/#install-or-upgrade-pip), which is installed with the latest version of [**Python**](https://www.python.org/downloads/).  
-
-##### Install required Python packages (prepending with `sudo` if unsuccessful)
-
-    pip install grip
-    pip install tabulate
-    pip install wheel
-    pip install scikit-learn
-
-Python tests require:
-
-    pip install scikit-learn
-    pip install numpy
-    pip install scipy
-    pip install pandas
-    pip install statsmodels
-    pip install patsy
-    pip install future
+The requirements for building / installing `h2o` are listed in file [h2o-py/conda/h2o/meta.yaml](h2o-py/conda/h2o/meta.yaml) file. Install the required Python packages (prepending with `sudo` if unsuccessful).
 
 ### 4.3. Setup on Windows
 

--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -634,7 +634,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div id="quickstart-py" style="display:none">
                 <h2>Use H<sub>2</sub>O directly from Python</h2>
 
-                <p>1. Prerequisite:    Python 2.7</p>
+                <p>1. Prerequisite:    Python 2.7 or 3.5</p>
                 <p>2. Install dependencies (prepending with `sudo` if needed):</p>
                  <button class="btn copy_button" id="btnCopy8" data-copied-hint="Copied!" data-clipboard-target='to_copy8'>
               <span class="octicon octicon-clippy"></span>

--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -634,7 +634,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div id="quickstart-py" style="display:none">
                 <h2>Use H<sub>2</sub>O directly from Python</h2>
 
-                <p>1. Prerequisite:    Python 2.7 or 3.5</p>
+                <p>1. Prerequisite:    Python 2.7 or 3.5+</p>
                 <p>2. Install dependencies (prepending with `sudo` if needed):</p>
                  <button class="btn copy_button" id="btnCopy8" data-copied-hint="Copied!" data-clipboard-target='to_copy8'>
               <span class="octicon octicon-clippy"></span>

--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -77,7 +77,11 @@ Run the following commands in a Terminal window to install H2O for Python.
 
 	pip install requests
 	pip install tabulate
-	pip install scikit-learn 
+	pip install scikit-learn
+	pip install colorama
+	pip install future
+
+ **Note**: These are the dependencies required to run H2O. A complete list of dependencies is maintained in the following file: `https://github.com/h2oai/h2o-3/blob/master/h2o-py/conda/h2o/meta.yaml <https://github.com/h2oai/h2o-3/blob/master/h2o-py/conda/h2o/meta.yaml>`__
 
 2. Run the following command to remove any existing H2O module for Python.
 


### PR DESCRIPTION
- In the H2O-3 README, the list of required Python packages now points to a yaml file, which is a maintained file.
- Added a link to this yaml file in the Downloading and Installing section of the User Guide.
Driveby fix: Added 3.5 as a supported Python version on the download page.