### PR TITLE
PUBDEV-4738: Enable access to Kerberized HDFS from standalone H2O

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,8 @@ ext {
       project(':h2o-jaas-pam'),
       project(':h2o-automl'),
       project(':h2o-genmodel-ext-xgboost'),
-      project(':h2o-ext-xgboost')
+      project(':h2o-ext-xgboost'),
+      project(':h2o-ext-krbstandalone')
     ]
 
     javaProjects = [
@@ -92,7 +93,8 @@ ext {
       project(':h2o-jaas-pam'),
       project(':h2o-automl'),
       project(':h2o-genmodel-ext-xgboost'),
-      project(':h2o-ext-xgboost')
+      project(':h2o-ext-xgboost'),
+      project(':h2o-ext-krbstandalone')
     ]
 
     scalaProjects = [

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ orcDefaultHiveExecVersion=1.1.0-cdh5.4.0
 #
 # Default hadoop client version
 #
-defaultHadoopClientVersion=2.0.0-cdh4.3.0
+defaultHadoopClientVersion=2.7.3
 #
 # Gradle arguments
 #

--- a/h2o-app/build.gradle
+++ b/h2o-app/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compile project(":h2o-core")
   compile project(":h2o-algos")
   compile project(":h2o-automl")
+  compile project(":h2o-ext-krbstandalone")
   // Note: orc parser is included at the assembly level for each
   // Hadoop distribution
 }

--- a/h2o-extensions/krbstandalone/build.gradle
+++ b/h2o-extensions/krbstandalone/build.gradle
@@ -1,0 +1,6 @@
+description = "H2O Kerberos Standalone support"
+
+dependencies {
+    compile project(":h2o-core")
+    compile project(":h2o-persist-hdfs")
+}

--- a/h2o-extensions/krbstandalone/src/main/java/hex/security/KerberosExtension.java
+++ b/h2o-extensions/krbstandalone/src/main/java/hex/security/KerberosExtension.java
@@ -8,6 +8,17 @@ import water.util.Log;
 
 import java.io.IOException;
 
+/**
+ * Authenticates the H2O Node to access secured Hadoop cluster in a standalone mode.
+ *
+ * This extension assumes that if Hadoop configuration is present and it has Kerberos enabled
+ * the user will likely want to read data from HDFS even though H2O is running in a standalone mode (not on Hadoop).
+ * The extension attempts to authenticate the user using an existing Kerberos ticket. This means the Kerberos ticket
+ * needs to be manually acquired by the user on each node before the H2O instance is started.
+ *
+ * The extension fails gracefully if the user cannot be authenticated and doesn't stop H2O start-up. The failure
+ * will be logged as an error.
+ */
 public class KerberosExtension extends AbstractH2OExtension {
 
   public static String NAME = "KrbStandalone";

--- a/h2o-extensions/krbstandalone/src/main/java/hex/security/KerberosExtension.java
+++ b/h2o-extensions/krbstandalone/src/main/java/hex/security/KerberosExtension.java
@@ -1,0 +1,35 @@
+package hex.security;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import water.AbstractH2OExtension;
+import water.persist.PersistHdfs;
+import water.util.Log;
+
+import java.io.IOException;
+
+public class KerberosExtension extends AbstractH2OExtension {
+
+  public static String NAME = "KrbStandalone";
+
+  @Override
+  public String getExtensionName() {
+    return NAME;
+  }
+
+  @Override
+  public void onLocalNodeStarted() {
+    Configuration conf = PersistHdfs.CONF;
+    if ("kerberos".equals(conf.get("hadoop.security.authentication"))) {
+      Log.info("Kerberos enabled in configuration - trying to login using existing keytab");
+      UserGroupInformation.setConfiguration(conf);
+      try {
+        UserGroupInformation.loginUserFromSubject(null);
+      } catch (IOException e) {
+        throw new RuntimeException("Kerberos initialization FAILED.", e);
+      }
+    } else
+      Log.info("Kerberos not configured");
+  }
+
+}

--- a/h2o-extensions/krbstandalone/src/main/java/hex/security/KerberosExtension.java
+++ b/h2o-extensions/krbstandalone/src/main/java/hex/security/KerberosExtension.java
@@ -20,16 +20,23 @@ public class KerberosExtension extends AbstractH2OExtension {
   @Override
   public void onLocalNodeStarted() {
     Configuration conf = PersistHdfs.CONF;
-    if ("kerberos".equals(conf.get("hadoop.security.authentication"))) {
-      Log.info("Kerberos enabled in configuration - trying to login using existing keytab");
+    if (conf == null)
+      return; // this is theoretically possible although unlikely
+
+    if (isKerberosEnabled(conf)) {
+      Log.info("Kerberos enabled in Hadoop configuration. Trying to login the (default) user.");
       UserGroupInformation.setConfiguration(conf);
       try {
         UserGroupInformation.loginUserFromSubject(null);
       } catch (IOException e) {
-        throw new RuntimeException("Kerberos initialization FAILED.", e);
+        Log.err("Kerberos initialization FAILED. Kerberos ticket needs to be acquired before starting H2O (run kinit).", e);
       }
     } else
-      Log.info("Kerberos not configured");
+      Log.debug("Kerberos not configured");
+  }
+
+  private static boolean isKerberosEnabled(Configuration conf) {
+    return "kerberos".equals(conf.get("hadoop.security.authentication"));
   }
 
 }

--- a/h2o-extensions/krbstandalone/src/main/resources/META-INF/services/water.AbstractH2OExtension
+++ b/h2o-extensions/krbstandalone/src/main/resources/META-INF/services/water.AbstractH2OExtension
@@ -1,0 +1,1 @@
+hex.security.KerberosExtension

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ include 'h2o-jaas-pam'
 include 'h2o-automl'
 include 'h2o-genmodel-ext-xgboost'
 include 'h2o-ext-xgboost'
+include 'h2o-ext-krbstandalone'
 
 // GRPC support
 if ("true".equals(System.getenv("H2O_BUILD_GRPC"))) {


### PR DESCRIPTION
User needs to get Kerberos ticket (kinit) and then start H2O instance (Hadoop configuration xml needs to have kerberos enabled).