### PR TITLE
PUBDEV-2767: Copy of factor column in R misses copy-on-write

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -996,7 +996,7 @@ class H2OFrame(object):
         :returns: A single-column H2OFrame with the desired levels.
         """
         assert_is_type(levels, [str])
-        return H2OFrame._expr(expr=ExprNode("setDomain", self, True, levels), cache=self._ex._cache)
+        return H2OFrame._expr(expr=ExprNode("setDomain", self, False, levels), cache=self._ex._cache)
 
 
     def set_names(self, names):

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -996,7 +996,7 @@ class H2OFrame(object):
         :returns: A single-column H2OFrame with the desired levels.
         """
         assert_is_type(levels, [str])
-        return H2OFrame._expr(expr=ExprNode("setDomain", self, levels), cache=self._ex._cache)
+        return H2OFrame._expr(expr=ExprNode("setDomain", self, True, levels), cache=self._ex._cache)
 
 
     def set_names(self, names):

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1812,7 +1812,8 @@ h2o.nlevels <- function(x) {
 #' \donttest{
 #' h2o.init()
 #' iris.hex <- as.h2o(iris)
-#' iris.hex$Species <- h2o.setLevels(iris.hex$Species, c("setosa", "versicolor", "caroliniana"), in.place = FALSE)
+#' new.levels <- c("setosa", "versicolor", "caroliniana")
+#' iris.hex$Species <- h2o.setLevels(iris.hex$Species, new.levels, in.place = FALSE)
 #' h2o.levels(iris.hex$Species)
 #' }
 h2o.setLevels <- function(x, levels, in.place = TRUE) .newExpr("setDomain", chk.H2OFrame(x), in.place, levels)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1794,16 +1794,28 @@ h2o.nlevels <- function(x) {
   if (!is.list(levels)) length(levels)
   else lapply(levels,length)
 }
+
+
 #'
 #' Set Levels of H2O Factor Column
 #'
 #' Works on a single categorical vector. New domains must be aligned with the old domains.
-#' This call has SIDE EFFECTS and mutates the column in place (does not make a copy).
+#' This call has SIDE EFFECTS and mutates the column in place (change of the levels will also affect all the frames
+#' that are referencing this column). If you want to make a copy of the column instead, use parameter in.place = FALSE.
 #'
 #' @param x A single categorical column.
 #' @param levels A character vector specifying the new levels. The number of new levels must match the number of old levels.
+#' @param in.place Indicates whether new domain will be directly applied to the column (in place change) or if a copy
+#'        of the column will be created with the given domain levels.
 #' @export
-h2o.setLevels <- function(x, levels) .newExpr("setDomain", chk.H2OFrame(x), levels)
+#' @examples
+#' \donttest{
+#' h2o.init()
+#' iris.hex <- as.h2o(iris)
+#' iris.hex$Species <- h2o.setLevels(iris.hex$Species, c("setosa", "versicolor", "caroliniana"), in.place = FALSE)
+#' h2o.levels(iris.hex$Species)
+#' }
+h2o.setLevels <- function(x, levels, in.place = TRUE) .newExpr("setDomain", chk.H2OFrame(x), in.place, levels)
 
 
 #'

--- a/h2o-r/tests/testdir_misc/runit_revalue.R
+++ b/h2o-r/tests/testdir_misc/runit_revalue.R
@@ -1,30 +1,27 @@
 setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
 ##
-# Generate lots of keys then remove them
+# Set levels of a factor column
 ##
 
 
 
 
-test <- function() {
+test.setLevels <- function() {
 
   hex <- as.h2o(iris)
+  hex.species.copy <- hex$Species
+  species.orig <- h2o.levels(hex$Species)
 
-  Log.info("Original factor column")
-  print(hex$Species)
-  print(h2o.levels(hex$Species))
-
-  zz <- h2o.setLevels(hex$Species, c(setosa = "NEW SETOSA ENUM", virginica = "NEW VIRG ENUM", versicolor = "NEW VERSI ENUM"))
-
-  Log.info("Revalued factor column")
-  print(zz)
-  print(h2o.levels(zz))
+  Log.info("Tests in-place modification")
+  hex$Species <- h2o.setLevels(hex$Species, c(setosa = "NEW SETOSA ENUM", virginica = "NEW VIRG ENUM", versicolor = "NEW VERSI ENUM"))
   vals <- c("NEW SETOSA ENUM", "NEW VIRG ENUM", "NEW VERSI ENUM")
-  expect_equal(h2o.levels(zz), vals)
+  expect_equal(h2o.levels(hex$Species), vals)
+  expect_equal(h2o.levels(hex.species.copy), vals) # setLevels has side effects
 
-  
-}
+  Log.info("Tests copy-on-write modification")
+  hex$Species <- h2o.setLevels(hex$Species, species.orig, in.place = FALSE)
+  expect_equal(h2o.levels(hex$Species), species.orig)
+                                                                                                                                   }
 
-doTest("Many Keys Test: Removing", test)
-
+doTest("Set levels of a factor column", test.setLevels)


### PR DESCRIPTION
Note: the fix is actually different for R and Python.

For Python: we treat this as a bug because implementation was not accordance with documentation.
For R: The documentation actually states this behavior and there might be users relying on it (calling h2o.setLevels(...) without using the return value). We therefore introduce a new flag that disables the in-place overwrite