### PR TITLE
[PUBDEV-4688] - added newline when printing H2OFrame in IPython

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -425,6 +425,9 @@ class H2OFrame(object):
                 print(self.head().as_data_frame(fill_cache=True))
             else:
                 s = self.__unicode__()
+                stk = traceback.extract_stack()
+                if "IPython" in stk[-3][0]:
+                    s = "\n%s" % s
                 try:
                     print(s)
                 except UnicodeEncodeError:


### PR DESCRIPTION
Fixed missing newline when using default print in IPython. The hack with stacktrace examination was taken from the `__repr__` method of the same class.