### PR TITLE
column with categorical value should not throw Exception "Unexpected …

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -645,7 +645,7 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
           else {
             value = levelIndex;
           }
-        } else if (o instanceof Double && Double.isNaN((double)o)) {
+        } else if (o instanceof Double && !Double.isNaN((double)o)) {
           value = (double)o; //Missing factor is the only Double value allowed
         } else {
           throw new PredictUnknownTypeException(


### PR DESCRIPTION
column with categorical value should not throws exception when casted correctly

when column has categorical value, a double value throws PredictUnknownTypeException "Unexpected object type " when it should not.