### PR TITLE
PUBDEV-4773: Document new "verbose" option

### DIFF
--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -262,6 +262,8 @@ H2O Deep Learning models have many input parameters, many of which are only acce
 
 -  **elastic_averaging_regularization**: Specify the elastic averaging regularization strength. This option is only available if ``elastic_averaging=True``. 
 
+-  **verbose**: Print scoring history to the console. For Deep Learning, metrics are per epoch. This value defaults to FALSE.
+
 
 Interpreting a Deep Learning Model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -245,6 +245,8 @@ Defining a DRF Model
 
 -  `calibrate_frame <algo-params/calibrate_frame.html>`__: Specifies the frame to be used for Platt scaling.
 
+-  **verbose**: Print scoring history to the console. For DRF, metrics are per tree. This value defaults to FALSE.
+
 Interpreting a DRF Model
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -274,6 +274,8 @@ Defining a GBM Model
 
 -  `calibrate_frame <algo-params/calibrate_frame.html>`__: Specifies the frame to be used for Platt scaling.
 
+-  **verbose**: Print scoring history to the console. For GBM, metrics are per tree. This value defaults to FALSE.
+
 Interpreting a GBM Model
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added the “verbose” option to list of parameters in GBM, DRF, and Deep Learning. Note that this was already added to XGBoost documentation.