### PR TITLE
Fix test dependencies for the Parquet Parser

### DIFF
--- a/h2o-parsers/h2o-parquet-parser/build.gradle
+++ b/h2o-parsers/h2o-parquet-parser/build.gradle
@@ -22,7 +22,9 @@ dependencies {
   testCompile project(path: ":h2o-core", configuration: "testArchives")
   testCompile("org.apache.parquet:parquet-avro:1.7.0")
   // We need correct version of MapRe Hadoop to run JUnits
-  testCompile("org.apache.hadoop:hadoop-client:$parquetHadoopVersion")
+  testCompile("org.apache.hadoop:hadoop-client:$parquetHadoopVersion") {
+    exclude module: "servlet-api"
+  }
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"


### PR DESCRIPTION
There were overlapping dependendencies:

- javax.servlet:servlet-api:2.5
- org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016