### PR TITLE
[HEXDEV-694] Added more generic handling of type overrides to ORC.

### DIFF
--- a/h2o-core/src/main/java/water/api/ParseSetupHandler.java
+++ b/h2o-core/src/main/java/water/api/ParseSetupHandler.java
@@ -46,10 +46,10 @@ public class ParseSetupHandler extends Handler {
         throw new H2OIllegalArgumentException(ex2.getMessage());
       throw ex;
     }
-    if(ps._errs != null && ps._errs.length > 0) {
-      p.warnings = new String[ps._errs.length];
-      for (int i = 0; i < ps._errs.length; ++i)
-        p.warnings[i] = ps._errs[i].toString();
+    if(ps.errs() != null && ps.errs().length > 0) {
+      p.warnings = new String[ps.errs().length];
+      for (int i = 0; i < ps.errs().length; ++i)
+        p.warnings[i] = ps.errs().toString();
     }
     // TODO: ParseSetup throws away the srcs list. . .
     if ((null == p.column_name_filter || "".equals(p.column_name_filter)) && (0 == p.column_offset) && (0 == p.column_count)) {

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -723,7 +723,7 @@ MAIN_LOOP:
       try {
         p.parseChunk(0,new ByteAryData(bits,0), dout);
         resSetup._column_previews = dout;
-        resSetup._errs = dout._errs;
+        resSetup.addErrs(dout._errs);
       } catch (Throwable e) {
         throw new RuntimeException(e);
       }

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -326,7 +326,7 @@ public final class ParseDataset {
     // Check for job cancellation
     if ( job.stop_requested() ) return pds;
 
-    ParseWriter.ParseErr [] errs = ArrayUtils.append(setup._errs,mfpt._errors);
+    ParseWriter.ParseErr [] errs = ArrayUtils.append(setup.errs(),mfpt._errors);
     if(errs.length > 0) {
       // compute global line numbers for warnings/errs
       HashMap<String, Integer> fileChunkOffsets = new HashMap<>();

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -44,7 +44,13 @@ public class ParseSetup extends Iced {
 
   public void setFileName(String name) {_fileNames[0] = name;}
 
-  public ParseWriter.ParseErr[] _errs;
+  private ParseWriter.ParseErr[] _errs;
+  public final ParseWriter.ParseErr[] errs() { return _errs;}
+
+  public void addErrs(ParseWriter.ParseErr... errs){
+    _errs = ArrayUtils.append(_errs,errs);
+  }
+
   public int _chunk_size = FileVec.DFLT_CHUNK_SIZE;  // Optimal chunk size to be used store values
   PreviewParseWriter _column_previews = null;
 

--- a/h2o-core/src/main/java/water/parser/ParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/ParseWriter.java
@@ -3,11 +3,23 @@ package water.parser;
 import water.Freezable;
 import water.Iced;
 
+import static water.parser.ParseWriter.ParseErr.ErrLvl.WARN;
+
 /** Interface for writing results of parsing, accumulating numbers and
  *  strings or handling invalid lines & parse errors.  */
 public interface ParseWriter extends Freezable {
 
-  class ParseErr extends Iced {
+  class ParseErr extends Iced implements Comparable<ParseErr>{
+    @Override
+    public int compareTo(ParseErr o) {
+      long res = _gLineNum - o._gLineNum;
+      if (res == 0) res = _byteOffset - _byteOffset;
+      if (res == 0) return _err.compareTo(o._err);
+      return (int) res < 0 ? -1 : 1;
+    }
+
+    public enum ErrLvl { ERR,WARN}
+    public ErrLvl errLvl(){return WARN;}
     public ParseErr(){}
     public ParseErr(String file, String err) {
       this(err, 0, -1, -1);
@@ -19,6 +31,7 @@ public interface ParseWriter extends Freezable {
       _lineNum = lineNum;
       _byteOffset = byteOff;
     }
+
     // as recorded during parsing
     String _file = "unknown";
     String _err = "unknown";
@@ -29,6 +42,12 @@ public interface ParseWriter extends Freezable {
     long _gLineNum = -1;
     public String toString(){
       return "ParseError at file " + _file + (_gLineNum == -1?"":" at line " + _lineNum + " ( destination line " + _gLineNum + " )") + (_byteOffset == -1 ? "" : "  at byte offset " + _byteOffset) + "; error = \'" + _err + "\'";
+    }
+  }
+  class UnsupportedTypeOverride extends ParseErr {
+    public UnsupportedTypeOverride(String fileName, String origType, String targetType, String columnName){
+      super(fileName,"Unsupported type override (" + origType + " -> " + targetType + "). Column " + columnName
+          + " will be parsed as " + origType);
     }
   }
 

--- a/h2o-core/src/main/java/water/parser/ParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/ParseWriter.java
@@ -3,8 +3,6 @@ package water.parser;
 import water.Freezable;
 import water.Iced;
 
-import static water.parser.ParseWriter.ParseErr.ErrLvl.WARN;
-
 /** Interface for writing results of parsing, accumulating numbers and
  *  strings or handling invalid lines & parse errors.  */
 public interface ParseWriter extends Freezable {
@@ -17,9 +15,6 @@ public interface ParseWriter extends Freezable {
       if (res == 0) return _err.compareTo(o._err);
       return (int) res < 0 ? -1 : 1;
     }
-
-    public enum ErrLvl { ERR,WARN}
-    public ErrLvl errLvl(){return WARN;}
     public ParseErr(){}
     public ParseErr(String file, String err) {
       this(err, 0, -1, -1);

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -1254,6 +1254,12 @@ public class ArrayUtils {
       res[i] = ary[idxs[i]];
     return res;
   }
+  public static String[] select(String[] ary, byte[] idxs) {
+    String [] res  = new String[idxs.length];
+    for(int i = 0; i < res.length; ++i)
+      res[i] = ary[idxs[i]];
+    return res;
+  }
 
   public static double[] select(double[] ary, int[] idxs) {
     double [] res = MemoryManager.malloc8d(idxs.length);

--- a/h2o-core/src/test/java/water/parser/ParserTest.java
+++ b/h2o-core/src/test/java/water/parser/ParserTest.java
@@ -992,7 +992,7 @@ public class ParserTest extends TestUtil {
       Key[] keys = new Key[]{fv._key};
       ParseSetup guessedSetup = ParseSetup.guessSetup(keys, false, 1);
       Assert.assertEquals(guessedSetup._number_columns, 2);
-      Assert.assertEquals(0, guessedSetup._errs.length);
+      Assert.assertEquals(0, guessedSetup.errs().length);
       guessedSetup._column_names = new String[] {"c1", "c2", "c3", "c4"};
       guessedSetup._column_types = new byte[] {Vec.T_NUM, Vec.T_STR, Vec.T_NUM, Vec.T_STR};
       guessedSetup._number_columns = 4;

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/ParseUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/ParseUtils.java
@@ -4,7 +4,6 @@ package hex.genmodel.utils;
  * Helper function for parsing the serialized model.
  */
 public class ParseUtils {
-
     public static double[] parseArrayOfDoubles(String input) {
         if (!(input.startsWith("[") && input.endsWith("]")))
             throw new NumberFormatException("Array should be enclosed in square brackets");

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestOrc.java
@@ -7,9 +7,11 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
 
+import water.Job;
 import water.Key;
 import water.TestUtil;
 import water.api.schemas3.ParseSetupV3;
@@ -17,6 +19,7 @@ import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.fvec.Vec;
 import water.parser.orc.OrcParserProvider;
+import water.util.ArrayUtils;
 import water.util.FileUtils;
 import water.util.Log;
 
@@ -75,7 +78,7 @@ public class ParseTestOrc extends TestUtil {
     };
 
     @BeforeClass
-    static public void setup() { TestUtil.stall_till_cloudsize(5); }
+    static public void setup() { TestUtil.stall_till_cloudsize(1); }
 
     @BeforeClass
     static public void _preconditionJavaVersion() { // NOTE: the `_` force execution of this check after setup
@@ -83,17 +86,27 @@ public class ParseTestOrc extends TestUtil {
         Assume.assumeTrue("Java6 is not supported", !System.getProperty("java.version", "NA").startsWith("1.6"));
     }
 
-    @Test public void testBadColumn(){
+    @Test public void testTypeOverrides(){
         NFSFileVec nfs = makeNfsFileVec("smalldata/parser/orc/orc_split_elim.orc");
         Key<Frame> outputKey = Key.make("orc_Test");
         ParseSetup pstp = new ParseSetup(new ParseSetupV3());
         pstp._parse_type = new OrcParserProvider.OrcParserInfo();
         ParseSetup ps = ParseSetup.guessSetup(new Key[]{nfs._key}, pstp);
         Assert.assertEquals(ps._parse_type.name(), "ORC");
-        System.out.println("ParseSetup");
-        System.out.println(ps);
         ps._column_types[0] = Vec.T_BAD;
-        Frame fr = ParseDataset.parse(outputKey, new Key[]{nfs._key},true,ps);
+        ps._column_types[1] = Vec.T_CAT;
+        ps._column_types[2] = Vec.T_STR;
+        ParseSetup ps2 = ParseSetup.guessSetup(new Key[]{nfs._key}, ps);
+        String errs = Arrays.deepToString(ps2.errs());
+        Assert.assertEquals(1,ps2.errs().length);
+        Assert.assertTrue(ps2.errs()[0] instanceof ParseWriter.UnsupportedTypeOverride);
+        System.out.println("types: " + Arrays.toString(ArrayUtils.select(Vec.TYPE_STR,ps2._column_types)));
+        Key k = Key.make();
+        Job<Frame> j = ParseDataset.forkParseDataset(k,new Key[]{nfs._key},ps,true)._job;
+        Frame fr = j.get();
+        String  warns = Arrays.toString(j.warns());
+        Assert.assertEquals(errs,warns);
+        Assert.assertArrayEquals(new String[]{"bar", "cat", "dog", "eat", "foo", "zebra"},fr.vec(1).domain());
         Assert.assertTrue(fr.vec(0).isBad());
         fr.delete();
     }

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
@@ -8,7 +8,6 @@ import water.fvec.ByteVec;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.parser.*;
-import water.util.ArrayUtils;
 
 /**
  * Parquet parser provider.
@@ -48,9 +47,7 @@ public class ParquetParserProvider extends ParserProvider {
     setup.setColumnTypes(types);
     for (int i = 0; i < types.length; i++)
       if (types[i] != requestedTypes[i])
-        setup._errs = ArrayUtils.append(setup._errs, new ParseWriter.ParseErr(inputs[0].toString(),
-                "Unsupported type override (" + Vec.TYPE_STR[types[i]] + " -> " + Vec.TYPE_STR[requestedTypes[i]] + "). Column " +
-                setup.getColumnNames()[i] + " will be parsed as " + Vec.TYPE_STR[types[i]]));
+        setup.addErrs(new ParseWriter.UnsupportedTypeOverride(inputs[0].toString(),Vec.TYPE_STR[types[i]], Vec.TYPE_STR[requestedTypes[i]], setup.getColumnNames()[i]));
     return setup;
   }
 


### PR DESCRIPTION
ORC parser can convert certain types (e.g. any type can be turned into BAD to be essentially ignored, String can be turned into CAT or time), other conversions will be refused and H2O will generate a warning.