### PR TITLE
PUBDEV-4639: use data.table.  Specified integer64=numeric and get rid…

### DIFF
--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -30,6 +30,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
 
     algo = "glm"
 
+
     def __init__(self, **kwargs):
         super(H2OGeneralizedLinearEstimator, self).__init__()
         self._parms = {}

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3221,13 +3221,13 @@ use.package <- function(package,
   stopifnot(is.character(package), length(package)==1L,
             is.character(version), length(version)==1L,
             is.logical(use), length(use)==1L)
-  # if (package=="data.table" && use) { # not sure if this is needed.  Keeping it for now.
-  #   if (!("bit64" %in% rownames(installed.packages())) || (packageVersion("bit64") < as.package_version("0.9.7"))) {
-  #      # print out warning to install bit64 in order to use data.table
-  #     warning("data.table cannot be used without R package bit64 version 0.9.7 or higher.  Please upgrade to take advangage of data.table speedups.")
-  #     return(FALSE)
-  #   }
-  # }
+   if (package=="data.table" && use) { # not sure if this is needed.  Keeping it for now.
+     if (!("bit64" %in% rownames(installed.packages())) || (packageVersion("bit64") < as.package_version("0.9.7"))) {
+        # print out warning to install bit64 in order to use data.table
+       warning("data.table cannot be used without R package bit64 version 0.9.7 or higher.  Please upgrade to take advangage of data.table speedups.")
+       return(FALSE)
+     }
+   }
   use && requireNamespace(package, quietly=TRUE) && (packageVersion(package) >= as.package_version(version))
 }
 

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3214,14 +3214,13 @@ destination_frame.guess <- function(x) {
 #' options(op)
 use.package <- function(package, 
                         version="1.9.8"[package=="data.table"], 
-                        use=getOption("h2o.use.data.table", FALSE)[package=="data.table"]) {
+                        use=getOption("h2o.use.data.table", TRUE)[package=="data.table"]) {
   ## methods that depends on use.package default arguments (to have control in single place):
   # as.h2o.data.frame
   # as.data.frame.H2OFrame
   stopifnot(is.character(package), length(package)==1L,
             is.character(version), length(version)==1L,
             is.logical(use), length(use)==1L)
-
   # if (package=="data.table" && use) { # not sure if this is needed.  Keeping it for now.
   #   if (!("bit64" %in% rownames(installed.packages())) || (packageVersion("bit64") < as.package_version("0.9.7"))) {
   #      # print out warning to install bit64 in order to use data.table


### PR DESCRIPTION
Implementing Matt D suggestion to add option integer64="numeric" inside data.table::fread calls instead of requiring bit64 R package.  