### PR TITLE
PUBDEV-4702: max_runtime_secs.  Fixed array out of bound error in PCA.

### DIFF
--- a/h2o-algos/src/main/java/hex/svd/SVD.java
+++ b/h2o-algos/src/main/java/hex/svd/SVD.java
@@ -745,7 +745,7 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
             // 4) Normalize output frame columns by singular values to get left singular vectors
             model._output._v = ArrayUtils.transpose(model._output._v);  // Transpose to get V (since vectors were stored as rows)
             if (!_parms._only_v && !_parms._keep_u) {         // Delete U vecs if computed, but user does not want it returned
-              for (int index=0; index < _parms._nv; index++){
+              for (int index=0; index < uvecs.length; index++){
                 uvecs[index].remove();
               }
               model._output._u_key = null;


### PR DESCRIPTION
Fix the java array out of bound error when PCA max_runtime_secs is set to be too short.  Here the PCA did not get to calculate all of its eigenvalues but have to stop due to max_runtime_secs overrun. 