### PR TITLE
PUBDEV-4804: Update links to Hive MOJO/POJO examples

### DIFF
--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -164,12 +164,13 @@ Scoring engine                                      H2O POJO
 Scoring latency SLA                                 Batch
 ==================================================  ===========================================================
 
-=========    ==================================================================================================
-Resource     Location
-=========    ==================================================================================================
-Git repos    https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/hive_udf_template
-Tutorials    http://docs.h2o.ai/h2o-tutorials/latest-stable/tutorials/hive_udf_template/index.html
-=========    ==================================================================================================
+=============    ==================================================================================================
+Resource         Location
+=============    ==================================================================================================
+Git repos        https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/hive_udf_template
+POJO Tutorial    http://docs.h2o.ai/h2o-tutorials/latest-stable/tutorials/hive_udf_template/hive_udf_pojo_template/index.html
+MOJO Tutorial    http://docs.h2o.ai/h2o-tutorials/latest-stable/tutorials/hive_udf_template/hive_udf_mojo_template/index.html
+=============    ==================================================================================================
 
 
 MOJO as a JAR Resource


### PR DESCRIPTION
- Updated the gitbook in the h2o-tutorials repo to include entries for both the POJO and MOJO examples.
- The productionizing.rst file now includes links for both of these examples.