### PR TITLE
PUBDEV-4711: GLRM error message to client.  Added code to RequestServ…

### DIFF
--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -1,6 +1,5 @@
 package water.api;
 
-import com.google.gson.Gson;
 import water.*;
 import water.api.schemas3.H2OErrorV3;
 import water.api.schemas3.H2OModelBuilderErrorV3;
@@ -314,12 +313,18 @@ public class RequestServer extends HttpServlet {
 
       resp.writeTo(response.getOutputStream());
 
+    } catch (IllegalArgumentException e) {  // This error type should be passed to clients.
+      try {
+        JettyHTTPD.sendResponseError(response, 500, e.getMessage());
+      } catch (IOException ex) {
+        ex.printStackTrace();
+      }
+      Log.err(e);
     } catch (IOException e) {
       e.printStackTrace();
       JettyHTTPD.setResponseStatus(response, 500);
       Log.err(e);
       // Trying to send an error message or stack trace will produce another IOException...
-
     } finally {
       JettyHTTPD.logRequest(method, request, response);
       // Handle shutdown if it was requested.

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_pubde_4711_glrm_pojo_error.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_pubde_4711_glrm_pojo_error.py
@@ -1,0 +1,27 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+
+
+def glrm_size_benchmark():
+  frame = h2o.upload_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+  model = H2OGeneralizedLowRankEstimator(k=8, init="svd", recover_svd=True)
+
+
+  model.train(x=frame.names, training_frame=frame)
+  try:
+    result_dir = pyunit_utils.locate("results")
+    h2o.download_pojo(model, path=result_dir)
+    assert False, "Java backend did not return correct client error message."
+  except Exception as e:
+    print(e)
+    if "GLRM" not in e.args[0]:
+      assert False, "Java backend did not return correct client error message."
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(glrm_size_benchmark)
+else:
+  glrm_size_benchmark()


### PR DESCRIPTION
When h2o.download_pojo is called for GLRM model, error message from java is now passed to Python client.