### PR TITLE
Changes to Stacked Ensembles

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -262,7 +262,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
 
         // NOTE: if we loosen this restriction and fold_column is set add a check below.
         Frame aTrainingFrame = aModel._parms.train();
-        if (trainingFrameChecksum != aTrainingFrame.checksum())
+        if (trainingFrameChecksum != aTrainingFrame.checksum() && !this._parms._is_cv_model)
           throw new H2OIllegalArgumentException("Base models are inconsistent: they use different training frames.  Found checksums: " + trainingFrameChecksum + " and: " + aTrainingFrame.checksum() + ".");
 
         NonBlockingHashSet<String> aNames = new NonBlockingHashSet<>();

--- a/h2o-algos/src/main/java/hex/schemas/DRFV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DRFV3.java
@@ -4,62 +4,63 @@ import hex.tree.drf.DRF;
 import hex.tree.drf.DRFModel.DRFParameters;
 import water.api.API;
 
-public class DRFV3 extends SharedTreeV3<DRF,DRFV3, DRFV3.DRFParametersV3> {
+public class DRFV3 extends SharedTreeV3<DRF, DRFV3, DRFV3.DRFParametersV3> {
 
-  public static final class DRFParametersV3 extends SharedTreeV3.SharedTreeParametersV3<DRFParameters, DRFParametersV3> {
-    static public String[] fields = new String[] {
-				"model_id",
-				"training_frame",
-				"validation_frame",
-        "nfolds",
-        "keep_cross_validation_predictions",
-        "keep_cross_validation_fold_assignment",
-        "score_each_iteration",
-        "score_tree_interval",
-        "fold_assignment",
-        "fold_column",
-				"response_column",
-				"ignored_columns",
-				"ignore_const_cols",
-				"offset_column",
-				"weights_column",
-				"balance_classes",
-				"class_sampling_factors",
-				"max_after_balance_size",
-				"max_confusion_matrix_size",
-				"max_hit_ratio_k",
-				"ntrees",
-				"max_depth",
-				"min_rows",
-				"nbins",
-        "nbins_top_level",
-				"nbins_cats",
-				"r2_stopping",
-        "stopping_rounds",
-        "stopping_metric",
-        "stopping_tolerance",
-        "max_runtime_secs",
-				"seed",
-				"build_tree_one_node",
-        "mtries",
-        "sample_rate",
-        "sample_rate_per_class",
-        "binomial_double_trees",
-        "checkpoint",
-        "col_sample_rate_change_per_level",
-        "col_sample_rate_per_tree",
-        "min_split_improvement",
-        "histogram_type",
-        "categorical_encoding",
-		"calibrate_model",
-		"calibration_frame"
-    };
+    public static final class DRFParametersV3 extends SharedTreeV3.SharedTreeParametersV3<DRFParameters, DRFParametersV3> {
+        static public String[] fields = new String[]{
+                "model_id",
+                "training_frame",
+                "validation_frame",
+                "nfolds",
+                "keep_cross_validation_predictions",
+                "keep_cross_validation_fold_assignment",
+                "score_each_iteration",
+                "score_tree_interval",
+                "fold_assignment",
+                "fold_column",
+                "response_column",
+                "ignored_columns",
+                "ignore_const_cols",
+                "offset_column",
+                "weights_column",
+                "balance_classes",
+                "class_sampling_factors",
+                "max_after_balance_size",
+                "max_confusion_matrix_size",
+                "max_hit_ratio_k",
+                "ntrees",
+                "max_depth",
+                "min_rows",
+                "nbins",
+                "nbins_top_level",
+                "nbins_cats",
+                "r2_stopping",
+                "stopping_rounds",
+                "stopping_metric",
+                "stopping_tolerance",
+                "max_runtime_secs",
+                "seed",
+                "build_tree_one_node",
+                "mtries",
+                "sample_rate",
+                "sample_rate_per_class",
+                "binomial_double_trees",
+                "checkpoint",
+                "col_sample_rate_change_per_level",
+                "col_sample_rate_per_tree",
+                "min_split_improvement",
+                "histogram_type",
+                "categorical_encoding",
+                "calibrate_model",
+                "calibration_frame",
+                "distribution"
+        };
 
-    // Input fields
-    @API(help = "Number of variables randomly sampled as candidates at each split. If set to -1, defaults to sqrt{p} for classification and p/3 for regression (where p is the # of predictors", gridable = true)
-    public int mtries;
+        // Input fields
+        @API(help = "Number of variables randomly sampled as candidates at each split. If set to -1, defaults to sqrt{p} for classification and p/3 for regression (where p is the # of predictors", gridable = true)
+        public int mtries;
 
-    @API(help="For binary classification: Build 2x as many trees (one per class) - can lead to higher accuracy.", level = API.Level.expert)
-    public boolean binomial_double_trees;
-  }
+        @API(help = "For binary classification: Build 2x as many trees (one per class) - can lead to higher accuracy.", level = API.Level.expert)
+        public boolean binomial_double_trees;
+    }
 }

--- a/h2o-algos/src/test/java/hex/ensemble/CheckSumTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/CheckSumTest.java
@@ -1,0 +1,112 @@
+package hex.ensemble;
+
+import hex.genmodel.utils.DistributionFamily;
+import hex.tree.gbm.GBM;
+import hex.tree.gbm.GBMModel;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.DKV;
+import water.Key;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import hex.tree.drf.DRF;
+import hex.tree.drf.DRFModel;
+import hex.StackedEnsembleModel;
+
+/***
+ * The main purpose of this test is to ensure the checksum() of a training frame is preserved throughout the
+ * stacked ensemble process. An issue is known with fold_column causing checksum() issues and also calling the
+ * wrong score method. However, stacked ensembles does not need fold column to be passed in explicitly. Rather, a user
+ * just needs to pass in the training frame, response name, and the base models. 
+ */
+public class CheckSumTest extends TestUtil {
+    
+    @BeforeClass public static void stall() { stall_till_cloudsize(1); }
+
+    @Test public void checkSumTest() {
+        Frame fr = null;
+        Frame frAfterGbm = null;
+        Frame frAfterDrf = null;
+        GBMModel gbm = null;
+        GBMModel.GBMParameters parmsGbm = new GBMModel.GBMParameters();
+        DRFModel drf = null;
+        DRFModel.DRFParameters parmsDrf = new DRFModel.DRFParameters();
+        StackedEnsembleModel stackedEnsembleModel = null;
+
+        String fname = "./smalldata/stackedensembles/stacking_fold.csv";
+        try {
+            Scope.enter();
+            Frame train = parse_test_file(fname);
+            DKV.put(train);
+            int resp = train.find("response");
+            Scope.track(train.replace(resp, train.vecs()[resp].toCategoricalVec()));
+            DKV.put(train._key,train);
+
+            //Build GBM
+            parmsGbm._train = train._key;
+            parmsGbm._response_column = "response"; // Train on the outcome
+            parmsGbm._ntrees = 10;
+            parmsGbm._max_depth = 3;
+            parmsGbm._min_rows = 2;
+            parmsGbm._learn_rate = .2f;
+            parmsGbm._distribution = DistributionFamily.bernoulli;
+            parmsGbm._fold_column = "fold_column";
+            parmsGbm._keep_cross_validation_predictions = true;
+            parmsGbm._seed = 1;
+            gbm = new GBM(parmsGbm).trainModel().get();
+            frAfterGbm = gbm._parms.train();
+            //Compare original train checksum to GBM train checksum
+            Assert.assertEquals(train.checksum(),frAfterGbm.checksum());
+
+            //Build DRF
+            parmsDrf._train = train._key;
+            parmsDrf._response_column = "response"; // Train on the outcome
+            parmsDrf._distribution = DistributionFamily.bernoulli;
+            parmsDrf._fold_column = "fold_column";
+            parmsDrf._keep_cross_validation_predictions = true;
+            parmsDrf._seed = 1;
+            drf = new DRF(parmsDrf).trainModel().get();
+            frAfterDrf= drf._parms.train();
+            //Compare original train checksum to DRF train checksum
+            Assert.assertEquals(train.checksum(),frAfterDrf.checksum());
+
+            // Build Stacked Ensemble of previous GBM and DRF
+            StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleModel.StackedEnsembleParameters();
+            stackedEnsembleParameters._train = train._key;
+            stackedEnsembleParameters._response_column = "response";
+            stackedEnsembleParameters._fold_column = "fold_column";
+            stackedEnsembleParameters._base_models = new Key[] {gbm._key,drf._key};
+            StackedEnsemble stackedEnsembleJob = new StackedEnsemble(stackedEnsembleParameters);
+            stackedEnsembleModel = stackedEnsembleJob.trainModel().get();
+
+        } finally {
+            if( fr != null ) fr.remove();
+            if( frAfterGbm != null) frAfterGbm.remove();
+            if(frAfterDrf != null) frAfterDrf.remove();
+            if( gbm != null ) {
+                gbm.delete();
+                parmsGbm._train.remove();
+                for (Key k : gbm._output._cross_validation_predictions) k.remove();
+                gbm._output._cross_validation_holdout_predictions_frame_id.remove();
+                gbm.deleteCrossValidationModels();
+            }
+            if( drf != null ) {
+                drf.delete();
+                parmsDrf._train.remove();
+                for (Key k : drf._output._cross_validation_predictions) k.remove();
+                drf._output._cross_validation_holdout_predictions_frame_id.remove();
+                drf.deleteCrossValidationModels();
+            }
+            if( stackedEnsembleModel != null ) {
+                stackedEnsembleModel.delete();
+                stackedEnsembleModel.remove();
+                stackedEnsembleModel._output._metalearner._output._training_metrics.remove();
+                stackedEnsembleModel._output._metalearner.remove();
+            }
+            Scope.exit();
+        }
+    }
+    
+}

--- a/h2o-algos/src/test/java/hex/ensemble/CheckSumTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/CheckSumTest.java
@@ -76,7 +76,6 @@ public class CheckSumTest extends TestUtil {
             StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleModel.StackedEnsembleParameters();
             stackedEnsembleParameters._train = train._key;
             stackedEnsembleParameters._response_column = "response";
-            stackedEnsembleParameters._fold_column = "fold_column";
             stackedEnsembleParameters._base_models = new Key[] {gbm._key,drf._key};
             StackedEnsemble stackedEnsembleJob = new StackedEnsemble(stackedEnsembleParameters);
             stackedEnsembleModel = stackedEnsembleJob.trainModel().get();

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -32,7 +32,7 @@ class H2ORandomForestEstimator(H2OEstimator):
                       "stopping_metric", "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node",
                       "mtries", "sample_rate", "sample_rate_per_class", "binomial_double_trees", "checkpoint",
                       "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
-                      "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame"}
+                      "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame", "distribution"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -717,5 +717,21 @@ class H2ORandomForestEstimator(H2OEstimator):
     def calibration_frame(self, calibration_frame):
         assert_is_type(calibration_frame, None, H2OFrame)
         self._parms["calibration_frame"] = calibration_frame
+
+
+    @property
+    def distribution(self):
+        """
+        Distribution function
+
+        One of: ``"auto"``, ``"bernoulli"``, ``"multinomial"``, ``"gaussian"``, ``"poisson"``, ``"gamma"``,
+        ``"tweedie"``, ``"laplace"``, ``"quantile"``, ``"huber"``  (default: ``"auto"``).
+        """
+        return self._parms.get("distribution")
+
+    @distribution.setter
+    def distribution(self, distribution):
+        assert_is_type(distribution, None, Enum("auto", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"))
+        self._parms["distribution"] = distribution
 
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_base_model_training_frame.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_base_model_training_frame.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+
+import h2o
+
+import sys
+sys.path.insert(1,"../../../")  # allow us to run this standalone
+
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from tests import pyunit_utils
+
+
+def stackedensemble_base_model_training_frame_test():
+    """This test checks the following:
+    1) That passing in base models that use different subsets of 
+       the features works. (different x, but same training_frame)
+    2) That passing in base models that use different subsets of 
+       the features works. (different training_frame) 
+    3) TO DO: That passing in base models that use training frames with different nrows fails.
+    """
+
+    # Import training set
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/higgs_train_5k.csv"),
+                            destination_frame="higgs_train_5k")
+
+    # Identify predictors and response
+    x = train.columns
+    y = "response"
+    x.remove(y)
+
+    # Convert response to a factor
+    train[y] = train[y].asfactor()
+
+    # Set number of folds
+    nfolds = 3
+
+    # Train and cross-validate a GBM
+    my_gbm = H2OGradientBoostingEstimator(distribution="bernoulli",
+                                          ntrees=10,
+                                          nfolds=nfolds,
+                                          fold_assignment="Modulo",
+                                          keep_cross_validation_predictions=True,
+                                          seed=1)
+    my_gbm.train(x=x[1:11], y=y, training_frame=train)
+
+    # Train and cross-validate a RF
+    my_rf = H2ORandomForestEstimator(ntrees=10,
+                                     nfolds=nfolds,
+                                     fold_assignment="Modulo",
+                                     keep_cross_validation_predictions=True,
+                                     seed=1)
+    my_rf.train(x=x[13:20], y=y, training_frame=train)
+
+    # Train a stacked ensemble
+    stack1 = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id])
+    stack1.train(x=x, y=y, training_frame=train)
+
+    # Train a stacked ensemble (no x)
+    stack2 = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id])
+    stack2.train(y=y, training_frame=train)
+
+    # Eval train AUC to assess equivalence
+    assert stack1.auc() == stack2.auc()
+
+
+    # Next create two different training frames
+    train1 = train[list(range(1,11,1))].cbind(train[y])
+    train2 = train[list(range(13,20,1))].cbind(train[y])
+
+    # Train and cross-validate a GBM
+    my_gbm = H2OGradientBoostingEstimator(distribution="bernoulli",
+                                          ntrees=10,
+                                          nfolds=nfolds,
+                                          fold_assignment="Modulo",
+                                          keep_cross_validation_predictions=True,
+                                          seed=1)
+    my_gbm.train(y=y, training_frame=train1)
+
+    # Train and cross-validate a RF
+    my_rf = H2ORandomForestEstimator(ntrees=10,
+                                     nfolds=nfolds,
+                                     fold_assignment="Modulo",
+                                     keep_cross_validation_predictions=True,
+                                     seed=1)
+    my_rf.train(y=y, training_frame=train2)
+
+    # Train a stacked ensemble
+    stack3 = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id])
+    stack3.train(y=y, training_frame=train)
+
+
+    # This will fail so we check for an exception being raised/failure and pass if it truly fails
+    # Create a new training frame that's a different size
+    train3 = train2[0:2000,:]
+
+    # Train and cross-validate a RF
+    my_rf = H2ORandomForestEstimator(ntrees=10,
+                                     nfolds=nfolds,
+                                     fold_assignment="Modulo",
+                                     keep_cross_validation_predictions=True,
+                                     seed=1)
+    my_rf.train(y=y, training_frame=train3)
+
+    # Train a stacked ensemble
+    stack4 = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id])
+    raised = False
+    try:
+        stack4.train(y=y, training_frame=train)
+    except:
+        raised = True
+
+    assert raised is True, "Stacked Ensembles with different training frame sizes should fail"
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(stackedensemble_base_model_training_frame_test)
+else:
+    stackedensemble_base_model_training_frame_test()

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -76,6 +76,8 @@
 #' @param calibrate_model \code{Logical}. Use Platt Scaling to calculate calibrated class probabilities. Calibration can provide more
 #'        accurate estimates of class probabilities. Defaults to FALSE.
 #' @param calibration_frame Calibration frame for Platt Scaling
+#' @param distribution Distribution function Must be one of: "AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma",
+#'        "tweedie", "laplace", "quantile", "huber". Defaults to AUTO.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
@@ -122,6 +124,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                              calibrate_model = FALSE,
                              calibration_frame = NULL,
+                             distribution = c("AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"),
                              verbose = FALSE 
                              ) 
 {
@@ -242,6 +245,8 @@ h2o.randomForest <- function(x, y, training_frame,
     parms$calibrate_model <- calibrate_model
   if (!missing(calibration_frame))
     parms$calibration_frame <- calibration_frame
+  if (!missing(distribution))
+    parms$distribution <- distribution
   # Error check and build model
   .h2o.modelJob('drf', parms, h2oRestApiVersion = 3, verbose=verbose) 
 }

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_base_model_training_frame.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_base_model_training_frame.R
@@ -1,0 +1,110 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# TO DO: Replicate for gaussian
+
+stackedensemble.base_model_training_frame.test <- function() {
+  
+  # This test checks the following (for binomial classification):
+  # 
+  # 1) That passing in base models that use different subsets of 
+  #    the features works. (different x, but same training_frame)
+  # 2) That passing in base models that use different subsets of 
+  #    the features works. (different training_frame) 
+  # 3) That passing in base models that use training frames with different nrows fails.
+
+  train <- h2o.uploadFile(locate("smalldata/testng/higgs_train_5k.csv"), 
+                          destination_frame = "higgs_train_5k")
+  
+  y <- "response"
+  x <- setdiff(names(train), y)
+  train[,y] <- as.factor(train[,y])
+  nfolds <- 3
+  
+  # Train & Cross-validate a GBM
+  my_gbm <- h2o.gbm(x = x[1:10], 
+                    y = y, 
+                    training_frame = train, 
+                    distribution = "bernoulli",
+                    ntrees = 10, 
+                    nfolds = nfolds, 
+                    fold_assignment = "Modulo",
+                    keep_cross_validation_predictions = TRUE,
+                    seed = 1)
+  
+  # Train & Cross-validate a RF
+  my_rf <- h2o.randomForest(x = x[14:20],
+                            y = y, 
+                            training_frame = train,
+                            ntrees = 10, 
+                            nfolds = nfolds, 
+                            fold_assignment = "Modulo",
+                            keep_cross_validation_predictions = TRUE,
+                            seed = 1)
+  
+  # Train a stacked ensemble using the GBM and RF above
+  stack1 <- h2o.stackedEnsemble(x = x, 
+                                y = y, 
+                                training_frame = train,
+                                base_models = list(my_gbm@model_id, my_rf@model_id))
+  
+  
+  # Train a stacked ensemble using the GBM and RF above (no x)
+  stack2 <- h2o.stackedEnsemble(y = y, 
+                                training_frame = train,
+                                base_models = list(my_gbm@model_id, my_rf@model_id))
+  
+  # Eval train AUC to assess equivalence
+  expect_equal(h2o.auc(stack1), h2o.auc(stack2))
+  
+  
+  # Next create two different training frames
+  train1 <- h2o.cbind(train[,1:10], train[,y])
+  train2 <- h2o.cbind(train[,14:20], train[,y])
+  
+  # Train & Cross-validate a GBM
+  my_gbm <- h2o.gbm(y = y, 
+                    training_frame = train1, 
+                    distribution = "bernoulli",
+                    ntrees = 10, 
+                    nfolds = nfolds, 
+                    fold_assignment = "Modulo",
+                    keep_cross_validation_predictions = TRUE,
+                    seed = 1)
+  
+  # Train & Cross-validate a RF
+  my_rf <- h2o.randomForest(y = y, 
+                            training_frame = train2,
+                            ntrees = 10, 
+                            nfolds = nfolds, 
+                            fold_assignment = "Modulo",
+                            keep_cross_validation_predictions = TRUE,
+                            seed = 1)
+
+  # Train a stacked ensemble using the GBM and RF above (no x)
+  stack3 <- h2o.stackedEnsemble(y = y, 
+                                training_frame = train,
+                                base_models = list(my_gbm@model_id, my_rf@model_id))
+
+  
+  # Create a new training frame that's a different size
+  train3 <- train2[1:2000,]
+  
+  # Train & Cross-validate a RF
+  my_rf <- h2o.randomForest(y = y, 
+                            training_frame = train3,
+                            ntrees = 10, 
+                            nfolds = nfolds, 
+                            fold_assignment = "Modulo",
+                            keep_cross_validation_predictions = TRUE,
+                            seed = 1)
+  
+  # Train a stacked ensemble using base models trained on different sized frames
+  expect_error(h2o.stackedEnsemble(y = y, 
+                      training_frame = train,
+                      base_models = list(my_gbm@model_id, my_rf@model_id)))
+  
+  
+}
+
+doTest("Stacked Ensemble base_models training_frame Test", stackedensemble.base_model_training_frame.test)


### PR DESCRIPTION
* This PR does the following changes to Stacked Ensembles:

1. Avoids passing fold column to stacked ensembles. Not needed.
2. Avoids a check for ignored columns in stacked ensembles. Not needed. Only need this from the first base model to compare to others.
3. No need to check `checksums` of training frames since the number of rows only need to match and the column length can vary.
4. No need to check `domains` of a frame because of point `3` above (training frames can vary)
5. Adds minor comments to the code.
6. Adds a test for check sum consistency in Stacked Ensembles. 
7. This PR also adds the `distribution` argument to random forest, which was found to be missing during these changes.