### PR TITLE
PUBDEV-4811: Updates to MOJO/POJO docs

### DIFF
--- a/h2o-docs/src/product/howto/MOJO_QuickStart.md
+++ b/h2o-docs/src/product/howto/MOJO_QuickStart.md
@@ -10,7 +10,7 @@ This document describes how to build and implement a MOJO (Model Object, Optimiz
 A MOJO (Model Object, Optimized) is an alternative to H2O's currently available
 [POJO](https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/howto/POJO_QuickStart.md). As with POJOs, H2O allows you to convert models that you build to MOJOs, which can then be deployed for scoring in real time.
 
-**Note**: MOJOs are supported for GBM, DRF, GLM, K-Means, and XGBoost models only.
+**Note**: MOJOs are supported for GBM, DRF, GLM, K-Means, SVM, Word2vec, and XGBoost models only.
 
 ## Benefit over POJOs
 
@@ -34,13 +34,13 @@ The examples below describe how to start H2O and create a model using R and Pyth
 1. Open a terminal window and start r.
 2. Run the following commands to build a simple GBM model. 
 
-	```R
+	```
 	library(h2o)
 	h2o.init(nthreads=-1)
-	path = system.file("extdata", "prostate.csv", package="h2o")
-	h2o_df = h2o.importFile(path)
-	h2o_df$RACE = as.factor(h2o_df$RACE)
-	model = h2o.gbm(y="CAPSULE",
+	path <- system.file("extdata", "prostate.csv", package="h2o")
+	h2o_df <- h2o.importFile(path)
+	h2o_df$CAPSULE <- as.factor(h2o_df$CAPSULE)
+	model <- h2o.gbm(y="CAPSULE",
 			x=c("AGE", "RACE", "PSA", "GLEASON"),
 			training_frame=h2o_df,
 			distribution="bernoulli",
@@ -51,8 +51,8 @@ The examples below describe how to start H2O and create a model using R and Pyth
 
 3. Download the MOJO and the resulting h2o-genmodel.jar file to a new **experiment** folder. Note that the ``h2o-genmodel.jar`` file is a library that supports scoring and contains the required readers and interpreters. This file is required when MOJO models are deployed to production.
 
-	```R
-	modelfile = model.download_mojo(path="~/experiment/", get_genmodel_jar=True)
+	```
+	modelfile <- h2o.download_mojo(model,path="~/experiments/", get_genmodel_jar=TRUE)
 	print("Model saved to " + modelfile)
 	Model saved to /Users/user/GBM_model_R_1475248925871_74.zip"
 	```
@@ -62,7 +62,7 @@ The examples below describe how to start H2O and create a model using R and Pyth
 1. Open a terminal window and start python. 
 2. Run the following commands to build a simple GBM model. The model, along with the **h2o-genmodel.jar** file will then be downloaded to an **experiment** folder. 
 
-	```R
+	```
 	import h2o
 	from h2o.estimators.gbm import H2OGradientBoostingEstimator
 	h2o.init()
@@ -79,7 +79,7 @@ The examples below describe how to start H2O and create a model using R and Pyth
 
 3. Download the MOJO and the resulting ``h2o-genmodel.jar`` file to a new **experiment** folder. Note that the ``h2o-genmodel.jar`` file is a library that supports scoring and contains the required readers and interpreters. This file is required when MOJO models are deployed to production.
 
-	```R
+	```
 	modelfile = model.download_mojo(path="~/experiment/", get_genmodel_jar=True)
 	print("Model saved to " + modelfile)
 	Model saved to /Users/user/GBM_model_python_1475248925871_888.zip           
@@ -129,6 +129,7 @@ The examples below describe how to start H2O and create a model using R and Pyth
 	```bash
 	$ javac -cp h2o-genmodel.jar -J-Xms2g -J-XX:MaxPermSize=128m main.java
 	```
+
 4. Run in terminal window 2.
 
 	For Linux and OS X users

--- a/h2o-docs/src/product/howto/POJO_QuickStart.md
+++ b/h2o-docs/src/product/howto/POJO_QuickStart.md
@@ -85,14 +85,25 @@ The only compilation and runtime dependency for a generated model is the ``h2o-g
 	}
 	```
 
-5. Compile and run in terminal window 2:
+5. Compile in terminal window 2:
 
 	```
 	$ javac -cp h2o-genmodel.jar -J-Xmx2g -J-XX:MaxPermSize=128m gbm_pojo_test.java main.java
+	```
+
+6. Run in terminal window 2.
+
+   For Linux and OS X users
+	```
 	$ java -cp .:h2o-genmodel.jar main
 	```
 
-    The following output displays: 
+   For Windows users
+   ```
+	$ java -cp .;h2o-genmodel.jar main
+	```
+	
+The following output displays: 
 	
 	```
 	Label (aka prediction) is flight departure delayed: YES
@@ -115,10 +126,10 @@ Generated models can be extracted from H2O in the following ways:
 	```
 	library(h2o)
 	h2o.init()
-	path = system.file("extdata", "prostate.csv", package = "h2o")
-	h2o_df = h2o.importFile(path)
-	h2o_df$CAPSULE = as.factor(h2o_df$CAPSULE)
-	model = h2o.glm(y = "CAPSULE",
+	path <- system.file("extdata", "prostate.csv", package = "h2o")
+	h2o_df <- h2o.importFile(path)
+	h2o_df$CAPSULE <- as.factor(h2o_df$CAPSULE)
+	model <- h2o.glm(y = "CAPSULE",
 	                x = c("AGE", "RACE", "PSA", "GLEASON"),
 	                training_frame = h2o_df,
 	                family = "binomial")

--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -19,7 +19,7 @@ Users can refer to the following Quick Start files for more information about ge
 
 **Notes**: 
 
-- MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, Word2vec, and XGBoost models only.
+- MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, SVM, Word2vec, and XGBoost models only.
 - POJOs are not supported for XGBoost.
 
 Developers can refer to the the `POJO and MOJO Model Javadoc <http://docs.h2o.ai/h2o/latest-stable/h2o-genmodel/javadoc/index.html>`__.

--- a/h2o-genmodel/src/main/java/overview.html
+++ b/h2o-genmodel/src/main/java/overview.html
@@ -158,7 +158,12 @@ public class main {
 <h3>Step 5 (in terminal window 2): Compile and Run</h3>
 <pre>
 $ javac -cp h2o-genmodel.jar -J-Xmx2g -J-XX:MaxPermSize=128m gbm_pojo_test.java main.java
+
+# Linux and OS X users
 $ java -cp .:h2o-genmodel.jar main
+
+# Windows users
+$ java -cp .;h2o-genmodel.jar main
 </pre>
 
 The following output displays:
@@ -193,10 +198,10 @@ corresponding POJO from an R script:
 {@code
 library(h2o)
 h2o.init()
-path = system.file("extdata", "prostate.csv", package = "h2o")
-h2o_df = h2o.importFile(path)
-h2o_df$CAPSULE = as.factor(h2o_df$CAPSULE)
-model = h2o.glm(y = "CAPSULE",
+path <- system.file("extdata", "prostate.csv", package = "h2o")
+h2o_df <- h2o.importFile(path)
+h2o_df$CAPSULE <- as.factor(h2o_df$CAPSULE)
+model <- h2o.glm(y = "CAPSULE",
                 x = c("AGE", "RACE", "PSA", "GLEASON"),
                 training_frame = h2o_df,
                 family = "binomial")
@@ -306,7 +311,7 @@ A MOJO (Model Object, Optimized) is an alternative to H2O's currently available 
 POJOs, H2O allows you to convert models that you build to MOJOs, which can then be deployed
 for scoring in real time.
 <p></p>
-<b>Note</b>: MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, Word2vec, and XGBoost algorithms only.
+<b>Note</b>: MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, SVM, Word2vec, and XGBoost algorithms only.
 
 <h3><u>Benefit of MOJOs over POJOs</u></h3>
 <p></p>
@@ -349,17 +354,15 @@ tree built in the model. Note that each tree file is saved as a binary file type
 
 <h5>Build and extract a model using R</h5>
 
-MOJOs are only supported for GBM, DRF, and GLM models.
-
 <ol><li>Open a terminal window and start r.</li>
     <li>Run the following commands to build a simple GBM model.
         <pre>
         library(h2o)
         h2o.init(nthreads=-1)
-        path = system.file("extdata", "prostate.csv", package="h2o")
-        h2o_df = h2o.importFile(path)
-        h2o_df$RACE = as.factor(h2o_df$RACE)
-        model = h2o.gbm(y="CAPSULE",
+        path <- system.file("extdata", "prostate.csv", package="h2o")
+        h2o_df <- h2o.importFile(path)
+        h2o_df$CAPSULE <- as.factor(h2o_df$CAPSULE)
+        model <- h2o.gbm(y="CAPSULE",
                         x=c("AGE", "RACE", "PSA", "GLEASON"),
                         training_frame=h2o_df,
                         distribution="bernoulli",
@@ -369,7 +372,7 @@ MOJOs are only supported for GBM, DRF, and GLM models.
         </pre>
     </li>
     <li>Download the MOJO and the resulting h2o-genmodel.jar file to a new **experiment** folder.
-        <pre>modelfile = model.download_mojo(path="~/experiment/", get_genmodel_jar=True)
+        <pre>modelfile <- h2o.download_mojo(model,path="~/experiments/", get_genmodel_jar=TRUE)
 		print("Model saved to " + modelfile)
 		Model saved to /Users/user/GBM_model_R_1475248925871_74.zip"
         </pre>
@@ -455,7 +458,12 @@ MOJOs are only supported for GBM, DRF, and GLM models.
         Compile and run in terminal window 2.
         <pre>
         $ javac -cp h2o-genmodel.jar -J-Xms2g -J-XX:MaxPermSize=128m main.java
+
+        # Linux and OS X users
         $ java -cp .:h2o-genmodel.jar main
+
+        # Windows users
+        $ java -cp .;h2o-genmodel.jar main
         </pre>
     </li>
 </ol>
@@ -483,8 +491,8 @@ the command line to make a .png file.
 <pre>
 library(h2o)
 h2o.init()
-df = h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
-model = h2o.gbm(model_id = "model",
+df <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
+model <- h2o.gbm(model_id = "model",
                 training_frame = df,
                 x = c("Year", "Month", "DayofMonth", "DayOfWeek", "UniqueCarrier"),
                 y = "IsDepDelayed",


### PR DESCRIPTION
- When compiling and running MOJOs/POJOs, separated out commands between Linux/OS X and Windows because the separate is different (“:” vs “;”)
- Replaced "RACE" with "CAPSULE" for the asfactor column in R examples
- Fixed the R download_mojo function example
- Changed “=“ to “<-“ in R examples