### PR TITLE
PUBDEV-4816: Clarify GLM's lambda_max value

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -146,9 +146,9 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help = "Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean of response does not reflect reality.", level = Level.expert)
     public double prior;
 
-    @API(help = "Minimum lambda used in lambda search, specified as a ratio of lambda_max." +
-    " Default indicates: if the number of observations is greater than the number of variables then lambda_min_ratio" +
-    " is set to 0.0001; if the number of observations is less than the number of variables then lambda_min_ratio" +
+    @API(help = "Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all coefficients to zero)." +
+    " Default indicates: if the number of observations is greater than the number of variables, then lambda_min_ratio" +
+    " is set to 0.0001; if the number of observations is less than the number of variables, then lambda_min_ratio" +
     " is set to 0.01.", level = Level.expert)
     public double lambda_min_ratio;
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -103,7 +103,7 @@ Defining a GLM Model
 
 -  `lambda <algo-params/lambda.html>`__: Specify the regularization strength.
 
--  `lambda_search <algo-params/lambda_search.html>`__: Specify whether to enable lambda search, starting with lambda max. If you also specify a value for ``lambda_min_ratio``, then this value is interpreted as lambda min. If you do not specify a value for ``lambda_min_ratio``, then GLM will calculate the minimum lambda. 
+-  `lambda_search <algo-params/lambda_search.html>`__: Specify whether to enable lambda search, starting with lambda max (the smallest :math:`\lambda` that drives all coefficients to zero). If you also specify a value for ``lambda_min_ratio``, then this value is interpreted as lambda min. If you do not specify a value for ``lambda_min_ratio``, then GLM will calculate the minimum lambda. 
 
 -  `early_stopping <algo-params/early_stopping.html>`__: Specify whether to stop early when there is no more relative improvement on the training  or validation set.
    
@@ -143,7 +143,7 @@ Defining a GLM Model
    
      **Note**: This is a simple method affecting only the intercept. You may want to use weights and offset for a better fit.
 
--  `lambda_min_ratio <algo-params/lambda_min_ratio.html>`__: Specify the minimum lambda to use for lambda search (specified as a ratio of **lambda\_max**).
+-  `lambda_min_ratio <algo-params/lambda_min_ratio.html>`__: Specify the minimum lambda to use for lambda search (specified as a ratio of **lambda_max**, which is the smallest :math:`\lambda` for which the solution is all zeros).
 
 -  beta_constraints: Specify a dataset to use beta constraints. The selected frame is used to constraint the coefficient vector to provide upper and lower bounds. The dataset must contain a names column with valid coefficient names.
 

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -600,9 +600,10 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def lambda_min_ratio(self):
         """
-        Minimum lambda used in lambda search, specified as a ratio of lambda_max. Default indicates: if the number of
-        observations is greater than the number of variables then lambda_min_ratio is set to 0.0001; if the number of
-        observations is less than the number of variables then lambda_min_ratio is set to 0.01.
+        Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all
+        coefficients to zero). Default indicates: if the number of observations is greater than the number of variables,
+        then lambda_min_ratio is set to 0.0001; if the number of observations is less than the number of variables, then
+        lambda_min_ratio is set to 0.01.
 
         Type: ``float``  (default: ``-1``).
         """

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -72,9 +72,10 @@
 #'        family_default.
 #' @param prior Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
 #'        of response does not reflect reality. Defaults to -1.
-#' @param lambda_min_ratio Minimum lambda used in lambda search, specified as a ratio of lambda_max. Default indicates: if the number of
-#'        observations is greater than the number of variables then lambda_min_ratio is set to 0.0001; if the number of
-#'        observations is less than the number of variables then lambda_min_ratio is set to 0.01. Defaults to -1.
+#' @param lambda_min_ratio Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all
+#'        coefficients to zero). Default indicates: if the number of observations is greater than the number of
+#'        variables, then lambda_min_ratio is set to 0.0001; if the number of observations is less than the number of
+#'        variables, then lambda_min_ratio is set to 0.01. Defaults to -1.
 #' @param beta_constraints Beta constraints
 #' @param max_active_predictors Maximum number of active predictors during computation. Use as a stopping criterion to prevent expensive model
 #'        building with many predictors. Default indicates: If the IRLSM solver is used, the value of


### PR DESCRIPTION
- Added info describing the value of “lambda_max” in the User Guide.
- Update the help string in the GLMV3.java file to include this information.
- Built H2O locally, and the glm.py and glm.R files auto updated. Tested locally that this change shows up in the R docs.