### PR TITLE
PUBDEV-4810: Clarifications in GBM booklet

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GBMBooklet.tex
@@ -253,10 +253,10 @@ and then picking the optimal split point among the bins.
 
 To specify a model that considers all factors individually (and perform an optimal group split,
 where every level goes in the right direction based on the training response), specify \texttt{nbins\_cats} to be at least as large as the number of factors.
-Values greater than 1024 (the maximum number of levels supported in R) are supported, but might increase model training time.
+For users familiar with R, values greater than 1024 are supported, but might increase model training time. (Note that 1024 represents the maximum number of levels supported in R; H2O has a limit of 10 million levels.)
 
 The value of \texttt{nbins\_cats} for categorical factors has a much greater impact on the generalization error rate than \texttt{nbins} for real- or integer-valued columns (where higher values mainly lead to more accurate numerical split points).
-For columns with many factors, a small \texttt{nbins\_cats} value can add randomness to the split decisions (since the columns are grouped together somewhat arbitrarily), while large values can lead to perfect splits, resulting in overfitting.
+For columns with many factors, a small \texttt{nbins\_cats} value can add randomness to the split decisions (since the factor levels get grouped together somewhat arbitrarily), while large values can lead to perfect splits, resulting in overfitting.
 
 \newpage
 \subsection{Key Parameters}

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -275,10 +275,10 @@ Leaf Node Assignment
 Trees cluster observations into leaf nodes, and this information can be
 useful for feature engineering or model interpretability. Use
 **h2o.predict\_leaf\_node\_assignment(** *model*, *frame* **)** to get an H2OFrame
-with the leaf node assignments, or click the checkbox when making
+with the leaf node assignments, or click the **Compute Leafe Node Assignment** checkbox when making
 predictions from Flow. Those leaf nodes represent decision rules that
 can be fed to other models (i.e., GLM with lambda search and strong
-rules) to obtain a limited set of the most important rules.
+rules) to obtain a limited set of the most important rules. 
 
 FAQ
 ~~~

--- a/h2o-docs/src/product/faq/java.rst
+++ b/h2o-docs/src/product/faq/java.rst
@@ -8,7 +8,7 @@ REST API from your Java program to a remote cluster and should meet the
 needs of most users.
 
 You can access the REST API documentation within Flow, or on our
-`documentation site <rest-api-reference.html>`__.
+`documentation site <../rest-api-reference.html>`__.
 
 Flow, Python, and R all rely on the REST API to run H2O. For example,
 each action in Flow translates into one or more REST API calls. The
@@ -28,7 +28,7 @@ To see how the REST API is used with H2O:
 
 The second way to use H2O with Java is to embed H2O within your Java
 application, similar to `Sparkling
-Water <https://github.com/h2oai/sparkling-water/blob/master/DEVEL.md>`__.
+Water <https://github.com/h2oai/sparkling-water/blob/master/DEVEL.rst>`__.
 
 --------------
 

--- a/h2o-docs/src/product/starting-h2o.rst
+++ b/h2o-docs/src/product/starting-h2o.rst
@@ -285,8 +285,11 @@ Authentication Options
 -  ``-session_timeout <minutes>``: Specifies the number of minutes that a session can remain idle before the server invalidates the session and requests a new login. Requires ``-form_auth``. This defaults to no timeout.
 -  ``-internal_security_conf <filename>``: Specify the path (absolute or relative) to a file containing all internal security related configurations.
 
+H2O Networking
+~~~~~~~~~~~~~~
+
 H2O Internal Communication
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default, H2O selects the IP and PORT for internal communication automatically using the following this process (if not specified):
 
@@ -308,7 +311,7 @@ By default, H2O selects the IP and PORT for internal communication automatically
 
 
 Cloud Formation Behavior
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 New H2O nodes join to form a cloud during launch. After a job has
 started on the cloud, it prevents new members from joining.
@@ -327,7 +330,7 @@ entering the above command again to add another node (the number for #
 will vary).
 
 Clouding Up: Cluster Creation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 H2O provides two modes for cluster creation:
 
@@ -335,7 +338,8 @@ H2O provides two modes for cluster creation:
 -  Flatfile based
 
 Multicast
-^^^^^^^^^
+'''''''''
+
 In this mode, H2O is using IP multicast to announce existence of H2O nodes. Each node selects the same multicast group and port based on specified shared cloud name (see ``-name`` option). For example, for IPv4/PORT a generated multicast group is ``228.246.114.236:58614`` (for cloud name ``michal``), 
 for IPv6/PORT a generated multicast group is ``ff05:0:3ff6:72ec:0:0:3ff6:72ec:58614`` (for cloud name ``michal`` and link-local address which enforce link-local scope).
 
@@ -345,7 +349,8 @@ class ``water.util.NetworkUtils``).
 For more information about scopes, see the following `image <http://www.tcpipguide.com/free/diagrams/ipv6scope.png>`_. 
 
 Flatfile
-^^^^^^^^
+''''''''
+
 The flatfile describes a topology of a H2O cluster. The flatfile definition is passed via the ``-flatfile`` option. It needs to be passed at each node in the cluster, but definition does not be the same at each node. However, transitive closure of all definitions should contains all nodes. For example, for the following definition
 
 +---------+-------+-------+-------+
@@ -374,17 +379,17 @@ The flatfile contains a list of nodes in the form ``IP:PORT`` that are going to 
 	0:0:0:0:0:0:0:1:54323
 
 Web Server
-~~~~~~~~~~
+^^^^^^^^^^
 
 The web server IP is auto-configured in the same way as internal communication IP, nevertheless the created socket listens on all available interfaces. A specific API can be specified with the ``-web_ip`` option.
 
 Options
-^^^^^^^
+'''''''
 
 - ``-web_ip``: specifies IP for web server to expose REST API
 
 Dual Stacks
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 Dual stack machines support IPv4 and IPv6 network stacks.
 Right now, H2O always prefer IPV4, however the preference can be changed via JVM system options ``java.net.preferIPv4Addresses`` and ``java.net.preferIPv6Addresses``. For example:

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -249,7 +249,7 @@ Getting Started with Sparkling Water
 
 -  `Sparkling Water Development Documentation <https://github.com/h2oai/sparkling-water/blob/master/doc/DEVEL.rst>`_: Read this document first to get started with Sparkling Water.
 
--  `Launch on Hadoop and Import from HDFS <https://github.com/h2oai/sparkling-water/tree/master/examples#sparkling-water-on-hadoop>`_: Go here to learn how to start Sparkling Water on Hadoop.
+-  `Launch on Hadoop and Import from HDFS <https://github.com/h2oai/sparkling-water/blob/master/doc/devel/integ_tests.rst>`_: Go here to learn how to start Sparkling Water on Hadoop.
 
 -  `Sparkling Water Tutorials <https://github.com/h2oai/sparkling-water/tree/master/examples>`_: Go here for demos and examples.
 


### PR DESCRIPTION
Changed, “since the columns are grouped together…” to “since the factor levels get grouped together…”
Successfully built booklets locally.
Driveby fixes: Minor update in DRF (adding a Flow button name). Fixed link in FAQ > Java. Updated headings in starting-h2o. Updated link to SW example in the Welcome section.