### PR TITLE
PUBDEV-4729-sw22-release

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -176,7 +176,7 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 6px;">
               <a href="h2o-docs/faq.html#sparkling-water">What is Sparkling Water?</a>
               <a href="h2o-docs/booklets/SparklingWaterBooklet.pdf">Sparkling Water Booklet</a>
-              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/py/README.rst">2.1</a></p>
+              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/py/README.rst">2.1</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/py/README.rst">2.2</a></p>
               <a href="https://github.com/h2oai/rsparkling/blob/master/README.md">RSparkling Readme</a>
               <a href="https://github.com/h2oai/sparkling-water/blob/master/LICENSE">Open Source License (Apache V2)</a>
            </div>
@@ -302,6 +302,13 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               <td><a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html">Reference</a></td>
               <td>Tuning</td>
             </tr>
+            <tr>
+              <td>XGBoost</td>
+              <td>Tutorial</td>
+              <td>Booklet</td>
+              <td><a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/xgboost.html">Reference</a></td>
+              <td>Tuning</td>
+            </tr>
             </tbody>
           </table>
         </div>
@@ -382,7 +389,7 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               <a href="h2o-docs/booklets/PythonBooklet.pdf">Python Booklet</a>
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-py/demos">Examples and Demos</a>
               <a href="h2o-docs/faq.html#python">Python FAQ</a>
-              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/py/README.rst">2.1</a></p>
+              <p style="margin: 0pt;">PySparkling Readme &nbsp;&nbsp;&nbsp;<a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/py/README.rst">2.0</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/py/README.rst">2.1</a> &nbsp;|&nbsp; <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/py/README.rst">2.2</a></p>
               <a href="https://tgsmith61591.github.io/skutil/">skutil Docs</a>
           </div>
         </div>
@@ -408,11 +415,13 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               <td style="padding-bottom: 3pt; padding-top: 0pt;">Sparkling Water API</td>
               <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/DEVEL.md">2.0</a></td>
               <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/DEVEL.md">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/DEVEL.md">2.2</a></td>
             </tr>
             <tr>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparkling Water Scaladoc</td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/9/scaladoc/index.html#package">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/8/scaladoc/index.html">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt; padding-right: 0pt;">Sparkling Water Scaladoc</td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/14/scaladoc/index.html#package">2.0</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/13/scaladoc/index.html">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/0/scaladoc/index.html">2.2</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">H2O Scaladoc</td>
@@ -551,6 +560,9 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
                 <td style="padding-bottom: 0pt; padding-top: 0pt;">
                   <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/DEVEL.md">2.1</a>
                 </td>
+                <td style="padding-bottom: 0pt; padding-top: 0pt;">
+                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/DEVEL.md">2.2</a>
+                </td>
               </td>
             </tr>
             <tr>
@@ -613,6 +625,7 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparkling Water Readme</td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/README.md">2.0</a></td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/README.md">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/README.md">2.2</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparking Water Scaladoc</td>
@@ -621,6 +634,9 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               </td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
                 <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/1/scaladoc/index.html">2.1</a>
+              </td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;">
+                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/0/scaladoc/index.html">2.2</a>
               </td>
             </tr>
             <tr>

--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -183,7 +183,6 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
           <hr>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 6px;">
               <a href="h2o-docs/quick-start-videos.html#h2o-quick-start-with-sparkling-water">Quick Start Video - Scala</a>
-              Quick Start Video - Python
           </div>
           <hr>
           <div class="primary txt-cntr" style="display: block; width: 100%; margin-bottom:10px;">
@@ -413,14 +412,14 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
             <tbody class="lt-gry-bg dltile">
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 0pt;">Sparkling Water API</td>
-              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/DEVEL.md">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/DEVEL.md">2.1</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/DEVEL.md">2.2</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/doc/DEVEL.rst">2.0</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/doc/DEVEL.rst">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 0pt;"align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/doc/DEVEL.rst">2.2</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt; padding-right: 0pt;">Sparkling Water Scaladoc</td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/14/scaladoc/index.html#package">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/13/scaladoc/index.html">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/15/scaladoc/index.html#package">2.0</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/14/scaladoc/index.html">2.1</a></td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/0/scaladoc/index.html">2.2</a></td>
             </tr>
             <tr>
@@ -555,13 +554,13 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               <td style="padding-bottom: 0pt; padding-top: 0pt;">
                 Sparkling Water API &nbsp;&nbsp;
                 <td style="padding-bottom: 0pt; padding-top: 0pt;">
-                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/DEVEL.md">2.0</a>
+                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/doc/DEVEL.rst">2.0</a>
                 </td>
                 <td style="padding-bottom: 0pt; padding-top: 0pt;">
-                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/DEVEL.md">2.1</a>
+                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/doc/DEVEL.rst">2.1</a>
                 </td>
                 <td style="padding-bottom: 0pt; padding-top: 0pt;">
-                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/DEVEL.md">2.2</a>
+                  <a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/doc/DEVEL.rst">2.2</a>
                 </td>
               </td>
             </tr>
@@ -623,17 +622,17 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparkling Water Readme</td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/README.md">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/README.md">2.1</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/README.md">2.2</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.0/README.rst">2.0</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/README.rst">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/README.rst">2.2</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparking Water Scaladoc</td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/0/scaladoc/index.html#package">2.0</a>
+                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/15/scaladoc/index.html#package">2.0</a>
               </td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/1/scaladoc/index.html">2.1</a>
+                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/14/scaladoc/index.html">2.1</a>
               </td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
                 <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/0/scaladoc/index.html">2.2</a>
@@ -655,7 +654,7 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
           <h4>Contributing</h4>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 10px;">
               <a href="https://github.com/h2oai/h2o-3/blob/master/CONTRIBUTING.md">To H2O</a>
-              <a href="https://github.com/h2oai/sparkling-water/blob/master/README.md">To Sparkling Water</a>
+              <a href="https://github.com/h2oai/sparkling-water/blob/master/README.rst">To Sparkling Water</a>
               <a href="https://github.com/h2oai/steam/blob/master/CONTRIBUTING.md">To Steam</a>
           </div>
         </div>


### PR DESCRIPTION
- Added links for the Sparkling Water 2.2 release, including links to github repos and scaladocs.
Driveby fix: Added a link to XGBoost documentation under supervised
algorithms.
Tested site in three browsers.