### PR TITLE
[ITA-149] Dockerfiles for building images of various versions of CDH and HDP

### DIFF
--- a/docker/Jenkinsfile-build-docker
+++ b/docker/Jenkinsfile-build-docker
@@ -33,12 +33,12 @@ pipeline {
             steps {
                 script {
                     final String stageName = 'Checkout Sources'
+                    def final scmEnv = git url: env.H2O_GIT_URL, branch: params.gitBranch
+
+                    def final pipelineContextFactory = load('scripts/jenkins/groovy/pipelineContext.groovy')
+                    pipelineContext = pipelineContextFactory('.', 'MODE_BUILD_DOCKER', scmEnv, true)
+
                     try {
-                        def final scmEnv = git url: env.H2O_GIT_URL, branch: params.gitBranch
-
-                        def final pipelineContextFactory = load('scripts/jenkins/groovy/pipelineContext.groovy')
-                        pipelineContext = pipelineContextFactory('.', 'MODE_BUILD_DOCKER', scmEnv, true)
-
                         final String version = pipelineContext.getBuildConfig().getDefaultImageVersion()
 
                         currentBuild.displayName += " v${version}"
@@ -72,18 +72,12 @@ pipeline {
                         pipelineContext.getBuildSummary().addStageSummary(this, stageName, '')
                         pipelineContext.getBuildSummary().setStageDetails(this, stageName, env.NODE_NAME, env.WORKSPACE)
 
-                        withCredentials([usernamePassword(credentialsId: "${params.dockerRegistry}", usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWORD')]) {
-                            final String response = "curl -k -u ${REGISTRY_USERNAME}:${REGISTRY_PASSWORD} https://${params.dockerRegistry}/v2/opsh2oai/h2o-3-runtime/tags/list".execute().text
-                            final def jsonResponse = new groovy.json.JsonSlurper().parseText(response)
-                            if (jsonResponse.errors || jsonResponse.tags == null) {
-                                echo "response: ${response}"
-                                error "Docker registry check failed."
-                            }
-                            final String version = pipelineContext.getBuildConfig().getDefaultImageVersion()
-                            final boolean conflict = jsonResponse.tags.contains(version)
-                            if (conflict && !params.force) {
-                                error "Tag already exists in the repository"
-                            }
+                        final String version = pipelineContext.getBuildConfig().getDefaultImageVersion()
+
+                        final boolean conflict = pipelineContext.getUtils()
+                                .dockerImageExistsInRegistry(this, params.dockerRegistry, 'opsh2oai/h2o-3-runtime', version)
+                        if (conflict && !params.force) {
+                            error "Tag opsh2oai/h2o-3-runtime:${version} already exists in the repository"
                         }
                         pipelineContext.getBuildSummary().markStageSuccessful(this, stageName)
                     } catch (Exception e) {
@@ -166,7 +160,9 @@ pipeline {
             emailext(
                     subject: "New ${IMAGE_NAME} docker image READY!",
                     body: """<p>The new ${IMAGE_NAME} docker image is ready.</p>
-                          <p>Check the build at "<a href="${env.BUILD_URL}">${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>"</p>""",
+                          <p>Check the build at "<a href="${env.BUILD_URL}">${env.JOB_NAME} [${
+                        env.BUILD_NUMBER
+                    }]</a>"</p>""",
                     to: "michalr@h2o.ai"
             )
         }

--- a/docker/Jenkinsfile-build-hadoop-docker
+++ b/docker/Jenkinsfile-build-hadoop-docker
@@ -1,0 +1,118 @@
+#! /usr/bin/groovy
+
+final String NODE_LABEL = 'docker && !mr-0xc8'
+final String DOCKER_STASH = 'h2o-3-hadoop-docker-stash'
+final String REGISTRY_PREFIX = "${params.dockerRegistry}"
+final String IMAGE_NAME_PREFIX = "opsh2oai/h2o-3-hadoop"
+
+def pipelineContext = null
+String version = null
+
+properties(
+    [
+        parameters(
+            [
+                string(defaultValue: 'master', description: 'Branch to checkout', name: 'gitBranch'),
+                string(name: 'dockerRegistry', defaultValue: 'docker.h2o.ai'),
+                booleanParam(name: 'force', defaultValue: false, description: 'If false and image with version specified by BuildConfig exists in repository, then the build fails.')
+            ]
+        )
+    ]
+)
+
+node (NODE_LABEL) {
+    final String stageName = 'Checkout and Prepare'
+    stage (stageName) {
+        def scmEnv = git credentialsId: 'c6bab81a-6bb5-4497-9ec9-285ef5db36ea',
+                poll: false,
+                url: 'https://github.com/h2oai/h2o-3',
+                branch: params.gitBranch
+
+        def pipelineContextFactory = load('scripts/jenkins/groovy/pipelineContext.groovy')
+        pipelineContext = pipelineContextFactory('.', 'MODE_HADOOP', scmEnv, true)
+
+        try {
+            version = pipelineContext.getBuildConfig().getHadoopImageVersion()
+            currentBuild.displayName += " v${version}"
+
+            pipelineContext.getBuildSummary().addStageSummary(this, stageName, '')
+            pipelineContext.getBuildSummary().setStageDetails(this, stageName, env.NODE_NAME, env.WORKSPACE)
+
+            pipelineContext.getBuildSummary().addSection(this, 'docker-details', "<a href=\"${currentBuild.rawBuild.getAbsoluteUrl()}\" style=\"color: black;\">Details</a>", """
+                <ul>
+                <li><strong>Git Branch:</strong> ${env.BRANCH_NAME}</li>
+                <li><strong>Version:</strong> ${version}</li>
+                <li><strong>Force Overwrite:</strong> ${params.force}</li>
+                </ul>
+            """)
+
+            pipelineContext.getUtils().stashFiles(this, DOCKER_STASH, 'docker/hadoop/**,docker/scripts/*')
+
+            pipelineContext.getBuildSummary().markStageSuccessful(this, stageName)
+        } catch (Exception e) {
+            pipelineContext.getBuildSummary().markStageFailed(this, stageName)
+            throw e
+        }
+    }
+}
+
+parallel(pipelineContext.getBuildConfig().getSupportedHadoopDistributions().collectEntries{distribution ->
+    [
+        "Build ${distribution.name.toUpperCase()} ${distribution.version}", {
+            node (pipelineContext.getBuildConfig().getDefaultNodeLabel()) {
+                final String buildStageName = "Build ${distribution.name.toUpperCase()} ${distribution.version}"
+                stage(buildStageName) {
+                    try {
+                        pipelineContext.getBuildSummary().addStageSummary(this, buildStageName, '')
+                        pipelineContext.getBuildSummary().setStageDetails(this, buildStageName, env.NODE_NAME, env.WORKSPACE)
+
+                        final String imageName = "${IMAGE_NAME_PREFIX}-${distribution.name}-${distribution.version}"
+                        final boolean conflict = pipelineContext.getUtils()
+                                .dockerImageExistsInRegistry(this, params.dockerRegistry, imageName, version)
+                        if (conflict && !params.force) {
+                            error "Tag ${imageName}:${version} already exists in the repository"
+                        }
+
+                        withCredentials([usernamePassword(credentialsId: "${params.dockerRegistry}", usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWORD')]) {
+                            pipelineContext.getUtils().unstashFiles(this, DOCKER_STASH)
+                            sh """
+                                cd docker
+                                pwd
+                                ls -alh
+                                docker build \
+                                    -t ${REGISTRY_PREFIX}/${imageName}:${version} \
+                                    -f hadoop/${distribution.name}/Dockerfile \
+                                    --build-arg PATH_PREFIX=hadoop/${distribution.name} \
+                                    --build-arg VERSION=${distribution.version} .
+                            """
+                        }
+                        pipelineContext.getBuildSummary().markStageSuccessful(this, buildStageName)
+                    } catch (Exception e) {
+                        pipelineContext.getBuildSummary().markStageFailed(this, buildStageName)
+                        throw e
+                    }
+                }
+
+                final String publishStageName = "Publish ${distribution.name.toUpperCase()} ${distribution.version}"
+                stage (publishStageName) {
+                    try {
+                        pipelineContext.getBuildSummary().addStageSummary(this, publishStageName, '')
+                        pipelineContext.getBuildSummary().setStageDetails(this, publishStageName, env.NODE_NAME, env.WORKSPACE)
+
+                        withCredentials([usernamePassword(credentialsId: "${params.dockerRegistry}", usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWORD')]) {
+                            sh """
+                                docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD ${params.dockerRegistry}
+                                docker push ${REGISTRY_PREFIX}/${IMAGE_NAME_PREFIX}-${distribution.name}-${distribution.version}:${version}
+                            """
+                            echo "###### Docker image ${IMAGE_NAME_PREFIX}-${distribution.name}-${distribution.version}:${version} built and pushed. ######"
+                        }
+                        pipelineContext.getBuildSummary().markStageSuccessful(this, publishStageName)
+                    } catch (Exception e) {
+                        pipelineContext.getBuildSummary().markStageFailed(this, publishStageName)
+                        throw e
+                    }
+                }
+            }
+        }
+    ]
+})

--- a/docker/hadoop/cdh/Dockerfile
+++ b/docker/hadoop/cdh/Dockerfile
@@ -1,0 +1,57 @@
+# pull base image
+FROM ubuntu:16.04
+
+# maintainer details
+MAINTAINER h2oai "h2o.ai"
+
+ARG VERSION
+ARG PATH_PREFIX='.'
+ARG DEFAULT_USER_UID=2117
+ARG PYTHON_VERSIONS='2.7'
+
+ENV DISTRIBUTION='cdh' VERSION=$VERSION HADOOP_CONF_DIR='/etc/hadoop/conf.pseudo' MASTER='yarn-client'
+
+# Prepare Cloudera repository
+RUN echo "# Packages for Cloudera's Distribution for Hadoop, Version 5, on Ubuntu 14.04 amd64\n\
+deb [arch=amd64] http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh trusty-cdh${VERSION} contrib\n\
+deb-src http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh trusty-cdh${VERSION} contrib\n" > /etc/apt/sources.list.d/cloudera.list
+COPY ${PATH_PREFIX}/conf/cloudera.pref /etc/apt/preferences.d/cloudera.pref
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl wget && \
+    wget http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh/archive.key -O archive.key && \
+    apt-key add archive.key && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y hadoop-conf-pseudo python-pip python-dev python-virtualenv libmysqlclient-dev sudo unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set required env vars and install Java 8 and Pythons
+COPY ${PATH_PREFIX}/../common/sbin/ scripts/install_java scripts/install_python_versions /usr/sbin/
+RUN \
+  chmod 700 /usr/sbin/install_java && \
+  chmod 700 /usr/sbin/install_python_versions && \
+  sync && \
+  /usr/sbin/install_java && \
+  /usr/sbin/install_python_versions
+ENV \
+  JAVA_HOME=/usr/lib/jvm/java-8-oracle \
+  PATH=/usr/lib/jvm/java-8-oracle/bin:${PATH}
+
+# Initialize namenode
+RUN service hadoop-hdfs-namenode init
+
+# Add jenkins user
+RUN adduser --disabled-password --gecos "" -u ${DEFAULT_USER_UID} jenkins
+
+# Copy scripts
+COPY ${PATH_PREFIX}/../common/startup ${PATH_PREFIX}/scripts/startup /etc/startup/
+
+# Copy sudoers so we can start hadoop stuff without root access to container
+COPY ${PATH_PREFIX}/../common/sudoers/jenkins /etc/sudoers.d/jenkins
+
+# Expose ports
+# H2O, HADOOP UI
+EXPOSE 54321 8088
+
+# Run this script on container run
+RUN chmod 700 /usr/sbin/startup.sh

--- a/docker/hadoop/cdh/conf/cloudera.pref
+++ b/docker/hadoop/cdh/conf/cloudera.pref
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=Cloudera, l=Cloudera
+Pin-Priority: 501

--- a/docker/hadoop/cdh/scripts/startup/00_hdfs_start
+++ b/docker/hadoop/cdh/scripts/startup/00_hdfs_start
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+for x in $(cd /etc/init.d && ls hadoop-hdfs-*); do service ${x} start; done

--- a/docker/hadoop/cdh/scripts/startup/30_yarn_start
+++ b/docker/hadoop/cdh/scripts/startup/30_yarn_start
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+service hadoop-yarn-resourcemanager start
+service hadoop-yarn-nodemanager start
+service hadoop-mapreduce-historyserver start

--- a/docker/hadoop/common/sbin/startup.sh
+++ b/docker/hadoop/common/sbin/startup.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+set -e
+
+NC='\033[0m'
+RED='\033[91m'
+
+if [[ -d /startup && $(ls /startup) ]]; then
+  cd /startup
+  echo
+  echo "###### Adding custom startup scripts ######"
+  for x in $(ls); do
+    echo -e "\tAdding startup script ${RED}${x}${NC}"
+    cp ${x} /etc/startup
+    chmod 700 /etc/startup/${x}
+  done
+  sync
+  echo "###### Custom startup scripts added ######"
+  echo
+fi
+
+cd /etc/startup/
+for x in $(ls . | sort -n); do
+  echo -e "###### Running startup script ${RED}${x}${NC} ######"
+  chmod 700 ${x}
+  sync
+  ./${x}
+done

--- a/docker/hadoop/common/startup/10_hdfs_setup
+++ b/docker/hadoop/common/startup/10_hdfs_setup
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+su -m - hdfs -c 'hadoop fs -mkdir -p /tmp/hadoop-yarn/staging/history/done_intermediate'
+su -m - hdfs -c 'hadoop fs -chown -R mapred:mapred /tmp/hadoop-yarn/staging'
+su -m - hdfs -c 'hadoop fs -chmod -R 1777 /tmp'
+su -m - hdfs -c 'hadoop fs -mkdir -p /var/log/hadoop-yarn'
+su -m - hdfs -c 'hadoop fs -chown yarn:mapred /var/log/hadoop-yarn'
+
+chown mapred /var/log/hadoop-mapreduce

--- a/docker/hadoop/common/startup/20_hdfs_create_jenkins_home
+++ b/docker/hadoop/common/startup/20_hdfs_create_jenkins_home
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+su -m - hdfs -c 'hadoop fs -mkdir -p /user/jenkins'
+su -m - hdfs -c 'hadoop fs -chown jenkins:jenkins /user/jenkins'

--- a/docker/hadoop/common/sudoers/jenkins
+++ b/docker/hadoop/common/sudoers/jenkins
@@ -1,0 +1,1 @@
+jenkins ALL=(ALL) NOPASSWD:SETENV: /usr/sbin/startup.sh

--- a/docker/hadoop/hdp/Dockerfile
+++ b/docker/hadoop/hdp/Dockerfile
@@ -1,0 +1,83 @@
+# pull base image
+FROM ubuntu:16.04
+
+# maintainer details
+MAINTAINER h2oai "h2o.ai"
+
+ARG VERSION
+ARG PATH_PREFIX='.'
+ARG DEFAULT_USER_UID=2117
+ARG PYTHON_VERSIONS='2.7'
+
+ENV DISTRIBUTION='hdp' VERSION=$VERSION HADOOP_CONF_DIR='/usr/hdp/2*/hadoop/conf/' MASTER='yarn-client' HADOOP_DAEMON=/usr/hdp/2*/hadoop/sbin/hadoop-daemon.sh YARN_DAEMON='/usr/hdp/2*/hadoop-yarn/sbin/yarn-daemon.sh' MAPRED_USER=mapred YARN_USER=yarn HDFS_USER=hdfs
+
+# Copy bin and sbin scripts
+COPY ${PATH_PREFIX}/scripts/sbin ${PATH_PREFIX}/../common/sbin scripts/install_java scripts/install_python_versions /usr/sbin/
+
+# Add HDP repository and install packages
+RUN apt-get update && \
+    apt-get install -y wget curl && \
+    chmod 700 /usr/sbin/add_hdp_repo.sh && \
+    sync && \
+    /usr/sbin/add_hdp_repo.sh $VERSION && \
+    rm /usr/sbin/add_hdp_repo.sh && \
+    apt-get update && \
+    apt-get install -y hadoop-conf-pseudo python-dev python-pip python-dev python-virtualenv libmysqlclient-dev sudo unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set required env vars and install Java 8 and Pythons
+COPY ${PATH_PREFIX}/../common/sbin/ scripts/install_java scripts/install_python_versions /usr/sbin/
+RUN \
+  chmod 700 /usr/sbin/install_java && \
+  chmod 700 /usr/sbin/install_python_versions && \
+  sync && \
+  /usr/sbin/install_java && \
+  /usr/sbin/install_python_versions
+ENV \
+  JAVA_HOME=/usr/lib/jvm/java-8-oracle \
+  PATH=/usr/lib/jvm/java-8-oracle/bin:${PATH}
+
+# Chown folders
+RUN chown hdfs:hdfs /usr/hdp/2*/hadoop && \
+    chown yarn:yarn /usr/hdp/2*/hadoop-yarn && \
+    chown yarn:yarn /usr/hdp/2*/hadoop-mapreduce && \
+    chown -R root:hadoop /usr/hdp/current/hadoop-yarn*/bin/container-executor && \
+    chmod -R 6050 /usr/hdp/current/hadoop-yarn*/bin/container-executor
+
+# Copy conf.pseudo to hadoop conf folder
+RUN rm /usr/hdp/2*/hadoop/conf/* && \
+    cp /usr/hdp/2*/etc/hadoop/conf.pseudo/* /usr/hdp/2*/hadoop/conf/
+
+# Copy configs
+COPY ${PATH_PREFIX}/conf/ /etc/hadoop/conf/
+
+# Generate mapred-site.xml
+RUN chmod 700 /usr/sbin/generate-mapred-site && \
+    sync && \
+    /usr/sbin/generate-mapred-site && \
+    rm /usr/sbin/generate-mapred-site
+
+# Generate yarn-site.xml
+RUN chmod 700 /usr/sbin/generate-yarn-site && \
+    sync && \
+    /usr/sbin/generate-yarn-site && \
+    rm /usr/sbin/generate-yarn-site
+
+# Format namenode
+RUN su - hdfs -c "/usr/hdp/current/hadoop-hdfs-namenode/../hadoop/bin/hdfs namenode -format"
+
+# Create jenkins user
+RUN adduser --disabled-password --gecos "" -u ${DEFAULT_USER_UID} jenkins
+
+# Copy startup scripts
+COPY ${PATH_PREFIX}/scripts/startup ${PATH_PREFIX}/../common/startup /etc/startup/
+
+# Copy sudoers so we can start hadoop stuff without root access to container
+COPY ${PATH_PREFIX}/../common/sudoers/jenkins /etc/sudoers.d/jenkins
+
+# Expose ports
+# H2O, Hadoop UI
+EXPOSE 54321 8088
+
+RUN chmod 700 /usr/sbin/startup.sh
+CMD "/usr/sbin/startup.sh"

--- a/docker/hadoop/hdp/conf/core-site.xml
+++ b/docker/hadoop/hdp/conf/core-site.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://localhost:8020</value>
+  </property>
+</configuration>

--- a/docker/hadoop/hdp/conf/hadoop-env.sh
+++ b/docker/hadoop/hdp/conf/hadoop-env.sh
@@ -1,0 +1,1 @@
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle/

--- a/docker/hadoop/hdp/scripts/sbin/add_hdp_repo.sh
+++ b/docker/hadoop/hdp/scripts/sbin/add_hdp_repo.sh
@@ -1,0 +1,55 @@
+#! /bin/bash
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+function print_red {
+  echo -e "${RED}${1}${NC}"
+}
+
+function print_green {
+  echo -e "${GREEN}${1}${NC}"
+}
+
+case "${1}" in
+  2.6)
+    hdp_version="2.6.1.0"
+    # minor_version="129"
+    ubuntu_repo_version="14"
+    ;;
+  2.5)
+    hdp_version="2.5.6.0"
+    # minor_version="40"
+    ubuntu_repo_version="14"
+    ;;
+  2.4)
+    hdp_version="2.4.3.0"
+    # minor_version="227"
+    ubuntu_repo_version="14"
+    ;;
+  2.3)
+    hdp_version="2.3.6.0"
+    # minor_version="3796"
+    ubuntu_repo_version="14"
+    ;;
+  2.2)
+    hdp_version="2.2.9.0"
+    # minor_version="3393"
+    ubuntu_repo_version="12"
+    ;;
+  *)
+    print_red "HDP version '${1}' not supported"
+    exit 1
+esac
+
+export HDP_VERSION=${hdp_version}
+export UBUNTU_REPO_VERSION=${ubuntu_repo_version}
+
+echo -e "Building for HDP version ${GREEN}${hdp_version}${NC}"
+
+wget http://public-repo-1.hortonworks.com/HDP/ubuntu${ubuntu_repo_version}/2.x/updates/${hdp_version}/hdp.list -O /etc/apt/sources.list.d/hdp.list
+gpg --keyserver keyserver.ubuntu.com --recv-keys B9733A7A07513CAD
+gpg -a --export 07513CAD | apt-key add -

--- a/docker/hadoop/hdp/scripts/sbin/generate-mapred-site
+++ b/docker/hadoop/hdp/scripts/sbin/generate-mapred-site
@@ -1,0 +1,53 @@
+#! /bin/bash
+
+HDP_VERSION=$(ls /usr/hdp/ | grep 2)
+echo "Generating mapred-site.xml for HDP ${HDP_VERSION}"
+echo -e """<configuration>
+  <property>
+    <name>mapreduce.admin.map.child.java.opts</name>
+    <value>-server -Djava.net.preferIPv4Stack=true -Dhdp.version=${HDP_VERSION}</value>
+    <final>true</final>
+  </property>
+
+  <property>
+    <name>mapred.job.tracker</name>
+    <value>localhost:8021</value>
+  </property>
+
+  <property>
+    <name>mapreduce.framework.name</name>
+    <value>yarn</value>
+  </property>
+
+  <property>
+    <name>mapreduce.jobhistory.address</name>
+    <value>localhost:10020</value>
+  </property>
+  <property>
+    <name>mapreduce.jobhistory.webapp.address</name>
+    <value>localhost:19888</value>
+  </property>
+
+  <property>
+    <description>To set the value of tmp directory for map and reduce tasks.</description>
+    <name>mapreduce.task.tmp.dir</name>
+    <value>/var/lib/hadoop-mapreduce/cache/\${user.name}/tasks</value>
+  </property>
+
+  <property>
+    <name>mapreduce.admin.user.env</name>
+    <value>LD_LIBRARY_PATH=/usr/hdp/${HDP_VERSION}/hadoop/lib/native:/usr/hdp/${HDP_VERSION}/hadoop/lib/native/Linux-amd64-64</value>
+  </property>
+
+  <property>
+    <name>mapreduce.application.framework.path</name>
+    <value>hdfs:///hdp/apps/${HDP_VERSION}/mapreduce/mapreduce.tar.gz#mr-framework</value>
+  </property>
+
+  <property>
+    <name>mapreduce.application.classpath</name>
+    <value>\$PWD/mr-framework/hadoop/share/hadoop/mapreduce/*:\$PWD/mr-framework/hadoop/share/hadoop/mapreduce/lib/*:\$PWD/mr-framework/hadoop/share/hadoop/common/*:\$PWD/mr-framework/hadoop/share/hadoop/common/lib/*:\$PWD/mr-framework/hadoop/share/hadoop/yarn/*:\$PWD/mr-framework/hadoop/share/hadoop/yarn/lib/*:\$PWD/mr-framework/hadoop/share/hadoop/hdfs/*:\$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*:/usr/hdp/2.2.9.0/hadoop/lib/hadoop-lzo-0.6.0.${HDP_VERSION}.jar:/etc/hadoop/conf/secure</value>
+  </property>
+
+  </configuration>
+""" > ${HADOOP_CONF_DIR}/mapred-site.xml

--- a/docker/hadoop/hdp/scripts/sbin/generate-yarn-site
+++ b/docker/hadoop/hdp/scripts/sbin/generate-yarn-site
@@ -1,0 +1,67 @@
+#! /bin/bash
+
+HDP_VERSION=$(ls /usr/hdp/ | grep 2)
+echo "Generating yarn-site.xml for HDP ${HDP_VERSION}"
+echo '''
+<configuration>
+  <property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
+    <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+  </property>
+
+  <property>
+    <name>yarn.log-aggregation-enable</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.dispatcher.exit-on-error</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <description>List of directories to store localized files in.</description>
+    <name>yarn.nodemanager.local-dirs</name>
+    <value>/var/lib/hadoop-yarn/cache/${user.name}/nm-local-dir</value>
+  </property>
+
+  <property>
+    <description>Where to store container logs.</description>
+    <name>yarn.nodemanager.log-dirs</name>
+    <value>/var/log/hadoop-yarn/containers</value>
+  </property>
+
+  <property>
+    <description>Where to aggregate logs to.</description>
+    <name>yarn.nodemanager.remote-app-log-dir</name>
+    <value>/var/log/hadoop-yarn/apps</value>
+  </property>
+
+  <property>
+     <name>yarn.application.classpath</name>
+     <value>$HADOOP_CONF_DIR,/usr/hdp/${HDP_VERSION}/hadoop-client/*,
+     /usr/hdp/${HDP_VERSION}/hadoop-client/lib/*,
+     /usr/hdp/${HDP_VERSION}/hadoop-hdfs-client/*,
+     /usr/hdp/${HDP_VERSION}/hadoop-hdfs-client/lib/*,
+     /usr/hdp/${HDP_VERSION}/hadoop-yarn-client/*,
+     /usr/hdp/${HDP_VERSION}/hadoop-yarn-client/lib/*</value>
+  </property>
+
+</configuration>
+''' > ${HADOOP_CONF_DIR}/yarn-site.xml
+
+
+echo '''
+yarn.nodemanager.linux-container-executor.group=hadoop
+banned.users=hdfs,yarn,mapred
+min.user.id=1000
+''' > /etc/hadoop/conf/container-executor.cfg
+chown root:hadoop /etc/hadoop/conf/container-executor.cfg
+chmod 400 /etc/hadoop/conf/container-executor.cfg
+chown root:hadoop /usr/hdp/${HDP_VERSION}/hadoop-yarn/bin/container-executor
+chmod 6050 /usr/hdp/${HDP_VERSION}/hadoop-yarn/bin/container-executor

--- a/docker/hadoop/hdp/scripts/startup/00_hdfs_start
+++ b/docker/hadoop/hdp/scripts/startup/00_hdfs_start
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+su -m - hdfs -c "/usr/hdp/current/hadoop-hdfs-namenode/../hadoop/sbin/hadoop-daemon.sh --config $HADOOP_CONF_DIR start namenode"
+su -m - hdfs -c "/usr/hdp/current/hadoop-hdfs-namenode/../hadoop/sbin/hadoop-daemon.sh --config $HADOOP_CONF_DIR start secondarynamenode"
+su -m - hdfs -c "/usr/hdp/current/hadoop-hdfs-namenode/../hadoop/sbin/hadoop-daemon.sh --config $HADOOP_CONF_DIR start datanode"

--- a/docker/hadoop/hdp/scripts/startup/30_yarn_start
+++ b/docker/hadoop/hdp/scripts/startup/30_yarn_start
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+HDP_VERSION=$(ls /usr/hdp/ | grep 2)
+
+su -m - hdfs -c "hdfs dfs -mkdir -p /hdp/apps/${HDP_VERSION}/mapreduce/"
+su -m - hdfs -c "hdfs dfs -put /usr/hdp/current/hadoop-client/mapreduce.tar.gz /hdp/apps/${HDP_VERSION}/mapreduce/"
+su -m - hdfs -c "hdfs dfs -chown -R hdfs:hadoop /hdp"
+su -m - hdfs -c "hdfs dfs -chmod -R 555 /hdp/apps/${HDP_VERSION}/mapreduce"
+su -m - hdfs -c "hdfs dfs -chmod 444 /hdp/apps/${HDP_VERSION}/mapreduce/mapreduce.tar.gz"
+
+su -m - hdfs -c "hdfs dfs -mkdir -p /mr-history/tmp "
+su -m - hdfs -c "hdfs dfs -chmod -R 1777 /mr-history/tmp "
+su -m - hdfs -c "hdfs dfs -mkdir -p /mr-history/done "
+su -m - hdfs -c "hdfs dfs -chmod -R 1777 /mr-history/done"
+su -m - hdfs -c "hdfs dfs -chown -R $MAPRED_USER:$HDFS_USER /mr-history"
+su -m - hdfs -c "hdfs dfs -mkdir -p /app-logs"
+su -m - hdfs -c "hdfs dfs -chmod -R 1777 /app-logs"
+su -m - hdfs -c "hdfs dfs -chown $YARN_USER:$HDFS_USER /app-logs"
+
+su -m - yarn -c "/usr/hdp/current/hadoop-yarn-resourcemanager/sbin/yarn-daemon.sh --config $HADOOP_CONF_DIR start resourcemanager"
+su -m - yarn -c "/usr/hdp/current/hadoop-yarn-resourcemanager/sbin/yarn-daemon.sh --config $HADOOP_CONF_DIR start nodemanager"
+su -m - yarn -c "/usr/hdp/current/hadoop-mapreduce-historyserver/sbin/mr-jobhistory-daemon.sh --config $HADOOP_CONF_DIR start historyserver"

--- a/h2o-hadoop/.gitignore
+++ b/h2o-hadoop/.gitignore
@@ -1,0 +1,2 @@
+# Tests
+tests/results

--- a/h2o-hadoop/tests/python/pyunit_gbm_on_hadoop.py
+++ b/h2o-hadoop/tests/python/pyunit_gbm_on_hadoop.py
@@ -1,0 +1,33 @@
+#! /usr/env/python
+
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+from tests import pyunit_utils
+import h2o
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+def gbm_on_hadoop():
+  local_frame = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+  hdfs_path = 'hdfs:///user/jenkins/tests/prostate_export'
+  h2o.export_file(local_frame, hdfs_path, force=True)
+  df = h2o.import_file(hdfs_path)
+  train = df.drop("ID")
+  vol = train['VOL']
+  vol[vol == 0] = None
+  gle = train['GLEASON']
+  gle[gle == 0] = None
+  train['CAPSULE'] = train['CAPSULE'].asfactor()
+  my_gbm = H2OGradientBoostingEstimator(ntrees=50,
+                                        learn_rate=0.1,
+                                        distribution="bernoulli")
+  my_gbm.train(x=list(range(1, train.ncol)),
+               y="CAPSULE",
+               training_frame=train,
+               validation_frame=train)
+  my_gbm.predict(train)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(gbm_on_hadoop)
+else:
+    gbm_on_hadoop()

--- a/h2o-hadoop/tests/python/pyunit_local_and_hdfs_frame_equality.py
+++ b/h2o-hadoop/tests/python/pyunit_local_and_hdfs_frame_equality.py
@@ -1,0 +1,20 @@
+#! /usr/env/python
+
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+from tests import pyunit_utils
+import h2o
+from pandas.util.testing import assert_frame_equal
+
+
+def local_and_hdfs_frame_equality():
+  local_frame = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+  hdfs_path = 'hdfs:///user/jenkins/tests/prostate_export'
+  h2o.export_file(local_frame, hdfs_path, force=True)
+  hdfs_frame = h2o.import_file(hdfs_path)
+  assert_frame_equal(local_frame.as_data_frame(), hdfs_frame.as_data_frame())
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(local_and_hdfs_frame_equality)
+else:
+  local_and_hdfs_frame_equality()

--- a/h2o-hadoop/tests/python/pyunit_read_invalid_file.py
+++ b/h2o-hadoop/tests/python/pyunit_read_invalid_file.py
@@ -1,0 +1,20 @@
+#! /usr/env/python
+
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+from tests import pyunit_utils
+import h2o
+
+
+def read_invalid_file():
+  try:
+      hdfs_path = 'hdfs:///user/jenkins/tests/invalid'
+      h2o.import_file(hdfs_path)
+      assert False, "Read of file, which does not exists was sucessfull. This is impossible"
+  except ValueError:
+      pass
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(read_invalid_file)
+else:
+    read_invalid_file()

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -205,3 +205,10 @@ test-junit-smoke:
 
 benchmark:
 	Rscript ml-benchmark/h2oR/benchmark.R -d $$DATASETS_PATH -t $$TEST_CASES_PATH -o $$OUTPUT_PREFIX --git-sha $$GIT_SHA --git-date "$$GIT_DATE" --model $$BENCHMARK_MODEL --build-id $$BUILD_ID
+
+test-package-hadoop:
+	zip -q -r test-package-hadoop \
+		h2o-hadoop/tests/python/ h2o-hadoop/h2o-*-assembly/build/libs/h2odriver.jar \
+
+test-hadoop-smoke:
+	cd h2o-hadoop/tests/python && ../../../scripts/run.py --wipeall --usecloud "$$CLOUD_IP:$$CLOUD_PORT"

--- a/scripts/jenkins/groovy/buildH2O3.groovy
+++ b/scripts/jenkins/groovy/buildH2O3.groovy
@@ -36,6 +36,14 @@ def call(final pipelineContext) {
               archiveFiles = false
               makefilePath = pipelineContext.getBuildConfig().MAKEFILE_PATH
             }
+            if (pipelineContext.getBuildConfig().getBuildHadoop()) {
+              makeTarget {
+                target = 'test-package-hadoop'
+                hasJUnit = false
+                archiveFiles = false
+                makefilePath = pipelineContext.getBuildConfig().MAKEFILE_PATH
+              }
+            }
             if (pipelineContext.getBuildConfig().componentChanged(pipelineContext.getBuildConfig().COMPONENT_JS)) {
               makeTarget {
                 target = 'test-package-js'
@@ -54,14 +62,14 @@ def call(final pipelineContext) {
             }
           } finally {
             archiveArtifacts """
-          h2o-3/${pipelineContext.getBuildConfig().MAKEFILE_PATH},
-          h2o-3/h2o-py/dist/*.whl,
-          h2o-3/build/h2o.jar,
-          h2o-3/h2o-3/src/contrib/h2o_*.tar.gz,
-          h2o-3/h2o-assemblies/genmodel/build/libs/genmodel.jar,
-          h2o-3/test-package-*.zip,
-          **/*.log, **/out.*, **/*py.out.txt, **/java*out.txt, **/tests.txt, **/status.*
-        """
+              h2o-3/${pipelineContext.getBuildConfig().MAKEFILE_PATH},
+              h2o-3/h2o-py/dist/*.whl,
+              h2o-3/build/h2o.jar,
+              h2o-3/h2o-3/src/contrib/h2o_*.tar.gz,
+              h2o-3/h2o-assemblies/genmodel/build/libs/genmodel.jar,
+              h2o-3/test-package-*.zip,
+              **/*.log, **/out.*, **/*py.out.txt, **/java*out.txt, **/tests.txt, **/status.*
+            """
           }
         }
       }

--- a/scripts/jenkins/groovy/defaultStage.groovy
+++ b/scripts/jenkins/groovy/defaultStage.groovy
@@ -50,6 +50,7 @@ def call(final pipelineContext, final stageConfig) {
           }
 
           makeTarget {
+            customBuildAction = stageConfig.customBuildAction
             target = stageConfig.target
             hasJUnit = stageConfig.hasJUnit
             h2o3dir = h2oFolder

--- a/scripts/jenkins/groovy/hadoopStage.groovy
+++ b/scripts/jenkins/groovy/hadoopStage.groovy
@@ -1,0 +1,31 @@
+def call(final pipelineContext, final stageConfig) {
+
+
+    final String distribution = stageConfig.customData.distribution
+    final String version = stageConfig.customData.version
+    
+    stageConfig.image = pipelineContext.getBuildConfig().getSmokeHadoopImage(distribution, version)
+    stageConfig.customBuildAction = """
+        echo "Activating Python ${stageConfig.pythonVersion}"
+        . /envs/h2o_env_python${stageConfig.pythonVersion}/bin/activate
+    
+        echo 'Initializing Hadoop environment...'
+        sudo -E /usr/sbin/startup.sh
+        
+        echo 'Starting H2O on Hadoop'
+        hadoop jar h2o-hadoop/h2o-${distribution}${version}-assembly/build/libs/h2odriver.jar -n 1 -mapperXmx 2g -baseport 54445 -output 161_${distribution}${version}_jenkins_test -notify h2o_one_node -ea -disown
+        
+        IFS=":" read CLOUD_IP CLOUD_PORT < h2o_one_node
+        export CLOUD_IP=\$CLOUD_IP
+        export CLOUD_PORT=\$CLOUD_PORT
+        echo "Cloud IP:PORT ----> \$CLOUD_IP:\$CLOUD_PORT"
+        
+        echo "Running Make"
+        make -f ${pipelineContext.getBuildConfig().MAKEFILE_PATH} test-hadoop-smoke
+    """
+
+    def defaultStage = load('h2o-3/scripts/jenkins/groovy/defaultStage.groovy')
+    defaultStage(pipelineContext, stageConfig)
+}
+
+return this

--- a/scripts/jenkins/groovy/pipelineContext.groovy
+++ b/scripts/jenkins/groovy/pipelineContext.groovy
@@ -14,10 +14,16 @@ def call(final String h2o3Root, final String mode, final scmEnv, final boolean i
     def final pipelineUtilsFactory = load("${h2o3Root}/scripts/jenkins/groovy/${PIPELINE_UTILS_SCRIPT_NAME}")
     def final emailerFactory = load("${h2o3Root}/scripts/jenkins/groovy/${EMAILER_SCRIPT_NAME}")
 
+    def final buildinfoPath = "${h2o3Root}/h2o-dist/buildinfo.json"
+
+    def final pipelineUtils = pipelineUtilsFactory()
+
     return new PipelineContext(
-            buildConfigFactory(this, mode, env.COMMIT_MESSAGE, getChanges(h2o3Root), ignoreChanges),
+            buildConfigFactory(this, mode, env.COMMIT_MESSAGE, getChanges(h2o3Root), ignoreChanges,
+                    pipelineUtils.readSupportedHadoopDistributions(this, buildinfoPath)
+            ),
             buildSummaryFactory(true),
-            pipelineUtilsFactory(),
+            pipelineUtils,
             emailerFactory()
     )
 }

--- a/scripts/jenkins/groovy/pipelineUtils.groovy
+++ b/scripts/jenkins/groovy/pipelineUtils.groovy
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 def call() {
     return new PipelineUtils()
 }
@@ -13,12 +15,61 @@ class PipelineUtils {
         return null
     }
 
+    void stashFiles(final context, final String stashName, final String includedFiles) {
+        context.stash name: stashName, includes: includedFiles, allowEmpty: false
+    }
+
+    void unstashFiles(final context, final String stashName) {
+        context.unstash stashName
+    }
+
     void stashScripts(final context) {
         context.stash name: PIPELINE_SCRIPTS_STASH_NAME, includes: 'h2o-3/scripts/jenkins/groovy/*', allowEmpty: false
     }
 
     void unstashScripts(final context) {
         context.unstash name: PIPELINE_SCRIPTS_STASH_NAME
+    }
+
+    List<String> readSupportedHadoopDistributions(final context, final String buildinfoPath) {
+        final List<String> DOCKERIZED_DISTRIBUTIONS = ['cdh', 'hdp']
+
+        final String buildinfoContent = context.sh(script: "sed 's/SUBST_BUILD_TIME_MILLIS/\"SUBST_BUILD_TIME_MILLIS\"/g' ${buildinfoPath} | sed -e 's/SUBST_BUILD_NUMBER/\"SUBST_BUILD_NUMBER\"/g'", returnStdout: true).trim()
+
+        def buildinfo = new JsonSlurper().parseText(buildinfoContent)
+
+        def distributionsToBuild = []
+
+        for (distSpec in buildinfo.hadoop_distributions) {
+            def distributionStr = distSpec.distribution.toLowerCase()
+            for (dockerizedDist in DOCKERIZED_DISTRIBUTIONS) {
+                if (distributionStr.startsWith(dockerizedDist)) {
+                    def distributionName = dockerizedDist
+                    def distributionVersion = distributionStr.replaceFirst(dockerizedDist, '')
+                    distributionsToBuild += [
+                            name: distributionName,
+                            version: distributionVersion
+                    ]
+                    context.echo "Supported dist found: dist: ${distributionName}, ver: ${distributionVersion}"
+                }
+            }
+        }
+
+        return distributionsToBuild
+    }
+
+    boolean dockerImageExistsInRegistry(final context, final String registry, final String imageName, final String version) {
+        context.withCredentials([context.usernamePassword(credentialsId: "${registry}", usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWORD')]) {
+            final String response = "curl -k -u ${context.REGISTRY_USERNAME}:${context.REGISTRY_PASSWORD} https://${registry}/v2/${imageName}/tags/list".execute().text
+
+            final def jsonResponse = new groovy.json.JsonSlurper().parseText(response)
+            if (jsonResponse.errors || jsonResponse.tags == null) {
+                context.echo "response: ${response}"
+                context.error "Docker registry check failed."
+            }
+
+            return jsonResponse.tags.contains(version)
+        }
     }
 }
 

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Hadoop
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Hadoop
@@ -1,0 +1,47 @@
+@Library('test-shared-library') _
+
+def DEFAULT_NODE_LABEL = 'docker && !mr-0xc8'
+
+def defineTestStages = null
+def pipelineContext = null
+def result = 'FAILURE'
+def scmEnv = null
+
+try {
+  ansiColor('xterm') {
+    timestamps {
+
+      node(DEFAULT_NODE_LABEL) {
+        stage('Prepare and Build') {
+          dir('h2o-3') {
+            // clear the folder
+            deleteDir()
+            // checkout H2O-3
+            retry(3) {
+              timeout(time: 1, unit: 'MINUTES') {
+                echo "###### Checkout H2O-3 ######"
+                scmEnv = checkout scm
+              }
+            }
+          }
+
+          def prepareH2O3 = load('h2o-3/scripts/jenkins/groovy/prepareH2O3.groovy')
+          pipelineContext = prepareH2O3(scmEnv, 'MODE_HADOOP', true)
+          pipelineContext.getBuildConfig().setIgnoreRerun(true)
+
+          final String scheduleString = 'H 21 * * *'
+          pipelineContext.getBuildConfig().setJobProperties(this, pipelineTriggers([cron(scheduleString)]))
+
+          // Load the defineTestStages script
+          defineTestStages = load('h2o-3/scripts/jenkins/groovy/defineTestStages.groovy')
+        }
+      }
+      defineTestStages(pipelineContext)
+      result = 'SUCCESS'
+    }
+  }
+} finally {
+  if (pipelineContext != null) {
+    pipelineContext.getEmailer().sendEmail(this, result, pipelineContext.getBuildSummary().getSummaryHTML(this))
+  }
+}


### PR DESCRIPTION
There is a Readme under `h2o-hadoop/scripts/docker` which should describe how to build and run these images.

The Jenkinsfile is for the Job which runs the tests. This Job is parametrized, version and distribution can be specified.

The Jenkinsfile-trigger fires multiple Jobs, one for each supported version for each supported distribution.

`h2o-hadoop/scripts/docker/common` contains files which are shared between the two distros.
`h2o-hadoop/scripts/docker/cdh` contains files which are specific for CDH.
`h2o-hadoop/scripts/docker/hdp` contains files which are specific for HDP.
`h2o-hadoop/tests/python` contains test files which are being executed in the Job.