### PR TITLE
HOTFIX: Ensure validation frame is updated in multinomial case for stacked ensembles

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -184,7 +184,14 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         Frame aPred = aModel.score(actuals, predsKey.toString()); // TODO: cache predictions
 
         baseModels.add(aModel);
-        baseModelPredictions.add(aPred);
+        if(!aModel._output.isMultinomialClassifier()){
+          baseModelPredictions.add(aPred);
+        }else {
+          List<String> predColNames= new ArrayList<>(Arrays.asList(aPred.names()));
+          predColNames.remove("predict");
+          String[] multClassNames  = predColNames.toArray(new String[0]);
+          baseModelPredictions.add(aPred.subframe(multClassNames));
+        }
       }
 
       Frame levelOne = prepareLevelOneFrame(levelOneKey, baseModels.toArray(new Model[0]), baseModelPredictions.toArray(new Frame[0]), actuals);

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -171,7 +171,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
      * Prepare a "level one" frame for a given set of models and actuals.  Used for preparing validation frames
      * for the metalearning step, and could also be used for bulk predictions for a StackedEnsemble.
      */
-    private Frame prepareLevelOneFrame(String levelOneKey, Key<Model>[] baseModelKeys, Frame actuals) {
+    private Frame prepareValidationLevelOneFrame(String levelOneKey, Key<Model>[] baseModelKeys, Frame actuals) {
       List<Model> baseModels = new ArrayList<>();
       List<Frame> baseModelPredictions = new ArrayList<>();
 
@@ -218,7 +218,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       if (_model._parms.valid() != null) {
         String levelOneKey = "levelone_validation_" + _model._key.toString();
         levelOneValidationFrame =
-                prepareLevelOneFrame(levelOneKey,
+                prepareValidationLevelOneFrame(levelOneKey,
                                      _model._parms._base_models,
                                      _model._parms.valid());
       }


### PR DESCRIPTION
* The `prepareValidationLevelOneFrame` method needs to remove the `predict` column in a multinomial case.