### PR TITLE
[WIP][PUBDEV-4848] rawModel.getResponseName() ArrayIndexOutOfBoundsException

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1518,6 +1518,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     sb.p("public class ").p(modelName).p(" extends GenModel {").nl().ii(1);
     sb.ip("public hex.ModelCategory getModelCategory() { return hex.ModelCategory." + _output
         .getModelCategory() + "; }").nl();
+    sb.ip("public String getResponseName() { return \"" + _output._names[_output._domains.length - 1] + "\";}").nl();
     toJavaInit(sb, fileCtx).nl();
     toJavaNAMES(sb, fileCtx);
     toJavaNCLASSES(sb);


### PR DESCRIPTION
rawModel.getResponseName() causes `ArrayIndexOutOfBoundsException `, because the NAMES field does not contain the response column. Waiting for tests, if the naive addition would be OK.