### PR TITLE
PUBDEV-4836: Add a `keep_levelone_frame` argument to Stacked Ensembles

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -58,6 +58,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
 
     /** Which models can we choose from? */
     public Key<Model> _base_models[] = new Key[0];
+    public boolean _keep_levelone_frame = false;
   }
 
   public static class StackedEnsembleOutput extends Model.Output {
@@ -67,6 +68,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     public StackedEnsembleOutput(Job job) { _job = job; }
     // The metalearner model (e.g., a GLM that has a coefficient for each of the base_learners).
     public Model _metalearner;
+    public Frame _levelone_frame_id;
   }
 
   /**

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -263,12 +263,15 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       // _model._output._model_summary = createModelSummaryTable(model._output);
       _model.update(_job);
       _model.unlock(_job);
-
-      // Cleanup
-      DKV.remove(levelOneTrainingFrame._key);
-      if (null != levelOneValidationFrame)
-        DKV.remove(levelOneValidationFrame._key);
+      if(_parms._keep_levelone_frame) {
+        _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+      }else{
+        DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+      }
+      if (null != levelOneValidationFrame) {
+          DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+        }
+      }
 
     } // computeImpl
   }
-}

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -261,17 +261,16 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       _model._output._metalearner = metaBuilder.get();
       _model.doScoreMetrics(_job);
       // _model._output._model_summary = createModelSummaryTable(model._output);
-      _model.update(_job);
-      _model.unlock(_job);
       if(_parms._keep_levelone_frame) {
         _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
       }else{
         DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
       }
+      _model.update(_job);
+      _model.unlock(_job);
       if (null != levelOneValidationFrame) {
           DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
         }
       }
-
     } // computeImpl
   }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -266,11 +266,11 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       }else{
         DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
       }
+      if (null != levelOneValidationFrame) {
+        DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+      }
       _model.update(_job);
       _model.unlock(_job);
-      if (null != levelOneValidationFrame) {
-          DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
-        }
       }
     } // computeImpl
   }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleModelV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleModelV99.java
@@ -6,14 +6,14 @@ import water.api.schemas3.KeyV3;
 import water.api.schemas3.ModelOutputSchemaV3;
 import water.api.schemas3.ModelSchemaV3;
 
-/**
- * Created by rpeck on 10/11/16.
- */
 public class StackedEnsembleModelV99 extends ModelSchemaV3<StackedEnsembleModel, StackedEnsembleModelV99, StackedEnsembleModel.StackedEnsembleParameters, StackedEnsembleV99.StackedEnsembleParametersV99, StackedEnsembleModel.StackedEnsembleOutput, StackedEnsembleModelV99.StackedEnsembleModelOutputV99> {
 
   public static final class StackedEnsembleModelOutputV99 extends ModelOutputSchemaV3<StackedEnsembleModel.StackedEnsembleOutput, StackedEnsembleModelOutputV99> {
     @API(help="Model which combines the base_models into a stacked ensemble.", direction = API.Direction.OUTPUT)
     KeyV3.ModelKeyV3 metalearner;
+
+    @API(help="Level one frame used for metalearner training.", direction = API.Direction.OUTPUT)
+    KeyV3.FrameKeyV3 levelone_frame_id;
   }
 
   public StackedEnsembleV99.StackedEnsembleParametersV99 createParametersSchema() { return new StackedEnsembleV99.StackedEnsembleParametersV99(); }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -6,9 +6,7 @@ import water.api.API;
 import water.api.schemas3.KeyV3;
 import water.api.schemas3.ModelParametersSchemaV3;
 
-/**
- * Created by rpeck on 10/11/16.
- */
+
 public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,StackedEnsembleV99,StackedEnsembleV99.StackedEnsembleParametersV99> {
   public static final class StackedEnsembleParametersV99 extends ModelParametersSchemaV3<StackedEnsembleModel.StackedEnsembleParameters, StackedEnsembleParametersV99> {
     static public String[] fields = new String[]{
@@ -17,6 +15,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "response_column",
       "validation_frame",
       "base_models",
+      "keep_levelone_frame",
       //"selection_strategy",
     };
 
@@ -30,5 +29,8 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
     @API(help = "List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
     public KeyV3.ModelKeyV3 base_models[];
+
+    @API(help = "Keep level one frame used for metalearner training.")
+    public boolean keep_levelone_frame;
   }
 }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -212,10 +212,11 @@ public class StackedEnsembleTest extends TestUtil {
                 stackedEnsembleModel.remove();
                 stackedEnsembleModel._output._metalearner._output._training_metrics.remove();
                 stackedEnsembleModel._output._metalearner.remove();
+                if(stackedEnsembleModel._output._levelone_frame_id != null){
+                    stackedEnsembleModel._output._levelone_frame_id.remove();
+                }
             }
-
             Scope.exit();
         }
     }
-
 }

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -48,7 +48,8 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def __init__(self, **kwargs):
         super(H2OStackedEnsembleEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models"}
+        names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models",
+                      "keep_levelone_frame"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -124,5 +125,20 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
          else:
             assert_is_type(base_models, None, [str])
             self._parms["base_models"] = base_models
+
+
+    @property
+    def keep_levelone_frame(self):
+        """
+        Keep level one frame used for metalearner training.
+
+        Type: ``bool``  (default: ``False``).
+        """
+        return self._parms.get("keep_levelone_frame")
+
+    @keep_levelone_frame.setter
+    def keep_levelone_frame(self, keep_levelone_frame):
+        assert_is_type(keep_levelone_frame, None, bool)
+        self._parms["keep_levelone_frame"] = keep_levelone_frame
 
 

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -686,6 +686,13 @@ class ModelBase(backwards_compatible()):
             return model["metalearner"]
         print("No metalearner for this model")
 
+    def levelone_frame_id(self):
+        """Fetch the levelone_frame_id for the model, if any.  Currently only used by H2OStackedEnsembleEstimator."""
+        model = self._model_json["output"]
+        if "levelone_frame_id" in model and model["levelone_frame_id"] is not None:
+            return model["levelone_frame_id"]
+        print("No levelone_frame_id for this model")
+
 
     def download_pojo(self, path="", get_genmodel_jar=False, genmodel_name=""):
         """

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_levelone_frame.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_levelone_frame.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+
+import h2o
+
+import sys
+sys.path.insert(1,"../../../")  # allow us to run this standalone
+
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from tests import pyunit_utils
+
+
+def stackedensemble_levelone_frame_test():
+
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    test = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_test.csv"))
+    y = "species"
+    x = list(range(4))
+    train[y] = train[y].asfactor()
+    test[y] = test[y].asfactor()
+    nfolds = 5
+    num_base_models = 2
+    num_col_level_one_frame = (train[y].unique().nrow) * num_base_models + 1 #Predicting 3 classes across two base models + response (3*2+1)
+
+
+    # train and cross-validate a GBM
+    my_gbm = H2OGradientBoostingEstimator(distribution="multinomial",
+                                          nfolds=nfolds,
+                                          ntrees=10,
+                                          fold_assignment="Modulo",
+                                          keep_cross_validation_predictions=True,
+                                          seed=1)
+    my_gbm.train(x=x, y=y, training_frame=train)
+
+    # train and cross-validate a RF
+    my_rf = H2ORandomForestEstimator(ntrees=10,
+                                     nfolds=nfolds,
+                                     fold_assignment="Modulo",
+                                     keep_cross_validation_predictions=True,
+                                     seed=1)
+
+    my_rf.train(x=x, y=y, training_frame=train)
+
+
+    # Train a stacked ensemble using the GBM and GLM above
+    stack = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id,  my_rf.model_id], keep_levelone_frame=True)
+    stack.train(x=x, y=y, training_frame=train, validation_frame=test)  # also test that validation_frame is working
+    level_one_frame = h2o.get_frame(stack.levelone_frame_id()["name"])
+    assert level_one_frame.ncols == num_col_level_one_frame, "The number of columns in a level one frame should be numClasses * numBaseModels + 1."
+    assert level_one_frame.nrows == train.nrows, "The number of rows in the level one frame should match train number of rows. "
+
+    stack2 = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id,  my_rf.model_id])
+    stack2.train(x=x, y=y, training_frame=train, validation_frame=test)  # also test that validation_frame is working
+    assert stack2.levelone_frame_id() is None, "Level one frame is only available when keep_levelone_frame is True."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(stackedensemble_levelone_frame_test)
+else:
+    stackedensemble_levelone_frame_test()
+
+

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_levelone_frame.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_levelone_frame.py
@@ -16,11 +16,9 @@ from tests import pyunit_utils
 def stackedensemble_levelone_frame_test():
 
     train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_train.csv"))
-    test = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_test.csv"))
     y = "species"
     x = list(range(4))
     train[y] = train[y].asfactor()
-    test[y] = test[y].asfactor()
     nfolds = 5
     num_base_models = 2
     num_col_level_one_frame = (train[y].unique().nrow) * num_base_models + 1 #Predicting 3 classes across two base models + response (3*2+1)
@@ -47,13 +45,13 @@ def stackedensemble_levelone_frame_test():
 
     # Train a stacked ensemble using the GBM and GLM above
     stack = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id,  my_rf.model_id], keep_levelone_frame=True)
-    stack.train(x=x, y=y, training_frame=train, validation_frame=test)  # also test that validation_frame is working
+    stack.train(x=x, y=y, training_frame=train)  # also test that validation_frame is working
     level_one_frame = h2o.get_frame(stack.levelone_frame_id()["name"])
     assert level_one_frame.ncols == num_col_level_one_frame, "The number of columns in a level one frame should be numClasses * numBaseModels + 1."
     assert level_one_frame.nrows == train.nrows, "The number of rows in the level one frame should match train number of rows. "
 
     stack2 = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id,  my_rf.model_id])
-    stack2.train(x=x, y=y, training_frame=train, validation_frame=test)  # also test that validation_frame is working
+    stack2.train(x=x, y=y, training_frame=train)  # also test that validation_frame is working
     assert stack2.levelone_frame_id() is None, "Level one frame is only available when keep_levelone_frame is True."
 
 if __name__ == "__main__":

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -16,6 +16,7 @@
 #' @param validation_frame Id of the validation data frame.
 #' @param base_models List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and
 #'        folds must be identical across models. Defaults to [].
+#' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
 #' @examples
 #' 
 #' # See example R code here:
@@ -25,7 +26,8 @@
 h2o.stackedEnsemble <- function(x, y, training_frame,
                                 model_id = NULL,
                                 validation_frame = NULL,
-                                base_models = list()
+                                base_models = list(),
+                                keep_levelone_frame = FALSE
                                 ) 
 {
   # If x is missing, then assume user wants to use all columns as features.
@@ -73,6 +75,8 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$validation_frame <- validation_frame
   if (!missing(base_models))
     parms$base_models <- base_models
+  if (!missing(keep_levelone_frame))
+    parms$keep_levelone_frame <- keep_levelone_frame
   # Error check and build model
   .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99) 
 }

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_levelone_frame.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_levelone_frame.R
@@ -4,11 +4,9 @@ source("../../../scripts/h2o-r-test-setup.R")
 stackedensemble.levelone.test <- function() {
 
     train <- h2o.uploadFile(locate("smalldata/iris/iris_train.csv"))
-    test <- h2o.uploadFile(locate("smalldata/iris/iris_test.csv"))
     y <- "species"
     x <- setdiff(names(train), y)
     train[,y] <- as.factor(train[,y])
-    test[,y] <- as.factor(test[,y])
     nfolds <- 5
     num_base_models <- 2
     num_col_level_one_frame <- nrow(h2o.unique(train[y])) * num_base_models + 1 #Predicting 3 classes across two base models + response (3*2+1)

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_levelone_frame.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_levelone_frame.R
@@ -1,0 +1,62 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+stackedensemble.levelone.test <- function() {
+
+    train <- h2o.uploadFile(locate("smalldata/iris/iris_train.csv"))
+    test <- h2o.uploadFile(locate("smalldata/iris/iris_test.csv"))
+    y <- "species"
+    x <- setdiff(names(train), y)
+    train[,y] <- as.factor(train[,y])
+    test[,y] <- as.factor(test[,y])
+    nfolds <- 5
+    num_base_models <- 2
+    num_col_level_one_frame <- nrow(h2o.unique(train[y])) * num_base_models + 1 #Predicting 3 classes across two base models + response (3*2+1)
+
+    # Train & Cross-validate a GBM
+    my_gbm <- h2o.gbm(x = x,
+                      y = y,
+                      training_frame = train,
+                      distribution = "multinomial",
+                      ntrees = 10,
+                      max_depth = 3,
+                      min_rows = 2,
+                      learn_rate = 0.2,
+                      nfolds = nfolds,
+                      fold_assignment = "Modulo",
+                      keep_cross_validation_predictions = TRUE,
+                      seed = 1)
+
+
+    # Train & Cross-validate a RF
+    my_rf <- h2o.randomForest(x = x,
+                            y = y,
+                            training_frame = train,
+                            ntrees = 50,
+                            nfolds = nfolds,
+                            fold_assignment = "Modulo",
+                            keep_cross_validation_predictions = TRUE,
+                            seed = 1)
+
+    # Train a stacked ensemble using the GBM and RF above
+    stack <- h2o.stackedEnsemble(x = x,
+                                 y = y,
+                                 training_frame = train,
+                                 model_id = "my_ensemble_l1",
+                                 base_models = list(my_gbm@model_id, my_rf@model_id),
+                                 keep_levelone_frame = TRUE)
+    level_one_frame = h2o.getFrame(stack@model$levelone_frame_id$name)
+    expect_equal(ncol(level_one_frame), num_col_level_one_frame) #Predicting 3 classes across two base models + response (3*2+1)
+    expect_equal(nrow(level_one_frame),nrow(train)) #Should predict for nrow of training frame
+
+    # Train a stacked ensemble using the GBM and RF above
+    stack2 <- h2o.stackedEnsemble(x = x,
+                                  y = y,
+                                  training_frame = train,
+                                  model_id = "my_ensemble_no_l1",
+                                  base_models = list(my_gbm@model_id, my_rf@model_id))
+    expect_equal(is.null(stack2@model$levelone_frame_id), TRUE) #fetching level one frame is off by default
+
+}
+
+doTest("Stacked Ensemble Level-One Frame Test", stackedensemble.levelone.test)


### PR DESCRIPTION
* Add a `keep_levelone_frame` argument to Stacked Ensembles. If set to `true`, then the stacked ensemble object has an attribute `level_one_frame_id` and a user can fetch said frame. 
* Added pyunit and runit to test previous.