### PR TITLE
[PUBDEV-4739] - h2o.sub now retains column names (#1444)

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceFirst.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceFirst.java
@@ -61,7 +61,7 @@ public class AstReplaceFirst extends AstPrimitive {
       i++;
     }
 
-    return new ValFrame(new Frame(nvs));
+    return new ValFrame(new Frame(fr.names(), nvs));
   }
 
   private Vec replaceFirstCategoricalCol(Vec vec, String pattern, String replacement, boolean ignoreCase) {

--- a/h2o-r/tests/testdir_jira/runit_pubdev_4739.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_4739.R
@@ -1,0 +1,16 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.pubdev_4739 <- function() {
+    feature.cols <- paste0("vote", 1:16)
+    voting.data.raw <- h2o.importFile(path = locate('smalldata/extdata/housevotes.csv'),
+    col.names = c("party", feature.cols),
+    col.types = rep("string", 17))
+
+    newdf <- h2o.sub("\\\\?", "n", x = voting.data.raw)
+    expect_true(all.equal(names(newdf), names(voting.data.raw)))
+}
+
+doTest("PUBDEV-$4739: h2o.sub() wipes out column names", test.pubdev_4739)


### PR DESCRIPTION
[PUBDEV-4739] 
- h2o.sub now retains column names
- simple test of this behavior