### PR TITLE
PUBDEV-4845: Adds support for on-the-fly decryption to ParseDataset

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -585,6 +585,10 @@ final public class H2O {
         i = s.incrementAndCheck(i, args);
         trgt.internal_security_conf = args[i];
       }
+      else if (s.matches("decrypt_tool")) {
+        i = s.incrementAndCheck(i, args);
+        trgt.decrypt_tool = args[i];
+      }
       else if (s.matches("no_latest_check")) {
         trgt.noLatestCheck = true;
       }

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -229,6 +229,9 @@ final public class H2O {
     /** -internal_security_enabled is a boolean that indicates if internal communication paths are secured*/
     public boolean internal_security_enabled = false;
 
+    /** -decrypt_tool specifies the DKV key where a default decrypt tool will be installed*/
+    public String decrypt_tool = null;
+
     //-----------------------------------------------------------------------------------
     // Networking
     //-----------------------------------------------------------------------------------

--- a/h2o-core/src/main/java/water/parser/DecryptionTool.java
+++ b/h2o-core/src/main/java/water/parser/DecryptionTool.java
@@ -1,0 +1,119 @@
+package water.parser;
+
+import water.DKV;
+import water.Key;
+import water.Keyed;
+import water.fvec.ByteVec;
+import water.fvec.Vec;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+/**
+ * Base class for implementations of the Decryption Tool
+ *
+ * Decryption Tool is applied to the raw data loaded from source files and decrypts them on-the-fly.
+ */
+public abstract class DecryptionTool extends Keyed<DecryptionTool> {
+
+  DecryptionTool(Key<DecryptionTool> key) {
+    super(key);
+  }
+
+  /**
+   * Decrypts the beginning of the file and returns its clear-text binary representation.
+   * @param bits the first chunk of data of the datafile. The input byte array can contain zero-bytes padding (eg. case of
+   *             DEFLATE compression in Zip files, the decompressed data can be smaller than the source chunk).
+   *             The implementation of the method should discard the padding (all zero bytes at the end of the array).
+   * @return Decrypted binary data or the input byte array if Tool is not compatible with this input.
+   */
+  public abstract byte[] decryptFirstBytes(final byte[] bits);
+
+  /**
+   * Wraps the source InputStream into deciphering input stream
+   * @param is InputStream created by ByteVec (H2O-specific behavior is expected!)
+   * @return InputStream of decrypted data
+   */
+  public abstract InputStream decryptInputStream(final InputStream is);
+
+  public boolean isTransparent() { return false; }
+
+  /**
+   * Retrieves a Decryption Tool from DKV using a given key.
+   * @param key a valid DKV key or null
+   * @return instance of Decryption Tool for a valid key, Null Decryption tool for a null key
+   */
+  public static DecryptionTool get(String key) {
+    if (key == null)
+      return new NullDecryptionTool();
+    DecryptionTool decrypt = DKV.getGet(key);
+    return decrypt == null ? new NullDecryptionTool() : decrypt;
+  }
+
+  /**
+   * Retrieves a Secret Key using a given Decryption Setup.
+   * @param ds decryption setup
+   * @return SecretKey
+   */
+  static SecretKeySpec readSecretKey(DecryptionSetup ds) {
+    ByteVec ksVec = DKV.getGet(ds._keystore_id);
+    InputStream ksStream = ksVec.openStream(null /*job key*/);
+    try {
+      KeyStore keystore = KeyStore.getInstance(ds._keystore_type);
+      keystore.load(ksStream, ds._password);
+
+      if (! keystore.containsAlias(ds._key_alias)) {
+        throw new IllegalArgumentException("Alias for key not found");
+      }
+
+      java.security.Key key = keystore.getKey(ds._key_alias, ds._password);
+      return new SecretKeySpec(key.getEncoded(), key.getAlgorithm());
+    } catch (GeneralSecurityException e) {
+      throw new RuntimeException("Unable to load key " + ds._key_alias + " from keystore " + ds._keystore_id, e);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read keystore " + ds._keystore_id, e);
+    }
+  }
+
+  /**
+   * Instantiates a Decryption Tool using a given Decryption Setup and installs it in DKV.
+   * @param ds decryption setup
+   * @return instance of a Decryption Tool
+   */
+  public static DecryptionTool make(DecryptionSetup ds) {
+    try {
+      Class<?> dtClass = DecryptionTool.class.getClassLoader().loadClass(ds._decrypt_impl);
+      if (! DecryptionTool.class.isAssignableFrom(dtClass)) {
+        throw new IllegalArgumentException("Class " + ds._decrypt_impl + " doesn't implement a Decryption Tool.");
+      }
+      Constructor<?> constructor = dtClass.getConstructor(DecryptionSetup.class);
+      DecryptionTool dt = (DecryptionTool) constructor.newInstance(ds);
+      DKV.put(dt);
+      return dt;
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Unknown decrypt tool: " + ds._decrypt_impl, e);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException("Invalid implementation of Decryption Tool (missing constructor).", e);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Blueprint of the Decryption Tool
+   */
+  public static class DecryptionSetup {
+    Key<DecryptionTool> _decrypt_tool_id; // where will be the instantiated tool installed
+    String _decrypt_impl = GenericDecryptionTool.class.getName(); // implementation
+    Key<Vec> _keystore_id; // where to find Java KeyStore file
+    String _keystore_type; // what kind of KeyStore is used
+    String _key_alias; // what is the alias of the key in the keystore
+    char[] _password; // password to the keystore and to the keyentry
+    String _cipher_spec; // specification of the cipher (and padding)
+  }
+
+}

--- a/h2o-core/src/main/java/water/parser/GenericDecryptionTool.java
+++ b/h2o-core/src/main/java/water/parser/GenericDecryptionTool.java
@@ -1,0 +1,71 @@
+package water.parser;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+
+public class GenericDecryptionTool extends DecryptionTool {
+
+  private byte[] _encoded_key = new byte[]{-14, 22, 35, -64, 29, -72, 115, 25, -122, 39, -57, -77, -63, -35, 32, 75};
+  private String _key_algo = "AES";
+  private String _cipher_spec = "AES/ECB/PKCS5Padding";
+
+  public GenericDecryptionTool(DecryptionSetup ds) {
+    super(ds._decrypt_tool_id);
+    SecretKeySpec secretKey = readSecretKey(ds);
+    _key_algo = secretKey.getAlgorithm();
+    _encoded_key = secretKey.getEncoded();
+    _cipher_spec = ds._cipher_spec;
+  }
+
+  @Override
+  public byte[] decryptFirstBytes(final byte[] bits) {
+    Cipher cipher = createDecipherer();
+
+    final int bs = cipher.getBlockSize();
+    int len = bits.length;
+    if (((bs > 0) && (len % bs != 0)) || bits[len - 1] == 0) {
+      while (len > 0 && bits[len - 1] == 0)
+        len--;
+      len = bs > 0 ? len - (len % bs) : len;
+    }
+
+    return cipher.update(bits, 0, len);
+  }
+
+  @Override
+  public InputStream decryptInputStream(final InputStream is) {
+    Cipher cipher = createDecipherer();
+    return new CipherInputStream(is, cipher) {
+      @Override
+      public int read(byte[] b, int off, int len) throws IOException {
+        if (b == null) { // Back-channel read of chunk idx (delegated to the original InputStream)
+          return is.read(null, off, len);
+        }
+        return super.read(b, off, len);
+      }
+      @Override
+      public int available() throws IOException {
+        int avail = super.available();
+        // H2O's contract with the available() method differs from the contract specified by InputStream
+        // we need to make sure we return a positive number (if we don't have anything in the buffer - ask the original IS)
+        return avail > 0 ? avail : is.available();
+      }
+    };
+  }
+
+  private Cipher createDecipherer() {
+    SecretKeySpec secKeySpec = new SecretKeySpec(_encoded_key, _key_algo);
+    try {
+      Cipher cipher = Cipher.getInstance(_cipher_spec);
+      cipher.init(Cipher.DECRYPT_MODE, secKeySpec);
+      return cipher;
+    } catch (GeneralSecurityException e) {
+      throw new RuntimeException("Cipher initialization failed", e);
+    }
+  }
+
+}

--- a/h2o-core/src/main/java/water/parser/NullDecryptionTool.java
+++ b/h2o-core/src/main/java/water/parser/NullDecryptionTool.java
@@ -1,0 +1,28 @@
+package water.parser;
+
+import water.Key;
+
+import java.io.InputStream;
+
+public class NullDecryptionTool extends DecryptionTool {
+
+  public NullDecryptionTool() {
+    super(null);
+  }
+
+  @Override
+  public byte[] decryptFirstBytes(byte[] bits) {
+    return bits;
+  }
+
+  @Override
+  public InputStream decryptInputStream(InputStream is) {
+    return is;
+  }
+
+  @Override
+  public boolean isTransparent() {
+    return true;
+  }
+
+}

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -725,8 +725,8 @@ public final class ParseDataset {
       try {
         switch( cpr ) {
         case NONE:
-          ParserInfo.ParseMethod pm = _parseSetup._parse_type.parseMethod(_keys.length, vec.nChunks(), ! decryptionTool.isTransparent());
-          if(pm == ParserInfo.ParseMethod.DistributedParse) {
+          ParserInfo.ParseMethod pm = _parseSetup._parse_type.parseMethod(_keys.length, vec.nChunks());
+          if((pm == ParserInfo.ParseMethod.DistributedParse) && decryptionTool.isTransparent()) {
             new DistributedParse(_vg, localSetup, _vecIdStart, chunkStartIdx, this, key, vec.nChunks()).dfork(vec).getResult(false);
             for( int i = 0; i < vec.nChunks(); ++i )
               _chunk2ParseNodeMap[chunkStartIdx + i] = vec.chunkKey(i).home_node().index();

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -726,7 +726,9 @@ public final class ParseDataset {
         switch( cpr ) {
         case NONE:
           ParserInfo.ParseMethod pm = _parseSetup._parse_type.parseMethod(_keys.length, vec.nChunks());
-          if((pm == ParserInfo.ParseMethod.DistributedParse) && decryptionTool.isTransparent()) {
+          if (pm == ParserInfo.ParseMethod.DistributedParse && ! decryptionTool.isTransparent())
+            pm = ParserInfo.ParseMethod.StreamParse;
+          if(pm == ParserInfo.ParseMethod.DistributedParse) {
             new DistributedParse(_vg, localSetup, _vecIdStart, chunkStartIdx, this, key, vec.nChunks()).dfork(vec).getResult(false);
             for( int i = 0; i < vec.nChunks(); ++i )
               _chunk2ParseNodeMap[chunkStartIdx + i] = vec.chunkKey(i).home_node().index();

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -41,6 +41,7 @@ public class ParseSetup extends Iced {
 
   String [] _fileNames = new String[]{"unknown"};
   public  boolean disableParallelParse;
+  String _decrypt_tool;
 
   public void setFileName(String name) {_fileNames[0] = name;}
 
@@ -331,6 +332,16 @@ public class ParseSetup extends Iced {
       byte [] bits = ZipUtil.getFirstUnzippedBytes(bv);
       // The bits can be null
       if (bits != null && bits.length > 0) {
+        String decryptToolId = _userSetup._decrypt_tool != null ? _userSetup._decrypt_tool : H2O.ARGS.decrypt_tool;
+        DecryptionTool decrypt = decryptToolId != null ? (DecryptionTool) DKV.getGet(decryptToolId) : null;
+        if (decrypt != null) {
+          byte[] plainBits = decrypt.decryptFirstBytes(bits);
+          if (plainBits != bits)
+            bits = plainBits;
+          else
+            decryptToolId = null;
+        }
+
         _empty = false;
 
         // get file size
@@ -357,6 +368,7 @@ public class ParseSetup extends Iced {
                 || decompRatio > 1.0) { */
         try {
           _gblSetup = guessSetup(bv, bits, _userSetup);
+          _gblSetup._decrypt_tool = decryptToolId;
           for(ParseWriter.ParseErr e:_gblSetup._errs) {
 //            e._byteOffset += e._cidx*Parser.StreamData.bufSz;
             e._cidx = 0;

--- a/h2o-core/src/main/java/water/parser/ParserInfo.java
+++ b/h2o-core/src/main/java/water/parser/ParserInfo.java
@@ -56,12 +56,12 @@ public class ParserInfo extends Iced<ParserInfo> {
   /*
   localSetup.disableParallelParse ||
    */
-  public ParseMethod parseMethod(int nfiles, int nchunks){
+  public ParseMethod parseMethod(int nfiles, int nchunks, boolean encrypted){
     if(isStreamParseSupported()) {
-      if (!isParallelParseSupported() || (nfiles > TOO_MANY_KEYS_COUNT && (nchunks <= SMALL_FILE_NCHUNKS)))
+      if (!isParallelParseSupported() || (nfiles > TOO_MANY_KEYS_COUNT && (nchunks <= SMALL_FILE_NCHUNKS)) || encrypted)
         return ParseMethod.StreamParse;
     }
-    if(isParallelParseSupported())
+    if(isParallelParseSupported() && (! encrypted))
       return ParseMethod.DistributedParse;
     throw H2O.unimpl();
   }

--- a/h2o-core/src/main/java/water/parser/ParserInfo.java
+++ b/h2o-core/src/main/java/water/parser/ParserInfo.java
@@ -56,12 +56,12 @@ public class ParserInfo extends Iced<ParserInfo> {
   /*
   localSetup.disableParallelParse ||
    */
-  public ParseMethod parseMethod(int nfiles, int nchunks, boolean encrypted){
+  public ParseMethod parseMethod(int nfiles, int nchunks){
     if(isStreamParseSupported()) {
-      if (!isParallelParseSupported() || (nfiles > TOO_MANY_KEYS_COUNT && (nchunks <= SMALL_FILE_NCHUNKS)) || encrypted)
+      if (!isParallelParseSupported() || (nfiles > TOO_MANY_KEYS_COUNT && (nchunks <= SMALL_FILE_NCHUNKS)))
         return ParseMethod.StreamParse;
     }
-    if(isParallelParseSupported() && (! encrypted))
+    if(isParallelParseSupported())
       return ParseMethod.DistributedParse;
     throw H2O.unimpl();
   }

--- a/h2o-core/src/test/java/water/parser/ParseTestEncrypted.java
+++ b/h2o-core/src/test/java/water/parser/ParseTestEncrypted.java
@@ -33,7 +33,7 @@ public class ParseTestEncrypted extends TestUtil {
   @ClassRule
   public static TemporaryFolder tmp = new TemporaryFolder();
 
-  private static String PLAINTEXT_FILE = "smalldata/airlines/AirlinesTrain.csv";
+  private static String PLAINTEXT_FILE = "smalldata/demos/citibike_20k.csv";
 
   private static String KEYSTORE_TYPE = "JCEKS"; // Note: need to use JCEKS, default JKS cannot store non-private keys!
   private static String MY_CIPHER_SPEC = "AES/ECB/PKCS5Padding";

--- a/h2o-core/src/test/java/water/parser/ParseTestEncrypted.java
+++ b/h2o-core/src/test/java/water/parser/ParseTestEncrypted.java
@@ -1,0 +1,183 @@
+package water.parser;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import water.*;
+import water.api.schemas3.ParseSetupV3;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import water.util.FileUtils;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.security.KeyStore;
+import java.util.Arrays;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class ParseTestEncrypted extends TestUtil {
+
+  @ClassRule
+  public static TemporaryFolder tmp = new TemporaryFolder();
+
+  private static String PLAINTEXT_FILE = "smalldata/airlines/AirlinesTrain.csv";
+
+  private static String KEYSTORE_TYPE = "JCEKS"; // Note: need to use JCEKS, default JKS cannot store non-private keys!
+  private static String MY_CIPHER_SPEC = "AES/ECB/PKCS5Padding";
+  private static char[] MY_PASSWORD = "Password123".toCharArray();
+  private static String MY_KEY_ALIAS = "secretKeyAlias";
+
+  private static File _jks;
+
+  @Parameterized.Parameter
+  public String _encrypted_name;
+
+  @Parameterized.Parameters
+  public static Iterable<? extends Object> data() { return Arrays.asList("encrypted.aes.csv", "encrypted.aes.zip"); };
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SecretKey secretKey = generateSecretKey();
+    // KeyStore
+    _jks = writeKeyStore(secretKey);
+    // Encrypted CSV
+    writeEncrypted(FileUtils.getFile(PLAINTEXT_FILE), tmp.newFile("encrypted.aes.csv"), secretKey);
+    // Encrypted CSV in a Zip
+    writeEncryptedZip(FileUtils.getFile(PLAINTEXT_FILE), tmp.newFile("encrypted.aes.zip"), secretKey);
+
+    TestUtil.stall_till_cloudsize(1);
+  }
+
+  private static SecretKey generateSecretKey() throws Exception {
+    KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+    keyGen.init(128);
+    return keyGen.generateKey();
+  }
+
+  private static File writeKeyStore(SecretKey secretKey) throws Exception {
+    KeyStore ks = KeyStore.getInstance(KEYSTORE_TYPE);
+    ks.load(null);
+    KeyStore.ProtectionParameter protParam = new KeyStore.PasswordProtection(MY_PASSWORD);
+
+    KeyStore.SecretKeyEntry skEntry = new KeyStore.SecretKeyEntry(secretKey);
+    ks.setEntry(MY_KEY_ALIAS, skEntry, protParam);
+
+    File jks = tmp.newFile("mykeystore.jks");
+    FileOutputStream fos = null;
+    try {
+      fos = new FileOutputStream(jks);
+      ks.store(fos, MY_PASSWORD);
+      fos.close();
+    } finally {
+      IOUtils.closeQuietly(fos);
+    }
+    return jks;
+  }
+
+  private static void writeEncrypted(File source, File target, SecretKey secretKey) throws Exception {
+    FileOutputStream fileOut = new FileOutputStream(target);
+    try {
+      encryptFile(source, fileOut, secretKey);
+    } finally {
+      IOUtils.closeQuietly(fileOut);
+    }
+  }
+
+  private static void writeEncryptedZip(File source, File target, SecretKey secretKey) throws Exception {
+    FileOutputStream fileOut = new FileOutputStream(target);
+    try {
+      ZipOutputStream zipOut = new ZipOutputStream(fileOut);
+      ZipEntry ze = new ZipEntry(source.getName());
+      zipOut.putNextEntry(ze);
+      encryptFile(source, zipOut, secretKey);
+      zipOut.closeEntry();
+      zipOut.close();
+    } finally {
+      IOUtils.closeQuietly(fileOut);
+    }
+  }
+
+  private static void encryptFile(File source, OutputStream outputStream, SecretKey secretKey) throws Exception {
+    FileInputStream inputStream = new FileInputStream(source);
+    try {
+      Cipher cipher = Cipher.getInstance(MY_CIPHER_SPEC);
+      cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+
+      byte[] inputBytes = new byte[(int) source.length()];
+      IOUtils.readFully(inputStream, inputBytes);
+      byte[] outputBytes = cipher.doFinal(inputBytes);
+      outputStream.write(outputBytes);
+
+      inputStream.close();
+    } finally {
+      IOUtils.closeQuietly(inputStream);
+    }
+  }
+
+  @Test
+  public void testParseEncrypted() {
+    Scope.enter();
+    try {
+      // 1. Upload the Keystore file
+      Vec jksVec = Scope.track(makeNfsFileVec(_jks.getAbsolutePath()));
+
+      // 2. Set Decryption Tool Parameters
+      DecryptionTool.DecryptionSetup ds = new DecryptionTool.DecryptionSetup();
+      ds._decrypt_tool_id = Key.make("aes_decrypt_tool");
+      ds._keystore_id = jksVec._key;
+      ds._key_alias = MY_KEY_ALIAS;
+      ds._keystore_type = KEYSTORE_TYPE;
+      ds._password = MY_PASSWORD;
+      ds._cipher_spec = MY_CIPHER_SPEC;
+
+      // 3. Instantiate & Install the Decryption Tool into DKV
+      Scope.track_generic(DecryptionTool.make(ds));
+
+      // 4. Load encrypted file into a ByteVec
+      Vec encVec = Scope.track(makeNfsFileVec(new File(tmp.getRoot(), _encrypted_name).getAbsolutePath()));
+
+      // 5. Create Parse Setup with a given Decryption Tool
+      ParseSetup ps = new ParseSetup(new ParseSetupV3());
+      ps._decrypt_tool = "aes_decrypt_tool";
+      ParseSetup guessedSetup = ParseSetup.guessSetup(new Key[]{encVec._key}, ps);
+      assertEquals("aes_decrypt_tool", guessedSetup._decrypt_tool);
+      assertEquals("CSV", guessedSetup._parse_type.name());
+
+      // 6. Parse encrypted dataset
+      Key<Frame> fKey = Key.make("decrypted_frame");
+      Frame decrypted = Scope.track(ParseDataset.parse(fKey, new Key[]{encVec._key}, false, guessedSetup));
+
+      // 7. Compare with source dataset
+      Frame plaintext = Scope.track(parse_test_file(PLAINTEXT_FILE));
+      assertArrayEquals(plaintext._names, decrypted._names);
+      for (String n : plaintext._names) {
+        switch (plaintext.vec(n).get_type_str()) {
+          case "String":
+            assertStringVecEquals(plaintext.vec(n), decrypted.vec(n));
+            break;
+          case "Enum":
+            assertCatVecEquals(plaintext.vec(n), decrypted.vec(n));
+            break;
+          default:
+            assertVecEquals(plaintext.vec(n), decrypted.vec(n), 0.001);
+        }
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
+}


### PR DESCRIPTION
This PR lays the ground work for ingesting encrypted datasets into H2O. Implemented is infrastructure that enables parsing encrypted data using Java API.

This can be further extended and full client API can be added.

Decryption can be used on dataset level (for a particular ParseSetup) or globally.

ParseSetup-level is demonstrated in a unit test.
Global level can be configured by specifying option -decrypt_tool <your desired key> and installing the tool in DKV after H2O starts up.