### PR TITLE
PUBDEV-4868 - glm scoring fix 

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1214,6 +1214,11 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
 
   private GLMScore makeScoringTask(Frame adaptFrm, boolean generatePredictions, Job j){
+    int responseId = adaptFrm.find(_output.responseName());
+    if(responseId >= -1 && adaptFrm.vec(responseId).isBad()) { // remove inserted invalid response
+      adaptFrm = new Frame(adaptFrm.names(),adaptFrm.vecs());
+      adaptFrm.remove(responseId);
+    }
     // Build up the names & domains.
     final boolean computeMetrics = adaptFrm.vec(_output.responseName()) != null && !adaptFrm.vec(_output.responseName()).isBad();
     String [] domain = _output.nclasses()<=1 ? null : !computeMetrics ? _output._domains[_output._domains.length-1] : adaptFrm.lastVec().domain();

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1215,7 +1215,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   private GLMScore makeScoringTask(Frame adaptFrm, boolean generatePredictions, Job j){
     int responseId = adaptFrm.find(_output.responseName());
-    if(responseId >= -1 && adaptFrm.vec(responseId).isBad()) { // remove inserted invalid response
+    if(responseId > -1 && adaptFrm.vec(responseId).isBad()) { // remove inserted invalid response
       adaptFrm = new Frame(adaptFrm.names(),adaptFrm.vecs());
       adaptFrm.remove(responseId);
     }

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -28,8 +28,12 @@ public class GLMTest  extends TestUtil {
 
   public static void testScoring(GLMModel m, Frame fr) {
     Scope.enter();
-    // standard predictions
+    // try scoring without response
     Frame fr2 = new Frame(fr);
+    fr2.remove(m._output.responseName());
+//    Frame preds0 = Scope.track(m.score(fr2));
+//    fr2.add(m._output.responseName(),fr.vec(m._output.responseName()));
+    // standard predictions
     Frame preds = Scope.track(m.score(fr2));
     m.adaptTestForTrain(fr2,true,false);
     fr2.remove(fr2.numCols()-1); // remove response


### PR DESCRIPTION
Wrong handling of missing (replaced by NAs) response, inconsistent counting => AIIOB.

Fixed by removing all NA response prior to GLM scoring, updated test.