### PR TITLE
[PUBDEV-4684] Support of Python 3.6

### DIFF
--- a/h2o-py/h2o/astfun.py
+++ b/h2o-py/h2o/astfun.py
@@ -14,6 +14,9 @@ from h2o.utils.compatibility import *
 from .expr import ExprNode, ASTId
 from . import h2o
 
+#
+# List of supported bytecode instructions.
+#
 BYTECODE_INSTRS = {
     "BINARY_SUBSCR": "cols",  # column slice; could be row slice?
     "UNARY_POSITIVE": "+",
@@ -30,7 +33,19 @@ BYTECODE_INSTRS = {
     "BINARY_AND": "&",
     "BINARY_OR": "|",
     "COMPARE_OP": "",  # some cmp_op
-    "CALL_FUNCTION": "",  # some function call, have nargs in ops list...
+    # Calls a function. argc indicates the number of positional arguments. The positional arguments
+    # are on the stack, with the right-most argument on top. Below the arguments, the function o
+    # bject to call is on the stack. Pops all function arguments, and the function
+    # itself off the stack, and pushes the return value.
+    "CALL_FUNCTION": "",
+    # Calls a function. argc indicates the number of arguments (positional and keyword).
+    # The top element on the stack contains a tuple of keyword argument names.
+    # Below the tuple, keyword arguments are on the stack, in the order corresponding to the tuple.
+    # Below the keyword arguments, the positional arguments are on the stack, with the
+    # right-most parameter on top. Below the arguments, the function object to call is on the stack.
+    # Pops all function arguments, and the function itself off the stack,
+    # and pushes the return value.
+    "CALL_FUNCTION_KW" : "",
 }
 
 
@@ -49,6 +64,9 @@ def is_unary(instr):
 def is_func(instr):
     return "CALL_FUNCTION" == instr
 
+def is_func_kw(instr):
+    return "CALL_FUNCTION_KW" == instr
+
 def is_load_fast(instr):
     return "LOAD_FAST" == instr
 
@@ -61,38 +79,60 @@ def is_load_global(instr):
 def is_return(instr):
     return "RETURN_VALUE" == instr
 
+try:
+    # Python 3
+    from dis import _unpack_opargs
+except ImportError:
+    # Reimplement from Python3 in Python2 syntax
+    def _unpack_opargs(code):
+        extended_arg = 0
+        i = 0
+        n = len(code)
+        while i < n:
+            op = ord(code[i]) if PY2 else code[i]
+            pos = i
+            i += 1
+            if op >= HAVE_ARGUMENT:
+                if PY2:
+                    arg = ord(code[i]) + ord(code[i+1])*256 + extended_arg
+                else: # to support Python version (3,3.5)
+                    arg = code[i] + code[i+1]*256 + extended_arg
+                extended_arg = 0
+                i += 2
+                if op == EXTENDED_ARG:
+                    extended_arg = arg*65536
+            else:
+                arg = None
+            yield (pos, op, arg)
 
-def _bytecode_decompile_lambda(co):
+
+def _disassemble_lambda(co):
     code = co.co_code
-    n = len(code)
-    i = 0
     ops = []
-    while i < n:
-        op = code[i]
-        if PY2:
-            op = ord(op)
+    for offset, op, arg in _unpack_opargs(code):
         args = []
-        i += 1
-        if op >= HAVE_ARGUMENT:
-            oparg = code[i] + code[i + 1] * 256
-            if PY2:
-                oparg = ord(code[i]) + ord(code[i + 1]) * 256
-            i += 2
+        if arg is not None:
             if op in hasconst:
-                args.append(co.co_consts[oparg])  # LOAD_CONST
+                args.append(co.co_consts[arg])  # LOAD_CONST
             elif op in hasname:
-                args.append(co.co_names[oparg])  # LOAD_CONST
+                args.append(co.co_names[arg])  # LOAD_CONST
             elif op in hasjrel:
                 raise ValueError("unimpl: op in hasjrel")
             elif op in haslocal:
-                args.append(co.co_varnames[oparg])  # LOAD_FAST
+                args.append(co.co_varnames[arg])  # LOAD_FAST
             elif op in hascompare:
-                args.append(cmp_op[oparg])  # COMPARE_OP
-            elif is_func(opname[op]):
-                args.append(oparg)  # oparg == nargs(fcn)
+                args.append(cmp_op[arg])  # COMPARE_OP
+            elif is_func(opname[op]) or is_func_kw(opname[op]):
+                args.append(arg)  # oparg == nargs(fcn)
         ops.append([opname[op], args])
-    return _lambda_bytecode_to_ast(co, ops)
 
+    return ops
+
+
+def lambda_to_expr(fun):
+    code = fun.__code__
+    lambda_dis = _disassemble_lambda(code)
+    return _lambda_bytecode_to_ast(code, lambda_dis)
 
 def _lambda_bytecode_to_ast(co, ops):
     # have a stack of ops, read from R->L to get correct oops
@@ -130,7 +170,9 @@ def _opcode_read_arg(start_index, ops, keys):
         elif is_unary(instr):
             return _unop_bc(BYTECODE_INSTRS[instr], return_idx, ops, keys)
         elif is_func(instr):
-            return _func_bc(ops[start_index][1][0], return_idx, ops, keys)
+            return _call_func_bc(ops[start_index][1][0], return_idx, ops, keys)
+        elif is_func_kw(instr):
+            return _call_func_kw_bc(ops[start_index][1][0], return_idx, ops, keys)
         else:
             raise ValueError("unimpl bytecode op: " + instr)
     elif is_load_fast(instr):
@@ -151,10 +193,22 @@ def _unop_bc(op, idx, ops, keys):
     return [ExprNode(op, arg), idx]
 
 
-def _func_bc(nargs, idx, ops, keys):
+def _call_func_bc(nargs, idx, ops, keys):
+    """
+    Implements transformation of CALL_FUNCTION bc inst to Rapids expression.
+    The implementation follows definition of behavior defined in
+    https://docs.python.org/3/library/dis.html
+    
+    :param nargs: number of arguments including keyword and positional arguments
+    :param idx: index of current instruction on the stack
+    :param ops: stack of instructions
+    :param keys:  names of instructions
+    :return: ExprNode representing method call
+    """
     named_args = {}
     unnamed_args = []
     args = []
+    # Extract arguments based on calling convention for CALL_FUNCTION_KW
     while nargs > 0:
         if nargs >= 256:  # named args ( foo(50,True,x=10) ) read first  ( right -> left )
             arg, idx = _opcode_read_arg(idx, ops, keys)
@@ -165,29 +219,12 @@ def _func_bc(nargs, idx, ops, keys):
             arg, idx = _opcode_read_arg(idx, ops, keys)
             unnamed_args.insert(0, arg)
             nargs -= 1
+    # LOAD_ATTR <method_name>: Map call arguments to a call of method on H2OFrame class
     op = ops[idx][1][0]
-    frcls = h2o.H2OFrame
-    if not hasattr(frcls, op):
-        raise ValueError("Unimplemented: op <%s> not bound in H2OFrame" % op)
-    if is_attr(ops[idx][0]):
-        if PY2:
-            argspec = inspect.getargspec(getattr(frcls, op))
-            argnames = argspec.args[1:]
-            argdefs = list(argspec.defaults or [])
-        else:
-            argnames = []
-            argdefs = []
-            for name, param in inspect.signature(getattr(frcls, op)).parameters.items():
-                if name == "self": continue
-                if param.kind == inspect._VAR_KEYWORD: continue
-                argnames.append(name)
-                argdefs.append(param.default)
-        args = unnamed_args + argdefs[len(unnamed_args):]
-        for a in named_args: args[argnames.index(a)] = named_args[a]
-    if op == "ceil": op = "ceiling"
-    if op == "sum" and len(args) > 0 and args[0]: op = "sumNA"
-    if op == "min" and len(args) > 0 and args[0]: op = "minNA"
-    if op == "max" and len(args) > 0 and args[0]: op = "maxNA"
+    args = _get_h2o_frame_method_args(op, named_args, unnamed_args) if is_attr(ops[idx][0]) else []
+    # Map function name to proper rapids name
+    op = _get_func_name(op, args)
+    # Go to next instruction
     idx -= 1
     if is_bytecode_instruction(ops[idx][0]):
         arg, idx = _opcode_read_arg(idx, ops, keys)
@@ -196,6 +233,69 @@ def _func_bc(nargs, idx, ops, keys):
         args.insert(0, _load_fast(ops[idx][1][0]))
         idx -= 1
     return [ExprNode(op, *args), idx]
+
+
+def _call_func_kw_bc(nargs, idx, ops, keys):
+    named_args = {}
+    unnamed_args = []
+    # Implemente calling convetion defined by CALL_FUNCTION_KW
+    # Read tuple of keyword arguments
+    keyword_args = ops[idx][1][0]
+    # Skip the LOAD_CONST tuple
+    idx -= 1
+    # Load keyword arguments from stack
+    for keyword_arg in keyword_args:
+        arg, idx = _opcode_read_arg(idx, ops, keys)
+        named_args[keyword_arg] = arg
+        nargs -= 1
+    # Load positional arguments from stack
+    while nargs > 0:
+        arg, idx = _opcode_read_arg(idx, ops, keys)
+        unnamed_args.insert(0, arg)
+        nargs -= 1
+    # LOAD_ATTR <method_name>: Map call arguments to a call of method on H2OFrame class
+    op = ops[idx][1][0]
+    args = _get_h2o_frame_method_args(op, named_args, unnamed_args) if is_attr(ops[idx][0]) else []
+    # Map function name to proper rapids name
+    op = _get_func_name(op, args)
+    # Go to next instruction
+    idx -= 1
+    if is_bytecode_instruction(ops[idx][0]):
+        arg, idx = _opcode_read_arg(idx, ops, keys)
+        args.insert(0, arg)
+    elif is_load_fast(ops[idx][0]):
+        args.insert(0, _load_fast(ops[idx][1][0]))
+        idx -= 1
+    return [ExprNode(op, *args), idx]
+
+
+def _get_h2o_frame_method_args(op, named_args, unnamed_args):
+    fr_cls = h2o.H2OFrame
+    if not hasattr(fr_cls, op):
+        raise ValueError("Unimplemented: op <%s> not bound in H2OFrame" % op)
+    if PY2:
+        argspec = inspect.getargspec(getattr(fr_cls, op))
+        argnames = argspec.args[1:]
+        argdefs = list(argspec.defaults or [])
+    else:
+        argnames = []
+        argdefs = []
+        for name, param in inspect.signature(getattr(fr_cls, op)).parameters.items():
+            if name == "self": continue
+            if param.kind == inspect._VAR_KEYWORD: continue
+            argnames.append(name)
+            argdefs.append(param.default)
+    args = unnamed_args + argdefs[len(unnamed_args):]
+    for a in named_args: args[argnames.index(a)] = named_args[a]
+    return args
+
+
+def _get_func_name(op, args):
+    if op == "ceil": op = "ceiling"
+    if op == "sum" and len(args) > 0 and args[0]: op = "sumNA"
+    if op == "min" and len(args) > 0 and args[0]: op = "minNA"
+    if op == "max" and len(args) > 0 and args[0]: op = "maxNA"
+    return op
 
 
 def _load_fast(x):

--- a/h2o-py/h2o/astfun.py
+++ b/h2o-py/h2o/astfun.py
@@ -295,6 +295,7 @@ def _get_func_name(op, args):
     if op == "sum" and len(args) > 0 and args[0]: op = "sumNA"
     if op == "min" and len(args) > 0 and args[0]: op = "minNA"
     if op == "max" and len(args) > 0 and args[0]: op = "maxNA"
+    if op == "nacnt": op = "naCnt"
     return op
 
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -3001,11 +3001,12 @@ class H2OFrame(object):
         :param axis: 0 = apply to each column; 1 = apply to each row
         :returns: a new H2OFrame with the results of applying ``fun`` to the current frame.
         """
-        from .astfun import _bytecode_decompile_lambda
+        from .astfun import lambda_to_expr
         assert_is_type(axis, 0, 1)
         assert_is_type(fun, FunctionType)
         assert_satisfies(fun, fun.__name__ == "<lambda>")
-        res = _bytecode_decompile_lambda(fun.__code__)
+        #res = _bytecode_decompile_lambda(fun.__code__)
+        res = lambda_to_expr(fun)
         return H2OFrame._expr(expr=ExprNode("apply", self, 1 + (axis == 0), *res))
 
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -3005,7 +3005,6 @@ class H2OFrame(object):
         assert_is_type(axis, 0, 1)
         assert_is_type(fun, FunctionType)
         assert_satisfies(fun, fun.__name__ == "<lambda>")
-        #res = _bytecode_decompile_lambda(fun.__code__)
         res = lambda_to_expr(fun)
         return H2OFrame._expr(expr=ExprNode("apply", self, 1 + (axis == 0), *res))
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_4672.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_4672.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+from __future__ import absolute_import, division, print_function, unicode_literals
+import h2o
+from tests import pyunit_utils
+import numpy as np
+
+
+def test_4672():
+    # Compute means in numpy
+    width = 4
+    data = data_fixture(100, width)
+    data_means = np.mean(data, axis=0)
+    # Now upload data to H2O and compute means with H2O Rapids lambda
+    fr = h2o.H2OFrame.from_python(data.tolist(), column_names=list("ABCD"))
+    # If this didn't throw an exception in Python 3.6, then we're good.
+    h2o_means = fr.apply(lambda x: x.mean(skipna=False))
+    # Explicitly check that all columns means are equal
+    assert all([abs(data_means[i] - h2o_means[0, i]) < 1e-12 for i in
+                range(0, width)]), "Numpy and H2O column means need to match"
+
+
+def data_fixture(height=100, width=4):
+    return np.random.randn(height, width)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_4672)
+else:
+    test_4672()

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_4673.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_4673.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from __future__ import absolute_import, division, print_function, unicode_literals
+import h2o
+from tests import pyunit_utils
+
+def test_4673():
+    fr = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    # If this didn't throw an exception in Python 3.6, then we're good.
+    print(fr.mean())
+    fr.apply(lambda x: x["class"] + x[0], axis=1).show()
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_4673)
+else:
+    test_4673()

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -20,6 +20,9 @@ def h2o_to_float(h2o, pd):
     return (h2o.astype(float), pd)
 
 
+def pd_to_int(h2o, pd):
+    return (h2o, pd.apply(lambda x: 1 if x else 0))
+
 #
 # List of operators which are usable in lambda expression
 # as parameter of `apply` function.
@@ -61,7 +64,7 @@ OPS_VEC_TO_VEC = {
     "floor" : [lambda col: col.floor(), [0], lambda col: np.floor(col), h2o_to_float],
     "log" : [lambda col: col.log(), [], lambda col: np.log(col), None],
     "select" : [lambda x: x["PSA"], [1], None, None],
-    "select2": [lambda x: x['PSA'] > x['VOL'], [1], None, None],
+    "select2": [lambda x: x['PSA'] > x['VOL'], [1], None, pd_to_int],
     "select3": [lambda x: 1 if x['PSA'] > x['VOL'] else 0, [], None, None]
 }
 

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -11,42 +11,58 @@ from pandas.util.testing import assert_frame_equal
 import numpy as np
 from functools import partial
 
+def h2o_to_float(h2o, pd):
+    """
+    The method transform h2o result into a frame of floats. It is used as assert helper
+    to compare with Pandas results.
+    :return:
+    """
+    return (h2o.astype(float), pd)
+
 
 #
 # List of operators which are usable in lambda expression
 # as parameter of `apply` function.
 #
-# Structure: '<name of op> : [h2o expression, supported axis, corresponding pandas expression or
-#                             None if it is same as h2o expression]
+# Structure: '<name of op> : [h2o expression,
+#                             supported axis,
+#                             corresponding pandas expression or None if it is same as h2o expression,
+#                             assert transformer or None to use default
+#                             ]
 #
+# Note (1): not all operators support all directions.
+#
+# Note (2): some of operators produces differently typed results than Pandas which is used for results
+# validation. Hence, each record can specify transformation before assert is invoked.
 #
 # Operators N:1 - transform a vector to a number
 #
 OPS_VEC_TO_SCALAR = {
-    "mean": [lambda x: x.mean(), [0,1], None],
-    "median": [lambda x: x.median(), [0,1], None],
-    "max": [lambda x: x.max(), [0,1], None],
-    "min": [lambda x: x.min(), [0,1], None],
-    "sd": [lambda x: x.sd(), [0,1], None],
-    "nacnt": [lambda x: x.nacnt(), [0,1], None],
+    "mean": [lambda x: x.mean(), [0,1], None, None],
+    "median": [lambda x: x.median(), [0], None, h2o_to_float],
+    "max": [lambda x: x.max(), [0,1], None, h2o_to_float],
+    "min": [lambda x: x.min(), [0,1], None, h2o_to_float],
+    "sd": [lambda x: x.sd(), [0], lambda x: x.std(), None],
+    "nacnt": [lambda x: x.nacnt(), [0], lambda x: sum(x.isnull()), None],
 }
 
 # Operators N:N - are applied on each element in vector
 OPS_VEC_TO_VEC = {
-    "adhoc-fce" : [lambda col: (col * col - col * 5 * col).abs() - 3.14, [0,1], None],
-    "abs" : [lambda col: col.abs(), [0,1], None],
-    "cos" : [lambda col: col.cos(), [0,1], lambda col: np.cos(col)],
-    "sin" : [lambda col: col.sin(), [0,1], lambda col: np.sin(col)],
-    "cosh" : [lambda col: col.cosh(), [0,1], lambda col: np.cosh(col)],
-    "exp" : [lambda col: col.exp(), [0,1], lambda col: np.exp(col)],
-    "sqrt" : [lambda col: col.sqrt(), [0,1], lambda col: np.sqrt(col)],
-    "tan" : [lambda col: col.tan(), [0,1], lambda col: np.tan(col)],
-    "tanh" : [lambda col: col.tanh(), [0,1], lambda col: np.tanh(col)],
-    "ceil" : [lambda col: col.ceil(), [0,1], lambda col: np.ceil(col)],
-    "floor" : [lambda col: col.floor(), [0,1], lambda col: np.floor(col)],
-    "log" : [lambda col: col.log(), [0,1], lambda col: np.log(col)],
-    "select" : [lambda x: x["PSA"], [1], None],
-    "select2": [lambda x: x['PSA'] > x['VOL'], [1], None]
+    "adhoc-fce" : [lambda col: (col * col - col * 5 * col).abs() - 3.14, [0], None, None],
+    "abs" : [lambda col: col.abs(), [0], None, None],
+    "cos" : [lambda col: col.cos(), [0], lambda col: np.cos(col), None],
+    "sin" : [lambda col: col.sin(), [0], lambda col: np.sin(col), None],
+    "cosh" : [lambda col: col.cosh(), [0], lambda col: np.cosh(col), None],
+    "exp" : [lambda col: col.exp(), [0], lambda col: np.exp(col), None],
+    "sqrt" : [lambda col: col.sqrt(), [0], lambda col: np.sqrt(col), h2o_to_float],
+    "tan" : [lambda col: col.tan(), [0], lambda col: np.tan(col), None],
+    "tanh" : [lambda col: col.tanh(), [0], lambda col: np.tanh(col), h2o_to_float],
+    "ceil" : [lambda col: col.ceil(), [0], lambda col: np.ceil(col), h2o_to_float],
+    "floor" : [lambda col: col.floor(), [0], lambda col: np.floor(col), h2o_to_float],
+    "log" : [lambda col: col.log(), [], lambda col: np.log(col), None],
+    "select" : [lambda x: x["PSA"], [1], None, None],
+    "select2": [lambda x: x['PSA'] > x['VOL'], [1], None, None],
+    "select3": [lambda x: 1 if x['PSA'] > x['VOL'] else 0, [], None, None]
 }
 
 
@@ -62,166 +78,69 @@ def pandas_frame_fixture():
     return pd.read_csv(datafile())
 
 
+def test_ops(fr, pf, ops_map):
+    for axis in range(0,2):
+        tester = partial(test_lambda, fr, pf, axis=axis)
+        for name, op in ops_map.items():
+            fce, supported_axes, pandas_fce, assert_transf = op
+            assert_fce = get_assert_fce_for_axis(axis, assert_transf)
+            op_desc = "Op '{}' (axis={}) ".format(name, axis)
+            sys.stdout.write(op_desc)
+            if axis not in supported_axes:
+                print("UNSUPPORTED")
+            else:
+                tester(fce=fce, pandas_fce=pandas_fce, assert_fce=assert_fce)
+                print("OK")
+
+
 def pyunit_apply_n_to_1_ops():
     # H2O Frame
     fr = h2o_frame_fixture()
     # And Pandas DataFrame
     pf = pandas_frame_fixture()
 
-    for axis in range(0,1):
-        tester = partial(test_lambda, fr, pf, axis=axis)
-        assert_fce = __AXIS_ASSERTS__[axis]
-        for name, op in OPS_VEC_TO_SCALAR.items():
-            fce, supported_axes, pandas_fce = op
-            if axis not in supported_axes:
-                print("Op '{}' does not support axis={}".format(name, axis))
-            else:
-                tester(fce=fce, pandas_fce=pandas_fce, assert_fce=assert_fce)
+    test_ops(fr, pf, OPS_VEC_TO_SCALAR)
 
-def pyunit_apply_on_row(): # axis = 1
+
+def pyunit_apply_n_to_n_ops():
     # H2O Frame
     fr = h2o_frame_fixture()
     # And Pandas DataFrame
     pf = pandas_frame_fixture()
 
-    test = partial(test_lambda, fr, pf, axis=1)
-
-    # Select all rows in PCA column:
-    test(lambda x: x["PSA"],
-         assert_fce=assert_row_equal)
-
-    # Generate logical vector identifying rows where x['PSA'] > x['VOL']
-    test(lambda x: x['PSA'] > x['VOL'],
-         assert_fce=lambda h, p: assert_row_equal(h, p.astype(int)))
+    test_ops(fr, pf, OPS_VEC_TO_VEC)
 
 
-def pyunit_apply_on_row_failing():
-    fr = h2o_frame_fixture()
-    # And Pandas DataFrame
-    pf = pandas_frame_fixture()
-
-    test = partial(test_lambda, fr, pf, axis=1)
-
-    # Generate binary vector identifying rows where x['PSA'] > x['VOL']
-    test(lambda x: 1 if x['PSA'] > x['VOL'] else 0,
-         assert_fce=assert_row_equal)
-
-    #  Error: Expected a Frame but found a class water.rapids.vals.ValRow
-    test(lambda x: x.median(),
-         assert_fce=assert_row_equal)
-
-def pyunit_apply_on_column_failing():
-    fr = h2o_frame_fixture()
-    # And Pandas DataFrame
-    pf = pandas_frame_fixture()
-
-    test = partial(test_lambda, fr, pf, axis=0)
-
-    test(lambda x: x.median(),
-         assert_fce=assert_column_equal)
-
-
-def pyunit_apply_on_column(): # axis = 0
-    # H2O Frame
-    fr = h2o_frame_fixture()
-    # And Pandas DataFrame
-    pf = pandas_frame_fixture()
-
-    test = partial(test_lambda, fr, pf, axis=0)
-
-    test(lambda x: x.mean(),
-         assert_fce=assert_column_equal)
-
-def pyunit_apply_on_elements(): # axis does not matter
-    # H2O Frame
-    fr = h2o_frame_fixture()
-    # And Pandas DataFrame
-    pf = pandas_frame_fixture()
-
-    test = partial(test_lambda, fr, pf, axis=0)
-
-    test(fce=lambda col: (col * col - col * 5 * col).abs() - 3.14,
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.abs(),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.cos(),
-         pandas_fce=lambda col: np.cos(col),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.sin(),
-         pandas_fce=lambda col: np.sin(col),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.cosh(),
-         pandas_fce=lambda col: np.cosh(col),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.exp(),
-         pandas_fce=lambda col: np.exp(col),
-         assert_fce=assert_all_equal)
-
-    # Improperly handle infinity
-    #test(fce=lambda col: col.log(),
-    #     pandas_fce=lambda col: np.log(col),
-    #     assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.sqrt(),
-         pandas_fce=lambda col: np.sqrt(col),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.tan(),
-         pandas_fce=lambda col: np.tan(col),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.tanh(),
-         pandas_fce=lambda col: np.tanh(col),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.ceil(),
-         pandas_fce=lambda col: np.ceil(col),
-         assert_fce=assert_all_equal)
-
-    test(fce=lambda col: col.floor(),
-         pandas_fce=lambda col: np.floor(col),
-         assert_fce=assert_all_equal)
-
-
-def test_lambda(h2o_frame, panda_frame, name, fce, axis, assert_fce, pandas_fce=None):
-    h2o_result = h2o_frame.apply(fce, axis=axis)
+def test_lambda(h2o_frame, panda_frame, fce, axis, assert_fce, pandas_fce=None):
+    h2o_result = h2o_frame.apply(fce, axis=axis).as_data_frame()
     pd_result = panda_frame.apply(pandas_fce if pandas_fce else fce, axis=axis)
 
     assert_fce(h2o_result, pd_result)
 
 
+def get_assert_fce_for_axis(axis, assert_transf=None):
+    assert_fce = __AXIS_ASSERTS__[axis]
+    if assert_transf:
+        return lambda h2o,pd: assert_fce(*assert_transf(h2o,pd))
+    else:
+        return assert_fce
+
+
 def assert_row_equal(h2o_result, pd_result):
-    assert_frame_equal(h2o_result.as_data_frame(), pd_result.to_frame(h2o_result.names[0]))
+    if type(pd_result) is pd.core.frame.Series:
+        pd_result = pd_result.to_frame(h2o_result.columns[0])
+    assert_frame_equal(h2o_result, pd_result)
 
 
 def assert_column_equal(h2o_result, pd_result):
-    assert_frame_equal(h2o_result.as_data_frame(), pd_result.to_frame().transpose())
+    if type(pd_result) is pd.core.frame.Series:
+        pd_result = pd_result.to_frame().transpose()
+    assert_frame_equal(h2o_result, pd_result)
 
-
-def assert_all_equal(h2o_result, pd_result):
-    h2o_as_pd = h2o_result.as_data_frame()
-    try:
-        assert_frame_equal(h2o_as_pd, pd_result)
-    except AssertionError as e:
-        print("H2O", h2o_as_pd)
-        print("Pandas", pd_result)
-        raise e
 
 __AXIS_ASSERTS__ = { 0: assert_column_equal, 1: assert_row_equal}
 
-__TESTS__ = [pyunit_apply_on_column, pyunit_apply_on_row]
-__TESTS__ = [pyunit_apply_on_row]
-__TESTS__ = [pyunit_apply_on_elements]
-__TESTS__ = [pyunit_apply_on_column, pyunit_apply_on_row, pyunit_apply_on_elements]
-
-__FAILING_TESTS__ = [pyunit_apply_on_row_failing, pyunit_apply_on_column_failing]
-
-__TESTS__ = [pyunit_apply_n_to_1_ops]
+__TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops]
 
 if __name__ == "__main__":
     for func in __TESTS__:

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -2,42 +2,230 @@
 # -*- encoding: utf-8 -*-
 from __future__ import division, print_function
 import sys
-sys.path.insert(1,"../../")
+
+sys.path.insert(1, "../../")
 import h2o
 from tests import pyunit_utils
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
+import numpy as np
+from functools import partial
 
 
-def pyunit_apply():
-    fr = h2o.import_file(pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+#
+# List of operators which are usable in lambda expression
+# as parameter of `apply` function.
+#
+# Structure: '<name of op> : [h2o expression, supported axis, corresponding pandas expression or
+#                             None if it is same as h2o expression]
+#
+#
+# Operators N:1 - transform a vector to a number
+#
+OPS_VEC_TO_SCALAR = {
+    "mean": [lambda x: x.mean(), [0,1], None],
+    "median": [lambda x: x.median(), [0,1], None],
+    "max": [lambda x: x.max(), [0,1], None],
+    "min": [lambda x: x.min(), [0,1], None],
+    "sd": [lambda x: x.sd(), [0,1], None],
+    "nacnt": [lambda x: x.nacnt(), [0,1], None],
+}
 
-    fr.apply(lambda x: x["PSA"], axis=1).show()
-    print()
-    print()
-    fr.apply(lambda x: x['PSA'] > x['VOL'], axis=1).show()
-    print()
-    print(fr.mean())
-    fr.apply(lambda x: x.mean(), axis=0).show()
-    fr.apply(lambda x: x.mean(), axis=1).show()
+# Operators N:N - are applied on each element in vector
+OPS_VEC_TO_VEC = {
+    "adhoc-fce" : [lambda col: (col * col - col * 5 * col).abs() - 3.14, [0,1], None],
+    "abs" : [lambda col: col.abs(), [0,1], None],
+    "cos" : [lambda col: col.cos(), [0,1], lambda col: np.cos(col)],
+    "sin" : [lambda col: col.sin(), [0,1], lambda col: np.sin(col)],
+    "cosh" : [lambda col: col.cosh(), [0,1], lambda col: np.cosh(col)],
+    "exp" : [lambda col: col.exp(), [0,1], lambda col: np.exp(col)],
+    "sqrt" : [lambda col: col.sqrt(), [0,1], lambda col: np.sqrt(col)],
+    "tan" : [lambda col: col.tan(), [0,1], lambda col: np.tan(col)],
+    "tanh" : [lambda col: col.tanh(), [0,1], lambda col: np.tanh(col)],
+    "ceil" : [lambda col: col.ceil(), [0,1], lambda col: np.ceil(col)],
+    "floor" : [lambda col: col.floor(), [0,1], lambda col: np.floor(col)],
+    "log" : [lambda col: col.log(), [0,1], lambda col: np.log(col)],
+    "select" : [lambda x: x["PSA"], [1], None],
+    "select2": [lambda x: x['PSA'] > x['VOL'], [1], None]
+}
 
 
-
-    fr.apply(lambda col: col.abs()).show()
-    fr.apply(lambda col: col.cos()).show()
-    fr.apply(lambda col: col.sin()).show()
-    fr.apply(lambda col: col.ceil()).show()
-    fr.apply(lambda col: col.floor()).show()
-    fr.apply(lambda col: col.cosh()).show()
-    fr.apply(lambda col: col.exp()).show()
-    fr.apply(lambda col: col.log()).show()
-    fr.apply(lambda col: col.sqrt()).show()
-    fr.apply(lambda col: col.tan()).show()
-    fr.apply(lambda col: col.tanh()).show()
-
-    fr.apply(lambda col: (col*col - col*5*col).abs() - 55/col ).show()
+def datafile():
+    return pyunit_utils.locate("smalldata/logreg/prostate.csv")
 
 
+def h2o_frame_fixture():
+    return h2o.import_file(datafile())
+
+
+def pandas_frame_fixture():
+    return pd.read_csv(datafile())
+
+
+def pyunit_apply_n_to_1_ops():
+    # H2O Frame
+    fr = h2o_frame_fixture()
+    # And Pandas DataFrame
+    pf = pandas_frame_fixture()
+
+    for axis in range(0,1):
+        tester = partial(test_lambda, fr, pf, axis=axis)
+        assert_fce = __AXIS_ASSERTS__[axis]
+        for name, op in OPS_VEC_TO_SCALAR.items():
+            fce, supported_axes, pandas_fce = op
+            if axis not in supported_axes:
+                print("Op '{}' does not support axis={}".format(name, axis))
+            else:
+                tester(fce=fce, pandas_fce=pandas_fce, assert_fce=assert_fce)
+
+def pyunit_apply_on_row(): # axis = 1
+    # H2O Frame
+    fr = h2o_frame_fixture()
+    # And Pandas DataFrame
+    pf = pandas_frame_fixture()
+
+    test = partial(test_lambda, fr, pf, axis=1)
+
+    # Select all rows in PCA column:
+    test(lambda x: x["PSA"],
+         assert_fce=assert_row_equal)
+
+    # Generate logical vector identifying rows where x['PSA'] > x['VOL']
+    test(lambda x: x['PSA'] > x['VOL'],
+         assert_fce=lambda h, p: assert_row_equal(h, p.astype(int)))
+
+
+def pyunit_apply_on_row_failing():
+    fr = h2o_frame_fixture()
+    # And Pandas DataFrame
+    pf = pandas_frame_fixture()
+
+    test = partial(test_lambda, fr, pf, axis=1)
+
+    # Generate binary vector identifying rows where x['PSA'] > x['VOL']
+    test(lambda x: 1 if x['PSA'] > x['VOL'] else 0,
+         assert_fce=assert_row_equal)
+
+    #  Error: Expected a Frame but found a class water.rapids.vals.ValRow
+    test(lambda x: x.median(),
+         assert_fce=assert_row_equal)
+
+def pyunit_apply_on_column_failing():
+    fr = h2o_frame_fixture()
+    # And Pandas DataFrame
+    pf = pandas_frame_fixture()
+
+    test = partial(test_lambda, fr, pf, axis=0)
+
+    test(lambda x: x.median(),
+         assert_fce=assert_column_equal)
+
+
+def pyunit_apply_on_column(): # axis = 0
+    # H2O Frame
+    fr = h2o_frame_fixture()
+    # And Pandas DataFrame
+    pf = pandas_frame_fixture()
+
+    test = partial(test_lambda, fr, pf, axis=0)
+
+    test(lambda x: x.mean(),
+         assert_fce=assert_column_equal)
+
+def pyunit_apply_on_elements(): # axis does not matter
+    # H2O Frame
+    fr = h2o_frame_fixture()
+    # And Pandas DataFrame
+    pf = pandas_frame_fixture()
+
+    test = partial(test_lambda, fr, pf, axis=0)
+
+    test(fce=lambda col: (col * col - col * 5 * col).abs() - 3.14,
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.abs(),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.cos(),
+         pandas_fce=lambda col: np.cos(col),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.sin(),
+         pandas_fce=lambda col: np.sin(col),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.cosh(),
+         pandas_fce=lambda col: np.cosh(col),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.exp(),
+         pandas_fce=lambda col: np.exp(col),
+         assert_fce=assert_all_equal)
+
+    # Improperly handle infinity
+    #test(fce=lambda col: col.log(),
+    #     pandas_fce=lambda col: np.log(col),
+    #     assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.sqrt(),
+         pandas_fce=lambda col: np.sqrt(col),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.tan(),
+         pandas_fce=lambda col: np.tan(col),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.tanh(),
+         pandas_fce=lambda col: np.tanh(col),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.ceil(),
+         pandas_fce=lambda col: np.ceil(col),
+         assert_fce=assert_all_equal)
+
+    test(fce=lambda col: col.floor(),
+         pandas_fce=lambda col: np.floor(col),
+         assert_fce=assert_all_equal)
+
+
+def test_lambda(h2o_frame, panda_frame, name, fce, axis, assert_fce, pandas_fce=None):
+    h2o_result = h2o_frame.apply(fce, axis=axis)
+    pd_result = panda_frame.apply(pandas_fce if pandas_fce else fce, axis=axis)
+
+    assert_fce(h2o_result, pd_result)
+
+
+def assert_row_equal(h2o_result, pd_result):
+    assert_frame_equal(h2o_result.as_data_frame(), pd_result.to_frame(h2o_result.names[0]))
+
+
+def assert_column_equal(h2o_result, pd_result):
+    assert_frame_equal(h2o_result.as_data_frame(), pd_result.to_frame().transpose())
+
+
+def assert_all_equal(h2o_result, pd_result):
+    h2o_as_pd = h2o_result.as_data_frame()
+    try:
+        assert_frame_equal(h2o_as_pd, pd_result)
+    except AssertionError as e:
+        print("H2O", h2o_as_pd)
+        print("Pandas", pd_result)
+        raise e
+
+__AXIS_ASSERTS__ = { 0: assert_column_equal, 1: assert_row_equal}
+
+__TESTS__ = [pyunit_apply_on_column, pyunit_apply_on_row]
+__TESTS__ = [pyunit_apply_on_row]
+__TESTS__ = [pyunit_apply_on_elements]
+__TESTS__ = [pyunit_apply_on_column, pyunit_apply_on_row, pyunit_apply_on_elements]
+
+__FAILING_TESTS__ = [pyunit_apply_on_row_failing, pyunit_apply_on_column_failing]
+
+__TESTS__ = [pyunit_apply_n_to_1_ops]
 
 if __name__ == "__main__":
-    pyunit_utils.standalone_test(pyunit_apply)
+    for func in __TESTS__:
+        pyunit_utils.standalone_test(func)
 else:
-    pyunit_apply()
+    for func in __TESTS__:
+        func()

--- a/h2o-py/tests/testdir_munging/pyunit_count_temps.py
+++ b/h2o-py/tests/testdir_munging/pyunit_count_temps.py
@@ -1,13 +1,13 @@
 from __future__ import print_function
 import sys, os
-sys.path.insert(1, os.path.join("..",".."))
+
+sys.path.insert(1, os.path.join("..", ".."))
 import h2o
 from tests import pyunit_utils
 
 
 def date_munge():
     crimes_path = pyunit_utils.locate("smalldata/chicago/chicagoCrimes10k.csv.zip")
-    # crimes_path = "smalldata/chicago/chicagoCrimes10k.csv.zip"
 
     hc = h2o.connection()
     assert hc.session_id  # Make sure the `POST /4/session` call has happened
@@ -18,12 +18,12 @@ def date_munge():
     # POST /3/Parse
     # GET /3/Job/{job_id}  (multiple times)
     # GET /3/Frames/crimes
-    crimes = h2o.import_file(path=crimes_path, destination_frame="crimes")
+    crimes = h2o.import_file(path=crimes_path, destination_frame="xxxx_crimes")
 
     rest1 = hc.requests_count
 
     crimes["Day"] = crimes["Date"].day()
-    crimes["Month"] = crimes["Date"].month() + 1    # Since H2O indexes from 0
+    crimes["Month"] = crimes["Date"].month() + 1  # Since H2O indexes from 0
     crimes["Year"] = crimes["Date"].year() + 1900  # Start of epoch is 1900
     crimes["WeekNum"] = crimes["Date"].week()
     crimes["WeekDay"] = crimes["Date"].dayOfWeek()
@@ -33,7 +33,8 @@ def date_munge():
     crimes["Weekend"] = (crimes["WeekDay"] == "Sun") | (crimes["WeekDay"] == "Sat")
     print("# of REST calls used: %d" % (hc.requests_count - rest1))
 
-    crimes["Season"] = crimes["Month"].cut([0, 2, 5, 7, 10, 12], ["Winter", "Spring", "Summer", "Autumn", "Winter"])
+    crimes["Season"] = crimes["Month"].cut([0, 2, 5, 7, 10, 12],
+                                           ["Winter", "Spring", "Summer", "Autumn", "Winter"])
     print("# of REST calls used: %d" % (hc.requests_count - rest1))
 
     crimes = crimes.drop("Date")
@@ -58,6 +59,7 @@ def date_munge():
     #                           ["Winter" "Spring" "Summer" "Autumn" "Winter"] FALSE TRUE 3) "Season") -3))}
     # GET /3/Frames/py8
     crimes.describe()
+
     print("# of REST calls used: %d" % (hc.requests_count - rest1))
 
     ntmps = pyunit_utils.temp_ctr() - tmps0
@@ -76,7 +78,8 @@ def test_date_munge():
     finally:
         h2o.enable_expr_optimizations(saved_flag)
 
+
 if __name__ == "__main__":
-    pyunit_utils.standalone_test(test_date_munge())
+    pyunit_utils.standalone_test(test_date_munge)
 else:
     test_date_munge()


### PR DESCRIPTION
This change correctly parse Python3+ bytecode using
utilities from the dis package. The missing functionality in Python2 is
reimplemented following Python3+ code.

---

TODO:

- [ ] Tests for multiple python versions via [tox](http://blog.pinaxproject.com/2015/12/08/how-test-against-multiple-python-versions-parallel/) 
- [ ] Documentation and requirements to mention Python 3.6
- [ ] More tests to stress lambda transformation into Rapids expr