### PR TITLE
Fix the way proxy propagates auth headers to H2O Node (avoid duplicates)

### DIFF
--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
@@ -53,7 +53,7 @@ public class JettyProxy extends AbstractHTTPD {
 
     @Override
     protected void customizeExchange(HttpExchange exchange, HttpServletRequest request) {
-      exchange.addRequestHeader("Authorization", _basicAuth);
+      exchange.setRequestHeader("Authorization", _basicAuth);
     }
   }
 


### PR DESCRIPTION
for rel-weierstrass