### PR TITLE
PUBDEV-4885: Verbose option for models fails when nfolds >=2

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -849,9 +849,17 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
       if (keepRunning) {
         Sys.sleep(pollInterval)
         if(verboseModelScoringHistory){
-          cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
-          print(paste0("Model Build is ", job$progress*100, "% done..."))
-          print(tail(h2o.getModel(job$dest$name)@model$scoring_history))
+          tryCatch({
+            cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
+            print(paste0("Model Build is ", job$progress*100, "% done..."))
+          }, error = function(e){
+            print("Model build is starting now...") #Catch 404 with model
+          })
+          tryCatch({
+            print(tail(h2o.getModel(job$dest$name)@model$scoring_history))
+          }, error = function(e){
+            print("Scoring history is not available yet...") #Catch 404 with scoring history. Can occur when nfolds >=2
+          })
         }
       } else {
         if (progressBar) {

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -849,12 +849,8 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
       if (keepRunning) {
         Sys.sleep(pollInterval)
         if(verboseModelScoringHistory){
-          tryCatch({
-            cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
-            print(paste0("Model Build is ", job$progress*100, "% done..."))
-          }, error = function(e){
-            print("Model build is starting now...") #Catch 404 with model
-          })
+          cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
+          print(paste0("Model Build is ", job$progress*100, "% done..."))
           tryCatch({
             print(tail(h2o.getModel(job$dest$name)@model$scoring_history))
           }, error = function(e){

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -851,11 +851,11 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
         if(verboseModelScoringHistory){
           cat(paste0("\nScoring History for Model ",job$dest$name, " at ", Sys.time(),"\n"))
           print(paste0("Model Build is ", job$progress*100, "% done..."))
-          tryCatch({
+          if(!is.null(job$progress_msg)){
             print(tail(h2o.getModel(job$dest$name)@model$scoring_history))
-          }, error = function(e){
+          }else{
             print("Scoring history is not available yet...") #Catch 404 with scoring history. Can occur when nfolds >=2
-          })
+          }
         }
       } else {
         if (progressBar) {


### PR DESCRIPTION
* `verbose` mode for tree/dl models in R api seems to cause a 404 error when `nfolds` >=2, which is most likely due to the polling happening before the server is ready.
* The solution is to wrap the calls in a `tryCatch()`, which is what is done in the Python API.

https://0xdata.atlassian.net/browse/PUBDEV-4885