### PR TITLE
PUBDEV-4881: Doc update in Stacked Ensembles

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/calibrate_frame.rst
+++ b/h2o-docs/src/product/data-science/algo-params/calibrate_frame.rst
@@ -99,27 +99,27 @@ Examples
     # Train an H2O GBM Model with Calibration
     ecology_gbm = H2OGradientBoostingEstimator(ntrees = 10, max_depth = 5, min_rows = 10,
                                                learn_rate = 0.1, distribution = "multinomial",
-                                               weights_column = "weight", calibrate_model = True,
-                                               calibration_frame = calib)
-    ecology_gbm.train(x = predictors, y = "Angaus", training_frame = train)
+                                               calibrate_model = True, calibration_frame = calib)
+    ecology_gbm.train(x = predictors, y = "Angaus", training_frame = train, weights_column = "weight")
 
-    predicted = ecology_gbm.predict(calib)
+    predicted = ecology_gbm.predict(train)
 
     # View the calibrated predictions appended to the original predictions
     predicted
-      predict        p0         p1    cal_p0     cal_p1
-    ---------  --------  ---------  --------  ---------
-            0  0.881607  0.118393   0.925676  0.0743243
-            0  0.917786  0.0822144  0.945076  0.0549236
-            0  0.697753  0.302247   0.706711  0.293289
-            1  0.538659  0.461341   0.367735  0.632265
-            1  0.442108  0.557892   0.197091  0.802909
-            1  0.382415  0.617585   0.125879  0.874121
-            0  0.923423  0.0765771  0.947633  0.0523671
-            0  0.879797  0.120203   0.924555  0.0754445
-            0  0.811017  0.188983   0.868916  0.131084
-            0  0.709102  0.290898   0.727279  0.272721
+      predict        p0         p1     cal_p0     cal_p1
+    ---------  --------  ---------  ---------  ---------
+            1  0.319428  0.680572   0.185613   0.814387
+            0  0         0          0.0274573  0.972543
+            0  0.90577   0.0942296  0.913323   0.0866773
+            0  0.783394  0.216606   0.825601   0.174399
+            0  0.899183  0.100817   0.909852   0.0901482
+            0  0         0          0.0274573  0.972543
+            0  0.909846  0.090154   0.915409   0.0845909
+            1  0.456384  0.543616   0.358169   0.641831
+            0  0         0          0.0274573  0.972543
+            0  0.918923  0.0810765  0.919893   0.0801069
 
-    [256 rows x 5 columns]
+    [744 rows x 5 columns]
+
 
 

--- a/h2o-docs/src/product/data-science/algo-params/y.rst
+++ b/h2o-docs/src/product/data-science/algo-params/y.rst
@@ -1,6 +1,6 @@
 ``y``
 -----
-- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, AutoML, XGBoost
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, Stacked Ensembles, AutoML, XGBoost
 - Hyperparameter: no
 
 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -283,6 +283,8 @@ FAQ
 
   Missing values are interpreted as containing information (i.e., missing for a reason), rather than missing at random. During tree building, split decisions for every node are found by minimizing the loss function and treating missing values as a separate category that can go either left or right.
 
+  **Note**: Unlike in GLM, in DRF numerical values are handled the same way as categorical values. Missing values are not imputed with the mean, as is done by default in GLM.
+
 -  **How does the algorithm handle missing values during testing?**
 
   During scoring, missing values follow the optimal path that was determined for them during training (minimized loss function).

--- a/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/missing_values.rst
@@ -1,7 +1,7 @@
 Missing Values 
 ^^^^^^^^^^^^^^
 
-**Note** Unlike in GLM, in GBM numerical values are handled the same way as categorical values. Missing values are not imputed with the mean, as is done by default in GLM.
+**Note**: Unlike in GLM, in GBM numerical values are handled the same way as categorical values. Missing values are not imputed with the mean, as is done by default in GLM.
 
 **Brief Overview of Missing Values Handling**
 

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -45,7 +45,6 @@ The steps below describe the individual tasks involved in training and testing a
    b. Feed those predictions into the metalearner to generate the ensemble prediction.
 
 
-
 Defining an H2O Stacked Ensemble Model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -55,6 +54,8 @@ Defining an H2O Stacked Ensemble Model
 
 -  `validation_frame <algo-params/validation_frame.html>`__: Specify the dataset used to evaluate the accuracy of the model.
 
+-  `y <algo-params/y.html>`__: (Required) Specify the column to use as the independent variable (response column). The data can be numeric or categorical.
+
 -  **base_models**: Specify a list of model IDs that can be stacked together. Models must have been cross-validated using ``nfolds`` > 1, they all must use the same cross-validation folds, and ``keep_cross_validation_folds`` must be set to True. 
 
   **Notes regarding** ``base_models``: 
@@ -62,6 +63,8 @@ Defining an H2O Stacked Ensemble Model
     - One way to guarantee identical folds across base models is to set ``fold_assignment = "Modulo"`` in all the base models.  It is also possible to get identical folds by setting ``fold_assignment = "Random"`` when the same seed is used in all base models.
 
     - In R, you can specify a list of models in the ``base_models`` parameter. 
+
+-  **keep_levelone_frame**: Keep the level one data frame that's constructed for the metalearning step. This option is disabled by default.
 
 Also in a `future release <https://0xdata.atlassian.net/browse/PUBDEV-3743>`__, there will be an additional **metalearner** parameter which allows for the user to specify the metalearning algorithm used.  Currently, the metalearner is fixed as a default H2O GLM with non-negative weights.
 

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -3,11 +3,7 @@
 Using Flow - H2O's Web UI
 =========================
 
-.. todo:: change the image links all to point to git hub if that's called for
-.. todo:: find all links and change so that they point to the right location
 .. todo:: add section on how to add outside algos to Flows buildModel dropdown menu
-.. todo:: add section on how to access models trained or data imported using R, Python, or Sparkling Water
-.. todo:: add section in Flow explaining how to impute values (if not currently included)
 
 ---------------------------------
 
@@ -812,7 +808,7 @@ types.
 
 -  **nfolds**: (GLM, GBM, DL, DRF) Specify the number of folds for cross-validation.
 
--  **response_column**: (Required for GLM, GBM, DL, DRF, Naïve Bayes) Select the column to use as the independent variable.
+-  **response_column**: (Required for GBM, DRF, Deep Learning, GLM, Naïve-Bayes, Stacked Ensembles, AutoML, XGBoost) Select the column to use as the independent variable.
 
 -  **ignored_columns**: (Optional) Click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
@@ -910,6 +906,8 @@ types.
 -  **max_models**: (AutoML) This option allows the user to specify the maximum number of models to build in an AutoML run. 
 
 -  **max_runtime_secs**: (XGBoost, AutoML) This option controls how long the AutoML run will execute. This value defaults to 3600 seconds.
+
+-  **keep_levelone_frame**: (Stacked Ensembles) Keep the level one data frame that's constructed for the metalearning step. This option is disabled by default.
 
 **Advanced Options**
 


### PR DESCRIPTION
- Added the `keep_levelone_frame` option to the Stacked Ensembles and Flow sections in the User Guide.
Driveby fixes:
- Added `y` to list of options in Stacked Ensembles. (This was missing.)
- Added a note in DRF regarding handling of numeric and categorical missing values.
- In the `calibrate_frame` parameter example, moved the weights column to the model training. It was being ignored in the config. Also updated the predicted output.