### PR TITLE
PUBDEV-4912: Document MOJO support for Deep Learning

### DIFF
--- a/h2o-docs/src/product/howto/MOJO_QuickStart.md
+++ b/h2o-docs/src/product/howto/MOJO_QuickStart.md
@@ -10,7 +10,7 @@ This document describes how to build and implement a MOJO (Model Object, Optimiz
 A MOJO (Model Object, Optimized) is an alternative to H2O's currently available
 [POJO](https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/howto/POJO_QuickStart.md). As with POJOs, H2O allows you to convert models that you build to MOJOs, which can then be deployed for scoring in real time.
 
-**Note**: MOJOs are supported for GBM, DRF, GLM, K-Means, SVM, Word2vec, and XGBoost models only.
+**Note**: MOJOs are supported for Deep Learning, DRF, GBM, GLM, K-Means, SVM, Word2vec, and XGBoost models only.
 
 ## Benefit over POJOs
 

--- a/h2o-docs/src/product/howto/POJO_QuickStart.md
+++ b/h2o-docs/src/product/howto/POJO_QuickStart.md
@@ -104,11 +104,10 @@ The only compilation and runtime dependency for a generated model is the ``h2o-g
 	```
 	
 The following output displays: 
-	
-	```
+
 	Label (aka prediction) is flight departure delayed: YES
 	Class probabilities: 0.4319916897116479,0.5680083102883521
-	```	
+
 
 ## Extracting Models from H2O
 

--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -19,7 +19,7 @@ Users can refer to the following Quick Start files for more information about ge
 
 **Notes**: 
 
-- MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, SVM, Word2vec, and XGBoost models only.
+- MOJOs are supported for Deep Learning, DRF, GBM, GLM, GLRM, K-Means, SVM, Word2vec, and XGBoost models only.
 - POJOs are not supported for XGBoost.
 
 Developers can refer to the the `POJO and MOJO Model Javadoc <http://docs.h2o.ai/h2o/latest-stable/h2o-genmodel/javadoc/index.html>`__.

--- a/h2o-genmodel/src/main/java/overview.html
+++ b/h2o-genmodel/src/main/java/overview.html
@@ -311,7 +311,7 @@ A MOJO (Model Object, Optimized) is an alternative to H2O's currently available 
 POJOs, H2O allows you to convert models that you build to MOJOs, which can then be deployed
 for scoring in real time.
 <p></p>
-<b>Note</b>: MOJOs are supported for DRF, GBM, GLM, GLRM, K-Means, SVM, Word2vec, and XGBoost algorithms only.
+<b>Note</b>: MOJOs are supported for Deep Learning, DRF, GBM, GLM, GLRM, K-Means, SVM, Word2vec, and XGBoost algorithms only.
 
 <h3><u>Benefit of MOJOs over POJOs</u></h3>
 <p></p>


### PR DESCRIPTION
Updated Javadoc, User Guide, and markdown files to include Deep Learning in list of MOJO-supported algorithms.
Driveby fix: Updated syntax in POJO quick start.