### PR TITLE
[PUBDEV-4917] Report only relevant clients ( the ones with the same c…

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -1001,7 +1001,7 @@ public final class AutoBuffer {
   int  getFlag( ) { return getSz(1+2+4+1).get(1+2+4); }
 
   /**
-   * Write UDP into the ByteBuffer with custom port sender's port number
+   * Write UDP into the ByteBuffer with custom sender's port number
    *
    * This method sets the ctrl, port, task.
    * Ready to write more bytes afterwards

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -1001,12 +1001,16 @@ public final class AutoBuffer {
   int  getFlag( ) { return getSz(1+2+4+1).get(1+2+4); }
 
   // Set the ctrl, port, task.  Ready to write more bytes afterwards
-  AutoBuffer putUdp (UDP.udp type) {
+  AutoBuffer putUdp(UDP.udp type, int senderPort){
     assert _bb.position() == 0;
     putSp(_bb.position()+1+2);
     _bb.put    ((byte)type.ordinal());
-    _bb.putChar((char)H2O.H2O_PORT  ); // Outgoing port is always the sender's (me) port
+    _bb.putChar((char)senderPort    );
     return this;
+  }
+
+  AutoBuffer putUdp (UDP.udp type) {
+    return putUdp(type, H2O.H2O_PORT); // Outgoing port is always the sender's (me) port
   }
 
   AutoBuffer putTask(UDP.udp type, int tasknum) {

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -1000,7 +1000,15 @@ public final class AutoBuffer {
   // Get the flag in the next 1 byte
   int  getFlag( ) { return getSz(1+2+4+1).get(1+2+4); }
 
-  // Set the ctrl, port, task.  Ready to write more bytes afterwards
+  /**
+   * Write UDP into the ByteBuffer with custom port sender's port number
+   *
+   * This method sets the ctrl, port, task.
+   * Ready to write more bytes afterwards
+   *
+   * @param type type of the UDP datagram
+   * @param senderPort port of the sender of the datagram
+   */
   AutoBuffer putUdp(UDP.udp type, int senderPort){
     assert _bb.position() == 0;
     putSp(_bb.position()+1+2);
@@ -1009,6 +1017,14 @@ public final class AutoBuffer {
     return this;
   }
 
+  /**
+   * Write UDP into the ByteBuffer with the current node as the sender.
+   *
+   * This method sets the ctrl, port, task.
+   * Ready to write more bytes afterwards
+   *
+   * @param type type of the UDP datagram
+   */
   AutoBuffer putUdp (UDP.udp type) {
     return putUdp(type, H2O.H2O_PORT); // Outgoing port is always the sender's (me) port
   }

--- a/h2o-core/src/main/java/water/UDPClientEvent.java
+++ b/h2o-core/src/main/java/water/UDPClientEvent.java
@@ -6,7 +6,7 @@ import water.util.Log;
  * A simple message which informs cluster about a new client
  * which was connected or about existing client who wants to disconnect.
  * The event is used only in flatfile mode where in case of connecting, it
- * it allows the client to connect to a single node, which will
+ * allows the client to connect to a single node, which will
  * inform a cluster about the client. Hence, the rest of nodes will
  * start ping client with heartbeat, and vice versa.
  */
@@ -15,6 +15,12 @@ public class UDPClientEvent extends UDP {
   @Override
   AutoBuffer call(AutoBuffer ab) {
     // Handle only by non-client nodes
+
+    // Ignore messages from different cloud
+    if(ab._h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash) {
+      return ab;
+    }
+
     if (ab._h2o != H2O.SELF && !H2O.ARGS.client) {
       ClientEvent ce = new ClientEvent().read(ab);
       switch(ce.type){

--- a/h2o-core/src/main/java/water/UDPHeartbeat.java
+++ b/h2o-core/src/main/java/water/UDPHeartbeat.java
@@ -9,7 +9,6 @@ package water;
 class UDPHeartbeat extends UDP {
   @Override AutoBuffer call(AutoBuffer ab) {
     if(ab._h2o != H2O.SELF ) {
-
       // Do not update self-heartbeat object
       // The self-heartbeat is the sole holder of racey cloud-concensus hashes
       // and if we update it here we risk dropping an update.

--- a/h2o-core/src/main/java/water/UDPHeartbeat.java
+++ b/h2o-core/src/main/java/water/UDPHeartbeat.java
@@ -8,14 +8,19 @@ package water;
  */
 class UDPHeartbeat extends UDP {
   @Override AutoBuffer call(AutoBuffer ab) {
-    if( ab._h2o != H2O.SELF ) { // Do not update self-heartbeat object
+    if(ab._h2o != H2O.SELF ) {
+
+      // Do not update self-heartbeat object
       // The self-heartbeat is the sole holder of racey cloud-concensus hashes
       // and if we update it here we risk dropping an update.
       ab._h2o._heartbeat = new HeartBeat().read(ab);
+      if(ab._h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash){
+        return ab;
+      }
       Paxos.doHeartbeat(ab._h2o);
 
       // record clients this node has ever heard off only in multicast mode.
-      // in flatfile mode we can use ClientEvent to discover client nodes
+      // in flatfile mode we re-use ClientEvent to discover client nodes
       if(!H2O.isFlatfileEnabled() && ab._h2o._heartbeat._client){
         H2O.reportClient(ab._h2o);
       }

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -25,8 +25,7 @@ public class UnknownHeartbeatTest extends TestUtil{
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
     AutoBuffer ab = new AutoBuffer(H2O.SELF, H2O.MAX_PRIORITY);
-    ab.put1((byte)UDP.udp.heartbeat.ordinal());
-    ab.put2((char)65400); // put different port number to simulate heartbeat from fake node
+    ab.putUdp(UDP.udp.heartbeat, 65400); // put different port number to simulate heartbeat from fake node
     hb.write(ab);
     ab.close();
 

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -35,7 +35,6 @@ public class UnknownHeartbeatTest extends TestUtil{
     ab.close();
 
     // Verify that we don't have a new client
-    assertEquals(H2O.CLOUD.size(), 1);
     assertEquals(H2O.getClients().size(), 0);
   }
 }

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -26,7 +26,7 @@ public class UnknownHeartbeatTest extends TestUtil{
 
     AutoBuffer ab = new AutoBuffer(H2O.SELF, H2O.MAX_PRIORITY);
     ab.put1((byte)UDP.udp.heartbeat.ordinal());
-    ab.put2((char)65400);
+    ab.put2((char)65400); // put different port name to simulate heartbeat from non-existent node
     hb.write(ab);
     ab.close();
 

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -3,13 +3,6 @@ package water;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.nio.channels.DatagramChannel;
-
 import static org.junit.Assert.assertEquals;
 
 public class UnknownHeartbeatTest extends TestUtil{
@@ -18,7 +11,7 @@ public class UnknownHeartbeatTest extends TestUtil{
   }
 
   @Test
-  public void testIgnoreUnknownHeartBeat() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+  public void testIgnoreUnknownHeartBeat() {
     HeartBeat hb = new HeartBeat();
     hb._cloud_name_hash = 777;
     hb._client = true;

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -24,13 +24,9 @@ public class UnknownHeartbeatTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    AutoBuffer ab = new AutoBuffer(H2O.SELF,H2O.MAX_PRIORITY);
-
-    Method putSpMethod = AutoBuffer.class.getDeclaredMethod("putSp", int.class);
-    putSpMethod.setAccessible(true);
-    putSpMethod.invoke(ab, ab._bb.position()+1+2);
-    ab._bb.put    ((byte)UDP.udp.heartbeat.ordinal());
-    ab._bb.putChar((char)65400);
+    AutoBuffer ab = new AutoBuffer(H2O.SELF, H2O.MAX_PRIORITY);
+    ab.put1((byte)UDP.udp.heartbeat.ordinal());
+    ab.put2((char)65400);
     hb.write(ab);
     ab.close();
 

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -31,6 +31,6 @@ public class UnknownHeartbeatTest extends TestUtil{
     ab.close();
 
     // Verify that we don't have a new client
-    assertEquals(H2O.getClients().size(), 0);
+    assertEquals(0, H2O.getClients().size());
   }
 }

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -1,0 +1,41 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.DatagramChannel;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnknownHeartbeatTest extends TestUtil{
+  @BeforeClass() public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void testIgnoreUnknownHeartBeat() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    HeartBeat hb = new HeartBeat();
+    hb._cloud_name_hash = 777;
+    hb._client = true;
+    hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
+
+    AutoBuffer ab = new AutoBuffer(H2O.SELF,H2O.MAX_PRIORITY);
+
+    Method putSpMethod = AutoBuffer.class.getDeclaredMethod("putSp", int.class);
+    putSpMethod.setAccessible(true);
+    putSpMethod.invoke(ab, ab._bb.position()+1+2);
+    ab._bb.put    ((byte)UDP.udp.heartbeat.ordinal());
+    ab._bb.putChar((char)65400);
+    hb.write(ab);
+    ab.close();
+
+    // Verify that we don't have a new client
+    assertEquals(H2O.CLOUD.size(), 1);
+    assertEquals(H2O.getClients().size(), 0);
+  }
+}

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -26,7 +26,7 @@ public class UnknownHeartbeatTest extends TestUtil{
 
     AutoBuffer ab = new AutoBuffer(H2O.SELF, H2O.MAX_PRIORITY);
     ab.put1((byte)UDP.udp.heartbeat.ordinal());
-    ab.put2((char)65400); // put different port number to simulate heartbeat from non-existent node
+    ab.put2((char)65400); // put different port number to simulate heartbeat from fake node
     hb.write(ab);
     ab.close();
 

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -26,7 +26,7 @@ public class UnknownHeartbeatTest extends TestUtil{
 
     AutoBuffer ab = new AutoBuffer(H2O.SELF, H2O.MAX_PRIORITY);
     ab.put1((byte)UDP.udp.heartbeat.ordinal());
-    ab.put2((char)65400); // put different port name to simulate heartbeat from non-existent node
+    ab.put2((char)65400); // put different port number to simulate heartbeat from non-existent node
     hb.write(ab);
     ab.close();
 


### PR DESCRIPTION
…loud name )

I saw in the logs that the cluster kill was caused by different watchdog then the one which belongs to the current cluster. This change ensures that only relevant clients are reported and thus we can't be affected by different clients ( clients who belong to different cluster)