### PR TITLE
Check to make sure number of models created to be <= rather than == i…

### DIFF
--- a/h2o-r/tests/testdir_algos/gbm/runit_GBMRandomGrid_airlines_large.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBMRandomGrid_airlines_large.R
@@ -68,7 +68,7 @@ gbm.random.grid.test <- function() {
                          nfolds = 5, fold_assignment = 'Modulo',
                          keep_cross_validation_predictions = TRUE)
     print(air.grid)
-    expect_that(length(air.grid@model_ids) == 5, is_true())
+    expect_that(length(air.grid@model_ids) <= 5, is_true())
 
     stacker <- h2o.stackedEnsemble(x = myX, y = "IsDepDelayed", 
                                    training_frame = air.hex,


### PR DESCRIPTION
fix intermittent failure in runit_GBMRandomGrid_airlines_large.R by changing the comparison from == to <=.