### PR TITLE
Reduce pyunit_pubdev_4870_sort_bug.py run time.

### DIFF
--- a/h2o-py/tests/testdir_munging/pyunit_pubdev_4870_sort_bug.py
+++ b/h2o-py/tests/testdir_munging/pyunit_pubdev_4870_sort_bug.py
@@ -8,7 +8,7 @@ def sort():
     df = h2o.import_file(pyunit_utils.locate("smalldata/synthetic/smallIntFloats.csv.zip"))
     sorted_column_indices = [0,1]
     df1 = df.sort(sorted_column_indices).asnumeric()
-    pyunit_utils.check_sorted_2_columns(df1, sorted_column_indices, prob=0.05) # check some rows
+    pyunit_utils.check_sorted_2_columns(df1, sorted_column_indices, prob=0.001) # check some rows
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(sort)


### PR DESCRIPTION
Test took 1850s to complete.  Sorry.  Let's reduce the number of elements compared here.