### PR TITLE
PUBDEV-4949: Download packages required for R

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -671,7 +671,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }<br/>
                     <br/>
                     <em># Next, we download packages that H<sub>2</sub>O depends on.</em><br/>
-                    pkgs &lt;- c("statmod","RCurl","jsonlite")<br/>
+                    pkgs &lt;- c("RCurl","jsonlite")<br/>
                     for (pkg in pkgs) {<br/>
                       if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }<br/>
                     }<br/>

--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -38,14 +38,10 @@ Perform the following steps in R to install H2O. Copy and paste these commands o
 
  ::
 
-	if (! ("methods" %in% rownames(installed.packages()))) { install.packages("methods") }
-	if (! ("statmod" %in% rownames(installed.packages()))) { install.packages("statmod") }
-	if (! ("stats" %in% rownames(installed.packages()))) { install.packages("stats") }
-	if (! ("graphics" %in% rownames(installed.packages()))) { install.packages("graphics") }
-	if (! ("RCurl" %in% rownames(installed.packages()))) { install.packages("RCurl") }
-	if (! ("jsonlite" %in% rownames(installed.packages()))) { install.packages("jsonlite") }
-	if (! ("tools" %in% rownames(installed.packages()))) { install.packages("tools") }
-	if (! ("utils" %in% rownames(installed.packages()))) { install.packages("utils") }
+    pkgs <- c("RCurl","jsonlite")
+    for (pkg in pkgs) {
+      if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
+    }
 
 3. Download and install the H2O package for R.
 


### PR DESCRIPTION
- On the download site for R, removed “statmod” from list of packages to download.
- Update the User Guide “Installing in R” topic to match the download site.