### PR TITLE
PUBDEV-4954: If parser fails to parse a valid Parquet file it is parsed a CSV instead

### DIFF
--- a/h2o-core/src/main/java/water/exceptions/H2OUnsupportedDataFileException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OUnsupportedDataFileException.java
@@ -1,0 +1,19 @@
+package water.exceptions;
+
+import water.util.IcedHashMapGeneric;
+
+/**
+ * Exception thrown by a parser when a file format is recognized but a certain feature used
+ * in the particular data file is not supported (eg. nested structures).
+ */
+public class H2OUnsupportedDataFileException extends H2OAbstractRuntimeException {
+
+  public H2OUnsupportedDataFileException(String message, String dev_message, IcedHashMapGeneric.IcedHashMapStringObject values) {
+    super(message, dev_message, values);
+  }
+
+  public H2OUnsupportedDataFileException(String message, String dev_message) {
+    super(message, dev_message, new IcedHashMapGeneric.IcedHashMapStringObject());
+  }
+
+}

--- a/h2o-core/src/main/java/water/parser/BinaryParserProvider.java
+++ b/h2o-core/src/main/java/water/parser/BinaryParserProvider.java
@@ -1,0 +1,30 @@
+package water.parser;
+
+import water.fvec.ByteVec;
+
+/**
+ * Base class for Binary format parsers that implements 2-phase ParseSetup.
+ */
+public abstract class BinaryParserProvider extends ParserProvider {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public abstract ParseSetup guessInitSetup(ByteVec v, byte[] bits, ParseSetup userSetup);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public abstract ParseSetup guessFinalSetup(ByteVec v, byte[] bits, ParseSetup ps);
+
+  @Override
+  @Deprecated
+  public final ParseSetup guessSetup(ByteVec v, byte[] bits, byte sep, int ncols, boolean singleQuotes, int checkHeader, String[] columnNames, byte[] columnTypes, String[][] domains, String[][] naStrings) {
+    ParseSetup ps = new ParseSetup(null, sep, singleQuotes, checkHeader,
+            ncols, columnNames, columnTypes, domains, naStrings, null);
+    return guessSetup(v, bits, ps);
+  }
+
+}

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -568,16 +568,20 @@ public class ParseSetup extends Iced {
    * @param bits Initial bytes from a parse source
    * @return ParseSetup settings from looking at all files
    */
-  public static ParseSetup guessSetup( ByteVec bv, byte [] bits, ParseSetup userSetup ) {
-    return guessSetup(bv, bits, userSetup._parse_type, userSetup._separator, GUESS_COL_CNT, userSetup._single_quotes, userSetup._check_header, userSetup._column_names, userSetup._column_types, null, null);
-  }
-
-  public static ParseSetup guessSetup(ByteVec bv, byte [] bits, ParserInfo parserType, byte sep, int ncols, boolean singleQuotes, int checkHeader, String[] columnNames, byte[] columnTypes, String[][] domains, String[][] naStrings ) {
-    ParserProvider pp = ParserService.INSTANCE.getByInfo(parserType);
+  public static ParseSetup guessSetup(ByteVec bv, byte [] bits, ParseSetup userSetup) {
+    ParserProvider pp = ParserService.INSTANCE.getByInfo(userSetup._parse_type);
     if (pp != null) {
-      return pp.guessSetup(bv, bits, sep, ncols, singleQuotes, checkHeader, columnNames, columnTypes, domains, naStrings);
+      return pp.guessSetup(bv, bits, userSetup.toInitialSetup());
     }
     throw new ParseDataset.H2OParseException("Cannot determine file type.");
+  }
+
+  /**
+   * Sanitizes a user-provided Parse Setup
+   * @return initial ParseSetup object to be passed to the ParserProvider
+   */
+  private ParseSetup toInitialSetup() {
+    return new ParseSetup(_parse_type, _separator, _single_quotes, _check_header, GUESS_COL_CNT, _column_names, _column_types, null, null, null);
   }
 
   /**

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -92,9 +92,8 @@ public abstract class Parser extends Iced {
   private boolean checkFileNHeader(final InputStream is, final StreamParseWriter dout, StreamData din, int cidx)
           throws IOException {
     byte[] headerBytes = ZipUtil.unzipForHeader(din.getChunkData(cidx), this._setup._chunk_size);
-    ParseSetup ps = ParseSetup.guessSetup(null, headerBytes, GUESS_INFO, ParseSetup.GUESS_SEP,
-            ParseSetup.GUESS_COL_CNT, this._setup._single_quotes, ParseSetup.GUESS_HEADER,
-            null, null, null, null);
+    ParseSetup ps = ParseSetup.guessSetup(null, headerBytes, new ParseSetup(GUESS_INFO, ParseSetup.GUESS_SEP,
+            this._setup._single_quotes, ParseSetup.GUESS_HEADER, ParseSetup.GUESS_COL_CNT, null, null));
     // check to make sure datasets in file belong to the same dataset
     // just check for number for number of columns/separator here.  Ignore the column type, user can force it
     if ((this._setup._number_columns != ps._number_columns) || (this._setup._separator != ps._separator)) {

--- a/h2o-core/src/main/java/water/parser/ParserProvider.java
+++ b/h2o-core/src/main/java/water/parser/ParserProvider.java
@@ -16,9 +16,73 @@ public abstract class ParserProvider {
    */
   public abstract Parser createParser(ParseSetup setup, Key<Job> jobKey);
 
+  /**
+   *
+   * @param v optional ByteVec (can be null if extracting eg. from a compressed file)
+   * @param bits first bytes of the file
+   * @param userSetup user specified setup
+   * @return derived ParseSetup
+   */
+  public final ParseSetup guessSetup(ByteVec v, byte[] bits, ParseSetup userSetup) {
+    return guessSetup_impl(v, bits, userSetup);
+  }
+
+  /**
+   * Actual implementation of the guessSetup method. Should almost never be overridden (the only
+   * exception is the GuessParserProvider).
+   * @param v
+   * @param bits
+   * @param userSetup
+   * @return
+   */
+  protected ParseSetup guessSetup_impl(ByteVec v, byte[] bits, ParseSetup userSetup) {
+    ParseSetup ps = guessInitSetup(v, bits, userSetup);
+    return guessFinalSetup(v, bits, ps);
+  }
+
+  /**
+   * Constructs initial ParseSetup from a given user setup
+   *
+   * Any exception thrown by this method will signal that this ParserProvider doesn't support
+   * the input data.
+   *
+   * Parsers of data formats that provide metadata (eg. a binary file formats like Parquet) should use the
+   * file metadata to identify the parse type and possibly other properties of the ParseSetup
+   * that can be determined just from the metadata itself. The goal should be perform the least amount of operations
+   * to correctly determine the ParseType (any exception means - format is not supported!).
+   *
+   * Note: Some file formats like CSV don't provide any metadata. In that case this method can return the final
+   * ParseSetup.
+   *
+   * @param v optional ByteVec
+   * @param bits first bytes of the file
+   * @param userSetup user specified setup
+   * @return null if this Provider cannot provide a parser for this file, otherwise an instance of ParseSetup
+   * with correct setting of ParseSetup._parse_type
+   */
+  public ParseSetup guessInitSetup(ByteVec v, byte[] bits, ParseSetup userSetup) {
+    return guessSetup(v, bits, userSetup._separator, userSetup._number_columns, userSetup._single_quotes,
+            userSetup._check_header, userSetup._column_names, userSetup._column_types, userSetup._domains, userSetup._na_strings);
+  }
+
+  /**
+   * Finalizes ParseSetup created by {@see guessInitSetup} using data read from a given ByteVec/bits.
+   *
+   * @param v optional ByteVec
+   * @param bits first bytes of the file
+   * @param ps parse setup as created by {@see guessInitSetup}
+   * @return fully initialized ParseSetup
+   */
+  public ParseSetup guessFinalSetup(ByteVec v, byte[] bits, ParseSetup ps) {
+    return ps; // by default assume the setup is already finalized
+  }
+
   /** Returns parser setup of throws exception if input is not recognized */
   // FIXME: should be more flexible
-  public abstract ParseSetup guessSetup(ByteVec v, byte[] bits, byte sep, int ncols, boolean singleQuotes, int checkHeader, String[] columnNames, byte[] columnTypes, String[][] domains, String[][] naStrings );
+  public ParseSetup guessSetup(ByteVec v, byte[] bits, byte sep, int ncols, boolean singleQuotes, int checkHeader, String[] columnNames, byte[] columnTypes, String[][] domains, String[][] naStrings) {
+    throw new UnsupportedOperationException("Not implemented. This method is kept only for backwards compatibility. " +
+            "Override methods guessInitSetup & guessFinalSetup if you are implementing a new parser.");
+  }
 
   /** Create a parser specific setup.
    *

--- a/h2o-core/src/test/java/water/parser/ParserTest2.java
+++ b/h2o-core/src/test/java/water/parser/ParserTest2.java
@@ -81,7 +81,8 @@ public class ParserTest2 extends TestUtil {
                                               ar("'Tomas''s","test2'","test2",null),
                                               ar("last","'line''s","trailing","piece'") };
     Key k = ParserTest.makeByteVec(data);
-    ParseSetup gSetupF = ParseSetup.guessSetup(null, StringUtils.bytesOf(data[0]), CSV_INFO, (byte)',', 4, false/*single quote*/, ParseSetup.NO_HEADER, null, null, null, null);
+
+    ParseSetup gSetupF = ParseSetup.guessSetup(null, StringUtils.bytesOf(data[0]), new ParseSetup(CSV_INFO, (byte)',', false/*single quote*/, 4, ParseSetup.NO_HEADER, null, null));
     gSetupF._column_types = ParseSetup.strToColumnTypes(new String[]{"Enum", "Enum", "Enum", "Enum"});
     Frame frF = ParseDataset.parse(Key.make(), new Key[]{k}, false, gSetupF);
     testParsed(frF,expectFalse);
@@ -89,7 +90,7 @@ public class ParserTest2 extends TestUtil {
     String[][] expectTrue = new String[][] { ar("Tomass,test,first,line", null),
                                              ar("Tomas''stest2","test2"),
                                              ar("last", "lines trailing piece") };
-    ParseSetup gSetupT = ParseSetup.guessSetup(null, StringUtils.bytesOf(data[0]), CSV_INFO, (byte)',', 2, true/*single quote*/, ParseSetup.NO_HEADER, null, null, null, null);
+    ParseSetup gSetupT = ParseSetup.guessSetup(null, StringUtils.bytesOf(data[0]), new ParseSetup(CSV_INFO, (byte)',', true/*single quote*/, 2, ParseSetup.NO_HEADER, null, null));
     gSetupT._column_types = ParseSetup.strToColumnTypes(new String[]{"Enum", "Enum", "Enum", "Enum"});
     Frame frT = ParseDataset.parse(Key.make(), new Key[]{k}, true, gSetupT);
     //testParsed(frT,expectTrue);  // not currently passing

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/org/apache/parquet/hadoop/VecParquetReader.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/org/apache/parquet/hadoop/VecParquetReader.java
@@ -40,6 +40,7 @@ import water.persist.VecDataInputStream;
 import water.util.Log;
 
 import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
 
 import water.persist.VecFileSystem;
@@ -140,6 +141,10 @@ public class VecParquetReader implements Closeable {
         Log.warn("Failed to close Vec data input stream", e);
       }
     }
+  }
+
+  public static ParquetMetadata readFooter(byte[] metadataBytes) {
+    return readFooter(metadataBytes, NO_FILTER);
   }
 
   public static ParquetMetadata readFooter(byte[] metadataBytes, MetadataFilter filter) {

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
@@ -12,7 +12,7 @@ import water.parser.*;
 /**
  * Parquet parser provider.
  */
-public class ParquetParserProvider extends ParserProvider {
+public class ParquetParserProvider extends BinaryParserProvider {
 
   /* Setup for this parser */
   static ParserInfo PARQUET_INFO = new ParserInfo("PARQUET", DefaultParserProviders.MAX_CORE_PRIO + 30, true, false, false);
@@ -28,10 +28,13 @@ public class ParquetParserProvider extends ParserProvider {
   }
 
   @Override
-  public ParseSetup guessSetup(ByteVec vec, byte[] bits, byte sep, int ncols, boolean singleQuotes,
-                               int checkHeader, String[] columnNames, byte[] columnTypes,
-                               String[][] domains, String[][] naStrings) {
-    return ParquetParser.guessSetup(vec, bits);
+  public ParseSetup guessInitSetup(ByteVec v, byte[] bits, ParseSetup userSetup) {
+    return ParquetParser.guessFormatSetup(v, bits);
+  }
+
+  @Override
+  public ParseSetup guessFinalSetup(ByteVec v, byte[] bits, ParseSetup ps) {
+    return ParquetParser.guessDataSetup(v, (ParquetParser.ParquetParseSetup) ps);
   }
 
   @Override


### PR DESCRIPTION
Port to rel-weierstrass