### PR TITLE
Empty try-catch block avoided. Variable names refactored.

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/FolderMojoReaderBackend.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/FolderMojoReaderBackend.java
@@ -5,35 +5,34 @@ import java.io.*;
 /**
  */
 class FolderMojoReaderBackend implements MojoReaderBackend {
-  private String root;
+  private final String rootFolder;
 
   public FolderMojoReaderBackend(String folder) {
-    root = folder;
+    this.rootFolder = folder;
   }
 
   @Override
-  public BufferedReader getTextFile(String filename) throws IOException {
-    File f = new File(root, filename);
-    FileReader fr = new FileReader(f);
-    return new BufferedReader(fr);
+  public BufferedReader getTextFile(final String filename) throws IOException {
+    final File sourceFile = new File(rootFolder, filename);
+    final FileReader sourceFileReader = new FileReader(sourceFile);
+
+    return new BufferedReader(sourceFileReader);
   }
 
   @Override
-  public byte[] getBinaryFile(String filename) throws IOException {
-    File f = new File(root, filename);
-    byte[] out = new byte[(int) f.length()];
-    DataInputStream dis = new DataInputStream(new FileInputStream(f));
-    try {
-      dis.readFully(out);
-      dis.close();
-    } finally {
-      try { dis.close(); } catch (IOException e) { /* ignored */ }
+  public byte[] getBinaryFile(final String filename) throws IOException {
+    final File sourceFile = new File(rootFolder, filename);
+    final byte[] sourceFileBytes = new byte[(int) sourceFile.length()];
+
+    try (final DataInputStream sourceFileDataInputStream =
+                 new DataInputStream(new FileInputStream(sourceFile))) {
+      sourceFileDataInputStream.readFully(sourceFileBytes);
+      return sourceFileBytes;
     }
-    return out;
   }
 
   @Override
-  public boolean exists(String filename) {
-    return new File(root, filename).exists();
+  public boolean exists(final String filename) {
+    return new File(rootFolder, filename).exists();
   }
 }


### PR DESCRIPTION
- Used try-with resources block to avoid empty exception catch block. Try-with-resouces has been introduced in JDK 1.7.
-  Refactored variable names.