### PR TITLE
syncSmalldata pagination bug

### DIFF
--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -72,12 +72,6 @@ def syncData(subdir) {
   while (needMoreData) {
       def remoteFiles = new XmlSlurper().parseText(new URL("https://h2o-public-test-data.s3.amazonaws.com/?marker=$lastKey").getText())
       needMoreData = remoteFiles.IsTruncated == "true"
-      // If no such file appears on the first result page skip to next page
-      if (remoteFiles.Contents.findAll{it.Key =~ subdir}.size() == 0) {
-          lastKey = remoteFiles.Contents.last().Key
-          continue
-      }
-
       remoteFiles.Contents.findAll{it.Key =~ subdir}.each { rfile ->
         def match = false
         def rname = localDestDir + rfile.Key.text().substring(trimLength).replaceAll("/", Matcher.quoteReplacement(File.separator))

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -71,6 +71,10 @@ def syncData(subdir) {
   String lastKey = ""
   while (needMoreData) {
       def remoteFiles = new XmlSlurper().parseText(new URL("https://h2o-public-test-data.s3.amazonaws.com/?marker=$lastKey").getText())
+      if (!remoteFiles.Contents) {
+        break
+      }
+
       needMoreData = remoteFiles.IsTruncated == "true"
       remoteFiles.Contents.findAll{it.Key =~ subdir}.each { rfile ->
         def match = false
@@ -92,7 +96,7 @@ def syncData(subdir) {
           downloadList.add(rfile)
         }
       }
-
+      
       lastKey = remoteFiles.Contents.last().Key
   }
 

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -72,6 +72,12 @@ def syncData(subdir) {
   while (needMoreData) {
       def remoteFiles = new XmlSlurper().parseText(new URL("https://h2o-public-test-data.s3.amazonaws.com/?marker=$lastKey").getText())
       needMoreData = remoteFiles.IsTruncated == "true"
+      // If no such file appears on the first result page skip to next page
+      if (remoteFiles.Contents.findAll{it.Key =~ subdir}.size() == 0) {
+          lastKey = remoteFiles.Contents.last().Key
+          continue
+      }
+
       remoteFiles.Contents.findAll{it.Key =~ subdir}.each { rfile ->
         def match = false
         def rname = localDestDir + rfile.Key.text().substring(trimLength).replaceAll("/", Matcher.quoteReplacement(File.separator))

--- a/gradle/s3sync.gradle
+++ b/gradle/s3sync.gradle
@@ -72,12 +72,6 @@ def syncData(subdir) {
   while (needMoreData) {
       def remoteFiles = new XmlSlurper().parseText(new URL("https://h2o-public-test-data.s3.amazonaws.com/?marker=$lastKey").getText())
       needMoreData = remoteFiles.IsTruncated == "true"
-      // If no such file appears on the first result page skip to next page
-      if (remoteFiles.Contents.findAll{it.Key =~ subdir}.size() == 0) {
-          lastKey = remoteFiles.Contents.last().Key
-          continue
-      }
-
       remoteFiles.Contents.findAll{it.Key =~ subdir}.each { rfile ->
         def match = false
         def rname = localDestDir + rfile.Key.text().substring(trimLength).replaceAll("/", Matcher.quoteReplacement(File.separator))
@@ -97,8 +91,9 @@ def syncData(subdir) {
         if (match == false) {
           downloadList.add(rfile)
         }
-        lastKey = rfile.Key
       }
+
+      lastKey = remoteFiles.Contents.last().Key
   }
 
   println("Going to download ${downloadList.size} files...")


### PR DESCRIPTION
Gradle script contained a bug, which occurred when no positive (smalldata) item was on the truncated list of test datasets. It failed to update [lastKey](https://github.com/h2oai/h2o-3/blob/d869cad60fa165fb1c918d405252083c6344330d/gradle/s3sync.gradle#L71) leading in an infinite loop...