### PR TITLE
PUBDEV-4966: FAQ for switching to a supported Java version

### DIFF
--- a/h2o-docs/src/product/faq/java.rst
+++ b/h2o-docs/src/product/faq/java.rst
@@ -3,65 +3,46 @@ Java
 
 **How do I use H2O with Java?**
 
-There are two ways to use H2O with Java. The simplest way is to call the
-REST API from your Java program to a remote cluster and should meet the
-needs of most users.
+There are two ways to use H2O with Java. The simplest way is to call the REST API from your Java program to a remote cluster and should meet the needs of most users.
 
-You can access the REST API documentation within Flow, or on our
-`documentation site <../rest-api-reference.html>`__.
+You can access the REST API documentation within Flow, or on our `documentation site <../rest-api-reference.html>`__.
 
-Flow, Python, and R all rely on the REST API to run H2O. For example,
-each action in Flow translates into one or more REST API calls. The
-script fragments in the cells in Flow are essentially the payloads for
-the REST API calls. Most R and Python API calls translate into a single
-REST API call.
+Flow, Python, and R all rely on the REST API to run H2O. For example, each action in Flow translates into one or more REST API calls. The script fragments in the cells in Flow are essentially the payloads for the REST API calls. Most R and Python API calls translate into a single REST API call.
 
 To see how the REST API is used with H2O:
 
--  Using Chrome as your internet browser, open the developer tab while
-   viewing the web UI. As you perform tasks, review the network calls
-   made by Flow.
+-  Using Chrome as your internet browser, open the developer tab while viewing the web UI. As you perform tasks, review the network calls made by Flow.
 
--  Write an R program for H2O using the H2O R package that uses
-   ``h2o.startLogging()`` at the beginning. All REST API calls used are
-   logged.
+-  Write an R program for H2O using the H2O R package that uses ``h2o.startLogging()`` at the beginning. All REST API calls used are logged.
 
-The second way to use H2O with Java is to embed H2O within your Java
-application, similar to `Sparkling
-Water <https://github.com/h2oai/sparkling-water/blob/master/DEVEL.rst>`__.
+The second way to use H2O with Java is to embed H2O within your Java application, similar to `Sparkling Water <https://github.com/h2oai/sparkling-water/blob/master/DEVEL.rst>`__.
 
 --------------
 
 **How do I communicate with a remote cluster using the REST API?**
 
-To create a set of bare POJOs for the REST API payloads that can be used
-by JVM REST API clients:
+To create a set of bare POJOs for the REST API payloads that can be used by JVM REST API clients:
 
 1. Clone the sources from GitHub.
 2. Start an H2O instance.
 3. Enter ``% cd py``.
 4. Enter ``% python generate_java_binding.py``.
 
-This script connects to the server, gets all the metadata for the REST
-API schemas, and writes the Java POJOs to
-``{sourcehome}/build/bindings/Java``.
+This script connects to the server, gets all the metadata for the REST API schemas, and writes the Java POJOs to ``{sourcehome}/build/bindings/Java``.
 
 --------------
 
-**I keep getting a message that I need to install Java. I have the
-latest version of Java installed, but I am still getting this message.
-What should I do?**
+**I keep getting a message that I need to install Java. I have a supported version of Java installed, but I am still getting this message. What should I do?**
 
-This error message displays if the ``JAVA_HOME`` environment variable is
-not set correctly. The ``JAVA_HOME`` variable is likely points to Apple
-Java version 6 instead of Oracle Java version 8.
+This error message displays if the ``JAVA_HOME`` environment variable is not set correctly. The ``JAVA_HOME`` variable is likely points to Apple Java version 6 instead of Oracle Java version 8.
 
-If you are running OS X 10.7 or earlier, enter the following in
-Terminal:
-``export JAVA_HOME=/Library/Internet\ Plug-Ins/JavaAppletPlugin.plugin/Contents/Home``
+If you are running OS X 10.7 or earlier, enter the following in Terminal:
 
-If you are running OS X 10.8 or later, modify the launchd.plist by
-entering the following in Terminal:
+::
+
+    export JAVA_HOME=/Library/Internet\ Plug-Ins/JavaAppletPlugin.plugin/Contents/Home``
+
+If you are running OS X 10.8 or later, modify the launchd.plist by entering the following in Terminal:
 
 ::
 
@@ -86,3 +67,33 @@ entering the following in Terminal:
     </dict>
     </plist>
     EOF
+
+--------------
+
+**I recently upgraded to Java 9, and now H2O no longer works. How can I switch to a supported version of Java?**
+
+Java 9 is not yet supported but will be in an upcoming release. In the meantime, you can tell H2O which version of Java you'd like to use by setting the ``JAVA_HOME`` environment variable. 
+
+ **On Mac OS X**
+
+ First, run the following to get the location of a previous version of Java (for example, 1.8).
+
+ ::
+  
+   /usr/libexec/java_home -v 1.8
+
+ This will return the path for Java. For example:
+
+ ::
+
+   /Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home
+
+ Next, add the path to your ``.bash_profile``.
+
+ :: 
+
+   export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home
+
+ **In RStudio**
+
+ In some cases, after you've set your JAVA_HOME environment variable to a supported version, H2O still fails in RStudio. If this is the case, add the path (for example, ``JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home``) to ``~/.Renviron``, and then restart RStudio.

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -23,7 +23,7 @@ At a minimum, we recommend the following for compatibility with H2O:
 
 -  **Languages**: Scala, R, and Python are not required to use H2O unless you want to use H2O in those environments, but Java is always required. Supported versions include:
 
-   -  Java 7 or later. **Note**: Java 9 is not yet released and is not currently supported.
+   -  Java 7 or later. **Note**: Java 9 is released, but is not currently supported. Java 9 support will be added in an upcoming version.
 
       - To build H2O or run H2O tests, the 64-bit JDK is required.
       - To run the H2O binary using either the command line, R, or Python packages, only 64-bit JRE is required.


### PR DESCRIPTION
- Added an entry in FAQ > Java describing how to switch to a supported Java version. This is specifically for Java 9 users.
- Updated the Welcome > Requirements topic to indicate that Java 9 is out, but it’s not supported in H2O.