### PR TITLE
[ITA-27] Use single Jenkinsfile for master and nightly as well. Reorganize jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,12 +2,14 @@
 
 import ai.h2o3.ci.Globals
 
-def SIZE_MEDIUM_LARGE = 'medium-large'
-def SIZE_SMALL = 'small'
-
 def SMOKE_JOBS = [
   [
     stageName: 'Py2.7 Smoke', target: 'test-py-smoke', pythonVersion: '2.7',
+    timeoutValue: 8, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'py',
+    filesToArchive: '**/*.log, **/out.*, **/*py.out.txt, **/java*out.txt, **/*ipynb.out.txt'
+  ],
+  [
+    stageName: 'Py3.5 Smoke', target: 'test-py-smoke', pythonVersion: '3.5',
     timeoutValue: 8, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'py',
     filesToArchive: '**/*.log, **/out.*, **/*py.out.txt, **/java*out.txt, **/*ipynb.out.txt'
   ],
@@ -18,7 +20,7 @@ def SMOKE_JOBS = [
   ]
 ]
 
-def SMALL_JOBS = [
+def MERGE_JOBS = [
   [
     stageName: 'Py2.7 Booklets', target: 'test-py-booklets', pythonVersion: '2.7',
     timeoutValue: 40, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'py',
@@ -63,10 +65,7 @@ def SMALL_JOBS = [
     stageName: 'R3.4 Datatable', target: 'test-r-datatable', rVersion: '3.4.1',
     timeoutValue: 20, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'r', pipInstall: false,
     filesToArchive: '**/results/*, **/*tmp_model*, **/*.log, **/out.*, **/*py.out.txt, **/java*out.txt'
-  ]
-]
-
-def MEDIUM_LARGE_JOBS = [
+  ],
   [
     stageName: 'Py2.7 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '2.7',
     timeoutValue: 90, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'py',
@@ -78,12 +77,20 @@ def MEDIUM_LARGE_JOBS = [
     filesToArchive: '**/*.log, **/out.*, **/*py.out.txt, **/java*out.txt, **/*ipynb.out.txt, h2o-py/tests/testdir_dynamic_tests/testdir_algos/glm/Rsandbox*/*.csv'
   ],
   [
+    stageName: 'R3.4 Medium-large', target: 'test-r-medium-large', rVersion: '3.4.1',
+    timeoutValue: 70, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'r', pipInstall: false,
+    filesToArchive: '**/results/*, **/*tmp_model*, **/*.log, **/out.*, **/*py.out.txt, **/java*out.txt'
+  ]
+]
+
+def NIGHTLY_JOBS = [
+  [
     stageName: 'Py3.6 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.6',
     timeoutValue: 90, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'py',
     filesToArchive: '**/*.log, **/out.*, **/*py.out.txt, **/java*out.txt, **/*ipynb.out.txt, h2o-py/tests/testdir_dynamic_tests/testdir_algos/glm/Rsandbox*/*.csv'
   ],
   [
-    stageName: 'R3.4 Medium-large', target: 'test-r-medium-large', rVersion: '3.4.1',
+    stageName: 'R3.3 Medium-large', target: 'test-r-medium-large', rVersion: '3.3.3',
     timeoutValue: 70, timeoutUnit: 'MINUTES', numToKeep: '25', hasJUnit: true, lang: 'r', pipInstall: false,
     filesToArchive: '**/results/*, **/*tmp_model*, **/*.log, **/out.*, **/*py.out.txt, **/java*out.txt'
   ]
@@ -95,8 +102,7 @@ properties(
           [
             choice(name: 'rVersion', description: 'R version used to compile H2O-3', choices: '3.4.1\n3.3.3\n3.2.5\n3.1.3\n3.0.3'),
             choice(name: 'pythonVersion', description: 'Python version used to compile H2O-3', choices: "3.5\n3.6\n3.7"),
-            string(name: 'customMakefileURL', defaultValue: '', description: 'Makefile used to build and test H2O-3. Leave empty to use docker/Makefile.jenkins from master'),
-            choice(name: 'testsSize', description:'Choose small for smoke and small tests only. Medium-large runs medium-large test as well.', choices: "${SIZE_SMALL}\n${SIZE_MEDIUM_LARGE}")
+            string(name: 'customMakefileURL', defaultValue: '', description: 'Makefile used to build and test H2O-3. Leave empty to use docker/Makefile.jenkins from master')
           ]
       ),
       buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '25', numToKeepStr: ''))
@@ -114,12 +120,16 @@ if (env.CHANGE_BRANCH != null && env.CHANGE_BRANCH != '') {
   cancelPreviousBuilds()
 }
 
+def jobsToRun = MERGE_JOBS
+if (startedByTimer()) {
+  jobsToRun += NIGHTLY_JOBS
+}
+
 node (getRootNodeLabel()) {
   node (Globals.DEFAULT_NODE_LABEL) {
     withDockerEnvironment(customEnv, 4, 'HOURS') {
 
       stage ('Checkout Sources') {
-        currentBuild.displayName = "${params.testsSize} #${currentBuild.id}"
         checkoutH2O()
         setJobDescription()
       }
@@ -158,12 +168,7 @@ node (getRootNodeLabel()) {
     }
   }
   executeInParallel(SMOKE_JOBS, customEnv, params.customMakefileURL)
-
-  def jobs = SMALL_JOBS
-  if (params.testsSize.toLowerCase() == SIZE_MEDIUM_LARGE.toLowerCase()) {
-    jobs += MEDIUM_LARGE_JOBS
-  }
-  executeInParallel(jobs, customEnv, params.customMakefileURL)
+  executeInParallel(jobsToRun, customEnv, params.customMakefileURL)
 }
 
 def executeInParallel(jobs, customEnv, customMakefileURL) {


### PR DESCRIPTION
In case of nightly job, run tests for various versions. In case of job triggered by merge to master, run smaller set of jobs