### PR TITLE
Pubdev 4697 early stop

### DIFF
--- a/h2o-core/src/main/java/hex/ScoreKeeper.java
+++ b/h2o-core/src/main/java/hex/ScoreKeeper.java
@@ -10,6 +10,8 @@ import water.util.MathUtils;
 import java.util.Arrays;
 import java.util.Comparator;
 
+import static hex.ScoreKeeper.StoppingMetric.deviance;
+
 /**
  * Low-weight keeper of scores
  * solely intended for display (either direct or as helper to create scoring history TwoDimTable).
@@ -105,7 +107,7 @@ public class ScoreKeeper extends Iced {
     if (len < 2*k) return false; //need at least k for SMA and another k to tell whether the model got better or not
 
     if (criterion==StoppingMetric.AUTO) {
-      criterion = classification ? StoppingMetric.logloss : StoppingMetric.deviance;
+      criterion = classification ? StoppingMetric.logloss : deviance;
     }
 
     boolean moreIsBetter = moreIsBetter(criterion);
@@ -189,6 +191,9 @@ public class ScoreKeeper extends Iced {
     assert(bestInLastK != Double.MAX_VALUE);
     if (verbose)
       Log.info("Windowed averages (window size " + k + ") of " + what + " " + (k+1) + " " + criterion.toString() + " metrics: " + Arrays.toString(movingAvg));
+
+    if (lastBeforeK==0 && !moreIsBetter && !criterion.equals(deviance)) // deviance: less is better and can be negative
+      return true;
 
     double ratio = bestInLastK / lastBeforeK;
     if (Double.isNaN(ratio)) return false;

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_4697_early_stop_gbm.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_4697_early_stop_gbm.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+import random
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+import numpy as np
+import pandas as pd
+from sklearn import datasets
+
+NUM_SAMPLES = 1000
+NUM_TREES = 5000
+
+# A user has noticed that our early stopping failed for special datasets.  Turns out that there is a bug.
+# For decreasing metrics, when the lastInK drop to zero, this implies that no more improvement is possible and
+# the early stopping should return true instead of false.  Good catch and thank you, Craig Milhiser!
+def generate_baseline_data(include_cat):
+    X, y = datasets.make_friedman1(NUM_SAMPLES, 5, 100, 1)
+
+    # convert  to a binomial
+    prob = 1 / (1 + np.exp(-y))
+    y = np.random.binomial(1, prob)
+
+    print('Event rate = {0:4.4f}'.format(np.sum(y) / NUM_SAMPLES))
+
+    data = np.hstack((y.reshape(-1, 1), X))
+    data = pd.DataFrame(data, columns=['y', 'x0', 'x1', 'x2', 'x3', 'x4'])
+
+    if include_cat is True:
+        data['c'] = data.apply(lambda row: 'A' if row.y == 1 else 'B', axis=1)
+
+    return data
+
+def test_early_stop_gbm():
+    random.seed(1)
+    np.random.seed(1)
+
+    data = generate_baseline_data(include_cat=True)
+    data_hex = h2o.H2OFrame(data,
+                        destination_frame='data_cat',
+                        column_types=['enum', 'real', 'real', 'real',
+                                      'real', 'real', 'enum'])
+
+    frames = data_hex.split_frame([0.8], ['train_cat', 'validate_cat'], seed=1)
+
+    train_it(frames, ['x0', 'x1', 'x2', 'x3', 'x4', 'c'])
+
+def train_it(frames, x):
+    estimator = H2OGradientBoostingEstimator(distribution='bernoulli',
+                                             ntrees=NUM_TREES,
+                                             learn_rate=0.1,
+                                             nfolds=0,
+                                             score_tree_interval=20,
+                                             stopping_rounds=3,
+                                             stopping_tolerance=0.001,
+                                             seed=1)
+    estimator.train(x=x,
+                    y='y',
+                    training_frame=frames[0],
+                    validation_frame=frames[1])
+
+
+    num_trees_trained = (int(estimator.summary()
+                             .as_data_frame()['number_of_trees']
+                             .get_values()[0]))
+    print('num trees trained = {0}'.format(num_trees_trained))
+    assert num_trees_trained < NUM_TREES, "Early stopping is not work."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_early_stop_gbm)
+else:
+    test_early_stop_gbm()


### PR DESCRIPTION
Fixed bug in backend to return true when a metric hits zero (which is the smallest it can get), the early_stop should return true since we can no longer improve on it.