### PR TITLE
PUBDEV-4987: fix any(), all().  (#1616)

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstAll.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstAll.java
@@ -7,6 +7,8 @@ import water.rapids.vals.ValNum;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
 
+import static hex.genmodel.utils.ArrayUtils.isBoolColumn;
+
 /**
  * Bulk AND operation on a scalar or numeric column; NAs count as true.  Returns 0 or 1.
  */
@@ -30,9 +32,15 @@ public class AstAll extends AstPrimitive {
   public ValNum apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
     Val val = stk.track(asts[1].exec(env));
     if (val.isNum()) return new ValNum(val.getNum() == 0 ? 0 : 1);
-    for (Vec vec : val.getFrame().vecs())
-      if (vec.nzCnt() + vec.naCnt() < vec.length())
+    for (Vec vec : val.getFrame().vecs()) {
+      String[] domainV = vec.domain();
+      if (domainV != null && !isBoolColumn(domainV))  // contain domain that are not true/fale levels
+        return new ValNum(0);         // not a boolean column
+      long trueCount = ((domainV != null) && domainV[0].equalsIgnoreCase("true"))
+              ?(vec.length()-vec.nzCnt()):vec.nzCnt()+vec.naCnt();
+      if (trueCount < vec.length())
         return new ValNum(0);   // Some zeros in there somewhere
+    }
     return new ValNum(1);
   }
 }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstAny.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/reducers/AstAny.java
@@ -7,6 +7,8 @@ import water.rapids.vals.ValNum;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
 
+import static hex.genmodel.utils.ArrayUtils.isBoolColumn;
+
 /**
  * Bulk OR operation on boolean column; NAs count as true.  Returns 0 or 1.
  */
@@ -30,9 +32,15 @@ public class AstAny extends AstPrimitive {
   public ValNum apply(Env env, Env.StackHelp stk, AstRoot asts[]) {
     Val val = stk.track(asts[1].exec(env));
     if (val.isNum()) return new ValNum(val.getNum() == 0 ? 0 : 1);
-    for (Vec vec : val.getFrame().vecs())
-      if (vec.nzCnt() + vec.naCnt() > 0)
+    for (Vec vec : val.getFrame().vecs()) {
+      String[] domainV = vec.domain();
+      if (domainV != null && !isBoolColumn(domainV))  // contain domain that are not true/fale levels
+        return new ValNum(0);         // not a boolean column
+      long trueCount = ((domainV != null) && domainV[0].equalsIgnoreCase("true"))
+              ?(vec.length()-vec.nzCnt()):vec.nzCnt()+vec.naCnt();
+      if (trueCount > 0)
         return new ValNum(1);   // Some nonzeros in there somewhere
+    }
     return new ValNum(0);
   }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
@@ -25,6 +25,28 @@ public class ArrayUtils {
     return sum;
   }
 
+  /**
+   * Check to see if a column is a boolean column.  A boolean column should contains only two
+   * levels and the string describing the domains should be true/false
+   * @param domains
+   * @return
+   */
+  public static boolean isBoolColumn(String[] domains) {
+    if (domains != null) {
+      if (domains.length == 2) {  // check domain names to be true/false
+        if (domains[0].equalsIgnoreCase("true") && domains[1].equalsIgnoreCase("false"))
+          return true;
+        else if (domains[1].equalsIgnoreCase("true") && domains[0].equalsIgnoreCase("false"))
+          return true;
+      } else if (domains.length == 1) {
+        if (domains[0].equalsIgnoreCase("true") || domains[0].equalsIgnoreCase("false")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   public static int maxIndex(double[] from, Random rand) {
     assert rand != null;
     int result = 0;

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1118,7 +1118,7 @@ class H2OFrame(object):
 
 
     def any(self):
-        """Return True if any element in the frame is either True or NA."""
+        """Return True if any element in the frame is either True, non-zero or NA."""
         return bool(ExprNode("any", self)._eager_scalar())
 
 
@@ -1128,7 +1128,7 @@ class H2OFrame(object):
 
 
     def all(self):
-        """Return True if every element in the frame is either True or NA."""
+        """Return True if every element in the frame is either True, non-zero or NA."""
         return bool(ExprNode("all", self)._eager_scalar())
 
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_4987_any_all.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_4987_any_all.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+def h2o_H2OFrame_all():
+    """
+    Python API test: h2o.frame.H2OFrame.all(), h2o.frame.H2OFrame.any()
+    """
+    python_lists=[[True, False], [False, True], [True, True], [True, 'NA']]
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, na_strings=['NA']) # contains true and false
+    assert not(h2oframe.all()), "h2o.H2OFrame.all() command is not working." # all elements are true or NA
+    assert h2oframe.any(), "h2o.H2OFrame.any() command is not working." # all elements are true or NA
+    h2o.remove(h2oframe)
+    python_lists=[[True, True], [True, True], [True, True], [True, 'NA']]   # check with one boolean level only
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, na_strings=['NA']) # contains true and false
+    assert h2oframe.all(), "h2o.H2OFrame.all() command is not working." # all elements are true or NA
+    assert h2oframe.any(), "h2o.H2OFrame.any() command is not working." # all elements are true or NA
+    h2o.remove(h2oframe)
+    python_lists=[[False, False], [False, False], [False, False], [False, 'NA']] # check with one boolean level only
+    h2oframe = h2o.H2OFrame(python_obj=python_lists, na_strings=['NA']) # contains true and false
+    assert not(h2oframe.all()), "h2o.H2OFrame.all() command is not working." # all elements are false or NA
+    assert h2oframe.any(), "h2o.H2OFrame.any() command is not working." # all elements are true or NA
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_H2OFrame_all())
+else:
+    h2o_H2OFrame_all()


### PR DESCRIPTION
* PUBDEV-4987: fix any(), all().  Added check to make sure we are dealing with boolean columns.  Next added code to count the number of true elements instead of just counting number of non-zeros.
PUBDEV-4987: fix all, any.  Added pyunit test to verify the fix.

* PUBDEV-4987 fix all, any.  Numerical columns are generated if clients check the condition of a column.