### PR TITLE
[PUBDEV-4988] Don't check H2O client hash-code ( Fix )

### DIFF
--- a/h2o-core/src/test/java/water/ClientJarMD5IgnoreTest.java
+++ b/h2o-core/src/test/java/water/ClientJarMD5IgnoreTest.java
@@ -1,0 +1,50 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+public class ClientJarMD5IgnoreTest extends TestUtil {
+  @BeforeClass() public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void testDontCheckMD5ForClient() {
+    Collection<H2OListenerExtension> listenerExtensions = ExtensionManager.getInstance().getListenerExtensions();
+    NodeLocalEventCollectingListener ext = (NodeLocalEventCollectingListener)listenerExtensions.iterator().next();
+    ext.clear();
+
+    HeartBeat hb = new HeartBeat();
+    hb._cloud_name_hash = H2O.SELF._heartbeat._cloud_name_hash;
+    hb._client = true;
+    byte[] fake_hash = new byte[1];
+    fake_hash[0] = 0;
+    hb._jar_md5 = fake_hash;
+
+    // send client heartbeat with different md5
+    AutoBuffer ab = new AutoBuffer(H2O.SELF, UDP.udp.heartbeat._prior);
+    ab.putUdp(UDP.udp.heartbeat, 65400); // put different port number to simulate heartbeat from fake node
+    hb.write(ab);
+    ab.close();
+
+    // Give it time so the packet can arrive
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    ArrayList<Object[]> client_wrong_md5 = ext.getData("client_wrong_md5");
+    assertEquals(1, client_wrong_md5.size());
+
+    byte[] received_hash= (byte[])client_wrong_md5.get(0)[0];
+    assertArrayEquals(fake_hash, received_hash);
+
+  }
+
+}


### PR DESCRIPTION
this PR fixes this PR https://0xdata.atlassian.net/browse/PUBDEV-4964 . In the original one the jar check is checked inside the condition and therefore this change does not have any effect.

Also wrote test for this behaviour.