### PR TITLE
[PUBDEV-4989] Ignoring additional R CMD check notes

### DIFF
--- a/scripts/validate_r_cmd_check_output.R
+++ b/scripts/validate_r_cmd_check_output.R
@@ -7,6 +7,8 @@ whitelist = list(
   "CRAN incoming feasibility" = c("Maintainer:",
                                   "Checking URLs requires 'libcurl' support in the R build",
                                   "Package has FOSS license, installs .class/.jar but has no 'java' directory",
+                                  "Version contains large components .*",
+                                  "Size of tarball: .* bytes",
                                   "Insufficient package version", # when we check older version of package than current available on CRAN
                                   "Days since last update", # when we submit to CRAN recently
                                   "Number of updates in past 6 months"), # when we submit to CRAN too often

--- a/scripts/validate_r_cmd_check_output.py
+++ b/scripts/validate_r_cmd_check_output.py
@@ -46,6 +46,7 @@ class Check:
             r"^Maintainer:",
             r"^New maintainer:",
             r"^\s*Tom Kraljevic",
+            r"^Version contains large components .*",
             r"^Insufficient package version .*",
             r"^\Days since last update: .*",
             r"^Old maintainer\(s\):",
@@ -76,6 +77,7 @@ class Check:
             r"^ OK",
 
             r"^Package has FOSS license, installs .class/.jar but has no 'java' directory.",
+            r"^Size of tarball: .* bytes",
             r"^\* DONE",
 
             r"^The Date field is over a month old.*",


### PR DESCRIPTION
Ignoring additional R CMD check notes regarding size of tarball and large version components. R 3.4 and possibly R 3.3 complains about them.