### PR TITLE
[ITA-36] Removed docker build target from docker/Makefile.jenkins

### DIFF
--- a/docker/Makefile.jenkins
+++ b/docker/Makefile.jenkins
@@ -3,10 +3,6 @@
 #
 .NOTPARALLEL: all
 
-docker-runtime:
-	@echo "+--Building Runtime Docker Image--+"
-	docker build -t h2o-3-runtime:${DOCKER_VERSION_TAG} -f Dockerfile .
-
 build-h2o-3:
 	@echo "+--Building H2O-3--+"
 	@echo


### PR DESCRIPTION
It's not used and it's not working.