### PR TITLE
PUBDEV-4996: Note that Python 3.6 is not yet supported

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -634,7 +634,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div id="quickstart-py" style="display:none">
                 <h2>Use H<sub>2</sub>O directly from Python</h2>
 
-                <p>1. Prerequisite:    Python 2.7 or 3.5+</p>
+                <p>1. Prerequisite:    Python 2.7.x or 3.5.x</p>
                 <p>2. Install dependencies (prepending with `sudo` if needed):</p>
                  <button class="btn copy_button" id="btnCopy8" data-copied-hint="Copied!" data-clipboard-target='to_copy8'>
               <span class="octicon octicon-clippy"></span>

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -31,7 +31,7 @@ At a minimum, we recommend the following for compatibility with H2O:
 
    -  Scala 2.10 or later
    -  R version 3 or later
-   -  Python 2.7.x or 3.5.x
+   -  Python 2.7.x or 3.5.x. Note that Python 3.6 is not yet supported.
 
 -  **Browser**: An internet browser is required to use H2O's web UI, Flow. Supported versions include the latest version of Chrome, Firefox, Safari, or Internet Explorer.
 


### PR DESCRIPTION
- Changed the “3.5+” to “3.5.x” on the Download site for supported python versions.
- Updated the welcome.rst file to indicate that Python 3.6 is not yet supported.