### PR TITLE
Pubdev 4995

### DIFF
--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -343,6 +343,8 @@ def init_extra_for(algo):
         return """self._parms["_rest_version"] = 3"""
     if algo == "stackedensemble":
         return """self._parms["_rest_version"] = 99"""
+    if algo == "aggregator":
+        return """self._parms["_rest_version"] = 99"""
 
 def class_extra_for(algo):
     if algo == "glm":

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -120,7 +120,7 @@ class H2OEstimator(ModelBase):
         if "__class__" in parms:  # FIXME: hackt for PY3
             del parms["__class__"]
         is_auto_encoder = bool(parms.get("autoencoder"))
-        is_supervised = not(is_auto_encoder or algo in {"pca", "svd", "kmeans", "glrm", "word2vec"})
+        is_supervised = not(is_auto_encoder or algo in {"aggregator", "pca", "svd", "kmeans", "glrm", "word2vec"})
         ncols = training_frame.ncols
         names = training_frame.names
         if is_supervised:
@@ -175,7 +175,7 @@ class H2OEstimator(ModelBase):
 
         # Step 2
         is_auto_encoder = "autoencoder" in parms and parms["autoencoder"]
-        is_unsupervised = is_auto_encoder or self.algo in {"pca", "svd", "kmeans", "glrm", "word2vec"}
+        is_unsupervised = is_auto_encoder or self.algo in {"aggregator", "pca", "svd", "kmeans", "glrm", "word2vec"}
         if is_auto_encoder and y is not None: raise ValueError("y should not be specified for autoencoder.")
         if not is_unsupervised and y is None: raise ValueError("Missing response")
 

--- a/h2o-py/tests/testdir_algos/aggregator/pyunit_cat_encoding.py
+++ b/h2o-py/tests/testdir_algos/aggregator/pyunit_cat_encoding.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""Aggregator categorical encoding test
+
+These tests verify, that `Aggregator` accepts different `categorical_encoding` values.
+"""
+import h2o
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+from h2o.estimators.aggregator import H2OAggregatorEstimator
+
+
+def is_consistent(train_rows, out_frame):
+    """ Check if a number of observations assigned to exemplars is equal to rows in train set
+    """
+    return out_frame.sum(return_frame=True)["counts"].round() == train_rows
+
+
+def correct_num_exemplars(out_frame, **kwargs):
+    tol = kwargs.get('rel_tol_num_exemplars', 0.5)
+    target_exemplars = kwargs.get('target_num_exemplars', 5000)
+    return (1-tol)*target_exemplars <= out_frame.nrows <= (1+tol)*target_exemplars
+
+
+def test_high_cardinality_eigen():
+    df = h2o.create_frame(
+        rows=10000,
+        cols=10,
+        categorical_fraction=0.6,
+        integer_fraction=0,
+        binary_fraction=0,
+        real_range=100,
+        integer_range=100,
+        missing_fraction=0,
+        factors=100,
+        seed=1234
+    )
+    params = {
+        "target_num_exemplars": 1000,
+        "rel_tol_num_exemplars": 0.5,
+        "categorical_encoding": "eigen"
+    }
+    agg = H2OAggregatorEstimator(**params)
+    agg.train(training_frame=df)
+    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
+    out_frame = H2OFrame.get_frame(out_frame_name)
+    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
+    assert correct_num_exemplars(out_frame, **params), "Generated number of exemplars should match target value"
+
+
+def test_high_cardinality_enum():
+    df = h2o.create_frame(
+        rows=10000,
+        cols=10,
+        categorical_fraction=0.6,
+        integer_fraction=0,
+        binary_fraction=0,
+        real_range=100,
+        integer_range=100,
+        missing_fraction=0,
+        factors=100,
+        seed=1234
+    )
+    params = {
+        "target_num_exemplars": 2000,
+        "rel_tol_num_exemplars": 0.5,
+        "categorical_encoding": "enum"
+    }
+    agg = H2OAggregatorEstimator(**params)
+    agg.train(training_frame=df)
+    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
+    out_frame = H2OFrame.get_frame(out_frame_name)
+    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
+    assert correct_num_exemplars(out_frame, **params), "Generated number of exemplars should match target value"
+
+
+def test_low_cardinality_enum_limited():
+    raw_data = [
+        "1|2|A|A",
+        "1|2|A|A",
+        "1|2|A|A",
+        "1|2|A|A",
+        "1|2|A|A",
+        "2|2|A|B",
+        "2|2|A|A",
+        "1|4|A|A",
+        "1|2|B|A",
+        "1|2|B|A",
+        "1|2|A|A",
+        "1|2|A|A",
+        "4|5|C|A",
+        "4|5|D|A",
+        "2|5|D|A",
+        "3|5|E|A",
+        "4|5|F|A",
+        "4|5|G|A",
+        "4|5|H|A",
+        "4|5|I|A",
+        "4|5|J|A",
+        "4|5|K|A",
+        "4|5|L|A",
+        "4|5|M|A",
+        "4|5|N|A",
+        "4|5|O|A",
+        "4|5|P|A"
+    ]
+    raw_data = [el.split("|") for el in raw_data]
+    df = H2OFrame(raw_data)
+    agg = H2OAggregatorEstimator(target_num_exemplars=5, categorical_encoding="enum_limited")
+    agg.train(training_frame=df)
+    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
+    out_frame = H2OFrame.get_frame(out_frame_name)
+    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
+    # from AggregatorTest.java
+    assert out_frame.nrows == 7, "Number of exemplars of this test case should be 7"
+
+
+def test_binary():
+    df = h2o.create_frame(
+        rows=1000,
+        cols=10,
+        categorical_fraction=0.6,
+        integer_fraction=0,
+        binary_fraction=0,
+        real_range=100,
+        integer_range=100,
+        missing_fraction=0.1,
+        factors=5,
+        seed=1234
+    )
+    params = {
+        "target_num_exemplars": 100,
+        "rel_tol_num_exemplars": 0.5,
+        "categorical_encoding": "binary",
+        "transform": "normalize"
+    }
+    agg = H2OAggregatorEstimator(**params)
+    agg.train(training_frame=df)
+    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
+    out_frame = H2OFrame.get_frame(out_frame_name)
+    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
+    assert correct_num_exemplars(out_frame, **params), "Generated number of exemplars should match target value"
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_high_cardinality_eigen)
+    pyunit_utils.standalone_test(test_high_cardinality_enum)
+    pyunit_utils.standalone_test(test_low_cardinality_enum_limited)
+    pyunit_utils.standalone_test(test_binary)
+else:
+    test_high_cardinality_eigen()
+    test_high_cardinality_enum()
+    test_low_cardinality_enum_limited()
+    test_binary()

--- a/h2o-py/tests/testdir_algos/aggregator/pyunit_num_exemplars.py
+++ b/h2o-py/tests/testdir_algos/aggregator/pyunit_num_exemplars.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""Aggregator number of exemplars test
+
+These tests verify, that `Aggregator` Model is producing correct number
+of exemplars on various setup of `target_num_exemplars` and `rel_tol_num_exemplars` parameters
+"""
+import h2o
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+from h2o.estimators.aggregator import H2OAggregatorEstimator
+
+
+def test_num_of_exemplars(target_exemplars, tol):
+    """Test whether number of generated exemplars corresponds to expected number +/- tolerance
+    """
+    df = h2o.create_frame(
+        rows=10000,
+        cols=2,
+        categorical_fraction=0.1,
+        integer_fraction=0.3,
+        real_range=100,
+        seed=1234
+    )
+
+    agg = H2OAggregatorEstimator(target_num_exemplars=target_exemplars, rel_tol_num_exemplars=tol)
+    agg.train(training_frame=df)
+    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
+    out_frame = H2OFrame.get_frame(out_frame_name)
+    assert (1-tol)*target_exemplars <= out_frame.nrows <= (1+tol)*target_exemplars, \
+        "Final number of aggregated exemplars should be in equal to target number +/- tolerance"
+
+
+def test_num_of_examplars_10_95():
+    test_num_of_exemplars(10, 0.95)
+
+
+def test_num_of_examplars_100_5():
+    test_num_of_exemplars(100, 0.5)
+
+
+def test_num_of_examplars_500_3():
+    test_num_of_exemplars(500, 0.3)
+
+
+def test_num_of_examplars_1500_05():
+    test_num_of_exemplars(1500, 0.05)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_num_of_examplars_10_95)
+    pyunit_utils.standalone_test(test_num_of_examplars_100_5)
+    pyunit_utils.standalone_test(test_num_of_examplars_500_3)
+    pyunit_utils.standalone_test(test_num_of_examplars_1500_05)
+else:
+    test_num_of_examplars_10_95()
+    test_num_of_examplars_100_5()
+    test_num_of_examplars_500_3()
+    test_num_of_examplars_1500_05()

--- a/h2o-py/tests/testdir_algos/aggregator/pyunit_parameters.py
+++ b/h2o-py/tests/testdir_algos/aggregator/pyunit_parameters.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+"""Aggregator parameters test
+
+These tests verify, that `Aggregator` can be passed all valid parameters
+"""
+import h2o
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+from h2o.estimators.aggregator import H2OAggregatorEstimator
+
+
+def test_all_params():
+    data_path = pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip")
+    df = h2o.import_file(data_path)
+    params = {
+        "model_id": "agg",
+        "training_frame": df,
+        "response_column": "IsDepDelayed",
+        "ignored_columns": ["UniqueCarrier"],
+        "ignore_const_cols": False,
+        "target_num_exemplars": 500,
+        "rel_tol_num_exemplars": 0.3,
+        "transform": "standardize",
+        "categorical_encoding": "eigen"
+    }
+    try:
+        model = H2OAggregatorEstimator(**params)
+        model.train(training_frame=df)
+    except Exception, err:
+        print(str(err))
+        assert False, "Should not throw error on valid parameters"
+
+
+def test_transform():
+    valid_values = ["none", "standardize", "normalize", "demean", "descale"]
+    df = h2o.create_frame(
+        rows=100,
+        cols=4,
+        categorical_fraction=0.4,
+        integer_fraction=0,
+        binary_fraction=0,
+        real_range=100,
+        integer_range=100,
+        missing_fraction=0,
+        seed=1234
+    )
+    model = H2OAggregatorEstimator(target_num_exemplars=5)
+    try:
+        for val in valid_values:
+            model.transform = val
+            model.train(training_frame=df)
+    except:
+        assert False, "Aggregator model should be able to process all valid transform values"
+
+    # Try with invalid value
+    try:
+        model = H2OAggregatorEstimator(target_num_exemplars=5, transform="some_invalid_value")
+        assert False, "Passing invalid value of transform should throw an error"
+    except:
+        pass
+
+
+def test_cat_encoding():
+    valid_values = [
+        "auto", "enum", "one_hot_internal",
+        "one_hot_explicit", "binary", "eigen",
+        "label_encoder", "enum_limited",
+        # "sort_by_response"    TODO: This is invalid parameter, remove it
+    ]
+    df = h2o.create_frame(
+        rows=100,
+        cols=4,
+        categorical_fraction=0.4,
+        integer_fraction=0,
+        binary_fraction=0,
+        real_range=100,
+        integer_range=100,
+        missing_fraction=0,
+        seed=1234
+    )
+    model = H2OAggregatorEstimator(target_num_exemplars=5)
+    try:
+        for val in valid_values:
+            model.categorical_encoding = val
+            model.train(training_frame=df)
+    except:
+        assert False, "Aggregator model should be able to process all valid categorical_encoding values"
+
+    # Try with invalid value
+    try:
+        model = H2OAggregatorEstimator(target_num_exemplars=5, categorical_encoding="some_invalid_value")
+        assert False, "Passing invalid value of categorical_encoding should throw an error"
+    except:
+        pass
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_all_params)
+    pyunit_utils.standalone_test(test_transform)
+    pyunit_utils.standalone_test(test_cat_encoding)
+else:
+    test_all_params()
+    test_transform()
+    test_cat_encoding()

--- a/h2o-py/tests/testdir_algos/aggregator/pyunit_parameters.py
+++ b/h2o-py/tests/testdir_algos/aggregator/pyunit_parameters.py
@@ -27,8 +27,7 @@ def test_all_params():
     try:
         model = H2OAggregatorEstimator(**params)
         model.train(training_frame=df)
-    except Exception, err:
-        print(str(err))
+    except:
         assert False, "Should not throw error on valid parameters"
 
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_4995.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_4995.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import h2o
+from tests import pyunit_utils
+
+from h2o.estimators.aggregator import H2OAggregatorEstimator
+from h2o.exceptions import H2OResponseError
+
+
+DATASET = pyunit_utils.locate("smalldata/extdata/australia.csv")
+
+
+def test_4995():
+    data = h2o.import_file(DATASET)
+
+    raised = False
+    agg = H2OAggregatorEstimator(model_id="aggregator")
+    try:
+        agg.train(training_frame=data, x="minairtemp", y="maxairtemp")
+    except H2OResponseError:
+        raised = True
+
+    # H2OAggregatorEstimator.train raises error, when requesting wrong API version
+    assert raised is False, "Local and Server versions of AggregatorEstimator should match!"
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_4995)
+else:
+    test_4995()

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_4995.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_4995.py
@@ -18,7 +18,7 @@ def test_4995():
     raised = False
     agg = H2OAggregatorEstimator(model_id="aggregator")
     try:
-        agg.train(training_frame=data, x="minairtemp", y="maxairtemp")
+        agg.train(training_frame=data)
     except H2OResponseError:
         raised = True
 


### PR DESCRIPTION
Well obviously Aggregator uses schema v99 now, so fixed it manually to that version for now.
Maybe we could parse the schema version from REST and include it in bindings.
Also added simple test, which may be more sophisticated, like comparing rest_version used in python API to the one received from server..