### PR TITLE
[PUBDEV-5003] Handle also case where I'm the Client and the md5 shoul…

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1584,7 +1584,7 @@ final public class H2O {
   public final H2ONode[] _memary;
 
   // mapping from a node ip to node index
-  private final HashMap<String, Integer> _node_ip_to_index;
+  public final HashMap<String, Integer> _node_ip_to_index;
   final int _hash;
 
   public H2ONode getNodeByIpPort(String ipPort) {

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1584,7 +1584,7 @@ final public class H2O {
   public final H2ONode[] _memary;
 
   // mapping from a node ip to node index
-  public final HashMap<String, Integer> _node_ip_to_index;
+  private final HashMap<String, Integer> _node_ip_to_index;
   final int _hash;
 
   public H2ONode getNodeByIpPort(String ipPort) {

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -38,7 +38,7 @@ public abstract class Paxos {
   static synchronized int doHeartbeat( H2ONode h2o ) {
     // Kill somebody if the jar files mismatch.  Do not attempt to deal with
     // mismatched jars.
-    if( !h2o._heartbeat._client) {
+    if(!H2O.ARGS.client && !h2o._heartbeat._client) {
       // don't check md5 for client nodes
       if (!h2o._heartbeat.check_jar_md5()) {
         if (H2O.CLOUD.size() > 1) {


### PR DESCRIPTION
…d be ignored

This is follow-up to the previous fix. We forgot to handle the case where I'm the client and checking the jar of incoming nodes which are not the clients. In that case we also need to disable md5 check.

Generally we need to disable md5 skip **from** H2O clients and **on** H2O clients