### PR TITLE
PUBDEV-4931: Updated documentation to show support for Python 3.6

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -634,7 +634,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div id="quickstart-py" style="display:none">
                 <h2>Use H<sub>2</sub>O directly from Python</h2>
 
-                <p>1. Prerequisite:    Python 2.7.x or 3.5.x</p>
+                <p>1. Prerequisite:    Python 2.7.x, 3.5.x, or 3.6.x</p>
                 <p>2. Install dependencies (prepending with `sudo` if needed):</p>
                  <button class="btn copy_button" id="btnCopy8" data-copied-hint="Copied!" data-clipboard-target='to_copy8'>
               <span class="octicon octicon-clippy"></span>

--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -15,8 +15,8 @@ Download and Run
   ::
 
 	cd ~/Downloads
-	unzip h2o-3.10.4.3.zip
-	cd h2o-3.10.4.3
+	unzip h2o-3.14.0.3.zip
+	cd h2o-3.14.0.3.3
 	java -jar h2o.jar
 
 3. Point your browser to http://localhost:54321.
@@ -109,13 +109,13 @@ Run the following commands in a Terminal window to install H2O for Python.
 Install on Anaconda Cloud
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This section describes how to set up and run H2O in an Anaconda Cloud environment. Conda 2.7 and 3.5 repos are supported as are a number of H2O versions. Refer to `https://anaconda.org/h2oai/h2o/files <https://anaconda.org/h2oai/h2o/files>`__ to view a list of available H2O versions.
+This section describes how to set up and run H2O in an Anaconda Cloud environment. Conda 2.7, 3.5, and 3.6 repos are supported as are a number of H2O versions. Refer to `https://anaconda.org/h2oai/h2o/files <https://anaconda.org/h2oai/h2o/files>`__ to view a list of available H2O versions.
 
 Open a terminal window and run the following command to install H2O on the Anaconda Cloud. 
       
    ::
 
-     user$ conda install -c h2oai h2o=3.10.4.3
+     user$ conda install -c h2oai h2o=3.14.0.3
 
 **Note**: The H2O version in the above command should match the version that you want to download. 
 
@@ -126,12 +126,12 @@ Install on Hadoop
 
 1. Go to `http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html <http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html>`__. Click on the **Install on Hadoop** tab, and download H2O for your version of Hadoop. This is a zip file that contains everything you need to get started.
 
-2. Unpack the zip file and launch a 6g instance of H2O. The example below describes how to unpack version 3.10.4.3. Replace this version with the version that you downloaded.
+2. Unpack the zip file and launch a 6g instance of H2O. The example below describes how to unpack version 3.14.0.3. Replace this version with the version that you downloaded.
 
  ::
 
-	unzip h2o-3.10.4.3-*.zip
-	cd h2o-3.10.4.3-*
+	unzip h2o-3.14.0.3-*.zip
+	cd h2o-3.14.0.3-*
 	hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g -output hdfsOutputDirName
 
 3. Point your browser to H2O. (See "Open H2O Flow in your web browser" in the output below.)

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -31,7 +31,7 @@ At a minimum, we recommend the following for compatibility with H2O:
 
    -  Scala 2.10 or later
    -  R version 3 or later
-   -  Python 2.7.x or 3.5.x. Note that Python 3.6 is not yet supported.
+   -  Python 2.7.x, 3.5.x, 3.6.x 
 
 -  **Browser**: An internet browser is required to use H2O's web UI, Flow. Supported versions include the latest version of Chrome, Firefox, Safari, or Internet Explorer.
 
@@ -47,7 +47,7 @@ Additional Requirements
 
   Refer to the :ref:`on-hadoop` section for detailed information.
 
--  **Conda 2.7 or 3.5 repo**: Conda is not required to run H2O unless you want to run H2O on the Anaconda Cloud. Refer to the :ref:`anaconda` section for more information.
+-  **Conda 2.7, 3.5, or 3.6 repo**: Conda is not required to run H2O unless you want to run H2O on the Anaconda Cloud. Refer to the :ref:`anaconda` section for more information.
 
 -  **Spark**: Version 1.6 or 2.0. Spark is only required if you want to run `Sparkling Water <https://github.com/h2oai/sparkling-water>`__.
 
@@ -366,7 +366,7 @@ Pythonistas will be glad to know that H2O now provides support for this popular 
 Anaconda Cloud Users
 ~~~~~~~~~~~~~~~~~~~~
 
-You can run H2O in an Anaconda Cloud environment. Conda 2.7 and 3.5 repos are supported as are a number of H2O versions. Refer to `https://anaconda.org/h2oai/h2o/files <https://anaconda.org/h2oai/h2o/files>`__ to view a list of available H2O versions. Anaconda users can refer to the `Install on Anaconda Cloud <downloading.html#install-on-anaconda-cloud>`__ section for information about installing H2O in an Anaconda Cloud.
+You can run H2O in an Anaconda Cloud environment. Conda 2.7, 3.5, and 3.6 repos are supported as are a number of H2O versions. Refer to `https://anaconda.org/h2oai/h2o/files <https://anaconda.org/h2oai/h2o/files>`__ to view a list of available H2O versions. Anaconda users can refer to the `Install on Anaconda Cloud <downloading.html#install-on-anaconda-cloud>`__ section for information about installing H2O in an Anaconda Cloud.
 
 R Users
 -------
@@ -412,7 +412,7 @@ For Java developers, the following resources will help you create your own custo
 -  `h2o-genmodel (POJO/MOJO) Javadoc <../h2o-genmodel/javadoc/index.html>`_: Provides a step-by-step guide to creating and implementing POJOs or MOJOs in a Java application.
 
 Developers
---------------
+----------
 
 If you're looking to use H2O to help you develop your own apps, the following links will provide helpful references.
 


### PR DESCRIPTION
- The welcome and downloading topics now state support for Python 3.6. This also includes support for the Conda 3.6 repo.
- Updated the Download site to show support for Python 3.6.x