### PR TITLE
PUBDEV-4995: Aggregator python api output_frame

### DIFF
--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -347,6 +347,15 @@ def init_extra_for(algo):
         return """self._parms["_rest_version"] = 99"""
 
 def class_extra_for(algo):
+    if algo == "aggregator":
+        # Add output_frame to model
+        return """
+            @property
+            def output_frame(self):
+                if (self._model_json is not None and
+                    self._model_json.get("output", {}).get("output_frame", {}).get("name") is not None):
+                    out_frame_name = self._model_json["output"]["output_frame"]["name"]
+                    return H2OFrame.get_frame(out_frame_name)"""
     if algo == "glm":
         # Before we were replacing .lambda property with .Lambda. However that violates Python naming conventions for
         # variables, so now we prefer to map that property to .lambda_. The old name remains, for compatibility reasons.

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -348,10 +348,10 @@ def init_extra_for(algo):
 
 def class_extra_for(algo):
     if algo == "aggregator":
-        # Add output_frame to model
+        # Add aggregated_frame to model
         return """
             @property
-            def output_frame(self):
+            def aggregated_frame(self):
                 if (self._model_json is not None and
                     self._model_json.get("output", {}).get("output_frame", {}).get("name") is not None):
                     out_frame_name = self._model_json["output"]["output_frame"]["name"]

--- a/h2o-py/h2o/estimators/aggregator.py
+++ b/h2o-py/h2o/estimators/aggregator.py
@@ -35,6 +35,7 @@ class H2OAggregatorEstimator(H2OEstimator):
                 setattr(self, pname, pvalue)
             else:
                 raise H2OValueError("Unknown parameter %s = %r" % (pname, pvalue))
+        self._parms["_rest_version"] = 99
 
     @property
     def training_frame(self):
@@ -157,3 +158,10 @@ class H2OAggregatorEstimator(H2OEstimator):
         self._parms["categorical_encoding"] = categorical_encoding
 
 
+
+    @property
+    def output_frame(self):
+        if (self._model_json is not None and
+            self._model_json.get("output", {}).get("output_frame", {}).get("name") is not None):
+            out_frame_name = self._model_json["output"]["output_frame"]["name"]
+            return H2OFrame.get_frame(out_frame_name)

--- a/h2o-py/h2o/estimators/aggregator.py
+++ b/h2o-py/h2o/estimators/aggregator.py
@@ -160,7 +160,7 @@ class H2OAggregatorEstimator(H2OEstimator):
 
 
     @property
-    def output_frame(self):
+    def aggregated_frame(self):
         if (self._model_json is not None and
             self._model_json.get("output", {}).get("output_frame", {}).get("name") is not None):
             out_frame_name = self._model_json["output"]["output_frame"]["name"]

--- a/h2o-py/tests/testdir_algos/aggregator/pyunit_cat_encoding.py
+++ b/h2o-py/tests/testdir_algos/aggregator/pyunit_cat_encoding.py
@@ -42,10 +42,10 @@ def test_high_cardinality_eigen():
     }
     agg = H2OAggregatorEstimator(**params)
     agg.train(training_frame=df)
-    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
-    out_frame = H2OFrame.get_frame(out_frame_name)
-    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
-    assert correct_num_exemplars(out_frame, **params), "Generated number of exemplars should match target value"
+    assert agg.aggregated_frame is not None, "Trained model should produce not empty aggregated frame"
+    assert is_consistent(df.nrows, agg.aggregated_frame), "Exemplar counts should sum up to number of training rows"
+    assert correct_num_exemplars(agg.aggregated_frame, **params), \
+        "Generated number of exemplars should match target value"
 
 
 def test_high_cardinality_enum():
@@ -68,10 +68,10 @@ def test_high_cardinality_enum():
     }
     agg = H2OAggregatorEstimator(**params)
     agg.train(training_frame=df)
-    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
-    out_frame = H2OFrame.get_frame(out_frame_name)
-    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
-    assert correct_num_exemplars(out_frame, **params), "Generated number of exemplars should match target value"
+    assert agg.aggregated_frame is not None, "Trained model should produce not empty aggregated frame"
+    assert is_consistent(df.nrows, agg.aggregated_frame), "Exemplar counts should sum up to number of training rows"
+    assert correct_num_exemplars(agg.aggregated_frame, **params), \
+        "Generated number of exemplars should match target value"
 
 
 def test_low_cardinality_enum_limited():
@@ -108,11 +108,10 @@ def test_low_cardinality_enum_limited():
     df = H2OFrame(raw_data)
     agg = H2OAggregatorEstimator(target_num_exemplars=5, categorical_encoding="enum_limited")
     agg.train(training_frame=df)
-    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
-    out_frame = H2OFrame.get_frame(out_frame_name)
-    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
+    assert agg.aggregated_frame is not None, "Trained model should produce not empty aggregated frame"
+    assert is_consistent(df.nrows, agg.aggregated_frame), "Exemplar counts should sum up to number of training rows"
     # from AggregatorTest.java
-    assert out_frame.nrows == 7, "Number of exemplars of this test case should be 7"
+    assert agg.aggregated_frame.nrows == 7, "Number of exemplars of this test case should be 7"
 
 
 def test_binary():
@@ -136,10 +135,11 @@ def test_binary():
     }
     agg = H2OAggregatorEstimator(**params)
     agg.train(training_frame=df)
-    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
-    out_frame = H2OFrame.get_frame(out_frame_name)
-    assert is_consistent(df.nrows, out_frame), "Exemplar counts should sum up to number of training rows"
-    assert correct_num_exemplars(out_frame, **params), "Generated number of exemplars should match target value"
+    assert agg.aggregated_frame is not None, "Trained model should produce not empty aggregated frame"
+    assert is_consistent(df.nrows, agg.aggregated_frame), \
+        "Exemplar counts should sum up to number of training rows"
+    assert correct_num_exemplars(agg.aggregated_frame, **params), \
+        "Generated number of exemplars should match target value"
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_algos/aggregator/pyunit_num_exemplars.py
+++ b/h2o-py/tests/testdir_algos/aggregator/pyunit_num_exemplars.py
@@ -25,9 +25,8 @@ def test_num_of_exemplars(target_exemplars, tol):
 
     agg = H2OAggregatorEstimator(target_num_exemplars=target_exemplars, rel_tol_num_exemplars=tol)
     agg.train(training_frame=df)
-    out_frame_name = agg._model_json["output"]["output_frame"]["name"]
-    out_frame = H2OFrame.get_frame(out_frame_name)
-    assert (1-tol)*target_exemplars <= out_frame.nrows <= (1+tol)*target_exemplars, \
+    assert agg.aggregated_frame is not None, "Trained model should produce not empty aggregated frame"
+    assert (1-tol)*target_exemplars <= agg.aggregated_frame.nrows <= (1+tol)*target_exemplars, \
         "Final number of aggregated exemplars should be in equal to target number +/- tolerance"
 
 


### PR DESCRIPTION
The `H2OAggregatorEstimator` is missing a reference to aggregated frame, so I propose to add it as a readonly property of the model, which returns `None` before training