### PR TITLE
PUBDEV_3567: merge.  

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -667,6 +667,31 @@ public class Frame extends Lockable<Frame> {
     String n=_names[lo]; _names[lo] = _names[hi]; _names[hi] = n;
   }
 
+  /**
+   * Re-order the columns according to the new order specified in newOrder.
+   *
+   * @param newOrder
+   */
+  public void reOrder(int[] newOrder) {
+    assert newOrder.length==_keys.length; // make sure column length match
+    int numCols = _keys.length;
+    Vec tmpvecs[] = vecs().clone();
+    Key<Vec> tmpkeys[] = _keys.clone();
+    String tmpnames[] = _names.clone();
+
+    for (int colIndex = 0; colIndex < numCols; colIndex++) {
+        tmpvecs[colIndex] = _vecs[newOrder[colIndex]];
+        tmpkeys[colIndex] = _keys[newOrder[colIndex]];
+        tmpnames[colIndex] = _names[newOrder[colIndex]];
+    }
+    // copy it back
+    for (int colIndex = 0; colIndex < numCols; colIndex++) {
+      _vecs[colIndex] = tmpvecs[colIndex];
+      _keys[colIndex] = tmpkeys[colIndex];
+      _names[colIndex] = tmpnames[colIndex];
+    }
+  }
+
   /** move the provided columns to be first, in-place. For Merge currently since method='hash' was coded like that */
   public void moveFirst( int cols[] ) {
     boolean colsMoved[] = new boolean[_keys.length];

--- a/h2o-core/src/main/java/water/rapids/RadixCount.java
+++ b/h2o-core/src/main/java/water/rapids/RadixCount.java
@@ -47,11 +47,11 @@ class RadixCount extends MRTask<RadixCount> {
     boolean isIntVal = chk.vec().isCategorical() || chk.vec().isInt();
     // TODO: assert chk instanceof integer or enum; -- but how since many
     // integers (C1,C2 etc)?  Alternatively: chk.getClass().equals(C8Chunk.class)
-    if (!(_isLeft && chk.vec().isCategorical())) {  // for numeric columns
+    if (!(_isLeft && chk.vec().isCategorical())) {  // for numeric columns or to deal with the rite frame during merge
       if (chk.vec().naCnt() == 0) { // no NAs in column
         // There are no NA in this join column; hence branch-free loop. Most
         // common case as should never really have NA in join columns.
-        for (int r = 0; r < chk._len; r++) {
+        for (int r = 0; r < chk._len; r++) {    // note that 0th bucket here is for rows to exclude from merge result
           long ctrVal = isIntVal ?
                   BigInteger.valueOf(chk.at8(r)*_ascending).subtract(_base).add(BigInteger.ONE).shiftRight(_shift).longValue():
                   MathUtils.convertDouble2BigInteger(_ascending*chk.atd(r)).subtract(_base).add(BigInteger.ONE).shiftRight(_shift).longValue();

--- a/h2o-core/src/test/java/water/rapids/RapidsTest.java
+++ b/h2o-core/src/test/java/water/rapids/RapidsTest.java
@@ -351,7 +351,7 @@ public class RapidsTest extends TestUtil {
       r = new Frame(r);
       DKV.put(r);
       System.out.println(r);
-      String x = String.format("(merge %s %s 1 0 [] [] \"auto\")",l._key,r._key);
+      String x = String.format("(merge %s %s 1 0 [] [] \"hash\")",l._key,r._key);
       Val res = Rapids.exec(x);
       f = res.getFrame();
       System.out.println(f);
@@ -581,10 +581,10 @@ public class RapidsTest extends TestUtil {
       exec_str("(rm weather.hex)",ses);
 
       // nary_op_37 = merge( X Y ); Vecs in X & nary_op_37 shared
-      exec_str("(tmp= nary_op_37 (merge subset_35 census.hex TRUE FALSE [] [] \"auto\"))", ses);
+      exec_str("(tmp= nary_op_37 (merge subset_35 census.hex TRUE FALSE [] [] \"hash\"))", ses);
 
       // nary_op_38 = merge( nary_op_37 subset_36_2); Vecs in nary_op_38 and nary_pop_37 and X shared
-      exec_str("(tmp= subset_41 (rows (tmp= nary_op_38 (merge nary_op_37 subset_36_2 TRUE FALSE [] [] \"auto\")) (tmp= binary_op_40 (<= (tmp= nary_op_39 (h2o.runif nary_op_38 30792152736.5179)) 0.8))))", ses);
+      exec_str("(tmp= subset_41 (rows (tmp= nary_op_38 (merge nary_op_37 subset_36_2 TRUE FALSE [] [] \"hash\")) (tmp= binary_op_40 (<= (tmp= nary_op_39 (h2o.runif nary_op_38 30792152736.5179)) 0.8))))", ses);
 
       // Standard "head of 10 rows" pattern for printing
       exec_str("(tmp= subset_44 (rows subset_41 [0:10]))", ses);

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1881,7 +1881,14 @@ class H2OFrame(object):
 
     def merge(self, other, all_x=False, all_y=False, by_x=None, by_y=None, method="auto"):
         """
-        Merge two datasets based on common column names.
+        Merge two datasets based on common column names.  We do not support all_x=True and all_y=True.
+        Only one can be True or none is True.  The default merge method is auto and the program will determine
+        for you which method (hash or radix) to use automatically depending on the contents of your left and right
+        frames.  If there are duplicated rows in your rite frame, they will not be included if you use the hash method.
+        Since it is rare to perform merge with duplicated rows an the right frames, this should be okay.  On the
+        other hand, radix method will return the correct merge result regardless of duplicated rows in the right frame.
+        However, it cannot merge frames containing string columns.  User will have to convert the string columns
+        to enum before proceeding.
 
         :param H2OFrame other: The frame to merge to the current one. By default, must have at least one column in common with
             this frame, and all columns in common are used as the merge key.  If you want to use only a subset of the
@@ -1891,6 +1898,7 @@ class H2OFrame(object):
         :param by_x: list of columns in the current frame to use as a merge key.
         :param by_y: list of columns in the ``other`` frame to use as a merge key. Should have the same number of
             columns as in the ``by_x`` list.
+        :param method: string representing the merge method, one of auto(default), radix or hash.
 
         :returns: New H2OFrame with the result of merging the current frame with the ``other`` frame.
         """

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2732,7 +2732,7 @@ def compare_frames(frame1, frame2, numElements, tol_time=0, tol_numeric=0, stric
     na_frame2 = frame2.isna().sum().sum(axis=1)[:,0]
 
     if compare_NA:      # check number of missing values
-        assert na_frame1 == na_frame2, "failed numbers of NA check!  Frame 1 NA number: {0}, frame 2 " \
+        assert na_frame1.flatten() == na_frame2.flatten(), "failed numbers of NA check!  Frame 1 NA number: {0}, frame 2 " \
                                    "NA number: {1}".format(na_frame1, na_frame2)
 
     # check column types are the same before proceeding to check each row content.
@@ -3055,9 +3055,14 @@ def compare_numeric_frames(f1, f2, prob=0.5, tol=1e-6):
     for colInd in range(f1.ncol):
         for rowInd in range(f2.nrow):
             if (random.uniform(0,1) < prob):
-                diff = abs(temp1[rowInd, colInd]-temp2[rowInd, colInd])/max(1.0, abs(temp1[rowInd, colInd]),
+                if (math.isnan(temp1[rowInd, colInd])):
+                    assert math.isnan(temp2[rowInd, colInd]), "Failed frame values check at row {2} and column {3}! " \
+                                                              "frame1 value: {0}, frame2 value: " \
+                                                              "{1}".format(temp1[rowInd, colInd], temp2[rowInd, colInd], rowInd, colInd)
+                else:
+                    diff = abs(temp1[rowInd, colInd]-temp2[rowInd, colInd])/max(1.0, abs(temp1[rowInd, colInd]),
                                                                             abs(temp2[rowInd, colInd]))
-                assert diff<=tol, "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
+                    assert diff<=tol, "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
                                   "{1}".format(temp1[rowInd, colInd], temp2[rowInd, colInd], rowInd, colInd)
 
 def check_sorted_2_columns(frame1, sorted_column_indices, prob=0.5, ascending=[True, True]):

--- a/h2o-py/tests/testdir_jira/pyunit_PUBDEV_3567_merge_stall_large.py
+++ b/h2o-py/tests/testdir_jira/pyunit_PUBDEV_3567_merge_stall_large.py
@@ -1,0 +1,24 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+def pubdev_3567():
+    train = h2o.import_file(pyunit_utils.locate("smalldata/jira/frameA2.csv"), header=1)
+    test = h2o.import_file(pyunit_utils.locate("smalldata/jira/frameB2.csv"), header=1)
+    mergedAns = h2o.import_file(pyunit_utils.locate("smalldata/jira/merged2.csv"), header=1)
+    mergedAnsLeft = h2o.import_file(pyunit_utils.locate("smalldata/jira/merged2Left.csv"), header=1)
+    mergedAnsRight = h2o.import_file(pyunit_utils.locate("smalldata/jira/merged2Right.csv"), header=1)
+    merged = train.merge(test,by_x=["A"],by_y=["A"],method="auto") # default is radix
+    mergedLeft = train.merge(test,by_x=["A"],by_y=["A"],all_x=True)
+    mergedRight = train.merge(test,by_x=["A"],by_y=["A"],all_y=True)    # new feature
+
+    pyunit_utils.compare_numeric_frames(mergedAnsRight, mergedRight, 0.01, tol=1e-10)
+    pyunit_utils.compare_numeric_frames(mergedAns, merged, 0.01, tol=1e-10)
+    pyunit_utils.compare_numeric_frames(mergedAnsLeft, mergedLeft, 0.01, tol=1e-10)
+    pyunit_utils.compare_numeric_frames(mergedAnsRight, mergedRight, 0.01, tol=1e-10)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_3567)
+else:
+    pubdev_3567()

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3631,7 +3631,13 @@ checkMatch = function(x,y) {
 #' Merge Two H2O Data Frames
 #'
 #' Merges two H2OFrame objects with the same arguments and meanings
-#' as merge() in base R.
+#' as merge() in base R.  However, we do not support all=TRUE, all.x=TRUE and all.y=TRUE.  The default method is auto
+#' where the program will choose for you which merge method (hash or radix) to use automatically depending on the
+#' contents of your left and right frames.  If there are duplicated
+#' rows in your rite frame, they will not be included if you use the hash method.  Since it is rare to perform merge
+#' with duplicated rows an the right frames, this should be okay.  On the other hand, the radix method will return the
+#' correct merge result regardless of duplicated rows in the right frame.  However, it cannot merge frames containing
+#' string columns.  User will have to convert the string columns to enum before proceeding.
 #'
 #' @param x,y H2OFrame objects
 #' @param by columns used for merging by default the common names
@@ -3641,7 +3647,7 @@ checkMatch = function(x,y) {
 #' @param all.x If all.x is true, all rows in the x will be included, even if there is no matching
 #'        row in y, and vice-versa for all.y.
 #' @param all.y see all.x
-#' @param method auto, radix, or hash (default)
+#' @param method auto(default), radix, hash
 #' @examples
 #' \donttest{
 #' h2o.init()
@@ -3654,7 +3660,7 @@ checkMatch = function(x,y) {
 #' left.hex <- h2o.merge(l.hex, r.hex, all.x = TRUE)
 #' }
 #' @export
-h2o.merge <- function(x, y, by=intersect(names(x), names(y)), by.x=by, by.y=by, all=FALSE, all.x=all, all.y=all, method="hash") {
+h2o.merge <- function(x, y, by=intersect(names(x), names(y)), by.x=by, by.y=by, all=FALSE, all.x=all, all.y=all, method="radix") {
   if (length(by.x) != length(by.y)) stop("`by.x` and `by.y` must be the same length.")
   if (!length(by.x)) stop("`by` or `by.x` must specify at least one column") 
   if (!is.numeric(by.x)) by.x = checkMatch(by.x, names(x))
@@ -3668,7 +3674,8 @@ h2o.merge <- function(x, y, by=intersect(names(x), names(y)), by.x=by, by.y=by, 
 }
 
 
-#' Sorts H2OFrame by the columns specified. H2OFrame should not contain any String columns.  Otherwise, an error will be thrown.  To sort column c1 in descending order, do desc(c1).  Returns a new H2OFrame, like dplyr::arrange.
+#' Sorts H2OFrame by the columns specified. H2OFrame should not contain any String columns.  Otherwise, an error will
+#'  be thrown.  To sort column c1 in descending order, do desc(c1).  Returns a new H2OFrame, like dplyr::arrange.
 #'
 #' @param x The H2OFrame input to be sorted.
 #' @param \dots The column names to sort by.

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -805,7 +805,11 @@ compareFrames <- function(frame1, frame2, prob=0.5, tolerance=1e-6) {
     temp2=as.numeric(frame2[,colInd])
     for (rowInd in range(1,nrow(frame1))) {
       if (runif(1,0,1) < prob)
-        expect_true(abs(temp1[rowInd,1]-temp2[rowInd,1])< tolerance, info=paste0("Error at row ", rowInd, ". Frame 1 value ", temp1[rowInd, 1], ". Frame 2 value ", temp2[rowInd, 1]))
+        if (is.nan(temp1[rowInd,1])) {
+          expect_true(is.nan(temp2[rowInd,1]), info=paste0("Errow at row ", rowInd, ". Frame is value is nan but Frame 2 value is ", temp2[rowInd, 1]))
+        } else {
+          expect_true(abs(temp1[rowInd,1]-temp2[rowInd,1])< tolerance, info=paste0("Error at row ", rowInd, ". Frame 1 value ", temp1[rowInd, 1], ". Frame 2 value ", temp2[rowInd, 1]))
+        }
     }
   }
 }

--- a/h2o-r/tests/testdir_jira/runit_PUBDEV_3567_merge_stall_large.R
+++ b/h2o-r/tests/testdir_jira/runit_PUBDEV_3567_merge_stall_large.R
@@ -1,0 +1,71 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test <- function() {
+  # generate random dataset to test our merging
+  alldata <- genDataFrames(10000, 1000, 2147483648, 10)
+  
+  # perform tests
+  performMergingTest(alldata$dataframeA, alldata$dataframeB, alldata$frameA, alldata$frameB, method="radix", testNo=1) # test radix sort with all.x=all.y=FALSE
+  performMergingTest(alldata$dataframeA, alldata$dataframeB, alldata$frameA, alldata$frameB, method="radix", testNo=2) # test radix sort with all.x=TRUE, all.y=FALSE
+  performMergingTest(alldata$dataframeA, alldata$dataframeB, alldata$frameA, alldata$frameB, method="radix", testNo=3) # test radix sort with all.x=FALSE, all.y=TRUE
+}
+
+genDataFrames <- function(nrow, intrange1, intrange2, numRepeats) {
+  # generate random dataset to test our merging
+  frameA <- h2o.cbind( h2o.createFrame(rows=nrow, cols=1, categorical_fraction=0, integer_fraction=1,
+                                       integer_range=intrange1, binary_fraction=0, binary_ones_fraction = 0, time_fraction = 0, string_fraction = 0, missing_fraction=0),
+                       h2o.createFrame(rows=nrow, cols=1, categorical_fraction=0, integer_fraction=1,
+                                       binary_fraction=0, binary_ones_fraction = 0, time_fraction = 0, string_fraction = 0,
+                                       integer_range=intrange2, missing_fraction=0))
+  frameB <- h2o.cbind( h2o.createFrame(rows=nrow, cols=1, categorical_fraction=0, integer_fraction=1,
+                                       integer_range=intrange1, binary_fraction=0, binary_ones_fraction = 0, time_fraction = 0, string_fraction = 0, missing_fraction=0),
+                       h2o.createFrame(rows=nrow, cols=1, categorical_fraction=0, integer_fraction=1,
+                                       binary_fraction=0, binary_ones_fraction = 0, time_fraction = 0, string_fraction = 0,
+                                       integer_range=intrange2, missing_fraction=0))
+  # repeat a frameA row random number of times in frameB to create repeated rows
+  numRep = sample(1:numRepeats,1)
+  for (ind in c(1:numRep)) {
+    frameB[ind,1] = frameA[1,1]
+    frameB[ind,2] = frameA[1,2]
+  }
+  # repeat a frame B row random number of times in frameA to create repeated rows
+  numRepB = sample(numRep+1:numRep+numRepeats,1)
+  for (ind in c(1:numRepB)) {
+    frameA[ind+numRepB,1] = frameB[numRepB,1]
+    frameA[ind+numRepB,2] = frameB[numRepB,2]
+  }
+  names(frameA) <- c("A", "X")
+  names(frameB) <- c("A", "Y")
+  frameAData <- as.data.frame(frameA)
+  frameBData <- as.data.frame(frameB)
+  return(list("frameA"=frameA, "frameB"=frameB, "dataframeA"=frameAData, "dataframeB"=frameBData))
+}
+performMergingTest <- function(frameAData, frameBData, frameA, frameB, methodS, testNo=1) {
+  if (testNo==1) {
+    fMergeAll <- h2o.arrange(h2o.merge(frameA, frameB,  method=methodS), "A", "X", "Y") # test radix, allRite and compare with R result
+    fMergeAllAns <- h2o.arrange(as.h2o(merge(frameAData, frameBData)), "A", "X", "Y")
+    checkResults(fMergeAll, fMergeAllAns)
+    return
+  } 
+  if (testNo==2) {
+    fMergeAll <- h2o.arrange(h2o.merge(frameA, frameB, all.x=TRUE,  method=methodS), "A", "X", "Y") # test radix, allRite and compare with R result
+    fMergeAllAns <- h2o.arrange(as.h2o(merge(frameAData, frameBData, all.x=TRUE)), "A", "X", "Y")
+    checkResults(fMergeAll, fMergeAllAns)
+    return
+  } 
+  if (testNo ==3) {
+    fMergeAll <- h2o.arrange(h2o.merge(frameA, frameB, all.y=TRUE, method=methodS), "A", "X", "Y") # test radix, allRite and compare with R result
+    fMergeAllAns <- h2o.arrange(as.h2o(merge(frameAData, frameBData, all.y=TRUE)), "A", "X", "Y")
+    checkResults(fMergeAll, fMergeAllAns)
+    return
+  }
+}
+
+checkResults <- function(frame1, frame2) {
+  compareFrames(frame1, frame2, prob=1)
+  h2o.rm(frame1)
+  h2o.rm(frame2)
+}
+
+doTest("PUBDEV-3567", test)

--- a/h2o-r/tests/testdir_misc/runit_mergecat.R
+++ b/h2o-r/tests/testdir_misc/runit_mergecat.R
@@ -24,7 +24,7 @@ test.mergecat <- function() {
   
   Log.info("Merge crimes and census data on community area number")
   names(census)[names(census) == "Community.Area.Number"] <- "Community.Area"
-  crimeMerge <- h2o.merge(crimes, census, all.x=TRUE)
+  crimeMerge <- h2o.merge(crimes, census, all.x=TRUE, method="hash")
   print(summary(crimeMerge))
   
   

--- a/h2o-r/tests/testdir_munging/runit_merge.R
+++ b/h2o-r/tests/testdir_munging/runit_merge.R
@@ -23,7 +23,7 @@ test.merge <- function() {
 run.merge.tests <- function (g,h) {
   h2o_g <- as.h2o(g)
   h2o_h <- as.h2o(h)
-  h2o_merge <- h2o.merge(h2o_g, h2o_h)
+  h2o_merge <- h2o.merge(h2o_g, h2o_h, method="hash")
   R_merge <- merge(g,h)
   h2o_and_R_equal(h2o_merge, R_merge[names(h2o_merge)])
 }

--- a/scripts/gen_numerical_data.py
+++ b/scripts/gen_numerical_data.py
@@ -5,6 +5,7 @@ import h2o
 from random import randint
 from random import uniform
 from random import shuffle
+import numpy as np
 
 # This test is used to generate a dataframe that contains two columns, one integer and one double which
 # should contain both positive, negative, zero.  Used to test sort float and the new TopN command.
@@ -149,9 +150,18 @@ def genStaticData(intA, floatA, upperBoundL, lowBoundF, upperBoundF, fMult):
         upperBoundL=upperBoundL-1
     intA.reverse()
 
+# This test will generate the merged data frame, the separate frame A and
+# frame B, such that if you call merge on the separate frames, the answer is
+# in the merged data frame.
+def genMergedSeparaData(MergedRows, intUpper, intLow, doubleUpper, doubleLow, bProb):
+    # first generate the single column that will be the merge key
+    merged = h2o.create_frame(rows=MergedRows, cols=3, integer_fraction=1, integer_range=intUpper-intLow)
+    print("Done, save with Flow")
+
+
 def main(argv):
     h2o.init(strict_version_check=False)
-    gen_data()
+    genMergedSeparaData(2000000000, pow(2,30), -1*pow(2,30), 1.0*pow(2,63), -1.0*pow(2,63), 0.8)
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
PUBDEV-3567: merge.  Change default method auto to either choose radix or hash depending on the contents of the left and right frame.  If there are no string columns in the frames, radix merge will be chosen.  If there are string columns in the right frame, hash merge will be chosen. Thanks to Michal K for the suggestion.
PUBDEV-3567: merge.  Added code to support left join or right join is set to true but not both.
PUBDEV-3567: Added pyunit and runit tests.
PUBDEV-3567: correct runit tests to choose method=hash since it is no longer the default