### PR TITLE
PUBDEV-5026: Updated SW links on docs.h2o.ai

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -474,9 +474,9 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt; padding-right: 0pt;">Sparkling Water Scaladoc</td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/16/scaladoc/index.html#package">2.0</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/15/scaladoc/index.html">2.1</a></td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/1/scaladoc/index.html">2.2</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/17/scaladoc/index.html#package">2.0</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/16/scaladoc/index.html">2.1</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/2/scaladoc/index.html">2.2</a></td>
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">H2O Scaladoc</td>
@@ -691,13 +691,13 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">Sparking Water Scaladoc</td>
                <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/16/scaladoc/index.html#package">2.0</a>
+                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.0/17/scaladoc/index.html#package">2.0</a>
               </td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/15/scaladoc/index.html">2.1</a>
+                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.1/16/scaladoc/index.html">2.1</a>
                </td>
                <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/1/scaladoc/index.html">2.2</a>
+                <a href="https://h2o-release.s3.amazonaws.com/sparkling-water/rel-2.2/2/scaladoc/index.html">2.2</a>
               </td>
             </tr>
             <tr>

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -8,7 +8,7 @@ Supported File Formats
 
 H2O currently supports the following file types:
 
-- CSV (delimited) files
+- CSV (delimited) files (including GZipped CSV)
 - ORC
 - SVMLight
 - ARFF

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -21,6 +21,12 @@ H2O currently supports the following file types:
  
  - ORC is available only if H2O is running as a Hadoop job. 
  - Users can also import Hive files that are saved in ORC format. 
+ - When doing a parallel data import into a cluster: 
+
+   - If the data is an unzipped csv file, H2O can do offset reads, so each node in your cluster can be directly reading its part of the csv file in parallel. 
+   - If the data is zipped, H2O will have to read the whole file and unzip it before doing the parallel read.
+
+   So, if you have very large data files reading from HDFS, it is best to use unzipped csv. But if the data is further away than the LAN, then it is best to use zipped csv.
 
 .. _data_sources:
 


### PR DESCRIPTION
- Updated the links for the new SW links on docs.h2o.ai.
Driveby fix: Noted in the docs that gzipped files are supported.