### PR TITLE
PUBDEV-4957: Allow multiclass stacking in AutoML now that we support it

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -192,7 +192,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       if (aModel._output.isBinomialClassifier())
         return DistributionFamily.bernoulli;
       else if (aModel._output.isClassifier())
-        throw new H2OIllegalArgumentException("Don't know how to set the distribution for a multinomial Random Forest classifier.");
+        return DistributionFamily.multinomial;
       else
         return DistributionFamily.gaussian;
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1059,30 +1059,24 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       userFeedback.info(Stage.ModelTraining, "No models were built, due to timeouts.");
     } else {
       Model m = allModels[0];
-      if (m._output.isClassifier() && !m._output.isBinomialClassifier()) {
-        // nada
-        this.job.update(50, "Multinomial classifier: StackedEnsemble build skipped");
-        userFeedback.info(Stage.ModelTraining,"Multinomial classifier: StackedEnsemble build skipped");
-      } else {
-        ///////////////////////////////////////////////////////////
-        // stack all models
-        ///////////////////////////////////////////////////////////
+      ///////////////////////////////////////////////////////////
+      // stack all models
+      ///////////////////////////////////////////////////////////
 
-        // Also stack models from other AutoML runs, by using the Leaderboard! (but don't stack stacks)
-        int nonEnsembleCount = 0;
-        for (Model aModel : allModels)
-          if (!(aModel instanceof StackedEnsembleModel))
-            nonEnsembleCount++;
+      // Also stack models from other AutoML runs, by using the Leaderboard! (but don't stack stacks)
+      int nonEnsembleCount = 0;
+      for (Model aModel : allModels)
+        if (!(aModel instanceof StackedEnsembleModel))
+          nonEnsembleCount++;
 
-        Key<Model>[] notEnsembles = new Key[nonEnsembleCount];
-        int notEnsembleIndex = 0;
-        for (Model aModel : allModels)
-          if (!(aModel instanceof StackedEnsembleModel))
-            notEnsembles[notEnsembleIndex++] = aModel._key;
+      Key<Model>[] notEnsembles = new Key[nonEnsembleCount];
+      int notEnsembleIndex = 0;
+      for (Model aModel : allModels)
+        if (!(aModel instanceof StackedEnsembleModel))
+          notEnsembles[notEnsembleIndex++] = aModel._key;
 
-        Job<StackedEnsembleModel> ensembleJob = stack(notEnsembles);
-        pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build", 50, this.job(), ensembleJob, JobType.ModelBuild);
-      }
+      Job<StackedEnsembleModel> ensembleJob = stack(notEnsembles);
+      pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build", 50, this.job(), ensembleJob, JobType.ModelBuild);
     }
     userFeedback.info(Stage.Workflow, "AutoML: build done; built " + modelCount + " models");
     Log.info(userFeedback.toString("User Feedback for AutoML Run " + this._key));

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -5,7 +5,7 @@ In recent years, the demand for machine learning experts has outpaced the supply
 
 Although H2O has made it easy for non-experts to experiment with machine learning, there is still a fair bit of knowledge and background in data science that is required to produce high-performing machine learning models.  Deep Neural Networks in particular are notoriously difficult for a non-expert to tune properly.  In order for machine learning software to truly be accessible to non-experts, we have designed an easy-to-use interface which automates the process of training a large selection of candidate models.  H2O's AutoML can also be a helpful tool for the advanced user, by providing a simple wrapper function that performs a large number of modeling-related tasks that would typically require many lines of code, and by freeing up their time to focus on other aspects of the data science pipeline tasks such as data-preprocessing, feature engineering and model deployment.
 
-H2O's AutoML can be used for automating the machine learning workflow, which includes automatic training and tuning of many models within a user-specified time-limit.  The user can also use a performance metric-based stopping criterion for the AutoML process rather than a specific time constraint.  `Stacked Ensembles <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html>`__ will be automatically trained on the collection individual models to produce a highly predictive ensemble model which, in most cases, will be the top performing model in the AutoML Leaderboard.  Stacked ensembles are not yet available for multiclass classification problems, so in that case, only singleton models will be trained. 
+H2O's AutoML can be used for automating the machine learning workflow, which includes automatic training and tuning of many models within a user-specified time-limit.  The user can also use a performance metric-based stopping criterion for the AutoML process rather than a specific time constraint.  `Stacked Ensembles <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html>`__ will be automatically trained on the collection individual models to produce a highly predictive ensemble model which, in most cases, will be the top performing model in the AutoML Leaderboard.  
 
 
 AutoML Interface
@@ -137,10 +137,9 @@ Here’s an example showing basic usage of the ``h2o.automl()`` function in *R* 
     # GBM_grid_0_AutoML_20170605_212658_model_0  0.735078   0.630062
     # GBM_grid_0_AutoML_20170605_212658_model_1  0.730645   0.674580
     #              XRT_0_AutoML_20170605_212658  0.728358   0.629296
-    # GLM_grid_0_AutoML_20170605_212658_model_1  0.685216   0.635137
     # GLM_grid_0_AutoML_20170605_212658_model_0  0.685216   0.635137
     #
-    # [8 rows x 3 columns]
+    # [7 rows x 3 columns]
 
     # The leader model is stored here
     aml@leader
@@ -195,10 +194,9 @@ Here’s an example showing basic usage of the ``h2o.automl()`` function in *R* 
     # GBM_grid_0_AutoML_20170605_212658_model_0  0.735078   0.630062
     # GBM_grid_0_AutoML_20170605_212658_model_1  0.730645   0.67458
     # XRT_0_AutoML_20170605_212658               0.728358   0.629296
-    # GLM_grid_0_AutoML_20170605_212658_model_1  0.685216   0.635137
     # GLM_grid_0_AutoML_20170605_212658_model_0  0.685216   0.635137
     #
-    # [8 rows x 3 columns]
+    # [7 rows x 3 columns]
 
     # The leader model is stored here
     aml.leader
@@ -248,11 +246,6 @@ FAQ
 -  **How do I save AutoML runs?**
 
   Rather than saving an AutoML object itself, currently, the best thing to do is to save the models you want to keep, individually.  A utility for saving all of the models at once will be added in a future release.
-
-
--  **Why is there no Stacked Ensemble on my Leaderboard?**
-
-  Currently, Stacked Ensembles supports binary classficiation and regression, but not multi-class classification, although multi-class support is in `development <https://0xdata.atlassian.net/browse/PUBDEV-3960>`__.  So if your leaderboard is missing a Stacked Ensemble, the reason is likely that you are performing multi-class classification and it's not meant to be there.
 
 
 Additional Information

--- a/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
+++ b/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
@@ -9,21 +9,26 @@ def iris_automl():
 
     df = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
 
-    #Split frames
+    # Split frames
     fr = df.split_frame(ratios=[.8,.1])
 
-    #Set up train, validation, and test sets
+    # Set up train, validation, and test sets
     train = fr[0]
     valid = fr[1]
     test = fr[2]
 
     aml = H2OAutoML(max_runtime_secs = 3,stopping_rounds=3,stopping_tolerance=0.001)
 
-    print("AutoML (Multinomial) run with x not provided with train, valid, and test")
+    print("AutoML (Multinomial) run with x not provided; uses train, valid, and leaderboard (test) frame")
     aml.train(y="class", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     print(aml.leader)
     print(aml.leaderboard)
     assert set(aml.leaderboard.columns) == set(["model_id","mean_per_class_error"])
+
+    # Check that a StackedEnsemble model was trained
+    lbdf = aml.leaderboard.as_data_frame()
+    assert len([x for x in lbdf['model_id'] if "StackedEnsemble" in x]) > 0
+
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(iris_automl)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_multinomial.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_multinomial.R
@@ -1,0 +1,27 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+automl.multinomial.test <- function() {
+  
+  # This test checks the following (for multinomial classification):
+  #
+  # 1) That h2o.automl executes w/o errors on multinomial data
+  # 2) That the leaderboard contains a StackedEnsemble model
+
+  # Example multiclass dataset
+  train <- as.h2o(iris)
+
+  # Run a multinomial AutoML
+  aml <- h2o.automl(x = 1:4,
+                    y = 5,
+                    training_frame = train,
+                    project_name = "automl.multinomial.test",
+                    seed = 1, 
+                    max_models = 3,
+                    stopping_rounds = 0)
+  
+  # Check that there's a StackedEnsemble model in the leaderboard
+  expect_true(sum(grepl("StackedEnsemble", as.vector(aml@leaderboard$model_id))) > 0)
+}
+
+doTest("AutoML Multinomial Test", automl.multinomial.test)


### PR DESCRIPTION
- Removing Java code that skips Stacked Ensemble for multinomial
- Fixed a Java bug with Stacked Ensemble for multinomial
- runit & pyunit to check that a Stacked Ensemble is included in the leaderboard for multinomial
- Updated AutoML user guide to indicate that we now do Stacked Ensembles for multinomial