### PR TITLE
PUBDEV-4882: Expose nfolds argument in the AutoML R/Py clients

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1060,14 +1060,14 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     Model[] allModels = leaderboard().getModels();
 
     if (allModels.length == 0){
-      this.job.update(50, "No models built: StackedEnsemble build skipped");
+      this.job.update(50, "No models built; StackedEnsemble build skipped");
       userFeedback.info(Stage.ModelTraining, "No models were built, due to timeouts.");
     } else {
       Model m = allModels[0];
       // If nfolds == 0, then skip the Stacked Ensemble
       if (buildSpec.build_control.nfolds == 0) {
-        this.job.update(50, "Cross-validation disabled by the user: StackedEnsemble build skipped");
-        userFeedback.info(Stage.ModelTraining,"Cross-validation disabled by the user: StackedEnsemble build skipped");
+        this.job.update(50, "Cross-validation disabled by the user; StackedEnsemble build skipped");
+        userFeedback.info(Stage.ModelTraining,"Cross-validation disabled by the user; StackedEnsemble build skipped");
       } else {
         ///////////////////////////////////////////////////////////
         // stack all models

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -638,7 +638,9 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       params._weights_column = buildSpec.input_spec.weights_column;
 
       if (buildSpec.input_spec.fold_column == null) {
-        params._nfolds = 5;
+        //params._nfolds = 5;
+        params._nfolds = buildSpec.build_control.nfolds;
+        // TO DO: below allow the user to specify this (vs Modulo)
         params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
       }
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -640,8 +640,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       if (buildSpec.input_spec.fold_column == null) {
         //params._nfolds = 5;
         params._nfolds = buildSpec.build_control.nfolds;
-        // TO DO: below allow the user to specify this (vs Modulo)
-        params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+        if (buildSpec.build_control.nfolds > 1) {
+          // TO DO: below allow the user to specify this (vs Modulo)
+          // TO DO: also, the docs currently say that we use Random folds... not Modulo
+          params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+        }
       }
     }
   }
@@ -1061,24 +1064,31 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       userFeedback.info(Stage.ModelTraining, "No models were built, due to timeouts.");
     } else {
       Model m = allModels[0];
-      ///////////////////////////////////////////////////////////
-      // stack all models
-      ///////////////////////////////////////////////////////////
+      // If nfolds == 0, then skip the Stacked Ensemble
+      if (buildSpec.build_control.nfolds == 0) {
+        this.job.update(50, "Cross-validation disabled by the user: StackedEnsemble build skipped");
+        userFeedback.info(Stage.ModelTraining,"Cross-validation disabled by the user: StackedEnsemble build skipped");
+      } else {
+        ///////////////////////////////////////////////////////////
+        // stack all models
+        ///////////////////////////////////////////////////////////
 
-      // Also stack models from other AutoML runs, by using the Leaderboard! (but don't stack stacks)
-      int nonEnsembleCount = 0;
-      for (Model aModel : allModels)
-        if (!(aModel instanceof StackedEnsembleModel))
-          nonEnsembleCount++;
+        // Also stack models from other AutoML runs, by using the Leaderboard! (but don't stack stacks)
+        int nonEnsembleCount = 0;
+        for (Model aModel : allModels)
+          if (!(aModel instanceof StackedEnsembleModel))
+            nonEnsembleCount++;
 
-      Key<Model>[] notEnsembles = new Key[nonEnsembleCount];
-      int notEnsembleIndex = 0;
-      for (Model aModel : allModels)
-        if (!(aModel instanceof StackedEnsembleModel))
-          notEnsembles[notEnsembleIndex++] = aModel._key;
+        Key<Model>[] notEnsembles = new Key[nonEnsembleCount];
+        int notEnsembleIndex = 0;
+        for (Model aModel : allModels)
+          if (!(aModel instanceof StackedEnsembleModel))
+            notEnsembles[notEnsembleIndex++] = aModel._key;
 
-      Job<StackedEnsembleModel> ensembleJob = stack(notEnsembles);
-      pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build", 50, this.job(), ensembleJob, JobType.ModelBuild);
+        Job<StackedEnsembleModel> ensembleJob = stack(notEnsembles);
+        pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build", 50, this.job(), ensembleJob, JobType.ModelBuild);
+
+      }
     }
     userFeedback.info(Stage.Workflow, "AutoML: build done; built " + modelCount + " models");
     Log.info(userFeedback.toString("User Feedback for AutoML Run " + this._key));

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -3,7 +3,6 @@ package ai.h2o.automl;
 import hex.ScoreKeeper;
 import hex.grid.HyperSpaceSearchCriteria;
 import hex.schemas.GridSearchSchema;
-//import hex.Model;
 import water.Iced;
 import water.Key;
 import water.api.schemas3.ImportFilesV3;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -52,7 +52,7 @@ public class AutoMLBuildSpec extends Iced {
     public HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria stopping_criteria;
 
     // Cross-validation fold construction
-    public int nfolds = 5;  // TODO: not working yet...
+    public int nfolds = 5; 
     //public Model.Parameters.FoldAssignmentScheme fold_assignment;
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -3,6 +3,7 @@ package ai.h2o.automl;
 import hex.ScoreKeeper;
 import hex.grid.HyperSpaceSearchCriteria;
 import hex.schemas.GridSearchSchema;
+//import hex.Model;
 import water.Iced;
 import water.Key;
 import water.api.schemas3.ImportFilesV3;
@@ -49,6 +50,10 @@ public class AutoMLBuildSpec extends Iced {
     public String project_name = null;
     public String loss = "AUTO";  // TODO: plumb through
     public HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria stopping_criteria;
+
+    // Cross-validation fold construction
+    public Integer nfolds = 5;  // TO DO: plumb through
+    //public Model.Parameters.FoldAssignmentScheme fold_assignment;
   }
 
   /**

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -52,7 +52,7 @@ public class AutoMLBuildSpec extends Iced {
     public HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria stopping_criteria;
 
     // Cross-validation fold construction
-    public Integer nfolds = 5;  // TO DO: plumb through
+    public int nfolds = 5;  // TODO: not working yet...
     //public Model.Parameters.FoldAssignmentScheme fold_assignment;
   }
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -25,10 +25,10 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="Optional project name used to group models from multiple runs into a leaderboard; derived from the training data name if not specified.")
+    @API(help="Optional project name used to group models from multiple AutoML runs into a single Leaderboard; derived from the training data name if not specified.")
     public String project_name;
 
-    @API(help="loss function (not yet enabled)", direction=API.Direction.INPUT)
+    @API(help="Loss function (not yet enabled).", direction=API.Direction.INPUT)
     public String loss;
 
     @API(help="Model performance based stopping criteria for the AutoML run.", direction=API.Direction.INPUT)
@@ -68,10 +68,10 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help = "ID of the training data frame.", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 training_frame;
 
-    @API(help = "ID of the validation data frame.", direction=API.Direction.INPUT)
+    @API(help = "ID of the validation data frame (used for early stopping in grid searches and for early stopping of the AutoML process itself).", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 validation_frame;
 
-    @API(help = "ID of the leaderboard/test data frame.", direction=API.Direction.INPUT)
+    @API(help = "ID of the leaderboard data frame (used to score models and rank them on the AutoML Leaderboard).", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 leaderboard_frame;
 
     @API(help = "Response column",
@@ -82,7 +82,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       )
     public FrameV3.ColSpecifierV3 response_column;
 
-    @API(help = "Fold column for cross-validation",
+    @API(help = "Fold column (contains fold IDs) in the training frame. These assignments are used to create the folds for cross-validation of the models.",
             direction=API.Direction.INPUT,
             is_member_of_frames = {"training_frame", "validation_frame", "leaderboard_frame"},
             is_mutually_exclusive_with = {"ignored_columns", "response_column", "weights_column"},
@@ -90,7 +90,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     )
     public FrameV3.ColSpecifierV3 fold_column;
 
-    @API(help = "Weights column, specifying row weights for model training",
+    @API(help = "Weights column in the training frame, which specifies the row weights used in model training.",
             direction=API.Direction.INPUT,
             is_member_of_frames = {"training_frame", "validation_frame", "leaderboard_frame"},
             is_mutually_exclusive_with = {"ignored_columns", "response_column", "fold_column"},
@@ -98,7 +98,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     )
     public FrameV3.ColSpecifierV3 weights_column;
 
-    @API(help = "Names of columns to ignore for training",
+    @API(help = "Names of columns to ignore in the training frame when building models.",
          direction=API.Direction.INPUT,
          is_member_of_frames = {"training_frame", "validation_frame", "leaderboard_frame"},
          is_mutually_exclusive_with = {"response_column", "fold_column", "weights_column"},
@@ -112,7 +112,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="Try frame transformations", direction=API.Direction.INPUT)
+    @API(help="Try frame transformations (boolean; not enabled).", direction=API.Direction.INPUT)
     public boolean try_mutations;
   } // class AutoMLFeatureEngineeringV99
 
@@ -124,7 +124,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help="Prevent AutoML from trying these algos; ignored if you use the model_searches parameter", values = {"DL","GLRM","KMEANS","RF","GBM","GLM"}, direction=API.Direction.INPUT)
     public AutoML.algo[] exclude_algos;
 
-    @API(help="Optional model build parameter sets, including base hyperparameters and optional hyperparameter search")
+    @API(help="Optional model build parameter sets, including base hyperparameters and optional hyperparameter search.")
     public GridSearchSchema[] model_searches;
   } // class AutoMLBuildModels
 
@@ -139,19 +139,19 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
   ////////////////
   // Input fields
 
-  @API(help="Specification of overall controls for the AutoML build process", direction=API.Direction.INPUT)
+  @API(help="Specification of overall controls for the AutoML build process.", direction=API.Direction.INPUT)
   public AutoMLBuildControlV99 build_control;
 
-  @API(help="Specification of the input data for the AutoML build process", direction=API.Direction.INPUT)
+  @API(help="Specification of the input data for the AutoML build process.", direction=API.Direction.INPUT)
   public AutoMLInputV99 input_spec;
 
-  @API(help="Specification of the feature engineering for the AutoML build process", direction=API.Direction.INPUT)
+  @API(help="Specification of the feature engineering for the AutoML build process.", direction=API.Direction.INPUT)
   public AutoMLFeatureEngineeringV99 feature_engineering;
 
-  @API(help="If present, specifies details of how to train models", direction=API.Direction.INPUT)
+  @API(help="If present, specifies details of how to train models.", direction=API.Direction.INPUT)
   public AutoMLBuildModelsV99 build_models;
 
-  @API(help="If present, AutoML should build ensembles; more control over the process is optional", direction=API.Direction.INPUT)
+  @API(help="If present, AutoML should build ensembles; more control over the process is optional.", direction=API.Direction.INPUT)
   public AutoMLEnsembleParametersV99 ensemble_parameters;
 
   ////////////////

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -35,7 +35,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     public HyperSpaceSearchCriteriaV99.RandomDiscreteValueSearchCriteriaV99 stopping_criteria;
 
     @API(help="Number of folds for k-fold cross-validation (0 to disable or >= 2). Disabling prevents Stacked Ensembles from being built.", direction=API.Direction.INPUT)
-    public Integer nfolds;
+    public int nfolds;
   } // class AutoMLBuildControlV99
 
   /**

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -25,14 +25,17 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="optional project name used to group models from multiple runs into a leaderboard; derived from the training data name if not specified")
+    @API(help="Optional project name used to group models from multiple runs into a leaderboard; derived from the training data name if not specified.")
     public String project_name;
 
-    @API(help="loss function", direction=API.Direction.INPUT)
+    @API(help="loss function (not yet enabled)", direction=API.Direction.INPUT)
     public String loss;
 
-    @API(help="stopping criteria for the search", direction=API.Direction.INPUT)
+    @API(help="Model performance based stopping criteria for the AutoML run.", direction=API.Direction.INPUT)
     public HyperSpaceSearchCriteriaV99.RandomDiscreteValueSearchCriteriaV99 stopping_criteria;
+
+    @API(help="Number of folds for k-fold cross-validation (0 to disable or >= 2). Disabling prevents Stacked Ensembles from being built.", direction=API.Direction.INPUT)
+    public Integer nfolds;
   } // class AutoMLBuildControlV99
 
   /**

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -34,7 +34,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help="Model performance based stopping criteria for the AutoML run.", direction=API.Direction.INPUT)
     public HyperSpaceSearchCriteriaV99.RandomDiscreteValueSearchCriteriaV99 stopping_criteria;
 
-    @API(help="Number of folds for k-fold cross-validation (0 to disable or >= 2). Disabling prevents Stacked Ensembles from being built.", direction=API.Direction.INPUT)
+    @API(help="Number of folds for k-fold cross-validation (defaults to 5, must be >=2 or use 0 to disable). Disabling prevents Stacked Ensembles from being built.", direction=API.Direction.INPUT)
     public int nfolds;
   } // class AutoMLBuildControlV99
 

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -79,6 +79,8 @@ Optional Data Parameters
 Optional Miscellaneous Parameters
 '''''''''''''''''''''''''''''''''
 
+- `nfolds <data-science/algo-params/nfolds.html>`__:  Number of folds for k-fold cross-validation of the models in the AutoML run. Defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensemble (thus decreasing the overall model performance).
+
 - `seed <data-science/algo-params/seed.html>`__: Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if ``max_models`` or early stopping is used because ``max_runtime_secs`` is resource limited, meaning that if the resources are not the same between runs, AutoML may be able to train more models on one run vs another.  Defaults to ``NULL/None``.
 
 - **project_name**: Character string to identify an AutoML project. Defaults to ``NULL/None``, which means a project name will be auto-generated based on the training frame ID.  More models can be trained on an existing AutoML project by specifying the same project name in muliple calls to the AutoML function (as long as the same training frame is used in subsequent runs).

--- a/h2o-docs/src/product/data-science/algo-params/nfolds.rst
+++ b/h2o-docs/src/product/data-science/algo-params/nfolds.rst
@@ -1,16 +1,16 @@
 ``nfolds``
 ---------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost, AutoML
 - Hyperparameter: no
 
 
 Description
 ~~~~~~~~~~~
 
-This option specifies the number of folds to use for `cross-validation <../../cross-validation.html>`__. 
+This option specifies the number of folds to use for k-fold `cross-validation <../../cross-validation.html>`__. 
 
-N-fold cross-validation is used to validate a model internally, i.e., estimate the model performance without having to sacrifice a validation split. Also, you avoid statistical issues with your validation split (it might be a “lucky” split, especially for imbalanced data). Good values for ``nfolds`` are generally from 5 to 10, but keep in mind that higher values result in higher computational cost. 
+`K-fold cross-validation <https://en.wikipedia.org/wiki/Cross-validation_(statistics)#k-fold_cross-validation>`__ is used to validate a model internally, i.e., estimate the model performance without having to sacrifice a validation split. Also, you avoid statistical issues with your validation split (it might be a “lucky” split, especially for imbalanced data). Good values for ``nfolds`` are generally from 5 to 10, but keep in mind that higher values result in higher computational cost. 
 
 When specifying ``nfolds``, the algorithm will build ``nfolds`` +1 models. For example, if you specify ``nfolds=5``, then 6 models are built. The first 5 models (cross-validation models) are built on 80% of the training data, and a different 20% is held out for each of the 5 models. Then the main model is built on 100% of the training data. This main model is the model you get back from H2O in R, Python, and Flow.
 

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -13,6 +13,8 @@ class H2OAutoML(object):
     a random grid of Gradient Boosting Machines (GBMs), a random grid of Deep Neural Nets,
     and a Stacked Ensemble of all the models.
 
+    :param int nfolds: Number of folds for k-fold cross-validation. Defaults to 5. Use 0 to disable cross-validation; this will also 
+      disable Stacked Ensemble (thus decreasing the overall model performance).
     :param int max_runtime_secs: This argument controls how long the AutoML run will execute. Defaults to 3600 seconds (1 hour).
     :param int max_models: Specify the maximum number of models to build in an AutoML run. (Does not include the Stacked Ensemble model.)
     :param str stopping_metric: Specifies the metric to use for early stopping. Defaults to ``"AUTO"``.
@@ -54,6 +56,7 @@ class H2OAutoML(object):
     >>> aml.train(x = x, y = y,training_frame = train,leaderboard_frame = test)
     """
     def __init__(self,
+                 nfolds=5,
                  max_runtime_secs=3600,
                  max_models=None,
                  stopping_metric="AUTO",
@@ -71,6 +74,7 @@ class H2OAutoML(object):
                   "*Please verify that your H2O jar has the proper AutoML extensions.*\n" \
                   "*******************************************************************\n" \
                   "\nVerbose Error Message:")
+
 
         #If max_runtime_secs is not provided, then it is set to default (3600 secs)
         if max_runtime_secs is not 3600:
@@ -117,6 +121,12 @@ class H2OAutoML(object):
             self.project_name = project_name
         else:
             self.project_name = None
+
+        #Set nfolds if a non-default value is specified by the user, otherwise don't send in build_control
+        if nfolds is not 5:
+            assert_is_type(nfolds,int)
+            self.build_control["nfolds"] = nfolds 
+        self.nfolds = nfolds       
 
         self._job = None
         self._automl_key = None

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -122,10 +122,11 @@ class H2OAutoML(object):
         else:
             self.project_name = None
 
-        #Set nfolds if a non-default value is specified by the user, otherwise don't send in build_control
+        ###Set nfolds if a non-default value is specified by the user, otherwise don't send in build_control
+        # Always send nfolds
         if nfolds is not 5:
             assert_is_type(nfolds,int)
-            self.build_control["nfolds"] = nfolds 
+        self.build_control["nfolds"] = nfolds 
         self.nfolds = nfolds       
 
         self._job = None

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -44,16 +44,16 @@ class H2OAutoML(object):
     >>> # Import a sample binary outcome train/test set into H2O
     >>> train = h2o.import_file("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
     >>> test = h2o.import_file("https://s3.amazonaws.com/erin-data/higgs/higgs_test_5k.csv")
-    >>> # Identify predictors and response
-    >>> x = train.columns
+    >>> # Identify the response and set of predictors
     >>> y = "response"
+    >>> x = train.columns  #if x is defined as all columns except the response, then x is not required
     >>> x.remove(y)
     >>> # For binary classification, response should be a factor
     >>> train[y] = train[y].asfactor()
     >>> test[y] = test[y].asfactor()
     >>> # Run AutoML for 30 seconds
     >>> aml = H2OAutoML(max_runtime_secs = 30)
-    >>> aml.train(x = x, y = y,training_frame = train,leaderboard_frame = test)
+    >>> aml.train(x = x, y = y, training_frame = train,leaderboard_frame = test)
     """
     def __init__(self,
                  nfolds=5,
@@ -65,7 +65,7 @@ class H2OAutoML(object):
                  seed=None,
                  project_name=None):
 
-        #Check if H2O jar contains AutoML
+        # Check if H2O jar contains AutoML
         try:
             h2o.api("GET /3/Metadata/schemas/AutoMLV99")
         except h2o.exceptions.H2OResponseError as e:
@@ -76,23 +76,27 @@ class H2OAutoML(object):
                   "\nVerbose Error Message:")
 
         
-        #nfolds must not be negative or equal to 1:
-        assert nfolds >= 0, "nfolds cannot be negative. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."
-        assert nfolds is not 1, "nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."       
+        # Make bare minimum build_control (if max_runtimes_secs is an invalid value, it will catch below)
+        self.build_control = {
+            'stopping_criteria': {
+                'max_runtime_secs': max_runtime_secs,
+            }
+        }
 
-        #If max_runtime_secs is not provided, then it is set to default (3600 secs)
+        # nfolds must be an non-negative integer and not equal to 1:
+        if nfolds is not 5:
+            assert_is_type(nfolds,int)
+        assert nfolds >= 0, "nfolds set to " + str(nfolds) + "; nfolds cannot be negative. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."
+        assert nfolds is not 1, "nfolds set to " + str(nfolds) + "; nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."           
+        self.build_control["nfolds"] = nfolds 
+        self.nfolds = nfolds   
+
+        # If max_runtime_secs is not provided, then it is set to default (3600 secs)
         if max_runtime_secs is not 3600:
             assert_is_type(max_runtime_secs,int)
         self.max_runtime_secs = max_runtime_secs
 
-        #Make bare minimum build_control
-        self.build_control = {
-            'stopping_criteria': {
-                'max_runtime_secs': self.max_runtime_secs,
-            }
-        }
-
-        #Add other parameters to build_control if available
+        # Add other parameters to build_control if available
         if max_models is not None:
             assert_is_type(max_models,int)
             self.build_control["stopping_criteria"]["max_models"] = max_models
@@ -118,20 +122,14 @@ class H2OAutoML(object):
             self.build_control["stopping_criteria"]["seed"] = seed
             self.seed = seed
 
-        #Set project name if provided. If None, then we set in .train() to "automl_" + training_frame.frame_id
+        # Set project name if provided. If None, then we set in .train() to "automl_" + training_frame.frame_id
         if project_name is not None:
             assert_is_type(project_name,str)
             self.build_control["project_name"] = project_name
             self.project_name = project_name
         else:
             self.project_name = None
-
-        ###Set nfolds if a non-default value is specified by the user, otherwise don't send in build_control
-        # Always send nfolds
-        if nfolds is not 5:
-            assert_is_type(nfolds,int)
-        self.build_control["nfolds"] = nfolds 
-        self.nfolds = nfolds       
+    
 
         self._job = None
         self._automl_key = None
@@ -151,9 +149,9 @@ class H2OAutoML(object):
         :examples:
         >>> # Set up an H2OAutoML object
         >>> aml = H2OAutoML(max_runtime_secs=30)
-        >>> # Launch H2OAutoML
+        >>> # Launch an AutoML run
         >>> aml.train(y=y, training_frame=training_frame)
-        >>> # Get the top model
+        >>> # Get the best model in the AutoML Leaderboard
         >>> aml.leader
         """
         return h2o.get_model(self._leader_id)
@@ -169,9 +167,9 @@ class H2OAutoML(object):
         :examples:
         >>> # Set up an H2OAutoML object
         >>> aml = H2OAutoML(max_runtime_secs=30)
-        >>> # Launch H2OAutoML
+        >>> # Launch an AutoML run
         >>> aml.train(y=y, training_frame=training_frame)
-        >>> # Get the leaderboard
+        >>> # Get the AutoML Leaderboard
         >>> aml.leaderboard
         """
         return self._leaderboard
@@ -202,13 +200,13 @@ class H2OAutoML(object):
         :examples:
         >>> # Set up an H2OAutoML object
         >>> aml = H2OAutoML(max_runtime_secs=30)
-        >>> # Launch H2OAutoML
+        >>> # Launch an AutoML run
         >>> aml.train(y=y, training_frame=training_frame)
         """
         ncols = training_frame.ncols
         names = training_frame.names
 
-        #Minimal required arguments are training_frame and y (response)
+        # Minimal required arguments are training_frame and y (response)
         if y is None:
             raise ValueError('The response column (y) is not set; please set it to the name of the column that you are trying to predict in your data.')
         else:
@@ -295,11 +293,11 @@ class H2OAutoML(object):
         :returns: A new H2OFrame of predictions.
 
         :examples:
-        >>> #Set up an H2OAutoML object
+        >>> # Set up an H2OAutoML object
         >>> aml = H2OAutoML(max_runtime_secs=30)
         >>> # Launch H2OAutoML
         >>> aml.train(y=y, training_frame=training_frame)
-        >>> #Predict with #1 model from H2OAutoML leaderboard
+        >>> # Predict with #1 model from AutoML Leaderboard
         >>> aml.predict(test_data)
 
         """

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -75,6 +75,10 @@ class H2OAutoML(object):
                   "*******************************************************************\n" \
                   "\nVerbose Error Message:")
 
+        
+        #nfolds must not be negative or equal to 1:
+        assert nfolds >= 0, "nfolds cannot be negative. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."
+        assert nfolds is not 1, "nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."       
 
         #If max_runtime_secs is not provided, then it is set to default (3600 secs)
         if max_runtime_secs is not 3600:

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -116,16 +116,11 @@ def prostate_automl_args():
     print("Check nfolds = 0 works properly")
     aml = H2OAutoML(project_name="aml_nfolds0", nfolds=0, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
-    # TO DO: Check that leaderboard does not contain any SEs
-    # grab the last model in the leaderboard (which should not be an SE model) and verify that nfolds = 0
+    # grab the last model in the leaderboard (which will not be an SE model) and verify that nfolds = 0
     # we assume that if one model correctly used nfolds = 0, then they all do, but we could add an extra check for this
     amodel = h2o.get_model(aml.leaderboard[aml.leaderboard.nrows-1,0])
     assert amodel.params['nfolds']['actual'] == 0
 
-    # TO DO:
-    #print("Check nfolds = 1 fails on the client side")
-    #aml = H2OAutoML(project_name="aml_nfolds1", nfolds=1, max_models=3, seed=1)
-    #aml.train(y="CAPSULE", training_frame=train)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(prostate_automl_args)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -11,7 +11,6 @@ This test is used to check arguments passed into H2OAutoML along with different 
 def prostate_automl_args():
 
     df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
-    df = h2o.import_file(path="/Users/me/h2oai/github/h2o-3/smalldata//logreg/prostate.csv")
 
     #Split frames
     fr = df.split_frame(ratios=[.8,.1])

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -25,100 +25,110 @@ def prostate_automl_args():
     test["CAPSULE"] = test["CAPSULE"].asfactor()
 
     print("Check arguments to H2OAutoML class")
-    aml = H2OAutoML(max_runtime_secs = 10, project_name="aml", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
-    assert aml.project_name == "aml", "Project name is not set"
+    assert aml.project_name == "py_aml0", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
     assert aml.max_models == 10, "max_models is not set to 10"
     assert aml.seed == 1234, "seed is not set to `1234`"
+    print("Check leaderboard")
+    print(aml.leaderboard)    
 
     print("AutoML run with x not provided and train set only")
-    aml.project_name = "Project1"
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml1", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
-    assert aml.project_name == "Project1", "Project name is not set"
-    assert aml.project_name == "Project1", "Project name is not set"
+    assert aml.project_name == "py_aml1", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
     assert aml.max_models == 10, "max_models is not set to 10"
     assert aml.seed == 1234, "seed is not set to `1234`"
+    print("Check leaderboard")
+    print(aml.leaderboard)    
 
     print("AutoML run with x not provided with train and valid")
-    aml.project_name = "Project2"
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml2", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y="CAPSULE", training_frame=train, validation_frame=valid)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
-    assert aml.project_name == "Project2", "Project name is not set"
+    assert aml.project_name == "py_aml2", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
     assert aml.max_models == 10, "max_models is not set to 10"
     assert aml.seed == 1234, "seed is not set to `1234`"
+    print("Check leaderboard")
+    print(aml.leaderboard)    
 
     print("AutoML run with x not provided with train and test")
-    aml.project_name = "Project3"
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml3", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y="CAPSULE", training_frame=train, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
-    assert aml.project_name == "Project3", "Project name is not set"
+    assert aml.project_name == "py_aml3", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
     assert aml.max_models == 10, "max_models is not set to 10"
     assert aml.seed == 1234, "seed is not set to `1234`"
+    print("Check leaderboard")
+    print(aml.leaderboard)    
 
     print("AutoML run with x not provided with train, valid, and test")
-    aml.project_name = "Project4"
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml4", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y="CAPSULE", training_frame=train, validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
-    assert aml.project_name == "Project4", "Project name is not set"
+    assert aml.project_name == "py_aml4", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
     assert aml.max_models == 10, "max_models is not set to 10"
     assert aml.seed == 1234, "seed is not set to `1234`"
+    print("Check leaderboard")
+    print(aml.leaderboard)    
 
     print("AutoML run with x not provided and y as col idx with train, valid, and test")
-    aml.project_name = "Project5"
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml5", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y=1, training_frame=train, validation_frame=valid, leaderboard_frame=test)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
-    assert aml.project_name == "Project5", "Project name is not set"
+    assert aml.project_name == "py_aml5", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
     assert aml.max_models == 10, "max_models is not set to 10"
     assert aml.seed == 1234, "seed is not set to `1234`"
+    print("Check leaderboard")
+    print(aml.leaderboard)
 
     print("Check predict, leader, and leaderboard")
     print("AutoML run with x not provided and train set only")
-    aml.project_name = "Project6"
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml6", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
-    print("Check leader")
-    print(aml.leader)
     print("Check leaderboard")
     print(aml.leaderboard)
     print("Check predictions")
     print(aml.predict(train))
 
     print("Check nfolds is passed through to base models")
-    aml = H2OAutoML(project_name="aml_nfolds3", nfolds=3, max_models=3, seed=1)
+    aml = H2OAutoML(project_name="py_aml_nfolds3", nfolds=3, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
     # grab the last model in the leaderboard, hoping that it's not an SE model
     amodel = h2o.get_model(aml.leaderboard[aml.leaderboard.nrows-1,0])
     # if you get a stacked ensemble, take the second to last 
     # right now, if the last is SE, then second to last must be non-SE, but when we add multiple SEs, this will need to be updated
-    if type(amodel) == h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
+    if type(amodel) == h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator:
       amodel = h2o.get_model(aml.leaderboard[aml.leaderboard.nrows-2,0])
     assert amodel.params['nfolds']['actual'] == 3
 
     print("Check nfolds = 0 works properly")
-    aml = H2OAutoML(project_name="aml_nfolds0", nfolds=0, max_models=3, seed=1)
+    aml = H2OAutoML(project_name="py_aml_nfolds0", nfolds=0, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
-    # grab the last model in the leaderboard (which will not be an SE model) and verify that nfolds = 0
+    # grab the last model in the leaderboard (which should not be an SE model) and verify that nfolds = 0
     # we assume that if one model correctly used nfolds = 0, then they all do, but we could add an extra check for this
     amodel = h2o.get_model(aml.leaderboard[aml.leaderboard.nrows-1,0])
+    assert type(amodel) is not h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
     assert amodel.params['nfolds']['actual'] == 0
 
 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -160,6 +160,12 @@ h2o.automl <- function(x, y, training_frame,
   }
   
   # Update build_control with nfolds
+  if (nfolds < 0) {
+    stop("nfolds cannot be negative. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable.")
+  }
+  if (nfolds == 1) {
+    stop("nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable.")
+  }
   build_control$nfolds <- nfolds
   
   # Create the parameter list to POST to the AutoMLBuilder 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -11,6 +11,7 @@
 #' @param training_frame Training data frame (or ID).
 #' @param validation_frame Validation data frame (or ID); Optional.
 #' @param leaderboard_frame Leaderboard data frame (or ID).  The Leaderboard will be scored using this data set. Optional.
+#' @param nfolds Number of folds for k-fold cross-validation. Defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensemble (thus decreasing the overall model performance).
 #' @param fold_column Column with cross-validation fold index assignment per observation; used to override the default, randomized, 5-fold cross-validation scheme for individual models in the AutoML run.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from 
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative weights are not allowed.
@@ -42,6 +43,7 @@
 h2o.automl <- function(x, y, training_frame,
                        validation_frame = NULL,
                        leaderboard_frame = NULL,
+                       nfolds = 5,
                        fold_column = NULL,
                        weights_column = NULL,
                        max_runtime_secs = 3600,
@@ -156,6 +158,9 @@ h2o.automl <- function(x, y, training_frame,
   } else {
     build_control$project_name <- project_name
   }
+  
+  # Update build_control with nfolds
+  build_control$nfolds <- nfolds
   
   # Create the parameter list to POST to the AutoMLBuilder 
   params <- list(input_spec = input_spec, build_control = build_control)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -173,6 +173,10 @@ automl.args.test <- function() {
                       nfolds = 0,
                       max_models = 3,
                       project_name = "aml13")
+  # TO DO: check that leaderboard does not contain any SEs
+  amodel <- h2o.getModel(tail(aml13@leaderboard, 1)$model_id)
+  expect_equal(amodel@parameters$nfolds, 0)
+  # TO DO: Also need to check that we handle the leaderboard properly
   
 }
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -96,7 +96,7 @@ automl.args.test <- function() {
                      max_runtime_secs = max_runtime_secs,
                      max_models = 3,
                      project_name = "aml8")
-  expect_equal(nrow(aml8@leaderboard) > nrow_aml8_lb,TRUE)
+  expect_equal(nrow(aml8@leaderboard) > nrow_aml8_lb, TRUE)
   
   
   # Add a fold_column and weights_column
@@ -112,12 +112,12 @@ automl.args.test <- function() {
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml9")
   amodel <- h2o.getModel(tail(aml9@leaderboard, 1)$model_id)
-  if(grepl("^StackedEnsemble",amodel@model_id)){
+  if (grepl("^StackedEnsemble", amodel@model_id)) {
     print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold_column test")
     amodel <- h2o.getModel(head(tail(aml9@leaderboard, 2), 1)$model_id)
     amodel_fold_column <- amodel@parameters$fold_column$column_name
     expect_equal(amodel_fold_column, fold_column)
-  }else{
+  } else {
     amodel_fold_column <- amodel@parameters$fold_column$column_name
     expect_equal(amodel_fold_column, fold_column)
   }
@@ -129,14 +129,14 @@ automl.args.test <- function() {
                       max_runtime_secs = max_runtime_secs,
                       project_name = "aml10")
   amodel <- h2o.getModel(tail(aml10@leaderboard, 1)$model_id)
-  if(grepl("^StackedEnsemble",amodel@model_id)){
-      print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for weights_column test")
-      amodel <- h2o.getModel(head(tail(aml10@leaderboard, 2), 1)$model_id)
-      amodel_weights_column <- amodel@parameters$weights_column$column_name
-      expect_equal(amodel_weights_column, weights_column)
-  }else{
-      amodel_weights_column <- amodel@parameters$weights_column$column_name
-      expect_equal(amodel_weights_column, weights_column)
+  if (grepl("^StackedEnsemble",amodel@model_id)) {
+    print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for weights_column test")
+    amodel <- h2o.getModel(head(tail(aml10@leaderboard, 2), 1)$model_id)
+    amodel_weights_column <- amodel@parameters$weights_column$column_name
+    expect_equal(amodel_weights_column, weights_column)
+  } else {
+    amodel_weights_column <- amodel@parameters$weights_column$column_name
+    expect_equal(amodel_weights_column, weights_column)
   }
   
   print("Check fold_colum and weights_column")
@@ -147,19 +147,29 @@ automl.args.test <- function() {
                       max_runtime_secs = max_runtime_secs,
                       project_name = "aml11")
   amodel <- h2o.getModel(tail(aml11@leaderboard, 1)$model_id)
-  if(grepl("^StackedEnsemble",amodel@model_id)){
-      print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold/weight column test")
-      amodel <- h2o.getModel(head(tail(aml11@leaderboard, 2), 1)$model_id)
-      amodel_fold_column <- amodel@parameters$fold_column$column_name
-      expect_equal(amodel_fold_column, fold_column)
-      amodel_weights_column <- amodel@parameters$weights_column$column_name
-      expect_equal(amodel_weights_column, weights_column)
-  }else{
-      amodel_fold_column <- amodel@parameters$fold_column$column_name
-      expect_equal(amodel_fold_column, fold_column)
-      amodel_weights_column <- amodel@parameters$weights_column$column_name
-      expect_equal(amodel_weights_column, weights_column)
+  if (grepl("^StackedEnsemble",amodel@model_id)) {
+    print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold/weight column test")
+    amodel <- h2o.getModel(head(tail(aml11@leaderboard, 2), 1)$model_id)
+    amodel_fold_column <- amodel@parameters$fold_column$column_name
+    expect_equal(amodel_fold_column, fold_column)
+    amodel_weights_column <- amodel@parameters$weights_column$column_name
+    expect_equal(amodel_weights_column, weights_column)
+  } else {
+    amodel_fold_column <- amodel@parameters$fold_column$column_name
+    expect_equal(amodel_fold_column, fold_column)
+    amodel_weights_column <- amodel@parameters$weights_column$column_name
+    expect_equal(amodel_weights_column, weights_column)
   }
+  
+  # TO DO: Finish this
+  print("Check nfolds")
+  aml12 <- h2o.automl(x = x, y = y, 
+                      training_frame = train,
+                      nfolds = 3,
+                      #max_runtime_secs = max_runtime_secs,
+                      max_models = 3,
+                      project_name = "aml12")
+  #expect_equal(nrow(aml12@leaderboard) > nrow_aml12_lb, TRUE)
   
 }
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -129,15 +129,12 @@ automl.args.test <- function() {
                       max_runtime_secs = max_runtime_secs,
                       project_name = "aml10")
   amodel <- h2o.getModel(tail(aml10@leaderboard, 1)$model_id)
-  if (grepl("^StackedEnsemble",amodel@model_id)) {
+  if (grepl("^StackedEnsemble", amodel@model_id)) {
     print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for weights_column test")
     amodel <- h2o.getModel(head(tail(aml10@leaderboard, 2), 1)$model_id)
-    amodel_weights_column <- amodel@parameters$weights_column$column_name
-    expect_equal(amodel_weights_column, weights_column)
-  } else {
-    amodel_weights_column <- amodel@parameters$weights_column$column_name
-    expect_equal(amodel_weights_column, weights_column)
-  }
+  } 
+  amodel_weights_column <- amodel@parameters$weights_column$column_name
+  expect_equal(amodel_weights_column, weights_column)
   
   print("Check fold_colum and weights_column")
   aml11 <- h2o.automl(x = x, y = y, 
@@ -147,29 +144,35 @@ automl.args.test <- function() {
                       max_runtime_secs = max_runtime_secs,
                       project_name = "aml11")
   amodel <- h2o.getModel(tail(aml11@leaderboard, 1)$model_id)
-  if (grepl("^StackedEnsemble",amodel@model_id)) {
+  if (grepl("^StackedEnsemble", amodel@model_id)) {
     print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold/weight column test")
     amodel <- h2o.getModel(head(tail(aml11@leaderboard, 2), 1)$model_id)
-    amodel_fold_column <- amodel@parameters$fold_column$column_name
-    expect_equal(amodel_fold_column, fold_column)
-    amodel_weights_column <- amodel@parameters$weights_column$column_name
-    expect_equal(amodel_weights_column, weights_column)
-  } else {
-    amodel_fold_column <- amodel@parameters$fold_column$column_name
-    expect_equal(amodel_fold_column, fold_column)
-    amodel_weights_column <- amodel@parameters$weights_column$column_name
-    expect_equal(amodel_weights_column, weights_column)
-  }
+  } 
+  amodel_fold_column <- amodel@parameters$fold_column$column_name
+  expect_equal(amodel_fold_column, fold_column)
+  amodel_weights_column <- amodel@parameters$weights_column$column_name
+  expect_equal(amodel_weights_column, weights_column)
   
-  # TO DO: Finish this
-  print("Check nfolds")
+  print("Check that nfolds is piped through properly to base models (nfolds > 1)")
   aml12 <- h2o.automl(x = x, y = y, 
                       training_frame = train,
                       nfolds = 3,
-                      #max_runtime_secs = max_runtime_secs,
                       max_models = 3,
                       project_name = "aml12")
-  #expect_equal(nrow(aml12@leaderboard) > nrow_aml12_lb, TRUE)
+  amodel <- h2o.getModel(tail(aml12@leaderboard, 1)$model_id)
+  if (grepl("^StackedEnsemble", amodel@model_id)) {
+    print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold/weight column test")
+    amodel <- h2o.getModel(head(tail(aml12@leaderboard, 2), 1)$model_id)
+  } 
+  expect_equal(amodel@parameters$nfolds, 3)
+  
+  # TO DO: Finish this
+  print("Check that nfolds = 0 works properly")  #will need to change after xval leaderboard is implemented
+  aml13 <- h2o.automl(x = x, y = y, 
+                      training_frame = train,
+                      nfolds = 0,
+                      max_models = 3,
+                      project_name = "aml13")
   
 }
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -166,17 +166,18 @@ automl.args.test <- function() {
   } 
   expect_equal(amodel@parameters$nfolds, 3)
   
-  # TO DO: Finish this
   print("Check that nfolds = 0 works properly")  #will need to change after xval leaderboard is implemented
   aml13 <- h2o.automl(x = x, y = y, 
                       training_frame = train,
                       nfolds = 0,
                       max_models = 3,
                       project_name = "aml13")
-  # TO DO: check that leaderboard does not contain any SEs
-  amodel <- h2o.getModel(tail(aml13@leaderboard, 1)$model_id)
+  # Check that leaderboard does not contain any SEs
+  for (model_id in as.vector(aml13@leaderboard$model_id)) {
+    expect_equal(grepl("^StackedEnsemble", model_id), FALSE)
+  }
+  amodel <- h2o.getModel(tail(aml12@leaderboard, 1)$model_id)
   expect_equal(amodel@parameters$nfolds, 0)
-  # TO DO: Also need to check that we handle the leaderboard properly
   
 }
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -176,8 +176,8 @@ automl.args.test <- function() {
   for (model_id in as.vector(aml13@leaderboard$model_id)) {
     expect_equal(grepl("^StackedEnsemble", model_id), FALSE)
   }
-  amodel <- h2o.getModel(tail(aml12@leaderboard, 1)$model_id)
-  expect_equal(amodel@parameters$nfolds, 0)
+  amodel <- h2o.getModel(tail(aml13@leaderboard, 1)$model_id)
+  expect_equal(amodel@allparameters$nfolds, 0)
   
 }
 


### PR DESCRIPTION
We now expose the `nfolds` argument field to the user in AutoML.  Changes were made to AutoML Java backend and R and Py clients and docs.
- Added `nfolds` to R and Python AutoML interface with a default value of 5 (not auto-generated).
- Added runit and pyunit to test for `nfolds >=2` and `nfolds = 0`
- Added client-side checking for the `nfolds = 1` case with nice error messages.
- Added `nfolds` to AutoML user guide docs & made some other updates to cross-validation and nfolds user guid pages.