### PR TITLE
[PUBDEV-5040] HTTP logs can't be obtained in Flow UI

### DIFF
--- a/h2o-core/src/main/java/water/api/LogsHandler.java
+++ b/h2o-core/src/main/java/water/api/LogsHandler.java
@@ -61,7 +61,6 @@ public class LogsHandler extends Handler {
           case "warn":
           case "error":
           case "fatal":
-          case "httpd":
             if(!Log.isLoggingFor(name)){
               log = "Logging for "+ name.toUpperCase() + " is not enabled as the log level is set to " + Log.LVLS[Log.getLogLevel()]+".";
             }else {
@@ -70,6 +69,13 @@ public class LogsHandler extends Handler {
               } catch (Exception e) {
                 log = "H2O logging not configured.";
               }
+            }
+            break;
+          case "httpd":
+            try {
+              logPathFilename = Log.getLogFilePath(name);
+            } catch (Exception e) {
+              log = "H2O logging not configured.";
             }
             break;
           default:


### PR DESCRIPTION
This change unblocks obtaining http logs. They are special kind of logs which are available independently on whatever the current log level is set to.

Before `Log.isLoggingFor(name)` was called with `httpd` as the argument and it always return `false`. We need to handle this as different situation and don't ask if logging is enabled for httpd.