### PR TITLE
PUBDEV-4791: Enable lambda search for the GLM metalearner in Stacked Ensemble

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -233,6 +233,12 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       metaBuilder._parms._train = levelOneTrainingFrame._key;
       metaBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
       metaBuilder._parms._response_column = _model.responseColumn;
+      //Enable lambda search if a validation frame is passed in to get a better GLM fit.
+      //Since we are also using non_negative to true, we should also set early_stopping = false.
+      if(metaBuilder._parms._valid != null){
+        metaBuilder._parms._lambda_search = true;
+        metaBuilder._parms._early_stopping = false;
+      }
 
       if(_model.modelCategory == ModelCategory.Regression){
           metaBuilder._parms._family = GLMModel.GLMParameters.Family.gaussian;

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_validation_frame.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_validation_frame.py
@@ -52,7 +52,7 @@ def stackedensemble_validation_frame_test():
     my_gbm.train(x=x, y=y, training_frame=train)
 
     # Train and cross-validate a RF
-    my_rf = H2ORandomForestEstimator(ntrees=50,
+    my_rf = H2ORandomForestEstimator(ntrees=10,
                                      nfolds=nfolds,
                                      fold_assignment="Modulo",
                                      keep_cross_validation_predictions=True,
@@ -74,7 +74,7 @@ def stackedensemble_validation_frame_test():
     # Compare test AUC (ensemble with validation_frame should not be worse)
     perf1 = stack1.model_performance(test_data=test)
     perf2 = stack2.model_performance(test_data=test)
-    assert perf1.auc() >= perf2.auc()
+    assert perf2.auc() >= perf1.auc()
 
 
 if __name__ == "__main__":

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_validation_frame.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_validation_frame.R
@@ -62,11 +62,19 @@ stackedensemble.validation_frame.test <- function() {
   expect_equal(inherits(h2o.performance(stack2, valid = TRUE), "H2OBinomialMetrics"), TRUE)
   expect_equal(class(h2o.auc(stack2, valid = TRUE)), "numeric")
   
-  
   # Compare test AUC (ensemble with validation_frame should not be worse)
   perf1 <- h2o.performance(model = stack1, newdata = test)
+  cat("\nstack 1 perf metrics(no validation)\n")
+  print(perf1)
   perf2 <- h2o.performance(model = stack2, newdata = test)
-  expect_true(h2o.auc(perf1) >= h2o.auc(perf2))
+  cat("\nstack 2 perf metrics(validation)\n")
+  print(perf2)
+  expect_true(h2o.auc(perf2) >= h2o.auc(perf1)) #Validation frame
+  cat("\nstack1 (no validation) auc\n")
+  print(h2o.auc(perf1))
+  cat("\nstack2 (validation) auc\n")
+  print(h2o.auc(perf2))
+
   
 }
 


### PR DESCRIPTION
* Now that we are piping the `validation_frame` through to the GLM metalearner in the Stacked Ensemble algo, we should enable lambda search so that we can make use of this `validation_frame` to get a better GLM fit.
* Since we are also using `non_negative = TRUE`, we should set `early_stopping = false`.
* Also updated unit tests to reflect previous changes.