### PR TITLE
PUBDEV-5029: GLM crashes whem there are too many active predictors

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1207,7 +1207,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     int max_active = 0;
     if(_parms._family == Family.multinomial )
       for(int c = 0; c < _nclass; ++c)
-        max_active = Math.max(_state.activeDataMultinomial(c).fullN(),max_active);
+        max_active += _state.activeDataMultinomial(c).fullN();
     else max_active = _state.activeData().fullN();
     if(max_active >= 5000) // cutoff has to be somewhere
       s = Solver.L_BFGS;

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5029.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5029.R
@@ -4,8 +4,7 @@ source("../../scripts/h2o-r-test-setup.R")
 
 
 test.pubdev.5029 <- function() {
-
-    test_file <- "private/test.csv.gz"
+    test_file <- locate("smalldata/flow_examples/mnist/test.csv.gz")
     df <- h2o.importFile(test_file)
     y <- "C785"
     x <- setdiff(names(df), y)

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5029.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5029.R
@@ -15,7 +15,7 @@ test.pubdev.5029 <- function() {
 
     model <- h2o.glm(x = x, y = y, training_frame = train, lambda_search = TRUE,
                      family = 'multinomial', alpha = 0, weights_column = "weights", seed = -1)
-    expect_equal("GLM", class(model)) # any assertion will do fine
+    expect_true(! is.null(model)) # any assertion will do fine
 }
 
 doTest("PUBDEV-5029: GLM crashes if there are too many active predictors", test.pubdev.5029)

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5029.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5029.R
@@ -1,0 +1,22 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.pubdev.5029 <- function() {
+
+    test_file <- "private/test.csv.gz"
+    df <- h2o.importFile(test_file)
+    y <- "C785"
+    x <- setdiff(names(df), y)
+    df[,y] <- as.factor(df[,y])
+    train <- df[1:1000,]
+
+    train$weights <- as.h2o(as.integer(seq(1000) %% 5 > 0))
+
+    model <- h2o.glm(x = x, y = y, training_frame = train, lambda_search = TRUE,
+                     family = 'multinomial', alpha = 0, weights_column = "weights", seed = -1)
+    expect_equal("GLM", class(model)) # any assertion will do fine
+}
+
+doTest("PUBDEV-5029: GLM crashes if there are too many active predictors", test.pubdev.5029)


### PR DESCRIPTION
For the multinomial case we need to consider the total of active
predictors for all classes to pick the correct solver (instead of maximum of the classes).

If total number of active predictors for the first lambda is > 5000
and solver L_BFGS was not auto-selected we will cap the number
of predictors to 5000. This will cause the algorithm to crash for the
next lambda because the number of active predictors is already > 5000
and this will violate the invariant #active < #max.