### PR TITLE
PUBDEV-5056: Binary models not compatible across h2o versions

### DIFF
--- a/h2o-docs/src/product/faq/general.rst
+++ b/h2o-docs/src/product/faq/general.rst
@@ -1,13 +1,17 @@
 General
 -------
 
+**I updated my H2O to the newest version. Why can I no longer load a pre-trained model?**
+
+When saving an H2O binary model with ``h2o.saveModel`` (R), ``h2o.save_model`` (Python), or in Flow, you will only be able to load and use that saved binary model with the same version of H2O that you used to train your model. H2O binary models are not compatible across H2O versions. If you update your H2O version, then you will need to retrain your model. For production, you can save your model as a :ref:`POJO/MOJO <about-pojo-mojo>`. These artifacts are not tied to a particular version of H2O because they are just plain Java code and do not require an H2O cluster to be running.
+
 **How do I score using an exported JSON model?**
 
 Since JSON is just a representation format, it cannot be directly
 executed, so a JSON export can't be used for scoring. However, you can
 score by:
 
--  including the POJO in your execution stream and handing it
+-  including the POJO/MOJO in your execution stream and handing it
    observations one at a time
 
 or

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -1192,6 +1192,8 @@ The following additional functions are available when viewing a model:
 
 --------------
 
+.. _export-import-models-flow:
+
 Exporting and Importing Models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -1,7 +1,7 @@
-Getting Data into H2O
-=====================
+Getting Data into Your H2O Cluster
+==================================
 
-Getting your data into H2O is the first step toward building and scoring your models. Whether you're importing data, uploading data, or retrieving data from HDFS or S3, be sure that your data is compatible with H2O.
+The first step toward building and scoring your models is getting your data into the H2O cluster/Java process that’s running on your local or remote machine. Whether you're importing data, uploading data, or retrieving data from HDFS or S3, be sure that your data is compatible with H2O.
 
 Supported File Formats
 ----------------------

--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -3,6 +3,8 @@
 Productionizing H2O
 ===================
 
+.. _about-pojo-mojo:
+
 About POJOs and MOJOs
 ---------------------
 

--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -3,6 +3,8 @@ Saving and Loading a Model
 
 This section describes how to save and load models using R, Python, and Flow. 
 
+**Note**: When saving an H2O binary model with ``h2o.saveModel`` (R), ``h2o.save_model`` (Python), or in Flow, you will only be able to load and use that saved binary model with the same version of H2O that you used to train your model. H2O binary models are not compatible across H2O versions. If you update your H2O version, then you will need to retrain your model. For production, you can save your model as a :ref:`POJO/MOJO <about-pojo-mojo>`. These artifacts are not tied to a particular version of H2O because they are just plain Java code and do not require an H2O cluster to be running.
+
 In R and Python
 ---------------
 
@@ -67,4 +69,4 @@ In R and Python, you can save a model locally or to HDFS using the ``h2o.saveMod
 In Flow
 -------
 
-The steps for saving and loading models in Flow are described in the **Using Flow - H2O's Web UI** section. Specifically, refer to `Exporting and Importing Models <flow.html#exporting-and-importing-models>`__ for information about loading models into Flow. 
+The steps for saving and loading models in Flow are described in the **Using Flow - H2O's Web UI** section. Specifically, refer to :ref:`Exporting and Importing Models <export-import-models-flow>` for information about loading models into Flow. 


### PR DESCRIPTION
Added a note to the “Saving and Loading a Model” and “Faq > General” sections describing that models saved in Python, R, or Flow using one version of h2o cannot be loaded in another version. A workaround is to use POJO/MOJO.
Driveby fix: Noted in the “Getting Data into H2O” section that this refers to getting data into your h2o cluster (as opposed to an H2O.ai cloud).