### PR TITLE
PUBDEV-5062: Splitting in DRF is same as GBM

### DIFF
--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -294,7 +294,7 @@ FAQ
 -  **What happens when you try to predict on a categorical level not
    seen during training?**
 
-  DRF converts a new categorical level to a NA value in the test set, and then splits left on the NA value during scoring. The algorithm splits left on NA values because, during training, Na values are grouped with the outliers in the left-most bin.
+  DRF converts a new categorical level to a NA value in the test set, and then splits left on the NA value during scoring. The algorithm splits left on NA values because, during training, NA values are grouped with the outliers in the left-most bin.
 
 -  **Does it matter if the data is sorted?**
 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -317,6 +317,24 @@ FAQ
 
   Large numbers of categoricals are handled very efficiently - there is never any one-hot encoding.
 
+- **Does the algo stop splitting when all the possible splits lead to worse error measures?**
+
+ It does if you use ``min_split_improvement`` (min_split_improvement turned ON by default (0.00001).) When properly tuned, this option can help reduce overfitting. 
+
+- **When does the algo stop splitting on an internal node?**
+
+ A single tree will stop splitting when there are no more splits that satisfy the minimum rows parameter, if it reaches ``max_depth``, or if there are no splits that satisfy the ``min_split_improvement`` parameter.
+
+- **How does DRF decide which feature to split on?**
+
+ It splits on the column and level that results in the greatest reduction in residual sum of the squares (RSS) in the subtree at that point. It considers all fields available from the algorithm. Note that any use of column sampling and row sampling will cause each decision to not consider all data points, and that this is on purpose to generate more robust trees. To find the best level, the histogram binning process is used to quickly compute the potential MSE of each possible split. The number of bins is controlled via ``nbins_cats`` for categoricals, the pair of ``nbins`` (the number of bins for the histogram to build, then split at the best point), and ``nbins_top_level`` (the minimum number of bins at the root level to use to build the histogram). This number will then be decreased by a factor of two per level. 
+
+ For ``nbins_top_level``, higher = more precise, but potentially more prone to overfitting. Higher also takes more memory and possibly longer to run.
+
+- **What is the difference between nbins and nbins_top_level?**
+
+ ``nbins`` and ``nbins_top_level`` are both for numerics (real and integer). ``nbins_top_level`` is the number of bins DRF uses at the top of each tree. It then divides by 2 at each ensuing level to find a new number. ``nbins`` controls when DRF stops dividing by 2.
+
 -  **How is variable importance calculated for DRF?**
 
  Variable importance is determined by calculating the relative influence of each variable: whether that variable was selected during splitting in the tree building process and how much the squared error (over all trees) improved as a result.

--- a/h2o-docs/src/product/data-science/gbm-faq/splitting.rst
+++ b/h2o-docs/src/product/data-science/gbm-faq/splitting.rst
@@ -23,6 +23,6 @@ Splitting
 
  ``nbins`` and ``nbins_top_level`` are both for numerics (real and integer). ``nbins_top_level`` is the number of bins GBM uses at the top of each tree. It then divides by 2 at each ensuing level to find a new number. ``nbins`` controls when GBM stops dividing by 2.
 
-- **Doesn't GBM do the same thing as RF for col_sample_rate < 1 ?**
+- **Doesn't GBM do the same thing as RF for splitting?**
 
  Yes for splitting, there is no difference between RF and GBM. They both use the same tree splitting.


### PR DESCRIPTION
Splitting criterion in GBM and DRF trees is identical, but this info was only included in GBM. Added the same FAQs to the DRF section (editing also name when necessary). 