### PR TITLE
PUBDEV-5057: `x` parameter missing from documentation

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -65,7 +65,7 @@ Optional Parameters
 Optional Data Parameters
 ''''''''''''''''''''''''
 
-- **x**: A list/vector of predictor column names or indexes.  This argument only needs to be specified if the user wants to exclude columns from the set of predictors.  If all columns (other than the response) should be used in prediction, then this does not need to be set.
+- `x <data-science/algo-params/x.html>`__: A list/vector of predictor column names or indexes.  This argument only needs to be specified if the user wants to exclude columns from the set of predictors.  If all columns (other than the response) should be used in prediction, then this does not need to be set.
 
 - `validation_frame <data-science/algo-params/validation_frame.html>`__: This argument is is used for early stopping within the training process of the individual models in the AutoML run.  
 
@@ -75,6 +75,7 @@ Optional Data Parameters
 
 - `weights_column <data-science/algo-params/weights_column.html>`__: Specifies a column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative weights are not allowed.
 
+-  `ignored_columns <data-science/algo-params/ignored_columns.html>`__: (Optional, Python only) Specify the column or columns to be excluded from the model. 
 
 Optional Miscellaneous Parameters
 '''''''''''''''''''''''''''''''''

--- a/h2o-docs/src/product/data-science/algo-params/ignored_columns.rst
+++ b/h2o-docs/src/product/data-science/algo-params/ignored_columns.rst
@@ -1,11 +1,13 @@
 ``ignored_columns``
 -------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, XGBoost
+- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, AutoML, XGBoost
 - Hyperparameter: no
 
 Description
 ~~~~~~~~~~~
+
+**Note**: This command is only available in the Python client and in Flow. It is not available in R. 
 
 There may be instances when your dataset includes information that you want to be ignored when building a model. Use the ``ignored_columns`` parameter to specify an array of column names that should be ignored. This is a strict parameter that takes into account the exact string of the column name. So, for example, if your dataset includes one column named **Type** and another column named **Types**, and you specify ``ignored_columns=["type"]``, then the algorithm will only ignore the **Type** column and will not ignore the **Types** column.
 
@@ -13,46 +15,13 @@ Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
 - `ignore_const_cols <ignore_const_cols.html>`__
+- `x <x.html>`__
 
 
 Example
 ~~~~~~~
 
 .. example-code::
-   .. code-block:: r
-
-	library(h2o)
-	h2o.init()
-	# import the airlines dataset:
-	# This dataset is used to classify whether a flight will be delayed 'YES' or not "NO"
-	# original data can be found at http://www.transtats.bts.gov/
-	airlines <-  h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
-
-	# convert columns to factors
-	airlines["Year"] <- as.factor(airlines["Year"])
-	airlines["Month"] <- as.factor(airlines["Month"])
-	airlines["DayOfWeek"] <- as.factor(airlines["DayOfWeek"])
-	airlines["Cancelled"] <- as.factor(airlines["Cancelled"])
-	airlines['FlightNum'] <- as.factor(airlines['FlightNum'])
-
-	# set the predictor names and the response column name
-	predictors <- colnames(airlines[1:9])
-	response <- "IsDepDelayed"
-
-	# split into train and validation
-	airlines.splits <- h2o.splitFrame(data =  airlines, ratios = .8, seed = 1234)
-	train <- airlines.splits[[1]]
-	valid <- airlines.splits[[2]]
-
-	# try using the `ignored_columns` parameter:
-	col_list <- c('DepTime','CRSDepTime','ArrTime','CRSArrTime')
-	# train your model
-	airlines.gbm <- h2o.gbm(x = predictors, y = response, training_frame = train, validation_frame = valid,
-	                        seed = 1234)
-
-	# print the auc for the validation data
-	print(h2o.auc(airlines.gbm, valid = TRUE))
-
    .. code-block:: python
 
 	import h2o

--- a/h2o-docs/src/product/data-science/algo-params/k.rst
+++ b/h2o-docs/src/product/data-science/algo-params/k.rst
@@ -1,7 +1,7 @@
 ``k``
 -----
 
-- Available in: K-Means, PCA
+- Available in: K-Means, PCA, GLRM
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/transform.rst
+++ b/h2o-docs/src/product/data-science/algo-params/transform.rst
@@ -1,7 +1,7 @@
 ``transform``
 -------------
 
-- Available in: PCA
+- Available in: PCA, GLRM
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/x.rst
+++ b/h2o-docs/src/product/data-science/algo-params/x.rst
@@ -1,0 +1,86 @@
+``x``
+-----
+
+- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, Stacked Ensembles, AutoML, XGBoost
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+There may be instances when your dataset includes more information than you want to be included when building a model. Use the ``x`` parameter to specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
+Note that this is a strict parameter that takes into account the exact string of the column name. So, for example, if your dataset includes one column named **Type** and another column named **Types**, and you specify ``x=["type"]``, then the algorithm will only include the **Type** column and will ignore the **Types** column.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `ignore_const_cols <ignore_const_cols.html>`__
+- `y <y.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the cars dataset: 
+	# this dataset is used to classify whether or not a car is economical based on 
+	# the car's displacement, power, weight, and acceleration, and the year it was made 
+	cars <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+
+	# convert response column to a factor
+	cars["economy_20mpg"] <- as.factor(cars["economy_20mpg"])
+
+	# set the predictor names and the response column name
+	predictors <- c("displacement","power","weight","acceleration","year")
+	response <- "economy_20mpg"
+
+	# split into train and validation sets
+	cars.split <- h2o.splitFrame(data = cars,ratios = 0.8, seed = 1234)
+	train <- cars.split[[1]]
+	valid <- cars.split[[2]]
+
+	# try using the `y` parameter:
+	# train your model, where you specify your 'x' predictors, your 'y' the response column
+	# training_frame and validation_frame
+	cars_gbm <- h2o.gbm(x = predictors, y = response, training_frame = train,
+	                    validation_frame = valid, seed = 1234)
+
+	# print the auc for your model
+	print(h2o.auc(cars_gbm, valid = TRUE))
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.gbm import H2OGradientBoostingEstimator
+	h2o.init()
+	h2o.cluster().show_status()
+
+	# import the cars dataset:
+	# this dataset is used to classify whether or not a car is economical based on
+	# the car's displacement, power, weight, and acceleration, and the year it was made
+	cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+
+	# convert response column to a factor
+	cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
+
+	# set the predictor names and the response column name
+	predictors = ["displacement","power","weight","acceleration","year"]
+	response = "economy_20mpg"
+
+	# split into train and validation sets
+	train, valid = cars.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `y` parameter:
+	# first initialize your estimator
+	cars_gbm = H2OGradientBoostingEstimator(seed = 1234)
+
+	# then train your model, where you specify your 'x' predictors, your 'y' the response column
+	# training_frame and validation_frame
+	cars_gbm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the auc for the validation data
+	cars_gbm.auc(valid=True)

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -40,11 +40,13 @@ H2O Deep Learning models have many input parameters, many of which are only acce
 
 -  `y <algo-params/y.html>`__: Specify the column to use as the independent variable. The data can be numeric or categorical.
 
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
 -  `fold_assignment <algo-params/fold_assignment.html>`__: (Applicable only if a value for **nfolds** is specified and **fold_column** is not specified) Specify the cross-validation fold assignment scheme. The available options are AUTO (which is Random), Random,  `Modulo <https://en.wikipedia.org/wiki/Modulo_operation>`__, or Stratified (which will stratify the folds based on the response variable for classification problems).
 
 -  `fold_column <algo-params/fold_column.html>`__: Specify the column that contains the cross-validation fold index assignment per observation.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
 -  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Specify whether to ignore constant training columns, since no information can be gained from them. This option is enabled by default.
 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -47,6 +47,8 @@ Defining a DRF Model
 -  `y <algo-params/y.html>`__: (Required) Specify the column to use as the
    independent variable. The data can be numeric or categorical.
 
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
 -  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Enable this option to keep the cross-validation prediction.
 
 -  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment.
@@ -66,7 +68,7 @@ Defining a DRF Model
 -  `fold_column <algo-params/fold_column.html>`__: Specify the column that contains the
    cross-validation fold index assignment per observation.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column
    name to add it to the list of columns excluded from the model. To add
    all columns, click the **All** button. To remove a column from the
    list of ignored columns, click the X next to the column name. To

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -50,17 +50,9 @@ Defining a GBM Model
 -  `y <algo-params/y.html>`__: (Required) Specify the column to use as the
    independent variable. The data can be numeric or categorical.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column
-   name to add it to the list of columns excluded from the model. To add
-   all columns, click the **All** button. To remove a column from the
-   list of ignored columns, click the X next to the column name. To
-   remove all columns from the list of ignored columns, click the
-   **None** button. To search for a specific column, type the column
-   name in the **Search** field above the column list. To only show
-   columns with a specific percentage of missing values, specify the
-   percentage in the **Only show columns with more than 0% missing
-   values** field. To change the selections for the hidden columns, use
-   the **Select Visible** or **Deselect Visible** buttons.
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
 -  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Specify whether to ignore constant
    training columns, since no information can be gained from them. This

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -46,6 +46,8 @@ Defining a GLM Model
       (**Enum** or **String**). If the family is **Binomial**, the
       dataset cannot contain more than two levels.
 
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
 -  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Specify whether to keep the cross-validation predictions.
 
 -  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment.
@@ -55,7 +57,7 @@ Defining a GLM Model
 
 -  `fold_column <algo-params/fold_column.html>`__: Specify the column that contains the cross-validation fold index assignment per observation.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column
    name to add it to the list of columns excluded from the model. To add
    all columns, click the **All** button. To remove a column from the
    list of ignored columns, click the X next to the column name. To

--- a/h2o-docs/src/product/data-science/glrm.rst
+++ b/h2o-docs/src/product/data-science/glrm.rst
@@ -4,30 +4,12 @@ Generalized Low Rank Models (GLRM)
 Introduction
 ~~~~~~~~~~~~
 
-Generalized Low Rank Models (GLRM) is an algorithm for dimensionality
-reduction of a dataset. It is a general, parallelized optimization
-algorithm that applies to a variety of loss and regularization
-functions. Categorical columns are handled by expansion into 0/1
-indicator columns for each level. With this approach, GLRM is useful for
-reconstructing missing values and identifying important features in
-heterogeneous data.
+Generalized Low Rank Models (GLRM) is an algorithm for dimensionality reduction of a dataset. It is a general, parallelized optimization algorithm that applies to a variety of loss and regularization functions. Categorical columns are handled by expansion into 0/1 indicator columns for each level. With this approach, GLRM is useful for reconstructing missing values and identifying important features in heterogeneous data.
 
 What is a Low-Rank Model?
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Given large collections of data with numeric and categorical values,
-entries in the table may be noisy or even missing altogether. Low rank
-models facilitate the understanding of tabular data by producing a
-condensed vector representation for every row and column in the dataset.
-Specifically, given a data table A with m rows and n columns, a GLRM
-consists of a decomposition of A into numeric matrices X and Y. The
-matrix X has the same number of rows as A, but only a small,
-user-specified number of columns k. The matrix Y has k rows and d
-columns, where d is equal to the total dimension of the embedded
-features in A. For example, if A has 4 numeric columns and 1 categorical
-column with 3 distinct levels (e.g., red, blue and green), then Y will
-have 7 columns. When A contains only numeric features, the number of
-columns in A and Y are identical.
+Given large collections of data with numeric and categorical values, entries in the table may be noisy or even missing altogether. Low rank models facilitate the understanding of tabular data by producing a condensed vector representation for every row and column in the dataset. Specifically, given a data table A with m rows and n columns, a GLRM consists of a decomposition of A into numeric matrices X and Y. The matrix X has the same number of rows as A, but only a small, user-specified number of columns k. The matrix Y has k rows and d columns, where d is equal to the total dimension of the embedded features in A. For example, if A has 4 numeric columns and 1 categorical column with 3 distinct levels (e.g., red, blue and green), then Y will have 7 columns. When A contains only numeric features, the number of columns in A and Y are identical.
 
 .. figure:: ../images/glrm_matrix_decomposition.png
    :alt: 
@@ -37,122 +19,78 @@ Both X and Y have practical interpretations. Each row of Y is an archetypal feat
 Defining a GLRM Model
 ~~~~~~~~~~~~~~~~~~~~~
 
--  **model\_id**: (Optional) Specify a custom name for the model to use
-   as a reference. By default, H2O automatically generates a destination
-   key.
+-  `model_id <algo-params/model_id.html>`__: (Optional) Specify a custom name for the model to use as a reference. By default, H2O automatically generates a destination key.
 
--  **training\_frame**: (Required) Specify the dataset used to build the
-   model. NOTE: In Flow, if you click the **Build a model** button from
-   the ``Parse`` cell, the training frame is entered automatically.
+-  `training_frame <algo-params/training_frame.html>`__: (Required) Specify the dataset used to build the model. NOTE: In Flow, if you click the **Build a model** button from the ``Parse`` cell, the training frame is entered automatically.
 
--  **validation\_frame**: (Optional) Specify the dataset used to
-   evaluate the accuracy of the model.
+-  `validation_frame <algo-params/validation_frame.html>`__: (Optional) Specify the dataset used to evaluate the accuracy of the model.
 
--  **ignored\_columns**: (Optional) Specify the column or columns to be
-   exclude from the model. In Flow, click the checkbox next to a column
-   name to add it to the list of columns excluded from the model. To add
-   all columns, click the **All** button. To remove a column from the
-   list of ignored columns, click the X next to the column name. To
-   remove all columns from the list of ignored columns, click the
-   **None** button. To search for a specific column, type the column
-   name in the **Search** field above the column list. To only show
-   columns with a specific percentage of missing values, specify the
-   percentage in the **Only show columns with more than 0% missing
-   values** field. To change the selections for the hidden columns, use
-   the **Select Visible** or **Deselect Visible** buttons.
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns are used.
 
--  **ignore\_const\_cols**: (Optional) Specify whether to ignore
-   constant training columns, since no information can be gained from
-   them. This option is selected by default.
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be exclude from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
--  **score\_each\_iteration**: (Optional) Specify whether to score
-   during each iteration of the model training.
+-  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: (Optional) Specify whether to ignore constant training columns, since no information can be gained from them. This option is selected by default.
 
--  **loading\_name**: Specify the frame key to save the resulting X.
+-  `score_each_iteration <algo-params/score_each_iteration.html>`__: (Optional) Specify whether to score during each iteration of the model training.
 
--  **transform**: Specify the transformation method for the training
-   data: None, Standardize, Normalize, Demean, or Descale. The default
-   is None.
+-  **loading_name**: Specify the frame key to save the resulting X.
 
--  **k**: (Required) Specify the rank of matrix approximation.
+-  `transform <algo-params/transform.html>`__: Specify the transformation method for the training data: None, Standardize, Normalize, Demean, or Descale. The default is None.
 
--  **loss**: Specify the numeric loss function: Quadratic, Absolute,
-   Huber, Poisson, Hinge, or Periodic.
+-  `k <algo-params/k.html>`__: (Required) Specify the rank of matrix approximation.
 
--  **multi\_loss**: Specify either **Categorical** or **Ordinal** for
-   the categorical loss function.
+-  **loss**: Specify the numeric loss function: Quadratic, Absolute, Huber, Poisson, Hinge, or Periodic.
+
+-  **multi_loss**: Specify either **Categorical** or **Ordinal** for the categorical loss function.
 
 -  **period**: When ``loss=periodic``, specify the length of the period.
 
--  **regularization\_x**: Specify the regularization function for the X
-   matrix: None, Quadratic, L2, L1, NonNegative, OneSparse,
-   UnitOneSparse, or Simplex.
+-  **regularization_x**: Specify the regularization function for the X matrix: None, Quadratic, L2, L1, NonNegative, OneSparse, UnitOneSparse, or Simplex.
 
--  **regularization\_y**: Specify the regularization function for the Y
-   matrix: None, Quadratic, L2, L1, NonNegative, OneSparse,
-   UnitOneSparse, or Simplex.
+-  **regularization_y**: Specify the regularization function for the Y matrix: None, Quadratic, L2, L1, NonNegative, OneSparse, UnitOneSparse, or Simplex.
 
--  **gamma\_x**: Specify the regularization weight on the X matrix.
+-  **gamma_x**: Specify the regularization weight on the X matrix.
 
--  **gamma\_y**: Specify the regularization weight on the Y matrix.
+-  **gamma_y**: Specify the regularization weight on the Y matrix.
 
--  **max\_iterations**: Specify the maximum number of training
-   iterations. The range is 0 to 1e6.
+-  `max_iterations <algo-params/max_iterations.html>`__: Specify the maximum number of training iterations. The range is 0 to 1e6.
 
--  **max\_updates**: Specify the maximum number of updates.
+-  **max_updates**: Specify the maximum number of updates.
 
--  **init\_step\_size**: Specify the initial step size.
+-  **init_step_size**: Specify the initial step size.
 
--  **min\_step\_size**: Specify the minimum step size.
+-  **min_step_size**: Specify the minimum step size.
 
--  **seed**: Specify the random number generator (RNG) seed for
-   algorithm components dependent on randomization. The seed is
-   consistent for each H2O instance so that you can create models with
-   the same starting conditions in alternative configurations.
+-  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for algorithm components dependent on randomization. The seed is consistent for each H2O instance so that you can create models with the same starting conditions in alternative configurations.
 
--  **init**: Specify the initialization mode: Random, SVD, PlusPlus, or
-   User.
+-  `init <algo-params/init.html>`__: Specify the initialization mode: Random, SVD, PlusPlus, or User.
 
--  **svd\_method**: Specify the method for computing SVD during
-   initialization: GramSVD, Power, Randomized.
+-  **svd_method**: Specify the method for computing SVD during initialization: GramSVD, Power, Randomized.
 
        **Caution**: Randomized is currently experimental.
 
--  **user\_y**: (Optional) Specify the initial Y value.
+-  **user_y**: (Optional) Specify the initial Y value.
 
--  **user\_x**: (Optional) Specify the initial X value.
+-  **user_x**: (Optional) Specify the initial X value.
 
--  **expand\_user\_y**: Specify whether to expand categorical columns in
-   the user-specified initial Y value.
+-  **expand_user_y**: Specify whether to expand categorical columns in the user-specified initial Y value.
 
--  **impute\_original**: Specify whether to reconstruct the original
-   training data by reversing the data transform after projecting
-   archetypes.
+-  **impute_original**: Specify whether to reconstruct the original training data by reversing the data transform after projecting archetypes.
 
--  **recover\_svd**: Specify whether to recover singular values and
-   eigenvectors of XY.
+-  **recover_svd**: Specify whether to recover singular values and eigenvectors of XY.
 
--  **max\_runtime\_secs**: Specify the maximum allowed runtime in
-   seconds for model training. Use 0 to disable.
+-  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: Specify the maximum allowed runtime in seconds for model training. Use 0 to disable.
 
 FAQ
 ~~~
 
 -  **What types of data can be used with GLRM?**
 
-   GLRM can handle mixed numeric, categorical, ordinal and Boolean data
-   with an arbitrary number of missing values. It allows the user to
-   apply regularization to X and Y, imposing restrictions like
-   non-negativity appropriate to a particular data science context.
+   GLRM can handle mixed numeric, categorical, ordinal and Boolean data with an arbitrary number of missing values. It allows the user to apply regularization to X and Y, imposing restrictions like non-negativity appropriate to a particular data science context.
 
 -  **What are the benefits to using low rank models?**
 
-   -  **Memory**: Saving only the X and Y matrices can significantly
-      reduce the amount of memory required to store a large data set. A
-      file that is 10 GB can be compressed down to 100 MB. When we need
-      the original data again, we can reconstruct it on the fly from X
-      and Y with minimal loss in accuracy.
-
+   -  **Memory**: Saving only the X and Y matrices can significantly reduce the amount of memory required to store a large data set. A file that is 10 GB can be compressed down to 100 MB. When we need the original data again, we can reconstruct it on the fly from X and Y with minimal loss in accuracy.
    -  **Speed**: GLRM can be used to compress data with high-dimensional, heterogeneous features into a few numeric columns. This leads to a huge speed-up in model building and prediction, especially by machine learning algorithms that scale poorly with the size of the feature space.
    -  **Feature Engineering**: The Y matrix represents the most important combination of features from the training data. These condensed features (called archetypes) can be analyzed, visualized, and incorporated into various data science applications.
    -  **Missing Data Imputation**: Reconstructing a data set from X and Y will automatically impute missing values. This imputation is accomplished by intelligently leveraging the information contained in the known values of each feature, as well as user-provided parameters such as the loss function.
@@ -162,6 +100,4 @@ References
 
 `Udell, Madeline, Corinne Horn, Reza Zadeh, and Stephen Boyd. "Generalized low rank models." arXiv preprint arXiv:1410.0342, 2014. <http://arxiv.org/abs/1410.0342>`_
 
-`Hamner, S.R., Delp, S.L. Muscle contributions to fore-aft and vertical
-body mass center accelerations over a range of running speeds. Journal
-of Biomechanics, vol 46, pp 780-787. (2013) <http://nmbl.stanford.edu/publications/pdf/Hamner2012.pdf>`_
+`Hamner, S.R., Delp, S.L. Muscle contributions to fore-aft and vertical body mass center accelerations over a range of running speeds. Journal of Biomechanics, vol 46, pp 780-787. (2013) <http://nmbl.stanford.edu/publications/pdf/Hamner2012.pdf>`_

--- a/h2o-docs/src/product/data-science/k-means.rst
+++ b/h2o-docs/src/product/data-science/k-means.rst
@@ -22,6 +22,8 @@ Defining a K-Means Model
 -  `validation_frame <algo-params/validation_frame.html>`__: (Optional) Specify the dataset used to evaluate
    the accuracy of the model.
 
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns are used.
+
 -  `nfolds <algo-params/nfolds.html>`__: Specify the number of folds for cross-validation.
 
 -  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Enable this option to keep the
@@ -33,7 +35,7 @@ Defining a K-Means Model
 
 -  `fold_column <algo-params/fold_column.html>`__: Specify the column that contains the cross-validation fold index assignment per observation.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be exclude from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be exclude from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
 -  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: (Optional) Specify whether to ignore constant training columns, since no information can be gained from them. This option is enabled by default.
 

--- a/h2o-docs/src/product/data-science/naive-bayes.rst
+++ b/h2o-docs/src/product/data-science/naive-bayes.rst
@@ -26,6 +26,8 @@ Defining a Naïve Bayes Model
    independent variable. The data must be categorical and must contain
    at least two unique categorical levels.
 
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
 -  `nfolds <algo-params/nfolds.html>`__: Specify the number of folds for cross-validation.
 
 -  `seed <algo-params/seed.html>`__: Specify the random number generator (RNG) seed for
@@ -41,7 +43,7 @@ Defining a Naïve Bayes Model
 
 -  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment. 
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
 -  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Specify whether to ignore constant training columns, since no information can be gained from them. This option is enabled by default.
 

--- a/h2o-docs/src/product/data-science/pca.rst
+++ b/h2o-docs/src/product/data-science/pca.rst
@@ -4,15 +4,9 @@ Principal Component Analysis (PCA)
 Introduction
 ~~~~~~~~~~~~
 
-Principal Components Analysis (PCA) is closely related to Principal
-Components Regression. The algorithm is carried out on a set of possibly
-collinear features and performs a transformation to produce a new set of
-uncorrelated features.
+Principal Components Analysis (PCA) is closely related to Principal Components Regression. The algorithm is carried out on a set of possibly collinear features and performs a transformation to produce a new set of uncorrelated features.
 
-PCA is commonly used to model without regularization or perform
-dimensionality reduction. It can also be useful to carry out as a
-preprocessing step before distance-based algorithms such as K-Means
-since PCA guarantees that all dimensions of a manifold are orthogonal.
+PCA is commonly used to model without regularization or perform dimensionality reduction. It can also be useful to carry out as a preprocessing step before distance-based algorithms such as K-Means since PCA guarantees that all dimensions of a manifold are orthogonal.
 
 Defining a PCA Model
 ~~~~~~~~~~~~~~~~~~~~
@@ -23,7 +17,9 @@ Defining a PCA Model
 
 -  `validation_frame <algo-params/validation_frame.html>`__: (Optional) Specify the dataset used to evaluate the accuracy of the model.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns are used.
+
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
 -  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Specify whether to ignore constant training columns, since no information can be gained from them. This option is enabled by default.
 
@@ -56,8 +52,7 @@ Defining a PCA Model
 Interpreting a PCA Model
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-PCA output returns a table displaying the number of components specified
-by the value for ``k``.
+PCA output returns a table displaying the number of components specified by the value for ``k``.
 
 The output for PCA includes the following:
 

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -56,6 +56,8 @@ Defining an H2O Stacked Ensemble Model
 
 -  `y <algo-params/y.html>`__: (Required) Specify the column to use as the independent variable (response column). The data can be numeric or categorical.
 
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
 -  **base_models**: Specify a list of model IDs that can be stacked together. Models must have been cross-validated using ``nfolds`` > 1, they all must use the same cross-validation folds, and ``keep_cross_validation_folds`` must be set to True. 
 
   **Notes regarding** ``base_models``: 

--- a/h2o-docs/src/product/data-science/xgboost.rst
+++ b/h2o-docs/src/product/data-science/xgboost.rst
@@ -6,8 +6,7 @@ XGBoost
 Introduction
 ~~~~~~~~~~~~
 
-XGBoost is a supervised learning algorithm that implements a process called boosting to yield accurate
-models. Boosting refers to the ensemble learning technique of building many models sequentially, with each new model attempting to correct for the deficiencies in the previous model. In tree boosting, each new model that is added to the ensemble is a decision tree. XGBoost provides parallel tree boosting (also known as GBDT, GBM) that solves many data science problems in a fast and accurate way. For many problems, XGBoost is one of the best gradient boosting machine (GBM) frameworks today. 
+XGBoost is a supervised learning algorithm that implements a process called boosting to yield accurate models. Boosting refers to the ensemble learning technique of building many models sequentially, with each new model attempting to correct for the deficiencies in the previous model. In tree boosting, each new model that is added to the ensemble is a decision tree. XGBoost provides parallel tree boosting (also known as GBDT, GBM) that solves many data science problems in a fast and accurate way. For many problems, XGBoost is one of the best gradient boosting machine (GBM) frameworks today. 
 
 The H2O XGBoost implementation is based on two separated modules. The first module, `h2o-genmodel-ext-xgboost <https://github.com/h2oai/h2o-3/tree/master/h2o-genmodel-extensions/xgboost>`__, extends module `h2o-genmodel <https://github.com/h2oai/h2o-3/tree/master/h2o-genmodel>`__  and registers an XGBoost-specific MOJO. The module also contains all necessary XGBoost binary libraries. The module can contain multiple libraries for each platform to support different configurations (e.g., with/without GPU/OMP). H2O always tries to load the most powerful one (currently a library with GPU and OMP support). If it fails, then the loader tries the next one in a loader chain. For each platform, H2O provide an XGBoost library with minimal configuration (supports only single CPU) that serves as fallback in case all other libraries could not be loaded.
 
@@ -28,6 +27,8 @@ Defining an XGBoost Model
 
 -  `y <algo-params/y.html>`__: (Required) Specify the column to use as the independent variable. The data can be numeric or categorical.
 
+-  `x <algo-params/x.html>`__: Specify a vector containing the names or indices of the predictor variables to use when building the model. If ``x`` is missing, then all columns except ``y`` are used.
+
 -  `keep_cross_validation_predictions <algo-params/keep_cross_validation_predictions.html>`__: Enable this option to keep the cross-validation predictions.
 
 -  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment. 
@@ -38,7 +39,7 @@ Defining an XGBoost Model
 
 -  `fold_column <algo-params/fold_column.html>`__: Specify the column that contains the cross-validation fold index assignment per observation.
 
--  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
+-  `ignored_columns <algo-params/ignored_columns.html>`__: (Optional, Python and Flow only) Specify the column or columns to be excluded from the model. In Flow, click the checkbox next to a column name to add it to the list of columns excluded from the model. To add all columns, click the **All** button. To remove a column from the list of ignored columns, click the X next to the column name. To remove all columns from the list of ignored columns, click the **None** button. To search for a specific column, type the column name in the **Search** field above the column list. To only show columns with a specific percentage of missing values, specify the percentage in the **Only show columns with more than 0% missing values** field. To change the selections for the hidden columns, use the **Select Visible** or **Deselect Visible** buttons.
 
 -  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Specify whether to ignore constant training columns, since no information can be gained from them. This option is enabled by default.
 

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -101,4 +101,5 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/user_points
    data-science/algo-params/validation_frame
    data-science/algo-params/weights_column
+   data-science/algo-params/x
    data-science/algo-params/y


### PR DESCRIPTION
- Added x parameter to AutoML section and to the “Defining a Model” section for each algorithm (where it had not been previously documented).
- Added ignored_columns parameter to AutoML section, noting that it is Python only
Driveby fixes: For all algos that use ignored_columns, noted that this parameter is only available in Python and Flow. Also added links to parameters appendix in the GLRM section.