### PR TITLE
[ITA-118] Fix huge logs in case of JUnit failure

### DIFF
--- a/docker/Makefile.jenkins
+++ b/docker/Makefile.jenkins
@@ -192,6 +192,10 @@ test-package-java:
 	find . -name "*test*.sh" | zip -q -r test-package-java -@
 	find . -name "*test*.jar" | zip -q -r test-package-java -@
 
+test-junit-jenkins:
+	find . -name 'test*Node.sh' -type f -exec sed -i 's/cat $$OUTDIR\/out*/echo "###### Printing last 400 lines of logs. Check artifacts for more. ######"; tail -n 400 $$OUTDIR\/out*/g' {} +
+	@$(MAKE) -f $(THIS_FILE) test-junit
+
 test-junit:
 	./gradlew test
 

--- a/scripts/jenkins/groovy/executeTestStages.groovy
+++ b/scripts/jenkins/groovy/executeTestStages.groovy
@@ -110,7 +110,7 @@ def call(buildConfig) {
       timeoutValue: 10, lang: buildConfig.LANG_PY
     ],
     [
-      stageName: 'Java 8 JUnit', target: 'test-junit', pythonVersion: '2.7',
+      stageName: 'Java 8 JUnit', target: 'test-junit-jenkins', pythonVersion: '2.7',
       timeoutValue: 90, lang: buildConfig.LANG_JAVA, additionalTestPackages: [buildConfig.LANG_PY]
     ]
   ]


### PR DESCRIPTION
Use `sed` to modify test*Node.sh files so after a test failure we print only last 400 lines from the logs. The rest of the logs is still accessible from artifacts.