### PR TITLE
PUBDEV-4727: GroupBy Median.  Added pyunit and runit tests.

### DIFF
--- a/h2o-algos/src/main/java/hex/pca/PCA.java
+++ b/h2o-algos/src/main/java/hex/pca/PCA.java
@@ -61,8 +61,12 @@ public class PCA extends ModelBuilder<PCAModel,PCAModel.PCAParameters,PCAModel.P
     boolean usePower = _parms._pca_method == PCAParameters.Method.Power;
     boolean useRandomized = _parms._pca_method == PCAParameters.Method.Randomized;
     boolean useGLRM = _parms._pca_method == PCAParameters.Method.GLRM;
+
+    // gets to zero if nChunks=1.  Denote number of reduces to combine results from chunks.  Each chunk will store
+    // its gram matrix using half the memory needed since it is symmetrical.  Hence, total number of of grams
+    // that will be created will be multiplied by the gram matrix size * number of reduces to be done.
     double gramSize =  _train.lastVec().nChunks()==1 ? 1 :
-            Math.log((double) _train.lastVec().nChunks()) / Math.log(2.); // gets to zero if nChunks=1
+            Math.log((double) _train.lastVec().nChunks()) / Math.log(2.);
 
     long mem_usage = (useGramSVD || usePower || useRandomized || useGLRM) ? (long) (hb._cpus_allowed * p * p * 8/*doubles*/ *
             gramSize) : 1; //one gram per core

--- a/h2o-core/src/test/java/water/rapids/GroupByTest.java
+++ b/h2o-core/src/test/java/water/rapids/GroupByTest.java
@@ -10,6 +10,8 @@ import water.TestUtil;
 import water.fvec.Frame;
 import water.rapids.vals.ValFrame;
 
+import static org.junit.Assert.assertTrue;
+
 public class GroupByTest extends TestUtil {
   @BeforeClass public static void setup() { stall_till_cloudsize(5); }
 
@@ -198,7 +200,7 @@ public class GroupByTest extends TestUtil {
   //       4   2747
   //       6  17367
   //   10000   9493
-  @Test public void testSplitCats() {
+  @Test public void testSplitCats() throws InterruptedException {
     Frame cov = parse_test_file(Key.make("cov"),"smalldata/covtype/covtype.altered.gz");
     System.out.println(cov.toString(0,10));
 
@@ -213,7 +215,28 @@ public class GroupByTest extends TestUtil {
     cov.delete();
   }
 
-  @Test public void testGroupbyTableSpeed() {
+  // Note that if this median test runs before the testSplitCats and/or testGroupbyTableSpeed,
+  // we will encounter the leaked key errors. This has been captured in JIRA PUBDEV-PUBDEV-5090.
+  @Test
+  public void testZGroupbyMedian() {
+    Frame fr = null;
+    String tree = "(GB hex [0] median 1 \"all\")"; // Group-By on col 0 median of col 1
+    double[] correct_median = {0.49851096435701053, 0.50183187047352851, 0.50187234362560651, 0.50528965387515079,
+            0.49887302541203787};  // order may not be correct
+    try {
+      //  fr = chkTree(tree, "smalldata/jira/pubdev_4727_median.csv");
+      fr = chkTree(tree, "smalldata/jira/pubdev_4727_junit_data.csv");
+      for (int index=0; index < fr.numRows(); index++) {  // compare with correct medians
+        assertTrue(Math.abs(correct_median[(int)fr.vec(0).at(index)]-fr.vec(1).at(index))<1e-12);
+      }
+    } finally {
+      if( fr != null ) fr.delete();
+      Keyed.remove(Key.make("hex"));
+    }
+  }
+
+  @Test
+  public void testGroupbyTableSpeed() {
     Frame ids = parse_test_file(Key.make("cov"),"smalldata/junit/id_cols.csv");
     ids.replace(0,ids.anyVec().toCategoricalVec()).remove();
     System.out.println(ids.toString(0,10));
@@ -231,6 +254,7 @@ public class GroupByTest extends TestUtil {
     v_tb.getFrame().delete();
 
     ids.delete();
+    Keyed.remove(Key.make("cov"));
   }    
 
 
@@ -240,7 +264,7 @@ public class GroupByTest extends TestUtil {
   }
   private void chkFr( Frame fr, int col, int row, double exp ) { chkFr(fr,col,row,exp,Math.ulp(1)); }
   private void chkFr( Frame fr, int col, int row, double exp, double tol ) { 
-    if( Double.isNaN(exp) ) Assert.assertTrue(fr.vec(col).isNA(row));
+    if( Double.isNaN(exp) ) assertTrue(fr.vec(col).isNA(row));
     else                    Assert.assertEquals(exp, fr.vec(col).at(row),tol); 
   }
   private void chkFr( Frame fr, int col, int row, String exp ) { 

--- a/h2o-core/src/test/java/water/rapids/GroupByTest.java
+++ b/h2o-core/src/test/java/water/rapids/GroupByTest.java
@@ -2,6 +2,7 @@ package water.rapids;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import water.DKV;
 import water.Key;
@@ -217,8 +218,8 @@ public class GroupByTest extends TestUtil {
 
   // Note that if this median test runs before the testSplitCats and/or testGroupbyTableSpeed,
   // we will encounter the leaked key errors. This has been captured in JIRA PUBDEV-PUBDEV-5090.
-  @Test
-  public void testZGroupbyMedian() {
+  @Ignore
+  public void testGroupbyMedian() {
     Frame fr = null;
     String tree = "(GB hex [0] median 1 \"all\")"; // Group-By on col 0 median of col 1
     double[] correct_median = {0.49851096435701053, 0.50183187047352851, 0.50187234362560651, 0.50528965387515079,

--- a/h2o-core/src/test/java/water/rapids/ZGroupByMedianTest.java
+++ b/h2o-core/src/test/java/water/rapids/ZGroupByMedianTest.java
@@ -1,0 +1,52 @@
+package water.rapids;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.Key;
+import water.Keyed;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.rapids.vals.ValFrame;
+
+import static org.junit.Assert.assertTrue;
+
+public class ZGroupByMedianTest extends TestUtil {
+  @BeforeClass public static void setup() { stall_till_cloudsize(5); }
+
+  // Note that if this median test runs before the testSplitCats and/or testGroupbyTableSpeed,
+  // we will encounter the leaked key errors. This has been captured in JIRA PUBDEV-PUBDEV-5090.
+  @Test
+  public void testGroupbyMedian() {
+    Frame fr = null;
+    String tree = "(GB hex [0] median 1 \"all\")"; // Group-By on col 0 median of col 1
+    double[] correct_median = {0.49851096435701053, 0.50183187047352851, 0.50187234362560651, 0.50528965387515079,
+            0.49887302541203787};  // order may not be correct
+    try {
+      //  fr = chkTree(tree, "smalldata/jira/pubdev_4727_median.csv");
+      fr = chkTree(tree, "smalldata/jira/pubdev_4727_junit_data.csv");
+      for (int index=0; index < fr.numRows(); index++) {  // compare with correct medians
+        assertTrue(Math.abs(correct_median[(int)fr.vec(0).at(index)]-fr.vec(1).at(index))<1e-12);
+      }
+    } finally {
+      if( fr != null ) fr.delete();
+      Keyed.remove(Key.make("hex"));
+    }
+  }
+
+  private Frame chkTree(String tree, String fname) { return chkTree(tree,fname,false); }
+  private Frame chkTree(String tree, String fname, boolean expectThrow) {
+    Frame fr = parse_test_file(Key.make("hex"),fname);
+    try {
+      Val val = Rapids.exec(tree);
+      System.out.println(val.toString());
+      if( val instanceof ValFrame )
+        return val.getFrame();
+      throw new IllegalArgumentException("expected a frame return");
+    } catch( IllegalArgumentException iae ) {
+      if( !expectThrow ) throw iae; // If not expecting a throw, then throw which fails the junit
+      fr.delete();                  // If expecting, then cleanup
+      return null;
+    }
+  }
+}
+

--- a/h2o-py/h2o/group_by.py
+++ b/h2o-py/h2o/group_by.py
@@ -46,9 +46,12 @@ class GroupBy(object):
         - "all" (default) -- any NAs are used in the calculation as-is; which usually results in the final result
           being NA too.
         - "ignore" -- NA entries are not included in calculations, but the total number of entries is taken as the
-          total number of rows. For example, mean([1, 2, 3, nan], na="ignore") will produce 1.5.
+          total number of rows. For example, mean([1, 2, 3, nan], na="ignore") will produce 1.5.  In addition,
+          median([1, 2, 3, nan], na="ignore") will first sort the row as [nan, 1, 2, 3].  Next, the median is the
+          mean of the two middle values in this case producing a median of 1.5.
         - "rm" entries are skipped during the calculations, reducing the total effective count of entries. For
-          example, mean([1, 2, 3, nan], na="rm") will produce 2.
+          example, mean([1, 2, 3, nan], na="rm") will produce 2.  The median in this case will be 2 as the middle
+          value.
 
     Variance (var) and standard deviation (sd) are the sample (not population) statistics.
     """
@@ -192,6 +195,19 @@ class GroupBy(object):
         :return: the original GroupBy object (self), for ease of constructing chained operations.
         """
         return self._add_agg("mode", col, na)
+
+
+    def median(self, col=None, na="all"):
+        """
+        Calculate the median of each column specified in col for each group of a GroupBy object.  If no col is given,
+        compute the median among all numeric columns other than those being grouped on.
+
+        :param col: col can be None (default), a column name (str) or an index (int) of a single column,  or a
+            list for multiple columns
+        :param str na:  one of 'rm', 'ignore' or 'all' (default).
+        :return: the original GroupBy object (self), for ease of constructing chained operations.
+        """
+        return self._add_agg("median", col, na)
 
 
     @property

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_categories.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_categories.py
@@ -18,7 +18,8 @@ def h2o_H2OFrame_categories():
     alllevels = [int(i) for i in alllevels]     # convert string into integers for comparison
     truelevels = np.unique(python_lists).tolist()   # categorical levels calculated from Python
     assert alllevels==truelevels, "h2o.H2OFrame.categories() command is not working."
-    pyunit_utils.equal_two_arrays(alllevels, truelevels, 1e-10, 0)
+    assert pyunit_utils.equal_two_arrays(alllevels, truelevels, 1e-10, 0), "h2o.H2OFrame.categories() command is" \
+                                                                           " not working."
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2o_H2OFrame_categories())

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_max_mean_median_min_large.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_max_mean_median_min_large.py
@@ -25,12 +25,12 @@ def h2o_H2OFrame_stats():
     assert_is_type(h2oMean, H2OFrame)
     numpmean = list(np.mean(python_lists, axis=0))
     h2omean = h2oMean.as_data_frame(use_pandas=True, header=False)
-    pyunit_utils.equal_two_arrays(numpmean, h2omean.values.tolist()[0], 1e-12, 1e-6)
+    assert pyunit_utils.equal_two_arrays(numpmean, h2omean.values.tolist()[0], 1e-12, 1e-6), "h2o.H2OFrame.mean() command is not working."
 
     h2oMedian = h2oframe.median(na_rm=True)
     assert_is_type(h2oMedian, list)
     numpmedian = list(np.median(python_lists, axis=0))
-    pyunit_utils.equal_two_arrays(numpmedian, h2oMedian, 1e-12, 1e-6)
+    assert pyunit_utils.equal_two_arrays(numpmedian, h2oMedian, 1e-12, 1e-6), "h2o.H2OFrame.median() command is not working."
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sum.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_sum.py
@@ -22,15 +22,16 @@ def h2o_H2OFrame_sum():
     assert_is_type(h2oSum, H2OFrame)
     numpsum = list(np.sum(python_lists, axis=0))
     h2omean = h2oSum.as_data_frame(use_pandas=True, header=False)
-    pyunit_utils.equal_two_arrays(numpsum, h2omean.values.tolist()[0], 1e-12, 1e-6)
+    assert pyunit_utils.equal_two_arrays(numpsum, h2omean.values.tolist()[0], 1e-12, 1e-6), "h2o.H2OFrame.meansum()" \
+                                                                                            " command is not working."
 
     # axis = 1
     h2oSum = h2oframe.sum(skipna=False, axis=1)
     assert_is_type(h2oSum, H2OFrame)
     numpsum = list(np.sum(python_lists, axis=1))
     h2omean = h2oSum.as_data_frame(use_pandas=True, header=False)
-    pyunit_utils.equal_two_arrays(numpsum, h2omean.values.T.tolist()[0], 1e-12, 1e-6)
-
+    assert pyunit_utils.equal_two_arrays(numpsum, h2omean.values.T.tolist()[0], 1e-12, 1e-6), "h2o.H2OFrame.meansum()" \
+                                                                                              " command is not working."
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2o_H2OFrame_sum())
 else:

--- a/h2o-py/tests/testdir_munging/pyunit_pubdev_4727_groupby_median_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_pubdev_4727_groupby_median_large.py
@@ -1,0 +1,93 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import numpy as np
+from random import randint
+
+# global dictionaries storing model answers
+g_iris_setosa_sepal_len=dict()
+g_iris_versicolor_sepal_wid=dict()
+g_iris_virginica_petal_wid=dict()
+g_iris_versicolor_petal_len_NA_ignore=dict()
+g_iris_versicolor_petal_len_NA_rm=dict()
+
+
+def group_by_all():
+    """
+    I am testing the groupby median function in PUBDEV_4727.
+    """
+
+    # generate random dataset with factor column and real columns
+    row_num_max = 100000 # 100000
+    row_num_min = 100
+    enumLow = 5
+    enumHigh = 30
+    enumVals = randint(enumLow, enumHigh)   # total number of groupby class
+    pIndex = []
+    pNum = []
+    numpMedian = [] # store python median calculated for each groupby class
+    numpMean = []  # store the python mean calculated for each groupby class for column2
+    numpMedian2 = []
+    numpMean2 = []
+    colFac = 1.1
+    for index in range(enumVals):
+        rowNum = randint(row_num_min, row_num_max)
+        indexList = [index]*rowNum
+        numList = np.random.rand(rowNum,1)
+
+        numpMedian.append(list(np.median(numList, axis=0))[0])
+        numpMean.append(list(np.mean(numList, axis=0))[0])
+        numpMedian2.append(list(np.median(numList*colFac, axis=0))[0])
+        numpMean2.append(list(np.mean(numList*colFac, axis=0))[0])
+
+        pIndex.extend(indexList)
+        pNum.extend(numList)
+
+    # generate random H2OFrame
+    newOrder = np.random.permutation(len(pIndex))
+    python_lists = []
+    for index in range(len(pIndex)):
+        temp = [pIndex[newOrder[index]], pNum[newOrder[index]][0], pNum[newOrder[index]][0]*colFac]
+        python_lists.append(temp)
+    h2oframe= h2o.H2OFrame(python_obj=python_lists, column_types=["enum","real","real"], column_names=["factors", "numerics", "numerics2"])
+
+    # generate h2o groupby medians and other groupby functions
+    groupedMedianF = h2oframe.group_by(["factors"]).median(na='rm').mean(na='all').sum(na="all").count(na="rm").get_frame()
+
+    groupbyMedian = [0]*len(numpMedian) # extract groupby median to compare with python median
+    groupbyMean = [0]*len(numpMean)
+    groupbyMedian2 = [0]*len(numpMedian2) # extract groupby median to compare with python median
+    groupbyMean2 = [0]*len(numpMean2)
+    for rowIndex in range(enumVals):
+        groupbyMedian[int(groupedMedianF[rowIndex,0])] = groupedMedianF[rowIndex,'median_numerics']
+        groupbyMean[int(groupedMedianF[rowIndex,0])] = groupedMedianF[rowIndex,'mean_numerics']
+        groupbyMedian2[int(groupedMedianF[rowIndex,0])] = groupedMedianF[rowIndex,'median_numerics2']
+        groupbyMean2[int(groupedMedianF[rowIndex,0])] = groupedMedianF[rowIndex,'mean_numerics2']
+
+    # print out groupby/numpy median and mean
+    print(groupedMedianF.as_data_frame(use_pandas=True, header=False))
+    print("H2O Groupby median is for numerics {0}".format(groupbyMedian))
+    print("Numpy median is numerics {0}".format(numpMedian))
+    print("H2O Groupby median is for numerics {0}".format(groupbyMedian))
+    print("Numpy median is numerics {0}".format(numpMedian))
+    print("H2O Groupby mean is for numerics2 {0}".format(groupbyMean2))
+    print("Numpy mean is numerics2 {0}".format(numpMean2))
+    print("H2O Groupby mean is for numerics2 {0}".format(groupbyMean2))
+    print("Numpy mean is numerics2 {0}".format(numpMean2))
+
+    # compare the h2o groupby medians, means with numpy medians and means.
+    assert pyunit_utils.equal_two_arrays(groupbyMedian, numpMedian, 1e-12, 1e-12), "H2O groupby median and numpy " \
+                                                                                   "median is different."
+    assert pyunit_utils.equal_two_arrays(groupbyMean, numpMean, 1e-12, 1e-12), "H2O groupby mean and numpy " \
+                                                                                   "mean is different."
+    assert pyunit_utils.equal_two_arrays(groupbyMedian2, numpMedian2, 1e-12, 1e-12), "H2O groupby median and numpy " \
+                                                                                   "median is different."
+    assert pyunit_utils.equal_two_arrays(groupbyMean2, numpMean2, 1e-12, 1e-12), "H2O groupby mean and numpy " \
+                                                                            "mean is different."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(group_by_all)
+else:
+    group_by_all()

--- a/h2o-r/tests/testdir_misc/runit_pubdev_4727_groupby_median_large.R
+++ b/h2o-r/tests/testdir_misc/runit_pubdev_4727_groupby_median_large.R
@@ -1,0 +1,43 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues = TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+##
+# PUBDEV_4727: Groupby median fix
+##
+
+test <- function(conn) {
+    tot = 1e-12
+    Log.info("Generateing random dataset ...")
+    numrows <- 10000000
+    numCols <- 4
+    numColEnd <- 3 + numCols - 1
+    dfEnum.hex <- h2o.createFrame(rows = numrows, col = 2, categorical_fraction = 1, integer_fraction = 0, binary_fraction = 0,
+    time_fraction = 0, string_fraction = 0, missing_fraction = 0.0, has_response = FALSE, factor = 5)
+    dfReal.hex <- h2o.createFrame(rows = numrows, col = numCols, categorical_fraction = 0, integer_fraction = 0, binary_fraction = 0,
+    time_fraction = 0, string_fraction = 0, missing_fraction = 0.0, has_response = FALSE)  # real numbers
+    df.hex <- h2o.cbind(dfEnum.hex, dfReal.hex)
+    column_names <- names(df.hex)
+    print("Number of rows in the data frame is: ")
+    print(nrow(df.hex))
+    # throw in a bunch of other junks just to check
+    aggregated_median <- h2o.group_by(data = df.hex, by = column_names[1 : 2], median(3), median(4), median(5), median(6), mean(3), sd(4), gb.control = list(na.methods = "rm"))
+    h2o_groupby_median <- as.data.frame(aggregated_median)
+
+    # generate R median and compare h2o.groupby median with it
+    c1Vals <- h2o_groupby_median$C1
+    c2Vals <- h2o_groupby_median$C2
+    temp <- as.data.frame(df.hex)
+ 
+    for (colIndex in c(3 : numColEnd)) {
+        for (index in c(1 : nrow(h2o_groupby_median))) {
+            temp2 <- temp[temp$C1 == c1Vals[index], 1 : numColEnd]
+            temp3 <- temp2[temp2$C2 == c2Vals[index], 1 : numColEnd]
+            tempCol <- temp3[, colIndex]
+            rmedian <- median(tempCol)  # R median for one of the groups
+            errText <- paste0("H2O groupby mean is ", h2o_groupby_median[index, colIndex], ". R median is ", rmedian, ".  They are not the same.")
+            expect_true(abs(h2o_groupby_median[index, colIndex] - rmedian) < tot, errText)
+        }
+    }
+}
+
+doTest("Testing groupby median", test)
+


### PR DESCRIPTION
PUBDEV-4727: groupby median.  Added client support for groupby median in Python.  Added backend code to AstGroup.java to support median operation.
PUBDEV-4727: groupby median.  Added pyunit and runit tests.
PUBDEV-4727: groupby median.  Fixed use of pyunit_utils.equal_two_arrays.
PUBDEV-4727: h2o groupby median.  Finished junit test.