### PR TITLE
PUBDEV-5070: Update R and Python strings for max_active_predictors

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -157,7 +157,7 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
 
     @API(help="Maximum number of active predictors during computation. Use as a stopping criterion" +
     " to prevent expensive model building with many predictors." + " Default indicates: If the IRLSM solver is used," +
-    " the value of max_active_predictors is set to 7000 otherwise it is set to 100000000.", direction = Direction.INPUT, level = Level.expert)
+    " the value of max_active_predictors is set to 5000 otherwise it is set to 100000000.", direction = Direction.INPUT, level = Level.expert)
     public int max_active_predictors = -1;
 
     @API(help="A list of predictor column indices to interact. All pairwise combinations will be computed for the list.", direction=Direction.INPUT, level=Level.expert)

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -637,7 +637,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         """
         Maximum number of active predictors during computation. Use as a stopping criterion to prevent expensive model
         building with many predictors. Default indicates: If the IRLSM solver is used, the value of
-        max_active_predictors is set to 7000 otherwise it is set to 100000000.
+        max_active_predictors is set to 5000 otherwise it is set to 100000000.
 
         Type: ``int``  (default: ``-1``).
         """

--- a/h2o-r/README.md
+++ b/h2o-r/README.md
@@ -23,26 +23,26 @@ The output of the build is a CRAN-like layout in the R directory.
 
 ###  Installation from the command line after build
 
-0. Navigate to the top-level `h2o-3` directory: `cd ~/h2o-3`. 
-0. Install the H2O package for R: `R CMD INSTALL h2o-r/R/src/contrib/h2o_****.tar.gz`
+1. Navigate to the top-level `h2o-3` directory: `cd ~/h2o-3`. 
+2. Install the H2O package for R: `R CMD INSTALL h2o-r/R/src/contrib/h2o_****.tar.gz`
 
    **Note**: Do not copy and paste the command above. You must replace the asterisks (*) with the current H2O .tar version number. Look in the `h2o-3/h2o-r/R/src/contrib/` directory for the version number. 
 
 ###  Installation from within R
 
-0. Detach any currently loaded H2O package for R.  
+1. Detach any currently loaded H2O package for R.  
 
   ```
   if ("package:h2o" %in% search()) detach("package:h2o", unload=TRUE)
   ```
 
-0. Remove any previously installed H2O package for R.  
+2. Remove any previously installed H2O package for R.  
 
   ```
   if ("h2o" %in% rownames(installed.packages())) remove.packages("h2o")
   ```
 
-0. Install H2O R package along with its dependencies.
+3. Install H2O R package along with its dependencies.
   
   Install latest CRAN version:
 
@@ -152,7 +152,7 @@ Note:  As started, H2O is limited to the CRAN default of 2 CPUs.
            > localH2O = h2o.init(nthreads = -1)
 ```
 
-#Documentation/References
+# Documentation/References
 
 - [R Package Documentation](http://h2o-release.s3.amazonaws.com/h2o/latest_stable_Rdoc.html)
 - [Porting R Scripts Guide](https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/upgrade/H2ODevPortingRScripts.md)

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -80,7 +80,7 @@
 #' @param beta_constraints Beta constraints
 #' @param max_active_predictors Maximum number of active predictors during computation. Use as a stopping criterion to prevent expensive model
 #'        building with many predictors. Default indicates: If the IRLSM solver is used, the value of
-#'        max_active_predictors is set to 7000 otherwise it is set to 100000000. Defaults to -1.
+#'        max_active_predictors is set to 5000 otherwise it is set to 100000000. Defaults to -1.
 #' @param interactions A list of predictor column indices to interact. All pairwise combinations will be computed for the list.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
 #'        FALSE.


### PR DESCRIPTION
In GLM, the default value for max_active_predictors when solver=IRLSM is now 5000 instead of 7000. Updated the Python and R strings to reflect this change.