### PR TITLE
[PUBDEV-5088] Support custom evaluation metrics in Python client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,8 @@ ext {
       project(':h2o-genmodel-ext-xgboost'),
       project(':h2o-ext-xgboost'),
       project(':h2o-ext-krbstandalone'),
-      project(':h2o-ext-authsupport')
+      project(':h2o-ext-authsupport'),
+      project(':h2o-ext-jython-cfunc'),
     ]
 
     javaProjects = [
@@ -96,7 +97,8 @@ ext {
       project(':h2o-genmodel-ext-xgboost'),
       project(':h2o-ext-xgboost'),
       project(':h2o-ext-krbstandalone'),
-      project(':h2o-ext-authsupport')
+      project(':h2o-ext-authsupport'),
+      project(':h2o-ext-jython-cfunc'),
     ]
 
     scalaProjects = [
@@ -151,7 +153,8 @@ ext {
     optionalComponents = [
             // NAME | VERSION | IS ENABLED? | HAS GENMODEL PART ?
             [name: "visDataServer", version : "1.0.0-SNAPSHOT", enabled: false, genmodel: false ],
-            [name: "xgboost", version: "$version", enabled: true, genmodel: true ]
+            [name: "xgboost", version: "$version", enabled: true, genmodel: true ],
+            [name: "jython-cfunc", version: "$version", enabled: true, genmodel: false],
     ]
 
     //

--- a/gradle/components/jython-cfunc.gradle
+++ b/gradle/components/jython-cfunc.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    compile project(":h2o-ext-jython-cfunc")
+}

--- a/h2o-core/src/main/java/water/udf/CFuncRef.java
+++ b/h2o-core/src/main/java/water/udf/CFuncRef.java
@@ -42,7 +42,7 @@ public class CFuncRef extends Iced<CFuncRef> {
   }
 
   public String getName() {
-    return keyName + "#" + funcName;
+    return keyName;
   }
 
   public Key getKey() {

--- a/h2o-docs/src/dev/custom_functions.md
+++ b/h2o-docs/src/dev/custom_functions.md
@@ -57,9 +57,9 @@ The loaders `water.udf.CFuncLoader` are registered via Java Service Provider Int
 The custom metrics is a function which implements `water.udf.CMetricFunc` interface.
 The interface follows design of `hex.MetricBuilder` and contains three methods to support
 distributed invocation:
-  - `perRow` : the method which maps a row into array of doubles. The method is designed to be called as
-  part of `water.MRTask#map` call and it corresponds to  `hex.MetricBuilder#perRow` call.
-  - `combine` : the method combines 2 row results. It is called as part of `water.MRTask#map` and `water.MRTask#reduce` calls.
+  - `map` : the method which maps a row into array of doubles. The method is designed to be called as
+  part of `water.MRTask#map` call and it corresponds to  `hex.MetricBuilder#map` call.
+  - `reduce` : the method combines 2 row results. It is called as part of `water.MRTask#map` and `water.MRTask#reduce` calls.
   - `metric` : the method computes the final metric value from given array of doubles. The method
   is called in the context of `water.MRtask#postGlobal` and corresponds to `hex.MetricBuilder#postGlobal` call.
 
@@ -82,20 +82,20 @@ That needs:
 #### Custom Metric Function
 The custom metric function is defined in Python as a class which provides
 3 methods following the semantics of Java API above:
-  - `perRow`
-  - `combine`
+  - `map`
+  - `reduce`
   - `metric`
 
 For example, custom RMSE model metric:
 
 ```python
 class CustomRmseFunc:
-    def perRow(self, pred, act, w, o, model):
+    def map(self, pred, act, w, o, model):
         idx = int(act[0])
         err = 1 - pred[idx + 1] if idx + 1 < len(pred) else 1
         return [err * err, 1]
 
-    def combine(self, l, r):
+    def reduce(self, l, r):
         return [l[0] + r[0], l[1] + r[1]]
 
     def metric(self, l):
@@ -146,13 +146,3 @@ model.train(y="AGE", x=ftrain.names, training_frame=ftrain, validation_frame=fva
 
 The computed custom model metric is part of model metric object and available
 via methods `custom_metric_name()` and `custom_metric_value()`.
-
-# todo
-  - tests in python
-  - dkv should use proper url classloader
-  - remove uneccessary parts
-  - remove Jython factory
-  - jython run tests via testMultiNode
-  - force multi-chunk tests
-  - move CFunc and and JTasks into tests
-

--- a/h2o-docs/src/dev/custom_functions.md
+++ b/h2o-docs/src/dev/custom_functions.md
@@ -72,10 +72,80 @@ distributed invocation:
       - missing transpiler from Python into Rapids (we have limited transpiler for Lambdas)
 
 ## Python Client
-TBD
+The idea is to pass definition of custom metric directly from Python in the form of Python code.
+That needs:
+  - an API which represents a custom metric function at caller side
+  - backend support to interpret Python code
 
 ### Public API
-TBD
+
+#### Custom Metric Function
+The custom metric function is defined in Python as a class which provides
+3 methods following the semantics of Java API above:
+  - `perRow`
+  - `combine`
+  - `metric`
+
+For example, custom RMSE model metric:
+
+```python
+class CustomRmseFunc:
+    def perRow(self, pred, act, w, o, model):
+        idx = int(act[0])
+        err = 1 - pred[idx + 1] if idx + 1 < len(pred) else 1
+        return [err * err, 1]
+
+    def combine(self, l, r):
+        return [l[0] + r[0], l[1] + r[1]]
+
+    def metric(self, l):
+        # Use Java API directly
+        import java.lang.Math as math
+        return math.sqrt(l[0] / l[1])
+```
+
+> Note: please mention, that code above is also referencing a java class `java.lang.Math`
+
+#### Publishing custom metric function in cluster
+The client local custom function represented as a class can be uploaded into running
+H2O cluster by calling method `h2o.upload_custom_metric(klazz, func_name, func_file)`:
+  - `klazz` represent custom function as described above
+  - `func_name` assigns a name with uploaded custom functions, the name corresponds to name of key in K/V
+  - `func_file` name of file to store function in uploaded jar. The source code of given class is saved into a file,
+  the file is zipped, and uploaded as zip-archive, and saved into K/V store.
+
+The call returns a reference to uploaded custom metric function. The internal form of reference
+is constructed based on passed parameters and follows the following structure: `<language>:<func_name>:<func_file>.<klazz-name>Wrapper`.
+
+> Note: The parameters `func_name` and `func_file` need to be unique for each uploaded custom metric!
+
+For example:
+```python
+custom_mm_func = h2o.upload_custom_metric(CustomRmseFunc, func_name="rmse", func_file="mm_rmse.py")
+```
+
+returns a function reference which has the following value:
+
+```
+> print(custom_mm_func)
+python:rmse=mm_rmse.CustomRmseFuncWrapper
+```
+
+#### Using custom model metric functions
+An algorithm model builder interface can expose parameter `custom_metric_func`
+which accepts a reference to uploaded custom metric function:
+
+```python
+model = H2OGradientBoostingEstimator(ntrees=3, max_depth=5,
+                  score_each_iteration=True,
+                  custom_metric_func=custom_mm_func)
+model.train(y="AGE", x=ftrain.names, training_frame=ftrain, validation_frame=fvalid)
+```
+
+> Note: Currently, only GBM and RandomForest expose the parameter.
+
+The computed custom model metric is part of model metric object and available
+via methods `custom_metric_name()` and `custom_metric_value()`.
 
 # todo
   - tests in python
@@ -83,11 +153,6 @@ TBD
   - remove uneccessary parts
   - remove Jython factory
   - jython run tests via testMultiNode
-
-
-### Example: user defined metrics
-TBD
-
-### Example: library of metrics
-TBD
+  - force multi-chunk tests
+  - move CFunc and and JTasks into tests
 

--- a/h2o-extensions/jython-cfunc/build.gradle
+++ b/h2o-extensions/jython-cfunc/build.gradle
@@ -1,0 +1,10 @@
+description = "H2O Jython Udfs"
+
+dependencies {
+    compile project(":h2o-core")
+    compile 'org.python:jython:2.7.1b3'
+
+    testCompile "junit:junit:${junitVersion}"
+    testCompile project(path: ":h2o-core", configuration: "testArchives")
+    testCompile "org.mockito:mockito-core:2.6.2"
+}

--- a/h2o-extensions/jython-cfunc/build.gradle
+++ b/h2o-extensions/jython-cfunc/build.gradle
@@ -8,3 +8,14 @@ dependencies {
     testCompile project(path: ":h2o-core", configuration: "testArchives")
     testCompile "org.mockito:mockito-core:2.6.2"
 }
+
+apply from: "${rootDir}/gradle/dataCheck.gradle"
+
+test {
+    dependsOn ":h2o-core:testJar"
+    // Note: multi node tests are ignored right now!
+    dependsOn smalldataCheck, cpLibs, jar, testJar, testSingleNode, testMultiNode
+
+    // Defeat task 'test' by running no tests.
+    exclude '**'
+}

--- a/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFunc2.java
+++ b/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFunc2.java
@@ -1,0 +1,9 @@
+package water.udf;
+
+public class JythonCFunc2 implements CFunc2 {
+
+  @Override
+  public double apply(CBlock.CRow row1, CBlock.CRow row2) {
+    return 0;
+  }
+}

--- a/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFunc2.java
+++ b/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFunc2.java
@@ -1,9 +1,0 @@
-package water.udf;
-
-public class JythonCFunc2 implements CFunc2 {
-
-  @Override
-  public double apply(CBlock.CRow row1, CBlock.CRow row2) {
-    return 0;
-  }
-}

--- a/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFuncLoader.java
+++ b/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFuncLoader.java
@@ -1,0 +1,38 @@
+package water.udf;
+
+import org.python.core.PySystemState;
+
+/**
+ * Custom function loader, which cna instantiate
+ * functions written in Python.
+ *
+ * The provider internally uses Jython.
+ *
+ * Note: Jython caches the loaded python programs. That means
+ * changing underlying function definition (i.e, Python code) is not
+ * reflected!
+ */
+public class JythonCFuncLoader extends CFuncLoader {
+
+  @Override
+  public String getLang() {
+    return "python";
+  }
+
+  @Override
+  public <F> F load(String jfuncName, Class<? extends F> targetKlazz, ClassLoader classLoader) {
+    int idxLastDot = jfuncName.lastIndexOf('.');
+    String module = jfuncName.substring(0, idxLastDot);
+    String clsName = jfuncName.substring(idxLastDot+1);
+
+    PySystemState pySystemState = new PySystemState();
+    pySystemState.setClassLoader(classLoader); // Note: do we need this one ???
+    ClassLoader savedCtxCl = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(classLoader);
+      return new JythonObjectFactory(pySystemState, targetKlazz, module, clsName).createObject();
+    } finally {
+      Thread.currentThread().setContextClassLoader(savedCtxCl);
+    }
+  }
+}

--- a/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFuncLoader.java
+++ b/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFuncLoader.java
@@ -26,7 +26,6 @@ public class JythonCFuncLoader extends CFuncLoader {
     String clsName = jfuncName.substring(idxLastDot+1);
 
     PySystemState pySystemState = new PySystemState();
-    pySystemState.setClassLoader(classLoader); // Note: do we need this one ???
     ClassLoader savedCtxCl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(classLoader);

--- a/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFuncLoader.java
+++ b/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonCFuncLoader.java
@@ -3,7 +3,7 @@ package water.udf;
 import org.python.core.PySystemState;
 
 /**
- * Custom function loader, which cna instantiate
+ * Custom function loader, which can instantiate
  * functions written in Python.
  *
  * The provider internally uses Jython.

--- a/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonObjectFactory.java
+++ b/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonObjectFactory.java
@@ -1,0 +1,37 @@
+package water.udf;
+
+import org.python.core.Py;
+import org.python.core.PyArray;
+import org.python.core.PyClass;
+import org.python.core.PyObject;
+import org.python.core.PySystemState;
+
+public class JythonObjectFactory {
+
+  private final Class interfaceType;
+  private final PyObject klass;
+
+  // Constructor obtains a reference to the importer, module, and the class name
+  public JythonObjectFactory(PySystemState state, Class interfaceType, String moduleName,
+                             String className) {
+    this.interfaceType = interfaceType;
+    PyObject importer = state.getBuiltins().__getitem__(Py.newString("__import__"));
+    PyObject module = importer.__call__(new PyObject[] {Py.newString(moduleName),  PyArray.zeros(1, String.class)}, new String[] {"fromlist"} );
+    klass = module.__getattr__(className);
+  }
+
+  // This constructor passes through to the other constructor
+  public JythonObjectFactory(Class interfaceType, String moduleName, String className) {
+    this(new PySystemState(), interfaceType, moduleName, className);
+  }
+
+  // All of the followng methods return
+  // a coerced Jython object based upon the pieces of information
+  // that were passed into the factory. The differences are
+  // between them are the number of arguments that can be passed
+  // in as arguents to the object.
+
+  public <T> T createObject() {
+    return (T) klass.__call__().__tojava__(interfaceType);
+  }
+}

--- a/h2o-extensions/jython-cfunc/src/main/resources/META-INF/services/water.udf.CFuncLoader
+++ b/h2o-extensions/jython-cfunc/src/main/resources/META-INF/services/water.udf.CFuncLoader
@@ -1,0 +1,1 @@
+water.udf.JythonCFuncLoader

--- a/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCFuncTest.java
+++ b/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCFuncTest.java
@@ -1,0 +1,77 @@
+package water.udf;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import water.DKV;
+import water.TestUtil;
+
+import static water.udf.JFuncTest.mockedRow;
+import static water.udf.JFuncUtils.getSkippingClassloader;
+import static water.udf.JFuncUtils.loadRawTestFunc;
+import static water.udf.JFuncUtils.loadTestFunc;
+import static water.util.ArrayUtils.sum;
+
+public class JythonCFuncTest extends TestUtil {
+
+  @BeforeClass
+  static public void setup() {
+    stall_till_cloudsize(1);
+  }
+  
+  @Test
+  public void testPyFunc2InvocationFromResources() throws Exception {
+    String[] functionResources = ar("py/test_cfunc2.py", "py/__init__.py");
+    CFuncRef
+        cFuncRef = loadTestFunc("python", "test1.py", functionResources, "py.test_cfunc2.TestCFunc2");
+    testPyFunc2Invocation(cFuncRef, functionResources);
+  }
+
+  @Test
+  public void testPyFunc2InvocationFromString() throws Exception {
+    // Load test python code
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    try(InputStream is = cl.getResourceAsStream("py/test_cfunc2.py")) {
+      byte[] ba = IOUtils.toByteArray(is);
+      CFuncRef cFuncRef = loadRawTestFunc("python", "test2.py", "test.TestCFunc2", ba, "test.py");
+      testPyFunc2Invocation(cFuncRef, new String[0]);
+    }
+  }
+
+  private void testPyFunc2Invocation(CFuncRef testFuncDef, String[] resourcesToSkip) throws Exception {
+    try {
+      ClassLoader skippingCl = getSkippingClassloader(JythonCFuncTest.class.getClassLoader(),
+                                                      new String[0], resourcesToSkip);
+      ClassLoader cl = new DkvClassLoader(testFuncDef, skippingCl);
+      JythonCFuncLoader loader = new JythonCFuncLoader();
+      CFunc2 testFunc = loader.load(testFuncDef.funcName, CFunc2.class, cl);
+
+      CBlock.CRow crow1 = mockedRow(10, 1.0);
+      CBlock.CRow crow2 = mockedRow(5, 1.0);
+
+      Assert.assertEquals("Test testFunc call should return expected value",
+                          sum(crow1.readDoubles()) + sum(crow2.readDoubles()),
+                          testFunc.apply(crow1, crow2), 1e-10);
+
+    } finally {
+      DKV.remove(testFuncDef.getKey());
+    }
+  }
+
+  @Test public void testWeirdIface() throws Exception {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    CFuncRef testFuncDef = null;
+    try(InputStream is = cl.getResourceAsStream("tt.py")) {
+      byte[] ba = IOUtils.toByteArray(is);
+      testFuncDef = loadRawTestFunc("python", "testWI.py", "test.Y", ba, "test.py");
+      ClassLoader dkvCl = new DkvClassLoader(testFuncDef, cl);
+      JythonCFuncLoader loader = new JythonCFuncLoader();
+    } finally {
+      DKV.remove(testFuncDef.getKey());
+    }
+  }
+}

--- a/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCFuncTest.java
+++ b/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCFuncTest.java
@@ -61,17 +61,4 @@ public class JythonCFuncTest extends TestUtil {
       DKV.remove(testFuncDef.getKey());
     }
   }
-
-  @Test public void testWeirdIface() throws Exception {
-    ClassLoader cl = Thread.currentThread().getContextClassLoader();
-    CFuncRef testFuncDef = null;
-    try(InputStream is = cl.getResourceAsStream("tt.py")) {
-      byte[] ba = IOUtils.toByteArray(is);
-      testFuncDef = loadRawTestFunc("python", "testWI.py", "test.Y", ba, "test.py");
-      ClassLoader dkvCl = new DkvClassLoader(testFuncDef, cl);
-      JythonCFuncLoader loader = new JythonCFuncLoader();
-    } finally {
-      DKV.remove(testFuncDef.getKey());
-    }
-  }
 }

--- a/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCustomMetricTest.java
+++ b/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCustomMetricTest.java
@@ -1,0 +1,31 @@
+package water.udf;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import water.TestUtil;
+
+import static water.udf.CustomMetricTest.testNullModelRegression;
+import static water.udf.JFuncUtils.loadRawTestFunc;
+
+public class JythonCustomMetricTest extends TestUtil {
+  @BeforeClass
+  static public void setup() { stall_till_cloudsize(1); }
+
+  @Test
+  public void testNullModelCustomMetric() throws Exception {
+    testNullModelRegression(maeCustomMetric());
+  }
+
+  private CFuncRef maeCustomMetric() throws IOException {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    try(InputStream is = cl.getResourceAsStream("py/test_mae_custom_metric.py")) {
+      byte[] ba = IOUtils.toByteArray(is);
+      return loadRawTestFunc("python", "test_mae.py", "test.MAE", ba, "test.py");
+    }
+  }
+}

--- a/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCustomMetricTest.java
+++ b/h2o-extensions/jython-cfunc/src/test/java/water/udf/JythonCustomMetricTest.java
@@ -25,7 +25,7 @@ public class JythonCustomMetricTest extends TestUtil {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try(InputStream is = cl.getResourceAsStream("py/test_mae_custom_metric.py")) {
       byte[] ba = IOUtils.toByteArray(is);
-      return loadRawTestFunc("python", "test_mae.py", "test.MAE", ba, "test.py");
+      return loadRawTestFunc("python", "test_mae.py", "test_cm.MAE", ba, "test_cm.py");
     }
   }
 }

--- a/h2o-extensions/jython-cfunc/src/test/resources/py/test_cfunc2.py
+++ b/h2o-extensions/jython-cfunc/src/test/resources/py/test_cfunc2.py
@@ -1,0 +1,10 @@
+import water.udf.CFunc2 as Func
+
+class TestCFunc2(Func):
+    """
+    Compute sum of actual + predict
+    """
+
+    def apply(self, rowActual, rowPredict):
+        return sum(rowActual.readDoubles()) + sum(rowPredict.readDoubles())
+

--- a/h2o-extensions/jython-cfunc/src/test/resources/py/test_mae_custom_metric.py
+++ b/h2o-extensions/jython-cfunc/src/test/resources/py/test_mae_custom_metric.py
@@ -1,0 +1,11 @@
+import water.udf.CMetricFunc as MetricFunc
+
+class MAE(MetricFunc):
+    def perRow(self, pred, act, w, o, model):
+        return [abs(pred[0] - act[0]), 1]
+
+    def combine(self, l, r):
+        return [l[0] + r[0], l[1] + r[1]]
+
+    def metric(self, l):
+        return l[0]/l[1]

--- a/h2o-extensions/jython-cfunc/src/test/resources/py/test_mae_custom_metric.py
+++ b/h2o-extensions/jython-cfunc/src/test/resources/py/test_mae_custom_metric.py
@@ -1,10 +1,10 @@
 import water.udf.CMetricFunc as MetricFunc
 
 class MAE(MetricFunc):
-    def perRow(self, pred, act, w, o, model):
+    def map(self, pred, act, w, o, model):
         return [abs(pred[0] - act[0]), 1]
 
-    def combine(self, l, r):
+    def reduce(self, l, r):
         return [l[0] + r[0], l[1] + r[1]]
 
     def metric(self, l):

--- a/h2o-extensions/jython-cfunc/testMultiNode.sh
+++ b/h2o-extensions/jython-cfunc/testMultiNode.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+source "${ROOT_DIR}/multiNodeUtils.sh"
+
+# Argument parsing
+if [ "$1" = "jacoco" ]
+then
+    JACOCO_ENABLED=true
+else
+    JACOCO_ENABLED=false
+fi
+
+# Clean out any old sandbox, make a new one
+OUTDIR=sandbox/multi
+
+MKDIR=mkdir
+SEP=:
+case "`uname`" in
+    CYGWIN* )
+      MKDIR=mkdir.exe
+      SEP=";"
+      ;;
+esac
+rm -fr $OUTDIR
+$MKDIR -p $OUTDIR
+
+function cleanup () {
+  kill -9 ${PID_11} 1> /dev/null 2>&1
+  kill -9 ${PID_12} 1> /dev/null 2>&1
+  kill -9 ${PID_13} 1> /dev/null 2>&1
+  wait 1> /dev/null 2>&1
+  RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
+  if [ "$RC" != "0" ]; then
+    cat $OUTDIR/out.*
+    echo h2o-algos junit tests FAILED
+    exit 1
+  else
+    echo h2o-algos junit tests PASSED
+    exit 0
+  fi
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Find java command
+if [ -z "$TEST_JAVA_HOME" ]; then
+  # Use default
+  JAVA_CMD="java"
+else
+  # Use test java home
+  JAVA_CMD="$TEST_JAVA_HOME/bin/java"
+  # Increase XMX since JAVA_HOME can point to java6
+  JAVA6_REGEXP=".*1\.6.*"
+  if [[ $TEST_JAVA_HOME =~ $JAVA6_REGEXP ]]; then
+    JAVA_CMD="${JAVA_CMD}"
+  fi
+fi
+# Gradle puts files:
+#   build/classes/main - Main h2o core classes
+#   build/classes/test - Test h2o core classes
+#   build/resources/main - Main resources (e.g. page.html)
+
+MAX_MEM=${H2O_JVM_XMX:-2500m}
+
+# Check if coverage should be run
+if [ $JACOCO_ENABLED = true ]
+then
+    AGENT="../jacoco/jacocoagent.jar"
+    COVERAGE="-javaagent:$AGENT=destfile=build/jacoco/h2o-algos.exec"
+    MAX_MEM=${H2O_JVM_XMX:-8g}
+else
+    COVERAGE=""
+fi
+JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -DcloudSize=4 -cp ${JVM_CLASSPATH}"
+echo "$JVM" > $OUTDIR/jvm_cmd.txt
+
+# Tests
+# Must run first, before the cloud locks (because it tests cloud locking)
+JUNIT_TESTS_BOOT=""
+JUNIT_TESTS_BIG="hex.word2vec.Word2VecTest"
+
+# Runner
+# Default JUnit runner is org.junit.runner.JUnitCore
+JUNIT_RUNNER="water.junit.H2OTestRunner"
+
+# find all java in the src/test directory
+# Cut the "./water/MRThrow.java" down to "water/MRThrow.java"
+# Cut the   "water/MRThrow.java" down to "water/MRThrow"
+# Slash/dot "water/MRThrow"      becomes "water.MRThrow"
+
+# On this h2o-algos testMultiNode.sh only, force the tests.txt to be in the same order for all machines.
+# If sorted, the result of the cd/grep varies by machine.
+# If randomness is desired, replace sort with the unix 'shuf'
+# Use /usr/bin/sort because of cygwin on windows.
+# Windows has sort.exe which you don't want. Fails? (is it a lineend issue)
+(cd src/test/java; /usr/bin/find . -name '*.java' | cut -c3- | sed 's/.....$//' | sed -e 's/\//./g') | grep -v $JUNIT_TESTS_BIG | /usr/bin/sort > $OUTDIR/tests.txt
+
+# Output the comma-separated list of ignored/dooonly tests
+# Ignored tests trump do-only tests
+echo $IGNORE > $OUTDIR/tests.ignore.txt
+echo $DOONLY > $OUTDIR/tests.doonly.txt
+
+# Launch 3 helper JVMs
+CLUSTER_NAME=junit_cluster_$$
+CLUSTER_BASEPORT_1=44000
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT_1 -ga_opt_out $SSL 1> $OUTDIR/out.1.1 2>&1 & PID_11=$!
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT_1 -ga_opt_out $SSL 1> $OUTDIR/out.1.2 2>&1 & PID_12=$!
+$JVM water.H2O -name $CLUSTER_NAME.1 -baseport $CLUSTER_BASEPORT_1 -ga_opt_out $SSL 1> $OUTDIR/out.1.3 2>&1 & PID_13=$!
+
+# If coverage is being run, then pass a system variable flag so that timeout limits are increased.
+if [ $JACOCO_ENABLED = true ]
+then
+    JACOCO_FLAG="-Dtest.jacocoEnabled=true"
+else
+    JACOCO_FLAG=""
+fi
+
+# Launch last driver JVM.  All output redir'd at the OS level to sandbox files.
+echo Running ${PROJECT_NAME} junit tests...
+
+sleep 10
+
+($JVM $TEST_SSL -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT_1 -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER $JUNIT_TESTS_BOOT `cat $OUTDIR/tests.txt` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
+
+wait ${PID_1} 1> /dev/null 2>&1
+grep EXECUTION $OUTDIR/out.* | sed -e "s/.*TEST \(.*\) EXECUTION TIME: \(.*\) (Wall.*/\2 \1/" | sort -gr | head -n 10 >> $OUTDIR/out.0
+
+cleanup

--- a/h2o-extensions/jython-cfunc/testSingleNode.sh
+++ b/h2o-extensions/jython-cfunc/testSingleNode.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Argument parsing
+if [ "$1" = "jacoco" ]
+then
+    JACOCO_ENABLED=true
+else
+    JACOCO_ENABLED=false
+fi
+
+# Clean out any old sandbox, make a new one
+OUTDIR=sandbox/single
+
+MKDIR=mkdir
+SEP=:
+case "`uname`" in
+    CYGWIN* )
+      MKDIR=mkdir.exe
+      SEP=";"
+      ;;
+esac
+rm -fr $OUTDIR
+$MKDIR -p $OUTDIR
+
+function cleanup () {
+  RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
+  if [ "$RC" != "00000" ]; then
+    cat $OUTDIR/out.*
+    echo ${PROJECT_NAME} junit tests FAILED
+    exit 1
+  else
+    echo ${PROJECT_NAME} junit tests PASSED
+    exit 0
+  fi
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Find java command
+if [ -z "$TEST_JAVA_HOME" ]; then
+  # Use default
+  JAVA_CMD="java"
+else
+  # Use test java home
+  JAVA_CMD="$TEST_JAVA_HOME/bin/java"
+  # Increase XMX since JAVA_HOME can point to java6
+  JAVA6_REGEXP=".*1\.6.*"
+  if [[ $TEST_JAVA_HOME =~ $JAVA6_REGEXP ]]; then
+    JAVA_CMD="${JAVA_CMD}"
+  fi
+fi
+# Gradle puts files:
+#   build/classes/main - Main h2o core classes
+#   build/classes/test - Test h2o core classes
+#   build/resources/main - Main resources (e.g. page.html)
+
+MAX_MEM=${H2O_JVM_XMX:-2200m}
+
+# Check if coverage should be run
+if [ $JACOCO_ENABLED = true ]
+then
+    AGENT="../jacoco/jacocoagent.jar"
+    COVERAGE="-javaagent:$AGENT=destfile=build/jacoco/h2o-algos.exec"
+    MAX_MEM=${H2O_JVM_XMX:-8g}
+else
+    COVERAGE=""
+fi
+JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp $JVM_CLASSPATH"
+echo "$JVM" > $OUTDIR/jvm_cmd.txt
+# Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
+# Also, sometimes see test files in the main-class directory, so put the test
+# classpath before the main classpath.
+#JVM="nice java -ea -cp build/classes/test${SEP}build/classes/main${SEP}../h2o-core/build/classes/test${SEP}../h2o-core/build/classes/main${SEP}../lib/*"
+
+# Tests
+# Must run first, before the cloud locks (because it tests cloud locking)
+JUNIT_TESTS_BIG="hex.word2vec.Word2VecTest"
+
+# Runner
+# Default JUnit runner is org.junit.runner.JUnitCore
+JUNIT_RUNNER="water.junit.H2OTestRunner"
+
+# find all java in the src/test directory
+# Cut the "./water/MRThrow.java" down to "water/MRThrow.java"
+# Cut the   "water/MRThrow.java" down to "water/MRThrow"
+# Slash/dot "water/MRThrow"      becomes "water.MRThrow"
+
+# On this h2o-algos testMultiNode.sh only, force the tests.txt to be in the same order for all machines.
+# If sorted, the result of the cd/grep varies by machine. 
+# If randomness is desired, replace sort with the unix 'shuf'
+# Use /usr/bin/sort because of cygwin on windows. 
+# Windows has sort.exe which you don't want. Fails? (is it a lineend issue)
+(cd src/test/java; /usr/bin/find . -name '*.java' | cut -c3- | sed 's/.....$//' | sed -e 's/\//./g') | grep -v $JUNIT_TESTS_BIG | /usr/bin/sort | grep -v AAA_PreCloudLock > $OUTDIR/tests.txt
+
+# Output the comma-separated list of ignored/dooonly tests
+# Ignored tests trump do-only tests
+echo $IGNORE > $OUTDIR/tests.ignore.txt
+echo $DOONLY > $OUTDIR/tests.doonly.txt
+
+# Launch 4 helper JVMs.  All output redir'd at the OS level to sandbox files.
+CLUSTER_NAME=junit_cluster_$$
+CLUSTER_BASEPORT=44000
+
+# If coverage is being run, then pass a system variable flag so that timeout limits are increased.
+if [ $JACOCO_ENABLED = true ]
+then
+    JACOCO_FLAG="-Dtest.jacocoEnabled=true"
+else
+    JACOCO_FLAG=""
+fi
+
+# Launch last driver JVM.  All output redir'd at the OS level to sandbox files.
+echo Running ${PROJECT_NAME} junit tests...
+
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.1 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==0'` 2>&1 ; echo $? > $OUTDIR/status.1) 1> $OUTDIR/out.1 2>&1 & PID_1=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.2 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==1'` 2>&1 ; echo $? > $OUTDIR/status.2) 1> $OUTDIR/out.2 2>&1 & PID_2=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.3 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==2'` 2>&1 ; echo $? > $OUTDIR/status.3) 1> $OUTDIR/out.3 2>&1 & PID_3=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.4 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==3'` 2>&1 ; echo $? > $OUTDIR/status.4) 1> $OUTDIR/out.4 2>&1 & PID_4=$!
+($JVM -Ddoonly.tests=$DOONLY -Dbuild.id=$BUILD_ID -Dignore.tests=$IGNORE -Djob.name=$JOB_NAME -Dgit.commit=$GIT_COMMIT -Dgit.branch=$GIT_BRANCH -Dai.h2o.name=$CLUSTER_NAME.5 -Dai.h2o.baseport=$CLUSTER_BASEPORT -Dai.h2o.ga_opt_out=yes $JACOCO_FLAG $JUNIT_RUNNER `cat $OUTDIR/tests.txt | awk 'NR%5==4'` 2>&1 ; echo $? > $OUTDIR/status.5) 1> $OUTDIR/out.5 2>&1 & PID_5=$!
+
+wait ${PID_1} ${PID_2} ${PID_3} ${PID_4} ${PID_5} 1> /dev/null 2>&1
+grep EXECUTION $OUTDIR/out.* | sed -e "s/.*TEST \(.*\) EXECUTION TIME: \(.*\) (Wall.*/\2 \1/" | sort -gr | head -n 10 >> $OUTDIR/out.0
+
+cleanup

--- a/h2o-py/h2o/__init__.py
+++ b/h2o-py/h2o/__init__.py
@@ -18,7 +18,7 @@ from h2o.h2o import (connect, init, api, connection,
                      cluster_status, cluster_info, shutdown, network_test, cluster,
                      interaction, as_list,
                      get_timezone, set_timezone, list_timezones,
-                     load_dataset, demo, make_metrics,flow)
+                     load_dataset, demo, make_metrics,flow, upload_custom_metric)
 # We have substantial amount of code relying on h2o.H2OFrame to exist. Thus, we make this class available from
 # root h2o module, without exporting it explicitly. In the future this import may be removed entirely, so that
 # one would have to import it from h2o.frames.
@@ -36,4 +36,5 @@ __all__ = ("connect", "init", "api", "connection", "upload_file", "lazy_import",
            "remove", "remove_all", "rapids", "ls", "frame",
            "frames", "download_pojo", "download_csv", "download_all_logs", "save_model", "load_model", "export_file",
            "cluster_status", "cluster_info", "shutdown", "create_frame", "interaction", "as_list", "network_test",
-           "set_timezone", "get_timezone", "list_timezones", "demo", "make_metrics", "cluster", "load_dataset","flow")
+           "set_timezone", "get_timezone", "list_timezones", "demo", "make_metrics", "cluster", "load_dataset","flow",
+           "upload_custom_metric")

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -1323,11 +1323,11 @@ def upload_custom_metric(func, func_file="metrics.py", func_name=None, class_nam
     _CFUNC_CODE_TEMPLATE = """# Generated code
 import water.udf.CMetricFunc as MetricFunc
 
-# User given metric function as a class implementing 
+# User given metric function as a class implementing
 # 3 methods defined by interface CMetricFunc
-{}    
+{}
 
-# Generated user metric which satisfies the interface 
+# Generated user metric which satisfies the interface
 # of Java MetricFunc
 class {}Wrapper({}, MetricFunc, object):
     pass
@@ -1357,7 +1357,7 @@ class {}Wrapper({}, MetricFunc, object):
         code = str
     else:
         assert_satisfies(func, inspect.isclass(func), "The parameter `func` should be str or class")
-        for method in ['perRow', 'combine', 'metric']:
+        for method in ['map', 'reduce', 'metric']:
             assert_satisfies(func, method in func.__dict__, "The class `func` needs to define method `{}`".format(method))
 
         assert_satisfies(class_name, class_name is None,
@@ -1377,7 +1377,7 @@ class {}Wrapper({}, MetricFunc, object):
     dest_key = _put_key(func_arch_file, dest_key=func_name)
     # Reference
     return "python:{}={}".format(dest_key, class_name)
-        
+
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Private

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -1329,7 +1329,7 @@ import water.udf.CMetricFunc as MetricFunc
 
 # Generated user metric which satisfies the interface 
 # of Java MetricFunc
-class UserMetric({}, MetricFunc, object):
+class {}Wrapper({}, MetricFunc, object):
     pass
 
 """
@@ -1363,9 +1363,9 @@ class UserMetric({}, MetricFunc, object):
         assert_satisfies(class_name, class_name is None,
                          "If class is specified then class_name parameter needs to be None")
 
-        class_name = "{}.UserMetric".format(module_name)
+        class_name = "{}.{}Wrapper".format(module_name, func.__name__)
         derived_func_name = "metrics_{}".format(func.__name__)
-        code = _CFUNC_CODE_TEMPLATE.format(get_source(func), func.__name__)
+        code = _CFUNC_CODE_TEMPLATE.format(get_source(func), func.__name__, func.__name__)
 
     # If the func name is not given, use whatever we can derived from given definition
     if not func_name:

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -129,6 +129,8 @@ class MetricsBase(backwards_compatible()):
         if metric_type in types_w_dim:
             print("Sum of Squared Error (Numeric): " + str(self.num_err()))
             print("Misclassification Error (Categorical): " + str(self.cat_err()))
+        if self.custom_metric_name():
+            print("{}: {}".format(self.custom_metric_name(), self.custom_metric_value()))
 
 
     def r2(self):

--- a/h2o-py/tests/pyunit_utils/__init__.py
+++ b/h2o-py/tests/pyunit_utils/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import absolute_import
 from .utilsPY import *
+from .utils_model_metrics import *

--- a/h2o-py/tests/pyunit_utils/utils_model_metrics.py
+++ b/h2o-py/tests/pyunit_utils/utils_model_metrics.py
@@ -3,10 +3,10 @@ from . import locate
 
 
 class CustomMaeFunc:
-    def perRow(self, pred, act, w, o, model):
+    def map(self, pred, act, w, o, model):
         return [abs(act[0] - pred[0]), 1]
 
-    def combine(self, l, r):
+    def reduce(self, l, r):
         return [l[0] + r[0], l[1] + r[1]]
 
     def metric(self, l):
@@ -14,12 +14,12 @@ class CustomMaeFunc:
 
 
 class CustomRmseFunc:
-    def perRow(self, pred, act, w, o, model):
+    def map(self, pred, act, w, o, model):
         idx = int(act[0])
         err = 1 - pred[idx + 1] if idx + 1 < len(pred) else 1
         return [err * err, 1]
 
-    def combine(self, l, r):
+    def reduce(self, l, r):
         return [l[0] + r[0], l[1] + r[1]]
 
     def metric(self, l):

--- a/h2o-py/tests/pyunit_utils/utils_model_metrics.py
+++ b/h2o-py/tests/pyunit_utils/utils_model_metrics.py
@@ -1,0 +1,77 @@
+import h2o
+from . import locate
+
+
+
+class CustomMaeFunc:
+    def perRow(self, pred, act, w, o, model):
+        print("XXX")
+        return [abs(act[0] - pred[0]), 1]
+
+    def combine(self, l, r):
+        return [l[0] + r[0], l[1] + r[1]]
+
+    def metric(self, l):
+        return l[0] / l[1]
+
+
+class CustomRmseFunc:
+    def perRow(self, pred, act, w, o, model):
+        idx = int(act[0])
+        err = 1 - pred[idx+1] if idx + 1 < len(pred) else 1
+        return [err*err, 1]
+
+    def combine(self, l, r):
+        return [l[0] + r[0], l[1] + r[1]]
+
+    def metric(self, l):
+        # Use Java API directly
+        import java.lang.Math as math
+        return math.sqrt(l[0] / l[1])
+
+
+def assert_metrics_equal(metric, metric_name1, metric_name2, msg=None):
+    metric_name1 = metric_name1 if metric_name1 in metric._metric_json else metric_name1.upper()
+    metric_name2 = metric_name2 if metric_name2 in metric._metric_json else metric_name2.upper()
+    assert metric._metric_json[metric_name1] == metric._metric_json[metric_name2], msg
+
+
+def assert_scoring_history(model, metric_name1, metric_name2, msg=None):
+    scoring_history = model.scoring_history()
+    sh1 = scoring_history[metric_name1]
+    sh2 = scoring_history[metric_name2]
+    assert (sh1.isnull() == sh2.isnull()).all(), msg
+    assert (sh1.dropna() == sh2.dropna()).all(), msg
+
+
+def assert_correct_custom_metric(model, f_test, metric_name, msg=None):
+    # Check model performance on training data
+    mm_train = model.model_performance(train=True)
+    print(mm_train)
+    assert_metrics_equal(mm_train, metric_name, "custom_metric_value",
+                         "{}: Train metric should match custom metric".format(msg))
+    # Check model performance on validation data
+    mm_valid = model.model_performance(valid=True)
+    assert_metrics_equal(mm_valid, metric_name, "custom_metric_value",
+                         "{}: Validation metric should match custom metric".format(msg))
+    # Make a new model metric
+    mm_test = model.model_performance(test_data=f_test)
+    assert_metrics_equal(mm_valid, metric_name, "custom_metric_value",
+                         "{}: Test metric should match custom metric".format(msg))
+
+    # Check scoring history
+    assert_scoring_history(model, "training_{}".format(metric_name), "training_custom",
+                           "{}: Scoring history for training data should match".format(msg))
+    assert_scoring_history(model, "validation_{}".format(metric_name), "validation_custom",
+                           "{}: Scoring history for validation data should match".format(msg))
+
+
+def dataset_prostate():
+    df = h2o.import_file(path=locate("smalldata/prostate/prostate.csv"))
+    df = df.drop("ID")
+    df["CAPSULE"] = df["CAPSULE"].asfactor()
+    return df.split_frame(ratios=[0.6, 0.3], seed=0)
+
+def dataset_iris():
+    df = h2o.import_file(path=locate("smalldata/iris/iris_wheader.csv"))
+    return df.split_frame(ratios=[0.6, 0.3], seed=0)

--- a/h2o-py/tests/pyunit_utils/utils_model_metrics.py
+++ b/h2o-py/tests/pyunit_utils/utils_model_metrics.py
@@ -2,10 +2,8 @@ import h2o
 from . import locate
 
 
-
 class CustomMaeFunc:
     def perRow(self, pred, act, w, o, model):
-        print("XXX")
         return [abs(act[0] - pred[0]), 1]
 
     def combine(self, l, r):
@@ -18,8 +16,8 @@ class CustomMaeFunc:
 class CustomRmseFunc:
     def perRow(self, pred, act, w, o, model):
         idx = int(act[0])
-        err = 1 - pred[idx+1] if idx + 1 < len(pred) else 1
-        return [err*err, 1]
+        err = 1 - pred[idx + 1] if idx + 1 < len(pred) else 1
+        return [err * err, 1]
 
     def combine(self, l, r):
         return [l[0] + r[0], l[1] + r[1]]
@@ -47,7 +45,6 @@ def assert_scoring_history(model, metric_name1, metric_name2, msg=None):
 def assert_correct_custom_metric(model, f_test, metric_name, msg=None):
     # Check model performance on training data
     mm_train = model.model_performance(train=True)
-    print(mm_train)
     assert_metrics_equal(mm_train, metric_name, "custom_metric_value",
                          "{}: Train metric should match custom metric".format(msg))
     # Check model performance on validation data
@@ -56,7 +53,7 @@ def assert_correct_custom_metric(model, f_test, metric_name, msg=None):
                          "{}: Validation metric should match custom metric".format(msg))
     # Make a new model metric
     mm_test = model.model_performance(test_data=f_test)
-    assert_metrics_equal(mm_valid, metric_name, "custom_metric_value",
+    assert_metrics_equal(mm_test, metric_name, "custom_metric_value",
                          "{}: Test metric should match custom metric".format(msg))
 
     # Check scoring history
@@ -72,6 +69,36 @@ def dataset_prostate():
     df["CAPSULE"] = df["CAPSULE"].asfactor()
     return df.split_frame(ratios=[0.6, 0.3], seed=0)
 
+
 def dataset_iris():
     df = h2o.import_file(path=locate("smalldata/iris/iris_wheader.csv"))
     return df.split_frame(ratios=[0.6, 0.3], seed=0)
+
+
+# Regression Model fixture
+def regression_model(ModelType, custom_metric_func):
+    (ftrain, fvalid, ftest) = dataset_prostate()
+    model = ModelType(model_id="regression", ntrees=3, max_depth=5,
+                      score_each_iteration=True,
+                      custom_metric_func=custom_metric_func)
+    model.train(y="AGE", x=ftrain.names, training_frame=ftrain, validation_frame=fvalid)
+    return model, ftest
+
+
+# Binomial model fixture
+def binomial_model(ModelType, custom_metric_func):
+    (ftrain, fvalid, ftest) = dataset_prostate()
+    model = ModelType(model_id="binomial", ntrees=3, max_depth=5,
+                      score_each_iteration=True,
+                      custom_metric_func=custom_metric_func)
+    model.train(y="CAPSULE", x=ftrain.names, training_frame=ftrain, validation_frame=fvalid)
+    return model, ftest
+
+
+def multinomial_model(ModelType, custom_metric_func):
+    (ftrain, fvalid, ftest) = dataset_iris()
+    model = ModelType(model_id="multinomial", ntrees=3, max_depth=5,
+                      score_each_iteration=True,
+                      custom_metric_func=custom_metric_func)
+    model.train(y="class", x=ftrain.names, training_frame=ftrain, validation_frame=fvalid)
+    return model, ftest

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_custom_metrics_pubdev_5088.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_custom_metrics_pubdev_5088.py
@@ -5,7 +5,7 @@ import h2o
 from tests import pyunit_utils
 from tests.pyunit_utils import CustomMaeFunc, CustomRmseFunc,\
     assert_correct_custom_metric, regression_model, multinomial_model, binomial_model
-from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
 
 
 # Custom model metrics fixture
@@ -20,17 +20,17 @@ def custom_rmse_mm():
 # Test that the custom model metric is computed
 # and compare them with implicit custom metric
 def test_custom_metric_computation_regression():
-    (model, f_test) = regression_model(H2ORandomForestEstimator, custom_mae_mm())
+    (model, f_test) = regression_model(H2OGradientBoostingEstimator, custom_mae_mm())
     assert_correct_custom_metric(model, f_test, "mae", "Regression on prostate")
 
 
 def test_custom_metric_computation_binomial():
-    (model, f_test) = binomial_model(H2ORandomForestEstimator, custom_rmse_mm())
+    (model, f_test) = binomial_model(H2OGradientBoostingEstimator, custom_rmse_mm())
     assert_correct_custom_metric(model, f_test, "rmse", "Binomial on prostate")
     
 
 def test_custom_metric_computation_multinomial():
-    (model, f_test) = multinomial_model(H2ORandomForestEstimator, custom_rmse_mm())
+    (model, f_test) = multinomial_model(H2OGradientBoostingEstimator, custom_rmse_mm())
     assert_correct_custom_metric(model, f_test, "rmse", "Multinomial on iris")
 
 

--- a/h2o-py/tests/testdir_algos/rf/pyunit_custom_metrics_pubdev_5088.py
+++ b/h2o-py/tests/testdir_algos/rf/pyunit_custom_metrics_pubdev_5088.py
@@ -1,0 +1,78 @@
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from tests.pyunit_utils import CustomMaeFunc, CustomRmseFunc,\
+    assert_correct_custom_metric, dataset_prostate, dataset_iris
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+
+
+# Custom model metrics fixture
+def custom_mae_mm():
+    return h2o.upload_custom_metric(CustomMaeFunc, func_name="mae", func_file="mm_mae.py")
+
+
+def custom_rmse_mm():
+    return h2o.upload_custom_metric(CustomRmseFunc, func_name="rmse", func_file="mm_rmse.py")
+
+
+# Regression Model fixture
+def regression_model(custom_metric_func):
+    (ftrain, fvalid, ftest) = dataset_prostate()
+    model = H2ORandomForestEstimator(model_id="rf_regression", ntrees=3, max_depth=5,
+                                     score_each_iteration=True,
+                                     custom_metric_func=custom_metric_func)
+    model.train(y="AGE", x=ftrain.names, training_frame=ftrain, validation_frame=fvalid)
+    return model, ftest
+
+
+# Binomial model fixture
+def binomial_model(custom_metric_func):
+    (ftrain, fvalid, ftest) = dataset_prostate()
+    model = H2ORandomForestEstimator(model_id="rf_binomial", ntrees=3, max_depth=5,
+                                     score_each_iteration=True,
+                                     custom_metric_func=custom_metric_func)
+    model.train(y="CAPSULE", x=ftrain.names, training_frame=ftrain, validation_frame=fvalid)
+    return model, ftest
+
+
+def multinomial_model(custom_metric_func):
+    (ftrain, fvalid, ftest) = dataset_iris()
+    model = H2ORandomForestEstimator(model_id="rf_multinomial", ntrees=3, max_depth=5,
+                                     score_each_iteration=True,
+                                     custom_metric_func=custom_metric_func)
+    model.train(y="class", x=ftrain.names, training_frame=ftrain, validation_frame=fvalid)
+    return model, ftest
+
+
+# Test that the custom model metric is computed
+# and compare them with implicit custom metric
+def test_custom_metric_computation_regression():
+    (model, f_test) = regression_model(custom_mae_mm())
+    assert_correct_custom_metric(model, f_test, "mae", "Regression on prostate")
+
+
+def test_custom_metric_computation_binomial():
+    (model, f_test) = binomial_model(custom_rmse_mm())
+    assert_correct_custom_metric(model, f_test, "rmse", "Binomial on prostate")
+    
+
+def test_custom_metric_computation_multinomial():
+    (model, f_test) = multinomial_model(custom_rmse_mm())
+    assert_correct_custom_metric(model, f_test, "rmse", "Multinomial on iris")
+
+
+# Tests to invoke in this suite
+__TESTS__ = [
+    test_custom_metric_computation_binomial,
+    test_custom_metric_computation_regression,
+    test_custom_metric_computation_multinomial
+]
+
+if __name__ == "__main__":
+    for func in __TESTS__:
+        pyunit_utils.standalone_test(func)
+else:
+    for func in __TESTS__:
+        func()

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ include 'h2o-genmodel-ext-xgboost'
 include 'h2o-ext-xgboost'
 include 'h2o-ext-krbstandalone'
 include 'h2o-ext-authsupport'
+include 'h2o-ext-jython-cfunc'
 
 // GRPC support
 if ("true".equals(System.getenv("H2O_BUILD_GRPC"))) {


### PR DESCRIPTION
This follows PUBDEV-5087 by extending functionality to Python client and bringing ability to pass Python code from client to backend.

**This is PR to `mm/jira/pubdev-5087` branch!**

TODO:
  - [ ] tests for `h2o.upload_custom_metric`
  - [x] tests for custom model metric interface of model
  - [ ] remove Jython factory
  - [x] jython run tests via testMultiNode
  - [ ] force multi-chunk tests

