### PR TITLE
PUBDEV-3743: StackedEnsemble should allow user to pass in metalearner type

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -65,7 +65,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     // https://0xdata.atlassian.net/browse/PUBDEV-5084
     // public String _metalearner_fold_column;
 
-    //What to use as a metalearner (GLM, GBM, DRF, or DL)
+    //What to use as a metalearner (GLM, GBM, DRF, or DeepLearning)
     public String _metalearner_algorithm;
   }
 

--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -64,6 +64,9 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     // TODO: Add _metalearner_fold_column
     // https://0xdata.atlassian.net/browse/PUBDEV-5084
     // public String _metalearner_fold_column;
+
+    //What to use as a metalearner (GLM, GBM, DRF, or DL)
+    public String _metalearner_algorithm;
   }
 
   public static class StackedEnsembleOutput extends Model.Output {

--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -66,7 +66,14 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     // public String _metalearner_fold_column;
 
     //What to use as a metalearner (GLM, GBM, DRF, or DeepLearning)
-    public String _metalearner_algorithm;
+    public enum MetalearnerAlgorithm {
+      glm,
+      gbm,
+      drf,
+      deeplearning
+    }
+    public MetalearnerAlgorithm _metalearner_algorithm = MetalearnerAlgorithm.glm;
+
   }
 
   public static class StackedEnsembleOutput extends Model.Output {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -243,7 +243,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     private void computeMetaLearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, String metalearner_algo){
         // train the metalearner model
         // Default Job for just this training
-        Key<Model> metalearnerKey = Key.<Model>make("metalearner_" + _model._parms._metalearner_algorithm + _model._key);
+        Key<Model> metalearnerKey = Key.<Model>make("metalearner_" + _model._parms._metalearner_algorithm + "_" + _model._key);
         Job job = new Job<>(metalearnerKey, ModelBuilder.javaName(_model._parms._metalearner_algorithm.toLowerCase()),
                 "StackingEnsemble metalearner (" + _model._parms._metalearner_algorithm + ")");
         GLM metaGLMBuilder = null;
@@ -344,7 +344,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
 
           Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
 
-          _model._output._metalearner = metaGLMBuilder.get();
+          _model._output._metalearner = metaGBMBuilder.get();
           _model.doScoreOrCopyMetrics(_job);
           // _model._output._model_summary = createModelSummaryTable(model._output);
           if (_parms._keep_levelone_frame) {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -232,8 +232,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       }
 
       if(_model._parms._metalearner_algorithm == null){
-        _model._parms._metalearner_algorithm = "GLM";
-        Log.info("`metalearner_algorithm` is detected to be null. Using default `GLM`.");
+        _model._parms._metalearner_algorithm = "glm_non_negative";
+        Log.info("`metalearner_algorithm` is detected to be null. Using default `glm_non_negative`.");
       }
       //Compute metalearner
       computeMetaLearner(levelOneTrainingFrame, levelOneValidationFrame, _model._parms._metalearner_algorithm);
@@ -244,17 +244,19 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         // train the metalearner model
         // Default Job for just this training
         Key<Model> metalearnerKey = Key.<Model>make("metalearner_" + _model._parms._metalearner_algorithm + "_" + _model._key);
-        Job job = new Job<>(metalearnerKey, ModelBuilder.javaName(_model._parms._metalearner_algorithm.toLowerCase()),
+        Job job = new Job<>(metalearnerKey, _model._parms._metalearner_algorithm,
                 "StackingEnsemble metalearner (" + _model._parms._metalearner_algorithm + ")");
         GLM metaGLMBuilder = null;
         GBM metaGBMBuilder;
         DRF metaDRFBuilder;
         DeepLearning metaDeepLearningBuilder;
         
-        if(metalearner_algo.equals("GLM")){
+        if(metalearner_algo.equals("glm") || metalearner_algo.equals("glm_non_negative")){
           metaGLMBuilder = ModelBuilder.make("GLM", job, metalearnerKey);
 
-          metaGLMBuilder._parms._non_negative = true;
+          if(metalearner_algo.equals("glm_non_negative")) {
+            metaGLMBuilder._parms._non_negative = true;
+          }
           metaGLMBuilder._parms._train = levelOneTrainingFrame._key;
           metaGLMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaGLMBuilder._parms._response_column = _model.responseColumn;
@@ -312,7 +314,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           }
           _model.update(_job);
           _model.unlock(_job);
-        } else if (metalearner_algo.equals("GBM")){
+        } else if (metalearner_algo.equals("gbm")){
           //GBM Metalearner
           metaGBMBuilder = ModelBuilder.make("GBM", job, metalearnerKey);
 
@@ -357,7 +359,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           }
           _model.update(_job);
           _model.unlock(_job);
-        } else if (metalearner_algo.equals("DRF")){
+        } else if (metalearner_algo.equals("randomForest")){
           //DRF Metalearner
           metaDRFBuilder = ModelBuilder.make("DRF", job, metalearnerKey);
           
@@ -402,7 +404,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           }
           _model.update(_job);
           _model.unlock(_job);
-        } else if (metalearner_algo.equals("DeepLearning")){
+        } else if (metalearner_algo.equals("deeplearning")){
           //DeepLearning Metalearner
           metaDeepLearningBuilder = ModelBuilder.make("DeepLearning", job, metalearnerKey);
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -232,8 +232,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       }
 
       if(_model._parms._metalearner_algorithm == null){
-        _model._parms._metalearner_algorithm = "glm_non_negative";
-        Log.info("`metalearner_algorithm` is detected to be null. Using default `glm_non_negative`.");
+        _model._parms._metalearner_algorithm = "glm";
+        Log.info("`metalearner_algorithm` is detected to be null. Using default `glm`.");
       }
       //Compute metalearner
       computeMetaLearner(levelOneTrainingFrame, levelOneValidationFrame, _model._parms._metalearner_algorithm);
@@ -251,12 +251,10 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         DRF metaDRFBuilder;
         DeepLearning metaDeepLearningBuilder;
         
-        if(metalearner_algo.equals("glm") || metalearner_algo.equals("glm_non_negative")){
+        if(metalearner_algo.equals("glm")){
           metaGLMBuilder = ModelBuilder.make("GLM", job, metalearnerKey);
 
-          if(metalearner_algo.equals("glm_non_negative")) {
-            metaGLMBuilder._parms._non_negative = true;
-          }
+          metaGLMBuilder._parms._non_negative = true;
           metaGLMBuilder._parms._train = levelOneTrainingFrame._key;
           metaGLMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaGLMBuilder._parms._response_column = _model.responseColumn;
@@ -451,7 +449,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           _model.unlock(_job);
         } else {
           throw new H2OIllegalArgumentException("Wrong `metalearner_algorithm`. Passed in " + _model._parms._metalearner_algorithm + " " +
-                  "but should have been GLM, GBM, DRF, DeepLearning");
+                  "but should have been glm, gbm, randomForest, or deeplearning.");
         }
       }
     }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -6,6 +6,12 @@ import hex.ModelCategory;
 import hex.StackedEnsembleModel;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
+import hex.tree.gbm.GBM;
+import hex.tree.gbm.GBMModel;
+import hex.tree.drf.DRF;
+import hex.tree.drf.DRFModel;
+import hex.deeplearning.DeepLearning;
+import hex.deeplearning.DeepLearningModel;
 import water.DKV;
 import water.Job;
 import water.Key;
@@ -225,70 +231,226 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
                                      _model._parms.valid());
       }
 
-      // train the metalearner model
-      // TODO: allow types other than GLM
-      // Default Job for just this training
-      Key<Model> metalearnerKey = Key.<Model>make("metalearner_" + _model._key);
-      Job job = new Job<>(metalearnerKey, ModelBuilder.javaName("glm"), "StackingEnsemble metalearner (GLM)");
-      GLM metaBuilder = ModelBuilder.make("GLM", job, metalearnerKey);
-      metaBuilder._parms._non_negative = true;
-      metaBuilder._parms._train = levelOneTrainingFrame._key;
-      metaBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
-      metaBuilder._parms._response_column = _model.responseColumn;
-      metaBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
-      if (_model._parms._metalearner_nfolds > 1) {
-        if (_model._parms._metalearner_fold_assignment == null) {
-          metaBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
-        } else {
-          metaBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
-        }
+      if(_model._parms._metalearner_algorithm == null){
+        _model._parms._metalearner_algorithm = "GLM";
+        Log.info("`metalearner_algorithm` is detected to be null. Using default `GLM`.");
       }
-      // TO DO: Add metalearner_fold_column
-      //metaBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
-      //Enable lambda search if a validation frame is passed in to get a better GLM fit.
-      //Since we are also using non_negative to true, we should also set early_stopping = false.
-      if (metaBuilder._parms._valid != null) {
-        metaBuilder._parms._lambda_search = true;
-        metaBuilder._parms._early_stopping = false;
-      }
+      //Compute metalearner
+      computeMetaLearner(levelOneTrainingFrame, levelOneValidationFrame, _model._parms._metalearner_algorithm);
 
-      if (_model.modelCategory == ModelCategory.Regression) {
-          metaBuilder._parms._family = GLMModel.GLMParameters.Family.gaussian;
-      } else if (_model.modelCategory == ModelCategory.Binomial) {
-          metaBuilder._parms._family = GLMModel.GLMParameters.Family.binomial;
-      } else if (_model.modelCategory == ModelCategory.Multinomial) {
-          metaBuilder._parms._family = GLMModel.GLMParameters.Family.multinomial;
-      } else {
-          throw new H2OIllegalArgumentException("Family " + _model.modelCategory + "  is not supported.");
-      }
-
-      metaBuilder.init(false);
-
-      Job<GLMModel> j = metaBuilder.trainModel();
-
-      while (j.isRunning()) {
-        try {
-          _job.update(j._work, "training metalearner");
-          Thread.sleep(100);
-        }
-        catch (InterruptedException e) {}
-      }
-
-      Log.info("Finished training metalearner model.");
-
-      _model._output._metalearner = metaBuilder.get();
-      _model.doScoreOrCopyMetrics(_job);
-      // _model._output._model_summary = createModelSummaryTable(model._output);
-      if (_parms._keep_levelone_frame) {
-        _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
-      } else{
-        DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
-      }
-      if (null != levelOneValidationFrame) {
-        DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
-      }
-      _model.update(_job);
-      _model.unlock(_job);
-      }
     } // computeImpl
+
+    private void computeMetaLearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, String metalearner_algo){
+        // train the metalearner model
+        // Default Job for just this training
+        Key<Model> metalearnerKey = Key.<Model>make("metalearner_" + _model._parms._metalearner_algorithm + _model._key);
+        Job job = new Job<>(metalearnerKey, ModelBuilder.javaName(_model._parms._metalearner_algorithm.toLowerCase()),
+                "StackingEnsemble metalearner (" + _model._parms._metalearner_algorithm + ")");
+        GLM metaGLMBuilder = null;
+        GBM metaGBMBuilder;
+        DRF metaDRFBuilder;
+        DeepLearning metaDeepLearningBuilder;
+        
+        if(metalearner_algo.equals("GLM")){
+          metaGLMBuilder = ModelBuilder.make("GLM", job, metalearnerKey);
+
+          metaGLMBuilder._parms._non_negative = true;
+          metaGLMBuilder._parms._train = levelOneTrainingFrame._key;
+          metaGLMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
+          metaGLMBuilder._parms._response_column = _model.responseColumn;
+          metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_nfolds > 1) {
+            if (_model._parms._metalearner_fold_assignment == null) {
+              metaGLMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+            } else {
+              metaGLMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+            }
+          }
+          // TO DO: Add metalearner_fold_column
+          //metaGLMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+          //Enable lambda search if a validation frame is passed in to get a better GLM fit.
+          //Since we are also using non_negative to true, we should also set early_stopping = false.
+          if (metaGLMBuilder._parms._valid != null) {
+            metaGLMBuilder._parms._lambda_search = true;
+            metaGLMBuilder._parms._early_stopping = false;
+          }
+
+          if (_model.modelCategory == ModelCategory.Regression) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.gaussian;
+          } else if (_model.modelCategory == ModelCategory.Binomial) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.binomial;
+          } else if (_model.modelCategory == ModelCategory.Multinomial) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.multinomial;
+          } else {
+            throw new H2OIllegalArgumentException("Family " + _model.modelCategory + "  is not supported.");
+          }
+
+          metaGLMBuilder.init(false);
+
+          Job<GLMModel> j = metaGLMBuilder.trainModel();
+
+          while (j.isRunning()) {
+            try {
+              _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm +")");
+              Thread.sleep(100);
+            }
+            catch (InterruptedException e) {}
+          }
+
+          Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+          _model._output._metalearner = metaGLMBuilder.get();
+          _model.doScoreOrCopyMetrics(_job);
+          // _model._output._model_summary = createModelSummaryTable(model._output);
+          if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+          } else{
+            DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+          }
+          if (null != levelOneValidationFrame) {
+            DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+          }
+          _model.update(_job);
+          _model.unlock(_job);
+        } else if (metalearner_algo.equals("GBM")){
+          //GBM Metalearner
+          metaGBMBuilder = ModelBuilder.make("GBM", job, metalearnerKey);
+
+          metaGBMBuilder._parms._train = levelOneTrainingFrame._key;
+          metaGBMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
+          metaGBMBuilder._parms._response_column = _model.responseColumn;
+          metaGBMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_nfolds > 1) {
+            if (_model._parms._metalearner_fold_assignment == null) {
+              metaGBMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+            } else {
+              metaGBMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+            }
+          }
+          // TO DO: Add metalearner_fold_column
+          //metaGBMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+
+          metaGBMBuilder.init(false);
+
+          Job<GBMModel> j = metaGBMBuilder.trainModel();
+
+          while (j.isRunning()) {
+            try {
+              _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm +")");
+              Thread.sleep(100);
+            }
+            catch (InterruptedException e) {}
+          }
+
+          Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+          _model._output._metalearner = metaGLMBuilder.get();
+          _model.doScoreOrCopyMetrics(_job);
+          // _model._output._model_summary = createModelSummaryTable(model._output);
+          if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+          } else{
+            DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+          }
+          if (null != levelOneValidationFrame) {
+            DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+          }
+          _model.update(_job);
+          _model.unlock(_job);
+        } else if (metalearner_algo.equals("DRF")){
+          //DRF Metalearner
+          metaDRFBuilder = ModelBuilder.make("DRF", job, metalearnerKey);
+          
+          metaDRFBuilder._parms._train = levelOneTrainingFrame._key;
+          metaDRFBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
+          metaDRFBuilder._parms._response_column = _model.responseColumn;
+          metaDRFBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_nfolds > 1) {
+            if (_model._parms._metalearner_fold_assignment == null) {
+              metaDRFBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+            } else {
+              metaDRFBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+            }
+          }
+          // TO DO: Add metalearner_fold_column
+          //metaDRFBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+
+          metaDRFBuilder.init(false);
+
+          Job<DRFModel> j = metaDRFBuilder.trainModel();
+
+          while (j.isRunning()) {
+            try {
+              _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm +")");
+              Thread.sleep(100);
+            }
+            catch (InterruptedException e) {}
+          }
+
+          Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+          _model._output._metalearner = metaDRFBuilder.get();
+          _model.doScoreOrCopyMetrics(_job);
+          // _model._output._model_summary = createModelSummaryTable(model._output);
+          if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+          } else{
+            DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+          }
+          if (null != levelOneValidationFrame) {
+            DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+          }
+          _model.update(_job);
+          _model.unlock(_job);
+        } else if (metalearner_algo.equals("DeepLearning")){
+          //DeepLearning Metalearner
+          metaDeepLearningBuilder = ModelBuilder.make("DeepLearning", job, metalearnerKey);
+
+          metaDeepLearningBuilder._parms._train = levelOneTrainingFrame._key;
+          metaDeepLearningBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
+          metaDeepLearningBuilder._parms._response_column = _model.responseColumn;
+          metaDeepLearningBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_nfolds > 1) {
+            if (_model._parms._metalearner_fold_assignment == null) {
+              metaDeepLearningBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+            } else {
+              metaDeepLearningBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+            }
+          }
+          // TO DO: Add metalearner_fold_column
+          //metaDeepLearningBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+
+          metaDeepLearningBuilder.init(false);
+
+          Job<DeepLearningModel> j = metaDeepLearningBuilder.trainModel();
+
+          while (j.isRunning()) {
+            try {
+              _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm +")");
+              Thread.sleep(100);
+            }
+            catch (InterruptedException e) {}
+          }
+
+          Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+          _model._output._metalearner = metaDeepLearningBuilder.get();
+          _model.doScoreOrCopyMetrics(_job);
+          // _model._output._model_summary = createModelSummaryTable(model._output);
+          if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+          } else{
+            DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+          }
+          if (null != levelOneValidationFrame) {
+            DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+          }
+          _model.update(_job);
+          _model.unlock(_job);
+        } else {
+          throw new H2OIllegalArgumentException("Wrong `metalearner_algorithm`. Passed in " + _model._parms._metalearner_algorithm + " " +
+                  "but should have been GLM, GBM, DRF, DeepLearning");
+        }
+      }
+    }
   }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -54,7 +54,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
     @API(level = API.Level.secondary, direction = API.Direction.INOUT,
             help = "Algorithm to use as metalearner. " +
-                    "Should either be 'GLM' (default), 'GBM', 'DRF', or 'DeepLearning'.")
-    public String metalearner_algorithm = "GLM";
+                    "Should either be 'glm_non_negative' (default), 'glm' (glm without non negative weights), 'gbm', 'randomForest', or 'deeplearning'.")
+    public String metalearner_algorithm = "glm";
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -54,7 +54,8 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
     @API(level = API.Level.secondary, direction = API.Direction.INOUT,
             help = "Algorithm to use as metalearner. " +
-                    "Should either be 'glm_non_negative' (default), 'glm' (glm without non negative weights), 'gbm', 'randomForest', or 'deeplearning'.")
+                    "Should either be 'glm_non_negative' (default, glm with non negative weights), 'glm' (glm without non negative weights), 'gbm (default parameters)', " +
+                    "'randomForest (default parameters)', or 'deeplearning (default parameters)'.")
     public String metalearner_algorithm = "glm";
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -54,7 +54,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
     @API(level = API.Level.secondary, direction = API.Direction.INOUT,
             help = "Algorithm to use as metalearner. " +
-                    "Should either be 'glm_non_negative' (default, glm with non negative weights), 'glm' (glm without non negative weights), 'gbm (default parameters)', " +
+                    "Should either be 'glm' (default, glm with non negative weights), 'gbm (default parameters)', " +
                     "'randomForest (default parameters)', or 'deeplearning (default parameters)'.")
     public String metalearner_algorithm = "glm";
   }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -26,12 +26,13 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
 
     // Base models
-    @API(help = "List of models (or model ids) to ensemble/stack together. Models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
+    @API(level = API.Level.critical,
+            help = "List of models (or model ids) to ensemble/stack together. Models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
     public KeyV3.ModelKeyV3 base_models[];
 
     
     // Metalearner algorithm
-    @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
+    @API(level = API.Level.critical, direction = API.Direction.INOUT, gridable = true,
             values = {"glm", "gbm", "drf", "deeplearning"},
             help = "Type of algorithm to use as the metalearner. " +
                     "Options include 'glm' (GLM with non negative weights), 'gbm' (GBM with default parameters), " +
@@ -61,7 +62,8 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     public FrameV3.ColSpecifierV3 metalearner_fold_column;
     */
 
-    @API(help = "Keep level one frame used for metalearner training.")
+    @API(level = API.Level.secondary,
+            help = "Keep level one frame used for metalearner training.")
     public boolean keep_levelone_frame;
   
   }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -17,23 +17,39 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "response_column",
       "validation_frame",
       "base_models",
+      "metalearner_algorithm",
       "metalearner_nfolds",
       "metalearner_fold_assignment",
-      "metalearner_algorithm",
       //"metalearner_fold_column",
       "keep_levelone_frame",
     };
 
 
-    @API(help = "List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
+    // Base models
+    @API(help = "List of models (or model ids) to ensemble/stack together. Models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
     public KeyV3.ModelKeyV3 base_models[];
 
-    @API(help = "Keep level one frame used for metalearner training.")
-    public boolean keep_levelone_frame;
+    
+    // Metalearner algorithm
+    @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
+            values = {"glm", "gbm", "drf", "deeplearning"},
+            help = "Type of algorithm to use as the metalearner. " +
+                    "Options include 'glm' (GLM with non negative weights), 'gbm' (GBM with default parameters), " +
+                    "'drf' (Random Forest with default parameters), or 'deeplearning' (Deep Learning with default parameters).")
+    public StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm metalearner_algorithm;
+    //public String metalearner_algorithm = "glm";
 
+    // For ensemble metalearner cross-validation
     @API(level = API.Level.critical, direction = API.Direction.INOUT, gridable = true,
             help = "Number of folds for K-fold cross-validation of the metalearner algorithm (0 to disable or >= 2).")
     public int metalearner_nfolds;
+
+    // For ensemble metalearner cross-validation
+    @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
+            values = {"AUTO", "Random", "Modulo", "Stratified"},
+            help = "Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is currently set to Random)." + 
+                  " The 'Stratified' option will stratify the folds based on the response variable, for classification problems.")
+    public Model.Parameters.FoldAssignmentScheme metalearner_fold_assignment;
 
     // TODO: Add metalearner_fold_column
     // also requires: import water.api.schemas3.FrameV3;
@@ -45,17 +61,8 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     public FrameV3.ColSpecifierV3 metalearner_fold_column;
     */
 
-    // For Ensemble cross-validation
-    @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
-            values = {"AUTO", "Random", "Modulo", "Stratified"},
-            help = "Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is currently set to Random). The 'Stratified' option will " +
-                    "stratify the folds based on the response variable, for classification problems.")
-    public Model.Parameters.FoldAssignmentScheme metalearner_fold_assignment;
-
-    @API(level = API.Level.secondary, direction = API.Direction.INOUT,
-            help = "Algorithm to use as metalearner. " +
-                    "Should either be 'glm' (default, glm with non negative weights), 'gbm (default parameters)', " +
-                    "'randomForest (default parameters)', or 'deeplearning (default parameters)'.")
-    public String metalearner_algorithm = "glm";
+    @API(help = "Keep level one frame used for metalearner training.")
+    public boolean keep_levelone_frame;
+  
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -19,6 +19,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "base_models",
       "metalearner_nfolds",
       "metalearner_fold_assignment",
+      "metalearner_algorithm",
       //"metalearner_fold_column",
       "keep_levelone_frame",
     };
@@ -50,5 +51,10 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
             help = "Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is currently set to Random). The 'Stratified' option will " +
                     "stratify the folds based on the response variable, for classification problems.")
     public Model.Parameters.FoldAssignmentScheme metalearner_fold_assignment;
+
+    @API(level = API.Level.secondary, direction = API.Direction.INOUT,
+            help = "Algorithm to use as metalearner. " +
+                    "Should either be 'GLM' (default), 'GBM', 'DRF', or 'DeepLearning'.")
+    public String metalearner_algorithm = "GLM";
   }
 }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -1,6 +1,5 @@
 package hex.ensemble;
 
-import hex.DataInfo;
 import hex.Model;
 import hex.StackedEnsembleModel;
 import hex.genmodel.utils.DistributionFamily;
@@ -298,6 +297,7 @@ public class StackedEnsembleTest extends TestUtil {
                 stackedEnsembleModel.remove();
                 stackedEnsembleModel._output._metalearner._output._training_metrics.remove();
                 stackedEnsembleModel._output._metalearner.remove();
+                stackedEnsembleModel._output._metalearner.delete();
                 if(stackedEnsembleModel._output._levelone_frame_id != null){
                     stackedEnsembleModel._output._levelone_frame_id.remove();
                 }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -20,9 +20,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-// TODO: Why is gaussian imported but other families not?  code is inconsistent below
-import static hex.genmodel.utils.DistributionFamily.gaussian;
-
 public class StackedEnsembleTest extends TestUtil {
 
     @BeforeClass public static void stall() { stall_till_cloudsize(1); }
@@ -38,7 +35,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.gbm);
+                false, DistributionFamily.gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.gbm);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -66,7 +63,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.drf);
+                false, DistributionFamily.gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.drf);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -94,7 +91,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.deeplearning);
+                false, DistributionFamily.gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.deeplearning);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -122,7 +119,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
+                false, DistributionFamily.gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         // Binomial tests
         basicEnsemble("./smalldata/junit/test_tree_minmax.csv",

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+// TODO: Why is gaussian imported but other families not?  code is inconsistent below
 import static hex.genmodel.utils.DistributionFamily.gaussian;
 
 public class StackedEnsembleTest extends TestUtil {
@@ -37,7 +38,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, "gbm");
+                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.gbm);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -45,19 +46,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, "gbm");
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.gbm);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, "gbm");
+                false, DistributionFamily.multinomial, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.gbm);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, "gbm");
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.gbm);
     }
 
     @Test public void testBasicEnsembleDRFMetalearner(){
@@ -65,7 +66,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, "randomForest");
+                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.drf);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -73,19 +74,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, "randomForest");
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.drf);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, "randomForest");
+                false, DistributionFamily.multinomial, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.drf);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, "randomForest");
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.drf);
     }
 
     @Test public void testBasicEnsembleDeepLearningMetalearner(){
@@ -93,7 +94,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, "deeplearning");
+                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.deeplearning);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -101,19 +102,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, "deeplearning");
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.deeplearning);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, "deeplearning");
+                false, DistributionFamily.multinomial, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.deeplearning);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, "deeplearning");
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.deeplearning);
     }
 
     @Test public void testBasicEnsembleGLMMetalearner() {
@@ -128,25 +129,25 @@ public class StackedEnsembleTest extends TestUtil {
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("response"); }
                 },
-                false, DistributionFamily.bernoulli, null);
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         basicEnsemble("./smalldata/logreg/prostate.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("ID").remove(); return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, null);
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, null);
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         basicEnsemble("./smalldata/gbm_test/alphabet_cattest.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("y"); }
                 },
-                false, DistributionFamily.bernoulli, null);
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -154,29 +155,29 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, null);
+                false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         // Multinomial tests
         basicEnsemble("./smalldata/logreg/prostate.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("ID").remove(); return fr.find("RACE"); }
                 },
-                false, DistributionFamily.multinomial, null);
+                false, DistributionFamily.multinomial, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("name").remove(); return fr.find("cylinders"); }
                 },
-                false, DistributionFamily.multinomial, null);
+                false, DistributionFamily.multinomial, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, null);
+                false, DistributionFamily.multinomial, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
     }
     // ==========================================================================
-    public StackedEnsembleModel.StackedEnsembleOutput basicEnsemble(String training_file, String validation_file, StackedEnsembleTest.PrepData prep, boolean dupeTrainingFrameToValidationFrame, DistributionFamily family, String metalearner_algo) {
+    public StackedEnsembleModel.StackedEnsembleOutput basicEnsemble(String training_file, String validation_file, StackedEnsembleTest.PrepData prep, boolean dupeTrainingFrameToValidationFrame, DistributionFamily family, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm metalearner_algo) {
         Set<Frame> framesBefore = new HashSet<>();
         framesBefore.addAll(Arrays.asList( Frame.fetchAll()));
 

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -116,35 +116,7 @@ public class StackedEnsembleTest extends TestUtil {
                 false, DistributionFamily.bernoulli, "deeplearning");
     }
 
-    @Test public void testBasicEnsembleGLMMetalearner(){
-
-        basicEnsemble("./smalldata/junit/cars.csv",
-                null,
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, "glm");
-
-        basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
-                null,
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {
-                    for( String s : ignored_aircols ) fr.remove(s).remove();
-                    return fr.find("IsArrDelayed"); }
-                },
-                false, DistributionFamily.bernoulli, "glm");
-
-        basicEnsemble("./smalldata/iris/iris_wheader.csv",
-                null,
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
-                },
-                false, DistributionFamily.multinomial, "glm");
-
-        basicEnsemble("./smalldata/logreg/prostate_train.csv",
-                "./smalldata/logreg/prostate_test.csv",
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
-                },
-                false, DistributionFamily.bernoulli, "glm");
-    }
-
-    @Test public void testBasicEnsembleGLMNonNegativeMetalearner() {
+    @Test public void testBasicEnsembleGLMMetalearner() {
         // Regression tests
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -37,7 +37,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, "GBM");
+                false, gaussian, "gbm");
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -45,19 +45,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, "GBM");
+                false, DistributionFamily.bernoulli, "gbm");
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, "GBM");
+                false, DistributionFamily.multinomial, "gbm");
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, "GBM");
+                false, DistributionFamily.bernoulli, "gbm");
     }
 
     @Test public void testBasicEnsembleDRFMetalearner(){
@@ -65,7 +65,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, "DRF");
+                false, gaussian, "randomForest");
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -73,19 +73,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, "DRF");
+                false, DistributionFamily.bernoulli, "randomForest");
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, "DRF");
+                false, DistributionFamily.multinomial, "randomForest");
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, "DRF");
+                false, DistributionFamily.bernoulli, "randomForest");
     }
 
     @Test public void testBasicEnsembleDeepLearningMetalearner(){
@@ -93,7 +93,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, "DeepLearning");
+                false, gaussian, "deeplearning");
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -101,22 +101,50 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, "DeepLearning");
+                false, DistributionFamily.bernoulli, "deeplearning");
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, "DeepLearning");
+                false, DistributionFamily.multinomial, "deeplearning");
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, "DeepLearning");
+                false, DistributionFamily.bernoulli, "deeplearning");
     }
 
-    @Test public void testBasicEnsembleGLMMetalearner() {
+    @Test public void testBasicEnsembleGLMMetalearner(){
+
+        basicEnsemble("./smalldata/junit/cars.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
+                false, gaussian, "glm");
+
+        basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {
+                    for( String s : ignored_aircols ) fr.remove(s).remove();
+                    return fr.find("IsArrDelayed"); }
+                },
+                false, DistributionFamily.bernoulli, "glm");
+
+        basicEnsemble("./smalldata/iris/iris_wheader.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
+                },
+                false, DistributionFamily.multinomial, "glm");
+
+        basicEnsemble("./smalldata/logreg/prostate_train.csv",
+                "./smalldata/logreg/prostate_test.csv",
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
+                },
+                false, DistributionFamily.bernoulli, "glm");
+    }
+
+    @Test public void testBasicEnsembleGLMNonNegativeMetalearner() {
         // Regression tests
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -1,5 +1,6 @@
 package hex.ensemble;
 
+import hex.DataInfo;
 import hex.Model;
 import hex.StackedEnsembleModel;
 import hex.genmodel.utils.DistributionFamily;
@@ -32,37 +33,12 @@ public class StackedEnsembleTest extends TestUtil {
             "TaxiOut", "Cancelled", "CancellationCode", "Diverted", "CarrierDelay", "WeatherDelay", "NASDelay", "SecurityDelay",
             "LateAircraftDelay", "IsDepDelayed"};
 
-    @Test public void testBasicEnsemble() {
-        // Regression tests
+    @Test public void testBasicEnsembleGBMMetalearner(){
+
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian);
-
-        // Binomial tests
-        basicEnsemble("./smalldata/junit/test_tree_minmax.csv",
-                null,
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("response"); }
-                },
-                false, DistributionFamily.bernoulli);
-
-        basicEnsemble("./smalldata/logreg/prostate.csv",
-                null,
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("ID").remove(); return fr.find("CAPSULE"); }
-                },
-                false, DistributionFamily.bernoulli);
-
-        basicEnsemble("./smalldata/logreg/prostate_train.csv",
-                "./smalldata/logreg/prostate_test.csv",
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
-                },
-                false, DistributionFamily.bernoulli);
-
-        basicEnsemble("./smalldata/gbm_test/alphabet_cattest.csv",
-                null,
-                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("y"); }
-                },
-                false, DistributionFamily.bernoulli);
+                false, gaussian, "GBM");
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -70,29 +46,138 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli);
+                false, DistributionFamily.bernoulli, "GBM");
+
+        basicEnsemble("./smalldata/iris/iris_wheader.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
+                },
+                false, DistributionFamily.multinomial, "GBM");
+
+        basicEnsemble("./smalldata/logreg/prostate_train.csv",
+                "./smalldata/logreg/prostate_test.csv",
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
+                },
+                false, DistributionFamily.bernoulli, "GBM");
+    }
+
+    @Test public void testBasicEnsembleDRFMetalearner(){
+
+        basicEnsemble("./smalldata/junit/cars.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
+                false, gaussian, "DRF");
+
+        basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {
+                    for( String s : ignored_aircols ) fr.remove(s).remove();
+                    return fr.find("IsArrDelayed"); }
+                },
+                false, DistributionFamily.bernoulli, "DRF");
+
+        basicEnsemble("./smalldata/iris/iris_wheader.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
+                },
+                false, DistributionFamily.multinomial, "DRF");
+
+        basicEnsemble("./smalldata/logreg/prostate_train.csv",
+                "./smalldata/logreg/prostate_test.csv",
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
+                },
+                false, DistributionFamily.bernoulli, "DRF");
+    }
+
+    @Test public void testBasicEnsembleDeepLearningMetalearner(){
+
+        basicEnsemble("./smalldata/junit/cars.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
+                false, gaussian, "DeepLearning");
+
+        basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {
+                    for( String s : ignored_aircols ) fr.remove(s).remove();
+                    return fr.find("IsArrDelayed"); }
+                },
+                false, DistributionFamily.bernoulli, "DeepLearning");
+
+        basicEnsemble("./smalldata/iris/iris_wheader.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
+                },
+                false, DistributionFamily.multinomial, "DeepLearning");
+
+        basicEnsemble("./smalldata/logreg/prostate_train.csv",
+                "./smalldata/logreg/prostate_test.csv",
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
+                },
+                false, DistributionFamily.bernoulli, "DeepLearning");
+    }
+
+    @Test public void testBasicEnsembleGLMMetalearner() {
+        // Regression tests
+        basicEnsemble("./smalldata/junit/cars.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
+                false, gaussian, null);
+
+        // Binomial tests
+        basicEnsemble("./smalldata/junit/test_tree_minmax.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("response"); }
+                },
+                false, DistributionFamily.bernoulli, null);
+
+        basicEnsemble("./smalldata/logreg/prostate.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("ID").remove(); return fr.find("CAPSULE"); }
+                },
+                false, DistributionFamily.bernoulli, null);
+
+        basicEnsemble("./smalldata/logreg/prostate_train.csv",
+                "./smalldata/logreg/prostate_test.csv",
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
+                },
+                false, DistributionFamily.bernoulli, null);
+
+        basicEnsemble("./smalldata/gbm_test/alphabet_cattest.csv",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("y"); }
+                },
+                false, DistributionFamily.bernoulli, null);
+
+        basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
+                null,
+                new StackedEnsembleTest.PrepData() { int prep(Frame fr) {
+                    for( String s : ignored_aircols ) fr.remove(s).remove();
+                    return fr.find("IsArrDelayed"); }
+                },
+                false, DistributionFamily.bernoulli, null);
 
         // Multinomial tests
         basicEnsemble("./smalldata/logreg/prostate.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("ID").remove(); return fr.find("RACE"); }
                 },
-                false, DistributionFamily.multinomial);
+                false, DistributionFamily.multinomial, null);
 
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("name").remove(); return fr.find("cylinders"); }
                 },
-                false, DistributionFamily.multinomial);
+                false, DistributionFamily.multinomial, null);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial);
+                false, DistributionFamily.multinomial, null);
     }
     // ==========================================================================
-    public StackedEnsembleModel.StackedEnsembleOutput basicEnsemble(String training_file, String validation_file, StackedEnsembleTest.PrepData prep, boolean dupeTrainingFrameToValidationFrame, DistributionFamily family) {
+    public StackedEnsembleModel.StackedEnsembleOutput basicEnsemble(String training_file, String validation_file, StackedEnsembleTest.PrepData prep, boolean dupeTrainingFrameToValidationFrame, DistributionFamily family, String metalearner_algo) {
         Set<Frame> framesBefore = new HashSet<>();
         framesBefore.addAll(Arrays.asList( Frame.fetchAll()));
 
@@ -176,6 +261,7 @@ public class StackedEnsembleTest extends TestUtil {
             stackedEnsembleParameters._train = training_frame._key;
             stackedEnsembleParameters._valid = (validation_frame == null ? null : validation_frame._key);
             stackedEnsembleParameters._response_column = training_frame._names[idx];
+            stackedEnsembleParameters._metalearner_algorithm = metalearner_algo;
             stackedEnsembleParameters._base_models = new Key[] {gbm._key,drf._key};
             // Invoke Stacked Ensemble and block till end
             StackedEnsemble stackedEnsembleJob = new StackedEnsemble(stackedEnsembleParameters);

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -122,7 +122,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, gaussian, null);
+                false, gaussian, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
 
         // Binomial tests
         basicEnsemble("./smalldata/junit/test_tree_minmax.csv",

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -49,7 +49,8 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         super(H2OStackedEnsembleEstimator, self).__init__()
         self._parms = {}
         names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models",
-                      "metalearner_nfolds", "metalearner_fold_assignment", "keep_levelone_frame"}
+                      "metalearner_nfolds", "metalearner_fold_assignment", "metalearner_algorithm",
+                      "keep_levelone_frame"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -157,6 +158,21 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def metalearner_fold_assignment(self, metalearner_fold_assignment):
         assert_is_type(metalearner_fold_assignment, None, Enum("auto", "random", "modulo", "stratified"))
         self._parms["metalearner_fold_assignment"] = metalearner_fold_assignment
+
+
+    @property
+    def metalearner_algorithm(self):
+        """
+        Algorithm to use as metalearner. Should either be 'GLM' (default), 'GBM', 'DRF', or 'DeepLearning'.
+
+        Type: ``str``.
+        """
+        return self._parms.get("metalearner_algorithm")
+
+    @metalearner_algorithm.setter
+    def metalearner_algorithm(self, metalearner_algorithm):
+        assert_is_type(metalearner_algorithm, None, str)
+        self._parms["metalearner_algorithm"] = metalearner_algorithm
 
 
     @property

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -49,7 +49,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         super(H2OStackedEnsembleEstimator, self).__init__()
         self._parms = {}
         names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models",
-                      "metalearner_nfolds", "metalearner_fold_assignment", "metalearner_algorithm",
+                      "metalearner_algorithm", "metalearner_nfolds", "metalearner_fold_assignment",
                       "keep_levelone_frame"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
@@ -111,8 +111,8 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def base_models(self):
         """
-        List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and folds
-        must be identical across models.
+        List of models (or model ids) to ensemble/stack together. Models must have been cross-validated using nfolds >
+        1, and folds must be identical across models.
 
         Type: ``List[str]``  (default: ``[]``).
         """
@@ -126,6 +126,23 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
          else:
             assert_is_type(base_models, None, [str])
             self._parms["base_models"] = base_models
+
+
+    @property
+    def metalearner_algorithm(self):
+        """
+        Type of algorithm to use as the metalearner. Options include 'glm' (GLM with non negative weights), 'gbm' (GBM
+        with default parameters), 'drf' (Random Forest with default parameters), or 'deeplearning' (Deep Learning with
+        default parameters).
+
+        One of: ``"glm"``, ``"gbm"``, ``"drf"``, ``"deeplearning"``  (default: ``"glm"``).
+        """
+        return self._parms.get("metalearner_algorithm")
+
+    @metalearner_algorithm.setter
+    def metalearner_algorithm(self, metalearner_algorithm):
+        assert_is_type(metalearner_algorithm, None, Enum("glm", "gbm", "drf", "deeplearning"))
+        self._parms["metalearner_algorithm"] = metalearner_algorithm
 
 
     @property
@@ -158,22 +175,6 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def metalearner_fold_assignment(self, metalearner_fold_assignment):
         assert_is_type(metalearner_fold_assignment, None, Enum("auto", "random", "modulo", "stratified"))
         self._parms["metalearner_fold_assignment"] = metalearner_fold_assignment
-
-
-    @property
-    def metalearner_algorithm(self):
-        """
-        Algorithm to use as metalearner. Should either be 'glm' (default, glm with non negative weights), 'gbm (default
-        parameters)', 'randomForest (default parameters)', or 'deeplearning (default parameters)'.
-
-        Type: ``str``.
-        """
-        return self._parms.get("metalearner_algorithm")
-
-    @metalearner_algorithm.setter
-    def metalearner_algorithm(self, metalearner_algorithm):
-        assert_is_type(metalearner_algorithm, None, str)
-        self._parms["metalearner_algorithm"] = metalearner_algorithm
 
 
     @property

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -163,7 +163,8 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def metalearner_algorithm(self):
         """
-        Algorithm to use as metalearner. Should either be 'GLM' (default), 'GBM', 'DRF', or 'DeepLearning'.
+        Algorithm to use as metalearner. Should either be 'glm_non_negative' (default), 'glm' (glm without non negative
+        weights), 'gbm', 'randomForest', or 'deeplearning'.
 
         Type: ``str``.
         """

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -163,9 +163,8 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def metalearner_algorithm(self):
         """
-        Algorithm to use as metalearner. Should either be 'glm_non_negative' (default, glm with non negative weights),
-        'glm' (glm without non negative weights), 'gbm (default parameters)', 'randomForest (default parameters)', or
-        'deeplearning (default parameters)'.
+        Algorithm to use as metalearner. Should either be 'glm' (default, glm with non negative weights), 'gbm (default
+        parameters)', 'randomForest (default parameters)', or 'deeplearning (default parameters)'.
 
         Type: ``str``.
         """

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -163,8 +163,9 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def metalearner_algorithm(self):
         """
-        Algorithm to use as metalearner. Should either be 'glm_non_negative' (default), 'glm' (glm without non negative
-        weights), 'gbm', 'randomForest', or 'deeplearning'.
+        Algorithm to use as metalearner. Should either be 'glm_non_negative' (default, glm with non negative weights),
+        'glm' (glm without non negative weights), 'gbm (default parameters)', 'randomForest (default parameters)', or
+        'deeplearning (default parameters)'.
 
         Type: ``str``.
         """

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_metalearner.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_metalearner.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+
+import h2o
+
+import sys
+sys.path.insert(1,"../../../")  # allow us to run this standalone
+
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from tests import pyunit_utils
+
+
+def stackedensemble_metalearner_test():
+    """This test checks the following:
+    1) That H2OStackedEnsembleEstimator `metalearner_nfolds` works correctly
+    2) That H2OStackedEnsembleEstimator `metalearner_nfolds` works in concert with `metalearner_nfolds`
+    """
+
+    # Import training set
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/higgs_train_5k.csv"),
+                            destination_frame="higgs_train_5k")
+    test = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/higgs_test_5k.csv"),
+                            destination_frame="higgs_test_5k")
+
+    # Identify predictors and response
+    x = train.columns
+    y = "response"
+    x.remove(y)
+
+    # Convert response to a factor
+    train[y] = train[y].asfactor()
+    test[y] = test[y].asfactor()
+
+    # Set number of folds for base learners
+    nfolds = 3
+
+    # Train and cross-validate a GBM
+    my_gbm = H2OGradientBoostingEstimator(distribution="bernoulli",
+                                          ntrees=10,
+                                          nfolds=nfolds,
+                                          fold_assignment="Modulo",
+                                          keep_cross_validation_predictions=True,
+                                          seed=1)
+    my_gbm.train(x=x, y=y, training_frame=train)
+
+    # Train and cross-validate a RF
+    my_rf = H2ORandomForestEstimator(ntrees=50,
+                                     nfolds=nfolds,
+                                     fold_assignment="Modulo",
+                                     keep_cross_validation_predictions=True,
+                                     seed=1)
+    my_rf.train(x=x, y=y, training_frame=train)
+
+    
+    # Check that not setting metalearner_algorithm still produces correct results
+    # should be glm with non-negative weights
+    stack0 = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf])
+    stack0.train(x=x, y=y, training_frame=train)
+    # Check that metalearner_algorithm default is GLM w/ non-negative
+    assert(stack0.params['metalearner_algorithm']['actual'] == "glm")
+    # Check that the metalearner is GLM w/ non-negative
+    meta0 = h2o.get_model(stack0.metalearner()['name'])
+    assert(meta0.algo == "glm")
+    assert(meta0.params['non_negative']['actual'] is True)
+
+
+    # Train a stacked ensemble & check that metalearner_algorithm works
+    stack1 = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], metalearner_algorithm="gbm")
+    stack1.train(x=x, y=y, training_frame=train)
+    # Check that metalearner_algorithm is a default GBM
+    assert(stack1.params['metalearner_algorithm']['actual'] == "gbm")
+    # Check that the metalearner is default GBM
+    meta1 = h2o.get_model(stack1.metalearner()['name'])
+    assert(meta1.algo == "gbm")
+    # TO DO: Add a check that no other hyperparams have been set
+
+
+    # Train a stacked ensemble & check that metalearner_algorithm works with CV    
+    stack2 = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], metalearner_algorithm="drf", metalearner_nfolds=3)
+    stack2.train(x=x, y=y, training_frame=train)
+    # Check that metalearner_algorithm is a default RF
+    assert(stack2.params['metalearner_algorithm']['actual'] == "drf")
+    # Check that CV was performed
+    assert(stack2.params['metalearner_nfolds']['actual'] == 3)
+    meta2 = h2o.get_model(stack2.metalearner()['name'])
+    assert(meta2.algo == "drf")
+    assert(meta2.params['nfolds']['actual'] == 3)
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(stackedensemble_metalearner_test)
+else:
+    stackedensemble_metalearner_test()

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -20,6 +20,7 @@
 #' @param metalearner_fold_assignment Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is
 #'        currently set to Random). The 'Stratified' option will stratify the folds based on the response variable, for
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
+#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'GLM' (default), 'GBM', 'DRF', or 'DeepLearning'.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
 #' @examples
 #' 
@@ -33,6 +34,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
                                 base_models = list(),
                                 metalearner_nfolds = 0,
                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
+                                metalearner_algorithm = NULL,
                                 keep_levelone_frame = FALSE
                                 ) 
 {
@@ -85,6 +87,8 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$metalearner_nfolds <- metalearner_nfolds
   if (!missing(metalearner_fold_assignment))
     parms$metalearner_fold_assignment <- metalearner_fold_assignment
+  if (!missing(metalearner_algorithm))
+    parms$metalearner_algorithm <- metalearner_algorithm
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
   # Error check and build model

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -20,7 +20,8 @@
 #' @param metalearner_fold_assignment Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is
 #'        currently set to Random). The 'Stratified' option will stratify the folds based on the response variable, for
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
-#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'GLM' (default), 'GBM', 'DRF', or 'DeepLearning'.
+#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'glm_non_negative' (default), 'glm' (glm without non
+#'        negative weights), 'gbm', 'randomForest', or 'deeplearning'.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
 #' @examples
 #' 

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -13,15 +13,16 @@
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param training_frame Id of the training data frame.
 #' @param validation_frame Id of the validation data frame.
-#' @param base_models List of model ids which we can stack together. Models must have been cross-validated using nfolds > 1, and
-#'        folds must be identical across models. Defaults to [].
+#' @param base_models List of models (or model ids) to ensemble/stack together. Models must have been cross-validated using nfolds >
+#'        1, and folds must be identical across models. Defaults to [].
+#' @param metalearner_algorithm Type of algorithm to use as the metalearner. Options include 'glm' (GLM with non negative weights), 'gbm' (GBM
+#'        with default parameters), 'drf' (Random Forest with default parameters), or 'deeplearning' (Deep Learning with
+#'        default parameters). Must be one of: "glm", "gbm", "drf", "deeplearning". Defaults to glm.
 #' @param metalearner_nfolds Number of folds for K-fold cross-validation of the metalearner algorithm (0 to disable or >= 2). Defaults to
 #'        0.
 #' @param metalearner_fold_assignment Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is
 #'        currently set to Random). The 'Stratified' option will stratify the folds based on the response variable, for
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
-#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'glm' (default, glm with non negative weights), 'gbm
-#'        (default parameters)', 'randomForest (default parameters)', or 'deeplearning (default parameters)'.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
 #' @examples
 #' 
@@ -33,9 +34,9 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
                                 model_id = NULL,
                                 validation_frame = NULL,
                                 base_models = list(),
+                                metalearner_algorithm = c("glm", "gbm", "drf", "deeplearning"),
                                 metalearner_nfolds = 0,
                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
-                                metalearner_algorithm = NULL,
                                 keep_levelone_frame = FALSE
                                 ) 
 {
@@ -84,12 +85,12 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$validation_frame <- validation_frame
   if (!missing(base_models))
     parms$base_models <- base_models
+  if (!missing(metalearner_algorithm))
+    parms$metalearner_algorithm <- metalearner_algorithm
   if (!missing(metalearner_nfolds))
     parms$metalearner_nfolds <- metalearner_nfolds
   if (!missing(metalearner_fold_assignment))
     parms$metalearner_fold_assignment <- metalearner_fold_assignment
-  if (!missing(metalearner_algorithm))
-    parms$metalearner_algorithm <- metalearner_algorithm
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
   # Error check and build model

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -20,8 +20,9 @@
 #' @param metalearner_fold_assignment Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is
 #'        currently set to Random). The 'Stratified' option will stratify the folds based on the response variable, for
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
-#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'glm_non_negative' (default), 'glm' (glm without non
-#'        negative weights), 'gbm', 'randomForest', or 'deeplearning'.
+#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'glm_non_negative' (default, glm with non negative weights),
+#'        'glm' (glm without non negative weights), 'gbm (default parameters)', 'randomForest (default parameters)', or
+#'        'deeplearning (default parameters)'.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
 #' @examples
 #' 

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -20,9 +20,8 @@
 #' @param metalearner_fold_assignment Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is
 #'        currently set to Random). The 'Stratified' option will stratify the folds based on the response variable, for
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
-#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'glm_non_negative' (default, glm with non negative weights),
-#'        'glm' (glm without non negative weights), 'gbm (default parameters)', 'randomForest (default parameters)', or
-#'        'deeplearning (default parameters)'.
+#' @param metalearner_algorithm Algorithm to use as metalearner. Should either be 'glm' (default, glm with non negative weights), 'gbm
+#'        (default parameters)', 'randomForest (default parameters)', or 'deeplearning (default parameters)'.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
 #' @examples
 #' 

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_metalearner.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_metalearner.R
@@ -1,0 +1,90 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+stackedensemble.metalearner.test <- function() {
+
+  # This test checks the following (for binomial classification):
+  #
+  # 1) That h2o.stackedEnsemble `metalearner_algorithm` works correctly
+  # 2) That h2o.stackedEnsemble `metalearner_algorithm` works in concert with `metalearner_nfolds`
+
+
+  train <- h2o.uploadFile(locate("smalldata/testng/higgs_train_5k.csv"),
+                          destination_frame = "higgs_train_5k")
+  test <- h2o.uploadFile(locate("smalldata/testng/higgs_test_5k.csv"),
+                         destination_frame = "higgs_test_5k")
+  y <- "response"
+  x <- setdiff(names(train), y)
+  train[,y] <- as.factor(train[,y])
+  test[,y] <- as.factor(test[,y])
+  nfolds <- 3  #number of folds for base learners
+
+  # Train & Cross-validate a GBM
+  my_gbm <- h2o.gbm(x = x,
+                    y = y,
+                    training_frame = train,
+                    distribution = "bernoulli",
+                    ntrees = 10,
+                    nfolds = nfolds,
+                    keep_cross_validation_predictions = TRUE,
+                    seed = 1)
+
+  # Train & Cross-validate a RF
+  my_rf <- h2o.randomForest(x = x,
+                            y = y,
+                            training_frame = train,
+                            ntrees = 10,
+                            nfolds = nfolds,
+                            keep_cross_validation_predictions = TRUE,
+                            seed = 1)
+
+
+  # Check that not setting metalearner_algorithm still produces correct results
+  # should be glm with non-negative weights
+  stack0 <- h2o.stackedEnsemble(x = x,
+                                y = y,
+                                training_frame = train,
+                                base_models = list(my_gbm, my_rf))
+  # Check that metalearner_algorithm default is GLM w/ non-negative
+  expect_equal(stack0@parameters$metalearner_algorithm, NULL)
+  expect_equal(stack0@allparameters$metalearner_algorithm, "glm")
+  # Check that the metalearner is GLM w/ non-negative
+  meta0 <- h2o.getModel(stack0@model$metalearner$name)
+  expect_equal(meta0@algorithm, "glm")
+  expect_equal(meta0@parameters$non_negative, TRUE)
+  expect_equal(meta0@allparameters$non_negative, TRUE)
+
+
+  # Train a stacked ensemble & check that metalearner_algorithm works
+  stack1 <- h2o.stackedEnsemble(x = x,
+                                y = y,
+                                training_frame = train,
+                                base_models = list(my_gbm, my_rf),
+                                metalearner_algorithm = "gbm")
+  # Check that metalearner_algorithm is a default GBM
+  expect_equal(stack1@parameters$metalearner_algorithm, "gbm")
+  expect_equal(stack1@allparameters$metalearner_algorithm, "gbm")
+  # Check that the metalearner is default GBM
+  meta1 <- h2o.getModel(stack1@model$metalearner$name)
+  expect_equal(meta1@algorithm, "gbm")
+  expect_equal(length(meta1@parameters), 5)  #no hyperparms are set (only the 5 basic: model_id, seed, distribution, x, y)
+
+
+  # Train a stacked ensemble & check that metalearner_algorithm works with CV
+  stack2 <- h2o.stackedEnsemble(x = x,
+                                y = y,
+                                training_frame = train,
+                                base_models = list(my_gbm, my_rf),
+                                metalearner_nfolds = 3,
+                                metalearner_algorithm = "drf")
+  # Check that metalearner_algorithm is a default RF
+  expect_equal(stack2@parameters$metalearner_algorithm, "drf")
+  # Check that CV was performed
+  expect_equal(stack2@allparameters$metalearner_nfolds, 3)
+  meta2 <- h2o.getModel(stack2@model$metalearner$name)
+  expect_equal(meta2@algorithm, "drf")
+  expect_equal(meta2@allparameters$nfolds, 3)
+
+}
+
+doTest("Stacked Ensemble metalearner Test", stackedensemble.metalearner.test)


### PR DESCRIPTION
* Currently the metalearner is hardcoded as a default H2O GLM with non-negative weights. (`non_negative = TRUE`)
* We need to add a `metalearner_algorithm` argument to allow customization of the metalearning algorithm.
Initially, this argument will take in either "glm" (default), "gbm", "drf", or "deeplearning".
* A user cannot specify the metalearner model hyperparameters at this point. This will be completed with the addition of another argument, e.g. `metalearner_params`
* junit, runit, pyunit for this argument is included