### PR TITLE
PUBDEV-4891: Add another Stacked Ensemble (top model for each algo) to AutoML

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1102,7 +1102,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
         //Get top models from each model type (GLM, GBM, DL, DRF, and XRT)
         for(int j = 0; j < bestModels.length; j++) {
           for (int i = 0; i < allModels.length; i++) {
-            if (allModels[i]._parms.algoName().equals("DRF")) {
+            if (allModels[i]._parms.algoName().equals("DRF") && !(allModels[i]._key.toString().contains("XRT_"))) {
               if (!fetchedDRF) {
                 bestModels[j] = allModels[i];
                 fetchedDRF = true;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1063,6 +1063,9 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     // (optionally) build StackedEnsemble
     ///////////////////////////////////////////////////////////
     Model[] allModels = leaderboard().getModels();
+
+    //Set aside Model[] for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).
+    //This will give another ensemble that is smaller than the original which takes all models into consideration.
     Model[] bestModels = new Model[5];
     boolean fetchedDRF = false;
     boolean fetchedXRT = false;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1088,7 +1088,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
             notEnsembles[notEnsembleIndex++] = aModel._key;
 
         Job<StackedEnsembleModel> ensembleJob = stack("StackedEnsemble", notEnsembles);
-        pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build", 50, this.job(), ensembleJob, JobType.ModelBuild);
+        pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using all AutoML models", 50, this.job(), ensembleJob, JobType.ModelBuild);
 
         //Set aside List<Model> for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).
         //This will give another ensemble that is smaller than the original which takes all models into consideration.
@@ -1106,8 +1106,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
         for (int i = 0; i < models.size(); i++)
           bestModelKeys[i] = models.get(i)._key;
 
-        Job<StackedEnsembleModel> bestEnsembleJob = stack("StackedEnsembleBestModels", bestModelKeys);
-        pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build with top models", 50, this.job(), bestEnsembleJob, JobType.ModelBuild);
+        Job<StackedEnsembleModel> bestEnsembleJob = stack("StackedEnsemble_topmodel", bestModelKeys);
+        pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using top model from each algorithm type", 50, this.job(), bestEnsembleJob, JobType.ModelBuild);
 
       }
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1061,15 +1061,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     ///////////////////////////////////////////////////////////
     Model[] allModels = leaderboard().getModels();
 
-    //Set aside Model[] for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).
-    //This will give another ensemble that is smaller than the original which takes all models into consideration.
-    Model[] bestModels = new Model[5];
-    boolean fetchedDRF = false;
-    boolean fetchedXRT = false;
-    boolean fetchedTopGBM = false;
-    boolean fetchedTopDL = false;
-    boolean fetchedTopGLM = false;
-
     if (allModels.length == 0){
       this.job.update(50, "No models built; StackedEnsemble build skipped");
       userFeedback.info(Stage.ModelTraining, "No models were built, due to timeouts.");
@@ -1099,6 +1090,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
         Job<StackedEnsembleModel> ensembleJob = stack("StackedEnsemble", notEnsembles);
         pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build", 50, this.job(), ensembleJob, JobType.ModelBuild);
 
+        //Set aside List<Model> for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).
+        //This will give another ensemble that is smaller than the original which takes all models into consideration.
         List<Model> models = new ArrayList();
         Set<String> types = new HashSet();
 

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -5,7 +5,7 @@ In recent years, the demand for machine learning experts has outpaced the supply
 
 Although H2O has made it easy for non-experts to experiment with machine learning, there is still a fair bit of knowledge and background in data science that is required to produce high-performing machine learning models.  Deep Neural Networks in particular are notoriously difficult for a non-expert to tune properly.  In order for machine learning software to truly be accessible to non-experts, we have designed an easy-to-use interface which automates the process of training a large selection of candidate models.  H2O's AutoML can also be a helpful tool for the advanced user, by providing a simple wrapper function that performs a large number of modeling-related tasks that would typically require many lines of code, and by freeing up their time to focus on other aspects of the data science pipeline tasks such as data-preprocessing, feature engineering and model deployment.
 
-H2O's AutoML can be used for automating the machine learning workflow, which includes automatic training and tuning of many models within a user-specified time-limit.  The user can also use a performance metric-based stopping criterion for the AutoML process rather than a specific time constraint.  `Stacked Ensembles <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html>`__ will be automatically trained on the collection individual models to produce a highly predictive ensemble model which, in most cases, will be the top performing model in the AutoML Leaderboard.  
+H2O's AutoML can be used for automating the machine learning workflow, which includes automatic training and tuning of many models within a user-specified time-limit.  The user can also use a performance metric-based stopping criterion for the AutoML process rather than a specific time constraint.  `Stacked Ensembles <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html>`__ will be automatically trained on collections of individual models to produce highly predictive ensemble models which, in most cases, will be the top performing models in the AutoML Leaderboard.  
 
 
 AutoML Interface
@@ -80,7 +80,7 @@ Optional Data Parameters
 Optional Miscellaneous Parameters
 '''''''''''''''''''''''''''''''''
 
-- `nfolds <data-science/algo-params/nfolds.html>`__:  Number of folds for k-fold cross-validation of the models in the AutoML run. Defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensemble (thus decreasing the overall model performance).
+- `nfolds <data-science/algo-params/nfolds.html>`__:  Number of folds for k-fold cross-validation of the models in the AutoML run. Defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensembles (thus decreasing the overall best model performance).
 
 - `seed <data-science/algo-params/seed.html>`__: Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if ``max_models`` or early stopping is used because ``max_runtime_secs`` is resource limited, meaning that if the resources are not the same between runs, AutoML may be able to train more models on one run vs another.  Defaults to ``NULL/None``.
 
@@ -98,6 +98,8 @@ When the user specifies:
    2. **training + validation**: The ``validation_frame`` is split into validation (50%) and leaderboard (50%) sets and the original training frame stays as-is.
    3. **training + leaderboard**: The ``training_frame`` is split into training (70%) and validation (30%) sets and the leaderboard frame stays as-is.
    4. **training + validation + leaderboard**: Leave all frames as-is.
+
+In the `future <https://0xdata.atlassian.net/browse/PUBDEV-5071>`__, the ``leaderboard_frame`` will be truely optional, as the leaderboard will be created using cross-validation metrics instead (unless the ``leaderboard_frame`` is excplicitly specified by the user).  However, for now, the holdout leaderboard frame must exist for scoring/ranking purposes.
 
 
 Code Examples
@@ -133,16 +135,15 @@ Here’s an example showing basic usage of the ``h2o.automl()`` function in *R* 
     lb <- aml@leaderboard
     lb
 
-    #                                  model_id       auc    logloss
-    #  StackedEnsemble_0_AutoML_20170605_212658  0.776164   0.564872
-    # GBM_grid_0_AutoML_20170605_212658_model_2  0.753550   0.587546
-    #              DRF_0_AutoML_20170605_212658  0.738885   0.611997
-    # GBM_grid_0_AutoML_20170605_212658_model_0  0.735078   0.630062
-    # GBM_grid_0_AutoML_20170605_212658_model_1  0.730645   0.674580
-    #              XRT_0_AutoML_20170605_212658  0.728358   0.629296
-    # GLM_grid_0_AutoML_20170605_212658_model_0  0.685216   0.635137
-    #
-    # [7 rows x 3 columns]
+    #                                             model_id      auc  logloss
+    #  1          StackedEnsemble_0_AutoML_20171121_012135 0.788321 0.554019
+    #  2 StackedEnsemble_topmodel_0_AutoML_20171121_012135 0.783099 0.559286
+    #  3         GBM_grid_0_AutoML_20171121_012135_model_1 0.780554 0.560248
+    #  4         GBM_grid_0_AutoML_20171121_012135_model_0 0.779713 0.562142
+    #  5         GBM_grid_0_AutoML_20171121_012135_model_2 0.776206 0.564970
+    #  6         GBM_grid_0_AutoML_20171121_012135_model_3 0.771026 0.570270
+
+    #  [10 rows x 3 columns] 
 
     # The leader model is stored here
     aml@leader
@@ -189,17 +190,19 @@ Here’s an example showing basic usage of the ``h2o.automl()`` function in *R* 
     lb = aml.leaderboard
     lb
 
-    # model_id                                        auc    logloss
-    # -----------------------------------------  --------  ---------
-    # StackedEnsemble_0_AutoML_20170605_212658   0.776164   0.564872
-    # GBM_grid_0_AutoML_20170605_212658_model_2  0.75355    0.587546
-    # DRF_0_AutoML_20170605_212658               0.738885   0.611997
-    # GBM_grid_0_AutoML_20170605_212658_model_0  0.735078   0.630062
-    # GBM_grid_0_AutoML_20170605_212658_model_1  0.730645   0.67458
-    # XRT_0_AutoML_20170605_212658               0.728358   0.629296
-    # GLM_grid_0_AutoML_20170605_212658_model_0  0.685216   0.635137
-    #
-    # [7 rows x 3 columns]
+    #  model_id                                                auc    logloss
+    #  -------------------------------------------------  --------  ---------
+    #  StackedEnsemble_0_AutoML_20171121_010846           0.786063   0.555833
+    #  StackedEnsemble_topmodel_0_AutoML_20171121_010846  0.783367   0.558511
+    #  GBM_grid_0_AutoML_20171121_010846_model_1          0.779242   0.562157
+    #  GBM_grid_0_AutoML_20171121_010846_model_0          0.778855   0.562648
+    #  GBM_grid_0_AutoML_20171121_010846_model_3          0.769666   0.572165
+    #  GBM_grid_0_AutoML_20171121_010846_model_2          0.769147   0.572064
+    #  XRT_0_AutoML_20171121_010846                       0.744612   0.593885
+    #  DRF_0_AutoML_20171121_010846                       0.733039   0.608609
+    #  GLM_grid_0_AutoML_20171121_010846_model_0          0.685211   0.635138
+
+    #  [9 rows x 3 columns]
 
     # The leader model is stored here
     aml.leader
@@ -219,32 +222,45 @@ Here’s an example showing basic usage of the ``h2o.automl()`` function in *R* 
 AutoML Output
 -------------
 
-The AutoML object includes a "leaderboard" of models that were trained in the process, ranked by a default metric based on the problem type (the second column of the leaderboard). In binary classification problems, that metric is AUC, and in multiclass classification problems, the metric is mean per-class error. In regression problems, the default sort metric is deviance.  Some additional metrics are also provided, for convenience.
+The AutoML object includes a "leaderboard" of models that were trained in the process, including the performance of the model on the ``leaderboard_frame`` test set.  If the user did not specify the ``leaderboard_frame`` argument, then a frame will be automatically partitioned, as explained in the `Auto-Generated Frames <#auto-generated-frames>`__ section.  In the `future <https://0xdata.atlassian.net/browse/PUBDEV-5071>`__, the leaderboard will be created using cross-validation metrics, unless a scoring frame is provided explicitly by the user.
+
+The models are ranked by a default metric based on the problem type (the second column of the leaderboard). In binary classification problems, that metric is AUC, and in multiclass classification problems, the metric is mean per-class error. In regression problems, the default sort metric is deviance.  Some additional metrics are also provided, for convenience.
+
+
 
 Here is an example leaderboard for a binary classification task:
 
-+-------------------------------------------+----------+----------+
-|                                  model_id |      auc |  logloss |
-+===========================================+==========+==========+
-| StackedEnsemble_0_AutoML_20170605_212658  | 0.776164 | 0.564872 | 
-+-------------------------------------------+----------+----------+
-| GBM_grid_0_AutoML_20170605_212658_model_2 | 0.75355  | 0.587546 |
-+-------------------------------------------+----------+----------+
-| DRF_0_AutoML_20170605_212658              | 0.738885 | 0.611997 |
-+-------------------------------------------+----------+----------+
-| GBM_grid_0_AutoML_20170605_212658_model_0 | 0.735078 | 0.630062 |
-+-------------------------------------------+----------+----------+
-| GBM_grid_0_AutoML_20170605_212658_model_1 | 0.730645 | 0.67458  |
-+-------------------------------------------+----------+----------+
-| XRT_0_AutoML_20170605_212658              | 0.728358 | 0.629296 |
-+-------------------------------------------+----------+----------+
-| GLM_grid_0_AutoML_20170605_212658_model_1 | 0.685216 | 0.635137 |
-+-------------------------------------------+----------+----------+
-| GLM_grid_0_AutoML_20170605_212658_model_0 | 0.685216 | 0.635137 |
-+-------------------------------------------+----------+----------+
++---------------------------------------------------+----------+----------+
+|                                          model_id |      auc |  logloss |
++===================================================+==========+==========+
+| StackedEnsemble_0_AutoML_20171121_012135          | 0.788321 | 0.554019 | 
++---------------------------------------------------+----------+----------+
+| StackedEnsemble_topmodel_0_AutoML_20171121_012135 | 0.783099 | 0.559286 |
++---------------------------------------------------+----------+----------+
+| GBM_grid_0_AutoML_20171121_012135_model_1         | 0.780554 | 0.560248 |
++---------------------------------------------------+----------+----------+
+| GBM_grid_0_AutoML_20171121_012135_model_0         | 0.779713 | 0.562142 |
++---------------------------------------------------+----------+----------+
+| GBM_grid_0_AutoML_20171121_012135_model_2         | 0.776206 | 0.564970 |
++---------------------------------------------------+----------+----------+
+| GBM_grid_0_AutoML_20171121_012135_model_3         | 0.771026 | 0.570270 |
++---------------------------------------------------+----------+----------+
+| DRF_0_AutoML_20171121_012135                      | 0.734653 | 0.601520 |
++---------------------------------------------------+----------+----------+
+| XRT_0_AutoML_20171121_012135                      | 0.730457 | 0.611706 |
++---------------------------------------------------+----------+----------+
+| GBM_grid_0_AutoML_20171121_012135_model_4         | 0.727098 | 0.666513 |
++---------------------------------------------------+----------+----------+
+| GLM_grid_0_AutoML_20171121_012135_model_0         | 0.685211 | 0.635138 |
++---------------------------------------------------+----------+----------+
+
 
 FAQ
 ~~~
+
+-  **Which models are trained in the AutoML process?**
+
+  The current version of AutoML trains and cross-validates a default Random Forest, an Extremely-Randomized Forest, a random grid of Gradient Boosting Machines (GBMs), a random grid of Deep Neural Nets, a fixed grid of GLMs, and then trains two Stacked Ensemble models.  One ensemble contains all the models, and the second ensemble contains just the top performing model from each algorithm class, so it's an ensemble of five base models.  The second "Top Model" ensemble is optimized for production use, since it only contains five constituent models.  More details about the hyperparamter settings for the models will be added to this page at a later date.
 
 -  **How do I save AutoML runs?**
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -111,6 +111,7 @@ def prostate_automl_args():
     print("Check predictions")
     print(aml.predict(train))
 
+    # TO DO: Clean up amodel creation below, should grep to get the DRF like we do in the runit
     print("Check nfolds is passed through to base models")
     aml = H2OAutoML(project_name="py_aml_nfolds3", nfolds=3, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
@@ -130,6 +131,11 @@ def prostate_automl_args():
     amodel = h2o.get_model(aml.leaderboard[aml.leaderboard.nrows-1,0])
     assert type(amodel) is not h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
     assert amodel.params['nfolds']['actual'] == 0
+
+    # TO DO
+    #print("Check that exactly two ensembles are trained")
+    #aml = H2OAutoML(project_name="py_aml_twoensembles", nfolds=3, max_models=5, seed=1)
+    #aml.train(y="CAPSULE", training_frame=train)
 
 
 if __name__ == "__main__":

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -2,12 +2,12 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
 automl.args.test <- function() {
-  
+
   # This test checks the following (for binomial classification):
   #
   # 1) That h2o.automl executes w/o errors
   # 2) That the arguments are working properly
-  
+
   # Load data and split into train, valid and test sets
   train <- h2o.uploadFile(locate("smalldata/testng/higgs_train_5k.csv"),
                           destination_frame = "higgs_train_5k")
@@ -15,63 +15,63 @@ automl.args.test <- function() {
                          destination_frame = "higgs_test_5k")
   ss <- h2o.splitFrame(test, seed = 1)
   valid <- ss[[1]]
-  test <- ss[[1]] 
-  
+  test <- ss[[1]]
+
   y <- "response"
   x <- setdiff(names(train), y)
   train[,y] <- as.factor(train[,y])
   test[,y] <- as.factor(test[,y])
-  max_runtime_secs <- 10 
-  
+  max_runtime_secs <- 10
+
   print("Check arguments to H2OAutoML class")
-  
+
   #print("Try without a y")
   #expect_failure(h2o.automl(training_frame = train,
   #                          max_runtime_secs = max_runtime_secs,
   #                          project_name = "aml0"))
-  
+
   print("Try without an x")
-  aml1 <- h2o.automl(y = y, 
+  aml1 <- h2o.automl(y = y,
                      training_frame = train,
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml1")
-  
+
   print("Try with y as a column index, x as colnames")
-  aml2 <- h2o.automl(x = x, y = 1, 
+  aml2 <- h2o.automl(x = x, y = 1,
                      training_frame = train,
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml2")
-  
+
   print("Single training frame; x and y both specified")
-  aml3 <- h2o.automl(x = x, y = y, 
+  aml3 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml3")
-  
+
   print("Training & validation frame")
-  aml4 <- h2o.automl(x = x, y = y, 
+  aml4 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      validation_frame = valid,
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml4")
-  
+
   print("Training & leaderboard frame")
-  aml5 <- h2o.automl(x = x, y = y, 
+  aml5 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      leaderboard_frame = test,
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml5")
-  
+
   print("Training, validaion & leaderboard frame")
-  aml6 <- h2o.automl(x = x, y = y, 
+  aml6 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      validation_frame = valid,
                      leaderboard_frame = test,
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml6")
-  
+
   print("Early stopping args")
-  aml7 <- h2o.automl(x = x, y = y, 
+  aml7 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      validation_frame = valid,
                      leaderboard_frame = test,
@@ -80,105 +80,98 @@ automl.args.test <- function() {
                      stopping_tolerance = 0.001,
                      stopping_rounds = 3,
                      project_name = "aml7")
-  
+
   print("Check max_models = 1")
-  aml8 <- h2o.automl(x = x, y = y, 
+  aml8 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      max_runtime_secs = max_runtime_secs,
                      max_models = 1,
                      project_name = "aml8")
   nrow_aml8_lb <- nrow(aml8@leaderboard)
   expect_equal(nrow_aml8_lb, 3)
-  
+
   print("Check max_models > 1; leaderboard continuity/growth")
-  aml8 <- h2o.automl(x = x, y = y, 
+  aml8 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      max_runtime_secs = max_runtime_secs,
                      max_models = 3,
                      project_name = "aml8")
   expect_equal(nrow(aml8@leaderboard) > nrow_aml8_lb, TRUE)
-  
-  
+
+
   # Add a fold_column and weights_column
   fold_column <- "fold_id"
   weights_column <- "weight"
   train[,fold_column] <- as.h2o(data.frame(rep(seq(1:3), 2000)[1:nrow(train)]))
   train[,weights_column] <- as.h2o(data.frame(runif(n = nrow(train), min = 0, max = 5)))
-  
+
   print("Check fold_column")
-  aml9 <- h2o.automl(x = x, y = y, 
+  aml9 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      fold_column = fold_column,
                      max_runtime_secs = max_runtime_secs,
                      project_name = "aml9")
-  amodel <- h2o.getModel(tail(aml9@leaderboard, 1)$model_id)
-  if (grepl("^StackedEnsemble", amodel@model_id)) {
-    print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold_column test")
-    amodel <- h2o.getModel(head(tail(aml9@leaderboard, 2), 1)$model_id)
-    amodel_fold_column <- amodel@parameters$fold_column$column_name
-    expect_equal(amodel_fold_column, fold_column)
-  } else {
-    amodel_fold_column <- amodel@parameters$fold_column$column_name
-    expect_equal(amodel_fold_column, fold_column)
-  }
-  
+  model_ids <- as.character(as.data.frame(aml9@leaderboard[,"model_id"])[,1])
+  amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
+  amodel_fold_column <- amodel@parameters$fold_column$column_name
+  expect_equal(amodel_fold_column, fold_column)
+
   print("Check weights_column")
-  aml10 <- h2o.automl(x = x, y = y, 
+  aml10 <- h2o.automl(x = x, y = y,
                       training_frame = train,
                       weights_column = weights_column,
                       max_runtime_secs = max_runtime_secs,
                       project_name = "aml10")
-  amodel <- h2o.getModel(tail(aml10@leaderboard, 1)$model_id)
-  if (grepl("^StackedEnsemble", amodel@model_id)) {
-    print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for weights_column test")
-    amodel <- h2o.getModel(head(tail(aml10@leaderboard, 2), 1)$model_id)
-  } 
+  model_ids <- as.character(as.data.frame(aml10@leaderboard[,"model_id"])[,1])
+  amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
   amodel_weights_column <- amodel@parameters$weights_column$column_name
   expect_equal(amodel_weights_column, weights_column)
-  
+
   print("Check fold_colum and weights_column")
-  aml11 <- h2o.automl(x = x, y = y, 
+  aml11 <- h2o.automl(x = x, y = y,
                       training_frame = train,
                       fold_column = fold_column,
                       weights_column = weights_column,
                       max_runtime_secs = max_runtime_secs,
                       project_name = "aml11")
-  amodel <- h2o.getModel(tail(aml11@leaderboard, 1)$model_id)
-  if (grepl("^StackedEnsemble", amodel@model_id)) {
-    print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold/weight column test")
-    amodel <- h2o.getModel(head(tail(aml11@leaderboard, 2), 1)$model_id)
-  } 
+  model_ids <- as.character(as.data.frame(aml11@leaderboard[,"model_id"])[,1])
+  amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
   amodel_fold_column <- amodel@parameters$fold_column$column_name
   expect_equal(amodel_fold_column, fold_column)
   amodel_weights_column <- amodel@parameters$weights_column$column_name
   expect_equal(amodel_weights_column, weights_column)
-  
+
   print("Check that nfolds is piped through properly to base models (nfolds > 1)")
-  aml12 <- h2o.automl(x = x, y = y, 
+  aml12 <- h2o.automl(x = x, y = y,
                       training_frame = train,
                       nfolds = 3,
                       max_models = 3,
                       project_name = "aml12")
-  amodel <- h2o.getModel(tail(aml12@leaderboard, 1)$model_id)
-  if (grepl("^StackedEnsemble", amodel@model_id)) {
-    print("Last model in leaderboard is Stacked Ensemble. Will need to use second to last for fold/weight column test")
-    amodel <- h2o.getModel(head(tail(aml12@leaderboard, 2), 1)$model_id)
-  } 
+  model_ids <- as.character(as.data.frame(aml12@leaderboard[,"model_id"])[,1])
+  amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
   expect_equal(amodel@parameters$nfolds, 3)
-  
+
   print("Check that nfolds = 0 works properly")  #will need to change after xval leaderboard is implemented
-  aml13 <- h2o.automl(x = x, y = y, 
+  aml13 <- h2o.automl(x = x, y = y,
                       training_frame = train,
                       nfolds = 0,
                       max_models = 3,
                       project_name = "aml13")
   # Check that leaderboard does not contain any SEs
-  for (model_id in as.vector(aml13@leaderboard$model_id)) {
-    expect_equal(grepl("^StackedEnsemble", model_id), FALSE)
-  }
-  amodel <- h2o.getModel(tail(aml13@leaderboard, 1)$model_id)
+  model_ids <- as.character(as.data.frame(aml13@leaderboard[,"model_id"])[,1])
+  amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
   expect_equal(amodel@allparameters$nfolds, 0)
-  
+
+  print("Check that two Stacked Ensembles are trained")
+  aml14 <- h2o.automl(x = x, y = y,
+                      training_frame = train,
+                      nfolds = 3,
+                      max_models = 6,
+                      project_name = "aml14")
+  # Check that leaderboard contains exactly two SEs: all model ensemble & top model ensemble
+  model_ids <- as.character(as.data.frame(aml14@leaderboard[,"model_id"])[,1])
+  expect_equal(sum(grepl("StackedEnsemble", model_ids)), 2)
+
 }
 
 doTest("AutoML Args Test", automl.args.test)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -88,7 +88,7 @@ automl.args.test <- function() {
                      max_models = 1,
                      project_name = "aml8")
   nrow_aml8_lb <- nrow(aml8@leaderboard)
-  expect_equal(nrow_aml8_lb, 2)
+  expect_equal(nrow_aml8_lb, 3)
   
   print("Check max_models > 1; leaderboard continuity/growth")
   aml8 <- h2o.automl(x = x, y = y, 


### PR DESCRIPTION
* Grab the "top" model from each algorithm class to create a lean Stacked Ensemble, at the end of the AutoML process. 
* Right now we only train a single ensemble that contains all the models, but we should add a few more ensembles for variety.