### PR TITLE
PUBDEV-5084: Added metalearner_fold_column arg to Stacked Ensemble

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -135,12 +135,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
 
     // Add response column to level one frame
     levelOneFrame.add(this.responseColumn, adaptFrm.vec(this.responseColumn));
-    /*
-    // Add metalearner_fold_column to level one frame if it exists
-    if (this._parms._metalearner_fold_column != null) {
-      levelOneFrame.add(this._parms._metalearner_fold_column, adaptFrm.vec(this._parms._metalearner_fold_column));
-    }
-    */
+    
     // TODO: what if we're running multiple in parallel and have a name collision?
     Log.info("Finished creating \"level one\" frame for scoring: " + levelOneFrame.toString());
 
@@ -279,6 +274,9 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
   public void checkAndInheritModelProperties() {
     if (null == _parms._base_models || 0 == _parms._base_models.length)
       throw new H2OIllegalArgumentException("When creating a StackedEnsemble you must specify one or more models; found 0.");
+
+    if (null != _parms._metalearner_fold_column && 0 != _parms._metalearner_nfolds)
+      throw new H2OIllegalArgumentException("Cannot specify fold_column and nfolds at the same time.");
 
     Model aModel = null;
     boolean beenHere = false;

--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -61,9 +61,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     // Metalearner params
     public int _metalearner_nfolds;
     public Parameters.FoldAssignmentScheme _metalearner_fold_assignment;
-    // TODO: Add _metalearner_fold_column
-    // https://0xdata.atlassian.net/browse/PUBDEV-5084
-    // public String _metalearner_fold_column;
+    public String _metalearner_fold_column;
 
     //What to use as a metalearner (GLM, GBM, DRF, or DeepLearning)
     public enum MetalearnerAlgorithm {
@@ -135,7 +133,14 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       baseIdx++;
     }
 
+    // Add response column to level one frame
     levelOneFrame.add(this.responseColumn, adaptFrm.vec(this.responseColumn));
+    /*
+    // Add metalearner_fold_column to level one frame if it exists
+    if (this._parms._metalearner_fold_column != null) {
+      levelOneFrame.add(this._parms._metalearner_fold_column, adaptFrm.vec(this._parms._metalearner_fold_column));
+    }
+    */
     // TODO: what if we're running multiple in parallel and have a name collision?
     Log.info("Finished creating \"level one\" frame for scoring: " + levelOneFrame.toString());
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -100,8 +100,12 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
 
         StackedEnsemble.addModelPredictionsToLevelOneFrame(baseModel, baseModelPreds, levelOneFrame);
       }
-
+      // Add response column to level one frame
       levelOneFrame.add(_model.responseColumn, actuals.vec(_model.responseColumn));
+      // Add metalearner_fold_column to level one frame if it exists
+      if (_model._parms._metalearner_fold_column != null) {
+        levelOneFrame.add(_model._parms._metalearner_fold_column, actuals.vec(_model._parms._metalearner_fold_column));
+      }
 
       // TODO: what if we're running multiple in parallel and have a name collision?
 
@@ -251,16 +255,19 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           metaGLMBuilder._parms._train = levelOneTrainingFrame._key;
           metaGLMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaGLMBuilder._parms._response_column = _model.responseColumn;
-          metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
-          if (_model._parms._metalearner_nfolds > 1) {
-            if (_model._parms._metalearner_fold_assignment == null) {
-              metaGLMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
-            } else {
-              metaGLMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_fold_column == null) {
+            metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+              if (_model._parms._metalearner_fold_assignment == null) {
+                metaGLMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+              } else {
+                metaGLMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+              }
             }
+          } else {
+            metaGLMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
           }
-          // TODO: Add metalearner_fold_column
-          // metaGLMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+
           // Enable lambda search if a validation frame is passed in to get a better GLM fit.
           // Since we are also using non_negative to true, we should also set early_stopping = false.
           if (metaGLMBuilder._parms._valid != null) {
@@ -312,15 +319,18 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         metaGLMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
         metaGLMBuilder._parms._response_column = _model.responseColumn;
         metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
-        if (_model._parms._metalearner_nfolds > 1) {
-          if (_model._parms._metalearner_fold_assignment == null) {
-            metaGLMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+          if (_model._parms._metalearner_fold_column == null) {
+            metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+              if (_model._parms._metalearner_fold_assignment == null) {
+                metaGLMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+              } else {
+                metaGLMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+              }
+            }
           } else {
-            metaGLMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+            metaGLMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
           }
-        }
-        // TODO: Add metalearner_fold_column
-        // metaGLMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
         // TODO: Possibly add this back in and turn on early stopping in all metalearners when a validation frame is present
         // Enable lambda search if a validation frame is passed in to get a better GLM fit.
          /*
@@ -373,15 +383,18 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           metaGBMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaGBMBuilder._parms._response_column = _model.responseColumn;
           metaGBMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
-          if (_model._parms._metalearner_nfolds > 1) {
-            if (_model._parms._metalearner_fold_assignment == null) {
-              metaGBMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
-            } else {
-              metaGBMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_fold_column == null) {
+            metaGBMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+              if (_model._parms._metalearner_fold_assignment == null) {
+                metaGBMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+              } else {
+                metaGBMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+              }
             }
+          } else {
+            metaGBMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
           }
-          //TO DO: Add metalearner_fold_column
-          //metaGBMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
 
           metaGBMBuilder.init(false);
 
@@ -418,15 +431,18 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           metaDRFBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaDRFBuilder._parms._response_column = _model.responseColumn;
           metaDRFBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
-          if (_model._parms._metalearner_nfolds > 1) {
-            if (_model._parms._metalearner_fold_assignment == null) {
-              metaDRFBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
-            } else {
-              metaDRFBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_fold_column == null) {
+            metaDRFBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+              if (_model._parms._metalearner_fold_assignment == null) {
+                metaDRFBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+              } else {
+                metaDRFBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+              }
             }
+          } else {
+            metaDRFBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
           }
-          // TO DO: Add metalearner_fold_column
-          //metaDRFBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
 
           metaDRFBuilder.init(false);
 
@@ -463,15 +479,18 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           metaDeepLearningBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaDeepLearningBuilder._parms._response_column = _model.responseColumn;
           metaDeepLearningBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
-          if (_model._parms._metalearner_nfolds > 1) {
-            if (_model._parms._metalearner_fold_assignment == null) {
-              metaDeepLearningBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
-            } else {
-              metaDeepLearningBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+          if (_model._parms._metalearner_fold_column == null) {
+            metaDeepLearningBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+              if (_model._parms._metalearner_fold_assignment == null) {
+                metaDeepLearningBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+              } else {
+                metaDeepLearningBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+              }
             }
+          } else {
+            metaDeepLearningBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
           }
-          // TO DO: Add metalearner_fold_column
-          //metaDeepLearningBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
 
           metaDeepLearningBuilder.init(false);
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -100,12 +100,12 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
 
         StackedEnsemble.addModelPredictionsToLevelOneFrame(baseModel, baseModelPreds, levelOneFrame);
       }
-      // Add response column to level one frame
-      levelOneFrame.add(_model.responseColumn, actuals.vec(_model.responseColumn));
       // Add metalearner_fold_column to level one frame if it exists
       if (_model._parms._metalearner_fold_column != null) {
         levelOneFrame.add(_model._parms._metalearner_fold_column, actuals.vec(_model._parms._metalearner_fold_column));
       }
+      // Add response column to level one frame
+      levelOneFrame.add(_model.responseColumn, actuals.vec(_model.responseColumn));
 
       // TODO: what if we're running multiple in parallel and have a name collision?
 

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -6,7 +6,7 @@ import water.api.API;
 import water.api.schemas3.KeyV3;
 import water.api.schemas3.ModelParametersSchemaV3;
 import hex.Model;
-
+import water.api.schemas3.FrameV3;
 
 
 public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,StackedEnsembleV99,StackedEnsembleV99.StackedEnsembleParametersV99> {
@@ -20,7 +20,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "metalearner_algorithm",
       "metalearner_nfolds",
       "metalearner_fold_assignment",
-      //"metalearner_fold_column",
+      "metalearner_fold_column",
       "keep_levelone_frame",
     };
 
@@ -51,15 +51,13 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
                   " The 'Stratified' option will stratify the folds based on the response variable, for classification problems.")
     public Model.Parameters.FoldAssignmentScheme metalearner_fold_assignment;
 
-    // TODO: Add metalearner_fold_column
-    // also requires: import water.api.schemas3.FrameV3;
-    /*
+    // For ensemble metalearner cross-validation
     @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
             is_member_of_frames = {"training_frame"},
-            is_mutually_exclusive_with = {"ignored_columns", "response_column", "weights_column", "offset_column"},
-            help = "Column with cross-validation fold index assignment per observation.")
+            //is_mutually_exclusive_with = {"ignored_columns", "response_column", "weights_column", "offset_column"},
+            is_mutually_exclusive_with = {"response_column"},
+            help = "Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.")
     public FrameV3.ColSpecifierV3 metalearner_fold_column;
-    */
 
     @API(level = API.Level.secondary,
             help = "Keep level one frame used for metalearner training.")

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -55,7 +55,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
             is_member_of_frames = {"training_frame"},
             //is_mutually_exclusive_with = {"ignored_columns", "response_column", "weights_column", "offset_column"},
-            is_mutually_exclusive_with = {"response_column"},
+            is_mutually_exclusive_with = {"ignored_columns", "response_column"},
             help = "Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.")
     public FrameV3.ColSpecifierV3 metalearner_fold_column;
 

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -81,6 +81,8 @@ Defining a Stacked Ensemble Model
 
 -  `metalearner_fold_assignment <algo-params/fold_assignment.html>`__: (Optional; Applicable only if a value for ``metalearner_nfolds`` is specified) Specify the cross-validation fold assignment scheme for the metalearner. The available options are AUTO (which is Random), Random, Modulo, or Stratified (which will stratify the folds based on the response variable for classification problems).
 
+-  `metalearner_fold_column <algo-params/fold_column.html>`__: (Optional; Cannot be used at the same time as ``nfolds``) Specify the name of the column that contains the cross-validation fold assignment per observation for cross-validation of the metalearner.  The column can be numeric (e.g. fold index or other integer value) or it can be categorical.  The number of folds is equal to the number of unique values in this column.
+
 -  **keep_levelone_frame**: (Optional) Keep the level one data frame that's constructed for the metalearning step. Defaults to False.
 
 Also in a `future release <https://0xdata.atlassian.net/browse/PUBDEV-5086>`__, there will be an additional ``metalearner_params`` argument which allows for full customization of the metalearner algorithm hyperparamters.  

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -50,7 +50,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         self._parms = {}
         names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models",
                       "metalearner_algorithm", "metalearner_nfolds", "metalearner_fold_assignment",
-                      "keep_levelone_frame"}
+                      "metalearner_fold_column", "keep_levelone_frame"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -176,6 +176,21 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def metalearner_fold_assignment(self, metalearner_fold_assignment):
         assert_is_type(metalearner_fold_assignment, None, Enum("auto", "random", "modulo", "stratified"))
         self._parms["metalearner_fold_assignment"] = metalearner_fold_assignment
+
+
+    @property
+    def metalearner_fold_column(self):
+        """
+        Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
+
+        Type: ``str``.
+        """
+        return self._parms.get("metalearner_fold_column")
+
+    @metalearner_fold_column.setter
+    def metalearner_fold_column(self, metalearner_fold_column):
+        assert_is_type(metalearner_fold_column, None, str)
+        self._parms["metalearner_fold_column"] = metalearner_fold_column
 
 
     @property

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -24,6 +24,7 @@
 #' @param metalearner_fold_assignment Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is
 #'        currently set to Random). The 'Stratified' option will stratify the folds based on the response variable, for
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
+#' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
 #' @examples
 #' 
@@ -38,6 +39,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
                                 metalearner_algorithm = c("AUTO", "glm", "gbm", "drf", "deeplearning"),
                                 metalearner_nfolds = 0,
                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
+                                metalearner_fold_column = NULL,
                                 keep_levelone_frame = FALSE
                                 ) 
 {
@@ -92,6 +94,8 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$metalearner_nfolds <- metalearner_nfolds
   if (!missing(metalearner_fold_assignment))
     parms$metalearner_fold_assignment <- metalearner_fold_assignment
+  if (!missing(metalearner_fold_column))
+    parms$metalearner_fold_column <- metalearner_fold_column
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
   # Error check and build model

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_nfolds.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_nfolds.R
@@ -130,25 +130,6 @@ stackedensemble.nfolds.test <- function() {
   expect_equal(meta4@allparameters$nfolds, 0)
   expect_equal(length(meta4@model$cross_validation_models), 3)
 
-
-  # Check that metalearner_fold_column works (even if nfolds is set -- we should add warning/error if both are set)
-  stack5 <- h2o.stackedEnsemble(x = x,
-                                y = y,
-                                training_frame = train,
-                                base_models = list(my_gbm, my_rf),
-                                metalearner_nfolds = 5,
-                                metalearner_fold_column = fold_column)
-  # Check that metalearner_fold_column is correctly stored in model output
-  expect_equal(stack5@parameters$metalearner_fold_column$column_name, fold_column)
-  expect_equal(stack5@allparameters$metalearner_fold_column$column_name, fold_column)
-  # Check that metalearner_fold_column is passed through to metalearner
-  meta5 <- h2o.getModel(stack5@model$metalearner$name)
-  expect_equal(meta5@parameters$fold_column$column_name, fold_column)
-  expect_equal(meta5@allparameters$fold_column$column_name, fold_column)
-  expect_equal(meta5@allparameters$nfolds, 0)
-  expect_equal(length(meta4@model$cross_validation_models), 3)
-
-
 }
 
 doTest("Stacked Ensemble nfolds & fold_assignment Test", stackedensemble.nfolds.test)

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_nfolds.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_nfolds.R
@@ -13,11 +13,14 @@ stackedensemble.nfolds.test <- function() {
                           destination_frame = "higgs_train_5k")
   test <- h2o.uploadFile(locate("smalldata/testng/higgs_test_5k.csv"),
                          destination_frame = "higgs_test_5k")
+  # Add a fold_column
+  fold_column <- "fold_id"
+  train[,fold_column] <- as.h2o(data.frame(rep(seq(1:3), 2000)[1:nrow(train)]))  #three folds
   y <- "response"
-  x <- setdiff(names(train), y)
+  x <- setdiff(names(train), c(y, fold_column))
   train[,y] <- as.factor(train[,y])
   test[,y] <- as.factor(test[,y])
-  nfolds <- 5  #number of folds for base learners
+  nfolds <- 3  #number of folds for base learners
 
   # Train & Cross-validate a GBM
   my_gbm <- h2o.gbm(x = x,
@@ -109,6 +112,42 @@ stackedensemble.nfolds.test <- function() {
   meta3 <- h2o.getModel(stack3@model$metalearner$name)
   expect_equal(meta3@parameters$fold_assignment, "Modulo")
   expect_equal(meta3@allparameters$fold_assignment, "Modulo")
+
+
+  # Check that metalearner_fold_column works
+  stack4 <- h2o.stackedEnsemble(x = x,
+                                y = y,
+                                training_frame = train,
+                                base_models = list(my_gbm, my_rf),
+                                metalearner_fold_column = fold_column)
+  # Check that metalearner_fold_column is correctly stored in model output
+  expect_equal(stack4@parameters$metalearner_fold_column$column_name, fold_column)
+  expect_equal(stack4@allparameters$metalearner_fold_column$column_name, fold_column)
+  # Check that metalearner_fold_column is passed through to metalearner
+  meta4 <- h2o.getModel(stack4@model$metalearner$name)
+  expect_equal(meta4@parameters$fold_column$column_name, fold_column)
+  expect_equal(meta4@allparameters$fold_column$column_name, fold_column)
+  expect_equal(meta4@allparameters$nfolds, 0)
+  expect_equal(length(meta4@model$cross_validation_models), 3)
+
+
+  # Check that metalearner_fold_column works (even if nfolds is set -- we should add warning/error if both are set)
+  stack5 <- h2o.stackedEnsemble(x = x,
+                                y = y,
+                                training_frame = train,
+                                base_models = list(my_gbm, my_rf),
+                                metalearner_nfolds = 5,
+                                metalearner_fold_column = fold_column)
+  # Check that metalearner_fold_column is correctly stored in model output
+  expect_equal(stack5@parameters$metalearner_fold_column$column_name, fold_column)
+  expect_equal(stack5@allparameters$metalearner_fold_column$column_name, fold_column)
+  # Check that metalearner_fold_column is passed through to metalearner
+  meta5 <- h2o.getModel(stack5@model$metalearner$name)
+  expect_equal(meta5@parameters$fold_column$column_name, fold_column)
+  expect_equal(meta5@allparameters$fold_column$column_name, fold_column)
+  expect_equal(meta5@allparameters$nfolds, 0)
+  expect_equal(length(meta4@model$cross_validation_models), 3)
+
 
 }
 


### PR DESCRIPTION
- Adds `metalearner_fold_column` to Stacked Ensemble (defaults to `NULL`)
- If user specifies `nfolds` and `metalearner_fold_column`, the user will receive an error
- If `metalearner_fold_column` is specified, then it's also added to the Level One frame.
- Includes runit, pyunit
- Added parameter to Stacked Ensemble user guide