### PR TITLE
Fix pyunit_PUBDEV_4090_grid_model_seeds.py

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2973,7 +2973,7 @@ def cannaryHDFSTest(hdfs_name_node, file_name):
             return False
 
 
-def extract_scoring_history_field(aModel, fieldOfInterest):
+def extract_scoring_history_field(aModel, fieldOfInterest, takeFirst=False):
     """
     Given a fieldOfInterest that are found in the model scoring history, this function will extract the list
     of field values for you from the model.
@@ -2989,6 +2989,8 @@ def extract_scoring_history_field(aModel, fieldOfInterest):
         fieldIndex = allFields.index(fieldOfInterest)
         for eachCell in aModel._model_json["output"]["scoring_history"].cell_values:
             cellValues.append(eachCell[fieldIndex])
+            if takeFirst:   # only grab the result from the first iteration.
+                break
         return cellValues
     else:
         return None

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
@@ -81,8 +81,8 @@ def random_grid_model_seeds_PUBDEV_4090():
                                                            "got %s" % (expectedSeeds, model2Seeds)
 
     # compare training_rmse from scoring history
-    metric_list1 = pyunit_utils.extract_scoring_history_field(air_grid1.models[0], "training_rmse")
-    metric_list2 = pyunit_utils.extract_scoring_history_field(air_grid2.models[0], "training_rmse")
+    metric_list1 = pyunit_utils.extract_scoring_history_field(air_grid1.models[0], "training_rmse", True)
+    metric_list2 = pyunit_utils.extract_scoring_history_field(air_grid2.models[0], "training_rmse", True)
     assert pyunit_utils.equal_two_arrays(metric_list1[0:model_len], metric_list2[0:model_len], 1e-5, 1e-6, False), \
         "Training_rmse are different between the two grid search models.  Tests are supposed to be repeatable in " \
         "this case.  Make sure model seeds are actually set correctly in the Java backend."


### PR DESCRIPTION
Fix this intermittent failure by comparing the training_rmse of first iteration only.  Gridsearch with stopping criteria max_runtime_secs may produce models built with different number of iterations due to timing differences between the various threads.