### PR TITLE
PUBDEV-5095: Pipe AutoML fold_column through to Stacked Ensemble

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -922,6 +922,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleModel.StackedEnsembleParameters();
     stackedEnsembleParameters._base_models = allModelKeys.toArray(new Key[0]);
     stackedEnsembleParameters._valid = (getValidationFrame() == null ? null : getValidationFrame()._key);
+    stackedEnsembleParameters._metalearner_fold_column = buildSpec.input_spec.fold_column;
     //stackedEnsembleParameters._selection_strategy = StackedEnsembleModel.StackedEnsembleParameters.SelectionStrategy.choose_all;
     Key modelKey = modelKey(modelName);
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -125,6 +125,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     handleDatafileParameters(buildSpec);
 
+    if (null != buildSpec.input_spec.fold_column && 5 != buildSpec.build_control.nfolds)
+      throw new H2OIllegalArgumentException("Cannot specify fold_column and a non-default nfolds value at the same time.");
+    if (null != buildSpec.input_spec.fold_column)
+      userFeedback.warn(Stage.Workflow, "Custom fold column, " + buildSpec.input_spec.fold_column + ", will be used. nfolds value will be ignored.");
+
     userFeedback.info(Stage.Workflow, "Build control seed: " +
             buildSpec.build_control.stopping_criteria.seed() +
             (buildSpec.build_control.stopping_criteria.seed() == -1 ? " (random)" : ""));
@@ -638,7 +643,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       params._weights_column = buildSpec.input_spec.weights_column;
 
       if (buildSpec.input_spec.fold_column == null) {
-        //params._nfolds = 5;
         params._nfolds = buildSpec.build_control.nfolds;
         if (buildSpec.build_control.nfolds > 1) {
           // TO DO: below allow the user to specify this (vs Modulo)
@@ -922,7 +926,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleModel.StackedEnsembleParameters();
     stackedEnsembleParameters._base_models = allModelKeys.toArray(new Key[0]);
     stackedEnsembleParameters._valid = (getValidationFrame() == null ? null : getValidationFrame()._key);
-    stackedEnsembleParameters._metalearner_fold_column = buildSpec.input_spec.fold_column;
+    if (buildSpec.input_spec.fold_column != null) {
+      stackedEnsembleParameters._metalearner_fold_column = buildSpec.input_spec.fold_column;
+      stackedEnsembleParameters._metalearner_nfolds = 0;  //if fold_column is used, set nfolds to 0 (default)
+    }
     //stackedEnsembleParameters._selection_strategy = StackedEnsembleModel.StackedEnsembleParameters.SelectionStrategy.choose_all;
     Key modelKey = modelKey(modelName);
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -137,6 +137,10 @@ def prostate_automl_args():
     #aml = H2OAutoML(project_name="py_aml_twoensembles", nfolds=3, max_models=5, seed=1)
     #aml.train(y="CAPSULE", training_frame=train)
 
+    # TO DO
+    # Add a test that checks fold_column like in runit
+
+
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(prostate_automl_args)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -115,6 +115,11 @@ automl.args.test <- function() {
   amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
   amodel_fold_column <- amodel@parameters$fold_column$column_name
   expect_equal(amodel_fold_column, fold_column)
+  ensemble <- h2o.getModel(grep("StackedEnsemble", model_ids, value = TRUE)[1])
+  ensemble_fold_column <- ensemble@parameters$metalearner_fold_column$column_name
+  expect_equal(ensemble_fold_column, fold_column)
+  ensemble_meta <- h2o.getModel(ensemble@model$metalearner$name)
+  expect_equal(length(ensemble_meta@model$cross_validation_models), 3)
 
   print("Check weights_column")
   aml10 <- h2o.automl(x = x, y = y,


### PR DESCRIPTION
- Now that we support `metalearner_fold_column` in Stacked Ensemble, we can pipe the AutoML `fold_column` all the way through to Stacked Ensemble (instead of just the base learners). 
- Added a UserFeedback log message to warn user if `fold_column` is set, that `nfolds` value will be ignored.
- Added a check to make sure the user does not try to also specify a non-default `nfolds` value at the same time as `fold_column`.  Will return an error if they do.