### PR TITLE
PUBDEV-4896: Cleanup levelone key & enable Stacked Ensemble junits

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -303,10 +303,10 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           if (_parms._keep_levelone_frame) {
             _model._output._levelone_frame_id = levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
           } else{
-            //DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+            DKV.remove(levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
           }
           if (null != levelOneValidationFrame) {
-            //DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+            DKV.remove(levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
           }
           _model.update(_job);
           _model.unlock(_job);

--- a/h2o-algos/src/test/java/hex/ensemble/CheckSumTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/CheckSumTest.java
@@ -25,11 +25,8 @@ public class CheckSumTest extends TestUtil {
     
     @BeforeClass public static void stall() { stall_till_cloudsize(1); }
 
-    // TODO: levelone leaked key also causing this test to fail, need to fix
-
     @Test public void checkSumTest() {
-        // TODO: Fix this (doing nothing right now)
-        /*
+
         Frame fr = null;
         Frame frAfterGbm = null;
         Frame frAfterDrf = null;
@@ -109,7 +106,7 @@ public class CheckSumTest extends TestUtil {
                 stackedEnsembleModel._output._metalearner.remove();
             }
             Scope.exit();
-        } */
+        } 
     }
 
     

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -30,9 +30,7 @@ public class StackedEnsembleTest extends TestUtil {
             "TaxiOut", "Cancelled", "CancellationCode", "Diverted", "CarrierDelay", "WeatherDelay", "NASDelay", "SecurityDelay",
             "LateAircraftDelay", "IsDepDelayed"};
 
-    // TODO: Fix these tests -- we have a levelone leaked key causing them all to fail
-    // The unit test logic is duplicated in R and Python (where they all pass)
-    /*
+
     @Test public void testBasicEnsembleAUTOMetalearner() {
 
         basicEnsemble("./smalldata/junit/cars.csv",
@@ -145,12 +143,11 @@ public class StackedEnsembleTest extends TestUtil {
                 },
                 false, DistributionFamily.bernoulli, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.deeplearning);
     }
-    */
+
 
 
     @Test public void testBasicEnsembleGLMMetalearner() {
-        // TODO: Fix this (doing nothing right now)
-    /*
+
         // Regression tests
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
@@ -208,7 +205,7 @@ public class StackedEnsembleTest extends TestUtil {
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
                 false, DistributionFamily.multinomial, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm.glm);
-    */
+
     }
 
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -169,7 +169,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   /**
    * If the user hasn't specified validation data, split it off for them.
    *                                                                  <p>
-   * For nfolds > 1, the user can specify:                                            <p>
+   * For nfolds > 1, the user can specify:                            <p>
    * 1. training only                                                 <p>
    * 2. training + leaderboard                                        <p>
    * 3. training + validation                                         <p>
@@ -177,13 +177,13 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
    *                                                                  <p>
    * In the top two cases we auto-split:                              <p>
    * training -> training:validation  80:20                           <p>
-   *
-   * For nfolds = 0, we have different rules:
+   *                                                                  <p>
+   * For nfolds = 0, we have different rules:                         <p>
    * 5. training only                                                 <p>
    * 6. training + leaderboard                                        <p>
    * 7. training + validation                                         <p>
    * 8. training + validation + leaderboard                           <p>
-   *                                         <p>
+   *                                                                  <p>
    * TODO: should the size of the splits adapt to origTrainingFrame.numRows()?
    */
   private void optionallySplitDatasets() {
@@ -1014,6 +1014,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleModel.StackedEnsembleParameters();
     stackedEnsembleParameters._base_models = allModelKeys.toArray(new Key[0]);
     stackedEnsembleParameters._valid = (getValidationFrame() == null ? null : getValidationFrame()._key);
+    stackedEnsembleParameters._keep_levelone_frame = true;
     // Add cross-validation args
     if (buildSpec.input_spec.fold_column != null) {
       stackedEnsembleParameters._metalearner_fold_column = buildSpec.input_spec.fold_column;


### PR DESCRIPTION
This is a follow-up to the previous PR: https://github.com/h2oai/h2o-3/pull/1782

- Removes the level-one frame key by default in Stacked Ensembles (return to the original functionality).
- Turn on all SE junits again (they are all passing now).
- Sets `keep_levelone_frame = true`  for ensembles in AutoML 