### PR TITLE
[PUBDEV-5117] Improve print of jar mismatch warning

### DIFF
--- a/h2o-core/src/main/java/water/HeartBeat.java
+++ b/h2o-core/src/main/java/water/HeartBeat.java
@@ -60,13 +60,8 @@ public class HeartBeat extends Iced<HeartBeat> {
   void set_max_disk (long n) {  _max_disk = (int)(n>>20); }
   public long get_max_disk ()  { return  ((long)_max_disk)<<20 ; }
 
-  boolean check_jar_md5(boolean print) {
-    if( H2O.ARGS.md5skip || Arrays.equals(JarHash.JARHASH, _jar_md5) ) return true;
-    if(print) {
-      System.out.println("Jar check fails; my hash=" + Arrays.toString(JarHash.JARHASH));
-      System.out.println("Jar check fails; received hash=" + Arrays.toString(_jar_md5));
-    }
-    return false;
+  boolean check_jar_md5() {
+    return H2O.ARGS.md5skip || Arrays.equals(JarHash.JARHASH, _jar_md5);
   }
 
   // Internal profiling

--- a/h2o-core/src/main/java/water/HeartBeat.java
+++ b/h2o-core/src/main/java/water/HeartBeat.java
@@ -60,10 +60,12 @@ public class HeartBeat extends Iced<HeartBeat> {
   void set_max_disk (long n) {  _max_disk = (int)(n>>20); }
   public long get_max_disk ()  { return  ((long)_max_disk)<<20 ; }
 
-  boolean check_jar_md5() {
+  boolean check_jar_md5(boolean print) {
     if( H2O.ARGS.md5skip || Arrays.equals(JarHash.JARHASH, _jar_md5) ) return true;
-    System.out.println("Jar check fails; my hash="+Arrays.toString(JarHash.JARHASH));
-    System.out.println("Jar check fails; received hash="+Arrays.toString(_jar_md5));
+    if(print) {
+      System.out.println("Jar check fails; my hash=" + Arrays.toString(JarHash.JARHASH));
+      System.out.println("Jar check fails; received hash=" + Arrays.toString(_jar_md5));
+    }
     return false;
   }
 

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -40,7 +40,7 @@ public abstract class Paxos {
     // mismatched jars.
     if(!H2O.ARGS.client && !h2o._heartbeat._client) {
       // don't check md5 for client nodes
-      if (!h2o._heartbeat.check_jar_md5()) {
+      if (!h2o._heartbeat.check_jar_md5(true)) {
         if (H2O.CLOUD.size() > 1) {
           Log.warn("Killing " + h2o + " because of H2O version mismatch (md5 differs).");
           UDPRebooted.T.mismatch.send(h2o);
@@ -50,7 +50,7 @@ public abstract class Paxos {
         return 0;
       }
     }else{
-      if (!h2o._heartbeat.check_jar_md5()) {
+      if (!h2o._heartbeat.check_jar_md5(false)) { // we do not want to disturb the user in this case
         // Just report that client with different md5 tried to connect
         ListenerService.getInstance().report("client_wrong_md5", new Object[]{h2o._heartbeat._jar_md5});
       }

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -2,6 +2,7 @@ package water;
 
 import java.util.Arrays;
 import water.H2ONode.H2Okey;
+import water.init.JarHash;
 import water.nbhm.NonBlockingHashMap;
 import water.util.Log;
 
@@ -40,7 +41,9 @@ public abstract class Paxos {
     // mismatched jars.
     if(!H2O.ARGS.client && !h2o._heartbeat._client) {
       // don't check md5 for client nodes
-      if (!h2o._heartbeat.check_jar_md5(true)) {
+      if (!h2o._heartbeat.check_jar_md5()) {
+        System.out.println("Jar check fails; my hash=" + Arrays.toString(JarHash.JARHASH));
+        System.out.println("Jar check fails; received hash=" + Arrays.toString(h2o._heartbeat._jar_md5));
         if (H2O.CLOUD.size() > 1) {
           Log.warn("Killing " + h2o + " because of H2O version mismatch (md5 differs).");
           UDPRebooted.T.mismatch.send(h2o);
@@ -50,7 +53,7 @@ public abstract class Paxos {
         return 0;
       }
     }else{
-      if (!h2o._heartbeat.check_jar_md5(false)) { // we do not want to disturb the user in this case
+      if (!h2o._heartbeat.check_jar_md5()) { // we do not want to disturb the user in this case
         // Just report that client with different md5 tried to connect
         ListenerService.getInstance().report("client_wrong_md5", new Object[]{h2o._heartbeat._jar_md5});
       }


### PR DESCRIPTION
The second call should not print to stdout as it's for internal use only. It also prints these warnings in sparkling water in case these should be hidden.