### PR TITLE
PUBDEV-5013: Add alpha to GLM grid in AutoML & PUBDEV-4792: Add another Stacked Ensemble (without the GLMs) to AutoML

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -856,12 +856,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   }
 
 
-  public Job<Grid> defaultSearchGLM() {
+  public Job<Grid> defaultSearchGLM(Key<Grid> gridKey) {
     ///////////////////////////////////////////////////////////
     // do a random hyperparameter search with GLM
     ///////////////////////////////////////////////////////////
-    // TODO: convert to using the REST API
-    Key<Grid> gridKey = Key.make("GLM_grid_default_" + this._key.toString());
 
     HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria searchCriteria = buildSpec.build_control.stopping_criteria;
 
@@ -873,13 +871,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     glmParameters._family = getResponseColumn().isBinary() && !(getResponseColumn().isNumeric()) ? GLMModel.GLMParameters.Family.binomial :
             getResponseColumn().isCategorical() ? GLMModel.GLMParameters.Family.multinomial :
                     GLMModel.GLMParameters.Family.gaussian;  // TODO: other continuous distributions!
-
+    glmParameters._missing_values_handling = DeepLearningModel.DeepLearningParameters.MissingValuesHandling.MeanImputation;
     Map<String, Object[]> searchParams = new HashMap<>();
-    glmParameters._alpha = new double[] {0.0, 0.2, 0.4, 0.6, 0.8, 1.0};  // Note: standard GLM parameter is an array; don't use searchParams!
-    // NOTE: removed MissingValuesHandling.Skip for now because it's crashing.  See https://0xdata.atlassian.net/browse/PUBDEV-4974
-    searchParams.put("_missing_values_handling", new DeepLearningModel.DeepLearningParameters.MissingValuesHandling[] {DeepLearningModel.DeepLearningParameters.MissingValuesHandling.MeanImputation /* , DeepLearningModel.DeepLearningParameters.MissingValuesHandling.Skip */});
-
-    Job<Grid>glmJob = hyperparameterSearch("GLM", glmParameters, searchParams);
+    searchParams.put("_alpha", new Double[][] {{0.0}, {0.2}, {0.4}, {0.6}, {0.8}, {1.0}});
+    Job<Grid>glmJob = hyperparameterSearch(gridKey,"GLM", glmParameters, searchParams);
     return glmJob;
   }
 
@@ -1075,7 +1070,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     // build GLMs with the default search parameters
     ///////////////////////////////////////////////////////////
     // TODO: run for only part of the remaining time?
-    Job<Grid>glmJob = defaultSearchGLM();
+    Key<Grid> glmGridKey = gridKey("GLM");
+    Job<Grid>glmJob = defaultSearchGLM(glmGridKey);
     pollAndUpdateProgress(Stage.ModelTraining, "GLM hyperparameter search", 50, this.job(), glmJob, JobType.HyperparamSearch);
 
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -88,7 +88,7 @@ automl.args.test <- function() {
                      max_models = 1,
                      project_name = "aml8")
   nrow_aml8_lb <- nrow(aml8@leaderboard)
-  expect_equal(nrow_aml8_lb, 3)
+  expect_equal(nrow_aml8_lb, 4)
 
   print("Check max_models > 1; leaderboard continuity/growth")
   aml8 <- h2o.automl(x = x, y = y,
@@ -175,7 +175,7 @@ automl.args.test <- function() {
                       project_name = "aml14")
   # Check that leaderboard contains exactly two SEs: all model ensemble & top model ensemble
   model_ids <- as.character(as.data.frame(aml14@leaderboard[,"model_id"])[,1])
-  expect_equal(sum(grepl("StackedEnsemble", model_ids)), 2)
+  expect_equal(sum(grepl("StackedEnsemble", model_ids)), 3)
 
 }
 


### PR DESCRIPTION
* Add grid search over alpha for GLM in AutoML.
* Previously the GLM "grid" was not really a grid. Just a search over a set of alphas which returned a single best GLM for a specified alpha. 
* This PR makes GLM a proper grid and will build at most 6 GLM models (1 per each alpha (`{{0.0}, {0.2}, {0.4}, {0.6}, {0.8}, {1.0}}`).
* This PR also adds another SE that does not use GLMs.