### PR TITLE
[PUBDEV-5126] Ensure that correct version is produced for both sdist …

### DIFF
--- a/h2o-py/.gitignore
+++ b/h2o-py/.gitignore
@@ -66,3 +66,7 @@ docs/docs/.buildinfo
 docs/docs/.doctrees/*
 docs/docs/_modules/*
 docs/docs/objects.inv
+
+# version files
+buildinfo.txt
+version.txt

--- a/h2o-py/.gitignore
+++ b/h2o-py/.gitignore
@@ -68,5 +68,5 @@ docs/docs/_modules/*
 docs/docs/objects.inv
 
 # version files
-buildinfo.txt
-version.txt
+h2o/buildinfo.txt
+h2o/version.txt

--- a/h2o-py/DESCRIPTION.rst
+++ b/h2o-py/DESCRIPTION.rst
@@ -1,5 +1,5 @@
 H2O
-========
+====
 
 H2O makes Hadoop do math! H2O scales statistics, machine learning and math over BigData. H2O is extensible and users can build blocks using simple math legos in the core. H2O keeps familiar interfaces like python, R, Excel & JSON so that BigData enthusiasts & experts can explore, munge, model and score datasets using a range of simple to advanced algorithms. Data collection is easy. Decision making is hard. H2O makes it fast and easy to derive insights from your data through faster and better predictive modeling. H2O has a vision of online scoring and modeling in a single platform.
 

--- a/h2o-py/MANIFEST.in
+++ b/h2o-py/MANIFEST.in
@@ -1,5 +1,5 @@
 # include additional files which are not fetched by default by setuptools
 include DESCRIPTION.rst
-include version.txt
-include buildinfo.txt
+include h2o/version.txt
+include h2o/buildinfo.txt
 

--- a/h2o-py/MANIFEST.in
+++ b/h2o-py/MANIFEST.in
@@ -1,8 +1,5 @@
+# include additional files which are not fetched by default by setuptools
 include DESCRIPTION.rst
+include version.txt
+include buildinfo.txt
 
-# Include the test suite (FIXME: does not work yet)
-# recursive-include tests *
-
-# If using Python 2.6 or less, then have to include package data, even though
-# it's already declared in setup.py
-#include sample/*.dat

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -76,8 +76,8 @@ task cleanBuild(type: Delete) {
     doFirst {
         println "Cleaning..."
     }
-    delete file("version.txt")
-    delete file("buildinfo.txt")
+    delete file("h2o/version.txt")
+    delete file("h2o/buildinfo.txt")
     delete file("dist/")
     delete file("h2o.egg-info/")
     delete file("build/")

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -72,7 +72,7 @@ task cleanCoverageData(type: Delete) {
     delete file("${testsPath}/results/jacoco")
 }
 
-task cleaner(type: Delete) {
+task cleanBuild(type: Delete) {
     doFirst {
         println "Cleaning..."
     }

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -22,10 +22,10 @@ ext {
 //
 task createVersionFiles() {
     doLast {
-        File version_file = new File("version.txt")
+        File version_file = new File(projectDir, "version.txt")
         version_file.write(PROJECT_VERSION)
 
-        File build_file = new File("buildinfo.txt")
+        File build_file = new File(projectDir, "buildinfo.txt")
         build_file.write(buildVersion.toString())
     }
 }

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -8,46 +8,37 @@ def buildVersion = new H2OBuildVersion(rootDir, version)
 
 ext {
     PROJECT_VERSION = buildVersion.getProjectVersion()
-    pythonexe       = findProperty("pythonExec") ?: "python"
-    pipexe          = findProperty("pipExec") ?: "pip"
+    pythonexe = findProperty("pythonExec") ?: "python"
+    pipexe = findProperty("pipExec") ?: "pip"
     if (System.env.VIRTUAL_ENV) {
         pythonexe = "${System.env.VIRTUAL_ENV}/bin/python".toString()
         pipexe = "${System.env.VIRTUAL_ENV}/bin/pip".toString()
     }
-    testsPath        = file("tests")
+    testsPath = file("tests")
 }
 
-task setProjectVersion << {
-    File INIT = file("${getProjectDir()}/h2o/__init__.py")
-    println "    INIT.path = " + INIT.path
-    def txt = INIT.text
-    txt = txt.replaceAll("SUBST_PROJECT_VERSION", PROJECT_VERSION)
-            .replaceAll("SUBST_PROJECT_BUILDINFO", buildVersion.toString())
-
-    INIT.write(txt)
-}
-
-task resetProjectVersion {
+//
+// Create a file with version for Python dist task
+//
+task createVersionFiles() {
     doLast {
-        File INIT = file("${getProjectDir()}/h2o/__init__.py")
-        println "    INIT.path = " + INIT.path
-        def txt = INIT.text
-        txt = txt.replaceAll(PROJECT_VERSION, "SUBST_PROJECT_VERSION")
-                .replaceAll("__buildinfo__ = .*", "__buildinfo__ = \"SUBST_PROJECT_BUILDINFO\"")
-        INIT.write(txt)
+        File version_file = new File("version.txt")
+        version_file.write(PROJECT_VERSION)
+
+        File build_file = new File("buildinfo.txt")
+        build_file.write(buildVersion.toString())
     }
 }
 
+
 task verifyDependencies(type: Exec) {
-    commandLine getOsSpecificCommandLine([
-            pythonexe, "scripts/verify_requirements.py", "--metayaml", "conda/h2o/meta.yaml"
-    ])
+    commandLine getOsSpecificCommandLine([pythonexe,
+                                          "scripts/verify_requirements.py",
+                                          "--metayaml", "conda/h2o/meta.yaml"])
 }
 
-task buildDist(type: Exec) {
-    dependsOn verifyDependencies
-    dependsOn setProjectVersion
 
+task buildDist(type: Exec, dependsOn: [verifyDependencies, createVersionFiles]) {
     doFirst {
         file("${buildDir}/tmp").mkdirs()
         standardOutput = new FileOutputStream(file("${buildDir}/tmp/h2o-py_buildDist.out"))
@@ -55,19 +46,14 @@ task buildDist(type: Exec) {
     commandLine getOsSpecificCommandLine([pythonexe, "setup.py", "bdist_wheel"])
 }
 
-task smokeTest(type: Exec) {
-    dependsOn build
+task smokeTest(type: Exec, dependsOn: build) {
     workingDir testsPath
-	List<String> args = [pythonexe, '../../scripts/run.py', '--wipeall', '--testsize', 's']
+    List<String> args = [pythonexe, '../../scripts/run.py', '--wipeall', '--testsize', 's']
     if (project.hasProperty("jacocoCoverage")) {
         args << '--jacoco'
     }
     commandLine getOsSpecificCommandLine(args)
 }
-
-//
-// Cleanup tasks
-//
 
 task pythonVersion(type: Exec) {
     doFirst {
@@ -77,8 +63,9 @@ task pythonVersion(type: Exec) {
     commandLine getOsSpecificCommandLine([pythonexe, "--version"])
 }
 
+
 task cleanUpSmokeTest(type: Delete) {
-    delete file("tests/results")
+    delete file("${testsPath}/results")
 }
 
 task cleanCoverageData(type: Delete) {
@@ -89,6 +76,8 @@ task cleaner(type: Delete) {
     doFirst {
         println "Cleaning..."
     }
+    delete file("version.txt")
+    delete file("buildinfo.txt")
     delete file("dist/")
     delete file("h2o.egg-info/")
     delete file("build/")
@@ -98,7 +87,5 @@ task cleaner(type: Delete) {
 //
 // Define the dependencies
 //
-clean.dependsOn cleaner, cleanUpSmokeTest
-resetProjectVersion.dependsOn buildDist
-task build_python(dependsOn: resetProjectVersion)
-build.dependsOn build_python
+clean.dependsOn cleanBuild, cleanUpSmokeTest, cleanCoverageData
+build.dependsOn buildDist

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -22,10 +22,10 @@ ext {
 //
 task createVersionFiles() {
     doLast {
-        File version_file = new File(projectDir, "version.txt")
+        File version_file = new File("${projectDir.toString()}/h2o", "version.txt")
         version_file.write(PROJECT_VERSION)
 
-        File build_file = new File(projectDir, "buildinfo.txt")
+        File build_file = new File("${projectDir.toString()}/h2o", "buildinfo.txt")
         build_file.write(buildVersion.toString())
     }
 }

--- a/h2o-py/clean.sh
+++ b/h2o-py/clean.sh
@@ -1,6 +1,0 @@
-rm -rf h2o.egg-info/
-rm -rf build/
-rm -rf dist/
-rm -rf tests/results/
-rm -rf h2o/backend/bin/
-rm -rf conda/local\:\:

--- a/h2o-py/h2o/__init__.py
+++ b/h2o-py/h2o/__init__.py
@@ -26,7 +26,7 @@ from h2o.frame import H2OFrame  # NOQA
 
 import os
 from codecs import open
-here = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+here = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(here, 'buildinfo.txt'), encoding='utf-8') as f:
     __buildinfo__ = f.read()

--- a/h2o-py/h2o/__init__.py
+++ b/h2o-py/h2o/__init__.py
@@ -31,6 +31,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'buildinfo.txt'), encoding='utf-8') as f:
     __buildinfo__ = f.read()
 
+__version__ = "0.0.local"
 with open(os.path.join(here, 'version.txt'), encoding='utf-8') as f:
     __version__ = f.read()
 

--- a/h2o-py/h2o/__init__.py
+++ b/h2o-py/h2o/__init__.py
@@ -24,8 +24,15 @@ from h2o.h2o import (connect, init, api, connection,
 # one would have to import it from h2o.frames.
 from h2o.frame import H2OFrame  # NOQA
 
-__version__ = "SUBST_PROJECT_VERSION"
-__buildinfo__ = "SUBST_PROJECT_BUILDINFO"
+import os
+from codecs import open
+here = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+
+with open(os.path.join(here, 'buildinfo.txt'), encoding='utf-8') as f:
+    __buildinfo__ = f.read()
+
+with open(os.path.join(here, 'version.txt'), encoding='utf-8') as f:
+    __version__ = f.read()
 
 if (__version__.endswith("99999")):
     print(__buildinfo__)

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 from codecs import open
 import os
 import shutil
-import h2o
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -12,7 +11,7 @@ with open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 # Get the version from the relevant file
-with open(os.path.join(here, 'version.txt'), encoding='utf-8') as f:
+with open(os.path.join(here, 'h2o/version.txt'), encoding='utf-8') as f:
     version = f.read()
 
 
@@ -90,6 +89,8 @@ setup(
     package_data={"h2o": [
         "h2o_data/*.*",     # several small datasets used in demos/examples
         "backend/bin/*.*",  # h2o.jar core Java library
+        "version.txt",      # version file
+        "buildinfo.txt"     # buildinfo file
     ]},
 
     # run-time dependencies

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -10,6 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+version = "0.0.local"
 # Get the version from the relevant file
 with open(os.path.join(here, 'h2o/version.txt'), encoding='utf-8') as f:
     version = f.read()

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -11,6 +11,11 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+# Get the version from the relevant file
+with open(os.path.join(here, 'version.txt'), encoding='utf-8') as f:
+    version = f.read()
+
+
 packages = find_packages(exclude=["tests*"])
 print("Found packages: %r" % packages)
 
@@ -29,17 +34,13 @@ elif os.path.exists(h2o_jar_dst):
 else:
     raise RuntimeError("Cannot locate %s to bundle with the h2o package (pwd: %s)." % (h2o_jar_src, here))
 
-
-if h2o.__version__ == "SUBST_PROJECT_VERSION":
-    h2o.__version__ = "3.14.15.92653"
-
 setup(
     name='h2o',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version=h2o.__version__,
+    version = version,
 
     description='H2O, Fast Scalable Machine Learning, for python ',
     long_description=long_description,


### PR DESCRIPTION
…and whl, clean up a little bit

At the end I tried to make this change as small as possible to minimise the side effects.

We use version files to obtain versions which mean that we use the same version for different build tools (python dist tool independent). 

This is also a good step for automating conda. @abal5 that is next step