### PR TITLE
PUBDEV-5115: Fixing AutoML leaderboard_frame bug & update AutoML docs

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -318,8 +318,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private void handleDatafileParameters(AutoMLBuildSpec buildSpec) {
     this.origTrainingFrame = DKV.getGet(buildSpec.input_spec.training_frame);
     this.validationFrame = DKV.getGet(buildSpec.input_spec.validation_frame);
-    if (null != this.leaderboardFrame)
-      this.leaderboardFrame = DKV.getGet(buildSpec.input_spec.leaderboard_frame);
+    this.leaderboardFrame = DKV.getGet(buildSpec.input_spec.leaderboard_frame);
+
 
     if (null == buildSpec.input_spec.training_frame && null != buildSpec.input_spec.training_path)
       this.origTrainingFrame = importParseFrame(buildSpec.input_spec.training_path, buildSpec.input_spec.parse_setup);
@@ -1214,6 +1214,13 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     Log.info(userFeedback.toString("User Feedback for AutoML Run " + this._key));
     Log.info();
 
+
+
+    // TODO: Look into adding optionally adding these back in
+    // We should not spend time computing train/valid leaderboards until we are ready to expose them to the user
+    // Commenting out for now
+
+    /*
     // Use a throwaway AutoML instance so the "New leader" message doesn't pollute our feedback
     AutoML dummyAutoML = new AutoML();
     UserFeedback dummyUF = new UserFeedback(dummyAutoML);
@@ -1229,6 +1236,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     validationLeaderboard.addModels(this.leaderboard().getModelKeys());
     Log.info(validationLeaderboard.toTwoDimTable("VALIDATION FRAME Leaderboard for project " + projectName(), true).toString());
     Log.info();
+    */
 
     Log.info(leaderboard().toTwoDimTable("Leaderboard for project " + projectName(), true).toString());
 

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -5,15 +5,15 @@ In recent years, the demand for machine learning experts has outpaced the supply
 
 Although H2O has made it easy for non-experts to experiment with machine learning, there is still a fair bit of knowledge and background in data science that is required to produce high-performing machine learning models.  Deep Neural Networks in particular are notoriously difficult for a non-expert to tune properly.  In order for machine learning software to truly be accessible to non-experts, we have designed an easy-to-use interface which automates the process of training a large selection of candidate models.  H2O's AutoML can also be a helpful tool for the advanced user, by providing a simple wrapper function that performs a large number of modeling-related tasks that would typically require many lines of code, and by freeing up their time to focus on other aspects of the data science pipeline tasks such as data-preprocessing, feature engineering and model deployment.
 
-H2O's AutoML can be used for automating the machine learning workflow, which includes automatic training and tuning of many models within a user-specified time-limit.  The user can also use a performance metric-based stopping criterion for the AutoML process rather than a specific time constraint.  `Stacked Ensembles <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html>`__ will be automatically trained on collections of individual models to produce highly predictive ensemble models which, in most cases, will be the top performing models in the AutoML Leaderboard.  
+H2O's AutoML can be used for automating the machine learning workflow, which includes automatic training and tuning of many models within a user-specified time-limit.  `Stacked Ensembles <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/stacked-ensembles.html>`__ will be automatically trained on collections of individual models to produce highly predictive ensemble models which, in most cases, will be the top performing models in the AutoML Leaderboard.  
 
 
 AutoML Interface
 ----------------
 
-The H2O AutoML interface is designed to have as few parameters as possible so that all the user needs to do is point to their dataset, identify the response column and optionally specify a time constraint, a maximum number of models constraint, and early stopping parameters. 
+The H2O AutoML interface is designed to have as few parameters as possible so that all the user needs to do is point to their dataset, identify the response column and optionally specify a time constraint or limit on the number of total models trained. 
 
-In both the R and Python API, AutoML uses the same data-related arguments, ``x``, ``y``, ``training_frame``, ``validation_frame``, as the other H2O algorithms.  Most of the time, all you'll need to do is specify the data arguments. You can then configure values for ``max_runtime_secs`` and/or ``max_models`` to set explicit time or number-of-model limits on your run, or you can set those values high and configure the early stopping arguments to take care of the rest.  
+In both the R and Python API, AutoML uses the same data-related arguments, ``x``, ``y``, ``training_frame``, ``validation_frame``, as the other H2O algorithms.  Most of the time, all you'll need to do is specify the data arguments. You can then configure values for ``max_runtime_secs`` and/or ``max_models`` to set explicit time or number-of-model limits on your run.  
 
 Required Parameters
 ~~~~~~~~~~~~~~~~~~~
@@ -28,35 +28,11 @@ Required Data Parameters
 Required Stopping Parameters
 ''''''''''''''''''''''''''''
 
-One of the following stopping strategies (time, model or metric-based) must be specified.  **Note:** When multiple options are set to control the stopping of the AutoML run (e.g. ``max_models`` and ``max_runtime_secs``), then whichever happens first will stop the AutoML run.
+One of the following stopping strategies (time or number-of-model based) must be specified.  When both options are set, then the AutoML run will stop as soon as it hits one of either of these limits. 
 
-Time-based:
+- `max_runtime_secs <data-science/algo-params/max_runtime_secs.html>`__: This argument controls how long the AutoML run will execute for. This defaults to 3600 seconds (1 hour).
 
-- `max_runtime_secs <data-science/algo-params/max_runtime_secs.html>`__: This argument controls how long the AutoML run will execute. This defaults to 3600 seconds (1 hour).
-
-Model-based:
-
-- **max_models**: Specify the maximum number of models to build in an AutoML run. (Does not include the Stacked Ensemble model.) 
-
-Metric-based (used as a group):
-
--  `stopping_metric <data-science/algo-params/stopping_metric.html>`__: Specifies the metric to use for early stopping. Defaults to ``"AUTO"``.  The available options are:
-
-    - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
-    - ``deviance``
-    - ``logloss``
-    - ``mse``
-    - ``rmse``
-    - ``mae``
-    - ``rmsle``
-    - ``auc``
-    - ``lift_top_group``
-    - ``misclassification``
-    - ``mean_per_class_error``
-
--  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping to stop the AutoML run if the improvement is less than this value. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the non-NA-rate.  In that case, the value is computed as 1/sqrt(nrows * non-NA-rate).
-
-- `stopping_rounds <data-science/algo-params/stopping_rounds.html>`__: This argument stops training new models in the AutoML run when the option selected for **stopping_metric** doesn't improve for the specified number of models, based on a simple moving average. Defaults to 3 and must be an non-negative integer.  To disable this feature, set it to 0. 
+- **max_models**: Specify the maximum number of models to build in an AutoML run, excluding the Stacked Ensemble models.  Defaults to ``NULL/None``. 
 
 
 Optional Parameters
@@ -75,23 +51,41 @@ Optional Data Parameters
 
 - `weights_column <data-science/algo-params/weights_column.html>`__: Specifies a column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative weights are not allowed.
 
--  `ignored_columns <data-science/algo-params/ignored_columns.html>`__: (Optional, Python only) Specify the column or columns to be excluded from the model. 
+-  `ignored_columns <data-science/algo-params/ignored_columns.html>`__: (Optional, Python only) Specify the column or columns (as a list/vector) to be excluded from the model.  This is the converse of the ``x`` argument.
 
 Optional Miscellaneous Parameters
 '''''''''''''''''''''''''''''''''
 
 - `nfolds <data-science/algo-params/nfolds.html>`__:  Number of folds for k-fold cross-validation of the models in the AutoML run. Defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensembles (thus decreasing the overall best model performance).
 
-- `seed <data-science/algo-params/seed.html>`__: Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if ``max_models`` or early stopping is used because ``max_runtime_secs`` is resource limited, meaning that if the resources are not the same between runs, AutoML may be able to train more models on one run vs another.  Defaults to ``NULL/None``.
+-  `stopping_metric <data-science/algo-params/stopping_metric.html>`__: Specifies the metric to use for early stopping of the grid searches and individual models. Defaults to ``"AUTO"``.  The available options are:
 
-- **project_name**: Character string to identify an AutoML project. Defaults to ``NULL/None``, which means a project name will be auto-generated based on the training frame ID.  More models can be trained on an existing AutoML project by specifying the same project name in muliple calls to the AutoML function (as long as the same training frame is used in subsequent runs).
+    - ``AUTO``: This defaults to ``logloss`` for classification, ``deviance`` for regression
+    - ``deviance``
+    - ``logloss``
+    - ``mse``
+    - ``rmse``
+    - ``mae``
+    - ``rmsle``
+    - ``auc``
+    - ``lift_top_group``
+    - ``misclassification``
+    - ``mean_per_class_error``
+
+-  `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping criterion to stop a grid search and the training of individual models within the AutoML run. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the non-NA-rate.  In that case, the value is computed as 1/sqrt(nrows * non-NA-rate).
+
+- `stopping_rounds <data-science/algo-params/stopping_rounds.html>`__: This argument is used to stop model training when the stopping metric (e.g. AUC) doesn’t improve for this specified number of training rounds, based on a simple moving average.   In the context of AutoML, this controls early stopping both within the random grid searches as well as the individual models.  Defaults to 3 and must be an non-negative integer.  To disable early stopping altogether, set this to 0. 
+
+- `seed <data-science/algo-params/seed.html>`__: Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if ``max_models`` is used because ``max_runtime_secs`` is resource limited, meaning that if the available compute resources are not the same between runs, AutoML may be able to train more models on one run vs another.  Defaults to ``NULL/None``.
+
+- **project_name**: Character string to identify an AutoML project. Defaults to ``NULL/None``, which means a project name will be auto-generated based on the training frame ID.  More models can be trained and added to an existing AutoML project by specifying the same project name in muliple calls to the AutoML function (as long as the same training frame is used in subsequent runs).
 
 Auto-Generated Frames
 ~~~~~~~~~~~~~~~~~~~~~
 
 If the user doesn't specify a ``validation_frame``, then one will be created automatically by randomly partitioning the training data.  The validation frame is required for early stopping of the individual algorithms, the grid searches and the AutoML process itself.  
 
-By default, AutoML uses cross-validation for all models, and therefore we can use cross-validation metrics to generate the leaderboard.  If the ``leaderboard_frame`` is explicitly specified by the user, then that frame will be used to generate the leaderboard metrics (See `JIRA <https://0xdata.atlassian.net/browse/PUBDEV-5115>`__: this is currently not working unless nfolds=0).  
+By default, AutoML uses cross-validation for all models, and therefore we can use cross-validation metrics to generate the leaderboard.  If the ``leaderboard_frame`` is explicitly specified by the user, then that frame will be used to generate the leaderboard metrics instead of using cross-validation metrics. 
 
 For cross-validated AutoML, when the user specifies:
 
@@ -265,13 +259,13 @@ FAQ
 
 -  **Which models are trained in the AutoML process?**
 
-  The current version of AutoML trains and cross-validates a default Random Forest, an Extremely-Randomized Forest, a random grid of Gradient Boosting Machines (GBMs), a random grid of Deep Neural Nets, a fixed grid of GLMs, and then trains two Stacked Ensemble models.  A list of the hyperparameters searched over for each algorithm in the AutoML process is included in the appendix below.
+  The current version of AutoML trains and cross-validates a default Random Forest, an Extremely-Randomized Forest, a random grid of Gradient Boosting Machines (GBMs), a random grid of Deep Neural Nets, a fixed grid of GLMs, and then trains two Stacked Ensemble models.  A list of the hyperparameters searched over for each algorithm in the AutoML process is included in the appendix below.  More details about the hyperparamter ranges for the models will be added to the appendix at a later date.
 
-  One ensemble contains all the models, and the second ensemble contains just the best performing model from each algorithm class/family, so it's an ensemble of five base models.  The second "Best of Family" ensemble is optimized for production use, since it only contains five constituent models.  More details about the hyperparamter settings for the models will be added to this page at a later date.
+  Both of the ensembles should produce better models than any individual model from the AutoML run.  One ensemble contains all the models, and the second ensemble contains just the best performing model from each algorithm class/family.  The "Best of Family" ensemble is optimized for production use since it only contains five models.  It should be relatively fast to use (to generate predictions on new data) without much degredation in model performance when compared to the "All Models" ensemble.   
 
 -  **How do I save AutoML runs?**
 
-  Rather than saving an AutoML object itself, currently, the best thing to do is to save the models you want to keep, individually.  A utility for saving all of the models at once will be added in a future release.
+  Rather than saving an AutoML object itself, currently, the best thing to do is to save the models you want to keep, individually.  A utility for saving all of the models at once, along with a way to save the AutoML object (with leaderboard), will be added in a future release.
 
 
 Appendix: Grid Search Parameters

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_binomial_leaderboard_higgs.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_binomial_leaderboard_higgs.R
@@ -20,19 +20,18 @@ automl.leaderboard.test <- function() {
   aml <- h2o.automl(y = y,
                     training_frame = train,
                     leaderboard_frame = test,
-                    max_runtime_secs = 30)
+                    max_models = 2,
+                    project_name = "runit_automl_binomial_leaderboard")
 
   # Get test set AUC from leaderboard vs h2o.performance() and check that it matches
   auc_aml_leaderboard_test <- as.numeric(aml@leaderboard[1,2])  #metric column in first/top row
   perf_aml_test <- h2o.performance(model = aml@leader, newdata = test)
   auc_aml_test <- h2o.auc(perf_aml_test)
 
-
   # Check that stack perf is better (bigger) than the best (biggest) base learner perf:
-  #print(sprintf("Leaderboard Test Set AUC:  %s", auc_aml_leaderboard_test))
-  #print(sprintf("h2o.performance() Test Set AUC:  %s", auc_aml_test))
-  #expect_equal(auc_aml_leaderboard_test, expected = auc_aml_test, tolerance = 0.000001)
-  # TO DO: Fix this
+  print(sprintf("Leaderboard Test Set AUC:  %s", auc_aml_leaderboard_test))
+  print(sprintf("h2o.performance() Test Set AUC:  %s", auc_aml_test))
+  expect_equal(auc_aml_leaderboard_test, expected = auc_aml_test, tolerance = 0.000001)
 }
 
 doTest("AutoML Leaderboard Test", automl.leaderboard.test)


### PR DESCRIPTION
- Bug fixed, `leaderboard_frame` now functional again in AutoML.
- Runit to check for this is now turned back on.
- Updates to AutoML docs related to this and also fixing incorrect statements about early stopping.