### PR TITLE
PUBDEV-5128 - show fails with a KeyError

### DIFF
--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -222,11 +222,17 @@ class MetricsBase(backwards_compatible()):
 
     def custom_metric_name(self):
         """Name of custom metric or None."""
-        return self._metric_json['custom_metric_name']
+        if MetricsBase._has(self._metric_json, "custom_metric_name"):
+            return self._metric_json['custom_metric_name']
+        else:
+            return None
 
     def custom_metric_value(self):
-        """Name of custom metric or None."""
-        return self._metric_json['custom_metric_value']
+        """Value of custom metric or None."""        
+        if MetricsBase._has(self._metric_json, "custom_metric_value"):
+            return self._metric_json['custom_metric_value']
+        else:
+            return None
 
     # Deprecated functions; left here for backward compatibility
     _bcim = {


### PR DESCRIPTION
Occured when looking at result from BinomialGLM:

>>> model._model_json['output']

ModelMetricsBinomialGLM: glm
** Reported on train data. **

MSE: blah
RMSE: blah
LogLoss: blah
Null degrees of freedom: blah
Residual degrees of freedom: blah
Null deviance:blah
Residual deviance: blah
AIC: blah
AUC: blah
Gini: blah
Confusion Matrix (Act/Pred) for max f1 @ threshold = blah:
       0       1     Error    Rate
-----  ------  ----  -------  ------------------
0    blah
1     blah
Total  blah
Maximum Metrics: Maximum metrics at their respective thresholds

metric                       threshold    value     idx
---------------------------  -----------  --------  -----
max f1                     blah
max f2                    blah
max f0point5             blah
max accuracy           blah
max precision                blah
max recall                 blah
max specificity           blah
max absolute_mcc            blah
max min_per_class_accuracy   blah
max mean_per_class_accuracy blah
Gains/Lift Table: Avg response rate:  blah

    group    cumulative_data_fraction    lower_threshold    lift         cumulative_lift    response_rate    cumulative_respo

--  -------  --------------------------  -----------------  -----------  -----------------  ---------------  ----------------
--
  blah blah blah

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python27\lib\site-packages\h2o\model\metrics_base.py", line 54, in __repr__
    self.show()
  File "C:\Python27\lib\site-packages\h2o\model\metrics_base.py", line 132, in show
    if self.custom_metric_name():
  File "C:\Python27\lib\site-packages\h2o\model\metrics_base.py", line 225, in custom_metric_name
    return self._metric_json['custom_metric_name']
KeyError: u'custom_metric_name'
