### PR TITLE
[SW-602] Introduce light REST API call to get frame info to fill Rapi…

### DIFF
--- a/h2o-core/src/main/java/water/api/ModelsHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelsHandler.java
@@ -128,7 +128,7 @@ public class ModelsHandler<I extends ModelsHandler.Models, S extends SchemaV3<I,
       ((ModelSchemaV3)s.models[0]).compatible_frames = new String[compatible.length];
       int i = 0;
       for (Frame f : compatible) {
-        s.compatible_frames[i] = new FrameV3(f).fillFromImpl(f); // TODO: FrameBaseV3
+        s.compatible_frames[i] = new FrameV3(f);
         ((ModelSchemaV3)s.models[0]).compatible_frames[i] = f._key.toString();
         i++;
       }

--- a/h2o-core/src/main/java/water/api/RegisterV3Api.java
+++ b/h2o-core/src/main/java/water/api/RegisterV3Api.java
@@ -168,6 +168,10 @@ public class RegisterV3Api extends AbstractRegister {
             "GET /3/Frames/{frame_id}/summary", FramesHandler.class, "summary",
             "Return a Frame, including the histograms, after forcing computation of rollups.");
 
+    context.registerEndpoint("lightFrame",
+            "GET /3/Frames/{frame_id}/light", FramesHandler.class, "fetchLight",
+            "Return a basic info about Frame to fill client Rapid expression cache.");
+
     context.registerEndpoint("frame",
             "GET /3/Frames/{frame_id}", FramesHandler.class, "fetch",
             "Return the specified Frame.");

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -420,6 +420,11 @@ public class RequestServer extends HttpServlet {
           parms.put("frame_id", url.substring(10, url.length()-8));
           route = findRouteByApiName("frameSummary");
         }
+        // /3/Frames/{frame_id}/light
+        else if (url.endsWith("/light")) {
+          parms.put("frame_id", url.substring(10, url.length()-"/light".length()));
+          route = findRouteByApiName("lightFrame");
+        }
         // /3/Frames/{frame_id}/columns
         else if (url.endsWith("/columns")) {
           parms.put("frame_id", url.substring(10, url.length()-8));

--- a/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
@@ -17,13 +17,13 @@ public class FramesV3 extends RequestSchemaV3<Frames, FramesV3> {
   public long row_offset;
 
   @API(help="Number of rows to return", direction=API.Direction.INOUT)
-  public int row_count;
+  public int row_count = -1;
 
   @API(help="Column offset to return", direction=API.Direction.INOUT)
   public int column_offset;
 
   @API(help="Number of columns to return", direction=API.Direction.INOUT)
-  public int column_count;
+  public int column_count = -1;
 
   @API(help="Find and return compatible models?", json=false)
   public boolean find_compatible_models = false;

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -317,18 +317,28 @@ class H2OCache(object):
 
     def is_valid(self):
         return (  # self._id is not None and
-                not self.is_empty() and \
+                not self.is_empty() and
                 self.nrows_valid() and
                 self.ncols_valid() and
                 self.names_valid() and
                 self.types_valid())
 
-    def fill(self, rows=10):
+    def fill(self, rows=10, rows_offset=0, cols=-1, cols_offset=0, light=False):
         assert self._id is not None
         if self._data is not None:
             if rows <= len(self):
                 return
-        res = h2o.api("GET /3/Frames/%s" % self._id, data={"row_count": rows})["frames"][0]
+        req_params = {
+            "row_count": rows,
+            "row_offset": rows_offset,
+            "column_count" : cols,
+            "column_offset" : cols_offset
+        }
+        if light:
+            endpoint = "/3/Frames/%s/light"
+        else:
+            endpoint = "/3/Frames/%s"
+        res = h2o.api("GET " + endpoint % self._id, data=req_params)["frames"][0]
         self._l = rows
         self._nrows = res["rows"]
         self._ncols = res["total_column_count"]

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -749,7 +749,7 @@ def get_grid(grid_id):
     return gs
 
 
-def get_frame(frame_id):
+def get_frame(frame_id, **kwargs):
     """
     Obtain a handle to the frame in H2O with the frame_id key.
 
@@ -757,7 +757,7 @@ def get_frame(frame_id):
     :returns: an :class:`H2OFrame` object
     """
     assert_is_type(frame_id, str)
-    return H2OFrame.get_frame(frame_id)
+    return H2OFrame.get_frame(frame_id, **kwargs)
 
 
 def no_progress():

--- a/h2o-py/tests/testdir_jira/pyunit_sw_602.py
+++ b/h2o-py/tests/testdir_jira/pyunit_sw_602.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from tests import pyunit_utils
+import h2o
+from h2o.frame import H2OFrame
+import numpy
+
+def test_sw_602_endpoints_equality():
+    data = [numpy.arange(0, 50000).tolist() for x in numpy.arange(0, 99).tolist()]
+    fr = h2o.H2OFrame(data)
+    full = H2OFrame.get_frame(fr.frame_id)
+    light = H2OFrame.get_frame(fr.frame_id, light=True)
+
+    assert full._ex._cache._id == light._ex._cache._id
+    assert full._ex._cache._nrows == light._ex._cache._nrows
+    assert full._ex._cache._ncols == light._ex._cache._ncols
+    assert full._ex._cache._names == light._ex._cache._names
+    assert full._ex._cache._data == light._ex._cache._data
+    assert full._ex._cache._l == light._ex._cache._l
+
+__TESTS__ = [test_sw_602_endpoints_equality]
+
+if __name__ == "__main__":
+    for func in __TESTS__:
+        pyunit_utils.standalone_test(func)
+else:
+    for func in __TESTS__:
+        func()


### PR DESCRIPTION
…… (#1808)

* [SW-602] Introduce light REST API call to get frame info to fill Rapids frame
cache

Includes:
  - the light REST call - provides only information which can be
  computed in non-expensive way
  - removing doubled filling of FrameV3 (once in ctor, second time in
  fillFromImpl)

(cherry picked from commit fbed3f2f4d72ba3ea4e92c3bbab6b0b2b23092c0)