### PR TITLE
HEXDEV-700: Fixed AUC2.java so that we can guarantee reproducibility

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/Score.java
+++ b/h2o-algos/src/main/java/hex/tree/Score.java
@@ -23,7 +23,7 @@ public class Score extends CMetricScoringTask<Score> {
   final boolean _computeGainsLift;
   final ScoreIncInfo _sii;      // Incremental scoring (on a validation dataset), null indicates full scoring
   final Frame _preds;           // Prediction cache (typically not too many Vecs => it is not too costly embed the object in MRTask)
-  
+
   /** Output parameter: Metric builder */
   ModelMetricsSupervised.MetricBuilderSupervised _mb;
 

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -337,13 +337,12 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
         _train.add(names, vs);
         // Append number of trees participating in on-the-fly scoring
         _train.add("OUT_BAG_TREES", _response.makeZero());
-
+        _model._output._nTrainChunks = _train.anyVec().nChunks();
         if (_valid != null) {
           _validWorkspace = makeValidWorkspace();
           _validPredsCache = Score.makePredictionCache(_model, vresponse());
         }
         _trainPredsCache = Score.makePredictionCache(_model, response());
-
         // Variable importance: squared-error-improvement-per-variable-per-split
         _improvPerVar = new float[_ncols];
         _rand = RandomUtils.getRNG(_parms._seed);

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -121,7 +121,7 @@ public abstract class SharedTreeModel<
 
   @Override public ModelMetricsSupervised.MetricBuilderSupervised makeMetricBuilder(String[] domain) {
     switch(_output.getModelCategory()) {
-      case Binomial: return new ModelMetricsBinomial.MetricBuilderBinomial(domain, setAUCWorkingBinSize(_parms.train()==null?1:_parms.train().anyVec().nChunks()));
+      case Binomial: return new ModelMetricsBinomial.MetricBuilderBinomial(domain, setAUCWorkingBinSize(Math.max(1,_output._nTrainChunks)));
       case Multinomial: return new ModelMetricsMultinomial.MetricBuilderMultinomial(_output.nclasses(),domain);
       case Regression:  return new ModelMetricsRegression.MetricBuilderRegression();
       default: throw H2O.unimpl();
@@ -138,7 +138,8 @@ public abstract class SharedTreeModel<
     if (!(_parms instanceof GBMModel.GBMParameters)   // only care about GBMModel here
             || (numChunks <= 1)   // if no early stopping is needed and finalScoring is false
             || (_parms instanceof GBMModel.GBMParameters && _output._ntrees == 0)
-            || (_parms instanceof GBMModel.GBMParameters &&  (_parms._stopping_rounds<=0) && (_parms._ntrees>_output._ntrees)))
+            || (_parms instanceof GBMModel.GBMParameters &&  (_parms._stopping_rounds<=0)
+               && (((GBMModel.GBMParameters) _parms)._max_runtime_secs<=0) && (_parms._ntrees>_output._ntrees)))
       return AUC2.NBINS;  // don't care about reproducibility here
 
     int nBinsAUC2;
@@ -174,6 +175,7 @@ public abstract class SharedTreeModel<
 
     /** Number of trees actually in the model (as opposed to requested) */
     public int _ntrees;
+    public int _nTrainChunks; // number of training frame chunks
 
     /** More indepth tree stats */
     public final TreeStats _treeStats;

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -129,9 +129,17 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
 
   public static class MetricBuilderBinomial<T extends MetricBuilderBinomial<T>> extends MetricBuilderSupervised<T> {
     protected double _logloss;
-    protected AUC2.AUCBuilder _auc;
+    public AUC2.AUCBuilder _auc;
 
-    public MetricBuilderBinomial( String[] domain ) { super(2,domain); _auc = new AUC2.AUCBuilder(AUC2.NBINS); }
+    public MetricBuilderBinomial( String[] domain ) {
+      super(2,domain);
+      _auc = new AUC2.AUCBuilder(AUC2.NBINS);
+    }
+
+    public MetricBuilderBinomial( String[] domain, int workingAUCBins ) {
+      super(2,domain);
+      _auc = new AUC2.AUCBuilder(AUC2.NBINS, workingAUCBins);
+    }
 
     public double auc() {return new AUC2(_auc)._auc;}
 

--- a/h2o-core/src/test/java/water/udf/CustomMetricTest.java
+++ b/h2o-core/src/test/java/water/udf/CustomMetricTest.java
@@ -44,10 +44,10 @@ public class CustomMetricTest extends TestUtil {
       model = new NullModelBuilder(params).trainModel().get();
       pred = model.score(f, null, null, true, func);
       Assert.assertEquals("Null model generates only a single model metrics",
-                          1, model._output.getModelMetrics().length);
+              1, model._output.getModelMetrics().length);
       ModelMetrics mm = model._output.getModelMetrics()[0].get();
       Assert.assertEquals("Custom model metrics should compute mean of response column",
-                          f.vec("sepal_len").mean(), mm._custom_metric.value, 1e-8);
+              f.vec("sepal_len").mean(), mm._custom_metric.value, 1e-8);
     } finally {
       FrameUtils.delete(f, pred, model);
       DKV.remove(func.getKey());
@@ -120,10 +120,10 @@ class NullModelBuilder extends ModelBuilder<NullModel, NullModelParameters, Null
   @Override
   public ModelCategory[] can_build() {
     return new ModelCategory[]{
-        ModelCategory.Regression,
-        ModelCategory.Binomial,
-        ModelCategory.Multinomial,
-        };
+            ModelCategory.Regression,
+            ModelCategory.Binomial,
+            ModelCategory.Multinomial,
+    };
   }
 
   @Override
@@ -131,5 +131,3 @@ class NullModelBuilder extends ModelBuilder<NullModel, NullModelParameters, Null
     return true;
   }
 }
-
-

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2982,12 +2982,25 @@ def extract_scoring_history_field(aModel, fieldOfInterest, takeFirst=False):
     :param fieldOfInterest: string representing a field of interest.
     :return: List of field values or None if it cannot be found
     """
+    extract_from_twoDimTable(aModel._model_json["output"]["scoring_history"], fieldOfInterest, takeFirst)
 
-    allFields = aModel._model_json["output"]["scoring_history"]._col_header
+
+
+def extract_from_twoDimTable(metricOfInterest, fieldOfInterest, takeFirst=False):
+    """
+    Given a fieldOfInterest that are found in the model scoring history, this function will extract the list
+    of field values for you from the model.
+
+    :param aModel: H2O model where you want to extract a list of fields from the scoring history
+    :param fieldOfInterest: string representing a field of interest.
+    :return: List of field values or None if it cannot be found
+    """
+
+    allFields = metricOfInterest._col_header
     if fieldOfInterest in allFields:
         cellValues = []
         fieldIndex = allFields.index(fieldOfInterest)
-        for eachCell in aModel._model_json["output"]["scoring_history"].cell_values:
+        for eachCell in metricOfInterest.cell_values:
             cellValues.append(eachCell[fieldIndex])
             if takeFirst:   # only grab the result from the first iteration.
                 break

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_HEXDEV_700_reproducibility_large.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_HEXDEV_700_reproducibility_large.py
@@ -1,0 +1,33 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from random import randint
+
+# HEXDEV-700: GBM reproducibility issue.
+def gbm_reproducibility():
+
+  # run GBM twice with true_reproducibility = True
+  seedv = randint(1,10000000000)
+  ntree = 50
+
+  auc2 = runGBM(seedv, ntree)
+  auc1 = runGBM(seedv, ntree)
+  pyunit_utils.equal_two_arrays(auc1, auc2, 1e-10, True)  # should be equal in this case
+
+def runGBM(seedV, ntree):
+  cars = h2o.import_file(path=pyunit_utils.locate("bigdata/laptop/jira/reproducibility_issue.csv.zip"))
+  gbm = H2OGradientBoostingEstimator(distribution='bernoulli', ntrees=ntree, seed= seedV, max_depth = 4,
+                                   min_rows = 7, score_tree_interval=ntree)
+  gbm.train(x=list(range(2,365)), y="response", training_frame=cars)
+  print("Model run time (ms) with reproducibility is {0}".format(gbm._model_json["output"]["run_time"]))
+  auc = pyunit_utils.extract_from_twoDimTable(gbm._model_json['output']['training_metrics']._metric_json['thresholds_and_metric_scores'], 'threshold', takeFirst=False)
+  h2o.remove(cars)
+  h2o.remove(gbm)
+  return auc
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(gbm_reproducibility)
+else:
+  gbm_reproducibility()

--- a/h2o-py/tests/testdir_hdfs/index.list
+++ b/h2o-py/tests/testdir_hdfs/index.list
@@ -10,3 +10,4 @@ pyunit_INTERNAL_HDFS_prostate_orc.py
 pyunit_INTERNAL_HDFS_import_folder_orc.py
 pyunit_INTERNAL_HDFS_baddata_orc.py
 pyunit_INTERNAL_HADOOP_download_logs.py
+pyunit_INTERNAL_HDFS_hexdev_700_gbm_reproducibility.py

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_hexdev_700_gbm_reproducibility.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_hexdev_700_gbm_reproducibility.py
@@ -1,0 +1,48 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from random import randint
+
+# HEXDEV-700: GBM reproducibility issue.
+def gbm_reproducibility():
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+    # run GBM twice with true_reproducibility = True
+        seedv = randint(1,10000000000)
+        ntree = 50
+        auc2 = runGBM(seedv, True, ntree)
+
+        if (randint(1,10) > 5):
+            auc1 = runGBM(seedv, ntree)
+            pyunit_utils.equal_two_arrays(auc1, auc2, 1e-10, True)  # should be equal in this case
+        else:
+            auc3 = runGBM(seedv, ntree)  # threshold should be different this run.
+            assert not(pyunit_utils.equal_two_arrays(auc2, auc3, 1e-10, False)), "parameter true_reproducibility is not working."
+    else:
+        raise EnvironmentError
+
+def runGBM(seedV, nt):
+    #import data frame
+    hdfs_name_node = pyunit_utils.hadoop_namenode()
+    hdfs_csv_file = "/datasets/reproducibility_issue.csv.zip"
+    url_csv = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_csv_file)
+    h2oframe_csv = h2o.import_file(url_csv)
+    gbm = H2OGradientBoostingEstimator(distribution='bernoulli', ntrees=nt, seed= seedV, max_depth = 4,
+                                       min_rows = 7, score_tree_interval=nt)
+    gbm.train(x=list(range(2,365)), y="response", training_frame=h2oframe_csv)
+    print("Model run time (ms) is {0}".format(gbm._model_json["output"]["run_time"]))
+    auc = pyunit_utils.extract_from_twoDimTable(gbm._model_json['output']['training_metrics']._metric_json['thresholds_and_metric_scores'], 'threshold', takeFirst=False)
+    h2o.remove(h2oframe_csv)
+    h2o.remove(gbm)
+    return auc
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(gbm_reproducibility)
+else:
+    gbm_reproducibility()

--- a/h2o-r/tests/testdir_algos/gbm/runit_GBM_PUBDEV_700_reproducibility_large.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBM_PUBDEV_700_reproducibility_large.R
@@ -1,0 +1,28 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.gbm <- function() {
+  # Determine model sizes
+  seeds = round(runif(1,min=1,max=1000000000000))
+ # seeds = c(987654321, 123456789, 1029384756)
+  ntree=50
+  
+  auc_run1 <- TrainGBM(seeds, ntree)
+  auc_run2 <- TrainGBM(seeds, ntree)
+  expect_equal(auc_run1, auc_run2)
+}
+
+# borrowed from Megan K
+TrainGBM <- function(seedNum, nt) {
+  data <- h2o.importFile(locate("bigdata/laptop/jira/reproducibility_issue.csv.zip"))
+  gbm_v1 <- h2o.gbm(x=2:365, y='response', training_frame = data,
+          distribution = "bernoulli", ntrees = nt, seed = seedNum, max_depth = 4, min_rows = 7,
+          score_tree_interval=nt
+  )
+  auc_gbm = gbm_v1@model$training_metrics@metrics$thresholds_and_metric_scores$threshold
+  h2o.rm(data)
+  h2o.rm(gbm_v1)
+  auc_gbm
+}
+
+doTest("GBM reproducibility test", test.gbm)


### PR DESCRIPTION
What was done:     
1.  Fixed AUC2.java so that we can guarantee reproducibility as much as machine memory allows.
    HEXDEV-700: Speed up Dups() by not checking duplicate elements from the beginning of the array _ths.:

2 Completed and verified correct operation with Dups() speedup in AUC2.java.
3. Finished speedup for mergeOneBin() in AUC2.java.
4.  Warning message about reproducibility issues are added to Java backend and also passed to clients.
5.  Add flag for user to determine whether she wants reproducibility across clusters or speed.  
6. Add meaningful Python unit test.
7. Generate Hadoop test
8.  Added speedup proposed by Michalk.  Thanks.

To do:
1. Work with Nidhi to duplicate and test customer setups and ensure that the fix actually works.