### PR TITLE
[PUBDEV-4375] Enable different PCA implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ h2o-web/src/main/resources/www/flow
 h2o-web/src/main/resources/www/3/h2o-genmodel.jar
 h2o*/test-output/
 test-output/
+results/
 out/
 .idea/
 *.ipr

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ git pull
 - Skip tests by adding `-x test` at the end the gradle build command line.  Tests typically run for 7-10 minutes on a Macbook Pro laptop with 4 CPUs (8 hyperthreads) and 16 GB of RAM.
 
 - Syncing smalldata is not required after each pull, but if tests fail due to missing data files, then try `./gradlew syncSmalldata` as the first troubleshooting step.  Syncing smalldata downloads data files from AWS S3 to the smalldata directory in your workspace.  The sync is incremental.  Do not check in these files.  The smalldata directory is in .gitignore.  If you do not run any tests, you do not need the smalldata directory.
-- Running `./gradlew syncRPackages` is supported on Windows, OS X, and Linux, and is strongly recommended but not required. `./gradlew syncRPackages` ensures a complete and consistent environment with pre-approved versions of the packages required for tests and builds. The packages can be installed manually, but we recommend setting an ENV variable and using `./gradlew syncRPackages`. To set the ENV variable, use the following format (where `${WORKSPACE} can be any path):
+- Running `./gradlew syncRPackages` is supported on Windows, OS X, and Linux, and is strongly recommended but not required. `./gradlew syncRPackages` ensures a complete and consistent environment with pre-approved versions of the packages required for tests and builds. The packages can be installed manually, but we recommend setting an ENV variable and using `./gradlew syncRPackages`. To set the ENV variable, use the following format (where `${WORKSPACE}` can be any path):
 
   ```
   mkdir -p ${WORKSPACE}/Rlibrary

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -9,6 +9,13 @@ dependencies {
   if (file("${rootDir}/lib/deepwater-all.jar").exists()) {
       compile files("${rootDir}/lib/deepwater-all.jar")
   }
+
+  // Jama dependencies
+  compile "gov.nist.math:jama:1.0.3"
+  // netlib-java / MTJ dependencies
+  compile 'com.github.fommil.netlib:all:1.1.2'
+  compile('com.googlecode.matrix-toolkits-java:mtj:1.0.4') { exclude group: 'com.github.fommil.netlib' }
+
   // Test dependencies only
   testCompile "junit:junit:${junitVersion}"
   testCompile project(path: ":h2o-core", configuration: "testArchives")

--- a/h2o-algos/src/jmh/java/hex/pca/JMHConfiguration.java
+++ b/h2o-algos/src/jmh/java/hex/pca/JMHConfiguration.java
@@ -1,0 +1,9 @@
+package hex.pca;
+
+public final class JMHConfiguration {
+  // The default values are for minimal working benchmarking. Set up your own values for your own benchmarking.
+  static final int WARM_UP_ITERATIONS = 1;
+  static final int MEASUREMENT_ITERATIONS = 1;
+  static final String logLevel = "ERRR";
+  public static final int TIMEOUT_MINUTES = 15;
+}

--- a/h2o-algos/src/jmh/java/hex/pca/PCACatOnlyPUBDEV3988Bench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCACatOnlyPUBDEV3988Bench.java
@@ -73,7 +73,7 @@ public class PCACatOnlyPUBDEV3988Bench {
       paramsCatOnlyPUBDEV3988._k = 4;
       paramsCatOnlyPUBDEV3988._transform = DataInfo.TransformType.NONE;
       paramsCatOnlyPUBDEV3988._pca_method = GramSVD;
-      paramsCatOnlyPUBDEV3988.setSvdImplementation(PCAImplementation);
+      paramsCatOnlyPUBDEV3988._pca_implementation = PCAImplementation;
       paramsCatOnlyPUBDEV3988._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
       paramsCatOnlyPUBDEV3988._seed = seed;
 

--- a/h2o-algos/src/jmh/java/hex/pca/PCACatOnlyPUBDEV3988Bench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCACatOnlyPUBDEV3988Bench.java
@@ -20,7 +20,10 @@ import static water.TestUtil.parse_test_file;
 import static water.TestUtil.stall_till_cloudsize;
 
 /**
- * PCA benchmark micro-benchmark based on hex.pca.PCATest.testImputeMissing()
+ * PCA benchmark micro-benchmark based on hex.pca.PCATest.testCatOnlyPUBDEV3988()
+ * TODO migrate from PCATest!!!
+ * - split train & score benchs
+ * - create interface on top of it
  */
 @Fork(1)
 @Threads(1)
@@ -30,18 +33,18 @@ import static water.TestUtil.stall_till_cloudsize;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Timeout(time = JMHConfiguration.TIMEOUT_MINUTES, timeUnit = TimeUnit.MINUTES)
-public class PCAImputeMissingScoringBench {
+public class PCACatOnlyPUBDEV3988Bench {
 
   @Param({"JAMA", "MTJ_SVD_DENSEMATRIX", "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX"})
   private PCAImplementation PCAImplementation;
 
-  private PCAParameters paramsImputeMissing;
+  private PCAParameters paramsCatOnlyPUBDEV3988;
   private PCAModel pcaModel;
   private Frame trainingFrame;
 
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(PCAImputeMissingScoringBench.class.getSimpleName())
+        .include(PCACatOnlyPUBDEV3988Bench.class.getSimpleName())
         .build();
 
     new Runner(opt).run();
@@ -65,14 +68,14 @@ public class PCAImputeMissingScoringBench {
       j.execImpl().get(); // MissingInserter is non-blocking, must block here explicitly
       DKV.remove(frame._key); // Delete the frame header (not the data)
 
-      paramsImputeMissing = new PCAParameters();
-      paramsImputeMissing._train = trainingFrame._key;
-      paramsImputeMissing._k = 4;
-      paramsImputeMissing._transform = DataInfo.TransformType.NONE;
-      paramsImputeMissing._pca_method = GramSVD;
-      paramsImputeMissing.setSvdImplementation(PCAImplementation);
-      paramsImputeMissing._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
-      paramsImputeMissing._seed = seed;
+      paramsCatOnlyPUBDEV3988 = new PCAParameters();
+      paramsCatOnlyPUBDEV3988._train = trainingFrame._key;
+      paramsCatOnlyPUBDEV3988._k = 4;
+      paramsCatOnlyPUBDEV3988._transform = DataInfo.TransformType.NONE;
+      paramsCatOnlyPUBDEV3988._pca_method = GramSVD;
+      paramsCatOnlyPUBDEV3988.setSvdImplementation(PCAImplementation);
+      paramsCatOnlyPUBDEV3988._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
+      paramsCatOnlyPUBDEV3988._seed = seed;
 
       if (!train()) {                               // prepare the model for scoring
         throw new RuntimeException("PCA model failed to be trained.");
@@ -81,7 +84,6 @@ public class PCAImputeMissingScoringBench {
       if (trainingFrame != null) {
         trainingFrame.delete();
       }
-      e.printStackTrace();
       throw e;
     }
   }
@@ -106,7 +108,7 @@ public class PCAImputeMissingScoringBench {
 
   private boolean train() {
     try {
-      pcaModel = new PCA(paramsImputeMissing).trainModel().get();
+      pcaModel = new PCA(paramsCatOnlyPUBDEV3988).trainModel().get();
     } catch (Exception exception) {
       return false;
     }

--- a/h2o-algos/src/jmh/java/hex/pca/PCAImputeMissingScoringBench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAImputeMissingScoringBench.java
@@ -70,7 +70,7 @@ public class PCAImputeMissingScoringBench {
       paramsImputeMissing._k = 4;
       paramsImputeMissing._transform = DataInfo.TransformType.NONE;
       paramsImputeMissing._pca_method = GramSVD;
-      paramsImputeMissing.setSvdImplementation(PCAImplementation);
+      paramsImputeMissing._pca_implementation = PCAImplementation;
       paramsImputeMissing._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
       paramsImputeMissing._seed = seed;
 

--- a/h2o-algos/src/jmh/java/hex/pca/PCAImputeMissingTrainingBench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAImputeMissingTrainingBench.java
@@ -13,6 +13,7 @@ import water.util.FrameUtils;
 
 import java.util.concurrent.TimeUnit;
 
+import static hex.pca.JMHConfiguration.logLevel;
 import static hex.pca.PCAModel.PCAParameters;
 import static hex.pca.PCAModel.PCAParameters.Method.GramSVD;
 import static water.TestUtil.parse_test_file;
@@ -24,12 +25,16 @@ import static water.TestUtil.stall_till_cloudsize;
 @Fork(1)
 @Threads(1)
 @State(Scope.Thread)
-@Warmup(iterations = 3)
-@Measurement(iterations = 10)
+@Warmup(iterations = JMHConfiguration.WARM_UP_ITERATIONS)
+@Measurement(iterations = JMHConfiguration.MEASUREMENT_ITERATIONS)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Timeout(time = JMHConfiguration.TIMEOUT_MINUTES, timeUnit = TimeUnit.MINUTES)
 public class PCAImputeMissingTrainingBench {
-	
+
+	@Param({"JAMA", "MTJ_SVD_DENSEMATRIX", "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX"})
+	private PCAImplementation PCAImplementation;
+
 	private PCAParameters paramsImputeMissing;
 	private PCAModel pcaModel;
 	private Frame trainingFrame;
@@ -44,7 +49,7 @@ public class PCAImputeMissingTrainingBench {
 	
 	@Setup(Level.Invocation)
 	public void setup() {
-		water.util.Log.setLogLevel("ERRR");
+		water.util.Log.setLogLevel(logLevel);
 		stall_till_cloudsize(1);
 		
 		trainingFrame = null;
@@ -65,6 +70,7 @@ public class PCAImputeMissingTrainingBench {
 			paramsImputeMissing._k = 4;
 			paramsImputeMissing._transform = DataInfo.TransformType.NONE;
 			paramsImputeMissing._pca_method = GramSVD;
+			paramsImputeMissing.setSvdImplementation(PCAImplementation);
 			paramsImputeMissing._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
 			paramsImputeMissing._seed = seed;
 			

--- a/h2o-algos/src/jmh/java/hex/pca/PCAImputeMissingTrainingBench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAImputeMissingTrainingBench.java
@@ -70,7 +70,7 @@ public class PCAImputeMissingTrainingBench {
 			paramsImputeMissing._k = 4;
 			paramsImputeMissing._transform = DataInfo.TransformType.NONE;
 			paramsImputeMissing._pca_method = GramSVD;
-			paramsImputeMissing.setSvdImplementation(PCAImplementation);
+			paramsImputeMissing._pca_implementation = PCAImplementation;
 			paramsImputeMissing._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
 			paramsImputeMissing._seed = seed;
 			

--- a/h2o-algos/src/jmh/java/hex/pca/PCAJMH.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAJMH.java
@@ -1,0 +1,92 @@
+package hex.pca;
+
+import hex.DataInfo;
+import water.DKV;
+import water.Key;
+import water.fvec.Frame;
+import water.util.FrameUtils;
+
+import static hex.pca.JMHConfiguration.logLevel;
+import static hex.pca.PCAModel.PCAParameters.Method.GramSVD;
+import static water.TestUtil.parse_test_file;
+import static water.TestUtil.stall_till_cloudsize;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ *     created on 24.6.17
+ */
+public class PCAJMH {
+  
+  PCAModel.PCAParameters paramsQuasar;
+  protected PCAModel pcaModel;
+  protected Frame trainingFrame;
+  protected String hexKey = "input_data.hex";
+  protected String dataSetFilePath = "smalldata/pca_test/SDSS_quasar.txt";
+//	protected String dataSetFilePath = "bigdata/laptop/jira/re0.wc.arff.csv";
+  
+  public void setup() {
+    water.util.Log.setLogLevel(logLevel);
+    stall_till_cloudsize(1);
+    
+    trainingFrame = null;
+    double missing_fraction = 0.75;
+    long seed = 12345;
+    
+    try {
+      // TODO update following comment
+    /* NOTE get the data this way
+     * 1) ./gradlew syncSmalldata
+     * 2) unzip SDSS_quasar.txt.zip
+     */
+      trainingFrame = parse_test_file(Key.make(hexKey), dataSetFilePath);
+      // Add missing values to the training data
+      Frame frame = new Frame(Key.<Frame>make(), trainingFrame.names(), trainingFrame.vecs());
+      DKV.put(frame._key, frame); // Need to put the frame (to be modified) into DKV for MissingInserter to pick up
+      FrameUtils.MissingInserter j = new FrameUtils.MissingInserter(frame._key, seed, missing_fraction);
+      j.execImpl().get(); // MissingInserter is non-blocking, must block here explicitly
+      DKV.remove(frame._key); // Delete the frame header (not the data)
+      
+      paramsQuasar = new PCAModel.PCAParameters();
+      paramsQuasar._train = trainingFrame._key;
+      paramsQuasar._k = 4;
+      paramsQuasar._transform = DataInfo.TransformType.NONE;
+      paramsQuasar._pca_method = GramSVD;
+      paramsQuasar._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
+      paramsQuasar._seed = seed;
+    } catch (RuntimeException e) {
+      if (trainingFrame != null) {
+        trainingFrame.delete();
+      }
+      e.printStackTrace();
+      throw e;
+    }
+  }
+  
+  public void tearDown() {
+    if (pcaModel != null) {
+      pcaModel.remove();
+    }
+    if (trainingFrame != null) {
+      trainingFrame.delete();
+    }
+  }
+  
+  boolean tryToTrain() {
+    try {
+      pcaModel = new PCA(paramsQuasar).trainModel().get();
+    } catch (Exception exception) {
+      return false;
+    }
+    return true;
+  }
+  
+  boolean tryToScore() {
+    try {
+      pcaModel.score(trainingFrame);
+    } catch (Exception e) {
+      return false;
+    }
+    return true;
+  }
+  
+}

--- a/h2o-algos/src/jmh/java/hex/pca/PCAJMH.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAJMH.java
@@ -11,10 +11,6 @@ import static hex.pca.PCAModel.PCAParameters.Method.GramSVD;
 import static water.TestUtil.parse_test_file;
 import static water.TestUtil.stall_till_cloudsize;
 
-/**
- * @author mathemage <ha@h2o.ai>
- *     created on 24.6.17
- */
 public class PCAJMH {
   
   PCAModel.PCAParameters paramsQuasar;

--- a/h2o-algos/src/jmh/java/hex/pca/PCAJMHScoring.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAJMHScoring.java
@@ -20,8 +20,8 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Timeout(time = JMHConfiguration.TIMEOUT_MINUTES, timeUnit = TimeUnit.MINUTES)
 public class PCAJMHScoring extends PCAJMH {
-  
-  @Param({"JAMA", "MTJ_SVD_DENSEMATRIX", "EVD_MTJ_DENSEMATRIX", "EVD_MTJ_SYMM"})
+
+  @Param({"JAMA", "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX"})
   private PCAImplementation PCAImplementation;
   private boolean isTrained;
   

--- a/h2o-algos/src/jmh/java/hex/pca/PCAJMHScoring.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAJMHScoring.java
@@ -1,0 +1,59 @@
+package hex.pca;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * PCA benchmark micro-benchmark based on hex.pca.PCATest.testImputeMissing() using dataset of Quasar data
+ */
+@Fork(value = 1, jvmArgsAppend = { "-Xmx16g", "-Dai.h2o.name=karel_PCABench"})
+@Threads(1)
+@State(Scope.Thread)
+@Warmup(iterations = JMHConfiguration.WARM_UP_ITERATIONS)
+@Measurement(iterations = JMHConfiguration.MEASUREMENT_ITERATIONS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Timeout(time = JMHConfiguration.TIMEOUT_MINUTES, timeUnit = TimeUnit.MINUTES)
+public class PCAJMHScoring extends PCAJMH {
+  
+  @Param({"JAMA", "MTJ_SVD_DENSEMATRIX", "EVD_MTJ_DENSEMATRIX", "EVD_MTJ_SYMM"})
+  private PCAImplementation PCAImplementation;
+  private boolean isTrained;
+  
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(PCAJMHScoring.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+  
+  @Setup(Level.Iteration)
+  public void setup() {
+  	super.setup();
+    paramsQuasar.setSvdImplementation(PCAImplementation);
+    isTrained = tryToTrain();
+  }
+  
+  @TearDown(Level.Iteration)
+  public void tearDown() {
+  	super.tearDown();
+  }
+  
+  @Benchmark
+  public boolean measureQuasarScoring() throws Exception {
+  	if (!isTrained) {
+      throw new Exception("Model for PCAJMHScoring failed to be trained!");
+    }
+    if (!tryToScore()) {
+      throw new Exception("Model for PCAJMHScoring failed to be scored!");
+    }
+    return true;
+  }
+  
+}

--- a/h2o-algos/src/jmh/java/hex/pca/PCAJMHScoring.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAJMHScoring.java
@@ -36,7 +36,7 @@ public class PCAJMHScoring extends PCAJMH {
   @Setup(Level.Iteration)
   public void setup() {
   	super.setup();
-    paramsQuasar.setSvdImplementation(PCAImplementation);
+    paramsQuasar._pca_implementation = PCAImplementation;
     isTrained = tryToTrain();
   }
   

--- a/h2o-algos/src/jmh/java/hex/pca/PCAJMHTraining.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAJMHTraining.java
@@ -8,13 +8,10 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-import static hex.pca.JMHConfiguration.logLevel;
-import static water.TestUtil.stall_till_cloudsize;
-
 /**
- * PCA benchmark
+ * PCA benchmark micro-benchmark based on hex.pca.PCATest.testImputeMissing() using dataset of Quasar data
  */
-@Fork(1)
+@Fork(value = 1, jvmArgsAppend = { "-Xmx16g", "-Dai.h2o.name=karel_PCABench"})
 @Threads(1)
 @State(Scope.Thread)
 @Warmup(iterations = JMHConfiguration.WARM_UP_ITERATIONS)
@@ -22,42 +19,36 @@ import static water.TestUtil.stall_till_cloudsize;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Timeout(time = JMHConfiguration.TIMEOUT_MINUTES, timeUnit = TimeUnit.MINUTES)
-public class PCAWideDataSetsTrainingBench {
+public class PCAJMHTraining extends PCAJMH {
   
-  private PCAWideDataSets pcaWideDataSetsBench;
-  @Param({"1", "2", "3", "4", "5", "6"})
-  private int dataSetCase;
   @Param({"JAMA", "MTJ_SVD_DENSEMATRIX", "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX"})
   private PCAImplementation PCAImplementation;
-
+  
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(PCAWideDataSetsTrainingBench.class.getSimpleName())
+        .include(PCAJMHTraining.class.getSimpleName())
         .build();
 
     new Runner(opt).run();
   }
   
-  @Setup(Level.Invocation)
+  @Setup(Level.Iteration)
   public void setup() {
-    water.util.Log.setLogLevel(logLevel);
-    stall_till_cloudsize(1);
-    
-    pcaWideDataSetsBench = new PCAWideDataSets(dataSetCase);
-    pcaWideDataSetsBench.setPCAImplementation(PCAImplementation);
+  	super.setup();
+    paramsQuasar.setSvdImplementation(PCAImplementation);
   }
-
+  
+  @TearDown(Level.Iteration)
+  public void tearDown() {
+  	super.tearDown();
+  }
+  
   @Benchmark
-  public boolean measureWideDataSetsBenchTrainingCase() throws Exception {
-    if (!pcaWideDataSetsBench.train()) {
-      throw new Exception("Model for PCAWideDataSetsBench failed to be trained!");
+  public boolean measureQuasarTraining() throws Exception {
+    if (!tryToTrain()) {
+      throw new Exception("Model for PCAJMHScoring failed to be trained!");
     }
     return true;
   }
-  
-  @TearDown(Level.Invocation)
-  public void tearDown() {
-    pcaWideDataSetsBench.tearDown();
-  }
-  
+
 }

--- a/h2o-algos/src/jmh/java/hex/pca/PCAJMHTraining.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAJMHTraining.java
@@ -35,7 +35,7 @@ public class PCAJMHTraining extends PCAJMH {
   @Setup(Level.Iteration)
   public void setup() {
   	super.setup();
-    paramsQuasar.setSvdImplementation(PCAImplementation);
+    paramsQuasar._pca_implementation = PCAImplementation;
   }
   
   @TearDown(Level.Iteration)

--- a/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSets.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSets.java
@@ -7,6 +7,7 @@ import water.fvec.Frame;
 
 import java.util.Random;
 
+import static hex.pca.JMHConfiguration.logLevel;
 import static hex.pca.PCAModel.PCAParameters.Method.GramSVD;
 import static water.TestUtil.parse_test_file;
 
@@ -17,15 +18,16 @@ import static water.TestUtil.parse_test_file;
  * using GramSVD under normal setting (_wideDataset is set to false).  Next, it builds a GramSVD model with
  * _wideDataSet set to true.
  */
-public class PCAWideDataSetsBenchModel {
+public class PCAWideDataSets {
 	private static final int numberOfModels = 6;
 	private Frame trainingFrame = null;
 	private PCA pca = null;
 	private int dataSetCase;
 	private PCAModel pcaModel;
 	private Frame pcaScore;
-	
-	PCAWideDataSetsBenchModel(int dataSetCase) {
+	private PCAImplementation PCAImplementation;
+
+	PCAWideDataSets(int dataSetCase) {
 		setDataSetCase(dataSetCase);
 		setup();
 	}
@@ -39,7 +41,7 @@ public class PCAWideDataSetsBenchModel {
 	}
 	
 	public void setup() {
-		water.util.Log.setLogLevel("ERRR");
+		water.util.Log.setLogLevel(logLevel);
 		final String _smallDataSet = "smalldata/pca_test/decathlon.csv";
 		final String _prostateDataSet = "smalldata/prostate/prostate_cat.csv";
 		final DataInfo.TransformType[] _transformTypes = {DataInfo.TransformType.NONE,
@@ -104,6 +106,7 @@ public class PCAWideDataSetsBenchModel {
 		parameters._transform = transformType;
 		parameters._use_all_factor_levels = true;
 		parameters._pca_method = GramSVD;
+		parameters._pca_implementation = getPCAImplementation();
 		parameters._impute_missing = false;
 		parameters._seed = 12345;
 		
@@ -143,5 +146,12 @@ public class PCAWideDataSetsBenchModel {
 		}
 		return true;
 	}
-	
+
+	public PCAImplementation getPCAImplementation() {
+		return PCAImplementation;
+	}
+
+	public void setPCAImplementation(PCAImplementation PCAImplementation) {
+		this.PCAImplementation = PCAImplementation;
+	}
 }

--- a/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSets.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSets.java
@@ -27,8 +27,9 @@ public class PCAWideDataSets {
 	private Frame pcaScore;
 	private PCAImplementation PCAImplementation;
 
-	PCAWideDataSets(int dataSetCase) {
+	PCAWideDataSets(int dataSetCase, PCAImplementation pcaImplementation) {
 		setDataSetCase(dataSetCase);
+		setPCAImplementation(pcaImplementation);
 		setup();
 	}
 	
@@ -115,7 +116,7 @@ public class PCAWideDataSets {
 		return pcaParametersWide;
 	}
 	
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		if (trainingFrame != null) {
 			trainingFrame.delete();
 		}
@@ -125,6 +126,7 @@ public class PCAWideDataSets {
 		if (pcaScore != null) {
 			pcaScore.delete();
 		}
+		water.H2O.getJetty().stop();
 	}
 	
 	public boolean train() {

--- a/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsScoringBench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsScoringBench.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
+import static hex.pca.JMHConfiguration.logLevel;
 import static water.TestUtil.stall_till_cloudsize;
 
 /**
@@ -16,16 +17,19 @@ import static water.TestUtil.stall_till_cloudsize;
 @Fork(1)
 @Threads(1)
 @State(Scope.Thread)
-@Warmup(iterations = 3)
-@Measurement(iterations = 10)
+@Warmup(iterations = JMHConfiguration.WARM_UP_ITERATIONS)
+@Measurement(iterations = JMHConfiguration.MEASUREMENT_ITERATIONS)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Timeout(time = JMHConfiguration.TIMEOUT_MINUTES, timeUnit = TimeUnit.MINUTES)
 public class PCAWideDataSetsScoringBench {
 	
-	private PCAWideDataSetsBenchModel pcaWideDataSetsBench;
+	private PCAWideDataSets pcaWideDataSetsBench;
 	@Param({"1", "2", "3", "4", "5", "6"})
 	private int dataSetCase;
-	
+	@Param({"JAMA", "MTJ_SVD_DENSEMATRIX", "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX"})
+	private PCAImplementation PCAImplementation;
+
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
 			.include(PCAWideDataSetsScoringBench.class.getSimpleName())
@@ -36,9 +40,11 @@ public class PCAWideDataSetsScoringBench {
 	
 	@Setup(Level.Invocation)
 	public void setup() {
+		water.util.Log.setLogLevel(logLevel);
 		stall_till_cloudsize(1);
 		
-		pcaWideDataSetsBench = new PCAWideDataSetsBenchModel(dataSetCase);
+		pcaWideDataSetsBench = new PCAWideDataSets(dataSetCase);
+		pcaWideDataSetsBench.setPCAImplementation(PCAImplementation);
 		// train model to prepare for score()
 		pcaWideDataSetsBench.train();
 	}

--- a/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsScoringBench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsScoringBench.java
@@ -27,7 +27,7 @@ public class PCAWideDataSetsScoringBench {
 	private PCAWideDataSets pcaWideDataSetsBench;
 	@Param({"1", "2", "3", "4", "5", "6"})
 	private int dataSetCase;
-	@Param({"JAMA", "MTJ_SVD_DENSEMATRIX", "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX"})
+	@Param({"JAMA", "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX"})
 	private PCAImplementation PCAImplementation;
 
 	public static void main(String[] args) throws RunnerException {

--- a/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsScoringBench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsScoringBench.java
@@ -43,8 +43,7 @@ public class PCAWideDataSetsScoringBench {
 		water.util.Log.setLogLevel(logLevel);
 		stall_till_cloudsize(1);
 		
-		pcaWideDataSetsBench = new PCAWideDataSets(dataSetCase);
-		pcaWideDataSetsBench.setPCAImplementation(PCAImplementation);
+		pcaWideDataSetsBench = new PCAWideDataSets(dataSetCase, PCAImplementation);
 		// train model to prepare for score()
 		pcaWideDataSetsBench.train();
 	}
@@ -58,7 +57,7 @@ public class PCAWideDataSetsScoringBench {
 	}
 	
 	@TearDown(Level.Invocation)
-	public void tearDown() {
+	public void tearDown() throws Exception {
 		pcaWideDataSetsBench.tearDown();
 	}
 	

--- a/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsTrainingBench.java
+++ b/h2o-algos/src/jmh/java/hex/pca/PCAWideDataSetsTrainingBench.java
@@ -43,8 +43,7 @@ public class PCAWideDataSetsTrainingBench {
     water.util.Log.setLogLevel(logLevel);
     stall_till_cloudsize(1);
     
-    pcaWideDataSetsBench = new PCAWideDataSets(dataSetCase);
-    pcaWideDataSetsBench.setPCAImplementation(PCAImplementation);
+    pcaWideDataSetsBench = new PCAWideDataSets(dataSetCase, PCAImplementation);
   }
 
   @Benchmark
@@ -56,7 +55,7 @@ public class PCAWideDataSetsTrainingBench {
   }
   
   @TearDown(Level.Invocation)
-  public void tearDown() {
+  public void tearDown() throws Exception {
     pcaWideDataSetsBench.tearDown();
   }
   

--- a/h2o-algos/src/jmh/java/hex/pca/jmhViaNohup.sh
+++ b/h2o-algos/src/jmh/java/hex/pca/jmhViaNohup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+H2O_DIR="../../../../../.."
+cd $H2O_DIR
+GRADLE="./gradlew"
+
+$GRADLE clean
+NOHUP_DIR="./h2o-algos/build/jmh/nohup"
+NOHUP_FILE="$NOHUP_DIR/$(date +%Y-%m-%d).out"
+mkdir $NOHUP_DIR -p
+BENCH_CMD="nohup $GRADLE :h2o-algos:jmh >$NOHUP_FILE"
+$BENCH_CMD

--- a/h2o-algos/src/main/java/hex/pca/PCA.java
+++ b/h2o-algos/src/main/java/hex/pca/PCA.java
@@ -458,7 +458,6 @@ public class PCA extends ModelBuilder<PCAModel,PCAModel.PCAParameters,PCAModel.P
   
   
       } catch (Exception e) {
-        e.printStackTrace();
         throw new RuntimeException(e);
       } finally {
         if (model != null) {

--- a/h2o-algos/src/main/java/hex/pca/PCAImplementation.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAImplementation.java
@@ -1,9 +1,5 @@
 package hex.pca;
 
-/**
- * @author mathemage <ha@h2o.ai>
- *         created on 2.5.17
- */
 public enum PCAImplementation {
 	MTJ_EVD_DENSEMATRIX, MTJ_EVD_SYMMMATRIX, MTJ_SVD_DENSEMATRIX, JAMA;
   final static PCAImplementation fastestImplementation = MTJ_EVD_SYMMMATRIX;    // set to the fastest implementation

--- a/h2o-algos/src/main/java/hex/pca/PCAImplementation.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAImplementation.java
@@ -1,0 +1,14 @@
+package hex.pca;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ *         created on 2.5.17
+ */
+public enum PCAImplementation {
+	MTJ_EVD_DENSEMATRIX, MTJ_EVD_SYMMMATRIX, MTJ_SVD_DENSEMATRIX, JAMA;
+  final static PCAImplementation fastestImplementation = MTJ_EVD_SYMMMATRIX;    // set to the fastest implementation
+  
+  public static PCAImplementation getFastestImplementation() {
+    return fastestImplementation;
+  }
+}

--- a/h2o-algos/src/main/java/hex/pca/PCAImplementationFactory.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAImplementationFactory.java
@@ -5,10 +5,6 @@ import hex.pca.mtj.PCA_MTJ_EVD_DenseMatrix;
 import hex.pca.mtj.PCA_MTJ_EVD_SymmMatrix;
 import hex.pca.mtj.PCA_MTJ_SVD_DenseMatrix;
 
-/**
- * @author mathemage <ha@h2o.ai>
- * created on 2.5.17
- */
 class PCAImplementationFactory {
   static PCAInterface createSVDImplementation(double[][] gramMatrix, PCAImplementation implementation)
       throws Exception {

--- a/h2o-algos/src/main/java/hex/pca/PCAImplementationFactory.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAImplementationFactory.java
@@ -1,0 +1,28 @@
+package hex.pca;
+
+import hex.pca.jama.PCAJama;
+import hex.pca.mtj.PCA_MTJ_EVD_DenseMatrix;
+import hex.pca.mtj.PCA_MTJ_EVD_SymmMatrix;
+import hex.pca.mtj.PCA_MTJ_SVD_DenseMatrix;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ * created on 2.5.17
+ */
+class PCAImplementationFactory {
+  static PCAInterface createSVDImplementation(double[][] gramMatrix, PCAImplementation implementation)
+      throws Exception {
+    switch (implementation) {
+      case MTJ_EVD_DENSEMATRIX:
+        return new PCA_MTJ_EVD_DenseMatrix(gramMatrix);
+      case MTJ_EVD_SYMMMATRIX:
+        return new PCA_MTJ_EVD_SymmMatrix(gramMatrix);
+      case MTJ_SVD_DENSEMATRIX:
+        return new PCA_MTJ_SVD_DenseMatrix(gramMatrix);
+      case JAMA:
+        return new PCAJama(gramMatrix);
+      default:
+        throw new Exception("Unrecognized svdImplementation " + implementation.toString());
+    }
+  }
+}

--- a/h2o-algos/src/main/java/hex/pca/PCAInterface.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAInterface.java
@@ -1,9 +1,5 @@
 package hex.pca;
 
-/**
- * @author mathemage </ha@h2o.ai>
- * created on 2.5.17
- */
 public interface PCAInterface {
   double[] getVariances();
 

--- a/h2o-algos/src/main/java/hex/pca/PCAInterface.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAInterface.java
@@ -1,0 +1,11 @@
+package hex.pca;
+
+/**
+ * @author mathemage </ha@h2o.ai>
+ * created on 2.5.17
+ */
+public interface PCAInterface {
+  double[] getVariances();
+
+  double[][] getPrincipalComponents();
+}

--- a/h2o-algos/src/main/java/hex/pca/PCAModel.java
+++ b/h2o-algos/src/main/java/hex/pca/PCAModel.java
@@ -30,6 +30,7 @@ public class PCAModel extends Model<PCAModel,PCAModel.PCAParameters,PCAModel.PCA
 
     public DataInfo.TransformType _transform = DataInfo.TransformType.NONE; // Data transformation
     public Method _pca_method = Method.GramSVD;   // Method for computing PCA
+    public PCAImplementation _pca_implementation = PCAImplementation.getFastestImplementation();   // PCA implementation
     public int _k = 1;                     // Number of principal components
     public int _max_iterations = 1000;     // Max iterations
     public boolean _use_all_factor_levels = false;   // When expanding categoricals, should first level be kept or dropped?

--- a/h2o-algos/src/main/java/hex/pca/jama/PCAJama.java
+++ b/h2o-algos/src/main/java/hex/pca/jama/PCAJama.java
@@ -4,10 +4,6 @@ import Jama.Matrix;
 import Jama.SingularValueDecomposition;
 import hex.pca.PCAInterface;
 
-/**
- * @author mathemage <ha@h2o.ai>
- * created on 1.5.17
- */
 public class PCAJama implements PCAInterface {
   private Matrix gramMatrix;
   private SingularValueDecomposition svd;

--- a/h2o-algos/src/main/java/hex/pca/jama/PCAJama.java
+++ b/h2o-algos/src/main/java/hex/pca/jama/PCAJama.java
@@ -1,0 +1,35 @@
+package hex.pca.jama;
+
+import Jama.Matrix;
+import Jama.SingularValueDecomposition;
+import hex.pca.PCAInterface;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ * created on 1.5.17
+ */
+public class PCAJama implements PCAInterface {
+  private Matrix gramMatrix;
+  private SingularValueDecomposition svd;
+  private double[][] rightEigenvectors;
+
+  public PCAJama(double[][] gramMatrix) {
+    this.gramMatrix = new Matrix(gramMatrix);
+    runSVD();
+  }
+
+  @Override
+  public double[] getVariances() {
+    return svd.getSingularValues();
+  }
+
+  @Override
+  public double[][] getPrincipalComponents() {
+    return rightEigenvectors;
+  }
+
+  private void runSVD() {
+    svd = gramMatrix.svd();
+    rightEigenvectors = svd.getV().getArray();
+  }
+}

--- a/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_DenseMatrix.java
+++ b/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_DenseMatrix.java
@@ -1,0 +1,54 @@
+package hex.pca.mtj;
+
+import hex.pca.PCAInterface;
+import hex.util.EigenPair;
+import hex.util.LinearAlgebraUtils;
+import no.uib.cipr.matrix.DenseMatrix;
+import no.uib.cipr.matrix.Matrix;
+import no.uib.cipr.matrix.NotConvergedException;
+import water.util.ArrayUtils;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ *         created on 1.5.17
+ */
+public class PCA_MTJ_EVD_DenseMatrix implements PCAInterface {
+  private DenseMatrix gramMatrix;
+  private no.uib.cipr.matrix.EVD evd;
+  private double[] eigenvalues;
+  private double[][] eigenvectors;
+
+  public PCA_MTJ_EVD_DenseMatrix(double[][] gramMatrix) {
+    this.gramMatrix = new DenseMatrix(gramMatrix);
+    runEVD();
+  }
+
+  private void runEVD() {
+    int gramDimension = gramMatrix.numRows();
+    try {
+      evd = no.uib.cipr.matrix.EVD.factorize(gramMatrix);
+    } catch (NotConvergedException e) {
+      throw new RuntimeException(e);
+    }
+    // initial eigenpairs
+    eigenvalues = evd.getRealEigenvalues();
+    Matrix eigenvectorMatrix = evd.getRightEigenvectors();
+    eigenvectors = LinearAlgebraUtils.reshape1DArray(((DenseMatrix) eigenvectorMatrix).getData(), gramDimension,
+        gramDimension);
+
+    // sort eigenpairs in descending order according to the magnitude of eigenvalues
+    EigenPair[] eigenPairs = LinearAlgebraUtils.createReverseSortedEigenpairs(eigenvalues, eigenvectors);
+    eigenvalues = LinearAlgebraUtils.extractEigenvaluesFromEigenpairs(eigenPairs);
+    eigenvectors = ArrayUtils.transpose(LinearAlgebraUtils.extractEigenvectorsFromEigenpairs(eigenPairs));
+  }
+
+  @Override
+  public double[] getVariances() {
+    return eigenvalues;
+  }
+
+  @Override
+  public double[][] getPrincipalComponents() {
+    return eigenvectors;
+  }
+}

--- a/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_DenseMatrix.java
+++ b/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_DenseMatrix.java
@@ -8,10 +8,6 @@ import no.uib.cipr.matrix.Matrix;
 import no.uib.cipr.matrix.NotConvergedException;
 import water.util.ArrayUtils;
 
-/**
- * @author mathemage <ha@h2o.ai>
- *         created on 1.5.17
- */
 public class PCA_MTJ_EVD_DenseMatrix implements PCAInterface {
   private DenseMatrix gramMatrix;
   private no.uib.cipr.matrix.EVD evd;

--- a/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_SymmMatrix.java
+++ b/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_SymmMatrix.java
@@ -1,0 +1,53 @@
+package hex.pca.mtj;
+
+import hex.pca.PCAInterface;
+import hex.util.EigenPair;
+import hex.util.LinearAlgebraUtils;
+import no.uib.cipr.matrix.DenseMatrix;
+import no.uib.cipr.matrix.NotConvergedException;
+import no.uib.cipr.matrix.UpperSymmDenseMatrix;
+import water.util.ArrayUtils;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ * created on 1.5.17
+ */
+public class PCA_MTJ_EVD_SymmMatrix implements PCAInterface {
+  private UpperSymmDenseMatrix symmGramMatrix;
+  private no.uib.cipr.matrix.SymmDenseEVD symmDenseEVD;
+  private double[][] eigenvectors;
+  private double[] eigenvalues;
+
+  public PCA_MTJ_EVD_SymmMatrix(double[][] gramMatrix) {
+    this.symmGramMatrix = new UpperSymmDenseMatrix(new DenseMatrix(gramMatrix));
+    runEVD();
+  }
+
+  @Override
+  public double[] getVariances() {
+    return eigenvalues;
+  }
+
+  @Override
+  public double[][] getPrincipalComponents() {
+    return eigenvectors;
+  }
+
+  private void runEVD() {
+    int gramDimension = symmGramMatrix.numRows();
+    try {
+      symmDenseEVD = no.uib.cipr.matrix.SymmDenseEVD.factorize(this.symmGramMatrix);
+    } catch (NotConvergedException e) {
+      throw new RuntimeException(e);
+    }
+    // initial eigenpairs
+    eigenvalues = symmDenseEVD.getEigenvalues();
+    double[] Vt_1D = symmDenseEVD.getEigenvectors().getData();
+    eigenvectors = LinearAlgebraUtils.reshape1DArray(Vt_1D, gramDimension, gramDimension);
+
+    // sort eigenpairs in descending order according to the magnitude of eigenvalues
+    EigenPair[] eigenPairs = LinearAlgebraUtils.createReverseSortedEigenpairs(eigenvalues, eigenvectors);
+    eigenvalues = LinearAlgebraUtils.extractEigenvaluesFromEigenpairs(eigenPairs);
+    eigenvectors = ArrayUtils.transpose(LinearAlgebraUtils.extractEigenvectorsFromEigenpairs(eigenPairs));
+  }
+}

--- a/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_SymmMatrix.java
+++ b/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_EVD_SymmMatrix.java
@@ -8,10 +8,6 @@ import no.uib.cipr.matrix.NotConvergedException;
 import no.uib.cipr.matrix.UpperSymmDenseMatrix;
 import water.util.ArrayUtils;
 
-/**
- * @author mathemage <ha@h2o.ai>
- * created on 1.5.17
- */
 public class PCA_MTJ_EVD_SymmMatrix implements PCAInterface {
   private UpperSymmDenseMatrix symmGramMatrix;
   private no.uib.cipr.matrix.SymmDenseEVD symmDenseEVD;

--- a/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_SVD_DenseMatrix.java
+++ b/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_SVD_DenseMatrix.java
@@ -1,0 +1,42 @@
+package hex.pca.mtj;
+
+import hex.pca.PCAInterface;
+import hex.util.LinearAlgebraUtils;
+import no.uib.cipr.matrix.DenseMatrix;
+import no.uib.cipr.matrix.NotConvergedException;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ * created on 1.5.17
+ */
+public class PCA_MTJ_SVD_DenseMatrix implements PCAInterface {
+  private DenseMatrix gramMatrix;
+  private no.uib.cipr.matrix.SVD svd;
+  private double[][] rightEigenvectors;
+
+  public PCA_MTJ_SVD_DenseMatrix(double[][] gramMatrix) {
+    this.gramMatrix = new DenseMatrix(gramMatrix);
+    runSVD();
+  }
+
+  @Override
+  public double[] getVariances() {
+    return svd.getS();
+  }
+
+  @Override
+  public double[][] getPrincipalComponents() {
+    return rightEigenvectors;
+  }
+
+  private void runSVD() {
+    int gramDimension = gramMatrix.numRows();
+    try {
+      svd = new no.uib.cipr.matrix.SVD(gramDimension, gramDimension).factor(gramMatrix);
+    } catch (NotConvergedException e) {
+      throw new RuntimeException(e);
+    }
+    double[] Vt_1D = svd.getVt().getData();
+    rightEigenvectors = LinearAlgebraUtils.reshape1DArray(Vt_1D, gramDimension, gramDimension);
+  }
+}

--- a/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_SVD_DenseMatrix.java
+++ b/h2o-algos/src/main/java/hex/pca/mtj/PCA_MTJ_SVD_DenseMatrix.java
@@ -5,10 +5,6 @@ import hex.util.LinearAlgebraUtils;
 import no.uib.cipr.matrix.DenseMatrix;
 import no.uib.cipr.matrix.NotConvergedException;
 
-/**
- * @author mathemage <ha@h2o.ai>
- * created on 1.5.17
- */
 public class PCA_MTJ_SVD_DenseMatrix implements PCAInterface {
   private DenseMatrix gramMatrix;
   private no.uib.cipr.matrix.SVD svd;

--- a/h2o-algos/src/main/java/hex/schemas/PCAV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/PCAV3.java
@@ -3,6 +3,7 @@ package hex.schemas;
 import hex.DataInfo;
 import hex.pca.PCA;
 import hex.pca.PCAModel.PCAParameters;
+import hex.pca.PCAImplementation;
 import water.api.API;
 import water.api.schemas3.ModelParametersSchemaV3;
 
@@ -35,7 +36,7 @@ public class PCAV3 extends ModelBuilderSchema<PCA,PCAV3,PCAV3.PCAParametersV3> {
     public PCAParameters.Method pca_method;
   
     @API(help = "Implementation for computing PCA (via SVD or EVD)", values = { "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA" })
-    public PCAParameters.Method pca_implementation;
+    public PCAImplementation pca_implementation;
     
     @API(help = "Rank of matrix approximation", required = true, direction = API.Direction.INOUT, gridable = true)
     public int k;

--- a/h2o-algos/src/main/java/hex/schemas/PCAV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/PCAV3.java
@@ -19,7 +19,7 @@ public class PCAV3 extends ModelBuilderSchema<PCA,PCAV3,PCAV3.PCAParametersV3> {
       "score_each_iteration",
       "transform",
       "pca_method",
-      "pca_implementation",
+      "pca_impl",
       "k",
       "max_iterations",
       "use_all_factor_levels",
@@ -51,7 +51,7 @@ public class PCAV3 extends ModelBuilderSchema<PCA,PCAV3,PCAV3.PCAParametersV3> {
                     "JAMA - http://math.nist.gov/javanumerics/jama/; " +
                     "MTJ - https://github.com/fommil/matrix-toolkits-java/",
             values = { "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA" })
-    public PCAImplementation pca_implementation;
+    public PCAImplementation pca_impl;
     
     @API(help = "Rank of matrix approximation", required = true, direction = API.Direction.INOUT, gridable = true)
     public int k;

--- a/h2o-algos/src/main/java/hex/schemas/PCAV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/PCAV3.java
@@ -32,10 +32,25 @@ public class PCAV3 extends ModelBuilderSchema<PCA,PCAV3,PCAV3.PCAParametersV3> {
     @API(help = "Transformation of training data", values = { "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE" }, gridable = true)  // TODO: pull out of categorical class
     public DataInfo.TransformType transform;
 
-    @API(help = "Method for computing PCA (Caution: GLRM is currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized", "GLRM" })   // TODO: pull out of categorical class
+    @API(
+            help =  "Specify the algorithm to use for computing the principal components: " +
+                    "GramSVD - uses a distributed computation of the Gram matrix, followed by a local SVD; " +
+                    "Power - computes the SVD using the power iteration method (experimental); " +
+                    "Randomized - uses randomized subspace iteration method; " +
+                    "GLRM - fits a generalized low-rank model with L2 loss function and no regularization and solves for the SVD using local matrix algebra (experimental)",
+            values = { "GramSVD", "Power", "Randomized", "GLRM" })   // TODO: pull out of categorical class
     public PCAParameters.Method pca_method;
   
-    @API(help = "Implementation for computing PCA (via SVD or EVD)", values = { "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA" })
+    @API(
+            help =  "Specify the implementation to use for computing PCA (via SVD or EVD): " +
+                    "MTJ_EVD_DENSEMATRIX - eigenvalue decompositions for dense matrix using MTJ; " +
+                    "MTJ_EVD_SYMMMATRIX - eigenvalue decompositions for symmetric matrix using MTJ; " +
+                    "MTJ_SVD_DENSEMATRIX - singular-value decompositions for dense matrix using MTJ; " +
+                    "JAMA - eigenvalue decompositions for dense matrix using JAMA. " +
+                    "References: " +
+                    "JAMA - http://math.nist.gov/javanumerics/jama/; " +
+                    "MTJ - https://github.com/fommil/matrix-toolkits-java/",
+            values = { "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA" })
     public PCAImplementation pca_implementation;
     
     @API(help = "Rank of matrix approximation", required = true, direction = API.Direction.INOUT, gridable = true)

--- a/h2o-algos/src/main/java/hex/schemas/PCAV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/PCAV3.java
@@ -18,6 +18,7 @@ public class PCAV3 extends ModelBuilderSchema<PCA,PCAV3,PCAV3.PCAParametersV3> {
       "score_each_iteration",
       "transform",
       "pca_method",
+      "pca_implementation",
       "k",
       "max_iterations",
       "use_all_factor_levels",
@@ -32,7 +33,10 @@ public class PCAV3 extends ModelBuilderSchema<PCA,PCAV3,PCAV3.PCAParametersV3> {
 
     @API(help = "Method for computing PCA (Caution: GLRM is currently experimental and unstable)", values = { "GramSVD", "Power", "Randomized", "GLRM" })   // TODO: pull out of categorical class
     public PCAParameters.Method pca_method;
-
+  
+    @API(help = "Implementation for computing PCA (via SVD or EVD)", values = { "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA" })
+    public PCAParameters.Method pca_implementation;
+    
     @API(help = "Rank of matrix approximation", required = true, direction = API.Direction.INOUT, gridable = true)
     public int k;
 

--- a/h2o-algos/src/main/java/hex/svd/SVD.java
+++ b/h2o-algos/src/main/java/hex/svd/SVD.java
@@ -32,7 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import static hex.util.DimensionReductionUtils.createScoringHistoryTableDR;
-import static hex.util.DimensionReductionUtils.transformEigenVectors;
+import static hex.util.DimensionReductionUtils.getTransformedEigenvectors;
 import static java.lang.StrictMath.sqrt;
 import static water.util.ArrayUtils.*;
 
@@ -744,7 +744,7 @@ public class SVD extends ModelBuilder<SVDModel,SVDModel.SVDParameters,SVDModel.S
             for (int vecIndex = 0; vecIndex < _parms._nv; vecIndex++) {
               model._output._d[vecIndex] = Math.sqrt(model._output._nobs*_estimatedSingularValues[vecIndex]);
             }
-            model._output._v = transformEigenVectors(dinfo, transpose(model._output._v));
+            model._output._v = getTransformedEigenvectors(dinfo, transpose(model._output._v));
           }
 
           if (!_wideDataset) {

--- a/h2o-algos/src/main/java/hex/util/DimensionReductionUtils.java
+++ b/h2o-algos/src/main/java/hex/util/DimensionReductionUtils.java
@@ -113,9 +113,9 @@ public class DimensionReductionUtils {
      * 
      * @param dinfo
      * @param vEigenIn
-     * @return
+     * @return transformed eigenvectors
      */
-    public static double[][] transformEigenVectors(DataInfo dinfo, double[][] vEigenIn) {
+    public static double[][] getTransformedEigenvectors(DataInfo dinfo, double[][] vEigenIn) {
         Frame tempFrame = new Frame(dinfo._adaptedFrame);
         Frame eigFrame = new water.util.ArrayUtils().frame(vEigenIn);
         tempFrame.add(eigFrame);

--- a/h2o-algos/src/main/java/hex/util/EigenPair.java
+++ b/h2o-algos/src/main/java/hex/util/EigenPair.java
@@ -1,9 +1,5 @@
 package hex.util;
 
-/**
- * @author mathemage <ha@h2o.ai>
- * created on 18.5.17
- */
 public class EigenPair implements Comparable<EigenPair> {
   public double eigenvalue;
   public double[] eigenvector;
@@ -14,7 +10,6 @@ public class EigenPair implements Comparable<EigenPair> {
   }
 
   /**
-   * @author mathemage <ha@h2o.ai>
    * Compare an eigenPair = (eigenvalue, eigenVector) against otherEigenPair based on respective eigenValues
    */
   @Override

--- a/h2o-algos/src/main/java/hex/util/EigenPair.java
+++ b/h2o-algos/src/main/java/hex/util/EigenPair.java
@@ -1,0 +1,24 @@
+package hex.util;
+
+/**
+ * @author mathemage <ha@h2o.ai>
+ * created on 18.5.17
+ */
+public class EigenPair implements Comparable<EigenPair> {
+  public double eigenvalue;
+  public double[] eigenvector;
+
+  public EigenPair(double eigenvalue, double[] eigenvector) {
+    this.eigenvalue = eigenvalue;
+    this.eigenvector = eigenvector;
+  }
+
+  /**
+   * @author mathemage <ha@h2o.ai>
+   * Compare an eigenPair = (eigenvalue, eigenVector) against otherEigenPair based on respective eigenValues
+   */
+  @Override
+  public int compareTo(EigenPair otherEigenPair) {
+    return eigenvalue < otherEigenPair.eigenvalue ? -1 : (eigenvalue > otherEigenPair.eigenvalue ? 1 : 0);
+  }
+}

--- a/h2o-algos/src/main/java/hex/util/LinearAlgebraUtils.java
+++ b/h2o-algos/src/main/java/hex/util/LinearAlgebraUtils.java
@@ -15,6 +15,9 @@ import water.fvec.Vec;
 import water.util.ArrayUtils;
 import water.util.Log;
 
+import static java.util.Arrays.sort;
+import static org.apache.commons.lang.ArrayUtils.reverse;
+
 public class LinearAlgebraUtils {
   /*
    * Forward substitution: Solve Lx = b for x with L = lower triangular matrix, b = real vector
@@ -77,6 +80,48 @@ public class LinearAlgebraUtils {
       exp_cnt++; chk_cnt++;
     }
     return tmp;
+  }
+
+  public static double[][] reshape1DArray(double[] arr, int m, int n) {
+    double[][] arr2D = new double[m][n];
+    for (int i = 0; i < m; i++) {
+      System.arraycopy(arr, i * n, arr2D[i], 0, n);
+    }
+    return arr2D;
+  }
+
+  public static EigenPair[] createSortedEigenpairs(double[] eigenvalues, double[][] eigenvectors) {
+    int count = eigenvalues.length;
+    EigenPair eigenPairs[] = new EigenPair[count];
+    for (int i = 0; i < count; i++) {
+      eigenPairs[i] = new EigenPair(eigenvalues[i], eigenvectors[i]);
+    }
+    sort(eigenPairs);
+    return eigenPairs;
+  }
+
+  public static EigenPair[] createReverseSortedEigenpairs(double[] eigenvalues, double[][] eigenvectors) {
+    EigenPair[] eigenPairs = createSortedEigenpairs(eigenvalues, eigenvectors);
+    reverse(eigenPairs);
+    return eigenPairs;
+  }
+
+  public static double[] extractEigenvaluesFromEigenpairs(EigenPair[] eigenPairs) {
+    int count = eigenPairs.length;
+    double[] eigenvalues = new double[count];
+    for (int i = 0; i < count; i++) {
+      eigenvalues[i] = eigenPairs[i].eigenvalue;
+    }
+    return eigenvalues;
+  }
+
+  public static double[][] extractEigenvectorsFromEigenpairs(EigenPair[] eigenPairs) {
+    int count = eigenPairs.length;
+    double[][] eigenvectors = new double[count][];
+    for (int i = 0; i < count; i++) {
+      eigenvectors[i] = eigenPairs[i].eigenvector;
+    }
+    return eigenvectors;
   }
 
   /**
@@ -444,4 +489,28 @@ public class LinearAlgebraUtils {
   public static ToEigenVec toEigen = new ToEigenVec() {
     @Override public Vec toEigenVec(Vec src) { return toEigen(src); }
   };
+
+  public static String getMatrixInString(double[][] matrix) {
+    int dimX = matrix.length;
+    if (dimX <= 0) {
+      return "";
+    }
+    int dimY = matrix[0].length;
+    for (int x = 1; x < dimX; x++) {
+      if (matrix[x].length != dimY) {
+        return "Stacked matrix!";
+      }
+    }
+    StringBuilder stringOfMatrix = new StringBuilder();
+    for (int x = 0; x < dimX; x++) {
+      for (int y = 0; y < dimY; y++) {
+        if (matrix[x][y] > 0) {
+          stringOfMatrix.append(' ');   // a leading space before a number
+        }
+        stringOfMatrix.append(String.format("%.4f\t", matrix[x][y]));
+      }
+      stringOfMatrix.append('\n');
+    }
+    return stringOfMatrix.toString();
+  }
 }

--- a/h2o-algos/src/test/java/hex/pca/PCATest.java
+++ b/h2o-algos/src/test/java/hex/pca/PCATest.java
@@ -4,8 +4,13 @@ import hex.DataInfo;
 import hex.SplitFrame;
 import hex.pca.PCAModel.PCAParameters;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import water.DKV;
 import water.Key;
 import water.Scope;
@@ -17,56 +22,25 @@ import water.util.FrameUtils;
 
 import java.util.concurrent.ExecutionException;
 
+@RunWith(Parameterized.class)
 public class PCATest extends TestUtil {
   public static final double TOLERANCE = 1e-6;
+  private PCAParameters pcaParameters;
+
+  @Parameters
+  public static PCAImplementation[] parametersForSvdImplementation() {
+    return hex.pca.PCAImplementation.values();
+  }
+
+  @Parameter
+  public PCAImplementation PCAImplementation;
+
   @BeforeClass public static void setup() { stall_till_cloudsize(1); }
 
-  @Test public void testArrests() throws InterruptedException, ExecutionException {
-    // Results with de-meaned training frame
-    double[] stddev = new double[] {83.732400, 14.212402, 6.489426, 2.482790};
-    double[][] eigvec = ard(ard(0.04170432, -0.04482166, 0.07989066, -0.99492173),
-                            ard(0.99522128, -0.05876003, -0.06756974, 0.03893830),
-                            ard(0.04633575, 0.97685748, -0.20054629, -0.05816914),
-                            ard(0.07515550, 0.20071807, 0.97408059, 0.07232502));
-
-    // Results with standardized training frame
-    double[] stddev_std = new double[] {1.5748783, 0.9948694, 0.5971291, 0.4164494};
-    double[][] eigvec_std = ard(ard(-0.5358995, 0.4181809, -0.3412327, 0.64922780),
-                                ard(-0.5831836, 0.1879856, -0.2681484, -0.74340748),
-                                ard(-0.2781909, -0.8728062, -0.3780158, 0.13387773),
-                                ard(-0.5434321, -0.1673186, 0.8177779, 0.08902432));
-
-    Frame train = null;
-    try {
-      train = parse_test_file(Key.make("arrests.hex"), "smalldata/pca_test/USArrests.csv");   // TODO: Move this outside loop
-      for (DataInfo.TransformType std : new DataInfo.TransformType[] {
-              DataInfo.TransformType.DEMEAN,
-              DataInfo.TransformType.STANDARDIZE }) {
-        PCAModel model = null;
-        try {
-          PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-          parms._train = train._key;
-          parms._k = 4;
-          parms._transform = std;
-          parms._max_iterations = 1000;
-          parms._pca_method = PCAParameters.Method.Power;
-
-          model = new PCA(parms).trainModel().get();
-
-          if (std == DataInfo.TransformType.DEMEAN) {
-            TestUtil.checkStddev(stddev, model._output._std_deviation, TOLERANCE);
-            TestUtil.checkEigvec(eigvec, model._output._eigenvectors, TOLERANCE);
-          } else if (std == DataInfo.TransformType.STANDARDIZE) {
-            TestUtil.checkStddev(stddev_std, model._output._std_deviation, TOLERANCE);
-            TestUtil.checkEigvec(eigvec_std, model._output._eigenvectors, TOLERANCE);
-          }
-        } finally {
-          if( model != null ) model.delete();
-        }
-      }
-    } finally {
-      if(train != null) train.delete();
-    }
+  @Before public void setupPcaParameters() {
+    pcaParameters = new PCAParameters();
+    pcaParameters._pca_implementation = PCAImplementation;
+    water.util.Log.info("pcaParameters._PCAImplementation: " + pcaParameters._pca_implementation.name());
   }
 
   @Test public void testArrestsScoring() throws InterruptedException, ExecutionException {
@@ -81,61 +55,19 @@ public class PCATest extends TestUtil {
     Frame train = null, score = null, scoreR = null;
     try {
       train = parse_test_file(Key.make("arrests.hex"), "smalldata/pca_test/USArrests.csv");
-      PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-      parms._train = train._key;
-      parms._k = 4;
-      parms._transform = DataInfo.TransformType.NONE;
-      parms._pca_method = PCAParameters.Method.GramSVD;
+      pcaParameters._train = train._key;
+      pcaParameters._k = 4;
+      pcaParameters._transform = DataInfo.TransformType.NONE;
+      pcaParameters._pca_method = PCAParameters.Method.GramSVD;
 
-      model = new PCA(parms).trainModel().get();
+      model = new PCA(pcaParameters).trainModel().get();
       TestUtil.checkStddev(stddev, model._output._std_deviation, 1e-5);
       boolean[] flippedEig = TestUtil.checkEigvec(eigvec, model._output._eigenvectors, 1e-5);
 
       score = model.score(train);
       scoreR = parse_test_file(Key.make("scoreR.hex"), "smalldata/pca_test/USArrests_PCAscore.csv");
-      TestUtil.checkProjection(scoreR, score, TOLERANCE, flippedEig);    // Flipped cols must match those from eigenvectors
-
-      // Build a POJO, validate same results
-      Assert.assertTrue(model.testJavaScoring(train,score,1e-5));
-    } finally {
-      if (train != null) train.delete();
-      if (score != null) score.delete();
-      if (scoreR != null) scoreR.delete();
-      if (model != null) model.delete();
-    }
-  }
-
-
-
-  @Test public void testIrisScoring() throws InterruptedException, ExecutionException {
-    // Results with original training frame
-    double[] stddev = new double[] {7.88175203, 1.56002774, 0.59189816, 0.25917329, 0.15415273, 0.09381276, 0.04768590};
-    double[][] eigvec = ard(ard(-0.03169051, -0.32305860,  0.185100382, -0.12336685, -0.14867156,  0.75932119, -0.496462912),
-                            ard(-0.04289677,  0.04037565, -0.780961964,  0.19727933,  0.07251338, -0.12216945, -0.572298338),
-                            ard(-0.05019689,  0.16836717,  0.551432201, -0.07122329,  0.08454116, -0.48327010, -0.647522462),
-                            ard(-0.74915107, -0.26629420, -0.101102186, -0.48920057,  0.32458460, -0.09176909,  0.067412858),
-                            ard(-0.37877011, -0.50636060,  0.142219195,  0.69081642, -0.26312992, -0.17811871,  0.041411296),
-                            ard(-0.51177078,  0.65945159, -0.005079934,  0.04881900, -0.52128288,  0.17038367,  0.006223427),
-                            ard(-0.16742875,  0.32166036,  0.145893901,  0.47102115,  0.72052968,  0.32523458,  0.020389463));
-
-    PCAModel model = null;
-    Frame train = null, score = null, scoreR = null;
-    try {
-      train = parse_test_file(Key.make("iris.hex"), "smalldata/iris/iris_wheader.csv");
-      PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-      parms._train = train._key;
-      parms._k = 7;
-      parms._transform = DataInfo.TransformType.NONE;
-      parms._use_all_factor_levels = true;
-      parms._pca_method = PCAParameters.Method.Power;
-
-      model = new PCA(parms).trainModel().get();
-      TestUtil.checkStddev(stddev, model._output._std_deviation, 1e-5);
-      boolean[] flippedEig = TestUtil.checkEigvec(eigvec, model._output._eigenvectors, 1e-5);
-
-      score = model.score(train);
-      scoreR = parse_test_file(Key.make("scoreR.hex"), "smalldata/pca_test/iris_PCAscore.csv");
-      TestUtil.checkProjection(scoreR, score, TOLERANCE, flippedEig);    // Flipped cols must match those from eigenvectors
+//      TestUtil.checkProjection(scoreR, score, TOLERANCE, flippedEig);    // Flipped cols must match those from eigenvectors
+      TestUtil.checkProjection(scoreR, score, 1e-6, flippedEig);    // Flipped cols must match those from eigenvectors
 
       // Build a POJO, validate same results
       Assert.assertTrue(model.testJavaScoring(train,score,1e-5));
@@ -162,14 +94,13 @@ public class PCATest extends TestUtil {
       tr = DKV.get(ksplits[0]).get();
       te = DKV.get(ksplits[1]).get();
 
-      PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-      parms._train = ksplits[0];
-      parms._valid = ksplits[1];
-      parms._k = 4;
-      parms._max_iterations = 1000;
-      parms._pca_method = PCAParameters.Method.GramSVD;
+      pcaParameters._train = ksplits[0];
+      pcaParameters._valid = ksplits[1];
+      pcaParameters._k = 4;
+      pcaParameters._max_iterations = 1000;
+      pcaParameters._pca_method = PCAParameters.Method.GramSVD;
 
-      model = new PCA(parms).trainModel().get();
+      model = new PCA(pcaParameters).trainModel().get();
 
       // Done building model; produce a score column with cluster choices
       fr2 = model.score(te);
@@ -177,8 +108,8 @@ public class PCATest extends TestUtil {
     } finally {
       if( fr  != null ) fr.delete();
       if( fr2 != null ) fr2.delete();
-      if( tr  != null ) tr .delete();
-      if( te  != null ) te .delete();
+      if( tr  != null ) tr.delete();
+      if( te  != null ) te.delete();
       if (model != null) model.delete();
     }
   }
@@ -199,31 +130,19 @@ public class PCATest extends TestUtil {
         DKV.remove(frtmp._key); // Delete the frame header (not the data)
       }
 
-      PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-      parms._train = train._key;
-      parms._k = 4;
-      parms._transform = DataInfo.TransformType.NONE;
-      parms._pca_method = PCAModel.PCAParameters.Method.GramSVD;
-      parms._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
-      parms._seed = seed;
+      pcaParameters._train = train._key;
+      pcaParameters._k = 4;
+      pcaParameters._transform = DataInfo.TransformType.NONE;
+      pcaParameters._pca_method = PCAModel.PCAParameters.Method.GramSVD;
+      pcaParameters._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
+      pcaParameters._seed = seed;
 
       PCAModel pca = null;
-      pca = new PCA(parms).trainModel().get();
+      pca = new PCA(pcaParameters).trainModel().get();
       if (pca != null) pca.remove();
     } finally {
       if (train != null) train.delete();
     }
-  }
-
-  @Test public void testGram() {
-    double[][] x = ard(ard(1, 2, 3), ard(4, 5, 6));
-    double[][] xgram = ard(ard(17, 22, 27), ard(22, 29, 36), ard(27, 36, 45));  // X'X
-    double[][] xtgram = ard(ard(14, 32), ard(32, 77));    // (X')'X' = XX'
-
-    double[][] xgram_glrm = ArrayUtils.formGram(x, false);
-    double[][] xtgram_glrm = ArrayUtils.formGram(x, true);
-    Assert.assertArrayEquals(xgram, xgram_glrm);
-    Assert.assertArrayEquals(xtgram, xtgram_glrm);
   }
 
   /* Make sure POJO works if the model is only built from categorical variables (no numeric columns) */
@@ -240,16 +159,15 @@ public class PCATest extends TestUtil {
         }
       }
       DKV.put(train);
-      PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-      parms._train = train._key;
-      parms._k = 2;
-      parms._transform = DataInfo.TransformType.STANDARDIZE;
-      parms._use_all_factor_levels = true;
-      parms._pca_method = PCAParameters.Method.GramSVD;
-      parms._impute_missing = false;
-      parms._seed = 12345;
+      pcaParameters._train = train._key;
+      pcaParameters._k = 2;
+      pcaParameters._transform = DataInfo.TransformType.STANDARDIZE;
+      pcaParameters._use_all_factor_levels = true;
+      pcaParameters._pca_method = PCAParameters.Method.GramSVD;
+      pcaParameters._impute_missing = false;
+      pcaParameters._seed = 12345;
 
-      PCA pcaParms = new PCA(parms);
+      PCA pcaParms = new PCA(pcaParameters);
       model = pcaParms.trainModel().get(); // get normal data
       score = model.score(train);
 
@@ -262,9 +180,7 @@ public class PCATest extends TestUtil {
     }
   }
 
-  /*
-  Quick test to make sure changes made to PCA for rank deficient matrices do not cause leakage.
-   */
+  /* Quick test to make sure changes made to PCA for rank deficient matrices do not cause leakage. */
   @Test public void testPUBDEV3500NoLeakage() throws InterruptedException, ExecutionException {
     Scope.enter();
     Frame train = null;
@@ -272,17 +188,16 @@ public class PCATest extends TestUtil {
       train = parse_test_file(Key.make("prostate_cat.hex"), "smalldata/prostate/prostate_cat.csv");
       Scope.track(train);
 
-      PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-      parms._train = train._key;
-      parms._k = 3;
-      parms._transform = DataInfo.TransformType.NONE;
-      parms._pca_method = PCAModel.PCAParameters.Method.Randomized;
-      parms._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
-      parms._seed = 12345;
-      parms._use_all_factor_levels=true;
+      pcaParameters._train = train._key;
+      pcaParameters._k = 3;
+      pcaParameters._transform = DataInfo.TransformType.NONE;
+      pcaParameters._pca_method = PCAModel.PCAParameters.Method.Randomized;
+      pcaParameters._impute_missing = true;   // Don't skip rows with NA entries, but impute using mean of column
+      pcaParameters._seed = 12345;
+      pcaParameters._use_all_factor_levels=true;
 
       PCAModel pca = null;
-      pca = new PCA(parms).trainModel().get();
+      pca = new PCA(pcaParameters).trainModel().get();
       Scope.track_generic(pca);
       Assert.assertTrue(pca._parms._k == pca._output._std_deviation.length);
     } finally {
@@ -322,5 +237,102 @@ public class PCATest extends TestUtil {
     } finally {
       Scope.exit();
     }
+  }
+
+  @Test public void testArrests() throws InterruptedException, ExecutionException {
+    // Results with de-meaned training frame
+    double[] stddev = new double[] {83.732400, 14.212402, 6.489426, 2.482790};
+    double[][] eigvec = ard(ard(0.04170432, -0.04482166, 0.07989066, -0.99492173),
+        ard(0.99522128, -0.05876003, -0.06756974, 0.03893830),
+        ard(0.04633575, 0.97685748, -0.20054629, -0.05816914),
+        ard(0.07515550, 0.20071807, 0.97408059, 0.07232502));
+
+    // Results with standardized training frame
+    double[] stddev_std = new double[] {1.5748783, 0.9948694, 0.5971291, 0.4164494};
+    double[][] eigvec_std = ard(ard(-0.5358995, 0.4181809, -0.3412327, 0.64922780),
+        ard(-0.5831836, 0.1879856, -0.2681484, -0.74340748),
+        ard(-0.2781909, -0.8728062, -0.3780158, 0.13387773),
+        ard(-0.5434321, -0.1673186, 0.8177779, 0.08902432));
+
+    Frame train = null;
+    try {
+      train = parse_test_file(Key.make("arrests.hex"), "smalldata/pca_test/USArrests.csv");   // TODO: Move this outside loop
+      for (DataInfo.TransformType std : new DataInfo.TransformType[] {
+          DataInfo.TransformType.DEMEAN,
+          DataInfo.TransformType.STANDARDIZE }) {
+        PCAModel model = null;
+        try {
+          pcaParameters._train = train._key;
+          pcaParameters._k = 4;
+          pcaParameters._transform = std;
+          pcaParameters._max_iterations = 1000;
+          pcaParameters._pca_method = PCAParameters.Method.Power;
+
+          model = new PCA(pcaParameters).trainModel().get();
+
+          if (std == DataInfo.TransformType.DEMEAN) {
+            TestUtil.checkStddev(stddev, model._output._std_deviation, TOLERANCE);
+            TestUtil.checkEigvec(eigvec, model._output._eigenvectors, TOLERANCE);
+          } else if (std == DataInfo.TransformType.STANDARDIZE) {
+            TestUtil.checkStddev(stddev_std, model._output._std_deviation, TOLERANCE);
+            TestUtil.checkEigvec(eigvec_std, model._output._eigenvectors, TOLERANCE);
+          }
+        } finally {
+          if( model != null ) model.delete();
+        }
+      }
+    } finally {
+      if(train != null) train.delete();
+    }
+  }
+
+  @Test public void testIrisScoring() throws InterruptedException, ExecutionException {
+    // Results with original training frame
+    double[] stddev = new double[] {7.88175203, 1.56002774, 0.59189816, 0.25917329, 0.15415273, 0.09381276, 0.04768590};
+    double[][] eigvec = ard(ard(-0.03169051, -0.32305860,  0.185100382, -0.12336685, -0.14867156,  0.75932119, -0.496462912),
+        ard(-0.04289677,  0.04037565, -0.780961964,  0.19727933,  0.07251338, -0.12216945, -0.572298338),
+        ard(-0.05019689,  0.16836717,  0.551432201, -0.07122329,  0.08454116, -0.48327010, -0.647522462),
+        ard(-0.74915107, -0.26629420, -0.101102186, -0.48920057,  0.32458460, -0.09176909,  0.067412858),
+        ard(-0.37877011, -0.50636060,  0.142219195,  0.69081642, -0.26312992, -0.17811871,  0.041411296),
+        ard(-0.51177078,  0.65945159, -0.005079934,  0.04881900, -0.52128288,  0.17038367,  0.006223427),
+        ard(-0.16742875,  0.32166036,  0.145893901,  0.47102115,  0.72052968,  0.32523458,  0.020389463));
+
+    PCAModel model = null;
+    Frame train = null, score = null, scoreR = null;
+    try {
+      train = parse_test_file(Key.make("iris.hex"), "smalldata/iris/iris_wheader.csv");
+      pcaParameters._train = train._key;
+      pcaParameters._k = 7;
+      pcaParameters._transform = DataInfo.TransformType.NONE;
+      pcaParameters._use_all_factor_levels = true;
+      pcaParameters._pca_method = PCAParameters.Method.Power;
+
+      model = new PCA(pcaParameters).trainModel().get();
+      TestUtil.checkStddev(stddev, model._output._std_deviation, 1e-5);
+      boolean[] flippedEig = TestUtil.checkEigvec(eigvec, model._output._eigenvectors, 1e-5);
+
+      score = model.score(train);
+      scoreR = parse_test_file(Key.make("scoreR.hex"), "smalldata/pca_test/iris_PCAscore.csv");
+      TestUtil.checkProjection(scoreR, score, TOLERANCE, flippedEig);    // Flipped cols must match those from eigenvectors
+
+      // Build a POJO, validate same results
+      Assert.assertTrue(model.testJavaScoring(train,score,1e-5));
+    } finally {
+      if (train != null) train.delete();
+      if (score != null) score.delete();
+      if (scoreR != null) scoreR.delete();
+      if (model != null) model.delete();
+    }
+  }
+
+  @Test public void testGram() {
+    double[][] x = ard(ard(1, 2, 3), ard(4, 5, 6));
+    double[][] xgram = ard(ard(17, 22, 27), ard(22, 29, 36), ard(27, 36, 45));  // X'X
+    double[][] xtgram = ard(ard(14, 32), ard(32, 77));    // (X')'X' = XX'
+
+    double[][] xgram_glrm = ArrayUtils.formGram(x, false);
+    double[][] xtgram_glrm = ArrayUtils.formGram(x, true);
+    Assert.assertArrayEquals(xgram, xgram_glrm);
+    Assert.assertArrayEquals(xtgram, xtgram_glrm);
   }
 }

--- a/h2o-algos/src/test/java/hex/pca/PCAWideDataSetsTests.java
+++ b/h2o-algos/src/test/java/hex/pca/PCAWideDataSetsTests.java
@@ -1,8 +1,12 @@
 package hex.pca;
 
 import hex.DataInfo;
+import hex.pca.PCAModel.PCAParameters;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import water.DKV;
 import water.Key;
 import water.Scope;
@@ -13,12 +17,15 @@ import water.util.Log;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
-import static water.TestUtil.parse_test_file;
 import static org.junit.Assert.assertTrue;
+import static org.junit.runners.Parameterized.Parameter;
+import static org.junit.runners.Parameterized.Parameters;
+import static water.TestUtil.parse_test_file;
 
 /**
 	* Created by wendycwong on 2/27/17.
 	*/
+@RunWith(Parameterized.class)
 public class PCAWideDataSetsTests extends TestUtil {
 		public static final double _TOLERANCE = 1e-6;
 		public static  String _smallDataset = "smalldata/pca_test/decathlon.csv";
@@ -27,10 +34,26 @@ public class PCAWideDataSetsTests extends TestUtil {
 										DataInfo.TransformType.STANDARDIZE, DataInfo.TransformType.DEMEAN, DataInfo.TransformType.DESCALE};
 		public Random _rand = new Random();
 		public PCAModel _golden = null;	//
-
+		private PCAParameters pcaParameters;
+	
+		@Parameters
+		public static PCAImplementation[] parametersForSvdImplementation() {
+			return hex.pca.PCAImplementation.values();
+		}
+		
+		@Parameter
+		public PCAImplementation PCAImplementation;
+		
 		@BeforeClass
 		public static void setup() {
 				stall_till_cloudsize(1);
+		}
+		
+		@Before
+		public void setupPcaParameters() {
+			pcaParameters = new PCAParameters();
+			pcaParameters._pca_implementation = PCAImplementation;
+			water.util.Log.info("pcaParameters._PCAImplementation: " + pcaParameters._pca_implementation.name());
 		}
 
 		/*
@@ -49,24 +72,24 @@ public class PCAWideDataSetsTests extends TestUtil {
 		*/
 		@Test
 		public void testWideDataSetGramSVD() throws InterruptedException, ExecutionException {
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.GramSVD,
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.GramSVD,
 												_TOLERANCE, _smallDataset, false, true,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 1
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.GramSVD,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 1
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.GramSVD,
 												_TOLERANCE, _smallDataset, true, true,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 2
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.GramSVD,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 2
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.GramSVD,
 												_TOLERANCE, _smallDataset, false, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 3
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.GramSVD,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 3
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.GramSVD,
 												_TOLERANCE, _smallDataset, true, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 4
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.GramSVD,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 4
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.GramSVD,
 												_TOLERANCE, _prostateDataset, false, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 5
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.GramSVD,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 5
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.GramSVD,
 												_TOLERANCE, _prostateDataset, true, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);		  // case 6
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);		  // case 6
 		}
 
 
@@ -80,24 +103,24 @@ public class PCAWideDataSetsTests extends TestUtil {
 */
 		@Test
 		public void testWideDataSetPower() throws InterruptedException, ExecutionException {
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.Power,
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.Power,
 												_TOLERANCE, _smallDataset, false, true,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 1
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Power, _TOLERANCE, _smallDataset, true, true,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);   // case 2
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Power, _TOLERANCE, _smallDataset, false, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 3
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Power, _TOLERANCE, _smallDataset, true, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 4
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Power, _TOLERANCE, _prostateDataset, false, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 5
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Power, _TOLERANCE, _prostateDataset, true, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 6
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 1
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Power, _TOLERANCE, _smallDataset, true, true,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);   // case 2
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Power, _TOLERANCE, _smallDataset, false, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 3
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Power, _TOLERANCE, _smallDataset, true, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 4
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Power, _TOLERANCE, _prostateDataset, false, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 5
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Power, _TOLERANCE, _prostateDataset, true, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 6
 		}
 
 		/*
@@ -110,24 +133,24 @@ public class PCAWideDataSetsTests extends TestUtil {
 		*/
 		@Test
 		public void testWideDataSetRandomized() throws InterruptedException, ExecutionException {
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, false, true,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 1
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, true, true,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);   // case 2
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, false, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 3
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, true, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 4
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Randomized, _TOLERANCE, _prostateDataset, false, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 5
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD,
-												PCAModel.PCAParameters.Method.Randomized, _TOLERANCE, _prostateDataset, true, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 6
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, false, true,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 1
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, true, true,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);   // case 2
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, false, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 3
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Randomized, _TOLERANCE, _smallDataset, true, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 4
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Randomized, _TOLERANCE, _prostateDataset, false, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 5
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD,
+												PCAParameters.Method.Randomized, _TOLERANCE, _prostateDataset, true, false,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 6
 		}
 
 		/*
@@ -140,21 +163,21 @@ public class PCAWideDataSetsTests extends TestUtil {
 */
 		@Test
 		public void testWideDataSetGLRM() throws InterruptedException, ExecutionException {
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GramSVD, PCAModel.PCAParameters.Method.GLRM,
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GramSVD, PCAParameters.Method.GLRM,
 												0.0001, _smallDataset, false, true,
-												_transformTypes[1]);  // case 1 numerical
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GLRM, PCAModel.PCAParameters.Method.GLRM,_TOLERANCE,
-												_smallDataset, true, true, _transformTypes[_rand.nextInt(_transformTypes.length)]);   // case 2
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GLRM, PCAModel.PCAParameters.Method.GLRM,_TOLERANCE,
-												_smallDataset, false, false, _transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 3
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GLRM, PCAModel.PCAParameters.Method.GLRM,_TOLERANCE,
-												_smallDataset, true, false, _transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 4
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GLRM, PCAModel.PCAParameters.Method.GLRM, _TOLERANCE,
+												_transformTypes[1], pcaParameters);  // case 1 numerical
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GLRM, PCAParameters.Method.GLRM,_TOLERANCE,
+												_smallDataset, true, true, _transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);   // case 2
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GLRM, PCAParameters.Method.GLRM,_TOLERANCE,
+												_smallDataset, false, false, _transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 3
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GLRM, PCAParameters.Method.GLRM,_TOLERANCE,
+												_smallDataset, true, false, _transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 4
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GLRM, PCAParameters.Method.GLRM, _TOLERANCE,
 												_prostateDataset, false, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 5
-				ActualPCATests.testWideDataSets(PCAModel.PCAParameters.Method.GLRM, PCAModel.PCAParameters.Method.GLRM, _TOLERANCE,
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 5
+				ActualPCATests.testWideDataSets(PCAParameters.Method.GLRM, PCAParameters.Method.GLRM, _TOLERANCE,
 												_prostateDataset, true, false,
-												_transformTypes[_rand.nextInt(_transformTypes.length)]);  // case 6
+												_transformTypes[_rand.nextInt(_transformTypes.length)], pcaParameters);  // case 6
 		}
 }
 
@@ -162,9 +185,10 @@ public class PCAWideDataSetsTests extends TestUtil {
 		This class performs the actual PCA tests.
  */
 class ActualPCATests {
-		public static void testWideDataSets(PCAModel.PCAParameters.Method pcaMethod, PCAModel.PCAParameters.Method pcaMethod2,
-																																						double tolerance, String datafile,
-																																						boolean addNAs, boolean removeColumns, DataInfo.TransformType transformType)
+		public static void testWideDataSets(PCAParameters.Method pcaMethod, PCAParameters.Method pcaMethod2,
+		                                    double tolerance, String datafile,
+		                                    boolean addNAs, boolean removeColumns, DataInfo.TransformType transformType,
+		                                    PCAParameters pcaParameters)
 										throws InterruptedException, ExecutionException {
 				Scope.enter();
 				PCAModel modelN = null;     // store PCA models generated with original implementation
@@ -185,23 +209,22 @@ class ActualPCATests {
 						}
 						DKV.put(train);
 
-						PCAModel.PCAParameters parms = new PCAModel.PCAParameters();
-						parms._train = train._key;
-						parms._k = 3;
-						parms._transform = transformType;
-						Log.info("Data transformation applied is "+parms._transform.name());
-						parms._use_all_factor_levels = true;
-						parms._pca_method = pcaMethod;
-						parms._impute_missing = false;
-						parms._seed = 12345;
-						PCA pcaParms = new PCA(parms);
+						pcaParameters._train = train._key;
+						pcaParameters._k = 3;
+						pcaParameters._transform = transformType;
+						Log.info("Data transformation applied is "+pcaParameters._transform.name());
+						pcaParameters._use_all_factor_levels = true;
+						pcaParameters._pca_method = pcaMethod;
+						pcaParameters._impute_missing = false;
+						pcaParameters._seed = 12345;
+						PCA pcaParms = new PCA(pcaParameters);
 						modelN = pcaParms.trainModel().get(); // get normal data
 						scoreN = modelN.score(train);
 						Scope.track(scoreN);
 						Scope.track_generic(modelN);
 
-						parms._pca_method = pcaMethod2;
-						PCA pcaParmsW = new PCA(parms);
+						pcaParameters._pca_method = pcaMethod2;
+						PCA pcaParmsW = new PCA(pcaParameters);
 						pcaParmsW.setWideDataset(true);  // force to treat dataset as wide even though it is not.
 						modelW = pcaParmsW.trainModel().get();
 						scoreW = modelW.score(train);
@@ -213,7 +236,7 @@ class ActualPCATests {
 						boolean[] flippedEig = TestUtil.checkEigvec(modelW._output._eigenvectors, modelN._output._eigenvectors, tolerance);
 						TestUtil.checkProjection(scoreW, scoreN, tolerance, flippedEig);
 
-						if (!(pcaMethod == PCAModel.PCAParameters.Method.GLRM)) {	// GLRM only works with numerical columns well
+						if (!(pcaMethod == PCAParameters.Method.GLRM)) {	// GLRM only works with numerical columns well
 
 								// Build a POJO, check results with original PCA
 								assertTrue(modelN.testJavaScoring(train, scoreN, tolerance));

--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -56,6 +56,26 @@ jar {
   }
 }
 
+
+// Run a single small JVM under heavy memory load, and confirm spilling works
+task testOOM(type: Exec) {
+    dependsOn cpLibs, jar, testJar
+    String iceRoot = project.projectDir.toString() + File.separator + "OOMsandbox" + File.separator + "iceRoot"
+            commandLine 'java', '-ea', '-Xmx1500m', '-Xms1500m', '-XX:+PrintGC', '-Dai.h2o.cleaner', '-cp',
+            'build/libs/h2o-core.jar'+File.pathSeparator+'build/libs/h2o-core-test.jar'+File.pathSeparator+'../lib/*'+File.pathSeparator+'../h2o-genmodel/build/libs/h2o-genmodel.jar',
+            'water.OOMTest', '-ice_root', iceRoot
+    // This is first action for Exec task
+    doFirst {
+      File sandbox = new File(project.projectDir, "OOMsandbox")
+      if (sandbox.exists()) { sandbox.deleteDir() }
+      sandbox.mkdir()
+      FileOutputStream fos = new FileOutputStream(new File(project.projectDir, "OOMsandbox" + File.separator +
+              "water.OOMTest.out"))
+      standardOutput = fos
+      errorOutput = fos
+    }
+}
+
 // The default 'test' behavior is broken in that it does not grok clusters.
 // For H2O, all tests need to be run on a cluster, where each JVM is
 // "free-running" - it's stdout/stderr are NOT hooked by another process.  If
@@ -72,7 +92,7 @@ test {
   exclude '**'
 }
 
-def buildVersionFile = new File(projectDir, "/src/main/java/water/init/BuildVersion.java");
+def buildVersionFile = new File(projectDir, "/src/main/java/water/init/BuildVersion.java")
 
 task generateBuildVersionJava {
   doLast {

--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -56,26 +56,6 @@ jar {
   }
 }
 
-
-// Run a single small JVM under heavy memory load, and confirm spilling works
-task testOOM(type: Exec) {
-    dependsOn cpLibs, jar, testJar
-    String iceRoot = project.projectDir.toString() + File.separator + "OOMsandbox" + File.separator + "iceRoot"
-            commandLine 'java', '-ea', '-Xmx1500m', '-Xms1500m', '-XX:+PrintGC', '-Dai.h2o.cleaner', '-cp',
-            'build/libs/h2o-core.jar'+File.pathSeparator+'build/libs/h2o-core-test.jar'+File.pathSeparator+'../lib/*'+File.pathSeparator+'../h2o-genmodel/build/libs/h2o-genmodel.jar',
-            'water.OOMTest', '-ice_root', iceRoot
-    // This is first action for Exec task
-    doFirst {
-      File sandbox = new File(project.projectDir, "OOMsandbox")
-      if (sandbox.exists()) { sandbox.deleteDir() }
-      sandbox.mkdir()
-      FileOutputStream fos = new FileOutputStream(new File(project.projectDir, "OOMsandbox" + File.separator +
-              "water.OOMTest.out"))
-      standardOutput = fos
-      errorOutput = fos
-    }
-}
-
 // The default 'test' behavior is broken in that it does not grok clusters.
 // For H2O, all tests need to be run on a cluster, where each JVM is
 // "free-running" - it's stdout/stderr are NOT hooked by another process.  If

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -130,7 +130,10 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     @property
     def pca_method(self):
         """
-        Method for computing PCA (Caution: GLRM is currently experimental and unstable)
+        Specify the algorithm to use for computing the principal components: GramSVD - uses a distributed computation of
+        the Gram matrix, followed by a local SVD; Power - computes the SVD using the power iteration method
+        (experimental); Randomized - uses randomized subspace iteration method; GLRM - fits a generalized low-rank model
+        with L2 loss function and no regularization and solves for the SVD using local matrix algebra (experimental)
 
         One of: ``"gram_s_v_d"``, ``"power"``, ``"randomized"``, ``"glrm"``  (default: ``"gram_s_v_d"``).
         """
@@ -145,7 +148,11 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     @property
     def pca_implementation(self):
         """
-        Implementation for computing PCA (via SVD or EVD)
+        Specify the implementation to use for computing PCA (via SVD or EVD): MTJ_EVD_DENSEMATRIX - eigenvalue
+        decompositions for dense matrix using MTJ; MTJ_EVD_SYMMMATRIX - eigenvalue decompositions for symmetric matrix
+        using MTJ; MTJ_SVD_DENSEMATRIX - singular-value decompositions for dense matrix using MTJ; JAMA - eigenvalue
+        decompositions for dense matrix using JAMA. References: JAMA - http://math.nist.gov/javanumerics/jama/; MTJ -
+        https://github.com/fommil/matrix-toolkits-java/
 
         One of: ``"mtj_evd_densematrix"``, ``"mtj_evd_symmmatrix"``, ``"mtj_svd_densematrix"``, ``"jama"``  (default:
         ``"mtj_evd_symmmatrix"``).

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -24,8 +24,8 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
         super(H2OPrincipalComponentAnalysisEstimator, self).__init__()
         self._parms = {}
         names_list = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
-                      "score_each_iteration", "transform", "pca_method", "k", "max_iterations", "use_all_factor_levels",
-                      "compute_metrics", "impute_missing", "seed", "max_runtime_secs"}
+                      "score_each_iteration", "transform", "pca_method", "pca_implementation", "k", "max_iterations",
+                      "use_all_factor_levels", "compute_metrics", "impute_missing", "seed", "max_runtime_secs"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -140,6 +140,22 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     def pca_method(self, pca_method):
         assert_is_type(pca_method, None, Enum("gram_s_v_d", "power", "randomized", "glrm"))
         self._parms["pca_method"] = pca_method
+
+
+    @property
+    def pca_implementation(self):
+        """
+        Implementation for computing PCA (via SVD or EVD)
+
+        One of: ``"mtj_evd_densematrix"``, ``"mtj_evd_symmmatrix"``, ``"mtj_svd_densematrix"``, ``"jama"``  (default:
+        ``"mtj_evd_symmmatrix"``).
+        """
+        return self._parms.get("pca_implementation")
+
+    @pca_implementation.setter
+    def pca_implementation(self, pca_implementation):
+        assert_is_type(pca_implementation, None, Enum("mtj_evd_densematrix", "mtj_evd_symmmatrix", "mtj_svd_densematrix", "jama"))
+        self._parms["pca_implementation"] = pca_implementation
 
 
     @property

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -24,7 +24,7 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
         super(H2OPrincipalComponentAnalysisEstimator, self).__init__()
         self._parms = {}
         names_list = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
-                      "score_each_iteration", "transform", "pca_method", "pca_implementation", "k", "max_iterations",
+                      "score_each_iteration", "transform", "pca_method", "pca_impl", "k", "max_iterations",
                       "use_all_factor_levels", "compute_metrics", "impute_missing", "seed", "max_runtime_secs"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
@@ -146,7 +146,7 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
 
 
     @property
-    def pca_implementation(self):
+    def pca_impl(self):
         """
         Specify the implementation to use for computing PCA (via SVD or EVD): MTJ_EVD_DENSEMATRIX - eigenvalue
         decompositions for dense matrix using MTJ; MTJ_EVD_SYMMMATRIX - eigenvalue decompositions for symmetric matrix
@@ -154,15 +154,14 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
         decompositions for dense matrix using JAMA. References: JAMA - http://math.nist.gov/javanumerics/jama/; MTJ -
         https://github.com/fommil/matrix-toolkits-java/
 
-        One of: ``"mtj_evd_densematrix"``, ``"mtj_evd_symmmatrix"``, ``"mtj_svd_densematrix"``, ``"jama"``  (default:
-        ``"mtj_evd_symmmatrix"``).
+        One of: ``"mtj_evd_densematrix"``, ``"mtj_evd_symmmatrix"``, ``"mtj_svd_densematrix"``, ``"jama"``.
         """
-        return self._parms.get("pca_implementation")
+        return self._parms.get("pca_impl")
 
-    @pca_implementation.setter
-    def pca_implementation(self, pca_implementation):
-        assert_is_type(pca_implementation, None, Enum("mtj_evd_densematrix", "mtj_evd_symmmatrix", "mtj_svd_densematrix", "jama"))
-        self._parms["pca_implementation"] = pca_implementation
+    @pca_impl.setter
+    def pca_impl(self, pca_impl):
+        assert_is_type(pca_impl, None, Enum("mtj_evd_densematrix", "mtj_evd_symmmatrix", "mtj_svd_densematrix", "jama"))
+        self._parms["pca_impl"] = pca_impl
 
 
     @property

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -13,6 +13,7 @@ class H2OPCA(H2OEstimator):
                  transform="NONE",
                  use_all_factor_levels=False,
                  pca_method="GramSVD",
+                 pca_implementation="mtj_evd_symmmatrix",
                  ignore_const_cols=True,
                  impute_missing=False,
                  compute_metrics=True):
@@ -45,7 +46,10 @@ class H2OPCA(H2OEstimator):
             - ``"GLRM"``: fit a generalized low rank model with an l2 loss function (no regularization) and solve for
               the SVD using local matrix algebra.
             - ``"Randomized"``: computation of the SVD using the randomized method from thesis of Nathan P. Halko,
-                Randomized methods for computing low-rank approximation of matrices,
+                Randomized methods for computing low-rank approximation of matrices.
+        :param str pca_implementation: A character string that indicates the implementation to use for
+            computing PCA (via SVD or EVD). One of the following implementations are available: ``"mtj_evd_densematrix"``,
+            ``"mtj_evd_symmmatrix"``, ``"mtj_svd_densematrix"``, ``"jama"``  (default: ``"mtj_evd_symmmatrix"``).
         :param bool ignore_const_cols: If true, will ignore constant columns.  Default is True.
         :param bool impute_missing:  whether to impute NA/missing values.
         :param bool compute_metrics: whether to compute metrics on training data.  Default to True
@@ -58,9 +62,11 @@ class H2OPCA(H2OEstimator):
         self._parms = {k: v for k, v in self._parms.items() if k != "self"}
 
         assert_is_type(pca_method, Enum("GramSVD", "Power", "GLRM", "Randomized"))
-        self._parms["pca_method"]=pca_method
+        self._parms["pca_method"] = pca_method
+        assert_is_type(pca_implementation, Enum("MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"))
+        self._parms["pca_implementation"] = pca_implementation
         assert_is_type(transform, Enum("NONE", "DEMEAN", "DESCALE", "STANDARDIZE", "NORMALIZE"))
-        self._parms["transform"]=transform
+        self._parms["transform"] = transform
 
     def fit(self, X, y=None, **params):
         return super(H2OPCA, self).fit(X)

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -13,7 +13,7 @@ class H2OPCA(H2OEstimator):
                  transform="NONE",
                  use_all_factor_levels=False,
                  pca_method="GramSVD",
-                 pca_implementation="mtj_evd_symmmatrix",
+                 pca_impl="mtj_evd_symmmatrix",
                  ignore_const_cols=True,
                  impute_missing=False,
                  compute_metrics=True):
@@ -47,8 +47,19 @@ class H2OPCA(H2OEstimator):
               the SVD using local matrix algebra.
             - ``"Randomized"``: computation of the SVD using the randomized method from thesis of Nathan P. Halko,
                 Randomized methods for computing low-rank approximation of matrices.
-        :param str pca_implementation: A character string that indicates the implementation to use for
-            computing PCA (via SVD or EVD). One of the following implementations are available: ``"mtj_evd_densematrix"``,
+        :param str pca_impl: A character string that indicates the implementation to use for
+            computing PCA (via SVD or EVD).
+
+            - ``"mtj_evd_densematrix"``: eigenvalue decompositions for dense matrix using MTJ
+            - ``"mtj_evd_symmmatrix"``: eigenvalue decompositions for symmetric matrix using MTJ
+            - ``"mtj_svd_densematrix"``: singular-value decompositions for dense matrix using MTJ
+            - ``"jama"``: eigenvalue decompositions for dense matrix using JAMA
+
+              References:
+              - JAMA: http://math.nist.gov/javanumerics/jama/
+              - MTJ: https://github.com/fommil/matrix-toolkits-java/
+
+            One of the following implementations are available: ``"mtj_evd_densematrix"``,
             ``"mtj_evd_symmmatrix"``, ``"mtj_svd_densematrix"``, ``"jama"``  (default: ``"mtj_evd_symmmatrix"``).
         :param bool ignore_const_cols: If true, will ignore constant columns.  Default is True.
         :param bool impute_missing:  whether to impute NA/missing values.
@@ -63,8 +74,8 @@ class H2OPCA(H2OEstimator):
 
         assert_is_type(pca_method, Enum("GramSVD", "Power", "GLRM", "Randomized"))
         self._parms["pca_method"] = pca_method
-        assert_is_type(pca_implementation, Enum("MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"))
-        self._parms["pca_implementation"] = pca_implementation
+        assert_is_type(pca_impl, Enum("MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"))
+        self._parms["pca_impl"] = pca_impl
         assert_is_type(transform, Enum("NONE", "DEMEAN", "DESCALE", "STANDARDIZE", "NORMALIZE"))
         self._parms["transform"] = transform
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+from builtins import str
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.transforms.decomposition import H2OPCA
+
+
+def pca_arrests():
+  print("Importing USArrests.csv data...")
+  arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
+
+  print("Testing to see whether the trained PCA are essentially the same using different implementation...")
+  for impl in ["MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"]:
+    model = H2OPCA(k = 4, pca_implementation=impl, seed=1234)
+    model.train(x=list(range(4)), training_frame=arrestsH2O)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(pca_arrests)
+else:
+  pca_arrests()

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
@@ -13,9 +13,24 @@ def pca_arrests():
   arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
 
   print("Testing to see whether the trained PCA are essentially the same using different implementation...")
+  
+  eigenvector_standard = None
   for impl in ["MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"]:
+    print("Run PCA with implementation: " + impl)
     model = H2OPCA(k = 4, pca_implementation=impl, seed=1234)
     model.train(x=list(range(4)), training_frame=arrestsH2O)
+    eigenvectors = model._model_json["output"]["eigenvectors"]
+    if eigenvector_standard is not None:
+      # Compare to see if they are fundamentally the same
+      pyunit_utils.assert_H2OTwoDimTable_equal(
+        eigenvector_standard,
+        eigenvectors,
+        model._model_json["output"]["names"],
+        tolerance=1e-6,
+        check_sign=True,
+        check_all=False)
+    else:
+      eigenvector_standard = eigenvectors
 
 if __name__ == "__main__":
   pyunit_utils.standalone_test(pca_arrests)

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
@@ -17,7 +17,7 @@ def pca_arrests():
   eigenvector_standard = None
   for impl in ["MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"]:
     print("Run PCA with implementation: " + impl)
-    model = H2OPCA(k = 4, pca_implementation=impl, seed=1234)
+    model = H2OPCA(k = 4, pca_impl=impl, seed=1234)
     model.train(x=list(range(4)), training_frame=arrestsH2O)
     eigenvectors = model._model_json["output"]["eigenvectors"]
     if eigenvector_standard is not None:

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -21,12 +21,12 @@
 #'        (experimental); Randomized - uses randomized subspace iteration method; GLRM - fits a generalized low-rank
 #'        model with L2 loss function and no regularization and solves for the SVD using local matrix algebra
 #'        (experimental) Must be one of: "GramSVD", "Power", "Randomized", "GLRM". Defaults to GramSVD.
-#' @param pca_implementation Specify the implementation to use for computing PCA (via SVD or EVD): MTJ_EVD_DENSEMATRIX - eigenvalue
+#' @param pca_impl Specify the implementation to use for computing PCA (via SVD or EVD): MTJ_EVD_DENSEMATRIX - eigenvalue
 #'        decompositions for dense matrix using MTJ; MTJ_EVD_SYMMMATRIX - eigenvalue decompositions for symmetric matrix
 #'        using MTJ; MTJ_SVD_DENSEMATRIX - singular-value decompositions for dense matrix using MTJ; JAMA - eigenvalue
 #'        decompositions for dense matrix using JAMA. References: JAMA - http://math.nist.gov/javanumerics/jama/; MTJ -
 #'        https://github.com/fommil/matrix-toolkits-java/ Must be one of: "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX",
-#'        "MTJ_SVD_DENSEMATRIX", "JAMA". Defaults to MTJ_EVD_SYMMMATRIX.
+#'        "MTJ_SVD_DENSEMATRIX", "JAMA".
 #' @param k Rank of matrix approximation Defaults to 1.
 #' @param max_iterations Maximum training iterations Defaults to 1000.
 #' @param use_all_factor_levels \code{Logical}. Whether first factor level is included in each categorical expansion Defaults to FALSE.
@@ -54,7 +54,7 @@ h2o.prcomp <- function(training_frame, x,
                        score_each_iteration = FALSE,
                        transform = c("NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"),
                        pca_method = c("GramSVD", "Power", "Randomized", "GLRM"),
-                       pca_implementation = c("MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"),
+                       pca_impl = c("MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"),
                        k = 1,
                        max_iterations = 1000,
                        use_all_factor_levels = FALSE,
@@ -98,8 +98,8 @@ h2o.prcomp <- function(training_frame, x,
     parms$transform <- transform
   if (!missing(pca_method))
     parms$pca_method <- pca_method
-  if (!missing(pca_implementation))
-    parms$pca_implementation <- pca_implementation
+  if (!missing(pca_impl))
+    parms$pca_impl <- pca_impl
   if (!missing(k))
     parms$k <- k
   if (!missing(max_iterations))

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -18,6 +18,8 @@
 #'        Defaults to NONE.
 #' @param pca_method Method for computing PCA (Caution: GLRM is currently experimental and unstable) Must be one of: "GramSVD",
 #'        "Power", "Randomized", "GLRM". Defaults to GramSVD.
+#' @param pca_implementation Implementation for computing PCA (via SVD or EVD) Must be one of: "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX",
+#'        "MTJ_SVD_DENSEMATRIX", "JAMA". Defaults to MTJ_EVD_SYMMMATRIX.
 #' @param k Rank of matrix approximation Defaults to 1.
 #' @param max_iterations Maximum training iterations Defaults to 1000.
 #' @param use_all_factor_levels \code{Logical}. Whether first factor level is included in each categorical expansion Defaults to FALSE.
@@ -45,6 +47,7 @@ h2o.prcomp <- function(training_frame, x,
                        score_each_iteration = FALSE,
                        transform = c("NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"),
                        pca_method = c("GramSVD", "Power", "Randomized", "GLRM"),
+                       pca_implementation = c("MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"),
                        k = 1,
                        max_iterations = 1000,
                        use_all_factor_levels = FALSE,
@@ -88,6 +91,8 @@ h2o.prcomp <- function(training_frame, x,
     parms$transform <- transform
   if (!missing(pca_method))
     parms$pca_method <- pca_method
+  if (!missing(pca_implementation))
+    parms$pca_implementation <- pca_implementation
   if (!missing(k))
     parms$k <- k
   if (!missing(max_iterations))

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -16,9 +16,16 @@
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
-#' @param pca_method Method for computing PCA (Caution: GLRM is currently experimental and unstable) Must be one of: "GramSVD",
-#'        "Power", "Randomized", "GLRM". Defaults to GramSVD.
-#' @param pca_implementation Implementation for computing PCA (via SVD or EVD) Must be one of: "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX",
+#' @param pca_method Specify the algorithm to use for computing the principal components: GramSVD - uses a distributed computation
+#'        of the Gram matrix, followed by a local SVD; Power - computes the SVD using the power iteration method
+#'        (experimental); Randomized - uses randomized subspace iteration method; GLRM - fits a generalized low-rank
+#'        model with L2 loss function and no regularization and solves for the SVD using local matrix algebra
+#'        (experimental) Must be one of: "GramSVD", "Power", "Randomized", "GLRM". Defaults to GramSVD.
+#' @param pca_implementation Specify the implementation to use for computing PCA (via SVD or EVD): MTJ_EVD_DENSEMATRIX - eigenvalue
+#'        decompositions for dense matrix using MTJ; MTJ_EVD_SYMMMATRIX - eigenvalue decompositions for symmetric matrix
+#'        using MTJ; MTJ_SVD_DENSEMATRIX - singular-value decompositions for dense matrix using MTJ; JAMA - eigenvalue
+#'        decompositions for dense matrix using JAMA. References: JAMA - http://math.nist.gov/javanumerics/jama/; MTJ -
+#'        https://github.com/fommil/matrix-toolkits-java/ Must be one of: "MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX",
 #'        "MTJ_SVD_DENSEMATRIX", "JAMA". Defaults to MTJ_EVD_SYMMMATRIX.
 #' @param k Rank of matrix approximation Defaults to 1.
 #' @param max_iterations Maximum training iterations Defaults to 1000.

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_3502_pca_hangs_large_NOPASS.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_3502_pca_hangs_large_NOPASS.R
@@ -6,30 +6,30 @@ source("../../../scripts/h2o-r-test-setup.R")
 # with wide dataset at all and I am in the process of making GLRM work with wide dataset.  For
 # the purpose of this test, we are only going to use Power.  You can try GramSVD as well.
 test.pca.la1s <- function() {
-  run_time_c = c()
-  num_run = 1
+  run_time_c <- c()
+  num_run <- 1
 
   browser()
-  dataR = h2o.importFile(locate("bigdata/laptop/jira/la1s.wc.arff.txt.zip"),sep=',',destination_frame = "data",header = T, parse=FALSE)
+  dataR <- h2o.importFile(locate("bigdata/laptop/jira/la1s.wc.arff.txt.zip"), sep = ',', destination_frame = "data", header = T, parse = FALSE)
   data <- h2o.parseRaw(dataR, destination_frame = "bigParse",
                               parse_type = "CSV", header = T) # chunk_size = 124022500 size will make one chunk.
-  data$CLASS_LABEL = NULL
+  data$CLASS_LABEL <- NULL
 
   for (runIndex in 1:num_run) {
     # k=1939 is very large and this is going to take a long time.
-    mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1938,max_iterations = 10,pca_method = "GramSVD")
+    mm <- h2o.prcomp(data, transform = "STANDARDIZE", k = 1938, max_iterations = 10, pca_method = "GramSVD")
     print("PCA (GramSVD) run time with car.arff.txt data in ms is ")
     print(mm@model$run_time)
 
     h2o.rm(mm)
 
-    mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1938,max_iterations = 10,pca_method = "Power")
+    mm <- h2o.prcomp(data, transform = "STANDARDIZE", k = 1938, max_iterations = 10, pca_method = "Power")
     print("PCA (Power) run time with car.arff.txt data in ms is ")
     print(mm@model$run_time)
 
     h2o.rm(mm)
 
-    mm = h2o.prcomp(data,transform = "STANDARDIZE",k =1938,max_iterations = 10,pca_method = "Randomized")
+    mm <- h2o.prcomp(data, transform = "STANDARDIZE", k = 1938, max_iterations = 10, pca_method = "Randomized")
     print("PCA (Randomized) run time with car.arff.txt data in ms is ")
     print(mm@model$run_time)
 

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_4961_pca_implementations.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_4961_pca_implementations.R
@@ -23,8 +23,8 @@ test.pca.implementations <- function() {
   
   # Compare to see if they are fundamentally the same
   invisible(lapply(names(eigenvectors[[1]]), function(pc_ind) {
-    eigenvector_standard <- abs(eigenvectors[[1]][[pc_ind]])
-    lapply(eigenvectors, function(x) expect_equal(abs(x[[pc_ind]]), eigenvector_standard))
+    eigenvectors_standard <- abs(eigenvectors[[1]][[pc_ind]])
+    lapply(eigenvectors, function(x) expect_equal(abs(x[[pc_ind]]), eigenvectors_standard))
   }))
 }
 

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_4961_pca_implementations.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_4961_pca_implementations.R
@@ -1,0 +1,31 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.pca.implementations <- function() {
+  Log.info("Importing arrests.csv data...") 
+  arrestsH2O <- h2o.uploadFile(
+    locate("smalldata/pca_test/USArrests.csv"),
+    destination_frame = "arrestsH2O")
+  
+  Log.info("Testing to see whether the trained PCA are essentially the same using different implementation...")
+  # Obtain eigenvectors for PCA trained using different implementations
+  eigenvectors <- lapply(
+    c("MTJ_EVD_DENSEMATRIX", "MTJ_EVD_SYMMMATRIX", "MTJ_SVD_DENSEMATRIX", "JAMA"),
+    function(impl) {
+      Log.info(paste0("Run PCA with implementation: ", impl))
+      model <- h2o.prcomp(
+        arrestsH2O,
+        k = 4,
+        pca_implementation = impl,
+        seed = 1234)
+      model@model$eigenvectors
+    })
+  
+  # Compare to see if they are fundamentally the same
+  invisible(lapply(names(eigenvectors[[1]]), function(pc_ind) {
+    eigenvector_standard <- abs(eigenvectors[[1]][[pc_ind]])
+    lapply(eigenvectors, function(x) expect_equal(abs(x[[pc_ind]]), eigenvector_standard))
+  }))
+}
+
+doTest("PCA Test: Different PCA Implementations", test.pca.implementations)

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_4961_pca_implementations.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_4961_pca_implementations.R
@@ -16,7 +16,7 @@ test.pca.implementations <- function() {
       model <- h2o.prcomp(
         arrestsH2O,
         k = 4,
-        pca_implementation = impl,
+        pca_impl = impl,
         seed = 1234)
       model@model$eigenvectors
     })

--- a/scripts/removeLastColumnFromCSV.sh
+++ b/scripts/removeLastColumnFromCSV.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+CSV_DIR="../bigdata/laptop/jira"
+CSV_BASENAME="${1:-re0.wc.arff}"
+CSV_INPUT_FILE="$CSV_DIR/$CSV_BASENAME.txt"
+CSV_OUTPUT_FILE="$CSV_DIR/$CSV_BASENAME.csv"
+
+awk 'BEGIN { FS=","; OFS="," }  {print $NF}' $CSV_INPUT_FILE  | less
+awk 'BEGIN { FS=","; OFS="," } NF{NF--};1' <$CSV_INPUT_FILE >$CSV_OUTPUT_FILE
+awk 'BEGIN { FS=","; OFS="," }  {print $NF}' $CSV_OUTPUT_FILE | less


### PR DESCRIPTION
This is a continuation of the efforts in https://github.com/h2oai/h2o-3/pull/1025. In addition:

- Exposed the `pca_implementation` parameter in R and Python bindings to select different implementations
- Added tests to make sure every implementation works and gives the correct result

Note that:

- testdir_algos/pca/runit_pubdev_3502_pca_hangs_large_NOPASS.R still hangs for randomized method. I spent some time but couldn't resolve it. The feedback loop is also very long and it would be great if other people can jump in and help.
- I left `PCAImplementation` to be `Enum` since at this point I don't see a huge potential that users would want to add their own implementation given that H2O users are mostly high-level "users" instead of developers. It's also more consistent with the current setup of `PCAMethod`. As @michalkurka pointed out, it would be better if the factory could discover the implementations dynamically (eg. using Java SPI) but it's a little trickier to make the R/Python bindings work similarly. We should probably leave that as future work/discussion for now.  

@michalkurka @mmalohlava @wendycwong Could you review this?

