### PR TITLE
PUBDEV-5120: Update docs to remove S3N data ingest examples

### DIFF
--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -3,13 +3,16 @@ EC2 Instances & S3 Storage
 
 *Tested on Redhat AMI, Amazon Linux AMI, and Ubuntu AMI*
 
-To use the Amazon Web Services (AWS) S3 storage solution, you will need to pass your S3 access credentials to H2O. This will allow you to access your data on S3 when importing data frames with path prefixes ``s3n://...``.
+To use the Amazon Web Services (AWS) S3 storage solution, you will need to pass your S3 access credentials to H2O. This will allow you to access your data on S3 when importing data frames with path prefixes ``s3://...``.
 
 To use the `Minio Cloud Storage <https://minio.io/>`__, you will need to pass an endpoint in addition to access credentials.
 
 For security reasons, we recommend writing a script to read the access credentials that are stored in a separate file. This will not only keep your credentials from propagating to other locations, but it will also make it easier to change the credential information later.
 
-**Note**: You can only specify one S3 endpoint. This means you can either read data from AWS S3 or Minio S3, not from both.
+**Notes**: 
+
+ - You can only specify one S3 endpoint. This means you can either read data from AWS S3 or Minio S3, not from both.
+ - We recommend using S3 for data ingestion and S3N for data export. 
 
 AWS Standalone Instance
 '''''''''''''''''''''''
@@ -23,12 +26,12 @@ When running H2O in standalone mode using the simple Java launch command, we can
      ::
 
        <property>
-         <name>fs.s3n.awsAccessKeyId</name>
+         <name>fs.s3.awsAccessKeyId</name>
          <value>[AWS SECRET KEY]</value>
        </property>
 
        <property>
-         <name>fs.s3n.awsSecretAccessKey</name>
+         <name>fs.s3.awsSecretAccessKey</name>
          <value>[AWS SECRET ACCESS KEY]</value>
        </property>
 
@@ -39,25 +42,25 @@ When running H2O in standalone mode using the simple Java launch command, we can
 
        java -jar h2o.jar -hdfs_config core-site.xml
 
-   3. Import the data using ``importFile`` with the S3 URL path: **s3n://bucket/path/to/file.csv**. You can pass the Minio Access Key and Secret Access Key in an S3N URL in Flow, R, or Python (where ``AWS_ACCESS_KEY`` represents your user name, and ``AWS_SECRET_KEY`` represents your password).
+   3. Import the data using ``importFile`` with the S3 URL path: **s3://bucket/path/to/file.csv**. You can pass the Minio Access Key and Secret Access Key in an S3 URL in Flow, R, or Python (where ``AWS_ACCESS_KEY`` represents your user name, and ``AWS_SECRET_KEY`` represents your password).
 
     -  To import the data from the Flow API:
 
       ::
 
-        importFiles [ "s3n://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@bucket/path/to/file.csv" ]
+        importFiles [ "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@bucket/path/to/file.csv" ]
 
     -  To import the data from the R API:
 
       ::
 
-        h2o.importFile(path = "s3n://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@bucket/path/to/file.csv")
+        h2o.importFile(path = "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@bucket/path/to/file.csv")
 
     -  To import the data from the Python API:
 
       ::
 
-        h2o.import_file(path = "s3n://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@bucket/path/to/file.csv")
+        h2o.import_file(path = "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>@bucket/path/to/file.csv")
 
 AWS Multi-Node Instance
 '''''''''''''''''''''''
@@ -145,25 +148,25 @@ Minio Cloud Storage is an alternative to Amazon AWS S3. When using a Minio serve
 
       java -jar h2o.jar -hdfs_config core-site.xml
 
-3. Import the data using ``importFile`` with the Minio S3 url path: **s3n://bucket/path/to/file.csv**. You can pass the AWS Access Key and Secret Access Key in an S3N URL in Flow, R, or Python (where ``MINIO_ACCESS_KEY`` represents your user name, and ``MINIO_SECRET_KEY`` represents your password).
+3. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**. You can pass the AWS Access Key and Secret Access Key in an S3 URL in Flow, R, or Python (where ``MINIO_ACCESS_KEY`` represents your user name, and ``MINIO_SECRET_KEY`` represents your password).
 
  - To import the data from the Flow API:
 
   ::
 
-   importFiles [ "s3n://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv" ]
+   importFiles [ "s3://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv" ]
 
  - To import the data from the R API:
 
   ::
 
-   h2o.importFile(path = "s3n://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv")
+   h2o.importFile(path = "s3://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv")
 
  - To import the data from the Python API:
 
   ::
 
-   h2o.import_file(path = "s3n://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv")
+   h2o.import_file(path = "s3://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv")
 
 
 .. _Core-site.xml:
@@ -185,17 +188,17 @@ The following is an example core-site.xml file:
         <!--
         <property>
         <name>fs.default.name</name>
-        <value>s3n://<your s3 bucket></value>
+        <value>s3://<your s3 bucket></value>
         </property>
         -->
 
         <property>
-            <name>fs.s3n.awsAccessKeyId</name>
+            <name>fs.s3.awsAccessKeyId</name>
             <value>insert access key here</value>
         </property>
 
         <property>
-            <name>fs.s3n.awsSecretAccessKey</name>
+            <name>fs.s3.awsSecretAccessKey</name>
             <value>insert secret key here</value>
         </property>
         </configuration>

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -44,7 +44,7 @@ providing input prompts, interactive help, and example flows.
 Download Flow
 -------------
 
-1. First `Download H2O <http://www.h2o.ai/download/>`_. This will download a zip file in your Downloads folder that contains everything you need to get started. Alternatively, you can run the following from your command line, replacing "{version}" with the appropriate version (for example, 3.8.2.5)
+1. First `Download H2O <http://www.h2o.ai/download/>`_. This will download a zip file in your Downloads folder that contains everything you need to get started. Alternatively, you can run the following from your command line, replacing "{version}" with the appropriate version (for example, 3.16.0.2):
 
   ::
 
@@ -53,11 +53,11 @@ Download Flow
 
 2. Next in your terminal, enter the following command lines one at a time:
 
-  *(The first line changes into your Downloads folder, the second line unzips your zipfile, the third line changes into your h2o-3.8.2.3 folder, and the fourth line runs your jar file.)*::
+  *(The first line changes into your Downloads folder, the second line unzips your zipfile, the third line changes into your h2o-3.16.0.2 folder, and the fourth line runs your jar file.)*::
 
     cd ~/Downloads
-    unzip h2o-3.8.2.3.zip
-    cd h2o-3.8.2.3
+    unzip h2o-3.16.0.2.zip
+    cd h2o-3.16.0.2
     java -jar h2o.jar
 
 3. Finally, to start Flow point your browser to http://localhost:54321.

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -552,7 +552,7 @@ There are multiple ways to import data in H2O flow:
    ``path/filename.format`` represents the complete file path to the
    file, including the full file name. The file path can be a local file
    path or a website address. **Note**: For S3 file locations, use the
-   format ``importFiles [ "s3n:/path/to/bucket/file/file.tab.gz" ]``
+   format ``importFiles [ "s3:/path/to/bucket/file/file.tab.gz" ]``
 
   **Note**: For an example of how to import a single file or a directory in R, refer to the following `example <https://github.com/h2oai/h2o-2/blob/master/R/tests/testdir_hdfs/runit_s3n_basic.R>`__.
 


### PR DESCRIPTION
- Changed “S3N” to “S3” in data import examples
- Added a note that S3 should be used for data ingest and S3N should be used for data export.