### PR TITLE
[PUBDEV-5157] Fix conda release

### DIFF
--- a/h2o-py/conda/h2o/meta.yaml
+++ b/h2o-py/conda/h2o/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 requirements:
   build:
-    - python >=2.7,<3|>=3.5
+    - python
     - pip >=9.0.1
     - setuptools
     - colorama >=0.3.7
@@ -18,7 +18,7 @@ requirements:
     - requests >=2.10
 
   run:
-    - python >=2.7,<3|>=3.5
+    - python
     - colorama >=0.3.7
     - future >=0.15.2
     - tabulate >=0.7.5


### PR DESCRIPTION
We can't specify versions in meta.yaml in order to be able to pass them later to conda build command