### PR TITLE
Create two rows for User Guides

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -272,7 +272,9 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
           </div>
         </div>
       </div>
-
+    </div>
+    
+    <div class="row">
       <div class="flex-vert col-4">
         <div class="well well-sm">
           <h5>Enterprise Steam</h5>


### PR DESCRIPTION
Safari attempts to include all documents on one row rather than wrap the boxes (as other browsers do). Broke these UG boxes into two rows so that all are visible on Safari.