### PR TITLE
PUBDEV-5162: Updates to Anaconda and PySparkling with pypi

### DIFF
--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -111,13 +111,20 @@ Install on Anaconda Cloud
 
 This section describes how to set up and run H2O in an Anaconda Cloud environment. Conda 2.7, 3.5, and 3.6 repos are supported as are a number of H2O versions. Refer to `https://anaconda.org/h2oai/h2o/files <https://anaconda.org/h2oai/h2o/files>`__ to view a list of available H2O versions.
 
-Open a terminal window and run the following command to install H2O on the Anaconda Cloud. 
+Open a terminal window and run the following command to install H2O on the Anaconda Cloud. The H2O version in this command should match the version that you want to download. If you leave the h2o version blank and specify just ``h2o``, then the latest version will be installed.
       
    ::
 
-     user$ conda install -c h2oai h2o=3.14.0.3
+     user$ conda install -c h2oai h2o=3.16.0.2
 
-**Note**: The H2O version in the above command should match the version that you want to download. 
+**Note**: For Python 3.6 users, H2O has ``tabulate>=0.75`` as a dependency; however, there is no ``tabulate`` available in the default channels for Python 3.6. This is available in the conda-forge channel. As a result, Python 3.6 users must add the ``conda-forge`` channel in order to load the latest version of H2O. This can be done by performing the following steps:
+
+ ::
+
+   conda create -n py36 python=3.6 anaconda
+   source activate py36
+   conda config --append channels conda-forge
+   conda install -c h2oai h2o 
 
 After H2O is installed, refer to the `Starting H2O from Anaconda <starting-h2o.html#from-anaconda>`__ section for information on how to start H2O and to view a GBM example run in Jupyter Notebook. 
 

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -289,23 +289,23 @@ Sparkling Water Meetup Slide Decks
 PySparkling
 ~~~~~~~~~~~~
 
-**Note**: PySparkling requires Sparkling Water 1.6 or later. Recommended Sparkling Water 2.0 or later. 
+**Note**: PySparkling requires Sparkling Water 2.0 or later. We recommended Sparkling Water 2.2. 
 
-PySparkling can be installed by downloading and running the PySparkling shell or using ``pip``. Note that the steps below describe how to install with Sparkling Water 2.1. Follow similar instructions on the `Download page <http://h2o.ai/download>`__ for a different version of Sparkling Water.
+PySparkling can be installed by downloading and running the PySparkling shell or using ``pip``. Note that the steps below describe how to install with Sparkling Water 2.2. Follow similar instructions on the `Download page <http://h2o.ai/download>`__ for a different version of Sparkling Water.
 
 Running the PySparkling Shell
 '''''''''''''''''''''''''''''
 
 Perform the following steps to install H2O's PySparkling package. 
 
-1. Download `Spark 2.1.1 <https://spark.apache.org/downloads.html>`__.
+1. Download `Spark 2.2.0 <https://spark.apache.org/downloads.html>`__.
 2. Point SPARK_HOME to the existing installation of Spark, and export the variable MASTER. For example:
 
   ::
 
     export SPARK_HOME="/path/to/spark/installation"
     # To launch a local Spark cluster with 3 worker nodes with 2 cores and 1g per node.
-    export MASTER="local-cluster[3,2,1024]" 
+    export MASTER="local" 
 
 3. Download and unpack the Sparkling Water distribution.
 
@@ -331,7 +331,7 @@ PySparkling Installed from PyPi Repository
 
   ::
 
-    pip install pysparkling_2.1
+    pip install h2o_pysparkling_2.2
 
 2. In your Python client, create a SparkSession. Note that for this step, you must have the PySpark package installed.
 


### PR DESCRIPTION
- Added a note in the Anaconda install section describing that Python 3.6 users must add the condo-forge channel in order to include the required tabulate dependency.
- Updated the Pypi install instructions based on recent changes.
Driveby fix: Sparkling Water section now uses 2.2 in examples.