### PR TITLE
Set pip.get_installed_distributions param skip to () 

### DIFF
--- a/h2o-py/scripts/verify_requirements.py
+++ b/h2o-py/scripts/verify_requirements.py
@@ -125,7 +125,7 @@ def test_module(mod, min_version, installed_modules):
 
 
 def main(metayaml_file):
-    installed = pip.get_installed_distributions()
+    installed = pip.get_installed_distributions(skip=())
     msgs = test_requirements("build", metayaml_file, installed)
     if msgs:
         print("\n    ERRORS:\n", file=sys.stderr)


### PR DESCRIPTION
Some python versions have pip.get_installed_distributions() with a default parameter skip = ('pip', 'setuptools', 'python', ... ), which means that the h2o3 build fails with the assertion that pip and setuptools don't exist, even though they actually do. 

This change just forces pip.get_installed_distributions() to not skip *any* installed package, especially when h2o3 relies on this script to verify that the appropriate python dependencies are installed. 