### PR TITLE
PUBDEV-5149: Note in docs that missing timestamps are UTC

### DIFF
--- a/h2o-docs/src/product/data-munging/importing-data.rst
+++ b/h2o-docs/src/product/data-munging/importing-data.rst
@@ -5,6 +5,11 @@ Unlike the `upload <uploading-data.html>`__ function, which is a push from the c
 
 Refer to the `Supported File Formats <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/getting-data-into-h2o.html#supported-file-formats>`__ topic to ensure that you are using a supported file type.
 
+**Note**: When parsing a data file containing timestamps that do not include a timezone, the timestamps will be interpreted as UTC (GMT). You can override the parsing timezone using the following:
+
+  - R: ``h2o.setTimezone("America/Los Angeles")``
+  - Python: ``h2o.cluster().timezone = "America/Los Angeles"``
+
 .. example-code::
    .. code-block:: r
 	

--- a/h2o-docs/src/product/data-munging/importing-files.rst
+++ b/h2o-docs/src/product/data-munging/importing-files.rst
@@ -11,7 +11,12 @@ The ``importFolder`` (R)/``import_file`` (Python) function can be used to import
 **Notes**: 
 
 - All files that are specified to be included must have the same number and set of columns. 
-- The Python example below assumes that the H2O-3 GitHub repository has been cloned, and that the following command was run in the **h2o** folder to retrieve the **smalldata** datasets. 
+- When parsing a data file containing timestamps that do not include a timezone, the timestamps will be interpreted as UTC (GMT). You can override the parsing timezone using the following:
+
+  - R: ``h2o.setTimezone("America/Los Angeles")``
+  - Python: ``h2o.cluster().timezone = "America/Los Angeles"``
+
+- The Python example below assumes that the H2O-3 GitHub repository has been cloned, and that the following command was run in the **h2o-3** folder to retrieve the **smalldata** datasets. 
 
   :: 
 

--- a/h2o-docs/src/product/data-munging/uploading-data.rst
+++ b/h2o-docs/src/product/data-munging/uploading-data.rst
@@ -5,6 +5,11 @@ Unlike the import function, which is a parallelized reader, the upload function 
 
 Refer to the `Supported File Formats <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/getting-data-into-h2o.html#supported-file-formats>`__ topic to ensure that you are using a supported file type.
 
+**Note**: When parsing a data file containing timestamps that do not include a timezone, the timestamps will be interpreted as UTC (GMT). You can override the parsing timezone using the following:
+
+  - R: ``h2o.setTimezone("America/Los Angeles")``
+  - Python: ``h2o.cluster().timezone = "America/Los Angeles"``
+
 Run the following command to load data that resides on the same machine that is running H2O. 
 
 .. example-code::

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -655,15 +655,13 @@ To change the column type, select the drop-down list to the right of the column 
 -  String
 -  Invalid
 
-You can search for a column by entering it in the *Search by column
-name...* entry field above the first column name entry field. As you
-type, H2O displays the columns that match the specified search terms.
+**Note**: When parsing a data file containing timestamps that do not include a timezone, the timestamps will be interpreted as UTC (GMT). 
 
-**Note**: Only custom column names are searchable. Default column names
-cannot be searched.
+You can search for a column by entering it in the *Search by column name...* entry field above the first column name entry field. As you type, H2O displays the columns that match the specified search terms.
 
-To navigate the data preview, click the **<- Previous page** or **->
-Next page** buttons.
+**Note**: Only custom column names are searchable. Default column names cannot be searched.
+
+To navigate the data preview, click the **<- Previous page** or **-> Next page** buttons. 
 
 .. figure:: images/Flow_PageButtons.png
    :alt: Flow - Pagination buttons

--- a/h2o-py/docs/data.rst
+++ b/h2o-py/docs/data.rst
@@ -4,7 +4,7 @@
 Data In H2O
 ===========
 
-A H2OFrame represents a 2D array of data where each column is uniformly typed.
+An H2OFrame represents a 2D array of data where each column is uniformly typed.
 
 The data may be local or it may be in an H2O cluster. The data are loaded from a CSV file
 or from a native Python data structure, and is either a Python client-relative file, a
@@ -23,26 +23,35 @@ H2O's parser supports data of various formats from multiple sources.
 The following formats are supported:
 
 * ARFF
-* CSV (data may delimited by any of the 128 ASCII characters)
+* CSV (data may delimited by any of the 128 ASCII characters; includes support for GZipped CSV)
 * SVMLight
 * XLS
 * XLSX
+* ORC (for Hadoop jobs; includes support for Hive files saved in ORC format)
+* Avro version 1.8.0 (without multifile parsing or column type modification)
+* Parquet
 
 
 The following data sources are supported:
 
- * NFS / Local File / List of Files
- * HDFS
- * URL
- * A Directory (with many data files inside at the *same* level -- no support for recursive import of data)
- * S3/S3N
- * Native Language Data Structure (c.f. the subsequent section)
+* NFS / Local File / List of Files
+* HDFS
+* URL
+* A Directory (with many data files inside at the *same* level -- no support for recursive import of data)
+* S3/S3N
+* Native Language Data Structure (c.f. the subsequent section)
 
-  .. code-block:: python
+.. code-block:: python
 
     >>> trainFrame = h2o.import_file(path="hdfs://192.168.1.10/user/data/data_test.csv")
     #or
     >>> trainFrame = h2o.import_file(path="~/data/data_test.csv")
+
+**Note**: When parsing a data file containing timestamps that do not include a timezone, the timestamps will be interpreted as UTC (GMT). You can override the parsing timezone using ``h2o.cluster().timezone``. For example:
+
+.. code-block:: python
+
+    h2o.cluster().timezone = "America/Los Angeles"
 
 Loading Data From A Python Object
 ---------------------------------

--- a/h2o-py/docs/intro.rst
+++ b/h2o-py/docs/intro.rst
@@ -42,17 +42,11 @@ produce a solution faster. The conceptual paradigm MapReduce (AKA "divide and co
 and combine"), along with a good concurrent application structure,
 (c.f. jsr166y and NonBlockingHashMap) enable this type of scaling in H2O.
 
-For application developers and data scientists, the gritty details of thread-safety,
-algorithm parallelism, and node coherence on a network are concealed by simple-to-use REST
-calls that are all documented here. In addition, H2O is an open-source project under the
-Apache v2 licence. All of the source code is on
-`github <https://github.com/h2oai/h2o-dev>`_, there is an active
-`google group mailing list <https://groups.google.com/forum/#!forum/h2ostream>`_,
-and our `JIRA ticketing system <http://jira.0xdata.com>`_
-is also open for public use. Last, but not least, we regularly engage the machine learning
-community all over the nation with a very busy `meetup schedule <https://www.h2o.ai/community/>`_
-(so if you're not in The Valley, no sweat, we're probably coming to your area soon!),
-and finally, we host our very own `H2O World conference <http://h2oworld.h2o.ai/>`_.
+For application developers and data scientists, the gritty details of thread-safety, algorithm parallelism, and node coherence on a network are concealed by simple-to-use REST calls that are all documented here. In addition, H2O is an open-source project under the Apache v2 licence. All of the source code is on `github <https://github.com/h2oai/h2o-3>`_. 
+
+For questions, there is an active `google group mailing list <https://groups.google.com/forum/#!forum/h2ostream>`_, or questions can be posted on the `H2O community site on Stack Overflow <http://stackoverflow.com/questions/tagged/h2o>`__. Our `JIRA ticketing system <http://jira.0xdata.com>`_ is also open for public use. 
+
+Last, but not least, we regularly engage the machine learning community all over the nation with a very busy `meetup schedule <https://www.h2o.ai/community/>`_ (so if you're not in The Valley, no sweat, we're probably coming to your area soon!), and finally, we host our very own `H2O World conference <http://h2oworld.h2o.ai/>`_.
 
 The rest of this document explains a few of the client-server details and the general
 programming model for interacting with H2O from Python.

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -25,6 +25,9 @@
 #' will be relative to the start location of the H2O instance. The default
 #' behavior is to pass-through to the parse phase automatically.
 #'
+#' Note that when parsing a data file containing timestamps that do not include a timezone, the timestamps 
+#' will be interpreted as UTC (GMT). You can override the parsing timezone using \code{h2o.setTimezone}.
+#'
 #' \code{h2o.importHDFS} is deprecated. Instead, use \code{h2o.importFile}.
 #'
 #' @param path The complete URL or normalized file path of the file to be


### PR DESCRIPTION
Added to User Guide and R/Python docs that when files contain timestamps without a timezone, the parser will set the timezone to UTC (GMT)
Driveby fixes: In python, added additional supported file formats. Also updated the intro with a link to stack overflow.