### PR TITLE
PUBDEV-5180 Python 2 timestamp interpreted as two tokens

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -13,6 +13,7 @@ import gc
 import math
 import sys
 import time
+import numbers
 
 import tabulate
 
@@ -78,7 +79,7 @@ class ExprNode(object):
     # Flag to control application of local expression tree optimizations
     __ENABLE_EXPR_OPTIMIZATIONS__ = True
 
-    def __init__(self, op="", *args):
+    def __init__(self, op="", *args):      
         # assert isinstance(op, str), op
         self._op = op  # Base opcode string
         self._children = tuple(
@@ -168,6 +169,9 @@ class ExprNode(object):
                 return "[%d:%s:%d]" % (start, str((stop - start + step - 1) // step), step)
         if isinstance(arg, ModelBase):
             return arg.model_id
+        # Number representation without Py2 L suffix enforced
+        if isinstance(arg, numbers.Integral):
+            return repr2(arg).strip('L')
         return repr2(arg)
 
     def __del__(self):

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5180.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5180.py
@@ -1,0 +1,16 @@
+import h2o
+
+from h2o.expr import ExprNode
+from tests import pyunit_utils
+
+
+def pubdev_5180():
+
+    frame = h2o.create_frame(binary_fraction=1, binary_ones_fraction=0.5, missing_fraction=0, rows=1, cols=1)
+    exp_str = ExprNode("assign", 123456789123456789123456789, frame)._get_ast_str(False)
+    assert exp_str.find('123456789123456789L') == -1
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_5180)
+else:
+    pubdev_5180()


### PR DESCRIPTION
The conversion itself is done when the expression is 'serialized' into a Rapids expression. When repr2() is invoked using Python2, an 'L' suffix appears to every number with more bits than int is capable of holding. At this place, the suffix is stripped.

This fix only affects integer-like types, not complex types nor rational types.

There is a test written, tested both with Python 2.7 and Python 3.5. Version 3.6 has not been tested yet. Manual testing was done as well. Please see the attached screenshot (debug window in IntelliJ IDEA). The outcoming expression contains Long type correctly represented.

![snimek obrazovky porizeny 2017-12-23 22-21-29](https://user-images.githubusercontent.com/8769110/34322732-194e2526-e830-11e7-84d8-959445b0d522.png)
