### PR TITLE
PUBDEV-4897 - PDP use different order of categorical

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2938,7 +2938,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
   pp.plot <- function(pp) {
     if(!all(is.na(pp))) {
       type = col_types[which(col_names == names(pp)[1])]
-      if(type == "enum") pp[,1] = as.factor( pp[,1])
+      if(type == "enum") pp[,1] = factor( pp[,1], levels=pp[,1])
       
       ## Plot one standard deviation above and below the mean
       if( plot_stddev) {

--- a/h2o-r/tests/testdir_jira/runit_pubdev_4897.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_4897.R
@@ -1,0 +1,20 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.pubdev_4897 <- function() {
+    data <- h2o.importFile(path = locate('smalldata/jira/pubdev_4897.csv'))
+    model <- h2o.gbm(x = "Var2", y = "Var1", training_frame = data, ntrees = 50)
+    pdf("plot")
+    dev.control(displaylist="enable")
+    h2o.partialPlot(object = model, data = data, cols = "Var2", plot = TRUE)
+    recordedPlot <- recordPlot()
+    dev.off()
+    unlink("plot")
+    recordedPlotAttributes <- capture.output(str(recordedPlot))
+    xAxisAlignment = grep(pattern = "\\$ x   : num \\[1:3\\] 1 2 3", x = recordedPlotAttributes, ignore.case = TRUE)
+    expect_true(length(xAxisAlignment) > 0)
+}
+
+doTest("PUBDEV-$4897: PDP use different order of categorical", test.pubdev_4897)


### PR DESCRIPTION
Ticket: https://0xdata.atlassian.net/browse/PUBDEV-4897

Manually tested. After the line proposed has been changed, order of values on X axis is preserved.