### PR TITLE
[PUBDEV-5113][PUBDEV-5184] Allow definition of custom functions directly

### DIFF
--- a/h2o-core/src/main/java/water/udf/DkvClassLoader.java
+++ b/h2o-core/src/main/java/water/udf/DkvClassLoader.java
@@ -1,23 +1,33 @@
 package water.udf;
 
-import java.io.File;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
 
-import water.H2O;
+import water.DKV;
 import water.Key;
-import water.Value;
-import water.persist.PersistFS;
-import water.util.Log;
+
+import static water.udf.DkvClassLoader.DkvUrlStreamHandler.PROTO;
 
 /**
- * An URI-based classloader which use content of K/V
+ * An classloader which use content of a jar file stored in K/V store under given key
  * to search and load classes.
- *
- * Note: the classloader is using disk and a temporary
- * storage for K/V values!
  */
-class DkvClassLoader extends URLClassLoader {
+class DkvClassLoader extends ClassLoader {
+
+  private final Map<String, byte[]> jarCache;
+  private final Key jarKey;
 
   public DkvClassLoader(CFuncRef cFuncRef, ClassLoader parent) {
     this(cFuncRef.keyName, parent);
@@ -28,20 +38,138 @@ class DkvClassLoader extends URLClassLoader {
   }
   
   public DkvClassLoader(Key jarKey, ClassLoader parent) {
-    super(new URL[] {}, parent);
-    Value v = water.DKV.get(jarKey);
-    // Get local persistent layer and use it to save
-    // content of K/V
-    PersistFS persistFS = (PersistFS) H2O.getPM().getIce();
-    File f = persistFS.getFile(v);
-    // Optimistic delete
-    f.deleteOnExit();
+    super(parent);
+    this.jarKey = jarKey;
+    this.jarCache = buildJarCache(jarKey);
+  }
+  
+  @Override
+  protected Class<?> findClass(String name) throws ClassNotFoundException {
     try {
-      Log.debug("DkvClassLoader: saving " + v + " into " + f.getAbsolutePath());
-      H2O.getPM().store(Value.ICE, v);
-      addURL(f.toURI().toURL());
-    } catch (Exception e) {
-      throw new IllegalArgumentException(e);
+      return super.findClass(name);
+    } catch (ClassNotFoundException e) {
+      // Parent does not contain the requested class, look into cache we built.
+      String path = name.replace('.', '/').concat(".class");
+      byte[] klazzBytes = jarCache.get(path);
+      if (klazzBytes != null && klazzBytes.length > 0) {
+        return defineClass(name, klazzBytes, 0, klazzBytes.length);
+      }
+
+      throw new ClassNotFoundException(name);
+    }
+  }
+  @Override
+  protected URL findResource(String name) {
+    return url(name);
+  }
+
+  @Override
+  protected Enumeration<URL> findResources(String name) {
+    URL url = url(name);
+    return url == null
+           ? Collections.<URL>emptyEnumeration()
+           : Collections.enumeration(Collections.singletonList(url));
+  }
+
+  protected URL url(String name) {
+    URL url = null;
+    byte[] content = jarCache.get(name);
+    if (content != null) {
+      try {
+        // Create a nice URL representing the resource following concept of JarUrl.
+        // Note: this is just for sake of clarity, but at this
+        // point we use cached content to serve content of URL.
+        url = new URL(PROTO, "", -1,
+                      this.jarKey + (name.startsWith("/") ? "!" : "!/") + name,
+                      new DkvUrlStreamHandler());
+      } catch (MalformedURLException e) {
+        // Fail quickly since this is not expected to fail
+        throw new RuntimeException(e);
+      }
+    }
+    return url;
+  }
+
+  static Map<String, byte[]> buildJarCache(Key jarKey) {
+    Map<String, byte[]> jarCache = new HashMap<>();
+    try(JarInputStream jis = new JarInputStream(new ByteArrayInputStream(DKV.get(jarKey).memOrLoad()))) {
+      JarEntry entry = null;
+      while ((entry = jis.getNextJarEntry()) != null) {
+        if (entry.isDirectory()) continue;
+        byte[] content = readJarEntry(jis, entry);
+        jarCache.put(entry.getName(), content);
+      }
+    } catch (IOException e) {
+      // Fail quickly
+      throw new RuntimeException(e);
+    }
+    return jarCache;
+  }
+
+  static byte[] readJarEntry(JarInputStream jis, JarEntry entry) throws IOException {
+    int len = (int) entry.getSize();
+    byte[] content = new byte[len > 0 ? len : 4096];
+    int actLen = 0;
+    for (int r = jis.read(content); r > 0; r = jis.read(content, actLen, content.length - actLen)) {
+      if (content.length == (actLen += r)) {
+        content = Arrays.copyOf(content, content.length * 2);
+      }
+    }
+    if (actLen != content.length) {
+      content = Arrays.copyOf(content, actLen);
+    }
+    return content;
+  }
+
+  final class DkvUrlStreamHandler extends URLStreamHandler {
+    
+    public static final String PROTO = "dkv";
+
+    @Override
+    protected URLConnection openConnection(URL url) throws IOException {
+      if (!url.getProtocol().equals(PROTO)) {
+        throw new IOException("Cannot handle protocol: " + url.getProtocol());
+      }
+      String path = url.getPath();
+      int separator = path.indexOf("!/");
+      if (separator == -1) {
+        throw new MalformedURLException("Cannot find '!/' in DKV URL!");
+      }
+      String file = path.substring(separator + 2);
+      byte[] content = jarCache.get(file);
+      assert content != null : " DkvUrlStreamHandler is not created properly to point to file resource: " + url.toString();
+
+      return new ByteArrayUrlConnection(url, new ByteArrayInputStream(content));
+    }
+  }
+
+  protected static class ByteArrayUrlConnection extends URLConnection {
+
+    /**
+     * The input stream to return for this connection.
+     */
+    private final InputStream inputStream;
+
+    /**
+     * Creates a new byte array URL connection.
+     *
+     * @param url         The URL that this connection represents.
+     * @param inputStream The input stream to return from this connection.
+     */
+    protected ByteArrayUrlConnection(URL url, InputStream inputStream) {
+      super(url);
+      this.inputStream = inputStream;
+    }
+
+    @Override
+    public void connect() {
+      connected = true;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      connect(); // Mimics the semantics of an actual URL connection.
+      return inputStream;
     }
   }
 }

--- a/h2o-core/src/main/java/water/udf/DkvClassLoader.java
+++ b/h2o-core/src/main/java/water/udf/DkvClassLoader.java
@@ -1,5 +1,7 @@
 package water.udf;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -108,17 +110,7 @@ class DkvClassLoader extends ClassLoader {
 
   static byte[] readJarEntry(JarInputStream jis, JarEntry entry) throws IOException {
     int len = (int) entry.getSize();
-    byte[] content = new byte[len > 0 ? len : 4096];
-    int actLen = 0;
-    for (int r = jis.read(content); r > 0; r = jis.read(content, actLen, content.length - actLen)) {
-      if (content.length == (actLen += r)) {
-        content = Arrays.copyOf(content, content.length * 2);
-      }
-    }
-    if (actLen != content.length) {
-      content = Arrays.copyOf(content, actLen);
-    }
-    return content;
+    return len > 0 ? IOUtils.toByteArray(jis, len) : IOUtils.toByteArray(jis);
   }
 
   final class DkvUrlStreamHandler extends URLStreamHandler {

--- a/h2o-core/src/test/java/water/udf/DkvClassLoaderTest.java
+++ b/h2o-core/src/test/java/water/udf/DkvClassLoaderTest.java
@@ -45,11 +45,10 @@ public class DkvClassLoaderTest extends TestUtil {
           String klazzName = entryName.replace('/', '.').substring(0, entryName.length() - ".class".length());
           assertLoadableClass(cl, klazzName);
           classCnt++;
-        } else {
-          byte[] exptectedContent = readJarEntry(jis, entry);
-          assertLoadableResource(cl, entryName, exptectedContent);
-          resourceCnt++;
         }
+        byte[] exptectedContent = readJarEntry(jis, entry);
+        assertLoadableResource(cl, entryName, exptectedContent);
+        resourceCnt++;
       }
       // Just make sure, that we tested at least one class file and one resource
       Assert.assertTrue("The file " + testJar +" needs to contain at least one classfile",

--- a/h2o-core/src/test/java/water/udf/DkvClassLoaderTest.java
+++ b/h2o-core/src/test/java/water/udf/DkvClassLoaderTest.java
@@ -1,13 +1,23 @@
 package water.udf;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
 
 import water.DKV;
 import water.Key;
 import water.TestUtil;
 
+import static water.udf.DkvClassLoader.readJarEntry;
 import static water.udf.JFuncUtils.loadTestJar;
 
 /**
@@ -20,15 +30,54 @@ public class DkvClassLoaderTest extends TestUtil {
 
   @Test
   public void testClassLoadFromKey() throws Exception {
-    Key k = loadTestJar("testKeyName.jar", "water/udf/cfunc_test.jar");
-    try {
-      ClassLoader cl = new DkvClassLoader(k, Thread.currentThread().getContextClassLoader());
-      Class clz = cl.loadClass("ai.h2o.TestRunnable");
-      Assert.assertNotNull(clz);
-      Runnable runnable = (Runnable) clz.newInstance();
-      runnable.run();
+    String testJar = "water/udf/cfunc_test.jar";
+    Key k = loadTestJar("testKeyName.jar", testJar);
+    ClassLoader cl = new DkvClassLoader(k, Thread.currentThread().getContextClassLoader());
+
+    int classCnt = 0;
+    int resourceCnt = 0;
+    try(JarInputStream jis = new JarInputStream(Thread.currentThread().getContextClassLoader().getResourceAsStream(testJar))) {
+      JarEntry entry = null;
+      while ((entry = jis.getNextJarEntry()) != null) {
+        if (entry.isDirectory()) continue;
+        String entryName = entry.getName();
+        if (entryName.endsWith(".class")) {
+          String klazzName = entryName.replace('/', '.').substring(0, entryName.length() - ".class".length());
+          assertLoadableClass(cl, klazzName);
+          classCnt++;
+        } else {
+          byte[] exptectedContent = readJarEntry(jis, entry);
+          assertLoadableResource(cl, entryName, exptectedContent);
+          resourceCnt++;
+        }
+      }
+      // Just make sure, that we tested at least one class file and one resource
+      Assert.assertTrue("The file " + testJar +" needs to contain at least one classfile",
+                        classCnt > 0);
+      Assert.assertTrue("The file " + testJar +" needs to contain at least one resource",
+                        resourceCnt > 0);
     } finally {
       DKV.remove(k);
     }
+  }
+
+  void assertLoadableClass(ClassLoader cl, String klazzName) throws Exception {
+    Class clz = cl.loadClass(klazzName);
+    Assert.assertNotNull("Classloader should not return null for klazz " + klazzName, clz);
+    if (Runnable.class.isAssignableFrom(clz)) {
+      Runnable instance = (Runnable) clz.newInstance();
+      instance.run();
+    }
+  }
+
+  void assertLoadableResource(ClassLoader cl, String path, byte[] expectedContent) throws IOException {
+    URL resourceUrl = cl.getResource(path);
+    Assert.assertNotNull("Classloader should not return null for resource " + path, resourceUrl);
+    Assert.assertEquals("Created URL should have 'dkv' protocol", "dkv", resourceUrl.getProtocol());
+    Assert.assertTrue(resourceUrl.toString().endsWith(path));
+    // Verify content
+    byte[] content = IOUtils.toByteArray(resourceUrl);
+    Assert.assertArrayEquals("Content of resource provided by classloader has to match content in the jar file",
+                             expectedContent, content);
   }
 }

--- a/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonObjectFactory.java
+++ b/h2o-extensions/jython-cfunc/src/main/java/water/udf/JythonObjectFactory.java
@@ -17,6 +17,9 @@ public class JythonObjectFactory {
     this.interfaceType = interfaceType;
     PyObject importer = state.getBuiltins().__getitem__(Py.newString("__import__"));
     PyObject module = importer.__call__(new PyObject[] {Py.newString(moduleName),  PyArray.zeros(1, String.class)}, new String[] {"fromlist"} );
+    // Reload module definition - this is important to enable iterative updates of function definitions
+    // from interactive environments
+    module = org.python.core.__builtin__.reload(module);
     klass = module.__getattr__(className);
   }
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -1278,7 +1278,7 @@ def flow():
     webbrowser.open(connection().base_url, new = 1)
 
 
-def _put_key(file_path, dest_key=None):
+def _put_key(file_path, dest_key=None, overwrite=True):
     """
     Upload given file into DKV and save it under give key as raw object.
 
@@ -1286,7 +1286,7 @@ def _put_key(file_path, dest_key=None):
     :param file_path:  path to file to upload
     :return: key name if object was uploaded successfully
     """
-    ret = api("POST /3/PutKey?destination_key={}".format(dest_key if dest_key else ''),
+    ret = api("POST /3/PutKey?destination_key={}&overwrite={}".format(dest_key if dest_key else '', overwrite),
               filename=file_path)
     return ret["destination_key"]
 
@@ -1299,7 +1299,25 @@ def _create_zip_file(dest_filename, *content_list):
     return dest_filename
 
 
-def upload_custom_metric(func, func_file="metrics.py", func_name=None, class_name=None):
+def _default_source_provider(obj):
+    import inspect
+    # First try to get source code via inspect
+    try:
+        return '    '.join(inspect.getsourcelines(obj)[0])
+    except (OSError, TypeError):
+        # It seems like we are in interactive shell and
+        # we do not have access to class source code directly
+        # At this point we can:
+        # (1) get IPython history and find class definition, or
+        # (2) compose body of class from methods, since it is still possible to get
+        #     method body
+        class_def = "class {}:\n".format(obj.__name__)
+        for name, member in inspect.getmembers(obj):
+            if inspect.ismethod(member):
+                class_def += inspect.getsource(member)
+        return class_def
+
+def upload_custom_metric(func, func_file="metrics.py", func_name=None, class_name=None, source_provider=None):
     """
     Upload given metrics function into H2O cluster.
 
@@ -1313,10 +1331,15 @@ def upload_custom_metric(func, func_file="metrics.py", func_name=None, class_nam
     :param func_file:  internal name of file to save given metrics representation
     :param func_name:  name for h2o key under which the given metric is saved
     :param class_name: name of class wrapping the metrics function
+    :param source_provider: a function which provides a source code for given function
     :return: reference to uploaded metrics function
     """
-    import inspect
     import tempfile
+    import inspect
+
+    # Use default source provider
+    if not source_provider:
+        source_provider = _default_source_provider
 
     # The template wraps given metrics representation
     _CFUNC_CODE_TEMPLATE = """# Generated code
@@ -1332,12 +1355,6 @@ class {}Wrapper({}, MetricFunc, object):
     pass
 
 """
-
-    # Give me source of give object - poorman version
-    def get_source(o):
-        # TODO: in interpreter mode, we cannot get source code
-        # of class. But we can get source code of individual methods
-        return '    '.join(inspect.getsourcelines(o)[0])
 
     assert_satisfies(func, inspect.isclass(func) or isinstance(func, str),
                      "The argument func needs to be string or class !")
@@ -1364,7 +1381,7 @@ class {}Wrapper({}, MetricFunc, object):
 
         class_name = "{}.{}Wrapper".format(module_name, func.__name__)
         derived_func_name = "metrics_{}".format(func.__name__)
-        code = _CFUNC_CODE_TEMPLATE.format(get_source(func), func.__name__, func.__name__)
+        code = _CFUNC_CODE_TEMPLATE.format(source_provider(func), func.__name__, func.__name__)
 
     # If the func name is not given, use whatever we can derived from given definition
     if not func_name:

--- a/h2o-py/tests/pyunit_utils/utils_model_metrics.py
+++ b/h2o-py/tests/pyunit_utils/utils_model_metrics.py
@@ -28,10 +28,47 @@ class CustomRmseFunc:
         return math.sqrt(l[0] / l[1])
 
 
+class CustomNullFunc:
+    def map(self, pred, act, w, o, model):
+        return []
+
+    def reduce(self, l, r):
+        return []
+
+    def metric(self, l):
+        return 0
+
+
+class CustomOneFunc:
+    def map(self, pred, act, w, o, model):
+        return  []
+
+    def reduce(self, l, r):
+        return []
+
+    def metric(self, l):
+        return 1
+
 def assert_metrics_equal(metric, metric_name1, metric_name2, msg=None):
     metric_name1 = metric_name1 if metric_name1 in metric._metric_json else metric_name1.upper()
     metric_name2 = metric_name2 if metric_name2 in metric._metric_json else metric_name2.upper()
     assert metric._metric_json[metric_name1] == metric._metric_json[metric_name2], msg
+
+
+def assert_all_metrics_equal(model, f_test, metric_name, value):
+    mm_train = model.model_performance(train=True)
+    print(mm_train._metric_json)
+    assert mm_train._metric_json["custom_metric_value"] == value, \
+        "{} metric on training data should be {}".format(metric_name, value)
+
+    mm_valid = model.model_performance(valid=True)
+    assert mm_valid._metric_json["custom_metric_value"] == value, \
+        "{} metric on validation data should be {}".format(metric_name, value)
+
+    # Make a new model metric
+    mm_test = model.model_performance(test_data=f_test)
+    assert mm_test._metric_json["custom_metric_value"] == value, \
+        "{} metric on validation data should be {}".format(metric_name, value)
 
 
 def assert_scoring_history(model, metric_name1, metric_name2, msg=None):

--- a/h2o-py/tests/pyunit_utils/utils_model_metrics.py
+++ b/h2o-py/tests/pyunit_utils/utils_model_metrics.py
@@ -57,7 +57,6 @@ def assert_metrics_equal(metric, metric_name1, metric_name2, msg=None):
 
 def assert_all_metrics_equal(model, f_test, metric_name, value):
     mm_train = model.model_performance(train=True)
-    print(mm_train._metric_json)
     assert mm_train._metric_json["custom_metric_value"] == value, \
         "{} metric on training data should be {}".format(metric_name, value)
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5184_custom_func_reloading.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5184_custom_func_reloading.py
@@ -1,0 +1,31 @@
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from tests.pyunit_utils import CustomNullFunc, CustomOneFunc, \
+    assert_all_metrics_equal, regression_model
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+def test_custom_metric_reload():
+    custom_metric = h2o.upload_custom_metric(CustomNullFunc, func_name="custom_mm")
+    (model1, f_test1) = regression_model(H2OGradientBoostingEstimator, custom_metric)
+    assert_all_metrics_equal(model1, f_test1, "custom_mm", 0)
+    # Redefine custom metric and build a new model
+    custom_metric = h2o.upload_custom_metric(CustomOneFunc, func_name="custom_mm")
+    (model2, f_test2) = regression_model(H2OGradientBoostingEstimator, custom_metric)
+    assert_all_metrics_equal(model2, f_test2, "custom_mm", 1)
+
+
+__TESTS__ = [
+    test_custom_metric_reload
+]
+
+if __name__ == "__main__":
+    for func in __TESTS__:
+        pyunit_utils.standalone_test(func)
+else:
+    for func in __TESTS__:
+        func()
+


### PR DESCRIPTION
in Python notebooks, also enables iterative updates of defined  functions.

The existing approach required custom functions to be defined in a
separated Python module. The main reason was that interactive
environments (ipython, python shell) does not preserve source code of
defined classes (which we need to upload to backend).

This change goes
around the limitation by re-assembling class definition from methods
definitions (yes, surprisingly code of method is available). This is
good enough solution for ipython environments, but not sufficient for
standard python shell.

Furthermore, this PR enables iterative updates of function definition by
reloading Jython module to get always fresh module definition.