### PR TITLE
PUBDEV-5190: Add quasibinomial distribution option in GBM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ Ivy Wang
 Terone Ward
 Leland Wilkinson
 Wendy Wong
+Nikhil Shekhar
 ```
 
 <a name="Advisors"></a>

--- a/h2o-docs/src/product/data-science/algo-params/distribution.rst
+++ b/h2o-docs/src/product/data-science/algo-params/distribution.rst
@@ -13,7 +13,8 @@ By default, the loss function method performs AUTO distribution. In this case, t
 
 Certain cases can exist, however, in which the median starting value for this loss function can lead to poor results (for example, if the median is the lowest or highest value in a tree node). The ``distribution`` option allows you to specify a different method. Available methods include AUTO, bernoulli, multinomial, gaussian, poisson, gamma, laplace, quantile, huber, and tweedie.
 
-- If the distribution is ``bernoulli``, the response column must be 2-class categorical
+- If the distribution is ``bernoulli``, the response column must be 2-class categorical.
+- If the distribution is ``quasibinomial``, the response column must be numeric and binary. (Available in GBM only.)
 - If the distribution is ``multinomial``, the response column must be categorical.
 - If the distribution is ``gaussian``, the response column must be numeric.
 - If the distribution is ``poisson``, the response column must be numeric.
@@ -29,7 +30,7 @@ The following general guidelines apply when selecting a distribution:
 
  For Classification problems:
 
- - A Bernoulli distribution is used for binary outcomes.
+ - Bernoulli and Quasibinomial distributions are used for binary outcomes.
  - A Multinomial distribution can handle multiple discrete outcomes.
 
  For Regression problems:
@@ -41,6 +42,8 @@ The following general guidelines apply when selecting a distribution:
  - A Laplacian loss function (absolute L1-loss function) can predict the median percentile.
  - A Quantile regression loss function can predict a specified percentile.
  - A Huber loss function, a combination of squared error and absolute error, is more robust to outliers than L2 squared-loss function. 
+
+When ``quasibinomial`` is specified, the response must be numeric and binary. The response must also have a low value of 0 (negative class). Note that this option is available in GBM only.
 
 When ``tweedie`` is specified, users must also specify a ``tweedie_power`` value. Users can tune over this option with values > 1.0 and < 2.0. More information is available `here <https://en.wikipedia.org/wiki/Tweedie_distribution>`__.	
 

--- a/h2o-docs/src/product/data-science/algo-params/offset_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/offset_column.rst
@@ -1,7 +1,7 @@
 ``offset_column``
 -----------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, XGBoost
+- Available in: GBM, Deep Learning, GLM, XGBoost
 - Hyperparameter: no
 
 
@@ -10,9 +10,9 @@ Description
 
 An offset is a per-row “bias value” that is used during model training. For Gaussian distributions, offsets can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. 
 
-When used with GBM, Deep Learning, or GLM distributions/family-link functions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For example, you may have fitted some other (logistic) regression using other variables (and data), and now you want to see if the present variables can add anything. So you use the predicted logit from the other model as an offset in. To get the logit from a predicted probability in H2O, you can use this expression: :math:`\text{logit} = \text{log}\big(\frac{prob}{(1-prob)}\big)`.
+When used with distributions/family-link functions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For example, you may have fitted some other (logistic) regression using other variables (and data), and now you want to see if the present variables can add anything. So you use the predicted logit from the other model as an offset in. To get the logit from a predicted probability in H2O, you can use this expression: :math:`\text{logit} = \text{log}\big(\frac{prob}{(1-prob)}\big)`.
 
-**Note**: 
+**Notes**: 
 
 - An offset column can only be used for regression problems.
 - This option is not applicable for multinomial distributions

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -17,11 +17,9 @@ with the exception of the following changes:
 -  Minor changes in histogramming logic for some corner cases
 -  By default, DRF builds half as many trees for binomial problems, similar to GBM: it uses a single tree to estimate class 0 (probability "p0"), and then computes the probability of class 0 as :math:`1.0 - p0`.  For multiclass problems, a tree is used to estimate the probability of each class separately.
 
-There was some code cleanup and refactoring to support the following
-features:
+There was some code cleanup and refactoring to support the following features:
 
 -  Per-row observation weights
--  Per-row offsets
 -  N-fold cross-validation
 
 DRF no longer has a special-cased histogram for classification (class
@@ -83,10 +81,6 @@ Defining a DRF Model
 -  `ignore_const_cols <algo-params/ignore_const_cols.html>`__: Specify whether to ignore constant
    training columns, since no information can be gained from them. This
    option is enabled by default.
-
--  `offset_column <algo-params/offset_column.html>`__: Specify a column to use as the offset. 
-
-    **Note**: Offsets are per-row "bias values" that are used during model training. For Gaussian distributions, they can be seen as simple corrections to the response (y) column. Instead of learning to predict the response (y-row), the model learns to predict the (row) offset of the response column. For other distributions, the offset corrections are applied in the linearized space before applying the inverse link function to get the actual response values. For more information, refer to the following `link <http://www.idg.pl/mirrors/CRAN/web/packages/gbm/vignettes/gbm.pdf>`__.
 
 -  `weights_column <algo-params/weights_column.html>`__: Specify a column to use for the observation
    weights, which are used for bias correction. The specified

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -88,7 +88,8 @@ Defining a GBM Model
 
 -  `distribution <algo-params/distribution.html>`__: Specify the distribution (i.e., the loss function). The options are AUTO, bernoulli, multinomial, gaussian, poisson, gamma, laplace, quantile, huber, or tweedie.
 
-  - If the distribution is ``bernoulli``, the the response column must be 2-class categorical
+  - If the distribution is ``bernoulli``, the the response column must be 2-class categorical.
+  - If the distribution is ``quasibinomial``, the response column must be numeric and binary. 
   - If the distribution is ``multinomial``, the response column must be categorical.
   - If the distribution is ``poisson``, the response column must be numeric.
   - If the distribution is ``laplace``, the response column must be numeric.


### PR DESCRIPTION
- In the GBM chapter, added “quasibinomail” to list of options available for the distribution parameter.
- In the parameters appendix for distribution, added quasibinomial to list of options available. Noted that this can only be used in GBM.
Driveby fixes:
- offset_column is not supported in DRF. Removed references to this option in the DRF chapter. Also removed “DRF” from list of “Available In” algos in the offset_column parameter description.