### PR TITLE
Compare two gridsearch models with the same seed

### DIFF
--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
@@ -81,8 +81,15 @@ def random_grid_model_seeds_PUBDEV_4090():
                                                            "got %s" % (expectedSeeds, model2Seeds)
 
     # compare training_rmse from scoring history
+    model1seed = air_grid1.models[0].full_parameters['seed']['actual_value']
+    index2 = 0  # find the model in grid2 with the same seed
+    for ind in range(0, len(air_grid2.models)):
+        if air_grid2.models[ind].full_parameters['seed']['actual_value']==model1seed:
+            index2=ind
+            break
+
     metric_list1 = pyunit_utils.extract_scoring_history_field(air_grid1.models[0], "training_rmse", False)
-    metric_list2 = pyunit_utils.extract_scoring_history_field(air_grid2.models[0], "training_rmse", False)
+    metric_list2 = pyunit_utils.extract_scoring_history_field(air_grid2.models[index2], "training_rmse", False)
     assert pyunit_utils.equal_two_arrays(metric_list1[0:model_len], metric_list2[0:model_len], 1e-5, 1e-6, False), \
         "Training_rmse are different between the two grid search models.  Tests are supposed to be repeatable in " \
         "this case.  Make sure model seeds are actually set correctly in the Java backend."


### PR DESCRIPTION
gridsearch model return list of models with seeds in the correct order as specified in the list most of the time.

However, lately, this has changed.  Hence, when I run the gridsearch model with the same seed lists, the models returned in the two lists with arbitrary seed order.

Added seed search before comparing training_rmse to make sure we are comparing two models with the same seed.