### PR TITLE
Print out training_rmse to make sure they are equal.

### DIFF
--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4090_grid_model_seeds.py
@@ -90,6 +90,8 @@ def random_grid_model_seeds_PUBDEV_4090():
 
     metric_list1 = pyunit_utils.extract_scoring_history_field(air_grid1.models[0], "training_rmse", False)
     metric_list2 = pyunit_utils.extract_scoring_history_field(air_grid2.models[index2], "training_rmse", False)
+    print(metric_list1)
+    print(metric_list2)
     len_list = min(len(metric_list1), len(metric_list2))
     assert pyunit_utils.equal_two_arrays(metric_list1[0:len_list], metric_list2[0:len_list], 1e-5, 1e-6, False), \
         "Training_rmse are different between the two grid search models.  Tests are supposed to be repeatable in " \


### PR DESCRIPTION
  Added print statements to print out the training_rmse from the two grid search models.  This is really strange fail.