### PR TITLE
PUBDEV-5192: Add save_mapping_frame to Aggregator docs

### DIFF
--- a/h2o-docs/src/product/data-science/aggregator.rst
+++ b/h2o-docs/src/product/data-science/aggregator.rst
@@ -46,6 +46,8 @@ Defining an Aggregator Model
   - ``label_encoder`` or ``LabelEncoder``:  Convert every enum into the integer of its index (for example, level 0 -> 0, level 1 -> 1, etc.)
   - ``enum_limited`` or ``EnumLimited``: Automatically reduce categorical levels to the most prevalent ones during Aggregator training and only keep the T most frequent levels.
 
+- **save_mapping_frame**: When this option is enabled, the mapping of rows in an aggregated frame to the one in the original/raw frame will be created and exported. This option is disabled by default. 
+
 Aggregator Output
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added a description of the new “save_mapping_frame” option in Aggregator. This can be merged after PUBDEV-5171 is merged.