### PR TITLE
[ITA-187] XGBoost installation inside docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ ARG PYTHON_VERSIONS='3.6,3.5,2.7'
 ARG JENKINS_UID='2117'
 ARG JENKINS_GID='2117'
 ARG H2O_BRANCH='master'
+ARG XGBOOST_REVISION='9dfabf5'
 
 # Initialize apt sources
 RUN \
@@ -64,16 +65,21 @@ RUN \
   tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/ && \
   rm phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
   ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin && \
+  wget http://www.cmake.org/files/v3.5/cmake-3.5.2.tar.gz && \
+  tar -xvzf cmake-3.5.2.tar.gz && \
+  cd cmake-3.5.2/ && ./configure && make && make install && cd ../ && \
+  rm -rf cmake-3.5.2/ && rm -rf cmake-3.5.2.tar.gz && \
   apt-get clean && \
   apt-get autoremove && \
   apt-get autoclean
 
 # Copy required scripts
-COPY scripts/install_R_version scripts/install_R_versions scripts/install_python_versions /usr/sbin/
+COPY scripts/install_R_version scripts/install_R_versions scripts/install_python_versions scripts/install_xgboost /usr/sbin/
 RUN \
   chmod 700 /usr/sbin/install_R_version && \
   chmod 700 /usr/sbin/install_R_versions && \
-  chmod 700 /usr/sbin/install_python_versions
+  chmod 700 /usr/sbin/install_python_versions && \
+  chmod 700 /usr/sbin/install_xgboost
 
 # Install Python
 RUN \

--- a/docker/Jenkinsfile-build-docker
+++ b/docker/Jenkinsfile-build-docker
@@ -9,11 +9,12 @@ pipeline {
     agent { label AGENT_LABEL }
 
     parameters {
-        string(name: 'gitBranch', defaultValue: 'master', description: 'Branch to load the Dockerfile from.')
-        booleanParam(name: 'force', defaultValue: false, description: 'If false and image with version specified by BuildConfig exists in repository, then the build fails.')
-        booleanParam(name: 'publishDockerImage', defaultValue: true, description: 'If true, publish the docker image')
-        string(name: 'dockerRegistry', defaultValue: 'docker.h2o.ai')
-        booleanParam(name: 'noCache', defaultValue: false, description: 'If true, build the docker image using the --no-cache flag')
+      string(name: 'gitBranch', defaultValue: 'master', description: 'Branch to load the Dockerfile from.')
+      booleanParam(name: 'force', defaultValue: false, description: 'If false and image with version specified by BuildConfig exists in repository, then the build fails.')
+      booleanParam(name: 'publishDockerImage', defaultValue: true, description: 'If true, publish the docker image')
+      string(name: 'dockerRegistry', defaultValue: 'docker.h2o.ai')
+      booleanParam(name: 'noCache', defaultValue: false, description: 'If true, build the docker image using the --no-cache flag')
+      string(name: 'XGBoostRevision', defaultValue: '9dfabf5', description: 'XGBoost revision to install in h2o_xgboost_env_python virtualenvs')
     }
 
     environment {
@@ -107,7 +108,7 @@ pipeline {
                         if (params.noCache) {
                             dockerBuildCMD += ' --no-cache'
                         }
-                        dockerBuildCMD += " -t ${IMAGE_NAME}:${version} --build-arg JENKINS_UID=\$(id -u) --build-arg JENKINS_GID=\$(id -g) --build-arg H2O_BRANCH=${params.gitBranch} ."
+                        dockerBuildCMD += " -t ${IMAGE_NAME}:${version} --build-arg JENKINS_UID=\$(id -u) --build-arg JENKINS_GID=\$(id -g) --build-arg H2O_BRANCH=${params.gitBranch} --build-arg XGBOOST_REVISION=${XGBoostRevision} ."
                         sh """
                             printenv
                             cd docker

--- a/docker/scripts/install_python_versions
+++ b/docker/scripts/install_python_versions
@@ -34,8 +34,11 @@ for python_version in "${array[@]}"; do
 
   echo "###### Installing dependencies for Python ${python_version} ######"
   source /envs/h2o_env_python${python_version}/bin/activate
-  pip install --upgrade pip
+  # install nose, it's required by XGBoost tests which are executed when installing XGBoost
+  pip install --upgrade pip nose
   pip install -r requirements.txt
+  PYTHON_VERSION=${python_version} /usr/sbin/install_xgboost
+  pip uninstall nose -y
   deactivate
 done
 

--- a/docker/scripts/install_xgboost
+++ b/docker/scripts/install_xgboost
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+DEFAULT_REVISION='h2oai'
+
+if [ ! ${XGBOOST_REVISION} ]; then
+	echo "No revision supplied, will checkout ${DEFAULT_REVISION}. If you wish to set XGBoost revision manually set the XGBOOST_REVISION"
+	XGBOOST_REVISION=${DEFAULT_REVISION}
+fi
+if [ ! ${PYTHON_VERSION} ]; then
+	echo "PYTHON_VERSION version not set."
+	exit 1
+fi
+cd ~
+
+rm -rf xgboost-py${PYTHON_VERSION}
+git clone https://github.com/h2oai/xgboost xgboost-py${PYTHON_VERSION}
+
+cd xgboost-py${PYTHON_VERSION}
+
+git checkout ${XGBOOST_REVISION}
+
+git submodule
+git submodule init
+git submodule update
+
+make clean
+
+mkdir build
+cd build
+cmake ..
+make -j
+cd ..
+
+cd python-package
+python setup.py bdist_wheel
+pip install dist/xgboost*.whl
+cd ..
+
+mkdir build/test-reports
+python -m nose --with-xunit --xunit-file=build/test-reports/xgboost.xml tests/python
+
+cd ..
+rm -rf xgboost-py${PYTHON_VERSION}

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -9,7 +9,7 @@ class BuildConfig {
   public static final String DOCKER_REGISTRY = 'docker.h2o.ai'
 
   private static final String DEFAULT_IMAGE_NAME = 'h2o-3-runtime'
-  private static final String DEFAULT_IMAGE_VERSION_TAG = '106'
+  private static final String DEFAULT_IMAGE_VERSION_TAG = '107'
   // This is the default image used for tests, build, etc.
   public static final String DEFAULT_IMAGE = DOCKER_REGISTRY + '/opsh2oai/' + DEFAULT_IMAGE_NAME + ':' + DEFAULT_IMAGE_VERSION_TAG
 


### PR DESCRIPTION
* add CMake to docker image
* additional parameter for Jenkins job which build the image -> revision of the XGBoost which should be part of the docker image
* create virtualenvs for all python versions which contain all the requirements + XGBoost
  * should I create two separate envs for each Python - **one with** and **one without** XGBoost or is **one env with XGBoost** sufficient? cc @michalkurka 
* `docker/scripts/install_xgboost` -> XGBoost build script, please review @mmalohlava I'm not exactly sure I'm building it right

Thanks 🙂 