### PR TITLE
[ITA-191] All JUnit test scripts should now use $JVM_CLASSPATH

### DIFF
--- a/h2o-algos/testMultiNode.sh
+++ b/h2o-algos/testMultiNode.sh
@@ -70,7 +70,7 @@ then
 else
     COVERAGE=""
 fi
-JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -DcloudSize=4 -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -DcloudSize=4 -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-algos/testSSL.sh
+++ b/h2o-algos/testSSL.sh
@@ -88,7 +88,7 @@ else
   fi
 fi
 
-JVM="nice $JAVA_CMD -ea -Xmx3g -Xms3g -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD -ea -Xmx3g -Xms3g -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 
 SSL=""

--- a/h2o-algos/testSingleNode.sh
+++ b/h2o-algos/testSingleNode.sh
@@ -65,7 +65,7 @@ then
 else
     COVERAGE=""
 fi
-JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-algos/testSingleNodeOneProc.sh
+++ b/h2o-algos/testSingleNodeOneProc.sh
@@ -66,7 +66,7 @@ then
 else
     COVERAGE=""
 fi
-JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*${SEP}../lib2/*"
+JVM="nice $JAVA_CMD $COVERAGE -ea -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-core/testClientNode.sh
+++ b/h2o-core/testClientNode.sh
@@ -44,7 +44,7 @@ else
     COVERAGE=""
 fi
 
-JVM="nice java $COVERAGE -ea $MAX_MEM -Xms2g -cp build/classes/main${SEP}build/resources/main${SEP}build/resources/test${SEP}build/classes/test${SEP}../lib/*${SEP}../h2o-algos/build/classes/main${SEP}../h2o-app/build/classes/main${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar"
+JVM="nice java $COVERAGE -ea $MAX_MEM -Xms2g -cp ${JVM_CLASSPATH}"
 
 # Tests
 # Must run first, before the cloud locks (because it tests cloud locking)

--- a/h2o-core/testMultiNode.sh
+++ b/h2o-core/testMultiNode.sh
@@ -76,7 +76,7 @@ else
     COVERAGE=""
 fi
 # Command to invoke test.
-JVM="nice $JAVA_CMD $COVERAGE -Xmx${MAX_MEM} -Xms${MAX_MEM} -ea -cp build/resources/main${SEP}build/resources/test${SEP}build/classes/test${SEP}build/classes/main${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD $COVERAGE -Xmx${MAX_MEM} -Xms${MAX_MEM} -ea -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 
 # Tests

--- a/h2o-parsers/h2o-avro-parser/testMultiNode.sh
+++ b/h2o-parsers/h2o-avro-parser/testMultiNode.sh
@@ -45,7 +45,7 @@ fi
 #   build/classes/main - Main h2o core classes
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
-JVM="nice $JAVA_CMD -DcloudSize=5 -ea -Xmx3g -Xms3g -cp build/libs/h2o-avro-parser-test.jar${SEP}build/libs/h2o-avro-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../lib/*"
+JVM="nice $JAVA_CMD -DcloudSize=5 -ea -Xmx3g -Xms3g -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-parsers/h2o-orc-parser/testMultiNode.sh
+++ b/h2o-parsers/h2o-orc-parser/testMultiNode.sh
@@ -65,7 +65,7 @@ fi
 #   build/classes/main - Main h2o core classes
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
-JVM="nice $JAVA_CMD -DcloudSize=5 -ea $COVERAGE -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp build/libs/h2o-orc-parser-test.jar${SEP}build/libs/h2o-orc-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../h2o-persist-hdfs/build/libs/h2o-persist-hdfs.jar${SEP}../../lib/*"
+JVM="nice $JAVA_CMD -DcloudSize=5 -ea $COVERAGE -Xmx${MAX_MEM} -Xms${MAX_MEM} -cp ${JVM_CLASSPATH}"
 
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.

--- a/h2o-parsers/h2o-parquet-parser/testMultiNode.sh
+++ b/h2o-parsers/h2o-parquet-parser/testMultiNode.sh
@@ -44,7 +44,7 @@ fi
 #   build/classes/main - Main h2o core classes
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
-JVM="nice $JAVA_CMD -DcloudSize=5 -ea -Xmx3g -Xms3g -cp build/libs/h2o-parquet-parser-test.jar${SEP}build/libs/h2o-parquet-parser.jar${SEP}../../h2o-core/build/libs/h2o-core-test.jar${SEP}../../h2o-core/build/libs/h2o-core.jar${SEP}../../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../../h2o-persist-hdfs/build/libs/h2o-persist-hdfs.jar${SEP}../../lib/*"
+JVM="nice $JAVA_CMD -DcloudSize=5 -ea -Xmx3g -Xms3g -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-persist-hdfs/testMultiNode.sh
+++ b/h2o-persist-hdfs/testMultiNode.sh
@@ -49,7 +49,7 @@ fi
 #   build/classes/main - Main h2o core classes
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
-JVM="nice $JAVA_CMD -ea -Xmx3g -Xms3g -cp build/libs/h2o-persist-hdfs-test.jar${SEP}build/libs/h2o-persist-hdfs.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD -ea -Xmx3g -Xms3g -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-persist-s3/testMultiNode.sh
+++ b/h2o-persist-s3/testMultiNode.sh
@@ -44,7 +44,7 @@ fi
 #   build/classes/main - Main h2o core classes
 #   build/classes/test - Test h2o core classes
 #   build/resources/main - Main resources (e.g. page.html)
-JVM="nice $JAVA_CMD -ea -Xmx3g -Xms3g -cp build/libs/h2o-persist-s3-test.jar${SEP}build/libs/h2o-persist-s3.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD -ea -Xmx3g -Xms3g -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 # Ahhh... but the makefile runs the tests skipping the jar'ing step when possible.
 # Also, sometimes see test files in the main-class directory, so put the test

--- a/h2o-scala/testMultiNode.sh
+++ b/h2o-scala/testMultiNode.sh
@@ -69,7 +69,7 @@ fi
 
 
 # Command to invoke test
-JVM="nice $JAVA_CMD $COVERAGE -Djunit.reports.dir="$BUILD_DIR/test-results" -ea -cp build/${PROJECT_NAME}/libs/${PROJECT_NAME}.jar${SEP}build/${PROJECT_NAME}/libs/${PROJECT_NAME}-test.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*"
+JVM="nice $JAVA_CMD $COVERAGE -Djunit.reports.dir="$BUILD_DIR/test-results" -ea -cp ${JVM_CLASSPATH}"
 echo "$JVM" > $OUTDIR/jvm_cmd.txt
 
 # Runner


### PR DESCRIPTION
All JUnit test scripts should now use `$JVM_CLASSPATH` passed from Gradle, instead of defining the classpath by themselves.