### PR TITLE
PUBDEV-4980: Exclude algos from AutoML

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -7,6 +7,7 @@ import hex.ModelBuilder;
 import hex.StackedEnsembleModel;
 import hex.deeplearning.DeepLearningModel;
 import hex.deepwater.DeepWater;
+import hex.deepwater.DeepWaterModel;
 import hex.deepwater.DeepWaterParameters;
 import hex.glm.GLMModel;
 import hex.grid.Grid;
@@ -16,7 +17,6 @@ import hex.splitframe.ShuffleSplitFrame;
 import hex.tree.SharedTreeModel;
 import hex.tree.drf.DRFModel;
 import hex.tree.gbm.GBMModel;
-import hex.deepwater.DeepWaterModel;
 import water.*;
 import water.api.schemas3.ImportFilesV3;
 import water.api.schemas3.KeyV3;
@@ -27,6 +27,7 @@ import water.fvec.Vec;
 import water.nbhm.NonBlockingHashMap;
 import water.parser.ParseDataset;
 import water.parser.ParseSetup;
+import water.util.ArrayUtils;
 import water.util.IcedHashMapGeneric;
 import water.util.Log;
 
@@ -82,12 +83,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
   private FrameMetadata frameMetadata;           // metadata for trainingFrame
 
-  // TODO: remove dead code
   private Key<Grid> gridKeys[] = new Key[0];  // Grid key for the GridSearches
   private boolean isClassification;
 
   private Date startTime;
-  static private Date lastStartTime; // protect against two runs with the same second in the timestamp
+  private static Date lastStartTime; // protect against two runs with the same second in the timestamp; be careful about races
   private long stopTimeMs;
   private Job job;                  // the Job object for the build of this AutoML.  TODO: can we have > 1?
 
@@ -103,11 +103,14 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private String[] originalTrainingFrameNames;
   private long[] originalTrainingFrameChecksums;
 
+  private String[] skipAlgosList = new String[0];
+
 
   // TODO: UGH: this should be dynamic, and it's easy to make it so
+  // NOTE: make sure that this is in sync with the exclude option in AutoMLBuildSpecV99
   public enum algo {
-    RF, GBM, GLM, GLRM, DL, KMEANS
-  }  // consider EnumSet
+    GLM, XRT, DRF, GBM, XGBoost, DeepLearning, DeepWater, StackedEnsemble;
+  }
 
   public AutoML() {
     super(null);
@@ -151,16 +154,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     userFeedback.info(Stage.Workflow, "Project: " + projectName());
     // TODO: does this need to be updated?  I think its okay to pass a null leaderboardFrame
     leaderboard = Leaderboard.getOrMakeLeaderboard(projectName(), userFeedback, this.leaderboardFrame);
-
-    /*
-    TODO
-    if( excludeAlgos!=null ) {
-      HashSet<algo> m = new HashSet<>();
-      Collections.addAll(m,excludeAlgos);
-      _excludeAlgos = m.toArray(new algo[m.size()]);
-    } else _excludeAlgos =null;
-    _allowMutations=tryMutations;
-    */
 
     this.jobs = new ArrayList<>();
     this.tempFrames = new ArrayList<>();
@@ -651,6 +644,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
    * @return the started hyperparameter search job
    */
   public Job<Grid> hyperparameterSearch(Key<Grid> gridKey, String algoName, Model.Parameters baseParms, Map<String, Object[]> searchParms) {
+    if (ArrayUtils.contains(skipAlgosList, algoName)) {
+      userFeedback.info(Stage.ModelTraining,"AutoML: skipping algo " + algoName + " hyperparameter search");
+      return null;
+    }
+
     setCommonModelBuilderParams(baseParms);
 
     if (remainingModels() <= 0) {
@@ -742,6 +740,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   }
 
   private boolean exceededSearchLimits(String whatWeAreSkipping) {
+    if (ArrayUtils.contains(skipAlgosList, whatWeAreSkipping)) {
+      userFeedback.info(Stage.ModelTraining,"AutoML: skipping algo " + whatWeAreSkipping + " build");
+      return true;
+    }
+
     if (timeRemainingMs() <= 0.001) {
       userFeedback.info(Stage.ModelTraining, "AutoML: out of time; skipping " + whatWeAreSkipping);
       return true;
@@ -1054,6 +1057,33 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   public void learn() {
     userFeedback.info(Stage.Workflow, "AutoML build started: " + fullTimestampFormat.format(new Date()));
 
+    if (buildSpec.build_models.exclude_algos != null)
+      for (AutoML.algo algo : buildSpec.build_models.exclude_algos)
+        skipAlgosList = ArrayUtils.append(skipAlgosList, algo.toString());
+
+    // This is useful during debugging.
+    skipAlgosList = ArrayUtils.append(skipAlgosList, new String[] {
+            /*
+            "GLM",
+            "XRT",
+            "DRF",
+            "GBM",
+            "XGBoost",
+            "DeepLearning",
+            "DeepWater",
+            "StackedEnsemble"
+             */
+            });
+
+    // Inform the user about skipped algos.
+    // Note: to make the keys short we use "DL" for the "DeepLearning" searches:
+    for (String skippedAlgo : skipAlgosList)
+      userFeedback.info(Stage.ModelTraining, "Disabling algo: " + skippedAlgo + " as requested by the user.");
+    if (ArrayUtils.contains(skipAlgosList, "DeepLearning"))
+      skipAlgosList = ArrayUtils.append(skipAlgosList,"DL");
+    if (ArrayUtils.contains(skipAlgosList, "GBM"))
+      skipAlgosList = ArrayUtils.append(skipAlgosList, "default GBMs");
+
     ///////////////////////////////////////////////////////////
     // gather initial frame metadata and guess the problem type
     ///////////////////////////////////////////////////////////
@@ -1160,9 +1190,12 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     ///////////////////////////////////////////////////////////
     Model[] allModels = leaderboard().getModels();
 
-    if (allModels.length == 0){
-      this.job.update(50, "No models built; StackedEnsemble build skipped");
-      userFeedback.info(Stage.ModelTraining, "No models were built, due to timeouts.");
+    if (allModels.length == 0) {
+      this.job.update(50, "No models built; StackedEnsemble builds skipped");
+      userFeedback.info(Stage.ModelTraining, "No models were built, due to timeouts or the exclude_algos option. StackedEnsemble builds skipped.");
+    } else if (ArrayUtils.contains(skipAlgosList, "StackedEnsemble")) {
+      this.job.update(50, "StackedEnsemble builds skipped");
+      userFeedback.info(Stage.ModelTraining, "StackedEnsemble builds skipped due to the exclude_algos option.");
     } else {
       Model m = allModels[0];
       // If nfolds == 0, then skip the Stacked Ensemble
@@ -1189,56 +1222,50 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
         Job<StackedEnsembleModel> ensembleJob = stack("StackedEnsemble_AllModels", notEnsembles);
         pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using all AutoML models", 50, this.job(), ensembleJob, JobType.ModelBuild);
 
-        //Set aside List<Model> for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).
-        //This will give another ensemble that is smaller than the original which takes all models into consideration.
-        List<Model> models = new ArrayList();
-        Set<String> types = new HashSet();
+        // Set aside List<Model> for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).
+        // This will give another ensemble that is smaller than the original which takes all models into consideration.
+        List<Model> bestModelsOfEachType = new ArrayList();
+        Set<String> typesOfGatheredModels = new HashSet();
 
-        for (Model bestM : allModels) {
-          String type = getModelType(bestM);
-          if (types.contains(type)) continue;
-          types.add(type);
-          models.add(bestM);
+        for (Model aModel : allModels) {
+          String type = getModelType(aModel);
+          if (typesOfGatheredModels.contains(type)) continue;
+          typesOfGatheredModels.add(type);
+          bestModelsOfEachType.add(aModel);
         }
 
-        Key<Model>[] bestModelKeys = new Key[models.size()];
-        for (int i = 0; i < models.size(); i++)
-          bestModelKeys[i] = models.get(i)._key;
+        Key<Model>[] bestModelKeys = new Key[bestModelsOfEachType.size()];
+        for (int i = 0; i < bestModelsOfEachType.size(); i++)
+          bestModelKeys[i] = bestModelsOfEachType.get(i)._key;
 
         Job<StackedEnsembleModel> bestEnsembleJob = stack("StackedEnsemble_BestOfFamily", bestModelKeys);
         pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using top model from each algorithm type", 50, this.job(), bestEnsembleJob, JobType.ModelBuild);
-
       }
     }
     userFeedback.info(Stage.Workflow, "AutoML: build done; built " + modelCount + " models");
-    Log.info(userFeedback.toString("User Feedback for AutoML Run " + this._key));
-    Log.info();
+    Log.info(userFeedback.toString("User Feedback for AutoML Run " + this._key + ":"));
+    for (UserFeedbackEvent event : userFeedback.feedbackEvents)
+      Log.info(event);
 
+    if (0 < this.leaderboard().getModelKeys().length) {
+      // Use a throwaway AutoML instance so the "New leader" message doesn't pollute our feedback
+      AutoML dummyAutoML = new AutoML();
+      UserFeedback dummyUF = new UserFeedback(dummyAutoML);
+      dummyAutoML.userFeedback = dummyUF;
 
+      Leaderboard trainingLeaderboard = Leaderboard.getOrMakeLeaderboard(projectName() + "_training", dummyUF, this.trainingFrame);
+      trainingLeaderboard.addModels(this.leaderboard().getModelKeys());
+      Log.info(trainingLeaderboard.toTwoDimTable("TRAINING FRAME Leaderboard for project " + projectName(), true).toString());
+      Log.info();
 
-    // TODO: Look into adding optionally adding these back in
-    // We should not spend time computing train/valid leaderboards until we are ready to expose them to the user
-    // Commenting out for now
+      // Use a throwawayUserFeedback instance so the "New leader" message doesn't pollute our feedback
+      Leaderboard validationLeaderboard = Leaderboard.getOrMakeLeaderboard(projectName() + "_validation", dummyUF, this.validationFrame);
+      validationLeaderboard.addModels(this.leaderboard().getModelKeys());
+      Log.info(validationLeaderboard.toTwoDimTable("VALIDATION FRAME Leaderboard for project " + projectName(), true).toString());
+      Log.info();
 
-    /*
-    // Use a throwaway AutoML instance so the "New leader" message doesn't pollute our feedback
-    AutoML dummyAutoML = new AutoML();
-    UserFeedback dummyUF = new UserFeedback(dummyAutoML);
-    dummyAutoML.userFeedback = dummyUF;
-
-    Leaderboard trainingLeaderboard = Leaderboard.getOrMakeLeaderboard(projectName() + "_training", dummyUF, this.trainingFrame);
-    trainingLeaderboard.addModels(this.leaderboard().getModelKeys());
-    Log.info(trainingLeaderboard.toTwoDimTable("TRAINING FRAME Leaderboard for project " + projectName(), true).toString());
-    Log.info();
-
-    // Use a throwawayUserFeedback instance so the "New leader" message doesn't pollute our feedback
-    Leaderboard validationLeaderboard = Leaderboard.getOrMakeLeaderboard(projectName() + "_validation", dummyUF, this.validationFrame);
-    validationLeaderboard.addModels(this.leaderboard().getModelKeys());
-    Log.info(validationLeaderboard.toTwoDimTable("VALIDATION FRAME Leaderboard for project " + projectName(), true).toString());
-    Log.info();
-    */
-
-    Log.info(leaderboard().toTwoDimTable("Leaderboard for project " + projectName(), true).toString());
+      Log.info(leaderboard().toTwoDimTable("Leaderboard for project " + projectName(), true).toString());
+    }
 
     possiblyVerifyImmutability();
 
@@ -1264,10 +1291,14 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
                 lastStartTime.getHours() == startTime.getHours() &&
                 lastStartTime.getMinutes() == startTime.getMinutes() &&
                 lastStartTime.getSeconds() == startTime.getSeconds())
+/*
+          // Sleep is causing a deadlock; busy-wait instead.
           try {
-            Thread.sleep(1000);
+            Thread.currentThread().sleep(1000);
           }
-          catch (InterruptedException e) {}
+          catch (InterruptedException e) {
+          }
+*/
           startTime = new Date();
       }
       lastStartTime = startTime;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1223,6 +1223,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       Log.info(event);
 
     if (0 < this.leaderboard().getModelKeys().length) {
+
+      // We should not spend time computing train/valid leaderboards until we are ready to expose them to the user
+      // Commenting this section out for now
+      /*
       // Use a throwaway AutoML instance so the "New leader" message doesn't pollute our feedback
       AutoML dummyAutoML = new AutoML();
       UserFeedback dummyUF = new UserFeedback(dummyAutoML);
@@ -1238,6 +1242,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       validationLeaderboard.addModels(this.leaderboard().getModelKeys());
       Log.info(validationLeaderboard.toTwoDimTable("VALIDATION FRAME Leaderboard for project " + projectName(), true).toString());
       Log.info();
+      */
 
       Log.info(leaderboard().toTwoDimTable("Leaderboard for project " + projectName(), true).toString());
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -106,7 +106,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   // TODO: UGH: this should be dynamic, and it's easy to make it so
   // NOTE: make sure that this is in sync with the exclude option in AutoMLBuildSpecV99
   public enum algo {
-    GLM, XRT, DRF, GBM, XGBoost, DeepLearning, StackedEnsemble;
+    GLM, DRF, GBM, DeepLearning, StackedEnsemble;  //removed XGBoost until we add that
   }
 
   public AutoML() {
@@ -768,7 +768,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
 
   Job<DRFModel>defaultExtremelyRandomTrees() {
-    if (exceededSearchLimits("XRT")) return null;
+    if (exceededSearchLimits("DRF (XRT)")) return null;
 
     DRFModel.DRFParameters drfParameters = new DRFModel.DRFParameters();
     setCommonModelBuilderParams(drfParameters);
@@ -1050,10 +1050,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     skipAlgosList = ArrayUtils.append(skipAlgosList, new String[] {
             /*
             "GLM",
-            "XRT",
             "DRF",
             "GBM",
-            "XGBoost",
             "DeepLearning",
             "StackedEnsemble"
              */
@@ -1067,6 +1065,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       skipAlgosList = ArrayUtils.append(skipAlgosList,"DL");
     if (ArrayUtils.contains(skipAlgosList, "GBM"))
       skipAlgosList = ArrayUtils.append(skipAlgosList, "default GBMs");
+    if (ArrayUtils.contains(skipAlgosList, "DRF"))
+      skipAlgosList = ArrayUtils.append(skipAlgosList, "DRF (XRT)");
 
     ///////////////////////////////////////////////////////////
     // gather initial frame metadata and guess the problem type
@@ -1097,7 +1097,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     // ... and another with "XRT" / extratrees settings
     ///////////////////////////////////////////////////////////
     Job<DRFModel>defaultExtremelyRandomTreesJob = defaultExtremelyRandomTrees();
-    pollAndUpdateProgress(Stage.ModelTraining, "Default Extremely Random Trees (XRT) build", 50, this.job(), defaultExtremelyRandomTreesJob, JobType.ModelBuild);
+    pollAndUpdateProgress(Stage.ModelTraining, "Extremely Randomized Trees (XRT) Random Forest build", 50, this.job(), defaultExtremelyRandomTreesJob, JobType.ModelBuild);
 
 
     ///////////////////////////////////////////////////////////

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -93,7 +93,7 @@ public class AutoMLBuildSpec extends Iced {
    */
   static final public class AutoMLBuildModels extends Iced {
     public AutoML.algo[] exclude_algos;
-    public GridSearchSchema[] model_searches;
+    //public GridSearchSchema[] model_searches;  //disable until used
   }
 
   /**

--- a/h2o-automl/src/main/java/ai/h2o/automl/UserFeedbackEvent.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/UserFeedbackEvent.java
@@ -10,6 +10,8 @@ public class UserFeedbackEvent extends Iced {
   public enum Level {
     Debug, Info, Warn;
   }
+  public final int longestLevel = longestLevel(); // for formatting
+
 
   public enum Stage {
     Workflow,
@@ -19,6 +21,7 @@ public class UserFeedbackEvent extends Iced {
     FeatureCreation,
     ModelTraining,
   }
+  public final int longestStage = longestStage(); // for formatting
 
   private long timestamp;
   transient private AutoML autoML;
@@ -52,6 +55,20 @@ public class UserFeedbackEvent extends Iced {
     this.message = message;
   }
 
+
+  private static int longestStage() {
+    int longest = -1;
+    for (Stage stage : Stage.values())
+      longest = Math.max(longest, stage.name().length());
+    return longest;
+  }
+
+  private static int longestLevel() {
+    int longest = -1;
+    for (Level level : Level.values())
+      longest = Math.max(longest, level.name().length());
+    return longest;
+  }
 
   protected static final String[] colHeaders = { "timestamp",
                                                  "level",
@@ -87,5 +104,15 @@ public class UserFeedbackEvent extends Iced {
     table.set(row, col++, level);
     table.set(row, col++, stage);
     table.set(row, col++, message);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%-12s %-" + longestLevel + "s %-" + longestStage + "s %s",
+            timestampFormat.format(new Date(timestamp)),
+            level,
+            stage,
+            message
+    );
   }
 }

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -121,11 +121,14 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="Prevent AutoML from trying these algos; ignored if you use the model_searches parameter", values = {"GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "StackedEnsemble"}, direction=API.Direction.INPUT)
+    @API(help="A list algorithms to skip during the model-building phase.", values = {"GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"}, direction=API.Direction.INPUT)
     public AutoML.algo[] exclude_algos;
 
+    // Disabling until we use/need this
+    /*
     @API(help="Optional model build parameter sets, including base hyperparameters and optional hyperparameter search.")
     public GridSearchSchema[] model_searches;
+    */
   } // class AutoMLBuildModels
 
   static final public class AutoMLEnsembleParametersV99 extends Schema<AutoMLBuildSpec.AutoMLEnsembleParameters, AutoMLEnsembleParametersV99> {

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -121,7 +121,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="Prevent AutoML from trying these algos; ignored if you use the model_searches parameter", values = {"GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "DeepWater", "StackedEnsemble"}, direction=API.Direction.INPUT)
+    @API(help="Prevent AutoML from trying these algos; ignored if you use the model_searches parameter", values = {"GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "StackedEnsemble"}, direction=API.Direction.INPUT)
     public AutoML.algo[] exclude_algos;
 
     @API(help="Optional model build parameter sets, including base hyperparameters and optional hyperparameter search.")

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -121,7 +121,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="Prevent AutoML from trying these algos; ignored if you use the model_searches parameter", values = {"DL","GLRM","KMEANS","RF","GBM","GLM"}, direction=API.Direction.INPUT)
+    @API(help="Prevent AutoML from trying these algos; ignored if you use the model_searches parameter", values = {"GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "DeepWater", "StackedEnsemble"}, direction=API.Direction.INPUT)
     public AutoML.algo[] exclude_algos;
 
     @API(help="Optional model build parameter sets, including base hyperparameters and optional hyperparameter search.")

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
@@ -2,6 +2,8 @@ package water.automl.api.schemas3;
 
 import ai.h2o.automl.AutoML;
 import ai.h2o.automl.Leaderboard;
+import ai.h2o.automl.UserFeedback;
+import water.DKV;
 import water.api.API;
 import water.api.schemas3.KeyV3;
 import water.api.schemas3.SchemaV3;
@@ -63,16 +65,22 @@ public class AutoMLV99 extends SchemaV3<AutoML,AutoMLV99> {
       this.leaderboard_frame = new KeyV3.FrameKeyV3(autoML.getLeaderboardFrame()._key);
     }
 
+    // NOTE: don't return nulls; return an empty leaderboard/userFeedback, to ease life for the client
     Leaderboard leaderboard = autoML.leaderboard();
-    if (null != leaderboard) {
-      this.leaderboard = new LeaderboardV99().fillFromImpl(leaderboard);
-      this.leaderboard_table = new TwoDimTableV3().fillFromImpl(leaderboard.toTwoDimTable());
+    if (null == leaderboard) {
+      leaderboard = new Leaderboard(autoML.projectName(), autoML.userFeedback(), autoML.getLeaderboardFrame());
+      DKV.put(leaderboard);
     }
+    this.leaderboard = new LeaderboardV99().fillFromImpl(leaderboard);
+    this.leaderboard_table = new TwoDimTableV3().fillFromImpl(leaderboard.toTwoDimTable());
 
-    if (null != autoML.userFeedback()) {
-      this.user_feedback = new UserFeedbackV99().fillFromImpl(autoML.userFeedback());
-      this.user_feedback_table = new TwoDimTableV3().fillFromImpl(autoML.userFeedback().toTwoDimTable(autoML._key.toString()));
+    UserFeedback userFeedback = autoML.userFeedback();
+    if (null == userFeedback) {
+      userFeedback = new UserFeedback(autoML);
     }
+    this.user_feedback = new UserFeedbackV99().fillFromImpl(userFeedback);
+    String tableHeader = (autoML._key == null ? "(new)" : autoML._key.toString());
+    this.user_feedback_table = new TwoDimTableV3().fillFromImpl(userFeedback.toTwoDimTable(tableHeader));
 
     return this;
   }

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -43,9 +43,9 @@ Optional Data Parameters
 
 - `x <data-science/algo-params/x.html>`__: A list/vector of predictor column names or indexes.  This argument only needs to be specified if the user wants to exclude columns from the set of predictors.  If all columns (other than the response) should be used in prediction, then this does not need to be set.
 
-- `validation_frame <data-science/algo-params/validation_frame.html>`__: This argument is used to specify the validation frame used for early stopping within the training process of the individual models, grid search and the AutoML run itself (unless a model or time limit is set).  
+- `validation_frame <data-science/algo-params/validation_frame.html>`__: This argument is used to specify the validation frame used for early stopping of individual models and early stopping of the grid searches (unless ``max_models`` or ``max_runtime_secs`` overrides metric-based early stopping).  
 
-- **leaderboard_frame**: This argument allows the user to specify a particular data frame use to score & rank models on the leaderboard. This frame will not be used for anything besides leaderboard scoring. If a leaderboard frame is not specified by the user, then the leaderboard will use cross-validation metrics instead or if cross-validation is turned off by setting ``nfolds = 0``, then a leaderboard frame will be generated automatically from the validation frame (if provided) or the training frame.
+- **leaderboard_frame**: This argument allows the user to specify a particular data frame use to score & rank models on the leaderboard. This frame will not be used for anything besides leaderboard scoring. If a leaderboard frame is not specified by the user, then the leaderboard will use cross-validation metrics instead (or if cross-validation is turned off by setting ``nfolds = 0``, then a leaderboard frame will be generated automatically from the validation frame (if provided) or the training frame).
 
 - `fold_column <data-science/algo-params/fold_column.html>`__: Specifies a column with cross-validation fold index assignment per observation. This is used to override the default, randomized, 5-fold cross-validation scheme for individual models in the AutoML run.
 
@@ -79,6 +79,15 @@ Optional Miscellaneous Parameters
 - `seed <data-science/algo-params/seed.html>`__: Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if ``max_models`` is used because ``max_runtime_secs`` is resource limited, meaning that if the available compute resources are not the same between runs, AutoML may be able to train more models on one run vs another.  Defaults to ``NULL/None``.
 
 - **project_name**: Character string to identify an AutoML project. Defaults to ``NULL/None``, which means a project name will be auto-generated based on the training frame ID.  More models can be trained and added to an existing AutoML project by specifying the same project name in muliple calls to the AutoML function (as long as the same training frame is used in subsequent runs).
+
+- **exclude_algos**: List/vector of character strings naming the algorithms to skip during the model-building phase.  An example use is ``exclude_algos = ["GLM", "DeepLearning", "DRF"]`` in Python or ``exclude_algos = c("GLM", "DeepLearning", "DRF")`` in R.  Defaults to ``None/NULL``, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow.  The algorithm names are:
+
+    - ``GLM``
+    - ``DeepLearning``
+    - ``GBM``
+    - ``DRF`` (includes both the Random Forest and Extremely-Randomized Trees models)
+    - ``StackedEnsemble``
+
 
 Auto-Generated Frames
 ~~~~~~~~~~~~~~~~~~~~~
@@ -259,7 +268,9 @@ FAQ
 
 -  **Which models are trained in the AutoML process?**
 
-  The current version of AutoML trains and cross-validates a default Random Forest, an Extremely-Randomized Forest, a random grid of Gradient Boosting Machines (GBMs), a random grid of Deep Neural Nets, a fixed grid of GLMs, and then trains two Stacked Ensemble models.  A list of the hyperparameters searched over for each algorithm in the AutoML process is included in the appendix below.  More details about the hyperparamter ranges for the models will be added to the appendix at a later date.
+  The current version of AutoML trains and cross-validates a default Random Forest, an Extremely-Randomized Forest, a random grid of Gradient Boosting Machines (GBMs), a random grid of Deep Neural Nets, a fixed grid of GLMs, and then trains two Stacked Ensemble models.  Particular algorithms (or groups of algorithms) can be switched off using the ``exclude_algos`` argument.  This is useful if you already have some idea of the algorithms that will do well on your dataset.  As a recommendation, if you have really wide or sparse data, you may consider skipping the tree-based algorithms (GBM, DRF).
+
+  A list of the hyperparameters searched over for each algorithm in the AutoML process is included in the appendix below.  More details about the hyperparamter ranges for the models will be added to the appendix at a later date.
 
   Both of the ensembles should produce better models than any individual model from the AutoML run.  One ensemble contains all the models, and the second ensemble contains just the best performing model from each algorithm class/family.  The "Best of Family" ensemble is optimized for production use since it only contains five models.  It should be relatively fast to use (to generate predictions on new data) without much degredation in model performance when compared to the "All Models" ensemble.   
 
@@ -271,7 +282,7 @@ FAQ
 Appendix: Grid Search Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-AutoML performs hyperparameter search over a variety of H2O algorithms in order to deliver the best model. In AutoML, the following hyperparameters are supported by grid search.
+AutoML performs hyperparameter search over a variety of H2O algorithms in order to deliver the best model. In AutoML, the following hyperparameters are supported by grid search.  Random Forest and Extremely Randomized Trees are not grid searched (in the current version of AutoML), so they are not included in the list below.
 
 **GBM Hyperparameters**
 

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -36,6 +36,7 @@ class H2OAutoML(object):
       a project name will be auto-generated based on the training frame ID.  More models can be trained on an
       existing AutoML project by specifying the same project name in muliple calls to the AutoML function
       (as long as the same training frame is used in subsequent runs).
+    :param exclude_algos: List of character strings naming model algorithms to skip during the model-building phase.  An example use is exclude_algos = ["GLM", "DeepLearning", "XRT", "DRF"]. Defaults to None, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow; Optional.
 
     :examples:
     >>> import h2o
@@ -63,7 +64,8 @@ class H2OAutoML(object):
                  stopping_tolerance=None,
                  stopping_rounds=3,
                  seed=None,
-                 project_name=None):
+                 project_name=None,
+                 exclude_algos=None):
 
         # Check if H2O jar contains AutoML
         try:
@@ -81,6 +83,12 @@ class H2OAutoML(object):
             'stopping_criteria': {
                 'max_runtime_secs': max_runtime_secs,
             }
+        }
+
+        # Make bare minimum build_models
+        self.build_models = {
+            'exclude_algos': None
+            #                [ "GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "DeepWater", "StackedEnsemble"]
         }
 
         # nfolds must be an non-negative integer and not equal to 1:
@@ -129,7 +137,12 @@ class H2OAutoML(object):
             self.project_name = project_name
         else:
             self.project_name = None
-    
+
+        if exclude_algos is not None:
+            assert_is_type(exclude_algos,list)
+            for elem in exclude_algos:
+                assert_is_type(elem,str)
+            self.build_models['exclude_algos'] = exclude_algos
 
         self._job = None
         self._automl_key = None
@@ -154,7 +167,7 @@ class H2OAutoML(object):
         >>> # Get the best model in the AutoML Leaderboard
         >>> aml.leader
         """
-        return h2o.get_model(self._leader_id)
+        return None if self._leader_id is None else h2o.get_model(self._leader_id)
 
     @property
     def leaderboard(self):
@@ -172,7 +185,7 @@ class H2OAutoML(object):
         >>> # Get the AutoML Leaderboard
         >>> aml.leaderboard
         """
-        return self._leaderboard
+        return H2OFrame([]) if self._leaderboard is None else self._leaderboard
 
     #---------------------------------------------------------------------------
     # Training AutoML
@@ -269,6 +282,7 @@ class H2OAutoML(object):
         # NOTE: if the user hasn't specified some block of parameters don't send them!
         # This lets the back end use the defaults.
         automl_build_params['build_control'] = self.build_control
+        automl_build_params['build_models']  = self.build_models
 
         resp = h2o.api('POST /99/AutoMLBuilder', json=automl_build_params)
         if 'job' not in resp:
@@ -295,7 +309,7 @@ class H2OAutoML(object):
         :examples:
         >>> # Set up an H2OAutoML object
         >>> aml = H2OAutoML(max_runtime_secs=30)
-        >>> # Launch H2OAutoML
+        >>> # Launch an H2OAutoML run
         >>> aml.train(y=y, training_frame=training_frame)
         >>> # Predict with #1 model from AutoML Leaderboard
         >>> aml.predict(test_data)
@@ -317,6 +331,7 @@ class H2OAutoML(object):
             self._leader_id = leaderboard_list[0]
         else:
             self._leader_id = None
+
         self._leaderboard = h2o.H2OFrame(res["leaderboard_table"].as_data_frame())[1:]
         return self._leader_id is not None
 

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -88,7 +88,7 @@ class H2OAutoML(object):
         # Make bare minimum build_models
         self.build_models = {
             'exclude_algos': None
-            #                [ "GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "DeepWater", "StackedEnsemble"]
+            #                [ "GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "StackedEnsemble"]
         }
 
         # nfolds must be an non-negative integer and not equal to 1:

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -36,7 +36,7 @@ class H2OAutoML(object):
       a project name will be auto-generated based on the training frame ID.  More models can be trained on an
       existing AutoML project by specifying the same project name in muliple calls to the AutoML function
       (as long as the same training frame is used in subsequent runs).
-    :param exclude_algos: List of character strings naming model algorithms to skip during the model-building phase.  An example use is exclude_algos = ["GLM", "DeepLearning", "XRT", "DRF"]. Defaults to None, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow; Optional.
+    :param exclude_algos: List of character strings naming algorithms to skip during the model-building phase.  An example use is exclude_algos = ["GLM", "DeepLearning", "DRF"], and the full list of options is: "GLM", "GBM", "DRF" (Random Forest and Extremely-Randomized Trees), "DeepLearning" and "StackedEnsemble". Defaults to None, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
 
     :examples:
     >>> import h2o
@@ -88,7 +88,7 @@ class H2OAutoML(object):
         # Make bare minimum build_models
         self.build_models = {
             'exclude_algos': None
-            #                [ "GLM", "XRT", "DRF", "GBM", "XGBoost", "DeepLearning", "StackedEnsemble"]
+            #                [ "GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"]
         }
 
         # nfolds must be an non-negative integer and not equal to 1:

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -416,6 +416,9 @@ class H2OFrame(object):
         if self._ex is None:
             print("This H2OFrame has been removed.")
             return
+        if self.nrows == 0:
+            print("This H2OFrame is empty.")
+            return
         if not self._ex._cache.is_valid(): self._frame()._ex._cache.fill()
         if H2ODisplay._in_ipy():
             import IPython.display

--- a/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
+++ b/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
@@ -20,7 +20,7 @@ def prostate_automl():
     test = fr[2]
 
 #    aml = H2OAutoML(max_runtime_secs = 30, stopping_rounds=3, stopping_tolerance=0.001, project_name='prostate')
-    aml = H2OAutoML(max_runtime_secs = 300, stopping_rounds=2, stopping_tolerance=0.05, project_name='prostate')
+    aml = H2OAutoML(max_runtime_secs = 30, stopping_rounds=2, stopping_tolerance=0.05, project_name='prostate', exclude_algos=["GLM", "DeepLearning"])
     # aml = H2OAutoML(max_models=8, stopping_rounds=2, seed=42, project_name='prostate')
 
     train["CAPSULE"] = train["CAPSULE"].asfactor()

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -24,8 +24,15 @@ def prostate_automl_args():
     valid["CAPSULE"] = valid["CAPSULE"].asfactor()
     test["CAPSULE"] = test["CAPSULE"].asfactor()
 
+    print("Check that exclude_algos implementation is complete, and empty leaderboard works")
+    aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["GLM", "XRT", "DRF", "GBM", "DeepLearning", "DeepWater", "StackedEnsemble"])
+    aml.train(y="CAPSULE", training_frame=train)
+    print("Check leaderboard to ensure that it only has a header")
+    print(aml.leaderboard)
+    assert aml.leaderboard.nrows == 0, "with all algos excluded, leaderboard is not empty"
+
     print("Check arguments to H2OAutoML class")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["DeepLearning", "DeepWater"])
     aml.train(y="CAPSULE", training_frame=train)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml0", "Project name is not set"
@@ -111,7 +118,7 @@ def prostate_automl_args():
     print("Check predictions")
     print(aml.predict(train))
 
-    # TO DO: Clean up amodel creation below, should grep to get the DRF like we do in the runit
+    # TODO: Clean up amodel creation below, should grep to get the DRF like we do in the runit
     print("Check nfolds is passed through to base models")
     aml = H2OAutoML(project_name="py_aml_nfolds3", nfolds=3, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
@@ -132,12 +139,12 @@ def prostate_automl_args():
     assert type(amodel) is not h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
     assert amodel.params['nfolds']['actual'] == 0
 
-    # TO DO
+    # TODO
     #print("Check that exactly two ensembles are trained")
     #aml = H2OAutoML(project_name="py_aml_twoensembles", nfolds=3, max_models=5, seed=1)
     #aml.train(y="CAPSULE", training_frame=train)
 
-    # TO DO
+    # TODO
     # Add a test that checks fold_column like in runit
 
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -120,6 +120,8 @@ def prostate_automl_args():
 
     # TO DO: Clean up amodel creation below, should grep to get the DRF like we do in the runit
     print("Check nfolds is passed through to base models")
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    train["CAPSULE"] = train["CAPSULE"].asfactor()
     aml = H2OAutoML(project_name="py_aml_nfolds3", nfolds=3, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
     # grab the last model in the leaderboard, hoping that it's not an SE model
@@ -131,6 +133,8 @@ def prostate_automl_args():
     assert amodel.params['nfolds']['actual'] == 3
 
     print("Check nfolds = 0 works properly")
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    train["CAPSULE"] = train["CAPSULE"].asfactor()
     aml = H2OAutoML(project_name="py_aml_nfolds0", nfolds=0, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
     # grab the last model in the leaderboard (which should not be an SE model) and verify that nfolds = 0

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -25,7 +25,7 @@ def prostate_automl_args():
     test["CAPSULE"] = test["CAPSULE"].asfactor()
 
     print("Check that exclude_algos implementation is complete, and empty leaderboard works")
-    aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["GLM", "XRT", "DRF", "GBM", "DeepLearning", "DeepWater", "StackedEnsemble"])
+    aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"])
     aml.train(y="CAPSULE", training_frame=train)
     print("Check leaderboard to ensure that it only has a header")
     print(aml.leaderboard)
@@ -118,7 +118,7 @@ def prostate_automl_args():
     print("Check predictions")
     print(aml.predict(train))
 
-    # TODO: Clean up amodel creation below, should grep to get the DRF like we do in the runit
+    # TO DO: Clean up amodel creation below, should grep to get the DRF like we do in the runit
     print("Check nfolds is passed through to base models")
     aml = H2OAutoML(project_name="py_aml_nfolds3", nfolds=3, max_models=3, seed=1)
     aml.train(y="CAPSULE", training_frame=train)
@@ -139,12 +139,12 @@ def prostate_automl_args():
     assert type(amodel) is not h2o.estimators.stackedensemble.H2OStackedEnsembleEstimator
     assert amodel.params['nfolds']['actual'] == 0
 
-    # TODO
+    # TO DO
     #print("Check that exactly two ensembles are trained")
     #aml = H2OAutoML(project_name="py_aml_twoensembles", nfolds=3, max_models=5, seed=1)
     #aml.train(y="CAPSULE", training_frame=train)
 
-    # TODO
+    # TO DO
     # Add a test that checks fold_column like in runit
 
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -32,7 +32,7 @@ def prostate_automl_args():
     assert aml.leaderboard.nrows == 0, "with all algos excluded, leaderboard is not empty"
 
     print("Check arguments to H2OAutoML class")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["DeepLearning", "DeepWater"])
+    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["DeepLearning"])
     aml.train(y="CAPSULE", training_frame=train)
     assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml0", "Project name is not set"

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -85,6 +85,7 @@ def automl_leaderboard():
 
 
     # Include all algorithms (all should be there, given large enough max_models)
+    fr3 = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
     aml = H2OAutoML(max_models=10, project_name="py_lb_test_aml5")
     aml.train(y=4, training_frame=fr3)
     lb = aml.leaderboard

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -19,13 +19,14 @@ def automl_leaderboard():
 
 
     # Binomial
+    print("Check leaderboard for Binomial")
     fr1 = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
     fr1["CAPSULE"] = fr1["CAPSULE"].asfactor()
     exclude_algos = ["GLM", "DeepLearning", "DRF"]
     aml = H2OAutoML(max_models=2, project_name="py_lb_test_aml1", exclude_algos=exclude_algos)
     aml.train(y="CAPSULE", training_frame=fr1)
     lb = aml.leaderboard
-    lb
+    print(lb)
     # check that correct leaderboard columns exist
     assert lb.names == ["model_id", "auc", "logloss"]
     model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
@@ -38,12 +39,13 @@ def automl_leaderboard():
 
     # Regression
     # TO DO: Change this dataset
+    print("Check leaderboard for Regression")
     fr2 = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
     exclude_algos = ["GBM", "DeepLearning"]
     aml = H2OAutoML(max_models=10, project_name="py_lb_test_aml2", exclude_algos=exclude_algos)
     aml.train(y=4, training_frame=fr2)
     lb = aml.leaderboard
-    lb
+    print(lb)
     # check that correct leaderboard columns exist
     assert lb.names == ["model_id", "mean_residual_deviance","rmse", "mae", "rmsle"]
     model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
@@ -55,12 +57,13 @@ def automl_leaderboard():
 
 
     # Multinomial
+    print("Check leaderboard for Multinomial")
     fr3 = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
     exclude_algos = ["GBM"]
     aml = H2OAutoML(max_models=6, project_name="py_lb_test_aml3", exclude_algos=exclude_algos)
     aml.train(y=4, training_frame=fr3)
     lb = aml.leaderboard
-    lb
+    print(lb)
     # check that correct leaderboard columns exist
     assert lb.names == ["model_id", "mean_per_class_error"]
     model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
@@ -72,24 +75,26 @@ def automl_leaderboard():
 
 
     # Exclude all the algorithms, check for empty leaderboard
-    fr1 = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
-    fr1["CAPSULE"] = fr1["CAPSULE"].asfactor()
+    print("Check leaderboard for excluding all algos (empty leaderboard)")    
+    fr4 = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    fr4["CAPSULE"] = fr4["CAPSULE"].asfactor()
     exclude_algos = ["GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"]
     aml = H2OAutoML(max_runtime_secs=5, project_name="py_lb_test_aml4", exclude_algos=exclude_algos)
-    aml.train(y="CAPSULE", training_frame=fr1)
+    aml.train(y="CAPSULE", training_frame=fr4)
     lb = aml.leaderboard
-    lb
+    print(lb)
     # check that correct leaderboard columns exist
     assert lb.names == ["model_id", "auc", "logloss"]
     assert lb.nrows == 0
 
 
     # Include all algorithms (all should be there, given large enough max_models)
-    fr3 = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    print("Check leaderboard for all algorithms")
+    fr5 = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
     aml = H2OAutoML(max_models=10, project_name="py_lb_test_aml5")
-    aml.train(y=4, training_frame=fr3)
+    aml.train(y=4, training_frame=fr5)
     lb = aml.leaderboard
-    lb
+    print(lb)
     model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
     include_algos = list(set(all_algos) - set(exclude_algos)) + ["XRT"]
     # check that expected algos are included in leaderboard

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -1,0 +1,103 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils
+from h2o.automl import H2OAutoML
+
+"""
+This test is used to check arguments passed into H2OAutoML along with different ways of using `.train()`
+"""
+def automl_leaderboard():
+
+    # Test each ML task to make sure the leaderboard is working as expected:
+    # Leaderboard columns are correct for each ML task 
+    # Check that correct algos are in the leaderboard
+
+
+    all_algos = ["GLM", "DeepLearning", "GBM", "DRF", "StackedEnsemble"]
+
+
+    # Binomial
+    fr1 = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    fr1["CAPSULE"] = fr1["CAPSULE"].asfactor()
+    exclude_algos = ["GLM", "DeepLearning", "DRF"]
+    aml = H2OAutoML(max_models=2, project_name="py_lb_test_aml1", exclude_algos=exclude_algos)
+    aml.train(y="CAPSULE", training_frame=fr1)
+    lb = aml.leaderboard
+    lb
+    # check that correct leaderboard columns exist
+    assert lb.names == ["model_id", "auc", "logloss"]
+    model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
+    # check that no exluded algos are present in leaderboard
+    assert len([a for a in exclude_algos if len([b for b in model_ids if a in b])>0]) == 0
+    include_algos = list(set(all_algos) - set(exclude_algos))
+    # check that expected algos are included in leaderboard
+    assert len([a for a in include_algos if len([b for b in model_ids if a in b])>0]) == len(include_algos)
+
+
+    # Regression
+    # TO DO: Change this dataset
+    fr2 = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    exclude_algos = ["GBM", "DeepLearning"]
+    aml = H2OAutoML(max_models=10, project_name="py_lb_test_aml2", exclude_algos=exclude_algos)
+    aml.train(y=4, training_frame=fr2)
+    lb = aml.leaderboard
+    lb
+    # check that correct leaderboard columns exist
+    assert lb.names == ["model_id", "mean_residual_deviance","rmse", "mae", "rmsle"]
+    model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
+    # check that no exluded algos are present in leaderboard
+    assert len([a for a in exclude_algos if len([b for b in model_ids if a in b])>0]) == 0
+    include_algos = list(set(all_algos) - set(exclude_algos)) + ["XRT"]
+    # check that expected algos are included in leaderboard
+    assert len([a for a in include_algos if len([b for b in model_ids if a in b])>0]) == len(include_algos)
+
+
+    # Multinomial
+    fr3 = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    exclude_algos = ["GBM"]
+    aml = H2OAutoML(max_models=6, project_name="py_lb_test_aml3", exclude_algos=exclude_algos)
+    aml.train(y=4, training_frame=fr3)
+    lb = aml.leaderboard
+    lb
+    # check that correct leaderboard columns exist
+    assert lb.names == ["model_id", "mean_per_class_error"]
+    model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
+    # check that no exluded algos are present in leaderboard
+    assert len([a for a in exclude_algos if len([b for b in model_ids if a in b])>0]) == 0
+    include_algos = list(set(all_algos) - set(exclude_algos)) + ["XRT"]
+    # check that expected algos are included in leaderboard
+    assert len([a for a in include_algos if len([b for b in model_ids if a in b])>0]) == len(include_algos)
+
+
+    # Exclude all the algorithms, check for empty leaderboard
+    fr1 = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    fr1["CAPSULE"] = fr1["CAPSULE"].asfactor()
+    exclude_algos = ["GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"]
+    aml = H2OAutoML(max_runtime_secs=5, project_name="py_lb_test_aml4", exclude_algos=exclude_algos)
+    aml.train(y="CAPSULE", training_frame=fr1)
+    lb = aml.leaderboard
+    lb
+    # check that correct leaderboard columns exist
+    assert lb.names == ["model_id", "auc", "logloss"]
+    assert lb.nrows == 0
+
+
+    # Include all algorithms (all should be there, given large enough max_models)
+    aml = H2OAutoML(max_models=10, project_name="py_lb_test_aml5")
+    aml.train(y=4, training_frame=fr3)
+    lb = aml.leaderboard
+    lb
+    model_ids = list(h2o.as_list(aml.leaderboard['model_id'])['model_id'])
+    include_algos = list(set(all_algos) - set(exclude_algos)) + ["XRT"]
+    # check that expected algos are included in leaderboard
+    assert len([a for a in include_algos if len([b for b in model_ids if a in b])>0]) == len(include_algos)
+
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(automl_leaderboard)
+else:
+    automl_leaderboard()

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -7,10 +7,13 @@
 #'
 #' @param x A vector containing the names or indices of the predictor variables to use in building the model.
 #'        If x is missing, then all columns except y are used.
-#' @param y The name or index of the response variable in the model. For classification, the y column must be a factor, otherwise regression will be performed. Indexes are 1-based in R.
-#' @param training_frame Training data frame (or ID).
-#' @param validation_frame Validation data frame (or ID); Optional.
-#' @param leaderboard_frame Leaderboard data frame (or ID).  The Leaderboard will be scored using this data set. Optional.
+#' @param y The name or index of the response variable in the model. For classification, the y column must be a 
+#'        factor, otherwise regression will be performed. Indexes are 1-based in R.
+#' @param training_frame Training frame (H2OFrame or ID).
+#' @param validation_frame Validation frame (H2OFrame or ID); Optional.  This frame is used for early stopping 
+#'        of individual models and early stopping of the grid searches (unless max_models or max_runtimes_secs overrides metric-based early stopping).
+#' @param leaderboard_frame Leaderboard frame (H2OFrame or ID); Optional.  If provided, the Leaderboard will be scored using 
+#'       this data frame intead of using cross-validation metrics, which is the default.
 #' @param nfolds Number of folds for k-fold cross-validation. Defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensemble (thus decreasing the overall model performance).
 #' @param fold_column Column with cross-validation fold index assignment per observation; used to override the default, randomized, 5-fold cross-validation scheme for individual models in the AutoML run.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from 
@@ -27,9 +30,9 @@
 #' @param seed Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if max_models or early stopping is used 
 #'        because max_runtime_secs is resource limited, meaning that if the resources are not the same between runs, AutoML may be able to train more models on one run vs another.
 #' @param project_name Character string to identify an AutoML project.  Defaults to NULL, which means a project name will be auto-generated based on the training frame ID.
-#' @param exclude_algos Vector of character strings naming algorithms to skip during the model-building phase.  An example use is exclude_algos = list("GLM", "DeepLearning", "DRF"), 
+#' @param exclude_algos Vector of character strings naming the algorithms to skip during the model-building phase.  An example use is exclude_algos = c("GLM", "DeepLearning", "DRF"), 
 #'        and the full list of options is: "GLM", "GBM", "DRF" (Random Forest and Extremely-Randomized Trees), "DeepLearning" and "StackedEnsemble". Defaults to NULL, which means that 
-#'        all appropriate H2O algorithms will be used, if the search stopping criteria allow; Optional.
+#'        all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
 #' @details AutoML finds the best model, given a training frame and response, and returns an H2OAutoML object,
 #'          which contains a leaderboard of all the models that were trained in the process, ranked by a default model performance metric.  
 #' @return An \linkS4class{H2OAutoML} object.
@@ -37,7 +40,7 @@
 #' \donttest{
 #' library(h2o)
 #' h2o.init()
-#' votes_path <- system.file("extdata", "housevotes.csv", package="h2o")
+#' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
 #' votes_hf <- h2o.uploadFile(path = votes_path, header = TRUE)
 #' aml <- h2o.automl(y = "Class", training_frame = votes_hf, max_runtime_secs = 30)
 #' }

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -5,13 +5,13 @@ automl.leaderboard.test <- function() {
     #binomial
     fr = h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
     fr["CAPSULE"] = as.factor(fr["CAPSULE"])
-    f = h2o.automl(y=2,training_frame = fr, max_runtime_secs = 5)
+    f = h2o.automl(y=2,training_frame = fr, max_runtime_secs = 5, exclude_algos = list("GLM", "DeepLearning", "XRT", "DRF"))
     f@leaderboard
     expect_equal(names(f@leaderboard),c( "model_id","auc","logloss"))
 
     #regression
     fr2 = h2o.uploadFile(locate("smalldata/covtype/covtype.20k.data"))
-    h = h2o.automl(y=55,training_frame = fr2, max_runtime_secs = 5)
+    h = h2o.automl(y=55,training_frame = fr2, max_runtime_secs = 5, exclude_algos = list("GBM", "DeepWater"))
     h@leaderboard
     expect_equal(names(h@leaderboard),c("model_id", "mean_residual_deviance","rmse", "mae", "rmsle"))
 
@@ -20,6 +20,17 @@ automl.leaderboard.test <- function() {
     g = h2o.automl(y=5,training_frame = fr3, max_runtime_secs = 5)
     g@leaderboard
     expect_equal(names(g@leaderboard),c( "model_id","mean_per_class_error"))
+
+
+    #test of exclude_algos, should yield an empty leaderboard
+    fr4 = h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
+    fr4["CAPSULE"] = as.factor(fr4["CAPSULE"])
+    f = h2o.automl(y=2,training_frame = fr4, max_runtime_secs = 5, exclude_algos = list("GLM", "XRT", "DRF", "GBM", "DeepLearning", "DeepWater", "StackedEnsemble"))
+    f@leaderboard
+
+    expect_equal(names(f@leaderboard),c( "model_id","auc","logloss"))
+    # TODO: for empty leaderboards there's a dummy row for some reason.
+    expect_equal(nrow(f@leaderboard), 1)
 }
 
 doTest("AutoML Leaderboard Test", automl.leaderboard.test)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -11,7 +11,7 @@ automl.leaderboard.test <- function() {
 
     #regression
     fr2 = h2o.uploadFile(locate("smalldata/covtype/covtype.20k.data"))
-    h = h2o.automl(y=55,training_frame = fr2, max_runtime_secs = 5, exclude_algos = list("GBM", "DeepWater"))
+    h = h2o.automl(y=55,training_frame = fr2, max_runtime_secs = 5, exclude_algos = list("GBM", "DeepLearning"))
     h@leaderboard
     expect_equal(names(h@leaderboard),c("model_id", "mean_residual_deviance","rmse", "mae", "rmsle"))
 
@@ -25,7 +25,7 @@ automl.leaderboard.test <- function() {
     #test of exclude_algos, should yield an empty leaderboard
     fr4 = h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
     fr4["CAPSULE"] = as.factor(fr4["CAPSULE"])
-    f = h2o.automl(y=2,training_frame = fr4, max_runtime_secs = 5, exclude_algos = list("GLM", "XRT", "DRF", "GBM", "DeepLearning", "DeepWater", "StackedEnsemble"))
+    f = h2o.automl(y=2,training_frame = fr4, max_runtime_secs = 5, exclude_algos = list("GLM", "XRT", "DRF", "GBM", "DeepLearning", "StackedEnsemble"))
     f@leaderboard
 
     expect_equal(names(f@leaderboard),c( "model_id","auc","logloss"))

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -14,26 +14,30 @@ automl.leaderboard.test <- function() {
     fr1["CAPSULE"] <- as.factor(fr1["CAPSULE"])
     exclude_algos <- c("GLM", "DeepLearning", "DRF")  #Expect GBM + StackedEnsemble
     aml1 <- h2o.automl(y = 2, training_frame = fr1, max_models = 2,
-                       project_name = "lb_test_aml1",
+                       project_name = "r_lb_test_aml1",
                        exclude_algos = exclude_algos)
     aml1@leaderboard
+    # check that correct leaderboard columns exist
     expect_equal(names(aml1@leaderboard), c("model_id", "auc", "logloss"))
     model_ids <- as.vector(aml1@leaderboard$model_id)
+    # check that no exluded algos are present in leaderboard
     exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
     expect_equal(exclude_algo_count, 0)
     include_algos <- setdiff(all_algos, exclude_algos)
+    # check that expected algos are included in leaderboard
     for (a in include_algos) {
       expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
     }
 
     # Regression:
+    # TO DO: Change this dataset
     fr2 <- h2o.uploadFile(locate("smalldata/covtype/covtype.20k.data"))
     exclude_algos <- c("GBM", "DeepLearning")  #Expect GLM, DRF (and XRT), StackedEnsemble
     aml2 <- h2o.automl(y = 55, training_frame = fr2, max_models = 4,
-                       project_name = "lb_test_aml5",
+                       project_name = "r_lb_test_aml2",
                        exclude_algos = exclude_algos)
     aml2@leaderboard
-    expect_equal(names(aml2@leaderboard), c("model_id", "mean_residual_deviance","rmse", "mae", "rmsle"))
+    expect_equal(names(aml2@leaderboard), c("model_id", "mean_residual_deviance", "rmse", "mae", "rmsle"))
     model_ids <- as.vector(aml2@leaderboard$model_id)
     exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
     expect_equal(exclude_algo_count, 0)
@@ -46,7 +50,7 @@ automl.leaderboard.test <- function() {
     fr3 <- as.h2o(iris)
     exclude_algos <- c("GBM")
     aml3 <- h2o.automl(y = 5, training_frame = fr3, max_models = 6,
-                       project_name = "lb_test_aml3",
+                       project_name = "r_lb_test_aml3",
                        exclude_algos = exclude_algos)
     aml3@leaderboard
     expect_equal(names(aml3@leaderboard),c("model_id", "mean_per_class_error"))
@@ -63,7 +67,7 @@ automl.leaderboard.test <- function() {
     fr1["CAPSULE"] <- as.factor(fr1["CAPSULE"])
     exclude_algos <- c("GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble")
     aml4 <- h2o.automl(y = 2, training_frame = fr1, max_runtime_secs = 5, 
-                       project_name = "lb_test_aml4",
+                       project_name = "r_lb_test_aml4",
                        exclude_algos = exclude_algos)
     aml4@leaderboard
     expect_equal(names(aml4@leaderboard), c("model_id","auc","logloss"))
@@ -72,7 +76,7 @@ automl.leaderboard.test <- function() {
     
     # Include all algorithms (all should be there, given large enough max_models)
     aml5 <- h2o.automl(y = 5, training_frame = fr3, max_models = 10, 
-                       project_name = "lb_test_aml5")
+                       project_name = "r_lb_test_aml5")
     model_ids <- as.vector(aml5@leaderboard$model_id)
     include_algos <- c(all_algos, "XRT")
     for (a in include_algos) {

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -75,6 +75,7 @@ automl.leaderboard.test <- function() {
     expect_equal(nrow(aml4@leaderboard), 1)
     
     # Include all algorithms (all should be there, given large enough max_models)
+    fr3 <- as.h2o(iris)
     aml5 <- h2o.automl(y = 5, training_frame = fr3, max_models = 10, 
                        project_name = "r_lb_test_aml5")
     model_ids <- as.vector(aml5@leaderboard$model_id)


### PR DESCRIPTION
AutoML exclude_algos + bugfixes for empty leaderboard and deadlock

Note: This replaces another [PR](https://github.com/h2oai/h2o-3/pull/1867/) which had a bunch of extra commits on it

### TO DO
- [x] Remove DeepWater from algorithm list (not used)
- [x] Remove XGBoost from algorithm list (not used)
- [x] Remove XRT from algorithm list; when "DRF" is in `exclude_algos`, remove XRT models as well
- [x] Remove train/valid leaderboard computation (not used)
- [x] Add User Guide documentation for `exclude_algos`
- [x] Add runits
- [x] Add pyunits