### PR TITLE
PUBDEV-5230: Update import statement for PCA

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/PythonBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/PythonBooklet.tex
@@ -572,11 +572,10 @@ dependent variable.
 
 \subsubsection{Principal Components Analysis (PCA)}
 To map a set of variables onto a subspace using linear
-transformations, use {\texttt{h2o.transforms.decomposition.H2OPCA}}.
+transformations, use {\texttt{H2OPrincipalComponentAnalysisEstimator}}.
 This is the first step in Principal Components Regression.
 \lstinputlisting[style=pythoncode]{python/python_train_pca_model.py}
 
-\newpage
 \subsection{Grid Search}
 H2O supports grid search across hyperparameters:
 
@@ -607,9 +606,12 @@ We would like to acknowledge the following individuals for their contributions t
 
 \bibentry{h2odocs}
 
+
 \bibentry{Pydocs}
 
 \bibentry{h2ogithubrepo}
+
+\newpage
 
 \bibentry{h2odatasets}
 

--- a/h2o-docs/src/booklets/v2_2015/source/python/python_randomized_grid_search.py
+++ b/h2o-docs/src/booklets/v2_2015/source/python/python_randomized_grid_search.py
@@ -17,7 +17,7 @@ In [61]: params = {"standardize__center":    [True, False],
 In [62]: custom_cv = H2OKFold(iris_df, n_folds=5, seed=42)
 
 In [63]: pipeline = Pipeline([("standardize", H2OScaler()),
-   ....:                      ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
+   ....:                      ("pca", H2OPCA(k=2)),
    ....:                      ("gbm", H2OGradientBoostingEstimator(distribution="gaussian"))])
 
 In [64]: random_search = RandomizedSearchCV(pipeline, params,

--- a/h2o-docs/src/booklets/v2_2015/source/python/python_randomized_grid_search.py
+++ b/h2o-docs/src/booklets/v2_2015/source/python/python_randomized_grid_search.py
@@ -6,30 +6,28 @@ In [59]: from h2o.model.regression import h2o_r2_score
 
 In [60]: from sklearn.metrics.scorer import make_scorer
 
-In [61]: from sklearn.metrics.scorer import make_scorer
-
 # Parameters to test
-In [62]: params = {"standardize__center":    [True, False],
+In [61]: params = {"standardize__center":    [True, False],
    ....:           "standardize__scale":     [True, False],
    ....:           "pca__k":                 [2,3],
    ....:           "gbm__ntrees":            [10,20],
    ....:           "gbm__max_depth":         [1,2,3],
    ....:           "gbm__learn_rate":        [0.1,0.2]}
 
-In [63]: custom_cv = H2OKFold(iris_df, n_folds=5, seed=42)
+In [62]: custom_cv = H2OKFold(iris_df, n_folds=5, seed=42)
 
-In [64]: pipeline = Pipeline([("standardize", H2OScaler()),
-   ....:                      ("pca", H2OPCA(k=2)),
+In [63]: pipeline = Pipeline([("standardize", H2OScaler()),
+   ....:                      ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
    ....:                      ("gbm", H2OGradientBoostingEstimator(distribution="gaussian"))])
 
-In [65]: random_search = RandomizedSearchCV(pipeline, params,
+In [64]: random_search = RandomizedSearchCV(pipeline, params,
    ....:                                  n_iter=5,
    ....:                                  scoring=make_scorer(h2o_r2_score),
    ....:                                  cv=custom_cv,
    ....:                                  random_state=42,
    ....:                                  n_jobs=1)
-In [66]: random_search.fit(iris_df[1:], iris_df[0])
-Out[66]:
+In [65]: random_search.fit(iris_df[1:], iris_df[0])
+Out[65]:
 RandomizedSearchCV(cv=<h2o.cross_validation.H2OKFold instance at 0x10ba413d0>,
           error_score='raise',
           estimator=Pipeline(steps=[('standardize', <h2o.transforms.preprocessing.H2OScaler object at 0x10c0f18d0>), ('pca', ), ('gbm', )]),
@@ -38,7 +36,7 @@ RandomizedSearchCV(cv=<h2o.cross_validation.H2OKFold instance at 0x10ba413d0>,
           pre_dispatch='2*n_jobs', random_state=42, refit=True,
           scoring=make_scorer(h2o_r2_score), verbose=0)
 
-In [67]: print random_search.best_estimator_
+In [66]: print random_search.best_estimator_
 Model Details
 =============
 H2OPCA :  Principal Component Analysis

--- a/h2o-docs/src/booklets/v2_2015/source/python/python_randomized_grid_search.py
+++ b/h2o-docs/src/booklets/v2_2015/source/python/python_randomized_grid_search.py
@@ -17,7 +17,7 @@ In [61]: params = {"standardize__center":    [True, False],
 In [62]: custom_cv = H2OKFold(iris_df, n_folds=5, seed=42)
 
 In [63]: pipeline = Pipeline([("standardize", H2OScaler()),
-   ....:                      ("pca", H2OPCA(k=2)),
+   ....:                      ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
    ....:                      ("gbm", H2OGradientBoostingEstimator(distribution="gaussian"))])
 
 In [64]: random_search = RandomizedSearchCV(pipeline, params,

--- a/h2o-docs/src/booklets/v2_2015/source/python/python_scikit_learn_pipeline.py
+++ b/h2o-docs/src/booklets/v2_2015/source/python/python_scikit_learn_pipeline.py
@@ -2,20 +2,22 @@ In [41]: from h2o.transforms.preprocessing import H2OScaler
 
 In [42]: from sklearn.pipeline import Pipeline
 
-In [43]: # Turn off h2o progress bars
+In [43]: from h2o.transforms.decomposition import H2OPCA
 
-In [44]: h2o.__PROGRESS_BAR__=False
+In [44]: # Turn off h2o progress bars
 
-In [45]: h2o.no_progress()
+In [45]: h2o.__PROGRESS_BAR__=False
 
-In [46]: # build transformation pipeline using sklearn's Pipeline and H2O transforms
+In [46]: h2o.no_progress()
 
-In [47]: pipeline = Pipeline([("standardize", H2OScaler()),
-   ....:                  ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
+In [47]: # build transformation pipeline using sklearn's Pipeline and H2O transforms
+
+In [48]: pipeline = Pipeline([("standardize", H2OScaler()),
+   ....:                  ("pca", H2OPCA(k=2)),
    ....:                  ("gbm", H2OGradientBoostingEstimator(distribution="multinomial"))])
 
-In [48]: pipeline.fit(iris_df[:4],iris_df[4])
-Out[48]: Model Details
+In [49]: pipeline.fit(iris_df[:4],iris_df[4])
+Out[49]: Model Details
 =============
 H2OPCA :  Principal Component Analysis
 Model Key:  PCA_model_python_1446220160417_32

--- a/h2o-docs/src/booklets/v2_2015/source/python/python_scikit_learn_pipeline.py
+++ b/h2o-docs/src/booklets/v2_2015/source/python/python_scikit_learn_pipeline.py
@@ -11,7 +11,7 @@ In [45]: h2o.no_progress()
 In [46]: # build transformation pipeline using sklearn's Pipeline and H2O transforms
 
 In [47]: pipeline = Pipeline([("standardize", H2OScaler()),
-   ....:                  ("pca", H2OPCA(k=2)),
+   ....:                  ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
    ....:                  ("gbm", H2OGradientBoostingEstimator(distribution="multinomial"))])
 
 In [48]: pipeline.fit(iris_df[:4],iris_df[4])

--- a/h2o-docs/src/booklets/v2_2015/source/python/python_scikit_learn_pipeline.py
+++ b/h2o-docs/src/booklets/v2_2015/source/python/python_scikit_learn_pipeline.py
@@ -2,8 +2,6 @@ In [41]: from h2o.transforms.preprocessing import H2OScaler
 
 In [42]: from sklearn.pipeline import Pipeline
 
-In [43]: from h2o.transforms.decomposition import H2OPCA
-
 In [44]: # Turn off h2o progress bars
 
 In [45]: h2o.__PROGRESS_BAR__=False
@@ -13,7 +11,7 @@ In [46]: h2o.no_progress()
 In [47]: # build transformation pipeline using sklearn's Pipeline and H2O transforms
 
 In [48]: pipeline = Pipeline([("standardize", H2OScaler()),
-   ....:                  ("pca", H2OPCA(k=2)),
+   ....:                  ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
    ....:                  ("gbm", H2OGradientBoostingEstimator(distribution="multinomial"))])
 
 In [49]: pipeline.fit(iris_df[:4],iris_df[4])

--- a/h2o-docs/src/booklets/v2_2015/source/python/python_train_pca_model.py
+++ b/h2o-docs/src/booklets/v2_2015/source/python/python_train_pca_model.py
@@ -1,6 +1,6 @@
-In [25]: from h2o.transforms.decomposition import H2OPCA
+In [25]: from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
 
-In [26]: pca_decomp = H2OPCA(k=2, transform="NONE", pca_method="Power")
+In [26]: pca_decomp = H2OPrincipalComponentAnalysisEstimator(k=2, transform="NONE", pca_method="Power", impute_missing=True)
 
 In [27]: pca_decomp.train(x=range(0,4), training_frame=iris_df)
 
@@ -12,19 +12,30 @@ Out[28]: Model Details
 H2OPCA :  Principal Component Analysis
 Model Key:  PCA_model_python_1446220160417_10
 
-Importance of components:
-                        pc1      pc2
-----------------------  -------  --------
-Standard deviation      7.86058  1.45192
-Proportion of Variance  0.96543  0.032938
-Cumulative Proportion   0.96543  0.998368
-
-
 ModelMetricsPCA: pca
 ** Reported on train data. **
 
 MSE: NaN
 RMSE: NaN
+
+Scoring History from Power SVD: 
+    timestamp            duration    iterations    err          principal_component_
+--  -------------------  ----------  ------------  -----------  ----------------------
+    2018-01-18 08:35:44  0.002 sec   0             29.6462      1
+    2018-01-18 08:35:44  0.002 sec   1             0.733806     1
+    2018-01-18 08:35:44  0.002 sec   2             0.0249718    1
+    2018-01-18 08:35:44  0.002 sec   3             0.000851969  1
+    2018-01-18 08:35:44  0.002 sec   4             2.90753e-05  1
+    2018-01-18 08:35:44  0.002 sec   5             1.3487e-06   1
+    2018-01-18 08:35:44  0.002 sec   6             nan          1
+    2018-01-18 08:35:44  0.003 sec   7             1.02322      2
+    2018-01-18 08:35:44  0.003 sec   8             0.0445794    2
+    2018-01-18 08:35:44  0.003 sec   9             0.00164307   2
+    2018-01-18 08:35:44  0.003 sec   10            6.27379e-05  2
+    2018-01-18 08:35:44  0.003 sec   11            2.40329e-06  2
+    2018-01-18 08:35:44  0.003 sec   12            9.88431e-08  2
+    2018-01-18 08:35:44  0.003 sec   13            nan          2
+<bound method H2OPrincipalComponentAnalysisEstimator.train of >
 
 In [29]: pred = pca_decomp.predict(iris_df)
 
@@ -34,13 +45,13 @@ In [30]: pred.head()  # Projection results
 Out[30]:
     PC1      PC2
 -------  -------
-5.9122   2.30344
-5.57208  1.97383
-5.44648  2.09653
-5.43602  1.87168
-5.87507  2.32935
-6.47699  2.32553
-5.51543  2.07156
-5.85042  2.14948
-5.15851  1.77643
-5.64458  1.99191
+-5.9122   2.30344
+-5.57208  1.97383
+-5.44648  2.09653
+-5.43602  1.87168
+-5.87507  2.32935
+-6.47699  2.32553
+-5.51543  2.07156
+-5.85042  2.14948
+-5.15851  1.77643
+-5.64458  1.99191

--- a/h2o-docs/src/product/data-science/algo-params/impute_missing.rst
+++ b/h2o-docs/src/product/data-science/algo-params/impute_missing.rst
@@ -102,13 +102,13 @@ Example
 
     import(h2o)
     h2o.init()
-    from h2o.transforms.decomposition import H2OPCA
+    from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
 
     # Load the Birds dataset
     birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
 
     # Train with impute_missing enabled
-    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+    birds.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "STANDARDIZE", pca_method="Power", 
                        use_all_factor_levels=True, impute_missing=True)
     birds.pca.train(x=list(range(4)), training_frame=birds)
 
@@ -139,7 +139,7 @@ Example
 
     # Train again without imputing missing values
     birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
-    birds2.pca = H2OPCA(k = 3, transform = "STANDARDIZE", 
+    birds2.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "STANDARDIZE", 
                         pca_method="Power", use_all_factor_levels=True, 
                         impute_missing=False)
     birds2.pca.train(x=list(range(4)), training_frame=birds2)

--- a/h2o-docs/src/product/data-science/algo-params/pca_method.rst
+++ b/h2o-docs/src/product/data-science/algo-params/pca_method.rst
@@ -107,13 +107,13 @@ Example
 
     import(h2o)
     h2o.init()
-    from h2o.transforms.decomposition import H2OPCA
+    from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
 
     # Load the Birds dataset
     birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
 
     # Train with the Power pca_method
-    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+    birds.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "STANDARDIZE", pca_method="Power", 
                        use_all_factor_levels=True, impute_missing=True)
     birds.pca.train(x=list(range(4)), training_frame=birds)
 
@@ -144,7 +144,7 @@ Example
 
     # Train again with the GLRM pca_method
     birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
-    birds2.pca = H2OPCA(k = 3, transform = "STANDARDIZE", 
+    birds2.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "STANDARDIZE", 
                         pca_method="GLRM", use_all_factor_levels=True, 
                         impute_missing=True)
     birds2.pca.train(x=list(range(4)), training_frame=birds2)

--- a/h2o-docs/src/product/data-science/algo-params/transform.rst
+++ b/h2o-docs/src/product/data-science/algo-params/transform.rst
@@ -103,13 +103,13 @@ Example
 
     import(h2o)
     h2o.init()
-    from h2o.transforms.decomposition import H2OPCA
+    from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
 
     # Load the Birds dataset
     birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
 
     # Train with the Power pca_method
-    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+    birds.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "STANDARDIZE", pca_method="Power", 
                        use_all_factor_levels=True, impute_missing=True)
     birds.pca.train(x=list(range(4)), training_frame=birds)
 
@@ -140,7 +140,7 @@ Example
 
     # Train again using Normalize transform
     birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
-    birds2.pca = H2OPCA(k = 3, transform = "NORMALIZE", pca_method="Power", 
+    birds2.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "NORMALIZE", pca_method="Power", 
                         use_all_factor_levels=True, impute_missing=True)
     birds2.pca.train(x=list(range(4)), training_frame=birds2)
 

--- a/h2o-docs/src/product/data-science/algo-params/use_all_factor_levels.rst
+++ b/h2o-docs/src/product/data-science/algo-params/use_all_factor_levels.rst
@@ -89,13 +89,13 @@ Example
 
     import(h2o)
     h2o.init()
-    from h2o.transforms.decomposition import H2OPCA
+    from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
 
     # Load the Birds dataset
     birds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
 
     # Train using all factor levels
-    birds.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+    birds.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "STANDARDIZE", pca_method="Power", 
                        use_all_factor_levels=True)
     birds.pca.train(x=list(range(4)), training_frame=birds)
 
@@ -126,7 +126,7 @@ Example
 
     # Train again without using all factor levels
     birds2 = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/birds.csv")
-    birds2.pca = H2OPCA(k = 3, transform = "STANDARDIZE", pca_method="Power", 
+    birds2.pca = H2OPrincipalComponentAnalysisEstimator(k = 3, transform = "STANDARDIZE", pca_method="Power", 
                         use_all_factor_levels=False) 
     birds2.pca.train(x=list(range(4)), training_frame=birds2)
 

--- a/h2o-py/demos/H2O_tutorial_medium_NOPASS.ipynb
+++ b/h2o-py/demos/H2O_tutorial_medium_NOPASS.ipynb
@@ -1606,7 +1606,7 @@
    "outputs": [],
    "source": [
     "from h2o.transforms.preprocessing import H2OScaler\n",
-    "from h2o.transforms.decomposition import H2OPCA"
+    "from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA"
    ]
   },
   {
@@ -1857,7 +1857,7 @@
    "outputs": [],
    "source": [
     "from h2o.transforms.preprocessing import H2OScaler\n",
-    "from h2o.transforms.decomposition import H2OPCA"
+    "from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA"
    ]
   },
   {

--- a/h2o-py/dynamic_tests/testdir_algos/pca/pyunit_pca_gridsearch_over_all_params_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/pca/pyunit_pca_gridsearch_over_all_params_large.py
@@ -10,7 +10,7 @@ sys.path.insert(1, "../../../")
 
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from h2o.grid.grid_search import H2OGridSearch
 
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -31,6 +31,7 @@ from .estimators.glm import H2OGeneralizedLinearEstimator
 from .estimators.glrm import H2OGeneralizedLowRankEstimator
 from .estimators.kmeans import H2OKMeansEstimator
 from .estimators.naive_bayes import H2ONaiveBayesEstimator
+from .estimators.pca import H2OPrincipalComponentAnalysisEstimator
 from .estimators.random_forest import H2ORandomForestEstimator
 from .estimators.stackedensemble import H2OStackedEnsembleEstimator
 from .estimators.word2vec import H2OWord2vecEstimator
@@ -39,7 +40,6 @@ from .frame import H2OFrame
 from .grid.grid_search import H2OGridSearch
 from .job import H2OJob
 from .model.model_base import ModelBase
-from .transforms.decomposition import H2OPCA
 from .transforms.decomposition import H2OSVD
 from .utils.debugging import *  # NOQA
 from .utils.compatibility import *  # NOQA
@@ -696,7 +696,7 @@ def get_model(model_id):
     model_json = api("GET /3/Models/%s" % model_id)["models"][0]
     algo = model_json["algo"]
     if algo == "svd":            m = H2OSVD()
-    elif algo == "pca":          m = H2OPCA()
+    elif algo == "pca":          m = H2OPrincipalComponentAnalysisEstimator()
     elif algo == "drf":          m = H2ORandomForestEstimator()
     elif algo == "naivebayes":   m = H2ONaiveBayesEstimator()
     elif algo == "kmeans":       m = H2OKMeansEstimator()

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -29,8 +29,8 @@ from h2o.estimators.deeplearning import H2ODeepLearningEstimator
 from h2o.estimators.random_forest import H2ORandomForestEstimator
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 from h2o.estimators.kmeans import H2OKMeansEstimator
-from h2o.transforms.decomposition import H2OPCA
 from h2o.estimators.naive_bayes import H2ONaiveBayesEstimator
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from decimal import *
 import urllib.request, urllib.error, urllib.parse
 import numpy as np
@@ -220,7 +220,7 @@ def javapredict(algo, equality, train, test, x, y, compile_only=False, separator
     elif algo == "glm": model = H2OGeneralizedLinearEstimator(**kwargs)
     elif algo == "naive_bayes": model = H2ONaiveBayesEstimator(**kwargs)
     elif algo == "kmeans": model = H2OKMeansEstimator(**kwargs)
-    elif algo == "pca": model = H2OPCA(**kwargs)
+    elif algo == "pca": model = H2OPrincipalComponentAnalysisEstimator(**kwargs)
     else: raise ValueError
     if algo == "kmeans" or algo == "pca": model.train(x=x, training_frame=train)
     else: model.train(x=x, y=y, training_frame=train)

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_4246_pro_var.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_4246_pro_var.py
@@ -4,7 +4,7 @@ sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
 from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 # This unit test makes sure that GLRM will not return proportional of variance with values exceeding 1 when
 # categorical columns exist.  However, when there are categorical columns, if the sole purpose is to perform

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3501_variance_metrics.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_PUBDEV_3501_variance_metrics.py
@@ -4,7 +4,7 @@ sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
 from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 
 def glrm_arrests():

--- a/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_3827_scoringHistory_importance.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_3827_scoringHistory_importance.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 def pca_scoring_history_importance():
     """

--- a/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_4314_varimp.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_PUBDEV_4314_varimp.py
@@ -3,7 +3,7 @@ import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from h2o.utils.typechecks import assert_is_type
 from pandas import DataFrame
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_arrestsPCA.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_arrestsPCA.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_grid_quasar_pca.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_grid_quasar_pca.py
@@ -6,7 +6,7 @@ import h2o
 from tests import pyunit_utils
 import random
 import copy
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from h2o.grid.grid_search import H2OGridSearch
 
 def grid_quasar_pca():

--- a/h2o-py/tests/testdir_algos/pca/pyunit_prostatePCA.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_prostatePCA.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_3500_max_k_large.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_3500_max_k_large.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(1, "../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from random import randint
 
 def pca_max_k():

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_3916_pca_hangs.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_3916_pca_hangs.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4167_pca_NOPASS_OOM.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4167_pca_NOPASS_OOM.py
@@ -5,7 +5,7 @@ sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
 from random import randint
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 def pca_pubdev_4167_OOM():
   """

--- a/h2o-py/tests/testdir_algos/pca/pyunit_scoringPCA.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_scoringPCA.py
@@ -4,7 +4,7 @@ import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 
 

--- a/h2o-py/tests/testdir_algos/pca/pyunit_wideDataset_Rotterdam_large.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_wideDataset_Rotterdam_large.py
@@ -4,7 +4,7 @@ sys.path.insert(1,"../../../")
 import h2o
 from random import randint
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
 
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_4702_algo_max_runtime_secs_large.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_4702_algo_max_runtime_secs_large.py
@@ -8,7 +8,7 @@ from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
 from h2o.estimators.kmeans import H2OKMeansEstimator
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from h2o.estimators.random_forest import H2ORandomForestEstimator
 from h2o.estimators.word2vec import H2OWord2vecEstimator
 from h2o.estimators.deepwater import H2ODeepWaterEstimator

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_4802_short_max_runtime_secs.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_4802_short_max_runtime_secs.py
@@ -8,7 +8,7 @@ from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
 from h2o.estimators.kmeans import H2OKMeansEstimator
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 from h2o.estimators.random_forest import H2ORandomForestEstimator
 from h2o.estimators.word2vec import H2OWord2vecEstimator
 from h2o.estimators.deepwater import H2ODeepWaterEstimator

--- a/h2o-py/tests/testdir_misc/pyunit_screeplot.py
+++ b/h2o-py/tests/testdir_misc/pyunit_screeplot.py
@@ -2,7 +2,7 @@ import sys
 sys.path.insert(1,"../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 
 def screeplot_test():

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -8,7 +8,7 @@ from tests import pyunit_utils
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.transforms.decomposition import H2OPCA
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
 

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -8,7 +8,7 @@ from tests import pyunit_utils
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.transforms.decomposition import H2OPCA
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
 
@@ -16,7 +16,7 @@ def scale_pca_rf_pipe():
 
   # build transformation pipeline using sklearn's Pipeline and H2O transforms
   pipe = Pipeline([("standardize", H2OScaler()),
-                   ("pca", H2OPCA(k=2)),
+                   ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
                    ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
   pipe.fit(iris[:4],iris[4])
 

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -8,7 +8,7 @@ from tests import pyunit_utils
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+  from h2o.transforms.decomposition import H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
 

--- a/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
+++ b/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
@@ -9,7 +9,7 @@ from tests import pyunit_utils
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.transforms.decomposition import H2OPCA
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
   from sklearn.grid_search import RandomizedSearchCV

--- a/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
+++ b/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
@@ -9,7 +9,7 @@ from tests import pyunit_utils
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.transforms.decomposition import H2OPCA
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
   from sklearn.grid_search import RandomizedSearchCV
@@ -23,7 +23,7 @@ def scale_pca_rf_pipe():
 
   # build  transformation pipeline using sklearn's Pipeline and H2O transforms
   pipe = Pipeline([("standardize", H2OScaler()),
-                   ("pca", H2OPCA()),
+                   ("pca", H2OPrincipalComponentAnalysisEstimator()),
                    ("rf", H2ORandomForestEstimator())])
 
   params = {"standardize__center":    [True, False],             # Parameters to test

--- a/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
+++ b/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
@@ -9,7 +9,7 @@ from tests import pyunit_utils
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+  from h2o.transforms.decomposition import H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
   from sklearn.grid_search import RandomizedSearchCV


### PR DESCRIPTION
PCA is now an estimator. Previous examples imported using:
`from h2o.transforms.decomposition import H2OPCA`
For this issue, I changed all of these examples to
`from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator`
or
`from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
as H2OPCA` (where appropriate)