### PR TITLE
Reverted a fix for x-axis ordering in PUBDEV-4897

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2963,7 +2963,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
   pp.plot <- function(pp) {
     if(!all(is.na(pp))) {
       type = col_types[which(col_names == names(pp)[1])]
-      if(type == "enum") pp[,1] = as.factor( pp[,1])
+      if(type == "enum") pp[,1] = factor( pp[,1], levels=pp[,1])
       
       ## Plot one standard deviation above and below the mean
       if( plot_stddev) {


### PR DESCRIPTION
This fixed failing PUBDEV-4897 test.