### PR TITLE
[PUBDEV-5179] Fix light endpoint - return all columns, but only first…

### DIFF
--- a/h2o-core/src/main/java/water/api/FramesHandler.java
+++ b/h2o-core/src/main/java/water/api/FramesHandler.java
@@ -224,7 +224,7 @@ public class FramesHandler<I extends FramesHandler.Frames, S extends SchemaV3<I,
 
     Frame frame = getFromDKV("key", s.frame_id.key()); // safe
     s.frames = new FrameV3[1];
-    s.frames[0] = new FrameV3(frame, s.row_offset, s.row_count, s.column_offset, s.column_count, expensive);
+    s.frames[0] = new FrameV3(frame, s.row_offset, s.row_count, s.column_offset, s.column_count, s.full_column_count, expensive);
 
     if (s.find_compatible_models) {
       Model[] compatible = Frames.findCompatibleModels(frame, Model.fetchAll());

--- a/h2o-core/src/main/java/water/api/schemas3/FrameV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FrameV3.java
@@ -289,13 +289,8 @@ public class FrameV3 extends FrameBaseV3<Frame, FrameV3> {
     for( int i = 0; i < column_count; i++ )
       if (null == DKV.get(vecs[column_offset + i]._key))
         Log.warn("For Frame: " + f._key + ", Vec number: " + (column_offset + i) + " (" + f.name((column_offset + i))+ ") is missing; not returning it.");
-      else {
-        if(i < full_column_count) {
-          columns[i] = new ColV3(f._names[column_offset + i], vecs[column_offset + i], this.row_offset, this.row_count);
-        }else{
-          columns[i] = new ColV3(f._names[column_offset + i], vecs[column_offset + i], this.row_offset, this.row_count, false);
-        }
-      }
+      else
+        columns[i] = new ColV3(f._names[column_offset + i], vecs[column_offset + i], this.row_offset, this.row_count, i < full_column_count);
 
     fs.blockForPending();
     this.is_text = f.numCols()==1 && vecs[0] instanceof ByteVec;

--- a/h2o-core/src/main/java/water/api/schemas3/FrameV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FrameV3.java
@@ -37,6 +37,9 @@ public class FrameV3 extends FrameBaseV3<Frame, FrameV3> {
   @API(help="Number of columns to return", direction=API.Direction.INOUT)
   public int column_count;
 
+  @API(help="Number of full columns to return. The columns between full_column_count and column_count will be returned without the data", direction=API.Direction.INOUT)
+  public int full_column_count;
+
   @API(help="Total number of columns in the Frame", direction=API.Direction.INOUT)
   public int total_column_count;
 
@@ -141,37 +144,37 @@ public class FrameV3 extends FrameBaseV3<Frame, FrameV3> {
 
     transient Vec _vec;
 
-    ColV3(String name, Vec vec, long off, int len, boolean expensive) {
+    ColV3(String name, Vec vec, long off, int len, boolean is_full_column) {
       label = name;
-      if (expensive) {
-        missing_count = vec.naCnt();
-        zero_count = vec.length() - vec.nzCnt() - missing_count;
-        positive_infinity_count = vec.pinfs();
-        negative_infinity_count = vec.ninfs();
-        mins = vec.mins();
-        maxs = vec.maxs();
-        mean = vec.mean();
-        sigma = vec.sigma();
 
-        // Histogram data is only computed on-demand.  By default here we do NOT
-        // compute it, but will return any prior computed & cached histogram.
-        histogram_bins = vec.lazy_bins();
-        histogram_base = histogram_bins == null ? 0 : vec.base();
-        histogram_stride = histogram_bins == null ? 0 : vec.stride();
-        percentiles = histogram_bins == null ? null : vec.pctiles();
+      missing_count = vec.naCnt();
+      zero_count = vec.length() - vec.nzCnt() - missing_count;
+      positive_infinity_count = vec.pinfs();
+      negative_infinity_count = vec.ninfs();
+      mins = vec.mins();
+      maxs = vec.maxs();
+      mean = vec.mean();
+      sigma = vec.sigma();
+      // Histogram data is only computed on-demand.  By default here we do NOT
+      // compute it, but will return any prior computed & cached histogram.
+      histogram_bins = vec.lazy_bins();
+      histogram_base = histogram_bins == null ? 0 : vec.base();
+      histogram_stride = histogram_bins == null ? 0 : vec.stride();
+      percentiles = histogram_bins == null ? null : vec.pctiles();
 
-        type = vec.isUUID() ? "uuid" :
-                vec.isString() ? "string" :
-                        vec.isCategorical() ? "enum" :
-                                vec.isTime() ? "time" :
-                                        vec.isInt() ? "int" : "real";
-        domain = vec.domain();
-        if (vec.isCategorical()) {
-          domain_cardinality = domain.length;
-        } else {
-          domain_cardinality = 0;
-        }
+      type = vec.isUUID() ? "uuid" :
+              vec.isString() ? "string" :
+                      vec.isCategorical() ? "enum" :
+                              vec.isTime() ? "time" :
+                                      vec.isInt() ? "int" : "real";
+      domain = vec.domain();
+      if (vec.isCategorical()) {
+        domain_cardinality = domain.length;
+      } else {
+        domain_cardinality = 0;
+      }
 
+      if (is_full_column) {
         len = (int) Math.min(len, vec.length() - off);
         if (vec.isUUID()) {
           string_data = new String[len];
@@ -191,10 +194,10 @@ public class FrameV3 extends FrameBaseV3<Frame, FrameV3> {
           string_data = null;
         }
         _vec = vec;               // Better HTML display, not in the JSON
-        if (len > 0)  // len == 0 is presumed to be a header file
-          precision = vec.chunkForRow(0).precision();
-
       }
+      if (len > 0)  // len == 0 is presumed to be a header file
+        precision = vec.chunkForRow(0).precision();
+
     }
 
     ColV3(String name, Vec vec, long off, int len) {
@@ -212,30 +215,45 @@ public class FrameV3 extends FrameBaseV3<Frame, FrameV3> {
   public FrameV3(Key<Frame> frame_id) { this.frame_id = new FrameKeyV3(frame_id); }
 
   public FrameV3(Frame fr) {
-    this(fr, 1, (int) fr.numRows(), 0, -1, true); // NOTE: possible row len truncation
+    this(fr, 1, (int) fr.numRows(), 0, -1, -1, true); // NOTE: possible row len truncation
   }
 
   public FrameV3(Frame f, long row_offset, int row_count) {
-    this(f, row_offset, row_count, 0, -1, true);
+    this(f, row_offset, row_count, 0, -1, -1, true);
   }
 
   public FrameV3(Frame f, long row_offset, int row_count, int column_offset, int column_count) {
-    this.fillFromImpl(f, row_offset, row_count, column_offset, column_count, true);
+    this.fillFromImpl(f, row_offset, row_count, column_offset, column_count, -1, true);
   }
 
-  public FrameV3(Frame f, long row_offset, int row_count, int column_offset, int column_count, boolean expensive) {
-    this.fillFromImpl(f, row_offset, row_count, column_offset, column_count, expensive);
+  public FrameV3(Frame f, long row_offset, int row_count, int column_offset, int column_count, int full_column_count, boolean expensive) {
+    this.fillFromImpl(f, row_offset, row_count, column_offset, column_count, full_column_count, expensive);
   }
 
   @Override public FrameV3 fillFromImpl(Frame f) {
-    return fillFromImpl(f, 1, (int)f.numRows(), 0, -1, false);
+    return fillFromImpl(f, 1, (int)f.numRows(), 0, -1, -1, false);
   }
 
+  /**
+   *
+   * @param f frame from which to obtain the data
+   * @param row_offset starting position for rows
+   * @param row_count number or rows to obtain
+   * @param column_offset starting position for columns
+   * @param column_count number of columns to obtain
+   * @param full_column_count number of columns starting at column_offset which will be obtained together with data.
+   *                          The columns on positions between column_offset+full_column_count and column_offset+column_count
+   *                          won't be backed by vectors so we won't transfer the data to the client side. By default, all columns
+   *                          we ask for are full columns.
+   * @param expensive whether to execute long-lasting but not exactly strictly required computations
+   * @return desired frame slice
+   */
   private FrameV3 fillFromImpl(Frame f, long row_offset, int row_count,
-                              int column_offset, int column_count,
+                              int column_offset, int column_count, int full_column_count,
                               boolean expensive) {
     if( row_count < 0 ) row_count = 100;                                 // 100 rows by default
     if( column_count < 0 ) column_count = f.numCols() - column_offset; // full width by default
+    if( full_column_count < 0 || full_column_count > column_count) full_column_count=column_count; // light_column_count can't be larger then number of columns we asked for
 
     row_count    = (int) Math.min(row_count, row_offset + f.numRows());
     column_count = Math.min(column_count, column_offset + f.numCols());
@@ -254,12 +272,8 @@ public class FrameV3 extends FrameBaseV3<Frame, FrameV3> {
     this.total_column_count = f.numCols();
     this.column_offset = column_offset;
     this.column_count = column_count;
-    if (expensive) {
-      this.columns = new ColV3[column_count];
-    } else {
-      // in light mode, we will fill all the columns, but just first few will be filled with data
-      this.columns = new ColV3[f.numCols()];
-    }
+    this.full_column_count = full_column_count;
+    this.columns = new ColV3[column_count];
     Vec[] vecs = f.vecs();
     Futures fs = new Futures();
     // Compute rollups in parallel as needed, by starting all of them and using
@@ -270,23 +284,19 @@ public class FrameV3 extends FrameBaseV3<Frame, FrameV3> {
         Log.warn("For Frame: " + f._key + ", Vec number: " + (column_offset + i) + " (" + f.name((column_offset + i))+ ") is missing; not returning it.");
       else
         vecs[column_offset + i].startRollupStats(fs);
+
+
     for( int i = 0; i < column_count; i++ )
       if (null == DKV.get(vecs[column_offset + i]._key))
         Log.warn("For Frame: " + f._key + ", Vec number: " + (column_offset + i) + " (" + f.name((column_offset + i))+ ") is missing; not returning it.");
-      else
-        columns[i] = new ColV3(f._names[column_offset + i], vecs[column_offset + i], this.row_offset, this.row_count);
-
-    if(!expensive){
-      // In light mode, read also additional columns
-      // This solution however assumes that the light mode will never be used to obtain really just specific
-      // number of columns.
-      for (int i = column_count; i < f.numCols(); i++) {
-        if (null == DKV.get(vecs[column_offset + i]._key))
-          Log.warn("For Frame: " + f._key + ", Vec number: " + (column_offset + i) + " (" + f.name((column_offset + i)) + ") is missing; not returning it.");
-        else
-          columns[i] = new ColV3(f._names[column_offset + i], null, this.row_offset, this.row_count, false);
+      else {
+        if(i < full_column_count) {
+          columns[i] = new ColV3(f._names[column_offset + i], vecs[column_offset + i], this.row_offset, this.row_count);
+        }else{
+          columns[i] = new ColV3(f._names[column_offset + i], vecs[column_offset + i], this.row_offset, this.row_count, false);
+        }
       }
-    }
+
     fs.blockForPending();
     this.is_text = f.numCols()==1 && vecs[0] instanceof ByteVec;
     this.default_percentiles = Vec.PERCENTILES;

--- a/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
@@ -23,7 +23,7 @@ public class FramesV3 extends RequestSchemaV3<Frames, FramesV3> {
   public int column_offset;
 
   @API(help="Number of full columns to return. The columns between full_column_count and column_count will be returned without the data", direction=API.Direction.INOUT)
-  public int full_column_count;
+  public int full_column_count = -1;
 
   @API(help="Number of columns to return", direction=API.Direction.INOUT)
   public int column_count = -1;

--- a/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
@@ -22,6 +22,9 @@ public class FramesV3 extends RequestSchemaV3<Frames, FramesV3> {
   @API(help="Column offset to return", direction=API.Direction.INOUT)
   public int column_offset;
 
+  @API(help="Number of full columns to return. The columns between full_column_count and column_count will be returned without the data", direction=API.Direction.INOUT)
+  public int full_column_count;
+
   @API(help="Number of columns to return", direction=API.Direction.INOUT)
   public int column_count = -1;
 

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -327,7 +327,7 @@ class H2OCache(object):
                 self.names_valid() and
                 self.types_valid())
 
-    def fill(self, rows=10, rows_offset=0, cols=-1, cols_offset=0, light=False):
+    def fill(self, rows=10, rows_offset=0, cols=-1, full_cols=-1, cols_offset=0, light=False):
         assert self._id is not None
         if self._data is not None:
             if rows <= len(self):
@@ -336,6 +336,7 @@ class H2OCache(object):
             "row_count": rows,
             "row_offset": rows_offset,
             "column_count" : cols,
+            "full_column_count" : full_cols,
             "column_offset" : cols_offset
         }
         if light:
@@ -365,7 +366,8 @@ class H2OCache(object):
             else:
                 if c['data'] and (len(c['data']) > 0):  # orc file parse can return frame with zero rows
                     c['data'] = [float('nan') if x == "NaN" else x for x in c['data']]
-            self._data[c.pop('label')] = c  # Label used as the Key
+            if c['data']:
+                self._data[c.pop('label')] = c  # Label used as the Key
         return self
 
     #---- pretty printing ----

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -187,7 +187,7 @@ class H2OFrame(object):
 
 
     @staticmethod
-    def get_frame(frame_id, rows=10, rows_offset=0, cols=-1, cols_offset=0, light=False):
+    def get_frame(frame_id, rows=10, rows_offset=0, cols=-1, full_cols=-1, cols_offset=0, light=False):
         """
         Retrieve an existing H2OFrame from the H2O cluster using the frame's id.
 
@@ -202,7 +202,7 @@ class H2OFrame(object):
         fr = H2OFrame()
         fr._ex._cache._id = frame_id
         try:
-            fr._ex._cache.fill(rows=rows, rows_offset=rows_offset, cols=cols, cols_offset=cols_offset, light=light)
+            fr._ex._cache.fill(rows=rows, rows_offset=rows_offset, cols=cols, full_cols=full_cols, cols_offset=cols_offset, light=light)
         except EnvironmentError:
             return None
         return fr

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -195,6 +195,7 @@ class H2OFrame(object):
         :param int rows: number of rows to fetch for preview (10 by default)
         :param int rows_offset: offset to fetch rows from (0 by default)
         :param int cols: number of columns to fetch (all by default)
+        :param full_cols: number of columns to fetch together with backed data
         :param int cols_offset: offset to fetch rows from (0 by default)
         :param bool light: wether to use light frame endpoint or not
         :returns: an existing H2OFrame with the id provided; or None if such frame doesn't exist.
@@ -468,8 +469,9 @@ class H2OFrame(object):
 
         :param bool chunk_summary: Retrieve the chunk summary along with the distribution summary
         """
-        self._ex._cache.flush()
-        self._ex._cache.fill(rows=10)
+        res = h2o.api("GET /3/Frames/%s" % self.frame_id, data={"row_count": 10})["frames"][0]
+        self._ex._cache._fill_data(res)
+
         print("Rows:{}".format(self.nrow))
         print("Cols:{}".format(self.ncol))
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -468,8 +468,8 @@ class H2OFrame(object):
 
         :param bool chunk_summary: Retrieve the chunk summary along with the distribution summary
         """
-        res = h2o.api("GET /3/Frames/%s" % self.frame_id, data={"row_count": 10})["frames"][0]
-        self._ex._cache._fill_data(res)
+        self._ex._cache.flush()
+        self._ex._cache.fill(rows=10)
         print("Rows:{}".format(self.nrow))
         print("Cols:{}".format(self.ncol))
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5179.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5179.py
@@ -1,0 +1,19 @@
+import h2o
+from h2o.frame import H2OFrame
+from tests import pyunit_utils
+import numpy
+
+def pubdev_5179():
+    
+    data = [numpy.arange(0, 999).tolist() for x in numpy.arange(0, 99).tolist()]
+    fr = h2o.H2OFrame(data)
+    light = H2OFrame.get_frame(fr.frame_id, light=True)
+
+    # verify that light frame have all columns
+    assert len(light.columns) == 999
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_5179)
+else:
+    pubdev_5179()

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5179.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5179.py
@@ -4,13 +4,14 @@ from tests import pyunit_utils
 import numpy
 
 def pubdev_5179():
-    
+
     data = [numpy.arange(0, 999).tolist() for x in numpy.arange(0, 99).tolist()]
     fr = h2o.H2OFrame(data)
     light = H2OFrame.get_frame(fr.frame_id, light=True)
 
     # verify that light frame have all columns
     assert len(light.columns) == 999
+    assert len(light.types) == 999
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5179.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5179.py
@@ -5,14 +5,14 @@ import numpy
 
 def pubdev_5179():
 
-    data = [numpy.arange(0, 999).tolist() for x in numpy.arange(0, 99).tolist()]
+    data = [numpy.arange(0, 20).tolist() for x in numpy.arange(0, 20).tolist()]
     fr = h2o.H2OFrame(data)
-    light = H2OFrame.get_frame(fr.frame_id, light=True)
+    light = H2OFrame.get_frame(fr.frame_id, full_cols=10) # only first 10 columns will be returned with data
 
     # verify that light frame have all columns
-    assert len(light.columns) == 999
-    assert len(light.types) == 999
-
+    assert len(light.columns) == 20
+    assert len(light.types) == 20
+    assert len(light._ex._cache._data) == 10 # But only data for 10 columns is available
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(pubdev_5179)


### PR DESCRIPTION
… few columns are actually backed by vectors
@mmalohlava This is one possible solution
Advantage -> it's simple
Disadvantage -> when people would really want just a specific number of columns in light endpoint, we anyway return all of them. However, we do not expose this API, for example in PySparkling, which is a single place where this endpoint is used, we do not allow users to set the desired number of columns.

The best solution for the LightEndpoint would still to implement it as LightFrame but that is limited by the Schemas structures (we tried that in the office)