### PR TITLE
[HOTFIX] Fixing PCA Estimator issues

### DIFF
--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -285,8 +285,8 @@ class H2OEstimator(ModelBase):
         if name == "H2ONaiveBayesEstimator": return "naivebayes"
         if name == "H2ORandomForestEstimator": return "drf"
         if name == "H2OXGBoostEstimator": return "xgboost"
-        if name == "H2OPCA": return "pca"
-        if name == "H2OSVD": return "svd"
+        if name in ["H2OPCA", "H2OPrincipalComponentAnalysisEstimator"]: return "pca"
+        if name in ["H2OSVD", "H2OSingularValueDecompositionEstimator"]: return "svd"
 
 
     @staticmethod

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -8,7 +8,9 @@ from tests import pyunit_utils
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
+  from h2o.transforms.decomposition import H2OPCA
+  # this should work below, but it's not yet: https://0xdata.atlassian.net/browse/PUBDEV-5236
+  #from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
 
@@ -16,7 +18,7 @@ def scale_pca_rf_pipe():
 
   # build transformation pipeline using sklearn's Pipeline and H2O transforms
   pipe = Pipeline([("standardize", H2OScaler()),
-                   ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
+                   ("pca", H2OPCA(k=2)),
                    ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
   pipe.fit(iris[:4],iris[4])
 


### PR DESCRIPTION
A push to master caused the following [tests](http://mr-0xc1:8080/job/h2o-3-pipeline/job/master/365/artifact/py2.7-small/h2o-3/h2o-py/tests/results/failed/) to fail.  This fixes at least the grid and sklearn pipeline.  Might need another fix for the javapredict test.


- testdir_algos_pca_pyunit_grid_quasar_pca.py
- testdir_javapredict_pyunit_javapredict_dynamic_data_paramsPCA.py
- testdir_pipeline_pyunit_scale_pca_rf.py 
- testdir_scikit_grid_pyunit_scal_pca_rf_grid.py

