### PR TITLE
PUBDEV-5086 Stacked Ensemble should allow user to pass in a customized metalearner

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -11,6 +11,7 @@ import water.fvec.Frame;
 import water.fvec.Vec;
 import water.nbhm.NonBlockingHashSet;
 import water.udf.CFuncRef;
+import water.util.IcedHashMap;
 import water.util.Log;
 import water.util.ReflectionUtils;
 
@@ -73,6 +74,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       deeplearning
     }
     public MetalearnerAlgorithm _metalearner_algorithm = MetalearnerAlgorithm.AUTO;
+    public IcedHashMap<String, Object[]> _metalearner_params = new IcedHashMap<>();
 
   }
 

--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -74,7 +74,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       deeplearning
     }
     public MetalearnerAlgorithm _metalearner_algorithm = MetalearnerAlgorithm.AUTO;
-    public IcedHashMap<String, Object[]> _metalearner_params = new IcedHashMap<>();
+    public String _metalearner_params = new String();
 
   }
 

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -1,0 +1,422 @@
+package hex.ensemble;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+
+import hex.Model;
+import hex.ModelBuilder;
+import hex.ModelCategory;
+import hex.StackedEnsembleModel;
+import hex.StackedEnsembleModel.StackedEnsembleParameters;
+import hex.deeplearning.DeepLearning;
+import hex.deeplearning.DeepLearningModel;
+import hex.glm.GLM;
+import hex.glm.GLMModel;
+import hex.schemas.DRFV3;
+import hex.schemas.DeepLearningV3;
+import hex.schemas.GBMV3;
+import hex.schemas.GLMV3;
+import hex.tree.drf.DRF;
+import hex.tree.drf.DRFModel;
+import hex.tree.gbm.GBM;
+import hex.tree.gbm.GBMModel;
+
+import water.DKV;
+import water.Job;
+import water.Key;
+import water.exceptions.H2OIllegalArgumentException;
+import water.fvec.Frame;
+import water.util.Log;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+class Metalearner {
+
+    private Frame _levelOneTrainingFrame;
+    private Frame _levelOneValidationFrame;
+    private String _metalearner_params;
+    private StackedEnsembleModel _model;
+    private Job _job;
+    private Key<Model> _metalearnerKey;
+    private Job _metalearnerJob;
+    private StackedEnsembleParameters _parms;
+    private boolean _hasMetalearnerParams;
+    
+    Metalearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, String metalearner_params,
+                       StackedEnsembleModel model, Job StackedEnsembleJob, Key<Model> metalearnerKey, Job metalearnerJob,
+                       StackedEnsembleParameters parms, boolean hasMetalearnerParams){
+
+        _levelOneTrainingFrame = levelOneTrainingFrame;
+        _levelOneValidationFrame = levelOneValidationFrame;
+        _metalearner_params = metalearner_params;
+        _model = model;
+        _job = StackedEnsembleJob;
+        _metalearnerKey = metalearnerKey;
+        _metalearnerJob = metalearnerJob;
+        _parms = parms;
+        _hasMetalearnerParams = hasMetalearnerParams;
+
+    }
+
+    void computeAutoMetalearner(){
+        //GLM Metalearner
+        GLM metaGLMBuilder = ModelBuilder.make("GLM", _metalearnerJob, _metalearnerKey);
+
+        metaGLMBuilder._parms._non_negative = true;
+        //metaGLMBuilder._parms._alpha = new double[] {0.0, 0.25, 0.5, 0.75, 1.0};
+        metaGLMBuilder._parms._train = _levelOneTrainingFrame._key;
+        metaGLMBuilder._parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
+        metaGLMBuilder._parms._response_column = _model.responseColumn;
+        if (_model._parms._metalearner_fold_column == null) {
+            metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+                if (_model._parms._metalearner_fold_assignment == null) {
+                    metaGLMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+                } else {
+                    metaGLMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+                }
+            }
+        } else {
+            metaGLMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+        }
+
+        // Enable lambda search if a validation frame is passed in to get a better GLM fit.
+        // Since we are also using non_negative to true, we should also set early_stopping = false.
+        if (metaGLMBuilder._parms._valid != null) {
+            metaGLMBuilder._parms._lambda_search = true;
+            metaGLMBuilder._parms._early_stopping = false;
+        }
+        if (_model.modelCategory == ModelCategory.Regression) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.gaussian;
+        } else if (_model.modelCategory == ModelCategory.Binomial) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.binomial;
+        } else if (_model.modelCategory == ModelCategory.Multinomial) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.multinomial;
+        } else {
+            throw new H2OIllegalArgumentException("Family " + _model.modelCategory + "  is not supported.");
+        }
+
+        metaGLMBuilder.init(false);
+
+        Job<GLMModel> j = metaGLMBuilder.trainModel();
+
+        while (j.isRunning()) {
+            try {
+                _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm + ")");
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+
+        Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+        _model._output._metalearner = metaGLMBuilder.get();
+        _model.doScoreOrCopyMetrics(_job);
+        if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = _levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+        } else {
+            DKV.remove(_levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+        }
+        if (null != _levelOneValidationFrame) {
+            DKV.remove(_levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+        }
+        _model.update(_job);
+        _model.unlock(_job);
+    }
+
+    void computeGBMMetalearner(){
+        //GBM Metalearner
+        GBM metaGBMBuilder;
+        metaGBMBuilder = ModelBuilder.make("GBM", _metalearnerJob, _metalearnerKey);
+        GBMV3.GBMParametersV3 params = new GBMV3.GBMParametersV3();
+        params.init_meta();
+        params.fillFromImpl(metaGBMBuilder._parms); // Defaults for this builder into schema
+
+        //Metalearner parameters
+        if (_hasMetalearnerParams) {
+            Properties p = new Properties();
+            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+            }.getType());
+            for (Map.Entry<String, String[]> param : map.entrySet()) {
+                String[] paramVal = param.getValue();
+                if (paramVal.length == 1) {
+                    p.setProperty(param.getKey(), paramVal[0]);
+                } else {
+                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+                }
+                params.fillFromParms(p, true);
+            }
+            GBMModel.GBMParameters gbmParams = params.createAndFillImpl();
+            metaGBMBuilder._parms = gbmParams;
+        }
+
+        metaGBMBuilder._parms._train = _levelOneTrainingFrame._key;
+        metaGBMBuilder._parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
+        metaGBMBuilder._parms._response_column = _model.responseColumn;
+        metaGBMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+        if (_model._parms._metalearner_fold_column == null) {
+            metaGBMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+                if (_model._parms._metalearner_fold_assignment == null) {
+                    metaGBMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+                } else {
+                    metaGBMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+                }
+            }
+        } else {
+            metaGBMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+        }
+
+        metaGBMBuilder.init(false);
+
+        Job<GBMModel> j = metaGBMBuilder.trainModel();
+
+        while (j.isRunning()) {
+            try {
+                _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm + ")");
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+
+        Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+        _model._output._metalearner = metaGBMBuilder.get();
+        _model.doScoreOrCopyMetrics(_job);
+        if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = _levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+        } else {
+            DKV.remove(_levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+        }
+        if (null != _levelOneValidationFrame) {
+            DKV.remove(_levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+        }
+        _model.update(_job);
+        _model.unlock(_job);
+
+    }
+
+    void computeDRFMetalearner(){
+        //DRF Metalearner
+        DRF metaDRFBuilder;
+        metaDRFBuilder = ModelBuilder.make("DRF", _metalearnerJob, _metalearnerKey);
+        DRFV3.DRFParametersV3 params = new DRFV3.DRFParametersV3();
+        params.init_meta();
+        params.fillFromImpl(metaDRFBuilder._parms); // Defaults for this builder into schema
+
+        //Metalearner parameters
+        if (_hasMetalearnerParams) {
+            Properties p = new Properties();
+            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+            }.getType());
+            for (Map.Entry<String, String[]> param : map.entrySet()) {
+                String[] paramVal = param.getValue();
+                if (paramVal.length == 1) {
+                    p.setProperty(param.getKey(), paramVal[0]);
+                } else {
+                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+                }
+                params.fillFromParms(p, true);
+            }
+            DRFModel.DRFParameters drfParams = params.createAndFillImpl();
+            metaDRFBuilder._parms = drfParams;
+        }
+        metaDRFBuilder._parms._train = _levelOneTrainingFrame._key;
+        metaDRFBuilder._parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
+        metaDRFBuilder._parms._response_column = _model.responseColumn;
+        metaDRFBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+        if (_model._parms._metalearner_fold_column == null) {
+            metaDRFBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+                if (_model._parms._metalearner_fold_assignment == null) {
+                    metaDRFBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+                } else {
+                    metaDRFBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+                }
+            }
+        } else {
+            metaDRFBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+        }
+
+        metaDRFBuilder.init(false);
+
+        Job<DRFModel> j = metaDRFBuilder.trainModel();
+
+        while (j.isRunning()) {
+            try {
+                _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm + ")");
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+
+        Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+        _model._output._metalearner = metaDRFBuilder.get();
+        _model.doScoreOrCopyMetrics(_job);
+        if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = _levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+        } else {
+            DKV.remove(_levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+        }
+        if (null != _levelOneValidationFrame) {
+            DKV.remove(_levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+        }
+        _model.update(_job);
+        _model.unlock(_job);
+    }
+
+    void computeGLMMetalearner(){
+        //GLM Metalearner
+        GLM metaGLMBuilder;
+        metaGLMBuilder = ModelBuilder.make("GLM", _metalearnerJob, _metalearnerKey);
+        GLMV3.GLMParametersV3 params = new GLMV3.GLMParametersV3();
+        params.init_meta();
+        params.fillFromImpl(metaGLMBuilder._parms); // Defaults for this builder into schema
+
+        //Metalearner parameters
+        if (_hasMetalearnerParams) {
+            Properties p = new Properties();
+            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+            }.getType());
+            for (Map.Entry<String, String[]> param : map.entrySet()) {
+                String[] paramVal = param.getValue();
+                if (paramVal.length == 1) {
+                    p.setProperty(param.getKey(), paramVal[0]);
+                } else {
+                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+                }
+                params.fillFromParms(p, true);
+            }
+            GLMModel.GLMParameters glmParams = params.createAndFillImpl();
+            metaGLMBuilder._parms = glmParams;
+        }
+
+        metaGLMBuilder._parms._train = _levelOneTrainingFrame._key;
+        metaGLMBuilder._parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
+        metaGLMBuilder._parms._response_column = _model.responseColumn;
+        metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+        if (_model._parms._metalearner_fold_column == null) {
+            metaGLMBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+                if (_model._parms._metalearner_fold_assignment == null) {
+                    metaGLMBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+                } else {
+                    metaGLMBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+                }
+            }
+        } else {
+            metaGLMBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+        }
+
+        if (_model.modelCategory == ModelCategory.Regression) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.gaussian;
+        } else if (_model.modelCategory == ModelCategory.Binomial) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.binomial;
+        } else if (_model.modelCategory == ModelCategory.Multinomial) {
+            metaGLMBuilder._parms._family = GLMModel.GLMParameters.Family.multinomial;
+        } else {
+            throw new H2OIllegalArgumentException("Family " + _model.modelCategory + "  is not supported.");
+        }
+        metaGLMBuilder.init(false);
+
+        Job<GLMModel> j = metaGLMBuilder.trainModel();
+
+        while (j.isRunning()) {
+            try {
+                _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm + ")");
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+
+        Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+        _model._output._metalearner = metaGLMBuilder.get();
+        _model.doScoreOrCopyMetrics(_job);
+        if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = _levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+        } else {
+            DKV.remove(_levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+        }
+        if (null != _levelOneValidationFrame) {
+            DKV.remove(_levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+        }
+        _model.update(_job);
+        _model.unlock(_job);
+
+    }
+
+    void computeDeepLearningMetalearner(){
+        //DeepLearning Metalearner
+        DeepLearning metaDeepLearningBuilder;
+        metaDeepLearningBuilder = ModelBuilder.make("DeepLearning", _metalearnerJob, _metalearnerKey);
+        DeepLearningV3.DeepLearningParametersV3 params = new DeepLearningV3.DeepLearningParametersV3();
+        params.init_meta();
+        params.fillFromImpl(metaDeepLearningBuilder._parms); // Defaults for this builder into schema
+
+        //Metalearner parameters
+        if (_hasMetalearnerParams) {
+            Properties p = new Properties();
+            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+            }.getType());
+            for (Map.Entry<String, String[]> param : map.entrySet()) {
+                String[] paramVal = param.getValue();
+                if (paramVal.length == 1) {
+                    p.setProperty(param.getKey(), paramVal[0]);
+                } else {
+                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+                }
+                params.fillFromParms(p, true);
+            }
+            DeepLearningModel.DeepLearningParameters dlParams = params.createAndFillImpl();
+            metaDeepLearningBuilder._parms = dlParams;
+        }
+        metaDeepLearningBuilder._parms._train = _levelOneTrainingFrame._key;
+        metaDeepLearningBuilder._parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
+        metaDeepLearningBuilder._parms._response_column = _model.responseColumn;
+        metaDeepLearningBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+        if (_model._parms._metalearner_fold_column == null) {
+            metaDeepLearningBuilder._parms._nfolds = _model._parms._metalearner_nfolds;  //cross-validation of the metalearner
+            if (_model._parms._metalearner_nfolds > 1) {
+                if (_model._parms._metalearner_fold_assignment == null) {
+                    metaDeepLearningBuilder._parms._fold_assignment = Model.Parameters.FoldAssignmentScheme.AUTO;
+                } else {
+                    metaDeepLearningBuilder._parms._fold_assignment = _model._parms._metalearner_fold_assignment;  //cross-validation of the metalearner
+                }
+            }
+        } else {
+            metaDeepLearningBuilder._parms._fold_column = _model._parms._metalearner_fold_column;  //cross-validation of the metalearner
+        }
+
+        metaDeepLearningBuilder.init(false);
+
+        Job<DeepLearningModel> j = metaDeepLearningBuilder.trainModel();
+
+        while (j.isRunning()) {
+            try {
+                _job.update(j._work, "training metalearner(" + _model._parms._metalearner_algorithm + ")");
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+
+        Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
+
+        _model._output._metalearner = metaDeepLearningBuilder.get();
+        _model.doScoreOrCopyMetrics(_job);
+        if (_parms._keep_levelone_frame) {
+            _model._output._levelone_frame_id = _levelOneTrainingFrame; //Keep Level One Training Frame in Stacked Ensemble model object
+        } else {
+            DKV.remove(_levelOneTrainingFrame._key); //Remove Level One Training Frame from DKV
+        }
+        if (null != _levelOneValidationFrame) {
+            DKV.remove(_levelOneValidationFrame._key); //Remove Level One Validation Frame from DKV
+        }
+        _model.update(_job);
+        _model.unlock(_job);
+    }
+}

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -7,6 +7,9 @@ import hex.StackedEnsembleModel;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
 import hex.schemas.GLMV3;
+import hex.schemas.GBMV3;
+import hex.schemas.DRFV3;
+import hex.schemas.DeepLearningV3;
 import hex.tree.gbm.GBM;
 import hex.tree.gbm.GBMModel;
 import hex.tree.drf.DRF;
@@ -404,6 +407,22 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
 
           //GBM Metalearner
           metaGBMBuilder = ModelBuilder.make("GBM", job, metalearnerKey);
+          GBMV3.GBMParametersV3 params = new GBMV3.GBMParametersV3();
+          params.init_meta();
+          params.fillFromImpl(metaGBMBuilder._parms); // Defaults for this builder into schema
+
+          //Metalearner parameters
+          if(metalearner_params != null){
+            Properties p = new Properties();
+            HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
+            for (Map.Entry<String, String> param : map.entrySet()) {
+              p.setProperty(param.getKey(), param.getValue());
+              params.fillFromParms(p, true);
+            }
+            GBMModel.GBMParameters glmParams = params.createAndFillImpl();
+            metaGBMBuilder._parms = glmParams;
+          }
+
           metaGBMBuilder._parms._train = levelOneTrainingFrame._key;
           metaGBMBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaGBMBuilder._parms._response_column = _model.responseColumn;
@@ -452,6 +471,21 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
 
           //DRF Metalearner
           metaDRFBuilder = ModelBuilder.make("DRF", job, metalearnerKey);
+          DRFV3.DRFParametersV3 params = new DRFV3.DRFParametersV3();
+          params.init_meta();
+          params.fillFromImpl(metaDRFBuilder._parms); // Defaults for this builder into schema
+
+          //Metalearner parameters
+          if(metalearner_params != null){
+            Properties p = new Properties();
+            HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
+            for (Map.Entry<String, String> param : map.entrySet()) {
+              p.setProperty(param.getKey(), param.getValue());
+              params.fillFromParms(p, true);
+            }
+            DRFModel.DRFParameters glmParams = params.createAndFillImpl();
+            metaDRFBuilder._parms = glmParams;
+          }
           metaDRFBuilder._parms._train = levelOneTrainingFrame._key;
           metaDRFBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaDRFBuilder._parms._response_column = _model.responseColumn;
@@ -500,6 +534,21 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
 
           //DeepLearning Metalearner
           metaDeepLearningBuilder = ModelBuilder.make("DeepLearning", job, metalearnerKey);
+          DeepLearningV3.DeepLearningParametersV3 params = new DeepLearningV3.DeepLearningParametersV3();
+          params.init_meta();
+          params.fillFromImpl(metaDeepLearningBuilder._parms); // Defaults for this builder into schema
+
+          //Metalearner parameters
+          if(metalearner_params != null){
+            Properties p = new Properties();
+            HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
+            for (Map.Entry<String, String> param : map.entrySet()) {
+              p.setProperty(param.getKey(), param.getValue());
+              params.fillFromParms(p, true);
+            }
+            DeepLearningModel.DeepLearningParameters glmParams = params.createAndFillImpl();
+            metaDeepLearningBuilder._parms = glmParams;
+          }
           metaDeepLearningBuilder._parms._train = levelOneTrainingFrame._key;
           metaDeepLearningBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
           metaDeepLearningBuilder._parms._response_column = _model.responseColumn;

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -15,15 +15,17 @@ import hex.deeplearning.DeepLearningModel;
 import water.DKV;
 import water.Job;
 import water.Key;
+import water.api.SchemaMetadata;
 import water.exceptions.H2OIllegalArgumentException;
 import water.exceptions.H2OModelBuilderIllegalArgumentException;
 import water.fvec.Frame;
 import water.fvec.Vec;
+import water.util.IcedHashMap;
 import water.util.Log;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An ensemble of other models, created by <i>stacking</i> with the SuperLearner algorithm or a variation.
@@ -228,12 +230,12 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       }
 
       //Compute metalearner
-      computeMetaLearner(levelOneTrainingFrame, levelOneValidationFrame, _model._parms._metalearner_algorithm);
+      computeMetaLearner(levelOneTrainingFrame, levelOneValidationFrame, _model._parms._metalearner_algorithm, _model._parms._metalearner_params);
 
 
     } // computeImpl
 
-    private void computeMetaLearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm metalearner_algo) {
+    private void computeMetaLearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm metalearner_algo, IcedHashMap<String, Object[]> metalearner_params) {
         // Train the metalearner model
         // Default Job for just this training
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -333,7 +333,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         params.fillFromImpl(metaGLMBuilder._parms); // Defaults for this builder into schema
 
         //Metalearner parameters
-        if(metalearner_params != null){
+        if(metalearner_params != null && !metalearner_params.isEmpty()){
           Properties p = new Properties();
           HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
           for (Map.Entry<String, String> param : map.entrySet()) {
@@ -476,7 +476,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           params.fillFromImpl(metaDRFBuilder._parms); // Defaults for this builder into schema
 
           //Metalearner parameters
-          if(metalearner_params != null){
+          if(metalearner_params != null && !metalearner_params.isEmpty()){
             Properties p = new Properties();
             HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
             for (Map.Entry<String, String> param : map.entrySet()) {
@@ -539,7 +539,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           params.fillFromImpl(metaDeepLearningBuilder._parms); // Defaults for this builder into schema
 
           //Metalearner parameters
-          if(metalearner_params != null){
+          if(metalearner_params != null && !metalearner_params.isEmpty()){
             Properties p = new Properties();
             HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
             for (Map.Entry<String, String> param : map.entrySet()) {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -13,6 +13,7 @@ import hex.tree.drf.DRF;
 import hex.tree.drf.DRFModel;
 import hex.deeplearning.DeepLearning;
 import hex.deeplearning.DeepLearningModel;
+
 import water.DKV;
 import water.Job;
 import water.Key;
@@ -21,7 +22,12 @@ import water.exceptions.H2OModelBuilderIllegalArgumentException;
 import water.fvec.Frame;
 import water.fvec.Vec;
 
-import java.util.*;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.Map;
 
 import water.util.Log;
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -412,7 +412,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           params.fillFromImpl(metaGBMBuilder._parms); // Defaults for this builder into schema
 
           //Metalearner parameters
-          if(metalearner_params != null){
+          if(metalearner_params != null && !metalearner_params.isEmpty()){
             Properties p = new Properties();
             HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
             for (Map.Entry<String, String> param : map.entrySet()) {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -335,9 +335,14 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         //Metalearner parameters
         if(metalearner_params != null && !metalearner_params.isEmpty()){
           Properties p = new Properties();
-          HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
-          for (Map.Entry<String, String> param : map.entrySet()) {
-            p.setProperty(param.getKey(), param.getValue());
+          HashMap<String,String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>(){}.getType());
+          for (Map.Entry<String, String[]> param : map.entrySet()) {
+            String[] paramVal = param.getValue();
+            if(paramVal.length == 1){
+              p.setProperty(param.getKey(), paramVal[0]);
+            } else {
+              p.setProperty(param.getKey(), Arrays.toString(paramVal));
+            }
             params.fillFromParms(p, true);
           }
           GLMModel.GLMParameters glmParams = params.createAndFillImpl();
@@ -414,13 +419,18 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           //Metalearner parameters
           if(metalearner_params != null && !metalearner_params.isEmpty()){
             Properties p = new Properties();
-            HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
-            for (Map.Entry<String, String> param : map.entrySet()) {
-              p.setProperty(param.getKey(), param.getValue());
+            HashMap<String,String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>(){}.getType());
+            for (Map.Entry<String, String[]> param : map.entrySet()) {
+              String[] paramVal = param.getValue();
+              if(paramVal.length == 1){
+                p.setProperty(param.getKey(), paramVal[0]);
+              } else {
+                p.setProperty(param.getKey(), Arrays.toString(paramVal));
+              }
               params.fillFromParms(p, true);
             }
-            GBMModel.GBMParameters glmParams = params.createAndFillImpl();
-            metaGBMBuilder._parms = glmParams;
+            GBMModel.GBMParameters gbmParams = params.createAndFillImpl();
+            metaGBMBuilder._parms = gbmParams;
           }
 
           metaGBMBuilder._parms._train = levelOneTrainingFrame._key;
@@ -478,13 +488,18 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           //Metalearner parameters
           if(metalearner_params != null && !metalearner_params.isEmpty()){
             Properties p = new Properties();
-            HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
-            for (Map.Entry<String, String> param : map.entrySet()) {
-              p.setProperty(param.getKey(), param.getValue());
+            HashMap<String,String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>(){}.getType());
+            for (Map.Entry<String, String[]> param : map.entrySet()) {
+              String[] paramVal = param.getValue();
+              if(paramVal.length == 1){
+                p.setProperty(param.getKey(), paramVal[0]);
+              } else {
+                p.setProperty(param.getKey(), Arrays.toString(paramVal));
+              }
               params.fillFromParms(p, true);
             }
-            DRFModel.DRFParameters glmParams = params.createAndFillImpl();
-            metaDRFBuilder._parms = glmParams;
+            DRFModel.DRFParameters drfParams = params.createAndFillImpl();
+            metaDRFBuilder._parms = drfParams;
           }
           metaDRFBuilder._parms._train = levelOneTrainingFrame._key;
           metaDRFBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);
@@ -541,9 +556,14 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
           //Metalearner parameters
           if(metalearner_params != null && !metalearner_params.isEmpty()){
             Properties p = new Properties();
-            HashMap<String,String> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String>>(){}.getType());
-            for (Map.Entry<String, String> param : map.entrySet()) {
-              p.setProperty(param.getKey(), param.getValue());
+            HashMap<String,String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>(){}.getType());
+            for (Map.Entry<String, String[]> param : map.entrySet()) {
+              String[] paramVal = param.getValue();
+              if(paramVal.length == 1){
+                p.setProperty(param.getKey(), paramVal[0]);
+              } else {
+                p.setProperty(param.getKey(), Arrays.toString(paramVal));
+              }
               params.fillFromParms(p, true);
             }
             DeepLearningModel.DeepLearningParameters dlParams = params.createAndFillImpl();

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -546,8 +546,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
               p.setProperty(param.getKey(), param.getValue());
               params.fillFromParms(p, true);
             }
-            DeepLearningModel.DeepLearningParameters glmParams = params.createAndFillImpl();
-            metaDeepLearningBuilder._parms = glmParams;
+            DeepLearningModel.DeepLearningParameters dlParams = params.createAndFillImpl();
+            metaDeepLearningBuilder._parms = dlParams;
           }
           metaDeepLearningBuilder._parms._train = levelOneTrainingFrame._key;
           metaDeepLearningBuilder._parms._valid = (levelOneValidationFrame == null ? null : levelOneValidationFrame._key);

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -7,7 +7,6 @@ import hex.StackedEnsembleModel;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
 import hex.schemas.GLMV3;
-import hex.schemas.ModelBuilderSchema;
 import hex.tree.gbm.GBM;
 import hex.tree.gbm.GBMModel;
 import hex.tree.drf.DRF;
@@ -17,17 +16,14 @@ import hex.deeplearning.DeepLearningModel;
 import water.DKV;
 import water.Job;
 import water.Key;
-import water.api.schemas3.ModelParametersSchemaV3;
 import water.exceptions.H2OIllegalArgumentException;
 import water.exceptions.H2OModelBuilderIllegalArgumentException;
 import water.fvec.Frame;
 import water.fvec.Vec;
-import water.TypeMap;
 
 import java.util.*;
 
 import water.util.Log;
-import water.util.IcedHashMap;
 
 import com.google.gson.Gson;
 import com.google.common.reflect.TypeToken;

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -7,7 +7,7 @@ import water.api.schemas3.KeyV3;
 import water.api.schemas3.ModelParametersSchemaV3;
 import hex.Model;
 import water.api.schemas3.FrameV3;
-
+import water.util.IcedHashMap;
 
 public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,StackedEnsembleV99,StackedEnsembleV99.StackedEnsembleParametersV99> {
   public static final class StackedEnsembleParametersV99 extends ModelParametersSchemaV3<StackedEnsembleModel.StackedEnsembleParameters, StackedEnsembleParametersV99> {
@@ -22,6 +22,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "metalearner_fold_assignment",
       "metalearner_fold_column",
       "keep_levelone_frame",
+      "metalearner_params"
     };
 
 
@@ -32,7 +33,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
     
     // Metalearner algorithm
-    @API(level = API.Level.critical, direction = API.Direction.INOUT, gridable = true,
+    @API(level = API.Level.critical, direction = API.Direction.INOUT, 
             values = {"AUTO", "glm", "gbm", "drf", "deeplearning"},
             help = "Type of algorithm to use as the metalearner. " +
                     "Options include 'AUTO' (GLM with non negative weights; if validation_frame is present, a lambda search is performed), 'glm' (GLM with default parameters), 'gbm' (GBM with default parameters), " +
@@ -40,19 +41,19 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     public StackedEnsembleModel.StackedEnsembleParameters.MetalearnerAlgorithm metalearner_algorithm;
 
     // For ensemble metalearner cross-validation
-    @API(level = API.Level.critical, direction = API.Direction.INOUT, gridable = true,
+    @API(level = API.Level.critical, direction = API.Direction.INOUT, 
             help = "Number of folds for K-fold cross-validation of the metalearner algorithm (0 to disable or >= 2).")
     public int metalearner_nfolds;
 
     // For ensemble metalearner cross-validation
-    @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
+    @API(level = API.Level.secondary, direction = API.Direction.INOUT, 
             values = {"AUTO", "Random", "Modulo", "Stratified"},
             help = "Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is currently set to Random)." + 
                   " The 'Stratified' option will stratify the folds based on the response variable, for classification problems.")
     public Model.Parameters.FoldAssignmentScheme metalearner_fold_assignment;
 
     // For ensemble metalearner cross-validation
-    @API(level = API.Level.secondary, direction = API.Direction.INOUT, gridable = true,
+    @API(level = API.Level.secondary, direction = API.Direction.INOUT, 
             is_member_of_frames = {"training_frame"},
             //is_mutually_exclusive_with = {"ignored_columns", "response_column", "weights_column", "offset_column"},
             is_mutually_exclusive_with = {"ignored_columns", "response_column"},
@@ -62,6 +63,9 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     @API(level = API.Level.secondary,
             help = "Keep level one frame used for metalearner training.")
     public boolean keep_levelone_frame;
+
+    @API(help = "Parameters for metalearner algo", direction = API.Direction.INOUT)
+    public IcedHashMap<String, Object[]> metalearner_params;
   
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -65,7 +65,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     public boolean keep_levelone_frame;
 
     @API(help = "Parameters for metalearner algo", direction = API.Direction.INOUT)
-    public IcedHashMap<String, Object[]> metalearner_params;
+    public String metalearner_params;
   
   }
 }

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -244,7 +244,7 @@ def gen_module(schema, algo, module):
         yield "  }"
         yield " "
         yield "  if(!missing(metalearner_params))"
-        yield "      parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE))"
+        yield "      parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE))"
     for param in schema["parameters"]:
         if param["name"] in ["ignored_columns", "response_column", "training_frame", "max_confusion_matrix_size"]:
             continue

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -115,9 +115,12 @@ def gen_module(schema, algo, module):
             temp = normalize_value(param).replace(' "quasibinomial",',"")
             list.append(indent("%s = %s" % (param["name"], temp), 17 + len(module)))
         else:
-            list.append(indent("%s = %s" % (param["name"], normalize_value(param)), 17 + len(module)))
+            if param["name"] != "metalearner_params":
+                list.append(indent("%s = %s" % (param["name"], normalize_value(param)), 17 + len(module)))
     if algo in ["deeplearning","drf", "gbm","xgboost"]:
         list.append(indent("verbose = FALSE ",17 + len(module)))
+    if algo in ["stackedensemble"]:
+        list.append(indent("metalearner_params = NULL ",17 + len(module)))
     yield ",\n".join(list)
     yield indent(") \n{", 17 + len(module))
     if algo in ["deeplearning", "deepwater", "xgboost", "drf", "gbm", "glm", "naivebayes", "stackedensemble"]:
@@ -240,6 +243,8 @@ def gen_module(schema, algo, module):
         yield "    }"
         yield "  }"
         yield " "
+        yield "  if(!missing(metalearner_params))"
+        yield "    parms$metalearner_params <- toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE)"
     for param in schema["parameters"]:
         if param["name"] in ["ignored_columns", "response_column", "training_frame", "max_confusion_matrix_size"]:
             continue
@@ -269,6 +274,8 @@ def gen_module(schema, algo, module):
         if param["name"] == "eps_prob":
             yield " if (!missing(eps_prob))"
             yield "   parms$%s <- eps_prob" % param["name"]
+            continue
+        if param["name"] == "metalearner_params":
             continue
         yield "  if (!missing(%s))" % param["name"]
         yield "    parms$%s <- %s" % (param["name"], param["name"])

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -243,7 +243,7 @@ def gen_module(schema, algo, module):
         yield "    }"
         yield "  }"
         yield " "
-        yield "  if(!missing(metalearner_params))"
+        yield "  if (!missing(metalearner_params))"
         yield "      parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE))"
     for param in schema["parameters"]:
         if param["name"] in ["ignored_columns", "response_column", "training_frame", "max_confusion_matrix_size"]:
@@ -290,7 +290,7 @@ def gen_module(schema, algo, module):
         yield "  # Error check and build model"
         yield "  model <- .h2o.modelJob('%s', parms, h2oRestApiVersion = %d)" % (algo, 99 if algo in ["svd", "stackedensemble"] else 3)
         yield "  #Convert metalearner_params back to list if not NULL"
-        yield "  if(!missing(metalearner_params)) {"
+        yield "  if (!missing(metalearner_params)) {"
         yield "      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))"
         yield "  }"
         yield "  return(model)"
@@ -1023,6 +1023,8 @@ def indent(string, n):
     return " " * n + string
 
 def normalize_value(param, is_help = False):
+    if param["name"] == "metalearner_params":
+        return "NULL"
     if not(is_help) and param["type"][:4] == "enum":
         return "c(%s)" % ", ".join('"%s"' % p for p in param["values"])
     if param["default_value"] is None:

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -244,7 +244,7 @@ def gen_module(schema, algo, module):
         yield "  }"
         yield " "
         yield "  if(!missing(metalearner_params))"
-        yield "    parms$metalearner_params <- toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE)"
+        yield "    parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE))"
     for param in schema["parameters"]:
         if param["name"] in ["ignored_columns", "response_column", "training_frame", "max_confusion_matrix_size"]:
             continue

--- a/h2o-bindings/bin/gen_java.py
+++ b/h2o-bindings/bin/gen_java.py
@@ -237,6 +237,7 @@ def generate_proxy(classname, endpoints):
     yield "import water.bindings.pojos.*;"
     yield "import retrofit2.*;"
     yield "import retrofit2.http.*;"
+    yield "import java.util.Map;" if classname == "Grid" or classname == "ModelBuilders" else None
     yield ""
     yield "public interface " + classname + " {"
     yield ""

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -198,11 +198,17 @@ def gen_module(schema, algo):
             vals = param["dtype"][5:-1].split(", ")
             extrahelp = "One of: " + ", ".join("``%s``" % v for v in vals)
         else:
-            extrahelp = "Type: ``%s``" % param["dtype"]
+            if pname == "metalearner_params":
+                extrahelp = "Type: ``dict``"
+            else:
+                extrahelp = "Type: ``%s``" % param["dtype"]
         if param["default_value"] is None:
             extrahelp += "."
         else:
-            extrahelp += "  (default: ``%s``)." % stringify(param["default_value"])
+            if pname == "metalearner_params":
+                extrahelp += "  (default: ``None``)."
+            else:
+                extrahelp += "  (default: ``%s``)." % stringify(param["default_value"])
 
         yield "    @property"
         yield "    def %s(self):" % pname

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -218,6 +218,8 @@ def gen_module(schema, algo):
         yield "        %s" % bi.wrap(param["help"], indent=(" " * 8), indent_first=False)
         yield ""
         yield "        %s" % bi.wrap(extrahelp, indent=(" " * 8), indent_first=False)
+        if pname == "metalearner_params":
+            yield "        Example: metalearner_gbm_params = {'max_depth': 2, 'col_sample_rate': 0.3}"
         yield '        """'
         if pname != "metalearner_params":
             yield "        return self._parms.get(\"%s\")" % sname

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -223,7 +223,11 @@ def gen_module(schema, algo):
             yield "        return self._parms.get(\"%s\")" % sname
         else:
             yield "        if self._parms.get(\"%s\") != None:" % sname
-            yield "            return ast.literal_eval(self._parms.get(\"%s\"))" % sname
+            yield "            metalearner_params_dict =  ast.literal_eval(self._parms.get(\"%s\"))" % sname
+            yield "            for k in metalearner_params_dict:"
+            yield "                if len(metalearner_params_dict[k]) == 1: #single parameter"
+            yield "                    metalearner_params_dict[k] = metalearner_params_dict[k][0]"
+            yield "            return metalearner_params_dict"
             yield "        else:"
             yield "            return self._parms.get(\"%s\")" % sname
         yield ""
@@ -246,6 +250,9 @@ def gen_module(schema, algo):
         elif pname in {"metalearner_params"}:
             yield "        assert_is_type(%s, None, %s)" % (pname, "dict")
             yield '        if %s is not None and %s != "":' % (pname, pname)
+            yield "            for k in %s:" % (pname)
+            yield '                if ("[" and "]") not in str(metalearner_params[k]):'
+            yield "                    metalearner_params[k]=[metalearner_params[k]]"
             yield "            self._parms[\"%s\"] = str(json.dumps(%s))" % (sname, pname)
             yield "        else:"
             yield "            self._parms[\"%s\"] = None" % (sname)

--- a/h2o-core/src/main/java/water/api/Schema.java
+++ b/h2o-core/src/main/java/water/api/Schema.java
@@ -118,7 +118,7 @@ public abstract class Schema<I extends Iced, S extends Schema<I,S>> extends Iced
     this.fillFromImpl(impl);
   }
 
-  public void init_meta() {
+  protected void init_meta() {
     if (_schema_name != null) return;
     _schema_name = this.getClass().getSimpleName();
     _schema_version = extractVersionFromSchemaName(_schema_name);

--- a/h2o-core/src/main/java/water/api/Schema.java
+++ b/h2o-core/src/main/java/water/api/Schema.java
@@ -118,7 +118,7 @@ public abstract class Schema<I extends Iced, S extends Schema<I,S>> extends Iced
     this.fillFromImpl(impl);
   }
 
-  protected void init_meta() {
+  public void init_meta() {
     if (_schema_name != null) return;
     _schema_name = this.getClass().getSimpleName();
     _schema_version = extractVersionFromSchemaName(_schema_name);

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -50,7 +50,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         self._parms = {}
         names_list = {"model_id", "training_frame", "response_column", "validation_frame", "base_models",
                       "metalearner_algorithm", "metalearner_nfolds", "metalearner_fold_assignment",
-                      "metalearner_fold_column", "keep_levelone_frame"}
+                      "metalearner_fold_column", "keep_levelone_frame", "metalearner_params"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -206,5 +206,20 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def keep_levelone_frame(self, keep_levelone_frame):
         assert_is_type(keep_levelone_frame, None, bool)
         self._parms["keep_levelone_frame"] = keep_levelone_frame
+
+
+    @property
+    def metalearner_params(self):
+        """
+        Parameters for metalearner algo
+
+        Type: ``Dict[object, object]``  (default: ``{}``).
+        """
+        return self._parms.get("metalearner_params")
+
+    @metalearner_params.setter
+    def metalearner_params(self, metalearner_params):
+        assert_is_type(metalearner_params, None, {object: object})
+        self._parms["metalearner_params"] = metalearner_params
 
 

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -216,6 +216,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         Parameters for metalearner algo
 
         Type: ``dict``  (default: ``None``).
+        Example: metalearner_gbm_params = {'max_depth': 2, 'col_sample_rate': 0.3}
         """
         if self._parms.get("metalearner_params") != None:
             metalearner_params_dict =  ast.literal_eval(self._parms.get("metalearner_params"))

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -218,7 +218,11 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         Type: ``dict``  (default: ``None``).
         """
         if self._parms.get("metalearner_params") != None:
-            return ast.literal_eval(self._parms.get("metalearner_params"))
+            metalearner_params_dict =  ast.literal_eval(self._parms.get("metalearner_params"))
+            for k in metalearner_params_dict:
+                if len(metalearner_params_dict[k]) == 1: #single parameter
+                    metalearner_params_dict[k] = metalearner_params_dict[k][0]
+            return metalearner_params_dict
         else:
             return self._parms.get("metalearner_params")
 
@@ -226,6 +230,9 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def metalearner_params(self, metalearner_params):
         assert_is_type(metalearner_params, None, dict)
         if metalearner_params is not None and metalearner_params != "":
+            for k in metalearner_params:
+                if ("[" and "]") not in str(metalearner_params[k]):
+                    metalearner_params[k]=[metalearner_params[k]]
             self._parms["metalearner_params"] = str(json.dumps(metalearner_params))
         else:
             self._parms["metalearner_params"] = None

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -10,6 +10,8 @@ from h2o.estimators.estimator_base import H2OEstimator
 from h2o.exceptions import H2OValueError
 from h2o.frame import H2OFrame
 from h2o.utils.typechecks import assert_is_type, Enum, numeric, is_type
+import json
+import ast
 
 
 class H2OStackedEnsembleEstimator(H2OEstimator):
@@ -215,11 +217,17 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
 
         Type: ``dict``  (default: ``None``).
         """
-        return self._parms.get("metalearner_params")
+        if self._parms.get("metalearner_params") != None:
+            return ast.literal_eval(self._parms.get("metalearner_params"))
+        else:
+            return self._parms.get("metalearner_params")
 
     @metalearner_params.setter
     def metalearner_params(self, metalearner_params):
-        assert_is_type(metalearner_params, None, str)
-        self._parms["metalearner_params"] = metalearner_params
+        assert_is_type(metalearner_params, None, dict)
+        if metalearner_params is not None and metalearner_params != "":
+            self._parms["metalearner_params"] = str(json.dumps(metalearner_params))
+        else:
+            self._parms["metalearner_params"] = None
 
 

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -213,13 +213,13 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         """
         Parameters for metalearner algo
 
-        Type: ``Dict[object, object]``  (default: ``{}``).
+        Type: ``dict``  (default: ``None``).
         """
         return self._parms.get("metalearner_params")
 
     @metalearner_params.setter
     def metalearner_params(self, metalearner_params):
-        assert_is_type(metalearner_params, None, {object: object})
+        assert_is_type(metalearner_params, None, str)
         self._parms["metalearner_params"] = metalearner_params
 
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_custom_metalearner.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_custom_metalearner.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+
+import h2o
+
+import sys
+sys.path.insert(1,"../../../")  # allow us to run this standalone
+
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from tests import pyunit_utils
+
+
+def stackedensemble_custom_metalearner_test():
+    """This test checks the following:
+    1) That H2OStackedEnsembleEstimator `metalearner_nfolds` works correctly
+    2) That H2OStackedEnsembleEstimator `metalearner_nfolds` works in concert with `metalearner_nfolds`
+    """
+
+    # Import training set
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/higgs_train_5k.csv"),
+                            destination_frame="higgs_train_5k")
+    test = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/higgs_test_5k.csv"),
+                           destination_frame="higgs_test_5k")
+
+    # Identify predictors and response
+    x = train.columns
+    y = "response"
+    x.remove(y)
+
+    # Convert response to a factor
+    train[y] = train[y].asfactor()
+    test[y] = test[y].asfactor()
+
+    # Set number of folds for base learners
+    nfolds = 3
+
+    #Metalearner params for gbm, drf, glm, and deep deeplearning
+    gbm_params = {"ntrees" : 100, "max_depth" : 6}
+    drf_params = {"ntrees" : 100, "max_depth" : 6}
+    glm_params = {"alpha" : 0, "lambda" : 0}
+    dl_params  = {"hidden" : [32,32,32], "epochs" : 20} ## small network, runs faster
+
+    # Train and cross-validate a GBM
+    my_gbm = H2OGradientBoostingEstimator(distribution="bernoulli",
+                                          ntrees=10,
+                                          nfolds=nfolds,
+                                          fold_assignment="Modulo",
+                                          keep_cross_validation_predictions=True,
+                                          seed=1)
+    my_gbm.train(x=x, y=y, training_frame=train)
+
+    # Train and cross-validate a RF
+    my_rf = H2ORandomForestEstimator(ntrees=50,
+                                     nfolds=nfolds,
+                                     fold_assignment="Modulo",
+                                     keep_cross_validation_predictions=True,
+                                     seed=1)
+    my_rf.train(x=x, y=y, training_frame=train)
+
+
+    # Train a stacked ensemble & check that metalearner_algorithm works
+    stack_gbm = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], metalearner_algorithm="gbm",
+                                            metalearner_params = gbm_params)
+    stack_gbm.train(x=x, y=y, training_frame=train)
+    # Check that metalearner_algorithm is a default GBM
+    assert(stack_gbm.params['metalearner_algorithm']['actual'] == "gbm")
+    # Check that the metalearner is default GBM
+    meta_gbm = h2o.get_model(stack_gbm.metalearner()['name'])
+    assert meta_gbm.algo == "gbm"
+    assert meta_gbm.params['ntrees']['actual'] == 100
+    assert meta_gbm.params['max_depth']['actual'] == 6
+
+
+    # Train a stacked ensemble & metalearner_algorithm "drf"; check that metalearner_algorithm works with CV
+    stack_drf = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], metalearner_algorithm="drf", metalearner_nfolds=3,
+                                            metalearner_params = drf_params)
+    stack_drf.train(x=x, y=y, training_frame=train)
+    # Check that metalearner_algorithm is a default RF
+    assert(stack_drf.params['metalearner_algorithm']['actual'] == "drf")
+    # Check that CV was performed
+    assert(stack_drf.params['metalearner_nfolds']['actual'] == 3)
+    meta_drf = h2o.get_model(stack_drf.metalearner()['name'])
+    assert meta_drf.algo == "drf"
+    assert meta_drf.params['nfolds']['actual'] == 3
+    assert meta_drf.params['ntrees']['actual'] == 100
+    assert meta_drf.params['max_depth']['actual'] == 6
+
+
+    # Train a stacked ensemble & check that metalearner_algorithm "glm" works
+    stack_glm = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], metalearner_algorithm="glm",
+                                            metalearner_params = glm_params)
+    stack_glm.train(x=x, y=y, training_frame=train)
+    # Check that metalearner_algorithm is a default GLM
+    assert(stack_glm.params['metalearner_algorithm']['actual'] == "glm")
+    # Check that the metalearner is default GLM
+    meta_glm = h2o.get_model(stack_glm.metalearner()['name'])
+    assert meta_glm.algo == "glm"
+    assert meta_glm.params['alpha']['actual'] == [0.0]
+    assert meta_glm.params['lambda']['actual'] == [0.0]
+
+
+    # Train a stacked ensemble & check that metalearner_algorithm "deeplearning" works
+    stack_dl = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], metalearner_algorithm="deeplearning",
+                                           metalearner_params = dl_params)
+    stack_dl.train(x=x, y=y, training_frame=train)
+    # Check that metalearner_algorithm is a default DNN
+    assert(stack_dl.params['metalearner_algorithm']['actual'] == "deeplearning")
+    # Check that the metalearner is default DNN
+    meta_dl = h2o.get_model(stack_dl.metalearner()['name'])
+    assert(meta_dl.algo == "deeplearning")
+    assert meta_dl.params['hidden']['actual'] == [32, 32, 32]
+    assert meta_dl.params['epochs']['actual'] == 20.0
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(stackedensemble_custom_metalearner_test)
+else:
+    stackedensemble_custom_metalearner_test()

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -28,6 +28,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
+#' @param metalearner_params Parameters for metalearner algo Defaults to {}.
 #' @examples
 #' 
 #' # See example R code here:
@@ -42,7 +43,8 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
                                 metalearner_nfolds = 0,
                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
                                 metalearner_fold_column = NULL,
-                                keep_levelone_frame = FALSE
+                                keep_levelone_frame = FALSE,
+                                metalearner_params = {}
                                 ) 
 {
   # If x is missing, then assume user wants to use all columns as features.
@@ -100,6 +102,8 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$metalearner_fold_column <- metalearner_fold_column
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
+  if (!missing(metalearner_params))
+    parms$metalearner_params <- metalearner_params
   # Error check and build model
   .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99) 
 }

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -28,7 +28,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
-#' @param metalearner_params Parameters for metalearner algo Defaults to {}.
+#' @param metalearner_params Parameters for metalearner algo Defaults to .
 #' @examples
 #' 
 #' # See example R code here:
@@ -44,7 +44,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
                                 metalearner_fold_column = NULL,
                                 keep_levelone_frame = FALSE,
-                                metalearner_params = {}
+                                metalearner_params = NULL 
                                 ) 
 {
   # If x is missing, then assume user wants to use all columns as features.
@@ -86,6 +86,8 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     }
   }
  
+  if(!missing(metalearner_params))
+    parms$metalearner_params <- toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE)
   if (!missing(model_id))
     parms$model_id <- model_id
   if (!missing(validation_frame))
@@ -102,8 +104,6 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$metalearner_fold_column <- metalearner_fold_column
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
-  if (!missing(metalearner_params))
-    parms$metalearner_params <- metalearner_params
   # Error check and build model
   .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99) 
 }

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -87,7 +87,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
   }
  
   if(!missing(metalearner_params))
-    parms$metalearner_params <- toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE)
+    parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE))
   if (!missing(model_id))
     parms$model_id <- model_id
   if (!missing(validation_frame))

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -87,7 +87,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
   }
  
   if(!missing(metalearner_params))
-    parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE))
+      parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE))
   if (!missing(model_id))
     parms$model_id <- model_id
   if (!missing(validation_frame))
@@ -105,5 +105,10 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
   # Error check and build model
-  .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99) 
+  model <- .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99)
+  #Convert metalearner_params back to list if not NULL
+  if(!missing(metalearner_params)) {
+      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))
+  }
+  return(model)
 }

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -87,7 +87,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
   }
  
   if(!missing(metalearner_params))
-      parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE, auto_unbox = TRUE))
+      parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE))
   if (!missing(model_id))
     parms$model_id <- model_id
   if (!missing(validation_frame))

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -28,7 +28,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
-#' @param metalearner_params Parameters for metalearner algo Defaults to .
+#' @param metalearner_params Parameters for metalearner algo Defaults to NULL.
 #' @examples
 #' 
 #' # See example R code here:
@@ -86,7 +86,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     }
   }
  
-  if(!missing(metalearner_params))
+  if (!missing(metalearner_params))
       parms$metalearner_params <- as.character(toJSON(metalearner_params, pretty = TRUE))
   if (!missing(model_id))
     parms$model_id <- model_id
@@ -107,7 +107,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
   # Error check and build model
   model <- .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99)
   #Convert metalearner_params back to list if not NULL
-  if(!missing(metalearner_params)) {
+  if (!missing(metalearner_params)) {
       model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))
   }
   return(model)

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_custom_metalearner_params.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_custom_metalearner_params.R
@@ -28,31 +28,31 @@ stackedensemble.custom.metalearner.test <- function() {
 
     # Train & Cross-validate a GBM
     my_gbm <- h2o.gbm(x = x,
-    y = y,
-    training_frame = train,
-    distribution = "bernoulli",
-    ntrees = 10,
-    nfolds = nfolds,
-    keep_cross_validation_predictions = TRUE,
-    seed = 1)
+                      y = y,
+                      training_frame = train,
+                      distribution = "bernoulli",
+                      ntrees = 10,
+                      nfolds = nfolds,
+                      keep_cross_validation_predictions = TRUE,
+                      seed = 1)
 
     # Train & Cross-validate a RF
     my_rf <- h2o.randomForest(x = x,
-    y = y,
-    training_frame = train,
-    ntrees = 10,
-    nfolds = nfolds,
-    keep_cross_validation_predictions = TRUE,
-    seed = 1)
+                              y = y,
+                              training_frame = train,
+                              ntrees = 10,
+                              nfolds = nfolds,
+                              keep_cross_validation_predictions = TRUE,
+                              seed = 1)
 
     # Train a stacked ensemble & check that metalearner_algorithm/metalearner_params works
     print("SE with GBM metalearner and custom params")
     stack_gbm <- h2o.stackedEnsemble(x = x,
-    y = y,
-    training_frame = train,
-    base_models = list(my_gbm, my_rf),
-    metalearner_algorithm = "gbm",
-    metalearner_params = gbm_params)
+                                     y = y,
+                                     training_frame = train,
+                                     base_models = list(my_gbm, my_rf),
+                                     metalearner_algorithm = "gbm",
+                                     metalearner_params = gbm_params)
     # Check that metalearner_algorithm is a default GBM
     expect_equal(stack_gbm@parameters$metalearner_algorithm, "gbm")
     expect_equal(stack_gbm@allparameters$metalearner_algorithm, "gbm")
@@ -66,12 +66,12 @@ stackedensemble.custom.metalearner.test <- function() {
     # Train a stacked ensemble & metalearner_algorithm "drf"; check that metalearner_algorithm works with CV
     print("SE with DRF metalearner and custom params")
     stack_drf <- h2o.stackedEnsemble(x = x,
-    y = y,
-    training_frame = train,
-    base_models = list(my_gbm, my_rf),
-    metalearner_nfolds = 3,
-    metalearner_algorithm = "drf",
-    metalearner_params = drf_params)
+                                     y = y,
+                                     training_frame = train,
+                                     base_models = list(my_gbm, my_rf),
+                                     metalearner_nfolds = 3,
+                                     metalearner_algorithm = "drf",
+                                     metalearner_params = drf_params)
     # Check that metalearner_algorithm is a default RF
     expect_equal(stack_drf@parameters$metalearner_algorithm, "drf")
     # Check that CV was performed
@@ -86,11 +86,11 @@ stackedensemble.custom.metalearner.test <- function() {
     # Train a stacked ensemble & metalearner_algorithm "glm"
     print("SE with GLM metalearner and custom params")
     stack_glm <- h2o.stackedEnsemble(x = x,
-    y = y,
-    training_frame = train,
-    base_models = list(my_gbm, my_rf),
-    metalearner_algorithm = "glm",
-    metalearner_params = glm_params)
+                                     y = y,
+                                     training_frame = train,
+                                     base_models = list(my_gbm, my_rf),
+                                     metalearner_algorithm = "glm",
+                                     metalearner_params = glm_params)
     # Check that metalearner_algorithm is a default GLM
     expect_equal(stack_glm@parameters$metalearner_algorithm, "glm")
     meta_glm <- h2o.getModel(stack_glm@model$metalearner$name)
@@ -102,11 +102,11 @@ stackedensemble.custom.metalearner.test <- function() {
     # Train a stacked ensemble & metalearner_algorithm "deeplearning"
     print("SE with DL metalearner and custom params")
     stack_deeplearning <- h2o.stackedEnsemble(x = x,
-    y = y,
-    training_frame = train,
-    base_models = list(my_gbm, my_rf),
-    metalearner_algorithm = "deeplearning",
-    metalearner_params = dl_params)
+                                              y = y,
+                                              training_frame = train,
+                                              base_models = list(my_gbm, my_rf),
+                                              metalearner_algorithm = "deeplearning",
+                                              metalearner_params = dl_params)
     # Check that metalearner_algorithm is a default DNN
     expect_equal(stack_deeplearning@parameters$metalearner_algorithm, "deeplearning")
     meta_dl <- h2o.getModel(stack_deeplearning@model$metalearner$name)

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_custom_metalearner_params.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_custom_metalearner_params.R
@@ -1,0 +1,119 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+stackedensemble.custom.metalearner.test <- function() {
+
+    # This test checks the following (for binomial classification):
+    #
+    # 1) That h2o.stackedEnsemble `metalearner_algorithm` and `metalearner_params` work correctly
+    # 2) That h2o.stackedEnsemble `metalearner_algorithm` works in concert with `metalearner_nfolds`
+
+
+    train <- h2o.uploadFile(locate("smalldata/testng/higgs_train_5k.csv"),
+    destination_frame = "higgs_train_5k")
+    test <- h2o.uploadFile(locate("smalldata/testng/higgs_test_5k.csv"),
+    destination_frame = "higgs_test_5k")
+    y <- "response"
+    x <- setdiff(names(train), y)
+    train[,y] <- as.factor(train[,y])
+    test[,y] <- as.factor(test[,y])
+    nfolds <- 3  #number of folds for base learners
+
+    #Metalearner params for gbm, drf, glm, and deep deeplearning
+    gbm_params <- list(ntrees=100, max_depth = 6)
+    drf_params <- list(ntrees=100, max_depth = 6)
+    glm_params <- list(alpha=0, lambda=0)
+    dl_params  <- list(hidden=c(32,32,32), epochs = 20) ## small network, runs faster
+
+
+    # Train & Cross-validate a GBM
+    my_gbm <- h2o.gbm(x = x,
+    y = y,
+    training_frame = train,
+    distribution = "bernoulli",
+    ntrees = 10,
+    nfolds = nfolds,
+    keep_cross_validation_predictions = TRUE,
+    seed = 1)
+
+    # Train & Cross-validate a RF
+    my_rf <- h2o.randomForest(x = x,
+    y = y,
+    training_frame = train,
+    ntrees = 10,
+    nfolds = nfolds,
+    keep_cross_validation_predictions = TRUE,
+    seed = 1)
+
+    # Train a stacked ensemble & check that metalearner_algorithm/metalearner_params works
+    print("SE with GBM metalearner and custom params")
+    stack_gbm <- h2o.stackedEnsemble(x = x,
+    y = y,
+    training_frame = train,
+    base_models = list(my_gbm, my_rf),
+    metalearner_algorithm = "gbm",
+    metalearner_params = gbm_params)
+    # Check that metalearner_algorithm is a default GBM
+    expect_equal(stack_gbm@parameters$metalearner_algorithm, "gbm")
+    expect_equal(stack_gbm@allparameters$metalearner_algorithm, "gbm")
+    # Check that the metalearner is default GBM
+    meta_gbm <- h2o.getModel(stack_gbm@model$metalearner$name)
+    expect_equal(meta_gbm@algorithm, "gbm")
+    expect_equal(meta_gbm@parameters$ntrees, 100)
+    expect_equal(meta_gbm@parameters$max_depth, 6)
+
+
+    # Train a stacked ensemble & metalearner_algorithm "drf"; check that metalearner_algorithm works with CV
+    print("SE with DRF metalearner and custom params")
+    stack_drf <- h2o.stackedEnsemble(x = x,
+    y = y,
+    training_frame = train,
+    base_models = list(my_gbm, my_rf),
+    metalearner_nfolds = 3,
+    metalearner_algorithm = "drf",
+    metalearner_params = drf_params)
+    # Check that metalearner_algorithm is a default RF
+    expect_equal(stack_drf@parameters$metalearner_algorithm, "drf")
+    # Check that CV was performed
+    expect_equal(stack_drf@allparameters$metalearner_nfolds, 3)
+    meta_drf <- h2o.getModel(stack_drf@model$metalearner$name)
+    expect_equal(meta_drf@algorithm, "drf")
+    expect_equal(meta_drf@allparameters$nfolds, 3)
+    expect_equal(meta_drf@parameters$ntrees, 100)
+    expect_equal(meta_drf@parameters$max_depth, 6)
+
+
+    # Train a stacked ensemble & metalearner_algorithm "glm"
+    print("SE with GLM metalearner and custom params")
+    stack_glm <- h2o.stackedEnsemble(x = x,
+    y = y,
+    training_frame = train,
+    base_models = list(my_gbm, my_rf),
+    metalearner_algorithm = "glm",
+    metalearner_params = glm_params)
+    # Check that metalearner_algorithm is a default GLM
+    expect_equal(stack_glm@parameters$metalearner_algorithm, "glm")
+    meta_glm <- h2o.getModel(stack_glm@model$metalearner$name)
+    expect_equal(meta_glm@algorithm, "glm")
+    expect_equal(meta_glm@parameters$alpha, 0)
+    expect_equal(meta_glm@parameters$lambda, 0)
+
+
+    # Train a stacked ensemble & metalearner_algorithm "deeplearning"
+    print("SE with DL metalearner and custom params")
+    stack_deeplearning <- h2o.stackedEnsemble(x = x,
+    y = y,
+    training_frame = train,
+    base_models = list(my_gbm, my_rf),
+    metalearner_algorithm = "deeplearning",
+    metalearner_params = dl_params)
+    # Check that metalearner_algorithm is a default DNN
+    expect_equal(stack_deeplearning@parameters$metalearner_algorithm, "deeplearning")
+    meta_dl <- h2o.getModel(stack_deeplearning@model$metalearner$name)
+    expect_equal(meta_dl@algorithm, "deeplearning")
+    expect_equal(meta_dl@parameters$hidden, c(32,32,32))
+    expect_equal(meta_dl@parameters$epochs, 20)
+
+}
+
+doTest("Stacked Ensemble Custom Metalearner Test", stackedensemble.custom.metalearner.test)


### PR DESCRIPTION
* Added customized metalearner for stacked ensembles.
* User passes in a dictionary/list of parameters to the argument `metalearner_params`, which are passed to `metalearner_algorithm`.
* Example in R: 
```
#Metalearner params for gbm
gbm_params <- list(ntrees=100, max_depth = 6)
stack_gbm <- h2o.stackedEnsemble(x = x,
    y = y,
    training_frame = train,
    base_models = list(my_gbm, my_rf),
    metalearner_algorithm = "gbm",
    metalearner_params = gbm_params)
```
* Example in Python:
```
gbm_params = {"ntrees" : 100, "max_depth" : 6}
stack_gbm = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], 
                                            metalearner_algorithm="gbm",
                                            metalearner_params = gbm_params)
```
* Note, the field `metalearner_params` is a `String` field in Java. I convert the string to a map which gets processed in the SE impl.
* Added a Metalearner class to store all compute methods for metalearners