### PR TITLE
PUBDEV-5129 - Fold column in Kmeans should not be required to be in x

### DIFF
--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -218,6 +218,13 @@ def gen_module(schema, algo, module):
         yield "  parms$response_column <- args$y\n"
     elif algo == "word2vec":
         yield ""
+    elif algo == "kmeans":
+        yield "  if(!missing(x)){"
+        yield "    parms$ignored_columns <- .verify_datacols(training_frame, x)$cols_ignore"
+        yield "    if(!missing(fold_column)){"
+        yield "      parms$ignored_columns <- setdiff(parms$ignored_columns, fold_column)"
+        yield "    }"
+        yield "  }"
     else:
         yield "  if(!missing(x))"
         yield "    parms$ignored_columns <- .verify_datacols(training_frame, x)$cols_ignore"

--- a/h2o-r/h2o-package/R/kmeans.R
+++ b/h2o-r/h2o-package/R/kmeans.R
@@ -88,8 +88,12 @@ h2o.kmeans <- function(training_frame, x,
   # Parameter list to send to model builder
   parms <- list()
   parms$training_frame <- training_frame
-  if(!missing(x))
+  if(!missing(x)){
     parms$ignored_columns <- .verify_datacols(training_frame, x)$cols_ignore
+    if(!missing(fold_column)){
+      parms$ignored_columns <- setdiff(parms$ignored_columns, fold_column)
+    }
+  }
   if (!missing(model_id))
     parms$model_id <- model_id
   if (!missing(validation_frame))

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5129.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5129.R
@@ -1,0 +1,14 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues = TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.pubdev.5129 <- function() {
+    prosPath <- system.file("extdata", "prostate.csv", package = "h2o")
+    prostate.hex <- h2o.uploadFile(path = prosPath)
+    fit <- h2o.kmeans(training_frame = prostate.hex, k = 10, x = c("AGE", "RACE", "VOL", "GLEASON"), fold_column = "DPROS")
+    expect_equal(attr(x = fit, "allparameters")$fold_column$column_name, "DPROS")
+    expect_true(all(attr(x = fit, "allparameters")$x == c("AGE", "RACE", "VOL", "GLEASON")))
+}
+
+doTest("PUBDEV-5129: Fold column in Kmeans should not be required to be in x", test.pubdev.5129)


### PR DESCRIPTION
Also manually tested.
![34567177-785f8156-f161-11e7-8107-5f6e4ae5773a](https://user-images.githubusercontent.com/8769110/35600898-9cea6638-0630-11e8-8df0-05b95062c572.png)
