### PR TITLE
Fix build of Hadoop docker images (no xgboost + specify master for req.txt)

### DIFF
--- a/docker/hadoop/cdh/Dockerfile
+++ b/docker/hadoop/cdh/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y hadoop-conf-pseudo python-pip python-dev python-virtualenv libmysqlclient-dev sudo unzip && \
     rm -rf /var/lib/apt/lists/*
 
+ENV H2O_BRANCH='master'
+
 # Set required env vars and install Java 8 and Pythons
 COPY ${PATH_PREFIX}/../common/sbin/ scripts/install_java scripts/install_python_versions /usr/sbin/
 RUN \

--- a/docker/hadoop/hdp/Dockerfile
+++ b/docker/hadoop/hdp/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && \
     apt-get install -y hadoop-conf-pseudo python-dev python-pip python-dev python-virtualenv libmysqlclient-dev sudo unzip && \
     rm -rf /var/lib/apt/lists/*
 
+ENV H2O_BRANCH='master'
+
 # Set required env vars and install Java 8 and Pythons
 COPY ${PATH_PREFIX}/../common/sbin/ scripts/install_java scripts/install_python_versions /usr/sbin/
 RUN \

--- a/docker/scripts/install_python_versions
+++ b/docker/scripts/install_python_versions
@@ -34,11 +34,13 @@ for python_version in "${array[@]}"; do
 
   echo "###### Installing dependencies for Python ${python_version} ######"
   source /envs/h2o_env_python${python_version}/bin/activate
-  # install nose, it's required by XGBoost tests which are executed when installing XGBoost
-  pip install --upgrade pip nose
   pip install -r requirements.txt
-  PYTHON_VERSION=${python_version} /usr/sbin/install_xgboost
-  pip uninstall nose -y
+  if [ -f /usr/sbin/install_xgboost ]; then
+    # install nose, it's required by XGBoost tests which are executed when installing XGBoost
+    pip install --upgrade pip nose
+    PYTHON_VERSION=${python_version} /usr/sbin/install_xgboost
+    pip uninstall nose -y
+  fi
   deactivate
 done
 


### PR DESCRIPTION
H2O_BRANCH="master" is needed to get requirements.txt (to install proper python libraries) - not really necessary for the Hadoop builds