### PR TITLE
PUBDEV-5249: add second batch of Runit tests ported from GBM to XGBoost and fixes for bugs found

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -109,11 +109,6 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
     public int _gpu_id = 0; // which GPU to use
     public Backend _backend = Backend.auto;
 
-    public XGBoostParameters() {
-      super();
-      _categorical_encoding = CategoricalEncodingScheme.LabelEncoder;
-    }
-
     public String algoName() { return "XGBoost"; }
     public String fullName() { return "XGBoost"; }
     public String javaName() { return XGBoostModel.class.getName(); }

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -361,7 +361,7 @@ class H2OXGBoostEstimator(H2OEstimator):
         Encoding scheme for categorical features
 
         One of: ``"auto"``, ``"enum"``, ``"one_hot_internal"``, ``"one_hot_explicit"``, ``"binary"``, ``"eigen"``,
-        ``"label_encoder"``, ``"sort_by_response"``, ``"enum_limited"``  (default: ``"label_encoder"``).
+        ``"label_encoder"``, ``"sort_by_response"``, ``"enum_limited"``  (default: ``"auto"``).
         """
         return self._parms.get("categorical_encoding")
 

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -43,7 +43,7 @@
 #'        "tweedie", "laplace", "quantile", "huber". Defaults to AUTO.
 #' @param tweedie_power Tweedie power for Tweedie regression, must be between 1 and 2. Defaults to 1.5.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
-#'        "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited". Defaults to LabelEncoder.
+#'        "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited". Defaults to AUTO.
 #' @param quiet_mode \code{Logical}. Enable quiet mode Defaults to TRUE.
 #' @param ntrees (same as n_estimators) Number of trees. Defaults to 50.
 #' @param max_depth Maximum tree depth. Defaults to 6.

--- a/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_new_category_in_predictor.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_new_category_in_predictor.R
@@ -1,0 +1,23 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+checkpoint.new.category.in.predictor <- function() {
+
+  sv1 = h2o.uploadFile(locate("smalldata/iris/setosa_versicolor.csv"))
+  sv2 = h2o.uploadFile(locate("smalldata/iris/setosa_versicolor.csv"))
+  vir = h2o.uploadFile(locate("smalldata/iris/virginica.csv"))
+
+  m1 = h2o.xgboost(x=c(1,2,3,5), y=4, training_frame=sv1, ntrees=100)
+
+  m2 = h2o.xgboost(x=c(1,2,3,5), y=4,training_frame=sv2, ntrees=200, checkpoint=m1@model_id)
+
+  # attempt to continue building model, but with an expanded categorical predictor domain.
+  # this should fail until we figure out proper behavior
+  expect_error(m3 <- h2o.xgboost(x=c(1,2,3,5), y=4, training_frame=vir, ntrees=200, checkpoint=m1@model_id))
+
+  
+}
+
+doTest("XGBoost checkpoint with new categoricals", checkpoint.new.category.in.predictor )

--- a/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_new_category_in_predictor.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_new_category_in_predictor.R
@@ -4,6 +4,7 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 checkpoint.new.category.in.predictor <- function() {
+  expect_true(h2o.xgboost.available())
 
   sv1 = h2o.uploadFile(locate("smalldata/iris/setosa_versicolor.csv"))
   sv2 = h2o.uploadFile(locate("smalldata/iris/setosa_versicolor.csv"))

--- a/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_remove_all.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_remove_all.R
@@ -1,0 +1,21 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+checkpoint.remove.all <- function() {
+
+  iris = h2o.importFile(locate("smalldata/iris/iris.csv"))
+  m1 = h2o.xgboost(x=1:4, y=5, training_frame=iris, ntrees=100)
+
+  path = h2o.saveModel(m1, path=sandbox(), force=TRUE)
+  h2o.removeAll()
+  restored = h2o.loadModel(path)
+
+  # update m1 with new training data
+  iris = h2o.importFile(locate("smalldata/iris/iris.csv"))
+  m2 = h2o.xgboost(x=1:4, y=5, training_frame=iris, ntrees=200, checkpoint=restored@model_id)
+
+}
+
+doTest("XGBoost checkpoint with remove all", checkpoint.remove.all)

--- a/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_remove_all.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_checkpoint_remove_all.R
@@ -4,6 +4,7 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 checkpoint.remove.all <- function() {
+  expect_true(h2o.xgboost.available())
 
   iris = h2o.importFile(locate("smalldata/iris/iris.csv"))
   m1 = h2o.xgboost(x=1:4, y=5, training_frame=iris, ntrees=100)

--- a/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_ecology_random_noise.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_ecology_random_noise.R
@@ -1,0 +1,12 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.XGBoost.ecology.random.noise <- function() {
+  df <- h2o.uploadFile(locate("smalldata/gbm_test/ecology_model.csv"))
+  # pred_noise_bandwidth is not implemented for XGBoost
+  model <- h2o.xgboost(x = 3:13, y = "Angaus", training_frame = df, pred_noise_bandwidth=0.5)
+  print(model)
+}
+
+doTest("XGBoost: Ecology Data", test.XGBoost.ecology.random.noise)
+

--- a/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_ecology_random_noise.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_NOFEATURE_XGBoost_ecology_random_noise.R
@@ -2,6 +2,8 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
 test.XGBoost.ecology.random.noise <- function() {
+  expect_true(h2o.xgboost.available())
+
   df <- h2o.uploadFile(locate("smalldata/gbm_test/ecology_model.csv"))
   # pred_noise_bandwidth is not implemented for XGBoost
   model <- h2o.xgboost(x = 3:13, y = "Angaus", training_frame = df, pred_noise_bandwidth=0.5)

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_col_sample_per_tree.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_col_sample_per_tree.R
@@ -4,6 +4,8 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 test.xgboost.colsamplepertree <- function() {
+  expect_true(h2o.xgboost.available())
+
   covtype <- h2o.importFile(locate("smalldata/covtype/covtype.20k.data"))
   covtype[,55] <- as.factor(covtype[,55])
   splits <- h2o.splitFrame(covtype, 0.8, seed=1234)

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_col_sample_per_tree.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_col_sample_per_tree.R
@@ -1,0 +1,32 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+test.xgboost.colsamplepertree <- function() {
+  covtype <- h2o.importFile(locate("smalldata/covtype/covtype.20k.data"))
+  covtype[,55] <- as.factor(covtype[,55])
+  splits <- h2o.splitFrame(covtype, 0.8, seed=1234)
+  train <- splits[[1]]
+  valid <- splits[[2]]
+
+  regular      <- h2o.xgboost(x=1:54,y=55,ntrees=50,seed=1234,training_frame=train)
+  colsample    <- h2o.xgboost(x=1:54,y=55,ntrees=50,seed=1234,training_frame=train,col_sample_rate_per_tree=0.9)
+
+  mm_regular   <- h2o.performance(regular, valid)
+  mm_colsample <- h2o.performance(colsample, valid)
+
+  err_regular   <- h2o.confusionMatrix(mm_regular)[8,8]
+  err_colsample <- h2o.confusionMatrix(mm_colsample)[8,8]
+
+
+  print("err_regular")
+  print(err_regular)
+  print("")
+  print("err_colsample")
+  print(err_colsample)
+
+  expect_true(err_regular >= 0.9*err_colsample, "col sampling made validation error worse!")
+}
+
+doTest("xgboost colSamplePerTree", test.xgboost.colsamplepertree)

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_cup98_01_medium.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_cup98_01_medium.R
@@ -1,0 +1,26 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+test.XGBoost <- function() {
+
+  print("about to parse train")
+  train.hex <- h2o.uploadFile(locate("bigdata/laptop/usecases/cup98LRN_z.csv"), destination_frame="cup98LRN_z.hex")
+  print("about to parse test")
+  test.hex  <- h2o.uploadFile(locate("bigdata/laptop/usecases/cup98VAL_z.csv"), destination_frame="cup98VAL_z.hex")
+
+  # Train H2O XGBoost Model:
+  train.hex$TARGET_B <- as.factor(train.hex$TARGET_B)
+  y = "TARGET_B"
+  excluded_column_names = c("", y, "TARGET_D", "CONTROLN")
+  x = setdiff(colnames(train.hex), excluded_column_names)
+  print("about to run xgboost")
+  model <- h2o.xgboost(training_frame = train.hex, y = y, x = x,
+                   distribution = "multinomial", ntrees = 5)
+  print("done running xgboost")
+
+  
+}
+
+doTest("XGBoost Test: KDD cup 98, test 01", test.XGBoost)

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_cup98_01_medium.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_cup98_01_medium.R
@@ -4,6 +4,7 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 test.XGBoost <- function() {
+  expect_true(h2o.xgboost.available())
 
   print("about to parse train")
   train.hex <- h2o.uploadFile(locate("bigdata/laptop/usecases/cup98LRN_z.csv"), destination_frame="cup98LRN_z.hex")

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_ecology.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_ecology.R
@@ -1,0 +1,76 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+test.XGBoost.ecology <- function() {
+  
+  Log.info("==============================")
+  Log.info("H2O XGBoost Params: ")
+  Log.info("x = 3:13")
+  Log.info("y = Angaus")
+  Log.info("data = ecology.hex,")
+  Log.info("n.trees = 100") 
+  Log.info("interaction.depth = 5")
+  Log.info("n.minobsinnode = 10") 
+  Log.info("shrinkage = 0.1")
+  Log.info("==============================")
+  Log.info("==============================")
+  Log.info("R XGBoost Params: ")
+  Log.info("Formula: Angaus ~ ., data = ecology.data[,-1]")
+  Log.info("distribution = gaussian")
+  Log.info("ntrees = 100")
+  Log.info("interaction.depth = 5")
+  Log.info("n.minobsinnode = 10")
+  Log.info("shrinkage = 0.1")
+  Log.info("bag.fraction = 1")
+  Log.info("==============================")
+  n.trees <<- 100
+  max_depth <<- 5
+  min_rows <<- 10
+  learn_rate <<- 1
+  
+  Log.info("Importing ecology_model.csv data...\n")
+  print("=============================")
+  print(locate("smalldata/gbm_test/ecology_model.csv"))
+  print("=============================")
+  ecology.hex <- h2o.uploadFile(locate("smalldata/gbm_test/ecology_model.csv"))
+  ecology.sum <- summary(ecology.hex)
+  Log.info("Summary of the ecology data from h2o: \n") 
+  print(ecology.sum)
+  
+  #import csv data for R to use
+  ecology.data <- read.csv(locate("smalldata/gbm_test/ecology_model.csv"), header = TRUE)
+  ecology.data <- na.omit(ecology.data) #this omits NAs... does XGBoost do this? Perhaps better to model w/o doing this?
+  
+  Log.info("H2O XGBoost with parameters:\nntrees = 100, max_depth = 5, min_rows = 10, learn_rate = 0.1\n")
+  #Train H2O XGBoost Model:
+  ecology.h2o <- h2o.xgboost(x = 3:13, 
+                        y = "Angaus", 
+           training_frame = ecology.hex,
+                   ntrees = n.trees,
+                max_depth = 5,
+                 min_rows = 10,
+               learn_rate = 0.1,
+                     distribution = "gaussian")
+
+  print(ecology.h2o)
+  
+  #Train R GBM Model: Using Gaussian distribution family for binary outcome OK... Also more comparable to H2O, which uses MSE
+  ecology.r <- gbm(Angaus ~ ., data = ecology.data[,-1], distribution = "gaussian", 
+                  n.trees = n.trees,
+                  interaction.depth = 5, 
+                  n.minobsinnode = 10, 
+                  shrinkage = 0.1,
+                  bag.fraction=1)
+
+  ecologyTest.hex <- h2o.uploadFile(locate("smalldata/gbm_test/ecology_eval.csv"))
+  ecologyTest.data <- read.csv(locate("smalldata/gbm_test/ecology_eval.csv")) 
+
+  checkGBMModel(ecology.h2o, ecology.r, ecologyTest.hex, ecologyTest.data)
+  
+  
+}
+
+doTest("XGBoost: Ecology Data", test.XGBoost.ecology)
+

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_ecology.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_ecology.R
@@ -4,6 +4,7 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 test.XGBoost.ecology <- function() {
+  expect_true(h2o.xgboost.available())
   
   Log.info("==============================")
   Log.info("H2O XGBoost Params: ")

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_forloop_attack_medium.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_forloop_attack_medium.R
@@ -89,6 +89,7 @@ randomParams <- function(distribution, train, test, x, y) {
 }
 
 test.XGBoost.rand_attk_forloop <- function() {
+  expect_true(h2o.xgboost.available())
   Log.info("Import and data munging...")
   pros.hex <- h2o.uploadFile(locate("smalldata/prostate/prostate.csv"))
   seed <- as.integer(runif(1,1,.Machine$integer.max))

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_forloop_attack_medium.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_forloop_attack_medium.R
@@ -1,0 +1,129 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+# Constants and setters
+bools <- c(TRUE, FALSE)
+set_x <- function(cols) {
+  if(sample(bools,1)) {
+    while (TRUE){
+      myX <- cols
+      for(i in 1:length(cols))
+        if (sample(bools, 1))
+          myX <- myX[-i]
+      if(length(myX) > 0)
+        break
+    }
+    return(myX)
+  } else
+    cols
+}
+set_y <- function(col) return(col)
+set_training_frame <- function(frame) return(frame)
+set_validation_frame <- function(frame) return(frame)
+set_distribution <- function(distribution) return(distribution)
+set_ntrees <- function() sample.int(3, 1)
+set_max_depth <- function() sample.int(3, 1)
+set_min_rows <- function() sample.int(10, 1)
+set_learn_rate <- function() runif(1)
+set_nbins <- function() sample(2:1000, 1)
+set_nbins_cats <- function() {}
+set_balance_classes <- function() sample(bools, 1)
+set_max_after_balance_size <- function(balance) {
+  if (sample(bools, 1))
+    return(runif(1, 1, 100))
+  else
+    return(runif(1, 0.1, 1))
+}
+set_nfolds <- function() {}
+set_score_each_iteration <- function() sample(bools, 1)
+
+randomParams <- function(distribution, train, test, x, y) {
+  parms <- list()
+
+  parm_set <- function(parm, required = FALSE, dep = TRUE, ...) {
+    if (!dep)
+      return(NULL)
+    if (required || sample(bools,1)) {
+      val <- do.call(paste0("set_", parm), list(...))
+      if (!is.null(val))
+        if (is.vector(val))
+          Log.info(paste0(sub("_", " ", parm), ": ", paste(val, collapse = ", ")))
+        else if (class(val) == "H2OFrame")
+          Log.info(paste("H2OFrame: ", head(val)))
+        else
+          Log.info(paste0(sub("_", " ", parm), ": ", val))
+      return(val)
+    }
+    return(NULL)
+  }
+
+  parms$x <- parm_set("x", required = TRUE, cols = x)
+  parms$y <- parm_set("y", required = TRUE, col = y)
+  parms$training_frame <- parm_set("training_frame", required = TRUE, frame = train)
+  parms$validation_frame <- parm_set("validation_frame", frame = test)
+  parms$distribution <- parm_set("distribution", required = TRUE, distribution = distribution)
+  parms$ntrees <- parm_set("ntrees")
+  parms$max_depth <- parm_set("max_depth")
+  parms$min_rows <- parm_set("min_rows")
+  parms$learn_rate <- parm_set("learn_rate")
+# balance_classes and nbins are not implemented for XGBoost:
+#  parms$nbins <- parm_set("nbins")
+# parms$nbins_cats <- parm_set("nbins_cats")
+#  parms$balance_classes <- parm_set("balance_classes",
+#    dep = distribution %in% c("multinomial", "bernoulli"))
+#  parms$max_after_balance_size <- parm_set("max_after_balance_size",
+#    dep = !is.null(parms$balance_classes) && parms$balance_classes)
+  parms$score_each_iteration <- parm_set("score_each_iteration")
+
+  t <- system.time(hh <- do.call("h2o.xgboost", parms))
+  print(hh)
+
+  h2o.rm(hh@model_id)
+  print("#########################################################################################")
+  print("")
+  print(t)
+  print("")
+
+}
+
+test.XGBoost.rand_attk_forloop <- function() {
+  Log.info("Import and data munging...")
+  pros.hex <- h2o.uploadFile(locate("smalldata/prostate/prostate.csv"))
+  seed <- as.integer(runif(1,1,.Machine$integer.max))
+  print("SEED: ")
+  print(seed)
+  p.sid <- h2o.runif(pros.hex,seed=seed)
+
+  pros.hex[,2] <- as.factor(pros.hex[,2])
+  pros.hex[,5] <- as.factor(pros.hex[,5])
+  pros.hex[,6] <- as.factor(pros.hex[,6])
+  pros.hex[,9] <- as.factor(pros.hex[,9])
+  pros.train <- h2o.assign(pros.hex[p.sid > .2, ], "pros.train")
+  pros.test <- h2o.assign(pros.hex[p.sid <= .2, ], "pros.test")
+
+  iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris_wheader.csv"))
+  i.sid <- h2o.runif(iris.hex,seed=seed)
+  iris.train <- h2o.assign(iris.hex[i.sid > .2, ], "iris.train")
+  iris.test <- h2o.assign(iris.hex[i.sid <= .2, ], "iris.test")
+
+  cars.hex <- h2o.uploadFile(locate("smalldata/junit/cars.csv"))
+  c.sid <- h2o.runif(cars.hex,seed=seed)
+  cars.train <- h2o.assign(cars.hex[c.sid > .2, ], "cars.train")
+  cars.test <- h2o.assign(cars.hex[c.sid <= .2, ], "cars.test")
+
+  Log.info("### Binomial ###")
+  for(i in 1:3)
+    randomParams("bernoulli", pros.train, pros.test, 3:9, 2)
+  Log.info("### Multinomial ###")
+  for(i in 1:3)
+    randomParams("multinomial", iris.train, iris.test, 1:4, 5)
+  Log.info("### Regression ###")
+  for(i in 1:3)
+    randomParams("gaussian", cars.train, cars.test, 4:7, 3)
+
+  
+}
+
+doTest("Checking XGBoost in Random Attack For Loops", test.XGBoost.rand_attk_forloop)

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_frameslice.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_frameslice.R
@@ -4,6 +4,7 @@ source("../../../scripts/h2o-r-test-setup.R")
 
 
 test.XGBoost.frameslice <- function() {
+  expect_true(h2o.xgboost.available())
   Log.info("Importing prostate data...\n")
   pros.hex <- h2o.importFile(path = locate("smalldata/logreg/prostate.csv"))
 

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_frameslice.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_frameslice.R
@@ -1,0 +1,17 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+test.XGBoost.frameslice <- function() {
+  Log.info("Importing prostate data...\n")
+  pros.hex <- h2o.importFile(path = locate("smalldata/logreg/prostate.csv"))
+
+  Log.info("Running XGBoost on a sliced data frame...\n")
+  pros.hex[,2] = as.factor(pros.hex[,2])
+  pros.xgboost <- h2o.xgboost(x = 2:8, y = 1, training_frame = pros.hex[, 2:9], distribution = "bernoulli")
+
+  
+}
+
+doTest("XGBoost Test: Model building on sliced h2o frame", test.XGBoost.frameslice)


### PR DESCRIPTION
Second batch of ported tests, and a fix for PUBDEV-5278, which I found via `runit_XGBoost_cup98_01_medium.R`.