### PR TITLE
[HOTFIX] PUBDEV-5286: GBM grid failing on some datasets

### DIFF
--- a/h2o-core/src/main/java/water/exceptions/H2OConcurrentModificationException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OConcurrentModificationException.java
@@ -1,0 +1,14 @@
+package water.exceptions;
+
+/**
+ * H2OConcurrentModificationException signals that object was modified while being used in another
+ * operation.
+ * Example use case is deleting a Vec while a checksum is being calculated on it.
+ */
+public class H2OConcurrentModificationException extends H2OAbstractRuntimeException {
+
+  public H2OConcurrentModificationException(String message) {
+    super(message, message);
+  }
+
+}


### PR DESCRIPTION
In GridSearch we are looking at the state of whole DKV and we might try to calculate a checksum on objects (Vecs) that are being modified. We should be able to detect this state and don't fail.