### PR TITLE
PUBDEV-5159: Removed pandas dependency from AutoML Python leaderboard

### DIFF
--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -345,9 +345,8 @@ class H2OAutoML(object):
             self._leader_id = None
 
         # Parse leaderboard H2OTwoDimTable & return as an H2OFrame
-        leaderboard = h2o.H2OFrame(res["leaderboard_table"].cell_values)[1:]
-        leaderboard.columns = res["leaderboard_table"].col_header[1:]
-        self._leaderboard = leaderboard
+        leaderboard = h2o.H2OFrame(res["leaderboard_table"].cell_values, column_names=res["leaderboard_table"].col_header)
+        self._leaderboard = leaderboard[1:]
         return self._leader_id is not None
 
     def _get_params(self):

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -344,7 +344,10 @@ class H2OAutoML(object):
         else:
             self._leader_id = None
 
-        self._leaderboard = h2o.H2OFrame(res["leaderboard_table"].as_data_frame())[1:]
+        # Parse leaderboard H2OTwoDimTable & return as an H2OFrame
+        leaderboard = h2o.H2OFrame(res["leaderboard_table"].cell_values)[1:]
+        leaderboard.columns = res["leaderboard_table"].col_header[1:]
+        self._leaderboard = leaderboard
         return self._leader_id is not None
 
     def _get_params(self):


### PR DESCRIPTION
Now we pull the data directly from the H2OTwoDimTable instead of converting to a pandas DataFrame then H2OFrame.