### PR TITLE
PUBDEV-5323: GLM doesn't need prediction post-processing

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1117,6 +1117,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     }
     return preds;
   }
+  @Override protected boolean needsPostProcess() { return false; /* pred[0] is already set by score0 */ }
 
   @Override protected void toJavaPredictBody(SBPrintStream body,
                                              CodeGeneratorPipeline classCtx,

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1623,9 +1623,17 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     for( int i=0; i< tmp.length; i++ )
       tmp[i] = chks[i].atd(row_in_chunk);
     double [] scored = score0(tmp, preds, offset);
-    if(isSupervised())
+    if(needsPostProcess() && isSupervised())
       score0PostProcessSupervised(scored, tmp);
     return scored;
+  }
+
+  /**
+   * Implementations can disable post-processing of predictions by overriding this method (eg. GLM)
+   * @return true, if output of score0 needs post-processing, false if the output is final
+   */
+  protected boolean needsPostProcess() {
+    return true;
   }
 
   protected final void score0PostProcessSupervised(double[] scored, double[] tmp) {

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5323_glm_ensemble.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5323_glm_ensemble.R
@@ -1,0 +1,32 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues = TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.pubdev.5323 <- function() {
+    train <- h2o.importFile(locate("smalldata/higgs/higgs_train_10k.csv"))
+    test <- h2o.importFile(locate("smalldata/higgs/higgs_test_5k.csv"))
+
+    y <- "response"
+    x <- setdiff(names(train), y)
+
+    train[,y] <- as.factor(train[,y])
+    test[,y] <- as.factor(test[,y])
+
+    # Train a bunch of GLM models
+    .wrapper <- function(alpha) {
+        h2o.glm(training_frame = train, family = "binomial", alpha = alpha, x = x, y = y, seed = 1, nfolds = 3,
+                keep_cross_validation_predictions = TRUE,
+                lambda_search = TRUE,
+                balance_classes = TRUE,
+                early_stopping = TRUE)
+    }
+    models <- sapply(X = seq(0, 0.10, 0.05), FUN = .wrapper)
+
+    # Build the ensemble from pre-trained models
+    ensemble <- h2o.stackedEnsemble(x = x, y = y, training_frame = train, base_models = models)
+    # It should not fail and return the ensemble
+    expect_false(is.null(ensemble))
+}
+
+doTest("PUBDEV-5323: Stacked Ensemble fails when using a grid or list of GLMs as base models", test.pubdev.5323)


### PR DESCRIPTION
GLM doesn't support 'balance classes' - however the option is present for backwards compatibility, we should prevent entering the code that attempts to do balancing because the prior distribution is not available in GLM