### PR TITLE
PUBDEV-5292: Adding beta_constraints and prior to UG parameters

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -788,7 +788,9 @@ The constraints are specified as a frame with following vecs (matched by name; a
 \item \texttt{lower\_bounds}: (optional) coefficient lower bounds , must be less than or equal to \texttt{upper\_bounds}
 \item \texttt{upper\_bounds}: (optional) coefficient upper bounds , must be greater than or equal to \texttt{lower\_bounds}
 \item \texttt{beta\_given}: (optional) specifies the given solution in proximal operator interface
-\item \texttt{rho} (mandatory if \texttt{beta\_given} is specified, otherwise ignored): specifies per-column  $\ell_2$ penalties on the distance from the given solution
+\item \texttt{rho}: (mandatory if \texttt{beta\_given} is specified, otherwise ignored): specifies per-column  $\ell_2$ penalties on the distance from the given solution
+\item \texttt{mean}: specifies the mean override (for data standardization)
+\item \texttt{std\_dev}: specifies the standard deviation override (for data standardization)
 \end{itemize}
  
 \subsubsection{Proximal Operators}

--- a/h2o-docs/src/product/data-science/algo-params/beta_constraints.rst
+++ b/h2o-docs/src/product/data-science/algo-params/beta_constraints.rst
@@ -1,0 +1,130 @@
+``beta_constraints``
+--------------------
+
+- Available in: GLM
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+Beta constraints allow you to set special conditions over the model coefficients. Currently supported constraints are upper and lower bounds and the proximal operator interface, as described in Proximal Algorithms by Boyd et. al. The proximal operator interface allows you to run the GLM with a proximal penalty on a distance from a specified given solution. There are many potential uses: for example, it can be used as part of an ADMM consensus algorithm to obtain a unified solution over separate H2O clouds or in Bayesian regression approximation.
+
+Use the ``beta_constraints`` parameter to specify a data frame or ``H2OParsedData`` object with the beta constraints, where each row corresponds to a predictor in the GLM. The selected frame is used to constrain the coefficient vector to provide upper and lower bounds. The constraints are specified as a frame with the following vectors (matched by name; all vecs can be sparse):
+
+ - ``names``: (mandatory) Specifies the predictor names. This is required. The dataset must contain a names column with valid coefficient names.
+ - ``lower_bounds``: (optional) The lower bounds of the beta. Must be less than or equal to upper_bounds.
+ - ``upper_bounds``: (optional) The upper bounds of the beta. Must be greater than or equal to ``lower_bounds``.
+ - ``beta_given``: (optional) Specifies the given solution. This works as a base in proximal penalty.
+ - ``beta_start``: (optional) Specifies the starting solution. This is useful for warm-starting GLM (otherwise GLM starts with all zeros).
+ - ``rho``: (mandatory if ``beta_given`` is specified; otherwise ignored): Specifies the per-column :math:`\ell_2` penalties on the distance from the given solution.
+ - ``mean``: (optional) Specifies the mean override (for data standardization).
+ - ``std_dev``: (optional) Specifies the standard deviation override (for data standardization).
+
+Running GLM with Weights and Beta Constraints
+'''''''''''''''''''''''''''''''''''''''''''''
+
+When running GLM with weights, the expectation is that it will produce the same model as up-sampling the training dataset. This is true when standardization is turned on and without beta constraints. But if you add beta constraints, the up-sampled and weighted cases produce different GLM models with different coefficients. This occurs for a couple of reasons:
+
+- Priors is standardized and changed when standardization is turned on for the model build. When standardization is turned on, the ``beta_given`` in ``beta_constraints`` is standardized as well. In the `code <https://github.com/h2oai/h2o-3/blob/master/h2o-algos/src/main/java/hex/glm/GLM.java#L1902>`__, you see that the ``beta_given`` is multiplied by factor ``d : _betaGiven *= d;``` where ``d = 1/sd``. In particular, be careful when using previous coefficients as priors and with standardization turned on because the penalty taken on different priors.
+
+- When weights is turned on, the variance will differ from the variance in an up-sampled dataset. The way variance is typically calculated is:
+
+    :math:`s2 = summation((x_i – x)^2) / N -1`
+
+ When using weights, the weighted variance is calculated as:
+
+    :math:`s2 = (N/ (N-1)) * (summation(w_i (x_i – x)^2) / summation(w_i))`
+
+ So when the sum of weights equals the number of observations, you have the exact same variance; otherwise your variance will differ by a factor of approximately N/N-1, which is a relatively small difference but something you will observe in your resulting coefficients.
+
+If you want to supply the beta constraints for a standardized model, scale your bounds and priors in ``beta_constraints`` down by the variance so that you will have ``(1/d)* betaGiven *= d;`` which equals ``betaGiven``.
+
+**Notes**:
+
+- ``beta_constraints`` is not supported for ``family="multinomial"``. 
+- P-values cannot be computed for constrained problems.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- none
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+    library(h2o)
+    h2o.init()
+
+    # Import the prostate dataset
+
+    prostate <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv.zip")
+
+    # Set the predictor names and the response column name
+    p_y <- "CAPSULE"
+    p_x <- setdiff(names(prostate), c(p_y, "ID"))
+    p_n <- length(p_x)
+
+    # Create a beta_constraints frame
+    con <- data.frame(names = p_x, 
+                      lower_bounds = rep(-10000, time = p_n),
+                      upper_bounds = rep(10000, time = p_n),
+                      beta_given = rep(1, time = p_n),
+                      rho = rep(0.2, time = p_n))
+
+    # Build a GLM with beta constraints and standardization.
+    # When standardization is turned on, the beta_given is also standardized.
+    glm1 <- h2o.glm(x = p_x, 
+                    y = p_y, 
+                    training_frame = prostate, 
+                    standardize = TRUE, 
+                    beta_constraints = con)
+
+    # Build a GLM with beta constraints and without standardization
+    glm2 <- h2o.glm(x = p_x, 
+                    y = p_y, 
+                    training_frame = prostate, 
+                    standardize = FALSE, 
+                    beta_constraints = con)
+
+    # Check the coefficients for both models
+    glm1@model$coefficients_table
+    glm2@model$coefficients_table
+
+   .. code-block:: python
+
+    import h2o
+    h2o.init()
+    from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+    # Import the prostate dataset
+    prostate = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv.zip")
+
+    # Set the predictor names and the response column name
+    response = "CAPSULE"
+    predictor = prostate.names[2:9]
+    n = len(predictor)
+
+    # Create a beta_constraints frame
+    constraints = h2o.H2OFrame({'names':predictor,
+                                'lower_bounds': [-1000]*n,
+                                'upper_bounds': [1000]*n,
+                                'beta_given': [1]*n,
+                                'rho': [0.2]*n})
+
+    # Build a GLM model with beta constraints and standardization
+    prostate_glm1 = H2OGeneralizedLinearEstimator(standardize=True, beta_constraints=constraints)
+    prostate_glm1.train(x = predictor, y = response, training_frame=prostate)
+
+    # Build a GLM model with beta constraints and without standardization
+    prostate_glm2 = H2OGeneralizedLinearEstimator(standardize=False, beta_constraints=constraints)
+    prostate_glm2.train(x = predictor, y = response, training_frame=prostate)
+
+    # Check the coefficients for both models
+    coeff_table1 = prostate_glm1._model_json['output']['coefficients_table']
+    coeff_table1
+
+    coeff_table2 = prostate_glm2._model_json['output']['coefficients_table']
+    coeff_table2

--- a/h2o-docs/src/product/data-science/algo-params/compute_p_values.rst
+++ b/h2o-docs/src/product/data-science/algo-params/compute_p_values.rst
@@ -13,7 +13,7 @@ Z-score, standard error, and `p-values <https://en.wikipedia.org/wiki/P-value>`_
 
 - This option is only applicable when regularization is disabled (``lambda=0``) and when ``solver=IRLSM``. 
 - If collinear columns exist in the data, then you must also specify ``remove_collinear_columns=TRUE``. Otherwise, H2O will return an error. 
-- This option cannot be used with ``family=multinomial``
+- This option cannot be used with ``family=multinomial`` or with ``beta_constraints``.
 - GLM auto-standardizes the data by default. This changes the p-value of the constant term (intercept).
 
 Related Parameters

--- a/h2o-docs/src/product/data-science/algo-params/prior.rst
+++ b/h2o-docs/src/product/data-science/algo-params/prior.rst
@@ -1,0 +1,96 @@
+``prior``
+---------
+
+- Available in: GLM
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+This option specifies the prior probability of class 1 in the response when ``family = "binomial"``.  The default value is the observation frequency of class 1. This must be a value from (0,1) exclusive range, and defaults to -1 (no prior). This parameter is useful for logistic regression if the data has been sampled and the mean of response does not reflect reality. 
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- none
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+    library(h2o)
+    h2o.init()
+
+    # import the cars dataset:
+    # this dataset is used to classify whether or not a car is economical based on
+    # the car's displacement, power, weight, and acceleration, and the year it was made
+    cars <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+
+    # convert response column to a factor
+    cars["economy_20mpg"] <- as.factor(cars["economy_20mpg"])
+
+    # set the predictor names and the response column name
+    predictors <- c("displacement","power","weight","acceleration","year")
+    response <- "economy_20mpg"
+
+    # split into train and validation
+    cars.splits <- h2o.splitFrame(data = cars, ratios = .8)
+    train <- cars.splits[[1]]
+    valid <- cars.splits[[2]]
+
+    # Build a GLM model and set a prior value of 0.5
+    car_glm1 <- h2o.glm(x = predictors, y = response, family = 'binomial', prior=0.5,
+                        training_frame = train, 
+                        validation_frame = valid)
+
+    # Build a GLM model without a prior value
+    car_glm2 <- h2o.glm(x = predictors, y = response, family = 'binomial',
+                        training_frame = train,
+                        validation_frame = valid)
+
+    # Check the coefficients for both models
+    car_glm1@model$coefficients_table
+    car_glm2@model$coefficients_table
+
+   .. code-block:: python
+
+    import h2o
+    from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+    h2o.init()
+
+    # import the cars dataset:
+    # this dataset is used to classify whether or not a car is economical based on
+    # the car's displacement, power, weight, and acceleration, and the year it was made
+    cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
+
+    # convert response column to a factor
+    cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
+
+    # set the predictor names and the response column name
+    predictors = ["displacement","power","weight","acceleration","year"]
+    response = "economy_20mpg"
+
+    # split into train and validation sets
+    train, valid = cars.split_frame(ratios = [.8])
+
+    # Build a GLM model and set a prior value of 0.5
+    cars_glm1 = H2OGeneralizedLinearEstimator(family = 'binomial', prior=0.5)
+    cars_glm1.train(x = predictors, y = response, 
+                    training_frame = train, 
+                    validation_frame = valid)
+
+    # Build a GLM model and set a prior value of 0.5
+    cars_glm2 = H2OGeneralizedLinearEstimator(family = 'binomial')
+    cars_glm2.train(x = predictors, y = response, 
+                    training_frame = train, 
+                    validation_frame = valid)
+
+    # Check the coefficients for both models
+    coeff_table1 = cars_glm1._model_json['output']['coefficients_table']
+    coeff_table1
+
+    coeff_table2 = cars_glm2._model_json['output']['coefficients_table']
+    coeff_table2
+

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -98,7 +98,7 @@ Defining a GLM Model
 -  `tweedie_link_power <algo-params/tweedie_link_power.html>`__: (Only applicable if *Tweedie* is specified
    for **Family**) Specify the Tweedie link power.
 
--  `solver <algo-params/solver.html>`__: Specify the solver to use (AUTO, IRLSM, L\_BFGS, COORDINATE\_DESCENT\_NAIVE, or COORDINATE\_DESCENT). IRLSM is fast on problems with a small number of predictors and for lambda search with L1 penalty, while `L\_BFGS <http://cran.r-project.org/web/packages/lbfgs/vignettes/Vignette.pdf>`__ scales better for datasets with many columns. COORDINATE\_DESCENT is IRLSM with the covariance updates version of cyclical coordinate descent in the innermost loop. COORDINATE\_DESCENT\_NAIVE is IRLSM with the naive updates version of cyclical coordinate descent in the innermost loop. COORDINATE\_DESCENT\_NAIVE and COORDINATE\_DESCENT are currently experimental.
+-  `solver <algo-params/solver.html>`__: Specify the solver to use (AUTO, IRLSM, L_BFGS, COORDINATE_DESCENT_NAIVE, or COORDINATE_DESCENT). IRLSM is fast on problems with a small number of predictors and for lambda search with L1 penalty, while `L_BFGS <http://cran.r-project.org/web/packages/lbfgs/vignettes/Vignette.pdf>`__ scales better for datasets with many columns. COORDINATE_DESCENT is IRLSM with the covariance updates version of cyclical coordinate descent in the innermost loop. COORDINATE_DESCENT_NAIVE is IRLSM with the naive updates version of cyclical coordinate descent in the innermost loop. COORDINATE_DESCENT_NAIVE and COORDINATE_DESCENT are currently experimental.
 
 -  `alpha <algo-params/alpha.html>`__: Specify the regularization distribution between L1 and L2.
 
@@ -140,13 +140,13 @@ Defining a GLM Model
    -  If the family is **Multinomial**, then only **Family_Default** is supported. (This defaults to ``multinomial``.)
    -  If the family is **Quasibinomial**, then only **Logit** is supported.
 
--  prior: Specify prior probability for p(y==1). Use this parameter for logistic regression if the data has been sampled and the mean of response does not reflect reality. 
+-  `prior <algo-params/prior.html>`__: Specify prior probability for p(y==1). Use this parameter for logistic regression if the data has been sampled and the mean of response does not reflect reality. This value defaults to -1 and must be a value in the range (0,1).
    
      **Note**: This is a simple method affecting only the intercept. You may want to use weights and offset for a better fit.
 
 -  `lambda_min_ratio <algo-params/lambda_min_ratio.html>`__: Specify the minimum lambda to use for lambda search (specified as a ratio of **lambda_max**, which is the smallest :math:`\lambda` for which the solution is all zeros).
 
--  beta_constraints: Specify a dataset to use beta constraints. The selected frame is used to constraint the coefficient vector to provide upper and lower bounds. The dataset must contain a names column with valid coefficient names.
+-  `beta_constraints <algo-params/beta_constraints.html>`__: Specify a dataset to use beta constraints. The selected frame is used to constrain the coefficient vector to provide upper and lower bounds. The dataset must contain a names column with valid coefficient names.
 
 -  `max_active_predictors <algo-params/max_active_predictors.html>`__: Specify the maximum number of active
    predictors during computation. This value is used as a stopping

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -15,6 +15,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
 
    data-science/algo-params/alpha
    data-science/algo-params/balance_classes
+   data-science/algo-params/beta_constraints
    data-science/algo-params/beta_epsilon
    data-science/algo-params/binomial_double_trees
    data-science/algo-params/build_tree_one_node
@@ -83,6 +84,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/offset_column
    data-science/algo-params/pca_method
    data-science/algo-params/pred_noise_bandwidth
+   data-science/algo-params/prior
    data-science/algo-params/quantile_alpha
    data-science/algo-params/remove_collinear_columns
    data-science/algo-params/sample_rate


### PR DESCRIPTION
- Added beta_constraints and prior to parameter appendix in the User Guide
- Updated parameters index to include these
- Added links to these topics in the GLM chapter
- For beta_constraints in the GLM booklet, added mean and std_dev to list of beta_constraints options