### PR TITLE
PUBDEV-5294 - XGBoost model in Flow doesn't seem to converge

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static hex.tree.xgboost.XGBoost.makeDataInfo;
 
 public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParameters, XGBoostOutput> {
+
   private XGBoostModelInfo model_info;
 
   XGBoostModelInfo model_info() { return model_info; }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -13,13 +13,16 @@ import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.util.Log;
 import hex.ModelMetrics;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Map;
 
 import static hex.tree.xgboost.XGBoost.makeDataInfo;
 
 public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParameters, XGBoostOutput> {
-
+  private static final NumberFormat localizedNumberFormatter = DecimalFormat.getNumberInstance();
   private XGBoostModelInfo model_info;
 
   XGBoostModelInfo model_info() { return model_info; }
@@ -290,7 +293,27 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
       Log.info(" " + s.getKey() + " = " + s.getValue());
     }
     Log.info("");
+
+    localizeDecimalParams(params);
     return params;
+  }
+
+  /**
+   * Iterates over a set of parameters and applies locale-specific formatting
+   * to decimal ones (Floats and Doubles).
+   *
+   * @param params Parameters to localize
+   */
+  private static void localizeDecimalParams(final HashMap<String, Object> params) {
+
+    for (String key : params.keySet()) {
+      final Object value = params.get(key);
+      if (value instanceof Float || value instanceof Double) {
+        final String localizedValue = localizedNumberFormatter.format(value);
+        params.put(key, localizedValue);
+      }
+    }
+
   }
 
   @Override

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import static hex.tree.xgboost.XGBoost.makeDataInfo;
 
 public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParameters, XGBoostOutput> {
-  private static final NumberFormat localizedNumberFormatter = DecimalFormat.getNumberInstance();
   private XGBoostModelInfo model_info;
 
   XGBoostModelInfo model_info() { return model_info; }
@@ -305,7 +304,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
    * @param params Parameters to localize
    */
   private static void localizeDecimalParams(final HashMap<String, Object> params) {
-
+    final NumberFormat localizedNumberFormatter = DecimalFormat.getNumberInstance();
     for (String key : params.keySet()) {
       final Object value = params.get(key);
       if (value instanceof Float || value instanceof Double) {
@@ -313,7 +312,6 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
         params.put(key, localizedValue);
       }
     }
-
   }
 
   @Override


### PR DESCRIPTION
Issue: https://0xdata.atlassian.net/browse/PUBDEV-5294

This is a known issue with XGBoost, when the library takes system Locale and uses it to determine decimal separator.

There are many countries with different decimal separator from US/UK decimal point, usually a decimal comma (arabic style). For example Japan shares the same settings with US/UK (one more reason for this to work for the US guys and Mateusz). https://en.wikipedia.org/wiki/Decimal_separator

This issue has been reported many times (e.g. here https://github.com/dmlc/xgboost/issues/2512), however for some uses, this is considered a feature and is unlikely to be fixed soon.

Therefore, fixing this issue on our side by passing localized parameters is the preferred option.
