### PR TITLE
PUBDEV-5326 - Bug in ParseTime which leads to parse failing

### DIFF
--- a/h2o-core/src/main/java/water/parser/ParseTime.java
+++ b/h2o-core/src/main/java/water/parser/ParseTime.java
@@ -57,8 +57,10 @@ public abstract class ParseTime {
       long t4 = attemptDayFirstTimeParse2(str); // "dd/MM/yy" and time if present; note that this format is ambiguous
       if( t4 != Long.MIN_VALUE ) return t4;     // Cant tell which date: 3/2/10 is
     } catch( org.joda.time.IllegalFieldValueException | // Not time at all
-             org.joda.time.IllegalInstantException      // Parsed as time, but falls into e.g. a daylight-savings hour hole
-             ie ) { } //FIXME should collect errors and report at end of parse
+        org.joda.time.IllegalInstantException |      // Parsed as time, but falls into e.g. a daylight-savings hour hole
+        ArrayIndexOutOfBoundsException
+        e) {
+    }
     return Long.MIN_VALUE;
   }
   // Tries to parse "yyyy-MM[-dd] [HH:mm:ss.SSS aa]"
@@ -248,7 +250,7 @@ public abstract class ParseTime {
       for (byte[] ms : mss) {
         MMM = ms;
         if (MMM == null) continue;
-        if (i + MMM.length > end) 
+        if (i + MMM.length > end)
           continue INNER;
         for (int j = 0; j < MMM.length; j++)
           if (MMM[j] != Character.toLowerCase(buf[i + j]))

--- a/h2o-core/src/main/java/water/util/Log.java
+++ b/h2o-core/src/main/java/water/util/Log.java
@@ -10,6 +10,8 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /** Log for H2O. 
  *

--- a/h2o-core/src/test/java/water/parser/ParseTimeTest.java
+++ b/h2o-core/src/test/java/water/parser/ParseTimeTest.java
@@ -1,5 +1,6 @@
 package water.parser;
 
+import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,6 +12,18 @@ import water.fvec.Vec;
 public class ParseTimeTest extends TestUtil {
   @BeforeClass static public void setup() { stall_till_cloudsize(1); }
   private double[] d(double... ds) { return ds; }
+
+  @Test
+  public void testDateWithColonEnding() {
+    long parsedMillis = ParseTime.attemptTimeParse(new BufferedString("2011-01-01:"));
+    Assert.assertEquals(Long.MIN_VALUE, parsedMillis);
+  }
+
+  @Test
+  public void testTimeWithColonEnding() {
+    long parsedMillis = ParseTime.attemptTimeParse(new BufferedString(":"));
+    Assert.assertEquals(Long.MIN_VALUE, parsedMillis);
+  }
 
   // Parse click & query times from a subset of kaggle bestbuy data
   @Test public void testTimeParse1() {


### PR DESCRIPTION
Issue link: https://0xdata.atlassian.net/browse/PUBDEV-5326

First problem is the time parsing method is vulnerable to index being out of bounds very quickly. Second problem is the unknown nature of the data our customer used. However, I was exactly able to reproduce the issue with "2011-01-01:" (or other variations for day-first and month-first alternatives...) or ":" for time-only case. 

This above-mentioned case causes time parsing method to try to parse first two digits (hours), when there is none or only one. This very specific case has been handled manually. If the parsing case is not time-only, the date is returned. If the parsing case is time-only, a Long.MIN_VALUE signaling the value could not be parsed as time.

However, there are potentially more cases where an ArrayOutOfBounds exception may arise, eventhough the code tries to avoid them. Therefore, I've altered handling to collect all the errors on the way and print them at the end **if no date or time** is parsed.