### PR TITLE
[PUBDEV-5282] Add Cache-Control=no-cache

### DIFF
--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -314,6 +314,7 @@ public class JettyHTTPD extends AbstractHTTPD {
   }
 
   private static void setCommonResponseHttpHeaders(HttpServletResponse response) {
+    response.setHeader("Cache-Control", "no-cache");
     response.setHeader("X-h2o-build-project-version", H2O.ABV.projectVersion());
     response.setHeader("X-h2o-rest-api-version-max", Integer.toString(water.api.RequestServer.H2O_REST_API_VERSION));
     response.setHeader("X-h2o-cluster-id", Long.toString(H2O.CLUSTER_ID));

--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -145,7 +145,7 @@ public class JettyHTTPD extends AbstractHTTPD {
         try { Thread.sleep(100); }
         catch (Exception ignore) {}
       }
-      setCommonResponseHttpHeaders(response);
+      setCommonResponseHttpHeaders(response, isXhrRequest(baseRequest));
     }
   }
 
@@ -313,8 +313,15 @@ public class JettyHTTPD extends AbstractHTTPD {
     }
   }
 
-  private static void setCommonResponseHttpHeaders(HttpServletResponse response) {
-    response.setHeader("Cache-Control", "no-cache");
+  private static boolean isXhrRequest(final Request request) {
+    final String requestedWithHeader = request.getHeader("X-Requested-With");
+    return "XMLHttpRequest".equals(requestedWithHeader);
+  }
+
+  private static void setCommonResponseHttpHeaders(HttpServletResponse response, final boolean xhrRequest) {
+    if (xhrRequest) {
+      response.setHeader("Cache-Control", "no-cache");
+    }
     response.setHeader("X-h2o-build-project-version", H2O.ABV.projectVersion());
     response.setHeader("X-h2o-rest-api-version-max", Integer.toString(water.api.RequestServer.H2O_REST_API_VERSION));
     response.setHeader("X-h2o-cluster-id", Long.toString(H2O.CLUSTER_ID));


### PR DESCRIPTION
The IE caches the response. Because of that, the first response from `Jobs/` endpoint is cached. All of the following requests are being handled by the cache -> the status bar does not move. This is supported also by provided logs, as there is **only one** request to `Jobs/` 

```
2018-02-01 11:01:16,538   POST    200      25 ms  /3/ModelBuilders/drf
2018-02-01 11:01:16,562   GET     200       0 ms  /3/Jobs/%2403017f00000132d4ffffffff%24_94ca1fffceba56563f1268bbaec14efe
2018-02-01 11:01:37,321   GET     200      31 ms  /3/Models
```

Here is a screen from IE console where the cached requests are recorded:

![obrazok](https://user-images.githubusercontent.com/29674210/36424963-73b46fc8-1645-11e8-844a-91ae2ab64974.png)
