### PR TITLE
[WOL-PUBDEV-5282] Add Cache-Control=no-cache (#2066)

### DIFF
--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -145,7 +145,7 @@ public class JettyHTTPD extends AbstractHTTPD {
         try { Thread.sleep(100); }
         catch (Exception ignore) {}
       }
-      setCommonResponseHttpHeaders(response);
+      setCommonResponseHttpHeaders(response, isXhrRequest(baseRequest));
     }
   }
 
@@ -313,7 +313,15 @@ public class JettyHTTPD extends AbstractHTTPD {
     }
   }
 
-  private static void setCommonResponseHttpHeaders(HttpServletResponse response) {
+  private static boolean isXhrRequest(final Request request) {
+    final String requestedWithHeader = request.getHeader("X-Requested-With");
+    return "XMLHttpRequest".equals(requestedWithHeader);
+  }
+
+  private static void setCommonResponseHttpHeaders(HttpServletResponse response, final boolean xhrRequest) {
+    if (xhrRequest) {
+      response.setHeader("Cache-Control", "no-cache");
+    }
     response.setHeader("X-h2o-build-project-version", H2O.ABV.projectVersion());
     response.setHeader("X-h2o-rest-api-version-max", Integer.toString(water.api.RequestServer.H2O_REST_API_VERSION));
     response.setHeader("X-h2o-cluster-id", Long.toString(H2O.CLUSTER_ID));


### PR DESCRIPTION
* [PUBDEV-5282] Add Cache-Control=no-cache. Otherwise the IE caches the responses and the status bar is not moving when building model.

* [PUBDEV-5282] Set the no-cache for Xhr requests only

Cherry picked from 6b68b49824