### PR TITLE
[PUBDEV-4968] Add a h2o.H2OFrame.rename method to rename columns in py

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1011,6 +1011,21 @@ class H2OFrame(object):
         return H2OFrame._expr(expr=ExprNode("setDomain", self, False, levels), cache=self._ex._cache)
 
 
+    def rename(self, columns=None):
+        """
+        Change names of columns in the frame.
+
+        Dict key is an index or name of the column whose name is to be set.
+        Dict value is the new name of the column.
+
+        :param columns: dict-like transformations to apply to the column names
+        """
+        assert_is_type(columns, None, dict)
+        for col, name in columns.items():
+            self.set_name(col, name)
+        return self
+
+
     def set_names(self, names):
         """
         Change names of all columns in the frame.

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1034,9 +1034,7 @@ class H2OFrame(object):
             if col_index is not None:
                 new_names[col_index] = name
 
-        assert_satisfies(new_names, len(new_names) == self.ncol)
-        self._ex = ExprNode("colnames=", self, range(self.ncol), new_names)  # Update-in-place, but still lazy
-        return self
+        return self.set_names(new_names)
 
 
     def set_names(self, names):

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1021,8 +1021,21 @@ class H2OFrame(object):
         :param columns: dict-like transformations to apply to the column names
         """
         assert_is_type(columns, None, dict)
+        new_names = self.names
+        ncols = self.ncols
+
         for col, name in columns.items():
-            self.set_name(col, name)
+            col_index = None
+            if is_type(col, int) and (-ncols <= col < ncols):
+                col_index = (col + ncols) % ncols  # handle negative indices
+            elif is_type(col, str) and col in self.names:
+                col_index = self.names.index(col)  # lookup the name
+
+            if col_index is not None:
+                new_names[col_index] = name
+
+        assert_satisfies(new_names, len(new_names) == self.ncol)
+        self._ex = ExprNode("colnames=", self, range(self.ncol), new_names)  # Update-in-place, but still lazy
         return self
 
 

--- a/h2o-py/tests/testdir_misc/pyunit_colname_rename.py
+++ b/h2o-py/tests/testdir_misc/pyunit_colname_rename.py
@@ -1,0 +1,28 @@
+from __future__ import print_function
+import sys
+import copy
+
+sys.path.insert(1, "../../")
+import h2o
+from tests import pyunit_utils
+
+
+def colname_rename():
+    print("Uploading iris data...")
+
+    f1 = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris.csv"))
+    f2 = copy.copy(f1)
+
+    t1 = f1.rename(columns={'C2': 'C1', 'C1': 'C2', 'C3': 'X3', 'F0': 'X0', 'C3': 'Y3'})
+    e1 = ['C2', 'C1', 'Y3', 'C4', 'C5']
+    assert t1.names == e1, "Expected the same column names but got {0} and {1}".format(t1.names, e1)
+
+    t2 = f2.rename(columns={0: 'X1', 2: 'X3', -1: 'X2', 20: 'X20', 2: 'Y3'})
+    e2 = ['X1', 'C2', 'Y3', 'C4', 'X2']
+    assert t2.names == e2, "Expected the same column names but got {0} and {1}".format(t2.names, e2)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(colname_rename)
+else:
+    colname_rename()


### PR DESCRIPTION
This is my first PR just to get familiar with the PR process here. Plase take note that I'm not a Python dev.

I added a new method that would have the same functionality as `pandas.DataFrame.rename` for renaming columns. It is just a simple wrapper around `H2OFrame.set_name`

I'm not sure if you wish to deprecate `H2OFrame.set_name` and `H2OFrame.set_names`. Let me know and I can extend this PR.

Test with:
```
df = pandas.DataFrame({'col1': [1, 1, 2], 'col2': ['a', 'b', 'c']})
hf = h2o.H2OFrame(df)
print(hf.col_names)
hf = hf.rename(columns={'col11': 'aa', "col2": "bb"})
print(hf.col_names)
hf = hf.rename(columns={0: "cc"})
print(hf.col_names)
```