### PR TITLE
PUBDEV-5324 & PUBDEV-5383 - Make  POJO log error messages for all wrong data types

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -61,7 +61,6 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
   private final boolean convertUnknownCategoricalLevelsToNa;
   private final boolean convertInvalidNumbersToNa;
   private final boolean useExtendedOutput;
-  private final ConcurrentHashMap<String,AtomicLong> unknownCategoricalLevelsSeenPerColumn;
 
   /**
    * Observer interface with methods corresponding to errors during the prediction.
@@ -200,11 +199,9 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
     }
 
     // How to handle unknown categorical levels.
-    unknownCategoricalLevelsSeenPerColumn = new ConcurrentHashMap<>();
     convertUnknownCategoricalLevelsToNa = config.getConvertUnknownCategoricalLevelsToNa();
     convertInvalidNumbersToNa = config.getConvertInvalidNumbersToNa();
     useExtendedOutput = config.getUseExtendedOutput();
-    setupConvertUnknownCategoricalLevelsToNa();
 
     // Create map of input variable domain information.
     // This contains the categorical string to numeric mapping.
@@ -232,34 +229,6 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
             .setModel(model));
   }
 
-  /**
-   * Get the total number unknown categorical levels seen.
-   *
-   * A single prediction may contribute more than one to the count.
-   * The count is only updated when setConvertUnknownCategoricalLevelsToNa is set to true.
-   *
-   * @return A long value.
-   */
-  public long getTotalUnknownCategoricalLevelsSeen() {
-    ConcurrentHashMap<String, AtomicLong> map = getUnknownCategoricalLevelsSeenPerColumn();
-    long total = 0;
-    for (AtomicLong l : map.values()) {
-      total += l.get();
-    }
-    return total;
-  }
-
-  /**
-   * Get unknown categorical level counts.
-   *
-   * A single prediction may contribute to more than one count.
-   * Counts are only updated when setConvertUnknownCategoricalLevelsToNa is set to true.
-   *
-   * @return A hash map with a per-column count of unknown categorical levels seen when making predictions.
-   */
-  public ConcurrentHashMap<String, AtomicLong> getUnknownCategoricalLevelsSeenPerColumn() {
-    return unknownCategoricalLevelsSeenPerColumn;
-  }
 
   /**
    * Make a prediction on a new data point.
@@ -587,20 +556,8 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
   // Private methods below this line.
   //----------------------------------------------------------------------
 
-  private void setupConvertUnknownCategoricalLevelsToNa() {
-    if (convertUnknownCategoricalLevelsToNa) {
-      for (int i = 0; i < m.getNumCols(); i++) {
-        String[] domainValues = m.getDomainValues(i);
-        if (domainValues != null) {
-          String columnName = m.getNames()[i];
-          unknownCategoricalLevelsSeenPerColumn.put(columnName, new AtomicLong());
-        }
-      }
-    }
-    else {
-      unknownCategoricalLevelsSeenPerColumn.clear();
-    }
-  }
+
+
 
   private void validateModelCategory(ModelCategory c) throws PredictException {
     if (!m.getModelCategories().contains(c))
@@ -720,7 +677,6 @@ public class EasyPredictModelWrapper implements java.io.Serializable {
             if (convertUnknownCategoricalLevelsToNa) {
               value = Double.NaN;
               errorConsumer.unseenCategorical(dataColumnName, o, "Previously unseen categorical level detected, marking as NaN.");
-              unknownCategoricalLevelsSeenPerColumn.get(dataColumnName).incrementAndGet();
             } else {
               errorConsumer.dataTransformError(dataColumnName, o, "Unknown categorical level detected.");
               throw new PredictUnknownCategoricalLevelException("Unknown categorical level (" + dataColumnName + "," + levelName + ")", dataColumnName, levelName);

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -41,6 +41,11 @@ import java.util.concurrent.atomic.AtomicLong;
  * with the data quality.
  * An alternate behavior is to automatically convert unknown categorical levels to N/A.  To do this, use
  * setConvertUnknownCategoricalLevelsToNa(true) instead.
+ * 
+ * Detection of unknown categoricals may be observed by registering an implementation of {@link ErrorConsumer}
+ * in the process of {@link Config} creation.
+ * 
+ * Deprecation note: Total number of unknown categorical variables is newly accessible by registering {@link hex.genmodel.easy.error.CountingErrorConsumer}.
  *
  *
  * <p></p>

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -42,11 +42,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * An alternate behavior is to automatically convert unknown categorical levels to N/A.  To do this, use
  * setConvertUnknownCategoricalLevelsToNa(true) instead.
  *
- * If you choose to convert unknown categorical levels to N/A, you can see how many times this is happening
- * with the following methods:
- *
- *     getTotalUnknownCategoricalLevelsSeen()
- *     getUnknownCategoricalLevelsSeenPerColumn()
  *
  * <p></p>
  * See the top-of-tree master version of this file <a href="https://github.com/h2oai/h2o-3/blob/master/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java" target="_blank">here on github</a>.

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/error/CountingErrorConsumer.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/error/CountingErrorConsumer.java
@@ -40,7 +40,7 @@ public class CountingErrorConsumer extends EasyPredictModelWrapper.ErrorConsumer
 
   /**
    * Counts and returns all previously unseen categorical variables across all columns.
-   * Results may vary wehen called during prediction phase.
+   * Results may vary when called during prediction phase.
    *
    * @return A sum of all previously unseen categoricals across all columns
    */

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/error/CountingErrorConsumer.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/error/CountingErrorConsumer.java
@@ -1,0 +1,74 @@
+package hex.genmodel.easy.error;
+
+import hex.genmodel.GenModel;
+import hex.genmodel.easy.EasyPredictModelWrapper;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * An implementation of {@link hex.genmodel.easy.EasyPredictModelWrapper.ErrorConsumer}
+ * counting number of each kind of error even received
+ */
+public class CountingErrorConsumer extends EasyPredictModelWrapper.ErrorConsumer {
+
+  private AtomicLong dataTransformationErrorsCount = new AtomicLong();
+  private Map<String, AtomicLong> unknownCategoricalsPerColumn = new ConcurrentHashMap<>();
+
+  /**
+   * @param model An instance of {@link GenModel}
+   */
+  public CountingErrorConsumer(GenModel model) {
+    for (int i = 0; i < model.getNumCols(); i++) {
+      String[] domainValues = model.getDomainValues(i);
+      if (domainValues != null) {
+        unknownCategoricalsPerColumn.put(model.getNames()[i], new AtomicLong());
+      }
+    }
+  }
+
+  @Override
+  public void dataTransformError(String columnName, Object value, String message) {
+    dataTransformationErrorsCount.incrementAndGet();
+  }
+
+  @Override
+  public void unseenCategorical(String columnName, Object value, String message) {
+    unknownCategoricalsPerColumn.get(columnName).incrementAndGet();
+  }
+
+  /**
+   * Counts and returns all previously unseen categorical variables across all columns.
+   * Results may vary wehen called during prediction phase.
+   *
+   * @return A sum of all previously unseen categoricals across all columns
+   */
+  public long getTotalUnknownCategoricalLevelsSeen() {
+    long total = 0;
+    for (AtomicLong l : unknownCategoricalsPerColumn.values()) {
+      total += l.get();
+    }
+    return total;
+  }
+
+  /***
+   * Returns a thread-safe Map with column names as keys and number of observed unknown categorical values
+   * associated with each column. The map returned is a direct reference to
+   * the backing this {@link CountingErrorConsumer}. Iteration during prediction phase may end up with
+   * undefined results.
+   *
+   * All the columns are listed.
+   * @return A thread-safe map.
+   */
+  public Map<String, AtomicLong> getUnknownCategoricalsPerColumn() {
+    return unknownCategoricalsPerColumn;
+  }
+
+  /**
+   * @return Number of transformation errors found
+   */
+  public long getDataTransformationErrorsCount() {
+    return dataTransformationErrorsCount.get();
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/error/VoidErrorConsumer.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/error/VoidErrorConsumer.java
@@ -1,0 +1,20 @@
+package hex.genmodel.easy.error;
+
+import hex.genmodel.easy.EasyPredictModelWrapper;
+
+/**
+ * A void implementation of {@link hex.genmodel.easy.EasyPredictModelWrapper.ErrorConsumer}.
+ * It's purpose is to avoid forcing developers do to null checks in code before each and every call.
+ */
+public final class VoidErrorConsumer extends EasyPredictModelWrapper.ErrorConsumer {
+
+  @Override
+  public final void dataTransformError(String columnName, Object value, String message) {
+    //Do nothing on purpose to avoid the need for null checks
+  }
+
+  @Override
+  public final void unseenCategorical(String columnName, Object value, String message) {
+    //Do nothing on purpose to avoid the need for null checks
+  }
+}


### PR DESCRIPTION
JIRA: https://0xdata.atlassian.net/browse/PUBDEV-5324

Example output:
```text
Following columns had NaN values in the predicted dataset: Origin,fDayofMonth
```