### PR TITLE
[PUBDEV-3901] Python MOJO predictions

### DIFF
--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -247,16 +247,7 @@ class H2OLocalServer(object):
 
         # Find Java and check version. (Note that subprocess.check_output returns the output as a bytes object)
         java = self._find_java()
-        jver_bytes = subprocess.check_output([java, "-version"], stderr=subprocess.STDOUT)
-        jver = jver_bytes.decode(encoding="utf-8", errors="ignore")
-        if self._verbose:
-            print("  Java Version: " + jver.strip().replace("\n", "; "))
-        if "GNU libgcj" in jver:
-            raise H2OStartupError("Sorry, GNU Java is not supported for H2O.\n"
-                                  "Please download the latest 64-bit Java SE JDK from Oracle.")
-        if "Client VM" in jver:
-            warn("  You have a 32-bit version of Java. H2O works best with 64-bit Java.\n"
-                 "  Please download the latest 64-bit Java SE JDK from Oracle.\n")
+        self._check_java(java, self._verbose)
 
         if self._verbose:
             print("  Starting server from " + self._jar_path)
@@ -327,6 +318,18 @@ class H2OLocalServer(object):
                 raise H2OServerError("Server wasn't able to start in %f seconds." % elapsed_time)
             time.sleep(0.2)
 
+    @staticmethod
+    def _check_java(java, verbose):
+        jver_bytes = subprocess.check_output([java, "-version"], stderr=subprocess.STDOUT)
+        jver = jver_bytes.decode(encoding="utf-8", errors="ignore")
+        if verbose:
+            print("  Java Version: " + jver.strip().replace("\n", "; "))
+        if "GNU libgcj" in jver:
+            raise H2OStartupError("Sorry, GNU Java is not supported for H2O.\n"
+                                  "Please download the latest 64-bit Java SE JDK from Oracle.")
+        if "Client VM" in jver:
+            warn("  You have a 32-bit version of Java. H2O works best with 64-bit Java.\n"
+                 "  Please download the latest 64-bit Java SE JDK from Oracle.\n")
 
     @staticmethod
     def _find_java():

--- a/h2o-py/h2o/utils/__init__.py
+++ b/h2o-py/h2o/utils/__init__.py
@@ -1,0 +1,3 @@
+from .shared_utils import mojo_predict_csv
+
+__all__ = ('mojo_predict_csv', 'mojo_predict_pandas')

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -17,10 +17,15 @@ import sys
 import zipfile
 import io
 import string
+import subprocess
+import csv
+import shutil
+import tempfile
 
 from h2o.exceptions import H2OValueError
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.typechecks import assert_is_type, is_type, numeric
+from h2o.backend.server import H2OLocalServer
 
 _id_ctr = 0
 
@@ -28,6 +33,8 @@ _id_ctr = 0
 # only contain characters allowed within the "segment" part of the URL (see RFC 3986). Additionally, we
 # forbid all characters that are declared as "illegal" in Key.java.
 _id_allowed_characters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+__all__ = ('mojo_predict_csv', 'mojo_predict_pandas')
 
 
 def _py_tmp_key(append):
@@ -360,6 +367,122 @@ is_num_list = _is_num_list
 is_str_list = _is_str_list
 handle_python_lists = _handle_python_lists
 check_lists_of_lists = _check_lists_of_lists
+
+gen_model_file_name = "h2o-genmodel.jar"
+h2o_predictor_class = "hex.genmodel.tools.PredictCsv"
+
+
+def mojo_predict_pandas(dataframe, mojo_zip_path, genmodel_jar_path=None, classpath=None, java_options=None, verbose=False):
+    """
+    MOJO scoring function to take a Pandas frame and use MOJO model as zip file to score.
+    :param dataframe: Pandas frame to score.
+    :param mojo_zip_path: Path to MOJO zip downloaded from H2O.
+    :param genmodel_jar_path: Optional, path to genmodel jar file. If None (default) then the h2o-genmodel.jar in the same
+    folder as the MOJO zip will be used.
+    :param classpath: Optional, specifies custom user defined classpath which will be used when scoring. If None
+    (default) then the default classpath for this MOJO model will be used.
+    :param java_options: Optional, custom user defined options for Java. By default '-Xmx4g' is used.
+    :param verbose: Optional, if True, then additional debug information will be printed. False by default.
+    :return: Pandas frame with predictions
+    """
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        if not can_use_pandas():
+            raise RuntimeException('Cannot import pandas')
+        import pandas
+        assert_is_type(dataframe, pandas.DataFrame)
+        input_csv_path = os.path.join(tmp_dir, 'input.csv')
+        prediction_csv_path = os.path.join(tmp_dir, 'prediction.csv')
+        dataframe.to_csv(input_csv_path)
+        mojo_predict_csv(input_csv_path=input_csv_path, mojo_zip_path=mojo_zip_path,
+                         output_csv_path=prediction_csv_path, genmodel_jar_path=genmodel_jar_path,
+                         classpath=classpath, java_options=java_options, verbose=verbose)
+        return pandas.read_csv(prediction_csv_path)
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
+def mojo_predict_csv(input_csv_path, mojo_zip_path, output_csv_path=None, genmodel_jar_path=None, classpath=None, java_options=None, verbose=False):
+    """
+    MOJO scoring function to take a CSV file and use MOJO model as zip file to score.
+    :param input_csv_path: Path to input CSV file.
+    :param mojo_zip_path: Path to MOJO zip downloaded from H2O.
+    :param output_csv_path: Optional, name of the output CSV file with computed predictions. If None (default), then
+    predictions will be saved as prediction.csv in the same folder as the MOJO zip.
+    :param genmodel_jar_path: Optional, path to genmodel jar file. If None (default) then the h2o-genmodel.jar in the same
+    folder as the MOJO zip will be used.
+    :param classpath: Optional, specifies custom user defined classpath which will be used when scoring. If None
+    (default) then the default classpath for this MOJO model will be used.
+    :param java_options: Optional, custom user defined options for Java. By default '-Xmx4g' is used. 
+    :param verbose: Optional, if True, then additional debug information will be printed. False by default.
+    :return: List of computed predictions
+    """
+    default_java_options = '-Xmx4g -XX:ReservedCodeCacheSize=256m'
+    prediction_output_file = 'prediction.csv'
+
+    # Checking java
+    java = H2OLocalServer._find_java()
+    H2OLocalServer._check_java(java=java, verbose=verbose)
+
+    # Ensure input_csv exists
+    if verbose:
+        print("input_csv:\t%s" % input_csv_path)
+    if not os.path.isfile(input_csv_path):
+        raise RuntimeError("Input csv cannot be found at %s" % input_csv_path)
+
+    # Ensure mojo_zip exists
+    mojo_zip_path = os.path.abspath(mojo_zip_path)
+    if verbose:
+        print("mojo_zip:\t%s" % mojo_zip_path)
+    if not os.path.isfile(mojo_zip_path):
+        raise RuntimeError("MOJO zip cannot be found at %s" % mojo_zip_path)
+
+    parent_dir = os.path.dirname(mojo_zip_path)
+
+    # Set output_csv if necessary
+    if output_csv_path is None:
+        output_csv_path = os.path.join(parent_dir, prediction_output_file)
+
+    # Set path to h2o-genmodel.jar if necessary and check it's valid
+    if genmodel_jar_path is None:
+        genmodel_jar_path = os.path.join(parent_dir, gen_model_file_name)
+    if verbose:
+        print("genmodel_jar:\t%s" % genmodel_jar_path)
+    if not os.path.isfile(genmodel_jar_path):
+        raise RuntimeError("Genmodel jar cannot be found at %s" % genmodel_jar_path)
+
+    if verbose and output_csv_path is not None:
+        print("output_csv:\t%s" % output_csv_path)
+
+    # Set classpath if necessary
+    if classpath is None:
+        classpath = genmodel_jar_path
+    if verbose:
+        print("classpath:\t%s" % classpath)
+
+    # Set java_options if necessary
+    if java_options is None:
+        java_options = default_java_options
+    if verbose:
+        print("java_options:\t%s" % java_options)
+
+    # Construct command to invoke java
+    cmd = [java]
+    for option in java_options.split(' '):
+        cmd += [option]
+    cmd += ["-cp", classpath, h2o_predictor_class, "--mojo", mojo_zip_path, "--input", input_csv_path,
+            '--output', output_csv_path, '--decimal']
+    if verbose:
+        cmd_str = " ".join(cmd)
+        print("java cmd:\t%s" % cmd_str)
+
+    # invoke the command
+    subprocess.check_call(cmd, shell=False)
+
+    # load predictions in form of a dict
+    with open(output_csv_path) as csv_file:
+        result = list(csv.DictReader(csv_file))
+    return result
 
 
 def deprecated(message):

--- a/h2o-py/tests/testdir_misc/pyunit_mojo_predict.py
+++ b/h2o-py/tests/testdir_misc/pyunit_mojo_predict.py
@@ -1,0 +1,246 @@
+import sys
+import tempfile
+import shutil
+import time
+import os
+
+import pandas
+
+sys.path.insert(1, "../../")
+import h2o
+import h2o.utils.shared_utils as h2o_utils
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+genmodel_name = "h2o-genmodel.jar"
+
+
+def download_mojo(model, mojo_zip_path, genmodel_path=None):
+    mojo_zip_path = os.path.abspath(mojo_zip_path)
+    parent_dir = os.path.dirname(mojo_zip_path)
+
+    print("\nDownloading MOJO @... " + parent_dir)
+    time0 = time.time()
+    if genmodel_path is None:
+        genmodel_path = os.path.join(parent_dir, genmodel_name)
+    mojo_file = model.download_mojo(path=mojo_zip_path, get_genmodel_jar=True, genmodel_name=genmodel_path)
+
+    print("    => %s  (%d bytes)" % (mojo_file, os.stat(mojo_file).st_size))
+    assert os.path.exists(mojo_file)
+    print("    Time taken = %.3fs" % (time.time() - time0))
+    assert os.path.exists(mojo_zip_path)
+    print("    => %s  (%d bytes)" % (mojo_zip_path, os.stat(mojo_zip_path).st_size))
+    assert os.path.exists(genmodel_path)
+    print("    => %s  (%d bytes)" % (genmodel_path, os.stat(genmodel_path).st_size))
+
+
+def mojo_predict_api_test(sandbox_dir):
+    data = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+
+    input_csv = "%s/in.csv" % sandbox_dir
+    output_csv = "%s/prediction.csv" % sandbox_dir
+    h2o.export_file(data[1, 2:], input_csv)
+
+    data[1] = data[1].asfactor()
+    model = H2OGradientBoostingEstimator(distribution="bernoulli")
+    model.train(x=[2, 3, 4, 5, 6, 7, 8], y=1, training_frame=data)
+
+    # download mojo
+    model_zip_path = os.path.join(sandbox_dir, 'model.zip')
+    genmodel_path = os.path.join(sandbox_dir, 'h2o-genmodel.jar')
+    download_mojo(model, model_zip_path)
+    assert os.path.isfile(model_zip_path)
+    assert os.path.isfile(genmodel_path)
+
+    # test that we can predict using default paths
+    h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path, verbose=True)
+    h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path, genmodel_jar_path=genmodel_path,
+                               verbose=True)
+    assert os.path.isfile(output_csv)
+    os.remove(model_zip_path)
+    os.remove(genmodel_path)
+    os.remove(output_csv)
+
+    # test that we can predict using custom genmodel path
+    other_sandbox_dir = tempfile.mkdtemp()
+    try:
+        genmodel_path = os.path.join(other_sandbox_dir, 'h2o-genmodel-custom.jar')
+        download_mojo(model, model_zip_path, genmodel_path)
+        assert os.path.isfile(model_zip_path)
+        assert os.path.isfile(genmodel_path)
+        try:
+            h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path, verbose=True)
+            assert False, "There should be no h2o-genmodel.jar at %s" % sandbox_dir
+        except RuntimeError:
+            pass
+        assert not os.path.isfile(output_csv)
+        h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path,
+                                   genmodel_jar_path=genmodel_path, verbose=True)
+        assert os.path.isfile(output_csv)
+        os.remove(output_csv)
+
+        output_csv = "%s/out.prediction" % other_sandbox_dir
+
+        # test that we can predict using default paths
+        h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path,
+                                   genmodel_jar_path=genmodel_path, verbose=True, output_csv_path=output_csv)
+        assert os.path.isfile(output_csv)
+        os.remove(model_zip_path)
+        os.remove(genmodel_path)
+        os.remove(output_csv)
+    finally:
+        shutil.rmtree(other_sandbox_dir)
+
+
+def mojo_predict_csv_test(target_dir):
+    mojo_file_name = "prostate_gbm_model.zip"
+    mojo_zip_path = os.path.join(target_dir, mojo_file_name)
+
+    prostate = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+
+    r = prostate[0].runif()
+    train = prostate[r < 0.70]
+    test = prostate[r >= 0.70]
+
+    # Getting first row from test data frame
+    pdf = test[1, 2:]
+    input_csv = "%s/in.csv" % target_dir
+    output_csv = "%s/output.csv" % target_dir
+    h2o.export_file(pdf, input_csv)
+
+    # =================================================================
+    # Regression
+    # =================================================================
+    regression_gbm1 = H2OGradientBoostingEstimator(distribution="gaussian")
+    regression_gbm1.train(x=[2, 3, 4, 5, 6, 7, 8], y=1, training_frame=train)
+    pred_reg = regression_gbm1.predict(pdf)
+    p1 = pred_reg[0, 0]
+    print("Regression prediction: " + str(p1))
+
+    download_mojo(regression_gbm1, mojo_zip_path)
+
+    print("\nPerforming Regression Prediction using MOJO @... " + target_dir)
+    prediction_result = h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=mojo_zip_path,
+                                                   output_csv_path=output_csv)
+    print("Prediction result: " + str(prediction_result))
+    assert p1 == float(prediction_result[0]['predict']), "expected predictions to be the same for binary and MOJO model for regression"
+
+    # =================================================================
+    # Binomial
+    # =================================================================
+    train[1] = train[1].asfactor()
+    bernoulli_gbm1 = H2OGradientBoostingEstimator(distribution="bernoulli")
+
+    bernoulli_gbm1.train(x=[2, 3, 4, 5, 6, 7, 8], y=1, training_frame=train)
+    pred_bin = bernoulli_gbm1.predict(pdf)
+
+    binary_prediction_0 = pred_bin[0, 1]
+    binary_prediction_1 = pred_bin[0, 2]
+    print("Binomial prediction: p0: " + str(binary_prediction_0))
+    print("Binomial prediction: p1: " + str(binary_prediction_1))
+
+    download_mojo(bernoulli_gbm1, mojo_zip_path)
+
+    print("\nPerforming Binomial Prediction using MOJO @... " + target_dir)
+    prediction_result = h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=mojo_zip_path,
+                                                   output_csv_path=output_csv)
+
+    mojo_prediction_0 = float(prediction_result[0]['0'])
+    mojo_prediction_1 = float(prediction_result[0]['1'])
+    print("Binomial prediction: p0: " + str(mojo_prediction_0))
+    print("Binomial prediction: p1: " + str(mojo_prediction_1))
+
+    assert binary_prediction_0 == mojo_prediction_0, "expected predictions to be the same for binary and MOJO model for Binomial - p0"
+    assert binary_prediction_1 == mojo_prediction_1, "expected predictions to be the same for binary and MOJO model for Binomial - p1"
+
+    # =================================================================
+    # Multinomial
+    # =================================================================
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris.csv"))
+
+    r = iris[0].runif()
+    train = iris[r < 0.90]
+    test = iris[r >= 0.10]
+
+    # Getting first row from test data frame
+    pdf = test[1, 0:4]
+    input_csv = "%s/in-multi.csv" % target_dir
+    output_csv = "%s/output.csv" % target_dir
+    h2o.export_file(pdf, input_csv)
+
+    multi_gbm = H2OGradientBoostingEstimator()
+    multi_gbm.train(x=['C1', 'C2', 'C3', 'C4'], y='C5', training_frame=train)
+
+    pred_multi = multi_gbm.predict(pdf)
+    multinomial_prediction_1 = pred_multi[0, 1]
+    multinomial_prediction_2 = pred_multi[0, 2]
+    multinomial_prediction_3 = pred_multi[0, 3]
+    print("Multinomial prediction (Binary): p0: " + str(multinomial_prediction_1))
+    print("Multinomial prediction (Binary): p1: " + str(multinomial_prediction_2))
+    print("Multinomial prediction (Binary): p2: " + str(multinomial_prediction_3))
+
+    download_mojo(multi_gbm, mojo_zip_path)
+
+    print("\nPerforming Binomial Prediction using MOJO @... " + target_dir)
+    prediction_result = h2o_utils.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=mojo_zip_path,
+                                                   output_csv_path=output_csv)
+
+    mojo_prediction_1 = float(prediction_result[0]['Iris-setosa'])
+    mojo_prediction_2 = float(prediction_result[0]['Iris-versicolor'])
+    mojo_prediction_3 = float(prediction_result[0]['Iris-virginica'])
+    print("Multinomial prediction (MOJO): p0: " + str(mojo_prediction_1))
+    print("Multinomial prediction (MOJO): p1: " + str(mojo_prediction_2))
+    print("Multinomial prediction (MOJO): p2: " + str(mojo_prediction_3))
+
+    assert multinomial_prediction_1 == mojo_prediction_1, "expected predictions to be the same for binary and MOJO model for Multinomial - p0"
+    assert multinomial_prediction_2 == mojo_prediction_2, "expected predictions to be the same for binary and MOJO model for Multinomial - p1"
+    assert multinomial_prediction_3 == mojo_prediction_3, "expected predictions to be the same for binary and MOJO model for Multinomial - p2"
+
+
+def mojo_predict_pandas_test(sandbox_dir):
+    data = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+
+    input_csv = "%s/in.csv" % sandbox_dir
+    pdf = data[1, 2:]
+    h2o.export_file(pdf, input_csv)
+
+    data[1] = data[1].asfactor()
+    model = H2OGradientBoostingEstimator(distribution="bernoulli")
+    model.train(x=[2, 3, 4, 5, 6, 7, 8], y=1, training_frame=data)
+
+    h2o_prediction = model.predict(pdf)
+
+    # download mojo
+    model_zip_path = os.path.join(sandbox_dir, 'model.zip')
+    genmodel_path = os.path.join(sandbox_dir, 'h2o-genmodel.jar')
+    download_mojo(model, model_zip_path)
+    assert os.path.isfile(model_zip_path)
+    assert os.path.isfile(genmodel_path)
+
+    pandas_frame = pandas.read_csv(input_csv)
+    mojo_prediction = h2o_utils.mojo_predict_pandas(dataframe=pandas_frame, mojo_zip_path=model_zip_path, genmodel_jar_path=genmodel_path)
+    print("Binomial Prediction (Binary) - p0: %f" % h2o_prediction[0,1])
+    print("Binomial Prediction (Binary) - p1: %f" % h2o_prediction[0,2])
+    print("Binomial Prediction (MOJO) - p0: %f" % mojo_prediction['0'].iloc[0])
+    print("Binomial Prediction (MOJO) - p1: %f" % mojo_prediction['1'].iloc[0])
+    assert h2o_prediction[0,1] == mojo_prediction['0'].iloc[0], "expected predictions to be the same for binary and MOJO model - p0"
+    assert h2o_prediction[0,2] == mojo_prediction['1'].iloc[0], "expected predictions to be the same for binary and MOJO model - p0"
+
+
+csv_test_dir = tempfile.mkdtemp()
+api_test_dir = tempfile.mkdtemp()
+pandas_test_dir = tempfile.mkdtemp()
+try:
+    if __name__ == "__main__":
+        pyunit_utils.standalone_test(lambda: mojo_predict_api_test(api_test_dir))
+        pyunit_utils.standalone_test(lambda: mojo_predict_csv_test(csv_test_dir))
+        pyunit_utils.standalone_test(lambda: mojo_predict_pandas_test(pandas_test_dir))
+    else:
+        mojo_predict_api_test(api_test_dir)
+        mojo_predict_csv_test(csv_test_dir)
+        mojo_predict_pandas_test(pandas_test_dir)
+finally:
+    shutil.rmtree(csv_test_dir)
+    shutil.rmtree(api_test_dir)
+    shutil.rmtree(pandas_test_dir)


### PR DESCRIPTION
The proposed API is following: `h2o_utils.mojo_predict(input_csv, mojo_zip, genmodel_jar, verbose, output_csv)`. Only `input_csv` and `mojo_zip` are required, rest is optional.

- `input_csv` - Path to CSV containing data to score.
- `mojo_zip` - Path to MOJO zip.
- `genmodel_jar` - Path to h2o-genmodel.jar. If None, then we'll look for the `h2o-genmodel.jar` in the same folder where is the `mojo_zip`.
- `output_csv` - Path where CSV with predictions should be saved. If None, then predictions will be saved to `prediction.csv` in the same folder where is the `mojo_zip`.
- `verbose` - If True, prints additional debug output.