### PR TITLE
[PUBDEV-5357] No more locking without owner in parse

### DIFF
--- a/h2o-core/src/main/java/water/util/FileIntegrityChecker.java
+++ b/h2o-core/src/main/java/water/util/FileIntegrityChecker.java
@@ -81,9 +81,10 @@ public class FileIntegrityChecker extends MRTask<FileIntegrityChecker> {
         if( files != null ) files.add(_files[i]);
         if( keys  != null ) keys .add(k.toString());
         if( DKV.get(k) != null ) dels.add(k.toString());
-        new Frame(k).delete_and_lock((Key)null); // Lock before making the NFS; avoids racing ImportFiles creating same Frame
+        Key lockOwner = Key.make();
+        new Frame(k).delete_and_lock(lockOwner); // Lock before making the NFS; avoids racing ImportFiles creating same Frame
         NFSFileVec nfs = NFSFileVec.make(f, fs);
-        new Frame(k,new String[]{"C1"}, new Vec[]{nfs}).update((Key)null).unlock((Key)null);
+        new Frame(k,new String[]{"C1"}, new Vec[]{nfs}).update(lockOwner).unlock(lockOwner);
       }
     }
     fs.blockForPending();


### PR DESCRIPTION
Found in DAI and MLI.

The change shows:
  - it is really bad idea to lock with `null` as lock owner (`null`
  causes unification of multiple locks into a single representation,
  where anybody can unlock. In case of ImportFiles this behaviro leads
  to NPE.