### PR TITLE
PUBDEV-5335: Add distribution and offset_column back into Random Forest

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/DRFV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DRFV3.java
@@ -21,6 +21,7 @@ public class DRFV3 extends SharedTreeV3<DRF, DRFV3, DRFV3.DRFParametersV3> {
                 "response_column",
                 "ignored_columns",
                 "ignore_const_cols",
+                "offset_column",
                 "weights_column",
                 "balance_classes",
                 "class_sampling_factors",
@@ -52,6 +53,7 @@ public class DRFV3 extends SharedTreeV3<DRF, DRFV3, DRFV3.DRFParametersV3> {
                 "categorical_encoding",
                 "calibrate_model",
                 "calibration_frame",
+                "distribution",
                 "custom_metric_func"
         };
 

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -40,6 +40,13 @@ def gen_module(schema, algo, module):
             continue
         if algo == "coxph" and param["name"] == "rcall":
             continue
+        if algo == "drf":
+            if param["name"] == "offset_column":
+                yield "#' @param offset_column Offset column. This argument is deprecated and has no use for Random Forest."
+                continue
+            if param["name"] == "distribution":
+                yield "#' @param distribution Distribution. This argument is deprecated and has no use for Random Forest."
+                continue
         if algo == "naivebayes":
             if param["name"] == "min_sdev":
                 yield "#' @param threshold This argument is deprecated, use `min_sdev` instead. The minimum standard deviation to use for observations without enough data. "
@@ -293,6 +300,14 @@ def gen_module(schema, algo, module):
             continue
         if algo == "coxph" and param["name"] == "rcall":
             yield "  parms$rcall <- deparse(match.call())"
+            continue
+        if algo == "drf" and (param["name"] == "offset_column" or param["name"] == "distribution"):
+            yield "  if (!missing(%s))" % param["name"]
+            yield "    warning(\"Argument %s is deprecated and has no use for Random Forest.\")" % param["name"]
+            if param["name"] == "distribution":
+                yield "    parms$%s <- 'AUTO'" % (param["name"])
+            else:
+                yield "    parms$%s <- NULL" % (param["name"])
             continue
         yield "  if (!missing(%s))" % param["name"]
         yield "    parms$%s <- %s" % (param["name"], param["name"])

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -214,12 +214,20 @@ def gen_module(schema, algo):
             else:
                 extrahelp += "  (default: ``%s``)." % stringify(param["default_value"])
 
-        yield "    @property"
-        yield "    def %s(self):" % pname
-        yield '        """'
-        yield "        %s" % bi.wrap(param["help"], indent=(" " * 8), indent_first=False)
-        yield ""
-        yield "        %s" % bi.wrap(extrahelp, indent=(" " * 8), indent_first=False)
+        if (pname == "offset_column" or pname == "distribution") and algo == "drf":
+            yield "    @property"
+            yield "    def %s(self):" % pname
+            yield '        """'
+            yield "        [Deprecated] %s" % bi.wrap(param["help"], indent=(" " * 8), indent_first=False)
+            yield ""
+            yield "        %s" % bi.wrap(extrahelp, indent=(" " * 8), indent_first=False)
+        else:
+            yield "    @property"
+            yield "    def %s(self):" % pname
+            yield '        """'
+            yield "        %s" % bi.wrap(param["help"], indent=(" " * 8), indent_first=False)
+            yield ""
+            yield "        %s" % bi.wrap(extrahelp, indent=(" " * 8), indent_first=False)
         if pname == "metalearner_params":
             yield "        Example: metalearner_gbm_params = {'max_depth': 2, 'col_sample_rate': 0.3}"
         yield '        """'

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -26,13 +26,13 @@ class H2ORandomForestEstimator(H2OEstimator):
         names_list = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_predictions",
                       "keep_cross_validation_fold_assignment", "score_each_iteration", "score_tree_interval",
                       "fold_assignment", "fold_column", "response_column", "ignored_columns", "ignore_const_cols",
-                      "weights_column", "balance_classes", "class_sampling_factors", "max_after_balance_size",
-                      "max_confusion_matrix_size", "max_hit_ratio_k", "ntrees", "max_depth", "min_rows", "nbins",
-                      "nbins_top_level", "nbins_cats", "r2_stopping", "stopping_rounds", "stopping_metric",
-                      "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node", "mtries", "sample_rate",
-                      "sample_rate_per_class", "binomial_double_trees", "checkpoint",
+                      "offset_column", "weights_column", "balance_classes", "class_sampling_factors",
+                      "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k", "ntrees", "max_depth",
+                      "min_rows", "nbins", "nbins_top_level", "nbins_cats", "r2_stopping", "stopping_rounds",
+                      "stopping_metric", "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node",
+                      "mtries", "sample_rate", "sample_rate_per_class", "binomial_double_trees", "checkpoint",
                       "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
-                      "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame",
+                      "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame", "distribution",
                       "custom_metric_func"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
@@ -224,6 +224,21 @@ class H2ORandomForestEstimator(H2OEstimator):
     def ignore_const_cols(self, ignore_const_cols):
         assert_is_type(ignore_const_cols, None, bool)
         self._parms["ignore_const_cols"] = ignore_const_cols
+
+
+    @property
+    def offset_column(self):
+        """
+        [Deprecated] Offset column. This will be added to the combination of columns before applying the link function.
+
+        Type: ``str``.
+        """
+        return self._parms.get("offset_column")
+
+    @offset_column.setter
+    def offset_column(self, offset_column):
+        assert_is_type(offset_column, None, str)
+        self._parms["offset_column"] = offset_column
 
 
     @property
@@ -705,6 +720,22 @@ class H2ORandomForestEstimator(H2OEstimator):
     def calibration_frame(self, calibration_frame):
         assert_is_type(calibration_frame, None, H2OFrame)
         self._parms["calibration_frame"] = calibration_frame
+
+
+    @property
+    def distribution(self):
+        """
+        [Deprecated] Distribution function
+
+        One of: ``"auto"``, ``"bernoulli"``, ``"multinomial"``, ``"gaussian"``, ``"poisson"``, ``"gamma"``,
+        ``"tweedie"``, ``"laplace"``, ``"quantile"``, ``"huber"``  (default: ``"auto"``).
+        """
+        return self._parms.get("distribution")
+
+    @distribution.setter
+    def distribution(self, distribution):
+        assert_is_type(distribution, None, Enum("auto", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"))
+        self._parms["distribution"] = distribution
 
 
     @property

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -24,6 +24,7 @@
 #'        "Random", "Modulo", "Stratified". Defaults to AUTO.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
 #' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
+#' @param offset_column Offset column. This argument is deprecated and has no use for Random Forest.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative
 #'        weights are not allowed. Note: Weights are per-row observation weights and do not increase the size of the
@@ -78,6 +79,7 @@
 #' @param calibrate_model \code{Logical}. Use Platt Scaling to calculate calibrated class probabilities. Calibration can provide more
 #'        accurate estimates of class probabilities. Defaults to FALSE.
 #' @param calibration_frame Calibration frame for Platt Scaling
+#' @param distribution Distribution. This argument is deprecated and has no use for Random Forest.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
@@ -94,6 +96,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
                              fold_column = NULL,
                              ignore_const_cols = TRUE,
+                             offset_column = NULL,
                              weights_column = NULL,
                              balance_classes = FALSE,
                              class_sampling_factors = NULL,
@@ -124,6 +127,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                              calibrate_model = FALSE,
                              calibration_frame = NULL,
+                             distribution = c("AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"),
                              custom_metric_func = NULL,
                              verbose = FALSE 
                              ) 
@@ -157,6 +161,7 @@ h2o.randomForest <- function(x, y, training_frame,
   parms <- list()
   parms$training_frame <- training_frame
   args <- .verify_dataxy(training_frame, x, y)
+  if( !missing(offset_column) && !is.null(offset_column))  args$x_ignore <- args$x_ignore[!( offset_column == args$x_ignore )]
   if( !missing(weights_column) && !is.null(weights_column)) args$x_ignore <- args$x_ignore[!( weights_column == args$x_ignore )]
   if( !missing(fold_column) && !is.null(fold_column)) args$x_ignore <- args$x_ignore[!( fold_column == args$x_ignore )]
   parms$ignored_columns <- args$x_ignore
@@ -182,6 +187,9 @@ h2o.randomForest <- function(x, y, training_frame,
     parms$fold_column <- fold_column
   if (!missing(ignore_const_cols))
     parms$ignore_const_cols <- ignore_const_cols
+  if (!missing(offset_column))
+    warning("Argument offset_column is deprecated and has no use for Random Forest.")
+    parms$offset_column <- NULL
   if (!missing(weights_column))
     parms$weights_column <- weights_column
   if (!missing(balance_classes))
@@ -242,6 +250,9 @@ h2o.randomForest <- function(x, y, training_frame,
     parms$calibrate_model <- calibrate_model
   if (!missing(calibration_frame))
     parms$calibration_frame <- calibration_frame
+  if (!missing(distribution))
+    warning("Argument distribution is deprecated and has no use for Random Forest.")
+    parms$distribution <- 'AUTO'
   if (!missing(custom_metric_func))
     parms$custom_metric_func <- custom_metric_func
   # Error check and build model


### PR DESCRIPTION

* Revert "PUBDEV-5191: removed offset and distribution parameters from distributed random forest algo (#1887)"

This reverts commit 1d5492893e62384d96862381d5cadd9cb1f19516.

* Add deprecation for offset_column and distribution

* Change deprecation docstring

* Remove dup params

* More fixes and add warning if deprecated args are used

* Explicitly set offset_column and distribution for random forest