### PR TITLE
PUBDEV-5334: col_sample_rate_change_per_level parameter

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -81,7 +81,7 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     @API(help = "Column sample rate per tree (from 0.0 to 1.0)", level = API.Level.secondary, gridable = true)
     public double col_sample_rate_per_tree;
 
-    @API(help = "Relative change of the column sampling rate for every level (from 0.0 to 2.0)", level = API.Level.expert, gridable = true)
+    @API(help = "Relative change of the column sampling rate for every level (must be > 0.0 and <= 2.0)", level = API.Level.expert, gridable = true)
     public double col_sample_rate_change_per_level;
 
     @API(help="Score the model after every so many trees. Disabled if set to 0.", level = API.Level.secondary, gridable = false)

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -167,7 +167,8 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
     if (!(0.0 < _parms._col_sample_rate_per_tree && _parms._col_sample_rate_per_tree <= 1.0))
       error("_col_sample_rate_per_tree", "col_sample_rate_per_tree should be in interval ]0,1] but it is " + _parms._col_sample_rate_per_tree + ".");
     if( !(0. < _parms._col_sample_rate_change_per_level && _parms._col_sample_rate_change_per_level <= 2) )
-      error("_col_sample_rate_change_per_level", "col_sample_rate_change_per_level must be between 0 and 2");
+      error("_col_sample_rate_change_per_level", "col_sample_rate_change_per_level must be > 0" +
+              " and <= 2");
     if (_train != null) {
       double sumWeights = _train.numRows() * (hasWeightCol() ? _train.vec(_parms._weights_column).mean() : 1);
       if (sumWeights < 2*_parms._min_rows ) // Need at least 2*min_rows weighted rows to split even once

--- a/h2o-docs/src/product/data-science/algo-params/col_sample_rate_change_per_level.rst
+++ b/h2o-docs/src/product/data-science/algo-params/col_sample_rate_change_per_level.rst
@@ -22,7 +22,7 @@ As indicated above, this option is multiplicative with ``col_sample_rate``. The 
 
 	col_sample_rate_per_tree * col_sample_rate * col_sample_rate_change_per_level^depth
 
-This option defaults to 1.0 and can be in the range of 0.0 to 2.0.
+This option defaults to 1.0 and must be > 0.0 and <= 2.0.
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -196,7 +196,7 @@ Defining a DRF Model
    previously trained model. Use this option to build a new model as a
    continuation of a previously generated model.
 
--  `col_sample_rate_change_per_level <algo-params/col_sample_rate_change_per_level.html>`__: This option specifies to change the column sampling rate as a function of the depth in the tree. This can be a value from 0.0 to 2.0 and defaults to 1. (Note that this method is sample without replacement.) For example:
+-  `col_sample_rate_change_per_level <algo-params/col_sample_rate_change_per_level.html>`__: This option specifies to change the column sampling rate as a function of the depth in the tree. This can be a value > 0.0 and <= 2.0 and defaults to 1. (Note that this method is sample without replacement.) For example:
 
    level 1: **col\_sample_rate**
   

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -104,7 +104,7 @@ Defining a GBM Model
 
 -  `col_sample_rate <algo-params/col_sample_rate.html>`__: Specify the column sampling rate (y-axis). (Note that this method is sampling without replacement.) The range is 0.0 to 1.0. Higher values may improve training accuracy. Test accuracy improves when either columns or rows are sampled. For details, refer to "Stochastic Gradient Boosting" (`Friedman, 1999 <https://statweb.stanford.edu/~jhf/ftp/stobst.pdf>`__).
    
--  `col_sample_rate_change_per_level <algo-params/col_sample_rate_change_per_level.html>`__: This option specifies to change the column sampling rate as a function of the depth in the tree. This can be a value from 0.0 to 2.0 and defaults to 1. (Note that this method is sample without replacement.) For example:
+-  `col_sample_rate_change_per_level <algo-params/col_sample_rate_change_per_level.html>`__: This option specifies to change the column sampling rate as a function of the depth in the tree. This can be a value > 0.0 and <= 2.0 and defaults to 1. (Note that this method is sample without replacement.) For example:
 	
 	  level 1: **col\_sample_rate**
 	

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -697,7 +697,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @property
     def col_sample_rate_change_per_level(self):
         """
-        Relative change of the column sampling rate for every level (from 0.0 to 2.0)
+        Relative change of the column sampling rate for every level (must be > 0.0 and <= 2.0)
 
         Type: ``float``  (default: ``1``).
         """

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -617,7 +617,7 @@ class H2ORandomForestEstimator(H2OEstimator):
     @property
     def col_sample_rate_change_per_level(self):
         """
-        Relative change of the column sampling rate for every level (from 0.0 to 2.0)
+        Relative change of the column sampling rate for every level (must be > 0.0 and <= 2.0)
 
         Type: ``float``  (default: ``1``).
         """

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2697,9 +2697,9 @@ def check_and_count_models(hyper_params, params_zero_one, params_more_than_zero,
 
     for param in hyper_keys:
 
-        # this param should be between 0 and 2
+        # this param should be > 0 and <= 2
         if param == "col_sample_rate_change_per_level":
-            param_len = len([x for x in hyper_params["col_sample_rate_change_per_level"] if (x >= 0)
+            param_len = len([x for x in hyper_params["col_sample_rate_change_per_level"] if (x > 0)
                                  and (x <= 2)])
         elif param in params_zero_one:
             param_len = len([x for x in hyper_params[param] if (x >= 0)

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5334_col_sample_rate_change_per_level.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5334_col_sample_rate_change_per_level.py
@@ -1,0 +1,36 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import random
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+
+def pubdev_5334():
+    '''
+    This pyunit test is used to make sure that the parameter col_sample_rate_change_per_level is set
+    correctly > 0.0 and <= 2.  Another other setting will bring an error.
+    '''
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris2.csv"))
+    tval = random.uniform(-3,3)
+    print("col_sample_rate_change_per_level is {0}".format(tval))
+    try:
+        model = H2ORandomForestEstimator(ntrees=5, max_depth=3, col_sample_rate_change_per_level=tval)
+        model.train(y=4, x=list(range(4)), training_frame=iris)
+        if tval > 0 and tval <= 2:
+            print("col_sample_rate_change_per_level is set correctly.")
+        else:
+            exit(1)
+    except:
+        if tval <= 0 or tval > 2:
+            print("An error has been thrown: col_sample_rate_change_per_level must be > 0 and <= 2.0.")
+        else:
+            exit(1)
+
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_5334)
+else:
+    pubdev_5334()

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -77,7 +77,7 @@
 #' @param sample_rate Row sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param sample_rate_per_class A list of row sample rates per class (relative fraction for each class, from 0.0 to 1.0), for each tree
 #' @param col_sample_rate Column sample rate (from 0.0 to 1.0) Defaults to 1.
-#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.
+#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (must be > 0.0 and <= 2.0) Defaults to 1.
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param min_split_improvement Minimum relative improvement in squared error reduction for a split to happen Defaults to 1e-05.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -69,7 +69,7 @@
 #' @param binomial_double_trees \code{Logical}. For binary classification: Build 2x as many trees (one per class) - can lead to higher
 #'        accuracy. Defaults to FALSE.
 #' @param checkpoint Model checkpoint to resume training with.
-#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (from 0.0 to 2.0) Defaults to 1.
+#' @param col_sample_rate_change_per_level Relative change of the column sampling rate for every level (must be > 0.0 and <= 2.0) Defaults to 1.
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param min_split_improvement Minimum relative improvement in squared error reduction for a split to happen Defaults to 1e-05.
 #' @param histogram_type What type of histogram to use for finding optimal split points Must be one of: "AUTO", "UniformAdaptive",

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5334_col_sample_rate_change_per_level.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5334_col_sample_rate_change_per_level.R
@@ -1,0 +1,29 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+######################################################################################
+# This is to test that an error is thrown only when col_sample_rate_change_per_level
+# <= 0 or > 2.0
+######################################################################################
+pubdev_5334_test <-
+function() {
+
+  tval <- runif(1,min=-3,max=3)
+  print("col_sample_rate_change_per_level is set to ")
+  tval <- -1
+  print(tval)
+  browser()
+  e <- tryCatch({
+    training1_data <- h2o.importFile(locate("smalldata/gridsearch/multinomial_training1_set.csv"))
+    y_index <- h2o.ncol(training1_data)
+    x_indices <- c(1:(y_index-1))
+    training1_data["C14"] <- as.factor(training1_data["C14"])
+    model <- h2o.gbm(x=x_indices, y=y_index, training_frame=training1_data, ntree=5,
+    col_sample_rate_change_per_level=tval)
+  }, error=function(error_message) {
+    if (!grepl(pattern='_col_sample_rate_change_per_level', error_message) && ((tval <= 0) || (tval > 2)))
+      FAIL(error_message)
+    }
+  )
+}
+
+doTest("Perform the test for pubdev 5334", pubdev_5334_test)


### PR DESCRIPTION
Confirmed with Arno that the col_sample_rate_change_per_level parameter must be > 0.0 and <= 2.0.

In our documentation we said something like between 0 and 2 which is not accurate.  I have changed all documentation (I hope) to say instead, > 0 and <= 2.  

Generated R and Py unit tests to make throw errors are thown when this parameter is not set correctly.