### PR TITLE
Pavel pubdev 5198

### DIFF
--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -458,16 +458,21 @@ MAIN_LOOP:
     return dout;
   }
 
-  @Override protected int fileHasHeader(byte[] bits, ParseSetup ps) {
+  @Override
+  protected int fileHasHeader(byte[] bits, ParseSetup parseSetup) {
     boolean hasHdr = true;
     String[] lines = getFirstLines(bits);
     if (lines != null && lines.length > 0) {
-      String[] firstLine = determineTokens(lines[0], _setup._separator, _setup._single_quotes);
-      if (_setup._column_names != null) {
-        for (int i = 0; hasHdr && i < firstLine.length; ++i)
-          hasHdr = (_setup._column_names[i] == firstLine[i]) || (_setup._column_names[i] != null && _setup._column_names[i].equalsIgnoreCase(firstLine[i]));
+      String[] firstLine = determineTokens(lines[0], parseSetup._separator, parseSetup._single_quotes);
+      if (parseSetup._column_names != null) {
+        if(parseSetup._number_columns != firstLine.length){
+          // If column count on first row does not match give number of columns, assume it's data.
+          hasHdr = false;
+        } else {
+          hasHdr = parseSetup._column_names.length == parseSetup._number_columns; 
+        }
       } else { // declared to have header, but no column names provided, assume header exist in all files
-        _setup._column_names = firstLine;
+        parseSetup._column_names = firstLine;
       }
     } // else FIXME Throw exception
     return hasHdr ? ParseSetup.HAS_HEADER: ParseSetup.NO_HEADER;

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -465,12 +465,7 @@ MAIN_LOOP:
     if (lines != null && lines.length > 0) {
       String[] firstLine = determineTokens(lines[0], parseSetup._separator, parseSetup._single_quotes);
       if (parseSetup._column_names != null) {
-        if(parseSetup._number_columns != firstLine.length){
-          // If column count on first row does not match give number of columns, assume it's data.
-          hasHdr = false;
-        } else {
           hasHdr = parseSetup._column_names.length == parseSetup._number_columns; 
-        }
       } else { // declared to have header, but no column names provided, assume header exist in all files
         parseSetup._column_names = firstLine;
       }

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -538,9 +538,11 @@ public class ParseSetup extends Iced {
       if (namesA == null) return namesB;
       else if (namesB == null) return namesA;
       else {
+        if (namesA.length != namesB.length) {
+          throw new ParseDataset.H2OParseException("Column length does not match between files.");
+        }
         for (int i = 0; i < namesA.length; i++) {
-          if (i > namesB.length || !namesA[i].equals(namesB[i])) {
-            // TODO improvement: if files match except for blanks, merge?
+          if (!namesA[i].equals(namesB[i])) {
             throw new ParseDataset.H2OParseException("Column names do not match between files.");
           }
         }


### PR DESCRIPTION
…oading file (with column names)

[JIRA PUBDEV-5198](https://0xdata.atlassian.net/browse/PUBDEV-5198)

Strict matching between headers in file and user-defined headers caused the bug with first line not being recognized as header and treated as data if at least one column header was renamed by the user.

Column headers are not matched strictly. Presence of the same number of columns is enforced, together with 

Tested manually with:
- One CSV without headers
- Two CSVs, one with headers and one without
- One CSV, all columns renamed. Even renamed to an empty string. ( e.g. `h2o.import_file(path = "/home/pavel/airlines_train.csv", col_names = ['', '', '', '', '', '', '', '', ''])` )
- Once CSV, all columns empty or renamed.

