### PR TITLE
PUBDEV-5154: Document new pca_impl parameter

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/pca_impl.rst
+++ b/h2o-docs/src/product/data-science/algo-params/pca_impl.rst
@@ -1,0 +1,84 @@
+``pca_impl``
+--------------
+
+- Available in: PCA
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+The ``pca_impl`` parameter allows you to specify PCA implementations for Singular-Value Decomposition (SVD) or Eigenvalue Decomposition (EVD), using either the Matrix Toolkit Java (`MTJ <https://github.com/fommil/matrix-toolkits-java/>`__) libary or the Java Matrix (`JAMA <http://math.nist.gov/javanumerics/jama/>`__) library.
+
+Available options include:
+
+- **mtj_evd_densematrix**: Eigenvalue decompositions for dense matrix using MTJ
+- **mtj_evd_symmmatrix**: Eigenvalue decompositions for symmetric matrix using MTJ (default)
+- **mtj_svd_densematrix**: Singular-value decompositions for dense matrix using MTJ
+- **jama**: Eigenvalue decompositions for dense matrix using JAMA
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+    library(h2o)
+    h2o.init()
+
+    # Load the US Arrests dataset
+    arrestsH2O = h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/USArrests.csv")
+
+    # Train using the JAMA PCA implementation option
+    model <- h2o.prcomp(training_frame=arrestsH2O, k=4, pca_impl="JAMA", seed=1234)
+
+    # View the importance of components
+    model@model$importance
+    Importance of components: 
+                                  pc1       pc2      pc3      pc4
+    Standard deviation     202.723056 27.832264 6.523048 2.581365
+    Proportion of Variance   0.980347  0.018479 0.001015 0.000159
+    Cumulative Proportion    0.980347  0.998826 0.999841 1.000000
+
+    # View the eigenvectors
+    model@model$eigenvectors
+    Rotation: 
+                   pc1       pc2       pc3       pc4
+    Murder   -0.042392 -0.016163  0.065884  0.996795
+    Assault  -0.943957 -0.320686 -0.066552 -0.040946
+    UrbanPop -0.308428  0.938459 -0.154967  0.012343
+    Rape     -0.109637  0.127257  0.983471 -0.067603
+
+   .. code-block:: python
+
+    import(h2o)
+    h2o.init()
+    from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+
+    # Load the US Arrests dataset
+    arrestsH2O = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/pca_test/USArrests.csv")
+
+    # Train using the jama PCA implementation option
+    impl = "jama"
+    model = H2OPCA(k = 4, pca_impl=impl, seed=1234)
+    model.train(x=list(range(4)), training_frame=arrestsH2O)
+
+    # View the importance of components
+    model.varimp(use_pandas=False)
+    [(u'Standard deviation', 202.7230564425318, 27.832263730019577, 6.523048232982174, 2.5813652317810947), 
+     (u'Proportion of Variance', 0.980347353161874, 0.0184786717900806, 0.0010150206303792286, 0.00015895441766549314), 
+     (u'Cumulative Proportion', 0.980347353161874, 0.9988260249519546, 0.9998410455823339, 0.9999999999999993)]
+
+    # View the eigenvectors
+    model.rotation()
+    Rotation: 
+              pc1         pc2         pc3         pc4
+    --------  ----------  ----------  ----------  ----------
+    Murder    -0.0423918  -0.0161626  0.0658843   0.996795
+    Assault   -0.943957   -0.320686   -0.0665517  -0.0409457
+    UrbanPop  -0.308428   0.938459    -0.154967   0.0123426
+    Rape      -0.109637   0.127257    0.983471    -0.0676028

--- a/h2o-docs/src/product/data-science/pca.rst
+++ b/h2o-docs/src/product/data-science/pca.rst
@@ -32,6 +32,13 @@ Defining a PCA Model
    -  **Randomized**: Uses randomized subspace iteration method
    -  **GLRM**: Fits a generalized low-rank model with L2 loss function and no regularization and solves for the SVD using local matrix algebra (experimental)
 
+-  `pca_impl <algo-params/pca_impl.html>`__: Specify the implementation to use for computing PCA (via SVD or EVD). Available options include:
+
+   - **mtj_evd_densematrix**: Eigenvalue decompositions for dense matrix using Matrix Toolkit Java (`MTJ <https://github.com/fommil/matrix-toolkits-java/>`__)
+   - **mtj_evd_symmmatrix**: Eigenvalue decompositions for symmetric matrix using Matrix Toolkit Java (`MTJ <https://github.com/fommil/matrix-toolkits-java/>`__) (default)
+   - **mtj_svd_densematrix**: Singular-value decompositions for dense matrix using Matrix Toolkit Java (`MTJ <https://github.com/fommil/matrix-toolkits-java/>`__)
+   - **jama**: Eigenvalue decompositions for dense matrix using Java Matrix (`JAMA <http://math.nist.gov/javanumerics/jama/>`__)
+
 -  `k <algo-params/k.html>`__: Specify the rank of matrix approximation. This can be a value from 1 to 9 and defaults to 1.
 
 -  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations. The value must be between 1 and 1e6 and the default is 1000.

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -82,6 +82,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/ntrees
    data-science/algo-params/objective_epsilon
    data-science/algo-params/offset_column
+   data-science/algo-params/pca_impl
    data-science/algo-params/pca_method
    data-science/algo-params/pred_noise_bandwidth
    data-science/algo-params/prior

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_4961_pca_implementations.py
@@ -5,7 +5,7 @@ import sys
 sys.path.insert(1,"../../../")
 import h2o
 from tests import pyunit_utils
-from h2o.transforms.decomposition import H2OPCA
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
 
 
 def pca_arrests():


### PR DESCRIPTION
- Added pca_impl to list of parameters in the PCA chapter
- Added a pca_impl topic to the parameters appendix
Driveby fix: Updated the PCA import statement in the pac_implementation
python test. This is now from h2o.estimators.pca import
H2OPrincipalComponentAnalysisEstimator as H2OPCA instead of from
h2o.transforms.decomposition import H2OPCA. (Verified that this works
locally.)