### PR TITLE
PUBDEV-4933: AutoML should not train Stacked Ensemble with only one model (#2125)

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1168,7 +1168,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     if (allModels.length == 0) {
       this.job.update(50, "No models built; StackedEnsemble builds skipped");
       userFeedback.info(Stage.ModelTraining, "No models were built, due to timeouts or the exclude_algos option. StackedEnsemble builds skipped.");
-    } else if (ArrayUtils.contains(skipAlgosList, "StackedEnsemble")) {
+    } else if (allModels.length == 1) {
+      this.job.update(50, "One model built; StackedEnsemble builds skipped");
+      userFeedback.info(Stage.ModelTraining, "StackedEnsemble builds skipped since there is only one model built");
+    }
+    else if (ArrayUtils.contains(skipAlgosList, "StackedEnsemble")) {
       this.job.update(50, "StackedEnsemble builds skipped");
       userFeedback.info(Stage.ModelTraining, "StackedEnsemble builds skipped due to the exclude_algos option.");
     } else {

--- a/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
+++ b/h2o-py/tests/testdir_algos/automl/multinomial/pyunit_automl_iris.py
@@ -25,11 +25,6 @@ def iris_automl():
     print(aml.leaderboard)
     assert set(aml.leaderboard.columns) == set(["model_id","mean_per_class_error"])
 
-    # Check that a StackedEnsemble model was trained
-    lbdf = aml.leaderboard.as_data_frame()
-    assert len([x for x in lbdf['model_id'] if "StackedEnsemble" in x]) > 0
-
-
 if __name__ == "__main__":
     pyunit_utils.standalone_test(iris_automl)
 else:

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -88,7 +88,7 @@ automl.args.test <- function() {
                      max_models = 1,
                      project_name = "aml8")
   nrow_aml8_lb <- nrow(aml8@leaderboard)
-  expect_equal(nrow_aml8_lb, 3)
+  expect_equal(nrow_aml8_lb, 1)
 
   print("Check max_models > 1; leaderboard continuity/growth")
   aml8 <- h2o.automl(x = x, y = y,


### PR DESCRIPTION


* Skip SE if only one model built in AutoML

* Update test as one model in AutoML does not produce a SE

* Fix pyunit test to account for SE not being built if only one model is built in AutoML