### PR TITLE
[Experimental] CoxPH & GLM: fixes categorical-numerical interactions

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -599,8 +599,16 @@ public class DataInfo extends Keyed<DataInfo> {
           normSub[idx] = v.mean();
           break;
         case DEMEAN:
-          normMul[idx] = 1;
-          normSub[idx] = v.mean();
+          if (isIWV) {
+            InteractionWrappedVec iwv = (InteractionWrappedVec)v;
+            for(int offset=0;offset<iwv.expandedLength();++offset) {
+              normSub[idx+offset] = iwv.getMeans()[offset];
+              normMul[idx+offset] = 1;
+            }
+          } else {
+            normSub[idx] = v.mean();
+            normMul[idx] = 1;
+          }
           break;
         case DESCALE:
           if( isIWV ) throw H2O.unimpl();

--- a/h2o-algos/src/main/java/hex/coxph/CoxPH.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPH.java
@@ -451,7 +451,7 @@ public class CoxPH extends ModelBuilder<CoxPHModel,CoxPHModel.CoxPHParameters,Co
         Frame f = reorderTrainFrameColumns();
 
         int nResponses = (_parms.startVec() == null ? 2 : 3) + (_parms.isStratified() ? 1 : 0);
-        final DataInfo dinfo = new DataInfo(f, null, nResponses, false, TransformType.DEMEAN, TransformType.NONE, true, false, false, false, false, false, _parms.interactionSpec())
+        final DataInfo dinfo = new DataInfo(f, null, nResponses, _parms._use_all_factor_levels, TransformType.DEMEAN, TransformType.NONE, true, false, false, false, false, false, _parms.interactionSpec())
                 .disableIntercept();
         Scope.track_generic(dinfo);
         DKV.put(dinfo);

--- a/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
@@ -40,6 +40,8 @@ public class CoxPHModel extends Model<CoxPHModel,CoxPHParameters,CoxPHOutput> {
     public double _lre_min = 9;
     public int _iter_max = 20;
 
+    public boolean _use_all_factor_levels;
+
     public String[] _interactions_only;
     public String[] _interactions = null;
     public StringPair[] _interaction_pairs = null;

--- a/h2o-algos/src/main/java/hex/schemas/CoxPHV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/CoxPHV3.java
@@ -25,7 +25,8 @@ public class CoxPHV3 extends ModelBuilderSchema<CoxPH,CoxPHV3,CoxPHV3.CoxPHParam
               "iter_max",
               "interactions_only",
               "interactions",
-              "interaction_pairs"
+              "interaction_pairs",
+              "use_all_factor_levels"
     };
 
     @API(help="How was the model invoked.", direction = API.Direction.INOUT)
@@ -60,6 +61,9 @@ public class CoxPHV3 extends ModelBuilderSchema<CoxPH,CoxPHV3,CoxPHV3.CoxPHParam
 
     @API(help="A list of pairwise (first order) column interactions.", direction= API.Direction.INPUT, level= API.Level.expert)
     public StringPairV3[] interaction_pairs;
+
+    @API(help="(Internal. For development only!) Indicates whether to use all factor levels.", direction = API.Direction.INPUT)
+    public boolean use_all_factor_levels;
 
   }
 }

--- a/h2o-r/h2o-package/R/coxph.R
+++ b/h2o-r/h2o-package/R/coxph.R
@@ -27,6 +27,8 @@
 #'        training.
 #' @param interactions A list of predictor column indices to interact. All pairwise combinations will be computed for the list.
 #' @param interaction_pairs A list of pairwise (first order) column interactions.
+#' @param use_all_factor_levels \code{Logical}. (Internal. For development only!) Indicates whether to use all factor levels. Defaults to
+#'        FALSE.
 #' @export
 h2o.coxph <- function(x, event_column, training_frame,
                       model_id = NULL,
@@ -41,7 +43,8 @@ h2o.coxph <- function(x, event_column, training_frame,
                       iter_max = 20,
                       interactions_only = NULL,
                       interactions = NULL,
-                      interaction_pairs = NULL
+                      interaction_pairs = NULL,
+                      use_all_factor_levels = FALSE
                       ) 
 {
 
@@ -104,6 +107,8 @@ h2o.coxph <- function(x, event_column, training_frame,
     parms$interactions <- interactions
   if (!missing(interaction_pairs))
     parms$interaction_pairs <- interaction_pairs
+  if (!missing(use_all_factor_levels))
+    parms$use_all_factor_levels <- use_all_factor_levels
   # Error check and build model
   .h2o.modelJob('coxph', parms, h2oRestApiVersion = 3) 
 }

--- a/h2o-r/tests/testdir_algos/coxph/runit_coxph_strata_inter.R
+++ b/h2o-r/tests/testdir_algos/coxph/runit_coxph_strata_inter.R
@@ -21,7 +21,7 @@ test.CoxPH.strata_inter <- function() {
 
     expect_equal(fit.coef, fit.ext$coefficients)
 
-    # 2. explicit interaction in H2O
+    # 3. explicit interaction in H2O
     lung.hex <- as.h2o(lung.ext)
     lung.hex$sex <- as.factor(lung.hex$sex)
     lung.hex$ph.ecog <- as.factor(lung.hex$ph.ecog)
@@ -30,6 +30,16 @@ test.CoxPH.strata_inter <- function() {
                          stratify_by = c("sex", "ph.ecog"), training_frame = lung.hex)
 
     expect_equal(fit.coef, .as.survival.coxph.model(fit.hex@model)$coef)
+
+    # 4. implicit interaction in H2O
+    fit.hex.implicit <- h2o.coxph(stop_column = "time", event_column = "status",
+                                  x = c("wt.loss", "sex", "ph.ecog"),
+                                  interaction_pairs = list(c("age", "sex")),
+                                  stratify_by = c("sex", "ph.ecog"),
+                                  training_frame = lung.hex,
+                                  use_all_factor_levels = TRUE)
+
+    expect_equal(fit.coef, .as.survival.coxph.model(fit.hex.implicit@model)$coef[names(fit.coef)])
 }
 
 doTest("CoxPH: Test Stratification with Interactions", test.CoxPH.strata_inter)


### PR DESCRIPTION
This workarounds an issue in GLM/DataInfo that cannot handle a mix of InteractionWrappedVec where some of them use all factor levels and some of them don't. This is an issue with numeric-categorical interactions.