### PR TITLE
PUBDEV-5370 - parser cannot handle some utf-8 characters in header

### DIFF
--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -6,6 +6,7 @@ import water.fvec.FileVec;
 import water.Key;
 import water.util.StringUtils;
 
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -516,7 +517,7 @@ MAIN_LOOP:
     while (offset < bits.length) {
       while ((offset < bits.length) && (bits[offset] == CsvParser.CHAR_SPACE)) ++offset; // skip first whitespace
       if(offset == bits.length)break;
-      StringBuilder t = new StringBuilder();
+      final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
       byte c = bits[offset];
       if ((c == CsvParser.CHAR_DOUBLE_QUOTE) || (c == singleQuote)) {
         quotes = c;
@@ -527,7 +528,7 @@ MAIN_LOOP:
         if ((c == quotes)) {
           ++offset;
           if ((offset < bits.length) && (bits[offset] == c)) {
-            t.append((char)c);
+            byteArrayOutputStream.write(c);
             ++offset;
             continue;
           }
@@ -535,12 +536,12 @@ MAIN_LOOP:
         } else if( quotes == 0 && ((c == separator) || CsvParser.isEOL(c)) ) {
           break;
         } else {
-          t.append((char)c);
+          byteArrayOutputStream.write(c);
           ++offset;
         }
       }
       c = (offset == bits.length) ? CsvParser.CHAR_LF : bits[offset];
-      tokens.add(t.toString());
+      tokens.add(byteArrayOutputStream.toString());
       if( CsvParser.isEOL(c) || (offset == bits.length) )
         break;
       if (c != separator)

--- a/h2o-core/src/test/java/water/parser/CsvParserTest.java
+++ b/h2o-core/src/test/java/water/parser/CsvParserTest.java
@@ -1,0 +1,19 @@
+package water.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CsvParserTest {
+
+  @Test
+  public void determineTokens_multipleByteCharacters() {
+    byte quoteType = '\'';
+    byte delimiter = ',';
+    // Japanese alphabet is represented as up to 3 bytes per character.
+    String[] strings = CsvParser.determineTokens("'C1', 'C2', '契約状態1709'", delimiter, quoteType);
+    Assert.assertEquals(3, strings.length);
+    Assert.assertEquals("C1", strings[0]);
+    Assert.assertEquals("C2", strings[1]);
+    Assert.assertEquals("契約状態1709", strings[2]);
+  }
+}


### PR DESCRIPTION
[JIRA PUBDEV-5370](https://0xdata.atlassian.net/browse/PUBDEV-5370)

When headers parsing was done, an assumption had been made for each character to only be represented as a single byte. However, there are many characters that are represented by more than 3 bytes.

Instead of feeding a StringBuilder directly, all the bytes are first collected in a ByteArrayOutputStream (A simple growing byte array). The final String is created at the very end. This saves a little memory (StringBuilder vs ByteArrayOutputStream) and is potentially a little bit faster as well.