### PR TITLE
Update Python test requirements to current Twine

### DIFF
--- a/h2o-py/test-requirements.txt
+++ b/h2o-py/test-requirements.txt
@@ -5,7 +5,7 @@ requests==2.18.4
 tabulate==0.8.2
 slam==0.6.0
 cython==0.27.3
-twine==1.9.1
+twine==1.10.0
 urllib3==1.22
 grip==4.4.0
 wheel==0.30.0


### PR DESCRIPTION
I'm one of the maintainers of [Twine](https://libraries.io/pypi/twine). We've just released 1.10.0 and I would appreciate if you could upgrade your Python tests requirement. Thanks.