### PR TITLE
PUBDEV-5388: Mask additional progress bar from h2o.automl() (#2122)

### DIFF
--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -199,7 +199,17 @@ h2o.automl <- function(x, y, training_frame,
   #project <- automl_job$project  # This is not functional right now, we can get project_name from user input instead
   leaderboard <- as.data.frame(automl_job["leaderboard_table"]$leaderboard_table)
   row.names(leaderboard) <- seq(nrow(leaderboard))
-  leaderboard <- as.h2o(leaderboard)  # Convert to H2OFrame
+  
+  # Intentionally mask the progress bar here since showing multiple progress bars is confusing to users.
+  # If any failure happens, revert back to user's original setting for progress and display the error message.
+  is_progress <- isTRUE(as.logical(.h2o.is_progress()))
+  h2o.no_progress()
+  leaderboard <- tryCatch(
+    as.h2o(leaderboard),
+    error = identity,
+    finally = if (is_progress) h2o.show_progress()
+  )
+
   leaderboard[,2:length(leaderboard)] <- as.numeric(leaderboard[,2:length(leaderboard)])  # Convert metrics to numeric
   # If leaderboard is empty, create a "dummy" leader
   if (nrow(leaderboard) > 1) {

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -779,7 +779,7 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
 #' Check if Progress Bar is Enabled
 #'
 .h2o.is_progress <- function() {
-  progress <- mget("PROGRESS_BAR", .pkg.env, ifnotfound=TRUE)
+  progress <- mget("PROGRESS_BAR", .pkg.env, ifnotfound = TRUE)
   if (is.list(progress)) progress <- unlist(progress)
   progress
 }


### PR DESCRIPTION
This is just a cherry-pick to hotfix release branch. 

* PUBDEV-5388: Mask additional progress bar from h2o.automl()

* Properly revert to show_progress during failure

* Avoid overriding user progress settings