### PR TITLE
PUBDEV 5397: added R2 as an early stopping criteria

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -875,6 +875,8 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
         return (float) classification_error();
       case AUC:
         return (float)(1-auc());
+      case r2:
+        return (float)(1-r2());
       case mean_per_class_error:
         return (float)mean_per_class_error();
       case lift_top_group:
@@ -914,6 +916,16 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
   public double mse() {
     if (scoringInfo != null)
       return last_scored().cross_validation ? last_scored().scored_xval._mse : last_scored().validation ? last_scored().scored_valid._mse : last_scored().scored_train._mse;
+
+    ModelMetrics mm = _output._cross_validation_metrics != null ? _output._cross_validation_metrics : _output._validation_metrics != null ? _output._validation_metrics : _output._training_metrics;
+    if (mm == null) return Double.NaN;
+
+    return mm.mse();
+  }
+
+  public double r2() {
+    if (scoringInfo != null)
+      return last_scored().cross_validation ? last_scored().scored_xval._r2 : last_scored().validation ? last_scored().scored_valid._r2 : last_scored().scored_train._r2;
 
     ModelMetrics mm = _output._cross_validation_metrics != null ? _output._cross_validation_metrics : _output._validation_metrics != null ? _output._validation_metrics : _output._training_metrics;
     if (mm == null) return Double.NaN;

--- a/h2o-core/src/main/java/hex/ScoringInfo.java
+++ b/h2o-core/src/main/java/hex/ScoringInfo.java
@@ -77,6 +77,7 @@ public class ScoringInfo extends Iced<ScoringInfo> {
       case misclassification: { return cross_validation ? scored_xval._classError : validation ? scored_valid._classError : scored_train._classError; }
       case lift_top_group:    { return cross_validation ? scored_xval._lift : validation ? scored_valid._lift : scored_train._lift; }
       case mean_per_class_error: { return cross_validation ? scored_xval._mean_per_class_error : validation ? scored_valid._mean_per_class_error : scored_train._mean_per_class_error; }
+      case r2: { return cross_validation ? scored_xval._r2 : validation ? scored_valid._r2 : scored_train._r2; }
       default:                throw H2O.unimpl("Undefined stopping criterion: " + criterion);
     }
   }
@@ -151,17 +152,15 @@ public class ScoringInfo extends Iced<ScoringInfo> {
     colHeaders.add("Training RMSE"); colTypes.add("double"); colFormat.add("%.5f");
     if (modelCategory == ModelCategory.Regression) {
       colHeaders.add("Training Deviance"); colTypes.add("double"); colFormat.add("%.5f");
-    }
-    if(modelCategory == ModelCategory.Regression) {
       colHeaders.add("Training MAE"); colTypes.add("double"); colFormat.add("%.5f");
+      colHeaders.add("Training r2"); colTypes.add("double"); colFormat.add("%.5f");
     }
     if (isClassifier) {
       colHeaders.add("Training LogLoss"); colTypes.add("double"); colFormat.add("%.5f");
+      colHeaders.add("Training r2"); colTypes.add("double"); colFormat.add("%.5f");
     }
     if (modelCategory == ModelCategory.Binomial) {
       colHeaders.add("Training AUC"); colTypes.add("double"); colFormat.add("%.5f");
-    }
-    if (modelCategory == ModelCategory.Binomial) {
       colHeaders.add("Training Lift"); colTypes.add("double"); colFormat.add("%.5f");
     }
     if (isClassifier) {
@@ -175,14 +174,14 @@ public class ScoringInfo extends Iced<ScoringInfo> {
       if (modelCategory == ModelCategory.Regression) {
         colHeaders.add("Validation Deviance"); colTypes.add("double"); colFormat.add("%.5f");
         colHeaders.add("Validation MAE"); colTypes.add("double"); colFormat.add("%.5f");
+        colHeaders.add("Validation r2"); colTypes.add("double"); colFormat.add("%.5f");
       }
       if (isClassifier) {
         colHeaders.add("Validation LogLoss"); colTypes.add("double"); colFormat.add("%.5f");
+        colHeaders.add("Validation r2"); colTypes.add("double"); colFormat.add("%.5f");
       }
       if (modelCategory == ModelCategory.Binomial) {
         colHeaders.add("Validation AUC"); colTypes.add("double"); colFormat.add("%.5f");
-      }
-      if (modelCategory == ModelCategory.Binomial) {
         colHeaders.add("Validation Lift"); colTypes.add("double"); colFormat.add("%.5f");
       }
       if (isClassifier) {
@@ -197,14 +196,14 @@ public class ScoringInfo extends Iced<ScoringInfo> {
       if (modelCategory == ModelCategory.Regression) {
         colHeaders.add("Cross-Validation Deviance"); colTypes.add("double"); colFormat.add("%.5f");
         colHeaders.add("Cross-Validation MAE"); colTypes.add("double"); colFormat.add("%.5f");
+        colHeaders.add("Cross-Validation r2"); colTypes.add("double"); colFormat.add("%.5f");
       }
       if (isClassifier) {
         colHeaders.add("Cross-Validation LogLoss"); colTypes.add("double"); colFormat.add("%.5f");
+        colHeaders.add("Cross-Validation r2"); colTypes.add("double"); colFormat.add("%.5f");
       }
       if (modelCategory == ModelCategory.Binomial) {
         colHeaders.add("Cross-Validation AUC"); colTypes.add("double"); colFormat.add("%.5f");
-      }
-      if (modelCategory == ModelCategory.Binomial) {
         colHeaders.add("Cross-Validation Lift"); colTypes.add("double"); colFormat.add("%.5f");
       }
       if (isClassifier) {
@@ -253,12 +252,12 @@ public class ScoringInfo extends Iced<ScoringInfo> {
       table.set(row, col++, si.scored_train != null ? si.scored_train._rmse : Double.NaN);
       if (modelCategory == ModelCategory.Regression) {
         table.set(row, col++, si.scored_train != null ? si.scored_train._mean_residual_deviance : Double.NaN);
-      }
-      if (modelCategory == ModelCategory.Regression) {
         table.set(row, col++, si.scored_train != null ? si.scored_train._mae : Double.NaN);
+        table.set(row, col++, si.scored_train != null ? si.scored_train._r2 : Double.NaN);
       }
       if (isClassifier) {
         table.set(row, col++, si.scored_train != null ? si.scored_train._logloss : Double.NaN);
+        table.set(row, col++, si.scored_train != null ? si.scored_train._r2 : Double.NaN);
       }
       if (modelCategory == ModelCategory.Binomial) {
         table.set(row, col++, si.training_AUC != null ? si.training_AUC._auc : Double.NaN);
@@ -274,12 +273,12 @@ public class ScoringInfo extends Iced<ScoringInfo> {
         table.set(row, col++, si.scored_valid != null ? si.scored_valid._rmse : Double.NaN);
         if (modelCategory == ModelCategory.Regression) {
           table.set(row, col++, si.scored_valid != null ? si.scored_valid._mean_residual_deviance : Double.NaN);
-        }
-        if (modelCategory == ModelCategory.Regression) {
           table.set(row, col++, si.scored_valid != null ? si.scored_valid._mae : Double.NaN);
+          table.set(row, col++, si.scored_valid != null ? si.scored_valid._r2 : Double.NaN);
         }
         if (isClassifier) {
           table.set(row, col++, si.scored_valid != null ? si.scored_valid._logloss : Double.NaN);
+          table.set(row, col++, si.scored_valid != null ? si.scored_valid._r2 : Double.NaN);
         }
         if (modelCategory == ModelCategory.Binomial) {
           table.set(row, col++, si.validation_AUC != null ? si.validation_AUC._auc : Double.NaN);
@@ -296,12 +295,12 @@ public class ScoringInfo extends Iced<ScoringInfo> {
         table.set(row, col++, si.scored_xval != null ? si.scored_xval._rmse : Double.NaN);
         if (modelCategory == ModelCategory.Regression) {
           table.set(row, col++, si.scored_xval != null ? si.scored_xval._mean_residual_deviance : Double.NaN);
-        }
-        if (modelCategory == ModelCategory.Regression) {
           table.set(row, col++, si.scored_xval != null ? si.scored_xval._mae : Double.NaN);
+          table.set(row, col++, si.scored_xval != null ? si.scored_xval._r2 : Double.NaN);
         }
         if (isClassifier) {
           table.set(row, col++, si.scored_xval != null ? si.scored_xval._logloss : Double.NaN);
+          table.set(row, col++, si.scored_xval != null ? si.scored_xval._r2 : Double.NaN);
         }
         if (modelCategory == ModelCategory.Binomial) {
           table.set(row, col++, si.validation_AUC != null ? si.validation_AUC._auc : Double.NaN);

--- a/h2o-core/src/main/java/hex/schemas/HyperSpaceSearchCriteriaV99.java
+++ b/h2o-core/src/main/java/hex/schemas/HyperSpaceSearchCriteriaV99.java
@@ -55,7 +55,7 @@ public class HyperSpaceSearchCriteriaV99<I extends HyperSpaceSearchCriteria, S e
     @API(help = "Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable)", level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
     public int stopping_rounds;
 
-    @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
+    @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
     public ScoreKeeper.StoppingMetric stopping_metric;
 
     @API(help = "Relative tolerance for metric-based stopping criterion Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)", level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)

--- a/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
@@ -157,7 +157,7 @@ public class ModelParametersSchemaV3<P extends Model.Parameters, S extends Model
   /**
    * Metric to use for convergence checking, only for _stopping_rounds > 0
    */
-  @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
+  @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
   public ScoreKeeper.StoppingMetric stopping_metric;
 
   @API(help = "Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)", level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -988,13 +988,13 @@ class H2ODeepLearningEstimator(H2OEstimator):
         Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"r2"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "r2"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -624,13 +624,13 @@ class H2ODeepWaterEstimator(H2OEstimator):
         Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"r2"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "r2"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -473,13 +473,13 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"r2"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "r2"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -468,13 +468,13 @@ class H2ORandomForestEstimator(H2OEstimator):
         Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"r2"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "r2"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -269,13 +269,13 @@ class H2OXGBoostEstimator(H2OEstimator):
         Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"r2"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "r2"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5397_r2_early_stop.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5397_r2_early_stop.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+model_runtime = []  # store actual model runtime in seconds
+model_maxRuntime = []   # store given maximum runtime restrictions placed on building models for different algos
+algo_names =[]
+actual_model_runtime = []   # in seconds
+model_runtime_overrun = []  # % by which the model runtime exceeds the maximum runtime.
+model_within_max_runtime = []
+err_bound = 0.5              # fractor by which we allow the model runtime over-run to be
+
+def test_r2_early_stop():
+    '''
+    This pyunit test is written to ensure that the max_runtime_secs can restrict the model training time for all
+    h2o algos.  See PUBDEV-4702.
+    '''
+    global model_within_max_runtime
+    global err_bound
+    seed = 12345
+
+    # GBM run
+    training1_data = h2o.import_file(path=pyunit_utils.locate("smalldata/gridsearch/multinomial_training1_set.csv"))
+    y_index = training1_data.ncol-1
+    x_indices = list(range(y_index))
+    training1_data[y_index] = training1_data[y_index].round().asfactor()
+
+    modelNoEarlyStop = H2OGradientBoostingEstimator(distribution="multinomial", seed=seed)
+    modelNoEarlyStop.train(x=x_indices, y=y_index, training_frame=training1_data)
+    numTrees = pyunit_utils.extract_from_twoDimTable(modelNoEarlyStop._model_json["output"]["model_summary"],
+                                                     "number_of_trees", takeFirst=True)
+
+    model = H2OGradientBoostingEstimator(distribution="multinomial", seed=seed, stopping_metric="r2",
+                                         stopping_tolerance=0.01, stopping_rounds=5)
+    model.train(x=x_indices, y=y_index, training_frame=training1_data)
+    numTreesEarlyStop = pyunit_utils.extract_from_twoDimTable(model._model_json["output"]["model_summary"],
+                                                              "number_of_trees", takeFirst=True)
+    print("Number of tress built with early stopping: {0}.  Number of trees built without early stopping: {1}".format(numTreesEarlyStop[0], numTrees[0]))
+    assert numTreesEarlyStop[0] <= numTrees[0], "Early stopping criteria r2 is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_r2_early_stop)
+else:
+    test_r2_early_stop()

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -97,7 +97,7 @@
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 5.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 #'        "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error". Defaults to AUTO.
+#'        "mean_per_class_error", "r2". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -204,7 +204,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              classification_stop = 0,
                              regression_stop = 1e-06,
                              stopping_rounds = 5,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"),
                              stopping_tolerance = 0,
                              max_runtime_secs = 0,
                              score_validation_sampling = c("Uniform", "Stratified"),

--- a/h2o-r/h2o-package/R/deepwater.R
+++ b/h2o-r/h2o-package/R/deepwater.R
@@ -67,7 +67,7 @@
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 5.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 #'        "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error". Defaults to AUTO.
+#'        "mean_per_class_error", "r2". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -137,7 +137,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           classification_stop = 0,
                           regression_stop = 0,
                           stopping_rounds = 5,
-                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
+                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"),
                           stopping_tolerance = 0,
                           max_runtime_secs = 0,
                           ignore_const_cols = TRUE,

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -57,7 +57,7 @@
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 #'        "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error". Defaults to AUTO.
+#'        "mean_per_class_error", "r2". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -132,7 +132,7 @@ h2o.gbm <- function(x, y, training_frame,
                     nbins_cats = 1024,
                     r2_stopping = 1.797693135e+308,
                     stopping_rounds = 0,
-                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
+                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"),
                     stopping_tolerance = 0.001,
                     max_runtime_secs = 0,
                     seed = -1,

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -54,7 +54,7 @@
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 #'        "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error". Defaults to AUTO.
+#'        "mean_per_class_error", "r2". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -110,7 +110,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              nbins_cats = 1024,
                              r2_stopping = 1.797693135e+308,
                              stopping_rounds = 0,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"),
                              stopping_tolerance = 0.001,
                              max_runtime_secs = 0,
                              seed = -1,

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -33,7 +33,7 @@
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 #'        "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error". Defaults to AUTO.
+#'        "mean_per_class_error", "r2". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -98,7 +98,7 @@ h2o.xgboost <- function(x, y, training_frame,
                         offset_column = NULL,
                         weights_column = NULL,
                         stopping_rounds = 0,
-                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error"),
+                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"),
                         stopping_tolerance = 0.001,
                         max_runtime_secs = 0,
                         seed = -1,

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5397_r2_early_stop.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5397_r2_early_stop.R
@@ -1,0 +1,26 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+######################################################################################
+#    This pyunit test is written to ensure that the r2 metric can restrict the model training time.
+#   See PUBDEV-5397.
+######################################################################################
+pubdev_5397_test <-
+function() {
+# random forest
+  training1_data <- h2o.importFile(locate("smalldata/gridsearch/multinomial_training1_set.csv"))
+  y_index <- h2o.ncol(training1_data)
+  x_indices <- c(1:(y_index-1))
+  training1_data["C14"] <- as.factor(training1_data["C14"])
+  print("*************  starting max_runtime_test for Random Forest")
+  model <- h2o.randomForest(y=y_index, x=x_indices, training_frame=training1_data, seed=12345, stopping_rounds=5, stopping_metric="r2", stopping_tolerance=0.01)
+  numTreesEarlyStop <- model@model$model_summary$number_of_trees
+  print("number of trees built with r2 early-stopping is")
+  print(numTreesEarlyStop)
+  model2 <- h2o.randomForest(y=y_index, x=x_indices, training_frame=training1_data, seed=12345)
+  numTrees <- model2@model$model_summary$number_of_trees
+  print("number of trees built without r2 early-stopping is")
+  print(numTrees)
+  expect_true(numTrees >= numTreesEarlyStop)
+}
+
+doTest("Perform the test for pubdev 5397", pubdev_5397_test)


### PR DESCRIPTION
Added code in Java backend to enable users to use r2 as a stopping criteria.

Added runit and pyunit tests to make sure clients can specify r2 as a stopping criteria.