### PR TITLE
PUBDEV-5394 - h2o parser wrongly treats Ctr-M character as end of lin…

### DIFF
--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -48,6 +48,7 @@ class CsvParser extends Parser {
     if (_setup._parse_type.equals(ARFF_INFO) && _setup._check_header == ParseSetup.HAS_HEADER) state = WHITESPACE_BEFORE_TOKEN;
 
     int quotes = 0;
+    byte quoteCount = 0;
     long number = 0;
     int exp = 0;
     int sgnExp = 1;
@@ -103,7 +104,7 @@ MAIN_LOOP:
             state = COND_QUOTE;
             break;
           }
-          if (!isEOL(c) && ((quotes != 0) || (c != CHAR_SEPARATOR))) {
+          if ((!isEOL(c) || quoteCount == 1) && ((quotes != 0) || (c != CHAR_SEPARATOR))) {
             str.addChar();
             if ((c & 0x80) == 128) //value beyond std ASCII
               isAllASCII = false;
@@ -147,12 +148,15 @@ MAIN_LOOP:
           // fallthrough to EOL
         // ---------------------------------------------------------------------
         case EOL:
-          if(quotes != 0){
+          if (quotes != 0 && quoteCount != 1) {
             //System.err.println("Unmatched quote char " + ((char)quotes) + " " + (((str.length()+1) < offset && str.getOffset() > 0)?new String(Arrays.copyOfRange(bits,str.getOffset()-1,offset)):""));
             String err = "Unmatched quote char " + ((char) quotes);
             dout.invalidLine(new ParseWriter.ParseErr(err, cidx, dout.lineNum(), offset + din.getGlobalByteOffset()));
             colIdx = 0;
             quotes = 0;
+          } else if (quoteCount == 1) {
+            state = STRING;
+            continue MAIN_LOOP;
           }else if (colIdx != 0) {
             dout.newLine();
             colIdx = 0;
@@ -209,6 +213,7 @@ MAIN_LOOP:
               ((_setup._single_quotes && c == CHAR_SINGLE_QUOTE) || (c == CHAR_DOUBLE_QUOTE))) {
             assert (quotes == 0);
             quotes = c;
+            quoteCount++;
             break;
           }
           // fallthrough to TOKEN
@@ -269,6 +274,7 @@ MAIN_LOOP:
           if ( c == quotes) {
             state = NUMBER_END;
             quotes = 0;
+            quoteCount = 0;
             break;
           }
           // fallthrough NUMBER_END
@@ -403,6 +409,7 @@ MAIN_LOOP:
             break;
           } else {
             quotes = 0;
+            quoteCount = 0;
             state = STRING_END;
             continue MAIN_LOOP;
           }
@@ -461,7 +468,7 @@ MAIN_LOOP:
 
   @Override protected int fileHasHeader(byte[] bits, ParseSetup ps) {
     boolean hasHdr = true;
-    String[] lines = getFirstLines(bits);
+    String[] lines = getFirstLines(bits, ps._single_quotes);
     if (lines != null && lines.length > 0) {
       String[] firstLine = determineTokens(lines[0], _setup._separator, _setup._single_quotes);
       if (_setup._column_names != null) {
@@ -623,7 +630,7 @@ MAIN_LOOP:
     int lastNewline = bits.length-1;
     while(lastNewline > 0 && !CsvParser.isEOL(bits[lastNewline]))lastNewline--;
     if(lastNewline > 0) bits = Arrays.copyOf(bits,lastNewline+1);
-    String[] lines = getFirstLines(bits);
+    String[] lines = getFirstLines(bits, singleQuotes);
     if(lines.length==0 )
       throw new ParseDataset.H2OParseException("No data!");
 
@@ -739,14 +746,27 @@ MAIN_LOOP:
     return resSetup;
   }
 
-  private static String[] getFirstLines(byte[] bits) {
+  private static String[] getFirstLines(byte[] bits, boolean singleQuotes) {
     // Parse up to 10 lines (skipping hash-comments & ARFF comments)
     String[] lines = new String[10]; // Parse 10 lines
     int nlines = 0;
     int offset = 0;
+    boolean comment = false;
     while( offset < bits.length && nlines < lines.length ) {
+      if (bits[offset] == HASHTAG) comment = true;
       int lineStart = offset;
-      while( offset < bits.length && !CsvParser.isEOL(bits[offset]) ) ++offset;
+      int quoteCount = 0;
+      while (offset < bits.length) {
+        if (!comment && (
+            (!singleQuotes && bits[offset] == CHAR_DOUBLE_QUOTE)
+            || (singleQuotes && bits[offset] == CHAR_SINGLE_QUOTE)))
+          quoteCount++;
+        if (CsvParser.isEOL(bits[offset]) && quoteCount % 2 == 0){
+          comment = false;
+          break;
+        }
+        ++offset;
+      }
       int lineEnd = offset;
       ++offset;
       // For Windoze, skip a trailing LF after CR

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -57,6 +57,7 @@ public abstract class Parser extends Iced {
   protected static final byte COND_QUOTED_NUMBER_END = 18;
   protected static final byte POSSIBLE_EMPTY_LINE = 19;
   protected static final byte POSSIBLE_CURRENCY = 20;
+  protected static final byte HASHTAG = 35;
 
   protected final byte CHAR_DECIMAL_SEP = '.';
   protected final byte CHAR_SEPARATOR;

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5394.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5394.py
@@ -1,0 +1,30 @@
+
+import h2o
+
+from tests import pyunit_utils
+
+
+def pubdev_5394():
+
+    multiLineEntry = """ First line
+    Second line
+    Third line"""
+
+    training_data = {
+        'C1': [1.765, 2.35],
+        'C2': [multiLineEntry, multiLineEntry]
+    }
+
+    training_data = h2o.H2OFrame(training_data)
+    pandas_frame = training_data.as_data_frame()
+    assert pandas_frame['C2'][0] == multiLineEntry
+    assert pandas_frame['C2'][1] == multiLineEntry
+    assert pandas_frame.shape == (2,2)
+
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_5394)
+else:
+    pubdev_5394()


### PR DESCRIPTION
…… (#2177)

* PUBDEV-5394 - h2o parser wrongly treats Ctr-M character as end of line on linux

* Unmatched quote char check kept.

* Offset leak fixed.

* Python test contains asserts.

* Code style: Quote counter variable has the same name across CsvParser.

* Quote counting based on ParseSetup setting - single vs double quotes are not counted together

* Comments considered in GuessSetup phase

* Comment status reset with each new line