### PR TITLE
Pavel pubdev 5336 rel wheeler 

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/operators/AstEq.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/operators/AstEq.java
@@ -17,6 +17,7 @@ public class AstEq extends AstBinOp {
     return "==";
   }
 
+  @Override
   public double op(double l, double r) {
     return MathUtils.equalsWithinOneSmallUlp(l, r) ? 1 : 0;
   }

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5336.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5336.py
@@ -1,0 +1,49 @@
+import h2o
+import pandas as pd
+from tests import pyunit_utils
+
+
+def pubdev_5336():
+    data = pd.DataFrame({'Origin': ['SFO', 'SAN', 'SFO', 'NYC', None],
+                         'Dest': ['SFO', 'SFO', 'SAN', 'SAN', None]})
+    frame = h2o.H2OFrame(data)
+    frame['Origin'].asfactor()
+    frame['Dest'].asfactor()
+
+    # First column has one more categorical variable
+    assert frame['Origin'].nlevels() == [3]
+    assert frame['Origin'].levels() == [['NYC', 'SAN', 'SFO']];
+    assert frame['Dest'].nlevels() == [2]
+    assert frame['Dest'].levels() == [['SAN', 'SFO']];
+    frame['eq'] = frame['Origin'] == frame['Dest']
+    assert frame['eq'][0,0] == 1
+    assert frame['eq'][1,0] == 0
+    assert frame['eq'][2,0] == 0
+    assert frame['eq'][3,0] == 0
+
+    # Compare in inverse order (tests one more categorical variable in first column)
+    frame['eqInv'] = frame['Dest'] == frame['Origin']
+    assert frame['eqInv'][0,0] == 1
+    assert frame['eqInv'][1,0] == 0
+    assert frame['eqInv'][2,0] == 0
+    assert frame['eqInv'][3,0] == 0
+
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
+    train['Origin'].asfactor()
+    train['Dest'].asfactor()
+    train['eq'] = train['Origin'] == train['Dest']
+    assert train[train['eq'] == 1].nrows is 0
+
+    missing = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate_missing.csv"))
+    missing['GLEASON'] = missing['GLEASON'].asfactor()
+    missing['DPROS'] = missing['DPROS'].asfactor()
+    missing['eq'] = missing['GLEASON'] == missing['DPROS']
+    # Both columns have NA on this row
+    assert missing['eq'][1,0] == 1
+    # One NA on this in GLEASON column
+    assert missing['eq'][7,0] == 0
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_5336)
+else:
+    pubdev_5336


### PR DESCRIPTION
* PUBDEV-5336 - h2o python: get wrong ans when run a conditional statement in h2o

(cherry picked from commit 447484d)

* Rename variable with transformed indices

(cherry picked from commit 8ef2130)

* Whitespaces deleted

(cherry picked from commit 935de15)

* Avoided allocation of additional memory by passing arguments in right order beforehand

(cherry picked from commit 75faba1)

* An attempt to quick fix/verify vec type problem

(cherry picked from commit 4e976bd)

* NaN handling. Pre-calculated categorical column conditions.

(cherry picked from commit f6c3cea)

* Testing NAs

(cherry picked from commit e0aeacb)

* NAs in test

(cherry picked from commit f746312)

(cherry picked from commit ba9d1b6)