### PR TITLE
Utilize model parameter objects for metalearner_params in Stacked Ensemble

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -74,7 +74,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       deeplearning
     }
     public MetalearnerAlgorithm _metalearner_algorithm = MetalearnerAlgorithm.AUTO;
-    public String _metalearner_params = new String();
+    public Model.Parameters _metalearner_params;
     public long _seed;
 
   }

--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -74,6 +74,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       deeplearning
     }
     public MetalearnerAlgorithm _metalearner_algorithm = MetalearnerAlgorithm.AUTO;
+    public String _metalearner_params = new String();
     public Model.Parameters _metalearner_parameters;
     public long _seed;
 

--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -74,7 +74,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       deeplearning
     }
     public MetalearnerAlgorithm _metalearner_algorithm = MetalearnerAlgorithm.AUTO;
-    public Model.Parameters _metalearner_params;
+    public Model.Parameters _metalearner_parameters;
     public long _seed;
 
   }

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -37,7 +37,7 @@ class Metalearner {
 
     private Frame _levelOneTrainingFrame;
     private Frame _levelOneValidationFrame;
-    private String _metalearner_params;
+    private Model.Parameters _metalearner_params;
     private StackedEnsembleModel _model;
     private Job _job;
     private Key<Model> _metalearnerKey;
@@ -46,7 +46,7 @@ class Metalearner {
     private boolean _hasMetalearnerParams;
     private long _metalearnerSeed;
     
-    Metalearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, String metalearner_params,
+    Metalearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, Model.Parameters metalearner_params,
                        StackedEnsembleModel model, Job StackedEnsembleJob, Key<Model> metalearnerKey, Job metalearnerJob,
                        StackedEnsembleParameters parms, boolean hasMetalearnerParams, long metalearnerSeed){
 
@@ -140,18 +140,19 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            Properties p = new Properties();
-            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-            }.getType());
-            for (Map.Entry<String, String[]> param : map.entrySet()) {
-                String[] paramVal = param.getValue();
-                if (paramVal.length == 1) {
-                    p.setProperty(param.getKey(), paramVal[0]);
-                } else {
-                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-                }
-                params.fillFromParms(p, true);
-            }
+            params.fillFromImpl((GBMModel.GBMParameters) _metalearner_params);
+//            Properties p = new Properties();
+//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+//            }.getType());
+//            for (Map.Entry<String, String[]> param : map.entrySet()) {
+//                String[] paramVal = param.getValue();
+//                if (paramVal.length == 1) {
+//                    p.setProperty(param.getKey(), paramVal[0]);
+//                } else {
+//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+//                }
+//                params.fillFromParms(p, true);
+//            }
             GBMModel.GBMParameters gbmParams = params.createAndFillImpl();
             metaGBMBuilder._parms = gbmParams;
         }
@@ -216,18 +217,19 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            Properties p = new Properties();
-            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-            }.getType());
-            for (Map.Entry<String, String[]> param : map.entrySet()) {
-                String[] paramVal = param.getValue();
-                if (paramVal.length == 1) {
-                    p.setProperty(param.getKey(), paramVal[0]);
-                } else {
-                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-                }
-                params.fillFromParms(p, true);
-            }
+            params.fillFromImpl((DRFModel.DRFParameters) _metalearner_params);
+//            Properties p = new Properties();
+//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+//            }.getType());
+//            for (Map.Entry<String, String[]> param : map.entrySet()) {
+//                String[] paramVal = param.getValue();
+//                if (paramVal.length == 1) {
+//                    p.setProperty(param.getKey(), paramVal[0]);
+//                } else {
+//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+//                }
+//                params.fillFromParms(p, true);
+//            }
             DRFModel.DRFParameters drfParams = params.createAndFillImpl();
             metaDRFBuilder._parms = drfParams;
         }
@@ -290,18 +292,19 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            Properties p = new Properties();
-            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-            }.getType());
-            for (Map.Entry<String, String[]> param : map.entrySet()) {
-                String[] paramVal = param.getValue();
-                if (paramVal.length == 1) {
-                    p.setProperty(param.getKey(), paramVal[0]);
-                } else {
-                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-                }
-                params.fillFromParms(p, true);
-            }
+            params.fillFromImpl((GLMModel.GLMParameters) _metalearner_params);
+//            Properties p = new Properties();
+//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+//            }.getType());
+//            for (Map.Entry<String, String[]> param : map.entrySet()) {
+//                String[] paramVal = param.getValue();
+//                if (paramVal.length == 1) {
+//                    p.setProperty(param.getKey(), paramVal[0]);
+//                } else {
+//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+//                }
+//                params.fillFromParms(p, true);
+//            }
             GLMModel.GLMParameters glmParams = params.createAndFillImpl();
             metaGLMBuilder._parms = glmParams;
         }
@@ -374,18 +377,19 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            Properties p = new Properties();
-            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-            }.getType());
-            for (Map.Entry<String, String[]> param : map.entrySet()) {
-                String[] paramVal = param.getValue();
-                if (paramVal.length == 1) {
-                    p.setProperty(param.getKey(), paramVal[0]);
-                } else {
-                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-                }
-                params.fillFromParms(p, true);
-            }
+            params.fillFromImpl((DeepLearningModel.DeepLearningParameters) _metalearner_params);
+//            Properties p = new Properties();
+//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+//            }.getType());
+//            for (Map.Entry<String, String[]> param : map.entrySet()) {
+//                String[] paramVal = param.getValue();
+//                if (paramVal.length == 1) {
+//                    p.setProperty(param.getKey(), paramVal[0]);
+//                } else {
+//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
+//                }
+//                params.fillFromParms(p, true);
+//            }
             DeepLearningModel.DeepLearningParameters dlParams = params.createAndFillImpl();
             metaDeepLearningBuilder._parms = dlParams;
         }

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -1,8 +1,5 @@
 package hex.ensemble;
 
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
-
 import hex.Model;
 import hex.ModelBuilder;
 import hex.ModelCategory;
@@ -28,16 +25,11 @@ import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.Frame;
 import water.util.Log;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
 class Metalearner {
 
     private Frame _levelOneTrainingFrame;
     private Frame _levelOneValidationFrame;
-    private Model.Parameters _metalearner_params;
+    private Model.Parameters _metalearner_parameters;
     private StackedEnsembleModel _model;
     private Job _job;
     private Key<Model> _metalearnerKey;
@@ -45,14 +37,14 @@ class Metalearner {
     private StackedEnsembleParameters _parms;
     private boolean _hasMetalearnerParams;
     private long _metalearnerSeed;
-    
-    Metalearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, Model.Parameters metalearner_params,
+
+    Metalearner(Frame levelOneTrainingFrame, Frame levelOneValidationFrame, Model.Parameters metalearner_parameters,
                        StackedEnsembleModel model, Job StackedEnsembleJob, Key<Model> metalearnerKey, Job metalearnerJob,
                        StackedEnsembleParameters parms, boolean hasMetalearnerParams, long metalearnerSeed){
 
         _levelOneTrainingFrame = levelOneTrainingFrame;
         _levelOneValidationFrame = levelOneValidationFrame;
-        _metalearner_params = metalearner_params;
+        _metalearner_parameters = metalearner_parameters;
         _model = model;
         _job = StackedEnsembleJob;
         _metalearnerKey = metalearnerKey;
@@ -140,24 +132,11 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            params.fillFromImpl((GBMModel.GBMParameters) _metalearner_params);
-//            Properties p = new Properties();
-//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-//            }.getType());
-//            for (Map.Entry<String, String[]> param : map.entrySet()) {
-//                String[] paramVal = param.getValue();
-//                if (paramVal.length == 1) {
-//                    p.setProperty(param.getKey(), paramVal[0]);
-//                } else {
-//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-//                }
-//                params.fillFromParms(p, true);
-//            }
-            GBMModel.GBMParameters gbmParams = params.createAndFillImpl();
+            GBMModel.GBMParameters gbmParams = (GBMModel.GBMParameters) _metalearner_parameters;
             metaGBMBuilder._parms = gbmParams;
         }
 
-        if(metaGBMBuilder._parms._seed == -1){ //Seed is not set in metalearner_params
+        if(metaGBMBuilder._parms._seed == -1){ //Seed is not set in metalearner_parameters
             metaGBMBuilder._parms._seed = _metalearnerSeed;
         }
         metaGBMBuilder._parms._seed = _metalearnerSeed;
@@ -217,24 +196,11 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            params.fillFromImpl((DRFModel.DRFParameters) _metalearner_params);
-//            Properties p = new Properties();
-//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-//            }.getType());
-//            for (Map.Entry<String, String[]> param : map.entrySet()) {
-//                String[] paramVal = param.getValue();
-//                if (paramVal.length == 1) {
-//                    p.setProperty(param.getKey(), paramVal[0]);
-//                } else {
-//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-//                }
-//                params.fillFromParms(p, true);
-//            }
-            DRFModel.DRFParameters drfParams = params.createAndFillImpl();
+            DRFModel.DRFParameters drfParams = (DRFModel.DRFParameters) _metalearner_parameters;
             metaDRFBuilder._parms = drfParams;
         }
 
-        if(metaDRFBuilder._parms._seed == -1) {//Seed is not set in metalearner_params
+        if(metaDRFBuilder._parms._seed == -1) {//Seed is not set in metalearner_parameters
             metaDRFBuilder._parms._seed = _metalearnerSeed;
         }
         metaDRFBuilder._parms._train = _levelOneTrainingFrame._key;
@@ -292,24 +258,11 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            params.fillFromImpl((GLMModel.GLMParameters) _metalearner_params);
-//            Properties p = new Properties();
-//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-//            }.getType());
-//            for (Map.Entry<String, String[]> param : map.entrySet()) {
-//                String[] paramVal = param.getValue();
-//                if (paramVal.length == 1) {
-//                    p.setProperty(param.getKey(), paramVal[0]);
-//                } else {
-//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-//                }
-//                params.fillFromParms(p, true);
-//            }
-            GLMModel.GLMParameters glmParams = params.createAndFillImpl();
+            GLMModel.GLMParameters glmParams = (GLMModel.GLMParameters) _metalearner_parameters;
             metaGLMBuilder._parms = glmParams;
         }
 
-        if(metaGLMBuilder._parms._seed == -1) {//Seed is not set in metalearner_params
+        if(metaGLMBuilder._parms._seed == -1) {//Seed is not set in metalearner_parameters
             metaGLMBuilder._parms._seed = _metalearnerSeed;
         }
         metaGLMBuilder._parms._train = _levelOneTrainingFrame._key;
@@ -377,24 +330,11 @@ class Metalearner {
 
         //Metalearner parameters
         if (_hasMetalearnerParams) {
-            params.fillFromImpl((DeepLearningModel.DeepLearningParameters) _metalearner_params);
-//            Properties p = new Properties();
-//            HashMap<String, String[]> map = new Gson().fromJson(_metalearner_params, new TypeToken<HashMap<String, String[]>>() {
-//            }.getType());
-//            for (Map.Entry<String, String[]> param : map.entrySet()) {
-//                String[] paramVal = param.getValue();
-//                if (paramVal.length == 1) {
-//                    p.setProperty(param.getKey(), paramVal[0]);
-//                } else {
-//                    p.setProperty(param.getKey(), Arrays.toString(paramVal));
-//                }
-//                params.fillFromParms(p, true);
-//            }
-            DeepLearningModel.DeepLearningParameters dlParams = params.createAndFillImpl();
+            DeepLearningModel.DeepLearningParameters dlParams = (DeepLearningModel.DeepLearningParameters) _metalearner_parameters;
             metaDeepLearningBuilder._parms = dlParams;
         }
 
-        if(metaDeepLearningBuilder._parms._seed == -1) {//Seed is not set in metalearner_params
+        if(metaDeepLearningBuilder._parms._seed == -1) {//Seed is not set in metalearner_parameters
             metaDeepLearningBuilder._parms._seed = _metalearnerSeed;
         }
         metaDeepLearningBuilder._parms._train = _levelOneTrainingFrame._key;

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -253,10 +253,10 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         Job metalearnerJob = new Job<>(metalearnerKey, ModelBuilder.javaName(metalearnerAlgoImpl.toString()),
                 "StackingEnsemble metalearner (" + metalearnerAlgoSpec + ")");
         //Check if metalearner_params are passed in
-        boolean hasMetaLearnerParams = _model._parms._metalearner_params != null;
+        boolean hasMetaLearnerParams = _model._parms._metalearner_parameters != null;
         long metalearnerSeed = _model._parms._seed;
         Metalearner metalearner = new Metalearner(levelOneTrainingFrame, levelOneValidationFrame,
-                                                  _model._parms._metalearner_params, _model, _job,
+                                                  _model._parms._metalearner_parameters, _model, _job,
                                                   metalearnerKey, metalearnerJob, _parms,
                                                   hasMetaLearnerParams, metalearnerSeed);
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -253,7 +253,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         Job metalearnerJob = new Job<>(metalearnerKey, ModelBuilder.javaName(metalearnerAlgoImpl.toString()),
                 "StackingEnsemble metalearner (" + metalearnerAlgoSpec + ")");
         //Check if metalearner_params are passed in
-        boolean hasMetaLearnerParams = _model._parms._metalearner_params != null && !_model._parms._metalearner_params.isEmpty();
+        boolean hasMetaLearnerParams = _model._parms._metalearner_params != null;
         long metalearnerSeed = _model._parms._seed;
         Metalearner metalearner = new Metalearner(levelOneTrainingFrame, levelOneValidationFrame,
                                                   _model._parms._metalearner_params, _model, _job,

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -86,6 +86,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     public long seed;
 
     public StackedEnsembleModel.StackedEnsembleParameters fillImpl(StackedEnsembleModel.StackedEnsembleParameters impl) {
+      super.fillImpl(impl);
       if (metalearner_params != null && !metalearner_params.isEmpty()) {
         Properties p = new Properties();
         HashMap<String, String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>() {

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -7,7 +7,6 @@ import water.api.schemas3.KeyV3;
 import water.api.schemas3.ModelParametersSchemaV3;
 import hex.Model;
 import water.api.schemas3.FrameV3;
-import water.util.IcedHashMap;
 
 public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,StackedEnsembleV99,StackedEnsembleV99.StackedEnsembleParametersV99> {
   public static final class StackedEnsembleParametersV99 extends ModelParametersSchemaV3<StackedEnsembleModel.StackedEnsembleParameters, StackedEnsembleParametersV99> {
@@ -66,7 +65,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     public boolean keep_levelone_frame;
 
     @API(help = "Parameters for metalearner algorithm", direction = API.Direction.INOUT)
-    public String metalearner_params;
+    public Model.Parameters metalearner_params;
 
     @API(help = "Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number)", gridable = true)
     public long seed;

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -2,11 +2,26 @@ package hex.schemas;
 
 import hex.ensemble.StackedEnsemble;
 import hex.StackedEnsembleModel;
+import hex.tree.gbm.GBMModel;
+import hex.tree.drf.DRFModel;
+import hex.deeplearning.DeepLearningModel;
+import hex.glm.GLMModel;
+import hex.Model;
+
 import water.api.API;
 import water.api.schemas3.KeyV3;
 import water.api.schemas3.ModelParametersSchemaV3;
-import hex.Model;
 import water.api.schemas3.FrameV3;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+
 
 public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,StackedEnsembleV99,StackedEnsembleV99.StackedEnsembleParametersV99> {
   public static final class StackedEnsembleParametersV99 extends ModelParametersSchemaV3<StackedEnsembleModel.StackedEnsembleParameters, StackedEnsembleParametersV99> {
@@ -65,10 +80,74 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
     public boolean keep_levelone_frame;
 
     @API(help = "Parameters for metalearner algorithm", direction = API.Direction.INOUT)
-    public Model.Parameters metalearner_params;
+    public String metalearner_params;
 
     @API(help = "Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number)", gridable = true)
     public long seed;
-  
+
+    public StackedEnsembleModel.StackedEnsembleParameters fillImpl(StackedEnsembleModel.StackedEnsembleParameters impl) {
+      if (metalearner_params != null && !metalearner_params.isEmpty()) {
+        Properties p = new Properties();
+        HashMap<String, String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>() {
+        }.getType());
+        for (Map.Entry<String, String[]> param : map.entrySet()) {
+          String[] paramVal = param.getValue();
+          if (paramVal.length == 1) {
+            p.setProperty(param.getKey(), paramVal[0]);
+          } else {
+            p.setProperty(param.getKey(), Arrays.toString(paramVal));
+          }
+        }
+        switch (metalearner_algorithm) {
+          case AUTO:
+            GLMV3.GLMParametersV3 paramsAuto = new GLMV3.GLMParametersV3();
+            paramsAuto.init_meta();
+            paramsAuto.fillFromImpl(new GLMModel.GLMParameters());
+            GLMModel.GLMParameters autoParams = paramsAuto.createAndFillImpl();
+            impl._metalearner_parameters = autoParams;
+            super.fillImpl(impl);
+            break;
+          case gbm:
+            GBMV3.GBMParametersV3 paramsGBM = new GBMV3.GBMParametersV3();
+            paramsGBM.init_meta();
+            paramsGBM.fillFromImpl(new GBMModel.GBMParameters());
+            paramsGBM.fillFromParms(p, true);
+            GBMModel.GBMParameters gbmParams = paramsGBM.createAndFillImpl();
+            impl._metalearner_parameters = gbmParams;
+            super.fillImpl(impl);
+            break;
+          case drf:
+            DRFV3.DRFParametersV3 paramsDRF = new DRFV3.DRFParametersV3();
+            paramsDRF.init_meta();
+            paramsDRF.fillFromImpl(new DRFModel.DRFParameters());
+            paramsDRF.fillFromParms(p, true);
+            DRFModel.DRFParameters drfParams = paramsDRF.createAndFillImpl();
+            impl._metalearner_parameters = drfParams;
+            super.fillImpl(impl);
+            break;
+          case glm:
+            GLMV3.GLMParametersV3 paramsGLM = new GLMV3.GLMParametersV3();
+            paramsGLM.init_meta();
+            paramsGLM.fillFromImpl(new GLMModel.GLMParameters());
+            paramsGLM.fillFromParms(p, true);
+            GLMModel.GLMParameters glmParams = paramsGLM.createAndFillImpl();
+            impl._metalearner_parameters = glmParams;
+            super.fillImpl(impl);
+            break;
+          case deeplearning:
+            DeepLearningV3.DeepLearningParametersV3 paramsDL = new DeepLearningV3.DeepLearningParametersV3();
+            paramsDL.init_meta();
+            paramsDL.fillFromImpl(new DeepLearningModel.DeepLearningParameters());
+            paramsDL.fillFromParms(p, true);
+            DeepLearningModel.DeepLearningParameters dlParams = paramsDL.createAndFillImpl();
+            impl._metalearner_parameters = dlParams;
+            super.fillImpl(impl);
+            break;
+          default:
+            throw new UnsupportedOperationException("Unknown meta-learner algo: " + metalearner_algorithm);
+        }
+      }
+      return impl;
+    }
   }
 }

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -329,6 +329,10 @@ def gen_module(schema, algo, module):
     if algo in ["stackedensemble"]:
         yield "  # Error check and build model"
         yield "  model <- .h2o.modelJob('%s', parms, h2oRestApiVersion = %d)" % (algo, 99 if algo in ["svd", "stackedensemble"] else 3)
+        yield "  #Convert metalearner_params back to list if not NULL"
+        yield "  if (!missing(metalearner_params)) {"
+        yield "      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]]" #Need the `[[ ]]` to a nested list
+        yield "  }"
         yield "  return(model)"
         yield "}"
     if algo in ["deeplearning", "drf", "gbm", "xgboost"]:

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -331,7 +331,7 @@ def gen_module(schema, algo, module):
         yield "  model <- .h2o.modelJob('%s', parms, h2oRestApiVersion = %d)" % (algo, 99 if algo in ["svd", "stackedensemble"] else 3)
         yield "  #Convert metalearner_params back to list if not NULL"
         yield "  if (!missing(metalearner_params)) {"
-        yield "      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]]" #Need the `[[ ]]` to a nested list
+        yield "      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]] #Need the `[[ ]]` to avoid a nested list"
         yield "  }"
         yield "  return(model)"
         yield "}"

--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -329,10 +329,6 @@ def gen_module(schema, algo, module):
     if algo in ["stackedensemble"]:
         yield "  # Error check and build model"
         yield "  model <- .h2o.modelJob('%s', parms, h2oRestApiVersion = %d)" % (algo, 99 if algo in ["svd", "stackedensemble"] else 3)
-        yield "  #Convert metalearner_params back to list if not NULL"
-        yield "  if (!missing(metalearner_params)) {"
-        yield "      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))"
-        yield "  }"
         yield "  return(model)"
         yield "}"
     if algo in ["deeplearning", "drf", "gbm", "xgboost"]:

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -215,7 +215,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         """
         Parameters for metalearner algorithm
 
-        Type: ``dict``.
+        Type: ``dict``  (default: ``None``).
         Example: metalearner_gbm_params = {'max_depth': 2, 'col_sample_rate': 0.3}
         """
         if self._parms.get("metalearner_params") != None:

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -215,7 +215,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         """
         Parameters for metalearner algorithm
 
-        Type: ``dict``  (default: ``None``).
+        Type: ``dict``.
         Example: metalearner_gbm_params = {'max_depth': 2, 'col_sample_rate': 0.3}
         """
         if self._parms.get("metalearner_params") != None:

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -113,7 +113,7 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
   model <- .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99)
   #Convert metalearner_params back to list if not NULL
   if (!missing(metalearner_params)) {
-      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]]
+      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]] #Need the `[[ ]]` to avoid a nested list
   }
   return(model)
 }

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -28,7 +28,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
-#' @param metalearner_params Parameters for metalearner algorithm
+#' @param metalearner_params Parameters for metalearner algorithm Defaults to NULL.
 #' @param seed Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number)
 #'        Defaults to -1 (time-based random number).
 #' @examples
@@ -111,5 +111,9 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$seed <- seed
   # Error check and build model
   model <- .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99)
+  #Convert metalearner_params back to list if not NULL
+  if (!missing(metalearner_params)) {
+      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]]
+  }
   return(model)
 }

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -28,7 +28,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
-#' @param metalearner_params Parameters for metalearner algorithm Defaults to NULL.
+#' @param metalearner_params Parameters for metalearner algorithm
 #' @param seed Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number)
 #'        Defaults to -1 (time-based random number).
 #' @examples

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -111,9 +111,5 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     parms$seed <- seed
   # Error check and build model
   model <- .h2o.modelJob('stackedensemble', parms, h2oRestApiVersion = 99)
-  #Convert metalearner_params back to list if not NULL
-  if (!missing(metalearner_params)) {
-      model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))
-  }
   return(model)
 }


### PR DESCRIPTION
* Keep API the same from R/Python
* Take `metalearner_params` input as a `String` and process as `Model.Parameter` type in backend
* This should help `metalearner` grid search efforts in the future