### PR TITLE
PUBDEV-5595: Do not calculate ModelMetrics for pure predict

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1223,7 +1223,6 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
         }
       }
       if( vec != null) {          // I have a column with a matching name
-        // Do not transform response, weights and fold columns if the metrics are not computed - case predict on test data.
         if( domains[i] != null) { // Model expects an categorical
           if (vec.isString())
             vec = VecUtils.stringToCategorical(vec); //turn a String column into a categorical column (we don't delete the original vec here)

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1208,7 +1208,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
         } else if (expensive) {   // generate warning even for response columns.  Other tests depended on this.
           final double defval;
           if (isWeights) defval = 1; // note: even though computeMetrics is false we should still have sensible weights (GLM skips rows with NA weights)
-          else if (isFold) defval = 0;
+          else if (isFold && domains[i] == null) defval = 0;
           else {
             defval = parms.missingColumnsType();
             convNaN++;
@@ -1224,8 +1224,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       }
       if( vec != null) {          // I have a column with a matching name
         // Do not transform response, weights and fold columns if the metrics are not computed - case predict on test data.
-        boolean transform = computeMetrics || (!isResponse && !isWeights && !isFold);
-        if( domains[i] != null && transform) { // Model expects an categorical
+        if( domains[i] != null) { // Model expects an categorical
           if (vec.isString())
             vec = VecUtils.stringToCategorical(vec); //turn a String column into a categorical column (we don't delete the original vec here)
           if( expensive && vec.domain() != domains[i] && !Arrays.equals(vec.domain(),domains[i]) ) { // Result needs to be the same categorical
@@ -1244,7 +1243,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
               msgs.add("Test/Validation dataset column '" + names[i] + "' has levels not trained on: " + Arrays.toString(Arrays.copyOfRange(ds, domains[i].length, ds.length)));
             vec = evec;
           }
-        } else if(vec.isCategorical() && transform) {
+        } else if(vec.isCategorical()) {
           if (parms._categorical_encoding == Parameters.CategoricalEncodingScheme.LabelEncoder) {
             Vec evec = vec.toNumericVec();
             toDelete.put(evec._key, "label encoded vec");

--- a/h2o-core/src/main/java/water/api/ModelMetricsHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelMetricsHandler.java
@@ -334,7 +334,8 @@ class ModelMetricsHandler extends Handler {
   }
 
   /**
-   * Score a frame with the given model and return the metrics AND the prediction frame.
+   * Score a frame with the given model and return a Job that output a frame with predictions.
+   * Do *not* calculate ModelMetrics.
    */
   @SuppressWarnings("unused") // called through reflection by RequestServer
   public JobV3 predictAsync(int version, final ModelMetricsListSchemaV3 s) {
@@ -371,7 +372,7 @@ class ModelMetricsHandler extends Handler {
       @Override
       public void compute2() {
         if (s.deep_features_hidden_layer < 0 && s.deep_features_hidden_layer_name == null) {
-          parms._model.score(parms._frame, parms._predictions_name, j, true, CFuncRef.from(s.custom_metric_func));
+          parms._model.score(parms._frame, parms._predictions_name, j, false, CFuncRef.from(s.custom_metric_func));
         }
         else if (s.deep_features_hidden_layer_name != null){
           Frame predictions = null;

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5595.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5595.R
@@ -1,0 +1,46 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.pubdev5595 <- function() {
+    # Here's a test where we use a weights or fold column to train
+    # and then we remove that column for prediction.
+
+    # test where fold_column and weights_column is an integer
+    hf_test <- as.h2o(iris)
+    iris$fold <- rep(1:5, n = 30)
+    hf_train <- as.h2o(iris)
+
+    fit <- h2o.gbm(x = 1:4, y = 5, training_frame = hf_train, fold_column = "fold")
+    h2o.predict(fit, newdata = hf_test)  #works
+
+    fit2 <- h2o.gbm(x = 1:4, y = 5, training_frame = hf_train, weights_column = "fold")
+    h2o.predict(fit2, newdata = hf_test)  #works
+
+
+    # test where fold_column is a factor
+    hf_test <- as.h2o(iris[,1:4])
+    hf_train <- as.h2o(iris)
+
+    fit <- h2o.gbm(x = 1:3, y = 4, training_frame = hf_train, fold_column = "Species")
+    h2o.predict(fit, newdata = hf_test)  #works
+
+    data("iris")  #reload iris
+    iris$fold <- rep(1:5, n = 30)  #add integer fold col
+    hf_train <- as.h2o(iris)
+    hf_test <- as.h2o(iris)[,-6]  #remove integer fold col
+
+    fit <- h2o.gbm(x = 1:3, y = 4, training_frame = hf_train, fold_column = "fold")
+    h2o.predict(fit, newdata = hf_test)
+
+    fit2 <- h2o.gbm(x = 1:3, y = 4, training_frame = hf_train, weights_column = "fold")
+    h2o.predict(fit2, newdata = hf_test)
+
+    data("iris")  #reload iris
+    hf_train <- as.h2o(iris)
+    hf_test <- as.h2o(iris)[,-5]
+
+    fit <- h2o.gbm(x = 1:3, y = 4, training_frame = hf_train, fold_column = "Species")
+    h2o.predict(fit, newdata = hf_test)
+}
+
+doTest("PUBDEV-5595: Do not calculate metric on test data", test.pubdev5595)


### PR DESCRIPTION
There doesn't seem to be a reason to calculate metrics in pure predict ("h2o.predict"). The metrics for the frame is calculated as a side effect, however, it doesn't seem to be ever used. "h2o.performance" will re-calculate the metrics from scratch, it will not use the old object.

This is an issue when the user provides a response but not weights. H2O complains that it doesn't have the weights column for this frame. Eventhough the metrics are never accessible to the user.