### PR TITLE
[HOTFIX] HEXDEV-714: Properly dispose memory of DMatrix in XGB score/train

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
@@ -79,7 +79,7 @@ public class XGBoostUtils {
             featureMap[0] = sb.toString();
         }
 
-        DMatrix trainMat;
+        final DMatrix trainMat;
         Vec.Reader w = weight == null ? null : f.vec(weight).new Reader();
         Vec.Reader[] vecs = new Vec.Reader[f.numCols()];
         for (int i = 0; i < vecs.length; ++i) {

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
@@ -16,6 +16,25 @@ import static water.H2O.technote;
 
 public class XGBoostUtils {
 
+    public static String makeFeatureMap(Frame f, DataInfo di) {
+        // set the names for the (expanded) columns
+        String[] coefnames = di.coefNames();
+        StringBuilder sb = new StringBuilder();
+        assert(coefnames.length == di.fullN());
+        for (int i = 0; i < di.fullN(); ++i) {
+            sb.append(i).append(" ").append(coefnames[i].replaceAll("\\s*","")).append(" ");
+            int catCols = di._catOffsets[di._catOffsets.length-1];
+            if (i < catCols || f.vec(i-catCols).isBinary())
+                sb.append("i");
+            else if (f.vec(i-catCols).isInt())
+                sb.append("int");
+            else
+                sb.append("q");
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
     /**
      * convert an H2O Frame to a sparse DMatrix
      * @param f H2O Frame
@@ -23,7 +42,6 @@ public class XGBoostUtils {
      * @param response name of the response column
      * @param weight name of the weight column
      * @param fold name of the fold assignment column
-     * @param featureMap featureMap[0] will be populated with the column names and types
      * @return DMatrix
      * @throws XGBoostError
      */
@@ -33,7 +51,6 @@ public class XGBoostUtils {
                                          String response,
                                          String weight,
                                          String fold,
-                                         String[] featureMap,
                                          boolean sparse) throws XGBoostError {
 
         int[] chunks;
@@ -59,26 +76,7 @@ public class XGBoostUtils {
 
         int nRows = (int) nRowsL;
 
-        DataInfo di = dataInfoKey.get();
-        // set the names for the (expanded) columns
-        if (featureMap!=null) {
-            String[] coefnames = di.coefNames();
-            StringBuilder sb = new StringBuilder();
-            assert(coefnames.length == di.fullN());
-            for (int i = 0; i < di.fullN(); ++i) {
-                sb.append(i).append(" ").append(coefnames[i].replaceAll("\\s*","")).append(" ");
-                int catCols = di._catOffsets[di._catOffsets.length-1];
-                if (i < catCols || f.vec(i-catCols).isBinary())
-                    sb.append("i");
-                else if (f.vec(i-catCols).isInt())
-                    sb.append("int");
-                else
-                    sb.append("q");
-                sb.append("\n");
-            }
-            featureMap[0] = sb.toString();
-        }
-
+        final DataInfo di = dataInfoKey.get();
         final DMatrix trainMat;
         Vec.Reader w = weight == null ? null : f.vec(weight).new Reader();
         Vec.Reader[] vecs = new Vec.Reader[f.numCols()];

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PersistentDMatrix.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PersistentDMatrix.java
@@ -1,0 +1,59 @@
+package ml.dmlc.xgboost4j.java;
+
+import water.Iced;
+
+/**
+ * Implementation of DMatrix that doesn't automatically dispose of the XGB native data when the object gets finalized
+ */
+public class PersistentDMatrix extends DMatrix {
+
+  private PersistentDMatrix(long handle) {
+    super(handle);
+  }
+
+  public Wrapper wrap() {
+    return new Wrapper(this);
+  }
+
+  @Override
+  protected void finalize() {
+    // Forget the handle but do not destroy the data - memory needs to be explicitly released by calling dispose()
+    handle = 0;
+    super.finalize();
+  }
+
+  /**
+   * Turn a DMatrix into a persisted one
+   * @param matrix matrix to be marked as persisted, this object will not be usable after the persist finishes
+   * @return instance of PersistentDMatrix or null if the input matrix is null
+   */
+  public static PersistentDMatrix persist(DMatrix matrix) {
+    if (matrix == null)
+      return null;
+
+    long handle = matrix.handle;
+    matrix.handle = 0;
+    return new PersistentDMatrix(handle);
+  }
+
+  public static class Wrapper extends Iced<Wrapper> {
+    private long _handle;
+
+    public Wrapper(PersistentDMatrix matrix) {_handle = matrix.handle; }
+
+    public PersistentDMatrix get() {
+      return new PersistentDMatrix(_handle);
+    }
+
+    @Override public boolean equals( Object o ) {
+      return o instanceof Wrapper && ((Wrapper) o)._handle == _handle;
+    }
+    @Override public int hashCode() {
+      return (int)(_handle ^ (_handle >>> 32));
+    }
+    @Override public String toString() {
+      return Long.toString(_handle);
+    }
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostCleanupTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostCleanupTask.java
@@ -1,0 +1,33 @@
+package ml.dmlc.xgboost4j.java;
+
+import water.H2O;
+import water.MRTask;
+import water.util.IcedHashMapGeneric;
+
+/**
+ * Cleans up after XGBoost training (releases any node-local data)
+ */
+public class XGBoostCleanupTask extends MRTask<XGBoostCleanupTask> {
+
+  private IcedHashMapGeneric.IcedHashMapStringObject _nodeToMatrixWrapper;
+
+  public XGBoostCleanupTask(XGBoostSetupTask setupTask) {
+    _nodeToMatrixWrapper = setupTask._nodeToMatrixWrapper;
+  }
+
+  @Override
+  protected void setupLocal() {
+    if (H2O.ARGS.client || _nodeToMatrixWrapper == null) {
+      return;
+    }
+
+    PersistentDMatrix.Wrapper wrapper = (PersistentDMatrix.Wrapper) _nodeToMatrixWrapper.get(H2O.SELF.toString());
+    if (wrapper != null)
+      wrapper.get().dispose();
+  }
+
+  public static void cleanUp(XGBoostSetupTask setupTask) {
+    new XGBoostCleanupTask(setupTask).doAllNodes();
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
@@ -7,6 +7,7 @@ import ml.dmlc.xgboost4j.java.BoosterHelper;
 import ml.dmlc.xgboost4j.java.XGBoostError;
 import water.Iced;
 import water.Key;
+import water.util.Log;
 import water.util.TwoDimTable;
 
 import java.io.ByteArrayInputStream;
@@ -30,6 +31,7 @@ final public class XGBoostModelInfo extends Iced {
     if(null == _booster && null != _boosterBytes) {
       try {
         _booster = Booster.loadModel(new ByteArrayInputStream(_boosterBytes));
+        Log.debug("Booster created from bytes, raw size = " + _boosterBytes.length);
       } catch (XGBoostError | IOException exception) {
         throw new IllegalStateException("Failed to load the booster.", exception);
       }

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
@@ -56,9 +56,7 @@ final public class XGBoostModelInfo extends Iced {
   }
 
   public void nukeBackend() {
-    if (_booster != null) {
-      _booster.dispose();
-    }
+    BoosterHelper.dispose(_booster);
     _booster = null;
   }
 

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
@@ -127,6 +127,7 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
     @Override
     public void map(Chunk[] cs, NewChunk[] ncs) {
         DMatrix data = null;
+        Booster booster = null;
         try {
             HashMap<String, Object> params = XGBoostModel.createParams(_parms, _output);
 
@@ -148,7 +149,6 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
                 return;
             }
 
-            Booster booster = null;
             try {
                 booster = Booster.loadModel(new ByteArrayInputStream(rawBooster));
                 booster.setParams(params);
@@ -204,6 +204,9 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
         } catch (XGBoostError xgBoostError) {
             throw new IllegalStateException("Failed to score with XGBoost.", xgBoostError);
         } finally {
+            if (booster != null) {
+                booster.dispose();
+            }
             if (data != null) {
                 data.dispose();
             }

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
@@ -126,6 +126,7 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
 
     @Override
     public void map(Chunk[] cs, NewChunk[] ncs) {
+        DMatrix data = null;
         try {
             HashMap<String, Object> params = XGBoostModel.createParams(_parms, _output);
 
@@ -134,7 +135,7 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
             // This might be fixed in future versions of XGBoost
             Rabit.init(rabitEnv);
 
-            DMatrix data = XGBoostUtils.convertChunksToDMatrix(
+            data = XGBoostUtils.convertChunksToDMatrix(
                     _sharedmodel._dataInfoKey,
                     cs,
                     _fr.find(_parms._response_column),
@@ -203,6 +204,9 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
         } catch (XGBoostError xgBoostError) {
             throw new IllegalStateException("Failed to score with XGBoost.", xgBoostError);
         } finally {
+            if (data != null) {
+                data.dispose();
+            }
             try {
                 Rabit.shutdown();
             } catch (XGBoostError xgBoostError) {

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
@@ -204,12 +204,7 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
         } catch (XGBoostError xgBoostError) {
             throw new IllegalStateException("Failed to score with XGBoost.", xgBoostError);
         } finally {
-            if (booster != null) {
-                booster.dispose();
-            }
-            if (data != null) {
-                data.dispose();
-            }
+            BoosterHelper.dispose(booster, data);
             try {
                 Rabit.shutdown();
             } catch (XGBoostError xgBoostError) {

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
@@ -1,0 +1,75 @@
+package ml.dmlc.xgboost4j.java;
+
+import hex.tree.xgboost.XGBoostExtension;
+import hex.tree.xgboost.XGBoostModel;
+import hex.tree.xgboost.XGBoostUtils;
+import water.ExtensionManager;
+import water.H2O;
+import water.MRTask;
+import water.util.IcedHashMapGeneric;
+
+/**
+ * Initializes XGBoost training (converts Frame to set of node-local DMatrices)
+ */
+public class XGBoostSetupTask extends MRTask<XGBoostSetupTask> {
+
+  private final XGBoostModelInfo _sharedModel;
+  private final XGBoostModel.XGBoostParameters _parms;
+  private boolean _sparse;
+
+  // OUT
+  IcedHashMapGeneric.IcedHashMapStringObject _nodeToMatrixWrapper;
+
+  public XGBoostSetupTask(XGBoostModelInfo inputModel, XGBoostModel.XGBoostParameters parms, boolean sparse) {
+    _sharedModel = inputModel;
+    _parms = parms;
+    _sparse = sparse;
+  }
+
+  @Override
+  protected void setupLocal() {
+    if (H2O.ARGS.client) {
+      return;
+    }
+
+    // We need to verify that the xgboost is available on the remote node
+    if (!ExtensionManager.getInstance().isCoreExtensionEnabled(XGBoostExtension.NAME)) {
+      throw new IllegalStateException("XGBoost is not available on the node " + H2O.SELF);
+    }
+
+    final PersistentDMatrix matrix;
+    try {
+      matrix = makeLocalMatrix();
+    } catch (XGBoostError xgBoostError) {
+      throw new IllegalStateException("Failed XGBoost training.", xgBoostError);
+    }
+
+    if (matrix == null)
+      return;
+
+    _nodeToMatrixWrapper = new IcedHashMapGeneric.IcedHashMapStringObject();
+    _nodeToMatrixWrapper.put(H2O.SELF.toString(), matrix.wrap());
+  }
+
+  private PersistentDMatrix makeLocalMatrix() throws XGBoostError {
+      return PersistentDMatrix.persist(XGBoostUtils.convertFrameToDMatrix(
+              _sharedModel._dataInfoKey,
+              _fr,
+              true,
+              _parms._response_column,
+              _parms._weights_column,
+              _parms._fold_column,
+              _sparse));
+  }
+
+  @Override
+  public void reduce(XGBoostSetupTask mrt) {
+    if (mrt._nodeToMatrixWrapper == null)
+      return;
+    if (_nodeToMatrixWrapper == null)
+      _nodeToMatrixWrapper = mrt._nodeToMatrixWrapper;
+    else
+      _nodeToMatrixWrapper.putAll(mrt._nodeToMatrixWrapper);
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
@@ -116,7 +116,7 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
             _rawBooster = _booster.toByteArray();
         } finally {
             if (trainMat != null) {
-                trainMat.dispose();
+                BoosterHelper.dispose(trainMat);
                 // Rabit was not started if the matrix was not properly initialized
                 try {
                     Rabit.shutdown();

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
@@ -3,11 +3,9 @@ package ml.dmlc.xgboost4j.java;
 import hex.tree.xgboost.XGBoostExtension;
 import hex.tree.xgboost.XGBoostModel;
 import hex.tree.xgboost.XGBoostOutput;
-import hex.tree.xgboost.XGBoostUtils;
 import water.ExtensionManager;
 import water.H2O;
 import water.MRTask;
-import water.util.FileUtils;
 import water.util.IcedHashMapGeneric;
 import water.util.Log;
 
@@ -16,7 +14,7 @@ import java.util.*;
 
 public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
 
-    private final XGBoostModelInfo _sharedModel;
+    private final IcedHashMapGeneric.IcedHashMapStringObject _nodeToMatrixWrapper;
     private final XGBoostOutput _output;
     private transient Booster _booster;
     private byte[] _rawBooster;
@@ -26,21 +24,18 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
 
     private IcedHashMapGeneric.IcedHashMapStringString rabitEnv = new IcedHashMapGeneric.IcedHashMapStringString();
 
-    private String[] _featureMap;
-
-    public XGBoostUpdateTask(Booster booster,
-                      XGBoostModelInfo inputModel,
-                      XGBoostOutput _output,
-                      XGBoostModel.XGBoostParameters _parms,
+    public XGBoostUpdateTask(
+                      XGBoostSetupTask setupTask,
+                      Booster booster,
+                      XGBoostOutput output,
+                      XGBoostModel.XGBoostParameters parms,
                       int tid,
-                      Map<String, String> workerEnvs,
-                      String[] featureMap) {
-        this._sharedModel = inputModel;
-        this._output = _output;
-        this._parms = _parms;
-        this._tid = tid;
-        this._featureMap = featureMap;
-        this._rawBooster = hex.tree.xgboost.XGBoost.getRawArray(booster);
+                      Map<String, String> workerEnvs) {
+        _nodeToMatrixWrapper = setupTask._nodeToMatrixWrapper;
+        _output = output;
+        _parms = parms;
+        _tid = tid;
+        _rawBooster = hex.tree.xgboost.XGBoost.getRawArray(booster);
         rabitEnv.putAll(workerEnvs);
     }
 
@@ -55,7 +50,11 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
             throw new IllegalStateException("XGBoost is not available on the node " + H2O.SELF);
         }
         try {
-            update();
+            PersistentDMatrix.Wrapper wrapper = (PersistentDMatrix.Wrapper) _nodeToMatrixWrapper.get(H2O.SELF.toString());
+            if (wrapper == null)
+                return;
+            DMatrix matrix = wrapper.get();
+            update(matrix);
         } catch (XGBoostError xgBoostError) {
             try {
                 Rabit.shutdown();
@@ -67,27 +66,12 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
         }
     }
 
-    private void update() throws XGBoostError {
+    private void update(DMatrix trainMat) throws XGBoostError {
         HashMap<String, Object> params = XGBoostModel.createParams(_parms, _output);
 
         rabitEnv.put("DMLC_TASK_ID", String.valueOf(H2O.SELF.index()));
 
-        DMatrix trainMat = null;
         try {
-            trainMat = XGBoostUtils.convertFrameToDMatrix(
-                    _sharedModel._dataInfoKey,
-                    _fr,
-                    true,
-                    _parms._response_column,
-                    _parms._weights_column,
-                    _parms._fold_column,
-                    _featureMap,
-                    _output._sparse);
-
-            if (null == trainMat) {
-                return;
-            }
-
             // DON'T put this before createParams, createPrams calls train() which isn't supposed to be distributed
             // just to check if we have GPU on the machine
             Rabit.init(rabitEnv);
@@ -115,14 +99,10 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
             }
             _rawBooster = _booster.toByteArray();
         } finally {
-            if (trainMat != null) {
-                BoosterHelper.dispose(trainMat);
-                // Rabit was not started if the matrix was not properly initialized
-                try {
-                    Rabit.shutdown();
-                } catch (XGBoostError xgBoostError) {
-                    Log.debug("Rabit shutdown during update failed", xgBoostError);
-                }
+            try {
+                Rabit.shutdown();
+            } catch (XGBoostError xgBoostError) {
+                Log.debug("Rabit shutdown during update failed", xgBoostError);
             }
         }
     }
@@ -131,30 +111,11 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
     public void reduce(XGBoostUpdateTask mrt) {
         if(null == _rawBooster) {
             _rawBooster = mrt._rawBooster;
-            _featureMap = mrt._featureMap;
-        }
-    }
-
-    private void updateFeatureMapFile(File featureMapFile) {
-        // For feature importances - write out column info
-        OutputStream os = null;
-        try {
-            os = new FileOutputStream(featureMapFile);
-            os.write(_featureMap[0].getBytes());
-            os.close();
-        } catch (IOException e) {
-            throw new RuntimeException("Cannot generate " + featureMapFile, e);
-        } finally {
-            FileUtils.close(os);
         }
     }
 
     // This is called from driver
     public Booster getBooster() {
-        return getBooster(null);
-    }
-
-    public Booster getBooster(File featureMapFile) {
         if (null == _booster) {
             try {
                 _booster = Booster.loadModel(new ByteArrayInputStream(_rawBooster));
@@ -162,9 +123,6 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
             } catch (XGBoostError | IOException xgBoostError) {
                 throw new IllegalStateException("Failed to load the booster.", xgBoostError);
             }
-        }
-        if (featureMapFile != null) {
-            updateFeatureMapFile(featureMapFile);
         }
         return _booster;
     }

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
@@ -103,6 +103,7 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
             } else {
                 try {
                     _booster = Booster.loadModel(new ByteArrayInputStream(_rawBooster));
+                    Log.debug("Booster created from bytes, raw size = " + _rawBooster.length);
                     // Set the parameters, some seem to get lost on save/load
                     _booster.setParams(params);
                 } catch (IOException e) {
@@ -157,6 +158,7 @@ public class XGBoostUpdateTask extends MRTask<XGBoostUpdateTask> {
         if (null == _booster) {
             try {
                 _booster = Booster.loadModel(new ByteArrayInputStream(_rawBooster));
+                Log.debug("Booster created from bytes, raw size = " + _rawBooster.length);
             } catch (XGBoostError | IOException xgBoostError) {
                 throw new IllegalStateException("Failed to load the booster.", xgBoostError);
             }

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
@@ -2,19 +2,20 @@ package hex.genmodel.algos.xgboost;
 
 import hex.genmodel.GenModel;
 import hex.genmodel.MojoModel;
-import ml.dmlc.xgboost4j.java.Booster;
-import ml.dmlc.xgboost4j.java.DMatrix;
-import ml.dmlc.xgboost4j.java.Rabit;
-import ml.dmlc.xgboost4j.java.XGBoostError;
+import ml.dmlc.xgboost4j.java.*;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 
 /**
  * "Gradient Boosting Machine" MojoModel
+ *
+ * Please note: user is advised to explicitly release the native resources of XGBoost by calling close method on the instance.
  */
-public final class XGBoostMojoModel extends MojoModel {
+public final class XGBoostMojoModel extends MojoModel implements Closeable {
   Booster _booster;
 
   public int _nums;
@@ -74,8 +75,7 @@ public final class XGBoostMojoModel extends MojoModel {
     } catch (XGBoostError xgBoostError) {
       throw new IllegalStateException("Failed XGBoost prediction.", xgBoostError);
     } finally {
-      if (dmat != null)
-        dmat.dispose();
+      BoosterHelper.dispose(dmat);
     }
 
     for(int r = 0; r < out.length; r++) {
@@ -120,8 +120,7 @@ public final class XGBoostMojoModel extends MojoModel {
     } catch (XGBoostError xgBoostError) {
       throw new IllegalStateException("Failed XGBoost prediction.", xgBoostError);
     } finally {
-      if (dmat != null)
-        dmat.dispose();
+      BoosterHelper.dispose(dmat);
     }
 
     if (nclasses > 2) {
@@ -138,6 +137,11 @@ public final class XGBoostMojoModel extends MojoModel {
       preds[0] = out[0][0];
     }
     return preds;
+  }
+
+  @Override
+  public void close() {
+    BoosterHelper.dispose(_booster);
   }
 
 }

--- a/h2o-genmodel-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/BoosterHelper.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/BoosterHelper.java
@@ -18,4 +18,39 @@ public class BoosterHelper {
   public static Booster loadModel(InputStream in) throws XGBoostError, IOException {
     return Booster.loadModel(in);
   }
+
+  /**
+   * Invalidates XGBoost objects (Booster, DMatrix) and frees up their memory
+   * @param xgbObjects list of XGBoost objects
+   * @throws IllegalStateException when object invalidation fails, only the first exception will be reported (as the
+   * exception cause), we assume the other ones will have a same reason
+   */
+  public static void dispose(Object... xgbObjects) throws IllegalStateException {
+    Exception firstException = null;
+    for (Object xgbObject : xgbObjects) {
+      if (xgbObject == null)
+        continue;
+      if (xgbObject instanceof Booster) {
+        try {
+          ((Booster) xgbObject).dispose();
+        } catch (Exception e) {
+          if (firstException == null)
+            firstException = e;
+        }
+      } else if (xgbObject instanceof DMatrix) {
+        try {
+          ((DMatrix) xgbObject).dispose();
+        } catch (Exception e) {
+          if (firstException == null)
+            firstException = e;
+        }
+      } else
+        assert false : "Unsupported XGBoost object type: " + xgbObject.getClass();
+    }
+    if (firstException != null) {
+      throw new IllegalStateException("We were unable to free-up xgboost memory. " +
+              "This could indicate a memory leak and it can lead to H2O instability.", firstException);
+    }
+  }
+
 }


### PR DESCRIPTION
Do not rely on GC to dispose of the XGBoost objects (DMatrix, Booster). We need to explicitly dispose of these object everytime we create a new instance. If we really on GC we can die on OOM because JVM might not see any need to dispose of the object even though the whole process is actually running out of memory (especially on Hadoop where the containers are running in constrained memory).