### PR TITLE
[PUBDEV-4299] Allow to process HTTP/HTTPS as part of new H2OFrame(URI…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ allprojects {
 
     // Support different IDEs
     apply plugin: 'idea'
+    idea.module.inheritOutputDirs = true
     apply plugin: 'eclipse'
     apply from: "$rootDir/gradle/artifacts.gradle"
 

--- a/h2o-core/src/main/java/water/fvec/UploadFileVec.java
+++ b/h2o-core/src/main/java/water/fvec/UploadFileVec.java
@@ -1,5 +1,6 @@
 package water.fvec;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.io.InputStream;
 import water.*;
@@ -52,15 +53,15 @@ public class UploadFileVec extends FileVec {
     public long total_bytes;
   }
 
-  static public Key readPut(String keyname, InputStream is, ReadPutStats stats) throws Exception {
+  static public Key readPut(String keyname, InputStream is, ReadPutStats stats) throws IOException {
     return readPut(Key.make(keyname), is, stats);
   }
 
-  static public Key readPut(Key k, InputStream is, ReadPutStats stats) throws Exception {
+  static public Key readPut(Key k, InputStream is, ReadPutStats stats) throws IOException {
     return readPut_impl(k, is, stats);
   }
 
-  static private Key readPut_impl(Key key, InputStream is, ReadPutStats stats) throws Exception {
+  static private Key readPut_impl(Key key, InputStream is, ReadPutStats stats) throws IOException {
     Log.info("Reading byte InputStream into Frame:");
     Log.info("    frameKey:    " + key.toString());
     Key newVecKey = Vec.newKey();
@@ -104,7 +105,7 @@ public class UploadFileVec extends FileVec {
 
       Log.info("    Success.");
     }
-    catch (Exception e) {
+    catch (IOException e) {
       // Clean up and do not leak keys.
       Log.err("Exception caught in Frame::readPut; attempting to clean up the new frame and vector");
       Log.err(e);

--- a/h2o-scala/src/test/scala/water/fvec/FrameOpsTest.scala
+++ b/h2o-scala/src/test/scala/water/fvec/FrameOpsTest.scala
@@ -1,6 +1,8 @@
 package water.fvec
 
-import org.junit.{Assert, Test, BeforeClass}
+import java.net.URI
+
+import org.junit.{Assert, BeforeClass, Test}
 import water.util.FileUtils
 import water.TestUtil
 import water.parser.ParseSetup
@@ -9,6 +11,34 @@ import water.parser.ParseSetup
  * Tests for exposed frame operations.
  */
 class FrameOpsTest extends TestUtil {
+
+  @Test
+  def testImportFromHTTP(): Unit = {
+    val fr = new H2OFrame(URI.create("http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/AirlinesTest.csv.zip"))
+    try {
+      assert(fr.numCols() == 12)
+      assert(fr.numRows() == 2691)
+      assert(fr.anyVec().nChunks() == 1)
+    } finally {
+      fr.delete()
+    }
+  }
+
+  /** Test importing from HTTP together with import from file://
+    * The purpose of this test is to test that we can specify multiple sources as part of one single frame creation call
+    */
+  @Test
+  def testImportFromHTTPWithFile(): Unit = {
+    val fr = new H2OFrame(URI.create("http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/AirlinesTest.csv.zip"), FileUtils.getFile("smalldata/airlines/AirlinesTest.csv.zip").toURI)
+    try {
+      assert(fr.numCols() == 12)
+      assert(fr.numRows() == 5382)
+      assert(fr.anyVec().nChunks() == 2)
+    } finally {
+      fr.delete()
+    }
+  }
+
 
   @Test
   def testParserSetup(): Unit = {

--- a/h2o-scala/src/test/scala/water/fvec/FrameOpsTest.scala
+++ b/h2o-scala/src/test/scala/water/fvec/FrameOpsTest.scala
@@ -18,7 +18,6 @@ class FrameOpsTest extends TestUtil {
     try {
       assert(fr.numCols() == 12)
       assert(fr.numRows() == 2691)
-      assert(fr.anyVec().nChunks() == 1)
     } finally {
       fr.delete()
     }
@@ -33,7 +32,6 @@ class FrameOpsTest extends TestUtil {
     try {
       assert(fr.numCols() == 12)
       assert(fr.numRows() == 5382)
-      assert(fr.anyVec().nChunks() == 2)
     } finally {
       fr.delete()
     }


### PR DESCRIPTION
…(https://.....))

@mmalohlava I followed your advice and tried to do a minimal code change.
HTTP/HTTPS doesn't fit nicely as the Persist backend. Even though we would decide to change it, currently, the number of Persist backends is limited in code to 8 - there is some magic with bytes. Not sure how much code change this would require.


This solution is simply based on existing code and allows http/https to be used in H2OFrame(URI..))