### PR TITLE
PUBDEV-5459: Create XGBoost training matrix just once

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -20,7 +20,9 @@ import water.util.*;
 import water.util.Timer;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.*;
 
 import static hex.tree.SharedTree.createModelSummaryTable;
@@ -288,9 +290,6 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
       // Single Rabit tracker per job. Manages the node graph for Rabit.
       IRabitTracker rt = null;
       try {
-        // Create a temporary storage for user files
-        featureMapFile = createFeatureMapFile();
-
         // Count on how many nodes the data resides
         Set<H2ONode> nodesHoldingFrame = new HashSet<>();
         Vec vec = train().anyVec();
@@ -309,6 +308,10 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
                                              + "make sure you have python installed!");
         }
 
+        // Create a temporary file with "feature map"
+        String featureMap = XGBoostUtils.makeFeatureMap(_train, model.model_info()._dataInfoKey.get());
+        featureMapFile = createFeatureMapFile(featureMap);
+
         try {
           model.model_info().setBooster(new XGBoostUpdateTask(
                   model.model_info().getBooster(),
@@ -316,8 +319,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
                   model._output,
                   _parms,
                   0,
-                  getWorkerEnvs(rt),
-                  new String[]{""}).doAll(_train).getBooster(featureMapFile));
+                  getWorkerEnvs(rt)).doAll(_train).getBooster());
           // Wait for results
           waitOnRabitWorkers(rt);
         } catch (RuntimeException e) {
@@ -341,13 +343,20 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
       }
     }
 
-    private File createFeatureMapFile() {
-      File tmpModelDir = null;
+    // For feature importances - write out column info
+    private File createFeatureMapFile(String featureMap) {
+      OutputStream os = null;
       try {
-        tmpModelDir = java.nio.file.Files.createTempDirectory("xgboost-model-" + _result.toString()).toFile();
-        return new File(tmpModelDir, featureMapFileName);
-      } catch(IOException e) {
-        throw new RuntimeException("Cannot generate temporary directory for feature map file", e);
+        File tmpModelDir = java.nio.file.Files.createTempDirectory("xgboost-model-" + _result.toString()).toFile();
+        File fmFile = new File(tmpModelDir, featureMapFileName);
+        os = new FileOutputStream(fmFile);
+        os.write(featureMap.getBytes());
+        os.close();
+        return fmFile;
+      } catch (IOException e) {
+        throw new RuntimeException("Cannot generate feature map file " + featureMapFileName, e);
+      } finally {
+        FileUtils.close(os);
       }
     }
 
@@ -370,12 +379,9 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
               model._output,
               _parms,
               tid,
-              getWorkerEnvs(rt),
-              null).doAll(_train).getBooster());
-          // Wait for succesful completion
+              getWorkerEnvs(rt)).doAll(_train).getBooster());
+          // Wait for successful completion
           waitOnRabitWorkers(rt);
-        } catch (RuntimeException e) {
-          throw e;
         } finally {
           rt.stop();
         }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
@@ -16,6 +16,25 @@ import static water.H2O.technote;
 
 public class XGBoostUtils {
 
+    public static String makeFeatureMap(Frame f, DataInfo di) {
+        // set the names for the (expanded) columns
+        String[] coefnames = di.coefNames();
+        StringBuilder sb = new StringBuilder();
+        assert(coefnames.length == di.fullN());
+        for (int i = 0; i < di.fullN(); ++i) {
+            sb.append(i).append(" ").append(coefnames[i].replaceAll("\\s*","")).append(" ");
+            int catCols = di._catOffsets[di._catOffsets.length-1];
+            if (i < catCols || f.vec(i-catCols).isBinary())
+                sb.append("i");
+            else if (f.vec(i-catCols).isInt())
+                sb.append("int");
+            else
+                sb.append("q");
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
     /**
      * convert an H2O Frame to a sparse DMatrix
      * @param f H2O Frame
@@ -23,7 +42,6 @@ public class XGBoostUtils {
      * @param response name of the response column
      * @param weight name of the weight column
      * @param fold name of the fold assignment column
-     * @param featureMap featureMap[0] will be populated with the column names and types
      * @return DMatrix
      * @throws XGBoostError
      */
@@ -33,7 +51,6 @@ public class XGBoostUtils {
                                          String response,
                                          String weight,
                                          String fold,
-                                         String[] featureMap,
                                          boolean sparse) throws XGBoostError {
 
         int[] chunks;
@@ -59,26 +76,7 @@ public class XGBoostUtils {
 
         int nRows = (int) nRowsL;
 
-        DataInfo di = dataInfoKey.get();
-        // set the names for the (expanded) columns
-        if (featureMap!=null) {
-            String[] coefnames = di.coefNames();
-            StringBuilder sb = new StringBuilder();
-            assert(coefnames.length == di.fullN());
-            for (int i = 0; i < di.fullN(); ++i) {
-                sb.append(i).append(" ").append(coefnames[i].replaceAll("\\s*","")).append(" ");
-                int catCols = di._catOffsets[di._catOffsets.length-1];
-                if (i < catCols || f.vec(i-catCols).isBinary())
-                    sb.append("i");
-                else if (f.vec(i-catCols).isInt())
-                    sb.append("int");
-                else
-                    sb.append("q");
-                sb.append("\n");
-            }
-            featureMap[0] = sb.toString();
-        }
-
+        final DataInfo di = dataInfoKey.get();
         final DMatrix trainMat;
         Vec.Reader w = weight == null ? null : f.vec(weight).new Reader();
         Vec.Reader[] vecs = new Vec.Reader[f.numCols()];

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PersistentDMatrix.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PersistentDMatrix.java
@@ -1,0 +1,59 @@
+package ml.dmlc.xgboost4j.java;
+
+import water.Iced;
+
+/**
+ * Implementation of DMatrix that doesn't automatically dispose of the XGB native data when the object gets finalized
+ */
+public class PersistentDMatrix extends DMatrix {
+
+  private PersistentDMatrix(long handle) {
+    super(handle);
+  }
+
+  public Wrapper wrap() {
+    return new Wrapper(this);
+  }
+
+  @Override
+  protected void finalize() {
+    // Forget the handle but do not destroy the data - memory needs to be explicitly released by calling dispose()
+    handle = 0;
+    super.finalize();
+  }
+
+  /**
+   * Turn a DMatrix into a persisted one
+   * @param matrix matrix to be marked as persisted, this object will not be usable after the persist finishes
+   * @return instance of PersistentDMatrix or null if the input matrix is null
+   */
+  public static PersistentDMatrix persist(DMatrix matrix) {
+    if (matrix == null)
+      return null;
+
+    long handle = matrix.handle;
+    matrix.handle = 0;
+    return new PersistentDMatrix(handle);
+  }
+
+  public static class Wrapper extends Iced<Wrapper> {
+    private long _handle;
+
+    public Wrapper(PersistentDMatrix matrix) {_handle = matrix.handle; }
+
+    public PersistentDMatrix get() {
+      return new PersistentDMatrix(_handle);
+    }
+
+    @Override public boolean equals( Object o ) {
+      return o instanceof Wrapper && ((Wrapper) o)._handle == _handle;
+    }
+    @Override public int hashCode() {
+      return (int)(_handle ^ (_handle >>> 32));
+    }
+    @Override public String toString() {
+      return Long.toString(_handle);
+    }
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostCleanupTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostCleanupTask.java
@@ -1,0 +1,33 @@
+package ml.dmlc.xgboost4j.java;
+
+import water.H2O;
+import water.MRTask;
+import water.util.IcedHashMapGeneric;
+
+/**
+ * Cleans up after XGBoost training (releases any node-local data)
+ */
+public class XGBoostCleanupTask extends MRTask<XGBoostCleanupTask> {
+
+  private IcedHashMapGeneric.IcedHashMapStringObject _nodeToMatrixWrapper;
+
+  public XGBoostCleanupTask(XGBoostSetupTask setupTask) {
+    _nodeToMatrixWrapper = setupTask._nodeToMatrixWrapper;
+  }
+
+  @Override
+  protected void setupLocal() {
+    if (H2O.ARGS.client || _nodeToMatrixWrapper == null) {
+      return;
+    }
+
+    PersistentDMatrix.Wrapper wrapper = (PersistentDMatrix.Wrapper) _nodeToMatrixWrapper.get(H2O.SELF.toString());
+    if (wrapper != null)
+      wrapper.get().dispose();
+  }
+
+  public static void cleanUp(XGBoostSetupTask setupTask) {
+    new XGBoostCleanupTask(setupTask).doAllNodes();
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
@@ -1,0 +1,75 @@
+package ml.dmlc.xgboost4j.java;
+
+import hex.tree.xgboost.XGBoostExtension;
+import hex.tree.xgboost.XGBoostModel;
+import hex.tree.xgboost.XGBoostUtils;
+import water.ExtensionManager;
+import water.H2O;
+import water.MRTask;
+import water.util.IcedHashMapGeneric;
+
+/**
+ * Initializes XGBoost training (converts Frame to set of node-local DMatrices)
+ */
+public class XGBoostSetupTask extends MRTask<XGBoostSetupTask> {
+
+  private final XGBoostModelInfo _sharedModel;
+  private final XGBoostModel.XGBoostParameters _parms;
+  private boolean _sparse;
+
+  // OUT
+  IcedHashMapGeneric.IcedHashMapStringObject _nodeToMatrixWrapper;
+
+  public XGBoostSetupTask(XGBoostModelInfo inputModel, XGBoostModel.XGBoostParameters parms, boolean sparse) {
+    _sharedModel = inputModel;
+    _parms = parms;
+    _sparse = sparse;
+  }
+
+  @Override
+  protected void setupLocal() {
+    if (H2O.ARGS.client) {
+      return;
+    }
+
+    // We need to verify that the xgboost is available on the remote node
+    if (!ExtensionManager.getInstance().isCoreExtensionEnabled(XGBoostExtension.NAME)) {
+      throw new IllegalStateException("XGBoost is not available on the node " + H2O.SELF);
+    }
+
+    final PersistentDMatrix matrix;
+    try {
+      matrix = makeLocalMatrix();
+    } catch (XGBoostError xgBoostError) {
+      throw new IllegalStateException("Failed XGBoost training.", xgBoostError);
+    }
+
+    if (matrix == null)
+      return;
+
+    _nodeToMatrixWrapper = new IcedHashMapGeneric.IcedHashMapStringObject();
+    _nodeToMatrixWrapper.put(H2O.SELF.toString(), matrix.wrap());
+  }
+
+  private PersistentDMatrix makeLocalMatrix() throws XGBoostError {
+      return PersistentDMatrix.persist(XGBoostUtils.convertFrameToDMatrix(
+              _sharedModel._dataInfoKey,
+              _fr,
+              true,
+              _parms._response_column,
+              _parms._weights_column,
+              _parms._fold_column,
+              _sparse));
+  }
+
+  @Override
+  public void reduce(XGBoostSetupTask mrt) {
+    if (mrt._nodeToMatrixWrapper == null)
+      return;
+    if (_nodeToMatrixWrapper == null)
+      _nodeToMatrixWrapper = mrt._nodeToMatrixWrapper;
+    else
+      _nodeToMatrixWrapper.putAll(mrt._nodeToMatrixWrapper);
+  }
+
+}


### PR DESCRIPTION
This PR makes sure the training input to XGBoost is created just once instead of in each iteration.

We only fix the training in this PR, scoring issue is not addressed.

Speed-up recorded on the dataset from HEXDEV-714

Before:
```Model    xgboost-c197fbfd-9573-4b36-8ab5-9a168952d311    XGBoost    2018-04-06 20:36:52    2018-04-06 20:51:36    00:14:44.672    DONE```
After:
    ```Model    xgboost-c197fbfd-9573-4b36-8ab5-9a168952d311    XGBoost    2018-04-09 18:14:25    2018-04-09 18:16:08    00:01:43.449    DONE```