### PR TITLE
[PUBDEV-5464] Fix issues preventing loading of h2o maven artifacts in DBC

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,27 +7,10 @@ codename=bleeding_edge
 doFindbugs=false
 # Run animal sniffer to verify compatibility of API with actual Java version
 doAnimalSniffer=false
-#
-# Version of Apache Parquet dependency (should be kept in sync with the version used in current Spark releases)
-#
-defaultParquetVersion=1.8.1
+
 # The flag to include ORC support inside default h2o.jar.
-# WARNING: this will upgrade default Hadoop client version to one supporting ORC
 doIncludeOrc=false
 
-#
-# Jetty Version
-jettyVersion=9.2.24.v20180105
-
-#
-# Version of hadoop dependency which is used for jUnit test execution
-#
-orcDefaultHadoopClientVersion=2.6.0-cdh5.4.0
-orcDefaultHiveExecVersion=1.1.0-cdh5.4.0
-#
-# Default hadoop client version
-#
-defaultHadoopClientVersion=2.7.3
 #
 # Gradle arguments
 #
@@ -47,3 +30,21 @@ doUploadUBenchResults=false
 # Internal Nexus location
 #
 localNexusLocation=http://nexus:8081/nexus/repository
+
+##
+# Version of libraries used inside H2O
+##
+
+# Version of Apache Parquet dependency (should be kept in sync with the version used in current Spark releases)
+defaultParquetVersion=1.8.1
+
+# Jetty Version
+jettyVersion=9.2.24.v20180105
+
+# Default Hadoop client version
+defaultHadoopClientVersion=2.7.3
+
+# Default Hive version
+defaultHiveExecVersion=1.1.0
+
+

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -12,9 +12,29 @@ dependencies {
 
   // Jama dependencies
   compile "gov.nist.math:jama:1.0.3"
+
   // netlib-java / MTJ dependencies
-  compile 'com.github.fommil.netlib:all:1.1.2'
-  compile('com.googlecode.matrix-toolkits-java:mtj:1.0.4') { exclude group: 'com.github.fommil.netlib' }
+
+  // Manually define all dependencies in com.github.fommil.netlib:all:1.1.2 to make Databricks maven resolver happy
+  compile('com.github.fommil.netlib:core:1.1.2')
+  compile('net.sourceforge.f2j:arpack_combined_all:0.1')
+  compile('com.github.fommil.netlib:netlib-native_ref-osx-x86_64:1.1')
+  compile('com.github.fommil.netlib:netlib-native_ref-linux-x86_64:1.1')
+  compile('com.github.fommil.netlib:netlib-native_ref-linux-i686:1.1')
+  compile('com.github.fommil.netlib:netlib-native_ref-win-x86_64:1.1')
+  compile('com.github.fommil.netlib:netlib-native_ref-win-i686:1.1')
+  compile('com.github.fommil.netlib:netlib-native_ref-linux-armhf:1.1')
+  compile('com.github.fommil.netlib:netlib-native_system-osx-x86_64:1.1')
+  compile('com.github.fommil.netlib:netlib-native_system-linux-x86_64:1.1')
+  compile('com.github.fommil.netlib:netlib-native_system-linux-i686:1.1')
+  compile('com.github.fommil.netlib:netlib-native_system-linux-armhf:1.1')
+  compile('com.github.fommil.netlib:netlib-native_system-win-x86_64:1.1')
+  compile('com.github.fommil.netlib:netlib-native_system-win-i686:1.1')
+
+  compile('com.googlecode.matrix-toolkits-java:mtj:1.0.4'){
+    exclude group: 'com.github.fommil.netlib', module: 'all'
+  }
+
 
   // Test dependencies only
   testCompile "junit:junit:${junitVersion}"

--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -36,7 +36,12 @@ dependencies {
   compile 'commons-lang:commons-lang:2.6'
   
   // Duke library: collection of String comparators
-  compile ('no.priv.garshol.duke:duke:1.2') { transitive = false }
+  compile ('no.priv.garshol.duke:duke:1.2'){
+    exclude group: 'org.apache.lucene', module: 'lucene-core'
+    exclude group: 'org.apache.lucene', module: 'lucene-analyzers-common'
+    exclude group: 'org.apache.lucene', module: 'lucene-spatial'
+    exclude group: 'org.mapdb', module: 'mapdb'
+  }
 
   // Jets3t is required by S3N support
   // compile 'net.java.dev.jets3t:jets3t:0.6.1'

--- a/h2o-parsers/h2o-orc-parser/build.gradle
+++ b/h2o-parsers/h2o-orc-parser/build.gradle
@@ -3,28 +3,56 @@
 //
 description = "H2O Orc Parser"
 
+configurations{
+    // Configuration used to get all transitive dependencies for org.apache.hadoop:hadoop-common
+    // We do this to avoid manually excluding the libraries
+    hadoopCommonExclude
+    // The same for hive exec
+    hiveExecExclude
+}
+
 dependencies {
+  hadoopCommonExclude("org.apache.hadoop:hadoop-common:${defaultHadoopClientVersion}")
+  hiveExecExclude("org.apache.hive:hive-exec:$defaultHiveExecVersion"){
+      // this dependency need to be excluded manually as Gradle can't find it in maven central
+      exclude group: 'org.pentaho', module: 'pentaho-aggdesigner-algorithm'
+      exclude group: 'eigenbase', module: 'eigenbase-properties'
+  }
   compile project(":h2o-core")
   // Only PersistHDFS API
   compile(project(":h2o-persist-hdfs")) {
-    transitive = false
+      exclude group: 'ai.h2o', module: 'h2o-core'
+      exclude group: 'net.java.dev.jets3t', module: 'jets3t'
+      exclude group: 'org.apache.hadoop', module: 'hadoop-client'
+      exclude group: 'org.apache.hadoop', module: 'hadoop-aws'
   }
 
   // Note: What is connection between hive-exec version and hadoop-version and orc version?
-  // Note: In this case we are using hive version which is compatible with $orcDefaultHadoopClientVersion
+  // Note: In this case we are using hive version which is compatible with $defaultHadoopClientVersion
   // Note: for newest version it should be replaces by hive-orc
-  compile("org.apache.hive:hive-exec:$orcDefaultHiveExecVersion") {
-    transitive = false
+  compile("org.apache.hive:hive-exec:$defaultHiveExecVersion") {
+      // we can't use transitive=false so we need to exclude the dependencies manually
+      configurations.hiveExecExclude.getResolvedConfiguration().getResolvedArtifacts().forEach {
+          if (it.moduleVersion.id.group != "org.apache.hive" && it.moduleVersion.id.module.name != "hive-exec") {
+              exclude group: it.moduleVersion.id.group, module: it.moduleVersion.id.module.name
+          }
+      }
+      exclude group: 'org.pentaho', module: 'pentaho-aggdesigner-algorithm'
   }
   // For compilation we need common
-  compile("org.apache.hadoop:hadoop-common:$orcDefaultHadoopClientVersion") {
-    transitive = false
+  compile("org.apache.hadoop:hadoop-common:$defaultHadoopClientVersion") {
+      // we can't use transitive=false so we need to exclude the dependencies manually
+      configurations.hadoopCommonExclude.getResolvedConfiguration().getResolvedArtifacts().forEach {
+          if (it.moduleVersion.id.group != "org.apache.hadoop" && it.moduleVersion.id.module.name != "hadoop-common") {
+              exclude group: it.moduleVersion.id.group, module: it.moduleVersion.id.module.name
+          }
+      }
   }
 
   testCompile "junit:junit:${junitVersion}"
   testCompile project(path: ":h2o-core", configuration: "testArchives")
   // We need correct version of MapRe Hadoop to run JUnits
-  testRuntime("org.apache.hadoop:hadoop-client:$orcDefaultHadoopClientVersion") {
+  testRuntime("org.apache.hadoop:hadoop-client:$defaultHadoopClientVersion") {
       exclude module: "jasper-runtime"
       exclude module: "jasper-compiler"
       exclude module: "curator-client"

--- a/h2o-parsers/h2o-parquet-parser/build.gradle
+++ b/h2o-parsers/h2o-parquet-parser/build.gradle
@@ -6,15 +6,33 @@ description = "H2O Parquet Parser"
 def parquetHadoopVersion = binding.variables.get("hadoopVersion") ?
   binding.variables.get("hadoopVersion") : defaultHadoopClientVersion
 
+configurations{
+    // Configuration used to get all transitive dependencies for org.apache.hadoop:hadoop-common
+    hadoopCommonExclude
+}
+
 dependencies {
+  hadoopCommonExclude("org.apache.hadoop:hadoop-common:${parquetHadoopVersion}")
+
   compile project(":h2o-core")
   compile(project(":h2o-persist-hdfs")) {
-    transitive = false
+    exclude group: 'ai.h2o', module: 'h2o-core'
+    exclude group: 'net.java.dev.jets3t', module: 'jets3t'
+    exclude group: 'org.apache.hadoop', module: 'hadoop-client'
+    exclude group: 'org.apache.hadoop', module: 'hadoop-aws'
   }
+
   // Parquet support
   compile("org.apache.parquet:parquet-hadoop:${defaultParquetVersion}")
+
+
   compile("org.apache.hadoop:hadoop-common:${parquetHadoopVersion}") {
-    transitive = false
+    // we can't use transitive=false so we need to exclude the dependencies manually
+    configurations.hadoopCommonExclude.getResolvedConfiguration().getResolvedArtifacts().forEach {
+      if (it.moduleVersion.id.group != "org.apache.hadoop" && it.moduleVersion.id.module.name != "hadoop-common") {
+        exclude group: it.moduleVersion.id.group, module: it.moduleVersion.id.module.name
+      }
+    }
   }
 
   testCompile "junit:junit:${junitVersion}"

--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -9,13 +9,11 @@ configurations {
 dependencies {
     compile project(":h2o-core")
     compile('net.java.dev.jets3t:jets3t:0.9.0')
-    def hadoopVersion = project.hasProperty("doIncludeOrc") && project.doIncludeOrc == "true" ?
-                        orcDefaultHadoopClientVersion : defaultHadoopClientVersion
-    compile("org.apache.hadoop:hadoop-client:$hadoopVersion") {
+    compile("org.apache.hadoop:hadoop-client:$defaultHadoopClientVersion") {
         // Pull all dependencies to allow run directly from IDE or command line
         transitive = true
     }
-    compile("org.apache.hadoop:hadoop-aws:$hadoopVersion")
+    compile("org.apache.hadoop:hadoop-aws:$defaultHadoopClientVersion")
     testCompile "junit:junit:${junitVersion}"
     testCompile project(path: ":h2o-core", configuration: "testArchives")
 }


### PR DESCRIPTION
See https://0xdata.atlassian.net/browse/PUBDEV-5464

With this fix, all published H2O artifacts can be loaded via their maven coordinates in Databrics cloud which will also unblock deployment of SW in DBC using maven