### PR TITLE
PUBDEV-4991 Add MOJO/POJO support for AutoML

### DIFF
--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -5,6 +5,7 @@ from h2o.exceptions import H2OValueError
 from h2o.job import H2OJob
 from h2o.frame import H2OFrame
 from h2o.utils.typechecks import assert_is_type, is_type
+from h2o.model.model_base import ModelBase
 
 class H2OAutoML(object):
     """
@@ -349,12 +350,6 @@ class H2OAutoML(object):
         :param genmodel_name Custom name of genmodel jar
         :returns: name of the POJO file written.
         """
-        assert_is_type(path, str)
-        assert_is_type(get_genmodel_jar, bool)
-        path = path.rstrip("/")
-
-        if not self.leader.have_pojo:
-            raise H2OValueError("Export to POJO for " + str(self.leader.algo) + " is not supported")
 
         return h2o.download_pojo(self.leader, path, get_jar=get_genmodel_jar, jar_name=genmodel_name)
 
@@ -367,18 +362,8 @@ class H2OAutoML(object):
         :param genmodel_name Custom name of genmodel jar
         :returns: name of the MOJO file written.
         """
-        assert_is_type(path, str)
-        assert_is_type(get_genmodel_jar, bool)
 
-        if not self.leader.have_mojo:
-            raise H2OValueError("Export to MOJO for " + str(self.leader.algo) + " is not supported")
-
-        if get_genmodel_jar:
-            if genmodel_name == "":
-                h2o.api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, "h2o-genmodel.jar"))
-            else:
-                h2o.api("GET /3/h2o-genmodel.jar", save_to=os.path.join(path, genmodel_name))
-        return h2o.api("GET /3/Models/%s/mojo" % self.leader.model_id, save_to=path)
+        return ModelBase.download_mojo(self.leader, path, get_genmodel_jar, genmodel_name)
 
     #-------------------------------------------------------------------------------------------------------------------
     # Private

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_mojo.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_mojo.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+import os
+import sys
+sys.path.insert(1, os.path.join("..","..",".."))
+import tempfile
+import time
+import h2o
+from tests import pyunit_utils
+from h2o.automl import H2OAutoML
+
+def automl_mojo():
+    fr1 = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    fr1["CAPSULE"] = fr1["CAPSULE"].asfactor()
+    aml = H2OAutoML(max_models=2, project_name="py_lb_test_aml1", seed=1234)
+    aml.train(y="CAPSULE", training_frame=fr1)
+
+    # download mojo
+    model_zip_path = os.path.join(tempfile.mkdtemp(), 'model.zip')
+    time0 = time.time()
+    print("\nDownloading MOJO @... " + model_zip_path)
+    mojo_file  = aml.download_mojo(model_zip_path)
+    print("    => %s  (%d bytes)" % (mojo_file, os.stat(mojo_file).st_size))
+    assert os.path.exists(mojo_file)
+    print("    Time taken = %.3fs" % (time.time() - time0))
+    assert os.path.isfile(model_zip_path)
+    os.remove(model_zip_path)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(automl_mojo)
+else:
+    automl_mojo()

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_pojo.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_pojo.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+import sys
+import os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+import time
+import tempfile
+from tests import pyunit_utils
+from h2o.automl import H2OAutoML
+
+def automl_pojo():
+    fr1 = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    fr1["CAPSULE"] = fr1["CAPSULE"].asfactor()
+    aml = H2OAutoML(max_models=2, project_name="py_lb_test_aml1", seed=1234)
+    aml.train(y="CAPSULE", training_frame=fr1)
+
+    # download pojo
+    if aml.leader.algo != "stackedensemble":
+        model_zip_path = os.path.join(tempfile.mkdtemp(), 'model.zip')
+        time0 = time.time()
+        print("\nDownloading POJO @... " + model_zip_path)
+        pojo_file  = aml.download_pojo(model_zip_path)
+        print("    => %s  (%d bytes)" % (pojo_file, os.stat(pojo_file).st_size))
+        assert os.path.exists(pojo_file)
+        print("    Time taken = %.3fs" % (time.time() - time0))
+        assert os.path.isfile(model_zip_path)
+        os.remove(model_zip_path)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(automl_pojo)
+else:
+    automl_pojo()

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -242,7 +242,11 @@ h2o.getModel <- function(model_id) {
 #' }
 #' @export
 h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE, jar_name="") {
-
+  
+  if (class(model) == "H2OAutoML") {
+    model <- model@leader
+  }
+  
   if (!(model@have_pojo)){
     stop(paste0(model@algrithm, ' does not support export to POJO'))
   }
@@ -315,7 +319,11 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE, jar_n
 #' }
 #' @export
 h2o.download_mojo <- function(model, path=getwd(), get_genmodel_jar=FALSE, genmodel_name="", genmodel_path="") {
-
+  
+  if (class(model) == "H2OAutoML") {
+    model <- model@leader
+  }
+  
   if (!(model@have_mojo)){
     stop(paste0(model@algorithm, ' does not support export to MOJO'))
   }

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -307,6 +307,8 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE, jar_n
 #' @param get_genmodel_jar If TRUE, then also download h2o-genmodel.jar and store it in either in the same folder
 #         as the MOJO or in ``genmodel_path`` if specified.
 #' @param genmodel_name Custom name of genmodel jar.
+#' @param genmodel_path Path to store h2o-genmodel.jar. If left blank and ``get_genmodel_jar`` is TRUE, then the h2o-genmodel.jar
+#         is saved to ``path``.
 #' @return Name of the MOJO file written to the path.
 #'
 #' @examples

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_mojo.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_mojo.R
@@ -1,0 +1,31 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.mojo <- function() {
+    #Set up path as dir.create() just sets up the directory and returns a logical based on if if failed or not
+    path <- file.path(sandbox(),"mojos")
+
+    #Set up tmp directory to write MOJO
+    dir <- dir.create(path)
+
+    #Build AutoML
+    iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
+    hh <- h2o.automl(x=c(1,2,3,4),y=5,training_frame=iris.hex, max_models=3)
+
+    #Download MOJO
+    print(sprintf("Dowloading MOJO..."))
+    start_time <- proc.time()[[3]]
+    mojo_file <- h2o.download_mojo(hh,path=path) #check mojo
+    end_time <- proc.time()[[3]]
+    cat(sprintf("MOJO file is %.2f bytes", object.size(mojo_file)),"\n")
+    #Just a check for MOJO size (PUBDEV 3819)
+    expect_that(object.size(mojo_file), is_more_than(1))
+    cat(sprintf("Time taken to dowloand MOJO: %.2f",end_time - start_time))
+
+    #Download genmodel
+    h2o.download_mojo(hh,path=path,get_genmodel_jar=TRUE) #Check genmodel.jar
+
+    #Delete tmp directory
+    on.exit(unlink(path,recursive=TRUE))
+}
+doTest("Test AutoML MOJO", test.mojo)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_pojo.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_pojo.R
@@ -1,0 +1,31 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.pojo <- function() {
+    #Set up path as dir.create() just sets up the directory and returns a logical based on if if failed or not
+    path <- file.path(sandbox(),"pojos")
+
+    #Set up tmp directory to write POJO
+    dir <- dir.create(path)
+
+    #Build AutoML
+    iris.hex <- h2o.uploadFile(locate("smalldata/iris/iris.csv"), "iris.hex")
+    hh <- h2o.automl(x=c(1,2,3,4),y=5,training_frame=iris.hex, max_models=3)
+
+    #Download POJO
+    if (hh@leader@algorithm != "stackedensemble") {
+        print(sprintf("Dowloading POJO..."))
+        start_time <- proc.time()[[3]]
+        pojo_file <- h2o.download_pojo(hh,path=path) #check pojo
+        end_time <- proc.time()[[3]]
+        cat(sprintf("POJO file is %.2f bytes", object.size(pojo_file)),"\n")
+        cat(sprintf("Time taken to dowloand POJO: %.2f",end_time - start_time))
+
+        #Download genmodel
+        h2o.download_pojo(hh,path=path,get_jar=TRUE) #Check genmodel.jar
+    }
+
+    #Delete tmp directory
+    on.exit(unlink(path,recursive=TRUE))
+}
+doTest("Test AutoML POJO", test.pojo)


### PR DESCRIPTION
* Added ability to download MOJO/POJO for leader model in AutoML directly.
* POJO download will not work for Stacked Ensembles as that is not supported.
* Also fixed R note about undocumented parameter, `genmodel_path` , in `h2o.download_mojo()`