### PR TITLE
PUBDEV-4939 Add the Option to Save CV Predictions and CV Models in AutoML

### DIFF
--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -425,5 +425,27 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     return new StackedEnsembleMojoWriter(this);
   }
 
+  @Override
+  public void deleteCrossValidationModels() {
+    if (_output._metalearner._output._cross_validation_models != null) {
+      for (Key k : _output._metalearner._output._cross_validation_models) {
+        Model m = DKV.getGet(k);
+        if (m!=null) m.delete(); //delete all subparts
+      }
+    }
+  }
+
+  @Override
+  public void deleteCrossValidationPreds() {
+    if (_output._metalearner._output._cross_validation_predictions != null) {
+      for (Key k : _output._metalearner._output._cross_validation_predictions) {
+        k.remove();
+      }
+    }
+    if (_output._metalearner._output._cross_validation_holdout_predictions_frame_id != null) {
+      _output._metalearner._output._cross_validation_holdout_predictions_frame_id.remove();
+    }
+  }
+
 }
 

--- a/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/StackedEnsembleModel.java
@@ -439,7 +439,8 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
   public void deleteCrossValidationPreds() {
     if (_output._metalearner._output._cross_validation_predictions != null) {
       for (Key k : _output._metalearner._output._cross_validation_predictions) {
-        k.remove();
+        Frame f = DKV.getGet(k);
+        if (f!=null) f.delete();
       }
     }
     if (_output._metalearner._output._cross_validation_holdout_predictions_frame_id != null) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1200,10 +1200,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
         Job<StackedEnsembleModel> ensembleJob = stack("StackedEnsemble_AllModels", notEnsembles);
         if (!buildSpec.build_control.keep_cross_validation_predictions) {
-          cleanUpStackedEnsemblesCVPreds(ensembleJob);
+          cleanUpModelsCVPreds();
         }
         if (!buildSpec.build_control.keep_cross_validation_models) {
-          cleanUpStackedEnsemblesCVModels(ensembleJob);
+          cleanUpModelsCVModels();
         }
         pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using all AutoML models", 50, this.job(), ensembleJob, JobType.ModelBuild);
 
@@ -1225,10 +1225,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
         Job<StackedEnsembleModel> bestEnsembleJob = stack("StackedEnsemble_BestOfFamily", bestModelKeys);
         if (!buildSpec.build_control.keep_cross_validation_predictions) {
-          cleanUpStackedEnsemblesCVPreds(bestEnsembleJob);
+          cleanUpModelsCVPreds();
         }
         if (!buildSpec.build_control.keep_cross_validation_models) {
-          cleanUpStackedEnsemblesCVModels(bestEnsembleJob);
+          cleanUpModelsCVModels();
         }
         pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using top model from each algorithm type", 50, this.job(), bestEnsembleJob, JobType.ModelBuild);
       }
@@ -1519,24 +1519,12 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private String getModelType(Model m) {
     return m._key.toString().startsWith("XRT_") ? "XRT" : m._parms.algoName();
   }
-  
-  private void cleanUpStackedEnsemblesCVPreds(Job<StackedEnsembleModel> ensembleJob) {
-    Log.info("Remove CV Preds & Models from " + ensembleJob.get()._key.toString() + "'s metalearner");
-    //Clear out all CV preds and CV models
-    ensembleJob.get()._output._metalearner.deleteCrossValidationPreds();
-  }
-
-  private void cleanUpStackedEnsemblesCVModels(Job<StackedEnsembleModel> ensembleJob) {
-    Log.info("Remove CV Models for " + ensembleJob.get()._output._metalearner._key.toString());
-    ensembleJob.get()._output._metalearner.deleteCrossValidationModels();
-  }
 
   private void cleanUpModelsCVPreds() {
     //Clear out all CV preds and CV models
     for (Model model : leaderboard().getModels()) {
-      if (!model._parms.algoName().equals("stackedensemble")) {
+        Log.info("Remove CV Preds for " + model._key.toString());
         model.deleteCrossValidationPreds();
-      }
     }
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1219,12 +1219,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
           bestModelKeys[i] = bestModelsOfEachType.get(i)._key;
 
         Job<StackedEnsembleModel> bestEnsembleJob = stack("StackedEnsemble_BestOfFamily", bestModelKeys);
-        if (!buildSpec.build_control.keep_cross_validation_predictions) {
-          cleanUpModelsCVPreds();
-        }
-        if (!buildSpec.build_control.keep_cross_validation_models) {
-          cleanUpModelsCVModels();
-        }
+
         pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using top model from each algorithm type", 50, this.job(), bestEnsembleJob, JobType.ModelBuild);
       }
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1523,16 +1523,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private void cleanUpStackedEnsemblesCVPreds(Job<StackedEnsembleModel> ensembleJob) {
     Log.info("Remove CV Preds & Models from " + ensembleJob.get()._key.toString() + "'s metalearner");
     //Clear out all CV preds and CV models
-    if (ensembleJob.get()._output._metalearner._output._cross_validation_predictions != null) {
-      for (Key k : ensembleJob.get()._output._metalearner._output._cross_validation_predictions) {
-        Log.info("Remove CV Predictions for " + ensembleJob.get()._output._metalearner._key.toString());
-        k.remove();
-      }
-    }
-    if (ensembleJob.get()._output._metalearner._output._cross_validation_holdout_predictions_frame_id != null) {
-      Log.info("Remove CV Prediction Frame for " + ensembleJob.get()._output._metalearner._key.toString());
-      ensembleJob.get()._output._metalearner._output._cross_validation_holdout_predictions_frame_id.remove();
-    }
+    ensembleJob.get()._output._metalearner.deleteCrossValidationPreds();
   }
 
   private void cleanUpStackedEnsemblesCVModels(Job<StackedEnsembleModel> ensembleJob) {
@@ -1544,16 +1535,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     //Clear out all CV preds and CV models
     for (Model model : leaderboard().getModels()) {
       if (!model._parms.algoName().equals("stackedensemble")) {
-        if (model._output._cross_validation_predictions != null) {
-          for (Key k : model._output._cross_validation_predictions) {
-            Log.info("Remove CV Predictions for " + model._key.toString());
-            k.remove();
-          }
-        }
-        if (model._output._cross_validation_holdout_predictions_frame_id != null) {
-          Log.info("Remove CV Prediction Frame for " + model._key.toString());
-          model._output._cross_validation_holdout_predictions_frame_id.remove();
-        }
+        model.deleteCrossValidationPreds();
       }
     }
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1199,12 +1199,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
             notEnsembles[notEnsembleIndex++] = aModel._key;
 
         Job<StackedEnsembleModel> ensembleJob = stack("StackedEnsemble_AllModels", notEnsembles);
-        if (!buildSpec.build_control.keep_cross_validation_predictions) {
-          cleanUpModelsCVPreds();
-        }
-        if (!buildSpec.build_control.keep_cross_validation_models) {
-          cleanUpModelsCVModels();
-        }
+
         pollAndUpdateProgress(Stage.ModelTraining, "StackedEnsemble build using all AutoML models", 50, this.job(), ensembleJob, JobType.ModelBuild);
 
         // Set aside List<Model> for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -53,6 +53,8 @@ public class AutoMLBuildSpec extends Iced {
     // Cross-validation fold construction
     public int nfolds = 5; 
     //public Model.Parameters.FoldAssignmentScheme fold_assignment;
+    public boolean keep_cross_validation_predictions = true;
+    public boolean keep_cross_validation_models = true;
   }
 
   /**

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -37,10 +37,10 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help="Number of folds for k-fold cross-validation (defaults to 5, must be >=2 or use 0 to disable). Disabling prevents Stacked Ensembles from being built.", direction=API.Direction.INPUT)
     public int nfolds;
 
-    @API(help="Keep CV predictions", direction=API.Direction.INPUT)
+    @API(help="Whether to keep the predictions of the cross-validation predictions. If set to false then running the same AutoML object for repeated runs will cause an exception as CV predictions are required to build additional Stacked Ensemble models in AutoML.", direction=API.Direction.INPUT)
     public boolean keep_cross_validation_predictions;
 
-    @API(help="Keep CV models", direction=API.Direction.INPUT)
+    @API(help="Whether to keep the cross-validated models. Deleting cross-validation models will save memory in the H2O cluster.", direction=API.Direction.INPUT)
     public boolean keep_cross_validation_models;
 
   } // class AutoMLBuildControlV99

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -36,6 +36,13 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
 
     @API(help="Number of folds for k-fold cross-validation (defaults to 5, must be >=2 or use 0 to disable). Disabling prevents Stacked Ensembles from being built.", direction=API.Direction.INPUT)
     public int nfolds;
+
+    @API(help="Keep CV predictions", direction=API.Direction.INPUT)
+    public boolean keep_cross_validation_predictions;
+
+    @API(help="Keep CV models", direction=API.Direction.INPUT)
+    public boolean keep_cross_validation_models;
+
   } // class AutoMLBuildControlV99
 
   /**

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2199,12 +2199,23 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     }
   }
 
-  public void deleteCrossValidationModels( ) {
+  public void deleteCrossValidationModels() {
     if (_output._cross_validation_models != null) {
       for (Key k : _output._cross_validation_models) {
         Model m = DKV.getGet(k);
         if (m!=null) m.delete(); //delete all subparts
       }
+    }
+  }
+
+  public void deleteCrossValidationPreds() {
+    if (_output._cross_validation_predictions != null) {
+      for (Key k : _output._cross_validation_predictions) {
+        k.remove();
+      }
+    }
+    if (_output._cross_validation_holdout_predictions_frame_id != null) {
+      _output._cross_validation_holdout_predictions_frame_id.remove();
     }
   }
 

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2211,7 +2211,8 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
   public void deleteCrossValidationPreds() {
     if (_output._cross_validation_predictions != null) {
       for (Key k : _output._cross_validation_predictions) {
-        k.remove();
+        Frame f = DKV.getGet(k);
+        if (f!=null) f.delete();
       }
     }
     if (_output._cross_validation_holdout_predictions_frame_id != null) {

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -43,8 +43,8 @@ class H2OAutoML(object):
       An example use is exclude_algos = ["GLM", "DeepLearning", "DRF"], and the full list of options is: "GLM", "GBM", "DRF" 
       (Random Forest and Extremely-Randomized Trees), "DeepLearning" and "StackedEnsemble". Defaults to None, which means that 
       all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
-    :param keep_cross_validation_predictions: Whether to keep the predictions of the cross-validation predictions. If set to ``False`` then running the same AutoML object for repeated runs will cause an exception as CV predictions are are required to build additional Stacked Ensemble models in AutoML. Defaults to ``True``.
-    :param keep_cross_validation_models: Whether to keep the cross-validated models. Defaults to ``True``.
+    :param keep_cross_validation_predictions: Whether to keep the predictions of the cross-validation predictions. If set to ``False`` then running the same AutoML object for repeated runs will cause an exception as CV predictions are required to build additional Stacked Ensemble models in AutoML. Defaults to ``True``.
+    :param keep_cross_validation_models: Whether to keep the cross-validated models. Deleting cross-validation models will save memory in the H2O cluster. Defaults to ``True``.
 
     :examples:
     >>> import h2o

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -43,6 +43,8 @@ class H2OAutoML(object):
       An example use is exclude_algos = ["GLM", "DeepLearning", "DRF"], and the full list of options is: "GLM", "GBM", "DRF" 
       (Random Forest and Extremely-Randomized Trees), "DeepLearning" and "StackedEnsemble". Defaults to None, which means that 
       all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
+    :param keep_cross_validation_predictions: Whether to keep the predictions of the cross-validation predictions. If set to ``False`` then running the same AutoML object for repeated runs will cause an exception as CV predictions are are required to build additional Stacked Ensemble models in AutoML. Defaults to ``True``.
+    :param keep_cross_validation_models: Whether to keep the cross-validated models. Defaults to ``True``.
 
     :examples:
     >>> import h2o
@@ -76,7 +78,9 @@ class H2OAutoML(object):
                  stopping_rounds=3,
                  seed=None,
                  project_name=None,
-                 exclude_algos=None):
+                 exclude_algos=None,
+                 keep_cross_validation_predictions = True,
+                 keep_cross_validation_models = True):
 
         # Check if H2O jar contains AutoML
         try:
@@ -107,7 +111,7 @@ class H2OAutoML(object):
             assert_is_type(nfolds,int)
         assert nfolds >= 0, "nfolds set to " + str(nfolds) + "; nfolds cannot be negative. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."
         assert nfolds is not 1, "nfolds set to " + str(nfolds) + "; nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable."           
-        self.build_control["nfolds"] = nfolds 
+        self.build_control["nfolds"] = nfolds
         self.nfolds = nfolds   
 
         # If max_runtime_secs is not provided, then it is set to default (3600 secs)
@@ -154,6 +158,12 @@ class H2OAutoML(object):
             for elem in exclude_algos:
                 assert_is_type(elem,str)
             self.build_models['exclude_algos'] = exclude_algos
+
+        assert_is_type(keep_cross_validation_predictions, bool)
+        self.build_control["keep_cross_validation_predictions"] = keep_cross_validation_predictions
+
+        assert_is_type(keep_cross_validation_models, bool)
+        self.build_control["keep_cross_validation_models"] = keep_cross_validation_models
 
         self._job = None
         self._automl_key = None
@@ -221,7 +231,7 @@ class H2OAutoML(object):
             (unless max_models or max_runtime_secs overrides metric-based early stopping).
         :param leaderboard_frame: H2OFrame with test data for scoring the leaderboard.  This is optional and
             if this is set to None (the default), then cross-validation metrics will be used to generate the leaderboard 
-            rankings instead.  
+            rankings instead.
 
         :returns: An H2OAutoML object.
 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -33,6 +33,8 @@
 #' @param exclude_algos Vector of character strings naming the algorithms to skip during the model-building phase.  An example use is exclude_algos = c("GLM", "DeepLearning", "DRF"), 
 #'        and the full list of options is: "GLM", "GBM", "DRF" (Random Forest and Extremely-Randomized Trees), "DeepLearning" and "StackedEnsemble". Defaults to NULL, which means that 
 #'        all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation predictions. If set to FALSE then running the same AutoML object for repeated runs will cause an exception as CV predictions are are required to build additional Stacked Ensemble models in AutoML. Defaults to TRUE.
+#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the cross-validated models. Defaults to TRUE.
 #' @details AutoML finds the best model, given a training frame and response, and returns an H2OAutoML object,
 #'          which contains a leaderboard of all the models that were trained in the process, ranked by a default model performance metric.  
 #' @return An \linkS4class{H2OAutoML} object.
@@ -58,7 +60,9 @@ h2o.automl <- function(x, y, training_frame,
                        stopping_rounds = 3,
                        seed = NULL,
                        project_name = NULL,
-                       exclude_algos = NULL)
+                       exclude_algos = NULL,
+                       keep_cross_validation_predictions = TRUE,
+                       keep_cross_validation_models = TRUE)
 {
 
   tryCatch({
@@ -182,7 +186,9 @@ h2o.automl <- function(x, y, training_frame,
     stop("nfolds = 1 is an invalid value. Use nfolds >=2 if you want cross-valiated metrics and Stacked Ensembles or use nfolds = 0 to disable.")
   }
   build_control$nfolds <- nfolds
-  
+  build_control$keep_cross_validation_predictions <- keep_cross_validation_predictions
+  build_control$keep_cross_validation_models <- keep_cross_validation_models
+
   # Create the parameter list to POST to the AutoMLBuilder 
   if (length(build_models) == 0) {
       params <- list(input_spec = input_spec, build_control = build_control)

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -34,7 +34,7 @@
 #'        and the full list of options is: "GLM", "GBM", "DRF" (Random Forest and Extremely-Randomized Trees), "DeepLearning" and "StackedEnsemble". Defaults to NULL, which means that 
 #'        all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
 #' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation predictions. If set to FALSE then running the same AutoML object for repeated runs will cause an exception as CV predictions are are required to build additional Stacked Ensemble models in AutoML. Defaults to TRUE.
-#' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the cross-validated models. Defaults to TRUE.
+#' @param keep_cross_validation_models \code{Logical}. Whether to keep the cross-validated models. Deleting cross-validation models will save memory in the H2O cluster. Defaults to TRUE.
 #' @details AutoML finds the best model, given a training frame and response, and returns an H2OAutoML object,
 #'          which contains a leaderboard of all the models that were trained in the process, ranked by a default model performance metric.  
 #' @return An \linkS4class{H2OAutoML} object.

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -177,6 +177,23 @@ automl.args.test <- function() {
   model_ids <- as.character(as.data.frame(aml14@leaderboard[,"model_id"])[,1])
   expect_equal(sum(grepl("StackedEnsemble", model_ids)), 2)
 
+  print("Check that cv preds/models are deleted")
+  nfolds <- 3
+  aml15 <- h2o.automl(x = x, y = y,
+  training_frame = train,
+  nfolds = nfolds,
+  max_models = max_models,
+  project_name = "aml15",
+  keep_cross_validation_models = FALSE,
+  keep_cross_validation_predictions = FALSE)
+  model_ids <- as.character(as.data.frame(aml15@leaderboard[,"model_id"])[,1])
+  model_ids <- setdiff(model_ids, grep("StackedEnsemble", model_ids, value = TRUE))
+  cv_model_ids <- list(NULL)
+  for(i in 1:nfolds) {
+      cv_model_ids[[i]] <- paste0(model_ids, "_cv_", i)
+  }
+  cv_model_ids <- unlist(cv_model_ids)
+  expect_equal(sum(sapply(cv_model_ids, function(i) grepl(i, h2o.ls()))), 0)
 }
 
 doTest("AutoML Args Test", automl.args.test)


### PR DESCRIPTION
* Added two parameters (`keep_cross_validation_predictions` & `keep_cross_validation_models`) that allows a user to clean up or keep CV prediction frames/models from the DKV after the AutoML process is done. This parameter is `True` by default.
* `keep_cross_validation_predictions` & `keep_cross_validation_models` are placed in `build_control` for AutoML.
* Also added method to delete cross validation predictions for a h2o-3 model