### PR TITLE
XGBoost: Create Booster parameters just once -> nicer log + single GPU check 

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -1837,6 +1837,8 @@ public final class AutoBuffer {
   public AutoBuffer putJSONAA8( String name, long ary[][] ) { return putJSONStr(name).put1(':').putJSONAA8(ary); }
   public AutoBuffer putJSONAAA8( String name, long ary[][][] ) { return putJSONStr(name).put1(':').putJSONAAA8(ary); }
 
+  public AutoBuffer putJSONZ(boolean b) { return putJStr(Boolean.toString(b)); }
+
   public AutoBuffer putJSON4(int i) { return putJStr(Integer.toString(i)); }
   AutoBuffer putJSONA4( int[] a) {
     if( a == null ) return putJNULL();
@@ -1873,7 +1875,7 @@ public final class AutoBuffer {
   public AutoBuffer putJSONAA4( String name, int[][] a ) { return putJSONStr(name).put1(':').putJSONAA4(a); }
   public AutoBuffer putJSONAAA4( String name, int[][][] a ) { return putJSONStr(name).put1(':').putJSONAAA4(a); }
 
-  AutoBuffer putJSON4f ( float f ) { return f==Float.POSITIVE_INFINITY?putJSONStr(JSON_POS_INF):(f==Float.NEGATIVE_INFINITY?putJSONStr(JSON_NEG_INF):(Float.isNaN(f)?putJSONStr(JSON_NAN):putJStr(Float .toString(f)))); }
+  public AutoBuffer putJSON4f ( float f ) { return f==Float.POSITIVE_INFINITY?putJSONStr(JSON_POS_INF):(f==Float.NEGATIVE_INFINITY?putJSONStr(JSON_NEG_INF):(Float.isNaN(f)?putJSONStr(JSON_NAN):putJStr(Float .toString(f)))); }
   public AutoBuffer putJSON4f ( String name, float f ) { return putJSONStr(name).put1(':').putJSON4f(f); }
   AutoBuffer putJSONA4f( float[] a ) {
     if( a == null ) return putJNULL();
@@ -1899,7 +1901,7 @@ public final class AutoBuffer {
     return put1(']');
   }
 
-  AutoBuffer putJSON8d( double d ) {
+  public AutoBuffer putJSON8d( double d ) {
     if (TwoDimTable.isEmpty(d)) return putJNULL();
     return d==Double.POSITIVE_INFINITY?putJSONStr(JSON_POS_INF):(d==Double.NEGATIVE_INFINITY?putJSONStr(JSON_NEG_INF):(Double.isNaN(d)?putJSONStr(JSON_NAN):putJStr(Double.toString(d))));
   }

--- a/h2o-core/src/test/java/water/util/IcedHashMapGenericTest.java
+++ b/h2o-core/src/test/java/water/util/IcedHashMapGenericTest.java
@@ -1,0 +1,45 @@
+package water.util;
+
+import org.junit.Test;
+import water.AutoBuffer;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class IcedHashMapGenericTest {
+
+  @Test
+  public void testJavaNativeValues() {
+    Map<String, Object> map = Collections.unmodifiableMap(new HashMap<String, Object>() {{
+      put("integer", 42);
+      put("float", 0.5f);
+      put("double", Math.E);
+      put("boolean-true", true);
+      put("boolean-false", false);
+    }});
+
+    final IcedHashMapGeneric<String, Object> icedMapOrig = new IcedHashMapGeneric.IcedHashMapStringObject();
+    icedMapOrig.putAll(map);
+    assertEquals(map, icedMapOrig);
+
+    final IcedHashMapGeneric<String, Object> icedMapDeser = new AutoBuffer()
+            .put(icedMapOrig)
+            .flipForReading()
+            .get();
+    assertEquals(map, icedMapDeser);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    AutoBuffer ab = new AutoBuffer(baos, false);
+    icedMapOrig.writeJSON_impl(ab);
+    ab.close();
+    assertEquals(
+            "\0\"integer\":42, \"boolean-false\":false, \"double\":2.718281828459045, \"float\":0.5, \"boolean-true\":true",
+            baos.toString());
+    System.out.println(baos.toString());
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
@@ -1,0 +1,56 @@
+package hex.tree.xgboost;
+
+import water.Iced;
+import water.util.IcedHashMapGeneric;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Iced Wrapper around Booster parameter map. The main purpose is to avoid mistakes when using the parameter
+ * object directly: this class ensures that returned parameters will be localized.
+ */
+public class BoosterParms extends Iced<BoosterParms> {
+
+  private IcedHashMapGeneric.IcedHashMapStringObject _parms;
+
+  public static BoosterParms fromMap(Map<String, Object> map) {
+    BoosterParms bp = new BoosterParms();
+    bp._parms = new IcedHashMapGeneric.IcedHashMapStringObject();
+    bp._parms.putAll(map);
+    return bp;
+  }
+
+  /**
+   * @return localized Booster parameters
+   */
+  public Map<String, Object> get() {
+    return localizeDecimalParams(_parms);
+  }
+
+  /**
+   * Iterates over a set of parameters and applies locale-specific formatting
+   * to decimal ones (Floats and Doubles).
+   *
+   * @param params Parameters to localize
+   * @return Map with localized parameter values
+   */
+  private static Map<String, Object> localizeDecimalParams(final Map<String, Object> params) {
+    Map<String, Object> localized = new HashMap<>(params.size());
+    final NumberFormat localizedNumberFormatter = DecimalFormat.getNumberInstance();
+    for (String key : params.keySet()) {
+      final Object value = params.get(key);
+      final Object newValue;
+      if (value instanceof Float || value instanceof Double) {
+        newValue = localizedNumberFormatter.format(value);
+      } else
+        newValue = value;
+      localized.put(key, newValue);
+    }
+    return Collections.unmodifiableMap(localized);
+  }
+
+}

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/BoosterParmsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/BoosterParmsTest.java
@@ -1,0 +1,33 @@
+package hex.tree.xgboost;
+
+import org.junit.Test;
+
+import java.text.DecimalFormat;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class BoosterParmsTest {
+
+  @Test
+  public void testGetLocalized() {
+    Map<String, Object> map = Collections.unmodifiableMap(new HashMap<String, Object>() {{
+      put("integer", 42);
+      put("float", 0.5f);
+      put("double", Math.E);
+      put("boolean", true);
+    }});
+    Map<String, Object> expected = Collections.unmodifiableMap(new HashMap<String, Object>() {{
+      put("integer", 42);
+      put("float", DecimalFormat.getNumberInstance().format(0.5f));
+      put("double", DecimalFormat.getNumberInstance().format(Math.E));
+      put("boolean", true);
+    }});
+
+    Map<String, Object> localized = BoosterParms.fromMap(map).get();
+    assertEquals(expected, localized);
+  }
+
+}


### PR DESCRIPTION
This PR refactors the XGB implementation in order to create the parameters for the Booster just one time (at the beginning of the training).

This produces a little bit nicer logs (no repeated dumps of the parameters) and performs GPU check just one time.