### PR TITLE
fix lossy conversions of longs to doubles:

### DIFF
--- a/h2o-core/src/main/java/water/fvec/C1SChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C1SChunk.java
@@ -21,6 +21,13 @@ public final class C1SChunk extends CSChunk {
     }
   }
 
+  @Override protected final long at8_impl( int i ) {
+    int x = 0xFF&_mem[_OFF+i];
+    if( x==C1Chunk._NA )
+      throw new IllegalArgumentException("at8_abs but value is missing");
+    return get8(x);
+  }
+
   @Override protected final double atd_impl( int i ) {
     return getD(0xFF&_mem[_OFF+i],C1Chunk._NA);
   }

--- a/h2o-core/src/main/java/water/fvec/C2SChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C2SChunk.java
@@ -22,6 +22,13 @@ public class C2SChunk extends CSChunk {
     }
   }
 
+  @Override protected final long at8_impl( int i ) {
+    int x = getMantissa(i);
+    if( x==C2Chunk._NA )
+      throw new IllegalArgumentException("at8_abs but value is missing");
+    return get8(x);
+  }
+
   private int getMantissa(int i){return UnsafeUtils.get2(_mem,_OFF+2*i);}
   private void setMantissa(int i, short s){
     UnsafeUtils.set2(_mem,(i*2)+_OFF,s);

--- a/h2o-core/src/main/java/water/fvec/CSChunk.java
+++ b/h2o-core/src/main/java/water/fvec/CSChunk.java
@@ -52,6 +52,7 @@ public abstract class CSChunk extends Chunk {
     return x == NA?naImpute:_isDecimal?(_bias + x)/_scale:(_bias + x)*_scale;
   }
 
+  protected final long get8(int x) { return (_bias + x)*(long)(_scale); }
 
   @Override public final boolean hasFloat(){ return _isDecimal || _scale < 1; }
 
@@ -65,7 +66,7 @@ public abstract class CSChunk extends Chunk {
     _scale = PrettyPrint.pow10(1,_isDecimal?-x:x);
   }
 
-  @Override protected final long at8_impl( int i ) {
+  @Override protected long at8_impl( int i ) {
     double res = atd_impl(i); // note: |mantissa| <= 4B => double is ok
     if(Double.isNaN(res)) throw new IllegalArgumentException("at8_abs but value is missing");
     return (long)res;


### PR DESCRIPTION
   - add at8_impl's for (C1S/C2S)Chunk
   - add new test cases to (C1S/C2S)ChunkTest
   - use BigInteger and smarter heueristics to detect "long" overflow

This new logic enables lossless handling of `long`s that cannot be encoded as java `double`s.
This does not prevent other abuses of `long` values, and all occurences of `long` -> `double` -> `long` are potentially lossy.

@mmalohlava @cliffclick @michalkurka @wendycwong @jakubhava 