### PR TITLE
Fix sort's lossy conversions

### DIFF
--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -187,8 +187,11 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     }
     @Override public void map(Chunk c) {
       for(int i=0; i<c._len; ++i) {
-        _colMin = Math.min(_colMin, c.at8(i));
-        _colMax = Math.max(_colMax, c.at8(i));
+        if( !c.isNA(i) ) {
+          long l = c.at8(i);
+          _colMin = Math.min(_colMin, l);
+          _colMax = Math.max(_colMax, l);
+        }
       }
     }
     @Override public void reduce(GetLongStatsTask that) {

--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -4,6 +4,7 @@ import water.H2O;
 import water.Key;
 import water.MRTask;
 import water.RPC;
+import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
@@ -147,8 +148,12 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
         double colMin = col.min();
         double colMax = col.max();
         if (col.isInt()) {
-          _base[i] = BigInteger.valueOf(Math.min((long)colMin, (long)colMax*(_ascending[i])));
-          max = BigInteger.valueOf(Math.max((long)colMax, (long)colMin*(_ascending[i])));
+          GetLongStatsTask glst = GetLongStatsTask.getLongStats(col);
+          long colMini = glst._colMin;
+          long colMaxi = glst._colMax;
+
+          _base[i] = BigInteger.valueOf(Math.min(colMini, colMaxi*(_ascending[i])));
+          max = BigInteger.valueOf(Math.max(colMaxi, colMini*(_ascending[i])));
         } else{
           _base[i] = MathUtils.convertDouble2BigInteger(Math.min(col.min(), colMax*(_ascending[i])));
           max = MathUtils.convertDouble2BigInteger(Math.max(col.max(), colMin*(_ascending[i])));
@@ -170,6 +175,25 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
 
       _bytesUsed[i] = Math.min(8, (_shift[i]+15) / 8);  // should not go over 8 bytes
       //assert (biggestBit-1)/8 + 1 == _bytesUsed[i];
+    }
+  }
+
+  // TODO: push these into Rollups?
+  private static class GetLongStatsTask extends MRTask<GetLongStatsTask> {
+    long _colMin=Long.MAX_VALUE;
+    long _colMax=Long.MIN_VALUE;
+    static GetLongStatsTask getLongStats(Vec col) {
+      return new GetLongStatsTask().doAll(col);
+    }
+    @Override public void map(Chunk c) {
+      for(int i=0; i<c._len; ++i) {
+        _colMin = Math.min(_colMin, c.at8(i));
+        _colMax = Math.max(_colMax, c.at8(i));
+      }
+    }
+    @Override public void reduce(GetLongStatsTask that) {
+      _colMin = Math.min(_colMin, that._colMin);
+      _colMax = Math.max(_colMax, that._colMax);
     }
   }
 

--- a/h2o-core/src/test/java/water/fvec/C1SChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/C1SChunkTest.java
@@ -213,6 +213,7 @@ public class C1SChunkTest extends TestUtil {
           for (int i = 0; i < 1000000; ++i)
             nc.addNum(bias + (i%255), exponent);
           Chunk c = nc.compress();
+
           Assert.assertTrue(c instanceof C1SChunk);
           long t0 = System.currentTimeMillis();
           sum += count_sum((C1SChunk)c);

--- a/h2o-core/src/test/java/water/rapids/SortTest.java
+++ b/h2o-core/src/test/java/water/rapids/SortTest.java
@@ -232,7 +232,7 @@ public class SortTest extends TestUtil {
   @Test public void testSortOverflows2() throws IOException {
     Scope.enter();
     Frame fr, sorted1, sorted2;
-    long ts=1485333188427000000L;
+    final long ts=1485333188427000000L;
     try {
 
       Vec dz = Vec.makeZero(1000);

--- a/h2o-persist-s3/build.gradle
+++ b/h2o-persist-s3/build.gradle
@@ -10,8 +10,8 @@ description = "H2O Persist S3"
 
 dependencies {
   compile project(":h2o-core")
-  compile 'com.amazonaws:aws-java-sdk-s3:1.10.47'
-  compile 'org.apache.httpcomponents:httpclient:4.3.6'
+  compile 'com.amazonaws:aws-java-sdk-s3:1.11.240'
+  compile 'org.apache.httpcomponents:httpclient:4.5.2'
   testCompile "junit:junit:${junitVersion}"
   testCompile project(path: ":h2o-core", configuration: "testArchives")
 }


### PR DESCRIPTION
Depends on #2309 !
   - add GetLongStatsTask to RadixOrder so that long -> double -> long never happens
     for col max/min
   - add paths in BinaryMerge for long vals in addition to double values (and str values)

@mattdowle @wendycwong 