### PR TITLE
Pubdev 5058 glrm mojo predict

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRMGenX.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMGenX.java
@@ -1,0 +1,77 @@
+package hex.glrm;
+
+import hex.genmodel.algos.glrm.GlrmMojoModel;
+import water.MRTask;
+import water.MemoryManager;
+import water.fvec.Chunk;
+import water.fvec.NewChunk;
+
+/**
+ * GLRMGenX will generate the coefficients (X matrix) of a GLRM model given the archetype
+ * for a dataframe.
+ */
+public class GLRMGenX  extends MRTask<GLRMGenX> {
+  final GLRMModel _m; // contains info to transfer to the glrm mojo model
+  final int _k;       // store column size of X matrix
+  GlrmMojoModel _gMojoModel;  // instantiate mojo model from GLRM model info
+
+  public GLRMGenX(GLRMModel m, int k) {
+    _m = m;
+    _m._parms = m._parms;
+    _k = k;
+  }
+
+  @Override
+  protected void setupLocal() {
+    _gMojoModel = new GlrmMojoModel(_m._output._names, _m._output._domains, null);
+    GLRM.Archetypes arch = _m._output._archetypes_raw;
+    // fill out the mojo model, no need to fill out every field
+    _gMojoModel._ncolA = _m._output._lossFunc.length;
+    _gMojoModel._ncolY = arch.nfeatures();
+    _gMojoModel._nrowY = arch.rank();
+    _gMojoModel._ncolX = _m._parms._k;
+    _gMojoModel._seed = _m._parms._seed;
+    _gMojoModel._regx = _m._parms._regularization_x;
+    _gMojoModel._gammax = _m._parms._gamma_x;
+    _gMojoModel._init = _m._parms._init;
+
+    _gMojoModel._ncats = _m._output._ncats;
+    _gMojoModel._nnums = _m._output._nnums;
+    _gMojoModel._normSub = _m._output._normSub;
+    _gMojoModel._normMul = _m._output._normMul;
+    _gMojoModel._permutation = _m._output._permutation;
+    _gMojoModel._reverse_transform = _m._parms._impute_original;
+    _gMojoModel._transposed = _m._output._archetypes_raw._transposed;
+
+    // loss functions
+    _gMojoModel._losses = _m._output._lossFunc;
+
+    // archetypes
+    _gMojoModel._numLevels = arch._numLevels;
+    _gMojoModel._catOffsets = arch._catOffsets;
+    _gMojoModel._archetypes = arch.getY(false);
+  }
+
+  public void map(Chunk[] chks, NewChunk[] preds) {
+    int featureLen = chks.length;
+    long rowStart = chks[0].start();
+    long baseSeed = _gMojoModel._seed+rowStart;
+
+    double[] rowdata = MemoryManager.malloc8d(chks.length);  // read in each row of data
+    double[] pdimensions = MemoryManager.malloc8d(_k);
+    for (int rid = 0; rid < chks[0]._len; ++rid) {
+      for (int col = 0; col < featureLen; col++) {
+        rowdata[col] = chks[col].atd(rid);
+      }
+
+      _gMojoModel.score0(rowdata, pdimensions, baseSeed+rid); // make prediction
+      for (int c=0; c<_k; c++) {
+        preds[c].addNum(pdimensions[c]);
+      }
+    }
+  }
+
+  public GlrmMojoWriter getMojo() {
+    return new GlrmMojoWriter(_m);
+  }
+}

--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -1,8 +1,12 @@
 package hex.glrm;
 
-import hex.*;
+import hex.DataInfo;
+import hex.Model;
+import hex.ModelCategory;
+import hex.ModelMetrics;
 import hex.genmodel.algos.glrm.GlrmInitialization;
 import hex.genmodel.algos.glrm.GlrmLoss;
+import hex.genmodel.algos.glrm.GlrmMojoModel;
 import hex.genmodel.algos.glrm.GlrmRegularizer;
 import hex.svd.SVDModel.SVDParameters;
 import water.*;
@@ -10,7 +14,7 @@ import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.udf.CFuncRef;
-import water.util.*;
+import water.util.ArrayUtils;
 import water.util.TwoDimTable;
 
 import java.util.ArrayList;
@@ -46,7 +50,6 @@ import java.util.ArrayList;
  */
 public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMModel.GLRMOutput>
         implements Model.GLRMArchetypes {
-
 
   //--------------------------------------------------------------------------------------------------------------------
   // Input parameters
@@ -130,6 +133,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     public String _representation_name;
     public Key<Frame> _representation_key;
     public Key<? extends Model> _init_key;
+    public Key<Frame> _x_factor_key;  // store key of x factor generated from dataset prediction
 
     // Number of categorical and numeric columns
     public int _ncats;
@@ -179,15 +183,15 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
   }
 
 
-
-
   public GLRMModel(Key<GLRMModel> selfKey, GLRMParameters parms, GLRMOutput output) {
     super(selfKey, parms, output);
   }
 
   @Override protected Futures remove_impl( Futures fs ) {
     if (_output._init_key != null) _output._init_key.remove(fs);
+    if (_output._x_factor_key !=null) _output._x_factor_key.remove(fs);
     if (_output._representation_key != null) _output._representation_key.remove(fs);
+
     return super.remove_impl(fs);
   }
 
@@ -208,21 +212,36 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
   }
 
 
-
   //--------------------------------------------------------------------------------------------------------------------
   // Scoring
   //--------------------------------------------------------------------------------------------------------------------
 
   // GLRM scoring is data imputation based on feature domains using reconstructed XY (see Udell (2015), Section 5.3)
+  // Check if the frame is the same as used in training.  If yes, return the XY.  Otherwise, take the archetypes and
+  // generate new coefficients for it and then do X*Y
   private Frame reconstruct(Frame orig, Frame adaptedFr, Key<Frame> destination_key, boolean save_imputed, boolean reverse_transform) {
     int ncols = _output._names.length;
     assert ncols == adaptedFr.numCols();
     String prefix = "reconstr_";
+    _output._x_factor_key = gen_representation_key(orig);
 
     // Need [A,X,P] where A = adaptedFr, X = loading frame, P = imputed frame
     // Note: A is adapted to original training frame, P has columns shuffled so cats come before nums!
     Frame fullFrm = new Frame(adaptedFr);
-    Frame loadingFrm = DKV.get(_output._representation_key).get();
+    Frame loadingFrm = null;  // get this from DKV or generate it from scratch
+    // call resconstruct only if test frame key and training frame key matches plus frame dimensions match as well
+    if (orig.checksum()!=(_parms.train().checksum())) { // compare with checksum instead of frame keys.
+      // need to generate the X matrix and put it in as a frame ID.  Mojo predict will return one row of x as a double[]
+      GLRMGenX gs = new GLRMGenX(this, _parms._k);
+      gs.doAll(gs._k, Vec.T_NUM, orig);
+      String[] loadingFrmNames = new String[gs._k];
+      for (int index=1; index <= gs._k; index++)
+        loadingFrmNames[index-1] = "Arch"+index;
+      String[][] loadingFrmDomains = new String[gs._k][];
+      DKV.put(gs.outputFrame(_output._x_factor_key,loadingFrmNames, loadingFrmDomains));
+    }
+  //  Key newXKey = gen_representation_key(orig);
+    loadingFrm = DKV.get(_output._x_factor_key).get();
     fullFrm.add(loadingFrm);
     String[][] adaptedDomme = adaptedFr.domains();
     Vec anyVec = fullFrm.anyVec();
@@ -232,7 +251,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
       v.setDomain(adaptedDomme[i]);
       fullFrm.add(prefix + _output._names[i], v);
     }
-    GLRMScore gs = new GLRMScore(ncols, _parms._k, save_imputed, reverse_transform).doAll(fullFrm);
+    GLRMScore gs = new GLRMScore(ncols, _parms._k, save_imputed, reverse_transform).doAll(fullFrm); // reconstruct X*Y
 
     // Return the imputed training frame
     int x = ncols + _parms._k, y = fullFrm.numCols();
@@ -242,6 +261,13 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     DKV.put(f);
     gs._mb.makeModelMetrics(GLRMModel.this, orig, null, null);   // save error metrics based on imputed data
     return f;
+  }
+
+  public Key<Frame> gen_representation_key(Frame fr) {
+    if (fr._key == _parms.train()._key) // use training X factor here.
+      return _output._representation_key;
+    else
+      return Key.make("GLRMLoading_"+fr._key);
   }
 
   @Override protected Frame predictScoreImpl(Frame orig, Frame adaptedFr, String destination_key, Job j, boolean computeMetrics, CFuncRef customMetricFunc) {
@@ -353,23 +379,10 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     }
 
     private double[] impute_data(double[] tmp, double[] preds) {
-      assert preds.length == _output._nnums + _output._ncats;
-
-      // Categorical columns
-      for (int d = 0; d < _output._ncats; d++) {
-        double[] xyblock = _output._archetypes_raw.lmulCatBlock(tmp,d);
-        preds[_output._permutation[d]] = _output._lossFunc[d].mimpute(xyblock);
-      }
-
-      // Numeric columns
-      for (int d = _output._ncats; d < preds.length; d++) {
-        int ds = d - _output._ncats;
-        double xy = _output._archetypes_raw.lmulNumCol(tmp, ds);
-        preds[_output._permutation[d]] = _output._lossFunc[d].impute(xy);
-        if (_reverse_transform)
-          preds[_output._permutation[d]] = preds[_output._permutation[d]] / _output._normMul[ds] + _output._normSub[ds];
-      }
-      return preds;
+      return GlrmMojoModel.impute_data(tmp, preds, _output._nnums, _output._ncats, _output._permutation,
+              _reverse_transform, _output._normMul, _output._normSub, _output._lossFunc,
+              _output._archetypes_raw._transposed, _output._archetypes_raw._archetypes, _output._catOffsets,
+              _output._archetypes_raw._numLevels);
     }
   }
 
@@ -389,7 +402,10 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
 
     // Append loading frame X for calculating XY
     Frame fullFrm = new Frame(adaptedFr);
-    Frame loadingFrm = DKV.get(_output._representation_key).get();
+    Value tempV = DKV.get(gen_representation_key(frame));
+    if (tempV == null)
+      tempV = DKV.get(_output._representation_key);
+    Frame loadingFrm = tempV.get();
     fullFrm.add(loadingFrm);
 
     GLRMScore gs = new GLRMScore(ncols, _parms._k, false).doAll(fullFrm);

--- a/h2o-algos/src/main/java/hex/glrm/GlrmMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/glrm/GlrmMojoWriter.java
@@ -20,7 +20,7 @@ public class GlrmMojoWriter extends ModelMojoWriter<GLRMModel, GLRMModel.GLRMPar
   }
 
   @Override public String mojoVersion() {
-    return "1.00";
+    return "1.10";
   }
 
   @Override
@@ -31,6 +31,8 @@ public class GlrmMojoWriter extends ModelMojoWriter<GLRMModel, GLRMModel.GLRMPar
     writekv("gammaX", model._parms._gamma_x);
     writekv("gammaY", model._parms._gamma_y);
     writekv("ncolX", model._parms._k);
+    writekv("seed", model._parms._seed);  // store seed for later use
+    writekv("reverse_transform", model._parms._impute_original);
 
     // DataInfo mapping
     writekv("cols_permutation", model._output._permutation);
@@ -38,6 +40,7 @@ public class GlrmMojoWriter extends ModelMojoWriter<GLRMModel, GLRMModel.GLRMPar
     writekv("num_numeric", model._output._nnums);
     writekv("norm_sub", model._output._normSub);
     writekv("norm_mul", model._output._normMul);
+    writekv("transposed", model._output._archetypes_raw._transposed);
 
     // Loss functions
     writekv("ncolA", model._output._lossFunc.length);
@@ -52,6 +55,7 @@ public class GlrmMojoWriter extends ModelMojoWriter<GLRMModel, GLRMModel.GLRMPar
     writekv("ncolY", arch.nfeatures());
     writekv("nrowY", arch.rank());
     writekv("num_levels_per_category", arch._numLevels);
+    writekv("catOffsets", arch._catOffsets);
     int n = arch.rank() * arch.nfeatures();
     ByteBuffer bb = ByteBuffer.wrap(new byte[n * 8]);
     for (double[] row : arch.getY(false))

--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -234,7 +234,7 @@ POJO Quick Start
 
 This section describes how to build and implement a POJO to use predictive scoring. Java developers should refer to the `Javadoc <http://docs.h2o.ai/h2o/latest-stable/h2o-genmodel/javadoc/index.html>`__ for more information, including packages.
 
-**Notes**: POJOs are not supported for source files larger than 1G. For more information, refer to the `FAQ <#POJO_Err>`__ below. POJOs are also not supported for XGBoost, Stacked Ensembles, or AutoML models. 
+**Notes**: POJOs are not supported for source files larger than 1G. For more information, refer to the `FAQ <#POJO_Err>`__ below. POJOs are also not supported for XGBoost, Stacked Ensembles, or AutoML models.
 
 What is a POJO?
 '''''''''''''''

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmMojoReader.java
@@ -36,7 +36,6 @@ public class GlrmMojoReader extends ModelMojoReader<GlrmMojoModel> {
     for (String line : readtext("losses")) {
       _model._losses[li++] = GlrmLoss.valueOf(line);
     }
-
     // archetypes
     _model._numLevels = readkv("num_levels_per_category");
     _model._archetypes = new double[_model._nrowY][];
@@ -46,6 +45,30 @@ public class GlrmMojoReader extends ModelMojoReader<GlrmMojoModel> {
       _model._archetypes[i] = row;
       for (int j = 0; j < _model._ncolY; j++)
         row[j] = bb.getDouble();
+    }
+
+    // new fields added after version 1.00
+    try {
+      _model._seed = readkv("seed");
+      _model._reverse_transform = readkv("reverse_transform");
+      _model._transposed = readkv("transposed");
+      _model._catOffsets = readkv("catOffsets");
+      // load in archetypes raw
+      if (_model._transposed) {
+        _model._archetypes_raw = new double[_model._archetypes[0].length][_model._archetypes.length];
+        for (int row = 0; row < _model._archetypes.length; row++) {
+          for (int col = 0; col < _model._archetypes[0].length; col++) {
+            _model._archetypes_raw[col][row] = _model._archetypes[row][col];
+          }
+        }
+      } else
+        _model._archetypes_raw = _model._archetypes;
+    } catch (NullPointerException re) { // only expect null pointer exception.
+      _model._seed = System.currentTimeMillis();  // randomly initialize seed
+      _model._reverse_transform = true;
+      _model._transposed = true;
+      _model._catOffsets = null;
+      _model._archetypes_raw = null;
     }
   }
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/DimReductionModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/DimReductionModelPrediction.java
@@ -4,5 +4,13 @@ package hex.genmodel.easy.prediction;
  * TODO
  */
 public class DimReductionModelPrediction extends AbstractPrediction {
-    public double[] dimensions;
+    public double[] dimensions; // contains the X factor/coefficient
+    /**
+     * This field is only used for GLRM and not for PCA.  Reconstructed data, the array has same length as the
+     * original input. The user can use the original input and reconstructed output to easily calculate eg. the
+     * reconstruction error.  Note that all values are either doubles or integers.  Users need to convert
+     * the enum columns from the integer columns if necessary.
+     */
+    public double[] reconstructed;
+
 }

--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5058_glrm_mojo_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5058_glrm_mojo_large.py
@@ -1,0 +1,59 @@
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+from random import randint
+import re
+
+
+def glrm_mojo():
+    h2o.remove_all()
+    NTESTROWS = 200    # number of test dataset rows
+    df = pyunit_utils.random_dataset("regression")       # generate random dataset
+    train = df[NTESTROWS:, :]
+    test = df[:NTESTROWS, :]
+    x = df.names
+
+    transform_types = ["NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"]
+    transformN = transform_types[randint(0, len(transform_types)-1)]
+    # build a GLRM model with random dataset generated earlier
+    glrmModel = H2OGeneralizedLowRankEstimator(k=3, transform=transformN, max_iterations=10)
+    glrmModel.train(x=x, training_frame=train)
+    glrmTrainFactor = h2o.get_frame(glrmModel._model_json['output']['representation_name'])
+
+    assert glrmTrainFactor.nrows==train.nrows, \
+        "X factor row number {0} should equal training row number {1}.".format(glrmTrainFactor.nrows, train.nrows)
+    save_GLRM_mojo(glrmModel) # ave mojo model
+
+    MOJONAME = pyunit_utils.getMojoName(glrmModel._id)
+    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
+
+    h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
+    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(glrmModel, TMPDIR, MOJONAME, glrmReconstruct=True) # save mojo predict
+    for col in range(pred_h2o.ncols):
+        if pred_h2o[col].isfactor():
+            pred_h2o[col] = pred_h2o[col].asnumeric()
+    print("Comparing mojo predict and h2o predict...")
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 1, tol=1e-10)
+
+    frameID, mojoXFactor = pyunit_utils.mojo_predict(glrmModel, TMPDIR, MOJONAME, glrmReconstruct=False) # save mojo XFactor
+    glrmTestFactor = h2o.get_frame("GLRMLoading_"+frameID)   # store the x Factor for new test dataset
+    print("Comparing mojo x Factor and model x Factor ...")
+    pyunit_utils.compare_frames_local(glrmTestFactor, mojoXFactor, 1, tol=1e-10)
+
+def save_GLRM_mojo(model):
+    # save model
+    regex = re.compile("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]")
+    MOJONAME = regex.sub("_", model._id)
+
+    print("Downloading Java prediction model code from H2O")
+    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
+    os.makedirs(TMPDIR)
+    model.download_mojo(path=TMPDIR)    # save mojo
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glrm_mojo)
+else:
+    glrm_mojo()

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -862,7 +862,7 @@ compareFrames <- function(frame1, frame2, prob=0.5, tolerance=1e-6) {
         if (is.nan(temp1[rowInd,1])) {
           expect_true(is.nan(temp2[rowInd,1]), info=paste0("Errow at row ", rowInd, ". Frame is value is nan but Frame 2 value is ", temp2[rowInd, 1]))
         } else {
-          expect_true(abs(temp1[rowInd,1]-temp2[rowInd,1])< tolerance, info=paste0("Error at row ", rowInd, ". Frame 1 value ", temp1[rowInd, 1], ". Frame 2 value ", temp2[rowInd, 1]))
+          expect_true((abs(temp1[rowInd,1]-temp2[rowInd,1])/max(1,abs(temp1[rowInd,1]), abs(temp2[rowInd, 1])))< tolerance, info=paste0("Error at row ", rowInd, ". Frame 1 value ", temp1[rowInd, 1], ". Frame 2 value ", temp2[rowInd, 1]))
         }
     }
   }
@@ -933,7 +933,24 @@ buildModelSaveMojoGLM <- function(params) {
   return(list("model"=model, "dirName"=tmpdir_name))
 }
 
-mojoH2Opredict<-function(model, tmpdir_name, filename, get_leaf_node_assignment=FALSE) {
+buildModelSaveMojoGLRM <- function(params) {
+  model <- do.call("h2o.glrm", params)
+  model_key <- model@model_id
+  tmpdir_name <- sprintf("%s/tmp_model_%s", sandbox(), as.character(Sys.getpid()))
+  if (.Platform$OS.type == "windows") {
+    shell(sprintf("C:\\cygwin64\\bin\\rm.exe -fr %s", normalizePath(tmpdir_name)))
+    shell(sprintf("C:\\cygwin64\\bin\\mkdir.exe -p %s", normalizePath(tmpdir_name)))
+  } else {
+    safeSystem(sprintf("rm -fr %s", tmpdir_name))
+    safeSystem(sprintf("mkdir -p %s", tmpdir_name))
+  }
+  h2o.saveMojo(model, path = tmpdir_name, force = TRUE) # save mojo
+  h2o.saveModel(model, path = tmpdir_name, force=TRUE) # save model to compare mojo/h2o predict offline
+
+  return(list("model"=model, "dirName"=tmpdir_name))
+}
+
+mojoH2Opredict<-function(model, tmpdir_name, filename, get_leaf_node_assignment=FALSE, glrmReconstruct=FALSE) {
   newTest <- h2o.importFile(filename)
   predictions1 <- h2o.predict(model, newTest)
 
@@ -968,10 +985,18 @@ mojoH2Opredict<-function(model, tmpdir_name, filename, get_leaf_node_assignment=
     cmd<-paste(cmd, "--leafNodeAssignment")
     predictions1 = h2o.predict_leaf_node_assignment(model, newTest)
   }
-
+  
+  if (glrmReconstruct) {
+    cmd <- paste(cmd, "--glrmReconstruct", sep=" ")
+  }
+  
   safeSystem(cmd)  # perform mojo prediction
   predictions2 = h2o.importFile(paste(tmpdir_name, "out_mojo.csv", sep =
   '/'), header=T)
 
-  return(list("h2oPredict"=predictions1, "mojoPredict"=predictions2))
+  if (glrmReconstruct || !(model@algorithm=="glrm")) {
+    return(list("h2oPredict"=predictions1, "mojoPredict"=predictions2))
+  } else {
+    return(list("frameId"=h2o.getId(newTest), "mojoPredict"=predictions2))
+  }
 }

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_5529_leaf_node_assign_drf_mojo.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_5529_leaf_node_assign_drf_mojo.R
@@ -9,7 +9,6 @@ test.drf.leaf.assignment.mojo <-
     # Run the test
     #----------------------------------------------------------------------
     e <- tryCatch({
-      browser()
       numTest = 1000 # set test dataset to contain 1000 rows
       params_prob_data <- setParmsData(numTest) # generate model parameters, random dataset
       modelAndDir<-buildModelSaveMojoTrees(params_prob_data$params, 'drf') # build the model and save mojo


### PR DESCRIPTION
GLRM predict can generate different outputs depending on the dataframe you use to perform the prediction on.

If you use the training dataframe, the prediction output will be the multiplication of X*Y where X were stored in representation_key.

If you use a brand new test dataframe, there will be two actions associated with prediction:
1. First, it needs to generate a new X frame from the test dataset and the existing archetype.
2. Second, it will then generate the reconstructed dataframe from Xnew*Y.

Problems with current implementation:
1. Current GLRM scoring will only generate X*Y.  Asking for scoring with different testframe will generate an error.  Need to add capability to our code to enable scoring on brand new dataset.
2. Current GLRM mojo will only generate the new X factor given a dataset.  Need to generate the reconstructed dataset.
3.  Need to add documentation to mojo/pojo here: https://github.com/h2oai/h2o-3/blob/master/h2o-genmodel/src/main/java/overview.html and https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/productionizing.rst

I have fixed the above two problems and added Java/Python/R unit tests to make sure GLRM predict function correctly under all circumstances