### PR TITLE
Doc updates for weights column and target encoding

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/weights_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/weights_column.rst
@@ -14,7 +14,6 @@ For scoring, all computed metrics will take the observation weights into account
 **Notes**: 
 
 - Weights can be specified as integers or as non-integers.
-- You do not have to specify a weight when calling ``model.predict()``. New test data will have the weights column with the same column name. 
 - The weights column cannot be the same as the `fold_column <fold_column.html>`__. 
 - Example unit test scripts are available on GitHub:
 

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -4489,7 +4489,9 @@ h2o.stringdist <- function(x, y, method = c("lv", "lcs", "qgram", "jaccard", "jw
 #'
 #' Create Target Encoding Map
 #' 
-#' Creates a target encoding map based on group-by columns (`x`) and a numeric or binary target column (`y`). Computing target encoding for high cardinality categorical columns can improve performance of supervised learning models.
+#' Creates a target encoding map based on group-by columns (`x`) and a numeric or binary target column (`y`). 
+#' Computing target encoding for high cardinality categorical columns can improve performance of supervised 
+#' learning models. A Target Encoding tutorial is available here: \url{https://github.com/h2oai/h2o-tutorials/blob/master/best-practices/categorical-predictors/target_encoding.md}.
 #' 
 #' @param data An H2OFrame object with which to create the target encoding map.
 #' @param x A list containing the names or indices of the variables to encode.  A target encoding map will be created for each element in the list.  Items in the list can be multiple columns.  For example, if `x = list(c("A"), c("B", "C"))`, then there will be one mapping frame for A and one mapping frame for B & C (in this case, we group by two columns). 
@@ -4584,7 +4586,9 @@ h2o.target_encode_create <- function(data, x, y, fold_column = NULL){
 
 #' Apply Target Encoding Map to Frame
 #' 
-#' Applies a target encoding map to an H2OFrame object.  Computing target encoding for high cardinality categorical columns can improve performance of supervised learning models.
+#' Applies a target encoding map to an H2OFrame object.  Computing target encoding for high cardinality 
+#' categorical columns can improve performance of supervised learning models. A Target Encoding tutorial 
+#' is available here: \url{https://github.com/h2oai/h2o-tutorials/blob/master/best-practices/categorical-predictors/target_encoding.md}.
 #' 
 #' @param data An H2OFrame object with which to apply the target encoding map.
 #' @param x A list containing the names or indices of the variables to encode.  A target encoding column will be created for each element in the list.  Items in the list can be multiple columns.  For example, if `x = list(c("A"), c("B", "C"))`, then the resulting frame will have a target encoding column for A and a target encoding column for B & C (in this case, we group by two columns). 

--- a/h2o-r/h2o-package/docs/authors.html
+++ b/h2o-r/h2o-package/docs/authors.html
@@ -85,7 +85,7 @@
 
     <ul class="list-unstyled">
       <li>
-        <p><strong>The H2O.ai team</strong>. Author, maintainer, copyright holder.
+        <p><strong>Tom Kraljevic</strong>. Author, maintainer, copyright holder.
         </p>
       </li>
     </ul>
@@ -97,7 +97,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/index.html
+++ b/h2o-r/h2o-package/docs/index.html
@@ -87,7 +87,7 @@
 <p>Apache License (== 2.0)</p>
 <h2>Developers</h2>
 <ul class="list-unstyled">
-<li>The H2O.ai team <br><small class="roles"> Author, maintainer, copyright holder </small> </li>
+<li>Tom Kraljevic <br><small class="roles"> Author, maintainer, copyright holder </small> </li>
 </ul>
 </div>
 
@@ -95,7 +95,7 @@
 
 
       <footer><div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OAutoML-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OAutoML-class.html
@@ -100,7 +100,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OClusteringModel-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OClusteringModel-class.html
@@ -127,7 +127,7 @@ the data used to build the model (an object of class H2OFrame).</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OConnection-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OConnection-class.html
@@ -141,7 +141,7 @@ is not found at port 54321.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OConnectionMutableState.html
+++ b/h2o-r/h2o-package/docs/reference/H2OConnectionMutableState.html
@@ -110,7 +110,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OFrame-Extract.html
+++ b/h2o-r/h2o-package/docs/reference/H2OFrame-Extract.html
@@ -171,7 +171,7 @@ a character</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OFrame-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OFrame-class.html
@@ -100,7 +100,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/H2OFrame.html
@@ -183,7 +183,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OGrid-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OGrid-class.html
@@ -137,7 +137,7 @@ failed_params and failure_details fields</p></dd>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OModel-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OModel-class.html
@@ -134,7 +134,7 @@ the data used to build the model (an object of class H2OFrame).</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OModelFuture-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OModelFuture-class.html
@@ -116,7 +116,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/H2OModelMetrics-class.html
+++ b/h2o-r/h2o-package/docs/reference/H2OModelMetrics-class.html
@@ -133,7 +133,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/Logical-or.html
+++ b/h2o-r/h2o-package/docs/reference/Logical-or.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/ModelAccessors.html
+++ b/h2o-r/h2o-package/docs/reference/ModelAccessors.html
@@ -154,7 +154,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/aaa.html
+++ b/h2o-r/h2o-package/docs/reference/aaa.html
@@ -110,7 +110,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/and-and.html
+++ b/h2o-r/h2o-package/docs/reference/and-and.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/apply.html
+++ b/h2o-r/h2o-package/docs/reference/apply.html
@@ -147,7 +147,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/as.character.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/as.character.H2OFrame.html
@@ -128,7 +128,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/as.data.frame.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/as.data.frame.H2OFrame.html
@@ -137,7 +137,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/as.factor.html
+++ b/h2o-r/h2o-package/docs/reference/as.factor.html
@@ -127,7 +127,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/as.h2o.html
+++ b/h2o-r/h2o-package/docs/reference/as.h2o.html
@@ -175,7 +175,7 @@ Turn on h2o datatable by options("h2o.use.data.table"=TRUE)</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/as.matrix.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/as.matrix.H2OFrame.html
@@ -128,7 +128,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/as.numeric.html
+++ b/h2o-r/h2o-package/docs/reference/as.numeric.html
@@ -125,7 +125,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/as.vector.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/as.vector.H2OFrame.html
@@ -131,7 +131,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/australia.html
+++ b/h2o-r/h2o-package/docs/reference/australia.html
@@ -107,7 +107,7 @@ the Australia coast. The data is available from <a href='http://cs.colby.edu/cou
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/colnames.html
+++ b/h2o-r/h2o-package/docs/reference/colnames.html
@@ -127,7 +127,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/dim.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/dim.H2OFrame.html
@@ -126,7 +126,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/dimnames.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/dimnames.H2OFrame.html
@@ -126,7 +126,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o-package.html
+++ b/h2o-r/h2o-package/docs/reference/h2o-package.html
@@ -101,10 +101,10 @@ Version: </td>
 <td> 3.19.0.99999</td>
 </tr><tr><td>
 Branch: </td>
-<td> PUBDEV-5432</td>
+<td> doc-updates-weightscolumn-targetencode</td>
 </tr><tr><td>
 Date: </td>
-<td> Mon Mar 26 12:02:01 PDT 2018</td>
+<td> Tue Apr 17 12:04:17 PDT 2018</td>
 </tr><tr><td>
 License: </td>
 <td> Apache License (== 2.0)</td>
@@ -145,7 +145,7 @@ Maintainer: The H2O.ai team &lt;tomk@0xdata.com&gt;
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.abs.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.abs.html
@@ -132,7 +132,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.acos.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.acos.html
@@ -126,7 +126,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.aggregated_frame.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.aggregated_frame.html
@@ -129,7 +129,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.aggregator.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.aggregator.html
@@ -171,7 +171,7 @@ Defaults to 500.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.aic.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.aic.html
@@ -139,7 +139,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.all.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.all.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.anomaly.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.anomaly.html
@@ -149,7 +149,7 @@ model to be used for anomaly detection.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.any.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.any.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.anyFactor.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.anyFactor.html
@@ -127,7 +127,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.arrange.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.arrange.html
@@ -117,7 +117,7 @@ String columns.  Otherwise, an error will
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.as_date.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.as_date.html
@@ -119,7 +119,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.ascharacter.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.ascharacter.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.asfactor.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.asfactor.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.asnumeric.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.asnumeric.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.assign.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.assign.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.auc.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.auc.html
@@ -150,7 +150,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.automl.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.automl.html
@@ -215,7 +215,7 @@ all appropriate H2O algorithms will be used, if the search stopping criteria all
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.betweenss.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.betweenss.html
@@ -126,7 +126,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.biases.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.biases.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.bottomN.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.bottomN.html
@@ -126,7 +126,7 @@ Extract the top N percent of values of a column and return it in a H2OFrame.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cbind.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cbind.html
@@ -135,7 +135,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.ceiling.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.ceiling.html
@@ -119,7 +119,7 @@ corresponding elements of x.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.centers.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.centers.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.centersSTD.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.centersSTD.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.centroid_stats.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.centroid_stats.html
@@ -126,7 +126,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.clearLog.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.clearLog.html
@@ -121,7 +121,7 @@ primarily for debugging purposes.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.clusterInfo.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.clusterInfo.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.clusterIsUp.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.clusterIsUp.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.clusterStatus.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.clusterStatus.html
@@ -114,7 +114,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cluster_sizes.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cluster_sizes.html
@@ -126,7 +126,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.coef.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.coef.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.coef_norm.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.coef_norm.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.colnames.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.colnames.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.columns_by_type.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.columns_by_type.html
@@ -140,7 +140,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.computeGram.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.computeGram.html
@@ -128,7 +128,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.confusionMatrix.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.confusionMatrix.html
@@ -184,7 +184,7 @@ objects. If no threshold is specified, all possible thresholds are selected.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.connect.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.connect.html
@@ -175,7 +175,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cor.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cor.html
@@ -141,7 +141,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cos.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cos.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cosh.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cosh.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.coxph.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.coxph.html
@@ -90,8 +90,8 @@
     <pre class="usage"><span class='fu'>h2o.coxph</span>(<span class='no'>x</span>, <span class='no'>event_column</span>, <span class='no'>training_frame</span>, <span class='kw'>model_id</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>start_column</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>stop_column</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>weights_column</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>offset_column</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>stratify_by</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>ties</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"efron"</span>, <span class='st'>"breslow"</span>),
-  <span class='kw'>init</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>lre_min</span> <span class='kw'>=</span> <span class='fl'>9</span>, <span class='kw'>iter_max</span> <span class='kw'>=</span> <span class='fl'>20</span>, <span class='kw'>interactions_only</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>interactions</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>interaction_pairs</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>init</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>lre_min</span> <span class='kw'>=</span> <span class='fl'>9</span>, <span class='kw'>iter_max</span> <span class='kw'>=</span> <span class='fl'>20</span>, <span class='kw'>interactions</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>interaction_pairs</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>interactions_only</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>use_all_factor_levels</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
@@ -155,17 +155,17 @@ well. During training, rows with higher weights matter more, due to the larger l
       <td><p>Maximum number of iterations. Defaults to 20.</p></td>
     </tr>
     <tr>
-      <th>interactions_only</th>
-      <td><p>A list of columns that should only be used to create interactions but should not itself participate in model
-training.</p></td>
-    </tr>
-    <tr>
       <th>interactions</th>
       <td><p>A list of predictor column indices to interact. All pairwise combinations will be computed for the list.</p></td>
     </tr>
     <tr>
       <th>interaction_pairs</th>
       <td><p>A list of pairwise (first order) column interactions.</p></td>
+    </tr>
+    <tr>
+      <th>interactions_only</th>
+      <td><p>A list of columns that should only be used to create interactions but should not itself participate in model
+training.</p></td>
     </tr>
     <tr>
       <th>use_all_factor_levels</th>
@@ -187,7 +187,7 @@ FALSE.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.createFrame.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.createFrame.html
@@ -206,7 +206,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cross_validation_fold_assignment.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cross_validation_fold_assignment.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cross_validation_holdout_predictions.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cross_validation_holdout_predictions.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cross_validation_models.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cross_validation_models.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cross_validation_predictions.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cross_validation_predictions.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cummax.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cummax.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cummin.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cummin.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cumprod.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cumprod.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cumsum.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cumsum.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.cut.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.cut.html
@@ -166,7 +166,7 @@ the break numbers.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.day.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.day.html
@@ -130,7 +130,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.dayOfWeek.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.dayOfWeek.html
@@ -130,7 +130,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.dct.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.dct.html
@@ -151,7 +151,7 @@ For 1D, use c(L,1,1), for 2D, use C(N,M,1).</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.ddply.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.ddply.html
@@ -156,7 +156,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.decryptionSetup.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.decryptionSetup.html
@@ -161,7 +161,7 @@ the reference (result of this function) to the import functions.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.deepfeatures.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.deepfeatures.html
@@ -115,8 +115,8 @@ learning model to be used for feature extraction.</p></td>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 
-    <p><code>link{h2o.deeplearning}</code> for making H2O Deep Learning models.
-    <code>link{h2o.deepwater}</code> for making H2O DeepWater models.</p>
+    <p><code><a href='h2o.deeplearning.html'>h2o.deeplearning</a></code> for making H2O Deep Learning models.
+    <code><a href='h2o.deepwater.html'>h2o.deepwater</a></code> for making H2O DeepWater models.</p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
@@ -161,7 +161,7 @@ learning model to be used for feature extraction.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.deeplearning.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.deeplearning.html
@@ -115,8 +115,8 @@
   <span class='kw'>score_validation_samples</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>score_duty_cycle</span> <span class='kw'>=</span> <span class='fl'>0.1</span>,
   <span class='kw'>classification_stop</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>regression_stop</span> <span class='kw'>=</span> <span class='fl'>1e-06</span>, <span class='kw'>stopping_rounds</span> <span class='kw'>=</span> <span class='fl'>5</span>,
   <span class='kw'>stopping_metric</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"deviance"</span>, <span class='st'>"logloss"</span>, <span class='st'>"MSE"</span>, <span class='st'>"RMSE"</span>, <span class='st'>"MAE"</span>,
-  <span class='st'>"RMSLE"</span>, <span class='st'>"AUC"</span>, <span class='st'>"lift_top_group"</span>, <span class='st'>"misclassification"</span>,
-  <span class='st'>"mean_per_class_error"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>,
+  <span class='st'>"RMSLE"</span>, <span class='st'>"AUC"</span>, <span class='st'>"lift_top_group"</span>, <span class='st'>"misclassification"</span>, <span class='st'>"mean_per_class_error"</span>,
+  <span class='st'>"r2"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>,
   <span class='kw'>score_validation_sampling</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"Uniform"</span>, <span class='st'>"Stratified"</span>),
   <span class='kw'>diagnostics</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>fast_mode</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>force_load_balance</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>variable_importances</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>replicate_training_data</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
@@ -406,7 +406,7 @@ stopping_metric does not improve for k:=stopping_rounds scoring events (0 to dis
       <th>stopping_metric</th>
       <td><p>Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-"mean_per_class_error". Defaults to AUTO.</p></td>
+"mean_per_class_error", "r2". Defaults to AUTO.</p></td>
     </tr>
     <tr>
       <th>stopping_tolerance</th>
@@ -555,7 +555,7 @@ propagation, but might slow down backpropagation. Defaults to FALSE.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.deepwater.available.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.deepwater.available.html
@@ -112,7 +112,7 @@ Returns TRUE if a Deep Water model can be built, or FALSE otherwise.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.deepwater.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.deepwater.html
@@ -107,13 +107,13 @@
   <span class='kw'>score_duty_cycle</span> <span class='kw'>=</span> <span class='fl'>0.1</span>, <span class='kw'>classification_stop</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>regression_stop</span> <span class='kw'>=</span> <span class='fl'>0</span>,
   <span class='kw'>stopping_rounds</span> <span class='kw'>=</span> <span class='fl'>5</span>, <span class='kw'>stopping_metric</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"deviance"</span>, <span class='st'>"logloss"</span>,
   <span class='st'>"MSE"</span>, <span class='st'>"RMSE"</span>, <span class='st'>"MAE"</span>, <span class='st'>"RMSLE"</span>, <span class='st'>"AUC"</span>, <span class='st'>"lift_top_group"</span>, <span class='st'>"misclassification"</span>,
-  <span class='st'>"mean_per_class_error"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>,
-  <span class='kw'>ignore_const_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>shuffle_training_data</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
-  <span class='kw'>mini_batch_size</span> <span class='kw'>=</span> <span class='fl'>32</span>, <span class='kw'>clip_gradient</span> <span class='kw'>=</span> <span class='fl'>10</span>, <span class='kw'>network</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"auto"</span>, <span class='st'>"user"</span>,
-  <span class='st'>"lenet"</span>, <span class='st'>"alexnet"</span>, <span class='st'>"vgg"</span>, <span class='st'>"googlenet"</span>, <span class='st'>"inception_bn"</span>, <span class='st'>"resnet"</span>),
-  <span class='kw'>backend</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"mxnet"</span>, <span class='st'>"caffe"</span>, <span class='st'>"tensorflow"</span>), <span class='kw'>image_shape</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='fl'>0</span>, <span class='fl'>0</span>),
-  <span class='kw'>channels</span> <span class='kw'>=</span> <span class='fl'>3</span>, <span class='kw'>sparse</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>gpu</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>device_id</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='fl'>0</span>),
-  <span class='kw'>cache_data</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>network_definition_file</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='st'>"mean_per_class_error"</span>, <span class='st'>"r2"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0</span>,
+  <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>ignore_const_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+  <span class='kw'>shuffle_training_data</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>mini_batch_size</span> <span class='kw'>=</span> <span class='fl'>32</span>, <span class='kw'>clip_gradient</span> <span class='kw'>=</span> <span class='fl'>10</span>,
+  <span class='kw'>network</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"auto"</span>, <span class='st'>"user"</span>, <span class='st'>"lenet"</span>, <span class='st'>"alexnet"</span>, <span class='st'>"vgg"</span>, <span class='st'>"googlenet"</span>,
+  <span class='st'>"inception_bn"</span>, <span class='st'>"resnet"</span>), <span class='kw'>backend</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"mxnet"</span>, <span class='st'>"caffe"</span>, <span class='st'>"tensorflow"</span>),
+  <span class='kw'>image_shape</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='fl'>0</span>, <span class='fl'>0</span>), <span class='kw'>channels</span> <span class='kw'>=</span> <span class='fl'>3</span>, <span class='kw'>sparse</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>gpu</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+  <span class='kw'>device_id</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='fl'>0</span>), <span class='kw'>cache_data</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>network_definition_file</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>network_parameters_file</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>mean_image_file</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>export_native_parameters_prefix</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>activation</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"Rectifier"</span>,
   <span class='st'>"Tanh"</span>), <span class='kw'>hidden</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>input_dropout_ratio</span> <span class='kw'>=</span> <span class='fl'>0</span>,
@@ -299,7 +299,7 @@ stopping_metric does not improve for k:=stopping_rounds scoring events (0 to dis
       <th>stopping_metric</th>
       <td><p>Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-"mean_per_class_error". Defaults to AUTO.</p></td>
+"mean_per_class_error", "r2". Defaults to AUTO.</p></td>
     </tr>
     <tr>
       <th>stopping_tolerance</th>
@@ -417,7 +417,7 @@ Model and builds a model on the provided H2OFrame (non-String columns). Must be 
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.describe.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.describe.html
@@ -128,7 +128,7 @@ information about column types, mins/maxs/missing/zero counts/stds/number of lev
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.diff.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.diff.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.dim.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.dim.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.dimnames.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.dimnames.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.distance.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.distance.html
@@ -132,7 +132,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.downloadAllLogs.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.downloadAllLogs.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.downloadCSV.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.downloadCSV.html
@@ -137,7 +137,7 @@ should be saved to.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.download_mojo.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.download_mojo.html
@@ -88,7 +88,7 @@
     
 
     <pre class="usage"><span class='fu'>h2o.download_mojo</span>(<span class='no'>model</span>, <span class='kw'>path</span> <span class='kw'>=</span> <span class='fu'>getwd</span>(), <span class='kw'>get_genmodel_jar</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>genmodel_name</span> <span class='kw'>=</span> <span class='st'>""</span>)</pre>
+  <span class='kw'>genmodel_name</span> <span class='kw'>=</span> <span class='st'>""</span>, <span class='kw'>genmodel_path</span> <span class='kw'>=</span> <span class='st'>""</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
     <table class="ref-arguments">
@@ -103,11 +103,15 @@
     </tr>
     <tr>
       <th>get_genmodel_jar</th>
-      <td><p>If TRUE, then also download h2o-genmodel.jar and store it in folder ``path``.</p></td>
+      <td><p>If TRUE, then also download h2o-genmodel.jar and store it in either in the same folder</p></td>
     </tr>
     <tr>
       <th>genmodel_name</th>
       <td><p>Custom name of genmodel jar.</p></td>
+    </tr>
+    <tr>
+      <th>genmodel_path</th>
+      <td><p>Path to store h2o-genmodel.jar. If left blank and ``get_genmodel_jar`` is TRUE, then the h2o-genmodel.jar</p></td>
     </tr>
     </table>
     
@@ -140,7 +144,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.download_pojo.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.download_pojo.html
@@ -152,7 +152,7 @@ to console. The file name will be a compilable java file name.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.entropy.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.entropy.html
@@ -120,7 +120,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.exp.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.exp.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.exportFile.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.exportFile.html
@@ -156,7 +156,7 @@ Otherwise, the operation will fail.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.exportHDFS.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.exportHDFS.html
@@ -120,7 +120,7 @@ filename.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.fillna.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.fillna.html
@@ -138,7 +138,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.filterNACols.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.filterNACols.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.findSynonyms.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.findSynonyms.html
@@ -119,7 +119,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.find_row_by_threshold.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.find_row_by_threshold.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.find_threshold_by_max_metric.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.find_threshold_by_max_metric.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.floor.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.floor.html
@@ -119,7 +119,7 @@ corresponding elements of x.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.flow.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.flow.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.gainsLift.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.gainsLift.html
@@ -177,7 +177,7 @@ Requires a valid response column.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.gbm.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.gbm.html
@@ -102,17 +102,17 @@ enum for "bernoulli" or "multinomial".</p>
   <span class='kw'>nbins</span> <span class='kw'>=</span> <span class='fl'>20</span>, <span class='kw'>nbins_top_level</span> <span class='kw'>=</span> <span class='fl'>1024</span>, <span class='kw'>nbins_cats</span> <span class='kw'>=</span> <span class='fl'>1024</span>,
   <span class='kw'>r2_stopping</span> <span class='kw'>=</span> <span class='fl'>Inf</span>, <span class='kw'>stopping_rounds</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>stopping_metric</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>,
   <span class='st'>"deviance"</span>, <span class='st'>"logloss"</span>, <span class='st'>"MSE"</span>, <span class='st'>"RMSE"</span>, <span class='st'>"MAE"</span>, <span class='st'>"RMSLE"</span>, <span class='st'>"AUC"</span>, <span class='st'>"lift_top_group"</span>,
-  <span class='st'>"misclassification"</span>, <span class='st'>"mean_per_class_error"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0.001</span>,
-  <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>seed</span> <span class='kw'>=</span> -<span class='fl'>1</span>, <span class='kw'>build_tree_one_node</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>learn_rate</span> <span class='kw'>=</span> <span class='fl'>0.1</span>, <span class='kw'>learn_rate_annealing</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>distribution</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>,
-  <span class='st'>"bernoulli"</span>, <span class='st'>"quasibinomial"</span>, <span class='st'>"multinomial"</span>, <span class='st'>"gaussian"</span>, <span class='st'>"poisson"</span>, <span class='st'>"gamma"</span>,
-  <span class='st'>"tweedie"</span>, <span class='st'>"laplace"</span>, <span class='st'>"quantile"</span>, <span class='st'>"huber"</span>), <span class='kw'>quantile_alpha</span> <span class='kw'>=</span> <span class='fl'>0.5</span>,
-  <span class='kw'>tweedie_power</span> <span class='kw'>=</span> <span class='fl'>1.5</span>, <span class='kw'>huber_alpha</span> <span class='kw'>=</span> <span class='fl'>0.9</span>, <span class='kw'>checkpoint</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>sample_rate_per_class</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>,
-  <span class='kw'>col_sample_rate_change_per_level</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>col_sample_rate_per_tree</span> <span class='kw'>=</span> <span class='fl'>1</span>,
-  <span class='kw'>min_split_improvement</span> <span class='kw'>=</span> <span class='fl'>1e-05</span>, <span class='kw'>histogram_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>,
-  <span class='st'>"UniformAdaptive"</span>, <span class='st'>"Random"</span>, <span class='st'>"QuantilesGlobal"</span>, <span class='st'>"RoundRobin"</span>),
-  <span class='kw'>max_abs_leafnode_pred</span> <span class='kw'>=</span> <span class='fl'>Inf</span>, <span class='kw'>pred_noise_bandwidth</span> <span class='kw'>=</span> <span class='fl'>0</span>,
+  <span class='st'>"misclassification"</span>, <span class='st'>"mean_per_class_error"</span>, <span class='st'>"r2"</span>),
+  <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0.001</span>, <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>seed</span> <span class='kw'>=</span> -<span class='fl'>1</span>,
+  <span class='kw'>build_tree_one_node</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>learn_rate</span> <span class='kw'>=</span> <span class='fl'>0.1</span>, <span class='kw'>learn_rate_annealing</span> <span class='kw'>=</span> <span class='fl'>1</span>,
+  <span class='kw'>distribution</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"bernoulli"</span>, <span class='st'>"quasibinomial"</span>, <span class='st'>"multinomial"</span>,
+  <span class='st'>"gaussian"</span>, <span class='st'>"poisson"</span>, <span class='st'>"gamma"</span>, <span class='st'>"tweedie"</span>, <span class='st'>"laplace"</span>, <span class='st'>"quantile"</span>, <span class='st'>"huber"</span>),
+  <span class='kw'>quantile_alpha</span> <span class='kw'>=</span> <span class='fl'>0.5</span>, <span class='kw'>tweedie_power</span> <span class='kw'>=</span> <span class='fl'>1.5</span>, <span class='kw'>huber_alpha</span> <span class='kw'>=</span> <span class='fl'>0.9</span>,
+  <span class='kw'>checkpoint</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>sample_rate_per_class</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='kw'>col_sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>col_sample_rate_change_per_level</span> <span class='kw'>=</span> <span class='fl'>1</span>,
+  <span class='kw'>col_sample_rate_per_tree</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>min_split_improvement</span> <span class='kw'>=</span> <span class='fl'>1e-05</span>,
+  <span class='kw'>histogram_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"UniformAdaptive"</span>, <span class='st'>"Random"</span>, <span class='st'>"QuantilesGlobal"</span>,
+  <span class='st'>"RoundRobin"</span>), <span class='kw'>max_abs_leafnode_pred</span> <span class='kw'>=</span> <span class='fl'>Inf</span>, <span class='kw'>pred_noise_bandwidth</span> <span class='kw'>=</span> <span class='fl'>0</span>,
   <span class='kw'>categorical_encoding</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"Enum"</span>, <span class='st'>"OneHotInternal"</span>, <span class='st'>"OneHotExplicit"</span>,
   <span class='st'>"Binary"</span>, <span class='st'>"Eigen"</span>, <span class='st'>"LabelEncoder"</span>, <span class='st'>"SortByResponse"</span>, <span class='st'>"EnumLimited"</span>),
   <span class='kw'>calibrate_model</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>calibration_frame</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
@@ -251,7 +251,7 @@ stopping_metric does not improve for k:=stopping_rounds scoring events (0 to dis
       <th>stopping_metric</th>
       <td><p>Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-"mean_per_class_error". Defaults to AUTO.</p></td>
+"mean_per_class_error", "r2". Defaults to AUTO.</p></td>
     </tr>
     <tr>
       <th>stopping_tolerance</th>
@@ -398,7 +398,7 @@ accurate estimates of class probabilities. Defaults to FALSE.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getConnection.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getConnection.html
@@ -107,7 +107,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getFrame.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getFrame.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getFutureModel.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getFutureModel.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getGLMFullRegularizationPath.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getGLMFullRegularizationPath.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getGrid.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getGrid.html
@@ -140,7 +140,7 @@ display even if a validation frame is provided.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getId.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getId.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getModel.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getModel.html
@@ -128,7 +128,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getTimezone.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getTimezone.html
@@ -104,7 +104,7 @@ Returns a string</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.getVersion.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.getVersion.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.giniCoef.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.giniCoef.html
@@ -150,7 +150,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.glm.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.glm.html
@@ -97,9 +97,10 @@ description of the error distribution.</p>
   <span class='st'>"binomial"</span>, <span class='st'>"quasibinomial"</span>, <span class='st'>"ordinal"</span>, <span class='st'>"multinomial"</span>, <span class='st'>"poisson"</span>, <span class='st'>"gamma"</span>,
   <span class='st'>"tweedie"</span>), <span class='kw'>tweedie_variance_power</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>tweedie_link_power</span> <span class='kw'>=</span> <span class='fl'>1</span>,
   <span class='kw'>solver</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"IRLSM"</span>, <span class='st'>"L_BFGS"</span>, <span class='st'>"COORDINATE_DESCENT_NAIVE"</span>,
-  <span class='st'>"COORDINATE_DESCENT"</span>), <span class='kw'>alpha</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>lambda</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>lambda_search</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>early_stopping</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>nlambdas</span> <span class='kw'>=</span> -<span class='fl'>1</span>,
-  <span class='kw'>standardize</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>missing_values_handling</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"MeanImputation"</span>, <span class='st'>"Skip"</span>),
+  <span class='st'>"COORDINATE_DESCENT"</span>, <span class='st'>"GRADIENT_DESCENT_LH"</span>, <span class='st'>"GRADIENT_DESCENT_SQERR"</span>),
+  <span class='kw'>alpha</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>lambda</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>lambda_search</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>early_stopping</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>nlambdas</span> <span class='kw'>=</span> -<span class='fl'>1</span>, <span class='kw'>standardize</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
+  <span class='kw'>missing_values_handling</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"MeanImputation"</span>, <span class='st'>"Skip"</span>),
   <span class='kw'>compute_p_values</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>remove_collinear_columns</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
   <span class='kw'>intercept</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>non_negative</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>max_iterations</span> <span class='kw'>=</span> -<span class='fl'>1</span>,
   <span class='kw'>objective_epsilon</span> <span class='kw'>=</span> -<span class='fl'>1</span>, <span class='kw'>beta_epsilon</span> <span class='kw'>=</span> <span class='fl'>1e-04</span>, <span class='kw'>gradient_epsilon</span> <span class='kw'>=</span> -<span class='fl'>1</span>,
@@ -202,7 +203,8 @@ Defaults to gaussian.</p></td>
       <td><p>AUTO will set the solver based on given data and the other parameters. IRLSM is fast on on problems with small
 number of predictors and for lambda-search with L1 penalty, L_BFGS scales better for datasets with many
 columns. Coordinate descent is experimental (beta). Must be one of: "AUTO", "IRLSM", "L_BFGS",
-"COORDINATE_DESCENT_NAIVE", "COORDINATE_DESCENT". Defaults to AUTO.</p></td>
+"COORDINATE_DESCENT_NAIVE", "COORDINATE_DESCENT", "GRADIENT_DESCENT_LH", "GRADIENT_DESCENT_SQERR". Defaults to
+AUTO.</p></td>
     </tr>
     <tr>
       <th>alpha</th>
@@ -412,7 +414,7 @@ Defaults to 0.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.glrm.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.glrm.html
@@ -284,7 +284,7 @@ Must be one of: "GramSVD", "Power", "Randomized". Defaults to Randomized.</p></t
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.grep.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.grep.html
@@ -155,7 +155,7 @@ if the element matches the pattern (1) or not (0).</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.grid.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.grid.html
@@ -183,7 +183,7 @@ or  <code>list(strategy = "RandomDiscrete", stopping_metric = "misclassification
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.group_by.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.group_by.html
@@ -162,7 +162,7 @@ that the aggregation should apply to all columns except the GroupBy columns. Not
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.gsub.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.gsub.html
@@ -133,7 +133,7 @@ the regex pattern replaced with the replacement substring.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.head.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.head.html
@@ -144,7 +144,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.hist.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.hist.html
@@ -123,7 +123,7 @@ A vector of numbers giving the split points, e.g., c(-50,213.2123,9324834)</p></
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.hit_ratio_table.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.hit_ratio_table.html
@@ -125,7 +125,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.hour.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.hour.html
@@ -130,7 +130,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.ifelse.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.ifelse.html
@@ -145,7 +145,7 @@ both conditions must be either both categorical or numeric.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.importFile.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.importFile.html
@@ -225,7 +225,7 @@ behavior is to pass-through to the parse phase automatically.
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.import_sql_select.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.import_sql_select.html
@@ -145,7 +145,7 @@ For example, "jdbc:mysql://localhost:3306/menagerie?&amp;useSSL=false"</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.import_sql_table.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.import_sql_table.html
@@ -149,7 +149,7 @@ For example, "jdbc:mysql://localhost:3306/menagerie?&amp;useSSL=false"</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.impute.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.impute.html
@@ -166,7 +166,7 @@ column types (e.g. String, Time, UUID) are not supported.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.init.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.init.html
@@ -243,7 +243,7 @@ in the environment before upgrading. It's recommended that users restart R or R 
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.insertMissingValues.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.insertMissingValues.html
@@ -148,7 +148,7 @@ this function should only be called on a subset of the original.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.interaction.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.interaction.html
@@ -182,7 +182,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.is_client.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.is_client.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.isax.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.isax.html
@@ -136,7 +136,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.ischaracter.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.ischaracter.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.isfactor.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.isfactor.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.isnumeric.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.isnumeric.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.kfold_column.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.kfold_column.html
@@ -125,7 +125,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.killMinus3.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.killMinus3.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.kmeans.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.kmeans.html
@@ -229,7 +229,7 @@ Defaults to -1 (time-based random number).</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.kurtosis.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.kurtosis.html
@@ -136,7 +136,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.levels.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.levels.html
@@ -128,7 +128,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.listTimezones.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.listTimezones.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.list_all_extensions.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.list_all_extensions.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.list_api_extensions.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.list_api_extensions.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.list_core_extensions.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.list_core_extensions.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.loadModel.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.loadModel.html
@@ -140,7 +140,7 @@ and port of the server running H2O.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.log.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.log.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.log10.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.log10.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.log1p.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.log1p.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.log2.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.log2.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.logAndEcho.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.logAndEcho.html
@@ -119,7 +119,7 @@ work ends and the next piece of work begins.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.logloss.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.logloss.html
@@ -127,7 +127,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.ls.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.ls.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.lstrip.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.lstrip.html
@@ -126,7 +126,7 @@ argument defaults to removing whitespace.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.mae.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.mae.html
@@ -139,7 +139,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.makeGLMModel.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.makeGLMModel.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.make_metrics.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.make_metrics.html
@@ -143,7 +143,7 @@ or per-class probabilities for multinomial), compute a model metrics object</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.match.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.match.html
@@ -151,7 +151,7 @@ values to be matched.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.max.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.max.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.mean.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.mean.html
@@ -159,7 +159,7 @@ is ignored.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.mean_per_class_error.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.mean_per_class_error.html
@@ -151,7 +151,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.mean_residual_deviance.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.mean_residual_deviance.html
@@ -140,7 +140,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.median.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.median.html
@@ -133,7 +133,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.merge.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.merge.html
@@ -161,7 +161,7 @@ row in y, and vice-versa for all.y.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.metric.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.metric.html
@@ -195,7 +195,7 @@ the indicated threshold.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.min.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.min.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.mktime.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.mktime.html
@@ -136,7 +136,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.month.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.month.html
@@ -130,7 +130,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.mse.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.mse.html
@@ -157,7 +157,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.na_omit.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.na_omit.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.nacnt.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.nacnt.html
@@ -127,7 +127,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.naiveBayes.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.naiveBayes.html
@@ -262,7 +262,7 @@ Must be at least 1e-10.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.names.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.names.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.nchar.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.nchar.html
@@ -120,7 +120,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.ncol.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.ncol.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.networkTest.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.networkTest.html
@@ -107,7 +107,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.nlevels.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.nlevels.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.no_progress.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.no_progress.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.nrow.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.nrow.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.null_deviance.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.null_deviance.html
@@ -125,7 +125,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.null_dof.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.null_dof.html
@@ -125,7 +125,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.num_iterations.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.num_iterations.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.num_valid_substrings.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.num_valid_substrings.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.openLog.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.openLog.html
@@ -134,7 +134,7 @@ Used primarily for debugging purposes.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.parseRaw.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.parseRaw.html
@@ -181,7 +181,7 @@ acquired by calling <a href='h2o.decryptionSetup.html'>h2o.decryptionSetup</a>.<
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.parseSetup.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.parseSetup.html
@@ -168,7 +168,7 @@ acquired by calling <a href='h2o.decryptionSetup.html'>h2o.decryptionSetup</a>.<
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.partialPlot.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.partialPlot.html
@@ -162,7 +162,7 @@ partial dependence the mean response (probabilities) is returned rather than the
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.performance.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.performance.html
@@ -162,7 +162,7 @@ For more information visit: <a href='https://0xdata.atlassian.net/browse/TN-9'>h
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.pivot.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.pivot.html
@@ -131,7 +131,7 @@ For cases of multiple indexes for a column label, the aggregation method is to p
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.prcomp.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.prcomp.html
@@ -218,7 +218,7 @@ Defaults to -1 (time-based random number).</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.predict_json.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.predict_json.html
@@ -146,7 +146,7 @@ from R.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.print.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.print.html
@@ -120,7 +120,7 @@ Anything bigger than 20 rows will require asking the server (first 20 rows are c
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.prod.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.prod.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.proj_archetypes.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.proj_archetypes.html
@@ -149,7 +149,7 @@ offset to each column of the projected archetypes.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.quantile.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.quantile.html
@@ -162,7 +162,7 @@ an <code>H2OFrame</code> object.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.r2.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.r2.html
@@ -140,7 +140,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.randomForest.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.randomForest.html
@@ -100,16 +100,16 @@
   <span class='kw'>nbins</span> <span class='kw'>=</span> <span class='fl'>20</span>, <span class='kw'>nbins_top_level</span> <span class='kw'>=</span> <span class='fl'>1024</span>, <span class='kw'>nbins_cats</span> <span class='kw'>=</span> <span class='fl'>1024</span>,
   <span class='kw'>r2_stopping</span> <span class='kw'>=</span> <span class='fl'>Inf</span>, <span class='kw'>stopping_rounds</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>stopping_metric</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>,
   <span class='st'>"deviance"</span>, <span class='st'>"logloss"</span>, <span class='st'>"MSE"</span>, <span class='st'>"RMSE"</span>, <span class='st'>"MAE"</span>, <span class='st'>"RMSLE"</span>, <span class='st'>"AUC"</span>, <span class='st'>"lift_top_group"</span>,
-  <span class='st'>"misclassification"</span>, <span class='st'>"mean_per_class_error"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0.001</span>,
-  <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>seed</span> <span class='kw'>=</span> -<span class='fl'>1</span>, <span class='kw'>build_tree_one_node</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>mtries</span> <span class='kw'>=</span> -<span class='fl'>1</span>, <span class='kw'>sample_rate</span> <span class='kw'>=</span> <span class='fl'>0.6320000291</span>, <span class='kw'>sample_rate_per_class</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>binomial_double_trees</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>checkpoint</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>col_sample_rate_change_per_level</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>col_sample_rate_per_tree</span> <span class='kw'>=</span> <span class='fl'>1</span>,
-  <span class='kw'>min_split_improvement</span> <span class='kw'>=</span> <span class='fl'>1e-05</span>, <span class='kw'>histogram_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>,
-  <span class='st'>"UniformAdaptive"</span>, <span class='st'>"Random"</span>, <span class='st'>"QuantilesGlobal"</span>, <span class='st'>"RoundRobin"</span>),
-  <span class='kw'>categorical_encoding</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"Enum"</span>, <span class='st'>"OneHotInternal"</span>, <span class='st'>"OneHotExplicit"</span>,
-  <span class='st'>"Binary"</span>, <span class='st'>"Eigen"</span>, <span class='st'>"LabelEncoder"</span>, <span class='st'>"SortByResponse"</span>, <span class='st'>"EnumLimited"</span>),
-  <span class='kw'>calibrate_model</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>calibration_frame</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+  <span class='st'>"misclassification"</span>, <span class='st'>"mean_per_class_error"</span>, <span class='st'>"r2"</span>),
+  <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0.001</span>, <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>seed</span> <span class='kw'>=</span> -<span class='fl'>1</span>,
+  <span class='kw'>build_tree_one_node</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>mtries</span> <span class='kw'>=</span> -<span class='fl'>1</span>, <span class='kw'>sample_rate</span> <span class='kw'>=</span> <span class='fl'>0.6320000291</span>,
+  <span class='kw'>sample_rate_per_class</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>binomial_double_trees</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
+  <span class='kw'>checkpoint</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>col_sample_rate_change_per_level</span> <span class='kw'>=</span> <span class='fl'>1</span>,
+  <span class='kw'>col_sample_rate_per_tree</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>min_split_improvement</span> <span class='kw'>=</span> <span class='fl'>1e-05</span>,
+  <span class='kw'>histogram_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"UniformAdaptive"</span>, <span class='st'>"Random"</span>, <span class='st'>"QuantilesGlobal"</span>,
+  <span class='st'>"RoundRobin"</span>), <span class='kw'>categorical_encoding</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"Enum"</span>, <span class='st'>"OneHotInternal"</span>,
+  <span class='st'>"OneHotExplicit"</span>, <span class='st'>"Binary"</span>, <span class='st'>"Eigen"</span>, <span class='st'>"LabelEncoder"</span>, <span class='st'>"SortByResponse"</span>,
+  <span class='st'>"EnumLimited"</span>), <span class='kw'>calibrate_model</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>calibration_frame</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>distribution</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"bernoulli"</span>, <span class='st'>"multinomial"</span>, <span class='st'>"gaussian"</span>, <span class='st'>"poisson"</span>,
   <span class='st'>"gamma"</span>, <span class='st'>"tweedie"</span>, <span class='st'>"laplace"</span>, <span class='st'>"quantile"</span>, <span class='st'>"huber"</span>),
   <span class='kw'>custom_metric_func</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>verbose</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>)</pre>
@@ -247,7 +247,7 @@ stopping_metric does not improve for k:=stopping_rounds scoring events (0 to dis
       <th>stopping_metric</th>
       <td><p>Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-"mean_per_class_error". Defaults to AUTO.</p></td>
+"mean_per_class_error", "r2". Defaults to AUTO.</p></td>
     </tr>
     <tr>
       <th>stopping_tolerance</th>
@@ -360,7 +360,7 @@ accurate estimates of class probabilities. Defaults to FALSE.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.range.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.range.html
@@ -125,7 +125,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.rbind.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.rbind.html
@@ -135,7 +135,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.reconstruct.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.reconstruct.html
@@ -151,7 +151,7 @@ offset to each column of the reconstructed frame.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.relevel.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.relevel.html
@@ -121,7 +121,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.removeAll.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.removeAll.html
@@ -129,7 +129,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.removeVecs.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.removeVecs.html
@@ -116,7 +116,7 @@ columns.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.rep_len.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.rep_len.html
@@ -123,7 +123,7 @@ vector.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.residual_deviance.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.residual_deviance.html
@@ -125,7 +125,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.residual_dof.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.residual_dof.html
@@ -125,7 +125,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.rm.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.rm.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.rmse.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.rmse.html
@@ -157,7 +157,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.rmsle.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.rmsle.html
@@ -139,7 +139,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.round.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.round.html
@@ -123,7 +123,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.rstrip.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.rstrip.html
@@ -126,7 +126,7 @@ argument defaults to removing whitespace.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.runif.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.runif.html
@@ -139,7 +139,7 @@ dataset.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.saveModel.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.saveModel.html
@@ -147,7 +147,7 @@ Otherwise, the operation will fail.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.saveModelDetails.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.saveModelDetails.html
@@ -138,7 +138,7 @@ will overwrite the file. Otherwise, the operation will fail.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.saveMojo.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.saveMojo.html
@@ -144,7 +144,7 @@ will overwrite the file. Otherwise, the operation will fail.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.scale.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.scale.html
@@ -135,7 +135,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.scoreHistory.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.scoreHistory.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.sd.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.sd.html
@@ -132,7 +132,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.sdev.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.sdev.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.setLevels.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.setLevels.html
@@ -132,7 +132,7 @@ of the column will be created with the given domain levels.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.setTimezone.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.setTimezone.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.show_progress.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.show_progress.html
@@ -101,7 +101,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.shutdown.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.shutdown.html
@@ -146,7 +146,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.signif.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.signif.html
@@ -123,7 +123,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.sin.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.sin.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.skewness.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.skewness.html
@@ -136,7 +136,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.splitFrame.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.splitFrame.html
@@ -150,7 +150,7 @@ specified plus one.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.sqrt.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.sqrt.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.stackedEnsemble.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.stackedEnsemble.html
@@ -184,7 +184,7 @@ Defaults to -1 (time-based random number).</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.startLogging.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.startLogging.html
@@ -130,7 +130,7 @@ primarily for debuggin purposes.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.std_coef_plot.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.std_coef_plot.html
@@ -137,7 +137,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.stopLogging.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.stopLogging.html
@@ -120,7 +120,7 @@ primarily for debugging purposes.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.str.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.str.html
@@ -119,7 +119,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.stringdist.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.stringdist.html
@@ -140,7 +140,7 @@ shape (N x M) and only contain string/factor columns. Return a matrix (H2OFrame)
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.strsplit.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.strsplit.html
@@ -130,7 +130,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.sub.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.sub.html
@@ -133,7 +133,7 @@ the regex pattern replaced with the replacement substring.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.substring.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.substring.html
@@ -134,7 +134,7 @@ is coerced to 0.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.sum.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.sum.html
@@ -129,7 +129,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.summary.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.summary.html
@@ -154,7 +154,7 @@ this behavior by setting up exact_quantiles argument to true.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.svd.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.svd.html
@@ -203,7 +203,7 @@ Defaults to -1 (time-based random number).</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.table.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.table.html
@@ -146,7 +146,7 @@ FALSE to expand counts across all combinations.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.tabulate.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.tabulate.html
@@ -153,7 +153,7 @@ Handles numerical/categorical data and missing values. Supports observation weig
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.tan.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.tan.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.tanh.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.tanh.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.toFrame.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.toFrame.html
@@ -124,7 +124,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.tokenize.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.tokenize.html
@@ -131,7 +131,7 @@ text into a single column making it easier for additional processing (filtering 
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.tolower.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.tolower.html
@@ -126,7 +126,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.topN.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.topN.html
@@ -125,7 +125,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.tot_withinss.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.tot_withinss.html
@@ -125,7 +125,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.totss.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.totss.html
@@ -125,7 +125,7 @@ or "xval".</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.toupper.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.toupper.html
@@ -126,7 +126,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.transform.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.transform.html
@@ -140,7 +140,7 @@ the same sentence are averaged and returned in the result.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.trim.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.trim.html
@@ -120,7 +120,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.trunc.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.trunc.html
@@ -118,7 +118,7 @@ formed by truncating the values in x toward 0.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.unique.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.unique.html
@@ -117,7 +117,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.var.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.var.html
@@ -143,7 +143,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.varimp.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.varimp.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.varimp_plot.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.varimp_plot.html
@@ -141,7 +141,7 @@ for a trained GLM</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.week.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.week.html
@@ -130,7 +130,7 @@ year (starting from 1).</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.weights.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.weights.html
@@ -115,7 +115,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.which.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.which.html
@@ -131,7 +131,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.which_max.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.which_max.html
@@ -135,7 +135,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.which_min.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.which_min.html
@@ -131,7 +131,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.withinss.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.withinss.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.word2vec.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.word2vec.html
@@ -159,7 +159,7 @@ will be randomly down-sampled; useful range is (0, 1e-5) Defaults to 0.001.</p><
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.xgboost.available.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.xgboost.available.html
@@ -102,7 +102,7 @@ Returns True if a XGBoost model can be built, or False otherwise.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.xgboost.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.xgboost.html
@@ -94,22 +94,22 @@
   <span class='st'>"Modulo"</span>, <span class='st'>"Stratified"</span>), <span class='kw'>fold_column</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>ignore_const_cols</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
   <span class='kw'>offset_column</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>weights_column</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>stopping_rounds</span> <span class='kw'>=</span> <span class='fl'>0</span>,
   <span class='kw'>stopping_metric</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"deviance"</span>, <span class='st'>"logloss"</span>, <span class='st'>"MSE"</span>, <span class='st'>"RMSE"</span>, <span class='st'>"MAE"</span>,
-  <span class='st'>"RMSLE"</span>, <span class='st'>"AUC"</span>, <span class='st'>"lift_top_group"</span>, <span class='st'>"misclassification"</span>,
-  <span class='st'>"mean_per_class_error"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0.001</span>, <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>,
-  <span class='kw'>seed</span> <span class='kw'>=</span> -<span class='fl'>1</span>, <span class='kw'>distribution</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"bernoulli"</span>, <span class='st'>"multinomial"</span>,
-  <span class='st'>"gaussian"</span>, <span class='st'>"poisson"</span>, <span class='st'>"gamma"</span>, <span class='st'>"tweedie"</span>, <span class='st'>"laplace"</span>, <span class='st'>"quantile"</span>, <span class='st'>"huber"</span>),
-  <span class='kw'>tweedie_power</span> <span class='kw'>=</span> <span class='fl'>1.5</span>, <span class='kw'>categorical_encoding</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"Enum"</span>,
-  <span class='st'>"OneHotInternal"</span>, <span class='st'>"OneHotExplicit"</span>, <span class='st'>"Binary"</span>, <span class='st'>"Eigen"</span>, <span class='st'>"LabelEncoder"</span>,
-  <span class='st'>"SortByResponse"</span>, <span class='st'>"EnumLimited"</span>), <span class='kw'>quiet_mode</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>ntrees</span> <span class='kw'>=</span> <span class='fl'>50</span>,
-  <span class='kw'>max_depth</span> <span class='kw'>=</span> <span class='fl'>6</span>, <span class='kw'>min_rows</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>min_child_weight</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>learn_rate</span> <span class='kw'>=</span> <span class='fl'>0.3</span>,
-  <span class='kw'>eta</span> <span class='kw'>=</span> <span class='fl'>0.3</span>, <span class='kw'>sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>subsample</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>col_sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>,
-  <span class='kw'>colsample_bylevel</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>col_sample_rate_per_tree</span> <span class='kw'>=</span> <span class='fl'>1</span>,
-  <span class='kw'>colsample_bytree</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>max_abs_leafnode_pred</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>max_delta_step</span> <span class='kw'>=</span> <span class='fl'>0</span>,
-  <span class='kw'>score_tree_interval</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>min_split_improvement</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>gamma</span> <span class='kw'>=</span> <span class='fl'>0</span>,
-  <span class='kw'>max_bins</span> <span class='kw'>=</span> <span class='fl'>256</span>, <span class='kw'>max_leaves</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>min_sum_hessian_in_leaf</span> <span class='kw'>=</span> <span class='fl'>100</span>,
-  <span class='kw'>min_data_in_leaf</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>sample_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"uniform"</span>, <span class='st'>"weighted"</span>),
-  <span class='kw'>normalize_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"tree"</span>, <span class='st'>"forest"</span>), <span class='kw'>rate_drop</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>one_drop</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>,
-  <span class='kw'>skip_drop</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>tree_method</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"auto"</span>, <span class='st'>"exact"</span>, <span class='st'>"approx"</span>, <span class='st'>"hist"</span>),
+  <span class='st'>"RMSLE"</span>, <span class='st'>"AUC"</span>, <span class='st'>"lift_top_group"</span>, <span class='st'>"misclassification"</span>, <span class='st'>"mean_per_class_error"</span>,
+  <span class='st'>"r2"</span>), <span class='kw'>stopping_tolerance</span> <span class='kw'>=</span> <span class='fl'>0.001</span>, <span class='kw'>max_runtime_secs</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>seed</span> <span class='kw'>=</span> -<span class='fl'>1</span>,
+  <span class='kw'>distribution</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"bernoulli"</span>, <span class='st'>"multinomial"</span>, <span class='st'>"gaussian"</span>, <span class='st'>"poisson"</span>,
+  <span class='st'>"gamma"</span>, <span class='st'>"tweedie"</span>, <span class='st'>"laplace"</span>, <span class='st'>"quantile"</span>, <span class='st'>"huber"</span>), <span class='kw'>tweedie_power</span> <span class='kw'>=</span> <span class='fl'>1.5</span>,
+  <span class='kw'>categorical_encoding</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"AUTO"</span>, <span class='st'>"Enum"</span>, <span class='st'>"OneHotInternal"</span>, <span class='st'>"OneHotExplicit"</span>,
+  <span class='st'>"Binary"</span>, <span class='st'>"Eigen"</span>, <span class='st'>"LabelEncoder"</span>, <span class='st'>"SortByResponse"</span>, <span class='st'>"EnumLimited"</span>),
+  <span class='kw'>quiet_mode</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>, <span class='kw'>ntrees</span> <span class='kw'>=</span> <span class='fl'>50</span>, <span class='kw'>max_depth</span> <span class='kw'>=</span> <span class='fl'>6</span>, <span class='kw'>min_rows</span> <span class='kw'>=</span> <span class='fl'>1</span>,
+  <span class='kw'>min_child_weight</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>learn_rate</span> <span class='kw'>=</span> <span class='fl'>0.3</span>, <span class='kw'>eta</span> <span class='kw'>=</span> <span class='fl'>0.3</span>, <span class='kw'>sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>,
+  <span class='kw'>subsample</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>col_sample_rate</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>colsample_bylevel</span> <span class='kw'>=</span> <span class='fl'>1</span>,
+  <span class='kw'>col_sample_rate_per_tree</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>colsample_bytree</span> <span class='kw'>=</span> <span class='fl'>1</span>,
+  <span class='kw'>max_abs_leafnode_pred</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>max_delta_step</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>score_tree_interval</span> <span class='kw'>=</span> <span class='fl'>0</span>,
+  <span class='kw'>min_split_improvement</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>gamma</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>max_bins</span> <span class='kw'>=</span> <span class='fl'>256</span>, <span class='kw'>max_leaves</span> <span class='kw'>=</span> <span class='fl'>0</span>,
+  <span class='kw'>min_sum_hessian_in_leaf</span> <span class='kw'>=</span> <span class='fl'>100</span>, <span class='kw'>min_data_in_leaf</span> <span class='kw'>=</span> <span class='fl'>0</span>,
+  <span class='kw'>sample_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"uniform"</span>, <span class='st'>"weighted"</span>), <span class='kw'>normalize_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"tree"</span>,
+  <span class='st'>"forest"</span>), <span class='kw'>rate_drop</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>one_drop</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>skip_drop</span> <span class='kw'>=</span> <span class='fl'>0</span>,
+  <span class='kw'>tree_method</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"auto"</span>, <span class='st'>"exact"</span>, <span class='st'>"approx"</span>, <span class='st'>"hist"</span>),
   <span class='kw'>grow_policy</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"depthwise"</span>, <span class='st'>"lossguide"</span>), <span class='kw'>booster</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"gbtree"</span>,
   <span class='st'>"gblinear"</span>, <span class='st'>"dart"</span>), <span class='kw'>reg_lambda</span> <span class='kw'>=</span> <span class='fl'>0</span>, <span class='kw'>reg_alpha</span> <span class='kw'>=</span> <span class='fl'>0</span>,
   <span class='kw'>dmatrix_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"auto"</span>, <span class='st'>"dense"</span>, <span class='st'>"sparse"</span>), <span class='kw'>backend</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"auto"</span>, <span class='st'>"gpu"</span>,
@@ -191,7 +191,7 @@ stopping_metric does not improve for k:=stopping_rounds scoring events (0 to dis
       <th>stopping_metric</th>
       <td><p>Metric to use for early stopping (AUTO: logloss for classification, deviance for regression) Must be one of:
 "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-"mean_per_class_error". Defaults to AUTO.</p></td>
+"mean_per_class_error", "r2". Defaults to AUTO.</p></td>
     </tr>
     <tr>
       <th>stopping_tolerance</th>
@@ -384,7 +384,7 @@ auto.</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/h2o.year.html
+++ b/h2o-r/h2o-package/docs/reference/h2o.year.html
@@ -135,7 +135,7 @@ starting from 1900.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/housevotes.html
+++ b/h2o-r/h2o-package/docs/reference/housevotes.html
@@ -124,7 +124,7 @@ California, Department of Information and Computer Science.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/index.html
+++ b/h2o-r/h2o-package/docs/reference/index.html
@@ -1924,7 +1924,7 @@ Returns a string</p></td>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/iris.html
+++ b/h2o-r/h2o-package/docs/reference/iris.html
@@ -114,7 +114,7 @@ respectively, for three species of iris flowers.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/is.character.html
+++ b/h2o-r/h2o-package/docs/reference/is.character.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/is.factor.html
+++ b/h2o-r/h2o-package/docs/reference/is.factor.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/is.h2o.html
+++ b/h2o-r/h2o-package/docs/reference/is.h2o.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/is.numeric.html
+++ b/h2o-r/h2o-package/docs/reference/is.numeric.html
@@ -111,7 +111,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/names.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/names.H2OFrame.html
@@ -112,7 +112,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/plot.H2OModel.html
+++ b/h2o-r/h2o-package/docs/reference/plot.H2OModel.html
@@ -168,7 +168,7 @@ available in the scoring history for a particular type of model.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/plot.H2OTabulate.html
+++ b/h2o-r/h2o-package/docs/reference/plot.H2OTabulate.html
@@ -122,7 +122,7 @@
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 
-    <p><code>link{h2o.tabulate}</code></p>
+    <p><code><a href='h2o.tabulate.html'>h2o.tabulate</a></code></p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
@@ -152,7 +152,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/predict.H2OAutoML.html
+++ b/h2o-r/h2o-package/docs/reference/predict.H2OAutoML.html
@@ -138,7 +138,7 @@ values or unseen factor levels).</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/predict.H2OModel.html
+++ b/h2o-r/h2o-package/docs/reference/predict.H2OModel.html
@@ -149,7 +149,7 @@ values or unseen factor levels).</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/predict_leaf_node_assignment.H2OModel.html
+++ b/h2o-r/h2o-package/docs/reference/predict_leaf_node_assignment.H2OModel.html
@@ -159,7 +159,7 @@ data was loaded</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/print.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/print.H2OFrame.html
@@ -121,7 +121,7 @@ Anything bigger than 20 rows will require asking the server (first 20 rows are c
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/print.H2OTable.html
+++ b/h2o-r/h2o-package/docs/reference/print.H2OTable.html
@@ -126,7 +126,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/prostate.html
+++ b/h2o-r/h2o-package/docs/reference/prostate.html
@@ -113,7 +113,7 @@ University Comprehensive Cancer Center.</p>
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/range.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/range.H2OFrame.html
@@ -116,7 +116,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/str.H2OFrame.html
+++ b/h2o-r/h2o-package/docs/reference/str.H2OFrame.html
@@ -120,7 +120,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/summary-H2OGrid-method.html
+++ b/h2o-r/h2o-package/docs/reference/summary-H2OGrid-method.html
@@ -116,7 +116,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/summary-H2OModel-method.html
+++ b/h2o-r/h2o-package/docs/reference/summary-H2OModel-method.html
@@ -116,7 +116,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/use.package.html
+++ b/h2o-r/h2o-package/docs/reference/use.package.html
@@ -149,7 +149,7 @@ It is possible to control just <code><a href='http://www.rdocumentation.org/pack
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/walking.html
+++ b/h2o-r/h2o-package/docs/reference/walking.html
@@ -115,7 +115,7 @@ The data is available from <a href='https://simtk.org/project/xml/downloads.xml?
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">

--- a/h2o-r/h2o-package/docs/reference/zzz.html
+++ b/h2o-r/h2o-package/docs/reference/zzz.html
@@ -109,7 +109,7 @@
 
       <footer>
       <div class="copyright">
-  <p>Developed by The H2O.ai team.</p>
+  <p>Developed by Tom Kraljevic.</p>
 </div>
 
 <div class="pkgdown">


### PR DESCRIPTION
- In documentation for weights_column, removed bullet point regarding model.predict().
- Added a link to the Target Encoding tutorial in the target_encoding_create and target_encoding_apply docs
- Rebuilt the html. The new author change requires that these individual html files be checked in.