### PR TITLE
PUBDEV-5505 - Closing Rabit connection after communication ends

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/RabitTrackerH2O.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/RabitTrackerH2O.java
@@ -108,6 +108,7 @@ public class RabitTrackerH2O implements IRabitTracker {
 
         @Override
         public void interrupt() {
+            super.interrupt();
             for (SocketChannel channel : socketChannels) {
                 try {
                     channel.close();
@@ -197,7 +198,6 @@ public class RabitTrackerH2O implements IRabitTracker {
                     }
                 } catch (IOException e) {
                     Log.info("Exception in Rabit tracker.", e);
-                    Log.err(e);
                 }
             }
             Log.debug("All Rabit nodes finished.");

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/RabitTrackerH2O.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/RabitTrackerH2O.java
@@ -7,7 +7,6 @@ import water.util.Log;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.*;
@@ -197,7 +196,7 @@ public class RabitTrackerH2O implements IRabitTracker {
                         }
                     }
                 } catch (IOException e) {
-                    Log.info("Exception in Rabit tracker.", e);
+                    Log.err("Exception in Rabit tracker.", e);
                 }
             }
             Log.debug("All Rabit nodes finished.");


### PR DESCRIPTION
Socket leak discovered as a part of  [#2035](https://github.com/h2oai/h2o-3/pull/2035).

The socket leak has been found on two places. Misallocated ServerSocketChannel.open() may thrown an exception when tried to be bound, but those connections seem to create hanging FDs until closed or garbage collected (or the process is terminated).

Also, if SHUTDOWN_CMD is received, there is no need to keep the connection opened, thus closing it immediately seems like a best option to free resources ASAP.

Last but not least, the thread where final SocketChannel channel = tracker.sock.accept(); is called (in its run method) may be interrupted (by calling this.trackerThread.interrupt(); from RabitTrackerH2O's stop() method. The ServerSocketChannel itself is closed explicitely, but not the accepted connections. If the thread is interrupted, then all the SocketChannels are closed explicitely. Calling close() method one more time (in case it had been called before as a reaction to SHUTDOWN_CMD) does no harm, as java.nio first checks for the connection being open before an attempt to close it is made.

Rebased on top of master (there was a big update to XGBoostUpdateTask). Worked on local cluster, waiting for tests to finish (this R test is heavy on resources and if it could, it would potentially allocated hundreds of thousands of DF's (actually counter with AtomicLong static counter).