### PR TITLE
PUBDEV-5524 - XGBoost - Check failed: param.max_depth < 16 Tree depth…

### DIFF
--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -958,12 +958,18 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       _valid = rebalance(_valid, false, _result + ".temporary.valid");
     }
 
+
     // Drop all non-numeric columns (e.g., String and UUID).  No current algo
     // can use them, and otherwise all algos will then be forced to remove
     // them.  Text algos (grep, word2vec) take raw text columns - which are
     // numeric (arrays of bytes).
     ignoreBadColumns(separateFeatureVecs(), expensive);
     ignoreInvalidColumns(separateFeatureVecs(), expensive);
+
+    if (_response != null && _response.isString()) {
+      error("_response_column", "Response variable can not be of type String. Please choose different variable or convert it.");
+    }
+
     // Check that at least some columns are not-constant and not-all-NAs
     if( _train.numCols() == 0 )
       error("_train","There are no usable columns to generate model");

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -11,12 +11,9 @@ import ml.dmlc.xgboost4j.java.XGBoostScoreTask;
 import water.*;
 import water.fvec.Chunk;
 import water.fvec.Frame;
-import water.util.IcedHashMapGeneric.IcedHashMapStringObject;
 import water.util.Log;
 import hex.ModelMetrics;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -132,6 +132,9 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
      */
     Map<String, Object> gpuIncompatibleParams() {
       Map<String, Object> incompat = new HashMap<>();
+      if (_max_depth > 15 || _max_depth < 1) {
+        incompat.put("max_depth",  _max_depth + " . Max depth must be greater than 0 and lower than 16 for GPU backend.");
+      }
       if (_grow_policy == GrowPolicy.lossguide)
         incompat.put("grow_policy", GrowPolicy.lossguide); // See PUBDEV-5302 (param.grow_policy != TrainParam::kLossGuide Loss guided growth policy not supported. Use CPU algorithm.)
       return incompat;

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostModelTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostModelTest.java
@@ -1,7 +1,10 @@
 package hex.tree.xgboost;
 
+import org.junit.Assert;
 import org.junit.Test;
 import water.H2O;
+
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -26,6 +29,32 @@ public class XGBoostModelTest {
     pOver._nthread = H2O.ARGS.nthreads + 1;
     BoosterParms bpOver = XGBoostModel.createParams(pOver, 2);
     assertEquals((int) H2O.ARGS.nthreads, bpOver.get().get("nthread"));
+  }
+
+  @Test
+  public void gpuIncompatibleParametersMaxDepth(){
+    XGBoostModel.XGBoostParameters xgBoostParameters = new XGBoostModel.XGBoostParameters();
+    xgBoostParameters._max_depth = 16;
+
+    Map<String, Object> incompatibleParams = xgBoostParameters.gpuIncompatibleParams();
+    assertEquals(incompatibleParams.size(), 1);
+    assertEquals(incompatibleParams.get("max_depth"), 16 + " . Max depth must be greater than 0 and lower than 16 for GPU backend.");
+
+    xgBoostParameters._max_depth = 0;
+    incompatibleParams = xgBoostParameters.gpuIncompatibleParams();
+    assertEquals(incompatibleParams.size(), 1);
+    assertEquals(incompatibleParams.get("max_depth"), 0 + " . Max depth must be greater than 0 and lower than 16 for GPU backend.");
+  }
+
+
+  @Test
+  public void gpuIncompatibleParametersGrowPolicy(){
+    XGBoostModel.XGBoostParameters xgBoostParameters = new XGBoostModel.XGBoostParameters();
+    xgBoostParameters._grow_policy = XGBoostModel.XGBoostParameters.GrowPolicy.lossguide;
+
+    Map<String, Object> incompatibleParams = xgBoostParameters.gpuIncompatibleParams();
+    assertEquals(incompatibleParams.size(), 1);
+    assertEquals(incompatibleParams.get("grow_policy"), XGBoostModel.XGBoostParameters.GrowPolicy.lossguide);
   }
 
 }


### PR DESCRIPTION
… too large.

[PUBDEV-5524 JIRA](https://0xdata.atlassian.net/browse/PUBDEV-5524)

This issue is about XGBoost check:  `param.max_depth < 16 Tree depth too large`.

**I offer two tests** - the Python tests has one little added value - it tests the backend is able to continue after the first failure, not being shut down. Otherwise it is equal to the JUnit test.

I observed UnsupportedOperationException is commonly used, even though in this case, I'd use IllegalArgumentException personally. It's important though.

