### PR TITLE
PUBDEV-5518: deeplearning grid search complained about lacking response column when autoencoder is TRUE

### DIFF
--- a/h2o-r/h2o-package/R/grid.R
+++ b/h2o-r/h2o-package/R/grid.R
@@ -68,7 +68,10 @@ h2o.grid <- function(algorithm,
     if(!missing(y)) {
       dots$y <- y
     } else {
-      stop("Must specify response, y")
+      # deeplearning with autoencoder param set to T is also okay.  Check this case before whining
+      if (!((algorithm %in% c("deeplearning") && dots$autoencoder==TRUE))) { # only complain if not DL autoencoder
+        stop("Must specify response, y")
+      }
     }
   } 
   if(!missing(training_frame)) {

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5518_autoencoder_grid.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5518_autoencoder_grid.R
@@ -1,0 +1,30 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Test derived from Nidhi Mehta.  Thanks.
+test.pubdev.5518 <- function() {
+  browser()
+    N=1000
+    set.seed(5)
+    color = sample(c("D","E","I","F","M"),size=N,replace=TRUE)
+    num = rnorm(N,mean = 12,sd = 21212)
+    sex = sample(c("male","female"),size=N,replace=TRUE)
+    sex = as.factor(sex)
+    color = as.factor(color)
+    data = sample(c(0,1),size = N,replace = T)
+    fdata = factor(data)
+    table(fdata)
+    dd = data.frame(color,sex,num,fdata)
+    data = as.h2o(dd)
+
+    dl_hyper_params <- list(activation = c("Tanh", "RectifierWithDropout", "TanhWithDropout"))
+    # will fail if any error function is caught.  Should be good now.
+    e<-tryCatch({dl_grid <- h2o.grid("deeplearning", x = 1:4, grid_id = "ae_grid", training_frame = data, epochs = 2,
+                                     autoencoder = TRUE, reproducible = TRUE, max_runtime_secs = 20, hyper_params = dl_hyper_params)},
+                error=function(error_message) {
+                  FAIL(error_message)
+                })
+    
+}
+
+doTest("PUBDEV-5518 Autoencoder grid get needs response column", test.pubdev.5518)


### PR DESCRIPTION
1. Fixed the parameter check in grid.R to not complain about lacking response column if algorithm is deeplearning with autoencoder set to TRUE.  
2. Added Runit test from Nidhi to make sure this is fixed.