### PR TITLE
Prevent scoring crash when response column is absent in scoring dataset

### DIFF
--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -64,6 +64,9 @@ class MetricsBase(backwards_compatible()):
 
     def show(self):
         """Display a short summary of the metrics."""
+        if self._metric_json==None:
+            print("WARNING: Model metrics cannot be calculated and metric_json is empty due to the absence of the response column in your dataset.")
+            return
         metric_type = self._metric_json['__meta']['schema_type']
         types_w_glm = ['ModelMetricsRegressionGLM', 'ModelMetricsBinomialGLM']
         types_w_clustering = ['ModelMetricsClustering']

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -281,6 +281,9 @@ class ModelBase(backwards_compatible()):
         else:  # cases dealing with test_data not None
             if not isinstance(test_data, h2o.H2OFrame):
                 raise ValueError("`test_data` must be of type H2OFrame.  Got: " + type(test_data))
+            if (self._model_json["response_column_name"] != None) and not(self._model_json["response_column_name"] in test_data.names):
+                print("WARNING: Model metrics cannot be calculated and metric_json is empty due to the absence of the response column in your dataset.")
+                return
             res = h2o.api("POST /3/ModelMetrics/models/%s/frames/%s" % (self.model_id, test_data.frame_id))
 
             # FIXME need to do the client-side filtering...  (PUBDEV-874)

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_magnus_gbm_empty_metrics.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_magnus_gbm_empty_metrics.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+def test_gbm_mangus():
+
+    train = pyunit_utils.random_dataset("regression")       # generate random dataset
+    test = train.drop("response")
+    xname = list(set(train.names) - {"response"})
+
+
+    model_original = H2OGradientBoostingEstimator(ntrees=10,
+                                               max_depth=2, col_sample_rate=0.8, sample_rate=0.7,
+                                               stopping_rounds=3,
+                                               seed=1234, score_tree_interval=10,
+                                               learn_rate=0.1,
+                                               stopping_metric="rmse")
+
+
+    model_original.train(x=xname, y="response", training_frame=train)
+    score_original_h2o = model_original.model_performance(test)
+    print("H2O score on original test frame:")
+    try:
+        print(score_original_h2o)
+    except:
+        assert False, "Should not have failed here with empty model metrics message."
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gbm_mangus)
+else:
+    test_gbm_mangus()

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3782,7 +3782,7 @@ h2o.arrange <- function(x, ...) {
   .newExpr("sort", x, by-1L, as.numeric(ascend))
 }
 
-generateColInd <-function(data, by) {
+generate_col_ind <-function(data, by) {
   ### handle the columns
   # we accept: c('col1', 'col2'), 1:2, c(1,2) as column names.
   if(base::is.character(by)) {
@@ -3901,8 +3901,8 @@ generateColInd <-function(data, by) {
 #'
 #' @export
 h2o.rank_within_group_by <- function(x, group_by_cols, sort_cols, ascending=NULL, new_col_name="New_Rank_column", sort_cols_sorted=FALSE) {
-  group.cols = generateColInd(x, group_by_cols)
-  sort.cols = generateColInd(x, sort_cols)
+  group.cols = generate_col_ind(x, group_by_cols)
+  sort.cols = generate_col_ind(x, sort_cols)
   numSort <- length(sort.cols)
   sortdir <- 1^(runif(numSort,1,1)) # default sort direction is ascending
   if (length(ascending) > 0) {

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -504,7 +504,8 @@ h2o.crossValidate <- function(model, nfolds, model.type = c("gbm", "glm", "deepl
 #' Model Performance Metrics in H2O
 #'
 #' Given a trained h2o model, compute its performance on the given
-#' dataset
+#' dataset.  However, if the dataset does not contain the response/target column, no performance will be returned.
+#' Instead, a warning message will be printed.
 #'
 #'
 #' @param model An \linkS4class{H2OModel} object
@@ -553,7 +554,12 @@ h2o.performance <- function(model, newdata=NULL, train=FALSE, valid=FALSE, xval=
   if(!is.logical(valid) || length(valid) != 1L || is.na(valid)) stop("`valid` must be TRUE or FALSE") 
   if(!is.logical(xval) || length(xval) != 1L || is.na(xval)) stop("`xval` must be TRUE or FALSE") 
   if(sum(valid, xval, train) > 1) stop("only one of `train`, `valid`, and `xval` can be TRUE")
-  
+
+  if (!is.null(model@parameters$y)  &&  !(model@parameters$y %in% names(newdata))) {
+    print("WARNING: Model metrics cannot be calculated and metric_json is empty due to the absence of the response column in your dataset.")
+    return(NULL)
+  }
+
   missingNewdata <- missing(newdata) || is.null(newdata)
   
   if( !missingNewdata ) {
@@ -2766,7 +2772,7 @@ h2o.sdev <- function(object) {
 #' \donttest{
 #' library(h2o)
 #' h2o.init()
-#' df <- as.h2o(iris)
+#' df <- as.h2o(iris)frame
 #' tab <- h2o.tabulate(data = df, x = "Sepal.Length", y = "Petal.Width",
 #'              weights_column = NULL, nbins_x = 10, nbins_y = 10)
 #' plot(tab)              

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2772,7 +2772,7 @@ h2o.sdev <- function(object) {
 #' \donttest{
 #' library(h2o)
 #' h2o.init()
-#' df <- as.h2o(iris)frame
+#' df <- as.h2o(iris)
 #' tab <- h2o.tabulate(data = df, x = "Sepal.Length", y = "Petal.Width",
 #'              weights_column = NULL, nbins_x = 10, nbins_y = 10)
 #' plot(tab)              

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -555,14 +555,12 @@ h2o.performance <- function(model, newdata=NULL, train=FALSE, valid=FALSE, xval=
   if(!is.logical(xval) || length(xval) != 1L || is.na(xval)) stop("`xval` must be TRUE or FALSE") 
   if(sum(valid, xval, train) > 1) stop("only one of `train`, `valid`, and `xval` can be TRUE")
 
-  if (!is.null(model@parameters$y)  &&  !(model@parameters$y %in% names(newdata))) {
-    print("WARNING: Model metrics cannot be calculated and metric_json is empty due to the absence of the response column in your dataset.")
-    return(NULL)
-  }
-
   missingNewdata <- missing(newdata) || is.null(newdata)
-  
   if( !missingNewdata ) {
+    if (!is.null(model@parameters$y)  &&  !(model@parameters$y %in% names(newdata))) {
+      print("WARNING: Model metrics cannot be calculated and metric_json is empty due to the absence of the response column in your dataset.")
+      return(NULL)
+    }
     newdata.id <- h2o.getId(newdata)
     parms <- list()
     parms[["model"]] <- model@model_id

--- a/h2o-r/tests/testdir_algos/gbm/runit_GBM_empty_metric_check.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBM_empty_metric_check.R
@@ -1,0 +1,14 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.emptyModelMetrics <- function() {
+  training_file <- random_dataset("regression", testrow = 200)
+  allNames = h2o.names(training_file)
+  xnames = allNames[-which(allNames=="response")]
+  y <- "response"
+  test <- training_file[xnames]
+  model2 <- h2o.gbm(x=xnames,y=y,training_frame=training_file,ntrees=10,max_depth=3)
+  tryCatch(h2o.performance(model2, newdata=test), error =function(x) FAIL("Should not have failed here with empty model metrics message."))
+}
+
+doTest("Test Empty Model Metrics", test.emptyModelMetrics)


### PR DESCRIPTION
Corrected empty metric_json problem:

 When the response column is not included in the scoring dataset, the metric_json is empty becuase we cannot calculate those metrics without the response column.  

However, instead of crashing, an warning message will be shown to the user.  A pyunit test was added to make sure this fix works.