### PR TITLE
PUBDEV-5524 - XGBoost - Check failed: param.max_depth < 16 Tree depth… (#2358)

### DIFF
--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -942,12 +942,18 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       _valid = rebalance(_valid, false, _result + ".temporary.valid");
     }
 
+
     // Drop all non-numeric columns (e.g., String and UUID).  No current algo
     // can use them, and otherwise all algos will then be forced to remove
     // them.  Text algos (grep, word2vec) take raw text columns - which are
     // numeric (arrays of bytes).
     ignoreBadColumns(separateFeatureVecs(), expensive);
     ignoreInvalidColumns(separateFeatureVecs(), expensive);
+
+    if (_response != null && _response.isString()) {
+      error("_response_column", "Response variable can not be of type String. Please choose different variable or convert it.");
+    }
+
     // Check that at least some columns are not-constant and not-all-NAs
     if( _train.numCols() == 0 )
       error("_train","There are no usable columns to generate model");

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -127,6 +127,9 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
      */
     Map<String, Object> gpuIncompatibleParams() {
       Map<String, Object> incompat = new HashMap<>();
+      if (_max_depth > 15 || _max_depth < 1) {
+        incompat.put("max_depth",  _max_depth + " . Max depth must be greater than 0 and lower than 16 for GPU backend.");
+      }
       if (_grow_policy == GrowPolicy.lossguide)
         incompat.put("grow_policy", GrowPolicy.lossguide); // See PUBDEV-5302 (param.grow_policy != TrainParam::kLossGuide Loss guided growth policy not supported. Use CPU algorithm.)
       return incompat;


### PR DESCRIPTION
* PUBDEV-5524 - XGBoost - Check failed: param.max_depth < 16 Tree depth too large.

* Testing GPU incompatible parameters. Removed unused imports.

* String-typed response column is no longer ignored in ModelBuilder, it causes an error during Model's init phase.

(cherry picked from commit fc14185)