### PR TITLE
PUBDEV-5444: Improve rebalance logic to consider multinode clusters

### DIFF
--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1205,18 +1205,19 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   /**
    * Rebalance a frame for load balancing
    * @param original_fr Input frame
-   * @param local Whether to only create enough chunks to max out all cores on one node only
+   * @param local Whether to only create enough chunks to max out all cores on one node only; Warning: IGNORED in the code!
    * @param name Name of rebalanced frame
    * @return Frame that has potentially more chunks
    */
-
   protected Frame rebalance(final Frame original_fr, boolean local, final String name) {
     if (original_fr == null) return null;
     int chunks = desiredChunks(original_fr, local);
-    if (original_fr.anyVec().nonEmptyChunks() >= chunks) {
+    double rebalanceRatio = rebalanceRatio();
+    int nonEmptyChunks = original_fr.anyVec().nonEmptyChunks();
+    if (nonEmptyChunks >= chunks * rebalanceRatio) {
       if (chunks>1)
-        Log.info(name.substring(name.length()-5)+ " dataset already contains " + original_fr.anyVec().nChunks() +
-              " chunks. No need to rebalance.");
+        Log.info(name.substring(name.length()-5)+ " dataset already contains " + nonEmptyChunks + " (non-empty) " +
+              " chunks. No need to rebalance. [desiredChunks=" + chunks, ", rebalanceRatio=" + rebalanceRatio + "]");
       return original_fr;
     }
     Log.info("Rebalancing " + name.substring(name.length()-5)  + " dataset into " + chunks + " chunks.");
@@ -1228,13 +1229,49 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     return rebalanced_fr;
   }
 
+  private double rebalanceRatio() {
+    String mode = H2O.getCloudSize() == 1 ? "single" : "multi";
+    String ratioStr = System.getProperty(H2O.OptArgs.SYSTEM_PROP_PREFIX + "rebalance.ratio." + mode, "1.0");
+    return Double.parseDouble(ratioStr);
+  }
+
   /**
    * Find desired number of chunks. If fewer, dataset will be rebalanced.
    * @return Lower bound on number of chunks after rebalancing.
    */
   protected int desiredChunks(final Frame original_fr, boolean local) {
-    return Math.min((int) Math.ceil(original_fr.numRows() / 1e3), H2O.NUMCPUS);
+    if (H2O.getCloudSize() > 1 && Boolean.getBoolean(H2O.OptArgs.SYSTEM_PROP_PREFIX + "rebalance.enableMulti"))
+      return desiredChunk_multi(original_fr);
+    else
+      return desiredChunk_single(original_fr);
   }
+
+  // single-node version (original version)
+  private int desiredChunk_single(final Frame originalFr) {
+    return Math.min((int) Math.ceil(originalFr.numRows() / 1e3), H2O.NUMCPUS);
+  }
+
+  // multi-node version (experimental version)
+  private int desiredChunk_multi(final Frame fr) {
+    for (int type : fr.types()) {
+      if (type != Vec.T_NUM && type != Vec.T_CAT) {
+        Log.warn("Training frame contains columns non-numeric/categorical columns. Using old rebalance logic.");
+        return desiredChunk_single(fr);
+      }
+    }
+    // estimate size of the Frame on disk as if it was represented in a binary _uncompressed_ format with no overhead
+    long nzCnt = 0;
+    for (Vec v : fr.vecs())
+      nzCnt += v.nzCnt();
+    final int itemSize = 4; // magic constant size of both Numbers and Categoricals
+    final long size = Math.max(nzCnt * itemSize, fr.byteSize());
+    final int desiredChunkSize = FileVec.calcOptimalChunkSize(size, fr.numCols(),
+            fr.numCols() * itemSize, H2O.NUMCPUS, H2O.getCloudSize(), false, true);
+    final int desiredChunks = (int) ((size / desiredChunkSize) + (size % desiredChunkSize > 0 ? 1 : 0));
+    Log.info("Calculated optimal number of chunks = " + desiredChunks);
+    return desiredChunks;
+  }
+
 
   public void checkDistributions() {
     if (_parms._distribution == DistributionFamily.quasibinomial) {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1222,7 +1222,6 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
               " chunks. No need to rebalance. [desiredChunks=" + chunks, ", rebalanceRatio=" + rebalanceRatio + "]");
       return original_fr;
     }
-    _job.update(0,"Load balancing " + name.substring(name.length() - 5) + " data...");
     Log.info("Rebalancing " + name.substring(name.length()-5)  + " dataset into " + chunks + " chunks.");
     Key newKey = Key.makeUserHidden(name + ".chunks" + chunks);
     RebalanceDataSet rb = new RebalanceDataSet(original_fr, newKey, chunks);

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -955,12 +955,6 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       _train.remove(_parms._ignored_columns);
       if( expensive ) Log.info("Dropping ignored columns: "+Arrays.toString(_parms._ignored_columns));
     }
-    // Rebalance train and valid datasets
-    if (expensive && error_count() == 0 && _parms._auto_rebalance) {
-      setTrain(rebalance(_train, false, _result + ".temporary.train"));
-      _valid = rebalance(_valid, false, _result + ".temporary.valid");
-    }
-
 
     // Drop all non-numeric columns (e.g., String and UUID).  No current algo
     // can use them, and otherwise all algos will then be forced to remove
@@ -969,6 +963,13 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     ignoreBadColumns(separateFeatureVecs(), expensive);
     ignoreInvalidColumns(separateFeatureVecs(), expensive);
     checkResponseVariable();
+
+    // Rebalance train and valid datasets (after invalid/bad columns are dropped)
+    if (expensive && error_count() == 0 && _parms._auto_rebalance) {
+      setTrain(rebalance(_train, false, _result + ".temporary.train"));
+      separateFeatureVecs(); // need to reset MB's fields (like response) after rebalancing
+      _valid = rebalance(_valid, false, _result + ".temporary.valid");
+    }
 
     // Check that at least some columns are not-constant and not-all-NAs
     if( _train.numCols() == 0 )

--- a/h2o-core/src/test/java/hex/ModelBuilderTest.java
+++ b/h2o-core/src/test/java/hex/ModelBuilderTest.java
@@ -9,6 +9,7 @@ import water.fvec.Vec;
 import water.parser.BufferedString;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ModelBuilderTest extends TestUtil {
@@ -58,6 +59,57 @@ public class ModelBuilderTest extends TestUtil {
       assertEquals(nRows, espc[nChunks]);
       for (int i = 0; i < espc.length; i++)
         assertEquals(i * 1000, espc[i]);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testRebalanceMulti() {
+    org.junit.Assume.assumeTrue(H2O.getCloudSize() > 1);
+    try {
+      Scope.enter();
+      double[] colA = new double[1000000];
+      String[] resp = new String[colA.length];
+      for (int i = 0; i < colA.length; i++) {
+        colA[i] = i % 7;
+        resp[i] = i % 3 == 0 ? "A" : "B";
+      }
+      final Frame train = Scope.track(new TestFrameBuilder()
+              .withName("testFrame")
+              .withColNames("ColA", "Response")
+              .withVecTypes(Vec.T_NUM, Vec.T_CAT)
+              .withDataForCol(0, colA)
+              .withDataForCol(1, resp)
+              .withChunkLayout(colA.length) // single chunk
+              .build());
+      assertEquals(1, train.anyVec().nChunks());
+
+      DummyModelParameters parms = new DummyModelParameters("Rebalance Test", Key.make( "rebalance-test"));
+      parms._train = train._key;
+      ModelBuilder<?, ?, ?> mb = new DummyModelBuilder(parms) {
+        @Override
+        protected String getSysProperty(String name, String def) {
+          if (name.equals("rebalance.ratio.multi"))
+            return "0.5";
+          if (name.equals("rebalance.enableMulti"))
+            return "true";
+          if (name.startsWith(H2O.OptArgs.SYSTEM_PROP_PREFIX + "rebalance"))
+            throw new IllegalStateException("Unexpected property: " + name);
+          return super.getSysProperty(name, def);
+        }
+      };
+
+      // the rebalance logic should spread the Frame across the whole cluster (>> single node CPUs)
+      final int desiredChunks = mb.desiredChunks(train, false);
+      assertTrue(desiredChunks > 4 * H2O.NUMCPUS);
+
+      // expensive init - should include rebalance
+      mb.init(true);
+
+      // check that dataset was rebalanced
+      final int rebalancedChunks = mb.train().anyVec().nonEmptyChunks();
+      assertEquals(desiredChunks, rebalancedChunks);
     } finally {
       Scope.exit();
     }


### PR DESCRIPTION
The rebalance logic is modified to consider all CPU cores in the cluster. We are trying to mimic the behavior of ParseDataset and how the Parse allocates chunks. To do that we calculate a virtual size of the Frame as it would take on disk if it was stored in a simple binary format that has no overhead but also doesn't apply any compression. The virtual size is then used to determine how would the Parser parse such dataset (what would be the chunk size). We use the derived number of chunks and if the number of non-empty chunks in the Frame is lower than 0.5 * desired number of chunks we rebalance the dataset (ratio is configurable by a system property).

Defaults to the old behavior which will tend to not rebalance the dataset. Has to be enabled by setting a system property.

This PR works well on datasets like Airlines.

- [x] Add tests