### PR TITLE
[ITA-291] Add standalone tests for H2O + Hadoop.

### DIFF
--- a/scripts/jenkins/groovy/buildH2O3.groovy
+++ b/scripts/jenkins/groovy/buildH2O3.groovy
@@ -15,7 +15,7 @@ def call(final pipelineContext) {
         try {
             // Launch docker container, build h2o-3, create test packages and archive artifacts
             def buildEnv = pipelineContext.getBuildConfig().getBuildEnv() + "PYTHON_VERSION=${PYTHON_VERSION}" + "R_VERSION=${R_VERSION}"
-            def timeoutMinutes = pipelineContext.getBuildConfig().getBuildHadoop() ? 40 : 15
+            def timeoutMinutes = pipelineContext.getBuildConfig().getBuildHadoop() ? 50 : 15
             stage(stageName) {
                 insideDocker(buildEnv, pipelineContext.getBuildConfig().DEFAULT_IMAGE, pipelineContext.getBuildConfig().DOCKER_REGISTRY, pipelineContext.getBuildConfig(), timeoutMinutes, 'MINUTES') {
                     try {

--- a/scripts/jenkins/groovy/hadoopStage.groovy
+++ b/scripts/jenkins/groovy/hadoopStage.groovy
@@ -1,13 +1,23 @@
+H2O_HADOOP_STARTUP_MODE_HADOOP='ON_HADOOP'
+H2O_HADOOP_STARTUP_MODE_STANDALONE='STANDALONE'
+
 def call(final pipelineContext, final stageConfig) {
 
-
-    final String distribution = stageConfig.customData.distribution
-    final String version = stageConfig.customData.version
-    
-    stageConfig.image = pipelineContext.getBuildConfig().getSmokeHadoopImage(distribution, version)
+    stageConfig.image = pipelineContext.getBuildConfig().getSmokeHadoopImage(stageConfig.customData.distribution, stageConfig.customData.version)
     withCredentials([usernamePassword(credentialsId: 'ldap-credentials', usernameVariable: 'LDAP_USERNAME', passwordVariable: 'LDAP_PASSWORD')]) {
 
         stageConfig.customBuildAction = """
+            if [ -n "\$HADOOP_CONF_DIR" ]; then
+                export HADOOP_CONF_DIR=\$(realpath \${HADOOP_CONF_DIR})
+            fi
+
+            if [ -n "\$HADOOP_DAEMON" ]; then
+                export HADOOP_DAEMON=\$(realpath \${HADOOP_DAEMON})
+            fi
+            if [ -n "\$YARN_DAEMON" ]; then
+                export YARN_DAEMON=\$(realpath \${YARN_DAEMON})
+            fi
+
             echo "Activating Python ${stageConfig.pythonVersion}"
             . /envs/h2o_env_python${stageConfig.pythonVersion}/bin/activate
         
@@ -15,11 +25,15 @@ def call(final pipelineContext, final stageConfig) {
             sudo -E /usr/sbin/startup.sh
             
             echo 'Starting H2O on Hadoop'
-            hadoop jar h2o-hadoop/h2o-${distribution}${version}-assembly/build/libs/h2odriver.jar -libjars "\$(cat /opt/hive-jars/hive-libjars)" -n 1 -mapperXmx 2g -baseport 54445 -notify h2o_one_node -ea -disown -login_conf ${stageConfig.customData.ldapConfigPath} -ldap_login
-            
-            IFS=":" read CLOUD_IP CLOUD_PORT < h2o_one_node
-            export CLOUD_IP=\$CLOUD_IP
-            export CLOUD_PORT=\$CLOUD_PORT
+            ${getH2OStartupCmd(stageConfig)}
+            if [ -z \${CLOUD_IP} ]; then
+                echo "CLOUD_IP must be set"
+                exit 1
+            fi
+            if [ -z \${CLOUD_PORT} ]; then
+                echo "CLOUD_PORT must be set"
+                exit 1
+            fi
             echo "Cloud IP:PORT ----> \$CLOUD_IP:\$CLOUD_PORT"
             
             echo "Running Make"
@@ -28,6 +42,33 @@ def call(final pipelineContext, final stageConfig) {
 
         def defaultStage = load('h2o-3/scripts/jenkins/groovy/defaultStage.groovy')
         defaultStage(pipelineContext, stageConfig)
+    }
+}
+
+/**
+ * Returns the cmd used to start H2O in given mode (on Hadoop or standalone). The cmd <strong>must</strong> export
+ * the CLOUD_IP and CLOUT_PORT env variables (they are checked afterwards).
+ * @param stageConfig stage configuration to read mode and additional information from
+ * @return the cmd used to start H2O in given mode
+ */
+private def getH2OStartupCmd(final stageConfig) {
+    switch (stageConfig.customData.mode) {
+        case H2O_HADOOP_STARTUP_MODE_HADOOP:
+            return """
+                hadoop jar h2o-hadoop/h2o-${stageConfig.customData.distribution}${stageConfig.customData.version}-assembly/build/libs/h2odriver.jar -libjars "\$(cat /opt/hive-jars/hive-libjars)" -n 1 -mapperXmx 2g -baseport 54445 -notify h2o_one_node -ea -disown -login_conf ${stageConfig.customData.ldapConfigPath} -ldap_login
+                IFS=":" read CLOUD_IP CLOUD_PORT < h2o_one_node
+                export CLOUD_IP=\$CLOUD_IP
+                export CLOUD_PORT=\$CLOUD_PORT
+            """
+        case H2O_HADOOP_STARTUP_MODE_STANDALONE:
+            def defaultPort = 54321
+            return """
+                java -cp build/h2o.jar:\$(cat /opt/hive-jars/hive-libjars | tr ',' ':') water.H2OApp -port ${defaultPort} -ip \$(hostname --ip-address) -name \$(date +%s) >standalone_h2o.log 2>&1 & sleep 15
+                export CLOUD_IP=\$(hostname --ip-address)
+                export CLOUD_PORT=${defaultPort}
+            """
+        default:
+            error("Startup mode ${stageConfig.customData.mode} for H2O with Hadoop is not supported")
     }
 }
 


### PR DESCRIPTION
Adds test of standalone H2O jar with various Hadoop distros.
Temporarily runs on micro nodes only, so there is only one node per executor.
Removes wildcards from HDP related env vars.
Increases build timeout to 50 minutes for hadoop build.