### PR TITLE
PUBDEV-5233-multinode-xgboost-tests

### DIFF
--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_bigCat_native_comparison_large.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_bigCat_native_comparison_large.py
@@ -1,0 +1,114 @@
+import pandas as pd
+import xgboost as xgb
+import time
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+
+'''
+The goal of this test is to compare h2oxgboost and native xgboost performance in terms of
+1. training time and performance
+2. scoring time and performance
+
+The dataset contains categoricals only of different cardinality.
+
+Ideally, the two should yield the same results with the same seeds.  However, we have slightly different
+parameter sets between the two.  Need to resolve this, Michalk/Pavel/Nidhi/Megan/whoever, help?
+'''
+def bigCat_test():
+    assert H2OXGBoostEstimator.available() is True
+    trainFileList = ['bigdata/laptop/jira/tenThousandCat10C.csv.zip', 'bigdata/laptop/jira/tenThousandCat50C.csv.zip',
+                     'bigdata/laptop/jira/tenThousandCat100C.csv.zip'] # all categorical files  # cannot use this ones
+    h2oParams = {"ntrees":100, "max_depth":10, "seed":987654321, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100}
+    nativeParam = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
+                   'max_depth': h2oParams["max_depth"], 'seed': h2oParams["seed"], 'min_child_weight':h2oParams["min_rows"],
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"]}
+    nrows = 100000
+    ncols = 10
+    factorL = 10
+
+#    for fname in trainFileList:
+#    for ind in range(2):
+    trainFile = genTrainFiles(nrows, ncols, factorL)     # load in dataset and add response column
+    myX = trainFile.names
+    y='response'
+    myX.remove(y)
+
+    # train the H2OXGBoost
+    h2oModel = H2OXGBoostEstimator(**h2oParams)
+    # gather, print and save performance numbers for h2o model
+    h2oModel.train(x=myX, y=y, training_frame=trainFile)
+    h2oTrainTime = h2oModel._model_json["output"]["run_time"]
+    time1 = time.time()
+    h2oPredict = h2oModel.predict(trainFile)
+    h2oPredictTime = time.time()-time1
+
+    # train the native XGBoost
+    nativeTrain = genDMatrix(trainFile, myX, y)
+    nativeModel = xgb.train(params=nativeParam,
+                            dtrain=nativeTrain ,
+                            num_boost_round=h2oParams["ntrees"])
+    nativeTrainTime = time.time()-time1
+    time1=time.time()
+    nativePred = nativeModel.predict(data=nativeTrain)
+    nativeScoreTime = time.time()-time1
+
+    summarizeResult(h2oPredict, nativePred, h2oTrainTime, h2oPredictTime, nativeTrainTime, nativeScoreTime,
+                    nativeTrain.get_label())
+
+def summarizeResult(h2oPredict, nativePred, h2oTrainTime, h2oPredictTime, nativeTrainTime, nativeScoreTime,
+                    nativeLabels):
+    # Result comparison in terms of time
+    print("H2OXGBoost train time is {0}ms.  Native XGBoost train time is {1}s\n.  H2OGBoost scoring time is {2}s."
+          "  Native XGBoost scoring time is {3}s.".format(h2oTrainTime, nativeTrainTime, h2oPredictTime,
+                                                          nativeScoreTime))
+    # Result comparison in terms of accuracy right now, that is the only thing available
+    nativeErr = sum(1 for i in range(len(nativePred)) if int(nativePred[i] > 0.5) != nativeLabels[i])/float(len(nativePred))
+    h2oPredict['predict'] = h2oPredict['predict'].asnumeric()
+    h2oPredictLocal = h2oPredict.as_data_frame(use_pandas=True, header=True)
+    h2oErr = sum(1 for i in range(h2oPredict.nrow)
+                 if abs(h2oPredictLocal['predict'][i] - nativeLabels[i])>1e-6)/float(len(nativePred))
+    print("H2OXGBoost error rate is {0} and native XGBoost error rate is {1}".format(h2oErr, nativeErr))
+#    assert (h2oErr <= nativeErr) or abs(h2oErr-nativeErr) < 1e-6, \
+ #       "H2OXGBoost predict accuracy {0} and native XGBoost predict accuracy are too different!".format(h2oErr, nativeErr)
+
+    # compare prediction probability and they should agree if they use the same seed
+    for ind in range(h2oPredict.nrow):
+        if abs(nativePred[ind]-h2oPredictLocal['c0.l1'][ind])>1e-6:
+            print("H2O prediction prob: {0} and XGBoost prediction prob: {1}.  They are very "
+                  "different.".format(h2oPredictLocal['c0.l1'][ind], nativePred[ind]))
+            break
+#        assert abs(nativePred[ind]-h2oPredictLocal['p1'][ind])<1e-6, \
+#            "H2O prediction prob: {0} and XGBoost prediction prob: {1}.  They are very " \
+#            "different.".format(h2oPredict[ind,'p1'], nativePred[ind])
+
+def genTrainFiles(nrow, ncol, factorL):
+    #trainFrame = h2o.import_file(pyunit_utils.locate(trainStr))
+    trainFrame = pyunit_utils.random_dataset_enums_only(nrow, ncol, factorL=factorL, misFrac=0)
+    yresponse = pyunit_utils.random_dataset_enums_only(trainFrame.nrow, 1, factorL=2, misFrac=0)
+    yresponse.set_name(0,'response')
+    trainFrame = trainFrame.cbind(yresponse)
+    return trainFrame
+
+def genDMatrix(h2oFrame, xlist, yresp):
+    pandaFtrain = h2oFrame.as_data_frame(use_pandas=True, header=True)
+    # need to fix categoricals
+    for cname in xlist:
+        ctemp = pd.get_dummies(pandaFtrain[cname], prefix=cname, drop_first=True)
+        pandaFtrain.drop([cname], axis=1, inplace=True)
+        pandaFtrain = pd.concat([ctemp, pandaFtrain], axis=1)
+
+    c0 = pd.get_dummies(pandaFtrain[yresp], prefix=yresp, drop_first=True)
+    pandaFtrain.drop([yresp], axis=1, inplace=True)
+    pandaF = pd.concat([c0, pandaFtrain], axis=1)
+    pandaF.rename(columns={c0.columns[0]:yresp}, inplace=True)
+    data = pandaF.as_matrix(xlist)
+    label = pandaF.as_matrix([yresp])
+
+    return xgb.DMatrix(data=data, label=label)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(bigCat_test)
+else:
+    bigCat_test()

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_native_comparison_large.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_native_comparison_large.py
@@ -31,7 +31,7 @@ def higgs_compare_test():
     runSeed = random.randint(1, 1073741824)
     print("Seed used in running {0}.".format(runSeed))
     h2oParams = {"ntrees":100, "max_depth":10, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
-                 "min_rows" : 5, "score_tree_interval": 100}
+                 "min_rows" : 5, "score_tree_interval": 100, 'reg_alpha':0.5, 'reg_lambda':0.5, 'gamma':0.5}
     h2oModel = H2OXGBoostEstimator(**h2oParams)
     # gather, print and save performance numbers for h2o model
     h2oModel.train(x=myX, y=y, training_frame=higgs_h2o_train)
@@ -46,7 +46,8 @@ def higgs_compare_test():
     time1 = time.time()
     nativeParam = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
              'max_depth': h2oParams["max_depth"], 'seed': h2oParams["seed"], 'min_child_weight':h2oParams["min_rows"],
-                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"], 'alpha':0.0, 'nrounds':h2oParams["ntrees"]}
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"], 'alpha':0.5,
+                   'gamma':0.5, 'lambda':0.5, 'nrounds':h2oParams["ntrees"]}
     nativeModel = xgb.train(params=nativeParam,
                             dtrain=nativeTrain)
     nativeTrainTime = time.time()-time1

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_native_comparison_large.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_native_comparison_large.py
@@ -2,6 +2,8 @@ import pandas as pd
 import xgboost as xgb
 import time
 import random
+from xgboost import plot_tree
+import matplotlib.pyplot as plt
 
 from h2o.estimators.xgboost import *
 from tests import pyunit_utils
@@ -27,6 +29,7 @@ def higgs_compare_test():
     myX.remove(y)
 
     runSeed = random.randint(1, 1073741824)
+    print("Seed used in running {0}.".format(runSeed))
     h2oParams = {"ntrees":100, "max_depth":10, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
                  "min_rows" : 5, "score_tree_interval": 100}
     h2oModel = H2OXGBoostEstimator(**h2oParams)
@@ -43,10 +46,9 @@ def higgs_compare_test():
     time1 = time.time()
     nativeParam = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
              'max_depth': h2oParams["max_depth"], 'seed': h2oParams["seed"], 'min_child_weight':h2oParams["min_rows"],
-                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"]}
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"], 'alpha':0.0, 'nrounds':h2oParams["ntrees"]}
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain ,
-                            num_boost_round=h2oParams["ntrees"])
+                            dtrain=nativeTrain)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTest)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_native_comparison_large.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_native_comparison_large.py
@@ -1,0 +1,90 @@
+import pandas as pd
+import xgboost as xgb
+import time
+import random
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+
+'''
+The goal of this test is to compare h2oxgboost and native xgboost performance in terms of
+1. training time and performance
+2. scoring time and performance
+
+Ideally, the two should yield the same results with the same seeds.  However, we have slightly different
+parameter sets between the two.  Need to resolve this, Michalk/Pavel/Nidhi/Megan/whoever, help?
+'''
+def higgs_compare_test():
+    assert H2OXGBoostEstimator.available() is True
+
+    # train H2O XGBoost first
+    higgs_h2o_train = h2o.import_file(pyunit_utils.locate('bigdata/laptop/higgs_train_imbalance_100k.csv'))
+    higgs_h2o_test = h2o.import_file(pyunit_utils.locate('bigdata/laptop/higgs_test_imbalance_100k.csv'))
+    higgs_h2o_train[0] = higgs_h2o_train[0].asfactor()
+    higgs_h2o_test[0] = higgs_h2o_test[0].asfactor()
+    myX = list(higgs_h2o_train.names)
+    y = "response"
+    myX.remove(y)
+
+    runSeed = random.randint(1, 1073741824)
+    h2oParams = {"ntrees":100, "max_depth":10, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100}
+    h2oModel = H2OXGBoostEstimator(**h2oParams)
+    # gather, print and save performance numbers for h2o model
+    h2oModel.train(x=myX, y=y, training_frame=higgs_h2o_train)
+    h2oTrainTime = h2oModel._model_json["output"]["run_time"]
+    time1 = time.time()
+    h2oPredict = h2oModel.predict(higgs_h2o_test)
+    h2oPredictTime = time.time()-time1
+
+    # build native XGBoost model
+    nativeTrain = genDMatrix(higgs_h2o_train, myX, y)
+    nativeTest = genDMatrix(higgs_h2o_test, myX, y)
+    time1 = time.time()
+    nativeParam = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
+             'max_depth': h2oParams["max_depth"], 'seed': h2oParams["seed"], 'min_child_weight':h2oParams["min_rows"],
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"]}
+    nativeModel = xgb.train(params=nativeParam,
+                            dtrain=nativeTrain ,
+                            num_boost_round=h2oParams["ntrees"])
+    nativeTrainTime = time.time()-time1
+    time1=time.time()
+    nativePred = nativeModel.predict(data=nativeTest)
+    nativeScoreTime = time.time()-time1
+
+    # Result comparison in terms of time
+    print("H2OXGBoost train time is {0}ms.  Native XGBoost train time is {1}s\n.  H2OGBoost scoring time is {2}s."
+          "  Native XGBoost scoring time is {3}s.".format(h2oTrainTime, nativeTrainTime, h2oPredictTime,
+                                                          nativeScoreTime))
+    # Result comparison in terms of accuracy right now, that is the only thing available
+    nativeLabels = nativeTest.get_label()
+    nativeErr = sum(1 for i in range(len(nativePred)) if int(nativePred[i] > 0.5) != nativeLabels[i])/float(len(nativePred))
+    h2oPredictLocal = h2oPredict.as_data_frame(use_pandas=True, header=True)
+    h2oErr = sum(1 for i in range(h2oPredict.nrow)
+                 if abs(h2oPredictLocal['predict'][i] - nativeLabels[i])>1e-6)/float(len(nativePred))
+    print("H2OXGBoost error rate is {0} and native XGBoost error rate is {1}".format(h2oErr, nativeErr))
+    assert (h2oErr <= nativeErr) or abs(h2oErr-nativeErr) < 1e-6, \
+        "H2OXGBoost predict accuracy {0} and native XGBoost predict accuracy are too different!".format(h2oErr, nativeErr)
+
+    # compare prediction probability and they should agree if they use the same seed
+    for ind in range(h2oPredict.nrow):
+        assert abs(nativePred[ind]-h2oPredictLocal['p1'][ind])<1e-6, \
+            "H2O prediction prob: {0} and XGBoost prediction prob: {1}.  They are very " \
+            "different.".format(h2oPredict[ind,'p1'], nativePred[ind])
+
+def genDMatrix(h2oFrame, xlist, yresp):
+    pandaFtrain = h2oFrame.as_data_frame(use_pandas=True, header=True)
+    # need to change column 0 to categorical
+    c0 = pd.get_dummies(pandaFtrain[yresp], prefix=yresp, drop_first=True)
+    pandaFtrain.drop([yresp], axis=1, inplace=True)
+    pandaF = pd.concat([c0, pandaFtrain], axis=1)
+    pandaF.rename(columns={c0.columns[0]:yresp}, inplace=True)
+    data = pandaF.as_matrix(xlist)
+    label = pandaF.as_matrix([yresp])
+
+    return xgb.DMatrix(data=data, label=label)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(higgs_compare_test)
+else:
+    higgs_compare_test()

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_random_seeds_large.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_random_seeds_large.py
@@ -1,0 +1,119 @@
+import pandas as pd
+import xgboost as xgb
+import random
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+
+'''
+The goal of this test is to compare h2oxgboost runs with different random seeds and the results should be repeatable
+with the same random seeds.
+'''
+def random_seeds_test():
+    assert H2OXGBoostEstimator.available() is True
+
+    # train H2O XGBoost first
+    higgs_h2o_train = h2o.import_file(pyunit_utils.locate('bigdata/laptop/higgs_train_imbalance_100k.csv'))
+    higgs_h2o_train[0] = higgs_h2o_train[0].asfactor()
+    higgs_h2o_test = h2o.import_file(pyunit_utils.locate('bigdata/laptop/higgs_test_imbalance_100k.csv'))
+    higgs_h2o_test[0] = higgs_h2o_test[0].asfactor()
+    myX = list(higgs_h2o_train.names)
+    y = "response"
+    myX.remove(y)
+
+    #seed1 = random.randint(1, 1073741824) # seed cannot be long, must be int size
+    seed1 = 12345
+    seed2 = seed1+10
+    h2oParams = {"ntrees":100, "max_depth":10, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100, "seed":seed1}
+
+    # train 2 models with the same seeds
+    h2oModel1 = H2OXGBoostEstimator(**h2oParams)
+    # gather, print and save performance numbers for h2o model
+    h2oModel1.train(x=myX, y=y, training_frame=higgs_h2o_train)
+    h2oPredict1 = h2oModel1.predict(higgs_h2o_test)
+    h2oModel2 = H2OXGBoostEstimator(**h2oParams)
+    # gather, print and save performance numbers for h2o model
+    h2oModel2.train(x=myX, y=y, training_frame=higgs_h2o_train)
+    h2oPredict2 = h2oModel2.predict(higgs_h2o_test)
+    h2oParams2 = {"ntrees":100, "max_depth":10, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100, "seed":seed2}
+    h2oModel3 = H2OXGBoostEstimator(**h2oParams2)
+    # gather, print and save performance numbers for h2o model
+    h2oModel3.train(x=myX, y=y, training_frame=higgs_h2o_train)
+    h2oPredict3 = h2oModel3.predict(higgs_h2o_test)
+
+    # Result comparison in terms of prediction output.  In theory, h2oModel1 and h2oModel2 should be the same
+    # h2oModel3 will be different from the other two models
+
+    # compare the logloss
+    assert abs(h2oModel1._model_json["output"]["training_metrics"]._metric_json["logloss"]-
+                    h2oModel2._model_json["output"]["training_metrics"]._metric_json["logloss"])<1e-10, \
+        "Model outputs should be the same with same seeds but are not!  Expected: {0}, actual: " \
+        "{1}".format(h2oModel1._model_json["output"]["training_metrics"]._metric_json["logloss"],
+                     h2oModel2._model_json["output"]["training_metrics"]._metric_json["logloss"])
+    assert abs(h2oModel1._model_json["output"]["training_metrics"]._metric_json["logloss"]-
+                    h2oModel3._model_json["output"]["training_metrics"]._metric_json["logloss"])>1e-10, \
+        "Model outputs should be different with same seeds but are not!"
+
+    # compare some prediction probabilities
+    pyunit_utils.compare_frames_local(h2oPredict1[['p0', 'p1']], h2oPredict2[['p0', 'p1']], prob=0.1, tol=1e-6) # should pass
+    try:
+        pyunit_utils.compare_frames_local(h2oPredict1[['p0', 'p1']], h2oPredict3[['p0', 'p1']], prob=0.1, tol=1e-6) # should fail
+        assert False, "Predict frames from two different seeds should be different but is not.  FAIL!"
+    except:
+        assert True
+
+    # train multiple native XGBoost
+    nativeTrain = genDMatrix(higgs_h2o_train, myX, y)
+    nativeTest = genDMatrix(higgs_h2o_test, myX, y)
+    h2o.remove_all()
+    nativeParam = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
+                   'max_depth': h2oParams["max_depth"], 'seed': h2oParams["seed"], 'min_child_weight':h2oParams["min_rows"],
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"]}
+    nativeModel1 = xgb.train(params=nativeParam,
+                            dtrain=nativeTrain ,
+                            num_boost_round=h2oParams["ntrees"])
+
+    nativePred1 = nativeModel1.predict(data=nativeTest)
+    nativeModel2 = xgb.train(params=nativeParam,
+                             dtrain=nativeTrain ,
+                             num_boost_round=h2oParams["ntrees"])
+    nativePred2 = nativeModel2.predict(data=nativeTest)
+
+    nativeParam2 = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
+                   'max_depth': h2oParams["max_depth"], 'seed': h2oParams2["seed"], 'min_child_weight':h2oParams["min_rows"],
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"]}
+
+    nativeModel3 = xgb.train(params=nativeParam2,
+                         dtrain=nativeTrain ,
+                         num_boost_round=h2oParams["ntrees"])
+    nativePred3 = nativeModel3.predict(data=nativeTest)
+
+    # nativeModel1 and nativeModel2 should generate the same results while nativeModel3 should provide different results
+    # compare prediction probability and they should agree if they use the same seed
+    for ind in range(h2oPredict3.nrow):
+        assert abs(nativePred1[ind]-nativePred2[ind])<1e-6, \
+            "Native XGBoost model 1 prediction prob: {0} and native XGBoost model 2 prediction prob: {1}.  They are very " \
+            "different.".format(nativePred1[ind], nativePred2[ind])
+
+        assert abs(nativePred1[ind]-nativePred3[ind])>=1e-6, \
+            "Native XGBoost model 1 prediction prob: {0} and native XGBoost model 3 prediction prob: {1}.  They are too  " \
+            "similar.".format(nativePred1[ind], nativePred2[ind])
+
+def genDMatrix(h2oFrame, xlist, yresp):
+    pandaFtrain = h2oFrame.as_data_frame(use_pandas=True, header=True)
+    # need to change column 0 to categorical
+    c0 = pd.get_dummies(pandaFtrain[yresp], prefix=yresp, drop_first=True)
+    pandaFtrain.drop([yresp], axis=1, inplace=True)
+    pandaF = pd.concat([c0, pandaFtrain], axis=1)
+    pandaF.rename(columns={c0.columns[0]:yresp}, inplace=True)
+    data = pandaF.as_matrix(xlist)
+    label = pandaF.as_matrix([yresp])
+
+    return xgb.DMatrix(data=data, label=label)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(random_seeds_test)
+else:
+    random_seeds_test()

--- a/h2o-py/tests/testdir_hdfs/index.list
+++ b/h2o-py/tests/testdir_hdfs/index.list
@@ -11,3 +11,6 @@ pyunit_INTERNAL_HDFS_import_folder_orc.py
 pyunit_INTERNAL_HDFS_baddata_orc.py
 pyunit_INTERNAL_HADOOP_download_logs.py
 pyunit_INTERNAL_XGBoostEstimation.py
+pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_multinodes_random_seeds.py
+pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_bigCat.py
+

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_bigCat.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_bigCat.py
@@ -28,7 +28,7 @@ def bigCat_test_hdfs():
                  "min_rows" : 5, "score_tree_interval": 100}
     nativeParam = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
                    'max_depth': h2oParams["max_depth"], 'seed': h2oParams["seed"], 'min_child_weight':h2oParams["min_rows"],
-                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"]}
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"], 'alpha':0.0, 'nrounds':h2oParams["ntrees"]}
 
     for fname in trainFileList:
         trainFile = genTrainFiles(fname, hdfs_name_node)     # load in dataset and add response column
@@ -48,8 +48,7 @@ def bigCat_test_hdfs():
         # train the native XGBoost
         nativeTrain = genDMatrix(trainFile, myX, y)
         nativeModel = xgb.train(params=nativeParam,
-                                dtrain=nativeTrain ,
-                                num_boost_round=h2oParams["ntrees"])
+                                dtrain=nativeTrain)
         nativeTrainTime = time.time()-time1
         time1=time.time()
         nativePred = nativeModel.predict(data=nativeTrain)

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_bigCat.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_bigCat.py
@@ -1,0 +1,111 @@
+import pandas as pd
+import xgboost as xgb
+import time
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+
+'''
+The goal of this test is to compare h2oxgboost and native xgboost performance in terms of
+1. training time and performance
+2. scoring time and performance
+
+The dataset contains categoricals only of different cardinality.
+
+Ideally, the two should yield the same results with the same seeds.  However, we have slightly different
+parameter sets between the two.  Need to resolve this, Michalk/Pavel/Nidhi/Megan/whoever, help?
+'''
+def bigCat_test_hdfs():
+    assert H2OXGBoostEstimator.available() is True
+
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+
+    trainFileList = ['/datasets/bigCatFiles/oneMillionCat10C.csv', '/datasets/bigCatFiles/oneMillionCat50C.csv',
+                     '/datasets/bigCatFiles/oneMillionCat100C.csv'] # all categorical files
+    h2oParams = {"ntrees":100, "max_depth":10, "seed":987654321, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100}
+    nativeParam = {'eta': h2oParams["learn_rate"], 'objective': 'binary:logistic', 'booster': 'gbtree',
+                   'max_depth': h2oParams["max_depth"], 'seed': h2oParams["seed"], 'min_child_weight':h2oParams["min_rows"],
+                   'colsample_bytree':h2oParams["col_sample_rate_per_tree"]}
+
+    for fname in trainFileList:
+        trainFile = genTrainFiles(fname, hdfs_name_node)     # load in dataset and add response column
+        myX = trainFile.names
+        y='response'
+        myX.remove(y)
+
+        # train the H2OXGBoost
+        h2oModel = H2OXGBoostEstimator(**h2oParams)
+        # gather, print and save performance numbers for h2o model
+        h2oModel.train(x=myX, y=y, training_frame=trainFile)
+        h2oTrainTime = h2oModel._model_json["output"]["run_time"]
+        time1 = time.time()
+        h2oPredict = h2oModel.predict(trainFile)
+        h2oPredictTime = time.time()-time1
+
+        # train the native XGBoost
+        nativeTrain = genDMatrix(trainFile, myX, y)
+        nativeModel = xgb.train(params=nativeParam,
+                                dtrain=nativeTrain ,
+                                num_boost_round=h2oParams["ntrees"])
+        nativeTrainTime = time.time()-time1
+        time1=time.time()
+        nativePred = nativeModel.predict(data=nativeTrain)
+        nativeScoreTime = time.time()-time1
+
+        summarizeResult(h2oPredict, nativePred, h2oTrainTime, h2oPredictTime, nativeTrainTime, nativeScoreTime,
+                        nativeTrain.get_label())
+
+def summarizeResult(h2oPredict, nativePred, h2oTrainTime, h2oPredictTime, nativeTrainTime, nativeScoreTime,
+                    nativeLabels):
+    # Result comparison in terms of time
+    print("H2OXGBoost train time is {0}ms.  Native XGBoost train time is {1}s\n.  H2OGBoost scoring time is {2}s."
+          "  Native XGBoost scoring time is {3}s.".format(h2oTrainTime, nativeTrainTime, h2oPredictTime,
+                                                          nativeScoreTime))
+    # Result comparison in terms of accuracy right now, that is the only thing available
+    nativeErr = sum(1 for i in range(len(nativePred)) if int(nativePred[i] > 0.5) != nativeLabels[i])/float(len(nativePred))
+    h2oPredictLocal = h2oPredict.as_data_frame(use_pandas=True, header=True)
+    h2oErr = sum(1 for i in range(h2oPredict.nrow)
+                 if abs(h2oPredictLocal['predict'][i] - nativeLabels[i])>1e-6)/float(len(nativePred))
+    print("H2OXGBoost error rate is {0} and native XGBoost error rate is {1}".format(h2oErr, nativeErr))
+    assert (h2oErr <= nativeErr) or abs(h2oErr-nativeErr) < 1e-6, \
+        "H2OXGBoost predict accuracy {0} and native XGBoost predict accuracy are too different!".format(h2oErr, nativeErr)
+
+    # compare prediction probability and they should agree if they use the same seed
+    for ind in range(h2oPredict.nrow):
+        assert abs(nativePred[ind]-h2oPredictLocal['p1'][ind])<1e-6, \
+            "H2O prediction prob: {0} and XGBoost prediction prob: {1}.  They are very " \
+            "different.".format(h2oPredict[ind,'p1'], nativePred[ind])
+
+def genTrainFiles(trainStr, hdfs_name_node):
+    print("Import airlines_all.csv from HDFS")
+    url = "hdfs://{0}{1}".format(hdfs_name_node, trainStr)
+    trainFrame = h2o.import_file(url)
+    yresponse = pyunit_utils.random_dataset_enums_only(trainFrame.nrow, 1, factorL=2, misFrac=0)
+    yresponse.set_name(0,'response')
+    trainFrame.cbind(yresponse)
+    return trainFrame
+
+def genDMatrix(h2oFrame, xlist, yresp):
+    pandaFtrain = h2oFrame.as_data_frame(use_pandas=True, header=True)
+    # need to fix categoricals
+    for cname in xlist:
+        ctemp = pd.get_dummies(pandaFtrain[cname], prefix=cname, drop_first=True)
+        pandaFtrain.drop([cname], axis=1, inplace=True)
+        pandaFtrain = pd.concat([ctemp, pandaFtrain], axis=1)
+        
+    c0 = pd.get_dummies(pandaFtrain[yresp], prefix=yresp, drop_first=True)
+    pandaFtrain.drop([yresp], axis=1, inplace=True)
+    pandaF = pd.concat([c0, pandaFtrain], axis=1)
+    pandaF.rename(columns={c0.columns[0]:yresp}, inplace=True)
+    data = pandaF.as_matrix(xlist)
+    label = pandaF.as_matrix([yresp])
+
+    return xgb.DMatrix(data=data, label=label)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(bigCat_test_hdfs)
+else:
+    bigCat_test_hdfs()

--- a/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_multinodes_random_seeds.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_INTERNAL_HDFS_PUBDEV_5233_xgboost_multinodes_random_seeds.py
@@ -1,0 +1,92 @@
+import random
+import sys, time
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+
+'''
+The goal of this test is to compare h2oxgboost runs with different random seeds and the results should be repeatable
+with the same random seeds.
+'''
+def randomDataset_random_seeds_test():
+    assert H2OXGBoostEstimator.available() is True
+
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+    else:
+        sys.exit("Hadoop cluster is not available!")
+
+    nrow = 1000000  # Megan suggests to use 5million rows and 1000 columns
+    ncol = 100  # in order to make Hadoop test, need to make this 1 million rows by 100 columns
+    trainFile = pyunit_utils.random_dataset_numeric_only(nrow, ncol, integerR=1000000, misFrac=0)
+    trainFile.set_name(0,"response") # randomly choose a response column
+    n = trainFile.nrow
+    print("rows: {0}".format(n))
+
+    print("Run Multinode H2O XGBoost")
+    myX = list(trainFile.col_names)
+    y = "response"
+    myX.remove(y)
+
+    seed1 = random.randint(1, 100000000000)
+    seed2 = seed1+10
+    h2oParams = {"ntrees":100, "max_depth":10, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100, "seed":seed1}
+
+    # train 2 models with the same seeds
+    h2oModel1 = H2OXGBoostEstimator(**h2oParams)
+    # gather, print and save performance numbers for h2o model
+    h2oModel1.train(x=myX, y=y, training_frame=trainFile)
+    h2oTrainTime = h2oModel1._model_json["output"]["run_time"]
+    time1 = time.time()
+    h2oPredict1 = h2oModel1.predict(trainFile)
+    h2oPredictTime = time.time()-time1
+    print("Model train time is {0}ms and scoring time is {1}s.".format(h2oTrainTime, h2oPredictTime))
+
+    h2oModel2 = H2OXGBoostEstimator(**h2oParams)
+    # gather, print and save performance numbers for h2o model
+    h2oModel2.train(x=myX, y=y, training_frame=trainFile)
+    h2oTrainTime = h2oModel2._model_json["output"]["run_time"]
+    time1 = time.time()
+    h2oPredict2 = h2oModel2.predict(trainFile)
+    h2oPredictTime = time.time()-time1
+    print("Model train time is {0}ms and scoring time is {1}s.".format(h2oTrainTime, h2oPredictTime))
+
+    h2oParams2 = {"ntrees":100, "max_depth":10, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100, "seed":seed2}
+    h2oModel3 = H2OXGBoostEstimator(**h2oParams2)
+    # gather, print and save performance numbers for h2o model
+    h2oModel3.train(x=myX, y=y, training_frame=trainFile)
+    h2oTrainTime = h2oModel3._model_json["output"]["run_time"]
+    time1 = time.time()
+    h2oPredict3 = h2oModel3.predict(trainFile)
+    h2oPredictTime = time.time()-time1
+    print("Model train time is {0}ms and scoring time is {1}s.".format(h2oTrainTime, h2oPredictTime))
+    # Result comparison in terms of prediction output.  In theory, h2oModel1 and h2oModel2 should be the same
+    # h2oModel3 will be different from the other two models
+
+    # compare the logloss
+    assert abs(h2oModel1._model_json["output"]["training_metrics"]._metric_json["logloss"]-
+                    h2oModel2._model_json["output"]["training_metrics"]._metric_json["logloss"])<1e-10, \
+        "Model outputs should be the same with same seeds but are not!  Expected: {0}, actual: " \
+        "{1}".format(h2oModel1._model_json["output"]["training_metrics"]._metric_json["logloss"],
+                     h2oModel2._model_json["output"]["training_metrics"]._metric_json["logloss"])
+    assert abs(h2oModel1._model_json["output"]["training_metrics"]._metric_json["logloss"]-
+                    h2oModel3._model_json["output"]["training_metrics"]._metric_json["logloss"])>1e-10, \
+        "Model outputs should be different with same seeds but are not!"
+
+    # compare some prediction probabilities
+    pyunit_utils.compare_frames_local(h2oPredict1[['p0', 'p1']], h2oPredict2[['p0', 'p1']], prob=0.1, tol=1e-6) # should pass
+    try:
+        pyunit_utils.compare_frames_local(h2oPredict1[['p0', 'p1']], h2oPredict3[['p0', 'p1']], prob=0.1, tol=1e-6) # should fail
+        assert False, "Predict frames from two different seeds should be different but is not.  FAIL!"
+    except:
+        assert True
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(randomDataset_random_seeds_test)
+else:
+    randomDataset_random_seeds_test()

--- a/h2o-py/tests/testdir_hdfs/pyunit_PUBDEV_5233_xgboost_multinodetests_airlines.py
+++ b/h2o-py/tests/testdir_hdfs/pyunit_PUBDEV_5233_xgboost_multinodetests_airlines.py
@@ -1,0 +1,58 @@
+from __future__ import print_function
+from builtins import range
+import sys
+import time
+sys.path.insert(1,"../../")
+from tests import pyunit_utils
+from h2o.estimators.xgboost import *
+#----------------------------------------------------------------------
+# Purpose:  This test runs xgboost on the full airlines dataset.
+#----------------------------------------------------------------------
+
+def hdfs_xgboost_airlines():
+    assert H2OXGBoostEstimator.available() is True  # check to make sure XGBoost is available
+
+    # Check if we are running inside the H2O network by seeing if we can touch
+    # the namenode.
+    hadoop_namenode_is_accessible = pyunit_utils.hadoop_namenode_is_accessible()
+
+    if hadoop_namenode_is_accessible:
+        hdfs_name_node = pyunit_utils.hadoop_namenode()
+        hdfs_file = "/datasets/airlines_all.csv"
+
+        print("Import airlines_all.csv from HDFS")
+        url = "hdfs://{0}{1}".format(hdfs_name_node, hdfs_file)
+        airlines_h2o = h2o.import_file(url)
+        n = airlines_h2o.nrow
+        print("rows: {0}".format(n))
+
+        print("Run Multinode XGBoost")
+        myX = list(airlines_h2o.col_names)
+        myX.remove("IsDepDelayed")
+        y = "IsDepDelayed"
+
+        h2oParams = {"ntrees":100, "max_depth":10, "seed":987654321, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                 "min_rows" : 5, "score_tree_interval": 100, 'booster':'gbtree', 'seed':12345}
+        # parameters used to train XGBoost, should be the same as in native and H2O
+        h2o_model = H2OXGBoostEstimator(**h2oParams)
+        h2o_model.train(x=myX, y=y, training_frame=airlines_h2o)
+
+        # get scoring time
+        startTime = time.time()
+        h2o_prediction = h2o_model.predict(airlines_h2o)
+        processTime = time.time()-startTime
+        print("Time (ms) taken to perform training is {0} and time (s) taking to perform scoring is "
+              "{1}".format(h2o_model._model_json["output"]['run_time'], processTime))
+
+        # compare H2O performance with native XGBoost performance.  Since I do not know how to run XGBoost in
+        # hadoop, I will try to save some python performance and try to compare with that one.
+
+    else:
+        raise EnvironmentError
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(hdfs_xgboost_airlines)
+else:
+    hdfs_xgboost_airlines()


### PR DESCRIPTION
I planned to write the following sets of tests for both single node and multinode (running off Hadoop) xgboost:

1. compare h2oXGBoost and native XGBoost, compare the training/scoring time/prediction accuracy.  Ideally they should be close.  In particular, with the same seeds, the predictions from both models should equal.

2. Random seed reproducibility: models run with the same seed should produce the same model and predictions.  Models run with different seeds should produce slightly different models and different prediction probabilities.

3. Categorical datasets: H2O XGBoost and native XGBoost should work with categorical datasets of different cardinality.  Again, compare the training/scoring/prediction accuracies among the models.

I will need to manually run the multinode models first.  In addition, since I do not know how to run native XGBoost in Hadoop, I probably need to run the native XGBoost and save the model outputs for comparison with the Hadoop runs.