### PR TITLE
Fix for adding Double.NaN to IntAryVisitor via addValue().

### DIFF
--- a/h2o-core/src/main/java/water/fvec/ChunkVisitor.java
+++ b/h2o-core/src/main/java/water/fvec/ChunkVisitor.java
@@ -169,10 +169,14 @@ public abstract class ChunkVisitor {
     }
     @Override
     public void addValue(double val) {
-      int i = (int)val;
-      if( i != val)
-        throw new RuntimeException(val + " does not fit into int");
-      vals[_k++] = i;
+      if (Double.isNaN(val)) {
+        vals[_k++] = _na;
+      } else {
+        int i = (int) val;
+        if (i != val)
+          throw new RuntimeException(val + " does not fit into int");
+        vals[_k++] = i;
+      }
     }
     @Override
     public void addZeros(int zeros) {


### PR DESCRIPTION
Fixes
```
at water.MRTask.getResult(MRTask.java:478) 
at water.MRTask.getResult(MRTask.java:486) 
at water.MRTask.doAll(MRTask.java:390) 
at water.MRTask.doAll(MRTask.java:385) 
at hex.glm.GLM$GLMGradientSolver.getGradient(GLM.java:1705) 
at hex.glm.GLM.init(GLM.java:477) 
at hex.glm.GLM$GLMDriver.computeImpl(GLM.java:1057) 
at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:206) 
at hex.glm.GLM$GLMDriver.compute2(GLM.java:543) 
at water.H2O$H2OCountedCompleter.compute(H2O.java:1263) 
at jsr166y.CountedCompleter.exec(CountedCompleter.java:468) 
at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263) 
at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974) 
at jsr1......ForkJoinTask.java:263) 
at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974) 
at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477) 
at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104) 
Caused by: java.lang.RuntimeException: NaN does not fit into int 
at water.fvec.ChunkVisitor$IntAryVisitor.addValue(ChunkVisitor.java:174) 
at water.fvec.C2SChunk.processRows2(C2SChunk.java:75) 
at water.fvec.CSChunk.processRows(CSChunk.java:95) 
at water.fvec.Chunk.getIntegers(Chunk.java:790) 
at hex.glm.GLMTask$GLMGradientTask.computeCategoricalEtas(GLMTask.java:496) 
at hex.glm.GLMTask$GLMGradientTask.map(GLMTask.java:597) 
at water.MRTask.compute2(MRTask.java:640) 
at water.MRTask.compute2(MRTask.java:591) 
at water.H2O$H2OCountedCompleter.compute1(H2O.java:1266) 
at hex.glm.GLMTask$GLMGaussianGradientTask$Icer.compute1(GLMTask$GLMGaussianGradientTask$Icer.java) 
at water.H2O$H2OCountedCompleter.compute(H2O.java:1262) 
... 5 more 
```