### PR TITLE
[WOL-PUBDEV-5567] Remove GoogleTagManager from Flow.

### DIFF
--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.7.18"
+    "h2o-flow": "0.7.23"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Updates Flow to 0.7.23.