### PR TITLE
PUBDEV-5545-relwolpert: Added section for enforcing system-level command-line arguments in h2odriver

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -192,7 +192,7 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
         <div class="well well-sm">
           <h5>Sparkling Water</h5>
           <div class="lt-gry-bg1 dltile" style="display: flex !important; display: -webkit-flex !important; flex-direction: column; padding: 6px;">
-              <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/faq/sparkling-water.html">What is Sparkling Water?</a>
+              <a href="https://www.h2o.ai/sparkling-water/">What is Sparkling Water?</a>
              <table class="table" style="padding: 0px; margin: 0px;">
               <tbody class="lt-gry-bg dltile">
                 <tr>
@@ -601,8 +601,8 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
             </tr>
             <tr>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">H2O Scaladoc</td>
-              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="http://docs.h2o.ai/h2o/latest-stable/h2o-scala_2.10/scaladoc/index.html">&nbsp;2.10</a></td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="http://docs.h2o.ai/h2o/latest-stable/h2o-scala_2.11/scaladoc/index.html">2.11</a></td>
+              <td style="padding-bottom: 3pt; padding-top: 3pt;"align="right"><a href="http://docs.h2o.ai/h2o/latest-stable/h2o-scala_2.10/scaladoc/index.html">&nbsp;2.10</a></td>
             </tr>
           </tbody>
         </table>
@@ -786,10 +786,10 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
                 H2O Scaladoc
               </td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-scala_2.10/scaladoc/index.html">2.10</a>
+                <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-scala_2.11/scaladoc/index.html">2.11</a>
               </td>
               <td style="padding-bottom: 3pt; padding-top: 3pt;">
-                <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-scala_2.11/scaladoc/index.html">2.11</a>
+                <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-scala_2.10/scaladoc/index.html">2.10</a>
               </td>
             </tr>
             <tr>

--- a/h2o-docs/src/product/api-reference.rst
+++ b/h2o-docs/src/product/api-reference.rst
@@ -7,7 +7,7 @@ The links below point to more detailed API/developer documentation.
 
 - `REST API Schemas <rest-api-reference.html#schema-reference>`_: This document represents the definitive guide to the H2O REST API schemas.
 
-- `R <../h2o-r/h2o_package.pdf>`_: This document provides the list of available functions that can be used when configuring H2O through R.
+- `R User HTML <../h2o-r/docs/index.html>`_ and R User PDF <../h2o-r/h2o_package.pdf>`_ : This document provides the list of available functions that can be used when configuring H2O through R.
 	
 - `Python <../h2o-py/docs/index.html>`_: This document provides the list of available functions that can be used when configuring H2O through R.
 	
@@ -15,8 +15,8 @@ The links below point to more detailed API/developer documentation.
 
 - `h2o-algos Javadoc <../h2o-algos/javadoc/index.html>`_: The definitive Java API guide for the algorithms used by H2O.
 
-- `POJO Model Javadoc <../h2o-genmodel/javadoc/index.html>`_: Provides a step-by-step guide to creating and implementing POJOs in a Java application.
+- `POJO/MOJO Javadoc <../h2o-genmodel/javadoc/index.html>`_: Provides a step-by-step guide to creating and implementing POJOs and MOJOs in a Java application.
 
 - `h2o-scala Scaladoc <../h2o-scala/scaladoc/index.html>`_: The definitive Scala API guide for H2O.
 
-- `Sparkling Water API <https://github.com/h2oai/sparkling-water/blob/master/DEVEL.md>`_: This document describes the configuration properties that can be passed to Spark to onfigure Sparkling Water. 
+- `Sparkling Water API <http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/devel/rest_api/scala_interpreter_endpoints.html>`_: This document describes the configuration properties that can be passed to Spark to configure Sparkling Water. 

--- a/h2o-docs/src/product/security.rst
+++ b/h2o-docs/src/product/security.rst
@@ -120,7 +120,7 @@ jobs.
 9. The authenticated user can access the same data in H2O that he could
    access via HDFS
 
-What is being Secured Today
+What is Being Secured Today
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Standard file permissions security is provided by the Operating
@@ -143,6 +143,27 @@ What is being Secured Today
 
 3. Internal H2O node-to-H2O node communication can be encrypted.
 
+
+Enforcing System-Level Command-Line Arguments in h2odriver.jar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+System administrators can create a configuration file with implicit arguments of h2odriver and use it to make sure the H2O cluster is started with the specified security settings. 
+
+1. Create the config file in **/etc/h2o/h2odriver.args**.
+2. Specify the default command-line options that you want to enforce. Note that each argument must be on a separate line. For example:
+
+ ::
+
+   h2o_ssl_jks_internal=keystore.jks
+   h2o_ssl_jks_password=password
+   h2o_ssl_jts_internal=truststore.jks
+   h2o_ssl_jts_password=password
+
+3. Start H2O.
+
+ ::
+
+  hadoop jar h2odriver.jar -mapperXmx 3g -nodes 1
 
 File Security in H2O
 --------------------
@@ -234,8 +255,8 @@ manipulated on the command line with the
 `keytool <http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html>`_
 command.
 
-The underlying HTTPS implementation is provided by Jetty 8 and the Java
-runtime. (**Note**: Jetty 8 was chosen to retain Java 6 compatibility.)
+The underlying HTTPS implementation is provided by Jetty 9 and the Java
+runtime.
 
 Standalone H2O
 ''''''''''''''
@@ -508,7 +529,7 @@ Example **ldap.conf**:
 ::
 
     ldaploginmodule {
-        org.eclipse.jetty.plus.jaas.spi.LdapLoginModule required
+        ai.h2o.org.eclipse.jetty.jaas.spi.LdapLoginModule required
         debug="true"
         useLdaps="false"
         contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
@@ -521,8 +542,8 @@ Example **ldap.conf**:
         userBaseDn="ou=users,dc=0xdata,dc=loc";
     };
 
-See the `Jetty 8 LdapLoginModule
-documentation <http://wiki.eclipse.org/Jetty/Feature/JAAS#LdapLoginModule>`__
+See the `Jetty 9 LdapLoginModule
+documentation <http://www.eclipse.org/jetty/documentation/current/jaas-support.html>`__
 for more information.
 
 Standalone H2O
@@ -790,7 +811,7 @@ Example **realm.properties**:
 
 ::
 
-    # See https://wiki.eclipse.org/Jetty/Howto/Secure_Passwords
+    # See http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html
     # java -cp h2o.jar org.eclipse.jetty.util.security.Password
     username1: password1
     username2: MD5:6cb75f652a9b52798eb6cf2201057c73
@@ -802,10 +823,10 @@ tool:
 
     java -cp h2o.jar org.eclipse.jetty.util.security.Password username password
 
-See the `Jetty 8 HashLoginService
+See the `Jetty 9 HashLoginService
 documentation <http://wiki.eclipse.org/Jetty/Tutorial/Realms#HashLoginService>`_
-and `Jetty 8 Secure Password
-HOWTO <http://wiki.eclipse.org/Jetty/Howto/Secure_Passwords>`_ for more
+and `Jetty 9 Secure Password
+HOWTO <http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html>`_ for more
 information.
 
 Standalone H2O

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -261,7 +261,7 @@ Getting Started with Sparkling Water
 
 -  `Building Machine Learning Applications with Sparkling Water <http://docs.h2o.ai/h2o-tutorials/latest-stable/tutorials/sparkling-water/index.html>`_: This short tutorial describes project building and demonstrates the capabilities of Sparkling Water using Spark Shell to build a Deep Learning model.
 
--  `Sparkling Water FAQ <https://github.com/h2oai/sparkling-water/blob/master/doc/FAQ.rst>`_: This FAQ provides answers to many common questions about Sparkling Water.
+-  `Sparkling Water FAQ <http://docs.h2o.ai/sparkling-water/master/bleeding-edge/doc/FAQ.html>`_: This FAQ provides answers to many common questions about Sparkling Water.
 
 -  `Connecting RStudio to Sparkling Water <https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/howto/Connecting_RStudio_to_Sparkling_Water.md>`_: This illustrated tutorial describes how to use RStudio to connect to Sparkling Water.
 
@@ -375,7 +375,7 @@ Currently, the only version of R that is known to be incompatible with H2O is R 
 
 To check which version of H2O is installed in R, use ``versions::installed.versions("h2o")``.
 
--  `R User Documentation <../h2o-r/h2o_package.pdf>`_: This document contains all commands in the H2O package for R, including examples and arguments. It represents the definitive guide to using H2O in R.
+-  `R User HTML <../h2o-r/docs/index.html>`_ and R User PDF <../h2o-r/h2o_package.pdf>`_ Documentation: This document contains all commands in the H2O package for R, including examples and arguments. It represents the definitive guide to using H2O in R.
 
 -  `Connecting RStudio to Sparkling Water <https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/howto/Connecting_RStudio_to_Sparkling_Water.md>`_: This illustrated tutorial describes how to use RStudio to connect to Sparkling Water.
 
@@ -528,7 +528,7 @@ The following steps show you how to download or build H2O with Hadoop and the pa
 
    ::
 
-       hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g -output hdfsOutputDirName
+     hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g
 
    The above command launches a 6g node of H2O. We recommend you launch the cluster with at least four times the memory of your data file size.
 


### PR DESCRIPTION
Driveby fixes: Adding links to R HTML and to SW API html format,
updated link for What is Sparkling Water on docs site.