### PR TITLE
Fixed gridsearch error for python client

### DIFF
--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -750,6 +750,8 @@ class H2OGridSearch(backwards_compatible()):
             model_class = H2ORegressionGridSearch
         elif model_type == "Multinomial":
             model_class = H2OMultinomialGridSearch
+        elif model_type == "Ordinal":
+            model_class = H2OOrdinalGridSearch
         elif model_type == "AutoEncoder":
             model_class = H2OAutoEncoderGridSearch
         elif model_type == "DimReduction":

--- a/h2o-py/h2o/grid/metrics.py
+++ b/h2o-py/h2o/grid/metrics.py
@@ -647,6 +647,50 @@ class H2OMultinomialGridSearch(object):
         return {model.model_id: model.mean_per_class_error(train, valid, xval) for model in self.models}
 
 
+#-----------------------------------------------------------------------------------------------------------------------
+# Ordinal Grid Search
+#-----------------------------------------------------------------------------------------------------------------------
+
+class H2OOrdinalGridSearch(object):
+    def confusion_matrix(self, data):
+        """
+        Returns a confusion matrix based of H2O's default prediction threshold for a dataset.
+
+        :param data: metric for which the confusion matrix will be calculated.
+        """
+        return {model.model_id: model.confusion_matrix(data) for model in self.models}
+
+
+    def hit_ratio_table(self, train=False, valid=False, xval=False):
+        """
+        Retrieve the Hit Ratios.
+
+        If all are False (default), then return the training metric value.
+        If more than one option is set to True, then return a dictionary of metrics where the keys are "train",
+        "valid", and "xval".
+
+        :param bool train: If train is True, then return the hit ratio value for the training data.
+        :param bool valid: If valid is True, then return the hit ratio value for the validation data.
+        :param bool xval:  If xval is True, then return the hit ratio value for the cross validation data.
+        :returns: The hit ratio for this ordinal model.
+        """
+        return {model.model_id: model.hit_ratio_table(train, valid, xval) for model in self.models}
+
+
+    def mean_per_class_error(self, train=False, valid=False, xval=False):
+        """
+        Get the mean per class error.
+
+        If all are False (default), then return the training metric value.
+        If more than one options is set to True, then return a dictionary of metrics where the keys are "train",
+        "valid", and "xval".
+
+        :param bool train: If train is True, then return the mean per class error value for the training data.
+        :param bool valid: If valid is True, then return the mean per class error value for the validation data.
+        :param bool xval:  If xval is True, then return the mean per class error value for the cross validation data.
+        :returns: The mean per class error for this ordinal model.
+        """
+        return {model.model_id: model.mean_per_class_error(train, valid, xval) for model in self.models}
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Regression Grid Search

--- a/h2o-py/tests/testdir_algos/glm/pyunit_ordinal_gridsearch_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_ordinal_gridsearch_large.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+# Test to make sure that gridsearch runs with Ordinal regression.  There is no assert at the end of the test and it
+# is okay in this case.  Need it to just run to completion
+def testOrdinalGridSearch():
+    yindex = 'C11'
+    Dtrain = h2o.import_file(pyunit_utils.locate("bigdata/laptop/glm_ordinal_logit/ordinal_multinomial_training_set.csv"))
+    Dtrain[yindex] = Dtrain[yindex].asfactor()
+
+    hyper_parameters = {'alpha': [0.01,0.3,0.5],
+                    'lambda': [1e-5,1e-6,1e-7,1e-8]}
+    gs = H2OGridSearch(H2OGeneralizedLinearEstimator(family='ordinal'),
+                   grid_id='ordinal_grid',
+                   hyper_params=hyper_parameters)
+    gs.train(x=list(range(0,10)), y="C11", training_frame=Dtrain)
+    gs.show()
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(testOrdinalGridSearch)
+else:
+    testOrdinalGridSearch()

--- a/h2o-r/tests/testdir_algos/glm/runit_ordinal_glm_gridsearch_large.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_ordinal_glm_gridsearch_large.R
@@ -1,0 +1,20 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+library(MASS)
+
+# This test makes sure gridsearch work with ordinal regression.  It is okay here not to have expect_true
+# tests here at the end of the test
+glmOrdinalGrid <- function() {
+  Dtrain <- h2o.uploadFile(locate("bigdata/laptop/glm_ordinal_logit/ordinal_multinomial_training_set.csv"))  
+  Dtrain$C11 <- h2o.asfactor(Dtrain$C11)
+  X   <- c(1:10)  
+  Y<-"C11"
+  Log.info("Build the gridsearch model")
+  alphas <- c(0.01, 0.3, 0.5)
+  lambdas <- c(1e-5, 1e-6, 1e-7, 1e-8)
+  hyper_params = list(alpha=alphas, lambda=lambdas)
+  model.grid <- h2o.grid("glm", y=Y, x=X, family='ordinal', training_frame=Dtrain, hyper_params=hyper_params)
+  print(model.grid)
+}
+
+doTest("GLM: Ordinal Gridsearch with multinomial dataset ", glmOrdinalGrid)


### PR DESCRIPTION
Gridsearch not working with Python.

Fixed the problem by adding the gridsearch class for ordinal regression.

Added pyunit and runit tests to make sure gridsearch worked for both clients.