### PR TITLE
PUBDEV-5177: Add a h2o.get_automl()/h2o.getAutoML function to R/Python APIs

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1225,7 +1225,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       lastStartTime = startTime;
     }
 
-    String keyString = "AutoML_" + timestampFormatForKeys.format(startTime);
+    String keyString = buildSpec.build_control.project_name;
     AutoML aml = AutoML.makeAutoML(Key.<AutoML>make(keyString), startTime, buildSpec);
 
     DKV.put(aml);

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -242,6 +242,11 @@ class H2OAutoML(object):
         ncols = training_frame.ncols
         names = training_frame.names
 
+        #Set project name if None
+        if self.project_name is None:
+            self.project_name = "automl_" + training_frame.frame_id
+            self.build_control["project_name"] = self.project_name
+
         # Minimal required arguments are training_frame and y (response)
         if y is None:
             raise ValueError('The response column (y) is not set; please set it to the name of the column that you are trying to predict in your data.')

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -165,7 +165,6 @@ class H2OAutoML(object):
         self.build_control["keep_cross_validation_models"] = keep_cross_validation_models
 
         self._job = None
-        self.automl_key = None
         self._leader_id = None
         self._leaderboard = None
 
@@ -317,7 +316,6 @@ class H2OAutoML(object):
             return
 
         self._job = H2OJob(resp['job'], "AutoML")
-        self.automl_key = self._job.dest_key
         self._job.poll()
         self._fetch()
 
@@ -380,7 +378,7 @@ class H2OAutoML(object):
     # Private
     #-------------------------------------------------------------------------------------------------------------------
     def _fetch(self):
-        res = h2o.api("GET /99/AutoML/" + self.automl_key)
+        res = h2o.api("GET /99/AutoML/" + self.project_name)
         leaderboard_list = [key["name"] for key in res['leaderboard']['models']]
 
         if leaderboard_list is not None and len(leaderboard_list) > 0:
@@ -407,17 +405,17 @@ class H2OAutoML(object):
         return self._leader_id is not None
 
     def _get_params(self):
-        res = h2o.api("GET /99/AutoML/" + self.automl_key)
+        res = h2o.api("GET /99/AutoML/" + self.project_name)
         return res
 
-def get_automl(automl_key):
+def get_automl(project_name):
     """
     Retrieve information about an AutoML instance.
 
-    :param str automl_key: A string indicating the unique automl_key of the automl instance to retrieve.
+    :param str project_name:  A string indicating the project_name of the automl instance to retrieve.
     :returns: A dictionary containing the AutoML key, project_name, leader model, and leaderboard.
     """
-    automl_json = h2o.api("GET /99/AutoML/%s" % automl_key)
+    automl_json = h2o.api("GET /99/AutoML/%s" % project_name)
     project_name = automl_json["project_name"]
     leaderboard_list = [key["name"] for key in automl_json['leaderboard']['models']]
 
@@ -443,5 +441,5 @@ def get_automl(automl_key):
             h2o.show_progress()
 
     leaderboard = leaderboard[1:]
-    automl_dict = {'automl_key': automl_key, 'project_name': project_name, "leader": leader, "leaderboard": leaderboard}
+    automl_dict = {'project_name': project_name, "leader": leader, "leaderboard": leaderboard}
     return automl_dict

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -413,7 +413,7 @@ def get_automl(project_name):
     Retrieve information about an AutoML instance.
 
     :param str project_name:  A string indicating the project_name of the automl instance to retrieve.
-    :returns: A dictionary containing the AutoML key, project_name, leader model, and leaderboard.
+    :returns: A dictionary containing the project_name, leader model, and leaderboard.
     """
     automl_json = h2o.api("GET /99/AutoML/%s" % project_name)
     project_name = automl_json["project_name"]

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
@@ -25,10 +25,9 @@ def prostate_automl_get_automl():
     aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
 
-    get_aml = get_automl(aml.automl_key)
+    get_aml = get_automl(aml.project_name)
 
     assert aml.project_name == get_aml["project_name"]
-    assert aml.automl_key == get_aml["automl_key"]
     get_aml_leader = get_aml["leader"]
     assert aml.leader.model_id == get_aml_leader.model_id
     assert aml.leaderboard.get_frame_data() == get_aml["leaderboard"].get_frame_data()

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils
+from h2o.automl import H2OAutoML
+from h2o.automl.autoh2o import get_automl
+
+def prostate_automl_get_automl():
+
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+
+    #Split frames
+    fr = df.split_frame(ratios=[.8,.1])
+
+    #Set up train, validation, and test sets
+    train = fr[0]
+    valid = fr[1]
+    test = fr[2]
+
+    train["CAPSULE"] = train["CAPSULE"].asfactor()
+    valid["CAPSULE"] = valid["CAPSULE"].asfactor()
+    test["CAPSULE"] = test["CAPSULE"].asfactor()
+
+    aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml.train(y="CAPSULE", training_frame=train)
+
+    get_aml = get_automl(aml.automl_key)
+
+    assert aml.project_name == get_aml["project_name"]
+    assert aml.automl_key == get_aml["automl_key"]
+    get_aml_leader = get_aml["leader"]
+    assert aml.leader.model_id == get_aml_leader.model_id
+    assert aml.leaderboard.get_frame_data() == get_aml["leaderboard"].get_frame_data()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(prostate_automl_get_automl)
+else:
+    prostate_automl_get_automl()

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -278,7 +278,8 @@ predict.H2OAutoML <- function(object, newdata, ...) {
 #' h2o.init()
 #' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
 #' votes_hf <- h2o.uploadFile(path = votes_path, header = TRUE)
-#' aml <- h2o.automl(y = "Class", project_name="aml_housevotes", training_frame = votes_hf, max_runtime_secs = 30)
+#' aml <- h2o.automl(y = "Class", project_name="aml_housevotes", 
+#'                   training_frame = votes_hf, max_runtime_secs = 30)
 #' automl.retrieved <- h2o.getAutoML("aml_housevotes")
 #' }
 #' @export

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -218,7 +218,7 @@ h2o.automl <- function(x, y, training_frame,
 
   leaderboard[,2:length(leaderboard)] <- as.numeric(leaderboard[,2:length(leaderboard)])  # Convert metrics to numeric
   # If leaderboard is empty, create a "dummy" leader
-  if (nrow(leaderboard) > 1) {
+  if (nrow(leaderboard) > 0) {
       leader <- h2o.getModel(automl_job$leaderboard$models[[1]]$name)
   } else {
       # create a phony leader
@@ -229,7 +229,6 @@ h2o.automl <- function(x, y, training_frame,
 
   # Make AutoML object
   new("H2OAutoML",
-      automl_key = res$job$dest$name,
       project_name = build_control$project_name,
       leader = leader,
       leaderboard = leaderboard
@@ -271,7 +270,7 @@ predict.H2OAutoML <- function(object, newdata, ...) {
 
 #' Get an R object that is a subclass of \linkS4class{H2OAutoML}
 #'
-#' @param automl_key A string indicating the unique automl_key of the automl instance to retrieve.
+#' @param project_name A string indicating the project_name of the automl instance to retrieve.
 #' @return Returns an object that is a subclass of \linkS4class{H2OAutoML}.
 #' @examples
 #' \donttest{
@@ -280,11 +279,11 @@ predict.H2OAutoML <- function(object, newdata, ...) {
 #' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
 #' votes_hf <- h2o.uploadFile(path = votes_path, header = TRUE)
 #' aml <- h2o.automl(y = "Class", training_frame = votes_hf, max_runtime_secs = 30)
-#' automl.retrieved <- h2o.getAutoML(aml@automl_key)
+#' automl.retrieved <- h2o.getAutoML(aml@project_name)
 #' }
 #' @export
-h2o.getAutoML <- function(automl_key) {
-  automl_job <- .h2o.__remoteSend(h2oRestApiVersion = 99, method = "GET", page = paste0("AutoML/", automl_key))
+h2o.getAutoML <- function(project_name) {
+  automl_job <- .h2o.__remoteSend(h2oRestApiVersion = 99, method = "GET", page = paste0("AutoML/", project_name))
   leaderboard <- as.data.frame(automl_job["leaderboard_table"]$leaderboard_table)
   row.names(leaderboard) <- seq(nrow(leaderboard))
   leaderboard <- as.h2o(leaderboard)
@@ -294,7 +293,6 @@ h2o.getAutoML <- function(automl_key) {
   
   # Make AutoML object
   return(new("H2OAutoML",
-             automl_key = automl_key,
              project_name = project,
              leader = leader,
              leaderboard = leaderboard

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -218,7 +218,7 @@ h2o.automl <- function(x, y, training_frame,
 
   leaderboard[,2:length(leaderboard)] <- as.numeric(leaderboard[,2:length(leaderboard)])  # Convert metrics to numeric
   # If leaderboard is empty, create a "dummy" leader
-  if (nrow(leaderboard) > 0) {
+  if (nrow(leaderboard) > 1) {
       leader <- h2o.getModel(automl_job$leaderboard$models[[1]]$name)
   } else {
       # create a phony leader

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -278,8 +278,8 @@ predict.H2OAutoML <- function(object, newdata, ...) {
 #' h2o.init()
 #' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
 #' votes_hf <- h2o.uploadFile(path = votes_path, header = TRUE)
-#' aml <- h2o.automl(y = "Class", training_frame = votes_hf, max_runtime_secs = 30)
-#' automl.retrieved <- h2o.getAutoML(aml@project_name)
+#' aml <- h2o.automl(y = "Class", project_name="aml_housevotes", training_frame = votes_hf, max_runtime_secs = 30)
+#' automl.retrieved <- h2o.getAutoML("aml_housevotes")
 #' }
 #' @export
 h2o.getAutoML <- function(project_name) {

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -741,7 +741,6 @@ setClass("H2OFrame")
 #' This class represents an H2OAutoML object
 #'
 #' @export
-setClass("H2OAutoML", slots = c(automl_key = "character",
-                                project_name = "character",
+setClass("H2OAutoML", slots = c(project_name = "character",
                                 leader = "H2OModel",
                                 leaderboard = "H2OFrame"))

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -741,6 +741,7 @@ setClass("H2OFrame")
 #' This class represents an H2OAutoML object
 #'
 #' @export
-setClass("H2OAutoML", slots = c(project_name = "character",
+setClass("H2OAutoML", slots = c(automl_key = "character",
+                                project_name = "character",
                                 leader = "H2OModel",
                                 leaderboard = "H2OFrame"))

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -115,6 +115,7 @@ reference:
       - h2o.flow
       - h2o.gainsLift
       - h2o.gbm
+      - h2o.getAutoML
       - h2o.getConnection
       - h2o.getFrame
       - h2o.getFutureModel

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
@@ -1,0 +1,52 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+automl.get.automl.test <- function() {
+
+    # Load data and split into train, valid and test sets
+    train <- h2o.uploadFile(locate("smalldata/testng/higgs_train_5k.csv"),
+    destination_frame = "higgs_train_5k")
+    test <- h2o.uploadFile(locate("smalldata/testng/higgs_test_5k.csv"),
+    destination_frame = "higgs_test_5k")
+    ss <- h2o.splitFrame(test, seed = 1)
+    valid <- ss[[1]]
+    test <- ss[[1]]
+
+    y <- "response"
+    x <- setdiff(names(train), y)
+    train[,y] <- as.factor(train[,y])
+    test[,y] <- as.factor(test[,y])
+    max_runtime_secs <- 30
+    max_models <- 10
+
+    aml1 <- h2o.automl(y = y,
+                        training_frame = train,
+                        max_runtime_secs = max_runtime_secs,
+                        project_name="r_aml1", 
+                        stopping_rounds=3, 
+                        stopping_tolerance=0.001, 
+                        stopping_metric="AUC", 
+                        max_models=max_models, 
+                        seed=1234)
+
+    #Use h2o.getAutoML to get previous automl instance
+    get_aml1 <- h2o.getAutoML(aml1@automl_key)
+    
+    print("Leader model ID/automl_key/project_name for original automl object")
+    print(aml1@leader@model_id)
+    print(aml1@automl_key)
+    print(aml1@project_name)
+    print("Leader model ID/automl_key/project_name after fetching original automl object")
+    print(get_aml1@leader@model_id)
+    print(get_aml1@automl_key)
+    print(get_aml1@project_name)
+    
+    
+    expect_equal(aml1@project_name, get_aml1@project_name)
+    expect_equal(aml1@automl_key, get_aml1@automl_key)
+    expect_equal(aml1@leader@model_id, get_aml1@leader@model_id)
+    expect_equal(aml1@leaderboard, get_aml1@leaderboard)
+
+}
+
+doTest("AutoML h2o.getAutoML Test", automl.get.automl.test)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
@@ -30,20 +30,17 @@ automl.get.automl.test <- function() {
                         seed=1234)
 
     #Use h2o.getAutoML to get previous automl instance
-    get_aml1 <- h2o.getAutoML(aml1@automl_key)
+    get_aml1 <- h2o.getAutoML(aml1@project_name)
     
-    print("Leader model ID/automl_key/project_name for original automl object")
+    print("Leader model ID/project_name for original automl object")
     print(aml1@leader@model_id)
-    print(aml1@automl_key)
     print(aml1@project_name)
-    print("Leader model ID/automl_key/project_name after fetching original automl object")
+    print("Leader model ID/project_name after fetching original automl object")
     print(get_aml1@leader@model_id)
-    print(get_aml1@automl_key)
     print(get_aml1@project_name)
     
     
     expect_equal(aml1@project_name, get_aml1@project_name)
-    expect_equal(aml1@automl_key, get_aml1@automl_key)
     expect_equal(aml1@leader@model_id, get_aml1@leader@model_id)
     expect_equal(aml1@leaderboard, get_aml1@leaderboard)
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
@@ -16,12 +16,10 @@ automl.get.automl.test <- function() {
     x <- setdiff(names(train), y)
     train[,y] <- as.factor(train[,y])
     test[,y] <- as.factor(test[,y])
-    max_runtime_secs <- 30
-    max_models <- 10
+    max_models <- 3
 
     aml1 <- h2o.automl(y = y,
                         training_frame = train,
-                        max_runtime_secs = max_runtime_secs,
                         project_name="r_aml1", 
                         stopping_rounds=3, 
                         stopping_tolerance=0.001, 


### PR DESCRIPTION
* Add functions `h2o.get_automl()/h2o.getAutoML` to Python and R APIs for AutoML
* These functions allow a user to fetch information about an AutoML instance from the H2O cluster
* The information fetched include the automl key, project name, leader model, and leaderboard, which is in par with what is currently returned in R/Python
* Note, the Python function does not return an instance of `H2OAutoML` since a lot of the metadata (stopping_tolerance, max_runtime_secs, etc) is not available via the REST api. So, I figured this is a good first pass as both functions between R and Python do the same thing.