### PR TITLE
PUBDEV-5611 Jetty 9 breaks h2odriver proxy mode

### DIFF
--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -14,9 +14,8 @@ dependencies {
   compile 'org.javassist:javassist:3.18.2-GA'
   compile "org.apache.commons:commons-math3:3.3"
   compile "commons-io:commons-io:2.4"
-  compile "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
-  compile "org.eclipse.jetty:jetty-jaas:${jettyVersion}"
-
+  compile "org.eclipse.jetty.aggregate:jetty-servlet:8.1.17.v20150415"
+  compile "org.eclipse.jetty:jetty-plus:8.1.17.v20150415"
   compile ("com.github.rwl:jtransforms:2.4.0") { exclude module: "junit" }
   compile project(":h2o-jaas-pam")
 

--- a/h2o-core/src/main/java/org/eclipse/jetty/plus/jaas/spi/LdapLoginModule.java
+++ b/h2o-core/src/main/java/org/eclipse/jetty/plus/jaas/spi/LdapLoginModule.java
@@ -1,8 +1,0 @@
-package org.eclipse.jetty.plus.jaas.spi;
-
-/**
- * It is preferred to use org.eclipse.jetty.jaas.spi.LdapLoginModule module which is directly
- * provided by Jetty 9. This module is written just for compatibility purposes. In Jetty 8, the module
- * was named org.eclipse.jetty.plus.jaas.spi.LdapLoginModule so this just acts as the compatibility layer.
- */
-public class LdapLoginModule extends org.eclipse.jetty.jaas.spi.LdapLoginModule { /* empty */ }

--- a/h2o-core/src/main/java/water/AbstractHTTPD.java
+++ b/h2o-core/src/main/java/water/AbstractHTTPD.java
@@ -1,21 +1,25 @@
 package water;
 
-
-import org.eclipse.jetty.jaas.JAASLoginService;
+import org.eclipse.jetty.plus.jaas.JAASLoginService;
 import org.eclipse.jetty.security.*;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.security.authentication.FormAuthenticator;
-import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.bio.SocketConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.server.session.HashSessionIdManager;
 import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.eclipse.jetty.server.ssl.SslSocketConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import water.util.Log;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -138,8 +142,22 @@ public abstract class AbstractHTTPD {
       constraint.setName("auth");
       constraint.setAuthenticate(true);
 
+      // Configure role stuff (to be disregarded).  We are ignoring roles, and only going off the user name.
+      //
+      //   Jetty 8 and prior.
+      //
+      //     Jetty 8 requires the security.setStrict(false) and ANY_ROLE.
+      security.setStrict(false);
+      constraint.setRoles(new String[]{Constraint.ANY_ROLE});
 
-      constraint.setRoles(new String[]{Constraint.ANY_AUTH});
+      //   Jetty 9 and later.
+      //
+      //     Jetty 9 and later uses a different servlet spec, and ANY_AUTH gives the same behavior
+      //     for that API version as ANY_ROLE did previously.  This required some low-level debugging
+      //     to figure out, so I'm documenting it here.
+      //     Jetty 9 did not require security.setStrict(false).
+      //
+      // constraint.setRoles(new String[]{Constraint.ANY_AUTH});
 
       ConstraintMapping mapping = new ConstraintMapping();
       mapping.setPathSpec("/*"); // Lock down all API calls
@@ -180,18 +198,14 @@ public abstract class AbstractHTTPD {
 
   protected abstract RuntimeException failEx(String message);
 
-  protected ConnectionFactory makeHttpConnectionFactory() {
-    HttpConfiguration http_config = new HttpConfiguration();
-    http_config.setSendServerVersion(false);
-    return new HttpConnectionFactory(http_config);
-  }
-
   protected void startHttp() throws Exception {
     _server = new Server();
-    ServerConnector httpConnector = new ServerConnector(_server, makeHttpConnectionFactory());
-    httpConnector.setHost(_ip);
-    httpConnector.setPort(_port);
-    createServer(httpConnector);
+
+    Connector connector=new SocketConnector();
+    connector.setHost(_ip);
+    connector.setPort(_port);
+
+    createServer(connector);
   }
 
   /**
@@ -204,13 +218,15 @@ public abstract class AbstractHTTPD {
 
     SslContextFactory sslContextFactory = new SslContextFactory(_args.jks);
     sslContextFactory.setKeyStorePassword(_args.jks_pass);
-    ServerConnector httpsConnector = new ServerConnector(_server, sslContextFactory, makeHttpConnectionFactory());
+
+    SslSocketConnector httpsConnector = new SslSocketConnector(sslContextFactory);
+
     if (getIp() != null) {
       httpsConnector.setHost(getIp());
     }
     httpsConnector.setPort(getPort());
-    createServer(httpsConnector);
 
+    createServer(httpsConnector);
   }
 
   /**
@@ -253,7 +269,7 @@ public abstract class AbstractHTTPD {
   public class AuthenticationHandler extends AbstractHandler {
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-            throws IOException {
+            throws IOException, ServletException {
 
       if (!_args.ldap_login && !_args.kerberos_login && !_args.pam_login) return;
 

--- a/h2o-core/src/main/java/water/DelegatingAuthenticator.java
+++ b/h2o-core/src/main/java/water/DelegatingAuthenticator.java
@@ -38,11 +38,6 @@ class DelegatingAuthenticator implements Authenticator {
   }
 
   @Override
-  public void prepareRequest(ServletRequest servletRequest) {
-    
-  }
-
-  @Override
   public Authentication validateRequest(ServletRequest request, ServletResponse response,
                                         boolean mandatory) throws ServerAuthException {
     if (isBrowserAgent((HttpServletRequest) request))

--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -1,6 +1,5 @@
 package water;
 
-
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -25,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URLDecoder;
-import java.util.Arrays;
+import java.util.*;
 
 /**
  * Embedded Jetty instance inside H2O.

--- a/h2o-core/src/test/java/water/api/CustomHttpFilterTest.java
+++ b/h2o-core/src/test/java/water/api/CustomHttpFilterTest.java
@@ -11,10 +11,10 @@ import water.JettyHTTPD;
 import water.TestUtil;
 
 import javax.servlet.ServletOutputStream;
-import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
+import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -95,16 +95,7 @@ public class CustomHttpFilterTest extends TestUtil {
     when(request.getParameterMap()).thenReturn(new HashMap<String, String[]>());
 
     when(response.getOutputStream()).thenReturn(new ServletOutputStream() {
-      @Override
-      public boolean isReady() {
-        return false;
-      }
-
-      @Override
-      public void setWriteListener(WriteListener writeListener) {
-      }
-
-      @Override public void write(int b) {
+      @Override public void write(int b) throws IOException {
       }
     });
 

--- a/h2o-docs/src/product/security.rst
+++ b/h2o-docs/src/product/security.rst
@@ -255,8 +255,8 @@ manipulated on the command line with the
 `keytool <http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html>`_
 command.
 
-The underlying HTTPS implementation is provided by Jetty 9 and the Java
-runtime.
+The underlying HTTPS implementation is provided by Jetty 8 and the Java
+runtime. (**Note**: Jetty 8 was chosen to retain Java 6 compatibility.)
 
 Standalone H2O
 ''''''''''''''
@@ -529,7 +529,7 @@ Example **ldap.conf**:
 ::
 
     ldaploginmodule {
-        ai.h2o.org.eclipse.jetty.jaas.spi.LdapLoginModule required
+        ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModule required
         debug="true"
         useLdaps="false"
         contextFactory="com.sun.jndi.ldap.LdapCtxFactory"
@@ -542,8 +542,8 @@ Example **ldap.conf**:
         userBaseDn="ou=users,dc=0xdata,dc=loc";
     };
 
-See the `Jetty 9 LdapLoginModule
-documentation <http://www.eclipse.org/jetty/documentation/current/jaas-support.html>`__
+See the `Jetty 8 LdapLoginModule
+documentation <http://wiki.eclipse.org/Jetty/Feature/JAAS#LdapLoginModule>`__
 for more information.
 
 Standalone H2O
@@ -811,7 +811,7 @@ Example **realm.properties**:
 
 ::
 
-    # See http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html
+    # See https://wiki.eclipse.org/Jetty/Howto/Secure_Passwords
     # java -cp h2o.jar org.eclipse.jetty.util.security.Password
     username1: password1
     username2: MD5:6cb75f652a9b52798eb6cf2201057c73
@@ -823,10 +823,10 @@ tool:
 
     java -cp h2o.jar org.eclipse.jetty.util.security.Password username password
 
-See the `Jetty 9 HashLoginService
+See the `Jetty 8 HashLoginService
 documentation <http://wiki.eclipse.org/Jetty/Tutorial/Realms#HashLoginService>`_
-and `Jetty 9 Secure Password
-HOWTO <http://www.eclipse.org/jetty/documentation/current/configuring-security-secure-passwords.html>`_ for more
+and `Jetty 8 Secure Password
+HOWTO <http://wiki.eclipse.org/Jetty/Howto/Secure_Passwords>`_ for more
 information.
 
 Standalone H2O

--- a/h2o-extensions/authsupport/build.gradle
+++ b/h2o-extensions/authsupport/build.gradle
@@ -1,6 +1,5 @@
 description = "H2O Authentication Support"
 
 dependencies {
-    compile "org.eclipse.jetty:jetty-jaas:${jettyVersion}"
     compile project(":h2o-core")
 }

--- a/h2o-extensions/authsupport/src/main/java/ai/h2o/org/eclipse/jetty/jaas/spi/LdapLoginModule.java
+++ b/h2o-extensions/authsupport/src/main/java/ai/h2o/org/eclipse/jetty/jaas/spi/LdapLoginModule.java
@@ -1,8 +1,0 @@
-package ai.h2o.org.eclipse.jetty.jaas.spi;
-
-/**
- * LdapLoginModule is relocated in Sparkling Water to package ai.h2o.org.eclipse.jetty.plus.jaas.spi
- * This class lets user define login module that will work both for H2O and SW
- * (user needs to put "ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModule required" in the login conf)
- */
-public class LdapLoginModule extends org.eclipse.jetty.jaas.spi.LdapLoginModule { /* empty */ }

--- a/h2o-extensions/authsupport/src/main/java/ai/h2o/org/eclipse/jetty/plus/jaas/spi/LdapLoginModule.java
+++ b/h2o-extensions/authsupport/src/main/java/ai/h2o/org/eclipse/jetty/plus/jaas/spi/LdapLoginModule.java
@@ -1,9 +1,8 @@
 package ai.h2o.org.eclipse.jetty.plus.jaas.spi;
 
-
 /**
  * LdapLoginModule is relocated in Sparkling Water to package ai.h2o.org.eclipse.jetty.plus.jaas.spi
  * This class lets user define login module that will work both for H2O and SW
  * (user needs to put "ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModule required" in the login conf)
  */
-public class LdapLoginModule extends org.eclipse.jetty.jaas.spi.LdapLoginModule { /* empty */ }
+public class LdapLoginModule extends org.eclipse.jetty.plus.jaas.spi.LdapLoginModule { /* empty */ }

--- a/h2o-hadoop/driverjar.gradle
+++ b/h2o-hadoop/driverjar.gradle
@@ -31,10 +31,7 @@ sourceSets {
 }
 
 dependencies {
- compile "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
- compile "org.eclipse.jetty:jetty-jaas:${jettyVersion}"
- compile "org.eclipse.jetty:jetty-proxy:${jettyVersion}"
-
+  compile "org.eclipse.jetty.aggregate:jetty-all-server:8.1.17.v20150415"
   if (project.hasProperty('notYarn')) {
     compile('org.apache.hadoop:hadoop-core:' + hadoopMavenArtifactVersion)
   }

--- a/h2o-hadoop/h2o-mapreduce-generic/build.gradle
+++ b/h2o-hadoop/h2o-mapreduce-generic/build.gradle
@@ -16,8 +16,7 @@ compileJava {
 
 dependencies {
   compile('org.apache.hadoop:hadoop-client:' + hadoopMavenArtifactVersion)
-  compile "org.eclipse.jetty:jetty-proxy:${jettyVersion}"
-
+  compile "org.eclipse.jetty.aggregate:jetty-all-server:8.1.17.v20150415"
   compile project(':h2o-app')
   compile project(":h2o-web")
   compile project(":h2o-avro-parser")

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
@@ -1,24 +1,27 @@
 package water;
 
-import org.apache.commons.io.IOUtils;
-import org.eclipse.jetty.proxy.ProxyServlet;
+import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlets.ProxyServlet;
 import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.security.Credential;
-import water.network.SecurityUtils;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayOutputStream;
+
+import org.apache.commons.io.IOUtils;
 import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+
+import water.network.SecurityUtils;
 
 public class JettyProxy extends AbstractHTTPD {
 
@@ -70,9 +73,8 @@ public class JettyProxy extends AbstractHTTPD {
     }
 
     @Override
-    protected void addProxyHeaders(HttpServletRequest clientRequest, org.eclipse.jetty.client.api.Request proxyRequest) {
-      proxyRequest.header("Authorization", _basicAuth);
-      super.addProxyHeaders(clientRequest, proxyRequest);
+    protected void customizeExchange(HttpExchange exchange, HttpServletRequest request) {
+      exchange.setRequestHeader("Authorization", _basicAuth);
     }
   }
 

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/ProxyStarter.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/ProxyStarter.java
@@ -1,12 +1,14 @@
 package water;
 
 import water.init.HostnameGuesser;
+import water.init.NetworkInit;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
+import java.security.UnrecoverableKeyException;
 
 public class ProxyStarter {
 


### PR DESCRIPTION
This reverts commit 88f081254766fe0321002714c00c9f8fceccacce.

Jetty 9 breaks `-proxy` mode of the h2odriver because Hadoop puts `servlet-api:2.5` on the classpath. Jetty 9 relies on `servlet-api:3.1`