### PR TITLE
PUBDEV-5625 Remove frame metadata calculation from AutoML

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -403,7 +403,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   }
 
   public void pollAndUpdateProgress(Stage stage, String name, long workContribution, Job parentJob, Job subJob, JobType subJobType) {
-    if (null == subJob) {
+    if (null == parentJob) {
+      Log.info("AutoML job is null...");
+      return;
+    }
+    else if (null == subJob) {
       parentJob.update(workContribution, "SKIPPED: " + name);
       return;
     }
@@ -1240,14 +1244,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     if (aml.job == null || !aml.job.isRunning()) {
       Job job = new /* Timed */ H2OJob(aml, aml._key, aml.timeRemainingMs()).start();
       aml.job = job;
-      // job._max_runtime_msecs = Math.round(1000 * aml.buildSpec.build_control.stopping_criteria.max_runtime_secs());
-
-      // job work:
-      // import/parse (30), Frame metadata (20), GBM grid (900), StackedEnsemble (50)
       job._work = 1000;
       DKV.put(aml);
-
-      job.update(30, "Data import and parse complete");
     }
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -67,9 +67,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   public Vec getFoldColumn() { return foldColumn; }
   public Vec getWeightsColumn() { return weightsColumn; }
 
-  public FrameMetadata getFrameMetadata() {
-    return frameMetadata;
-  }
+//  Disabling metadata collection for now as there is no use for it...
+//  public FrameMetadata getFrameMetadata() {
+////    return frameMetadata;
+////  }
 
   private Frame trainingFrame;    // required training frame: can add and remove Vecs, but not mutate Vec data in place
   private Frame validationFrame;  // optional validation frame; the training_frame is split automagically if it's not specified
@@ -79,10 +80,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private Vec foldColumn;
   private Vec weightsColumn;
 
-  private FrameMetadata frameMetadata;           // metadata for trainingFrame
+//  Disabling metadata collection for now as there is no use for it...
+//  private FrameMetadata frameMetadata;           // metadata for trainingFrame
 
   private Key<Grid> gridKeys[] = new Key[0];  // Grid key for the GridSearches
-  private boolean isClassification;
+//  private boolean isClassification;
 
   private Date startTime;
   private static Date lastStartTime; // protect against two runs with the same second in the timestamp; be careful about races
@@ -1000,20 +1002,20 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     ///////////////////////////////////////////////////////////
     // gather initial frame metadata and guess the problem type
     ///////////////////////////////////////////////////////////
+//    Disabling metadata collection for now as there is no use for it...
+//    // TODO: Nishant says sometimes frameMetadata is null, so maybe we need to wait for it?
+//    // null FrameMetadata arises when delete() is called without waiting for start() to finish.
+//    frameMetadata = new FrameMetadata(userFeedback, trainingFrame,
+//            trainingFrame.find(buildSpec.input_spec.response_column),
+//            trainingFrame._key.toString()).computeFrameMetaPass1();
+//
+//    HashMap<String, Object> frameMeta = FrameMetadata.makeEmptyFrameMeta();
+//    frameMetadata.fillSimpleMeta(frameMeta);
+//    giveDatasetFeedback(trainingFrame, userFeedback, frameMeta);
+//
+//    job.update(20, "Computed dataset metadata");
 
-    // TODO: Nishant says sometimes frameMetadata is null, so maybe we need to wait for it?
-    // null FrameMetadata arises when delete() is called without waiting for start() to finish.
-    frameMetadata = new FrameMetadata(userFeedback, trainingFrame,
-            trainingFrame.find(buildSpec.input_spec.response_column),
-            trainingFrame._key.toString()).computeFrameMetaPass1();
-
-    HashMap<String, Object> frameMeta = FrameMetadata.makeEmptyFrameMeta();
-    frameMetadata.fillSimpleMeta(frameMeta);
-    giveDatasetFeedback(trainingFrame, userFeedback, frameMeta);
-
-    job.update(20, "Computed dataset metadata");
-
-    isClassification = frameMetadata.isClassification();
+//    isClassification = frameMetadata.isClassification();
 
     ///////////////////////////////////////////////////////////
     // build a fast RF with default settings...

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -403,11 +403,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   }
 
   public void pollAndUpdateProgress(Stage stage, String name, long workContribution, Job parentJob, Job subJob, JobType subJobType) {
-    if (null == parentJob) {
-      Log.info("AutoML job is null...");
-      return;
-    }
-    else if (null == subJob) {
+    if (null == subJob) {
       parentJob.update(workContribution, "SKIPPED: " + name);
       return;
     }


### PR DESCRIPTION
* Metadata collection in AutoML can be time consuming for no particular reason as this information is not utilized by AutoML in terms of model building, parameter tuning, etc. 
* Metadata information is only logged out to java logs.