### PR TITLE
PUBDEV-5560: handle corner-cases consistently when creating H2OFrame with empty objects in Python

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -451,7 +451,9 @@ class H2OFrame(object):
         """
         if not self._ex._cache.is_valid(): self._frame()._ex._cache.fill()
         if not return_data:
-            if H2ODisplay._in_ipy():
+            if self.nrows == 0:
+                print("This H2OFrame is empty.")
+            elif H2ODisplay._in_ipy():
                 import IPython.display
                 IPython.display.display_html(self._ex._cache._tabulate("html", True), raw=True)
             else:

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -97,8 +97,8 @@ class H2OFrame(object):
         self._ex = ExprNode()
         self._ex._children = None
         self._is_frame = True  # Indicate that this is an actual frame, allowing typechecks to be made
-        if python_obj is not None:
-            self._upload_python_object(python_obj, destination_frame, header, separator,
+        python_obj = [] if python_obj is None else python_obj
+        self._upload_python_object(python_obj, destination_frame, header, separator,
                                        column_names, column_types, na_strings)
 
     @staticmethod

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -178,8 +178,8 @@ def _handle_pandas_data_frame(python_obj, header):
     return list(python_obj.columns), data
 
 def _handle_python_dicts(python_obj, check_header):
-    header = list(python_obj.keys())
-    is_valid = bool(header) and all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
+    header = list(python_obj.keys()) if python_obj else _gen_header(1)
+    is_valid = all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
     if not is_valid:
         raise ValueError(
             "Did not get a valid set of column names! Must match the regular expression: ^[a-zA-Z_][a-zA-Z0-9_.]*$ ")

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -109,7 +109,7 @@ def _gen_header(cols):
 def _check_lists_of_lists(python_obj):
     # check we have a lists of flat lists
     # returns longest length of sublist
-    most_cols = 0
+    most_cols = 1
     for l in python_obj:
         # All items in the list must be a list!
         if not isinstance(l, (tuple, list)):
@@ -179,7 +179,7 @@ def _handle_pandas_data_frame(python_obj, header):
 
 def _handle_python_dicts(python_obj, check_header):
     header = list(python_obj.keys())
-    is_valid = all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
+    is_valid = bool(header) and all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
     if not is_valid:
         raise ValueError(
             "Did not get a valid set of column names! Must match the regular expression: ^[a-zA-Z_][a-zA-Z0-9_.]*$ ")

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
@@ -7,38 +7,44 @@ Checking corner cases when initializing H2OFrame
 
 """
 
+def test_new_empty_frame():
+    fr = h2o.H2OFrame()
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
 def test_new_frame_with_empty_list():
     fr = h2o.H2OFrame([])
-    assert fr.nrows == 0
-    assert fr.ncols == 1
+    assert_empty(fr)
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_tuple():
     fr = h2o.H2OFrame(())
-    assert fr.nrows == 0
-    assert fr.ncols == 1
+    assert_empty(fr)
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_nested_list():
     fr = h2o.H2OFrame([[]])
-    assert fr.nrows == 0
-    assert fr.ncols == 1
+    assert_empty(fr)
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_dict():
-    try:
-        h2o.H2OFrame({})
-        assert False, "should have thrown ValueError"
-    except ValueError:
-        pass
+    fr = h2o.H2OFrame({})
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
+def assert_empty(frame):
+    assert frame.nrows == 0
+    assert frame.ncols == 1
 
 if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_new_empty_frame)
     pyunit_utils.standalone_test(test_new_frame_with_empty_list)
     pyunit_utils.standalone_test(test_new_frame_with_empty_tuple)
     pyunit_utils.standalone_test(test_new_frame_with_empty_nested_list)
     pyunit_utils.standalone_test(test_new_frame_with_empty_dict)
 
 else:
+    test_new_empty_frame()
     test_new_frame_with_empty_list()
     test_new_frame_with_empty_tuple()
     test_new_frame_with_empty_nested_list()

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import h2o
+from tests import pyunit_utils
+
+"""
+Checking corner cases when initializing H2OFrame
+
+"""
+
+def test_new_frame_with_empty_list():
+    fr = h2o.H2OFrame([])
+    assert fr.nrows == 0
+    assert fr.ncols == 1
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_tuple():
+    fr = h2o.H2OFrame(())
+    assert fr.nrows == 0
+    assert fr.ncols == 1
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_nested_list():
+    fr = h2o.H2OFrame([[]])
+    assert fr.nrows == 0
+    assert fr.ncols == 1
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_dict():
+    try:
+        h2o.H2OFrame({})
+        assert False, "should have thrown ValueError"
+    except ValueError:
+        pass
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_new_frame_with_empty_list)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_tuple)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_nested_list)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_dict)
+
+else:
+    test_new_frame_with_empty_list()
+    test_new_frame_with_empty_tuple()
+    test_new_frame_with_empty_nested_list()
+    test_new_frame_with_empty_dict()
+


### PR DESCRIPTION
cf. https://0xdata.atlassian.net/browse/PUBDEV-5560

currently with Python client, creation of H2OFrame is inconsistent:
* `fr = h2o.H2OFrame()` > OK, but then `fr.describe/summary()` raises an exception 'NoneType' object is not iterable.
* `fr = h2o.H2OFrame([])` > OK, but then `fr.describe/summary()` raises an exception on iteration.
* `fr = h2o.H2OFrame(())` > same as above.
* `fr = h2o.H2OFrame([[]])` > KO, raises a H2OIllegalArgumentException. 
* `fr = h2o.H2OFrame({})` > KO, raises a H2OIllegalArgumentException.

fixing this for following behaviour:
* `fr = h2o.H2OFrame()` > no change.
* `fr = h2o.H2OFrame([])` > OK, empty frame 0 row, 1 col, `fr.describe/summary()` prints "This H2OFrame is empty."
* `fr = h2o.H2OFrame(())` > same as above.
* `fr = h2o.H2OFrame([[]])` > same as above.
* `fr = h2o.H2OFrame({})` > KO, raises a client-side ValueError (instead of java exception) as headers are mandatory when creating from dictionary.
