### PR TITLE
PUBDEV 5625 Remove frame metadata calculation from AutoML/PUBDEV-5623 Intermittent test failures for AutoML

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -959,17 +959,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     return ensembleJob;
   }
 
-  // manager thread:
-  //  1. Do extremely cursory pass over data and gather only the most basic information.
-  //
-  //     During this pass, AutoML will learn how timely it will be to do more info
-  //     gathering on _fr. There's already a number of interesting stats available
-  //     thru the rollups, so no need to do too much too soon.
-  //
-  //  2. Build a very dumb RF (with stopping_rounds=1, stopping_tolerance=0.01)
-  //
-  //  3. TODO: refinement passes and strategy selection
-  //
   public void learn() {
     userFeedback.info(Stage.Workflow, "AutoML build started: " + fullTimestampFormat.format(new Date()));
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -67,9 +67,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   public Vec getFoldColumn() { return foldColumn; }
   public Vec getWeightsColumn() { return weightsColumn; }
 
-  public FrameMetadata getFrameMetadata() {
-    return frameMetadata;
-  }
+//  Disabling metadata collection for now as there is no use for it...
+//  public FrameMetadata getFrameMetadata() {
+////    return frameMetadata;
+////  }
 
   private Frame trainingFrame;    // required training frame: can add and remove Vecs, but not mutate Vec data in place
   private Frame validationFrame;  // optional validation frame; the training_frame is split automagically if it's not specified
@@ -79,10 +80,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private Vec foldColumn;
   private Vec weightsColumn;
 
-  private FrameMetadata frameMetadata;           // metadata for trainingFrame
+//  Disabling metadata collection for now as there is no use for it...
+//  private FrameMetadata frameMetadata;           // metadata for trainingFrame
 
   private Key<Grid> gridKeys[] = new Key[0];  // Grid key for the GridSearches
-  private boolean isClassification;
+//  private boolean isClassification;
 
   private Date startTime;
   private static Date lastStartTime; // protect against two runs with the same second in the timestamp; be careful about races
@@ -1000,20 +1002,20 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     ///////////////////////////////////////////////////////////
     // gather initial frame metadata and guess the problem type
     ///////////////////////////////////////////////////////////
+//    Disabling metadata collection for now as there is no use for it...
+//    // TODO: Nishant says sometimes frameMetadata is null, so maybe we need to wait for it?
+//    // null FrameMetadata arises when delete() is called without waiting for start() to finish.
+//    frameMetadata = new FrameMetadata(userFeedback, trainingFrame,
+//            trainingFrame.find(buildSpec.input_spec.response_column),
+//            trainingFrame._key.toString()).computeFrameMetaPass1();
+//
+//    HashMap<String, Object> frameMeta = FrameMetadata.makeEmptyFrameMeta();
+//    frameMetadata.fillSimpleMeta(frameMeta);
+//    giveDatasetFeedback(trainingFrame, userFeedback, frameMeta);
+//
+//    job.update(20, "Computed dataset metadata");
 
-    // TODO: Nishant says sometimes frameMetadata is null, so maybe we need to wait for it?
-    // null FrameMetadata arises when delete() is called without waiting for start() to finish.
-    frameMetadata = new FrameMetadata(userFeedback, trainingFrame,
-            trainingFrame.find(buildSpec.input_spec.response_column),
-            trainingFrame._key.toString()).computeFrameMetaPass1();
-
-    HashMap<String, Object> frameMeta = FrameMetadata.makeEmptyFrameMeta();
-    frameMetadata.fillSimpleMeta(frameMeta);
-    giveDatasetFeedback(trainingFrame, userFeedback, frameMeta);
-
-    job.update(20, "Computed dataset metadata");
-
-    isClassification = frameMetadata.isClassification();
+//    isClassification = frameMetadata.isClassification();
 
     ///////////////////////////////////////////////////////////
     // build a fast RF with default settings...
@@ -1238,14 +1240,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     if (aml.job == null || !aml.job.isRunning()) {
       Job job = new /* Timed */ H2OJob(aml, aml._key, aml.timeRemainingMs()).start();
       aml.job = job;
-      // job._max_runtime_msecs = Math.round(1000 * aml.buildSpec.build_control.stopping_criteria.max_runtime_secs());
-
-      // job work:
-      // import/parse (30), Frame metadata (20), GBM grid (900), StackedEnsemble (50)
       job._work = 1000;
       DKV.put(aml);
-
-      job.update(30, "Data import and parse complete");
     }
   }
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
@@ -1,7 +1,6 @@
 package water.automl.api.schemas3;
 
 import ai.h2o.automl.AutoML;
-import ai.h2o.automl.AutoMLBuildSpec;
 import ai.h2o.automl.Leaderboard;
 import ai.h2o.automl.UserFeedback;
 import water.DKV;


### PR DESCRIPTION
* Remove frame metadata calculation from AutoML (this is not used by AutoML and can decrease runtime)
* 473d815 should help with intermittent NPE's in AutoML Jenkins testing
* Minor comment fixes and removal of an extra import in AutoMLV99
