### PR TITLE
PUBDEV-5622 rel-wright: Replace 'calibrate_frame' with 'calibration_frame' in docs

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -62,7 +62,7 @@ Optional Miscellaneous Parameters
 
 -  `class_sampling_factors <data-science/algo-params/class_sampling_factors.html>`__: Specify the per-class (in lexicographical order) over/under-sampling ratios. By default, these ratios are automatically computed during training to obtain the class balance.
 
--  `max_after_balance_size <data-science/algo-params/max_after_balance_size.html>`__: Specify the maximum relative size of the training data after balancing class counts (**balance\_classes**must be enabled). Defaults to 5.0.  (The value can be less than 1.0).
+-  `max_after_balance_size <data-science/algo-params/max_after_balance_size.html>`__: Specify the maximum relative size of the training data after balancing class counts (**balance\_classes** must be enabled). Defaults to 5.0.  (The value can be less than 1.0).
 
 -  `stopping_metric <data-science/algo-params/stopping_metric.html>`__: Specifies the metric to use for early stopping of the grid searches and individual models. Defaults to ``"AUTO"``.  The available options are:
 

--- a/h2o-docs/src/product/cloud-integration/google-compute.rst
+++ b/h2o-docs/src/product/cloud-integration/google-compute.rst
@@ -40,9 +40,17 @@ This section describes how to install and start H2O Flow (H2O-3 web offering) in
 
 6. Start H2O-3 using one of the following methods:
 
-  **Python**: Run ``h2o.connect(address, port=443, username, password)``
+  **Python**: Run the following
 
-  **R**: Run ``h2o.connect(address, port=443, username, password)``
+  ::
+
+    h2o.connect(url="https://[external ip]:443", auth=(username, password))
+
+  **R**: Run the following
+
+  ::
+
+    h2o.connect(ip="[external ip]", port=443, https=TRUE, username=username, password=password)
 
   **Flow**: In your browser, go to http://[External_IP]:443 or https://[External_IP]:80 to start Flow. Enter your username and password when prompted. 
 

--- a/h2o-docs/src/product/data-science/algo-params/calibrate_model.rst
+++ b/h2o-docs/src/product/data-science/algo-params/calibrate_model.rst
@@ -11,7 +11,7 @@ The ``calibrate_model`` option allows you to specify Platt scaling in GBM and DR
 
 The ``calibrate_model`` option is disabled by default. When enabled, the calibrated probabilities will be appended to the frame with the original prediction. 
 
-Note that when this option is enabled, then you must also specify the calibration dataframe (specified with `calibrate_frame <calibrate_frame.html>`__) that will be used for Platt scaling. A best practice is to split the original dataset into training and calibration sets. 
+Note that when this option is enabled, then you must also specify the calibration dataframe (specified with `calibration_frame <calibration_frame.html>`__) that will be used for Platt scaling. A best practice is to split the original dataset into training and calibration sets. 
 
 Refer to the following for more information about Platt scaling:
 
@@ -21,7 +21,7 @@ Refer to the following for more information about Platt scaling:
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
-- `calibrate_frame <calibrate_frame.html>`__
+- `calibration_frame <calibration_frame.html>`__
 
 
 Examples

--- a/h2o-docs/src/product/data-science/algo-params/calibration_frame.rst
+++ b/h2o-docs/src/product/data-science/algo-params/calibration_frame.rst
@@ -1,5 +1,5 @@
-``calibrate_frame``
--------------------
+``calibration_frame``
+---------------------
 
 - Available in: GBM, DRF
 - Hyperparameter: no
@@ -7,7 +7,7 @@
 Description
 ~~~~~~~~~~~
 
-The ``calibrate_frame`` specifies the calibration frame that will be used for Platt scaling. This option is required if `calibrate_model <calibrate_model.html>`__ is enabled. 
+The ``calibration_frame`` option specifies the calibration frame that will be used for Platt scaling. This option is required if `calibrate_model <calibrate_model.html>`__ is enabled. 
 
 `Platt scaling <https://en.wikipedia.org/wiki/Platt_scaling>`__ transforms the output of a classification model into a probability distribution over classes. It works by fitting a logistic regression model to a classifier's scores. Platt scaling will generally not affect the ranking of observations. Logloss, however, will generally improve with Platt scaling.
 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -234,7 +234,7 @@ Defining a DRF Model
 
 -  `calibrate_model <algo-params/calibrate_model.html>`__: Use Platt scaling to calculate calibrated class probabilities. Defaults to False.
 
--  `calibrate_frame <algo-params/calibrate_frame.html>`__: Specifies the frame to be used for Platt scaling.
+-  `calibration_frame <algo-params/calibration_frame.html>`__: Specifies the frame to be used for Platt scaling.
 
 -  **verbose**: Print scoring history to the console. For DRF, metrics are per tree. This value defaults to FALSE.
 

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -256,7 +256,7 @@ Defining a GBM Model
 
 -  `calibrate_model <algo-params/calibrate_model.html>`__: Use Platt scaling to calculate calibrated class probabilities. Defaults to False.
 
--  `calibrate_frame <algo-params/calibrate_frame.html>`__: Specifies the frame to be used for Platt scaling.
+-  `calibration_frame <algo-params/calibration_frame.html>`__: Specifies the frame to be used for Platt scaling.
 
 -  **verbose**: Print scoring history to the console. For GBM, metrics are per tree. This value defaults to FALSE.
 

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -19,8 +19,8 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/beta_epsilon
    data-science/algo-params/binomial_double_trees
    data-science/algo-params/build_tree_one_node
-   data-science/algo-params/calibrate_frame
    data-science/algo-params/calibrate_model
+   data-science/algo-params/calibration_frame
    data-science/algo-params/categorical_encoding
    data-science/algo-params/checkpoint
    data-science/algo-params/class_sampling_factors


### PR DESCRIPTION
- Docs now reference ‘calibration_frame’ instead of ‘calibrate_frame’
- Driveby fixes: Added missing space after ** in AutoML topic. Fixed
Python and R commands for starting H2O-3 with Google offering