### PR TITLE
HEXDEV-715: spencer_2309_2310

### DIFF
--- a/h2o-core/src/main/java/water/fvec/C1SChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C1SChunk.java
@@ -21,6 +21,13 @@ public final class C1SChunk extends CSChunk {
     }
   }
 
+  @Override protected final long at8_impl( int i ) {
+    int x = 0xFF&_mem[_OFF+i];
+    if( x==C1Chunk._NA )
+      throw new IllegalArgumentException("at8_abs but value is missing");
+    return get8(x);
+  }
+
   @Override protected final double atd_impl( int i ) {
     return getD(0xFF&_mem[_OFF+i],C1Chunk._NA);
   }

--- a/h2o-core/src/main/java/water/fvec/C2SChunk.java
+++ b/h2o-core/src/main/java/water/fvec/C2SChunk.java
@@ -22,6 +22,13 @@ public class C2SChunk extends CSChunk {
     }
   }
 
+  @Override protected final long at8_impl( int i ) {
+    int x = getMantissa(i);
+    if( x==C2Chunk._NA )
+      throw new IllegalArgumentException("at8_abs but value is missing");
+    return get8(x);
+  }
+
   private int getMantissa(int i){return UnsafeUtils.get2(_mem,_OFF+2*i);}
   private void setMantissa(int i, short s){
     UnsafeUtils.set2(_mem,(i*2)+_OFF,s);

--- a/h2o-core/src/main/java/water/fvec/CSChunk.java
+++ b/h2o-core/src/main/java/water/fvec/CSChunk.java
@@ -52,6 +52,7 @@ public abstract class CSChunk extends Chunk {
     return x == NA?naImpute:_isDecimal?(_bias + x)/_scale:(_bias + x)*_scale;
   }
 
+  protected final long get8(int x) { return (_bias + x)*(long)(_scale); }
 
   @Override public final boolean hasFloat(){ return _isDecimal || _scale < 1; }
 
@@ -65,7 +66,7 @@ public abstract class CSChunk extends Chunk {
     _scale = PrettyPrint.pow10(1,_isDecimal?-x:x);
   }
 
-  @Override protected final long at8_impl( int i ) {
+  @Override protected long at8_impl( int i ) {
     double res = atd_impl(i); // note: |mantissa| <= 4B => double is ok
     if(Double.isNaN(res)) throw new IllegalArgumentException("at8_abs but value is missing");
     return (long)res;

--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -9,7 +9,11 @@ import water.util.PrettyPrint;
 import water.util.StringUtils;
 import water.util.UnsafeUtils;
 
-import java.util.*;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.UUID;
 
 import static water.H2OConstants.MAX_STR_LEN;
 
@@ -1102,6 +1106,13 @@ public class NewChunk extends Chunk {
     return res < 0 ? 0 /*happens for rare FP roundoff computation of min & max */: res;
   }
 
+  private static BigInteger pow10bi(int x) {
+    BigInteger v = BigInteger.ONE;
+    while(x-->0)
+      v = v.multiply(BigInteger.TEN);
+    return v;
+  }
+
   private Chunk compress2() {
     // Check for basic mode info: all missing or all strings or mixed stuff
     byte mode = type();
@@ -1208,6 +1219,9 @@ public class NewChunk extends Chunk {
     boolean floatOverflow = false;
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
+    BigInteger MAX = BigInteger.valueOf(Long.MAX_VALUE);
+    BigInteger min_l = MAX.multiply(MAX);
+    BigInteger max_l = BigInteger.valueOf(-1L).multiply(MAX.multiply(MAX));
     int p10iLength = PrettyPrint.powers10i.length;
     long llo=Long   .MAX_VALUE, lhi=Long   .MIN_VALUE;
     int  xlo=Integer.MAX_VALUE, xhi=Integer.MIN_VALUE;
@@ -1220,32 +1234,39 @@ public class NewChunk extends Chunk {
       assert l!=0 || x==0:"l == 0 while x = " + x + " ms = " + _ms.toString();      // Exponent of zero is always zero
       long t;                   // Remove extra scaling
       while( l!=0 && (t=l/10)*10==l ) { l=t; x++; }
+      BigInteger ll = BigInteger.valueOf(l).multiply(pow10bi(x));
       // Compute per-chunk min/max
-      double d = PrettyPrint.pow10(l,x);
+      double d = PrettyPrint.pow10(l,x);  // WARNING: this is lossy!!
       if(d == 0) {
         hasZero = true;
         continue;
       }
-      if( d < min ) { min = d; llo=l; xlo=x; }
-      if( d > max ) { max = d; lhi=l; xhi=x; }
+      if( x >=0 && ((long)d != ll.longValue()) ) {
+        if( ll.compareTo(min_l)==-1 ) { min=d; min_l=ll; llo=l; xlo=x; }
+        if( ll.compareTo(max_l)== 1 ) { max=d; max_l=ll; lhi=l; xhi=x; }
+      } else {
+        if( d < min ) { min = d; min_l=ll; llo=l; xlo=x; }
+        if( d > max ) { max = d; max_l=ll; lhi=l; xhi=x; }
+      }
+
       floatOverflow = l < Integer.MIN_VALUE+1 || l > Integer.MAX_VALUE;
       xmin = Math.min(xmin,x);
     }
-    boolean hasNonZero = min != Double.POSITIVE_INFINITY && max != Double.NEGATIVE_INFINITY;
+    boolean hasNonZero = min != Double.POSITIVE_INFINITY &&
+                         max != Double.NEGATIVE_INFINITY;
 
     if(hasZero){ // sparse?  then compare vs implied 0s
-      if( min > 0 ) { min = 0; llo=0; }
-      if( max < 0 ) { max = 0; lhi=0; }
+      if( min > 0 ) { min = 0; llo=0; min_l=BigInteger.ZERO; }
+      if( max < 0 ) { max = 0; lhi=0; max_l=BigInteger.ZERO; }
     }
     if(!hasNonZero) xlo = xhi = xmin = 0;
+
     // Constant column?
-    if( _naCnt==0 && (min==max)) {
-      if (llo == lhi && xlo == 0 && xhi == 0)
-        return new C0LChunk(llo, _len);
-      else if ((long)min == min)
-        return new C0LChunk((long)min, _len);
-      else
-        return new C0DChunk(min, _len);
+    if( _naCnt==0 && (min_l.compareTo(max_l)==0) && xmin >=0 ) {
+      return new C0LChunk(min_l.longValue(), _len);
+    }
+    if( _naCnt==0 && (min==max) && xmin<0 ) {
+      return new C0DChunk(min, _len);
     }
     // Compute min & max, as scaled integers in the xmin scale.
     // Check for overflow along the way
@@ -1263,6 +1284,10 @@ public class NewChunk extends Chunk {
       if( (lemin/pow10lo) != llo ) overflow = true;
     }
     final long leRange = leRange(lemin,lemax);
+
+    // put min_l in xmin scale
+    if( xmin > 0 )
+      min_l = min_l.divide(BigInteger.valueOf(PrettyPrint.pow10i(xmin)));
 
     // Boolean column?
     if (max == 1 && min == 0 && xmin == 0 && !overflow) {
@@ -1332,7 +1357,7 @@ public class NewChunk extends Chunk {
     if( leRange < 255 ) {    // Span fits in a byte?
       if(0 <= min && max < 255 ) // Span fits in an unbiased byte?
         return new C1Chunk( bufX(0,0,C1Chunk._OFF,0));
-      return new C1SChunk( bufX(lemin,xmin,C1SChunk._OFF,0),lemin,xmin);
+      return new C1SChunk( bufX(min_l.longValue(),xmin,C1SChunk._OFF,0),min_l.longValue(),xmin);
     }
 
     // Compress column into a short

--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -9,7 +9,6 @@ import water.util.PrettyPrint;
 import water.util.StringUtils;
 import water.util.UnsafeUtils;
 
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
@@ -1106,13 +1105,6 @@ public class NewChunk extends Chunk {
     return res < 0 ? 0 /*happens for rare FP roundoff computation of min & max */: res;
   }
 
-  private static BigInteger pow10bi(int x) {
-    BigInteger v = BigInteger.ONE;
-    while(x-->0)
-      v = v.multiply(BigInteger.TEN);
-    return v;
-  }
-
   private Chunk compress2() {
     // Check for basic mode info: all missing or all strings or mixed stuff
     byte mode = type();
@@ -1219,13 +1211,15 @@ public class NewChunk extends Chunk {
     boolean floatOverflow = false;
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
-    BigInteger MAX = BigInteger.valueOf(Long.MAX_VALUE);
-    BigInteger min_l = MAX.multiply(MAX);
-    BigInteger max_l = BigInteger.valueOf(-1L).multiply(MAX.multiply(MAX));
+    long min_l = Long.MAX_VALUE;
+    long max_l = Long.MIN_VALUE;
+    double longMax = (double) Long.MAX_VALUE;
+    double longMin = (double) Long.MIN_VALUE;
     int p10iLength = PrettyPrint.powers10i.length;
     long llo=Long   .MAX_VALUE, lhi=Long   .MIN_VALUE;
     int  xlo=Integer.MAX_VALUE, xhi=Integer.MIN_VALUE;
     boolean hasZero = sparse;
+    long ll;
     for(int i = 0; i< _sparseLen; i++ ) {
       if( isNA2(i) ) continue;
       long l = _ms.get(i);
@@ -1234,19 +1228,23 @@ public class NewChunk extends Chunk {
       assert l!=0 || x==0:"l == 0 while x = " + x + " ms = " + _ms.toString();      // Exponent of zero is always zero
       long t;                   // Remove extra scaling
       while( l!=0 && (t=l/10)*10==l ) { l=t; x++; }
-      BigInteger ll = BigInteger.valueOf(l).multiply(pow10bi(x));
       // Compute per-chunk min/max
       double d = PrettyPrint.pow10(l,x);  // WARNING: this is lossy!!
       if(d == 0) {
         hasZero = true;
         continue;
       }
-      if( x >=0 && ((long)d != ll.longValue()) ) {
-        if( ll.compareTo(min_l)==-1 ) { min=d; min_l=ll; llo=l; xlo=x; }
-        if( ll.compareTo(max_l)== 1 ) { max=d; max_l=ll; lhi=l; xhi=x; }
+
+      if (isInteger)  // once set to false don't want to reset back to true
+        isInteger = (x>=0) && (d<=longMax) && (d>=longMin);
+
+      if (isInteger) {
+        ll = l*PrettyPrint.pow10i(x); // only perform operation if still fit in Long and still integer
+        if( ll<min_l ) { min = d; min_l=ll; llo=l; xlo=x; } //
+        if( ll>max_l ) { max = d; max_l=ll; lhi=l; xhi=x; }
       } else {
-        if( d < min ) { min = d; min_l=ll; llo=l; xlo=x; }
-        if( d > max ) { max = d; max_l=ll; lhi=l; xhi=x; }
+        if (d < min) { min = d; llo = l; xlo = x; }
+        if (d > max) { max=d; lhi=l; xhi=x; }
       }
 
       floatOverflow = l < Integer.MIN_VALUE+1 || l > Integer.MAX_VALUE;
@@ -1256,16 +1254,16 @@ public class NewChunk extends Chunk {
                          max != Double.NEGATIVE_INFINITY;
 
     if(hasZero){ // sparse?  then compare vs implied 0s
-      if( min > 0 ) { min = 0; llo=0; min_l=BigInteger.ZERO; }
-      if( max < 0 ) { max = 0; lhi=0; max_l=BigInteger.ZERO; }
+      if( min > 0 ) { min = 0; llo=0; min_l=0l; }
+      if( max < 0 ) { max = 0; lhi=0; max_l=0l; }
     }
     if(!hasNonZero) xlo = xhi = xmin = 0;
 
     // Constant column?
-    if( _naCnt==0 && (min_l.compareTo(max_l)==0) && xmin >=0 ) {
-      return new C0LChunk(min_l.longValue(), _len);
+    if( _naCnt==0 && (min_l==max_l) && xmin >=0 && isInteger) {
+      return new C0LChunk(min_l, _len);
     }
-    if( _naCnt==0 && (min==max) && xmin<0 ) {
+    if( _naCnt==0 && (min==max) && (xmin<0 || !isInteger) ) {
       return new C0DChunk(min, _len);
     }
     // Compute min & max, as scaled integers in the xmin scale.
@@ -1287,7 +1285,7 @@ public class NewChunk extends Chunk {
 
     // put min_l in xmin scale
     if( xmin > 0 )
-      min_l = min_l.divide(BigInteger.valueOf(PrettyPrint.pow10i(xmin)));
+      min_l = min_l/PrettyPrint.pow10i(xmin);
 
     // Boolean column?
     if (max == 1 && min == 0 && xmin == 0 && !overflow) {
@@ -1357,7 +1355,7 @@ public class NewChunk extends Chunk {
     if( leRange < 255 ) {    // Span fits in a byte?
       if(0 <= min && max < 255 ) // Span fits in an unbiased byte?
         return new C1Chunk( bufX(0,0,C1Chunk._OFF,0));
-      return new C1SChunk( bufX(min_l.longValue(),xmin,C1SChunk._OFF,0),min_l.longValue(),xmin);
+      return new C1SChunk( bufX(lemin,xmin,C1SChunk._OFF,0),lemin,xmin);
     }
 
     // Compress column into a short

--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -187,8 +187,11 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     }
     @Override public void map(Chunk c) {
       for(int i=0; i<c._len; ++i) {
-        _colMin = Math.min(_colMin, c.at8(i));
-        _colMax = Math.max(_colMax, c.at8(i));
+        if( !c.isNA(i) ) {
+          long l = c.at8(i);
+          _colMin = Math.min(_colMin, l);
+          _colMax = Math.max(_colMax, l);
+        }
       }
     }
     @Override public void reduce(GetLongStatsTask that) {

--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -4,6 +4,7 @@ import water.H2O;
 import water.Key;
 import water.MRTask;
 import water.RPC;
+import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
@@ -147,8 +148,12 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
         double colMin = col.min();
         double colMax = col.max();
         if (col.isInt()) {
-          _base[i] = BigInteger.valueOf(Math.min((long)colMin, (long)colMax*(_ascending[i])));
-          max = BigInteger.valueOf(Math.max((long)colMax, (long)colMin*(_ascending[i])));
+          GetLongStatsTask glst = GetLongStatsTask.getLongStats(col);
+          long colMini = glst._colMin;
+          long colMaxi = glst._colMax;
+
+          _base[i] = BigInteger.valueOf(Math.min(colMini, colMaxi*(_ascending[i])));
+          max = BigInteger.valueOf(Math.max(colMaxi, colMini*(_ascending[i])));
         } else{
           _base[i] = MathUtils.convertDouble2BigInteger(Math.min(col.min(), colMax*(_ascending[i])));
           max = MathUtils.convertDouble2BigInteger(Math.max(col.max(), colMin*(_ascending[i])));
@@ -170,6 +175,25 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
 
       _bytesUsed[i] = Math.min(8, (_shift[i]+15) / 8);  // should not go over 8 bytes
       //assert (biggestBit-1)/8 + 1 == _bytesUsed[i];
+    }
+  }
+
+  // TODO: push these into Rollups?
+  private static class GetLongStatsTask extends MRTask<GetLongStatsTask> {
+    long _colMin=Long.MAX_VALUE;
+    long _colMax=Long.MIN_VALUE;
+    static GetLongStatsTask getLongStats(Vec col) {
+      return new GetLongStatsTask().doAll(col);
+    }
+    @Override public void map(Chunk c) {
+      for(int i=0; i<c._len; ++i) {
+        _colMin = Math.min(_colMin, c.at8(i));
+        _colMax = Math.max(_colMax, c.at8(i));
+      }
+    }
+    @Override public void reduce(GetLongStatsTask that) {
+      _colMin = Math.min(_colMin, that._colMin);
+      _colMax = Math.max(_colMax, that._colMax);
     }
   }
 

--- a/h2o-core/src/test/java/water/fvec/C1SChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/C1SChunkTest.java
@@ -237,7 +237,7 @@ public class C1SChunkTest extends TestUtil {
 
   @Test public void testOverflow() throws IOException {
     Scope.enter();
-    long min = 1485333188427000000L;
+    final long min = 1485333188427000000L;
     int len = 100;
     try {
       Vec dz = Vec.makeZero(len);
@@ -263,7 +263,7 @@ public class C1SChunkTest extends TestUtil {
 
   @Test public void testOverflowConst() throws IOException {
     Scope.enter();
-    long min = 1485333188427000000L;
+    final long min = 1485333188427000000L;
     int len = 100;
     try {
       Vec dz = Vec.makeZero(len);

--- a/h2o-core/src/test/java/water/fvec/C2SChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/C2SChunkTest.java
@@ -11,7 +11,6 @@ import water.util.PrettyPrint;
 
 import java.io.IOException;
 import java.util.Arrays;
-
 import static org.junit.Assert.assertTrue;
 
 public class C2SChunkTest extends TestUtil {
@@ -213,7 +212,7 @@ public class C2SChunkTest extends TestUtil {
 
   @Test public void testOverflow() throws IOException {
     Scope.enter();
-    long min = 1485333188427000000L;
+    final long min = 1485333188427000000L;
     int len = 10000;
     try {
       Vec dz = Vec.makeZero(len);

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -11,8 +11,6 @@ import java.util.Set;
 
 import static org.junit.Assert.*;
 
-import static org.junit.Assert.assertTrue;
-
 /**
  * Tests for Frame.java
  */

--- a/h2o-core/src/test/java/water/fvec/NewChunkSpeedTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkSpeedTest.java
@@ -1,7 +1,6 @@
 package water.fvec;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import water.MRTask;
 import water.Scope;
@@ -97,7 +96,7 @@ public class NewChunkSpeedTest extends TestUtil {
 
 
   // todo: This should be changed to test after Spencer PR is in.
-  @Ignore
+  @Test
   public void testParseLong(){
     double startTime = System.currentTimeMillis();
     for (int index=0; index<numberLoops; index++)
@@ -108,7 +107,7 @@ public class NewChunkSpeedTest extends TestUtil {
             +PrettyPrint.msecs((long) endTime, false));
   }
 
-  @Ignore
+  @Test
   public void testParseLongConsts(){
     double startTime = System.currentTimeMillis();
     for (int index=0; index<numberLoops; index++)
@@ -117,6 +116,19 @@ public class NewChunkSpeedTest extends TestUtil {
     Log.info("New Chunk test for constant longs:", " time taken for "+numberLoops+" is "
             +PrettyPrint.msecs((long) endTime, false));
   }
+
+  @Test
+  public void testParseLongMAXMINV(){
+    double startTime = System.currentTimeMillis();
+    for (int index=0; index<numberLoops; index++) {
+      testsForLongsMaxMin(Long.MAX_VALUE); // read in Long.MAX_VALUE
+      testsForLongsMaxMin(Long.MIN_VALUE); // read in Long.MIN_VALUE
+    }
+    double endTime = System.currentTimeMillis()-startTime;  // change time to seconds
+    Log.info("New Chunk test for constant longs:", " time taken for "+numberLoops+" is "
+            +PrettyPrint.msecs((long) endTime, false));
+  }
+
 
   @Test
   public void testParseDataFromFiles() {
@@ -142,6 +154,39 @@ public class NewChunkSpeedTest extends TestUtil {
               +PrettyPrint.msecs((long) endTime, false));
     }
   }
+
+  // Added this test to make sure we can read in Long.MAX_VALUE and Long.MIN_VALUE and still get a
+  // C8Chunk back.
+  public void testsForLongsMaxMin(long base) {
+    Scope.enter();
+    final long baseD = base;
+
+    try {
+      Vec tVec = Vec.makeZero(rowNumber);
+      Vec v;
+      v = new MRTask() {
+        @Override
+        public void map(Chunk cs) {
+          for (int r = 0; r < cs._len; r++) {
+            cs.set(r, baseD);
+          }
+        }
+      }.doAll(tVec)._fr.vecs()[0];
+
+      Scope.track(tVec);
+      Scope.track(v);
+
+      assertTrue(v.chunkForChunkIdx(0)  instanceof C0LChunk);
+      for (int rowInd = 0; rowInd < rowNumber; rowInd = rowInd + rowInterval) {
+        assertTrue("rowIndex: " + rowInd + " rowInd+baseD: " + (rowInd + baseD) + " v.at(rowIndex): "
+                        + v.at8(rowInd) + " chk= " + v.elem2ChunkIdx(rowInd),
+                v.at8(rowInd) == baseD);
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
 
   public void testsForLongs(boolean forConstants) {
     Scope.enter();

--- a/h2o-core/src/test/java/water/fvec/NewChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkTest.java
@@ -79,7 +79,7 @@ public class NewChunkTest extends TestUtil {
     int missingSize()  {return _missing == null?0:_missing.size();}
   }
 
-  
+
   private void testIntegerChunk(long [] values, int mantissaSize) {
     Vec v = Vec.makeCon(0,0);
     // single bytes
@@ -485,22 +485,22 @@ public class NewChunkTest extends TestUtil {
       assertEquals("Wrong (3) at " + (K-4), 0, nc.atd(K-4), Math.ulp(0));
       assertEquals("Wrong (4) at " + (K-3), Double.NaN, nc.atd(K-3), Math.ulp(Double.NaN)); // this is weird: ulp(NaN) is NaN)
       for (int i = K-2; i < K; i++) assertEquals("Wrong (5) at " + i, 0, nc.atd(i), Math.ulp(0));
-      
+
       post();
       cc.set(K-5, 0);
       post_write();
       assertEquals(K, nc._len);
       assertEquals(0,cc.atd(K-5),Math.ulp(0));
       assertTrue(cc.chk2() instanceof CXIChunk);
-      
+
       for (int i = 0; i < K-3; i++) assertEquals(0, cc.atd(i), Math.ulp(0));
       assertEquals(Double.NaN, cc.atd(K-3), Math.ulp(Double.NaN));
       for (int i = K-2; i < K; i++) assertEquals(0, cc.atd(i), Math.ulp(0));
       assertEquals(1,cc.chk2().sparseLenZero());
-      
+
     } finally { remove();}
   }
-  
+
   @Test public void testCNAXDChunk_setPostSparse() {
     try {
       pre();
@@ -532,7 +532,7 @@ public class NewChunkTest extends TestUtil {
       assertEquals(4,cc.chk2().sparseLenNA());
     } finally {remove();}
   }
-  
+
   @Test public void testSparseCat() {
     try {
       av = new AppendableVec(Vec.newKey(), Vec.T_CAT);

--- a/h2o-core/src/test/java/water/rapids/SortTest.java
+++ b/h2o-core/src/test/java/water/rapids/SortTest.java
@@ -230,6 +230,43 @@ public class SortTest extends TestUtil {
   }
 
 
+  @Test public void testSortOverflows2() throws IOException {
+    Scope.enter();
+    Frame fr, sorted1, sorted2;
+    long ts=1485333188427000000L;
+    try {
+
+      Vec dz = Vec.makeZero(1000);
+      Vec z = dz.makeZero(); // make a vec consisting of C0LChunks
+      Vec v = new MRTask() {
+        @Override public void map(Chunk[] cs) {
+          for (Chunk c : cs)
+            for (int r = 0; r < c._len; r++)
+              c.set(r, r + ts + c.start());
+        }
+      }.doAll(z)._fr.vecs()[0];
+      Scope.track(dz);
+      Scope.track(z);
+      Scope.track(v);
+      Vec rand = dz.makeRand(12345678);
+
+      fr = new Frame(v, rand);
+      sorted1 = fr.sort(new int[]{1});
+      sorted2 = sorted1.sort(new int[]{0});
+
+      for(long i=0; i < fr.numRows(); i++) {
+        assertTrue(fr.vec(0).at8(i) == sorted2.vec(0).at8(i));
+      }
+
+      Scope.track(fr);
+      Scope.track(sorted1);
+      Scope.track(sorted2);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
   @Test public void testSortIntegersFloats() throws IOException {
     // test small integers sort
     testSortOneColumn("smalldata/synthetic/smallIntFloats.csv.zip", 0, false, false);

--- a/h2o-core/src/test/java/water/rapids/SortTest.java
+++ b/h2o-core/src/test/java/water/rapids/SortTest.java
@@ -233,7 +233,7 @@ public class SortTest extends TestUtil {
   @Test public void testSortOverflows2() throws IOException {
     Scope.enter();
     Frame fr, sorted1, sorted2;
-    long ts=1485333188427000000L;
+    final long ts=1485333188427000000L;
     try {
 
       Vec dz = Vec.makeZero(1000);

--- a/h2o-py/tests/testdir_jira/pyunit_PUBDEV_3567_merge_stall_large.py
+++ b/h2o-py/tests/testdir_jira/pyunit_PUBDEV_3567_merge_stall_large.py
@@ -10,12 +10,15 @@ def pubdev_3567():
     mergedAnsLeft = h2o.import_file(pyunit_utils.locate("smalldata/jira/merged2Left.csv"), header=1)
     mergedAnsRight = h2o.import_file(pyunit_utils.locate("smalldata/jira/merged2Right.csv"), header=1)
     merged = train.merge(test,by_x=["A"],by_y=["A"],method="auto") # default is radix
+    print(merged[0,0])
     mergedLeft = train.merge(test,by_x=["A"],by_y=["A"],all_x=True)
+    print(mergedLeft[0,0])
     mergedRight = train.merge(test,by_x=["A"],by_y=["A"],all_y=True)    # new feature
+    print(mergedRight[0,0])
 
-    pyunit_utils.compare_numeric_frames(mergedAnsRight, mergedRight, 0.0001, tol=1e-10)
-    pyunit_utils.compare_numeric_frames(mergedAns, merged, 0.0001, tol=1e-10)
-    pyunit_utils.compare_numeric_frames(mergedAnsLeft, mergedLeft, 0.0001, tol=1e-10)
+    pyunit_utils.compare_frames_local(mergedAnsRight, mergedRight, 1, tol=1e-10)
+    pyunit_utils.compare_frames_local(mergedAns, merged, 1, tol=1e-10)
+    pyunit_utils.compare_frames_local(mergedAnsLeft, mergedLeft, 1, tol=1e-10)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(pubdev_3567)


### PR DESCRIPTION
fix lossy conversions of longs to doubles:
   - add at8_impl's for (C1S/C2S)Chunk
   - add new test cases to (C1S/C2S)ChunkTest
   - use BigInteger and smarter heueristics to detect "long" overflow