### PR TITLE
PUBDEV-5613 Ensure AutoML respects max_runtime_secs

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -430,11 +430,9 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
           Log.info("Skipping " + name + " due to Job cancel");
           subJob.stop();
         }
-        if (buildSpec.build_control.stopping_criteria.max_models() == 0) { //Ensure we do not have max models set
-          if (timeRemainingMs() <= 0) { //Check runtime left. If it is at zero cancel job.
-            Log.info("Skipping " + name + " due to no time left");
-            subJob.stop();
-          }
+        if (timeRemainingMs() <= 0) { //Check runtime left. If it is at zero cancel job.
+          Log.info("Skipping " + name + " due to no time left");
+          subJob.stop();
         }
       }
       long workedSoFar = Math.round(subJob.progress() * workContribution);

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -609,6 +609,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       searchCriteria.set_max_runtime_secs(Math.min(searchCriteria.max_runtime_secs(),
               timeRemainingMs() / 1000.0));
 
+    if (searchCriteria.max_runtime_secs() <= 0.001) {
+      userFeedback.info(Stage.ModelTraining,"AutoML: out of time; skipping " + algoName + " hyperparameter search");
+      return null;
+    }
+
     if (searchCriteria.max_models() == 0)
       searchCriteria.set_max_models(remainingModels());
     else
@@ -689,6 +694,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private boolean exceededSearchLimits(String whatWeAreSkipping) {
     if (ArrayUtils.contains(skipAlgosList, whatWeAreSkipping)) {
       userFeedback.info(Stage.ModelTraining,"AutoML: skipping algo " + whatWeAreSkipping + " build");
+      return true;
+    }
+
+    if (timeRemainingMs() <= 0.001) {
+      userFeedback.info(Stage.ModelTraining, "AutoML: out of time; skipping " + whatWeAreSkipping);
       return true;
     }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -427,11 +427,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     while (subJob.isRunning()) {
       if (null != parentJob) {
         if (parentJob.stop_requested()) {
-          Log.info("Skipping " + name + " due to Job cancel");
+          userFeedback.info(Stage.ModelTraining, "AutoML job cancelled; skipping " + name);
           subJob.stop();
         }
         if (timeRemainingMs() <= 0) { //Check runtime left. If it is at zero cancel job.
-          Log.info("Skipping " + name + " due to no time left");
+          userFeedback.info(Stage.ModelTraining, "AutoML: out of time; skipping " + name);
           subJob.stop();
         }
       }
@@ -609,11 +609,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       searchCriteria.set_max_runtime_secs(Math.min(searchCriteria.max_runtime_secs(),
               timeRemainingMs() / 1000.0));
 
-    if (searchCriteria.max_runtime_secs() <= 0.001) {
-      userFeedback.info(Stage.ModelTraining,"AutoML: out of time; skipping " + algoName + " hyperparameter search");
-      return null;
-    }
-
     if (searchCriteria.max_models() == 0)
       searchCriteria.set_max_models(remainingModels());
     else
@@ -694,11 +689,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private boolean exceededSearchLimits(String whatWeAreSkipping) {
     if (ArrayUtils.contains(skipAlgosList, whatWeAreSkipping)) {
       userFeedback.info(Stage.ModelTraining,"AutoML: skipping algo " + whatWeAreSkipping + " build");
-      return true;
-    }
-
-    if (timeRemainingMs() <= 0.001) {
-      userFeedback.info(Stage.ModelTraining, "AutoML: out of time; skipping " + whatWeAreSkipping);
       return true;
     }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -430,6 +430,12 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
           Log.info("Skipping " + name + " due to Job cancel");
           subJob.stop();
         }
+        if (buildSpec.build_control.stopping_criteria.max_models() == 0) { //Ensure we do not have max models set
+          if (timeRemainingMs() <= 0) { //Check runtime left. If it is at zero cancel job.
+            Log.info("Skipping " + name + " due to no time left");
+            subJob.stop();
+          }
+        }
       }
       long workedSoFar = Math.round(subJob.progress() * workContribution);
       cumulative += workedSoFar;

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -590,8 +590,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
   }
 
   protected static final String[] colHeaders(String metric, String[] other_metric) {
-    //return new String[] {"model ID", "timestamp", metric.toString()};
-    String[] headers = ArrayUtils.append(new String[]{"model_id",metric.toString()},other_metric);
+    String[] headers = ArrayUtils.append(new String[]{"model_id",metric},other_metric);
     return headers;
   }
 
@@ -732,7 +731,10 @@ public class Leaderboard extends Keyed<Leaderboard> {
     //long[] timestamps = getTimestamps(models);
     String[] modelIDsFormatted = new String[models.length];
 
-    if(models[0]._output.isBinomialClassifier()) {
+    if (models.length == 0) { //No models due to exclude algos or ran out of time
+      this.other_metrics = new String[] {null, null, null, null};
+    }
+    else if(models[0]._output.isBinomialClassifier()) {
       this.other_metrics = new String[] {"logloss", "mean_per_class_error", "rmse", "mse"};
     } else if (models[0]._output.isMultinomialClassifier()) {
       this.other_metrics = new String[] {"logloss", "rmse", "mse"};

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -652,7 +652,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
       return new TwoDimTable(tableHeader,
               "no models in this leaderboard",
               rowHeaders,
-              Leaderboard.colHeaders(sort_metric, other_metrics),
+              Leaderboard.colHeaders("auc", other_metrics),
               Leaderboard.colTypesBinomial,
               Leaderboard.colFormatsBinomial,
               "-");
@@ -732,7 +732,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
     String[] modelIDsFormatted = new String[models.length];
 
     if (models.length == 0) { //No models due to exclude algos or ran out of time
-      this.other_metrics = new String[] {null, null, null, null};
+      this.other_metrics = new String[] {"logloss", "mean_per_class_error", "rmse", "mse"};
     }
     else if(models[0]._output.isBinomialClassifier()) {
       this.other_metrics = new String[] {"logloss", "mean_per_class_error", "rmse", "mse"};

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -732,6 +732,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
     String[] modelIDsFormatted = new String[models.length];
 
     if (models.length == 0) { //No models due to exclude algos or ran out of time
+      //Just use binomial metrics as a placeholder (no way to tell as user can pass in any metric to sort by)
       this.other_metrics = new String[] {"logloss", "mean_per_class_error", "rmse", "mse"};
     }
     else if(models[0]._output.isBinomialClassifier()) {

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -23,97 +23,93 @@ def prostate_automl_args():
     train["CAPSULE"] = train["CAPSULE"].asfactor()
     valid["CAPSULE"] = valid["CAPSULE"].asfactor()
     test["CAPSULE"] = test["CAPSULE"].asfactor()
-
+    
+    max_models = 2
+    
     # Below fails bc there are no models in the leaderboard, but AutoML needs to check the models to get the
     # model type (binomial, multinomial, or regression)
     # print("Check that exclude_algos implementation is complete, and empty leaderboard works")
-    # aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"])
+    # aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234, exclude_algos=["GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"])
     # aml.train(y="CAPSULE", training_frame=train)
     # print("Check leaderboard to ensure that it only has a header")
     # print(aml.leaderboard)
     # assert aml.leaderboard.nrows == 0, "with all algos excluded, leaderboard is not empty"
 
     print("Check arguments to H2OAutoML class")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234, exclude_algos=["DeepLearning"])
+    aml = H2OAutoML(project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234, exclude_algos=["DeepLearning"])
     aml.train(y="CAPSULE", training_frame=train)
-    assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml0", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
-    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.max_models == 2, "max_models is not set to 2"
     assert aml.seed == 1234, "seed is not set to `1234`"
     print("Check leaderboard")
     print(aml.leaderboard)    
 
     print("AutoML run with x not provided and train set only")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml1", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(project_name="py_aml1", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
-    assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml1", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
-    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.max_models == 2, "max_models is not set to 2"
     assert aml.seed == 1234, "seed is not set to `1234`"
     print("Check leaderboard")
     print(aml.leaderboard)    
 
     print("AutoML run with x not provided with train and valid")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml2", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(project_name="py_aml2", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234)
     aml.train(y="CAPSULE", training_frame=train, validation_frame=valid)
-    assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml2", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
-    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.max_models == 2, "max_models is not set to 2"
     assert aml.seed == 1234, "seed is not set to `1234`"
     print("Check leaderboard")
     print(aml.leaderboard)    
 
     print("AutoML run with x not provided with train and test")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml3", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(project_name="py_aml3", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234)
     aml.train(y="CAPSULE", training_frame=train, leaderboard_frame=test)
-    assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml3", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
-    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.max_models == 2, "max_models is not set to 2"
     assert aml.seed == 1234, "seed is not set to `1234`"
     print("Check leaderboard")
     print(aml.leaderboard)    
 
     print("AutoML run with x not provided with train, valid, and test")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml4", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(project_name="py_aml4", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234)
     aml.train(y="CAPSULE", training_frame=train, validation_frame=valid, leaderboard_frame=test)
-    assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml4", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
-    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.max_models == 2, "max_models is not set to 2"
     assert aml.seed == 1234, "seed is not set to `1234`"
     print("Check leaderboard")
     print(aml.leaderboard)    
 
     print("AutoML run with x not provided and y as col idx with train, valid, and test")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml5", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(project_name="py_aml5", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234)
     aml.train(y=1, training_frame=train, validation_frame=valid, leaderboard_frame=test)
-    assert aml.max_runtime_secs == 10, "max_runtime_secs is not set to 10 secs"
     assert aml.project_name == "py_aml5", "Project name is not set"
     assert aml.stopping_rounds == 3, "stopping_rounds is not set to 3"
     assert aml.stopping_tolerence == 0.001, "stopping_tolerance is not set to 0.001"
     assert aml.stopping_metric == "AUC", "stopping_metrics is not set to `AUC`"
-    assert aml.max_models == 10, "max_models is not set to 10"
+    assert aml.max_models == 2, "max_models is not set to 2"
     assert aml.seed == 1234, "seed is not set to `1234`"
     print("Check leaderboard")
     print(aml.leaderboard)
 
     print("Check predict, leader, and leaderboard")
     print("AutoML run with x not provided and train set only")
-    aml = H2OAutoML(max_runtime_secs=10, project_name="py_aml6", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(project_name="py_aml6", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=max_models, seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
     print("Check leaderboard")
     print(aml.leaderboard)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
@@ -22,7 +22,7 @@ def prostate_automl_get_automl():
     valid["CAPSULE"] = valid["CAPSULE"].asfactor()
     test["CAPSULE"] = test["CAPSULE"].asfactor()
 
-    aml = H2OAutoML(max_runtime_secs=30, project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=10, seed=1234)
+    aml = H2OAutoML(project_name="py_aml0", stopping_rounds=3, stopping_tolerance=0.001, stopping_metric="AUC", max_models=2, seed=1234)
     aml.train(y="CAPSULE", training_frame=train)
 
     get_aml = get_automl(aml.project_name)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_ignore_cols.py
@@ -21,7 +21,7 @@ def prostate_automl():
     test = fr[2]
 
     #Use same project_name so we add to leaderboard for each run
-    aml = H2OAutoML(max_runtime_secs = 30, stopping_rounds=3, stopping_tolerance=0.001, project_name="aml1")
+    aml = H2OAutoML(max_models=2, stopping_rounds=3, stopping_tolerance=0.001, project_name="aml1")
 
     train["CAPSULE"] = train["CAPSULE"].asfactor()
     valid["CAPSULE"] = valid["CAPSULE"].asfactor()

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -21,45 +21,44 @@ automl.args.test <- function() {
   x <- setdiff(names(train), y)
   train[,y] <- as.factor(train[,y])
   test[,y] <- as.factor(test[,y])
-  max_runtime_secs <- 10
   max_models <- 2
   print("Check arguments to H2OAutoML class")
 
   #print("Try without a y")
   #expect_failure(h2o.automl(training_frame = train,
-  #                          max_runtime_secs = max_runtime_secs,
+  #                          max_models = max_models,
   #                          project_name = "aml0"))
 
   print("Try without an x")
   aml1 <- h2o.automl(y = y,
                      training_frame = train,
-                     max_runtime_secs = max_runtime_secs,
+                     max_models = max_models,
                      project_name = "aml1")
 
   print("Try with y as a column index, x as colnames")
   aml2 <- h2o.automl(x = x, y = 1,
                      training_frame = train,
-                     max_runtime_secs = max_runtime_secs,
+                     max_models = max_models,
                      project_name = "aml2")
 
   print("Single training frame; x and y both specified")
   aml3 <- h2o.automl(x = x, y = y,
                      training_frame = train,
-                     max_runtime_secs = max_runtime_secs,
+                     max_models = max_models,
                      project_name = "aml3")
 
   print("Training & validation frame")
   aml4 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      validation_frame = valid,
-                     max_runtime_secs = max_runtime_secs,
+                     max_models = max_models,
                      project_name = "aml4")
 
   print("Training & leaderboard frame")
   aml5 <- h2o.automl(x = x, y = y,
                      training_frame = train,
                      leaderboard_frame = test,
-                     max_runtime_secs = max_runtime_secs,
+                     max_models = max_models,
                      project_name = "aml5")
 
   print("Training, validation & leaderboard frame")
@@ -67,7 +66,7 @@ automl.args.test <- function() {
                      training_frame = train,
                      validation_frame = valid,
                      leaderboard_frame = test,
-                     max_runtime_secs = max_runtime_secs,
+                     max_models = max_models,
                      project_name = "aml6")
 
   print("Early stopping args")
@@ -75,7 +74,7 @@ automl.args.test <- function() {
                      training_frame = train,
                      validation_frame = valid,
                      leaderboard_frame = test,
-                     max_runtime_secs = max_runtime_secs,
+                     max_models = max_models,
                      stopping_metric = "AUC",
                      stopping_tolerance = 0.001,
                      stopping_rounds = 3,

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -84,7 +84,6 @@ automl.args.test <- function() {
   print("Check max_models = 1")
   aml8 <- h2o.automl(x = x, y = y,
                      training_frame = train,
-                     max_runtime_secs = max_runtime_secs,
                      max_models = 1,
                      project_name = "aml8")
   nrow_aml8_lb <- nrow(aml8@leaderboard)
@@ -93,7 +92,6 @@ automl.args.test <- function() {
   print("Check max_models > 1; leaderboard continuity/growth")
   aml8 <- h2o.automl(x = x, y = y,
                      training_frame = train,
-                     max_runtime_secs = max_runtime_secs,
                      max_models = max_models,
                      project_name = "aml8")
   expect_equal(nrow(aml8@leaderboard) > nrow_aml8_lb, TRUE)
@@ -125,7 +123,7 @@ automl.args.test <- function() {
   aml10 <- h2o.automl(x = x, y = y,
                       training_frame = train,
                       weights_column = weights_column,
-                      max_runtime_secs = max_runtime_secs,
+                      max_models = max_models,
                       project_name = "aml10")
   model_ids <- as.character(as.data.frame(aml10@leaderboard[,"model_id"])[,1])
   amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
@@ -137,7 +135,7 @@ automl.args.test <- function() {
                       training_frame = train,
                       fold_column = fold_column,
                       weights_column = weights_column,
-                      max_runtime_secs = max_runtime_secs,
+                      max_models = max_models,
                       project_name = "aml11")
   model_ids <- as.character(as.data.frame(aml11@leaderboard[,"model_id"])[,1])
   amodel <- h2o.getModel(grep("DRF", model_ids, value = TRUE))
@@ -181,7 +179,7 @@ automl.args.test <- function() {
   aml15 <- h2o.automl(x = x, y = y,
                       training_frame = train,
                       nfolds = 3,
-                      max_models = 3,
+                      max_models = max_models,
                       balance_classes = TRUE,
                       max_after_balance_size = 3.0,  
                       class_sampling_factors = c(0.2, 1.4),


### PR DESCRIPTION
* This PR ensures AutoML respects the `max_runtime_secs` parameter by always checking the amount of time remaining in every poll of a job, which in this case is a model build.
* This PR also adds in a case for an empty leaderboard, which returns an empty leaderboard that has binomial metrics (we can change the headers to something else if needed)
* This PR also updates each test that uses a small `max_runtime_secs` parameter by always using `max_models` >=2 to avoid issues if the leaderboard is empty due to lack of run time.