### PR TITLE
PUBDEV-5576 - grid search from flow reports wrong cross validation auc

### DIFF
--- a/h2o-core/src/main/java/hex/ScoringInfo.java
+++ b/h2o-core/src/main/java/hex/ScoringInfo.java
@@ -315,7 +315,6 @@ public class ScoringInfo extends Iced<ScoringInfo> {
         }
       } // hasCrossValidation
       row++;
-      assert col == colHeaders.size() - 1;
     }
     return table;
   }

--- a/h2o-core/src/main/java/hex/ScoringInfo.java
+++ b/h2o-core/src/main/java/hex/ScoringInfo.java
@@ -281,7 +281,7 @@ public class ScoringInfo extends Iced<ScoringInfo> {
           table.set(row, col++, si.scored_valid != null ? si.scored_valid._r2 : Double.NaN);
         }
         if (modelCategory == ModelCategory.Binomial) {
-          table.set(row, col++, si.validation_AUC != null ? si.validation_AUC._auc : Double.NaN);
+          table.set(row, col++, si.scored_valid != null ? si.scored_valid._AUC : Double.NaN);
           table.set(row, col++, si.scored_valid != null ? si.scored_valid._lift : Double.NaN);
         }
         if (isClassifier) {
@@ -299,11 +299,12 @@ public class ScoringInfo extends Iced<ScoringInfo> {
           table.set(row, col++, si.scored_xval != null ? si.scored_xval._r2 : Double.NaN);
         }
         if (isClassifier) {
+          table.set(row, col++, si.scored_xval != null ? si.scored_xval._rmse : Double.NaN);
           table.set(row, col++, si.scored_xval != null ? si.scored_xval._logloss : Double.NaN);
           table.set(row, col++, si.scored_xval != null ? si.scored_xval._r2 : Double.NaN);
         }
         if (modelCategory == ModelCategory.Binomial) {
-          table.set(row, col++, si.validation_AUC != null ? si.validation_AUC._auc : Double.NaN);
+          table.set(row, col++, si.scored_xval != null ? si.scored_xval._AUC : Double.NaN);
           table.set(row, col++, si.scored_xval != null ? si.scored_xval._lift : Double.NaN);
         }
         if (isClassifier) {
@@ -314,6 +315,7 @@ public class ScoringInfo extends Iced<ScoringInfo> {
         }
       } // hasCrossValidation
       row++;
+      assert col == colHeaders.size() - 1;
     }
     return table;
   }


### PR DESCRIPTION
[PUBDEV-5576](https://0xdata.atlassian.net/browse/PUBDEV-5576)

The original issue reported was wrong `x-validation AUC`. That was just a symptom however.

In the end, I found the whole process of filling the table from ScoringInfo was buggy. The values filled did not make any sense (especially coefficient of determination being 1.7 in x-validation was suspicious).

-Root mean square error for x-validation was just forgotten to be filled, resulting in all columns to be shifted to left by one since position 14.
- Cross-validation AUC was filled with validation AUC

The following screenshots demonstrate the situation before and after fix.
## Before fix
![snimek z 2018-06-18 13-42-40](https://user-images.githubusercontent.com/8769110/41534797-241b1058-7300-11e8-9f00-aab64d229262.png)

## After fix
![snimek z 2018-06-18 13-47-24](https://user-images.githubusercontent.com/8769110/41534799-267cc6ca-7300-11e8-90a6-33c7900bb369.png)

Also tested other algorithms manually, such as GLM. Added a simple assert at the end to check if number of values in the table (in each row) is the same as number of column headers.