### PR TITLE
PUBDEV-5641: Remove "udp" from H2O-3 UG

### DIFF
--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -207,7 +207,7 @@ The following is an example core-site.xml file:
 Launching H2O
 '''''''''''''
 
-**Note**: Before launching H2O on an EC2 cluster, verify that ports ``54321`` and ``54322`` are both accessible by TCP and UDP.
+**Note**: Before launching H2O on an EC2 cluster, verify that ports ``54321`` and ``54322`` are both accessible by TCP.
 
 **Selecting the Operating System and Virtualization Type**
 

--- a/h2o-docs/src/product/faq/clusters.rst
+++ b/h2o-docs/src/product/faq/clusters.rst
@@ -20,7 +20,7 @@ troubleshooting tips:
    enter curl http://:54321 (where is the IP address of the second node.
    Then, log in to the second node and enter curl http://:54321 (where
    is the IP address of the first node). Look for output from H2O.
--  Confirm ports 54321 and 54322 are available for both TCP and UDP.
+-  Confirm ports 54321 and 54322 are available for TCP.
 -  Confirm your firewall is not preventing the nodes from locating each
    other.
 -  Confirm the nodes are not using different versions of H2O.
@@ -81,7 +81,7 @@ H2O uses two ports:
 -  The ``REST_API`` port (54321): Specify when launching H2O using
    ``-port``; uses TCP only.
 -  The ``INTERNAL_COMMUNICATION`` port (54322): Implied based on the
-   port specified as the ``REST_API`` port, +1; requires TCP and UDP.
+   port specified as the ``REST_API`` port, +1; requires TCP.
 
 You can start the cluster behind the firewall, but to reach it, you must
 make a tunnel to reach the ``REST_API`` port. To use the cluster, the
@@ -216,10 +216,7 @@ The following information displays for each message:
 -  ``HH:MM:SS:MS`` and ``nanosec``: The local time of the event
 -  ``Who``: The endpoint of the message; can be either a source/receiver
    node or source node and multicast for broadcasted messages
--  ``I/O Type``: The type of communication (either UDP for small
-   messages or TCP for large messages) >\ **Note**: UDP messages are
-   only sent if the UDP option was enabled when launching H2O or for
-   multicast when a flatfile is not used for configuration.
+-  ``I/O Type``: The type of communication (TCP)
 -  ``Event``: The type of H2O message. The most common type is a
    distributed task, which displays as ``exec`` (the requested task) ->
    ``ack`` (results of the processed task) -> ``ackck`` (sender

--- a/h2o-docs/src/product/faq/general-troubleshooting.rst
+++ b/h2o-docs/src/product/faq/general-troubleshooting.rst
@@ -23,7 +23,7 @@ General Troubleshooting Tips
 -  Confirm that no other sessions of H2O are running. To stop all
    running H2O sessions, enter ``ps -efww | grep h2o`` in your shell
    (OSX or Linux).
--  Confirm ports 54321 and 54322 are available for both TCP and UDP.
+-  Confirm ports 54321 and 54322 are available for TCP.
    Launch Telnet (for Windows users) or Terminal (for OS X users), then
    type ``telnet localhost 54321``, ``telnet localhost 54322``
 -  Confirm your firewall is not preventing the nodes from locating each

--- a/h2o-docs/src/product/faq/hadoop.rst
+++ b/h2o-docs/src/product/faq/hadoop.rst
@@ -69,12 +69,6 @@ documentation, launch H2O using the following command:
 
 --------------
 
-**How does H2O handle UDP packet failures? Does H2O quit or retry?**
-
- In standard settings, H2O only uses UDP for cloud forming and only if you do not provide a flat file. All other communication is done via TCP. Cloud forming with no flat file is done by repeated broadcasts that are repeated until the cloud forms.
-
---------------
-
 **How do I import data from HDFS in R and in Flow?**
 
 To import from HDFS in R:

--- a/h2o-docs/src/product/howto/FAQ.md
+++ b/h2o-docs/src/product/howto/FAQ.md
@@ -12,7 +12,7 @@
 - Try allocating more memory to H2O by modifying the `-Xmx` value when launching H2O from the command line (for example, `java -Xmx10g -jar h2o.jar` allocates 10g of memory for H2O). If you create a cluster with four 20g nodes (by specifying `-Xmx20g` four times), H2O will have a total of 80 gigs of memory available. For best performance, we recommend sizing your cluster to be about four times the size of your data. To avoid swapping, the `-Xmx` allocation must not exceed the physical memory on any node. Allocating the same amount of memory for all nodes is strongly recommended, as H2O works best with symmetric nodes.
 
 - Confirm that no other sessions of H2O are running. To stop all running H2O sessions, enter `ps -efww | grep h2o` in your shell (OSX or Linux).
-- Confirm ports 54321 and 54322 are available for both TCP and UDP. Launch Telnet (for Windows users) or Terminal (for OS X users), then type `telnet localhost 54321`, `telnet localhost 54322`
+- Confirm ports 54321 and 54322 are available for TCP. Launch Telnet (for Windows users) or Terminal (for OS X users), then type `telnet localhost 54321`, `telnet localhost 54322`
 - Confirm your firewall is not preventing the nodes from locating each other. If you can't launch H2O, we recommend temporarily disabling any firewalls until you can confirm they are not preventing H2O from launching.
 - Confirm the nodes are not using different versions of H2O. If the H2O initialization is not successful, look at the output in the shell - if you see `Attempting to join /localhost:54321 with an H2O version mismatch (md5 differs)`, update H2O on all the nodes to the same version.
 - Confirm that there is space in the `/tmp` directory.
@@ -280,7 +280,7 @@ If this does not resolve the issue, try the following additional troubleshooting
 
 - Test connectivity using curl: First, log in to the first node and enter curl http://<Node2IP>:54321 (where <Node2IP> is the IP address of the second node. Then, log in to the second node and enter curl http://<Node1IP>:54321 (where <Node1IP> is the IP address of the first node). Look for output from H2O.
 
-- Confirm ports 54321 and 54322 are available for both TCP and UDP.
+- Confirm ports 54321 and 54322 are available for TCP.
 - Confirm your firewall is not preventing the nodes from locating each other.
 - Confirm the nodes are not using different versions of H2O.
 - Confirm that the username is the same on all nodes; if not, define the cloud in the terminal when launching using `-name`:`java -jar h2o.jar -name myCloud`.
@@ -321,7 +321,7 @@ In the Flow web UI, click the **Admin** menu and select **Cluster Status**.
 H2O uses two ports:
 
 - The `REST_API` port (54321): Specify when launching H2O using `-port`; uses TCP only.
-- The `INTERNAL_COMMUNICATION` port (54322): Implied based on the port specified as the `REST_API` port, +1; requires TCP and UDP.
+- The `INTERNAL_COMMUNICATION` port (54322): Implied based on the port specified as the `REST_API` port, +1; requires TCP.
 
 You can start the cluster behind the firewall, but to reach it, you must make a tunnel to reach the `REST_API` port. To use the cluster, the `REST_API` port of at least one node must be reachable.
 
@@ -364,8 +364,7 @@ The following information displays for each message:
 
 - `HH:MM:SS:MS` and `nanosec`: The local time of the event
 - `Who`: The endpoint of the message; can be either a source/receiver node or source node and multicast for broadcasted messages
-- `I/O Type`: The type of communication (either UDP for small messages or TCP for large messages)
-   >**Note**: UDP messages are only sent if the UDP option was enabled when launching H2O or for multicast when a flatfile is not used for configuration.
+- `I/O Type`: The type of communication (TCP)
 - `Event`: The type of H2O message. The most common type is a distributed task, which displays as `exec` (the requested task) -> `ack` (results of the processed task) -> `ackck` (sender acknowledges receiving the response, task is completed and removed)
 - `rebooted`: Sent during node startup
 - `heartbeat`: Provides small message tracking information about node health, exchanged periodically between nodes
@@ -794,12 +793,6 @@ After creating and applying the desired node labels and associating them with sp
 - `-nodes <num-nodes>` represents the number of nodes
 - `-mapperXmx 6g` launches H2O with 6g of memory
 - `-output hdfsOutputDirName` specifies the HDFS output directory as `hdfsOutputDirName`
-
----
-
-**How does H2O handle UDP packet failures? Does H2O quit or retry?**
-
- In standard settings, H2O only uses UDP for cloud forming and only if you do not provide a flat file. All other communication is done via TCP. Cloud forming with no flat file is done by repeated broadcasts that are repeated until the cloud forms.
 
 ---
 

--- a/h2o-docs/src/product/howto/H2O-DevHadoop.md
+++ b/h2o-docs/src/product/howto/H2O-DevHadoop.md
@@ -4,19 +4,24 @@
 
 Currently supported versions:
 
-- CDH 5.2
-- CDH 5.3
-- CDH 5.4.2
-- CDH 5.5.3
-- CDH 5.6.0
-- CDH 5.7.0
-- HDP 2.1
+- CDH 5.4
+- CDH 5.5
+- CDH 5.6
+- CDH 5.7
+- CDH 5.8
+- CDH 5.10
+- CDH 5.13
+- CDH 5.14
 - HDP 2.2
 - HDP 2.3
 - HDP 2.4
-- MapR 4.0.1
+- HDP 2.5
+- HDP 2.6
+- MapR 4.0
 - MapR 5.0
 - MapR 5.1
+- MapR 5.2
+- IOP 4.2
 
 **Important Points to Remember**:
 
@@ -41,7 +46,7 @@ Optionally specify this port using the `-driverport` option in the `hadoop jar` 
 
 **Path 2: mapper to mapper**
 
-Optionally specify this port using the `-baseport` option in the `hadoop jar` command (refer to [Hadoop Launch Parameters](#LaunchParam) below. This port and the next subsequent port are opened on the mapper hosts (the Hadoop worker nodes) where the H2O mapper nodes are placed by the Resource Manager. By default, ports 54321 (TCP) and 54322 (TCP & UDP) are used.
+Optionally specify this port using the `-baseport` option in the `hadoop jar` command (refer to [Hadoop Launch Parameters](#LaunchParam) below. This port and the next subsequent port are opened on the mapper hosts (the Hadoop worker nodes) where the H2O mapper nodes are placed by the Resource Manager. By default, ports 54321 and 54322 are used.
 
 The mapper port is adaptive: if 54321 and 54322 are not available, H2O will try 54323 and 54324 and so on. The mapper port is designed to be adaptive because sometimes if the YARN cluster is low on resources, YARN will place two H2O mappers for the same H2O cluster request on the same physical host. For this reason, we recommend opening a range of more than two ports (20 ports should be sufficient).
 

--- a/h2o-docs/src/product/howto/H2O-DevS3Creds.md
+++ b/h2o-docs/src/product/howto/H2O-DevS3Creds.md
@@ -135,7 +135,7 @@ The following is an example core-site.xml file:
 
 ## Launching H2O
 
-**Note**: Before launching H2O on an EC2 cluster, verify that ports `54321` and `54322` are both accessible by TCP and UDP. 
+**Note**: Before launching H2O on an EC2 cluster, verify that ports `54321` and `54322` are both accessible by TCP. 
 
 ### Selecting the Operating System and Virtualization Type
 

--- a/h2o-docs/src/product/security.rst
+++ b/h2o-docs/src/product/security.rst
@@ -948,7 +948,6 @@ To enable this feature, set the ``-internal_security_conf`` parameter when start
 
 This must be set for every node in the cluster. Every node needs to have access to both Java keystore and Java truststore containing appropriate keys and certificates.
 
-This feature should not be used together with the ``-useUDP`` flag, as we currently do not support UDP encryption through DTLS or any other protocol that might result in unencrypted data transfers.
 
 Keystore/Truststore Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1004,7 +1003,6 @@ Example benchmark on a 5 node cluster (6GB memory per node) working with a 5.8ml
 Caveats and Missing Pieces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- - This feature CANNOT be used together with the ``-useUDP`` flag. We currently do not support DTLS or any other encryption for UDP.
  - Should you start a mixed cloud of SSL and nonSSL nodes, the SSL ones will fail to bootstrap, while the nonSSL ones will become unresponsive.
  - H2O does not provide in-memory data encryption. This might spill data to disk in unencrypted form should swaps to disk occur. As a workaround, an encrypted drive is advised.
  - H2O does not support encryption of data saved to disk, should appropriate flags be enabled. Similar to the previous caveat, the user can use an encrypted drive to work around this issue.


### PR DESCRIPTION
Removed references to UDP in the user guide and from markdown files in the howto folder. 