### PR TITLE
PUBDEV-5560[reopen]: handle corner-cases consistently when creating H2OFrame with empty objects in Python

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -140,7 +140,7 @@ class ExprNode(object):
             return str(self._cache._data) if self._cache.is_scalar() else self._cache._id
         if self._cache._id is not None:
             return self._cache._id  # Data already computed under ID, but not cached
-        # assert isinstance(self._children,tuple)
+        assert isinstance(self._children,tuple)
         exec_str = "({} {})".format(self._op, " ".join([ExprNode._arg_to_expr(ast) for ast in self._children]))
         gc_ref_cnt = len(gc.get_referrers(self))
         if top or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
@@ -312,6 +312,9 @@ class H2OCache(object):
 
     def __len__(self):
         return self._l
+
+    def is_detached(self):
+        return self._id is None
 
     def is_empty(self):
         return self._data is None

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -313,9 +313,6 @@ class H2OCache(object):
     def __len__(self):
         return self._l
 
-    def is_detached(self):
-        return self._id is None
-
     def is_empty(self):
         return self._data is None
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -421,7 +421,7 @@ class H2OFrame(object):
             print("This H2OFrame has been removed.")
             return
         if not self._has_content():
-            print("This H2OFrame is not initialized.")
+            print("This H2OFrame is empty and not initialized.")
             return
         if self.nrows == 0:
             print("This H2OFrame is empty.")
@@ -456,7 +456,7 @@ class H2OFrame(object):
         :param bool return_data: Return a dictionary of the summary output
         """
         if not self._has_content():
-            print("This H2OFrame is not initialized.")
+            print("This H2OFrame is empty and not initialized.")
             return self._ex._cache._data;
         if not self._ex._cache.is_valid(): self._frame()._ex._cache.fill()
         if not return_data:

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -417,6 +417,9 @@ class H2OFrame(object):
         if self._ex is None:
             print("This H2OFrame has been removed.")
             return
+        if self._ex._cache.is_detached():
+            print("This H2OFrame is detached.")
+            return
         if self.nrows == 0:
             print("This H2OFrame is empty.")
             return
@@ -449,6 +452,9 @@ class H2OFrame(object):
 
         :param bool return_data: Return a dictionary of the summary output
         """
+        if self._ex._cache.is_detached():
+            print("This H2OFrame is detached.")
+            return self._ex._cache._data;
         if not self._ex._cache.is_valid(): self._frame()._ex._cache.fill()
         if not return_data:
             if self.nrows == 0:
@@ -471,17 +477,18 @@ class H2OFrame(object):
 
         :param bool chunk_summary: Retrieve the chunk summary along with the distribution summary
         """
-        res = h2o.api("GET /3/Frames/%s" % self.frame_id, data={"row_count": 10})["frames"][0]
-        self._ex._cache._fill_data(res)
+        if not self._ex._cache.is_detached():
+            res = h2o.api("GET /3/Frames/%s" % self.frame_id, data={"row_count": 10})["frames"][0]
+            self._ex._cache._fill_data(res)
 
-        print("Rows:{}".format(self.nrow))
-        print("Cols:{}".format(self.ncol))
+            print("Rows:{}".format(self.nrow))
+            print("Cols:{}".format(self.ncol))
 
-        #The chunk & distribution summaries are not cached, so must be pulled if chunk_summary=True.
-        if chunk_summary:
-            res["chunk_summary"].show()
-            res["distribution_summary"].show()
-        print("\n")
+            #The chunk & distribution summaries are not cached, so must be pulled if chunk_summary=True.
+            if chunk_summary:
+                res["chunk_summary"].show()
+                res["distribution_summary"].show()
+            print("\n")
         self.summary()
 
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -451,7 +451,9 @@ class H2OFrame(object):
         """
         if not self._ex._cache.is_valid(): self._frame()._ex._cache.fill()
         if not return_data:
-            if H2ODisplay._in_ipy():
+            if self.nrows == 0:
+                print("This H2OFrame is empty.")
+            elif H2ODisplay._in_ipy():
                 import IPython.display
                 IPython.display.display_html(self._ex._cache._tabulate("html", True), raw=True)
             else:

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -97,8 +97,8 @@ class H2OFrame(object):
         self._ex = ExprNode()
         self._ex._children = None
         self._is_frame = True  # Indicate that this is an actual frame, allowing typechecks to be made
-        python_obj = [] if python_obj is None else python_obj
-        self._upload_python_object(python_obj, destination_frame, header, separator,
+        if python_obj is not None:
+            self._upload_python_object(python_obj, destination_frame, header, separator,
                                        column_names, column_types, na_strings)
 
     @staticmethod

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -97,8 +97,8 @@ class H2OFrame(object):
         self._ex = ExprNode()
         self._ex._children = None
         self._is_frame = True  # Indicate that this is an actual frame, allowing typechecks to be made
-        if python_obj is not None:
-            self._upload_python_object(python_obj, destination_frame, header, separator,
+        python_obj = [] if python_obj is None else python_obj
+        self._upload_python_object(python_obj, destination_frame, header, separator,
                                        column_names, column_types, na_strings)
 
     @staticmethod

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -408,6 +408,9 @@ class H2OFrame(object):
                 self.show()
         return ""
 
+    def _has_content(self):
+        return self._ex and (self._ex._children or self._ex._cache._id)
+
     def show(self, use_pandas=False, rows=10, cols=200):
         """
         Used by the H2OFrame.__repr__ method to print or display a snippet of the data frame.
@@ -417,8 +420,8 @@ class H2OFrame(object):
         if self._ex is None:
             print("This H2OFrame has been removed.")
             return
-        if self._ex._cache.is_detached():
-            print("This H2OFrame is detached.")
+        if not self._has_content():
+            print("This H2OFrame is not initialized.")
             return
         if self.nrows == 0:
             print("This H2OFrame is empty.")
@@ -452,8 +455,8 @@ class H2OFrame(object):
 
         :param bool return_data: Return a dictionary of the summary output
         """
-        if self._ex._cache.is_detached():
-            print("This H2OFrame is detached.")
+        if not self._has_content():
+            print("This H2OFrame is not initialized.")
             return self._ex._cache._data;
         if not self._ex._cache.is_valid(): self._frame()._ex._cache.fill()
         if not return_data:
@@ -477,7 +480,7 @@ class H2OFrame(object):
 
         :param bool chunk_summary: Retrieve the chunk summary along with the distribution summary
         """
-        if not self._ex._cache.is_detached():
+        if self._has_content():
             res = h2o.api("GET /3/Frames/%s" % self.frame_id, data={"row_count": 10})["frames"][0]
             self._ex._cache._fill_data(res)
 
@@ -1540,7 +1543,6 @@ class H2OFrame(object):
         if self._ex is expr: return True
         if expr._children is None: return False
         return any(self._is_expr_in_self(ch) for ch in expr._children)
-
 
     def drop(self, index, axis=1):
         """

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -178,8 +178,8 @@ def _handle_pandas_data_frame(python_obj, header):
     return list(python_obj.columns), data
 
 def _handle_python_dicts(python_obj, check_header):
-    header = list(python_obj.keys())
-    is_valid = bool(header) and all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
+    header = list(python_obj.keys()) if python_obj else _gen_header(1)
+    is_valid = all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
     if not is_valid:
         raise ValueError(
             "Did not get a valid set of column names! Must match the regular expression: ^[a-zA-Z_][a-zA-Z0-9_.]*$ ")

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -109,7 +109,7 @@ def _gen_header(cols):
 def _check_lists_of_lists(python_obj):
     # check we have a lists of flat lists
     # returns longest length of sublist
-    most_cols = 0
+    most_cols = 1
     for l in python_obj:
         # All items in the list must be a list!
         if not isinstance(l, (tuple, list)):
@@ -179,7 +179,7 @@ def _handle_pandas_data_frame(python_obj, header):
 
 def _handle_python_dicts(python_obj, check_header):
     header = list(python_obj.keys())
-    is_valid = all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
+    is_valid = bool(header) and all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
     if not is_valid:
         raise ValueError(
             "Did not get a valid set of column names! Must match the regular expression: ^[a-zA-Z_][a-zA-Z0-9_.]*$ ")

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
@@ -7,38 +7,44 @@ Checking corner cases when initializing H2OFrame
 
 """
 
+def test_new_empty_frame():
+    fr = h2o.H2OFrame()
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
 def test_new_frame_with_empty_list():
     fr = h2o.H2OFrame([])
-    assert fr.nrows == 0
-    assert fr.ncols == 1
+    assert_empty(fr)
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_tuple():
     fr = h2o.H2OFrame(())
-    assert fr.nrows == 0
-    assert fr.ncols == 1
+    assert_empty(fr)
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_nested_list():
     fr = h2o.H2OFrame([[]])
-    assert fr.nrows == 0
-    assert fr.ncols == 1
+    assert_empty(fr)
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_dict():
-    try:
-        h2o.H2OFrame({})
-        assert False, "should have thrown ValueError"
-    except ValueError:
-        pass
+    fr = h2o.H2OFrame({})
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
+def assert_empty(frame):
+    assert frame.nrows == 0
+    assert frame.ncols == 1
 
 if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_new_empty_frame)
     pyunit_utils.standalone_test(test_new_frame_with_empty_list)
     pyunit_utils.standalone_test(test_new_frame_with_empty_tuple)
     pyunit_utils.standalone_test(test_new_frame_with_empty_nested_list)
     pyunit_utils.standalone_test(test_new_frame_with_empty_dict)
 
 else:
+    test_new_empty_frame()
     test_new_frame_with_empty_list()
     test_new_frame_with_empty_tuple()
     test_new_frame_with_empty_nested_list()

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import h2o
+from tests import pyunit_utils
+
+"""
+Checking corner cases when initializing H2OFrame
+
+"""
+
+def test_new_frame_with_empty_list():
+    fr = h2o.H2OFrame([])
+    assert fr.nrows == 0
+    assert fr.ncols == 1
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_tuple():
+    fr = h2o.H2OFrame(())
+    assert fr.nrows == 0
+    assert fr.ncols == 1
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_nested_list():
+    fr = h2o.H2OFrame([[]])
+    assert fr.nrows == 0
+    assert fr.ncols == 1
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_dict():
+    try:
+        h2o.H2OFrame({})
+        assert False, "should have thrown ValueError"
+    except ValueError:
+        pass
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_new_frame_with_empty_list)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_tuple)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_nested_list)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_dict)
+
+else:
+    test_new_frame_with_empty_list()
+    test_new_frame_with_empty_tuple()
+    test_new_frame_with_empty_nested_list()
+    test_new_frame_with_empty_dict()
+

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
@@ -9,7 +9,7 @@ Checking corner cases when initializing H2OFrame
 
 def test_new_empty_frame():
     fr = h2o.H2OFrame()
-    assert fr._ex._cache.is_detached()
+    assert not fr._has_content()
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_list():
@@ -33,7 +33,7 @@ def test_new_frame_with_empty_dict():
     fr.describe()  # just checking no exception is raised
 
 def assert_empty(frame):
-    assert not frame._ex._cache.is_detached()
+    assert frame._has_content()
     assert frame.nrows == 0
     assert frame.ncols == 1
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
@@ -9,7 +9,7 @@ Checking corner cases when initializing H2OFrame
 
 def test_new_empty_frame():
     fr = h2o.H2OFrame()
-    assert_empty(fr)
+    assert fr._ex._cache.is_detached()
     fr.describe()  # just checking no exception is raised
 
 def test_new_frame_with_empty_list():
@@ -33,6 +33,7 @@ def test_new_frame_with_empty_dict():
     fr.describe()  # just checking no exception is raised
 
 def assert_empty(frame):
+    assert not frame._ex._cache.is_detached()
     assert frame.nrows == 0
     assert frame.ncols == 1
 


### PR DESCRIPTION
cf. https://0xdata.atlassian.net/browse/PUBDEV-5560

currently with Python client, creation of H2OFrame is inconsistent:

fr = h2o.H2OFrame() > OK, but then fr.describe/summary() raises an exception 'NoneType' object is not iterable.
fr = h2o.H2OFrame([]) > OK, but then fr.describe/summary() raises an exception on iteration.
fr = h2o.H2OFrame(()) > same as above.
fr = h2o.H2OFrame([[]]) > KO, raises a H2OIllegalArgumentException.
fr = h2o.H2OFrame({}) > KO, raises a H2OIllegalArgumentException.

this PR is fixing this for following behaviour:

fr = h2o.H2OFrame() > OK, fr.describe/summary() prints "This H2OFrame is empty and not initialized." as it doesn't have any data nor representation on server side.
fr = h2o.H2OFrame([]) > OK, empty frame 0 row, 1 col, fr.describe/summary() prints "This H2OFrame is empty."
fr = h2o.H2OFrame(()) > same as above.
fr = h2o.H2OFrame([[]]) > same as above.
fr = h2o.H2OFrame({}) > same as above

choice to represent empty frames as having 1 column is legacy (empty list): for consistency, I just ensured that we obtain the same representation for other kind of empty frames