### PR TITLE
PUBDEV-5686: cross-platform compatibility when importing files from Python API

### DIFF
--- a/h2o-core/src/main/java/water/persist/PersistNFS.java
+++ b/h2o-core/src/main/java/water/persist/PersistNFS.java
@@ -9,6 +9,7 @@ import water.*;
 import water.exceptions.H2ONotFoundArgumentException;
 import water.fvec.NFSFileVec;
 import water.util.FileIntegrityChecker;
+import water.util.FileUtils;
 import water.util.Log;
 
 // Persistence backend for network file system.
@@ -131,7 +132,7 @@ public final class PersistNFS extends Persist {
 
   @Override
   public void importFiles(String path, String pattern, ArrayList<String> files, ArrayList<String> keys, ArrayList<String> fails, ArrayList<String> dels) {
-    File f = new File(path);
+    File f = new File(FileUtils.getURI(path));
     if( !f.exists() ) throw new H2ONotFoundArgumentException("File " + path + " does not exist");
     FileIntegrityChecker.check(f).syncDirectory(files,keys,fails,dels);
   }

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -306,8 +306,6 @@ class H2OFrame(object):
 
 
     def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings):
-        if is_type(path, str) and "://" not in path:
-            path = os.path.abspath(path)
         rawkey = h2o.lazy_import(path, pattern)
         self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings)
         return self

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -47,6 +47,9 @@ class H2OFrame(object):
     ``H2OFrame`` represents a mere handle to that data.
     """
 
+    # Flag to prevent
+    __LOCAL_EXPANSION_ON_SINGLE_IMPORT__ = True
+
     #-------------------------------------------------------------------------------------------------------------------
     # Construction
     #-------------------------------------------------------------------------------------------------------------------
@@ -306,6 +309,8 @@ class H2OFrame(object):
 
 
     def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings):
+        if H2OFrame.__LOCAL_EXPANSION_ON_SINGLE_IMPORT__ and is_type(path, str) and "://" not in path:  # fixme: delete those 2 lines, cf. PUBDEV-5717
+            path = os.path.abspath(path)
         rawkey = h2o.lazy_import(path, pattern)
         self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings)
         return self

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -47,7 +47,7 @@ class H2OFrame(object):
     ``H2OFrame`` represents a mere handle to that data.
     """
 
-    # Flag to prevent
+    # Temp flag: set this to false for now if encountering path conversion/expansion issues when import files to remote server
     __LOCAL_EXPANSION_ON_SINGLE_IMPORT__ = True
 
     #-------------------------------------------------------------------------------------------------------------------

--- a/py/testdir_multi_jvm/test_gbm_prostate.py
+++ b/py/testdir_multi_jvm/test_gbm_prostate.py
@@ -21,7 +21,7 @@ port = int(ip_port[1])
 # Connect to a pre-existing cluster
 h2o.init(ip=ip, port=port, strict_version_check=False)
 
-df = h2o.import_file(path="../../smalldata/logreg/prostate.csv")
+df = h2o.import_file(path=os.path.realpath("../../smalldata/logreg/prostate.csv"))
 df.describe()
 
 # Remove ID from training frame

--- a/py/testdir_multi_jvm/test_gbm_prostate.py
+++ b/py/testdir_multi_jvm/test_gbm_prostate.py
@@ -21,7 +21,7 @@ port = int(ip_port[1])
 # Connect to a pre-existing cluster
 h2o.init(ip=ip, port=port, strict_version_check=False)
 
-df = h2o.import_file(path=os.path.realpath("../../smalldata/logreg/prostate.csv"))
+df = h2o.import_file(path="../../smalldata/logreg/prostate.csv")
 df.describe()
 
 # Remove ID from training frame


### PR DESCRIPTION
python client converted path with no scheme to local format,  breaking cross-platform interoperability.
also fixed handling of paths with a "file" scheme on import