### PR TITLE
PUBDEV-5560: handle corner-cases consistently when creating H…

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -140,7 +140,7 @@ class ExprNode(object):
             return str(self._cache._data) if self._cache.is_scalar() else self._cache._id
         if self._cache._id is not None:
             return self._cache._id  # Data already computed under ID, but not cached
-        # assert isinstance(self._children,tuple)
+        assert isinstance(self._children,tuple)
         exec_str = "({} {})".format(self._op, " ".join([ExprNode._arg_to_expr(ast) for ast in self._children]))
         gc_ref_cnt = len(gc.get_referrers(self))
         if top or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -109,7 +109,7 @@ def _gen_header(cols):
 def _check_lists_of_lists(python_obj):
     # check we have a lists of flat lists
     # returns longest length of sublist
-    most_cols = 0
+    most_cols = 1
     for l in python_obj:
         # All items in the list must be a list!
         if not isinstance(l, (tuple, list)):
@@ -178,7 +178,7 @@ def _handle_pandas_data_frame(python_obj, header):
     return list(python_obj.columns), data
 
 def _handle_python_dicts(python_obj, check_header):
-    header = list(python_obj.keys())
+    header = list(python_obj.keys()) if python_obj else _gen_header(1)
     is_valid = all(re.match(r"^[a-zA-Z_][a-zA-Z0-9_.]*$", col) for col in header)  # is this a valid header?
     if not is_valid:
         raise ValueError(

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5560.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+import h2o
+from tests import pyunit_utils
+
+"""
+Checking corner cases when initializing H2OFrame
+
+"""
+
+def test_new_empty_frame():
+    fr = h2o.H2OFrame()
+    assert not fr._has_content()
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_list():
+    fr = h2o.H2OFrame([])
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_tuple():
+    fr = h2o.H2OFrame(())
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_nested_list():
+    fr = h2o.H2OFrame([[]])
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
+def test_new_frame_with_empty_dict():
+    fr = h2o.H2OFrame({})
+    assert_empty(fr)
+    fr.describe()  # just checking no exception is raised
+
+def assert_empty(frame):
+    assert frame._has_content()
+    assert frame.nrows == 0
+    assert frame.ncols == 1
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_new_empty_frame)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_list)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_tuple)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_nested_list)
+    pyunit_utils.standalone_test(test_new_frame_with_empty_dict)
+
+else:
+    test_new_empty_frame()
+    test_new_frame_with_empty_list()
+    test_new_frame_with_empty_tuple()
+    test_new_frame_with_empty_nested_list()
+    test_new_frame_with_empty_dict()
+


### PR DESCRIPTION
* PUBDEV-5560: handle corner-cases consistently when creating H2OFrame with empty objects in Python

no more errors thrown when creating and/or printing H2OFrame special-cases:
fr = h2o.H2OFrame() > fr.describe/summary() prints "This H2OFrame is empty and not initialized."
fr = h2o.H2OFrame([]) > empty frame 0 row, 1 col, fr.describe/summary() prints "This H2OFrame is empty."
fr = h2o.H2OFrame(()) > same as previous.
fr = h2o.H2OFrame([[]]) > same as previous.
fr = h2o.H2OFrame({}) > same as previous.
