### PR TITLE
PUBDEV-5703: fix bug when enum cardinality > 10.

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3498,7 +3498,20 @@ def generatePandaEnumCols(pandaFtrain, cname, nrows):
     zeroFrame = pd.DataFrame(tempnp)
     zeroFrame.columns=cmissingNames
     temp = pd.get_dummies(pandaFtrain[cname], prefix=cname, drop_first=False)
-    ctemp=pd.concat([temp,zeroFrame], axis=1)   # transformed H2O enum column to panda enum columns plus NA column
+    tempNames = list(temp)  # get column names
+    colLength = len(tempNames)
+    newNames = ['a']*colLength
+    newIndics = [0]*colLength
+    header = tempNames[0].split('.')[0]
+
+    for ind in range(colLength):
+        newIndics[ind] = int(tempNames[ind].split('.')[1][1:])
+    newIndics.sort()
+
+    for ind in range(colLength):
+        newNames[ind] = header+'.l'+str(newIndics[ind])  # generate correct order of names
+    ftemp = temp[newNames]
+    ctemp = pd.concat([ftemp, zeroFrame], axis=1)
     return ctemp
 
 def summarizeResult_binomial(h2oPredictD, nativePred, h2oTrainTimeD, nativeTrainTime, h2oPredictTimeD,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_dense_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_dense_NOPASS_multinode.py
@@ -34,9 +34,9 @@ def comparison_test_dense():
                    'gamma': 0.0,
                    'max_depth': h2oParamsD["max_depth"]}
 
-    nrows = random.randint(100000, 500000)
-    ncols = random.randint(1, 10)
-    factorL = random.randint(2, 10)
+    nrows = random.randint(10000, 100000)
+    ncols = random.randint(5, 20)
+    factorL = random.randint(11, 20)
     numCols = random.randint(1, ncols)
     enumCols = ncols-numCols
 

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_dense_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_dense_NOPASS_multinode.py
@@ -16,9 +16,9 @@ def comparison_test_dense():
     testTol = 1e-6
     ntrees = 10
     maxdepth = 5
-    nrows = random.randint(100000, 500000)
-    ncols = random.randint(1, 10)
-    factorL = random.randint(2, 10)
+    nrows = random.randint(10000, 100000)
+    ncols = random.randint(5, 20)
+    factorL = random.randint(11, 20)
     numCols = random.randint(1, ncols)
     enumCols = ncols-numCols
     responseL = random.randint(3,10)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_dense_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_dense_NOPASS_multinode.py
@@ -34,9 +34,9 @@ def comparison_test_dense():
                    'gamma': 0.0,
                    'max_depth': h2oParamsD["max_depth"]}
 
-    nrows = random.randint(100000, 500000)
-    ncols = random.randint(1, 10)
-    factorL = random.randint(2, 10)
+    nrows = random.randint(10000, 100000)
+    ncols = random.randint(5, 20)
+    factorL = random.randint(11, 20)
     numCols = random.randint(1, ncols)
     enumCols = ncols-numCols
 


### PR DESCRIPTION
Pavel has noticed that tests failed when categorical levels > 10.  This is caused by sorting order difference between H2OXGBoost and native XGBoost.

I fixed the problem in Python utilsPY.py