### PR TITLE
PUBDEV-5687: added groupby with String columns in Java.

### DIFF
--- a/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5687_groupby_with_stringCols.py
+++ b/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5687_groupby_with_stringCols.py
@@ -1,0 +1,52 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+try:    # redirect python output
+    from StringIO import StringIO  # for python 3
+except ImportError:
+    from io import StringIO  # for python 2
+
+def group_by():
+    '''
+    This test checks that if a groupby operation is specified for frames with string columns, a warning is
+    generated about the string columns being skipped.
+
+    In addition, it checks that operations on numeric/enum columns are performed and generated the correct
+    expected outputs.
+    
+    '''
+    # Connect to a pre-existing cluster
+
+    buffer = StringIO() # redirect output
+    sys.stderr=buffer
+    h2o_f1 = h2o.import_file(path=pyunit_utils.locate("smalldata/jira/test_groupby_with_strings.csv"),col_types=['real','string','string','real'])
+    grouped = h2o_f1.group_by("C1")
+    grouped.mean(na="all").median(na="all").max(na="all").min(na="all").sum(na="all")
+    print(grouped.get_frame())
+    print("Checking number of warning messages...")
+    check_warnings(2, buffer) # make sure we receieved two warning, one per string row
+
+def check_warnings(warnNumber, buffer):
+    warn_phrase = "UserWarning"
+    warn_string_of_interest = "slash (/) found"
+    sys.stderr=sys.__stderr__   # redirect printout back to normal path
+
+    try:        # for python 2.7
+        assert len(buffer.buflist)==warnNumber
+        if len(buffer.buflist) > 0:  # check to make sure we have the right number of warning
+            for index in range(len(buffer.buflist)):
+                print("*** captured warning message: {0}".format(buffer.buflist[index]))
+                assert (warn_phrase in buffer.buflist[index]) and (warn_string_of_interest in buffer.buflist[index])
+    except:     # for python 3.
+        warns = buffer.getvalue()
+        print("*** captured warning message: {0}".format(warns))
+        countWarns = warns.count("UserWarning")
+        assert countWarns==warnNumber, "Expected number of warnings: {0}, but received {1}.".format(warnNumber, countWarns)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(group_by)
+else:
+    group_by()

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3991,7 +3991,8 @@ h2o.relevel <- function(x,y) {
 #' GroupBy object; and \code{var} calculates the variance of each column specified in \code{col} for 
 #' each group of a GroupBy object. If an aggregate is provided without a value (for example, as 
 #' \code{max} in \code{sum(col="X1", na="all").mean(col="X5", na="all").max()}), then it is assumed 
-#' that the aggregation should apply to all columns except the GroupBy columns. Note again that 
+#' that the aggregation should apply to all columns except the GroupBy columns. However, operations
+#'  will not be performed on String columns.  They will be skipped.  Note again that
 #' \code{nrow} is required and cannot be empty.
 #'
 #' @param data an H2OFrame object.
@@ -4050,6 +4051,11 @@ h2o.group_by <- function(data, by, ..., gb.control=list(na.methods=NULL, col.nam
   # default to "all" na.method
   na.methods.defaults <- rep("all", nAggs)
 
+  for (colIndex in col.idxs) {
+    if (h2o.ischaracter(data[colIndex])) {
+      warning(paste0("Column ", names(data)[colIndex], " is a String column.  Groupby operations are not performend on it."))
+    }
+  }
   # 1 -> 0 based indexing of columns
   col.idxs <- col.idxs - 1
 

--- a/h2o-r/tests/testdir_misc/runit_PUBDEV_5687_groupby_with_string_columns.R
+++ b/h2o-r/tests/testdir_misc/runit_PUBDEV_5687_groupby_with_string_columns.R
@@ -1,0 +1,29 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+##
+# Test groupby functions on a frame with String columns and make sure a warning
+# message was received.  
+# 
+# When groupby operations are performed on numeric columns, make sure it still returns the
+# correct output.a 
+##
+
+test <- function(conn) {
+  Log.info("Upload dataset with String columns into H2O...")
+  df.hex <- h2o.uploadFile(locate("smalldata/jira/test_groupby_with_strings.csv"))
+
+  Log.info("Test method = nrow and median with string columns") # check warning is generated
+  expect_warning(gp_nrow <- h2o.group_by(data = df.hex, by = "C1", nrow("C2")))
+  expect_warning(gp_nrow <- h2o.group_by(data = df.hex, by = "C1", median("C3")))
+  
+  Log.info("Test method = nrow and median with numeric columns") # check groupby still works
+  gp_nrow <- h2o.group_by(data = df.hex, by = "C1", nrow("C4"))
+  gp_nrow <- as.data.frame(gp_nrow)[,2]
+  r_nrow  <- c(1,2,3,4,5,6)
+  print(r_nrow)
+  print(gp_nrow)
+  checkEqualsNumeric(gp_nrow, r_nrow)
+}
+
+doTest("Testing different methods for groupby for dataset with String columns:", test)
+


### PR DESCRIPTION
DO NOT REVIEW THIS ONE.  It duplicates the one for master.

PUBDEV-5687: groupby with string columns.  Fixed Java backend and added pyunit and Runit tests.
PUBDEV-5687: added documentation to remind users that string columns will be skipped.
PUBDEV-5687: added warning statements to Python and R clients per Michalk code review suggestions.