### PR TITLE
PUBDEV-5711: Fix group_by R example

### DIFF
--- a/h2o-docs/src/product/data-munging/groupby.rst
+++ b/h2o-docs/src/product/data-munging/groupby.rst
@@ -83,7 +83,7 @@ Note that once the aggregation operations are complete, calling the GroupBy obje
 
     # Find the number of flights in a given month based on the origin
     > cols <- c("Origin","Month")
-    > flightsByOriginMonth <- h2o.group_by(data=airlines.hex, by=cols, nrow("NumberOfFlights"), gb.control=list(na.methods="rm")
+    > flightsByOriginMonth <- h2o.group_by(data=airlines.hex, by=cols, nrow("Month"), gb.control=list(na.methods="rm"))
     > flightsByOriginMonth.R <- as.data.frame(flightsByOriginMonth)
     > flightsByOriginMonth.R
         Origin Month nrow_NumberOfFlights


### PR DESCRIPTION
Replaced “NumberOfFlights” with “Month” in the R example. Also added ending “)” to that line.