### PR TITLE
PUBDEV-5710-relwright: Fix R example for replacing values in a frame

### DIFF
--- a/h2o-docs/src/product/data-munging/replacing-values.rst
+++ b/h2o-docs/src/product/data-munging/replacing-values.rst
@@ -9,29 +9,29 @@ This example shows how to replace numeric values in a frame of data. Note that i
     > library(h2o)
     > h2o.init()
 
-    #Upload the iris dataset
-    > path <- "http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv""
+    # Upload the iris dataset
+    > path <- "http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv"
     > df <- h2o.importFile(path)
 
-    #Replace a single numerical datum. Note that columns and rows start at 0,
-    #so in the example below, the value in the 15th row and 3rd column will be set to 2.0.
+    # Replace a single numerical datum. Note that columns and rows start at 1,
+    # so in the example below, the value in the 14th row and 2nd column will be set to 2.0.
     > df[14,2] <- 2.0
 
-    #Replace a whole column. The example below multiplies all values in the second column by 3. 
+    # Replace a whole column. The example below multiplies all values in the second column by 3. 
     > df[,1] <- 3*df[,1]
 
-    #Replace by row mask. The example below searches for value less than 4.4 in the 
-    #sepal_len column and replaces those values with 4.6. 
+    # Replace by row mask. The example below searches for value less than 4.4 in the 
+    # sepal_len column and replaces those values with 4.6. 
     > df[df[,”sepal_len”] <- 4.6, “sepal_len”] <- 4.6
 
-    #Replace using ifelse. Similar to the previous example, 
-    #this replaces values less than 4.6 with 4.6. 
+    # Replace using ifelse. Similar to the previous example, 
+    # this replaces values less than 4.6 with 4.6. 
     > df[,”sepal_len”] <- h2o.ifelse(df[,”sepal_len”] < 4.4, 4.6, df[,”sepal_len”])
 
-    #Replace missing values with 0 
+    # Replace missing values with 0 
     > df[is.na(df[,”sepal_len”]), “sepal_len”] <- 0
 
-    #Alternative with ifelse 
+    # Alternative with ifelse 
     > df[,”sepal_len”] <- h2o.ifelse(is.na(df[,”sepal_len”]), 0, df[,”sepal_len”]
 
    .. code-block:: python


### PR DESCRIPTION
- R uses 1-based index. Updated the R example in the replacing-values.rst file to state this. Also verified that Python uses 0, so that example is correct.