### PR TITLE
Fixed bug found by Pavel.  

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3645,7 +3645,7 @@ def summarizeResult_regression(h2oPredictD, nativePred, h2oTrainTimeD, nativeTra
     # compare prediction probability and they should agree if they use the same seed
     for ind in range(h2oPredictD.nrow):
         assert abs((h2oPredictLocalD['predict'][ind]-nativePred[ind])/max(1, abs(h2oPredictLocalD['predict'][ind]), abs(nativePred[ind])))<tolerance, \
-            "H2O prediction prob: {0} and native XGBoost prediction prob: {1}.  They are very " \
+            "H2O prediction: {0} and native XGBoost prediction: {1}.  They are very " \
             "different.".format(h2oPredictLocalD['predict'][ind], nativePred[ind])
 
 def summarizeResult_binomial_DS(h2oPredictD, nativePred, h2oTrainTimeD, nativeTrainTime, h2oPredictTimeD,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_binomial_compare_sparse_NOPASS.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_binomial_compare_sparse_NOPASS.py
@@ -11,7 +11,7 @@ The dataset contains only enum columns.
 def comparison_test():
     assert H2OXGBoostEstimator.available() is True
     runSeed = 1
-    ntrees = 10
+    ntrees = 17
     # CPU Backend is forced for the results to be comparable
     h2oParamsS = {"ntrees":ntrees, "max_depth":4, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
                   "min_rows" : 5, "score_tree_interval": ntrees+1, "dmatrix_type":"sparse", "tree_method": "exact", "backend":"cpu"}
@@ -55,7 +55,7 @@ def comparison_test():
     # train the native XGBoost
 
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain, num_boost_round=10)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_multinomial_compare_sparse_NOPASS.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_multinomial_compare_sparse_NOPASS.py
@@ -11,7 +11,7 @@ The dataset contains only enum columns.
 def comparison_test():
     assert H2OXGBoostEstimator.available() is True
     runSeed = 1
-    ntrees = 10
+    ntrees = 17
     responseL = 11
     # CPU Backend is forced for the results to be comparable
     h2oParamsS = {"ntrees":ntrees, "max_depth":4, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
@@ -57,7 +57,7 @@ def comparison_test():
     # train the native XGBoost
 
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain, num_boost_round=10)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_dense_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_dense_NOPASS_multinode.py
@@ -1,6 +1,5 @@
 import xgboost as xgb
 import time
-import random
 
 from h2o.estimators.xgboost import *
 from tests import pyunit_utils
@@ -14,7 +13,7 @@ def comparison_test_dense():
 
     runSeed = 1
     testTol = 1e-6
-    ntrees = 10
+    ntrees = 17
     maxdepth = 5
     # CPU Backend is forced for the results to be comparable
     h2oParamsD = {"ntrees":ntrees, "max_depth":maxdepth, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
@@ -57,8 +56,8 @@ def comparison_test_dense():
 
     # train the native XGBoost
     nativeTrain = pyunit_utils.convertH2OFrameToDMatrix(trainFile, y, enumCols=enumCols)
-    nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain)
+    nativeModel = xgb.trainxgb.train(params=nativeParam,
+                                     dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_sparse_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_sparse_NOPASS_multinode.py
@@ -13,7 +13,7 @@ def comparison_test_dense():
 
     runSeed = 1
     testTol = 1e-6
-    ntrees = 10
+    ntrees = 17
     maxdepth = 5
     # CPU Backend is forced for the results to be comparable
     h2oParamsD = {"ntrees":ntrees, "max_depth":maxdepth, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
@@ -58,7 +58,7 @@ def comparison_test_dense():
     # train the native XGBoost
     nativeTrain = pyunit_utils.convertH2OFrameToDMatrixSparse(trainFile, y, enumCols=enumCols)
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_dense_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_dense_NOPASS_multinode.py
@@ -14,7 +14,7 @@ def comparison_test_dense():
 
     runSeed = 1
     testTol = 1e-6
-    ntrees = 10
+    ntrees = 17
     maxdepth = 5
     nrows = 10000
     ncols = 10
@@ -59,7 +59,7 @@ def comparison_test_dense():
     # train the native XGBoost
     nativeTrain = pyunit_utils.convertH2OFrameToDMatrix(trainFile, y, enumCols=enumCols)
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_sparse_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_sparse_NOPASS_multinode.py
@@ -12,7 +12,7 @@ def comparison_test_dense():
 
     runSeed = 1
     testTol = 1e-6
-    ntrees = 10
+    ntrees = 17
     maxdepth = 5
     responseL = 11
     # CPU Backend is forced for the results to be comparable
@@ -58,7 +58,7 @@ def comparison_test_dense():
     # train the native XGBoost
     nativeTrain = pyunit_utils.convertH2OFrameToDMatrixSparse(trainFile, y, enumCols=enumCols)
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_dense_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_dense_NOPASS_multinode.py
@@ -13,7 +13,7 @@ def comparison_test_dense():
 
     runSeed = 1
     testTol = 1e-6
-    ntrees = 10
+    ntrees = 17
     maxdepth = 5
     # CPU Backend is forced for the results to be comparable
     h2oParamsD = {"ntrees":ntrees, "max_depth":maxdepth, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
@@ -61,7 +61,7 @@ def comparison_test_dense():
     # train the native XGBoost
     nativeTrain = pyunit_utils.convertH2OFrameToDMatrix(trainFile, y, enumCols=enumCols)
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_sparse_NOPASS_multinode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_sparse_NOPASS_multinode.py
@@ -13,7 +13,7 @@ def comparison_test_dense():
 
     runSeed = 1
     testTol = 1e-6
-    ntrees = 10
+    ntrees = 17
     maxdepth = 5
     # CPU Backend is forced for the results to be comparable
     h2oParamsD = {"ntrees":ntrees, "max_depth":maxdepth, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
@@ -64,7 +64,7 @@ def comparison_test_dense():
     # train the native XGBoost
     nativeTrain = pyunit_utils.convertH2OFrameToDMatrixSparse(trainFile, y, enumCols=enumCols)
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_numerical_binomial_compare_sparse_NOPASS.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_numerical_binomial_compare_sparse_NOPASS.py
@@ -11,7 +11,7 @@ The dataset contains only enum columns.
 def comparison_test():
     assert H2OXGBoostEstimator.available() is True
     runSeed = 1
-    ntrees = 10
+    ntrees = 17
     h2oParamsS = {"ntrees":ntrees, "max_depth":4, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
                   "min_rows" : 5, "score_tree_interval": ntrees+1, "dmatrix_type":"sparse", "tree_method": "exact", "backend":"cpu"}
     nativeParam = {'colsample_bytree': h2oParamsS["col_sample_rate_per_tree"],
@@ -52,7 +52,7 @@ def comparison_test():
     # train the native XGBoost
     nativeTrain = pyunit_utils.convertH2OFrameToDMatrixSparse(trainFile, y, enumCols=[])
     nativeModel = xgb.train(params=nativeParam,
-                            dtrain=nativeTrain)
+                            dtrain=nativeTrain, num_boost_round=ntrees)
     nativeTrainTime = time.time()-time1
     time1=time.time()
     nativePred = nativeModel.predict(data=nativeTrain, ntree_limit=ntrees)


### PR DESCRIPTION
Fixed bug found by Pavel.  Native XGBoost will build only 10 trees.  Need to specify it via num_boost_round if we want to build a different number of trees in our comparison tests.