### PR TITLE
PUBDEV-5424: Add new functions to _pkgdown.yml file

### DIFF
--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -181,6 +181,8 @@ reference:
       - h2o.metric
       - h2o.min
       - h2o.mktime
+      - h2o.mojo_predict_csv
+      - h2o.mojo_predict_df
       - h2o.month
       - h2o.mse
       - h2o.na_omit


### PR DESCRIPTION
This is required in order for the functions to appear in the R HTML docs. Verified that they now appear when I build locally.