### PR TITLE
PUBDEV-5612 XGBoost Crashes on Tesla

### DIFF
--- a/h2o-genmodel-extensions/xgboost/build.gradle
+++ b/h2o-genmodel-extensions/xgboost/build.gradle
@@ -11,17 +11,17 @@ dependencies {
 
     // XGBoost dependencies published into Maven central by H2O
     // Versioning rules may differ for XGBoost artifacts published by H2O
-    compile('ai.h2o:xgboost4j:0.7.8') {
+        compile('ai.h2o:xgboost4j:0.7.9') {
         exclude group: 'org.scala-lang', module: 'scala-compiler'
         exclude group: 'org.scala-lang', module: 'scala-reflect'
         exclude group: 'org.scala-lang', module: 'scala-library'
         exclude group: 'com.typesafe.akka', module: 'akka-actor_2.11'
         exclude group: 'com.esotericsoftware.kryo', module: 'kryo'
     }
-    compile 'ai.h2o:xgboost4j-linux-gpuv4:0.7.8'
-    compile 'ai.h2o:xgboost4j-linux-minimal:0.7.8'
-    compile 'ai.h2o:xgboost4j-osx-minimal:0.7.8'
-    compile 'ai.h2o:xgboost4j-linux-ompv3:0.7.8'
+    compile 'ai.h2o:xgboost4j-linux-gpuv4:0.7.9'
+    compile 'ai.h2o:xgboost4j-linux-minimal:0.7.9'
+    compile 'ai.h2o:xgboost4j-osx-minimal:0.7.9'
+    compile 'ai.h2o:xgboost4j-linux-ompv3:0.7.9'
     compileOnly 'com.esotericsoftware.kryo:kryo:2.21'
 
     testCompile 'com.esotericsoftware.kryo:kryo:2.21'

--- a/h2o-genmodel-extensions/xgboost/build.gradle
+++ b/h2o-genmodel-extensions/xgboost/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     // XGBoost dependencies published into Maven central by H2O
     // Versioning rules may differ for XGBoost artifacts published by H2O
-        compile('ai.h2o:xgboost4j:0.7.9') {
+    compile('ai.h2o:xgboost4j:0.7.9') {
         exclude group: 'org.scala-lang', module: 'scala-compiler'
         exclude group: 'org.scala-lang', module: 'scala-reflect'
         exclude group: 'org.scala-lang', module: 'scala-library'


### PR DESCRIPTION
[PUBDEV-5612](https://0xdata.atlassian.net/browse/PUBDEV-5612)

After recent changes to H2O-XGBoost had been made in https://github.com/h2oai/xgboost/pull/45 (approved, merged), a new release of `ai.h2o:xgboost4j` version `0.7.9` was done.

After release (huge thank you to @michal-raska for setting-up the pipeline), dependency version in H2O were raised to `0.7.9`.

## Does it work ?

Tried on p3.2xlarge Amazon EC2 machine with one Tesla V100 (the same configuration as reporter). 

- Build H2O.jar with H2O XGBoost version `0.7.9`
- Use this newly generated JAR in the benchmark. This means to put it into the docker, start it and make the `R` benchmark connect to this H2O instance, instead of downloading and starting its own old one.
- Start the benchmark.

I used a [fork](https://github.com/Pscheidl/GBM-perf) of Szilard's original benchmark repository. Main changes are in the [dockerfile](https://github.com/Pscheidl/GBM-perf/blob/h2o_PUBDEV-5612/gpu/Dockerfile-h2o) (starting H2O separately) and [H2O R benchmark](https://github.com/Pscheidl/GBM-perf/blob/h2o_PUBDEV-5612/gpu/run/1-h2o.R) (connecting to the separately started H2O, force not to start its own instance).

The platform setup (EC2 machine with Tesla V100) contains only components (docker, nvidia docker) used by Szilard plus R and Python libraries required to build H2O-3 on the machine.

### Video 
There is a video available: https://youtu.be/UyIKEF820T4

### Full log
A full H2O log of the benchmark run on the EC2 machine with Tesla V100 is attached.
[tesla_v100_ec2_log.txt](https://github.com/h2oai/h2o-3/files/2173806/tesla_v100_ec2_log.txt)

The machine is now stopped, but before I delete it, I can provide access if you with to ry it on your own.