### PR TITLE
[PUBDEV-5724] Expose full frame into in Java H2ORestAPI

### DIFF
--- a/h2o-bindings/src/main/java/water/bindings/examples/Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/Example.java
@@ -195,11 +195,11 @@ public class Example {
 
         try {
             // NOTE: the Call objects returned by the service can't be reused, but they can be cloned.
-            Response<FramesV3> all_frames_response = framesService.list().execute();
+            Response<FramesListV3> all_frames_response = framesService.list().execute();
             Response<ModelsV3> all_models_response = modelsService.list().execute();
 
             if (all_frames_response.isSuccessful()) {
-                FramesV3 all_frames = all_frames_response.body();
+                FramesListV3 all_frames = all_frames_response.body();
                 System.out.println("All Frames: ");
                 System.out.println(all_frames);
             } else {
@@ -227,7 +227,7 @@ public class Example {
 
                 all_frames_response = framesService.list().execute();
                 if (all_frames_response.isSuccessful()) {
-                    FramesV3 all_frames = all_frames_response.body();
+                    FramesListV3 all_frames = all_frames_response.body();
                     System.out.println("All Frames (after createFrame): ");
                     System.out.println(all_frames);
                 } else {

--- a/h2o-core/src/main/java/water/api/FramesHandler.java
+++ b/h2o-core/src/main/java/water/api/FramesHandler.java
@@ -104,7 +104,7 @@ public class FramesHandler<I extends FramesHandler.Frames, S extends SchemaV3<I,
    * @see FrameSynopsisV3
    */
   @SuppressWarnings("unused") // called through reflection by RequestServer
-  public FramesV3 list(int version, FramesV3 s) {
+  public FramesListV3 list(int version, FramesListV3 s) {
     Frames f = s.createAndFillImpl();
     f.frames = Frame.fetchAll();
 

--- a/h2o-core/src/main/java/water/api/schemas3/FramesListV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FramesListV3.java
@@ -1,0 +1,31 @@
+package water.api.schemas3;
+
+import water.api.API;
+import water.api.FramesHandler.Frames;
+import water.fvec.Frame;
+
+public class FramesListV3 extends RequestSchemaV3<Frames, FramesListV3> {
+
+    // Input fields
+    @API(help="Name of Frame of interest", json=false)
+    public KeyV3.FrameKeyV3 frame_id;
+
+    // Output fields
+    @API(help="Frames", direction=API.Direction.OUTPUT)
+    public FrameBaseV3[] frames;
+
+
+    public FramesListV3 fillFromImplWithSynopsis(Frames f) {
+    this.frame_id = new KeyV3.FrameKeyV3(f.frame_id);
+
+    if (f.frames != null) {
+      this.frames = new FrameSynopsisV3[f.frames.length];
+
+      int i = 0;
+      for (Frame frame : f.frames) {
+        this.frames[i++] = new FrameSynopsisV3(frame);
+      }
+    }
+    return this;
+  }
+}

--- a/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/FramesV3.java
@@ -45,7 +45,7 @@ public class FramesV3 extends RequestSchemaV3<Frames, FramesV3> {
 
   // Output fields
   @API(help="Frames", direction=API.Direction.OUTPUT)
-  public FrameBaseV3[] frames;
+  public FrameV3[] frames;
 
   @API(help="Compatible models", direction=API.Direction.OUTPUT)
   public ModelSchemaV3[] compatible_models;
@@ -80,20 +80,6 @@ public class FramesV3 extends RequestSchemaV3<Frames, FramesV3> {
       int i = 0;
       for (Frame frame : f.frames) {
         this.frames[i++] = new FrameV3(frame, f.row_offset, f.row_count);
-      }
-    }
-    return this;
-  }
-
-  public FramesV3 fillFromImplWithSynopsis(Frames f) {
-    this.frame_id = new KeyV3.FrameKeyV3(f.frame_id);
-
-    if (f.frames != null) {
-      this.frames = new FrameSynopsisV3[f.frames.length];
-
-      int i = 0;
-      for (Frame frame : f.frames) {
-        this.frames[i++] = new FrameSynopsisV3(frame);
       }
     }
     return this;

--- a/h2o-core/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-core/src/main/resources/META-INF/services/water.api.Schema
@@ -28,6 +28,7 @@ water.api.schemas3.FrameV3
 water.api.schemas3.FrameV3$ColSpecifierV3
 water.api.schemas3.FrameV3$ColV3
 water.api.schemas3.FramesV3
+water.api.schemas3.FramesListV3
 water.api.schemas3.GarbageCollectV3
 water.api.schemas3.H2OErrorV3
 water.api.schemas3.H2OModelBuilderErrorV3


### PR DESCRIPTION
## Jira
https://0xdata.atlassian.net/browse/PUBDEV-5724

## The issue
In Java `H2oAPI` class, `FrameBaseV3` is exposed instead of `FrameV3`, therefore it's not possible to get all the information about the frame.

## The cause
The cause is that in `FramesV3` schema class we use `FrameBaseV3` as the storage of the frames.
The `BaseFrameV3` is parent of other representations of frames. If we assign child to this field, the Rest API will anyway send the data of the underlying object, therefore we get all information from `FrameV3` via Rest API from browser.

However when using the Java H2O Rest API, the generated class is using `FrameBaseV3` -> therefore that's why we can't see the full result there.

## The ideal solution from my point of view
The ideal solution would be to separate handling of operations on a single frame and for example listing all frames. That would consist of having
`FramesHandler` -> would handle list and frames, could use just `FrameBaseV3`
`FrameHandler` -> would handle all operations on a single Frame -> such as select column, etc. This should use the full `FramesV3`. 

The impact on the code would be bigger in this case and I didn't want to start working on it before we discuss it. 

## The implemented solution
The solution was to use `FrameV3` in the `FramesV3` as the storage for frames so the Java API is correctly generated, but that also required created new Schema for the list of frames. We could go without this, but then list of frames would contain all information and the output would break the API (because at this moment it's printing just specific information)

What changes is that the users of the Java API now need to use `FrameListV3` as the class containing list of returned frames instead of `FramesV3`. Without more refactoring of the code as described on the previous section this is the simplest solution.

Please let me know, thanks!