### PR TITLE
PUBDEV-5733: Fast ingest of 100s of small Parquet files

### DIFF
--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -733,11 +733,12 @@ public final class ParseDataset {
             localSetup = ParserService.INSTANCE.getByInfo(localSetup._parse_type).setupLocal(vec,localSetup);
             Parser p = localSetup.parser(_jobKey);
 
-            FVecParseWriter writer = makeDout(localSetup,chunkStartIdx,vec.nChunks());
+            final FVecParseWriter writer = makeDout(localSetup,chunkStartIdx,vec.nChunks());
             final ParseWriter dout;
             if (pm == ParserInfo.ParseMethod.StreamParse) {
-              InputStream bvs = vec.openStream(_jobKey);
-              dout = p.streamParse(decryptionTool.decryptInputStream(bvs), writer);
+              try (InputStream bvs = vec.openStream(_jobKey)) {
+                dout = p.streamParse(decryptionTool.decryptInputStream(bvs), writer);
+              }
             } else { // pm == ParserInfo.ParseMethod.SequentialParse
               dout = p.sequentialParse(vec, writer);
             }

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -711,7 +711,7 @@ public final class ParseDataset {
       final int chunkStartIdx = _fileChunkOffsets[_lo];
       Log.trace("Begin a map stage of a file parse with start index " + chunkStartIdx + ".");
 
-      DecryptionTool decryptionTool = DecryptionTool.get(_parseSetup._decrypt_tool);
+      DecryptionTool decryptionTool = _parseSetup.getDecryptionTool();
       byte[] zips = vec.getFirstBytes();
       ZipUtil.Compression cpr = ZipUtil.guessCompressionMethod(zips);
       if (localSetup._check_header == ParseSetup.HAS_HEADER) { //check for header on local file
@@ -722,20 +722,28 @@ public final class ParseDataset {
       try {
         switch( cpr ) {
         case NONE:
-          ParserInfo.ParseMethod pm = _parseSetup._parse_type.parseMethod(_keys.length, vec.nChunks());
-          if (pm == ParserInfo.ParseMethod.DistributedParse && ! decryptionTool.isTransparent())
-            pm = ParserInfo.ParseMethod.StreamParse;
+          ParserInfo.ParseMethod pm = _parseSetup.parseMethod(_keys.length, vec);
+          Log.debug("Key " + key + " will be parsed using method " + pm + ".");
+
           if(pm == ParserInfo.ParseMethod.DistributedParse) {
             new DistributedParse(_vg, localSetup, _vecIdStart, chunkStartIdx, this, key, vec.nChunks()).dfork(vec).getResult(false);
             for( int i = 0; i < vec.nChunks(); ++i )
               _chunk2ParseNodeMap[chunkStartIdx + i] = vec.chunkKey(i).home_node().index();
-          } else if(pm == ParserInfo.ParseMethod.StreamParse){
+          } else if(pm == ParserInfo.ParseMethod.StreamParse || pm == ParserInfo.ParseMethod.SequentialParse){
             localSetup = ParserService.INSTANCE.getByInfo(localSetup._parse_type).setupLocal(vec,localSetup);
-            InputStream bvs = vec.openStream(_jobKey);
             Parser p = localSetup.parser(_jobKey);
-            _dout[_lo] = ((FVecParseWriter) p.streamParse(decryptionTool.decryptInputStream(bvs),
-                    makeDout(localSetup,chunkStartIdx,vec.nChunks()))).close(_fs);
+
+            FVecParseWriter writer = makeDout(localSetup,chunkStartIdx,vec.nChunks());
+            final ParseWriter dout;
+            if (pm == ParserInfo.ParseMethod.StreamParse) {
+              InputStream bvs = vec.openStream(_jobKey);
+              dout = p.streamParse(decryptionTool.decryptInputStream(bvs), writer);
+            } else { // pm == ParserInfo.ParseMethod.SequentialParse
+              dout = p.sequentialParse(vec, writer);
+            }
+            _dout[_lo] = ((FVecParseWriter) dout).close(_fs);
             _errors = _dout[_lo].removeErrors();
+
             chunksAreLocal(vec,chunkStartIdx,key);
           } else throw H2O.unimpl();
           break;

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -40,7 +40,7 @@ public class ParseSetup extends Iced {
   String[][] _data;           // First few rows of parsed/tokenized data
 
   String [] _fileNames = new String[]{"unknown"};
-  public  boolean disableParallelParse;
+  public boolean disableParallelParse;
   Key<DecryptionTool> _decrypt_tool;
 
   public void setFileName(String name) {_fileNames[0] = name;}
@@ -217,6 +217,15 @@ public class ParseSetup extends Iced {
     }
 
     throw new H2OIllegalArgumentException("Unknown parser configuration! Configuration=" + this);
+  }
+
+  public final DecryptionTool getDecryptionTool() {
+    return DecryptionTool.get(_decrypt_tool);
+  }
+
+  public final ParserInfo.ParseMethod parseMethod(int nfiles, Vec v) {
+    boolean isEncrypted = ! getDecryptionTool().isTransparent();
+    return _parse_type.parseMethod(nfiles, v.nChunks(), disableParallelParse, isEncrypted);
   }
 
   // Set of duplicated column names

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -4,6 +4,7 @@ import water.H2O;
 import water.Iced;
 import water.Job;
 import water.Key;
+import water.fvec.Vec;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,6 +73,12 @@ public abstract class Parser extends Iced {
 
   // Parse this one Chunk (in parallel with other Chunks)
   protected abstract ParseWriter parseChunk(int cidx, final ParseReader din, final ParseWriter dout);
+
+
+  // Parse the Vec sequentially writing out one chunk after another
+  protected StreamParseWriter sequentialParse(Vec vec, StreamParseWriter dout) {
+    throw new UnsupportedOperationException("Sequential Parsing is not supported by " + this.getClass().getName());
+  }
 
   protected ParseWriter streamParse( final InputStream is, final StreamParseWriter dout) throws IOException {
     return streamParseZip(is,dout,is);

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -873,6 +873,11 @@ public class TestUtil extends Iced {
     }
   }
 
+  /**
+   * Tests can hook into the parse process using this interface and modify some of the guessed parameters.
+   * This simplifies the test workflow as usually most of the guessed parameters are correct and the test really only
+   * needs to modify/add few parameters.
+   */
   public interface ParseSetupTransformer {
     ParseSetup transformSetup(ParseSetup guessedSetup);
   }

--- a/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
+++ b/h2o-parsers/h2o-orc-parser/src/test/java/water/parser/ParseTestMultiFileOrc.java
@@ -39,10 +39,16 @@ public class ParseTestMultiFileOrc extends TestUtil {
 
     @Test
     public void testParseMultiFileOrcs() {
-
-        for(boolean disableParallelParse:new boolean[]{false,true}) {
+        for(final boolean disableParallelParse:new boolean[]{false,true}) {
+            final ParseSetupTransformer pst = new ParseSetupTransformer() {
+                @Override
+                public ParseSetup transformSetup(ParseSetup guessedSetup) {
+                    guessedSetup.disableParallelParse = disableParallelParse;
+                    return guessedSetup;
+                }
+            };
             for (int f_index = 0; f_index < csvDirectories.length; f_index++) {
-                Frame csv_frame = parse_test_folder(csvDirectories[f_index], "\\N", 0, null,disableParallelParse);
+                Frame csv_frame = parse_test_folder(csvDirectories[f_index], "\\N", 0, null, pst);
 
                 byte[] types = csv_frame.types();
 
@@ -51,7 +57,7 @@ public class ParseTestMultiFileOrc extends TestUtil {
                         types[index] = 4;
                 }
 
-                Frame orc_frame = parse_test_folder(orcDirectories[f_index], null, 0, types,disableParallelParse);
+                Frame orc_frame = parse_test_folder(orcDirectories[f_index], null, 0, types, pst);
                 assertTrue(TestUtil.isIdenticalUpToRelTolerance(csv_frame, orc_frame, 1e-5));
 
                 csv_frame.delete();

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkReadSupport.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkReadSupport.java
@@ -9,12 +9,12 @@ import water.parser.ParseWriter;
 
 import java.util.Map;
 
-public class ChunkReadSupport extends ReadSupport<Integer> {
+public class ChunkReadSupport extends ReadSupport<Long> {
 
-  private ParseWriter _writer;
+  private WriterDelegate _writer;
   private byte[] _chunkSchema;
 
-  public ChunkReadSupport(ParseWriter writer, byte[] chunkSchema) {
+  public ChunkReadSupport(WriterDelegate writer, byte[] chunkSchema) {
     _writer = writer;
     _chunkSchema = chunkSchema;
   }
@@ -25,7 +25,7 @@ public class ChunkReadSupport extends ReadSupport<Integer> {
   }
 
   @Override
-  public RecordMaterializer<Integer> prepareForRead(Configuration configuration, Map<String, String> keyValueMetaData,
+  public RecordMaterializer<Long> prepareForRead(Configuration configuration, Map<String, String> keyValueMetaData,
                                                     MessageType fileSchema, ReadContext readContext) {
     return new ChunkRecordMaterializer(fileSchema, _chunkSchema, _writer);
   }

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkRecordMaterializer.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ChunkRecordMaterializer.java
@@ -12,16 +12,16 @@ import water.parser.ParseWriter;
  * indirectly using a ParseWriter and function getCurrentRecord returns the index of the record
  * in the current chunk.
  */
-class ChunkRecordMaterializer extends RecordMaterializer<Integer> {
+class ChunkRecordMaterializer extends RecordMaterializer<Long> {
 
   private ChunkConverter _converter;
 
-  ChunkRecordMaterializer(MessageType parquetSchema, byte[] chunkSchema, ParseWriter writer) {
+  ChunkRecordMaterializer(MessageType parquetSchema, byte[] chunkSchema, WriterDelegate writer) {
     _converter = new ChunkConverter(parquetSchema, chunkSchema, writer);
   }
 
   @Override
-  public Integer getCurrentRecord() {
+  public Long getCurrentRecord() {
     return _converter.getCurrentRecordIdx();
   }
 

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParser.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParser.java
@@ -47,8 +47,8 @@ public class ParquetParser extends Parser {
       throw new IllegalStateException("Unsupported Parquet file. Too many records (#" + totalRecs + ", nChunks=" + nChunks + ").");
     }
 
-    WriterDelegate w = new WriterDelegate(dout, _setup.getColumnTypes().length);
-    VecParquetReader reader = new VecParquetReader(vec, metadata, w, _setup.getColumnTypes());
+    final WriterDelegate w = new WriterDelegate(dout, _setup.getColumnTypes().length);
+    final VecParquetReader reader = new VecParquetReader(vec, metadata, w, _setup.getColumnTypes());
 
     StreamParseWriter nextChunk = dout;
     try {

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/ParquetParserProvider.java
@@ -14,7 +14,7 @@ import water.parser.*;
 public class ParquetParserProvider extends BinaryParserProvider {
 
   /* Setup for this parser */
-  static ParserInfo PARQUET_INFO = new ParserInfo("PARQUET", DefaultParserProviders.MAX_CORE_PRIO + 30, true, false, false);
+  static ParserInfo PARQUET_INFO = new ParserInfo("PARQUET", DefaultParserProviders.MAX_CORE_PRIO + 30, true, false, true,false);
 
   @Override
   public ParserInfo info() {

--- a/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/WriterDelegate.java
+++ b/h2o-parsers/h2o-parquet-parser/src/main/java/water/parser/parquet/WriterDelegate.java
@@ -1,0 +1,85 @@
+package water.parser.parquet;
+
+import water.DKV;
+import water.Iced;
+import water.Key;
+import water.parser.BufferedString;
+import water.parser.ParseWriter;
+import water.util.IcedInt;
+import water.util.Log;
+
+import java.util.Arrays;
+
+import static water.H2OConstants.MAX_STR_LEN;
+
+final class WriterDelegate {
+
+  private final int _maxStringSize;
+  private final int[] _colRawSize; // currently only used for String columns
+  private final int _numCols;
+
+  private ParseWriter _writer;
+  private int _col;
+
+  WriterDelegate(ParseWriter writer, int numCols) {
+    _maxStringSize = getMaxStringSize();
+    _numCols = numCols;
+    _colRawSize = new int[numCols];
+    setWriter(writer);
+  }
+
+  // For unit tests only: allows to set maximum string size in a test for all nodes
+  private int getMaxStringSize() {
+    Iced<?> maxSize = DKV.getGet(Key.make(WriterDelegate.class.getCanonicalName() + "_maxStringSize"));
+    return (maxSize instanceof IcedInt) ? ((IcedInt) maxSize)._val : MAX_STR_LEN;
+  }
+
+  void startLine() {
+    _col = -1;
+  }
+
+  void endLine() {
+    moveToCol(_numCols);
+    _writer.newLine();
+  }
+
+  private int moveToCol(int colIdx) {
+    for (int c = _col + 1; c < colIdx; c++) _writer.addInvalidCol(c);
+    _col = colIdx;
+    return _col;
+  }
+
+  void addNumCol(int colIdx, long number, int exp) {
+    _writer.addNumCol(moveToCol(colIdx), number, exp);
+  }
+
+  void addNumCol(int colIdx, double d) {
+    _writer.addNumCol(moveToCol(colIdx), d);
+  }
+
+  void addStrCol(int colIdx, BufferedString str) {
+    if (_colRawSize[colIdx] == -1)
+      return; // already exceeded max length
+
+    long totalSize = (long) str.length() + _colRawSize[colIdx];
+    if (totalSize > _maxStringSize) {
+      _colRawSize[colIdx] = -1;
+      Log.err("Total String size limit reached: skipping remaining values in column: " + colIdx + "!");
+      return;
+    }
+
+    _colRawSize[colIdx] += str.length();
+    _writer.addStrCol(moveToCol(colIdx), str);
+  }
+
+  long lineNum() {
+    return _writer.lineNum();
+  }
+
+  final void setWriter(ParseWriter writer) {
+    _writer = writer;
+    _col = Integer.MIN_VALUE;
+    Arrays.fill(_colRawSize, 0);
+  }
+
+}


### PR DESCRIPTION
Ingesting large number (= thousands) of Parquet files can be slow because Parquet parser doesn't support stream parse (due to nature of Parquet file format - metadata are at the end). CSV parser can handle this case by switching from a distributed parse to stream parse and distributed the workload on file level instead of block level. Parquet parser doesn't have this option because stream parse method is not available.

In this PR we introduces a new type of parse method - sequential parse. Sequential parse will be an alternative to stream parse and will be used when "local" = (non-distributed) parse is requested.