### PR TITLE
PUBDEV-5429: Add support for ingesting from multiple directories + speedup

### DIFF
--- a/h2o-core/src/main/java/water/api/ImportFilesHandler.java
+++ b/h2o-core/src/main/java/water/api/ImportFilesHandler.java
@@ -1,6 +1,7 @@
 package water.api;
 
 import water.H2O;
+import water.api.schemas3.ImportFilesMultiV3;
 import water.api.schemas3.ImportFilesV3;
 
 import java.util.ArrayList;
@@ -16,10 +17,10 @@ public class ImportFilesHandler extends Handler {
 
   @SuppressWarnings("unused") // called through reflection by RequestServer
   public ImportFilesV3 importFiles(int version, ImportFilesV3 importFiles) {
-    ArrayList<String> files = new ArrayList();
-    ArrayList<String> keys = new ArrayList();
-    ArrayList<String> fails = new ArrayList();
-    ArrayList<String> dels = new ArrayList();
+    ArrayList<String> files = new ArrayList<>();
+    ArrayList<String> keys = new ArrayList<>();
+    ArrayList<String> fails = new ArrayList<>();
+    ArrayList<String> dels = new ArrayList<>();
 
     H2O.getPM().importFiles(importFiles.path, importFiles.pattern, files, keys, fails, dels);
 
@@ -29,5 +30,22 @@ public class ImportFilesHandler extends Handler {
     importFiles.dels = dels.toArray(new String[dels.size()]);
     return importFiles;
   }
+
+  @SuppressWarnings("unused") // called through reflection by RequestServer
+  public ImportFilesMultiV3 importFilesMulti(int version, ImportFilesMultiV3 importFiles) {
+    ArrayList<String> files = new ArrayList<>();
+    ArrayList<String> keys = new ArrayList<>();
+    ArrayList<String> fails = new ArrayList<>();
+    ArrayList<String> dels = new ArrayList<>();
+
+    H2O.getPM().importFiles(importFiles.paths, importFiles.pattern, files, keys, fails, dels);
+
+    importFiles.files = files.toArray(new String[files.size()]);
+    importFiles.destination_frames = keys.toArray(new String[keys.size()]);
+    importFiles.fails = fails.toArray(new String[fails.size()]);
+    importFiles.dels = dels.toArray(new String[dels.size()]);
+    return importFiles;
+  }
+
 }
 

--- a/h2o-core/src/main/java/water/api/RegisterV3Api.java
+++ b/h2o-core/src/main/java/water/api/RegisterV3Api.java
@@ -42,6 +42,10 @@ public class RegisterV3Api extends AbstractRegister {
             "POST /3/ImportFiles", ImportFilesHandler.class, "importFiles",
             "Import raw data files into a single-column H2O Frame.");
 
+    context.registerEndpoint("importFilesMulti",
+            "POST /3/ImportFilesMulti", ImportFilesHandler.class, "importFilesMulti",
+            "Import raw data files from multiple directories (or different data sources) into a single-column H2O Frame.");
+
     context.registerEndpoint("importSqlTable",
             "POST /99/ImportSQLTable", ImportSQLTableHandler.class, "importSQLTable",
             "Import SQL table into an H2O Frame.");

--- a/h2o-core/src/main/java/water/api/schemas3/ImportFilesMultiV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportFilesMultiV3.java
@@ -1,0 +1,37 @@
+package water.api.schemas3;
+
+import water.Iced;
+import water.api.API;
+
+public class ImportFilesMultiV3 extends RequestSchemaV3<ImportFilesMultiV3.ImportFilesMulti, ImportFilesMultiV3> {
+
+  public final static class ImportFilesMulti extends Iced<ImportFilesMulti> {
+    public String[] paths;
+    public String pattern;
+    public String files[];
+    public String destination_frames[];
+    public String fails[];
+    public String dels[];
+  }
+
+  // Input fields
+  @API(help = "paths", required = true)
+  public String[] paths;
+
+  @API(help = "pattern", direction = API.Direction.INPUT)
+  public String pattern;
+
+  // Output fields
+  @API(help = "files", direction = API.Direction.OUTPUT)
+  public String files[];
+
+  @API(help = "names", direction = API.Direction.OUTPUT)
+  public String destination_frames[];
+
+  @API(help = "fails", direction = API.Direction.OUTPUT)
+  public String fails[];
+
+  @API(help = "dels", direction = API.Direction.OUTPUT)
+  public String dels[];
+
+}

--- a/h2o-core/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-core/src/main/resources/META-INF/services/water.api.Schema
@@ -32,6 +32,7 @@ water.api.schemas3.GarbageCollectV3
 water.api.schemas3.H2OErrorV3
 water.api.schemas3.H2OModelBuilderErrorV3
 water.api.schemas3.ImportFilesV3
+water.api.schemas3.ImportFilesMultiV3
 water.api.schemas3.ImportSQLTableV99
 water.api.schemas3.InitIDV3
 water.api.schemas3.InteractionV3

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -278,17 +278,15 @@ def lazy_import(path, pattern=None):
     """
     assert_is_type(path, str, [str])
     assert_is_type(pattern, str, None)
-    if is_type(path, str):
-        return _import(path, pattern)
-    else:
-        return [_import(p, pattern)[0] for p in path]
+    paths = [path] if is_type(path, str) else path
+    return _import_multi(paths, pattern)
 
 
-def _import(path, pattern):
-    assert_is_type(path, str)
+def _import_multi(paths, pattern):
+    assert_is_type(paths, [str])
     assert_is_type(pattern, str, None)
-    j = api("GET /3/ImportFiles", data={"path": path, "pattern": pattern})
-    if j["fails"]: raise ValueError("ImportFiles of " + path + " failed on " + str(j["fails"]))
+    j = api("POST /3/ImportFilesMulti", {"paths": paths, "pattern": pattern})
+    if j["fails"]: raise ValueError("ImportFiles of " + paths + " failed on " + str(j["fails"]))
     return j["destination_frames"]
 
 

--- a/h2o-py/tests/testdir_misc/pyunit_import_multi.py
+++ b/h2o-py/tests/testdir_misc/pyunit_import_multi.py
@@ -1,0 +1,19 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+# test that h2o.import_file works on multiple sources
+def import_multi():
+    airlines = h2o.import_file(path=[
+        pyunit_utils.locate("smalldata/testng/airlines_train.csv"),
+        pyunit_utils.locate("smalldata/testng/airlines_test.csv")
+    ])
+
+    assert airlines.nrows == 24421 + 2691
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(import_multi)
+else:
+    import_multi()


### PR DESCRIPTION
This change also improves performance of ingest when importing from
large number of source files / directories. Previous implementation
was sequential and resulted in a single request per source. This is
especially bad for HTTP ingest which is done eagerly.

Current implementation does a single request for all the files. Loading
is paralellized on a single node (not distributed - typically not necessary).