### PR TITLE
PUBDEV-5730: Reduce size of h2o.jar in order to deploy to PyPI

### DIFF
--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -20,16 +20,12 @@ dependencies {
   compile('net.sourceforge.f2j:arpack_combined_all:0.1')
   compile('com.github.fommil.netlib:netlib-native_ref-osx-x86_64:1.1')
   compile('com.github.fommil.netlib:netlib-native_ref-linux-x86_64:1.1')
-  compile('com.github.fommil.netlib:netlib-native_ref-linux-i686:1.1')
   compile('com.github.fommil.netlib:netlib-native_ref-win-x86_64:1.1')
-  compile('com.github.fommil.netlib:netlib-native_ref-win-i686:1.1')
   compile('com.github.fommil.netlib:netlib-native_ref-linux-armhf:1.1')
   compile('com.github.fommil.netlib:netlib-native_system-osx-x86_64:1.1')
   compile('com.github.fommil.netlib:netlib-native_system-linux-x86_64:1.1')
-  compile('com.github.fommil.netlib:netlib-native_system-linux-i686:1.1')
   compile('com.github.fommil.netlib:netlib-native_system-linux-armhf:1.1')
   compile('com.github.fommil.netlib:netlib-native_system-win-x86_64:1.1')
-  compile('com.github.fommil.netlib:netlib-native_system-win-i686:1.1')
 
   compile('com.googlecode.matrix-toolkits-java:mtj:1.0.4'){
     exclude group: 'com.github.fommil.netlib', module: 'all'

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -11,6 +11,7 @@ configurations {
     compile.exclude module: 'javax.mail.glassfish'
     compile.exclude module: 'servlet-api'
     compile.exclude group: 'org.mortbay.jetty' // exclude the whole group, nothing good in there
+    compile.exclude(group: 'com.amazonaws', module: 'aws-java-sdk') // this dependency is introduced by hdfs-persist but we only really need aws-java-sdk-s3 (for PersistS3)
 }
 
 // Dependencies


### PR DESCRIPTION
This change will get us to 129MB (< 130MB limit of PyPI)

Dependencies removed:
- full aws-sdk (we only need aws-s3-sdk)
- 32 bit versions of netlib libraries