### PR TITLE
PUBDEV-5669: Hive import performance improvement

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -371,12 +371,20 @@ public class Vec extends Keyed<Vec> {
     return makeCon(x,len,log_rows_per_chunk,true);
   }
 
+  private static int VALUE_MAX = 1<<28; //original = 1<<28 = Value.MAX / 8
   /**
    * Make a new constant vector with minimal number of chunks. Used for importing SQL tables.
    *  @return New constant vector with the given row count. */
   public static Vec makeCon(long totSize, long len) {
-    int safetyInflationFactor = 8;
-    int nchunks = (int) Math.max(safetyInflationFactor * totSize / Value.MAX , 1);
+      return makeCon(totSize, len, VALUE_MAX);
+  }
+
+  public static Vec makeCon(long totSize, long len, int valueMax) {
+    int nchunks = (int) Math.max(totSize / valueMax , 1);
+    return makeCon(len, nchunks);
+  }
+
+  public static Vec makeCon(long len, int nchunks) {
     long[] espc = new long[nchunks+1];
     espc[0] = 0;
     for( int i=1; i<nchunks; i++ )
@@ -394,7 +402,7 @@ public class Vec extends Keyed<Vec> {
 
   public static Vec makeCon(double x, long len, int log_rows_per_chunk, boolean redistribute, byte type) {
     int chunks0 = (int)Math.max(1,len>>log_rows_per_chunk); // redistribute = false
-    int chunks1 = (int)Math.min( 4 * H2O.NUMCPUS * H2O.CLOUD.size(), len); // redistribute = true
+    int chunks1 = (int)Math.min( 4 * H2O.ARGS.nthreads * H2O.CLOUD.size(), len); // redistribute = true
     int nchunks = (redistribute && chunks0 < chunks1 && len > 10*chunks1) ? chunks1 : chunks0;
     long[] espc = new long[nchunks+1];
     espc[0] = 0;

--- a/h2o-core/src/main/java/water/jdbc/SQLManager.java
+++ b/h2o-core/src/main/java/water/jdbc/SQLManager.java
@@ -183,7 +183,7 @@ public class SQLManager {
         } else {
           fr = new Frame(destination_key, retrieval_fr.names(), retrieval_fr.vecs());
         }
-        k.remove();
+        Frame.deleteTempFrameAndItsNonSharedVecs(retrieval_fr, fr);
         _retrieval_v.remove();
         _v.remove();
 

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -289,7 +289,7 @@ public class ParseSetup extends Iced {
       t._gblSetup._chunk_size = FileVec.DFLT_CHUNK_SIZE;
     } else {
       t._gblSetup._chunk_size = FileVec.calcOptimalChunkSize(t._totalParseSize, t._gblSetup._number_columns, t._maxLineLength,
-              Runtime.getRuntime().availableProcessors(), H2O.getCloudSize(), false /*use new heuristic*/, true);
+              H2O.ARGS.nthreads, H2O.getCloudSize(), false /*use new heuristic*/, true);
     }
 
     return t._gblSetup;
@@ -656,7 +656,7 @@ public class ParseSetup extends Iced {
    * @return The longest line length in the given bytes
    */
   private static final int maxLineLength(byte[] bytes) {
-    int start = bytes.length;
+    int start = bytes.length; //??? mistake? why not init at 0?
     int max = -1;
     for(int i = 0; i < bytes.length; ++i){
       if(CsvParser.isEOL(bytes[i])){


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5669

Idea is to first use one frame for optimal data retrieval (minimum amount of chunks but with maximum connections for max parallelism) and then rebalance automatically to another frame for optimal data manipulation later.

Also added possibility to use a subselect instead of a temp table as table creation can become very expensive on large tables: the drawback is that we lose some isolation when querying the table, but it should not be a major concern on hive tables (the amount of rows being retrieved is computed first): for now could be activated just for hive.
