### PR TITLE
Exposed h2o.pr_auc in _pkgdown.yml

### DIFF
--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -49,7 +49,6 @@ reference:
       - h2o.asnumeric
       - h2o.assign
       - h2o.auc
-      - h2o.pr_auc
       - h2o.automl
       - h2o.betweenss
       - h2o.biases
@@ -211,6 +210,7 @@ reference:
       - h2o.print
       - h2o.prod 
       - h2o.proj_archetypes
+      - h2o.pr_auc
       - h2o.quantile
       - h2o.r2
       - h2o.randomForest

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -49,6 +49,7 @@ reference:
       - h2o.asnumeric
       - h2o.assign
       - h2o.auc
+      - h2o.pr_auc
       - h2o.automl
       - h2o.betweenss
       - h2o.biases


### PR DESCRIPTION
h2o.pr_auc() will be accessible as a h2o function when user call it after installing it.