### PR TITLE
PUBDEV-5694: Add info about supported version of XLS/XLSX (rel-wright)

### DIFF
--- a/h2o-docs/src/front/index.html
+++ b/h2o-docs/src/front/index.html
@@ -199,9 +199,14 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               </tbody>
             </table>
               <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/booklets/SparklingWaterBooklet.pdf">Sparkling Water Booklet</a>
-              <a href="https://github.com/h2oai/rsparkling/blob/master/README.md">RSparkling Readme</a>
              <table class="table" style="padding: 0px; margin: 0px;">
               <tbody class="lt-gry-bg dltile">
+                <tr>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; padding-right: 0pt; padding-left: 0pt;">RSparkling Readme</td>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; "align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.3/r/README.rst">2.3</a></td>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; "align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/r/README.rst">2.2</a></td>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; "align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/r/README.rst">2.1</a></td>
+                </tr>
                 <tr>
                   <td style="padding-bottom: 3pt; padding-top: 3pt; padding-right: 0pt; padding-left: 0pt;">PySparkling User Guide</td>
                   <td style="padding-bottom: 3pt; padding-top: 3pt; "align="right"><a href="http://docs.h2o.ai/sparkling-water/2.3/latest-stable/doc/pysparkling.html">2.3</a></td>
@@ -535,7 +540,16 @@ _atrk_opts = { atrk_acct:"GTD0p1IWhd10O7", domain:"h2o.ai",dynamic: true};
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/demos">Examples and Demos</a>
               <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/faq/r.html">R FAQ</a>
               <a href="https://github.com/h2oai/h2o-3/tree/master/h2o-r/ensemble/README.md">h2oEnsemble R Package Readme</a>
-              <a href="https://github.com/h2oai/rsparkling/blob/master/README.md">RSparkling Readme</a>
+             <table class="table" style="padding: 0px; margin: 0px;">
+              <tbody class="lt-gry-bg dltile">
+                <tr>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; padding-right: 0pt; padding-left: 0pt;">RSparkling Readme</td>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; "align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.3/r/README.rst">2.3</a></td>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; "align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.2/r/README.rst">2.2</a></td>
+                  <td style="padding-bottom: 3pt; padding-top: 3pt; "align="right"><a href="https://github.com/h2oai/sparkling-water/blob/rel-2.1/r/README.rst">2.1</a></td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -488,8 +488,8 @@ The read-only **Sources** field shows the file path for the imported data select
 
  -  AUTO
  -  ARFF
- -  XLS
- -  XLSX
+ -  XLS (BIFF 8 only)
+ -  XLSX (BIFF 8 only)
  -  CSV
  -  SVMLight
  -  ORC
@@ -1358,7 +1358,7 @@ By default, H2O reports the Gains/Lift for all binary classification models if t
 How the Gains/Lift Chart is Built
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To compute Gains/Lift, H2O applies the model to the original dataset to find the response probability. The data is divided into groups by quantile thresholds of the response probability. Note that the default number of groups is 20; if there are fewer than 20 unique probability values, then the number of groups is reduced to the number of unique quantile thresholds. For binning, H2O computes exact ventiles. (Weighted cases are in development.) ``h2o.quantile(x, probs=seq(0,1,0.05))`` is used for cut points, similar to R's ``quantile()`` method. 
+To compute Gains/Lift, H2O applies the model to the original dataset to find the response probability. The data is divided into groups by quantile thresholds of the response probability. Note that the default number of groups is 16; if there are fewer than 16 unique probability values, then the number of groups is reduced to the number of unique quantile thresholds. For binning, H2O uses the following probabilities vector to create cut points (0.99, 0.98, 0.97, 0.96, 0.95, 0.9, 0.85, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0). 
 
 For each group, the lift is calculated as the proportion of observations that are events (targets) in the group to the overall proportion of events (targets). 
 

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -12,8 +12,8 @@ H2O currently supports the following file types:
 - ORC
 - SVMLight
 - ARFF
-- XLS
-- XLSX
+- XLS (BIFF 8 only)
+- XLSX (BIFF 8 only)
 - Avro version 1.8.0 (without multifile parsing or column type modification)
 - Parquet
 
@@ -21,6 +21,7 @@ H2O currently supports the following file types:
  
  - ORC is available only if H2O is running as a Hadoop job. 
  - Users can also import Hive files that are saved in ORC format (experimental).
+ - If you encounter issues importing XLS or XLSX files, you may be using an unsupported version. In this case, re-save the file in BIFF 8 format. Also note that XLS and XLSX support will eventually be deprecated. 
  - When doing a parallel data import into a cluster: 
 
    - If the data is an unzipped csv file, H2O can do offset reads, so each node in your cluster can be directly reading its part of the csv file in parallel. 


### PR DESCRIPTION
- Added info that XLS/XLSX files must be BIFF 8 format. Also noted that support for XLS and XLSX files will eventually be deprecated.
Driveby fix: updated links for RSparkling readme now that RSparkling has moved to Sparkling Water repo.