### PR TITLE
PUBDEV-5760: Avoid unnecessary memory allocation in GBM/DRF mojo scoring

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree.java
@@ -1,0 +1,9 @@
+package hex.genmodel.algos.tree;
+
+import java.io.Serializable;
+
+public interface ScoreTree extends Serializable {
+
+  double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains);
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree0.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree0.java
@@ -1,0 +1,10 @@
+package hex.genmodel.algos.tree;
+
+public final class ScoreTree0 implements ScoreTree {
+
+  @Override
+  public final double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains) {
+    return SharedTreeMojoModel.scoreTree0(tree, row, nclasses, computeLeafAssignment);
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree1.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree1.java
@@ -1,0 +1,10 @@
+package hex.genmodel.algos.tree;
+
+public final class ScoreTree1 implements ScoreTree {
+
+  @Override
+  public final double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains) {
+    return SharedTreeMojoModel.scoreTree1(tree, row, nclasses, computeLeafAssignment);
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree2.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree2.java
@@ -1,0 +1,10 @@
+package hex.genmodel.algos.tree;
+
+public final class ScoreTree2 implements ScoreTree {
+
+  @Override
+  public final double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains) {
+    return SharedTreeMojoModel.scoreTree(tree, row, nclasses, computeLeafAssignment, domains);
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoReader.java
@@ -20,10 +20,10 @@ public abstract class SharedTreeMojoReader<M extends SharedTreeMojoModel> extend
     _model._ntree_groups = readkv("n_trees");
     _model._ntrees_per_group = tpc;
     _model._compressed_trees = new byte[_model._ntree_groups * tpc][];
-    _model._mojo_version = readkv("mojo_version");
+    _model._mojo_version = ((Number) readkv("mojo_version")).doubleValue();
 
-    // In mojos v=1.0 this info wasn't saved.
-    if (_model._mojo_version != null && !_model._mojo_version.equals(1.0)) {
+
+    if (_model._mojo_version > 1.0) { // In mojos v=1.0 this info wasn't saved
       _model._compressed_trees_aux = new byte[_model._ntree_groups * tpc][];
     }
 
@@ -44,5 +44,7 @@ public abstract class SharedTreeMojoReader<M extends SharedTreeMojoModel> extend
         throw new IllegalStateException("Unknown calibration method: " + calibMethod);
       _model._calib_glm_beta = readkv("calib_glm_beta", new double[0]);
     }
+
+    _model.postInit();
   }
 }


### PR DESCRIPTION
Field _mojo_version was declared as Number, comparison `_mojo_version.equals(1.0)`
is harmful because it triggers autoboxing of a constant to an object.
This happens for every scored row.

Microbenchmark results:

- Current (master) version:

     Benchmark                             (rows)  Mode  Cnt    Score   Error  Units
     GbmMojoScoringBench.measureGbmScore0    1000  avgt   10    5.805 ± 0.044  ms/op
     GbmMojoScoringBench.measureGbmScore0  100000  avgt   10  571.884 ± 3.827  ms/op

- This PR:

     Benchmark                             (rows)  Mode  Cnt    Score   Error  Units
     GbmMojoScoringBench.measureGbmScore0    1000  avgt   10    5.643 ± 0.039  ms/op
     GbmMojoScoringBench.measureGbmScore0  100000  avgt   10  555.807 ± 5.626  ms/op

- Optimal version (simplified implementation that assumes single MOJO version and doesn't need to make a decision based on version):

     Benchmark                             (rows)  Mode  Cnt    Score   Error  Units
     GbmMojoScoringBench.measureGbmScore0    1000  avgt   10    5.658 ± 0.059  ms/op
     GbmMojoScoringBench.measureGbmScore0  100000  avgt   10  558.564 ± 3.152  ms/op

This PR improves the performance of scoring, it is now similar to the "optimal" version. There is no unnecessary object allocation.

To reproduce run:

    gw -PdoUBench=true -PubenchIncludeOnly=GbmMojoScoringBench :h2o-algos:ubench -x test