### PR TITLE
PUBDEV-5752: H2O API port and the internal port don't have to be adjacent

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -82,7 +82,7 @@ final public class H2O {
             "          IP address of this node.\n" +
             "\n" +
             "    -port <port>\n" +
-            "          Port number for this node (note: port+1 is also used).\n" +
+            "          Port number for this node (note: port+1 is also used by default).\n" +
             "          (The default port is " + ARGS.port + ".)\n" +
             "\n" +
             "    -network <IPv4network1Specification>[,<IPv4network2Specification> ...]\n" +
@@ -239,6 +239,9 @@ final public class H2O {
 
     /** -baseport=####; Port to start upward searching from. */
     public int baseport = 54321;
+
+    /** -port_offset=####; Offset between the API(=web) port and the internal communication port; api_port + port_offset = h2o_port */
+    public int port_offset = 1;
 
     /** -web_ip=ip4_or_ip6; IP used for web server. By default it listen to all interfaces. */
     public String web_ip = null;
@@ -454,6 +457,10 @@ final public class H2O {
       else if (s.matches("baseport")) {
         i = s.incrementAndCheck(i, args);
         trgt.baseport = s.parsePort(args[i]);
+      }
+      else if (s.matches("port_offset")) {
+        i = s.incrementAndCheck(i, args);
+        trgt.port_offset = s.parsePort(args[i]); // port offset has the same properties as a port, we don't allow negative offsets
       }
       else if (s.matches("ip")) {
         i = s.incrementAndCheck(i, args);

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -78,7 +78,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
         _ipLow = ArrayUtils.encodeAsLong(b, 0, 8);
       }
     }
-    public int htm_port() { return getPort()-1; }
+    public int htm_port() { return getPort()-H2O.ARGS.port_offset; }
     public int udp_port() { return getPort()  ; }
     @Override public String toString() { return getAddress()+":"+htm_port(); }
     public String getIpPortString() {

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -80,6 +80,7 @@ public class h2odriver extends Configured implements Tool {
   static int nthreads = -1;
   static String contextPath = null;
   static int basePort = -1;
+  static int portOffset = -1;
   static boolean beta = false;
   static boolean enableRandomUdpDrop = false;
   static boolean enableExceptions = false;
@@ -834,6 +835,13 @@ public class h2odriver extends Configured implements Tool {
             error("Base port must be between 1 and 65535");
         }
       }
+      else if (s.equals("-port_offset")) {
+        i++; if (i >= args.length) { usage(); }
+        portOffset = Integer.parseInt(args[i]);
+        if ((portOffset <= 0) || (portOffset > 65534)) {
+          error("Port offset must be between 1 and 65534");
+        }
+      }
       else if (s.equals("-beta")) {
         beta = true;
       }
@@ -1448,6 +1456,9 @@ public class h2odriver extends Configured implements Tool {
     }
     if (basePort >= 0) {
       addMapperArg(conf, "-baseport", Integer.toString(basePort));
+    }
+    if (portOffset >= 1) {
+      addMapperArg(conf, "-port_offset", Integer.toString(portOffset));
     }
     if (beta) {
       addMapperArg(conf, "-beta");


### PR DESCRIPTION
Introduces a new parameter `port_offset`. This parameter lets the user specify the relationship of the API port ("web port") and the internal communication port. Old implementation expected `h2o port = api port + 1`. Because there are assumptions in the code that the h2o port and api port can be derived from each other we cannot fully decouple them. Instead, we let the user specify an offset such that `h2o port = api port + offset`. This enables the user to move the communication port to a specific range which can be firewalled. 

Example:

    hadoop jar h2odriver.jar -mapperXmx 64g -nodes 4 -baseport 55000 -port_offset 5000

Port bindings:

    java      11186     yarn  249u  IPv4 30424314      0t0  TCP *:55000 (LISTEN)
    java      11186     yarn  251u  IPv4 30434363      0t0  TCP mr-0xd1.0xdata.loc:60000 (LISTEN)
