### PR TITLE
[PUBDEV-5792] Minimal test, that reproduce a bug of numerical instability

### DIFF
--- a/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
+++ b/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
@@ -17,5 +17,10 @@ public class FVecParseWriterTest {
                 new AppendableVec[0]
         );
         writer.addNumCol(1, 2E19);
+        writer.addNumCol(2, -123.123);
+        writer.addNumCol(3, 3e39);
+        writer.addNumCol(4, 0.0);
+        writer.addNumCol(5, 1.0);
+        writer.addNumCol(6, 3);
     }
 }

--- a/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
+++ b/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
@@ -1,0 +1,21 @@
+package water.parser;
+
+import org.junit.Test;
+import water.fvec.AppendableVec;
+import water.fvec.Vec;
+
+public class FVecParseWriterTest {
+
+    @Test(timeout = 10000)
+    public void addNumCol() {
+        FVecParseWriter writer = new FVecParseWriter(
+                Vec.VectorGroup.VG_LEN1,
+                1,
+                new Categorical[0],
+                new byte[0],
+                1,
+                new AppendableVec[0]
+        );
+        writer.addNumCol(1, 2E19);
+    }
+}


### PR DESCRIPTION
Parser hangs on reading large numbers. The method of conversion should be fixed.

Sponsored by fingerprints.digital