### PR TITLE
[PUBDEV-5794] Fix importSqlTable button in Flow.

### DIFF
--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.7.32"
+    "h2o-flow": "0.7.33"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
There was an issue with the build pipeline (libs and modules were not populated correctly).