### PR TITLE
[WRI-FLOW-PUBDEV-5794] Fix importSqlTable button in Flow. (#2704)

### DIFF
--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.7.32"
+    "h2o-flow": "0.7.33"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
There was an issue with the build pipeline (libs and modules were not populated correctly).

(cherry picked from commit d7e40bcda37d7d3a841d70b495d124c25e890235)