### PR TITLE
[WRI] Update Flow to 0.7.34.

### DIFF
--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.7.33"
+    "h2o-flow": "0.7.34"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Removes `keep_cross_validation_fold_assignment` from AutoML, which is missing on backend. Caused by a wrong cherry-pick.

[PUBDEV-5793] AutoML not correctly ignoring columns via Flow