### PR TITLE
PUBDEV-5735 Tree traversal API (#2702) - MASTER

### DIFF
--- a/h2o-algos/src/main/java/hex/api/RegisterAlgos.java
+++ b/h2o-algos/src/main/java/hex/api/RegisterAlgos.java
@@ -1,6 +1,7 @@
 package hex.api;
 
 import hex.ModelBuilder;
+import hex.tree.TreeHandler;
 import water.api.AlgoAbstractRegister;
 import water.api.RestApiContext;
 import water.api.SchemaServer;
@@ -58,6 +59,8 @@ public class RegisterAlgos extends AlgoAbstractRegister {
 
     context.registerEndpoint("glm_datainfo_frame", "POST /3/DataInfoFrame",MakeGLMModelHandler.class, "getDataInfoFrame",
             "Test only" );
+
+    context.registerEndpoint("get_tree", "GET /3/Tree", TreeHandler.class, "getTree", "Obtain a traverseable representation of a specific tree");
   }
 
   @Override

--- a/h2o-algos/src/main/java/hex/schemas/TreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/TreeV3.java
@@ -1,0 +1,39 @@
+package hex.schemas;
+
+import water.Iced;
+import water.api.API;
+import water.api.schemas3.KeyV3;
+import water.api.schemas3.SchemaV3;
+
+public class TreeV3 extends SchemaV3<Iced, TreeV3> {
+    @API(required = true, direction = API.Direction.INPUT, help = "Key of the model the desired tree belongs to",level = API.Level.critical)
+    public KeyV3.ModelKeyV3 model;
+
+    @API(required = true, direction = API.Direction.INPUT, help = "Index of the tree in the model.", level = API.Level.critical)
+    public int tree_number;
+
+    @API(direction = API.Direction.INOUT, help = "Name of the class of the tree. Ignored for regression and binomial.", level = API.Level.critical)
+    public String tree_class;
+
+    @API(direction = API.Direction.OUTPUT, help = "Left child nodes in the tree")
+    public int[] left_children;
+
+    @API(direction = API.Direction.OUTPUT, help = "Right child nodes in the tree")
+    public int[] right_children;
+
+    @API(direction = API.Direction.OUTPUT, help = "Number of the root node")
+    public int root_node_id;
+
+    @API(direction = API.Direction.OUTPUT, help = "Split thresholds (numeric and possibly categorical columns)")
+    public float[] thresholds;
+
+    @API(direction = API.Direction.OUTPUT, help = "Names of the column of the split")
+    public String[] features;
+
+    @API(direction = API.Direction.OUTPUT, help = "Which way NA Splits (LEFT, RIGHT, NA)")
+    public String[] nas;
+
+    @API(direction = API.Direction.OUTPUT, help = "Description of the tree's nodes")
+    public String[] descriptions;
+
+}

--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -171,7 +171,7 @@ public class TreeHandler extends Handler {
                 nodeDescriptionBuilder.append(" >= ");
             }
             nodeDescriptionBuilder.append(node.getParent().getSplitValue());
-        } else {
+        } else if (node.getParent().isBitset()) {
             final BitSet childInclusiveLevels = node.getInclusiveLevels();
             final int cardinality = childInclusiveLevels.cardinality();
             if ((cardinality > 0)) {
@@ -185,6 +185,8 @@ public class TreeHandler extends Handler {
                     bitsignCounter++;
                 }
             }
+        } else{
+            nodeDescriptionBuilder.append("NA only");
         }
 
         nodeDescriptions[pointer] = nodeDescriptionBuilder.toString();

--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -1,0 +1,221 @@
+package hex.tree;
+
+import hex.ModelCategory;
+import hex.genmodel.algos.tree.SharedTreeNode;
+import hex.genmodel.algos.tree.SharedTreeSubgraph;
+import hex.schemas.TreeV3;
+import water.MemoryManager;
+import water.api.Handler;
+
+import java.util.*;
+
+/**
+ * Handling requests for various model trees
+ */
+public class TreeHandler extends Handler {
+    private static final int NO_CHILD = -1;
+
+    public TreeV3 getTree(final int version, final TreeV3 args) {
+        final SharedTreeModel model = (SharedTreeModel) args.model.key().get();
+        if (model == null) throw new IllegalArgumentException("Given model does not exist: " + args.model.key().toString());
+        final SharedTreeModel.SharedTreeOutput sharedTreeOutput = (SharedTreeModel.SharedTreeOutput) model._output;
+        final int treeClass = getResponseLevelIndex(args.tree_class, sharedTreeOutput);
+        validateArgs(args, sharedTreeOutput, treeClass);
+
+        final CompressedTree auxCompressedTree = sharedTreeOutput._treeKeysAux[args.tree_number][treeClass].get();
+        final SharedTreeSubgraph sharedTreeSubgraph = sharedTreeOutput._treeKeys[args.tree_number][treeClass].get()
+                .toSharedTreeSubgraph(auxCompressedTree, sharedTreeOutput._names, sharedTreeOutput._domains);
+
+        final TreeProperties treeProperties = convertSharedTreeSubgraph(sharedTreeSubgraph);
+
+        args.left_children = treeProperties._leftChildren;
+        args.right_children = treeProperties._rightChildren;
+        args.descriptions = treeProperties._descriptions;
+        args.root_node_id = sharedTreeSubgraph.rootNode.getNodeNumber();
+        args.thresholds = treeProperties._thresholds;
+        args.features = treeProperties._features;
+        args.nas = treeProperties._nas;
+        // Class may not be provided by the user, should be always filled correctly on output. NULL for regression.
+        if (ModelCategory.Regression.equals(sharedTreeOutput.getModelCategory())) {
+            args.tree_class = null;
+        } else {
+            args.tree_class = sharedTreeOutput._domains[sharedTreeOutput.responseIdx()][treeClass];
+        }
+
+        return args;
+    }
+
+    private static int getResponseLevelIndex(final String categorical, final SharedTreeModel.SharedTreeOutput sharedTreeOutput) {
+        final String[] responseColumnDomain = sharedTreeOutput._domains[sharedTreeOutput.responseIdx()];
+        final String trimmedCategorical = categorical.trim(); // Trim the categorical once - input from the user
+
+        switch (sharedTreeOutput.getModelCategory()) {
+            case Binomial:
+                if (!trimmedCategorical.isEmpty() && !trimmedCategorical.equals(responseColumnDomain[0])) {
+                    throw new IllegalArgumentException("For binomial, only one tree class has been built per each iteration: " + responseColumnDomain[0]);
+                } else {
+                    return 0;
+                }
+            case Regression:
+                if (!trimmedCategorical.isEmpty())
+                    throw new IllegalArgumentException("There are no tree classes for regression.");
+                return 0; // There is only one tree for regression
+            default:
+                for (int i = 0; i < responseColumnDomain.length; i++) {
+                    // User is supposed to enter the name of the categorical level correctly, not ignoring case
+                    if (trimmedCategorical.equals(responseColumnDomain[i])) return i;
+                }
+        }
+        return -1;
+    }
+
+    /**
+     * @param args An instance of {@link TreeV3} input arguments to validate
+     * @param output An instance of {@link SharedTreeModel.SharedTreeOutput} to validate input arguments against
+     * @param responseLevelIndex
+     */
+    private static void validateArgs(TreeV3 args, SharedTreeModel.SharedTreeOutput output, final int responseLevelIndex) {
+        if (args.tree_number < 0) throw new IllegalArgumentException("Tree number must be greater than 0.");
+
+        if (args.tree_number > output._treeKeys.length - 1)
+            throw new IllegalArgumentException("There is no such tree.");
+
+        if (responseLevelIndex < 0)
+            throw new IllegalArgumentException("There is no such tree class. Given categorical level does not exist in response column: " + args.tree_class.trim());
+    }
+
+
+    /**
+     * Converts H2O-3's internal representation of a boosted tree in a form of {@link SharedTreeSubgraph} to a format
+     * expected by H2O clients.
+     *
+     * @param sharedTreeSubgraph An instance of {@link SharedTreeSubgraph} to convert
+     * @return An instance of {@link TreeProperties} with some attributes possibly empty if suitable. Never null.
+     */
+    static TreeProperties convertSharedTreeSubgraph(final SharedTreeSubgraph sharedTreeSubgraph) {
+        Objects.requireNonNull(sharedTreeSubgraph);
+
+        final TreeProperties treeprops = new TreeProperties();
+
+        treeprops._leftChildren = MemoryManager.malloc4(sharedTreeSubgraph.nodesArray.size());
+        treeprops._rightChildren = MemoryManager.malloc4(sharedTreeSubgraph.nodesArray.size());
+        treeprops._descriptions = new String[sharedTreeSubgraph.nodesArray.size()];
+        treeprops._thresholds = MemoryManager.malloc4f(sharedTreeSubgraph.nodesArray.size());
+        treeprops._features = new String[sharedTreeSubgraph.nodesArray.size()];
+        treeprops._nas = new String[sharedTreeSubgraph.nodesArray.size()];
+
+        // Set root node's children, there is no guarantee the root node will be number 0
+        treeprops._rightChildren[0] = sharedTreeSubgraph.rootNode.getRightChild() != null ? sharedTreeSubgraph.rootNode.getRightChild().getNodeNumber() : -1;
+        treeprops._leftChildren[0] = sharedTreeSubgraph.rootNode.getLeftChild() != null ? sharedTreeSubgraph.rootNode.getLeftChild().getNodeNumber() : -1;
+        treeprops._thresholds[0] = sharedTreeSubgraph.rootNode.getSplitValue();
+        treeprops._features[0] = sharedTreeSubgraph.rootNode.getColName();
+        treeprops._nas[0] = getNaDirection(sharedTreeSubgraph.rootNode);
+
+        List<SharedTreeNode> nodesToTraverse = new ArrayList<>();
+        nodesToTraverse.add(sharedTreeSubgraph.rootNode);
+        append(treeprops._rightChildren, treeprops._leftChildren,
+                treeprops._descriptions, treeprops._thresholds, treeprops._features, treeprops._nas,
+                nodesToTraverse, -1, false);
+
+        return treeprops;
+    }
+
+    private static void append(final int[] rightChildren, final int[] leftChildren, final String[] nodesDescriptions,
+                               final float[] thresholds, final String[] splitColumns, final String[] naHandlings,
+                               List<SharedTreeNode> nodesToTraverse, int pointer, boolean visitedRoot) {
+        if(nodesToTraverse.isEmpty()) return;
+
+        List<SharedTreeNode> discoveredNodes = new ArrayList<>();
+
+        for (SharedTreeNode node : nodesToTraverse) {
+            pointer++;
+            final SharedTreeNode leftChild = node.getLeftChild();
+            final SharedTreeNode rightChild = node.getRightChild();
+            if(visitedRoot){
+                fillnodeDescriptions(node, nodesDescriptions, thresholds, splitColumns, naHandlings, pointer);
+            } else {
+                nodesDescriptions[pointer] = "Root node";
+                visitedRoot = true;
+            }
+
+            if (leftChild != null) {
+                discoveredNodes.add(leftChild);
+                leftChildren[pointer] = leftChild.getNodeNumber();
+            } else {
+                leftChildren[pointer] = NO_CHILD;
+            }
+
+            if (rightChild != null) {
+                discoveredNodes.add(rightChild);
+                rightChildren[pointer] = rightChild.getNodeNumber();
+            } else {
+                rightChildren[pointer] = NO_CHILD;
+            }
+        }
+
+        append(rightChildren, leftChildren, nodesDescriptions, thresholds, splitColumns, naHandlings,
+                discoveredNodes, pointer, true);
+    }
+
+    private static void fillnodeDescriptions(final SharedTreeNode node, final String[] nodeDescriptions,
+                                             final float[] thresholds, final String[] splitColumns,
+                                             final String[] naHandlings, final int pointer) {
+        final StringBuilder nodeDescriptionBuilder = new StringBuilder();
+
+        if (!Float.isNaN(node.getParent().getSplitValue())) {
+            nodeDescriptionBuilder.append("Parent split threshold: ");
+            nodeDescriptionBuilder.append(node.getParent().getColName());
+            if (node.isLeftward()) {
+                nodeDescriptionBuilder.append(" < ");
+            } else {
+                nodeDescriptionBuilder.append(" >= ");
+            }
+            nodeDescriptionBuilder.append(node.getParent().getSplitValue());
+        } else {
+            final BitSet childInclusiveLevels = node.getInclusiveLevels();
+            final int cardinality = childInclusiveLevels.cardinality();
+            if ((cardinality > 0)) {
+                nodeDescriptionBuilder.append("Parent split column [");
+                nodeDescriptionBuilder.append(node.getParent().getColName());
+                nodeDescriptionBuilder.append("]: ");
+                int bitsignCounter = 0;
+                for (int i = childInclusiveLevels.nextSetBit(0); i >= 0; i = childInclusiveLevels.nextSetBit(i + 1)) {
+                    nodeDescriptionBuilder.append(node.getParent().getDomainValues()[i]);
+                    if (bitsignCounter != cardinality - 1) nodeDescriptionBuilder.append(", ");
+                    bitsignCounter++;
+                }
+            }
+        }
+
+        nodeDescriptions[pointer] = nodeDescriptionBuilder.toString();
+        splitColumns[pointer] = node.getColName();
+        naHandlings[pointer] = getNaDirection(node);
+        thresholds[pointer] = node.getSplitValue();
+
+
+    }
+
+    private static String getNaDirection(final SharedTreeNode node) {
+        final boolean leftNa = node.getLeftChild() != null && node.getLeftChild().isInclusiveNa();
+        final boolean rightNa = node.getRightChild() != null && node.getRightChild().isInclusiveNa();
+        assert (rightNa ^ leftNa) || (rightNa == false && leftNa == false);
+
+        if (leftNa) {
+            return "LEFT";
+        } else if (rightNa) {
+            return "RIGHT";
+        }
+        return null; // No direction
+    }
+
+    public static class TreeProperties {
+
+        public int[] _leftChildren;
+        public int[] _rightChildren;
+        public String[] _descriptions; // General node description, most likely to contain serialized threshold or inclusive dom. levels
+        public float[] _thresholds;
+        public String[] _features;
+        public String[] _nas;
+
+    }
+}

--- a/h2o-algos/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-algos/src/main/resources/META-INF/services/water.api.Schema
@@ -66,6 +66,7 @@ hex.schemas.StackedEnsembleModelV99
 hex.schemas.StackedEnsembleModelV99$StackedEnsembleModelOutputV99
 hex.schemas.StackedEnsembleV99
 hex.schemas.StackedEnsembleV99$StackedEnsembleParametersV99
+hex.schemas.TreeV3
 hex.schemas.TreeStatsV3
 hex.schemas.Word2VecModelV3
 hex.schemas.Word2VecModelV3$Word2VecModelOutputV3

--- a/h2o-algos/src/test/java/hex/tree/TreeHandlerTest.java
+++ b/h2o-algos/src/test/java/hex/tree/TreeHandlerTest.java
@@ -1,0 +1,314 @@
+package hex.tree;
+
+import hex.genmodel.algos.tree.SharedTreeNode;
+import hex.genmodel.algos.tree.SharedTreeSubgraph;
+import hex.genmodel.utils.DistributionFamily;
+import hex.schemas.TreeV3;
+import hex.tree.gbm.GBM;
+import hex.tree.gbm.GBMModel;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import water.*;
+import water.api.schemas3.KeyV3;
+import water.fvec.Frame;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class TreeHandlerTest extends TestUtil {
+
+    @BeforeClass
+    public static void stall() {
+        stall_till_cloudsize(1);
+    }
+
+    @Test
+    public void testSharedTreeSubgraphConversion() {
+        Frame tfr = null;
+        GBMModel model = null;
+
+        Scope.enter();
+        try {
+            tfr = parse_test_file("./smalldata/airlines/allyears2k_headers.zip");
+            DKV.put(tfr);
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            parms._train = tfr._key;
+            parms._response_column = "Dest";
+            parms._ntrees = 1;
+            parms._seed = 0;
+
+            model = new GBM(parms).trainModel().get();
+            final SharedTreeModel.SharedTreeOutput sharedTreeOutput = model._output;
+            assertEquals(parms._ntrees, sharedTreeOutput._ntrees);
+            assertEquals(parms._ntrees, sharedTreeOutput._treeKeys.length);
+            assertEquals(parms._ntrees, sharedTreeOutput._treeKeysAux.length);
+
+            final int treeIndex = 0; //Not a tree number, numbered from 0
+            final int treeClass = 0;
+            final CompressedTree auxCompressedTree = sharedTreeOutput._treeKeysAux[treeIndex][treeClass].get();
+            final SharedTreeSubgraph sharedTreeSubgraph = sharedTreeOutput._treeKeys[treeIndex][treeClass].get()
+                    .toSharedTreeSubgraph(auxCompressedTree, sharedTreeOutput._names, sharedTreeOutput._domains);
+
+            assertNotNull(sharedTreeSubgraph);
+
+            final TreeHandler.TreeProperties treeProperties = TreeHandler.convertSharedTreeSubgraph(sharedTreeSubgraph);
+            assertNotNull(treeProperties);
+            assertEquals(sharedTreeSubgraph.nodesArray.size(), treeProperties._descriptions.length);
+            assertEquals(sharedTreeSubgraph.nodesArray.size(), treeProperties._thresholds.length);
+            assertEquals(sharedTreeSubgraph.nodesArray.size(), treeProperties._features.length);
+            assertEquals(sharedTreeSubgraph.nodesArray.size(), treeProperties._nas.length);
+
+            final int[] leftChildren = treeProperties._leftChildren;
+            final int[] rightChildren = treeProperties._rightChildren;
+            assertEquals(leftChildren.length, rightChildren.length);
+
+            final SharedTreeNode rootNode = sharedTreeSubgraph.rootNode;
+            final Deque<SharedTreeNode> discoverednodes = new ArrayDeque<>();
+            discoverednodes.push(rootNode);
+            int nonRootNodesFound = 0;
+            for (int i = 0; i < leftChildren.length; i++) {
+                final SharedTreeNode sharedTreeNode = discoverednodes.pollLast();
+                final SharedTreeNode leftChild = sharedTreeNode.getLeftChild();
+                final SharedTreeNode rightChild = sharedTreeNode.getRightChild();
+
+                if (leftChildren[i] != -1) {
+                    assertEquals(leftChildren[i], leftChild.getNodeNumber());
+                    discoverednodes.push(sharedTreeNode.getLeftChild());
+                    nonRootNodesFound++;
+                }
+                if (rightChildren[i] != -1) {
+                    assertEquals(rightChildren[i], rightChild.getNodeNumber());
+                    discoverednodes.push(sharedTreeNode.getRightChild());
+                    nonRootNodesFound++;
+                }
+            }
+
+            assertEquals(sharedTreeSubgraph.nodesArray.size(), nonRootNodesFound + 1); // +1 for the root node that is not represented explicitely
+
+
+        } finally {
+            Scope.exit();
+            if (tfr != null) tfr.remove();
+            if (model != null) model.remove();
+        }
+    }
+
+    @Test
+    public void testSharedTreeSubgraphConversion_inclusiveLevelsIris() {
+
+        Frame tfr = null;
+        GBMModel model = null;
+
+        Scope.enter();
+        try {
+            tfr = parse_test_file("./smalldata/iris/iris2.csv");
+            DKV.put(tfr);
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            parms._train = tfr._key;
+            parms._response_column = "response";
+            parms._ntrees = 1;
+            parms._seed = 0;
+
+            model = new GBM(parms).trainModel().get();
+            final SharedTreeModel.SharedTreeOutput sharedTreeOutput = model._output;
+            assertEquals(parms._ntrees, sharedTreeOutput._ntrees);
+            assertEquals(parms._ntrees, sharedTreeOutput._treeKeys.length);
+            assertEquals(parms._ntrees, sharedTreeOutput._treeKeysAux.length);
+
+            final int treeNumber = 0;
+            final int treeClass = 0;
+            final CompressedTree auxCompressedTree = sharedTreeOutput._treeKeysAux[treeNumber][treeClass].get();
+            final SharedTreeSubgraph sharedTreeSubgraph = sharedTreeOutput._treeKeys[treeNumber][treeClass].get()
+                    .toSharedTreeSubgraph(auxCompressedTree, sharedTreeOutput._names, sharedTreeOutput._domains);
+
+            assertNotNull(sharedTreeSubgraph);
+
+            final TreeHandler.TreeProperties treeProperties = TreeHandler.convertSharedTreeSubgraph(sharedTreeSubgraph);
+            assertNotNull(treeProperties);
+
+            final String[] nodeDescriptions = treeProperties._descriptions;
+            assertEquals(sharedTreeSubgraph.nodesArray.size(), nodeDescriptions.length);
+
+            for (String nodeDescription : nodeDescriptions) {
+                assertFalse(nodeDescription.isEmpty());
+            }
+
+        } finally {
+            if (tfr != null) tfr.remove();
+            if (model != null) model.remove();
+        }
+
+    }
+
+    @Test
+    public void testSharedTreeSubgraphConversion_argumentValidationMultinomial() {
+
+        Frame tfr = null;
+        GBMModel model = null;
+
+        Scope.enter();
+        try {
+            tfr = parse_test_file("./smalldata/iris/iris2.csv");
+            DKV.put(tfr);
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            parms._train = tfr._key;
+            parms._response_column = "response";
+            parms._ntrees = 1;
+            parms._seed = 0;
+
+            model = new GBM(parms).trainModel().get();
+
+            final TreeHandler treeHandler = new TreeHandler();
+            final TreeV3 args = new TreeV3();
+            args.model = new KeyV3.ModelKeyV3(Key.make());
+
+            //Non-existing key
+
+            boolean exceptionThrown = false;
+            try {
+                treeHandler.getTree(3, args);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage().contains("Given model does not exist"));
+                exceptionThrown = true;
+            }
+            assertTrue(exceptionThrown);
+            exceptionThrown = false;
+
+            // Invalid tree index
+            args.tree_number = 1;
+            args.tree_class = "Iris-setosa";
+            args.model = new KeyV3.ModelKeyV3(model._key);
+            try {
+                treeHandler.getTree(3, args);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage().contains("There is no such tree."));
+                exceptionThrown = true;
+            }
+            assertTrue(exceptionThrown);
+            exceptionThrown = false;
+
+            // Invalid tree class
+            args.tree_number = 0;
+            args.tree_class = "NonExistingCategoricalLevel";
+
+            try {
+                treeHandler.getTree(3, args);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage().contains("There is no such tree class. Given categorical level does not exist in response column: NonExistingCategoricalLevel"));
+                exceptionThrown = true;
+            }
+            assertTrue(exceptionThrown);
+            exceptionThrown = false;
+
+            //  Tree number < 0
+            args.tree_number = -1;
+
+            try {
+                treeHandler.getTree(3, args);
+            } catch (IllegalArgumentException e){
+                assertTrue(e.getMessage().contains("Tree number must be greater than 0."));
+                exceptionThrown = true;
+            }
+            assertTrue(exceptionThrown);
+        } finally {
+            Scope.exit();
+            if (tfr != null) tfr.remove();
+            if (model != null) model.remove();
+        }
+    }
+
+    @Test
+    public void testSharedTreeSubgraphConversion_argumentValidationRegression() {
+
+
+        Frame tfr = null;
+        GBMModel regressionModel = null;
+
+        Scope.enter();
+        try {
+            tfr = parse_test_file("./smalldata/iris/iris2.csv");
+            DKV.put(tfr);
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            parms._train = tfr._key;
+            parms._ntrees = 1;
+            parms._seed = 0;
+            parms._response_column = "Sepal.Length";
+
+            final TreeV3 args = new TreeV3();
+            regressionModel = new GBM(parms).trainModel().get();
+            args.model = new KeyV3.ModelKeyV3(regressionModel._key);
+            args.tree_class = "NonExistingClass";
+
+
+            final TreeHandler treeHandler = new TreeHandler();
+            boolean exceptionThrown = false;
+            try {
+                treeHandler.getTree(3, args);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage().contains("There are no tree classes for regression."));
+                exceptionThrown = true;
+            }
+            assertTrue(exceptionThrown);
+
+
+        } finally {
+            if (tfr != null) tfr.remove();
+            if (regressionModel != null) regressionModel.remove();
+            Scope.exit();
+        }
+    }
+
+    @Test
+    public void testSharedTreeSubgraphConversion_argumentValidationBinomial() {
+
+
+        Frame tfr = null;
+        GBMModel model = null;
+
+        Scope.enter();
+        try {
+            tfr = parse_test_file("./smalldata/testng/airlines_train.csv");
+            DKV.put(tfr);
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            parms._train = tfr._key;
+            parms._ntrees = 1;
+            parms._seed = 0;
+            parms._response_column = "IsDepDelayed";
+
+            // Test incorrect tree request
+            final TreeV3 args = new TreeV3();
+            model = new GBM(parms).trainModel().get();
+            args.model = new KeyV3.ModelKeyV3(model._key);
+            args.tree_class = "YES";
+
+            // If the tree class name is specified, it must be the tree class built exactly
+            final TreeHandler treeHandler = new TreeHandler();
+            boolean exceptionThrown = false;
+            try {
+                treeHandler.getTree(3, args);
+            } catch (IllegalArgumentException e) {
+                assertTrue(e.getMessage().contains("For binomial, only one tree class has been built per each iteration: NO"));
+                exceptionThrown = true;
+            }
+            assertTrue(exceptionThrown);
+
+            args.tree_class = "NO";
+            final TreeV3 correctlySpecifiedClassTree = treeHandler.getTree(3, args);
+            assertNotNull(correctlySpecifiedClassTree);
+
+            args.tree_class = "";
+            final TreeV3 noClassTree = treeHandler.getTree(3, args);
+            assertNotNull(noClassTree);
+
+        } finally {
+            if (tfr != null) tfr.remove();
+            if (model != null) model.remove();
+            Scope.exit();
+        }
+    }
+
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
@@ -29,9 +29,7 @@ public class SharedTreeNode {
   float predValue = Float.NaN;
   float squaredError = Float.NaN;
   SharedTreeNode leftChild;
-
-
-  public  SharedTreeNode rightChild;
+  public SharedTreeNode rightChild;
 
   // Whether NA for this colId is reachable to this node.
   private boolean inclusiveNa;
@@ -269,7 +267,7 @@ public class SharedTreeNode {
     return "SG_" + subgraphNumber + "_Node_" + nodeNumber;
   }
 
-  private boolean isBitset() {
+  public boolean isBitset() {
     return (domainValues != null);
   }
 

--- a/h2o-r/demos/rdemo.tree.fetch.R
+++ b/h2o-r/demos/rdemo.tree.fetch.R
@@ -1,0 +1,54 @@
+library(h2o)
+h2o.init()
+
+# Import Airlines training dataset
+
+locate_source <- function(file) {
+  file_path <- try(h2o:::.h2o.locate(file), silent = TRUE)
+  if (inherits(file_path, "try-error")) {
+    file_path <- paste0("https://s3.amazonaws.com/h2o-public-test-data/", file)
+  }
+  file_path
+}
+
+airlines.filePath <- "smalldata/airlines/AirlinesTrain.csv.zip"
+airlines.data <- h2o.importFile(locate_source(airlines.filePath))
+
+# Traing a Gradient Boosting Machine model on the dataset. The model predicts delayed departure best on the travel distance, origin and destination of the flight.
+# There are 10 trees built
+gbm.model <- h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 10)
+
+# An example of fetching a single tree from H2O. H2O needs to know about model the tree is fetched from. Then the number of the tree and tree class.
+# One tree class is built per each level in categorical response, thus the third argument is a character vector representing the name of the categorical level.
+# Note: In case of regression and binomial, the name of the categorical level is ignored can be omitted, as there is exactly one tree built in both cases.
+gbm.tree <- h2o.getModelTree(gbm.model, 1,"NO")
+
+# Show the structure of the three fetched. The tree contains lists of left and right child nodes. A list with description of each edge in the graph is also present.
+# The length of the descriptions list equals to the number of nodes in the tree. For each node's index, there is a description to be found.
+# The descriptions consists of categorical levels/thresholds related to the edge leading from node's parent to the node itself.
+print(gbm.tree)
+
+# Iterate over the nodes in the tree, printing numbers (identifiers) of nodes and the split rules.
+# Each split rule represents the decision path from node's parent. May contain threshold in case numerical column or categorical levels for categorical columns.
+for(node_index in 1:length(gbm.tree@left_children)){
+  left_child <- gbm.tree@left_children[node_index]
+  right_child <- gbm.tree@right_children[node_index]
+  node_description <- gbm.tree@descriptions[node_index]
+  
+  if(left_child == -1 && right_child == -1){
+    sprintf("Node %d is a leaf node.", node_index)
+    next
+  }
+  
+  cat(sprintf("Left child of node %d has number %d, right child has number %d. \n", node_index, left_child, right_child))
+  cat(sprintf("Split rule for node %d is: %s.\n\n", node_index, node_description))
+  
+}
+
+
+# An example of fetching all the trees in a model
+# First, a list is allocated. Size of the equals the number of trees built in the model.
+gbm.trees <- list(gbm.model@parameters$ntrees)
+for (tree_number in 1:gbm.model@parameters$ntrees) {
+  gbm.trees[[tree_number]] <- h2o.getModelTree(gbm.model,tree_number)
+}

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
@@ -5,7 +5,7 @@ source("../../scripts/h2o-r-test-setup.R")
 
 test.gbm.trees <- function() {
   airlines.data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
-  gbm.model = h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1)
+  gbm.model = h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   gbm.tree <-h2o.getModelTree(gbm.model, 1, "NO") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(gbm.tree)[1])
@@ -40,7 +40,7 @@ test.gbm.trees <- function() {
   
   # DRF model test
   
-  drf.model = h2o.randomForest(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1)
+  drf.model = h2o.randomForest(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   drf.tree <-h2o.getModelTree(drf.model, 1) # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(drf.tree)[1])
@@ -79,7 +79,7 @@ test.gbm.trees <- function() {
   # Cars test - multinomial
   cars.data <- h2o.importFile(path = locate('smalldata/junit/cars_nice_header.csv'))
   cars.data['cylinders'] <- h2o.asfactor(cars.data['cylinders'])
-  multinomial.model = h2o.randomForest(x=c("power", "acceleration"),y="cylinders",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1)
+  multinomial.model = h2o.randomForest(x=c("power", "acceleration"),y="cylinders",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   multinomial.tree <-h2o.getModelTree(multinomial.model, 1, "4") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(multinomial.tree)[1])
@@ -117,7 +117,7 @@ test.gbm.trees <- function() {
   
   
   # Cars test - regression
-  regression.model = h2o.randomForest(x=c("cylinders", "acceleration"),y="power",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1)
+  regression.model = h2o.randomForest(x=c("cylinders", "acceleration"),y="power",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   expect_equal("Regression", regression.model@model$training_metrics@metrics$model_category)
   regression.tree <-h2o.getModelTree(regression.model, 1) # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
@@ -1,0 +1,160 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.gbm.trees <- function() {
+  airlines.data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
+  gbm.model = h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1)
+  gbm.tree <-h2o.getModelTree(gbm.model, 1, "NO") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
+  
+  expect_equal("H2OTree", class(gbm.tree)[1])
+  expect_equal("integer", class(gbm.tree@left_children)[1])
+  expect_equal("integer", class(gbm.tree@right_children)[1])
+  expect_equal("numeric", class(gbm.tree@thresholds)[1])
+  expect_equal("character", class(gbm.tree@features)[1])
+  expect_equal("character", class(gbm.tree@nas)[1])
+  expect_equal("character", class(gbm.tree@descriptions)[1])
+  expect_equal("character", class(gbm.tree@model_id)[1])
+  expect_equal("integer", class(gbm.tree@tree_number)[1])
+  expect_equal("character", class(gbm.tree@tree_class)[1])
+  expect_equal("integer", class(gbm.tree@root_node_id)[1])
+  
+  expect_equal(length(gbm.tree@left_children)[1], length(gbm.tree@right_children)[1])
+  expect_true(is.na(match(0, gbm.tree@left_children)[1])) # There are no zeros in the list of nodes
+  expect_true(is.na(match(0, gbm.tree@right_children)[1])) # There are no zeros in the list of nodes
+  
+  totalLength <- length(gbm.tree@left_children)
+  expect_equal(totalLength, length(gbm.tree@descriptions))
+  
+  # All descriptions must be non-empty
+  for (description in gbm.tree@descriptions) {
+    expect_false(identical(description, ""))
+  }
+  
+  # First node's description is root node
+  expect_equal("Root node", gbm.tree@descriptions[1])
+  
+  expect_equal(1, gbm.tree@tree_number)
+  expect_equal("NO", gbm.tree@tree_class)
+  
+  # DRF model test
+  
+  drf.model = h2o.randomForest(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1)
+  drf.tree <-h2o.getModelTree(drf.model, 1) # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
+  
+  expect_equal("H2OTree", class(drf.tree)[1])
+  expect_equal("integer", class(drf.tree@left_children)[1])
+  expect_equal("integer", class(drf.tree@right_children)[1])
+  expect_equal("numeric", class(drf.tree@thresholds)[1])
+  expect_equal("character", class(drf.tree@features)[1])
+  expect_equal("character", class(drf.tree@nas)[1])
+  expect_equal("character", class(drf.tree@descriptions)[1])
+  expect_equal("character", class(drf.tree@model_id)[1])
+  expect_equal("integer", class(drf.tree@tree_number)[1])
+  expect_equal("character", class(drf.tree@tree_class)[1]) # The value must be properly filled by the backend, even if unspecified
+  expect_equal("integer", class(drf.tree@root_node_id)[1])
+  
+  expect_equal(length(drf.tree@left_children)[1], length(drf.tree@right_children)[1])
+  expect_true(is.na(match(0, drf.tree@left_children)[1])) # There are no zeros in the list of nodes
+  expect_true(is.na(match(0, drf.tree@right_children)[1])) # There are no zeros in the list of nodes
+  
+  totalLength <- length(drf.tree@left_children)
+  expect_equal(totalLength, length(drf.tree@descriptions))
+  expect_equal(totalLength, length(drf.tree@thresholds))
+  expect_equal(totalLength, length(drf.tree@nas))
+  expect_equal(totalLength, length(drf.tree@features))
+  
+  # All descriptions must be non-empty
+  for (description in drf.tree@descriptions) {
+    expect_false(identical(description, ""))
+  }
+  
+  # First node's description is root node
+  expect_equal("Root node", drf.tree@descriptions[1])
+  
+  expect_equal(1, drf.tree@tree_number)
+  expect_equal("NO", drf.tree@tree_class)
+  
+  # Cars test - multinomial
+  cars.data <- h2o.importFile(path = locate('smalldata/junit/cars_nice_header.csv'))
+  cars.data['cylinders'] <- h2o.asfactor(cars.data['cylinders'])
+  multinomial.model = h2o.randomForest(x=c("power", "acceleration"),y="cylinders",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1)
+  multinomial.tree <-h2o.getModelTree(multinomial.model, 1, "4") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
+  
+  expect_equal("H2OTree", class(multinomial.tree)[1])
+  expect_equal("integer", class(multinomial.tree@left_children)[1])
+  expect_equal("integer", class(multinomial.tree@right_children)[1])
+  expect_equal("numeric", class(multinomial.tree@thresholds)[1])
+  expect_equal("character", class(multinomial.tree@features)[1])
+  expect_equal("character", class(multinomial.tree@nas)[1])
+  expect_equal("character", class(multinomial.tree@descriptions)[1])
+  expect_equal("character", class(multinomial.tree@model_id)[1])
+  expect_equal("integer", class(multinomial.tree@tree_number)[1])
+  expect_equal("character", class(multinomial.tree@tree_class)[1]) # The value must be properly filled by the backend, even if unspecified
+  expect_equal("integer", class(multinomial.tree@root_node_id)[1])
+  
+  expect_equal(length(multinomial.tree@left_children)[1], length(multinomial.tree@right_children)[1])
+  expect_true(is.na(match(0, multinomial.tree@left_children)[1])) # There are no zeros in the list of nodes
+  expect_true(is.na(match(0, multinomial.tree@right_children)[1])) # There are no zeros in the list of nodes
+  
+  totalLength <- length(multinomial.tree@left_children)
+  expect_equal(totalLength, length(multinomial.tree@descriptions))
+  expect_equal(totalLength, length(multinomial.tree@thresholds))
+  expect_equal(totalLength, length(multinomial.tree@nas))
+  expect_equal(totalLength, length(multinomial.tree@features))
+  
+  # All descriptions must be non-empty
+  for (description in multinomial.tree@descriptions) {
+    expect_false(identical(description, ""))
+  }
+  
+  # First node's description is root node
+  expect_equal("Root node", multinomial.tree@descriptions[1])
+  
+  expect_equal(1, multinomial.tree@tree_number)
+  expect_equal("4", multinomial.tree@tree_class)
+  
+  
+  # Cars test - regression
+  regression.model = h2o.randomForest(x=c("cylinders", "acceleration"),y="power",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1)
+  expect_equal("Regression", regression.model@model$training_metrics@metrics$model_category)
+  regression.tree <-h2o.getModelTree(regression.model, 1) # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
+  
+  expect_equal("H2OTree", class(regression.tree)[1])
+  expect_equal("integer", class(regression.tree@left_children)[1])
+  expect_equal("integer", class(regression.tree@right_children)[1])
+  expect_equal("numeric", class(regression.tree@thresholds)[1])
+  expect_equal("character", class(regression.tree@features)[1])
+  expect_equal("character", class(regression.tree@nas)[1])
+  expect_equal("character", class(regression.tree@descriptions)[1])
+  expect_equal("character", class(regression.tree@model_id)[1])
+  expect_equal("integer", class(regression.tree@tree_number)[1])
+  expect_equal("character", class(regression.tree@tree_class)[1])
+  expect_equal("integer", class(regression.tree@root_node_id)[1])
+  
+  expect_equal(length(regression.tree@left_children)[1], length(regression.tree@right_children)[1])
+  expect_true(is.na(match(0, regression.tree@left_children)[1])) # There are no zeros in the list of nodes
+  expect_true(is.na(match(0, regression.tree@right_children)[1])) # There are no zeros in the list of nodes
+  
+  totalLength <- length(regression.tree@left_children)
+  expect_equal(totalLength, length(regression.tree@descriptions))
+  expect_equal(totalLength, length(regression.tree@thresholds))
+  expect_equal(totalLength, length(regression.tree@nas))
+  expect_equal(totalLength, length(regression.tree@features))
+  
+  # All descriptions must be non-empty
+  for (description in regression.tree@descriptions) {
+    expect_false(identical(description, ""))
+  }
+  
+  # First node's description is root node
+  expect_equal("Root node", regression.tree@descriptions[1])
+  
+  expect_equal(0, length(regression.tree@tree_class))
+  
+  expect_equal(1, regression.tree@tree_number)
+  
+}
+
+doTest("GBM & DRF tree fetching", test.gbm.trees)


### PR DESCRIPTION
* PUBDEV-5735 Tree traversal API

* Made rightChild of SharedTreeNode public (reverted accidental change in this PR).

* Extracting SharedTreeSubgraph from SharedTreeModel's output for a specific tree & class

* Basic tree conversion from SharedTreeSubgraph to scikit format. Tested output tree structure.

* Inclusive levels per node

* Split values and inclusive levels as a description string. Removed unused methods from TreeHandler class.

* Non-static tree format conversion test

* Class with tree properties in TreeHandler named TreeProperties to reflect its purpose

* Splits taken from root node, not currently visited node

* Take included categorical levels split from root. Evade putting a colon at the end of node description for categorical split.

* Avoid sending root node number through the API, it is not required.

* Don't prefix the inclusive levels.

* R client transformed to accept list of nodes and description from H2O backend

* Tree retrieval argument validation (tree index, class index).

* Tree traversal R API test.

* Tree traversal API argument validation test

* Model and tree indices start with 1 in R - changed our API accordingly. Tested.

* TreeProperties class has its properties named with underscore convention.

* Added R documentation for tree traversal. With tiny usage example. Documented to H2OTree class.

* Distributed Random Forest test in R (fetching the model). Documented getModelTree usability for both GBM & DRF.

* Root node number R documentation. Described relationship between tree class number and response variable.

* Split column is not printed for categorical splits. R demo added.

* Tree class and tree number index description changed to describe the numbering better

* Model name in R API renamed to model_id. Categorical split gets split column correctly from parent. Renamed StringBuffer that was in fact a StringBuilde.

* Thresholds, features and NaNs in separate properties.

* Tree classes defined by related levels of categorical response (ignored for regr. and binom.). Added multinomial R test with cars.

* R API documentation for new fields: thresholds, features and NAs.

* Underscore placed as a prefix to TreePropertie's class fields

* Tree class is not filled for regression. Regression test added.

* Validation of tree class input from the user for binomial and regression. Regression accepts no tree class names, binomial accepts only the one that exists, if specified

* Test of array output lengths.

* Information at node's index is about the node, not about parent