### PR TITLE
Node description handles case of NA-only node with node threshold nor…

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -171,7 +171,7 @@ public class TreeHandler extends Handler {
                 nodeDescriptionBuilder.append(" >= ");
             }
             nodeDescriptionBuilder.append(node.getParent().getSplitValue());
-        } else {
+        } else if (node.getParent().isBitset()) {
             final BitSet childInclusiveLevels = node.getInclusiveLevels();
             final int cardinality = childInclusiveLevels.cardinality();
             if ((cardinality > 0)) {
@@ -185,6 +185,8 @@ public class TreeHandler extends Handler {
                     bitsignCounter++;
                 }
             }
+        } else{
+            nodeDescriptionBuilder.append("NA only");
         }
 
         nodeDescriptions[pointer] = nodeDescriptionBuilder.toString();

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
@@ -5,7 +5,7 @@ source("../../scripts/h2o-r-test-setup.R")
 
 test.gbm.trees <- function() {
   airlines.data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
-  gbm.model = h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1)
+  gbm.model = h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   gbm.tree <-h2o.getModelTree(gbm.model, 1, "NO") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(gbm.tree)[1])
@@ -40,7 +40,7 @@ test.gbm.trees <- function() {
   
   # DRF model test
   
-  drf.model = h2o.randomForest(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1)
+  drf.model = h2o.randomForest(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   drf.tree <-h2o.getModelTree(drf.model, 1) # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(drf.tree)[1])
@@ -79,7 +79,7 @@ test.gbm.trees <- function() {
   # Cars test - multinomial
   cars.data <- h2o.importFile(path = locate('smalldata/junit/cars_nice_header.csv'))
   cars.data['cylinders'] <- h2o.asfactor(cars.data['cylinders'])
-  multinomial.model = h2o.randomForest(x=c("power", "acceleration"),y="cylinders",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1)
+  multinomial.model = h2o.randomForest(x=c("power", "acceleration"),y="cylinders",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   multinomial.tree <-h2o.getModelTree(multinomial.model, 1, "4") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(multinomial.tree)[1])
@@ -117,7 +117,7 @@ test.gbm.trees <- function() {
   
   
   # Cars test - regression
-  regression.model = h2o.randomForest(x=c("cylinders", "acceleration"),y="power",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1)
+  regression.model = h2o.randomForest(x=c("cylinders", "acceleration"),y="power",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   expect_equal("Regression", regression.model@model$training_metrics@metrics$model_category)
   regression.tree <-h2o.getModelTree(regression.model, 1) # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   


### PR DESCRIPTION
… categorical split (no threshold either) in parent. Added fixed seed to pubdev_5735 test.

## The problem
There is a bug discovered while tests without seed (corrected in this PR) ran within PR against master: https://github.com/h2oai/h2o-3/pull/2727

The call childInclusiveLevels.cardinality(); fails, because the node's BitSet with inclusive levels may be empty, yet this behaviour is non-deterministic. It is not a rule for the BitSet to be null.

            final BitSet childInclusiveLevels = node.getInclusiveLevels();
            final int cardinality = childInclusiveLevels.cardinality();

Non-direct reason for this might be absence of seed in pubdev_5735.R test.

## The solution
Affected node was number 61 built in model based on cars dataset. This node is left child of its parent. Split column on parent node is "power", a non-categorical predictor. However, the split value is NA, as only NAs go to this node. This case was NOT HANDLED by description creator, effectively ending in a situation where serializing split threshold is value (it is NaN) and the only option left was to serialize inclusive categorical levels, which were also null. Now, this third option is there !

However, the very same test is done in SharedTreeNode before inclusive categorical levels are extracted from the BitSet:

    if (isBitset()) {
      BitSet childInclusiveLevels = child.getInclusiveLevels();
      int total = childInclusiveLevels.cardinality();
      if ((total > 0) && (total <= maxLevelsToPrintPerEdge)) {
        for (int i = childInclusiveLevels.nextSetBit(0); i >= 0; i = childInclusiveLevels.nextSetBit(i+1)) {
          arr.add(domainValues[i]);
        }
      }

## Testing issues

This condition is very hard to create unit test for, unless we expose SharedTreeGraph and SharedTreeNode. These methods are package private/private or protected. I'd like to create a custom SharedTreeGraph that enables us to test such cases directly and not fit whole models. WDYT @michalkurka ? Let's do it ? During the previous week we decided not to expose it, yet I'd think the structures may be exposed.

A way to expose the API would be to create new static methods that create instances just for testing purpose, if the rest is required to be hidden. Personally, I see no point in sharing the constructors and getters/setters with outer world in case of SharedTreeGraph/SharedTreeNode.