### PR TITLE
PUBDEV-5789: cleaner message after failure to locally start server

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1845,6 +1845,7 @@ final public class H2O {
    */
   public static boolean checkUnsupportedJava() {
     String version = System.getProperty("java.version");
+    // NOTE for developers: make sure that the following whitelist is logically consistent with whitelist in R code - see file connection.R near line 536
     if (version != null && !(version.startsWith("1.7") || version.startsWith("1.8") || version.startsWith("9") || version.startsWith("10"))) {
       System.err.println("Only Java 1.7-1.8, 9 and 10 is supported, system version is " + version);
       return true;

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -190,8 +190,6 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
         print(rv$httpStatusCode)
         print(rv$curlErrorMessage)
 
-        #try a hail mary curl
-        print(system("curl 'http://localhost:54321'"))
         stop("H2O failed to start, stopping execution.")
       }
     } else
@@ -547,6 +545,13 @@ h2o.clusterStatus <- function() {
 
     # Set default max_memory to be 1g for 32-bit JVM.
     if(is.null(max_memory)) max_memory = "1g"
+  }
+
+  # NOTE for developers: keep the following blacklist in logically consistent with whitelist in java code - see water.H2O.checkUnsupportedJava, near line 1849
+  if (any(grepl("^java version \"1\\.[1-6]\\.", jver))) {
+    stop("Your java is not supported: ", jver[1], "\n",
+    "Please download the latest Java SE JDK 8 from the following URL:\n",
+    "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html")
   }
 
   if (.Platform$OS.type == "windows") {

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5789.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5789.R
@@ -1,0 +1,99 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.jira.pubdev5789 <- function() {
+
+  ######  Versions that must fail  ######
+
+  # oracle jdk 6
+  expect_equal('Your java is not supported: java version "1.6.0_45"', .h2o.check_java_version(c(
+    'java version "1.6.0_45"',
+    'Java(TM) SE Runtime Environment (build 1.6.0_45-b06)',
+    'Java HotSpot(TM) 64-Bit Server VM (build 20.45-b01, mixed mode)'
+  )))
+
+  # docker run -it --rm xaas/jrockit java -version
+  expect_equal('Your java is not supported: java version "1.6.0_45"', .h2o.check_java_version(c(
+    'java version "1.6.0_45"',
+    'Java(TM) SE Runtime Environment (build 1.6.0_45-b06)',
+    'Oracle JRockit(R) (build R28.2.7-7-155314-1.6.0_45-20130329-0641-linux-x86_64, compiled mode)'
+  )))
+
+
+  # docker run -it --rm java:6-jdk java -version
+  expect_equal('Your java is not supported: java version "1.6.0_38"', .h2o.check_java_version(c(
+    'java version "1.6.0_38"',
+    'OpenJDK Runtime Environment (IcedTea6 1.13.10) (6b38-1.13.10-1~deb7u1)',
+    'OpenJDK 64-Bit Server VM (build 23.25-b01, mixed mode)'
+  )))
+
+  # docker run -it --rm java:7-jdk-alpine java -version
+  expect_null(.h2o.check_java_version(c(
+  'java version "1.7.0_121"',
+    'OpenJDK Runtime Environment (IcedTea 2.6.8) (Alpine 7.121.2.6.8-r0)',
+    'OpenJDK 64-Bit Server VM (build 24.121-b00, mixed mode)'
+  )))
+
+  ###### Versions that must pass  ######
+
+  # docker run -it --rm java:7-jdk java -version
+  expect_null(.h2o.check_java_version(c(
+    'java version "1.7.0_111"',
+    'OpenJDK Runtime Environment (IcedTea 2.6.7) (7u111-2.6.7-2~deb8u1)',
+    'OpenJDK 64-Bit Server VM (build 24.111-b01, mixed mode)'
+  )))
+
+  # docker run -it --rm java:openjdk-7-jdk-alpine java -version
+  expect_null(.h2o.check_java_version(c(
+    'java version "1.7.0_121"',
+    'OpenJDK Runtime Environment (IcedTea 2.6.8) (Alpine 7.121.2.6.8-r0)',
+    'OpenJDK 64-Bit Server VM (build 24.121-b00, mixed mode)'
+  )))
+
+  # oracle jdk 8
+  expect_null(.h2o.check_java_version(c(
+    'java version "1.8.0_181"',
+    'Java(TM) SE Runtime Environment (build 1.8.0_181-b13)',
+    'Java HotSpot(TM) 64-Bit Server VM (build 25.181-b13, mixed mode)'
+  )))
+
+  # oracle jdk 10
+  expect_null(.h2o.check_java_version(c(
+    'java version "10.0.2" 2018-07-17',
+    'Java(TM) SE Runtime Environment 18.3 (build 10.0.2+13)',
+    'Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.2+13, mixed mode)'
+  )))
+
+  # docker run -it --rm openjdk:8-jre-slim java -version
+  expect_null(.h2o.check_java_version(c(
+    'openjdk version "1.8.0_181"',
+    'OpenJDK Runtime Environment (build 1.8.0_181-8u181-b13-1~deb9u1-b13)',
+    'OpenJDK 64-Bit Server VM (build 25.181-b13, mixed mode)'
+  )))
+
+  # docker run -it --rm openjdk:9-jre-slim java -version
+  expect_null(.h2o.check_java_version(c(
+    'openjdk version "9.0.4"',
+    'OpenJDK Runtime Environment (build 9.0.4+12-Debian-4)',
+    'OpenJDK 64-Bit Server VM (build 9.0.4+12-Debian-4, mixed mode)'
+  )))
+
+  # docker run -it --rm openjdk:10-jre-slim java -version
+  expect_null(.h2o.check_java_version(c(
+    'openjdk version "10.0.2" 2018-07-17',
+    'OpenJDK Runtime Environment (build 10.0.2+13-Debian-1)',
+    'OpenJDK 64-Bit Server VM (build 10.0.2+13-Debian-1, mixed mode)'
+  )))
+
+  # docker run -it --rm openjdk:11-jre-slim java -version
+  expect_null(.h2o.check_java_version(c(
+    'openjdk version "11" 2018-09-25',
+    'OpenJDK Runtime Environment (build 11+24-Debian-1)',
+    'OpenJDK 64-Bit Server VM (build 11+24-Debian-1, mixed mode, sharing)'
+  )))
+
+}
+
+doTest("PUBDEV-5789 check java version", test.jira.pubdev5789)


### PR DESCRIPTION
- removed useless call to curl
- replaced with message suggesting that the user should check Java version used for starting h2o
 
When the failure occurs, this can be for couple of reasons, including (1) connection problems and (2) problems to start the application. Before this change, the console output always showed the symptom, twice (failure to connect) but did not indicate possible causes.

In the first case, the symptom is already indicated by the message from R output (which anyway seems to be equal to the one from `curl`). Therefore calling curl again (probably meant just to get the error message) does not seem useful.

In the latter case, one of possible causes is, incorrect version of Java. So the user is instructed to check it.
For any other causes, the user can explore the indicated console log files; and here it comes handy to get rid of the (IMHO useless) curl output which would otherwise place the log pointer several lines more behind in the console history.

Now the error output in RStudio looks like this:
```
...
> h2o.init()
Reading in config file: ./.h2oconfig

H2O is not running yet, starting it now...

Note:  In case of errors look at the following log files:
    /tmp/RtmpssoTKx/h2o_pk_started_from_r.out
    /tmp/RtmpssoTKx/h2o_pk_started_from_r.err

java version "1.6.0_45"
Java(TM) SE Runtime Environment (build 1.6.0_45-b06)
Java HotSpot(TM) 64-Bit Server VM (build 20.45-b01, mixed mode)

Starting H2O JVM and connecting: ............................................................ 
[1] "localhost"
[1] 54321
[1] TRUE
[1] -1
[1] "Failed to connect to localhost port 54321: Connection refused"
[1] "Please check JAVA version used for running the H2O server"
Error in h2o.init() : H2O failed to start, stopping execution.
```


BTW, the original `curl` command was also somewhat ill; it always assumes default values for `ip` and `port` parameters. If it should stay, its params should be rather constructed from actual parameter values.