### PR TITLE
Pubdev 5826 glrm predict mojo mismatch

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRMGenX.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMGenX.java
@@ -24,6 +24,8 @@ public class GLRMGenX  extends MRTask<GLRMGenX> {
   @Override
   protected void setupLocal() {
     _gMojoModel = new GlrmMojoModel(_m._output._names, _m._output._domains, null);
+    _gMojoModel._allAlphas = GlrmMojoModel.initializeAlphas(_gMojoModel._numAlphaFactors);  // set _allAlphas array
+
     GLRM.Archetypes arch = _m._output._archetypes_raw;
     // fill out the mojo model, no need to fill out every field
     _gMojoModel._ncolA = _m._output._lossFunc.length;

--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -228,7 +228,8 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     Frame fullFrm = new Frame(adaptedFr);
     Frame loadingFrm = null;  // get this from DKV or generate it from scratch
     // call resconstruct only if test frame key and training frame key matches plus frame dimensions match as well
-    if ((_parms.train() == null) || orig.checksum()!=(_parms.train().checksum())) { // compare with checksum instead of frame keys.
+    if ((_parms.train() == null) || orig.checksum()!=(_parms.train().checksum()) ||
+            !(orig._key.equals(_parms.train()._key))) { // compare with checksum instead of frame keys.
       // need to generate the X matrix and put it in as a frame ID.  Mojo predict will return one row of x as a double[]
       GLRMGenX gs = new GLRMGenX(this, _parms._k);
       gs.doAll(gs._k, Vec.T_NUM, adaptedFr);
@@ -262,7 +263,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
   }
 
   public Key<Frame> gen_representation_key(Frame fr) {
-    if ((_parms.train() != null) && (fr.checksum() == _parms.train().checksum())) // use training X factor here.
+    if ((_parms.train() != null) && (fr.checksum() == _parms.train().checksum()) && fr._key.equals(_parms.train()._key)) // use training X factor here.
       return _output._representation_key;
     else
       return Key.make("GLRMLoading_"+fr._key);

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmMojoModel.java
@@ -25,11 +25,13 @@ public class GlrmMojoModel extends MojoModel {
   public GlrmInitialization _init;
   public int _ncats;
   public int _nnums;
-  public double[] _normSub;
-  public double[] _normMul;
+  public double[] _normSub; // used to perform dataset transformation.  When no transform is needed, will be 0
+  public double[] _normMul; // used to perform dataset transformation.  When no transform is needed, will be 1
   public long _seed;  // added to ensure reproducibility
   public boolean _transposed;
   public boolean _reverse_transform;
+  public double _accuracyEps = 1e-10; // reconstruction accuracy A=X*Y
+  public int _iterNumber = 200; // maximum number of iterations to perform X update.
 
   // We don't really care about regularization of Y since it is changed during scoring
 
@@ -49,6 +51,8 @@ public class GlrmMojoModel extends MojoModel {
   private static final double DOWN_FACTOR = 0.5;
   private static final double UP_FACTOR = Math.pow(1.0/DOWN_FACTOR, 1.0/4);
   public long _rcnt = 0;  // increment per row and can be changed to different values to ensure reproducibility
+  public int _numAlphaFactors = 20;
+  public double[] _allAlphas;
 
   static {
     //noinspection ConstantAssertCondition,ConstantConditions
@@ -70,54 +74,51 @@ public class GlrmMojoModel extends MojoModel {
     return _ncolX;
   }
 
+  public static double[] initializeAlphas(int numAlpha) {
+    double[] alphas = new double[numAlpha];
+    double alpha = 1.0;
+    for (int index=0; index < numAlpha; index++) {
+      alpha *= DOWN_FACTOR;
+      alphas[index] = alpha;
+    }
+    return alphas;
+  }
+
   public double[] score0(double[] row, double[] preds, long seedValue) {
     assert row.length == _ncolA;
     assert preds.length == _ncolX;
     assert _nrowY == _ncolX;
     assert _archetypes.length == _nrowY;
     assert _archetypes[0].length == _ncolY;
-    double alpha=1.0;  // reset back to 1 for each row
 
     // Step 0: prepare the data row
     double[] a = getRowData(row);
 
     // Step 1: initialize X  (for now do Random initialization only)
     double[] x = new double[_ncolX];
+    double[] u = new double[_ncolX];
     Random random = new Random(seedValue);  // change the random seed everytime it is used
-    for (int i = 0; i < _ncolX; i++)
+    for (int i = 0; i < _ncolX; i++)  // randomly generate initial x coefficients
       x[i] = random.nextGaussian();
     x = _regx.project(x, random);
 
     // Step 2: update X based on prox-prox algorithm, iterate until convergence
     double obj = objective(x, a);
+    double oldObj = obj;  // store original obj value
     boolean done = false;
     int iters = 0;
-    while (!done && iters++ < 100) {
+
+    while (!done && iters++ < _iterNumber) {
       // Compute the gradient of the loss function
       double[] grad = gradientL(x, a);
       // Try to make a step of size alpha, until we can achieve improvement in the objective.
-      double[] u = new double[_ncolX];
-      while (true) {  // inner loop to run and make sure we find a stepsize and x factor that decrease objective
-        // System.out.println("  " + alpha);
-        // Compute the tentative new x (using the prox algorithm)
-        for (int k = 0; k < _ncolX; k++) {
-          u[k] = x[k] - alpha * grad[k];
-        }
-        double[] xnew = _regx.rproxgrad(u, alpha * _gammax, random);
-        double newobj = objective(xnew, a);
 
-        if (newobj == 0) break;
-        double obj_improvement = 1 - newobj/obj;
-        if (obj_improvement >= 0) {
-          if (obj_improvement < 1e-6) done = true;
-          obj = newobj;
-          x = xnew;
-          alpha *= UP_FACTOR;
-          break;
-        } else {
-          alpha *= DOWN_FACTOR;
-        }
-      }
+      obj = applyBestAlpha(u, x, grad, a, oldObj, random);
+      double obj_improvement = 1 - obj/oldObj;
+      if ((obj_improvement < 0) || (obj_improvement < _accuracyEps))
+        done = true;  // not getting improvement or significant improvement, quit
+      oldObj = obj;
+
     }
     System.arraycopy(x, 0, preds, 0, _ncolX);
     return preds;
@@ -135,6 +136,51 @@ public class GlrmMojoModel extends MojoModel {
       a[i] = row[_permutation[i]];
 
     return a;
+  }
+
+  /***
+   * This method will try a bunch of arbitray alpha values and pick the best to return which get the best obj
+   * improvement.
+   *
+   * @param u
+   * @param x
+   * @param grad
+   * @param a
+   * @param oldObj
+   * @param random
+   * @return
+   */
+  public double applyBestAlpha(double[] u, double[] x, double[] grad, double[] a, double oldObj, Random random) {
+    double[] bestX = new double[x.length];
+    double lowestObj = Double.MAX_VALUE;
+
+    if (oldObj == 0) { // done optimization, loss is now zero.
+      return 0;
+    }
+
+    double alphaScale = oldObj > 10?(1.0/oldObj):1.0;
+
+    for (int index=0; index < _numAlphaFactors; index++) {
+      double alpha = _allAlphas[index]*alphaScale;  // scale according to object function size
+      // Compute the tentative new x (using the prox algorithm)
+      for (int k = 0; k < _ncolX; k++) {
+        u[k] = x[k] - alpha * grad[k];
+      }
+      double[] xnew = _regx.rproxgrad(u, alpha * _gammax, random);
+      double newobj = objective(xnew, a);
+
+      if (lowestObj > newobj) {
+        System.arraycopy(xnew, 0, bestX, 0, xnew.length);
+        lowestObj = newobj;
+      }
+
+      if (newobj == 0)
+        break;
+    }
+    if (lowestObj < oldObj) // only copy if new result is good
+      System.arraycopy(bestX, 0, x, 0, x.length);
+
+    return lowestObj;
   }
 
   /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/glrm/GlrmMojoReader.java
@@ -49,7 +49,7 @@ public class GlrmMojoReader extends ModelMojoReader<GlrmMojoModel> {
 
     // new fields added after version 1.00
     try {
-      _model._seed = readkv("seed");
+      _model._seed = readkv("seed", 0l);
       _model._reverse_transform = readkv("reverse_transform");
       _model._transposed = readkv("transposed");
       _model._catOffsets = readkv("catOffsets");
@@ -74,7 +74,9 @@ public class GlrmMojoReader extends ModelMojoReader<GlrmMojoModel> {
 
   @Override
   protected GlrmMojoModel makeModel(String[] columns, String[][] domains, String responseColumn) {
-    return new GlrmMojoModel(columns, domains, responseColumn);
+    GlrmMojoModel glrmModel = new GlrmMojoModel(columns, domains, responseColumn);
+    glrmModel._allAlphas = GlrmMojoModel.initializeAlphas(glrmModel._numAlphaFactors);  // set _allAlphas array
+    return glrmModel;
   }
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/ParseUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/ParseUtils.java
@@ -37,11 +37,29 @@ public class ParseUtils {
     public static Object tryParse(String input, Object defVal) {
         if (input.equals("null")) return defVal;
 
-        if (defVal instanceof Boolean) {
-            return Boolean.valueOf(input);
-        } else {
-            if (input.equals("true")) return true;
-            if (input.equals("false")) return false;
+        if (input.equals("true")) return true;
+        if (input.equals("false")) return false;
+
+        if (defVal != null && !(defVal.getClass().isArray())) {
+            if (defVal instanceof Boolean)     // parse according to data type of defVal
+                return Boolean.valueOf(input);
+            else if (defVal instanceof Long)
+                return Long.valueOf(input);
+            else if (defVal instanceof Integer)
+                return Integer.valueOf(input);
+            else if (defVal instanceof Float)
+                return Float.valueOf(input);
+            else if (defVal instanceof Double)
+                return Double.valueOf(input);
+        }
+
+        if (defVal != null && (defVal.getClass().isArray())) {
+            if (defVal instanceof Long[])
+                return parseArrayOfLongs(input);
+            else if (defVal instanceof Integer[])
+                return parseArrayOfInts(input);
+            else if (defVal instanceof Double[])
+                return parseArrayOfDoubles(input);
         }
 
         if ("[]".equals(input) && (defVal != null) && defVal.getClass().isArray())

--- a/h2o-genmodel/src/test/java/hex/genmodel/utils/ParseUtilsTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/utils/ParseUtilsTest.java
@@ -20,6 +20,7 @@ public class ParseUtilsTest {
     int oneValue = _random.nextInt();
     String valStr = Integer.toString(oneValue);
     assertEquals(ParseUtils.tryParse(valStr, null), oneValue);
+    assertEquals(ParseUtils.tryParse(valStr, oneValue), oneValue);
 
     int arraySize = _random.nextInt(10)+1;
     int arrySizeM1 = arraySize-1;
@@ -34,7 +35,9 @@ public class ParseUtilsTest {
     }
     sb.append("]");
     int[] readback = (int[]) ParseUtils.tryParse(sb.toString(), null);
+    int[] readbackdefVal = (int[]) ParseUtils.tryParse(sb.toString(), readback);
     assertArrayEquals(readback, valArray);
+    assertArrayEquals(readbackdefVal, valArray);
   }
 
   @Test
@@ -42,6 +45,7 @@ public class ParseUtilsTest {
     double oneValue = _random.nextDouble();
     String valStr = Double.toString(oneValue);
     assertEquals(ParseUtils.tryParse(valStr, null), oneValue);
+    assertEquals(ParseUtils.tryParse(valStr, oneValue), oneValue);
 
     int arraySize = _random.nextInt(10)+1;
     int arrySizeM1 = arraySize-1;
@@ -56,7 +60,9 @@ public class ParseUtilsTest {
     }
     sb.append("]");
     double[] readback = (double[]) ParseUtils.tryParse(sb.toString(), null);
+    double[] readbackdefVal = (double[]) ParseUtils.tryParse(sb.toString(), readback);
     assertArrayEquals(readback, valArray, 1e-10);
+    assertArrayEquals(readbackdefVal, valArray, 1e-10);
   }
 
   @Test
@@ -64,6 +70,7 @@ public class ParseUtilsTest {
     long oneValue = _random.nextLong();
     String valStr = Long.toString(oneValue);
     assertEquals(ParseUtils.tryParse(valStr, null), oneValue);
+    assertEquals(ParseUtils.tryParse(valStr, oneValue), oneValue);
 
     int arraySize = _random.nextInt(10)+1;
     int arrySizeM1 = arraySize-1;
@@ -78,6 +85,8 @@ public class ParseUtilsTest {
     }
     sb.append("]");
     long[] readback = (long[]) ParseUtils.tryParse(sb.toString(), null);
+    long[] readbackdefVal = (long[]) ParseUtils.tryParse(sb.toString(), readback);
     assertArrayEquals(readback, valArray);
+    assertArrayEquals(readbackdefVal, valArray);
   }
 }

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3266,6 +3266,95 @@ def compare_string_frames_local(f1, f2, prob=0.5):
                                                                      "{1}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd)
 
 
+def check_data_rows(f1, f2, index_list=[], num_rows=10):
+    '''
+        This method will compare the relationships of the data rows within each frames.  In particular, we are
+        interested in the relative direction of each row vectors and the relative distances. No assertions will
+        be thrown.
+
+    :param f1:
+    :param f2:
+    :param index_list:
+    :param num_rows:
+    :return:
+    '''
+    temp1 = f1.as_data_frame(use_pandas=True).as_matrix()
+    temp2 = f2.as_data_frame(use_pandas=True).as_matrix()
+    if len(index_list)==0:
+        index_list = random.sample(range(f1.nrow), num_rows)
+
+    maxInnerProduct = 0
+    maxDistance = 0
+
+    for row_index in range(1, len(index_list)):
+        r1 = np.inner(temp1[index_list[row_index-1]], temp1[index_list[row_index]])
+        r2 = np.inner(temp2[index_list[row_index-1]], temp2[index_list[row_index]])
+        d1 = np.linalg.norm(temp1[index_list[row_index-1]]-temp1[index_list[row_index]])
+        d2 = np.linalg.norm(temp2[index_list[row_index-1]]-temp2[index_list[row_index]])
+
+        diff1 = min(abs(r1-r2), abs(r1-r2)/max(abs(r1), abs(r2)))
+        maxInnerProduct = max(maxInnerProduct, diff1)
+        diff2 = min(abs(d1-d2), abs(d1-d2)/max(abs(d1), abs(d2)))
+        maxDistance = max(maxDistance, diff2)
+
+    print("Maximum inner product different is {0}.  Maximum distance difference is "
+      "{1}".format(maxInnerProduct, maxDistance))
+
+
+def compare_data_rows(f1, f2, index_list=[], num_rows=10, tol=1e-3):
+    '''
+        This method will compare the relationships of the data rows within each frames.  In particular, we are
+        interested in the relative direction of each row vectors and the relative distances. An assertion will be
+        thrown if they are different beyond a tolerance.
+
+    :param f1:
+    :param f2:
+    :param index_list:
+    :param num_rows:
+    :return:
+    '''
+    temp1 = f1.as_data_frame(use_pandas=True).as_matrix()
+    temp2 = f2.as_data_frame(use_pandas=True).as_matrix()
+    if len(index_list)==0:
+        index_list = random.sample(range(f1.nrow), num_rows)
+
+    maxInnerProduct = 0
+    maxDistance = 0
+    for row_index in range(1, len(index_list)):
+        r1 = np.inner(temp1[index_list[row_index-1]], temp1[index_list[row_index]])
+        r2 = np.inner(temp2[index_list[row_index-1]], temp2[index_list[row_index]])
+        d1 = np.linalg.norm(temp1[index_list[row_index-1]]-temp1[index_list[row_index]])
+        d2 = np.linalg.norm(temp2[index_list[row_index-1]]-temp2[index_list[row_index]])
+
+        diff1 = min(abs(r1-r2), abs(r1-r2)/max(abs(r1), abs(r2)))
+        maxInnerProduct = max(maxInnerProduct, diff1)
+        diff2 = min(abs(d1-d2), abs(d1-d2)/max(abs(d1), abs(d2)))
+        maxDistance = max(maxDistance, diff2)
+
+        assert diff1 < tol, \
+            "relationship between data row {0} and data row {1} are different among the two dataframes.  Inner " \
+            "product from frame 1 is {2}.  Inner product from frame 2 is {3}.  The difference between the two is" \
+            " {4}".format(index_list[row_index-1], index_list[row_index], r1, r2, diff1)
+
+
+        assert diff2 < tol, \
+                "distance betwee data row {0} and data row {1} are different among the two dataframes.  Distance " \
+                "between 2 rows from frame 1 is {2}.  Distance between 2 rows from frame 2 is {3}.  The difference" \
+                " between the two is {4}".format(index_list[row_index-1], index_list[row_index], d1, d2, diff2)
+    print("Maximum inner product different is {0}.  Maximum distance difference is "
+          "{1}".format(maxInnerProduct, maxDistance))
+
+def compute_frame_diff(f1, f2):
+    '''
+    This method will take the absolute difference two frames and sum across all elements
+    :param f1:
+    :param f2:
+    :return:
+    '''
+
+    frameDiff = h2o.H2OFrame.sum(h2o.H2OFrame.sum(h2o.H2OFrame.abs(f1-f2)), axis=1)[0,0]
+    return frameDiff
+
 def compare_frames_local(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
     temp1 = f1.as_data_frame(use_pandas=False)
     temp2 = f2.as_data_frame(use_pandas=False)

--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5826_glrm_predict_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5826_glrm_predict_large.py
@@ -1,0 +1,98 @@
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+from random import randint
+import re
+
+'''
+PUBDEV-5826: GLRM model predict and mojo predict differ
+
+During training, we are trying to decompose a dataset A = X*Y.  The X and Y matrices are updated iteratively until
+the reconstructed dataset A' converges to A using some metrics.
+
+During prediction/scoring, we try to do A = X'*Y where A and Y are known.  H2O will automatically detect if 
+A is the same dataset used to train the model.  If it is, it will automatically return X.  If A is not the same
+dataset used during training, we will try to get X' given A and Y.  In this case, we will still use the GLRM framework
+of update.  However, we only perform update on X' since Y is already known.
+
+At first glance, we will expect that predict on the training frame and predict on a brand new frame will give 
+different results since two different procedures are used.  Here, I am trying to narrow the differences between the
+two X generated in this case.
+
+I will use a numerical dataset benign.csv and then work with another dataset that contains both numerical and enum
+columns prostate_cat.csv.
+
+The comparisons performed here are:
+1. investigate the relationship among rows of the X factor.  Note that we will have two X factors, one from training 
+and one from mojo prediction.  If the relationships among the X factor are the same, this means that even if the two
+X factors are different, the relationship among the rows have not changed.  We checked two relationships, a. the
+direction between two rows (use inner product), b. the distance between two rows (use ||row1-row2||^2).
+2. compare the reconstructed datasets from A=X*Y (reconstruction from training X factor) and A=X'*Y (reconstruction
+from mojo predict X factor).
+
+'''
+def glrm_mojo():
+    h2o.remove_all()
+    # dataset with numerical values only
+    print("Checking GLRM predict performance with numerical dataset.....")
+    train = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    get_glrm_xmatrix(train, test, K=3, tol=1e-1)
+
+    # dataset with enum and numerical columns
+    print("Checking GLRM predict performance with mixed dataset.....")
+    train = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate_cat.csv"))
+    get_glrm_xmatrix(train, test, K=5, compare_predict=False, tol=1.5)
+
+def get_glrm_xmatrix(train, test, K = 3, compare_predict=True, tol=1e-3):
+    x = train.names
+    transform_types = ["NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"]
+    transformN = transform_types[randint(0, len(transform_types)-1)]
+    print("dataset transform is {0}.".format(transformN))
+    # build a GLRM model with random dataset generated earlier
+    glrmModel = H2OGeneralizedLowRankEstimator(k=K, transform=transformN, max_iterations=1000, seed=12345)
+    glrmModel.train(x=x, training_frame=train)
+    glrmTrainFactor = h2o.get_frame(glrmModel._model_json['output']['representation_name'])
+
+    # assert glrmTrainFactor.nrows==train.nrows, \
+    #     "X factor row number {0} should equal training row number {1}.".format(glrmTrainFactor.nrows, train.nrows)
+    mojoDir = save_GLRM_mojo(glrmModel) # save mojo model
+
+    MOJONAME = pyunit_utils.getMojoName(glrmModel._id)
+    h2o.download_csv(test[x], os.path.join(mojoDir, 'in.csv'))  # save test file, h2o predict/mojo use same file
+
+    frameID, mojoXFactor = pyunit_utils.mojo_predict(glrmModel, mojoDir, MOJONAME, glrmReconstruct=False) # save mojo XFactor
+    print("Comparing mojo x Factor and model x Factor ...")
+
+    if transformN=="NONE":  # bad performance with no transformation on dataset
+        pyunit_utils.check_data_rows(mojoXFactor, glrmTrainFactor, num_rows=mojoXFactor.nrow)
+    else:
+        pyunit_utils.compare_data_rows(mojoXFactor, glrmTrainFactor, num_rows=mojoXFactor.nrow, tol=tol)
+
+    if compare_predict: # only compare reconstructed data frames with numerical data
+        pred2 = glrmModel.predict(test) # predict using mojo
+        pred1 = glrmModel.predict(train)    # predict using the X from A=X*Y from training
+
+        predictDiff = pyunit_utils.compute_frame_diff(train, pred1)
+        mojoDiff = pyunit_utils.compute_frame_diff(train, pred2)
+        print("absolute difference of mojo predict and original frame is {0} and model predict and original frame is {1}".format(mojoDiff, predictDiff))
+
+
+def save_GLRM_mojo(model):
+    # save model
+    MOJONAME = pyunit_utils.getMojoName(model._id)
+
+    print("Downloading Java prediction model code from H2O")
+    tmpdir = os.path.join(pyunit_utils.locate("results"), MOJONAME)
+    os.makedirs(tmpdir)
+    model.download_mojo(path=tmpdir)    # save mojo
+    return tmpdir
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glrm_mojo)
+else:
+    glrm_mojo()


### PR DESCRIPTION
Due to the fact that during training, glrm performs alternating updates between X and Y and during mojo scoring, it only performs updates of X and skipping the Y, the X factors generated are different.

I have implemented a small optimization which will return the X updates with the alpha that produces the best objective function improvement.