### PR TITLE
PUBDEV-5792: Parsing large numbers (2E19) can cause the parser to hang

### DIFF
--- a/h2o-core/src/main/java/water/parser/FVecParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/FVecParseWriter.java
@@ -145,18 +145,13 @@ public class FVecParseWriter extends Iced implements StreamParseWriter {
 
   /** Adds double value to the column. */
   @Override public void addNumCol(int colIdx, double value) {
-    if (Double.isNaN(value)) {
+    if (Double.isNaN(value) || Double.isInfinite(value)) {
       addInvalidCol(colIdx);
     } else {
-      double d= value;
-      int exp = 0;
-      long number = (long)d;
-      while (number != d) {
-        d *= 10;
-        --exp;
-        number = (long)d;
+      if( colIdx < _nCols ) {
+        _nvs[_col = colIdx].addNumDecompose(value);
+        if(_ctypes != null && _ctypes[colIdx] == Vec.T_BAD ) _ctypes[colIdx] = Vec.T_NUM;
       }
-      addNumCol(colIdx, number, exp);
     }
   }
   @Override public void setColumnNames(String [] names){}

--- a/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
+++ b/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
@@ -17,5 +17,10 @@ public class FVecParseWriterTest {
                 new AppendableVec[0]
         );
         writer.addNumCol(1, 2E19);
+        writer.addNumCol(2, -123.123);
+        writer.addNumCol(3, 3e39);
+        writer.addNumCol(4, 0.0);
+        writer.addNumCol(5, 1.0);
+        writer.addNumCol(6, 3);
     }
 }

--- a/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
+++ b/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
@@ -1,0 +1,21 @@
+package water.parser;
+
+import org.junit.Test;
+import water.fvec.AppendableVec;
+import water.fvec.Vec;
+
+public class FVecParseWriterTest {
+
+    @Test(timeout = 10000)
+    public void addNumCol() {
+        FVecParseWriter writer = new FVecParseWriter(
+                Vec.VectorGroup.VG_LEN1,
+                1,
+                new Categorical[0],
+                new byte[0],
+                1,
+                new AppendableVec[0]
+        );
+        writer.addNumCol(1, 2E19);
+    }
+}

--- a/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
+++ b/h2o-core/src/test/java/water/parser/FVecParseWriterTest.java
@@ -1,26 +1,86 @@
 package water.parser;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import water.Key;
 import water.fvec.AppendableVec;
+import water.fvec.Chunk;
+import water.fvec.NewChunk;
 import water.fvec.Vec;
+
+import java.util.Random;
 
 public class FVecParseWriterTest {
 
-    @Test(timeout = 10000)
-    public void addNumCol() {
-        FVecParseWriter writer = new FVecParseWriter(
-                Vec.VectorGroup.VG_LEN1,
-                1,
-                new Categorical[0],
-                new byte[0],
-                1,
-                new AppendableVec[0]
-        );
-        writer.addNumCol(1, 2E19);
-        writer.addNumCol(2, -123.123);
-        writer.addNumCol(3, 3e39);
-        writer.addNumCol(4, 0.0);
-        writer.addNumCol(5, 1.0);
-        writer.addNumCol(6, 3);
+  private FVecParseWriter writer;
+
+  @Before
+  public void setup() {
+    writer = makeWriter();
+  }
+
+  @Test
+  public void addNumColLosesPrecision() { // needs to be fixed: PUBDEV-5840
+    writer.addNumCol(0, Math.PI);
+    double h2oPI = writer._nvs[0].compress().atd(0);
+    Assert.assertEquals(h2oPI, Math.PI, 1e-15);
+    Assert.assertNotEquals(h2oPI, Math.PI, 0);
+  }
+
+  @Test
+  public void testBackwardsCompatibility() {
+    Random r = new Random(42);
+    FVecParseWriter wr2 = makeWriter();
+    for (int i = 0; i < 2000; i++) {
+      double v = r.nextDouble();
+      wr2.addNumCol(0, v);
+      oldAddNumDecompose(v, 0, writer);
     }
+    Chunk nc = writer._nvs[0].compress();
+    Chunk nc2 = wr2._nvs[0].compress();
+    for (int i = 0; i < nc._len; i++) {
+      Assert.assertEquals(nc2.atd(i), nc.atd(i), 0);
+    }
+  }
+
+  private static void oldAddNumDecompose(final double value, int colIdx, FVecParseWriter w) {
+    double d = value;
+    int exp = 0;
+    long number = (long)d;
+    while (number != d) {
+      d *= 10;
+      --exp;
+      number = (long) d;
+    }
+    w.addNumCol(colIdx, number, exp);
+  }
+
+  @Test(timeout = 10000)
+  public void addNumCol() {
+    double values[] = {2E19, -123.123, 0.0, 1.0, Math.exp(1), 3};
+
+    for (double v : values)
+      writer.addNumCol(0, v);
+
+    Chunk ds = writer._nvs[0].compress();
+
+    for (int i = 0; i < values.length; i++)
+      Assert.assertEquals(i+"th values differ", values[i], ds.atd(i), 0);
+  }
+
+  private static FVecParseWriter makeWriter() {
+    byte bits[] = new byte[512];
+    bits[0] = Key.VEC;
+    AppendableVec vec = new AppendableVec(Key.<Vec>make(bits), Vec.T_NUM);
+    return new FVecParseWriter(
+            Vec.VectorGroup.VG_LEN1,
+            1,
+            new Categorical[1],
+            new byte[]{Vec.T_NUM},
+            1,
+            new AppendableVec[]{vec}
+    );
+  }
+
 }


### PR DESCRIPTION
Affects binary parsers: Parquet, ORC and Avro