### PR TITLE
PUBDEV-5832 - GBM/DRF tree API categorical levels compression (#2743)

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/TreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/TreeV3.java
@@ -36,4 +36,7 @@ public class TreeV3 extends SchemaV3<Iced, TreeV3> {
     @API(direction = API.Direction.OUTPUT, help = "Description of the tree's nodes")
     public String[] descriptions;
 
+    @API(direction = API.Direction.OUTPUT, help = "Categorical levels on the edge from the parent node")
+    public int[][] levels;
+
 }

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -141,7 +141,7 @@ h2o.getModel <- function(model_id) {
   else if (!(model_category %in% c("Unknown", "Binomial", "Multinomial", "Ordinal", "Regression", "Clustering", "AutoEncoder", "DimReduction", "WordEmbedding", "CoxPH")))
     stop(paste0("model_category, \"", model_category,"\", missing in the output"))
   Class <- paste0("H2O", model_category, "Model")
-  model <- json$output[!(names(json$output) %in% c("__meta", "names", "domains", "model_category"))]
+  model <- json$output[!(names(json$output) %in% c("__meta", "model_category"))]
   MetricsClass <- paste0("H2O", model_category, "Metrics")
   # setup the metrics objects inside of model...
   model$training_metrics   <- new(MetricsClass, algorithm=json$algo, on_train=TRUE, on_valid=FALSE, on_xval=FALSE, metrics=model$training_metrics)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3188,6 +3188,7 @@ h2o.deepfeatures <- function(object, data, layer) {
 #' @slot root_node_id An \code{integer} representing number of the root node (may differ from 0).
 #' @slot thresholds A \code{numeric} split thresholds. Split thresholds are not only related to numerical splits, but might be present in case of categorical split as well.
 #' @slot features A \code{character} with names of the feature/column used for the split.
+#' @slot levels A \code{character} representing categorical levels on split from parent's node belonging into this node. NULL for root node or non-categorical splits.
 #' @slot nas A \code{character} representing if NA values go to the left node or right node. May be NA if node is a leaf.
 #' @aliases H2OTree
 #' @export
@@ -3203,8 +3204,10 @@ setClass(
     root_node_id = "integer",
     thresholds = "numeric",
     features = "character",
+    levels = "list",
     nas = "character"
   )
+  
 )
 
 #' Fetchces a single tree of a H2O model. This function is intended to be used on Gradient Boosting Machine models or Distributed Random Forest models.
@@ -3214,7 +3217,7 @@ setClass(
 #' gbm.model = h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model")
 #' tree <-h2o.getModelTree(gbm.model, 1, 1);
 #'
-#' @param model Models with trees
+#' @param model Model with trees
 #' @param tree_number Number of the tree in the model to fetch, starting with 1
 #' @param tree_class Name of the class of the tree (if applicable). This value is ignored for regression and binomial response column, as there is only one tree built.
 #'                   As there is exactly one class per categorical level, name of tree's class equals to the corresponding categorical level of response column.
@@ -3243,7 +3246,7 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
     left_children = res$left_children,
     right_children = res$right_children,
     descriptions = res$descriptions,
-    model_id = res$model$name,
+    model_id = model@model_id,
     tree_number = as.integer(res$tree_number + 1),
     root_node_id = res$root_node_id,
     thresholds = res$thresholds,
@@ -3253,6 +3256,55 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
   
   if(!is.null(res$tree_class)){
     tree@tree_class <- res$tree_class
+  }
+  
+  if(is.logical(res$levels)){ # Vector of NAs is recognized as logical type in R
+    tree@levels <- rep(list(NULL), length(res$levels))
+  } else {
+    tree@levels <- res$levels
+  }
+  
+  for (i in 1:length(tree@levels)){
+    if(!is.null(tree@levels[[i]])){
+    tree@levels[[i]] <- tree@levels[[i]] + 1
+    }
+  }
+  
+  # Convert numerical categorical levels to characters
+  pointer <-as.integer(1);
+  for(i in 1:length(tree@left_children)){
+
+    right <- tree@right_children[i];
+    left <- tree@left_children[i]
+    split_column_cat_index <- match(tree@features[i], model@model$names) # Indexof split column on children's parent node
+    if(is.na(split_column_cat_index)){ # If the split is not categorical, just increment & continue
+      if(right != -1) pointer <- pointer + 1;
+      if(left != -1) pointer <- pointer + 1;
+      next
+    }
+    split_column_domain <- model@model$domains[[split_column_cat_index]]
+    
+    # Left child node's levels converted to characters
+    left_char_categoricals <- c()
+    if(left != -1)  {
+      pointer <- pointer + 1;
+      
+      if(!is.null(tree@levels[[pointer]])){
+        for(level_index in 1:length(tree@levels[[pointer]])){
+          left_char_categoricals[level_index] <- split_column_domain[tree@levels[[pointer]][level_index]]
+        }
+        tree@levels[[pointer]] <- left_char_categoricals;
+      }
+    }
+    
+    # Right child node's levels converted to characters, if there is any
+    if(right != -1)  {
+      pointer <- pointer + 1;
+      if(!is.null(tree@levels[[pointer]])){
+        right_char_categoricals <-setdiff(split_column_domain, left_char_categoricals)
+        tree@levels[[pointer]] <- right_char_categoricals
+      }
+    }
   }
   
   tree

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
@@ -5,7 +5,7 @@ source("../../scripts/h2o-r-test-setup.R")
 
 test.gbm.trees <- function() {
   airlines.data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
-  gbm.model = h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
+  gbm.model <- h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   gbm.tree <-h2o.getModelTree(gbm.model, 1, "NO") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(gbm.tree)[1])
@@ -15,14 +15,17 @@ test.gbm.trees <- function() {
   expect_equal("character", class(gbm.tree@features)[1])
   expect_equal("character", class(gbm.tree@nas)[1])
   expect_equal("character", class(gbm.tree@descriptions)[1])
-  expect_equal("character", class(gbm.tree@model_id)[1])
   expect_equal("integer", class(gbm.tree@tree_number)[1])
   expect_equal("character", class(gbm.tree@tree_class)[1])
   expect_equal("integer", class(gbm.tree@root_node_id)[1])
+  expect_equal("list", class(gbm.tree@levels)[1])
   
   expect_equal(length(gbm.tree@left_children)[1], length(gbm.tree@right_children)[1])
   expect_true(is.na(match(0, gbm.tree@left_children)[1])) # There are no zeros in the list of nodes
   expect_true(is.na(match(0, gbm.tree@right_children)[1])) # There are no zeros in the list of nodes
+  expect_true(is.null(gbm.tree@levels[[1]])) # Root node has no categorical splits
+  expect_equal(length(gbm.tree@left_children), length(gbm.tree@levels))
+  expect_true(!is.null(gbm.tree@model_id))
   
   totalLength <- length(gbm.tree@left_children)
   expect_equal(totalLength, length(gbm.tree@descriptions))
@@ -50,20 +53,23 @@ test.gbm.trees <- function() {
   expect_equal("character", class(drf.tree@features)[1])
   expect_equal("character", class(drf.tree@nas)[1])
   expect_equal("character", class(drf.tree@descriptions)[1])
-  expect_equal("character", class(drf.tree@model_id)[1])
   expect_equal("integer", class(drf.tree@tree_number)[1])
   expect_equal("character", class(drf.tree@tree_class)[1]) # The value must be properly filled by the backend, even if unspecified
   expect_equal("integer", class(drf.tree@root_node_id)[1])
+  expect_equal("list", class(drf.tree@levels)[1])
   
   expect_equal(length(drf.tree@left_children)[1], length(drf.tree@right_children)[1])
   expect_true(is.na(match(0, drf.tree@left_children)[1])) # There are no zeros in the list of nodes
   expect_true(is.na(match(0, drf.tree@right_children)[1])) # There are no zeros in the list of nodes
+  expect_true(is.null(drf.tree@levels[[1]])) # Root node has no categorical splits
+  expect_equal(length(drf.tree@left_children), length(drf.tree@levels))
   
   totalLength <- length(drf.tree@left_children)
   expect_equal(totalLength, length(drf.tree@descriptions))
   expect_equal(totalLength, length(drf.tree@thresholds))
   expect_equal(totalLength, length(drf.tree@nas))
   expect_equal(totalLength, length(drf.tree@features))
+  expect_true(!is.null(drf.tree@model_id))
   
   # All descriptions must be non-empty
   for (description in drf.tree@descriptions) {
@@ -81,7 +87,7 @@ test.gbm.trees <- function() {
   cars.data['cylinders'] <- h2o.asfactor(cars.data['cylinders'])
   multinomial.model = h2o.randomForest(x=c("power", "acceleration"),y="cylinders",training_frame=cars.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   multinomial.tree <-h2o.getModelTree(multinomial.model, 1, "4") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
-  
+
   expect_equal("H2OTree", class(multinomial.tree)[1])
   expect_equal("integer", class(multinomial.tree@left_children)[1])
   expect_equal("integer", class(multinomial.tree@right_children)[1])
@@ -89,14 +95,17 @@ test.gbm.trees <- function() {
   expect_equal("character", class(multinomial.tree@features)[1])
   expect_equal("character", class(multinomial.tree@nas)[1])
   expect_equal("character", class(multinomial.tree@descriptions)[1])
-  expect_equal("character", class(multinomial.tree@model_id)[1])
   expect_equal("integer", class(multinomial.tree@tree_number)[1])
   expect_equal("character", class(multinomial.tree@tree_class)[1]) # The value must be properly filled by the backend, even if unspecified
   expect_equal("integer", class(multinomial.tree@root_node_id)[1])
+  expect_equal("list", class(multinomial.tree@levels)[1])
   
   expect_equal(length(multinomial.tree@left_children)[1], length(multinomial.tree@right_children)[1])
   expect_true(is.na(match(0, multinomial.tree@left_children)[1])) # There are no zeros in the list of nodes
   expect_true(is.na(match(0, multinomial.tree@right_children)[1])) # There are no zeros in the list of nodes
+  expect_true(is.null(multinomial.tree@levels[[1]])) # Root node has no categorical splits
+  expect_equal(length(multinomial.tree@left_children), length(multinomial.tree@levels))
+  expect_true(!is.null(multinomial.tree@model_id))
   
   totalLength <- length(multinomial.tree@left_children)
   expect_equal(totalLength, length(multinomial.tree@descriptions))
@@ -128,20 +137,23 @@ test.gbm.trees <- function() {
   expect_equal("character", class(regression.tree@features)[1])
   expect_equal("character", class(regression.tree@nas)[1])
   expect_equal("character", class(regression.tree@descriptions)[1])
-  expect_equal("character", class(regression.tree@model_id)[1])
   expect_equal("integer", class(regression.tree@tree_number)[1])
   expect_equal("character", class(regression.tree@tree_class)[1])
   expect_equal("integer", class(regression.tree@root_node_id)[1])
+  expect_equal("list", class(regression.tree@levels)[1])
   
   expect_equal(length(regression.tree@left_children)[1], length(regression.tree@right_children)[1])
   expect_true(is.na(match(0, regression.tree@left_children)[1])) # There are no zeros in the list of nodes
   expect_true(is.na(match(0, regression.tree@right_children)[1])) # There are no zeros in the list of nodes
+  expect_true(!is.null(multinomial.tree@model_id))
   
   totalLength <- length(regression.tree@left_children)
   expect_equal(totalLength, length(regression.tree@descriptions))
   expect_equal(totalLength, length(regression.tree@thresholds))
   expect_equal(totalLength, length(regression.tree@nas))
   expect_equal(totalLength, length(regression.tree@features))
+  expect_true(is.null(regression.tree@levels[[1]])) # Root node has no categorical splits
+  expect_equal(length(regression.tree@left_children), length(regression.tree@levels))
   
   # All descriptions must be non-empty
   for (description in regression.tree@descriptions) {


### PR DESCRIPTION
* PUBDEV-5832 - GBM/DRF tree API categorical levels compression

* Added documentation for levels array in R tree API

* Moved column names and column domaines exposed in H2OModel R class into common field columns.

* Added presence of filled categorical levels to the tree traversal structure test.

* An empty array of levels is recognized as a vector of logicals by R. This case needs to be handled explicitely.

* Fixed a typo in tree fetch demo

* Renamed columns variable on model in R API to var.names

* Not storing whole for GBM/DRF tree structure, storing the id instead

* Removed unused ArrayUtils in TreeHandler

* Model categorical domains & column names are not explicitely added to the Model R class, they're just not excluded.

* Only left-side categorical levels are sent by Tree API to the client. Rest is in the model.