### PR TITLE
PUBDEV-5803 fixed bug in setting http headers

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -205,7 +205,7 @@
     if(!autoML){
       header['Expect'] = ''
     }else{
-      header = "Content-Type: application/json"
+      header["Content-Type"] <- "application/json"
     }
     tmp = tryCatch(curlPerform(url = URLencode(url),
                                postfields = postBody,


### PR DESCRIPTION
Assigning whole header array discards any previously prepared headers.
I think the diff is pretty self-explanatory.

After this fix, the call to automl fails with following exception:

```
ERROR: Unexpected HTTP Status code: 400 Bad Request (url = https://steam.0xdata.loc:9999/ondrej_pk-test/99/AutoMLBuilder)

java.lang.IllegalArgumentException
 [1] "java.lang.IllegalArgumentException: Field not found: 'keep_cross_validation_fold_assignment' on object water.automl.api.schemas3.AutoMLBuildSpecV99$AutoMLBuildControlV99@277213f4"
 [2] "    water.util.PojoUtils.fillFromMap(PojoUtils.java:653)"                                                                                                                          
 [3] "    water.util.PojoUtils.fillFromMap(PojoUtils.java:623)"                                                                                                                          
 [4] "    water.util.PojoUtils.fillFromJson(PojoUtils.java:603)"                                                                                                                         
 [5] "    water.api.Handler.handle(Handler.java:56)"                                                                                                                                     
 [6] "    water.automl.api.AutoMLBuilderHandler.handle(AutoMLBuilderHandler.java:25)"                                                                                                    
 [7] "    water.api.RequestServer.serve(RequestServer.java:451)"                                                                                                                         
 [8] "    water.api.RequestServer.doGeneric(RequestServer.java:296)"                                                                                                                     
 [9] "    water.api.RequestServer.doPost(RequestServer.java:222)"                                                                                                                        
[10] "    javax.servlet.http.HttpServlet.service(HttpServlet.java:727)"                                                                                                           
...
```

but it's a different problem, which can be handled in a separate PR and probably also separate JIRA.
Chances are that it is due to a missing/incorrect parameter.