### PR TITLE
PUBDEV-5803 fixed bug in setting http headers

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -205,7 +205,7 @@
     if(!autoML){
       header['Expect'] = ''
     }else{
-      header = "Content-Type: application/json"
+      header["Content-Type"] <- "application/json"
     }
     tmp = tryCatch(curlPerform(url = URLencode(url),
                                postfields = postBody,


### PR DESCRIPTION
Assigning whole header array discards any previously prepared headers.
This is rel-wright duplicate of PR #2757 .