### PR TITLE
PUBDEV-5838: Update solver documentation

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/solver.rst
+++ b/h2o-docs/src/product/data-science/algo-params/solver.rst
@@ -32,7 +32,7 @@ Below are some general guidelines to follow when specifying a solver.
 - L_BFGS works much better for L2-only multininomial and if you have too many active predictors. 
 - You must use IRLSM if you have p-values. 
 - IRLSM and COORDINATE_DESCENT share the same path (i.e., they both compute the same gram matrix), they just solve it differently.
-- Use COORDINATE_DESCENT if you have less than 5000 predictors and L1 penalty.
+- Use COORDINATE_DESCENT if you have less than 5000 predictors and L1 penalty and when ``family`` is not ``multinomial``. 
 - COORDINATE_DESCENT performs better when ``lambda_search`` is enabled. Also with bounds, it tends to get a higher accuracy.
 - Use GRADIENT_DESCENT_LH or GRADIENT_DESCENT_SQERR when ``family=ordinal``. With GRADIENT_DESCENT_LH, the model parameters are adjusted by minimizing the loss function; with GRADIENT_DESCENT_SQERR, the model parameters are adjusted using the loss function. 
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -519,7 +519,7 @@ In GLM, you can specify one of the following solvers:
 - IRLSM: Iteratively Reweighted Least Squares Method (default)
 - L_BFGS: Limited-memory Broyden-Fletcher-Goldfarb-Shanno algorithm
 - AUTO: Sets the solver based on given data and parameters.
-- COORDINATE_DESCENT: Coordinate Decent (experimental)
+- COORDINATE_DESCENT: Coordinate Decent (experimental, and not available when ``family=multinomial``)
 - COORDINATE_DESCENT_NAIVE: Coordinate Decent Naive (experimental)
 - GRADIENT_DESCENT_LH: Gradient Descent Likelihood (available for Ordinal family only; default for Ordinal family)
 - GRADIENT_DESCENT_SQERR: Gradient Descent Squared Error (available for Ordinal family only)
@@ -549,6 +549,7 @@ In addition to IRLSM and L-BFGS, H2O's GLM includes options for specifying Coord
 - Coordinate Descent is IRLSM with the covariance updates version of cyclical coordinate descent in the innermost loop. This version is faster when :math:`N > p` and :math:`p` ~ :math:`500`.
 - Coordinate Descent Naive is IRLSM with the naive updates version of cyclical coordinate descent in the innermost loop.
 - Coordinate Descent provides much better results if lambda search is enabled. Also, with bounds, it tends to get higher accuracy.
+- Coordinate Descent cannot be used with ``family=multinomial``. 
 
 Both of the above method are explained in the `glmnet paper <https://core.ac.uk/download/pdf/6287975.pdf>`__. 
 


### PR DESCRIPTION
- Coordinate Descent cannot be used when family=multinomial.