### PR TITLE
PUBDEV-5836: Doc update to Hive2 JDBC section

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -522,7 +522,7 @@
                 <p class="terminal" id="to_copy8">
                     pip install requests<br/>
                     pip install tabulate<br/>
-                    pip install colorama  # >=0.3.8<br/>
+                    pip install colorama>=0.3.8<br/>
                     pip install future
                 </p>
                 <p>At the command line, copy and paste these commands one line at a time:</p>

--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -67,19 +67,16 @@ Install in Python
 
 Run the following commands in a Terminal window to install H2O for Python. 
 
-1. Install dependencies (prepending with `sudo` if needed):
+1. Install dependencies (prepending with ``sudo`` if needed):
 
  ::
 
 	pip install requests
 	pip install tabulate
-	pip install colorama
+	pip install colorama>=0.3.8
 	pip install future
 
- **Notes**: 
-
- - The colorama version must be >=0.3.8.
- - These are the dependencies required to run H2O. A complete list of dependencies is maintained in the following file: `https://github.com/h2oai/h2o-3/blob/master/h2o-py/conda/h2o/meta.yaml <https://github.com/h2oai/h2o-3/blob/master/h2o-py/conda/h2o/meta.yaml>`__.
+ **Note**: These are the dependencies required to run H2O. A complete list of dependencies is maintained in the following file: `https://github.com/h2oai/h2o-3/blob/master/h2o-py/conda/h2o/meta.yaml <https://github.com/h2oai/h2o-3/blob/master/h2o-py/conda/h2o/meta.yaml>`__.
 
 2. Run the following command to remove any existing H2O module for Python.
 

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -286,8 +286,9 @@ H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O w
 
 **Notes**: 
 
-- H2O can only load data from Hive v2 due to a limited implementation of the JDBC interface by Hive in earlier versions.
-- This feature is still experimental. In addition, Hive2 support in H2O is not yet suitable for large datasets. 
+- H2O can only load data from Hive version 2.2.0 or greater due to a limited implementation of the JDBC interface by Hive in earlier versions.
+
+- This feature is still experimental. In addition, Hive2 support in H2O is not yet suitable for large datasets.
 
 A demo showing how to ingest data from Hive through the Hive v2 JDBC driver is available `here <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/hive_jdbc_driver/Hive.md>`__. The basic steps are described below. 
 

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -315,12 +315,12 @@ reference:
       - predict.H2OAutoML 
       - predict.H2OModel 
       - predict_leaf_node_assignment.H2OModel
-      - staged_predict_proba.H2OModel
       - print.H2OFrame 
       - print.H2OTable 
       - prostate
       - range.H2OFrame
       - show,H2OCoxPHModelSummary-method
+      - staged_predict_proba.H2OModel
       - str.H2OFrame
       - summary,H2OCoxPHModel-method
       - summary,H2OGrid-method


### PR DESCRIPTION
Noted that currently only Hive 2.2 is supported. Will update this when 2.1 support is added.
Driveby fixes:
- Fixed formatting for installing colorama in docs and on the download site.
- alphabetized new r function.