### PR TITLE
PUBDEV-5735 - Descriptions contain information about split on current node and heritage of its parent (master

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -185,6 +185,7 @@ public class TreeHandler extends Handler {
             nodeDescriptionBuilder.append(".");
         } else if (node.getParent().isBitset()) {
             nodeLevels = extractNodeLevels(node);
+            assert nodeLevels != null;
             nodeDescriptionBuilder.append(" Parent node split on column [");
             nodeDescriptionBuilder.append(node.getParent().getColName());
             nodeDescriptionBuilder.append("]. Inherited categorical levels from parent split: ");
@@ -262,7 +263,7 @@ public class TreeHandler extends Handler {
 
         if (rightChild != null) {
             nodeDescriptionBuilder.append(". Right child node (");
-            nodeDescriptionBuilder.append(leftChild.getNodeNumber());
+            nodeDescriptionBuilder.append(rightChild.getNodeNumber());
             nodeDescriptionBuilder.append(") inherits categorical levels: ");
 
             for (int nodeLevelsindex = 0; nodeLevelsindex < rightChildLevels.length; nodeLevelsindex++) {

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3307,10 +3307,13 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
     }
     
     # Right child node's levels converted to characters, if there is any
+    right_char_categoricals <- c()
     if(right != -1)  {
       pointer <- pointer + 1;
       if(!is.null(tree@levels[[pointer]])){
-        right_char_categoricals <-setdiff(split_column_domain, left_char_categoricals)
+        for(level_index in 1:length(tree@levels[[pointer]])){
+          right_char_categoricals[level_index] <- split_column_domain[tree@levels[[pointer]][level_index]]
+        }
         tree@levels[[pointer]] <- right_char_categoricals
       }
     }
@@ -3318,6 +3321,8 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
   
   tree
 }
+
+
 
 #' @export
 print.h2o.stackedEnsemble.summary <- function(x, ...) cat(x, sep = "\n")

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
@@ -34,10 +34,7 @@ test.gbm.trees <- function() {
   for (description in gbm.tree@descriptions) {
     expect_false(identical(description, ""))
   }
-  
-  # First node's description is root node
-  expect_equal("Root node", gbm.tree@descriptions[1])
-  
+
   expect_equal(1, gbm.tree@tree_number)
   expect_equal("NO", gbm.tree@tree_class)
   
@@ -75,9 +72,7 @@ test.gbm.trees <- function() {
   for (description in drf.tree@descriptions) {
     expect_false(identical(description, ""))
   }
-  
-  # First node's description is root node
-  expect_equal("Root node", drf.tree@descriptions[1])
+
   
   expect_equal(1, drf.tree@tree_number)
   expect_equal("NO", drf.tree@tree_class)
@@ -117,9 +112,7 @@ test.gbm.trees <- function() {
   for (description in multinomial.tree@descriptions) {
     expect_false(identical(description, ""))
   }
-  
-  # First node's description is root node
-  expect_equal("Root node", multinomial.tree@descriptions[1])
+
   
   expect_equal(1, multinomial.tree@tree_number)
   expect_equal("4", multinomial.tree@tree_class)
@@ -159,10 +152,7 @@ test.gbm.trees <- function() {
   for (description in regression.tree@descriptions) {
     expect_false(identical(description, ""))
   }
-  
-  # First node's description is root node
-  expect_equal("Root node", regression.tree@descriptions[1])
-  
+
   expect_equal(0, length(regression.tree@tree_class))
   
   expect_equal(1, regression.tree@tree_number)


### PR DESCRIPTION
Note there is one another bug fixed in this PR. Before, when the compression has been introduced, only the left categorical levels were sent. Levels of the other node were guessed by setdiff. This approach is **wrong**. Not the rest of the domain may always go to the other node. Because of earlier splits, some categorical levels may not even appear on this very node.

Temporarily, categorical levels are sent (still in the compressed format) for both nodes when the split is categorical. This is fixable on the client as well, yet the client code needs to be familiar with the path and exclude categorical levels that went elsewhere on the path. This is tightly coupled with tree walking mechanism, so I suggest to do this enhancement with rolling out the tree walker.