### PR TITLE
PUBDEV-5790 - H2O imports headers into first row of the dataframe (master)

### DIFF
--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5790.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5790.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+import csv
+import random
+import os
+import tempfile
+from tests import pyunit_utils
+
+#
+def csv_header_test():
+    components = []
+    for idx in range(704):
+        components.append('Field{idx}')
+
+    # 1000 columns
+    keys = list(set('_'.join(random.sample(components, 5)) for _ in range(1000)))
+
+    fieldnames = keys[:idx]
+    fd, temp_filename = tempfile.mkstemp()
+    try:
+        with open(temp_filename, 'w') as file_:
+            writer = csv.DictWriter(file_, fieldnames=fieldnames)
+            writer.writeheader()
+
+            # write 100 lines, resulting chunk size should be very small
+            for _ in range(100):
+                writer.writerow({k: 'Y' for k in fieldnames})
+
+        h2oframe = h2o.import_file(temp_filename, header=1)
+        pandas_df = h2oframe.as_data_frame()
+        first_line = pandas_df.iloc[0]
+
+        assert not any(first_line[k] == k for k in fieldnames)
+    finally:
+        os.remove(temp_filename)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(csv_header_test)
+else:
+    csv_header_test()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5790

Header scan is limited to first chunk during actual parse. But the header might be greater than chunk size.

Luckily, if the column headers are known from earlier phase (or supplied by the user), we may try to assume (number of characters + delimiters + possible quotes) the header length and provide the header matcher more bits.