### PR TITLE
PUBDEV-5855 - Error when parsing double quotations in a column (master)

### DIFF
--- a/h2o-core/src/main/java/water/parser/BufferedString.java
+++ b/h2o-core/src/main/java/water/parser/BufferedString.java
@@ -77,6 +77,10 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
      _len++;
    }
 
+   void removeChar(){
+     _len--;
+   }
+
    void addBuff(byte [] bits){
      byte [] buf = new byte[_len];
      int l1 = _buf.length- _off;
@@ -145,7 +149,7 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
     return set(buf, 0, buf.length);
   }
 
-  public final BufferedString set(byte[] buf, int off, int len) {
+  public BufferedString set(byte[] buf, int off, int len) {
     _buf = buf;
     _off = off;
     _len = len;

--- a/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
+++ b/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
@@ -1,0 +1,55 @@
+package water.parser;
+
+import java.util.Arrays;
+
+/**
+ * A schema over a string represented as an array of bytes.
+ * This schema enables characters to be skipped inside the string. unlike the basic {@link BufferedString}
+ * Skipped characters are not serialized by toString method.
+ */
+class CharSkippingBufferedString extends BufferedString {
+
+    private int[] _skipped;
+    private int _skippedWriteIndex;
+
+    public CharSkippingBufferedString() {
+        _skipped = new int[0];
+        _skippedWriteIndex = 0;
+    }
+
+    /**
+     * Marks a character in the backing array as skipped. Such character is no longer serialized when toString() method
+     * is called on this buffer.
+     *
+     * @param skippedCharIndex Index of the character in the backing array to skip
+     */
+    public final void skipIndex(int skippedCharIndex) {
+        super.addChar();
+        if (_skipped.length == 0 || _skipped[_skipped.length - 1] != -1) {
+            _skipped = Arrays.copyOf(_skipped, Math.max(_skipped.length + 1, 1));
+        }
+
+        _skipped[_skippedWriteIndex] = skippedCharIndex;
+        _skippedWriteIndex++;
+    }
+
+    @Override
+    public BufferedString set(byte[] buf, int off, int len) {
+        _skipped = new int[0];
+        _skippedWriteIndex = 0;
+        return super.set(buf, off, len);
+    }
+
+    @Override
+    public String toString() {
+        if(getBuffer() == null) return null;
+        StringBuilder stringBuilder = new StringBuilder(super.toString());
+        int nSkipped = 0;
+        for (int skippedChar : _skipped) {
+            skippedChar = skippedChar - getOffset() - nSkipped - 1;
+            stringBuilder.deleteCharAt(skippedChar);
+            nSkipped++;
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
+++ b/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
@@ -13,7 +13,7 @@ class CharSkippingBufferedString {
 
     private int[] _skipped;
     private int _skippedWriteIndex;
-    private BufferedString _bufferedString;
+    private final BufferedString _bufferedString;
 
     CharSkippingBufferedString() {
         _skipped = new int[0];
@@ -33,15 +33,12 @@ class CharSkippingBufferedString {
         return _bufferedString.getBuffer();
     }
 
-    protected int getOffset() {
-        return _bufferedString.getOffset();
-    }
-
     /**
-     * @return Length of the underlying chunk limited by offset and limit. Not subtracting skipped characters.
+     *
+     * @return
      */
-    protected int length() {
-        return _bufferedString.length();
+    protected boolean isOverflown(){
+       return  _bufferedString.getOffset() + _bufferedString.length() > _bufferedString.getBuffer().length;
     }
 
     protected void addBuff(final byte[] bits) {
@@ -87,10 +84,10 @@ class CharSkippingBufferedString {
      * @return An instance of {@link BufferedString} containing only bytes from the original window, without skipped bytes.
      */
     public BufferedString toBufferedString() {
-        byte[] buf = MemoryManager.malloc1(length() - _skipped.length); // Length of the buffer window minus skipped chars
+        byte[] buf = MemoryManager.malloc1(_bufferedString.length() - _skipped.length); // Length of the buffer window minus skipped chars
 
         int nSkipped = 0;
-        for (int i = getOffset(); i < getOffset() + length(); i++) {
+        for (int i = _bufferedString.getOffset(); i < _bufferedString.getOffset() + _bufferedString.length(); i++) {
 
             if (Arrays.binarySearch(_skipped, i) >= 0) {
                 nSkipped++;
@@ -98,7 +95,7 @@ class CharSkippingBufferedString {
             }
 
             final byte character = getBuffer()[i];
-            buf[i - getOffset() - nSkipped] = character;
+            buf[i - _bufferedString.getOffset() - nSkipped] = character;
         }
 
         return new BufferedString(buf, 0, buf.length);

--- a/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
+++ b/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
@@ -35,7 +35,7 @@ class CharSkippingBufferedString {
 
     /**
      *
-     * @return
+     * @return True if offset plus limit exceed the length of the underlying buffer. Otherwise false.
      */
     protected boolean isOverflown(){
        return  _bufferedString.getOffset() + _bufferedString.length() > _bufferedString.getBuffer().length;

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -100,7 +100,8 @@ MAIN_LOOP:
           continue MAIN_LOOP;
         // ---------------------------------------------------------------------
         case STRING:
-          if (c == quotes) {
+          final byte nextByte = offset + 1 < bits.length ? bits[offset + 1] : -1;
+          if (c == quotes && (isEOL(nextByte) || _setup._separator == nextByte || offset == bits.length - 1)) {
             if (quoteCount>1) {
               str.addChar();
               quoteCount--;

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -148,11 +148,11 @@ MAIN_LOOP:
             str.addBuff(bits);
           }
           if( !isNa &&
-              _setup.isNA(colIdx, str)) {
+              _setup.isNA(colIdx, str.toBufferedString())) {
             isNa = true;
           }
           if (!isNa) {
-            dout.addStrCol(colIdx, str);
+            dout.addStrCol(colIdx, str.toBufferedString());
             if (!isAllASCII)
               dout.setIsAllASCII(colIdx, isAllASCII);
           } else {

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -143,7 +143,7 @@ MAIN_LOOP:
           if ((c != CHAR_SEPARATOR) && (c == CHAR_SPACE))
             break;
           // we have parsed the string categorical correctly
-          if((str.getOffset() + str.length()) > str.getBuffer().length){ // crossing chunk boundary
+          if(str.isOverflown()){ // crossing chunk boundary
             assert str.getBuffer() != bits;
             str.addBuff(bits);
           }

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -241,7 +241,7 @@ public abstract class Parser extends Iced {
     }
 
     @Override
-    public int getChunkDataStart(int cidx) {return  _off;}
+    public int getChunkDataStart(int cidx) {return -1;}
 
     @Override
     public void setChunkDataStart(int cidx, int offset) {

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -241,7 +241,7 @@ public abstract class Parser extends Iced {
     }
 
     @Override
-    public int getChunkDataStart(int cidx) {return -1;}
+    public int getChunkDataStart(int cidx) {return  _off;}
 
     @Override
     public void setChunkDataStart(int cidx, int offset) {

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -59,6 +59,7 @@ public abstract class Parser extends Iced {
   protected static final byte POSSIBLE_EMPTY_LINE = 19;
   protected static final byte POSSIBLE_CURRENCY = 20;
   protected static final byte HASHTAG = 35;
+  protected static final byte POSSIBLE_ESCAPED_QUOTE = 36;
 
   protected final byte CHAR_DECIMAL_SEP = '.';
   protected final byte CHAR_SEPARATOR;

--- a/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
+++ b/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
@@ -22,8 +22,6 @@ public class CharSkippingBufferedStringTest {
         charSkippingBufferedString.skipIndex(bytes.length - 1);
 
         assertNotNull(charSkippingBufferedString.getBuffer());
-        assertEquals(4, charSkippingBufferedString.length());
-        assertEquals(0, charSkippingBufferedString.getOffset());
 
         final BufferedString bufferedString = charSkippingBufferedString.toBufferedString();
         assertNotNull(bufferedString.getBuffer());
@@ -34,20 +32,31 @@ public class CharSkippingBufferedStringTest {
     }
 
     @Test
-    public void removeChar() {
-        final byte[] bytes = "abcd".getBytes();
-        charSkippingBufferedString.set(bytes,0, bytes.length);
-        assertEquals(4, charSkippingBufferedString.length());
+    public void toBufferedString_nonZeroOffset() {
+        final byte[] bytes = "abcdefgh".getBytes();
+        charSkippingBufferedString.set(bytes,4, 0);
+        charSkippingBufferedString.skipIndex(4);
+        charSkippingBufferedString.addChar();
+        charSkippingBufferedString.addChar();
+        charSkippingBufferedString.addChar();
 
-        charSkippingBufferedString.removeChar();
-        assertEquals(3, charSkippingBufferedString.length());
+        assertNotNull(charSkippingBufferedString.getBuffer());
+
+        final BufferedString bufferedString = charSkippingBufferedString.toBufferedString();
+        assertNotNull(bufferedString.getBuffer());
+        assertEquals(3, bufferedString.length());
+        assertEquals(0, bufferedString.getOffset());
+
+        assertEquals("fgh", bufferedString.toString());
     }
 
     @Test
-    public void getOffset() {
+    public void removeChar() {
         final byte[] bytes = "abcd".getBytes();
-        charSkippingBufferedString.set(bytes,1, bytes.length);
-        assertEquals(1, charSkippingBufferedString.getOffset());
+        charSkippingBufferedString.set(bytes,0, bytes.length);
+
+        charSkippingBufferedString.removeChar();
+        assertEquals("abc", charSkippingBufferedString.toString());
     }
 
     @Test

--- a/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
+++ b/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
@@ -1,0 +1,78 @@
+package water.parser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CharSkippingBufferedStringTest {
+
+
+    private CharSkippingBufferedString charSkippingBufferedString;
+
+    @Before
+    public void setUp() {
+        charSkippingBufferedString = new CharSkippingBufferedString();
+    }
+
+    @Test
+    public void toBufferedString() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, bytes.length - 1);
+        charSkippingBufferedString.skipIndex(bytes.length - 1);
+
+        assertNotNull(charSkippingBufferedString.getBuffer());
+        assertEquals(4, charSkippingBufferedString.length());
+        assertEquals(0, charSkippingBufferedString.getOffset());
+
+        final BufferedString bufferedString = charSkippingBufferedString.toBufferedString();
+        assertNotNull(bufferedString.getBuffer());
+        assertEquals(3, bufferedString.length());
+        assertEquals(0, bufferedString.getOffset());
+
+        assertEquals("abc", bufferedString.toString());
+    }
+
+    @Test
+    public void removeChar() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, bytes.length);
+        assertEquals(4, charSkippingBufferedString.length());
+
+        charSkippingBufferedString.removeChar();
+        assertEquals(3, charSkippingBufferedString.length());
+    }
+
+    @Test
+    public void getOffset() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,1, bytes.length);
+        assertEquals(1, charSkippingBufferedString.getOffset());
+    }
+
+    @Test
+    public void addChar() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, 0);
+        charSkippingBufferedString.addChar();
+
+        assertEquals("a", charSkippingBufferedString.toString());
+    }
+
+    @Test
+    public void emptyStringBehavior() {
+        final byte[] bytes = "".getBytes();
+        charSkippingBufferedString.set(bytes,0, 0);
+        final String string = charSkippingBufferedString.toString();
+        assertNotNull(string);
+        assertTrue(string.isEmpty());
+    }
+
+    @Test
+    public void testToString() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, 0);
+
+        assertEquals(charSkippingBufferedString.toString(), charSkippingBufferedString.toBufferedString().toString());
+    }
+}

--- a/h2o-core/src/test/java/water/parser/CsvParserTest.java
+++ b/h2o-core/src/test/java/water/parser/CsvParserTest.java
@@ -2,6 +2,12 @@ package water.parser;
 
 import org.junit.Assert;
 import org.junit.Test;
+import water.fvec.Vec;
+import water.util.StringUtils;
+
+import java.util.StringTokenizer;
+
+import static org.junit.Assert.*;
 
 public class CsvParserTest {
 
@@ -11,9 +17,94 @@ public class CsvParserTest {
     byte delimiter = ',';
     // Japanese alphabet is represented as up to 3 bytes per character.
     String[] strings = CsvParser.determineTokens("'C1', 'C2', '契約状態1709'", delimiter, quoteType);
-    Assert.assertEquals(3, strings.length);
-    Assert.assertEquals("C1", strings[0]);
-    Assert.assertEquals("C2", strings[1]);
-    Assert.assertEquals("契約状態1709", strings[2]);
+    assertEquals(3, strings.length);
+    assertEquals("C1", strings[0]);
+    assertEquals("C2", strings[1]);
+    assertEquals("契約状態1709", strings[2]);
   }
+
+  @Test
+  public void testParseMultipleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\")\"\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final ParseWriter outWriter = csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testRecognizeEOLWithoutQuote(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"IsDepDelayed","fYear","fMonth","fDayofMonth","fDayOfWeek","UniqueCarrier","Origin","Dest","Distance"};
+    parseSetup._number_columns = 9;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"YES\",\"f1987\",\"f10\",\"f14\",\"f3\",\"PS\",\"SAN\",\"SFO\",447\n" +
+            "\"NO\",\"f1987\",\"f10\",\"f18\",\"f7\",\"PS\",\"SAN\",\"SFO\",447"), 0); // first two lines of airlines training dataset
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(2, outWriter.lineNum());
+    assertEquals(0, outWriter._invalidLines);
+    assertFalse(outWriter.hasErrors());
+
+    for (int lineIndex = 1; lineIndex < 3; lineIndex++) {
+      for (int colIndex = 0; colIndex < parseSetup._number_columns; colIndex++) {
+        assertNotNull(outWriter._data[lineIndex][colIndex]);
+        assertFalse(outWriter._data[lineIndex][colIndex].isEmpty());
+      }
+    }
+
+  }
+
+  @Test
+  public void testParseTitanicTrain_multiple_qotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"PassengerId","Survived","Pclass","Name","Sex","Age","SibSp","Parch","Ticket","Fare","Cabin","Embarked"};
+    parseSetup._number_columns = 12;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final String parsedString = "102,0,3,\"Petroff, Mr. Pastcho (\"\"Pentcho\"\")\",male,,0,0,349215,7.8958,,S";
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf(parsedString), 0); // first two lines of airlines training dataset
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals(0, outWriter._invalidLines);
+    assertFalse(outWriter.hasErrors());
+
+    final StringTokenizer stringTokenizer = new StringTokenizer(parsedString, ",");
+
+    for (int lineIndex = 1; lineIndex < 2; lineIndex++) {
+      for (int colIndex = 0; colIndex < parseSetup._number_columns; colIndex++) {
+        assertNotNull(outWriter._data[lineIndex][colIndex]);
+        assertFalse(outWriter._data[lineIndex][colIndex].isEmpty());
+      }
+    }
+
+    //Make sure internal quotes are parsed well
+    assertEquals(12, outWriter._data[1].length);
+    assertEquals("NA", outWriter._data[1][5]);
+    assertEquals("NA", outWriter._data[1][10]);
+    assertEquals("Petroff, Mr. Pastcho (\"\"Pentcho\"\")", outWriter._data[1][3]);
+  }
+
 }

--- a/h2o-core/src/test/java/water/parser/CsvParserTest.java
+++ b/h2o-core/src/test/java/water/parser/CsvParserTest.java
@@ -24,7 +24,7 @@ public class CsvParserTest {
   }
 
   @Test
-  public void testParseMultipleQuotes(){
+  public void testParseEscapedDoubleQuotes(){
     ParseSetup parseSetup = new ParseSetup();
     parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
     parseSetup._check_header = ParseSetup.NO_HEADER;
@@ -32,13 +32,120 @@ public class CsvParserTest {
     parseSetup._column_types = new byte[]{Vec.T_STR};
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
-    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\")\"\""), 0);
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\"\"abcd\"\"\""), 0);
     final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
-    final ParseWriter outWriter = csvParser.parseChunk(0, byteAryData, parseWriter);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
 
     assertEquals(1, outWriter.lineNum());
+    assertEquals("\"abcd\"", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseEscapedSingleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = true;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("'''abcd'''"), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("'abcd'", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseDoubleEscapedSingleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = true;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("'''''abcd'''''"), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("''abcd''", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseEscapedMixedQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"'abcd'\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("'abcd'", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseDoubleEscapedDoubleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\"\"\"\"abcd\"\"\"\"\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("\"\"abcd\"\"", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testDelimiterInsideQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\",\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals(",", outWriter._data[1][0]);
     assertFalse(outWriter.hasErrors());
   }
 
@@ -54,7 +161,7 @@ public class CsvParserTest {
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"YES\",\"f1987\",\"f10\",\"f14\",\"f3\",\"PS\",\"SAN\",\"SFO\",447\n" +
-            "\"NO\",\"f1987\",\"f10\",\"f18\",\"f7\",\"PS\",\"SAN\",\"SFO\",447"), 0); // first two lines of airlines training dataset
+            "\"NO\",\"f1987\",\"f10\",\"f18\",\"f7\",\"PS\",\"SAN\",\"SFO\",448"), 0); // first two lines of airlines training dataset
     final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
     final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
 
@@ -72,7 +179,7 @@ public class CsvParserTest {
   }
 
   @Test
-  public void testParseTitanicTrain_multiple_qotes(){
+  public void tesParseMultipleQuotes_withDelimiterInside(){
     ParseSetup parseSetup = new ParseSetup();
     parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
     parseSetup._check_header = ParseSetup.NO_HEADER;
@@ -104,7 +211,50 @@ public class CsvParserTest {
     assertEquals(12, outWriter._data[1].length);
     assertEquals("NA", outWriter._data[1][5]);
     assertEquals("NA", outWriter._data[1][10]);
-    assertEquals("Petroff, Mr. Pastcho (\"\"Pentcho\"\")", outWriter._data[1][3]);
+    assertEquals("Petroff, Mr. Pastcho (\"Pentcho\")", outWriter._data[1][3]);
+  }
+
+  @Test
+  public void tesParseMultipleQuotes_withDelimiterInside_multiline(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"PassengerId","Survived","Pclass","Name","Sex","Age","SibSp","Parch","Ticket","Fare","Cabin","Embarked"};
+    parseSetup._number_columns = 12;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final String parsedString = "1,0,3,\"Braund, Mr. Owen Harris\",male,22,1,0,A/5 21171,7.25,,S\r\n"
+            + "2,1,1,\"Cumings, Mrs. John Bradley (Florence Briggs Thayer)\",female,38,1,0,PC 17599,71.2833,C85,C";
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf(parsedString), 0); // first two lines of airlines training dataset
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(2, outWriter.lineNum());
+    assertEquals(0, outWriter._invalidLines);
+    assertFalse(outWriter.hasErrors());
+
+    final StringTokenizer stringTokenizer = new StringTokenizer(parsedString, ",");
+
+    for (int lineIndex = 1; lineIndex < 3; lineIndex++) {
+      for (int colIndex = 0; colIndex < parseSetup._number_columns; colIndex++) {
+        assertNotNull(outWriter._data[lineIndex][colIndex]);
+        assertFalse(outWriter._data[lineIndex][colIndex].isEmpty());
+      }
+    }
+
+    //Make sure internal quotes are parsed well
+    assertEquals(12, outWriter._data[1].length);
+    assertEquals("A/5 21171", outWriter._data[1][8]);
+    assertEquals("NA", outWriter._data[1][10]);
+    assertEquals("Braund, Mr. Owen Harris", outWriter._data[1][3]);
+
+    //Make sure internal quotes are parsed well
+    assertEquals(12, outWriter._data[1].length);
+    assertEquals("PC 17599", outWriter._data[2][8]);
+    assertEquals("C85", outWriter._data[2][10]);
+    assertEquals("Cumings, Mrs. John Bradley (Florence Briggs Thayer)", outWriter._data[2][3]);
   }
 
 }

--- a/h2o-py/tests/testdir_parser/pyunit_csv_parser.py
+++ b/h2o-py/tests/testdir_parser/pyunit_csv_parser.py
@@ -1,0 +1,43 @@
+import h2o
+
+from tests import pyunit_utils
+
+
+def pyunit_csv_parser():
+    airlines_frame = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
+    assert airlines_frame.nrow == 24421 # 24,423 rows in total. Last row is empty, first one is header
+
+    airquality_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airquality_train1.csv"))
+    assert airquality_train.nrow == 77 # 79 rows in total. Last row is empty, first one is header
+
+    airquality_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airquality_train1.csv"))
+    assert airquality_train.nrow == 77 # 79 rows in total. Last row is empty, first one is header
+
+    cars_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/cars_train.csv"))
+    assert cars_train.nrow == 331 # 333 rows in total. Last row is empty, first one is header
+
+    higgs_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/higgs_train_5k.csv"))
+    assert higgs_train.nrow == 5000 # 5002 rows in total. Last row is empty, first one is header
+
+    housing_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/housing_train.csv"))
+    assert housing_train.nrow == 413 # 415 rows in total. Last row is empty, first one is header
+
+    insurance_gamma_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/insurance_gamma_dense_train.csv"))
+    assert insurance_gamma_train.nrow == 45 # 47 rows in total. Last row is empty, first one is header
+
+    iris_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/iris.csv"))
+    assert iris_train.nrow == 150 # 152 rows in total. Last row is empty, first one is header
+
+    agaricus_train = h2o.import_file(path=pyunit_utils.locate("smalldata/xgboost/demo/data/agaricus.txt.train"))
+    assert agaricus_train.nrow == 6513 # 6514 rows in total. Last row is empty, no header.
+
+    featmap = h2o.import_file(path=pyunit_utils.locate("smalldata/xgboost/demo/data/featmap.txt"))
+    assert featmap.nrow == 126 # 6514 rows in total. Last row is empty, no header.
+
+    diabetes_train = h2o.import_file(path=pyunit_utils.locate("smalldata/diabetes/diabetes_train.csv"))
+    assert diabetes_train.nrow == 50001 # 50,003 rows in total. Last row is empty, first one is header.
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pyunit_csv_parser)
+else:
+    pyunit_csv_parser()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5855

Started JUNIT testing of CSV parser. Tested the very case reported. The fix is general - there must be a separator or line terminator after a quote to end a string.

In the second commit, there is Python test parsing basic datasets. The test is very quick and gives us the certainty of basic CSV datasets being parsed with correct number of rows.