### PR TITLE
PUBDEV-5855 - Error when parsing double quotations in a column (rel-wright)

### DIFF
--- a/h2o-core/src/main/java/water/parser/BufferedString.java
+++ b/h2o-core/src/main/java/water/parser/BufferedString.java
@@ -17,9 +17,9 @@ import java.util.Formatter;
  * Warning: This data structure is not designed for parallel access!
  */
 public class BufferedString extends Iced implements Comparable<BufferedString> {
-   private byte [] _buf;
-   private int _off;
-   private int _len;
+   protected byte [] _buf;
+   protected int _off;
+   protected int _len;
 
    public BufferedString(byte[] buf, int off, int len) { 
      _buf = buf;  
@@ -75,6 +75,10 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
    // TODO(vlad): make sure that this method is not as destructive as it now is (see tests) 
    void addChar() {
      _len++;
+   }
+
+   void removeChar(){
+     _len--;
    }
 
    void addBuff(byte [] bits){
@@ -145,7 +149,7 @@ public class BufferedString extends Iced implements Comparable<BufferedString> {
     return set(buf, 0, buf.length);
   }
 
-  public final BufferedString set(byte[] buf, int off, int len) {
+  public BufferedString set(byte[] buf, int off, int len) {
     _buf = buf;
     _off = off;
     _len = len;

--- a/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
+++ b/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
@@ -91,21 +91,19 @@ class CharSkippingBufferedString {
         byte[] buf = MemoryManager.malloc1(_bufferedString._len - _skipped.length); // Length of the buffer window minus skipped chars
 
         int copyStart = _bufferedString._off;
-        int nSkipped = 0;
+        int target = 0;
         for (int skippedIndex : _skipped) {
             for (int i = copyStart; i < skippedIndex; i++) {
-                buf[i - _bufferedString._off - nSkipped] = _bufferedString._buf[i];
+                buf[target++] = _bufferedString._buf[i];
             }
-            nSkipped++;
-
-            copyStart = skippedIndex;
+            copyStart = skippedIndex + 1;
         }
 
-        int windowEnd = _bufferedString._off + _bufferedString._len - 1;
+        int windowEnd = _bufferedString._off + _bufferedString._len;
         for (int i = copyStart; i < windowEnd; i++) {
-            buf[i - _bufferedString._off - _skipped.length] = _bufferedString._buf[i];
+            buf[target++] = _bufferedString._buf[i];
         }
-
+        assert target == buf.length;
         return new BufferedString(buf, 0, buf.length);
     }
 

--- a/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
+++ b/h2o-core/src/main/java/water/parser/CharSkippingBufferedString.java
@@ -1,0 +1,119 @@
+package water.parser;
+
+import water.MemoryManager;
+import water.util.ArrayUtils;
+
+import java.util.Arrays;
+
+/**
+ * A schema over a string represented as an array of bytes.
+ * This schema enables characters to be skipped inside the string. unlike the basic {@link BufferedString}
+ * Skipped characters are not serialized by toString method.
+ */
+class CharSkippingBufferedString {
+
+    private int[] _skipped;
+    private int _skippedWriteIndex;
+    private final BufferedString _bufferedString;
+
+    CharSkippingBufferedString() {
+        _skipped = new int[0];
+        _skippedWriteIndex = 0;
+        _bufferedString = new BufferedString();
+    }
+
+    protected void addChar() {
+        _bufferedString.addChar();
+    }
+
+    protected void removeChar() {
+        _bufferedString.removeChar();
+    }
+
+    protected byte[] getBuffer() {
+        return _bufferedString.getBuffer();
+    }
+
+    /**
+     *
+     * @return True if offset plus limit exceed the length of the underlying buffer. Otherwise false.
+     */
+    protected boolean isOverflown(){
+       return  _bufferedString._off + _bufferedString._len > _bufferedString.getBuffer().length;
+    }
+
+    protected void addBuff(final byte[] bits) {
+        _bufferedString.addBuff(bits);
+        _skipped = new int[0];
+        _skippedWriteIndex = 0;
+    }
+
+    /**
+     * Marks a character in the backing array as skipped. Such character is no longer serialized when toString() method
+     * is called on this buffer.
+     *
+     * @param skippedCharIndex Index of the character in the backing array to skip
+     */
+    protected final void skipIndex(final int skippedCharIndex) {
+        _bufferedString.addChar();
+        if (_skipped.length == 0 || _skipped[_skipped.length - 1] != -1) {
+            _skipped = Arrays.copyOf(_skipped, Math.max(_skipped.length + 1, 1));
+        }
+
+        _skipped[_skippedWriteIndex] = skippedCharIndex;
+        _skippedWriteIndex++;
+    }
+
+    /**
+     * A delegate to the underlying {@link StringBuffer}'s set() method.
+     *
+     * @param buf Buffer to operate with
+     * @param off Beginning of the string (offset in the buffer)
+     * @param len Length of the string from the offset.
+     */
+    protected void set(final byte[] buf, final int off, final int len) {
+        _skipped = new int[0];
+        _skippedWriteIndex = 0;
+        _bufferedString.set(buf, off, len);
+    }
+
+    /**
+     * Converts the current window into byte buffer to a {@link BufferedString}. The resulting new instance of {@link BufferedString}
+     * is backed by a newly allocated byte[] buffer sized exactly to fit the desired string represented by current buffer window,
+     * excluding the skipped characters.
+     *
+     * @return An instance of {@link BufferedString} containing only bytes from the original window, without skipped bytes.
+     */
+    public BufferedString toBufferedString() {
+        if (_skipped.length == 0)
+            return _bufferedString;
+
+        byte[] buf = MemoryManager.malloc1(_bufferedString._len - _skipped.length); // Length of the buffer window minus skipped chars
+
+        int copyStart = _bufferedString._off;
+        int nSkipped = 0;
+        for (int skippedIndex : _skipped) {
+            for (int i = copyStart; i < skippedIndex; i++) {
+                buf[i - _bufferedString._off - nSkipped] = _bufferedString._buf[i];
+            }
+            nSkipped++;
+
+            copyStart = skippedIndex;
+        }
+
+        int windowEnd = _bufferedString._off + _bufferedString._len - 1;
+        for (int i = copyStart; i < windowEnd; i++) {
+            buf[i - _bufferedString._off - _skipped.length] = _bufferedString._buf[i];
+        }
+
+        return new BufferedString(buf, 0, buf.length);
+    }
+
+    /**
+     * @return A string representation of the buffer window, excluding skipped characters
+     */
+    @Override
+    public String toString() {
+        return toBufferedString().toString();
+    }
+}

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -24,7 +24,7 @@ class CsvParser extends Parser {
   // Parse this one Chunk (in parallel with other Chunks)
   @SuppressWarnings("fallthrough")
   @Override public ParseWriter parseChunk(int cidx, final ParseReader din, final ParseWriter dout) {
-    BufferedString str = new BufferedString();
+    CharSkippingBufferedString str = new CharSkippingBufferedString();
     byte[] bits = din.getChunkData(cidx);
     if( bits == null ) return dout;
     int offset  = din.getChunkDataStart(cidx); // General cursor into the giant array of bytes
@@ -50,6 +50,7 @@ class CsvParser extends Parser {
     int quotes = 0;
     byte quoteCount = 0;
     long number = 0;
+    int escaped = -1;
     int exp = 0;
     int sgnExp = 1;
     boolean decimal = false;
@@ -80,8 +81,8 @@ class CsvParser extends Parser {
     final boolean forceable = dout instanceof FVecParseWriter && ((FVecParseWriter)dout)._ctypes != null && _setup._column_types != null;
 MAIN_LOOP:
     while (true) {
-      boolean forcedCategorical = forceable && colIdx < _setup._column_types.length && _setup._column_types[colIdx] == Vec.T_CAT;
-      boolean forcedString = forceable && colIdx < _setup._column_types.length && _setup._column_types[colIdx] == Vec.T_STR;
+      final boolean forcedCategorical = forceable && colIdx < _setup._column_types.length && _setup._column_types[colIdx] == Vec.T_CAT;
+      final boolean forcedString = forceable && colIdx < _setup._column_types.length && _setup._column_types[colIdx] == Vec.T_STR;
 
       switch (state) {
         // ---------------------------------------------------------------------
@@ -99,6 +100,21 @@ MAIN_LOOP:
             break;
           continue MAIN_LOOP;
         // ---------------------------------------------------------------------
+        case POSSIBLE_ESCAPED_QUOTE:
+          if (c == quotes) {
+            quoteCount--;
+            str.skipIndex(offset);
+            state = STRING;
+            break;
+          } else if (quoteCount > 1) {
+            state = STRING_END;
+            str.removeChar();
+            quoteCount = 0;
+            continue MAIN_LOOP;
+          } else {
+            state = STRING;
+          }
+
         case STRING:
           if (c == quotes) {
             if (quoteCount>1) {
@@ -107,13 +123,18 @@ MAIN_LOOP:
             }
 
             state = COND_QUOTE;
-            break;
+            continue MAIN_LOOP;
           }
-          if ((!isEOL(c) || quoteCount == 1) && ((quotes != 0) || (c != CHAR_SEPARATOR))) {
+          if ((!isEOL(c) || quoteCount == 1) && (c != CHAR_SEPARATOR)) {
             if (str.getBuffer() == null && isEOL(c)) str.set(bits, offset, 0);
             str.addChar();
             if ((c & 0x80) == 128) //value beyond std ASCII
               isAllASCII = false;
+            break;
+          }
+
+          if(quoteCount == 1){
+            str.addChar(); //Anything not enclosed properly by second quotes is considered to be part of the string
             break;
           }
           // fallthrough to STRING_END
@@ -122,16 +143,16 @@ MAIN_LOOP:
           if ((c != CHAR_SEPARATOR) && (c == CHAR_SPACE))
             break;
           // we have parsed the string categorical correctly
-          if((str.getOffset() + str.length()) > str.getBuffer().length){ // crossing chunk boundary
+          if(str.isOverflown()){ // crossing chunk boundary
             assert str.getBuffer() != bits;
             str.addBuff(bits);
           }
           if( !isNa &&
-              _setup.isNA(colIdx, str)) {
+              _setup.isNA(colIdx, str.toBufferedString())) {
             isNa = true;
           }
           if (!isNa) {
-            dout.addStrCol(colIdx, str);
+            dout.addStrCol(colIdx, str.toBufferedString());
             if (!isAllASCII)
               dout.setIsAllASCII(colIdx, isAllASCII);
           } else {
@@ -139,6 +160,7 @@ MAIN_LOOP:
             isNa = false;
           }
           str.set(null, 0, 0);
+          quotes = 0;
           isAllASCII = true;
           ++colIdx;
           state = SEPARATOR_OR_EOL;
@@ -154,16 +176,15 @@ MAIN_LOOP:
           // fallthrough to EOL
         // ---------------------------------------------------------------------
         case EOL:
-          if (quotes != 0 && quoteCount != 1) {
-            //System.err.println("Unmatched quote char " + ((char)quotes) + " " + (((str.length()+1) < offset && str.getOffset() > 0)?new String(Arrays.copyOfRange(bits,str.getOffset()-1,offset)):""));
+          if (quoteCount == 1) { //There may be a new line character inside quotes
+            state = STRING;
+            continue MAIN_LOOP;
+          } else if (quoteCount > 2) {
             String err = "Unmatched quote char " + ((char) quotes);
             dout.invalidLine(new ParseWriter.ParseErr(err, cidx, dout.lineNum(), offset + din.getGlobalByteOffset()));
             colIdx = 0;
             quotes = 0;
-          } else if (quoteCount == 1) {
-            state = STRING;
-            continue MAIN_LOOP;
-          }else if (colIdx != 0) {
+          } else if (colIdx != 0) {
             dout.newLine();
             colIdx = 0;
           }
@@ -217,7 +238,6 @@ MAIN_LOOP:
           state = TOKEN;
           if( CHAR_SEPARATOR!=HIVE_SEP && // Only allow quoting in CSV not Hive files
               ((_setup._single_quotes && c == CHAR_SINGLE_QUOTE) || (c == CHAR_DOUBLE_QUOTE))) {
-            assert (quotes == 0);
             quotes = c;
             quoteCount++;
             break;
@@ -411,8 +431,8 @@ MAIN_LOOP:
         case COND_QUOTE:
           if (c == quotes) {
             str.addChar();
-            state = STRING;
             quoteCount++;
+            state = POSSIBLE_ESCAPED_QUOTE;
             break;
           } else {
             quotes = 0;
@@ -459,8 +479,6 @@ MAIN_LOOP:
           break; // MAIN_LOOP; // when the first character we see is a line end
       }
       c = bits[offset];
-      if(isEOL(c) && state != COND_QUOTE && quotes != 0) // quoted string having newline character => fail the line!
-        state = EOL;
 
     } // end MAIN_LOOP
     if (colIdx == 0)

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -59,6 +59,7 @@ public abstract class Parser extends Iced {
   protected static final byte POSSIBLE_EMPTY_LINE = 19;
   protected static final byte POSSIBLE_CURRENCY = 20;
   protected static final byte HASHTAG = 35;
+  protected static final byte POSSIBLE_ESCAPED_QUOTE = 36;
 
   protected final byte CHAR_DECIMAL_SEP = '.';
   protected final byte CHAR_SEPARATOR;

--- a/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
+++ b/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
@@ -35,7 +35,26 @@ public class CharSkippingBufferedStringTest {
     public void toBufferedString_nonZeroOffset() {
         final byte[] bytes = "abcdefgh".getBytes();
         charSkippingBufferedString.set(bytes,4, 0);
-        charSkippingBufferedString.skipIndex(5);
+        charSkippingBufferedString.skipIndex(4);
+        charSkippingBufferedString.addChar();
+        charSkippingBufferedString.addChar();
+        charSkippingBufferedString.addChar();
+
+        assertNotNull(charSkippingBufferedString.getBuffer());
+
+        final BufferedString bufferedString = charSkippingBufferedString.toBufferedString();
+        assertNotNull(bufferedString.getBuffer());
+        assertEquals(3, bufferedString.length());
+        assertEquals(0, bufferedString.getOffset());
+
+        assertEquals("fgh", bufferedString.toString());
+    }
+
+    @Test
+    public void toBufferedString_skipFirst() {
+        final byte[] bytes = "efgh".getBytes();
+        charSkippingBufferedString.set(bytes,0, 0);
+        charSkippingBufferedString.skipIndex(0);
         charSkippingBufferedString.addChar();
         charSkippingBufferedString.addChar();
         charSkippingBufferedString.addChar();

--- a/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
+++ b/h2o-core/src/test/java/water/parser/CharSkippingBufferedStringTest.java
@@ -1,0 +1,87 @@
+package water.parser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CharSkippingBufferedStringTest {
+
+
+    private CharSkippingBufferedString charSkippingBufferedString;
+
+    @Before
+    public void setUp() {
+        charSkippingBufferedString = new CharSkippingBufferedString();
+    }
+
+    @Test
+    public void toBufferedString() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, bytes.length - 1);
+        charSkippingBufferedString.skipIndex(bytes.length - 1);
+
+        assertNotNull(charSkippingBufferedString.getBuffer());
+
+        final BufferedString bufferedString = charSkippingBufferedString.toBufferedString();
+        assertNotNull(bufferedString.getBuffer());
+        assertEquals(3, bufferedString.length());
+        assertEquals(0, bufferedString.getOffset());
+
+        assertEquals("abc", bufferedString.toString());
+    }
+
+    @Test
+    public void toBufferedString_nonZeroOffset() {
+        final byte[] bytes = "abcdefgh".getBytes();
+        charSkippingBufferedString.set(bytes,4, 0);
+        charSkippingBufferedString.skipIndex(5);
+        charSkippingBufferedString.addChar();
+        charSkippingBufferedString.addChar();
+        charSkippingBufferedString.addChar();
+
+        assertNotNull(charSkippingBufferedString.getBuffer());
+
+        final BufferedString bufferedString = charSkippingBufferedString.toBufferedString();
+        assertNotNull(bufferedString.getBuffer());
+        assertEquals(3, bufferedString.length());
+        assertEquals(0, bufferedString.getOffset());
+
+        assertEquals("fgh", bufferedString.toString());
+    }
+
+    @Test
+    public void removeChar() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, bytes.length);
+
+        charSkippingBufferedString.removeChar();
+        assertEquals("abc", charSkippingBufferedString.toString());
+    }
+
+    @Test
+    public void addChar() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, 0);
+        charSkippingBufferedString.addChar();
+
+        assertEquals("a", charSkippingBufferedString.toString());
+    }
+
+    @Test
+    public void emptyStringBehavior() {
+        final byte[] bytes = "".getBytes();
+        charSkippingBufferedString.set(bytes,0, 0);
+        final String string = charSkippingBufferedString.toString();
+        assertNotNull(string);
+        assertTrue(string.isEmpty());
+    }
+
+    @Test
+    public void testToString() {
+        final byte[] bytes = "abcd".getBytes();
+        charSkippingBufferedString.set(bytes,0, 0);
+
+        assertEquals(charSkippingBufferedString.toString(), charSkippingBufferedString.toBufferedString().toString());
+    }
+}

--- a/h2o-core/src/test/java/water/parser/CsvParserTest.java
+++ b/h2o-core/src/test/java/water/parser/CsvParserTest.java
@@ -2,6 +2,12 @@ package water.parser;
 
 import org.junit.Assert;
 import org.junit.Test;
+import water.fvec.Vec;
+import water.util.StringUtils;
+
+import java.util.StringTokenizer;
+
+import static org.junit.Assert.*;
 
 public class CsvParserTest {
 
@@ -11,9 +17,244 @@ public class CsvParserTest {
     byte delimiter = ',';
     // Japanese alphabet is represented as up to 3 bytes per character.
     String[] strings = CsvParser.determineTokens("'C1', 'C2', '契約状態1709'", delimiter, quoteType);
-    Assert.assertEquals(3, strings.length);
-    Assert.assertEquals("C1", strings[0]);
-    Assert.assertEquals("C2", strings[1]);
-    Assert.assertEquals("契約状態1709", strings[2]);
+    assertEquals(3, strings.length);
+    assertEquals("C1", strings[0]);
+    assertEquals("C2", strings[1]);
+    assertEquals("契約状態1709", strings[2]);
   }
+
+  @Test
+  public void testParseEscapedDoubleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\"\"abcd\"\"\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("\"abcd\"", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseEscapedSingleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = true;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("'''abcd'''"), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("'abcd'", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseDoubleEscapedSingleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = true;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("'''''abcd'''''"), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("''abcd''", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseEscapedMixedQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"'abcd'\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("'abcd'", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testParseDoubleEscapedDoubleQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\"\"\"\"abcd\"\"\"\"\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals("\"\"abcd\"\"", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testDelimiterInsideQuotes(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"Name"};
+    parseSetup._number_columns = 1;
+    parseSetup._single_quotes = false;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\",\""), 0);
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals(",", outWriter._data[1][0]);
+    assertFalse(outWriter.hasErrors());
+  }
+
+  @Test
+  public void testRecognizeEOLWithoutQuote(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"IsDepDelayed","fYear","fMonth","fDayofMonth","fDayOfWeek","UniqueCarrier","Origin","Dest","Distance"};
+    parseSetup._number_columns = 9;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"YES\",\"f1987\",\"f10\",\"f14\",\"f3\",\"PS\",\"SAN\",\"SFO\",447\n" +
+            "\"NO\",\"f1987\",\"f10\",\"f18\",\"f7\",\"PS\",\"SAN\",\"SFO\",448"), 0); // first two lines of airlines training dataset
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(2, outWriter.lineNum());
+    assertEquals(0, outWriter._invalidLines);
+    assertFalse(outWriter.hasErrors());
+
+    for (int lineIndex = 1; lineIndex < 3; lineIndex++) {
+      for (int colIndex = 0; colIndex < parseSetup._number_columns; colIndex++) {
+        assertNotNull(outWriter._data[lineIndex][colIndex]);
+        assertFalse(outWriter._data[lineIndex][colIndex].isEmpty());
+      }
+    }
+
+  }
+
+  @Test
+  public void tesParseMultipleQuotes_withDelimiterInside(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"PassengerId","Survived","Pclass","Name","Sex","Age","SibSp","Parch","Ticket","Fare","Cabin","Embarked"};
+    parseSetup._number_columns = 12;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final String parsedString = "102,0,3,\"Petroff, Mr. Pastcho (\"\"Pentcho\"\")\",male,,0,0,349215,7.8958,,S";
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf(parsedString), 0); // first two lines of airlines training dataset
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(1, outWriter.lineNum());
+    assertEquals(0, outWriter._invalidLines);
+    assertFalse(outWriter.hasErrors());
+
+    final StringTokenizer stringTokenizer = new StringTokenizer(parsedString, ",");
+
+    for (int lineIndex = 1; lineIndex < 2; lineIndex++) {
+      for (int colIndex = 0; colIndex < parseSetup._number_columns; colIndex++) {
+        assertNotNull(outWriter._data[lineIndex][colIndex]);
+        assertFalse(outWriter._data[lineIndex][colIndex].isEmpty());
+      }
+    }
+
+    //Make sure internal quotes are parsed well
+    assertEquals(12, outWriter._data[1].length);
+    assertEquals("NA", outWriter._data[1][5]);
+    assertEquals("NA", outWriter._data[1][10]);
+    assertEquals("Petroff, Mr. Pastcho (\"Pentcho\")", outWriter._data[1][3]);
+  }
+
+  @Test
+  public void tesParseMultipleQuotes_withDelimiterInside_multiline(){
+    ParseSetup parseSetup = new ParseSetup();
+    parseSetup._parse_type = DefaultParserProviders.CSV_INFO;
+    parseSetup._check_header = ParseSetup.NO_HEADER;
+    parseSetup._separator = ',';
+    parseSetup._column_types = new byte[]{Vec.T_STR};
+    parseSetup._column_names = new String[]{"PassengerId","Survived","Pclass","Name","Sex","Age","SibSp","Parch","Ticket","Fare","Cabin","Embarked"};
+    parseSetup._number_columns = 12;
+    CsvParser csvParser = new CsvParser(parseSetup, null);
+
+    final String parsedString = "1,0,3,\"Braund, Mr. Owen Harris\",male,22,1,0,A/5 21171,7.25,,S\r\n"
+            + "2,1,1,\"Cumings, Mrs. John Bradley (Florence Briggs Thayer)\",female,38,1,0,PC 17599,71.2833,C85,C";
+    final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf(parsedString), 0); // first two lines of airlines training dataset
+    final PreviewParseWriter parseWriter = new PreviewParseWriter(parseSetup._number_columns);
+    final PreviewParseWriter outWriter = (PreviewParseWriter) csvParser.parseChunk(0, byteAryData, parseWriter);
+
+    assertEquals(2, outWriter.lineNum());
+    assertEquals(0, outWriter._invalidLines);
+    assertFalse(outWriter.hasErrors());
+
+    final StringTokenizer stringTokenizer = new StringTokenizer(parsedString, ",");
+
+    for (int lineIndex = 1; lineIndex < 3; lineIndex++) {
+      for (int colIndex = 0; colIndex < parseSetup._number_columns; colIndex++) {
+        assertNotNull(outWriter._data[lineIndex][colIndex]);
+        assertFalse(outWriter._data[lineIndex][colIndex].isEmpty());
+      }
+    }
+
+    //Make sure internal quotes are parsed well
+    assertEquals(12, outWriter._data[1].length);
+    assertEquals("A/5 21171", outWriter._data[1][8]);
+    assertEquals("NA", outWriter._data[1][10]);
+    assertEquals("Braund, Mr. Owen Harris", outWriter._data[1][3]);
+
+    //Make sure internal quotes are parsed well
+    assertEquals(12, outWriter._data[1].length);
+    assertEquals("PC 17599", outWriter._data[2][8]);
+    assertEquals("C85", outWriter._data[2][10]);
+    assertEquals("Cumings, Mrs. John Bradley (Florence Briggs Thayer)", outWriter._data[2][3]);
+  }
+
 }

--- a/h2o-core/src/test/java/water/parser/ParserTest2.java
+++ b/h2o-core/src/test/java/water/parser/ParserTest2.java
@@ -116,7 +116,7 @@ public class ParserTest2 extends TestUtil {
      Vec[] vecs = fr.vecs();
      Assert.assertEquals(fr.numCols(),4);
      Assert.assertEquals(fr.numRows(), 3);
-     Assert.assertEquals("Feline says \"\"meh\"\".", vecs[2].atStr(str, 0).toString());
+     Assert.assertEquals("Feline says \"meh\".", vecs[2].atStr(str, 0).toString());
      fr.delete();
    }
    finally {

--- a/h2o-py/tests/testdir_parser/pyunit_csv_parser.py
+++ b/h2o-py/tests/testdir_parser/pyunit_csv_parser.py
@@ -1,0 +1,43 @@
+import h2o
+
+from tests import pyunit_utils
+
+
+def pyunit_csv_parser():
+    airlines_frame = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
+    assert airlines_frame.nrow == 24421 # 24,423 rows in total. Last row is empty, first one is header
+
+    airquality_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airquality_train1.csv"))
+    assert airquality_train.nrow == 77 # 79 rows in total. Last row is empty, first one is header
+
+    airquality_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airquality_train1.csv"))
+    assert airquality_train.nrow == 77 # 79 rows in total. Last row is empty, first one is header
+
+    cars_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/cars_train.csv"))
+    assert cars_train.nrow == 331 # 333 rows in total. Last row is empty, first one is header
+
+    higgs_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/higgs_train_5k.csv"))
+    assert higgs_train.nrow == 5000 # 5002 rows in total. Last row is empty, first one is header
+
+    housing_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/housing_train.csv"))
+    assert housing_train.nrow == 413 # 415 rows in total. Last row is empty, first one is header
+
+    insurance_gamma_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/insurance_gamma_dense_train.csv"))
+    assert insurance_gamma_train.nrow == 45 # 47 rows in total. Last row is empty, first one is header
+
+    iris_train = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/iris.csv"))
+    assert iris_train.nrow == 150 # 152 rows in total. Last row is empty, first one is header
+
+    agaricus_train = h2o.import_file(path=pyunit_utils.locate("smalldata/xgboost/demo/data/agaricus.txt.train"))
+    assert agaricus_train.nrow == 6513 # 6514 rows in total. Last row is empty, no header.
+
+    featmap = h2o.import_file(path=pyunit_utils.locate("smalldata/xgboost/demo/data/featmap.txt"))
+    assert featmap.nrow == 126 # 6514 rows in total. Last row is empty, no header.
+
+    diabetes_train = h2o.import_file(path=pyunit_utils.locate("smalldata/diabetes/diabetes_train.csv"))
+    assert diabetes_train.nrow == 50001 # 50,003 rows in total. Last row is empty, first one is header.
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pyunit_csv_parser)
+else:
+    pyunit_csv_parser()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5855

Started JUNIT testing of CSV parser. Tested the very case reported. The fix is general - there must be a separator or line terminator after a quote to end a string.

In the second commit, there is Python test parsing basic datasets. The test is very quick and gives us the certainty of basic CSV datasets being parsed with correct number of rows.