### PR TITLE
PUBDEV-5848: error when manipulating previous AutoML leaderboard after multiple runs

### DIFF
--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -325,7 +325,7 @@ h2o.getAutoML <- function(project_name) {
   automl_job <- .h2o.__remoteSend(h2oRestApiVersion = 99, method = "GET", page = paste0("AutoML/", project_name))
   leaderboard <- as.data.frame(automl_job["leaderboard_table"]$leaderboard_table)
   row.names(leaderboard) <- seq(nrow(leaderboard))
-  leaderboard <- as.h2o(leaderboard, paste(build_control$project_name, "leaderboard", sep="."))
+  leaderboard <- as.h2o(leaderboard, paste(project_name, "leaderboard", sep="."))
   leaderboard[,2:length(leaderboard)] <- as.numeric(leaderboard[,2:length(leaderboard)])
   leader <- h2o.getModel(automl_job$leaderboard$models[[1]]$name)
   project <- automl_job$project

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -249,7 +249,7 @@ h2o.automl <- function(x, y, training_frame,
   is_progress <- isTRUE(as.logical(.h2o.is_progress()))
   h2o.no_progress()
   leaderboard <- tryCatch(
-    as.h2o(leaderboard),
+    as.h2o(leaderboard, paste(build_control$project_name, "leaderboard", sep=".")),
     error = identity,
     finally = if (is_progress) h2o.show_progress()
   )
@@ -325,7 +325,7 @@ h2o.getAutoML <- function(project_name) {
   automl_job <- .h2o.__remoteSend(h2oRestApiVersion = 99, method = "GET", page = paste0("AutoML/", project_name))
   leaderboard <- as.data.frame(automl_job["leaderboard_table"]$leaderboard_table)
   row.names(leaderboard) <- seq(nrow(leaderboard))
-  leaderboard <- as.h2o(leaderboard)
+  leaderboard <- as.h2o(leaderboard, paste(build_control$project_name, "leaderboard", sep="."))
   leaderboard[,2:length(leaderboard)] <- as.numeric(leaderboard[,2:length(leaderboard)])
   leader <- h2o.getModel(automl_job$leaderboard$models[[1]]$name)
   project <- automl_job$project

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_multiple_runs.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_multiple_runs.R
@@ -22,7 +22,7 @@ automl.multiple_runs.test <- function() {
         seed = 1234,
         training_frame = train,
         validation_frame = test,
-        max_models = 10,
+        max_models = 3,
         project_name = "run_1.hex"
     )
 
@@ -30,10 +30,10 @@ automl.multiple_runs.test <- function() {
     test$Sepal.Length <- 1
     automl_2 <- h2o.automl(
         x = x, y = y,
-        seed = 1234,
+        seed = 4321,
         training_frame = train,
         validation_frame = test,
-        max_models = 10,
+        max_models = 3,
         project_name = "run_2.hex"
     )
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_multiple_runs.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_multiple_runs.R
@@ -1,0 +1,46 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+automl.multiple_runs.test <- function() {
+
+    # This test runs multiple automl projects,
+    # keeping a reference to each of them
+    # and tries to manipulate results from both previous and last runs, especially leaderboard
+    # ensuring that old references have not been overridden during last run.
+    # This checks an issue raised by PUBDEV-5848.
+
+    df <- as.h2o(iris)
+    splits <- h2o.splitFrame(df, seed = 1234)
+    train <- splits[[1]]
+    test <- splits[[2]]
+
+    ## Run First AutoML
+    y <- "Species"
+    x <- setdiff(colnames(train), y)
+    automl_1 <- h2o.automl(
+        x = x, y = y,
+        seed = 1234,
+        training_frame = train,
+        validation_frame = test,
+        max_models = 10,
+        project_name = "run_1.hex"
+    )
+
+    ## Run Second AutoML
+    test$Sepal.Length <- 1
+    automl_2 <- h2o.automl(
+        x = x, y = y,
+        seed = 1234,
+        training_frame = train,
+        validation_frame = test,
+        max_models = 10,
+        project_name = "run_2.hex"
+    )
+
+    expect_true(sum(automl_1@leaderboard$mean_per_class_error) > 0)
+    expect_true(sum(automl_2@leaderboard$mean_per_class_error) > 0)
+    expect_true(sum(automl_1@leaderboard$mean_per_class_error) != sum(automl_2@leaderboard$mean_per_class_error))
+
+}
+
+doTest("AutoML Multiple Runs Test", automl.multiple_runs.test)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5848
- R API: avoid naming conflicts when creating destination frame for automl leaderboard.