### PR TITLE
PUBDEV-5841: Properly dispose all XGBoost native memory

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1515,7 +1515,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     return bs._mb;
   }
 
-  protected class BigScore extends CMetricScoringTask<BigScore> {
+  protected class BigScore extends CMetricScoringTask<BigScore> implements BigScorePredict, BigScoreChunkPredict {
     final protected String[] _domain; // Prediction domain; union of test and train classes
     final protected int _npredcols;  // Number of columns in prediction; nclasses+1 - can be less than the prediction domain
     final double[] _mean;  // Column means of test frame
@@ -1523,6 +1523,8 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     final public boolean _hasWeights;
     final public boolean _makePreds;
     final public Job _j;
+
+    private transient BigScorePredict _localPredict;
 
     /** Output parameter: Metric builder */
     public ModelMetrics.MetricBuilder _mb;
@@ -1537,7 +1539,14 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       _hasWeights = testHasWeights;
     }
 
-    @Override public void map( Chunk chks[], NewChunk cpreds[] ) {
+    @Override
+    protected void setupLocal() {
+      super.setupLocal();
+      _localPredict = setupBigScorePredict(this);
+      assert _localPredict != null;
+    }
+
+    @Override public void map(Chunk chks[], NewChunk cpreds[] ) {
       if (isCancelled() || _j != null && _j.stop_requested()) return;
       Chunk weightsChunk = _hasWeights && _computeMetrics ? chks[_output.weightsIdx()] : null;
       Chunk offsetChunk = _output.hasOffset() ? chks[_output.offsetIdx()] : null;
@@ -1552,96 +1561,54 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
           actual = new float[chks.length];
       }
       int len = chks[0]._len;
-
-      try {
-        setupBigScorePredict();
-
-        if(!bulkBigScorePredict()) {
-          double [] tmp = new double[_output.nfeatures()];
-          double[] preds = _mb._work;  // Sized for the union of test and train classes
-          for (int row = 0; row < len; row++) {
-            double weight = weightsChunk != null ? weightsChunk.atd(row) : 1;
-            if (weight == 0) {
-              if (_makePreds) {
-                for (int c = 0; c < _npredcols; c++)  // Output predictions; sized for train only (excludes extra test classes)
-                  cpreds[c].addNum(0);
-              }
-              continue;
-            }
-            double offset = offsetChunk != null ? offsetChunk.atd(row) : 0;
-            double[] p = score0(chks, offset, row, tmp, preds);
-            if (_computeMetrics) {
-              if (isSupervised()) {
-                actual[0] = (float) responseChunk.atd(row);
-              } else {
-                for (int i = 0; i < actual.length; ++i)
-                  actual[i] = (float) data(chks, row, i);
-              }
-              _mb.perRow(preds, actual, weight, offset, Model.this);
-              // Handle custom metric
-              customMetricPerRow(preds, actual, weight, offset, Model.this);
-            }
+      try (BigScoreChunkPredict predict = _localPredict.initMap(_fr, chks)) {
+        double[] tmp = new double[_output.nfeatures()];
+        for (int row = 0; row < len; row++) {
+          double weight = weightsChunk != null ? weightsChunk.atd(row) : 1;
+          if (weight == 0) {
             if (_makePreds) {
               for (int c = 0; c < _npredcols; c++)  // Output predictions; sized for train only (excludes extra test classes)
-                cpreds[c].addNum(p[c]);
+                cpreds[c].addNum(0);
             }
+            continue;
           }
-        } else {
-          int[] indices = new int[len];
-          double[] offsets = offsetChunk != null ? new double[len] : null;
-          int nonZeroW = 0;
-          for (int row = 0; row < len; row++) {
-            double weight = getWeight(weightsChunk, row);
-            if (weight == 0) {
-              if (_makePreds) {
-                for (int c = 0; c < _npredcols; c++)  // Output predictions; sized for train only (excludes extra test classes)
-                  cpreds[c].addNum(0);
-              }
-              continue;
+          double offset = offsetChunk != null ? offsetChunk.atd(row) : 0;
+          double[] preds = predict.score0(chks, offset, row, tmp, _mb._work);
+          if (_computeMetrics) {
+            if (isSupervised()) {
+              actual[0] = (float) responseChunk.atd(row);
+            } else {
+              for (int i = 0; i < actual.length; ++i)
+                actual[i] = (float) data(chks, row, i);
             }
-            if(offsetChunk != null) {
-              offsets[nonZeroW] = getOffset(offsetChunk, row);
-            }
-            indices[nonZeroW++] = row;
+            _mb.perRow(preds, actual, weight, offset, Model.this);
+            // Handle custom metric
+            customMetricPerRow(preds, actual, weight, offset, Model.this);
           }
-
-          indices = Arrays.copyOf(indices, nonZeroW);
-
-          if(0 == nonZeroW) {
-            return;
-          }
-
-          double[][] bulkPreds = new double[nonZeroW][];
-          for(int i = 0; i < bulkPreds.length; i++) {
-            bulkPreds[i] = new double[_mb._work.length];
-          }
-          double[][] bulkTmp = new double[nonZeroW][];
-          for(int i = 0; i < bulkTmp.length; i++) {
-            bulkTmp[i] = new double[_output.nfeatures()];
-          }
-          double[][] p = score0(chks, offsets, indices, bulkTmp, bulkPreds);
-          for(int rowIdx = 0; rowIdx < indices.length; rowIdx++) {
-            int row = indices[rowIdx];
-            if (_computeMetrics) {
-              if (isSupervised()) {
-                actual[0] = (float) responseChunk.atd(row);
-              } else {
-                for (int i = 0; i < actual.length; ++i)
-                  actual[i] = (float) data(chks, row, i);
-              }
-              _mb.perRow(bulkPreds[rowIdx], actual, getWeight(weightsChunk, row), getOffset(offsetChunk, row), Model.this);
-            }
-            if (_makePreds) {
-              for (int c = 0; c < _npredcols; c++)  // Output predictions; sized for train only (excludes extra test classes)
-                cpreds[c].addNum(p[rowIdx][c]);
-            }
+          if (_makePreds) {
+            for (int c = 0; c < _npredcols; c++)  // Output predictions; sized for train only (excludes extra test classes)
+              cpreds[c].addNum(preds[c]);
           }
         }
-      } finally {
-        closeBigScorePredict();
       }
     }
-    @Override public void reduce( BigScore bs ) {
+
+    @Override
+    public double[] score0(Chunk[] chks, double offset, int row_in_chunk, double[] tmp, double[] preds) {
+      return Model.this.score0(chks, offset, row_in_chunk, tmp, preds);
+    }
+
+    @Override
+    public BigScoreChunkPredict initMap(final Frame fr, final Chunk[] chks) {
+      return this;
+    }
+
+    @Override
+    public void close() {
+      // nothing to do - meant to be overridden
+    }
+
+    @Override public void reduce(BigScore bs ) {
       super.reduce(bs);
       if (_mb != null) _mb.reduce(bs._mb);
     }
@@ -1652,20 +1619,19 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
         _mb.postGlobal(getComputedCustomMetric());
       }
     }
-
-    private double getOffset(Chunk offsetChunk, int row) {
-      return offsetChunk != null ? offsetChunk.atd(row) : 0;
-    }
-
-    private double getWeight(Chunk weightsChunk, int row) {
-      return weightsChunk != null ? weightsChunk.atd(row) : 1;
-    }
-
   }
 
-  protected boolean bulkBigScorePredict() { return false; }
-  protected void setupBigScorePredict() {}
-  protected void closeBigScorePredict() {}
+  protected interface BigScorePredict {
+    BigScoreChunkPredict initMap(final Frame fr, final Chunk chks[]);
+  }
+
+  protected interface BigScoreChunkPredict extends AutoCloseable {
+    double[] score0(Chunk chks[], double offset, int row_in_chunk, double[] tmp, double[] preds);
+    @Override
+    void close();
+  }
+
+  protected BigScorePredict setupBigScorePredict(BigScore bs) { return bs; };
 
   // OVerride this if your model needs data preprocessing (on the fly standardization, NA handling)
   protected double data(Chunk[] chks, int row, int col) {
@@ -1679,11 +1645,6 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
    *  subclass scoring logic. */
   public double[] score0( Chunk chks[], int row_in_chunk, double[] tmp, double[] preds ) {
     return score0(chks, 0, row_in_chunk, tmp, preds);
-  }
-
-  // To be implemented by Models that override bulkBigScorePredict() to return true
-  public double[][] score0( Chunk chks[], double[] offset, int[] rowsInChunk, double[][] tmp, double[][] preds ) {
-    throw new IllegalStateException("Not implemented.");
   }
 
   public double[] score0( Chunk chks[], double offset, int row_in_chunk, double[] tmp, double[] preds ) {

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -3,7 +3,6 @@ package hex.tree.xgboost;
 import hex.*;
 import hex.genmodel.utils.DistributionFamily;
 import hex.glm.GLMTask;
-import hex.tree.SharedTreeModel;
 import hex.tree.xgboost.rabit.RabitTrackerH2O;
 import ml.dmlc.xgboost4j.java.Booster;
 import ml.dmlc.xgboost4j.java.DMatrix;
@@ -17,10 +16,7 @@ import water.fvec.Vec;
 import water.util.*;
 import water.util.Timer;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.*;
 
 import static hex.tree.SharedTree.createModelSummaryTable;
@@ -295,6 +291,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
 
         // Create a "feature map" and store in a temporary file (for Variable Importance, MOJO, ...)
         DataInfo dataInfo = model.model_info()._dataInfoKey.get();
+        assert dataInfo != null;
         String featureMap = XGBoostUtils.makeFeatureMap(_train, dataInfo);
         model.model_info().setFeatureMap(featureMap);
         featureMapFile = createFeatureMapFile(featureMap);
@@ -302,13 +299,13 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
         BoosterParms boosterParms = XGBoostModel.createParams(_parms, model._output.nclasses());
 
         setupTask = new XGBoostSetupTask(model, _parms, boosterParms, getWorkerEnvs(rt), trainFrameNodes).run();
-
         try {
           // initial iteration
-          model.model_info().setBooster(new XGBoostUpdateTask(setupTask, 0).run().getBooster());
+          XGBoostUpdateTask nullModelTask = new XGBoostUpdateTask(setupTask, 0).run();
+          BoosterProvider boosterProvider = new BoosterProvider(model.model_info(), nullModelTask);
 
           // train the model
-          scoreAndBuildTrees(setupTask, model);
+          scoreAndBuildTrees(setupTask, boosterProvider, model);
 
           // shutdown rabit & XGB native resources
           XGBoostCleanupTask.cleanUp(setupTask);
@@ -318,10 +315,6 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
         } finally {
           rt.stop();
         }
-
-        // save the model to DKV
-        model.model_info().nativeToJava();
-        model._output._boosterBytes = model.model_info()._boosterBytes;
       } catch (XGBoostError xgBoostError) {
         xgBoostError.printStackTrace();
         throw new RuntimeException("XGBoost failure", xgBoostError);
@@ -388,9 +381,8 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
       }
     }
 
-    private void scoreAndBuildTrees(final XGBoostSetupTask setupTask, final XGBoostModel model) throws XGBoostError {
-      BoosterProvider boosterProvider = new BoosterProvider(model.model_info()); // initial model always has a Booster
-
+    private void scoreAndBuildTrees(final XGBoostSetupTask setupTask, final BoosterProvider boosterProvider,
+                                    final XGBoostModel model) throws XGBoostError {
       for( int tid=0; tid< _parms._ntrees; tid++) {
         // During first iteration model contains 0 trees, then 1-tree, ...
         boolean scored = doScoring(model, boosterProvider, false);
@@ -401,7 +393,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
 
         Timer kb_timer = new Timer();
         XGBoostUpdateTask t = new XGBoostUpdateTask(setupTask, tid).run();
-        boosterProvider = new OnDemandBoosterProvider(model.model_info(), t);
+        boosterProvider.reset(t);
         Log.info((tid + 1) + ". tree was built in " + kb_timer.toString());
         _job.update(1);
 
@@ -472,11 +464,25 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
               (timeToScore && _parms._score_tree_interval == 0) || // use time-based duty-cycle heuristic only if the user didn't specify _score_tree_interval
               manualInterval) {
         _timeLastScoreStart = now;
-        Booster booster = boosterProvider.getBooster();
-        model.doScoring(booster, _train, _parms.train(), _valid, _parms.valid());
+        boosterProvider.updateBooster(); // retrieve booster, expensive!
+        model.doScoring(_train, _parms.train(), _valid, _parms.valid());
         _timeLastScoreEnd = System.currentTimeMillis();
-        model.computeVarImp(booster.getFeatureScore(featureMapFile.getAbsolutePath()));
         XGBoostOutput out = model._output;
+        final Map<String, Integer> varimp;
+        Booster booster = null;
+        try {
+          booster = model.model_info().deserializeBooster();
+          varimp = BoosterHelper.doWithLocalRabit(new BoosterHelper.BoosterOp<Map<String, Integer>>() {
+            @Override
+            public Map<String, Integer> apply(Booster booster) throws XGBoostError {
+              return booster.getFeatureScore(featureMapFile.getAbsolutePath());
+            }
+          }, booster);
+        } finally {
+          if (booster != null)
+            BoosterHelper.dispose(booster);
+        }
+        out._varimp = model.computeVarImp(varimp);
         out._model_summary = createModelSummaryTable(out._ntrees, null);
         out._scoring_history = createScoringHistoryTable(out, model._output._scored_train, out._scored_valid, _job, out._training_time_ms, _parms._custom_metric_func != null);
         out._variable_importances = hex.ModelMetrics.calcVarImp(out._varimp);
@@ -489,42 +495,27 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     }
   }
 
-  private static class BoosterProvider {
-    final XGBoostModelInfo _modelInfo;
-
-    BoosterProvider(XGBoostModelInfo modelInfo) {
-      _modelInfo = modelInfo;
-    }
-
-    Booster getBooster() {
-      return _modelInfo.getBooster();
-    }
-  }
-
-  private static class OnDemandBoosterProvider extends BoosterProvider {
+  private static final class BoosterProvider {
+    XGBoostModelInfo _modelInfo;
     XGBoostUpdateTask _updateTask;
-    boolean _boosterRetrieved;
 
-    OnDemandBoosterProvider(XGBoostModelInfo modelInfo, XGBoostUpdateTask updateTask) {
-      super(modelInfo);
+    BoosterProvider(XGBoostModelInfo modelInfo, XGBoostUpdateTask updateTask) {
+      _modelInfo = modelInfo;
       _updateTask = updateTask;
-      _boosterRetrieved = false;
+      _modelInfo.setBoosterBytes(_updateTask.getBoosterBytes());
     }
 
-    Booster getBooster() {
-      if (! _boosterRetrieved) {
-        Booster booster = _updateTask.getBooster();
-        _modelInfo.setBooster(booster);
-        _boosterRetrieved = true;
-        _updateTask = null;
+    final void reset(XGBoostUpdateTask updateTask) {
+      _updateTask = updateTask;
+    }
+
+    final void updateBooster() {
+      if (_updateTask == null) {
+        throw new IllegalStateException("Booster can be retrieved only once!");
       }
-      return super.getBooster();
+      final byte[] boosterBytes = _updateTask.getBoosterBytes();
+      _modelInfo.setBoosterBytes(boosterBytes);
     }
-
-  }
-
-  private double effective_learning_rate(XGBoostModel model) {
-    return _parms._learn_rate * Math.pow(_parms._learn_rate_annealing, (model._output._ntrees-1));
   }
 
   private static Set<Integer> GPUS = new HashSet<>();

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -1,17 +1,13 @@
 package hex.tree.xgboost;
 
 import hex.*;
-import hex.genmodel.GenModel;
-import hex.genmodel.algos.xgboost.XGBoostMojoModel;
 import hex.genmodel.algos.xgboost.XGBoostNativeMojoModel;
 import hex.genmodel.utils.DistributionFamily;
-import ml.dmlc.xgboost4j.java.Booster;
-import ml.dmlc.xgboost4j.java.XGBoostError;
-import ml.dmlc.xgboost4j.java.XGBoostModelInfo;
-import ml.dmlc.xgboost4j.java.XGBoostScoreTask;
+import ml.dmlc.xgboost4j.java.*;
 import water.*;
 import water.fvec.Chunk;
 import water.fvec.Frame;
+import water.udf.CFuncRef;
 import water.util.Log;
 import hex.ModelMetrics;
 
@@ -155,7 +151,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
     final DataInfo dinfo = makeDataInfo(train, valid, _parms, output.nclasses());
     DKV.put(dinfo);
     setDataInfoToOutput(dinfo);
-    model_info = new XGBoostModelInfo(parms,output.nclasses());
+    model_info = new XGBoostModelInfo(parms);
     model_info._dataInfoKey = dinfo._key;
   }
 
@@ -310,11 +306,6 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
     return Integer.getInteger(H2O.OptArgs.SYSTEM_PROP_PREFIX + "xgboost.nthread", H2O.ARGS.nthreads);
   }
 
-  @Override
-  protected double[] score0(double[] data, double[] preds) {
-    return score0(data, preds, 0.0);
-  }
-
   @Override protected AutoBuffer writeAll_impl(AutoBuffer ab) {
     ab.putKey(model_info._dataInfoKey);
     return super.writeAll_impl(ab);
@@ -333,38 +324,33 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
   // Fast scoring using the C++ data structures
   // However, we need to bring the data back to Java to compute the metrics
   // For multinomial, we also need to transpose the data - which is slow
-  private ModelMetrics makeMetrics(Booster booster, Frame data, Frame originalData, String description) throws XGBoostError {
-    return makeMetrics(booster, data, originalData, description, null);
+  private ModelMetrics makeMetrics(Frame data, Frame originalData, String description) throws XGBoostError {
+    return makeMetrics(data, originalData, description, null);
   }
 
-  private ModelMetrics makeMetrics(Booster booster, Frame data, Frame originalData, String description, Key<Frame> predFrameKey) throws XGBoostError {
-    Futures fs = new Futures();
+  private ModelMetrics makeMetrics(Frame data, Frame originalData, String description, Key<Frame> predFrameKey) {
     ModelMetrics[] mms = new ModelMetrics[1];
-    Frame predictions = makePreds(booster,originalData, data, mms, true, predFrameKey, fs);
+    Frame predictions = makePreds(originalData, data, mms, true, predFrameKey);
     if (predFrameKey == null) {
-        predictions.remove(fs);
+        predictions.remove();
     } else {
-      DKV.put(predictions, fs);
+      DKV.put(predictions);
     }
-    fs.blockForPending();
-    ModelMetrics mm = mms[0];
-    return mm;
+    return mms[0];
   }
 
-  private Frame makePredsOnly(Booster booster, Frame data, Key<Frame> destinationKey) throws XGBoostError {
-    Futures fs = new Futures();
-    Frame preds = makePreds(booster,null, data, null, false, destinationKey, fs);
-    DKV.put(preds, fs);
-    fs.blockForPending();
+  private Frame makePredsOnly(Frame data, Key<Frame> destinationKey) {
+    Frame preds = makePreds(null, data, null, false, destinationKey);
+    DKV.put(preds);
     return preds;
   }
 
-  private Frame makePreds(Booster booster,Frame originalData, Frame data, ModelMetrics[] mms, boolean computeMetrics, Key<Frame> destinationKey, Futures fs) throws XGBoostError {
+  private Frame makePreds(Frame originalData, Frame data, ModelMetrics[] mms, boolean computeMetrics, Key<Frame> destinationKey) {
       assert (! computeMetrics) || (mms != null && mms.length == 1);
 
       XGBoostScoreTask.XGBoostScoreTaskResult score = XGBoostScoreTask.runScoreTask(
               model_info(), _output, _parms,
-              booster, destinationKey, data,
+              destinationKey, data,
               originalData,
               computeMetrics,
               this
@@ -378,28 +364,27 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
   /**
    * Score an XGBoost model on training and validation data (optional)
    * Note: every row is scored, all observation weights are assumed to be equal
-   * @param booster xgboost model
    * @param _train training data in the form of matrix
    * @param _valid validation data (optional, can be null)
    * @throws XGBoostError
    */
-  public void doScoring(Booster booster, Frame _train, Frame _trainOrig, Frame _valid, Frame _validOrig) throws XGBoostError {
-    ModelMetrics mm = makeMetrics(booster, _train, _trainOrig, "Metrics reported on training frame");
+  public void doScoring(Frame _train, Frame _trainOrig, Frame _valid, Frame _validOrig) throws XGBoostError {
+    ModelMetrics mm = makeMetrics(_train, _trainOrig, "Metrics reported on training frame");
     _output._training_metrics = mm;
     _output._scored_train[_output._ntrees].fillFrom(mm);
     addModelMetrics(mm);
     // Optional validation part
     if (_valid!=null) {
-      assert _valid != null : "Validation frame (source of validation matrix) has to be not null!";
-      mm = makeMetrics(booster, _valid, _validOrig, "Metrics reported on validation frame");
+      mm = makeMetrics(_valid, _validOrig, "Metrics reported on validation frame");
       _output._validation_metrics = mm;
       _output._scored_valid[_output._ntrees].fillFrom(mm);
       addModelMetrics(mm);
     }
   }
 
-  void computeVarImp(Map<String, Integer> varimp) {
-    if (varimp.isEmpty()) return;
+  VarImp computeVarImp(Map<String, Integer> varimp) {
+    if (varimp.isEmpty())
+      return null;
     // compute variable importance
     float[] viFloat = new float[varimp.size()];
     String[] names = new String[varimp.size()];
@@ -409,46 +394,35 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
       names[j] = it.getKey();
       j++;
     }
-    _output._varimp = new VarImp(viFloat, names);
+    return new VarImp(viFloat, names);
   }
 
   @Override
-  public double[] score0(double[] data, double[] preds, double offset) {
-    DataInfo di = model_info._dataInfoKey.get();
-    return XGBoostNativeMojoModel.score0(data, offset, preds,
-            model_info.getBooster(), di._nums, di._cats, di._catOffsets, di._useAllFactorLevels,
-            _output.nclasses(), _output._priorClassDist, defaultThreshold(), _output._sparse);
+  protected boolean needsPostProcess() {
+    return false; // scoring functions return final predictions
   }
 
   @Override
-  public double[][] score0( Chunk chks[], double[] offset, int[] rowsInChunk, double[][] tmp, double[][] preds ) {
-    for( int row=0; row < rowsInChunk.length; row++ ) {
-      for( int i=0; i< tmp[row].length; i++ ) {
-        tmp[row][i] = chks[i].atd(rowsInChunk[row]);
-      }
+  protected double[] score0(double[] data, double[] preds) {
+    return score0(data, preds, 0.0);
+  }
+
+  @Override // per row scoring will be slow and should be avoided!
+  public double[] score0(final double[] data, final double[] preds, final double offset) {
+    final DataInfo di = model_info._dataInfoKey.get();
+    assert di != null;
+    final double threshold = defaultThreshold();
+    Booster booster = null;
+    try {
+      booster = model_info.deserializeBooster();
+      return XGBoostNativeMojoModel.score0(data, offset, preds,
+              model_info.deserializeBooster(), di._nums, di._cats, di._catOffsets, di._useAllFactorLevels,
+              _output.nclasses(), _output._priorClassDist, threshold, _output._sparse);
+    } finally {
+      if (booster != null)
+        BoosterHelper.dispose(booster);
     }
-    DataInfo di = model_info._dataInfoKey.get();
-    double[][] scored = XGBoostNativeMojoModel.bulkScore0(tmp, offset, preds,
-            model_info.getBooster(), di._nums, di._cats, di._catOffsets, di._useAllFactorLevels,
-            _output.nclasses(), _output._priorClassDist, defaultThreshold(), _output._sparse);
-
-    if(isSupervised()) {
-      // Correct probabilities obtained from training on oversampled data back to original distribution
-      // C.f. http://gking.harvard.edu/files/0s.pdf Eq.(27)
-      if( _output.isClassifier()) {
-        for( int row=0; row < rowsInChunk.length; row++ ) {
-          if (_parms._balance_classes)
-            GenModel.correctProbabilities(scored[row], _output._priorClassDist, _output._modelClassDist);
-          //assign label at the very end (after potentially correcting probabilities)
-          scored[row][0] = hex.genmodel.GenModel.getPrediction(scored[row], _output._priorClassDist, tmp[row], defaultThreshold());
-        }
-      }
-    }
-    return scored;
   }
-
-  @Override
-  protected boolean bulkBigScorePredict() { return false; }
 
   private void setDataInfoToOutput(DataInfo dinfo) {
     _output._names = dinfo._adaptedFrame.names();
@@ -463,33 +437,27 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
 
   @Override
   protected Futures remove_impl(Futures fs) {
-    model_info().nukeBackend();
     if (model_info()._dataInfoKey !=null)
       model_info()._dataInfoKey.get().remove(fs);
     return super.remove_impl(fs);
   }
 
   @Override
-  public Frame score(Frame fr, String destination_key, Job j, boolean computeMetrics) throws IllegalArgumentException {
-    Frame adaptFr = new Frame(fr);
-    computeMetrics = computeMetrics && (!isSupervised() || (adaptFr.vec(_output.responseName()) != null && !adaptFr.vec(_output.responseName()).isBad()));
-    String[] msg = adaptTestForTrain(adaptFr,true, computeMetrics);   // Adapt
-    if (msg.length > 0) {
-      for (String s : msg)
-        Log.warn(s);
+  protected Frame predictScoreImpl(Frame fr, Frame adaptFrm, String destination_key, Job j, boolean computeMetrics, CFuncRef customMetricFunc) {
+    if (CFuncRef.NOP != customMetricFunc) {
+      throw new IllegalArgumentException("XGBoost doesn't support custom evaluation functions!");
     }
-    try {
-      Key<Frame> destFrameKey = Key.make(destination_key);
-      if (computeMetrics){
-        ModelMetrics mm = makeMetrics(model_info().booster(), adaptFr, fr, "Prediction on frame " + fr._key, destFrameKey);
-        // Update model with newly computed model metrics
-        this.addModelMetrics(mm);
-        DKV.put(this);
-      } else
-        makePredsOnly(model_info().booster(), adaptFr, destFrameKey);
-      return destFrameKey.get();
-    } catch (XGBoostError xgBoostError) {
-      throw new IllegalStateException("Failed scoring.", xgBoostError);
+    Key<Frame> destFrameKey = Key.make(destination_key);
+    if (computeMetrics) {
+      ModelMetrics mm = makeMetrics(adaptFrm, fr, "Prediction on frame " + fr._key, destFrameKey);
+      // Update model with newly computed model metrics
+      this.addModelMetrics(mm);
+      DKV.put(this);
+    } else {
+      Frame preds = makePredsOnly(adaptFrm, destFrameKey);
+      assert destFrameKey.equals(preds._key);
     }
+    return destFrameKey.get();
   }
+
 }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostMojoWriter.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostMojoWriter.java
@@ -23,7 +23,7 @@ public class XGBoostMojoWriter extends ModelMojoWriter<XGBoostModel, XGBoostMode
 
   @Override
   protected void writeModelData() throws IOException {
-    writeblob("boosterBytes", this.model._output._boosterBytes);
+    writeblob("boosterBytes", this.model.model_info()._boosterBytes);
     writekv("nums", model._output._nums);
     writekv("cats", model._output._cats);
     writekv("cat_offsets", model._output._catOffsets);

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostOutput.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostOutput.java
@@ -14,7 +14,6 @@ public class XGBoostOutput extends Model.Output {
     _scored_valid = new ScoreKeeper[]{new ScoreKeeper(Double.NaN)};
   }
 
-  byte[] _boosterBytes;
   int _nums;
   int _cats;
   int[] _catOffsets;

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostUtils.java
@@ -94,7 +94,7 @@ public class XGBoostUtils {
         }
 
         if (sparse) {
-            Log.info("Treating matrix as sparse.");
+            Log.debug("Treating matrix as sparse.");
             // 1 0 2 0
             // 4 0 0 3
             // 3 1 2 0
@@ -108,7 +108,7 @@ public class XGBoostUtils {
                 trainMat = csr(f, chunks, vecs, w, f.vec(response).new Reader(), nRows, di, resp, weights);
             }
         } else {
-            Log.info("Treating matrix as dense.");
+            Log.debug("Treating matrix as dense.");
 
             int cols = di.fullN();
             float[][] data = allocateDenseMatrix(nRows, di);
@@ -271,7 +271,7 @@ public class XGBoostUtils {
         }
         try {
             if (sparse) {
-                Log.info("Treating matrix as sparse.");
+                Log.debug("Treating matrix as sparse.");
                 // 1 0 2 0
                 // 4 0 0 3
                 // 3 1 2 0
@@ -309,7 +309,7 @@ public class XGBoostUtils {
 
     private static DMatrix dense(Chunk[] chunks, int weight, DataInfo di, int respIdx, float[] resp, float[] weights) throws XGBoostError {
         DMatrix trainMat;
-        Log.info("Treating matrix as dense.");
+        Log.debug("Treating matrix as dense.");
 
         // extract predictors
         int cols = di.fullN();

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
@@ -2,17 +2,12 @@ package ml.dmlc.xgboost4j.java;
 
 import hex.DataInfo;
 import hex.tree.xgboost.XGBoostModel;
-import ml.dmlc.xgboost4j.java.Booster;
-import ml.dmlc.xgboost4j.java.BoosterHelper;
-import ml.dmlc.xgboost4j.java.XGBoostError;
 import water.Iced;
 import water.Key;
 import water.util.Log;
-import water.util.TwoDimTable;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 
 
@@ -24,10 +19,6 @@ final public class XGBoostModelInfo extends Iced {
   public String _featureMap;
   public byte[] _boosterBytes; // internal state of native backend
 
-  private TwoDimTable summaryTable;
-
-  private transient Booster _booster;  //pointer to C++ process
-
   public String getFeatureMap() {
     return _featureMap;
   }
@@ -36,54 +27,22 @@ final public class XGBoostModelInfo extends Iced {
     _featureMap = featureMap;
   }
 
-  public Booster getBooster() {
-    if(null == _booster && null != _boosterBytes) {
-      try {
-        _booster = Booster.loadModel(new ByteArrayInputStream(_boosterBytes));
-        Log.debug("Booster created from bytes, raw size = " + _boosterBytes.length);
-      } catch (XGBoostError | IOException exception) {
-        throw new IllegalStateException("Failed to load the booster.", exception);
-      }
-    }
-
-    return _booster;
-  }
-
-  public void setBooster(Booster _booster) {
-    this._booster = _booster;
-  }
-
   public Key<DataInfo> _dataInfoKey;
 
-  public final Booster booster() {
-    if (_booster == null) {
-      // We do not synchronize here since the booster should be setup/read
-      // only by single threaded driver, the same for setter below
-      _booster = javaToNative(_boosterBytes);
+  public void setBoosterBytes(byte[] boosterBytes) {
+    _boosterBytes = boosterBytes;
+  }
+
+  public Booster deserializeBooster() {
+    if (_boosterBytes == null) {
+      throw new IllegalStateException("Booster not initialized!");
     }
-    return _booster;
-  }
-
-  public void nukeBackend() {
-    BoosterHelper.dispose(_booster);
-    _booster = null;
-  }
-
-  public void nativeToJava() {
     try {
-      _boosterBytes = _booster.toByteArray();
-    } catch (XGBoostError xgBoostError) {
-      xgBoostError.printStackTrace();
-      throw new RuntimeException(xgBoostError);
-    }
-  }
-
-  private static Booster javaToNative(byte[] boosterBytes) {
-    InputStream is = new ByteArrayInputStream(boosterBytes);
-    try {
-      return BoosterHelper.loadModel(is);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+      Booster booster = Booster.loadModel(new ByteArrayInputStream(_boosterBytes));
+      Log.debug("Booster created from bytes, raw size = " + _boosterBytes.length);
+      return booster;
+    } catch (XGBoostError | IOException exception) {
+      throw new IllegalStateException("Failed to load the booster.", exception);
     }
   }
 
@@ -101,50 +60,13 @@ final public class XGBoostModelInfo extends Iced {
   }
 
   public XGBoostModel.XGBoostParameters parameters;
-  public final XGBoostModel.XGBoostParameters get_params() { return parameters; }
-
-  private final boolean _classification; // Classification cache (nclasses>1)
 
   /**
    * Main constructor
    * @param origParams Model parameters
-   * @param nClasses number of classes (1 for regression, 0 for autoencoder)
    */
-  public XGBoostModelInfo(final XGBoostModel.XGBoostParameters origParams, int nClasses) {
-    _classification = nClasses > 1;
+  public XGBoostModelInfo(final XGBoostModel.XGBoostParameters origParams) {
     parameters = (XGBoostModel.XGBoostParameters) origParams.clone(); //make a copy, don't change model's parameters
-  }
-
-
-  /**
-   * Create a summary table
-   * @return TwoDimTable with the summary of the model
-   */
-  TwoDimTable createSummaryTable() {
-    TwoDimTable table = new TwoDimTable(
-            "Status of XGBoost Model",
-            "Ha",
-            new String[1], //rows
-            new String[]{"Input Neurons", "Rate", "Momentum" },
-            new String[]{"int", "double", "double" },
-            new String[]{"%d", "%5f", "%5f"},
-            "");
-    table.set(0, 0, 123);
-    table.set(0, 1, 1234);
-    table.set(0, 2, 12345);
-    summaryTable = table;
-    return summaryTable;
-  }
-
-  /**
-   * Print a summary table
-   * @return String containing ASCII version of summary table
-   */
-  @Override public String toString() {
-    StringBuilder sb = new StringBuilder();
-    createSummaryTable();
-    if (summaryTable!=null) sb.append(summaryTable.toString(1));
-    return sb.toString();
   }
 
 }

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
@@ -5,8 +5,6 @@ import hex.tree.xgboost.*;
 import water.*;
 import water.fvec.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +24,6 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
     private final double _threshold;
 
     private ModelMetrics.MetricBuilder _metricBuilder;
-    private byte[] _boosterBytes;
 
     public static class XGBoostScoreTaskResult {
         public Frame preds;
@@ -114,7 +111,6 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
         _output = output;
         _parms = parms;
         _boosterParms = boosterParms;
-        _boosterBytes = sharedmodel._boosterBytes;
         _computeMetrics = computeMetrics;
         _weightsChunkId = weightsChunkId;
         _model = model;
@@ -139,12 +135,16 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
         }
     }
 
+    private static class ScoreResult {
+        float[][] _preds;
+        float[] _labels;
+    }
 
-    @Override
-    public void map(Chunk[] cs, NewChunk[] ncs) {
+    private static ScoreResult scoreChunkExt(final XGBoostModelInfo sharedmodel, final XGBoostModel.XGBoostParameters parms,
+                                             final BoosterParms boosterParms, final XGBoostOutput output,
+                                             final Frame fr, final Chunk[] cs) {
         DMatrix data = null;
         Booster booster = null;
-        _metricBuilder = _computeMetrics ? createMetricsBuilder(_output.nclasses(), _output.classNames()) : null;
         try {
             Map<String, String> rabitEnv = new HashMap<>();
             // Rabit has to be initialized as parts of booster.predict() are using Rabit
@@ -152,80 +152,27 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
             Rabit.init(rabitEnv);
 
             data = XGBoostUtils.convertChunksToDMatrix(
-                    _sharedmodel._dataInfoKey,
+                    sharedmodel._dataInfoKey,
                     cs,
-                    _fr.find(_parms._response_column),
+                    fr.find(parms._response_column),
                     -1, // not used for preds
-                    _fr.find(_parms._fold_column),
-                    _output._sparse);
+                    fr.find(parms._fold_column),
+                    output._sparse);
 
             // No local chunks for this frame
             if (data.rowNum() == 0) {
-                return;
+                return null;
             }
 
-            try {
-                booster = Booster.loadModel(new ByteArrayInputStream(_boosterBytes));
-                booster.setParams(_boosterParms.get());
-            } catch (IOException e) {
-                throw new IllegalStateException("Failed to load the booster.", e);
-            }
-            final float[][] preds = booster.predict(data);
+            // Initialize Booster
+            booster = sharedmodel.deserializeBooster();
+            booster.setParams(boosterParms.get());
 
-            float[] labels = data.getLabel();
-
-
-            if (_output.nclasses() == 1) {
-                double[] currentPred = new double[1];
-                float[] yact = new float[1];
-                for (int j = 0; j < preds.length; ++j) {
-                    currentPred[0] = preds[j][0];
-                    if (_computeMetrics) {
-                        yact[0] = labels[j];
-                        double weight = _weightsChunkId != -1 ? cs[_weightsChunkId].atd(j) : 1; // If there is no chunk with weights, the weight is considered to be 1
-                        _metricBuilder.perRow(currentPred, yact, weight, 0, _model);
-                    }
-                }
-                for (int i = 0; i < cs[0]._len; ++i) {
-                    ncs[0].addNum(preds[i][0]);
-                }
-            } else if (_output.nclasses() == 2) {
-                double[] row = new double[3];
-                float[] yact = new float[1];
-                for (int i = 0; i < cs[0]._len; ++i) {
-                    final double p = preds[i][0];
-                    row[1] = 1 - p;
-                    row[2] = p;
-                    row[0] = hex.genmodel.GenModel.getPrediction(row, _output._priorClassDist, null, _threshold);
-
-                    ncs[0].addNum(row[0]);
-                    ncs[1].addNum(row[1]);
-                    ncs[2].addNum(row[2]);
-
-                    if (_computeMetrics) {
-                        double weight = _weightsChunkId != -1 ? cs[_weightsChunkId].atd(i) : 1; // If there is no chunk with weights, the weight is considered to be 1
-                        yact[0] = labels[i];
-                        _metricBuilder.perRow(row, yact, weight, 0, _model);
-                    }
-                }
-            } else {
-                float[] yact = new float[1];
-                double[] row = MemoryManager.malloc8d(ncs.length);
-                for (int i = 0; i < cs[0]._len; ++i) {
-                    for (int j = 1; j < row.length; ++j) {
-                        double val = preds[i][j - 1];
-                        ncs[j].addNum(val);
-                        row[j] = val;
-                    }
-                    row[0] = hex.genmodel.GenModel.getPrediction(row, _output._priorClassDist, null, _threshold);
-                    ncs[0].addNum(row[0]);
-                    if (_computeMetrics) {
-                        yact[0] = labels[i];
-                        double weight = _weightsChunkId != -1 ? cs[_weightsChunkId].atd(i) : 1; // If there is no chunk with weights, the weight is considered to be 1
-                        _metricBuilder.perRow(row, yact, weight, 0, _model);
-                    }
-                }
-            }
+            // Predict
+            ScoreResult result = new ScoreResult();
+            result._preds = booster.predict(data);
+            result._labels = data.getLabel();
+            return result;
         } catch (XGBoostError xgBoostError) {
             throw new IllegalStateException("Failed to score with XGBoost.", xgBoostError);
         } finally {
@@ -238,6 +185,75 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
         }
     }
 
+    public static float[][] scoreChunk(final XGBoostModelInfo sharedmodel, final XGBoostModel.XGBoostParameters parms,
+                                       final BoosterParms boosterParms, final XGBoostOutput output,
+                                       final Frame fr, final Chunk[] cs) {
+        ScoreResult r = scoreChunkExt(sharedmodel, parms, boosterParms, output, fr, cs);
+        return r == null ? new float[0][] : r._preds;
+    }
+
+    @Override
+    public void map(Chunk[] cs, NewChunk[] ncs) {
+        _metricBuilder = _computeMetrics ? createMetricsBuilder(_output.nclasses(), _output.classNames()) : null;
+
+        final ScoreResult r = scoreChunkExt(_sharedmodel, _parms, _boosterParms, _output, _fr, cs);
+
+        if (r == null)
+            return;
+
+        if (_output.nclasses() == 1) {
+            double[] currentPred = new double[1];
+            float[] yact = new float[1];
+            for (int j = 0; j < r._preds.length; ++j) {
+                currentPred[0] = r._preds[j][0];
+                if (_computeMetrics) {
+                    yact[0] = r._labels[j];
+                    double weight = _weightsChunkId != -1 ? cs[_weightsChunkId].atd(j) : 1; // If there is no chunk with weights, the weight is considered to be 1
+                    _metricBuilder.perRow(currentPred, yact, weight, 0, _model);
+                }
+            }
+            for (int i = 0; i < cs[0]._len; ++i) {
+                ncs[0].addNum(r._preds[i][0]);
+            }
+        } else if (_output.nclasses() == 2) {
+            double[] row = new double[3];
+            float[] yact = new float[1];
+            for (int i = 0; i < cs[0]._len; ++i) {
+                final double p = r._preds[i][0];
+                row[1] = 1 - p;
+                row[2] = p;
+                row[0] = hex.genmodel.GenModel.getPrediction(row, _output._priorClassDist, null, _threshold);
+
+                ncs[0].addNum(row[0]);
+                ncs[1].addNum(row[1]);
+                ncs[2].addNum(row[2]);
+
+                if (_computeMetrics) {
+                    double weight = _weightsChunkId != -1 ? cs[_weightsChunkId].atd(i) : 1; // If there is no chunk with weights, the weight is considered to be 1
+                    yact[0] = r._labels[i];
+                    _metricBuilder.perRow(row, yact, weight, 0, _model);
+                }
+            }
+        } else {
+            float[] yact = new float[1];
+            double[] row = MemoryManager.malloc8d(ncs.length);
+            for (int i = 0; i < cs[0]._len; ++i) {
+                for (int j = 1; j < row.length; ++j) {
+                    double val = r._preds[i][j - 1];
+                    ncs[j].addNum(val);
+                    row[j] = val;
+                }
+                row[0] = hex.genmodel.GenModel.getPrediction(row, _output._priorClassDist, null, _threshold);
+                ncs[0].addNum(row[0]);
+                if (_computeMetrics) {
+                    yact[0] = r._labels[i];
+                    double weight = _weightsChunkId != -1 ? cs[_weightsChunkId].atd(i) : 1; // If there is no chunk with weights, the weight is considered to be 1
+                    _metricBuilder.perRow(row, yact, weight, 0, _model);
+                }
+            }
+        }
+    }
+
     @Override
     public void reduce(XGBoostScoreTask mrt) {
         super.reduce(mrt);
@@ -245,6 +261,5 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
             _metricBuilder.reduce(mrt._metricBuilder);
         }
     }
-
 
 }

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
@@ -59,6 +59,9 @@ public class XGBoostUpdater extends Thread {
     } finally {
       _in = null; // Will throw NPE if used wrong
       _out = null;
+      _trainMat.dispose();
+      if (_booster != null)
+        _booster.dispose();
       updaters.remove(_modelKey);
       try {
         Rabit.shutdown();

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
@@ -28,7 +28,7 @@ public abstract class XGBoostMojoModel extends MojoModel implements Closeable {
   }
 
   // for float output
-  static double[] toPreds(double in[], float[] out, double[] preds,
+  public static double[] toPreds(double in[], float[] out, double[] preds,
                           int nclasses, double[] priorClassDistrib, double defaultThreshold) {
     if (nclasses > 2) {
       for (int i = 0; i < out.length; ++i)

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostNativeMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostNativeMojoModel.java
@@ -38,53 +38,6 @@ public final class XGBoostNativeMojoModel extends XGBoostMojoModel {
             _nclasses, _priorClassDistrib, _defaultThreshold, _sparse);
   }
 
-  public static double[][] bulkScore0(double[][] doubles, double[] offsets, double[][] preds,
-                                      Booster _booster, int _nums, int _cats,
-                                      int[] _catOffsets, boolean _useAllFactorLevels,
-                                      int nclasses, double[] _priorClassDistrib,
-                                      double _defaultThreshold, boolean _sparse) {
-    if (offsets != null) throw new UnsupportedOperationException("Unsupported: offset != null or only 0s");
-    float[][] floats;
-    int cats = _catOffsets == null ? 0 : _catOffsets[_cats];
-    // convert dense doubles to expanded floats
-    floats = new float[doubles.length][_nums + cats]; //TODO: use thread-local storage
-    for(int i = 0; i < doubles.length; i++) {
-      GenModel.setInput(doubles[i], floats[i], _nums, _cats, _catOffsets, null, null, _useAllFactorLevels, _sparse /*replace NA with 0*/);
-    }
-    float[][] out;
-    DMatrix dmat = null;
-    try {
-      dmat = new DMatrix(floats,1, floats.length, _sparse ? 0 : Float.NaN);
-      final DMatrix rows = dmat;
-      BoosterHelper.BoosterOp<float[][]> predictOp = new BoosterHelper.BoosterOp<float[][]>() {
-        @Override
-        public float[][] apply(Booster booster) throws XGBoostError {
-          return booster.predict(rows);
-        }
-      };
-      out = BoosterHelper.doWithLocalRabit(predictOp, _booster);
-    } catch (XGBoostError xgBoostError) {
-      throw new IllegalStateException("Failed XGBoost prediction.", xgBoostError);
-    } finally {
-      BoosterHelper.dispose(dmat);
-    }
-
-    for(int r = 0; r < out.length; r++) {
-      if (nclasses > 2) {
-        for (int i = 0; i < out[0].length; ++i)
-          preds[r][1 + i] = out[r][i];
-        preds[r][0] = GenModel.getPrediction(preds[r], _priorClassDistrib, doubles[r], _defaultThreshold);
-      } else if (nclasses == 2) {
-        preds[r][1] = 1 - out[r][0];
-        preds[r][2] = out[r][0];
-        preds[r][0] = GenModel.getPrediction(preds[r], _priorClassDistrib, doubles[r], _defaultThreshold);
-      } else {
-        preds[r][0] = out[r][0];
-      }
-    }
-    return preds;
-  }
-
   public static double[] score0(double[] doubles, double offset, double[] preds,
                                 Booster _booster, int _nums, int _cats,
                                 int[] _catOffsets, boolean _useAllFactorLevels,

--- a/h2o-genmodel-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/BoosterHelper.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/BoosterHelper.java
@@ -9,10 +9,6 @@ import java.util.Map;
  * Utility to access package private Booster methods.
  */
 public class BoosterHelper {
-  
-  public static Booster loadModel(String modelPath) throws XGBoostError {
-    return Booster.loadModel(modelPath);
-  }
 
   public static Booster loadModel(InputStream in) throws XGBoostError, IOException {
     return Booster.loadModel(in);


### PR DESCRIPTION
This PR reworks Booster's lifecycle in XGBoost training. The previous implementation didn't explicitly dispose of the XGBoost training matrix and allowed to leak the Booster.

With this change: booster is only "live" during training or scoring. There is no native memory allocated after the model training is completed. The booster needs to be deserialized when the users want to predict.

This PR also fixes a hidden issue: when BigScore is used it was scoring per-row - that is super slow! I modified XGBoost to utilize bulk(=per chunk) scoring. This makes scoring CV models faster and allows to use XGBoost efficiently in Stacked Ensembles and AutoML.