### PR TITLE
PUBDEV-5878 - TreeHandler model validation (rel-wright)

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -4,6 +4,7 @@ import hex.ModelCategory;
 import hex.genmodel.algos.tree.SharedTreeNode;
 import hex.genmodel.algos.tree.SharedTreeSubgraph;
 import hex.schemas.TreeV3;
+import water.Keyed;
 import water.MemoryManager;
 import water.api.Handler;
 
@@ -16,8 +17,14 @@ public class TreeHandler extends Handler {
     private static final int NO_CHILD = -1;
 
     public TreeV3 getTree(final int version, final TreeV3 args) {
-        final SharedTreeModel model = (SharedTreeModel) args.model.key().get();
-        if (model == null) throw new IllegalArgumentException("Given model does not exist: " + args.model.key().toString());
+
+        final Keyed possibleModel = args.model.key().get();
+        if (possibleModel == null) throw new IllegalArgumentException("Given model does not exist: " + args.model.key().toString());
+        if(! (possibleModel instanceof SharedTreeModel)){
+            throw new IllegalArgumentException("Given model is not tree-based.");
+        }
+
+        final SharedTreeModel model = (SharedTreeModel) possibleModel;
         final SharedTreeModel.SharedTreeOutput sharedTreeOutput = (SharedTreeModel.SharedTreeOutput) model._output;
         final int treeClass = getResponseLevelIndex(args.tree_class, sharedTreeOutput);
         validateArgs(args, sharedTreeOutput, treeClass);


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5878

TreeHandler class receives a model from the client. The model should be validated to be instance of SharedTreeModel in order to avoid ClassCastException when this method is called on a model that is not backed by a tree.

In R, this will result in 

```R
Error in .h2o.doSafeREST(h2oRestApiVersion = h2oRestApiVersion, urlSuffix = page,  : 
  

ERROR MESSAGE:

Given model is not tree-based.
```

master: https://github.com/h2oai/h2o-3/pull/2813