### PR TITLE
PUBDEV-5888: Use custom implementation to score XGBoost regression trees

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PredictorFactory.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PredictorFactory.java
@@ -1,0 +1,44 @@
+package ml.dmlc.xgboost4j.java;
+
+import biz.k11i.xgboost.Predictor;
+import biz.k11i.xgboost.config.PredictorConfiguration;
+import biz.k11i.xgboost.tree.RegTree;
+import biz.k11i.xgboost.tree.RegTreeFactory;
+import biz.k11i.xgboost.util.ModelReader;
+import water.util.Log;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteOrder;
+
+public class PredictorFactory {
+
+  public static Predictor makePredictor(byte[] boosterBytes) {
+    PredictorConfiguration.Builder bldr = PredictorConfiguration.builder();
+    if (unsafeTreesSupported()) {
+      Log.warn("XGBoost Predictor is using EXPERIMENTAL scoring implementation!");
+      bldr.regTreeFactory(UnsafeRegTreeFactory.INSTANCE);
+    }
+    PredictorConfiguration cfg = bldr.build();
+    try (InputStream is = new ByteArrayInputStream(boosterBytes)) {
+      return new Predictor(is, cfg);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static boolean unsafeTreesSupported() {
+    // XGBoost Predictor uses LE, we can only use our scoring if the system has the same endianness
+    return ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
+  }
+
+  private static class UnsafeRegTreeFactory implements RegTreeFactory {
+    private static final UnsafeRegTreeFactory INSTANCE = new UnsafeRegTreeFactory();
+    @Override
+    public RegTree loadTree(ModelReader reader) throws IOException {
+      return new XGBoostRegTree(reader);
+    }
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostRegTree.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostRegTree.java
@@ -1,0 +1,82 @@
+package ml.dmlc.xgboost4j.java;
+
+import biz.k11i.xgboost.tree.RegTree;
+import biz.k11i.xgboost.util.FVec;
+import biz.k11i.xgboost.util.ModelReader;
+import water.util.UnsafeUtils;
+
+import java.io.IOException;
+
+/**
+ * Regression tree.
+ */
+public class XGBoostRegTree implements RegTree {
+
+  private static final int NODE_SIZE = 20;
+  private static final int STATS_SIZE = 16;
+
+  private byte[] _nodes;
+
+  /**
+   * Loads model from stream.
+   *
+   * @param reader input stream
+   * @throws IOException If an I/O error occurs
+   */
+  XGBoostRegTree(ModelReader reader) throws IOException {
+    final int numNodes = readNumNodes(reader);
+    _nodes = reader.readByteArray(numNodes * NODE_SIZE);
+    reader.skip(numNodes * STATS_SIZE);
+  }
+
+  /**
+   * Retrieves nodes from root to leaf and returns leaf index.
+   *
+   * @param feat    feature vector
+   * @param root_id starting root index
+   * @return leaf index
+   */
+  @Override
+  public int getLeafIndex(FVec feat, int root_id) {
+    throw new UnsupportedOperationException("Leaf node id assignment is currently not supported");
+  }
+
+  /**
+   * Retrieves nodes from root to leaf and returns leaf value.
+   *
+   * @param feat    feature vector
+   * @param root_id starting root index
+   * @return leaf value
+   */
+  @Override
+  public final float getLeafValue(FVec feat, int root_id) {
+    int pid = root_id;
+
+    int pos = pid * NODE_SIZE + 4;
+    int cleft_ = UnsafeUtils.get4(_nodes, pos);
+
+    while (cleft_ != -1) {
+      final int sindex_ = UnsafeUtils.get4(_nodes, pos + 8);
+      final float fvalue = feat.fvalue((int) (sindex_ & ((1L << 31) - 1L)));
+      if (Float.isNaN(fvalue)) {
+        pid = (sindex_ >>> 31) != 0 ? cleft_ : UnsafeUtils.get4(_nodes, pos + 4);
+      } else {
+        final float value_ = UnsafeUtils.get4f(_nodes, pos + 12);
+        pid = (fvalue < value_) ? cleft_ : UnsafeUtils.get4(_nodes, pos + 4);
+      }
+      pos = pid * NODE_SIZE + 4;
+      cleft_ = UnsafeUtils.get4(_nodes, pos);
+    }
+
+    return UnsafeUtils.get4f(_nodes, pos + 12);
+  }
+
+  private static int readNumNodes(ModelReader reader) throws IOException {
+    int numRoots = reader.readInt();
+    assert numRoots == 1;
+    int numNodes = reader.readInt();
+    reader.skip(4 * 4 + 31 * 4); // skip {int num_deleted, int max_depth, int num_feature, size_leaf_vector, 31 * reserved int}
+    return numNodes;
+  }
+
+}

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -20,7 +20,6 @@ import water.fvec.Frame;
 import water.fvec.TestFrameBuilder;
 import water.fvec.Vec;
 import water.rapids.Rapids;
-import water.rapids.Val;
 import water.util.Log;
 
 import java.io.*;
@@ -32,17 +31,23 @@ import static water.util.FileUtils.locateFile;
 @RunWith(Parameterized.class)
 public class XGBoostTest extends TestUtil {
 
-  @Parameterized.Parameters(name = "XGBoost(javaMojoScoring={0}")
-  public static Iterable<? extends Object> data() {
-    return Arrays.asList("true", "false");
+  @Parameterized.Parameters(name = "XGBoost(javaMojoScoring={0},javaPredict={1}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+            {"false", "false"}, {"true", "true"}, {"true", "false"}, {"false", "true"}
+    });
   }
 
   @Parameterized.Parameter
-  public String confJavaScoring;
+  public String confMojoJavaScoring;
+
+  @Parameterized.Parameter(1)
+  public String confJavaPredict;
 
   @Before
   public void setupMojoJavaScoring() {
-    System.setProperty("sys.ai.h2o.xgboost.scoring.java.enable", confJavaScoring);
+    System.setProperty("sys.ai.h2o.xgboost.scoring.java.enable", confMojoJavaScoring); // mojo scoring
+    System.setProperty("sys.ai.h2o.xgboost.predict.java.enable", confMojoJavaScoring); // in-h2o predict
   }
 
   public static final class FrameMetadata {

--- a/h2o-genmodel-extensions/xgboost/build.gradle
+++ b/h2o-genmodel-extensions/xgboost/build.gradle
@@ -5,7 +5,7 @@ description = "H2O GenModel XGBoost support"
 dependencies {
     compile project(":h2o-genmodel")
 
-    compile('ai.h2o:xgboost-predictor:0.3.3') {
+    compile('ai.h2o:xgboost-predictor:0.3.4') {
         exclude group: 'net.jafama', 'module': 'jafama'
     }
 

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
@@ -64,7 +64,7 @@ public abstract class XGBoostMojoModel extends MojoModel implements Closeable {
         preds[1 + i] = out[i];
       preds[0] = GenModel.getPrediction(preds, priorClassDistrib, in, defaultThreshold);
     } else if (nclasses==2){
-      preds[1] = 1 - out[0];
+      preds[1] = 1f - out[0];
       preds[2] = out[0];
       preds[0] = GenModel.getPrediction(preds, priorClassDistrib, in, defaultThreshold);
     } else {


### PR DESCRIPTION
This change provides an experimental Java implementation of predict() for XGBoost models.

It uses a modified xgboost-predictor and adds high-perf scoring of RegTrees.

This is a first step. Next steps will be to
- use java scoring for scoring during model training,
- use prediction cache to scoring with each tree exactly once (same way as we do in GBM).