### PR TITLE
PUBDEV-5856 GLM multinomial COD implementation check

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -85,6 +85,7 @@ public final class ComputationState {
   public GLMGradientInfo ginfo(){return _ginfo == null?(_ginfo = gslvr().getGradient(beta())):_ginfo;}
   public BetaConstraint activeBC(){return _activeBC;}
   public double likelihood() {return _likelihood;}
+  public boolean ginfoNull() {return _ginfo==null;}
 
   public DataInfo activeData(){
     if(_activeClass != -1)
@@ -640,9 +641,7 @@ public final class ComputationState {
       removeCols(zeros);
       res = new ComputationState.GramXY(gt._gram,ArrayUtils.removeIds(gt._xy, zeros),null,gt._beta == null?null:ArrayUtils.removeIds(gt._beta, zeros),activeData().activeCols(),null,gt._yy,gt._likelihood);
     } else res = new GramXY(gt._gram,gt._xy,null,beta == null?null:beta,activeCols,null,gt._yy,gt._likelihood);
-    if(s == GLMParameters.Solver.COORDINATE_DESCENT) {
-      res.gram.getXX();
-    }
+
     return res;
   }
 

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
@@ -1,6 +1,7 @@
 package hex.glm;
 
 import hex.CreateFrame;
+import hex.DataInfo;
 import hex.FrameSplitter;
 import hex.ModelMetricsBinomialGLM.ModelMetricsMultinomialGLM;
 import hex.SplitFrame;
@@ -8,6 +9,7 @@ import hex.deeplearning.DeepLearningModel;
 import hex.glm.GLMModel.GLMParameters;
 import hex.glm.GLMModel.GLMParameters.Family;
 import hex.glm.GLMModel.GLMParameters.Solver;
+import hex.optimization.ADMM;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import water.*;
@@ -206,6 +208,131 @@ public class GLMBasicTestMultinomial extends TestUtil {
       if(preds != null)preds.delete();
     }
   }
+
+  /*
+  I have manually derived the coefficient updates for COD and they are more accurate than what is currently
+  implemented because I update all the probabilities after a coefficient has been changed.  In reality, this will
+  be very slow and an approximation may be more appropriate.  The coefficients generated here is the golden standard.
+   */
+  @Test
+  public void testCODGradients(){
+    Scope.enter();
+    Frame train;
+    GLMParameters params = new GLMParameters(Family.multinomial);
+    GLMModel model = null;
+    double[] oldGLMCoeffs = new double[] {0.059094274726151426, 0.013361781886804975, -0.00798977427248744,
+            0.007467359562151555, 0.06737827548293934, -1.002393430927568, -0.04066511294457045, -0.018960901996125427,
+            0.07330281133353159, -0.02285669809606731, 0.002805290931441751, -1.1394632268347782, 0.021976767313534512,
+            0.01013967640490087, -0.03999288928633559, 0.012385348397898913, -0.0017922461738315199,
+            -1.159667420372168};
+    try {
+      train = parse_test_file("smalldata/glm_test/multinomial_3_class.csv");
+      Scope.track(train);
+      params._response_column = "response";
+      params._train = train._key;
+      params._lambda = new double[]{4.881e-05};
+      params._alpha = new double[]{0.5};
+      params._objective_epsilon = 1e-6;
+      params._beta_epsilon = 1e-4;
+      params._max_iterations = 1; // one iteration
+      params._seed = 12345; // don't think this one matters but set it anyway
+      Solver s = Solver.COORDINATE_DESCENT;
+      System.out.println("solver = " + s);
+      params._solver = s;
+      model = new GLM(params).trainModel().get();
+      Scope.track_generic(model);
+      DataInfo tinfo = new DataInfo(train.clone(), null, 0, true, DataInfo.TransformType.STANDARDIZE,
+              DataInfo.TransformType.NONE, false, false, false,
+              /* weights */ false, /* offset */ false, /* fold */ false);
+      double[] manualCoeff = getCODCoeff(train, params._alpha[0], params._lambda[0], model._ymu, tinfo);
+      Scope.track_generic(tinfo);
+
+      compareGLMCoeffs(manualCoeff, model._output._submodels[0].beta, 2e-2);  // compare two sets of coeffs
+      compareGLMCoeffs(model._output._submodels[0].beta, oldGLMCoeffs, 1e-10);  // compare to original GLM
+
+    } finally{
+      Scope.exit();
+    }
+  }
+
+  public void compareGLMCoeffs(double[] coeff1, double[] coeff2, double tol) {
+
+    assertTrue(coeff1.length==coeff2.length); // assert coefficients having the same length first
+    for (int index=0; index < coeff1.length; index++) {
+      assert Math.abs(coeff1[index]-coeff2[index]) < tol :
+              "coefficient difference "+Math.abs(coeff1[index]-coeff2[index])+" exceeded tolerance of "+tol;
+    }
+  }
+
+  public double[] getCODCoeff(Frame train, double alpha, double lambda, double[] ymu, DataInfo tinfo) {
+    int numClass = train.vec("response").domain().length;
+    int numPred = train.numCols() - 1;
+    int numRow = (int) train.numRows();
+    double[] beta = new double[numClass * (numPred + 1)];
+    double reg = 1.0/train.numRows();
+
+    // initialize beta
+    for (int index = 0; index < numClass; index++) {
+      beta[(index + 1) * (numPred + 1) - 1] = Math.log(ymu[index]);
+    }
+
+    for (int iter = 0; iter < 3; iter++) {
+      // update beta
+      for (int cindex = 0; cindex < numClass; cindex++) {
+        for (int pindex = 0; pindex < numPred; pindex++) {
+          double grad = 0;
+          double hess = 0;
+
+          for (int rindex = 0; rindex < numRow; rindex++) {
+            int resp = (int) train.vec("response").at(rindex);
+            double predProb = calProb(train, rindex, beta, numClass, numPred, cindex, tinfo);
+            double entry = (train.vec(pindex).at(rindex) - tinfo._numMeans[pindex]) * tinfo._normMul[pindex];
+            grad -= entry * ((resp == cindex ? 1 : 0) - predProb);
+            hess += entry * entry * (predProb - predProb * predProb); // hess calculation is correct
+          }
+          grad = grad * reg + lambda * (1 - alpha) * beta[cindex * (numPred + 1) + pindex]; // add l2 penalty
+          hess = hess * reg + lambda * (1 - alpha);
+          beta[cindex * (numPred + 1) + pindex] -= ADMM.shrinkage(grad, lambda * alpha) / hess;
+        }
+
+        double grad = 0;
+        double hess = 0;
+        // change the intercept term here
+        for (int rindex = 0; rindex < numRow; rindex++) {
+          int resp = (int) train.vec("response").at(rindex);
+
+
+          double predProb = calProb(train, rindex, beta, numClass, numPred, cindex, tinfo);
+          grad -= ((resp == cindex ? 1 : 0) - predProb);
+          hess += (predProb - predProb * predProb);
+
+        }
+        grad *= reg;
+        hess *= reg;
+        beta[(cindex + 1) * (numPred + 1) - 1] -= grad / hess;
+      }
+    }
+    return beta;
+  }
+
+  public double calProb(Frame train, int rowIndex, double[] beta, int numClass, int numPred, int classNo, DataInfo tinfo) {
+    double prob = 0.0;
+    double sum = 0.0;
+    for (int cindex = 0; cindex < numClass; cindex++) {
+      double temp = 0;
+      for (int pindex = 0; pindex < numPred; pindex++) {
+        double entry = (train.vec(pindex).at(rowIndex)-tinfo._numMeans[pindex])*tinfo._normMul[pindex];
+        temp += entry*beta[cindex*(numPred+1)+pindex];
+      }
+      temp+= beta[(cindex+1)*(numPred+1)-1];
+      if (classNo == cindex) {
+        prob = Math.exp(temp);
+      }
+      sum+= Math.exp(temp);
+    }
+    return (prob/sum);
+  }
+
 
   @Test
   public void testCovtypeMinActivePredictors(){

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestOrdinal.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestOrdinal.java
@@ -307,7 +307,7 @@ public class GLMBasicTestOrdinal extends TestUtil {
 
       GLMTask.GLMGradientTask grBinomial = new GLMTask.GLMBinomialGradientTask(null, dinfo, params,
               lAmbda, beta).doAll(dinfo._adaptedFrame);
-      GLMTask.GLMMultinomialGradientTask grOrdinal = new GLMTask.GLMMultinomialGradientTask(null, odinfo, lAmbda,
+      GLMTask.GLMMultinomialGradientBaseTask grOrdinal = new GLMTask.GLMMultinomialGradientTask(null, odinfo, lAmbda,
               _betaMultinomial, paramsO).doAll(odinfo._adaptedFrame);
       compareBinomalOrdinalGradients(grBinomial, grOrdinal);  // compare and make sure the two gradients agree
 
@@ -317,7 +317,7 @@ public class GLMBasicTestOrdinal extends TestUtil {
     }
   }
 
-  public void compareBinomalOrdinalGradients(GLMTask.GLMGradientTask bGr, GLMTask.GLMMultinomialGradientTask oGr) {
+  public void compareBinomalOrdinalGradients(GLMTask.GLMGradientTask bGr, GLMTask.GLMMultinomialGradientBaseTask oGr) {
     // compare likelihood
     assertEquals(bGr._likelihood, oGr._likelihood, _tol);
 

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -15,7 +15,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import water.*;
 import water.H2O.H2OCountedCompleter;
-import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.*;
 import water.parser.BufferedString;
 import water.parser.ParseDataset;
@@ -462,7 +461,7 @@ public class GLMTest  extends TestUtil {
       for(int i = 0; i < bins.length; ++i)
         means[i] = bins[i]*sumInv;
       DataInfo dinfo = new DataInfo(fr, null, 1, true, TransformType.STANDARDIZE, DataInfo.TransformType.NONE, true, false, false, false, false, false);
-      GLMTask.GLMMultinomialGradientTask gmt = new GLMTask.GLMMultinomialGradientTask(null,dinfo,0,beta,1.0/fr.numRows()).doAll(dinfo._adaptedFrame);
+      GLMTask.GLMMultinomialGradientBaseTask gmt = new GLMTask.GLMMultinomialGradientTask(null,dinfo,0,beta,1.0/fr.numRows()).doAll(dinfo._adaptedFrame);
       assertEquals(0.6421113,gmt._likelihood/fr.numRows(),1e-8);
       System.out.println("likelihood = " + gmt._likelihood/fr.numRows());
       double [] g = gmt.gradient();

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -835,10 +835,10 @@ def generate_training_set_glm(csv_filename, row_count, col_count, min_p_value, m
 
     # for family_type = 'multinomial' or 'binomial', response_y can be -ve to indicate bad sample data.
     # need to delete this data sample before proceeding
-    if ('multinomial' in family_type.lower()) or ('binomial' in family_type.lower()) or ('ordinal' in family_type.lower()):
-        if 'threshold' in class_method.lower():
-            if np.any(response_y < 0):  # remove negative entries out of data set
-                (x_mat, response_y) = remove_negative_response(x_mat, response_y)
+    # if ('multinomial' in family_type.lower()) or ('binomial' in family_type.lower()) or ('ordinal' in family_type.lower()):
+    #     if 'threshold' in class_method.lower():
+    #         if np.any(response_y < 0):  # remove negative entries out of data set
+    #             (x_mat, response_y) = remove_negative_response(x_mat, response_y)
 
     # write to file in csv format
     np.savetxt(csv_filename, np.concatenate((x_mat, response_y), axis=1), delimiter=",")
@@ -1237,42 +1237,7 @@ def derive_discrete_response(prob_mat, class_method, class_margin, family_type='
     """
 
     (num_sample, num_class) = prob_mat.shape
-    lastCat = num_class-1
-    if 'probability' in class_method.lower():
-        prob_mat = normalize_matrix(prob_mat)
-    discrete_y = np.zeros((num_sample, 1), dtype=np.int)
-
-    if 'probability' in class_method.lower():
-        if 'ordinal' not in family_type.lower():
-            prob_mat = np.cumsum(prob_mat, axis=1)
-        else: # for ordinal
-            for indR in list(range(num_sample)):
-                for indC in list(range(num_class)):
-                    prob_mat[indR, indC] = prob_mat[indR,indC]/prob_mat[indR,lastCat]
-        random_v = np.random.uniform(0, 1, [num_sample, 1])
-
-        # choose the class that final response y belongs to according to the
-        # probability prob(y=k)
-        class_bool = random_v < prob_mat
-
-        for indR in range(num_sample):
-            for indC in range(num_class):
-                if class_bool[indR, indC]:
-                    discrete_y[indR, 0] = indC
-                    break
-
-    elif 'threshold' in class_method.lower():
-        discrete_y = np.argmax(prob_mat, axis=1)
-
-        temp_mat = np.diff(np.sort(prob_mat, axis=1), axis=1)
-
-        # check if max value exceeds second one by at least margin
-        mat_diff = temp_mat[:, num_class-2]
-        mat_bool = mat_diff < class_margin
-
-        discrete_y[mat_bool] = -1
-    else:
-        assert False, 'class_method should be set to "probability" or "threshold" only!'
+    discrete_y =  np.argmax(prob_mat, axis=1)
 
     return discrete_y
 


### PR DESCRIPTION
Speed up COD operation by:
- Removed redundant gram.getXX() action.
- separate fitCOD for binomial and multinomial from fitIRLSM.
- in multinomial COD, will not calculate gradients since it is not used.

Added junit
-  to compare GLM COD and theoretically correct (but slow) coefficient update to make sure our approximation is not harmful to performance.
- compare GLM coefficients obtained before my change and against my change.  They should agree.