### PR TITLE
PUBDEV-4507: XGBoost integration to AutoML

### DIFF
--- a/h2o-automl/build.gradle
+++ b/h2o-automl/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   compile project(":h2o-genmodel")
   compile project(":h2o-core")
   compile project(":h2o-algos")
+  compile project(":h2o-ext-xgboost")
 
   // Test dependencies only
   testCompile "junit:junit:${junitVersion}"

--- a/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
@@ -1,0 +1,18 @@
+package ai.h2o.automl;
+
+// if we need to make the Algo list dynamic, we should just turn this enum into a class...
+// implementation of AutoML.algo can be safely removed once we get rid of this interface: current purpose
+// is to keep backward compatibility with {@link AutoML.algo}
+public enum Algo implements AutoML.algo {
+  GLM,
+  DRF,
+  GBM,
+  DeepLearning,
+  StackedEnsemble,
+  XGBoost,
+  ;
+
+  String urlName() {
+    return this.name().toLowerCase();
+  }
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -45,6 +45,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
+
+
   static class WorkAllocations extends Iced<WorkAllocations> {
 
     private static class Work extends Iced<Work> {
@@ -124,6 +126,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     }
 
   }
+
+  private static final String DISTRIBUTED_XGBOOST_ENABLED = H2O.OptArgs.SYSTEM_PROP_PREFIX + "automl.multinode.xgboost.enabled";
 
   private final static boolean verifyImmutability = true; // check that trainingFrame hasn't been messed with
   private final static SimpleDateFormat fullTimestampFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.S");
@@ -276,7 +280,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
         skipAlgosList = ArrayUtils.append(skipAlgosList, algo);
       }
     }
-    if (!ExtensionManager.getInstance().isCoreExtensionEnabled("XGBoost")) {
+    if (!ExtensionManager.getInstance().isCoreExtensionEnabled("XGBoost")
+        || (H2O.CLOUD.size() > 1 && !Boolean.parseBoolean(System.getProperty(DISTRIBUTED_XGBOOST_ENABLED, "false")))) {
       userFeedback.warn(Stage.ModelTraining, "AutoML: XGBoost extension is not available; skipping default XGBoost");
       skipAlgosList = ArrayUtils.append(skipAlgosList, Algo.XGBoost);
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1,7 +1,6 @@
 package ai.h2o.automl;
 
 import ai.h2o.automl.UserFeedbackEvent.Stage;
-import ai.h2o.automl.utils.AutoMLUtils;
 import hex.Model;
 import hex.ModelBuilder;
 import hex.ScoreKeeper.StoppingMetric;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -127,7 +127,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
   }
 
-  private static final String DISTRIBUTED_XGBOOST_ENABLED = H2O.OptArgs.SYSTEM_PROP_PREFIX + "automl.multinode.xgboost.enabled";
+  private static final String DISTRIBUTED_XGBOOST_ENABLED = H2O.OptArgs.SYSTEM_PROP_PREFIX + "automl.xgboost.multinode.enabled";
 
   private final static boolean verifyImmutability = true; // check that trainingFrame hasn't been messed with
   private final static SimpleDateFormat fullTimestampFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.S");

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -116,7 +116,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="A list algorithms to skip during the model-building phase.", values = {"GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble"}, direction=API.Direction.INPUT)
+    @API(help="A list algorithms to skip during the model-building phase.", values = {"GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble", "XGBoost", "LightGBM"}, direction=API.Direction.INPUT)
     public AutoML.algo[] exclude_algos;
 
   } // class AutoMLBuildModels

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -116,8 +116,8 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
       super();
     }
 
-    @API(help="A list algorithms to skip during the model-building phase.", values = {"GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble", "XGBoost", "LightGBM"}, direction=API.Direction.INPUT)
-    public AutoML.algo[] exclude_algos;
+    @API(help="A list algorithms to skip during the model-building phase.", values = {"GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble", "XGBoost"}, direction=API.Direction.INPUT)
+    public AutoML.Algo[] exclude_algos;
 
   } // class AutoMLBuildModels
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -1,10 +1,11 @@
 package water.automl.api.schemas3;
 
 
-import ai.h2o.automl.AutoML;
+import ai.h2o.automl.Algo;
 import ai.h2o.automl.AutoMLBuildSpec;
 import hex.schemas.HyperSpaceSearchCriteriaV99;
 import water.api.API;
+import water.api.EnumValuesProvider;
 import water.api.Schema;
 import water.api.schemas3.*;
 
@@ -111,13 +112,19 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
 
   } // class AutoMLInputV99
 
+  public static final class AlgoProvider extends EnumValuesProvider<Algo> {
+    public AlgoProvider() {
+      super(Algo.class);
+    }
+  }
+
   static final public class AutoMLBuildModelsV99 extends Schema<AutoMLBuildSpec.AutoMLBuildModels, AutoMLBuildModelsV99> {
     public AutoMLBuildModelsV99() {
       super();
     }
 
-    @API(help="A list algorithms to skip during the model-building phase.", values = {"GLM", "DRF", "GBM", "DeepLearning", "StackedEnsemble", "XGBoost"}, direction=API.Direction.INPUT)
-    public AutoML.Algo[] exclude_algos;
+    @API(help="A list algorithms to skip during the model-building phase.", valuesProvider=AlgoProvider.class, direction=API.Direction.INPUT)
+    public Algo[] exclude_algos;
 
   } // class AutoMLBuildModels
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -10,6 +10,7 @@ import water.fvec.Frame;
 import java.util.Date;
 import java.util.Random;
 
+import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 
 public class AutoMLTest extends water.TestUtil {
@@ -160,6 +161,37 @@ public class AutoMLTest extends water.TestUtil {
       // cleanup
       if(aml!=null) aml.deleteWithChildren();
       if(fr != null) fr.delete();
+    }
+  }
+
+  @Test public void testWorkPlan() {
+    AutoML aml = null;
+    Frame fr=null;
+    try {
+      AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+      fr = parse_test_file("./smalldata/airlines/allyears2k_headers.zip");
+      autoMLBuildSpec.input_spec.training_frame = fr._key;
+      autoMLBuildSpec.input_spec.response_column = "IsDepDelayed";
+      aml = new AutoML(Key.<AutoML>make(), new Date(), autoMLBuildSpec);
+
+      AutoML.WorkAllocations workPlan = aml.planWork();
+
+      int max_total_work = 1*10+3*20     //DL
+                         + 2*10          //DRF
+                         + 5*10+1*60     //GBM
+                         + 1*20          //GLM
+                         + 3*10+1*100    //XGBoost
+                         + 2*15;         //SE
+      assertEquals(workPlan.remainingWork(), max_total_work);
+
+      autoMLBuildSpec.build_models.exclude_algos = new AutoML.Algo[] {AutoML.Algo.DeepLearning, AutoML.Algo.XGBoost, };
+      workPlan = aml.planWork();
+
+      assertEquals(workPlan.remainingWork(), max_total_work - (/*DL*/ 1*10+3*20 + /*XGB*/ 3*10+1*100));
+
+    } finally {
+      if (aml != null) aml.deleteWithChildren();
+      if (fr != null) fr.remove();
     }
   }
 }

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -120,7 +120,7 @@ public class AutoMLTest extends water.TestUtil {
       fr = parse_test_file("./smalldata/logreg/prostate_train.csv");
       autoMLBuildSpec.input_spec.training_frame = fr._key;
       autoMLBuildSpec.input_spec.response_column = "CAPSULE";
-      autoMLBuildSpec.build_models.exclude_algos = new AutoML.algo[] {AutoML.algo.DeepLearning, AutoML.algo.DRF, AutoML.algo.GLM};
+      autoMLBuildSpec.build_models.exclude_algos = new Algo[] {Algo.DeepLearning, Algo.DRF, Algo.GLM};
 
       autoMLBuildSpec.build_control.stopping_criteria.set_max_runtime_secs(8);
 //      autoMLBuildSpec.build_control.stopping_criteria.set_max_runtime_secs(new Random().nextInt(30));
@@ -184,7 +184,7 @@ public class AutoMLTest extends water.TestUtil {
                          + 2*15;         //SE
       assertEquals(workPlan.remainingWork(), max_total_work);
 
-      autoMLBuildSpec.build_models.exclude_algos = new AutoML.Algo[] {AutoML.Algo.DeepLearning, AutoML.Algo.XGBoost, };
+      autoMLBuildSpec.build_models.exclude_algos = new Algo[] {Algo.DeepLearning, Algo.XGBoost, };
       workPlan = aml.planWork();
 
       assertEquals(workPlan.remainingWork(), max_total_work - (/*DL*/ 1*10+3*20 + /*XGB*/ 3*10+1*100));

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -251,7 +251,12 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     if (H2O.ARGS.client) {
       RemoteTrainModelTask tmt = new RemoteTrainModelTask(_job, _job._result, _parms);
       H2ONode leader = H2O.CLOUD.leader();
-      new RPC<>(leader, tmt).call().get();
+      try {
+        new RPC<>(leader, tmt).call().get();
+      } catch (DistributedException de) {
+        if (de.getCause() instanceof RuntimeException) throw (RuntimeException)de.getCause();
+        throw de;
+      }
       return _job;
     } else {
       return trainModel(); // use directly

--- a/h2o-core/src/main/java/water/api/EnumValuesProvider.java
+++ b/h2o-core/src/main/java/water/api/EnumValuesProvider.java
@@ -1,0 +1,28 @@
+package water.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EnumValuesProvider<E extends Enum<E>> implements ValuesProvider {
+
+  private String[] _values;
+
+  public EnumValuesProvider(Class<E> clazz) {
+    _values = getValuesOf(clazz);
+  }
+
+  @Override
+  public String[] values() {
+    return _values;
+  }
+
+  private String[] getValuesOf(Class<E> clazz) {
+    E[] values = clazz.getEnumConstants();
+    List<String> names = new ArrayList<>(values.length);
+    for (E val : values) {
+      names.add(val.name());
+    }
+    return names.toArray(new String[0]);
+  }
+}
+

--- a/h2o-core/src/main/java/water/util/PojoUtils.java
+++ b/h2o-core/src/main/java/water/util/PojoUtils.java
@@ -138,7 +138,12 @@ public class PojoUtils {
             //
             // You can't use reflection to set an int[] with an Integer[].  Argh.
             // TODO: other types of arrays. . .
-            if (dest_field.getType().getComponentType() == double.class && orig_field.getType().getComponentType() == Double.class) {
+            if (dest_field.getType().getComponentType().isAssignableFrom(orig_field.getType().getComponentType())) {
+              //
+              //Assigning an T[] to an U[] if T extends U
+              //
+              dest_field.set(dest, orig_field.get(origin));
+            } else if (dest_field.getType().getComponentType() == double.class && orig_field.getType().getComponentType() == Double.class) {
               //
               // Assigning an Double[] to an double[]
               //

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -291,6 +291,19 @@ Here is an example leaderboard for a binary classification task:
 +--------------------------------------------------------+----------+----------+----------------------+----------+----------+
 
 
+Experimental features
+~~~~~~~~~~~~~~~~~~~~~
+
+XGBoost
+'''''''
+
+AutoML now includes `XGBoost <data-science/xgboost.html>`__ in its selection of algorithms used to train the best model.
+This feature is however currently provided with the following restrictions:
+- XGBoost is used only if it is available globally, especially if it hasn't been explicitly `disabled <data-science/xgboost.html#disabling-xgboost>`__.
+- Even so, XGBoost is disabled by default in AutoML when running H2O-3 in multi-node due to current `limitations <data-science/xgboost.html#limitations>`__.
+- XGBoost can however be enabled experimentally in multi-node by setting the environment variable ``-Dsys.ai.h2o.automl.xgboost.multinode.enabled=true`` for every node of the H2O cloud.
+
+
 FAQ
 ~~~
 
@@ -306,6 +319,7 @@ FAQ
 
   Rather than saving an AutoML object itself, currently, the best thing to do is to save the models you want to keep, individually.  A utility for saving all of the models at once, along with a way to save the AutoML object (with leaderboard), will be added in a future release.
 
+-  **Why don't I see XGBoost models when using AutoML in multinode**
 
 Resources
 ~~~~~~~~~

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -17,7 +17,7 @@ else: # Python 3
     automl_seed = random.randint(0, sys.maxsize)
 print("Random Seed for pyunit_automl_leaderboard.py = " + str(automl_seed))
 
-all_algos = ["DeepLearning", "DRF", "GBM", "GLM", "StackedEnsemble"] #add XGBoost when available
+all_algos = ["DeepLearning", "DRF", "GBM", "GLM", "XGBoost", "StackedEnsemble"]
 
 
 class Obj(object):

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -153,8 +153,8 @@ def test_clean_cv_predictions():
         assert len(se) == len(se_all_models) + len(se_best_of_family)
         assert len(se_all_models) == 1, "expecting only the first StackedEnsemble_AllModels, but got {}".format(len(se_all_models))
         assert se_all_models[0] in first_se, "first StackedEnsemble_AllModels got replaced by new one"
-        assert len(se_best_of_family) == 1, "expecting only the first StackedEnsemble_BestOfFamily, but got {}".format(len(se_all_models))
-        assert se_best_of_family[0] in first_se, "first StackedEnsemble_AllModels got replaced by new one"
+        assert len(se_best_of_family) == 1, "expecting only the first StackedEnsemble_BestOfFamily, but got {}".format(len(se_best_of_family))
+        assert se_best_of_family[0] in first_se, "first StackedEnsemble_Best_of_Family got replaced by new one"
 
 
     def test_SE_retraining_works_when_param_enabled():

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -13,7 +13,7 @@ automl.leaderboard.test <- function() {
     fr1 <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
     fr1["CAPSULE"] <- as.factor(fr1["CAPSULE"])
     exclude_algos <- c("GLM", "DeepLearning", "DRF")  #Expect GBM + StackedEnsemble
-    aml1 <- h2o.automl(y = 2, training_frame = fr1, max_models = 2,
+    aml1 <- h2o.automl(y = 2, training_frame = fr1, max_models = 10,
                        project_name = "r_lb_test_aml1",
                        exclude_algos = exclude_algos)
     aml1@leaderboard
@@ -30,10 +30,9 @@ automl.leaderboard.test <- function() {
     }
 
     # Regression:
-    # TO DO: Change this dataset
-    fr2 <- h2o.uploadFile(locate("smalldata/covtype/covtype.20k.data"))
+    fr2 <- h2o.uploadFile(locate("smalldata/extdata/australia.csv"))
     exclude_algos <- c("GBM", "DeepLearning")  #Expect GLM, DRF (and XRT), StackedEnsemble
-    aml2 <- h2o.automl(y = 55, training_frame = fr2, max_models = 4,
+    aml2 <- h2o.automl(y = "runoffnew", training_frame = fr2, max_models = 10,
                        project_name = "r_lb_test_aml2",
                        exclude_algos = exclude_algos)
     aml2@leaderboard
@@ -48,8 +47,8 @@ automl.leaderboard.test <- function() {
 
     # Multinomial:
     fr3 <- as.h2o(iris)
-    exclude_algos <- c("GBM")
-    aml3 <- h2o.automl(y = 5, training_frame = fr3, max_models = 6,
+    exclude_algos <- c("DeepLearning")
+    aml3 <- h2o.automl(y = 5, training_frame = fr3, max_models = 10,
                        project_name = "r_lb_test_aml3",
                        exclude_algos = exclude_algos)
     aml3@leaderboard
@@ -78,7 +77,7 @@ automl.leaderboard.test <- function() {
     
     # Include all algorithms (all should be there, given large enough max_models)
     fr3 <- as.h2o(iris)
-    aml5 <- h2o.automl(y = 5, training_frame = fr3, max_models = 10, 
+    aml5 <- h2o.automl(y = 5, training_frame = fr3, max_models = 12,
                        project_name = "r_lb_test_aml5")
     model_ids <- as.vector(aml5@leaderboard$model_id)
     include_algos <- c(all_algos, "XRT")

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
@@ -37,9 +37,8 @@ automl.leaderboard_sort_metric.test <- function() {
 
 
   # Regression:
-  # TO DO: Change this dataset
-  fr2 <- h2o.uploadFile(locate("smalldata/covtype/covtype.20k.data"))
-  aml2 <- h2o.automl(y = 55, training_frame = fr2, max_models = 2,
+  fr2 <- h2o.uploadFile(locate("smalldata/extdata/australia.csv"))
+  aml2 <- h2o.automl(y = 'runoffnew', training_frame = fr2, max_models = 2,
                      project_name = "r_lbsm_test_aml2",
                      sort_metric = "RMSE")
   aml2@leaderboard
@@ -49,7 +48,7 @@ automl.leaderboard_sort_metric.test <- function() {
   expect_equal(identical(rmse_col, sort(rmse_col, decreasing = FALSE)), TRUE)
 
   # new AutoML run, sort_metric AUTO (check sorting by mean_residual_deviance)
-  aml2 <- h2o.automl(y = 55, training_frame = fr2, max_models = 2,
+  aml2 <- h2o.automl(y = 'runoffnew', training_frame = fr2, max_models = 2,
                      project_name = "r_lbsm_test_aml2_auto")
   aml2@leaderboard
   # check that leaderboard is sorted by mean_residual_deviance


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-4507
- tuned 3 default XGBoost models for small to larger datasets.
- added them before existing default GBMs.
- added XGBoost hyperparam search before GBM one.
- based on XGBoost, added experimental support for emulated LightGBM (currently disabled as I expected faster perf according to https://lightgbm.readthedocs.io/en/latest/Experiments.html#result)
- orchestration of various hyperparam searches to ensure that one is not monopolising resources (remaining models + time), and ensure we have a balance between XGB, GBM and DL.