### PR TITLE
PUBDEV-5824: AutoML fails training new BestofFamily SE model on multiple runs

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -6,6 +6,7 @@ import hex.Model;
 import hex.ModelBuilder;
 import hex.StackedEnsembleModel;
 import hex.deeplearning.DeepLearningModel;
+import hex.ensemble.StackedEnsemble;
 import hex.glm.GLMModel;
 import hex.grid.Grid;
 import hex.grid.GridSearch;
@@ -1090,7 +1091,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
       for (Model aModel : allModels) {
         String type = getModelType(aModel);
-        if (typesOfGatheredModels.contains(type)) continue;
+        if (aModel instanceof StackedEnsembleModel || typesOfGatheredModels.contains(type)) continue;
         typesOfGatheredModels.add(type);
         bestModelsOfEachType.add(aModel);
       }

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -170,8 +170,7 @@ def test_clean_cv_predictions():
         se_best_of_family = [m for m in se if re.search(r'_BestOfFamily_', m)]
         assert len(se) == len(se_all_models) + len(se_best_of_family)
         assert len(se_all_models) == total_runs, "some StackedEnsemble_AllModels are missing"
-        # assert len(se_best_of_family) == total_runs, "some StackedEnsemble_BestOfFamily are missing"
-        assert len(se_best_of_family) == 1, "BUG! should be fixed by PUBDEV-5824"
+        assert len(se_best_of_family) == total_runs, "some StackedEnsemble_BestOfFamily are missing"
 
 
     test_default_behaviour()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5824
- removed previous SEs from the list of Best of Family models to be able to compute new SE model