### PR TITLE
PUBDEV-5927: Streaming ingest from JDBC datasources

### DIFF
--- a/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
+++ b/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
@@ -15,7 +15,8 @@ public class ImportSQLTableHandler extends Handler {
   @SuppressWarnings("unused") // called through reflection by RequestServer
   public JobV3 importSQLTable(int version, ImportSQLTableV99 importSqlTable) {
      Job j = SQLManager.importSqlTable(importSqlTable.connection_url, importSqlTable.table, importSqlTable.select_query, 
-             importSqlTable.username, importSqlTable.password, importSqlTable.columns, importSqlTable.optimize);
+             importSqlTable.username, importSqlTable.password, importSqlTable.columns,
+             importSqlTable.optimize, importSqlTable.streaming);
     return new JobV3().fillFromImpl(j);
     
   }

--- a/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
+++ b/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
@@ -18,7 +18,7 @@ public class ImportSQLTableHandler extends Handler {
   public JobV3 importSQLTable(int version, ImportSQLTableV99 importSqlTable) {
       final SqlFetchMode sqlFetchMode;
       if (importSqlTable.sqlFetchMode == null) {
-        sqlFetchMode = SqlFetchMode.SINGLE;
+        sqlFetchMode = SqlFetchMode.DISTRIBUTED;
       } else {
           sqlFetchMode = EnumUtils.valueOfIgnoreCase(SqlFetchMode.class, importSqlTable.sqlFetchMode);
       }

--- a/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
+++ b/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
@@ -17,10 +17,10 @@ public class ImportSQLTableHandler extends Handler {
   @SuppressWarnings("unused") // called through reflection by RequestServer
   public JobV3 importSQLTable(int version, ImportSQLTableV99 importSqlTable) {
       final SqlFetchMode sqlFetchMode;
-      if (importSqlTable.sqlFetchMode == null) {
+      if (importSqlTable.fetch_mode == null) {
         sqlFetchMode = SqlFetchMode.DISTRIBUTED;
       } else {
-          sqlFetchMode = EnumUtils.valueOfIgnoreCase(SqlFetchMode.class, importSqlTable.sqlFetchMode);
+          sqlFetchMode = EnumUtils.valueOfIgnoreCase(SqlFetchMode.class, importSqlTable.fetch_mode);
       }
       Job j = SQLManager.importSqlTable(importSqlTable.connection_url, importSqlTable.table, importSqlTable.select_query,
              importSqlTable.username, importSqlTable.password, importSqlTable.columns,

--- a/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
+++ b/h2o-core/src/main/java/water/api/ImportSQLTableHandler.java
@@ -5,6 +5,8 @@ import water.Job;
 import water.api.schemas3.ImportSQLTableV99;
 import water.api.schemas3.JobV3;
 import water.jdbc.SQLManager;
+import water.jdbc.SqlFetchMode;
+import water.util.EnumUtils;
 
 /**
  * Import Sql Table into H2OFrame
@@ -14,9 +16,15 @@ public class ImportSQLTableHandler extends Handler {
 
   @SuppressWarnings("unused") // called through reflection by RequestServer
   public JobV3 importSQLTable(int version, ImportSQLTableV99 importSqlTable) {
-     Job j = SQLManager.importSqlTable(importSqlTable.connection_url, importSqlTable.table, importSqlTable.select_query, 
+      final SqlFetchMode sqlFetchMode;
+      if (importSqlTable.sqlFetchMode == null) {
+        sqlFetchMode = SqlFetchMode.SINGLE;
+      } else {
+          sqlFetchMode = EnumUtils.valueOfIgnoreCase(SqlFetchMode.class, importSqlTable.sqlFetchMode);
+      }
+      Job j = SQLManager.importSqlTable(importSqlTable.connection_url, importSqlTable.table, importSqlTable.select_query,
              importSqlTable.username, importSqlTable.password, importSqlTable.columns,
-             importSqlTable.optimize, importSqlTable.streaming);
+             sqlFetchMode);
     return new JobV3().fillFromImpl(j);
     
   }

--- a/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
@@ -28,4 +28,7 @@ public class ImportSQLTableV99 extends RequestSchemaV3<Iced,ImportSQLTableV99> {
   @API(help = "optimize")
   public boolean optimize = true;
 
+  @API(help = "streaming")
+  public boolean streaming = false;
+
 }

--- a/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
@@ -26,9 +26,6 @@ public class ImportSQLTableV99 extends RequestSchemaV3<Iced,ImportSQLTableV99> {
   @API(help = "columns")
   public String columns = "*";
 
-  @API(help = " Deprecated. Optimize data loading. Ignored - use fetch_mode instead.")
-  public boolean optimize = false;
-
   @API(help = "Mode for data loading. All modes may not be supported by all databases.")
   public String fetch_mode;
 

--- a/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
@@ -2,6 +2,7 @@ package water.api.schemas3;
 
 import water.Iced;
 import water.api.API;
+import water.jdbc.SqlFetchMode;
 
 
 public class ImportSQLTableV99 extends RequestSchemaV3<Iced,ImportSQLTableV99> {
@@ -25,10 +26,10 @@ public class ImportSQLTableV99 extends RequestSchemaV3<Iced,ImportSQLTableV99> {
   @API(help = "columns")
   public String columns = "*";
 
-  @API(help = "optimize")
+  @API(help = " Deprecated. Optimize data loading.")
   public boolean optimize = true;
 
-  @API(help = "streaming")
-  public boolean streaming = false;
+  @API(help = "Mode for data loading. All modes may not be supported by all databases.")
+  public String sqlFetchMode;
 
 }

--- a/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
@@ -26,8 +26,8 @@ public class ImportSQLTableV99 extends RequestSchemaV3<Iced,ImportSQLTableV99> {
   @API(help = "columns")
   public String columns = "*";
 
-  @API(help = " Deprecated. Optimize data loading.")
-  public boolean optimize = true;
+  @API(help = " Deprecated. Optimize data loading. Ignored - use sqlFetchMode instead.")
+  public boolean optimize = false;
 
   @API(help = "Mode for data loading. All modes may not be supported by all databases.")
   public String sqlFetchMode;

--- a/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ImportSQLTableV99.java
@@ -26,10 +26,10 @@ public class ImportSQLTableV99 extends RequestSchemaV3<Iced,ImportSQLTableV99> {
   @API(help = "columns")
   public String columns = "*";
 
-  @API(help = " Deprecated. Optimize data loading. Ignored - use sqlFetchMode instead.")
+  @API(help = " Deprecated. Optimize data loading. Ignored - use fetch_mode instead.")
   public boolean optimize = false;
 
   @API(help = "Mode for data loading. All modes may not be supported by all databases.")
-  public String sqlFetchMode;
+  public String fetch_mode;
 
 }

--- a/h2o-core/src/main/java/water/jdbc/SQLManager.java
+++ b/h2o-core/src/main/java/water/jdbc/SQLManager.java
@@ -197,7 +197,6 @@ public class SQLManager {
     }
     final boolean estimateConcurrentConnections = optimize && (! streaming);
     if (estimateConcurrentConnections) {
-      assert ! streaming;
       final int num_retrieval_chunks = ConnectionPoolProvider.estimateConcurrentConnections(H2O.getCloudSize(), H2O.ARGS.nthreads);
       vec = num_retrieval_chunks >= num_chunks
               ? Vec.makeConN(numRow, num_chunks)

--- a/h2o-core/src/main/java/water/jdbc/SqlFetchMode.java
+++ b/h2o-core/src/main/java/water/jdbc/SqlFetchMode.java
@@ -1,0 +1,6 @@
+package water.jdbc;
+
+public enum SqlFetchMode {
+    SINGLE,
+    DISTRIBUTED
+}

--- a/h2o-core/src/main/java/water/util/EnumUtils.java
+++ b/h2o-core/src/main/java/water/util/EnumUtils.java
@@ -76,4 +76,21 @@ public class EnumUtils {
     return (T) value;
   }
 
+  /**
+   *
+   * @param enumeration Enumeration to search in
+   * @param value String to search fore
+   * @param <T> Class of the Enumeration to search in
+   * @return
+   */
+  public static <T extends Enum<?>> T valueOfIgnoreCase(Class<T> enumeration,
+                                                 String value) {
+    for (T field : enumeration.getEnumConstants()) {
+      if (field.name().compareToIgnoreCase(value) == 0) {
+        return field;
+      }
+    }
+    return null;
+  }
+
 }

--- a/h2o-core/src/test/java/water/jdbc/SQLManagerIntegTest.java
+++ b/h2o-core/src/test/java/water/jdbc/SQLManagerIntegTest.java
@@ -1,0 +1,71 @@
+package water.jdbc;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import water.Job;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import static org.junit.Assert.*;
+
+public class SQLManagerIntegTest extends TestUtil {
+
+  @Rule
+  public TemporaryFolder tmp = new TemporaryFolder();
+
+  private String connectionString;
+
+  @BeforeClass
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @BeforeClass
+  public static void initDB() throws ClassNotFoundException {
+    Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+  }
+
+  @Before
+  public void createTable() throws Exception  {
+    connectionString = "jdbc:derby:" + tmp.newFolder("derby").getAbsolutePath() + "/myDB";
+    try (Connection conn = DriverManager.getConnection(connectionString + ";create=true");
+         Statement stmt = conn.createStatement()) {
+
+      stmt.executeUpdate("CREATE TABLE TestData (ID INT PRIMARY KEY, NAME VARCHAR(12))");
+      stmt.executeUpdate("INSERT INTO TestData VALUES (1,'TOM'),(2,'BILL'),(3,'AMY'),(4,'OWEN')");
+    }
+  }
+
+  @Test
+  public void importSqlTable() {
+    Scope.enter();
+    try {
+      Frame expected = Scope.track(new TestFrameBuilder()
+              .withColNames("ID", "NAME")
+              .withVecTypes(Vec.T_NUM, Vec.T_STR)
+              .withDataForCol(0, new long[]{1, 2, 3, 4})
+              .withDataForCol(1, new String[]{"TOM", "BILL", "AMY", "OWEN"})
+              .build());
+
+      Job<Frame> j = SQLManager.importSqlTable("jdbc:derby:myDB", "TestData", "", "", "", "*", false, true);
+      Frame fr = Scope.track(j.get());
+
+      assertArrayEquals(expected._names, fr._names);
+      assertVecEquals(expected.vec(0), fr.vec(0), 0);
+      assertStringVecEquals(expected.vec(1), fr.vec(1));
+    } finally {
+      Scope.exit();
+    }
+  }
+
+}

--- a/h2o-core/src/test/java/water/jdbc/SQLManagerIntegTest.java
+++ b/h2o-core/src/test/java/water/jdbc/SQLManagerIntegTest.java
@@ -57,7 +57,7 @@ public class SQLManagerIntegTest extends TestUtil {
               .withDataForCol(1, new String[]{"TOM", "BILL", "AMY", "OWEN"})
               .build());
 
-      Job<Frame> j = SQLManager.importSqlTable(connectionString, "TestData", "", "", "", "*", false, true);
+      Job<Frame> j = SQLManager.importSqlTable(connectionString, "TestData", "", "", "", "*", SqlFetchMode.DISTRIBUTED);
       Frame fr = Scope.track(j.get());
 
       assertArrayEquals(expected._names, fr._names);

--- a/h2o-core/src/test/java/water/jdbc/SQLManagerIntegTest.java
+++ b/h2o-core/src/test/java/water/jdbc/SQLManagerIntegTest.java
@@ -57,7 +57,7 @@ public class SQLManagerIntegTest extends TestUtil {
               .withDataForCol(1, new String[]{"TOM", "BILL", "AMY", "OWEN"})
               .build());
 
-      Job<Frame> j = SQLManager.importSqlTable("jdbc:derby:myDB", "TestData", "", "", "", "*", false, true);
+      Job<Frame> j = SQLManager.importSqlTable(connectionString, "TestData", "", "", "", "*", false, true);
       Frame fr = Scope.track(j.get());
 
       assertArrayEquals(expected._names, fr._names);

--- a/h2o-core/src/test/java/water/parser/ImportSQLTest.java
+++ b/h2o-core/src/test/java/water/parser/ImportSQLTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import water.TestUtil;
 import water.fvec.Frame;
 import water.jdbc.SQLManager;
+import water.jdbc.SqlFetchMode;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -23,7 +24,6 @@ public class ImportSQLTest extends TestUtil{
   
   String select_query = "";
   String columns = "*";
-  boolean optimize = true;
   
   @BeforeClass
   static public void setup() {stall_till_cloudsize(1);}
@@ -31,11 +31,11 @@ public class ImportSQLTest extends TestUtil{
   @Ignore @Test
   public void citibike20k() {
     String table = "citibike20k";
-    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, optimize).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.SINGLE).get();
     assertTrue(sql_f.numRows() == 2e4);
     assertTrue(sql_f.numCols() == 15);
     sql_f.delete();
-    sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, "bikeid, starttime", optimize).get();
+    sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, "bikeid, starttime", SqlFetchMode.SINGLE).get();
     assertTrue(sql_f.numRows() == 2e4);
     assertTrue(sql_f.numCols() == 2);
     sql_f.delete();
@@ -44,7 +44,7 @@ public class ImportSQLTest extends TestUtil{
   @Ignore @Test
   public void allSQLTypes() {
     String table = "allSQLTypes";
-    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, optimize).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.SINGLE).get();
     sql_f.delete();
     
   }
@@ -54,13 +54,13 @@ public class ImportSQLTest extends TestUtil{
     String conUrl = "jdbc:mysql://localhost:3306/menagerie?&useSSL=false";
     String table = "air";
     String password = "ludi";
-    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, optimize).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.SINGLE).get();
     sql_f.delete();
   }
 
   @Ignore @Test
   public void select_query() {
-    Frame sql_f = SQLManager.importSqlTable(conUrl, "", "SELECT bikeid from citibike20k", user, password, columns, optimize).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, "", "SELECT bikeid from citibike20k", user, password, columns, SqlFetchMode.SINGLE).get();
     assertTrue(sql_f.numCols() == 1);
     assertTrue(sql_f.numRows() == 2e4);
     sql_f.delete();

--- a/h2o-core/src/test/java/water/parser/ImportSQLTest.java
+++ b/h2o-core/src/test/java/water/parser/ImportSQLTest.java
@@ -31,11 +31,11 @@ public class ImportSQLTest extends TestUtil{
   @Ignore @Test
   public void citibike20k() {
     String table = "citibike20k";
-    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.SINGLE).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.DISTRIBUTED).get();
     assertTrue(sql_f.numRows() == 2e4);
     assertTrue(sql_f.numCols() == 15);
     sql_f.delete();
-    sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, "bikeid, starttime", SqlFetchMode.SINGLE).get();
+    sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, "bikeid, starttime", SqlFetchMode.DISTRIBUTED).get();
     assertTrue(sql_f.numRows() == 2e4);
     assertTrue(sql_f.numCols() == 2);
     sql_f.delete();
@@ -44,7 +44,7 @@ public class ImportSQLTest extends TestUtil{
   @Ignore @Test
   public void allSQLTypes() {
     String table = "allSQLTypes";
-    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.SINGLE).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.DISTRIBUTED).get();
     sql_f.delete();
     
   }
@@ -54,13 +54,13 @@ public class ImportSQLTest extends TestUtil{
     String conUrl = "jdbc:mysql://localhost:3306/menagerie?&useSSL=false";
     String table = "air";
     String password = "ludi";
-    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.SINGLE).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, table, select_query, user, password, columns, SqlFetchMode.DISTRIBUTED).get();
     sql_f.delete();
   }
 
   @Ignore @Test
   public void select_query() {
-    Frame sql_f = SQLManager.importSqlTable(conUrl, "", "SELECT bikeid from citibike20k", user, password, columns, SqlFetchMode.SINGLE).get();
+    Frame sql_f = SQLManager.importSqlTable(conUrl, "", "SELECT bikeid from citibike20k", user, password, columns, SqlFetchMode.DISTRIBUTED).get();
     assertTrue(sql_f.numCols() == 1);
     assertTrue(sql_f.numRows() == 2e4);
     sql_f.delete();

--- a/h2o-hadoop/tests/python/pyunit_gbm_on_hive.py
+++ b/h2o-hadoop/tests/python/pyunit_gbm_on_hive.py
@@ -5,8 +5,18 @@ import os
 import h2o
 sys.path.insert(1, os.path.join("..", "..", "..", "h2o-py"))
 from tests import pyunit_utils
-from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from numpy import isclose
 
+def adapt_airlines(airlines_dataset):
+    airlines_dataset["table_for_h2o_import.origin"] = airlines_dataset["table_for_h2o_import.origin"].asfactor()
+    airlines_dataset["table_for_h2o_import.fdayofweek"] = airlines_dataset["table_for_h2o_import.fdayofweek"].asfactor()
+    airlines_dataset["table_for_h2o_import.uniquecarrier"] = airlines_dataset["table_for_h2o_import.uniquecarrier"].asfactor()
+    airlines_dataset["table_for_h2o_import.dest"] = airlines_dataset["table_for_h2o_import.dest"].asfactor()
+    airlines_dataset["table_for_h2o_import.fyear"] = airlines_dataset["table_for_h2o_import.fyear"].asfactor()
+    airlines_dataset["table_for_h2o_import.fdayofmonth"] = airlines_dataset["table_for_h2o_import.fdayofmonth"].asfactor()
+    airlines_dataset["table_for_h2o_import.isdepdelayed"] = airlines_dataset["table_for_h2o_import.isdepdelayed"].asfactor()
+    airlines_dataset["table_for_h2o_import.fmonth"] = airlines_dataset["table_for_h2o_import.fmonth"].asfactor()
+    return airlines_dataset
 
 def gbm_on_hive():
     connection_url = "jdbc:hive2://localhost:10000/default"
@@ -17,24 +27,29 @@ def gbm_on_hive():
     select_query = "select * from airlinestest"
     username = "hive"
     password = ""
+
+    # read from S3
     airlines_dataset_original = h2o.import_file(path="https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/AirlinesTest.csv.zip")
+    # read from Hive Distributed
     airlines_dataset = h2o.import_sql_select(connection_url, select_query, username, password)
+    airlines_dataset = adapt_airlines(airlines_dataset)
+    # read from Hive Streaming
+    airlines_dataset_streaming = h2o.import_sql_select(connection_url, select_query, username, password, streaming=True)
+    airlines_dataset_streaming = adapt_airlines(airlines_dataset_streaming)
+
+    # datasets should be identical from user's point of view
     pyunit_utils.compare_frames(airlines_dataset_original, airlines_dataset, 100, tol_numeric=0)
-    airlines_dataset["table_for_h2o_import.origin"] = airlines_dataset["table_for_h2o_import.origin"].asfactor()
-    airlines_dataset["table_for_h2o_import.fdayofweek"] = airlines_dataset["table_for_h2o_import.fdayofweek"].asfactor()
-    airlines_dataset["table_for_h2o_import.uniquecarrier"] = airlines_dataset["table_for_h2o_import.uniquecarrier"].asfactor()
-    airlines_dataset["table_for_h2o_import.dest"] = airlines_dataset["table_for_h2o_import.dest"].asfactor()
-    airlines_dataset["table_for_h2o_import.fyear"] = airlines_dataset["table_for_h2o_import.fyear"].asfactor()
-    airlines_dataset["table_for_h2o_import.fdayofmonth"] = airlines_dataset["table_for_h2o_import.fdayofmonth"].asfactor()
-    airlines_dataset["table_for_h2o_import.isdepdelayed"] = airlines_dataset["table_for_h2o_import.isdepdelayed"].asfactor()
-    airlines_dataset["table_for_h2o_import.fmonth"] = airlines_dataset["table_for_h2o_import.fmonth"].asfactor()
+    pyunit_utils.compare_frames(airlines_dataset_original, airlines_dataset_streaming, 100, tol_numeric=0)
+
+    from h2o.estimators.gbm import H2OGradientBoostingEstimator
     airlines_X_col_names = airlines_dataset.col_names[:-2]
     airlines_y_col_name = airlines_dataset.col_names[-2]
-    train, valid, test = airlines_dataset.split_frame([0.6, 0.2], seed=1234)
-    from h2o.estimators.gbm import H2OGradientBoostingEstimator
     gbm_v1 = H2OGradientBoostingEstimator(model_id="gbm_airlines_v1", seed=2000000)
-    gbm_v1.train(airlines_X_col_names, airlines_y_col_name, training_frame=train, validation_frame=valid)
-    gbm_v1.predict(test)
+    gbm_v1.train(airlines_X_col_names, airlines_y_col_name,
+                 training_frame=airlines_dataset, validation_frame=airlines_dataset_streaming)
+    print(gbm_v1)
+    # demonstrates that metrics can be slightly different due to different chunking on the backend
+    assert isclose(gbm_v1.auc(train=True), gbm_v1.auc(valid=True), rtol=1e-4)
 
 
 if __name__ == "__main__":

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -414,7 +414,7 @@ def import_file(path=None, destination_frame=None, parse=True, header=0, sep=Non
         return H2OFrame()._import_parse(path, pattern, destination_frame, header, sep, col_names, col_types, na_strings)
 
 
-def import_sql_table(connection_url, table, username, password, columns=None, optimize=True, streaming=False):
+def import_sql_table(connection_url, table, username, password, columns=None, optimize=True, fetch_mode=None):
     """
     Import SQL table to H2OFrame in memory.
 
@@ -434,9 +434,9 @@ def import_sql_table(connection_url, table, username, password, columns=None, op
     :param columns: a list of column names to import from SQL table. Default is to import all columns.
     :param username: username for SQL server
     :param password: password for SQL server
-    :param optimize: optimize import of SQL table for faster imports. Experimental.
-    :param streaming: disable distributed import, read data sequentially on single H2O node and stream it to
-        the rest of the cluster. Use for databases that do not support OFFSET-like clauses in SQL statements.
+    :param optimize: DEPRECATED. Ignored - use fetch_mode instead. Optimize import of SQL table for faster imports.
+    :param fetch_mode: Set to DISTRIBUTED to enable distributed import. Set to SINGLE to force a sequential read by a single node
+        from the database.
 
     :returns: an :class:`H2OFrame` containing data of the specified SQL table.
 
@@ -453,16 +453,16 @@ def import_sql_table(connection_url, table, username, password, columns=None, op
     assert_is_type(password, str)
     assert_is_type(columns, [str], None)
     assert_is_type(optimize, bool)
-    assert_is_type(streaming, bool)
+    assert_is_type(fetch_mode, str, None)
     p = {"connection_url": connection_url, "table": table, "username": username, "password": password,
-         "optimize": optimize, "streaming": streaming}
+         "optimize": optimize, "fetch_mode": fetch_mode}
     if columns:
         p["columns"] = ", ".join(columns)
     j = H2OJob(api("POST /99/ImportSQLTable", data=p), "Import SQL Table").poll()
     return get_frame(j.dest_key)
 
 
-def import_sql_select(connection_url, select_query, username, password, optimize=True, streaming=False):
+def import_sql_select(connection_url, select_query, username, password, optimize=True, fetch_mode=False):
     """
     Import the SQL table that is the result of the specified SQL query to H2OFrame in memory.
 
@@ -480,9 +480,9 @@ def import_sql_select(connection_url, select_query, username, password, optimize
     :param select_query: SQL query starting with `SELECT` that returns rows from one or more database tables.
     :param username: username for SQL server
     :param password: password for SQL server
-    :param optimize: optimize import of SQL table for faster imports. Experimental.
-    :param streaming: disable distributed import, read data sequentially on single H2O node and stream it to
-        the rest of the cluster. Use for databases that do not support OFFSET-like clauses in SQL statements.
+    :param optimize: DEPRECATED. Ignored - use fetch_mode instead. Optimize import of SQL table for faster imports.
+    :param fetch_mode: Set to DISTRIBUTED to enable distributed import. Set to SINGLE to force a sequential read by a single node
+        from the database.
 
     :returns: an :class:`H2OFrame` containing data of the specified SQL query.
 
@@ -499,9 +499,9 @@ def import_sql_select(connection_url, select_query, username, password, optimize
     assert_is_type(username, str)
     assert_is_type(password, str)
     assert_is_type(optimize, bool)
-    assert_is_type(streaming, bool)
+    assert_is_type(fetch_mode, str, None)
     p = {"connection_url": connection_url, "select_query": select_query, "username": username, "password": password,
-         "optimize": optimize, "streaming": streaming}
+         "optimize": optimize, "fetch_mode": fetch_mode}
     j = H2OJob(api("POST /99/ImportSQLTable", data=p), "Import SQL Table").poll()
     return get_frame(j.dest_key)
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -455,14 +455,14 @@ def import_sql_table(connection_url, table, username, password, columns=None, op
     assert_is_type(optimize, bool)
     assert_is_type(fetch_mode, str, None)
     p = {"connection_url": connection_url, "table": table, "username": username, "password": password,
-         "optimize": optimize, "fetch_mode": fetch_mode}
+         "fetch_mode": fetch_mode}
     if columns:
         p["columns"] = ", ".join(columns)
     j = H2OJob(api("POST /99/ImportSQLTable", data=p), "Import SQL Table").poll()
     return get_frame(j.dest_key)
 
 
-def import_sql_select(connection_url, select_query, username, password, optimize=True, fetch_mode=False):
+def import_sql_select(connection_url, select_query, username, password, optimize=True, fetch_mode=None):
     """
     Import the SQL table that is the result of the specified SQL query to H2OFrame in memory.
 
@@ -492,7 +492,7 @@ def import_sql_select(connection_url, select_query, username, password, optimize
         >>> username = "root"
         >>> password = "abc123"
         >>> my_citibike_data = h2o.import_sql_select(conn_url, select_query,
-        ...                                          username, password)
+        ...                                          username, password, fetch_mode)
     """
     assert_is_type(connection_url, str)
     assert_is_type(select_query, str)
@@ -501,7 +501,7 @@ def import_sql_select(connection_url, select_query, username, password, optimize
     assert_is_type(optimize, bool)
     assert_is_type(fetch_mode, str, None)
     p = {"connection_url": connection_url, "select_query": select_query, "username": username, "password": password,
-         "optimize": optimize, "fetch_mode": fetch_mode}
+         "fetch_mode": fetch_mode}
     j = H2OJob(api("POST /99/ImportSQLTable", data=p), "Import SQL Table").poll()
     return get_frame(j.dest_key)
 

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -194,9 +194,12 @@ h2o.uploadFile <- function(path, destination_frame = "",
 #' @param username Username for SQL server
 #' @param password Password for SQL server
 #' @param columns (Optional) Character vector of column names to import from SQL table. Default is to import all columns. 
-#' @param optimize (Optional) Optimize import of SQL table for faster imports. Experimental. Default is true. 
+#' @param optimize (Optional) Optimize import of SQL table for faster imports. Experimental. Default is true.
+#' @param streaming (Optional) Turn on to disable distributed import. Streaming mode reads the data sequentially
+#'        using a single H2O node and then streams it to the rest of the nodes of the cluster.
+#'        Can be used for databases that do not support OFFSET-like clauses in SQL statements.
 #' @export
-h2o.import_sql_table <- function(connection_url, table, username, password, columns = NULL, optimize = NULL) {
+h2o.import_sql_table <- function(connection_url, table, username, password, columns = NULL, optimize = NULL, streaming = NULL) {
   parms <- list()
   parms$connection_url <- connection_url
   parms$table <- table
@@ -207,6 +210,7 @@ h2o.import_sql_table <- function(connection_url, table, username, password, colu
     parms$columns <- columns
   }
   if (!is.null(optimize)) parms$optimize <- optimize
+  if (!is.null(streaming)) parms$streaming <- streaming
   res <- .h2o.__remoteSend('ImportSQLTable', method = "POST", .params = parms, h2oRestApiVersion = 99)
   job_key <- res$key$name
   dest_key <- res$dest$name
@@ -238,14 +242,18 @@ h2o.import_sql_table <- function(connection_url, table, username, password, colu
 #' @param username Username for SQL server
 #' @param password Password for SQL server
 #' @param optimize (Optional) Optimize import of SQL table for faster imports. Experimental. Default is true. 
+#' @param streaming (Optional) Turn on to disable distributed import. Streaming mode reads the data sequentially
+#'        using a single H2O node and then streams it to the rest of the nodes of the cluster.
+#'        Can be used for databases that do not support OFFSET-like clauses in SQL statements.
 #' @export
-h2o.import_sql_select<- function(connection_url, select_query, username, password, optimize = NULL) {
+h2o.import_sql_select<- function(connection_url, select_query, username, password, optimize = NULL, streaming = NULL) {
   parms <- list()
   parms$connection_url <- connection_url
   parms$select_query <- select_query
   parms$username <- username
   parms$password <- password
   if (!is.null(optimize)) parms$optimize <- optimize
+  if (!is.null(streaming)) parms$streaming <- streaming
   res <- .h2o.__remoteSend('ImportSQLTable', method = "POST", .params = parms, h2oRestApiVersion = 99)
   job_key <- res$key$name
   dest_key <- res$dest$name

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -210,7 +210,6 @@ h2o.import_sql_table <- function(connection_url, table, username, password, colu
     columns <- toString(columns)
     parms$columns <- columns
   }
-  if (!is.null(optimize)) parms$optimize <- optimize
   if (!is.null(fetch_mode)) parms$fetch_mode <- fetch_mode
   res <- .h2o.__remoteSend('ImportSQLTable', method = "POST", .params = parms, h2oRestApiVersion = 99)
   job_key <- res$key$name
@@ -253,7 +252,6 @@ h2o.import_sql_select<- function(connection_url, select_query, username, passwor
   parms$select_query <- select_query
   parms$username <- username
   parms$password <- password
-  if (!is.null(optimize)) parms$optimize <- optimize
   if (!is.null(fetch_mode)) parms$fetch_mode <- fetch_mode
   res <- .h2o.__remoteSend('ImportSQLTable', method = "POST", .params = parms, h2oRestApiVersion = 99)
   job_key <- res$key$name

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -194,12 +194,13 @@ h2o.uploadFile <- function(path, destination_frame = "",
 #' @param username Username for SQL server
 #' @param password Password for SQL server
 #' @param columns (Optional) Character vector of column names to import from SQL table. Default is to import all columns. 
-#' @param optimize (Optional) Optimize import of SQL table for faster imports. Experimental. Default is true.
-#' @param streaming (Optional) Turn on to disable distributed import. Streaming mode reads the data sequentially
-#'        using a single H2O node and then streams it to the rest of the nodes of the cluster.
+#' @param optimize (Optional) Optimize import of SQL table for faster imports. Default is true.
+#'        Ignored - use fetch_mode instead.
+#' @param fetch_mode (Optional) Set to DISTRIBUTED to enable distributed import. Set to SINGLE to force a sequential read
+#'        from the database
 #'        Can be used for databases that do not support OFFSET-like clauses in SQL statements.
 #' @export
-h2o.import_sql_table <- function(connection_url, table, username, password, columns = NULL, optimize = NULL, streaming = NULL) {
+h2o.import_sql_table <- function(connection_url, table, username, password, columns = NULL, optimize = NULL, fetch_mode = NULL) {
   parms <- list()
   parms$connection_url <- connection_url
   parms$table <- table
@@ -210,7 +211,7 @@ h2o.import_sql_table <- function(connection_url, table, username, password, colu
     parms$columns <- columns
   }
   if (!is.null(optimize)) parms$optimize <- optimize
-  if (!is.null(streaming)) parms$streaming <- streaming
+  if (!is.null(fetch_mode)) parms$fetch_mode <- fetch_mode
   res <- .h2o.__remoteSend('ImportSQLTable', method = "POST", .params = parms, h2oRestApiVersion = 99)
   job_key <- res$key$name
   dest_key <- res$dest$name
@@ -242,18 +243,18 @@ h2o.import_sql_table <- function(connection_url, table, username, password, colu
 #' @param username Username for SQL server
 #' @param password Password for SQL server
 #' @param optimize (Optional) Optimize import of SQL table for faster imports. Experimental. Default is true. 
-#' @param streaming (Optional) Turn on to disable distributed import. Streaming mode reads the data sequentially
-#'        using a single H2O node and then streams it to the rest of the nodes of the cluster.
+#' @param fetch_mode (Optional) Set to DISTRIBUTED to enable distributed import. Set to SINGLE to force a sequential read
+#'        from the database
 #'        Can be used for databases that do not support OFFSET-like clauses in SQL statements.
 #' @export
-h2o.import_sql_select<- function(connection_url, select_query, username, password, optimize = NULL, streaming = NULL) {
+h2o.import_sql_select<- function(connection_url, select_query, username, password, optimize = NULL, fetch_mode = NULL) {
   parms <- list()
   parms$connection_url <- connection_url
   parms$select_query <- select_query
   parms$username <- username
   parms$password <- password
   if (!is.null(optimize)) parms$optimize <- optimize
-  if (!is.null(streaming)) parms$streaming <- streaming
+  if (!is.null(fetch_mode)) parms$fetch_mode <- fetch_mode
   res <- .h2o.__remoteSend('ImportSQLTable', method = "POST", .params = parms, h2oRestApiVersion = 99)
   job_key <- res$key$name
   dest_key <- res$dest$name


### PR DESCRIPTION
Introduces a new mode of data ingests compatible with a vast majority
of JDBC data sources. Instead of trying to do distributed ingest streams
all data through a single H2O node. The source database doesn't need to
support OFFSET-like clauses. The original intent was to support reading
from Hive 1.2.x.

Chunks are compressed and distributed to H2O nodes asynchronously.