### PR TITLE
PUBDEV-5910: Doc update to MOJOs

### DIFF
--- a/h2o-docs/src/product/mojo-quickstart.rst
+++ b/h2o-docs/src/product/mojo-quickstart.rst
@@ -8,7 +8,19 @@ What is a MOJO?
 
 A MOJO (Model Object, Optimized) is an alternative to H2O's POJO. As with POJOs, H2O allows you to convert models that you build to MOJOs, which can then be deployed for scoring in real time.
 
-**Note**: MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, Stacked Ensembles, SVM, Word2vec, and XGBoost models.
+**Notes**: 
+
+- MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, Stacked Ensembles, SVM, Word2vec, and XGBoost models.
+- MOJOs are only supported for encodings that are either default or ``enum``. 
+
+Benefits of MOJOs over POJOs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While POJOs continue to be supported, some customers encountered issues with large POJOs not compiling. (Note that POJOs are not supported for source files larger than 1G.) MOJOs do not have a size restriction and address the size issue by taking the tree out of the POJO and using generic tree-walker code to navigate the model. The resulting executable is much smaller and faster than a POJO.
+
+At large scale, new models are roughly 20-25 times smaller in disk space, 2-3 times faster during "hot" scoring (after JVM is able to optimize the typical execution paths), and 10-40 times faster in "cold" scoring (when JVM doesn't know yet know the execution paths) compared to POJOs. The efficiency gains are larger the bigger the size of the model.
+
+H2O conducted in-house testing using models with 5000 trees of depth 25. At very small scale (50 trees / 5 depth), POJOs were found to perform ≈10% faster than MOJOs for binomial and regression models, but 50% slower than MOJOs for multinomial models.
 
 Building a MOJO
 ~~~~~~~~~~~~~~~
@@ -594,14 +606,6 @@ The following code snippet shows how to download a MOJO from R and run the Print
 
 FAQ
 ~~~
-
--  **What are the benefits of MOJOs vs POJOs?**
-
-  While POJOs continue to be supported, some customers encountered issues with large POJOs not compiling. (Note that POJOs are not supported for source files larger than 1G.) MOJOs do not have a size restriction and address the size issue by taking the tree out of the POJO and using generic tree-walker code to navigate the model. The resulting executable is much smaller and faster than a POJO.
-
-  At large scale, new models are roughly 20-25 times smaller in disk space, 2-3 times faster during "hot" scoring (after JVM is able to optimize the typical execution paths), and 10-40 times faster in "cold" scoring (when JVM doesn't know yet know the execution paths) compared to POJOs. The efficiency gains are larger the bigger the size of the model.
-
-  H2O conducted in-house testing using models with 5000 trees of depth 25. At very small scale (50 trees / 5 depth), POJOs were found to perform ≈10% faster than MOJOs for binomial and regression models, but 50% slower than MOJOs for multinomial models.
 
 -  **How can I use an XGBoost MOJO with Maven?**
 

--- a/h2o-genmodel/src/main/java/overview.html
+++ b/h2o-genmodel/src/main/java/overview.html
@@ -311,8 +311,11 @@ A MOJO (Model Object, Optimized) is an alternative to H2O's currently available 
 POJOs, H2O allows you to convert models that you build to MOJOs, which can then be deployed
 for scoring in real time.
 <p></p>
-<b>Note</b>: MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, Stacked Ensembles, SVM, Word2vec,
-and XGBoost algorithms.
+<b>Notes</b>: 
+<ul>
+<li>MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, Stacked Ensembles, SVM, Word2vec, and XGBoost algorithms.</li>
+<li>MOJOs are only supported for encodings that are either default or Enum.</li>
+</ul>
 
 <h3><u>Benefit of MOJOs over POJOs</u></h3>
 <p></p>


### PR DESCRIPTION
- Added note in User Guide and Javadoc that MOJOs are only supported for categorical that are default or enum.
- In User Guide, moved “Benefits” paragraphs from FAQ into a separate subsection to make it more prominent.