### PR TITLE
PUBDEV-5919: ARFF File Import fails if header is too large (>4MB)

### DIFF
--- a/h2o-core/src/main/java/water/parser/ARFFParser.java
+++ b/h2o-core/src/main/java/water/parser/ARFFParser.java
@@ -1,6 +1,7 @@
 package water.parser;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import water.Key;
 import water.fvec.ByteVec;
@@ -34,7 +35,7 @@ class ARFFParser extends CsvParser {
     String last_line_fragment = null;
     do {
       offset = readArffHeader(0, header, bits, singleQuotes, last_line_fragment);
-      if (offset > bits.length) {
+      if (offset > bits.length && isValidHeader(header)) {
         last_line_fragment = header.remove(header.size() - 1);
         bits = bv.chunkForChunkIdx(++chunk_idx).getBytes();
       } else {
@@ -113,6 +114,17 @@ class ARFFParser extends CsvParser {
 
     // Return the final setup
     return new ParseSetup(ARFF_INFO, sep, singleQuotes, ParseSetup.NO_HEADER, ncols, labels, ctypes, domains, naStrings, data);
+  }
+
+  private static boolean isValidHeader(List<String> header) {
+    for (String line : header) {
+      if (!isValidHeaderLine(line)) return false;
+    }
+    return header.size() > 0;
+  }
+
+  private static boolean isValidHeaderLine(String str) {
+    return str.startsWith("@");
   }
 
   private static int readArffHeader(int offset, ArrayList<String> header, byte[] bits, boolean singleQuotes, String line_fragment) {

--- a/h2o-core/src/main/java/water/parser/ARFFParser.java
+++ b/h2o-core/src/main/java/water/parser/ARFFParser.java
@@ -32,20 +32,20 @@ class ARFFParser extends CsvParser {
     // header section
     ArrayList<String> header = new ArrayList<>();
 
-    int offset;
+    int offset = 0;
     int chunk_idx = 0; //relies on the assumption that bits param have been extracted from first chunk: cf. ParseSetup#map
-    boolean readNextChunk;
-    do {
+    boolean readHeader = true;
+    while (readHeader) {
       offset = readArffHeader(0, header, bits, singleQuotes);
-      readNextChunk = false;
       if (isValidHeader(header)) {
         String lastHeader = header.get(header.size() - 1);
         if (INCOMPLETE_HEADER.equals(lastHeader) || SKIP_NEXT_HEADER.equals(lastHeader)) {
           bits = bv.chunkForChunkIdx(++chunk_idx).getBytes();
-          readNextChunk = true;
+          continue;
         }
       }
-    } while (readNextChunk);
+      readHeader = false;
+    }
 
     if (offset < bits.length && !CsvParser.isEOL(bits[offset]))
       haveData = true; //more than just the header

--- a/h2o-core/src/main/java/water/parser/ARFFParser.java
+++ b/h2o-core/src/main/java/water/parser/ARFFParser.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import water.Key;
+import water.exceptions.H2OUnsupportedDataFileException;
 import water.fvec.ByteVec;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
@@ -51,6 +52,10 @@ class ARFFParser extends CsvParser {
           bits = bv.chunkForChunkIdx(++chunk_idx).getBytes();
           continue;
         }
+      } else if (chunk_idx > 0) { //first chunk parsed correctly, but not the next => formatting issue
+        throw new H2OUnsupportedDataFileException(
+            "Arff parsing: Invalid header. If compressed file, please try without compression",
+            "First chunk was parsed correctly, but a following one failed, common with archives as only first chunk in decompressed");
       }
       readHeader = false;
     }

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -65,8 +65,9 @@ class CsvParser extends Parser {
     int colIdx = 0;
     byte c = bits[offset];
     // skip comments for the first chunk (or if not a chunk)
+    byte[] nonDataLineMarkers = nonDataLineMarkers();
     if( cidx == 0 ) {
-      while (ArrayUtils.contains(nonDataLineMarkers(), c) || isEOL(c)) {
+      while (ArrayUtils.contains(nonDataLineMarkers, c) || isEOL(c)) {
         while ((offset   < bits.length) && (bits[offset] != CHAR_CR) && (bits[offset  ] != CHAR_LF)) {
 //          System.out.print(String.format("%c",bits[offset]));
           ++offset;
@@ -220,7 +221,7 @@ MAIN_LOOP:
               state = EXPECT_COND_LF;
             break;
           }
-          if (ArrayUtils.contains(nonDataLineMarkers(), c)) {
+          if (ArrayUtils.contains(nonDataLineMarkers, c)) {
             state = SKIP_LINE;
             break;
           }

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import water.Key;
 import water.fvec.FileVec;
 import water.fvec.Vec;
+import water.util.ArrayUtils;
 import water.util.StringUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -18,8 +19,13 @@ class CsvParser extends Parser {
   private static final int NO_HEADER = ParseSetup.NO_HEADER;
   private static final int GUESS_HEADER = ParseSetup.GUESS_HEADER;
   private static final int HAS_HEADER = ParseSetup.HAS_HEADER;
+  private static final byte[] NON_DATA_LINE_MARKERS = {'#'};
 
   CsvParser( ParseSetup ps, Key jobKey ) { super(ps, jobKey); }
+
+  protected byte[] nonDataLineMarkers() {
+    return NON_DATA_LINE_MARKERS;
+  }
 
   // Parse this one Chunk (in parallel with other Chunks)
   @SuppressWarnings("fallthrough")
@@ -60,10 +66,7 @@ class CsvParser extends Parser {
     byte c = bits[offset];
     // skip comments for the first chunk (or if not a chunk)
     if( cidx == 0 ) {
-      while ( c == '#'
-              || isEOL(c)
-              || c == '@' /*also treat as comments leading '@' from ARFF format*/
-              || c == '%' /*also treat as comments leading '%' from ARFF format*/) {
+      while (ArrayUtils.contains(nonDataLineMarkers(), c) || isEOL(c)) {
         while ((offset   < bits.length) && (bits[offset] != CHAR_CR) && (bits[offset  ] != CHAR_LF)) {
 //          System.out.print(String.format("%c",bits[offset]));
           ++offset;
@@ -215,6 +218,10 @@ MAIN_LOOP:
           if (isEOL(c)) {
             if (c == CHAR_CR)
               state = EXPECT_COND_LF;
+            break;
+          }
+          if (ArrayUtils.contains(nonDataLineMarkers(), c)) {
+            state = SKIP_LINE;
             break;
           }
           state = WHITESPACE_BEFORE_TOKEN;
@@ -494,7 +501,7 @@ MAIN_LOOP:
 
   @Override protected int fileHasHeader(byte[] bits, ParseSetup ps) {
     boolean hasHdr = true;
-    String[] lines = getFirstLines(bits, ps._single_quotes);
+    String[] lines = getFirstLines(bits, ps._single_quotes, nonDataLineMarkers());
     if (lines != null && lines.length > 0) {
       String[] firstLine = determineTokens(lines[0], _setup._separator, _setup._single_quotes);
       if (_setup._column_names != null) {
@@ -656,7 +663,7 @@ MAIN_LOOP:
     int lastNewline = bits.length-1;
     while(lastNewline > 0 && !CsvParser.isEOL(bits[lastNewline]))lastNewline--;
     if(lastNewline > 0) bits = Arrays.copyOf(bits,lastNewline+1);
-    String[] lines = getFirstLines(bits, singleQuotes);
+    String[] lines = getFirstLines(bits, singleQuotes, NON_DATA_LINE_MARKERS);
     if(lines.length==0 )
       throw new ParseDataset.H2OParseException("No data!");
 
@@ -772,7 +779,7 @@ MAIN_LOOP:
     return resSetup;
   }
 
-  private static String[] getFirstLines(byte[] bits, boolean singleQuotes) {
+  private static String[] getFirstLines(byte[] bits, boolean singleQuotes, byte[] nonDataLineMarkers) {
     // Parse up to 10 lines (skipping hash-comments & ARFF comments)
     String[] lines = new String[10]; // Parse 10 lines
     int nlines = 0;
@@ -797,9 +804,7 @@ MAIN_LOOP:
       ++offset;
       // For Windoze, skip a trailing LF after CR
       if( (offset < bits.length) && (bits[offset] == CsvParser.CHAR_LF)) ++offset;
-      if( bits[lineStart] == '#') continue; // Ignore      comment lines
-      if( bits[lineStart] == '%') continue; // Ignore ARFF comment lines
-      if( bits[lineStart] == '@') continue; // Ignore ARFF lines
+      if (ArrayUtils.contains(nonDataLineMarkers, bits[lineStart])) continue;
       if( lineEnd > lineStart ) {
         String str = new String(bits, lineStart,lineEnd-lineStart).trim();
         if( !str.isEmpty() ) lines[nlines++] = str;

--- a/h2o-core/src/main/java/water/parser/DefaultParserProviders.java
+++ b/h2o-core/src/main/java/water/parser/DefaultParserProviders.java
@@ -42,7 +42,7 @@ public final class DefaultParserProviders {
     public ParseSetup guessSetup(ByteVec bv, byte[] bits, byte sep, int ncols, boolean singleQuotes,
                                  int checkHeader, String[] columnNames, byte[] columnTypes,
                                  String[][] domains, String[][] naStrings) {
-      return ARFFParser.guessSetup(bits, sep, singleQuotes, columnNames, naStrings);
+      return ARFFParser.guessSetup(bv, bits, sep, singleQuotes, columnNames, naStrings);
     }
   }
 

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -559,6 +559,11 @@ public class ArrayUtils {
     return false;
   }
 
+  static public boolean contains(byte[] a, byte d) {
+    for (int anA : a) if (anA == d) return true;
+    return false;
+  }
+
   static public boolean contains(int[] a, int d) {
     for (int anA : a) if (anA == d) return true;
     return false;

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -560,7 +560,7 @@ public class ArrayUtils {
   }
 
   static public boolean contains(byte[] a, byte d) {
-    for (int anA : a) if (anA == d) return true;
+    for (byte anA : a) if (anA == d) return true;
     return false;
   }
 

--- a/h2o-core/src/test/java/water/parser/ParserTestARFF.java
+++ b/h2o-core/src/test/java/water/parser/ParserTestARFF.java
@@ -8,20 +8,12 @@ import water.DKV;
 import water.H2O;
 import water.Key;
 import water.TestUtil;
-import water.fvec.ByteVec;
 import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.fvec.Vec;
-import water.util.FileUtils;
-import water.util.RandomUtils;
 
 import static water.parser.ParserTest.makeByteVec;
 
-import java.io.*;
-import java.nio.file.CopyOption;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/h2o-core/src/test/java/water/parser/ParserTestARFF.java
+++ b/h2o-core/src/test/java/water/parser/ParserTestARFF.java
@@ -8,28 +8,56 @@ import water.DKV;
 import water.H2O;
 import water.Key;
 import water.TestUtil;
+import water.fvec.ByteVec;
 import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.fvec.Vec;
 import water.util.FileUtils;
+import water.util.RandomUtils;
 
 import static water.parser.ParserTest.makeByteVec;
 
+import java.io.*;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
 
 public class ParserTestARFF extends TestUtil {
   @BeforeClass static public void setup() { stall_till_cloudsize(1); }
 
-  /**
-   * Helper to check parsed column types
-   */
-  private void testTypes(String[] dataset, byte[] exp, int len, String sep) {
-    StringBuilder sb1 = new StringBuilder();
-    for (String ds : dataset) sb1.append(ds).append(sep);
-    Key k1 = makeByteVec(sb1.toString());
+  private Frame getParsedFrame(String[] dataset, String sep, int chunks_count) {
+    StringBuilder sb = new StringBuilder();
+    for (String ds : dataset) sb.append(ds).append(sep);
+
+    String[] data_chunks = new String[chunks_count];
+    int offset = 0;
+    for (int i = 0; i < chunks_count; i++) {
+      int chunk_length = sb.length() % chunks_count == 0
+          ? sb.length() / chunks_count
+          : Math.min((int)Math.ceil((double)sb.length() / chunks_count), sb.length() - offset);
+      data_chunks[i] = sb.substring(offset, offset + chunk_length);
+      offset += chunk_length;
+    }
+    assert offset == sb.length();
+
+    Key k1 = makeByteVec(data_chunks);
     Key r1 = Key.make("r1");
     ParseDataset.parse(r1, k1);
     Frame fr = DKV.get(r1).get();
+    Assert.assertNotNull(fr);
+    return fr;
+  }
+
+  /**
+   * Helper to check parsed column types
+   */
+  private void testTypes(String[] dataset, byte[] exp, int len, String sep, int chunks_count) {
+    Frame fr = getParsedFrame(dataset, sep, chunks_count);
     try {
       Assert.assertEquals(len, fr.numRows());
       Assert.assertEquals(exp.length, fr.numCols());
@@ -71,13 +99,8 @@ public class ParserTestARFF extends TestUtil {
   /**
    * Helper to check parsed column names
    */
-  private void testColNames(String[] dataset, String[] exp, int len, String sep) {
-    StringBuilder sb1 = new StringBuilder();
-    for (String ds : dataset) sb1.append(ds).append(sep);
-    Key k1 = makeByteVec(sb1.toString());
-    Key r1 = Key.make("r1");
-    ParseDataset.parse(r1, k1);
-    Frame fr = DKV.get(r1).get();
+  private void testColNames(String[] dataset, String[] exp, int len, String sep, int chunks_count) {
+    Frame fr = getParsedFrame(dataset, sep, chunks_count);
     try {
       Assert.assertEquals(len, fr.numRows());
       Assert.assertEquals(exp.length, fr.numCols());
@@ -155,10 +178,10 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // numbers are numbers
@@ -183,10 +206,10 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // force numbers to be categoricals //PUBDEV-17
@@ -215,10 +238,10 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // force numbers to be categoricals
@@ -243,10 +266,10 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // force numbers to be categoricals
@@ -271,10 +294,10 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // force numbers to be strings
@@ -300,11 +323,11 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
 
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // mixed ARFF file with numbers as numbers
@@ -340,11 +363,11 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
 
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // mixed ARFF file with numbers as categoricals
@@ -380,11 +403,11 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
 
-    testColNames(dataset, exp_names, len, "\n");
-    testColNames(dataset, exp_names, len, "\r\n");
+    testColNames(dataset, exp_names, len, "\n", 1);
+    testColNames(dataset, exp_names, len, "\r\n", 1);
   }
 
   // UUID
@@ -420,8 +443,8 @@ public class ParserTestARFF extends TestUtil {
 
     String[] dataset = ParserTest.getDataForSeparator(',', data);
 
-    testTypes(dataset, exp_types, len, "\n");
-    testTypes(dataset, exp_types, len, "\r\n");
+    testTypes(dataset, exp_types, len, "\n", 1);
+    testTypes(dataset, exp_types, len, "\r\n", 1);
   }
 
 
@@ -792,5 +815,117 @@ public class ParserTestARFF extends TestUtil {
     Assert.assertTrue(fr.anyVec().atStr(tmpStr, 7).toString().equals("1.324e-13"));
     Assert.assertTrue(fr.anyVec().atStr(tmpStr, 8).toString().equals("-2"));
     fr.delete();
+  }
+
+  @Test public void testStandardNAs() {
+    String[] arff = new String[] {
+        "@relation test_nas",
+        "@attribute y {'0', '1'}",
+        "@attribute x1 numeric",
+        "@attribute x2 string",
+        "@attribute x3 {y, n}",
+        "@attribute x4 {0, 1}",
+        "@attribute x5 {'1', '10', '100'}",
+        "@data",
+        "'0',42,\"foo\",y,0,'1'",
+        "'1',?,\"bar\",n,1,'10'",
+        "?,42,\"baz\",?,0,'100'",
+        "'0',24,?,y,1,?",
+        "'1',42,\"foo\",n,?,'1'"
+    };
+
+    byte[] expected_types = new byte[]{
+        Vec.T_CAT,
+        Vec.T_NUM,
+        Vec.T_STR,
+        Vec.T_CAT,
+        Vec.T_CAT,
+        Vec.T_CAT,
+    };
+    String[] expected_names = new String[]{"y", "x1", "x2", "x3", "x4", "x5"};
+    int expected_data_length = 5;
+
+    testTypes(arff, expected_types, expected_data_length, "\n", 1);
+    testColNames(arff, expected_names, expected_data_length, "\n", 1);
+
+    Frame parsed = getParsedFrame(arff, "\n", 1);
+    try {
+      Assert.assertTrue(parsed.hasNAs());
+      Assert.assertEquals(6, parsed.naCount());
+
+      Assert.assertFalse(parsed.vec("y").isNA(0));
+      Assert.assertTrue(parsed.vec("y").isNA(2));
+
+      Assert.assertFalse(parsed.vec("x1").isNA(0));
+      Assert.assertTrue(parsed.vec("x1").isNA(1));
+
+      Assert.assertFalse(parsed.vec("x2").isNA(0));
+      Assert.assertTrue(parsed.vec("x2").isNA(3));
+
+      Assert.assertFalse(parsed.vec("x3").isNA(0));
+      Assert.assertTrue(parsed.vec("x3").isNA(2));
+
+      Assert.assertFalse(parsed.vec("x4").isNA(0));
+      Assert.assertTrue(parsed.vec("x4").isNA(4));
+
+      Assert.assertFalse(parsed.vec("x5").isNA(0));
+      Assert.assertTrue(parsed.vec("x5").isNA(3));
+
+    } finally {
+      parsed.delete();
+    }
+  }
+
+
+  @Test public void testMultiChunkHeader() {
+    final int col_count = 51;
+    final int cat_length = 10_000;
+    final int data_count = 10_000;
+
+    byte[] expected_types = new byte[col_count];
+    String[] expected_names = new String[col_count];
+
+    List<String> arff = new ArrayList<>();
+    arff.add("@relation test_large_header");
+    arff.add("@attribute y numeric");
+    expected_types[0] = Vec.T_NUM;
+    expected_names[0] = "y";
+
+    //add 50 categoricals of about 100kB each;
+    for (int i = 1; i < col_count; i++) {
+      final StringBuilder cat = new StringBuilder("@attribute x_").append(i).append(' ').append('{');
+      for (int c = 0; c < cat_length; c++) {
+        if (c != 0) cat.append(',');
+        cat.append("factor_x").append(i).append('_').append(c);
+      }
+      cat.append('}');
+      arff.add(cat.toString());
+      expected_types[i] = Vec.T_CAT;
+      expected_names[i] = "x_"+i;
+    }
+
+    //add a few data rows
+    arff.add("@data");
+    Random rnd = new Random();
+    for (int i = 0; i < data_count; i++) {
+      final StringBuilder row = new StringBuilder();
+      row.append(rnd.nextInt(100));
+      for (int c = 1; c < col_count; c++) {
+        row.append(',')
+            .append("factor_x").append(c).append('_').append(rnd.nextInt(cat_length));
+      }
+      arff.add(row.toString());
+    }
+
+    String[] arffa = arff.toArray(new String[]{});
+    testTypes(arffa, expected_types, data_count, "\n", 10);
+    testColNames(arffa, expected_names, data_count, "\n", 10);
+
+    Frame parsed = getParsedFrame(arffa, "\n", 10);
+    try {
+      Assert.assertFalse(parsed.hasNAs());
+    } finally {
+      parsed.delete();
+    }
   }
 }


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5919

- change ARFF guess setup logic to loop through the dataset chunks as soon as the chunk looks like a valid part of the ARFF header and until the @data segment.