### PR TITLE
Explicitly allow just Java 11 in junit builds

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1849,8 +1849,9 @@ final public class H2O {
     if (Boolean.getBoolean(H2O.OptArgs.SYSTEM_PROP_PREFIX + "debug.noJavaVersionCheck")) {
       return false;
     }
-    // NOTE for developers: make sure that the following whitelist is logically consistent with whitelist in R code - see file connection.R near line 536
-    if (JAVA_VERSION.isKnown() && (JAVA_VERSION.getMajor()<7 || JAVA_VERSION.getMajor()>10)) {
+
+    // NOTE for developers: make sure that the following whitelist is logically consistent with whitelist in R code - see function .h2o.check_java_version in connection.R
+    if (JAVA_VERSION.isKnown() && !isUserEnabledJavaVersion() && (JAVA_VERSION.getMajor()<7 || JAVA_VERSION.getMajor()>10)) {
       System.err.println("Only Java 7, 8, 9 and 10 are supported, system version is " + System.getProperty("java.version"));
       return true;
     }
@@ -1858,6 +1859,20 @@ final public class H2O {
     if (vmName != null && vmName.equals("GNU libgcj")) {
       System.err.println("GNU gcj is not supported");
       return true;
+    }
+    return false;
+  }
+
+  private static boolean isUserEnabledJavaVersion() {
+    String extraJavaVersionsStr = System.getProperty(H2O.OptArgs.SYSTEM_PROP_PREFIX + "debug.allowJavaVersions");
+    if (extraJavaVersionsStr == null || extraJavaVersionsStr.isEmpty())
+      return false;
+    String[] vs = extraJavaVersionsStr.split(",");
+    for (String v : vs) {
+      int majorVersion = Integer.valueOf(v);
+      if (JAVA_VERSION.getMajor() == majorVersion) {
+        return true;
+      }
     }
     return false;
   }

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -252,7 +252,7 @@ test-junit-11-jenkins:
 	@$(MAKE) -f $(THIS_FILE) test-junit-11
 
 test-junit-11:
-	ADDITIONAL_TEST_JVM_OPTS="-Dsys.ai.h2o.debug.noJavaVersionCheck=true" ./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test $$ADDITIONAL_GRADLE_OPTS
+	ADDITIONAL_TEST_JVM_OPTS="-Dsys.ai.h2o.debug.allowJavaVersions=11" ./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-smoke-jenkins:
 	$(call sed_test_scripts)
@@ -269,7 +269,7 @@ test-junit-10-smoke:
 	DOONLY=$$(head -n 1 tests/doOnlyJunitSmokeTestList) ./gradlew h2o-core:test h2o-algos:test $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-11-smoke:
-	ADDITIONAL_TEST_JVM_OPTS="-Dsys.ai.h2o.debug.noJavaVersionCheck=true" DOONLY=$$(head -n 1 tests/doOnlyJunitSmokeTestList) ./gradlew h2o-core:test h2o-algos:test $$ADDITIONAL_GRADLE_OPTS
+	ADDITIONAL_TEST_JVM_OPTS="-Dsys.ai.h2o.debug.allowJavaVersions=11" DOONLY=$$(head -n 1 tests/doOnlyJunitSmokeTestList) ./gradlew h2o-core:test h2o-algos:test $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-11-smoke-jenkins:
 	$(call sed_test_scripts)


### PR DESCRIPTION
We don't want to allow any java version, instead we want to have a whitelist of user-approved java versions.