### PR TITLE
[ITA-344] Build Python package under h2o-py/build/.

### DIFF
--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -100,10 +100,6 @@ task cleanBuild(type: Delete) {
     doFirst {
         println "Cleaning..."
     }
-    delete file("h2o/version.txt")
-    delete file("h2o/buildinfo.txt")
-    delete file("dist/")
-    delete file("h2o.egg-info/")
     delete file("build/")
     delete fileTree(dir: "$projectDir/h2o" , include: '**/*.pyc')
 }

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -22,10 +22,10 @@ ext {
 //
 task createVersionFiles() {
     doLast {
-        File version_file = new File("${projectDir.toString()}/h2o", "version.txt")
+        File version_file = new File("${buildDir}/h2o", "version.txt")
         version_file.write(PROJECT_VERSION)
 
-        File build_file = new File("${projectDir.toString()}/h2o", "buildinfo.txt")
+        File build_file = new File("${buildDir}/h2o", "buildinfo.txt")
         build_file.write(buildVersion.toString())
     }
 }
@@ -37,13 +37,37 @@ task verifyDependencies(type: Exec) {
                                           "--metayaml", "conda/h2o/meta.yaml"])
 }
 
+task copyH2OJar(type: Copy) {
+    from "${rootDir}/build/h2o.jar"
+    into "${buildDir}/h2o/backend/bin/"
+}
 
-task buildDist(type: Exec, dependsOn: [verifyDependencies, createVersionFiles]) {
+task copySrcFiles(type: Copy, dependsOn: [copyH2OJar]) {
+    from ("${projectDir}") {
+        include "setup.py"
+        include "setup.cfg"
+        include "h2o/**"
+        include "DESCRIPTION.rst"
+        include "MANIFEST.in"
+        include "README.md"
+        include "requirements.txt"
+    }
+    into "${buildDir}"
+}
+
+task buildDist(type: Exec, dependsOn: [verifyDependencies, createVersionFiles, copySrcFiles]) {
+    workingDir buildDir
     doFirst {
         file("${buildDir}/tmp").mkdirs()
         standardOutput = new FileOutputStream(file("${buildDir}/tmp/h2o-py_buildDist.out"))
     }
     commandLine getOsSpecificCommandLine([pythonexe, "setup.py", "bdist_wheel"])
+
+    file("${projectDir}/dist/").mkdirs()
+    copy {
+        from "${buildDir}/dist/*.whl"
+        into "${projectDir}/dist/"
+    }
 }
 
 task smokeTest(type: Exec, dependsOn: build) {

--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -62,12 +62,6 @@ task buildDist(type: Exec, dependsOn: [verifyDependencies, createVersionFiles, c
         standardOutput = new FileOutputStream(file("${buildDir}/tmp/h2o-py_buildDist.out"))
     }
     commandLine getOsSpecificCommandLine([pythonexe, "setup.py", "bdist_wheel"])
-
-    file("${projectDir}/dist/").mkdirs()
-    copy {
-        from "${buildDir}/dist/*.whl"
-        into "${projectDir}/dist/"
-    }
 }
 
 task smokeTest(type: Exec, dependsOn: build) {

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -19,21 +19,6 @@ with open(os.path.join(here, 'h2o/version.txt'), encoding='utf-8') as f:
 packages = find_packages(exclude=["tests*"])
 print("Found packages: %r" % packages)
 
-
-# Copy h2o.jar to the h2o/backend/bin directory
-h2o_jar_src = os.path.join(here, "..", "build", "h2o.jar")
-h2o_jar_dst = os.path.join(here, "h2o", "backend", "bin", "h2o.jar")
-if not os.path.exists(os.path.dirname(h2o_jar_dst)):
-    os.makedirs(os.path.dirname(h2o_jar_dst))
-
-if os.path.exists(h2o_jar_src):
-    shutil.copyfile(h2o_jar_src, h2o_jar_dst)
-elif os.path.exists(h2o_jar_dst):
-    # The h2o.jar already exists in the target directory -- don't do anything (even if it's an old version)
-    pass
-else:
-    raise RuntimeError("Cannot locate %s to bundle with the h2o package (pwd: %s)." % (h2o_jar_src, here))
-
 setup(
     name='h2o',
 

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -21,7 +21,7 @@ function make_zip_common {
 
   mkdir $IMAGEDIR/python
 
-  cp h2o-py/dist/*whl $IMAGEDIR/python
+  cp h2o-py/build/dist/*whl $IMAGEDIR/python
 
   mkdir -p $IMAGEDIR/bindings/java
   cp h2o-bindings/build/distributions/h2o-bindings-*.zip $IMAGEDIR/bindings/java
@@ -113,7 +113,7 @@ do
   name=${f##*/}
 done
 
-cp h2o-py/dist/*whl target/Python
+cp h2o-py/build/dist/*whl target/Python
 
 cd h2o-py && sphinx-build -b html docs/ docs/docs/
 cd ..

--- a/scripts/install-clients.sh
+++ b/scripts/install-clients.sh
@@ -4,6 +4,6 @@
 # run this script to install the new R and Python clients.
 
 pip uninstall -y h2o
-pip install ../h2o-py/dist/h2o-*-py2.py3-none-any.whl
+pip install ../h2o-py/build/dist/h2o-*-py2.py3-none-any.whl
 R CMD REMOVE h2o
 R CMD INSTALL ../h2o-r/R/src/contrib/h2o*.tar.gz

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -27,7 +27,7 @@ warmup-caches:
 test-package-py:
 	cd h2o-py/tests/ && rm -f -r testdir_hdfs
 	zip -q -r test-package-py.zip h2o-py/tests/ h2o-py/demos/ \
-	h2o-docs/src/booklets/v2_2015/source h2o-py/dist/*.whl \
+	h2o-docs/src/booklets/v2_2015/source h2o-py/build/dist/*.whl \
 	h2o-genmodel/build/libs/h2o-genmodel.jar h2o-assemblies/genmodel/build/libs/genmodel.jar scripts/run.py \
 	$(JENKINS_MAKEFILE_PATH) tests/pyunitSmokeTestList tests/pyunitAutoMLList tests/pyunitSingleNodeList h2o-py/scripts/h2o-py-test-setup.py
 
@@ -183,7 +183,7 @@ test-info:
 	fi
 
 test-demos:
-	cd h2o-py/tests/testdir_demos && python ../../../scripts/run.py --whl ../../../h2o-py/dist/h2o-*.whl --wipeall --numclouds 1 --jvm.xmx 5g
+	cd h2o-py/tests/testdir_demos && python ../../../scripts/run.py --whl ../../../h2o-py/build/dist/h2o-*.whl --wipeall --numclouds 1 --jvm.xmx 5g
 
 test-package-java:
 	zip -q -r test-package-java \

--- a/scripts/jenkins/PR_startup_checks.sh
+++ b/scripts/jenkins/PR_startup_checks.sh
@@ -131,7 +131,7 @@ echo "*********************************************"
 echo ""
 cd ${WORKSPACE}
 /usr/bin/yes | pip uninstall h2o || true
-pip install --force h2o-py/dist/*.whl
+pip install --force h2o-py/build/dist/*.whl
 
 cd h2o-py/tests/testdir_jira
 python h2o.init_test_HOQE-16.py

--- a/scripts/jenkins/groovy/defaultStage.groovy
+++ b/scripts/jenkins/groovy/defaultStage.groovy
@@ -54,7 +54,7 @@ def installPythonPackage(String h2o3dir) {
     sh """
         echo "Activating Python ${env.PYTHON_VERSION}"
         . /envs/h2o_env_python${env.PYTHON_VERSION}/bin/activate
-        pip install ${h2o3dir}/h2o-py/dist/*.whl
+        pip install ${h2o3dir}/h2o-py/build/dist/*.whl
     """
 }
 


### PR DESCRIPTION
Build the Python package inside `h2o-py/build` directory. The idea is to keep the source files intact, and do everything build related in the `build` directory.