### PR TITLE
PUBDEV-5924: Fixed merge bug where rows without merge key should be NaN or null

### DIFF
--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -83,7 +83,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
   }
 
   // In X[Y], 'left'=i and 'right'=x
-  BinaryMerge(FFSB leftSB, FFSB riteSB, boolean allLeft) {   
+  BinaryMerge(FFSB leftSB, FFSB riteSB, boolean allLeft) {
     assert riteSB._msb!=-1 || allLeft;
     _leftSB = leftSB;
     _riteSB = riteSB;
@@ -197,7 +197,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
     // occur, they only happen for leftMSB 0 and 255, and will quickly resolve
     // to no match in the right bucket via bmerge
     t0 = System.nanoTime();
-    bmerge_r(_leftFrom, leftTo, -1, rightN);   
+    bmerge_r(_leftFrom, leftTo, -1, rightN);
     _timings[1] += (System.nanoTime() - t0) / 1e9;
 
     if (_allLeft) {
@@ -412,7 +412,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
     assert lUpp - lLow >= 2;
 
     // if value found, rLow and rUpp surround it, unlike standard binary search where rLow falls on it
-    long len = rUpp - rLow - 1;  
+    long len = rUpp-rLow-1;
     // TODO - we don't need loop here :)  Why does perNodeNumRightRowsToFetch increase so much?
     if (len > 0 || _allLeft) {
       long t0 = System.nanoTime();
@@ -730,21 +730,43 @@ class BinaryMerge extends DTask<BinaryMerge> {
           ni = _riteSB._chunkNode[chkIdx];
           pnl = perNodeRightLoc[ni]++;   // pnl = per node location.   // TODO Split to an if() and batch and offset separately
           chks = grrrsRite[ni][(int)(pnl / batchSizeUUID)]._chk;
+          boolean leftChkExist = (grrrsLeft!=null) && (grrrsLeft.length > ni) && (grrrsLeft[ni]!=null) &&
+                  (grrrsLeft[ni].length > (int)(pnl / batchSizeUUID)) &&
+                  (grrrsLeft[ni][(int)(pnl / batchSizeUUID)]!=null);
+          double[][] leftchks = leftChkExist?grrrsLeft[ni][(int)(pnl / batchSizeUUID)]._chk:null;
           chksString = grrrsRite[ni][(int)(pnl / batchSizeUUID)]._chkString;
           o = (int)(pnl % batchSizeUUID);
           for (int col=0; col<numColsInResult-numLeftCols; col++) {
             // TODO: this only works for numeric columns (not for UUID, strings, etc.)
             int colIndex = numLeftCols + col;
             if (this._stringCols[colIndex]) {
-              if (chksString[_numJoinCols + col][o]!=null)
-                frameLikeChunks4String[colIndex][whichChunk][offset] = chksString[_numJoinCols + col][o];  // colForBatch.atd(row);
-            } else
-              frameLikeChunks[colIndex][whichChunk][offset] = chks[_numJoinCols + col][o];  // colForBatch.atd(row);
+              if (chksString[_numJoinCols + col][o]!=null) {
+                frameLikeChunks4String[colIndex][whichChunk][offset] = validateKeys(chks, leftchks, _numJoinCols, o) ?
+                        chksString[_numJoinCols + col][o] : null;  // colForBatch.atd(row);
+              }
+            } else {
+              frameLikeChunks[colIndex][whichChunk][offset] = validateKeys(chks, leftchks, _numJoinCols, o) ?
+                      chks[_numJoinCols + col][o] : Double.NaN;  // colForBatch.atd(row);
+            }
           }
           resultLoc++;
         }
       }
     }
+  }
+
+  private boolean validateKeys(double[][] chks, double[][] leftChks, int numJointCols, int row) {
+    if ((leftChks == null))
+      return true;
+    for (int cindex=0; cindex < numJointCols; cindex++) {
+      if (row >= leftChks[cindex].length) // dealing with duplicates on the right
+        return true;
+      if (Double.isNaN(chks[cindex][row]) && !(Double.isNaN(leftChks[cindex][row])))
+        return false;
+      if (Double.isNaN(leftChks[cindex][row]))
+        return false; // will not attempt to merge left nan keys to anything on the right
+    }
+    return true;
   }
 
   // compress all chunks and store them

--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -741,32 +741,16 @@ class BinaryMerge extends DTask<BinaryMerge> {
             int colIndex = numLeftCols + col;
             if (this._stringCols[colIndex]) {
               if (chksString[_numJoinCols + col][o]!=null) {
-                frameLikeChunks4String[colIndex][whichChunk][offset] = validateKeys(chks, leftchks, _numJoinCols, o) ?
-                        chksString[_numJoinCols + col][o] : null;  // colForBatch.atd(row);
+                frameLikeChunks4String[colIndex][whichChunk][offset] = chksString[_numJoinCols + col][o];  // colForBatch.atd(row);
               }
             } else {
-              frameLikeChunks[colIndex][whichChunk][offset] = validateKeys(chks, leftchks, _numJoinCols, o) ?
-                      chks[_numJoinCols + col][o] : Double.NaN;  // colForBatch.atd(row);
+              frameLikeChunks[colIndex][whichChunk][offset] = chks[_numJoinCols + col][o];  // colForBatch.atd(row);
             }
           }
           resultLoc++;
         }
       }
     }
-  }
-
-  private boolean validateKeys(double[][] chks, double[][] leftChks, int numJointCols, int row) {
-    if ((leftChks == null))
-      return true;
-    for (int cindex=0; cindex < numJointCols; cindex++) {
-      if (row >= leftChks[cindex].length) // dealing with duplicates on the right
-        return true;
-      if (Double.isNaN(chks[cindex][row]) && !(Double.isNaN(leftChks[cindex][row])))
-        return false;
-      if (Double.isNaN(leftChks[cindex][row]))
-        return false; // will not attempt to merge left nan keys to anything on the right
-    }
-    return true;
   }
 
   // compress all chunks and store them

--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -412,7 +412,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
     assert lUpp - lLow >= 2;
 
     // if value found, rLow and rUpp surround it, unlike standard binary search where rLow falls on it
-    long len = rUpp-rLow-1;
+    long len = rUpp - rLow - 1;
     // TODO - we don't need loop here :)  Why does perNodeNumRightRowsToFetch increase so much?
     if (len > 0 || _allLeft) {
       long t0 = System.nanoTime();
@@ -730,22 +730,16 @@ class BinaryMerge extends DTask<BinaryMerge> {
           ni = _riteSB._chunkNode[chkIdx];
           pnl = perNodeRightLoc[ni]++;   // pnl = per node location.   // TODO Split to an if() and batch and offset separately
           chks = grrrsRite[ni][(int)(pnl / batchSizeUUID)]._chk;
-          boolean leftChkExist = (grrrsLeft!=null) && (grrrsLeft.length > ni) && (grrrsLeft[ni]!=null) &&
-                  (grrrsLeft[ni].length > (int)(pnl / batchSizeUUID)) &&
-                  (grrrsLeft[ni][(int)(pnl / batchSizeUUID)]!=null);
-          double[][] leftchks = leftChkExist?grrrsLeft[ni][(int)(pnl / batchSizeUUID)]._chk:null;
           chksString = grrrsRite[ni][(int)(pnl / batchSizeUUID)]._chkString;
           o = (int)(pnl % batchSizeUUID);
           for (int col=0; col<numColsInResult-numLeftCols; col++) {
             // TODO: this only works for numeric columns (not for UUID, strings, etc.)
             int colIndex = numLeftCols + col;
             if (this._stringCols[colIndex]) {
-              if (chksString[_numJoinCols + col][o]!=null) {
+              if (chksString[_numJoinCols + col][o]!=null)
                 frameLikeChunks4String[colIndex][whichChunk][offset] = chksString[_numJoinCols + col][o];  // colForBatch.atd(row);
-              }
-            } else {
+            } else
               frameLikeChunks[colIndex][whichChunk][offset] = chks[_numJoinCols + col][o];  // colForBatch.atd(row);
-            }
           }
           resultLoc++;
         }

--- a/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstMergeTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstMergeTest.java
@@ -1,0 +1,294 @@
+package water.rapids.ast.prims.mungers;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+import water.rapids.Rapids;
+import water.rapids.Val;
+
+/***
+ * This test is written by Andrey Spiridonov in JIRA PUBDEV-5924.
+ */
+public class AstMergeTest extends TestUtil {
+
+  @BeforeClass
+  static public void setup() {
+    stall_till_cloudsize(1);
+  }
+
+
+  @Test
+  public void mergeWithNaOnTheRightMapsToEverythingTest4() {
+    Scope.enter();
+
+    try {
+      Frame fr = new TestFrameBuilder()
+              .withName("leftFrame")
+              .withColNames("ColA",  "ColB")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM)
+              .withDataForCol(0, ar("a", "b", "c", "e", null))
+              .withDataForCol(1, ard(-1,2,3,4,Double.NaN))
+              .build();
+      Scope.track(fr);
+      Frame holdoutEncodingMap = new TestFrameBuilder()
+              .withName("holdoutEncodingMap")
+              .withColNames( "ColB", "ColC")
+              .withVecTypes(Vec.T_NUM, Vec.T_STR)
+              .withDataForCol(0, ard(0,-1,2,Double.NaN))
+              .withDataForCol(1, ar("str42", "no", "yes", "WTF"))
+              .build();
+      Frame answer = new TestFrameBuilder()
+              .withColNames("ColB",  "ColA", "ColC")
+              .withVecTypes(Vec.T_NUM, Vec.T_CAT, Vec.T_STR)
+              .withDataForCol(0, ard(Double.NaN, -1, 2, 3, 4))
+              .withDataForCol(1, ar(null, "a", "b", "c", "e"))
+              .withDataForCol(2, ar(null, "no", "yes", null, null))
+              .build();
+      Scope.track(answer);
+      Scope.track(holdoutEncodingMap);
+      String tree = "(merge leftFrame holdoutEncodingMap TRUE FALSE [1.0] [0.0] 'auto')";
+      Val val = Rapids.exec(tree);
+      Frame result = val.getFrame();
+      Scope.track(result);
+      System.out.println("\n\nLeft frame: ");
+      printFrames(fr);
+      System.out.println("\n\nRight frame: ");
+      printFrames(holdoutEncodingMap);
+      System.out.println("\n\nMerged frame with command (merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0]" +
+              " 'auto'): ");
+      printFrames(result);
+      System.out.println("\n\nMerged frame with command (merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0]" +
+              " 'auto'): ");
+      printFrames(result);
+      System.out.println("\n\nCorrect merged frame should be");
+      printFrames(answer);
+      assert isBitIdentical(result, answer):"The two frames are not the same.";
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void mergeWithNaOnTheRightMapsToEverythingTest3() {
+    Scope.enter();
+
+    try {
+      Frame fr = new TestFrameBuilder()
+              .withName("leftFrame")
+              .withColNames("ColA",  "ColB")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM)
+              .withDataForCol(0, ar("a", "b", "c", "e", null))
+              .withDataForCol(1, ar(1, 2, 3, 4, 5))
+              .build();
+      Scope.track(fr);
+      Frame holdoutEncodingMap = new TestFrameBuilder()
+              .withName("holdoutEncodingMap")
+              .withColNames( "ColA", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_STR)
+              .withDataForCol(0, ar(null, "c", null, "g"))
+              .withDataForCol(1, ar("str42", "no", "yes", "WTF"))
+              .build();
+      Frame answer = new TestFrameBuilder()
+              .withColNames("ColA",  "ColB", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_STR)
+              .withDataForCol(0, ar(null, "a", "b", "c", "e"))
+              .withDataForCol(1, ar(5, 1, 2, 3, 4))
+              .withDataForCol(2, ar(null, null, null, "no", null))
+              .build();
+      Scope.track(answer);
+      Scope.track(holdoutEncodingMap);
+      String tree = "(merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0] 'auto')";
+      Val val = Rapids.exec(tree);
+      Frame result = val.getFrame();
+      Scope.track(result);
+      Frame sortedResult = result.sort(new int[]{0});
+      Scope.track(sortedResult);
+      System.out.println("\n\nLeft frame: ");
+      printFrames(fr);
+      System.out.println("\n\nRight frame: ");
+      printFrames(holdoutEncodingMap);
+      System.out.println("\n\nMerged frame with command (merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0]" +
+              " 'auto'): ");
+      printFrames(sortedResult);
+      System.out.println("\n\nCorrect merged frame should be");
+      printFrames(answer);
+      assert isBitIdentical(sortedResult, answer):"The two frames are not the same!";
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void mergeWithNaOnTheRightMapsToEverythingTest2() {
+    Scope.enter();
+
+    try {
+      Frame fr = new TestFrameBuilder()
+              .withName("leftFrame")
+              .withColNames("ColA",  "ColB")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM)
+              .withDataForCol(0, ar("a", "b", "c", "e", null))
+              .withDataForCol(1, ar(1, 2, 3, 4, 5))
+              .build();
+      Scope.track(fr);
+      Frame holdoutEncodingMap = new TestFrameBuilder()
+              .withName("holdoutEncodingMap")
+              .withColNames( "ColA", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_STR)
+              .withDataForCol(0, ar(null, "c", null))
+              .withDataForCol(1, ar("str42", "no", "yes"))
+              .build();
+      Frame answer = new TestFrameBuilder()
+              .withColNames("ColA",  "ColB", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_STR)
+              .withDataForCol(0, ar(null, "a", "b", "c", "e"))
+              .withDataForCol(1, ar(5, 1, 2, 3, 4))
+              .withDataForCol(2, ar(null, null, null, "no", null))
+              .build();
+      Scope.track(answer);
+      Scope.track(holdoutEncodingMap);
+      String tree = "(merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0] 'auto')";
+      Val val = Rapids.exec(tree);
+      Frame result = val.getFrame();
+      Scope.track(result);
+      Frame sortedResult = result.sort(new int[]{0});
+      Scope.track(sortedResult);
+      System.out.println("\n\nLeft frame: ");
+      printFrames(fr);
+      System.out.println("\n\nRight frame: ");
+      printFrames(holdoutEncodingMap);
+      System.out.println("\n\nMerged frame with command (merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0]" +
+              " 'auto'): ");
+      printFrames(sortedResult);
+      System.out.println("\n\nCorrect merged frame should be");
+      printFrames(answer);
+      assert isBitIdentical(sortedResult, answer):"The two frames are not the same.";
+    } finally {
+      Scope.exit();
+    }
+  }
+  @Test
+  public void mergeWithNaOnTheRightMapsToEverythingTest0() {
+    Scope.enter();
+
+    try {
+      Frame fr = new TestFrameBuilder()
+              .withName("leftFrame")
+              .withColNames("ColA",  "ColB")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM)
+              .withDataForCol(0, ar("a", "b", "c", "e"))
+              .withDataForCol(1, ar(1, 2, 3, 4))
+              .build();
+      Scope.track(fr);
+      Frame holdoutEncodingMap = new TestFrameBuilder()
+              .withName("holdoutEncodingMap")
+              .withColNames( "ColA", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_STR)
+              .withDataForCol(0, ar(null, "a", "b"))
+              .withDataForCol(1, ar("str42", "no", "yes"))
+              .build();
+      Frame answer = new TestFrameBuilder()
+              .withColNames("ColA",  "ColB", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_STR)
+              .withDataForCol(0, ar( "a", "b", "c", "e"))
+              .withDataForCol(1, ar(1, 2, 3, 4))
+              .withDataForCol(2, ar("no", "yes", null, null))
+              .build();
+      Scope.track(answer);
+      Scope.track(holdoutEncodingMap);
+      String tree = "(merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0] 'auto')";
+      Val val = Rapids.exec(tree);
+      Frame result = val.getFrame();
+      Scope.track(result);
+      Frame sortedResult = result.sort(new int[]{0});
+      Scope.track(sortedResult);
+      System.out.println("\n\nLeft frame: ");
+      printFrames(fr);
+      System.out.println("\n\nRight frame: ");
+      printFrames(holdoutEncodingMap);
+      System.out.println("\n\nMerged frame with command (merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0]" +
+              " 'auto'): ");
+      printFrames(sortedResult);
+      System.out.println("\n\nCorrect merged frame should be");
+      printFrames(answer);
+      assert isBitIdentical(sortedResult, answer):"The two frames are not the same.";
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
+  @Test
+  public void mergeWithNaOnTheRightMapsToEverythingTest() {
+    Scope.enter();
+
+    try {
+      Frame fr = new TestFrameBuilder()
+              .withName("leftFrame")
+              .withColNames("ColA",  "ColB")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM)
+              .withDataForCol(0, ar("a", "b", "c", "e"))
+              .withDataForCol(1, ar(1, 2, 3, 4))
+              .build();
+      Scope.track(fr);
+      Frame holdoutEncodingMap = new TestFrameBuilder()
+              .withName("holdoutEncodingMap")
+              .withColNames( "ColA", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_STR)
+              .withDataForCol(0, ar(null, "c", null))
+              .withDataForCol(1, ar("str42", "no", "yes"))
+              .build();
+      Frame answer = new TestFrameBuilder()
+              .withColNames("ColA",  "ColB", "ColC")
+              .withVecTypes(Vec.T_CAT, Vec.T_NUM, Vec.T_STR)
+              .withDataForCol(0, ar("a", "b", "c", "e"))
+              .withDataForCol(1, ar(1, 2, 3, 4))
+              .withDataForCol(2, ar(null, null, "no", null))
+              .build();
+      Scope.track(answer);
+      Scope.track(holdoutEncodingMap);
+      String tree = "(merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0] 'auto')";
+      Val val = Rapids.exec(tree);
+      Frame result = val.getFrame();
+      Scope.track(result);
+      Frame sortedResult = result.sort(new int[]{0});
+      Scope.track(sortedResult);
+      System.out.println("\n\nLeft frame: ");
+      printFrames(fr);
+      System.out.println("\n\nRight frame: ");
+      printFrames(holdoutEncodingMap);
+      System.out.println("\n\nMerged frame with command (merge leftFrame holdoutEncodingMap TRUE FALSE [0.0] [0.0]" +
+              " 'auto'): ");
+      printFrames(sortedResult);
+      System.out.println("\n\nCorrect merged frame should be");
+      printFrames(answer);
+      assert isBitIdentical(sortedResult, answer):"The two frames are not the same.";
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
+  public void printFrames(Frame fr) {
+    int numRows = (int) fr.numRows();
+    int numCols = fr.numCols();
+    String[] colTypes = fr.typesStr();
+    for (String cname: fr.names()) {
+      System.out.print(cname+"\t");
+    }
+    System.out.println("");
+    for (int rindex = 0; rindex < numRows; rindex++) {
+      for (int cindex = 0; cindex < numCols; cindex++) {
+        if (colTypes[cindex].equals("Numeric"))
+          System.out.print(fr.vec(cindex).at(rindex)+"\t\t");
+        else
+          System.out.print(fr.vec(cindex).stringAt(rindex)+"\t\t");
+      }
+      System.out.println("");
+    }
+  }
+}

--- a/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5924_merge_bug_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5924_merge_bug_large.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+def verify_merge():
+    nrow = 10000
+    ncol = 3
+    seed1 = 12345
+    seed2 = 54321
+    cardinality = 2*nrow
+    integerR = 100000000
+    frame1_enum = pyunit_utils.random_dataset_enums_only(nrow, ncol, factorL=cardinality, misFrac=0, randSeed=seed1)
+    frame1_str = pyunit_utils.random_dataset_strings_only(nrow, ncol, seed=seed1)
+    frame1_int = pyunit_utils.random_dataset_int_only(nrow, ncol, rangeR=integerR, misFrac=0, randSeed=seed1)
+    frame1 = frame1_int.cbind(frame1_str.cbind(frame1_enum))
+    frame2_enum = pyunit_utils.random_dataset_enums_only(nrow, ncol, factorL=cardinality, misFrac=0, randSeed=seed2)
+    frame2_str = pyunit_utils.random_dataset_strings_only(nrow, ncol, seed=seed2)
+    frame2_int = pyunit_utils.random_dataset_int_only(nrow, ncol, rangeR=integerR, misFrac=0, randSeed=seed2)
+    frame2 = frame2_int.cbind(frame2_str.cbind(frame2_enum))
+
+    # merge one column only
+    frame1.set_names(["f1_1", "f1_2", "f1_3", "f1_4", "f1_5", "f1_6", "enum1", "f1_8", "f1_9"])
+    frame2.set_names(["f2_1", "f2_2", "f2_3", "f2_4", "f2_5", "f2_6", "enum1", "f28", "f2_9"])
+    perform_merges_assert_correct_merge(frame1, frame2)
+
+    # merge two columns
+    frame1.set_names(["f1_1", "f1_2", "f1_3", "f1_4", "f1_5", "f1_6", "enum1", "enum2", "f1_9"])
+    frame2.set_names(["f2_1", "f2_2", "f2_3", "f2_4", "f2_5", "f2_6", "enum1", "enum2", "f2_9"])
+    perform_merges_assert_correct_merge(frame1, frame2)
+
+    # merge three columns
+    frame1.set_names(["f1_1", "f1_2", "f1_3", "f1_4", "f1_5", "f1_6", "enum1", "enum2", "enum3"])
+    frame2.set_names(["f2_1", "f2_2", "f2_3", "f2_4", "f2_5", "f2_6", "enum1", "enum2", "enum3"])
+    perform_merges_assert_correct_merge(frame1, frame2)
+
+
+def perform_merges_assert_correct_merge(frame1, frame2):
+    mergeKeepLeft = frame1.merge(frame2, all_x = True) # should equal to mergeKeepRight2
+    mergeKeepRight2 = frame2.merge(frame1, all_y=True)
+    assert_equal_frames(mergeKeepLeft, mergeKeepRight2, "f1_1")
+
+    mergeKeepRight = frame1.merge(frame2, all_y=True) # should equal to mergeLeft2
+    mergeKeepLeft2 = frame2.merge(frame1, all_x = True)
+    assert_equal_frames(mergeKeepRight, mergeKeepLeft2, "f1_1")
+
+    # merge right, left should all have equal NaNs in them
+    assert total_na_cnts(mergeKeepRight)==total_na_cnts(mergeKeepLeft2), \
+        "Na counts should equal but frame 1 has {0} and frame 2 has {1}".format(mergeKeepRight.nacnt(),
+                                                                                mergeKeepLeft2.nacnt())
+    assert total_na_cnts(mergeKeepRight2)==total_na_cnts(mergeKeepLeft), \
+        "Na counts should equal but frame 1 has {0} and frame 2 has {1}".format(mergeKeepRight2.nacnt(),
+                                                                                mergeKeepLeft.nacnt())
+
+def assert_equal_frames(f1, f2, sortColName):
+    f1sorted = f1.sort(sortColName)
+    f2sorted = f2.sort(sortColName)
+
+    pyunit_utils.compare_frames_equal_names(f1sorted, f2sorted)
+
+def total_na_cnts(fr):
+    na_list = fr.nacnt()
+    sum=0.0
+    for ele in na_list:
+        sum=sum+ele
+    return sum
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(verify_merge)
+else:
+    verify_merge()
+


### PR DESCRIPTION
This PR fixes JIRA: https://0xdata.atlassian.net/browse/PUBDEV-5924?filter=-1

Andrey found the following merge bug:
If there is a NaN in the right frame merge column, it will be included in the final merged frame.  However, this should not be the case.  Any rows in the right frame that contains NaN in the merge columns should be removed.

In this PR, I fixed this problem by going through the right frame and delete all rows with NaN in the merged columns. 

I have written a Junit unit test to verify that the bug exposed by Andrey is no longer there.

I wrote a longer pyunit test for large datasets to make sure that merge values found in one frame but not the other should be filled with NaN/null.  I checked and made sure that this is true for all.x=True, and all.y=True.