### PR TITLE
[PUBDEV-5939] Enable configuration of buffers for http/https connection.

### DIFF
--- a/h2o-core/src/main/java/water/AbstractHTTPD.java
+++ b/h2o-core/src/main/java/water/AbstractHTTPD.java
@@ -211,7 +211,8 @@ public abstract class AbstractHTTPD {
     connector.setHost(_ip);
     connector.setPort(_port);
 
-    createServer(connector);
+    createServer(
+        configureConnector("http", connector));
   }
 
   /**
@@ -232,7 +233,19 @@ public abstract class AbstractHTTPD {
     }
     httpsConnector.setPort(getPort());
 
-    createServer(httpsConnector);
+    createServer(
+        configureConnector("https", httpsConnector));
+  }
+
+  // Configure connector via properties which we can modify.
+  // Also increase request header size and buffer size from default values
+  // located in org.eclipse.jetty.http.HttpBuffersImpl
+  private Connector configureConnector(String proto, Connector connector) {
+    connector.setRequestHeaderSize(H2O.OptArgs.getSysPropInt(proto+".requestHeaderSize", 32*1024));
+    connector.setRequestBufferSize(H2O.OptArgs.getSysPropInt(proto+".requestBufferSize", 32*1024));
+    connector.setResponseHeaderSize(H2O.OptArgs.getSysPropInt(proto+".responseHeaderSize", connector.getResponseHeaderSize()));
+    connector.setResponseBufferSize(H2O.OptArgs.getSysPropInt(proto+".responseBufferSize", connector.getResponseBufferSize()));
+    return connector;
   }
 
   /**

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -376,6 +376,10 @@ final public class H2O {
     public boolean launchedWithHadoopJar() {
       return hdfs_skip;
     }
+
+    public static int getSysPropInt(String suffix, int defaultValue) {
+      return Integer.getInteger(SYSTEM_PROP_PREFIX + suffix, defaultValue);
+    }
   }
 
   public static void parseFailed(String message) {


### PR DESCRIPTION
Large requests (>8Kb) are rejected by Jetty response 413: `Request
Entity Too Large: heada`.

This change includes:
  - bump request header size from 6k to 32k
  - bump request buffer size from 16k to 32k
  - enable configuration of request/response headers&buffers via system
  properties.