### PR TITLE
PUBDEV-5961: making Lockable#delete final to avoid mutiple delete paths and logic …

### DIFF
--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -929,19 +929,15 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
     assert (bestModel.compareTo(this) <= 0);
   }
 
-  @Override public void delete() {
+  @Override protected Futures remove_impl(Futures fs) {
     if (_output.weights != null && _output.biases != null) {
-      for (Key k : _output.weights) {
-        if (DKV.getGet(k) != null) ((Frame) DKV.getGet(k)).delete();
-      }
-      for (Key k : _output.biases) {
-        if (DKV.getGet(k) != null) ((Frame) DKV.getGet(k)).delete();
-      }
+      for (Key k : _output.weights) if (k!=null) DKV.remove(k,fs);
+      for (Key k : _output.biases) if (k!=null) DKV.remove(k,fs);
     }
     if (actual_best_model_key!=null) DKV.remove(actual_best_model_key);
-    DKV.remove(model_info().data_info()._key);
+    DKV.remove(model_info().data_info()._key, fs);
     deleteElasticAverageModels();
-    super.delete();
+    return super.remove_impl(fs);
   }
 
   void deleteElasticAverageModels() {

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -931,8 +931,8 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
 
   @Override protected Futures remove_impl(Futures fs) {
     if (_output.weights != null && _output.biases != null) {
-      for (Key k : _output.weights) if (k!=null) DKV.remove(k,fs);
-      for (Key k : _output.biases) if (k!=null) DKV.remove(k,fs);
+      for (Key k : _output.weights) if (k!=null) k.remove(fs);
+      for (Key k : _output.biases) if (k!=null) k.remove(fs);
     }
     if (actual_best_model_key!=null) DKV.remove(actual_best_model_key);
     DKV.remove(model_info().data_info()._key, fs);

--- a/h2o-algos/src/main/java/hex/word2vec/Word2VecModel.java
+++ b/h2o-algos/src/main/java/hex/word2vec/Word2VecModel.java
@@ -282,11 +282,6 @@ public class Word2VecModel extends Model<Word2VecModel, Word2VecParameters, Word
     _output._vocab = vocab;
   }
 
-  @Override public void delete() {
-    remove();
-    super.delete();
-  }
-
   public static class Word2VecParameters extends Model.Parameters {
     public String algoName() { return "Word2Vec"; }
     public String fullName() { return "Word2Vec"; }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1215,12 +1215,13 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   /**
    * Delete the AutoML-related objects, but leave the grids and models that it built.
    */
-  public void delete() {
-    //if (frameMetadata != null) frameMetadata.delete(); //TODO: We shouldn't have to worry about FrameMetadata being null
+  @Override
+  protected Futures remove_impl(Futures fs) {
+  //if (frameMetadata != null) frameMetadata.delete(); //TODO: We shouldn't have to worry about FrameMetadata being null
     AutoMLUtils.cleanup_adapt(trainingFrame, origTrainingFrame);
     leaderboard.delete();
     userFeedback.delete();
-    remove();
+    return super.remove_impl(fs);
   }
 
   /**

--- a/h2o-core/src/main/java/water/Lockable.java
+++ b/h2o-core/src/main/java/water/Lockable.java
@@ -86,7 +86,7 @@ public abstract class Lockable<T extends Lockable<T>> extends Keyed<T> {
   /** Write-lock 'this' and delete; blocking.
    *  Throws IAE if the _key is already locked.  
    */
-  public void delete( ) { delete(null,new Futures()).blockForPending(); }
+  public final void delete( ) { delete(null,new Futures()).blockForPending(); }
   /** Write-lock 'this' and delete. 
    *  Throws IAE if the _key is already locked.  
    */

--- a/h2o-core/src/main/java/water/Lockable.java
+++ b/h2o-core/src/main/java/water/Lockable.java
@@ -84,13 +84,19 @@ public abstract class Lockable<T extends Lockable<T>> extends Keyed<T> {
     ((Lockable)val.get()).delete();
   }
   /** Write-lock 'this' and delete; blocking.
-   *  Throws IAE if the _key is already locked.  
+   *  Throws IAE if the _key is already locked.
+   *
+   *  Subclasses that need custom deletion logic should override {@link #remove_impl(Futures)}
+   *  as by contract, the only difference between {@link #delete()} and {@link #remove()}
+   *  is that `delete` first write-locks `this`.
    */
   public final void delete( ) { delete(null,new Futures()).blockForPending(); }
   /** Write-lock 'this' and delete. 
-   *  Throws IAE if the _key is already locked.  
+   *  Throws IAE if the _key is already locked.
+   *
+   *  Subclasses that need custom deletion logic should override {@link #remove_impl(Futures)}.
    */
-  public Futures delete( Key<Job> job_key, Futures fs ) {
+  public final Futures delete( Key<Job> job_key, Futures fs ) {
     if( _key != null ) {
       Log.debug("lock-then-delete "+_key+" by job "+job_key);
       new PriorWriteLock(job_key).invoke(_key);


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5961

Making Lockable#delete final to avoid mutiple delete paths and logic or worse changing the semantic of delete which is clearly defined in Lockable as `lock and remove`: 
any subclass should only consider overriding `remove_impl` as it is the case almost everywhere in current codebase.
