### PR TITLE
[PUBDEV-5959] PySparking client is hanging after re-connecting to the H2O external backend

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -980,6 +980,10 @@ public final class AutoBuffer {
   // Get the 1st control byte
   int  getCtrl( ) { return getSz(1).get(0)&0xFF; }
   // Get node timestamp in next 2 bytes
+
+  // the timestamp is on purpose where port was previously.
+  // In code, getPort is used to skip bytes before the value and the bytes for port itself.
+  // This ensures getPort will still have the same side-effect except we skip also the timestamp which is desired
   short getTimestamp() { return getSz(1+2).getShort(1);}
   // Get the port in next 2 bytes
   int getPort( ) { return getSz(1+2+2).getChar(1+2); }

--- a/h2o-core/src/main/java/water/FailedNodeWatchdogExtension.java
+++ b/h2o-core/src/main/java/water/FailedNodeWatchdogExtension.java
@@ -139,7 +139,7 @@ public class FailedNodeWatchdogExtension extends AbstractH2OExtension {
             try {
                 sleep(watchdogClientConnectTimeout);
                 boolean watchDogConnected = false;
-                HashSet<H2ONode> clients = H2O.getClients();
+                H2ONode[] clients = H2O.getClients();
 
                 if (Log.getLogLevel() == Log.DEBUG) {
                     Log.debug("Checking if watchdog client connected to the cluster, available clients at this moment are: ");
@@ -211,7 +211,7 @@ public class FailedNodeWatchdogExtension extends AbstractH2OExtension {
         @Override
         public void run() {
             while (true) {
-                HashSet<H2ONode> clients = H2O.getClients();
+                H2ONode[] clients = H2O.getClients();
 
                 if (Log.getLogLevel() == Log.DEBUG) {
                     Log.debug("Checking if watchdog client is connected, available clients are: ");

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1567,16 +1567,6 @@ final public class H2O {
     SELF._heartbeat._jar_md5 = JarHash.JARHASH;
     SELF._heartbeat._client = ARGS.client;
     SELF._heartbeat._cloud_name_hash = ARGS.name.hashCode();
-
-    if(ARGS.client){
-      reportClient(H2O.SELF); // report myself as the client to myself
-      // This is useful for the consistency and used, for example, in LogsHandler where, in case we couldn't find ip of
-      // regular worker node, we try to obtain the logs from the client.
-      //
-      // In case we wouldn't report the client to the client and the request for the logs would come to the client, we would
-      // need to handle that case differently. But since we handle this consistently like this, we do not need to worry about cases if the request
-      // came to the client node or not since we always report the client.
-    }
   }
 
   /** Starts the worker threads, receiver threads, heartbeats and all other
@@ -2192,25 +2182,19 @@ final public class H2O {
     return new HashSet<>(STATIC_H2OS);
   }
 
-  public static H2ONode reportClient(H2ONode client) {
-    H2ONode oldClient = CLIENTS_MAP.put(client.getIpPortString(), client);
-    if (oldClient == null) {
-        Log.info("New client discovered: " + client.toDebugString());
-    }
-    return oldClient;
+  /**
+   * Forgets H2O client
+   */
+  static boolean removeClient(H2ONode client){
+    return H2ONode.removeClient(client);
   }
 
-  public static H2ONode removeClient(H2ONode client){
-    client.stopSendThread();
-    return CLIENTS_MAP.remove(client.getIpPortString());
-  }
-
-  public static HashSet<H2ONode> getClients(){
-    return new HashSet<>(CLIENTS_MAP.values());
+  public static H2ONode[] getClients(){
+    return H2ONode.getClients();
   }
 
   public static H2ONode getClientByIPPort(String ipPort){
-    return CLIENTS_MAP.get(ipPort);
+    return H2ONode.getClientByIPPort(ipPort);
   }
 
   public static Key<DecryptionTool> defaultDecryptionTool() {

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2207,7 +2207,7 @@ final public class H2O {
    * Select last 15 bytes from the jvm boot start time and return it as short. If the timestamp is 0, we increment it by
    * 1 to be able to distinguish between client and node as -0 is the same as 0.
    */
-  private static short createTimestamp(long jvmStartTime){
+  private static short truncateTimestamp(long jvmStartTime){
     int bitMask = (1 << 15) - 1;
     // select the lower 15 bits
     short timestamp = (short) (jvmStartTime & bitMask);
@@ -2221,7 +2221,7 @@ final public class H2O {
    * we are client or not. We combine these 2 information and create a char(2 bytes) with this info in a single variable.
    */
   private static short calculateNodeTimestamp() {
-    return calculateNodeTimestamp(createTimestamp(TimeLine.JVM_BOOT_MSEC), H2O.ARGS.client);
+    return calculateNodeTimestamp(TimeLine.JVM_BOOT_MSEC, H2O.ARGS.client);
   }
 
   /**
@@ -2230,10 +2230,11 @@ final public class H2O {
    *
    * The negative timestamp represents a client node, the positive one a regular H2O node
    *
-   * @param timestamp  timestamp created by createTimestamp.
+   * @param bootTimestamp H2O node boot timestamp
    * @param amIClient true if this node is client, otherwise false
    */
-  private static short calculateNodeTimestamp(short timestamp, boolean amIClient) {
+  static short calculateNodeTimestamp(long bootTimestamp, boolean amIClient) {
+    short timestamp = truncateTimestamp(bootTimestamp);
     //if we are client, return negative timestamp, otherwise positive
     return amIClient ? (short) -timestamp : timestamp;
   }

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1567,6 +1567,7 @@ final public class H2O {
     SELF._heartbeat._jar_md5 = JarHash.JARHASH;
     SELF._heartbeat._client = ARGS.client;
     SELF._heartbeat._cloud_name_hash = ARGS.name.hashCode();
+    SELF.timestamp = calculateNodeTimestamp();
   }
 
   /** Starts the worker threads, receiver threads, heartbeats and all other
@@ -1978,6 +1979,7 @@ final public class H2O {
     // Validate arguments
     validateArguments();
 
+    // Create Timestamp for SELF
     Log.info("X-h2o-cluster-id: " + H2O.CLUSTER_ID);
     Log.info("User name: '" + H2O.ARGS.user_name + "'");
 
@@ -2199,6 +2201,50 @@ final public class H2O {
 
   public static Key<DecryptionTool> defaultDecryptionTool() {
     return H2O.ARGS.decrypt_tool != null ? Key.<DecryptionTool>make(H2O.ARGS.decrypt_tool) : null;
+  }
+
+  /**
+   * Select last 15 bytes from the jvm boot start time and return it as short. If the timestamp is 0, we increment it by
+   * 1 to be able to distinguish between client and node as -0 is the same as 0.
+   */
+  private static short createTimestamp(long jvmStartTime){
+    int bitMask = (1 << 15) - 1;
+    // select the lower 15 bits
+    short timestamp = (short) (jvmStartTime & bitMask);
+    // if the timestamp is 0 return 1 to be able to distinguish between positive and negative values
+    return timestamp == 0 ? 1 : timestamp;
+  }
+
+
+  /**
+   * Calculate node timestamp from Current's node information. We use start of jvm boot time and information whether
+   * we are client or not. We combine these 2 information and create a char(2 bytes) with this info in a single variable.
+   */
+  private static short calculateNodeTimestamp() {
+    return calculateNodeTimestamp(createTimestamp(TimeLine.JVM_BOOT_MSEC), H2O.ARGS.client);
+  }
+
+  /**
+   * Calculate node timestamp from the provided information. We use start of jvm boot time and information whether
+   * we are client or not.
+   *
+   * The negative timestamp represents a client node, the positive one a regular H2O node
+   *
+   * @param timestamp  timestamp created by createTimestamp.
+   * @param amIClient true if this node is client, otherwise false
+   */
+  private static short calculateNodeTimestamp(short timestamp, boolean amIClient) {
+    //if we are client, return negative timestamp, otherwise positive
+    return amIClient ? (short) -timestamp : timestamp;
+  }
+
+  /**
+   * Decodes whether the node is client or regular node from the timestamp
+   * @param timestamp timestamp
+   * @return true if timestamp is from client node, false otherwise
+   */
+  static boolean decodeIsClient(short timestamp) {
+    return timestamp < 0;
   }
 
 }

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -168,9 +168,10 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
 
   static boolean removeClient(H2ONode node){
       // Before we remove the Client, stop the sending thread
+      boolean ret = INTERN.remove(node._key, node);
       node.stopSendThread();
       Log.info("Removing client: " + node.toDebugString());
-      return INTERN.remove(node._key, node);
+      return ret;
   }
 
 

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -318,7 +318,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert res && !sock2.isConnectionPending() && sock2.isBlocking() && sock2.isConnected() && sock2.isOpen();
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
     bb.put((byte)2);
-    bb.putShort(AutoBuffer.calculateNodeTimestamp());
+    bb.putShort(H2O.SELF.timestamp);
     bb.putChar((char)H2O.H2O_PORT);
     bb.put((byte)0xef);
     bb.flip();
@@ -369,7 +369,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert !sock.isConnectionPending() && sock.isBlocking() && sock.isConnected() && sock.isOpen();
     sock.socket().setTcpNoDelay(true);
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
-    bb.put(tcpType).putShort(AutoBuffer.calculateNodeTimestamp()).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
+    bb.put(tcpType).putShort(H2O.SELF.timestamp).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
 
     ByteChannel wrappedSocket = socketFactory.clientChannel(sock, isa.getHostName(), isa.getPort());
 

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -37,7 +37,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   transient public volatile HeartBeat _heartbeat;  // My health info.  Changes 1/sec.
   transient public int _tcp_readers;               // Count of started TCP reader threads
 
-  transient char uniqueMetaId;
+  transient short timestamp;
   public boolean _removed_from_cloud;
 
   public void stopSendThread(){
@@ -317,7 +317,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert res && !sock2.isConnectionPending() && sock2.isBlocking() && sock2.isConnected() && sock2.isOpen();
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
     bb.put((byte)2);
-    bb.putChar(AutoBuffer.calculateNodeUniqueMeta());
+    bb.putShort(AutoBuffer.calculateNodeTimestamp());
     bb.putChar((char)H2O.H2O_PORT);
     bb.put((byte)0xef);
     bb.flip();
@@ -368,7 +368,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert !sock.isConnectionPending() && sock.isBlocking() && sock.isConnected() && sock.isOpen();
     sock.socket().setTcpNoDelay(true);
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
-    bb.put(tcpType).putChar(AutoBuffer.calculateNodeUniqueMeta()).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
+    bb.put(tcpType).putShort(AutoBuffer.calculateNodeTimestamp()).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
 
     ByteChannel wrappedSocket = socketFactory.clientChannel(sock, isa.getHostName(), isa.getPort());
 

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -71,23 +71,12 @@ public abstract class Paxos {
         // A new client was reported to this node so we propagate this information to all nodes in the cluster, to this
         // as well
         UDPClientEvent.ClientEvent.Type.CONNECT.broadcast(h2o);
-      } else if (!H2O.ARGS.client && h2o._heartbeat._client) {
-        // When we put the client ip:port to flatfile as well as the rest of the nodes, this client node is not in the
-        // client hash map. We need to handle this case to properly to handle client disconnects and add the client
-        // there as well for consistency
-        H2O.reportClient(h2o);
-      }
-      else if (H2O.ARGS.client && !H2O.isNodeInFlatfile(h2o)) {
+      } else if (H2O.ARGS.client && !H2O.isNodeInFlatfile(h2o)) {
         // This node is a client and using a flatfile to figure out a topology of the cluster. The flatfile passed to the
         // client is always modified at the start of H2O to contain only a single node. This node is used to propagate
         // information about the client to the cluster. Once the nodes have the information about the client, then propagate
         // themselves via heartbeat to the client
         H2O.addNodeToFlatfile(h2o);
-      }
-    }else{
-      // We are operating in the multicast mode and heard from the client, so we need to report the client on this node
-      if(h2o._heartbeat._client){
-        H2O.reportClient(h2o);
       }
     }
 

--- a/h2o-core/src/main/java/water/RPC.java
+++ b/h2o-core/src/main/java/water/RPC.java
@@ -378,7 +378,7 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
 
           UDP.udp udp = dt.priority()==H2O.FETCH_ACK_PRIORITY ? UDP.udp.fetchack : UDP.udp.ack;
           ab = new AutoBuffer(_client,udp._prior).putTask(udp,_tsknum).put1(SERVER_UDP_SEND);
-          assert ab.position() == 1+2+4+1;
+          assert ab.position() == 1+2+2+4+1;
           dt.write(ab);         // Write the DTask - could be very large write
           dt._repliedTcp = ab.hasTCP(); // Resends do not need to repeat TCP result
           ab.close();                   // Then close; send final byte
@@ -421,7 +421,7 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
       if( wasTCP )  rab.put1(RPC.SERVER_TCP_SEND) ; // Original reply sent via TCP
       else {
         rab.put1(RPC.SERVER_UDP_SEND); // Original reply sent via UDP
-        assert rab.position() == 1+2+4+1;
+        assert rab.position() == 1+2+2+4+1;
         dt.write(rab);
       }
       assert sz_check(rab) : "Resend of " + _dt.getClass() + " changes size from "+_size+" to "+rab.size();

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -101,7 +101,7 @@ public class TCPReceiverThread extends Thread {
         int chanType = bb.get(); // 1 - small , 2 - big
         short timestamp = bb.getShort(); // read timestamp
         int port = bb.getChar(); // read port
-        boolean isClient = AutoBuffer.decodeIsClient(timestamp);
+        boolean isClient = H2O.decodeIsClient(timestamp);
         int sentinel = (0xFF) & bb.get();
         if(sentinel != 0xef) {
           if(H2O.SELF.getSecurityManager().securityEnabled) {

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -49,17 +49,17 @@ public class TCPReceiverThread extends Thread {
     this.socketChannelFactory = H2O.SELF.getSocketFactory();
   }
 
-  public static H2ONode processNewNode(InetAddress inetAddress, int port, boolean isClient, char uniqueId) {
+  public static H2ONode processNewNode(InetAddress inetAddress, int port, boolean isClient, short timestamp) {
     H2ONode node = H2O.getClientByIPPort(inetAddress.getHostAddress() + ":" + (port - 1));
-    if (!H2O.ARGS.client && isClient && node != null && node.uniqueMetaId != uniqueId) {
+    if (!H2O.ARGS.client && isClient && node != null && node.timestamp != timestamp) {
       // don't do this check in case we are the client
       H2ONode.removeClient(node);
     }
     H2ONode h2o = H2ONode.intern(inetAddress, port);
-    if(!H2O.ARGS.client && ((node == null && isClient) || (node != null && isClient && node.uniqueMetaId != uniqueId))){
+    if(!H2O.ARGS.client && ((node == null && isClient) || (node != null && isClient && node.timestamp != timestamp))){
       Log.info("New client discovered: " + h2o.toDebugString());
     }
-    h2o.uniqueMetaId = uniqueId;
+    h2o.timestamp = timestamp;
     return h2o;
   }
 
@@ -99,10 +99,9 @@ public class TCPReceiverThread extends Thread {
         }
         bb.flip();
         int chanType = bb.get(); // 1 - small , 2 - big
-        char nodeMeta = bb.getChar(); // read note id
+        short timestamp = bb.getShort(); // read timestamp
         int port = bb.getChar(); // read port
-        boolean isClient = AutoBuffer.decodeIsClient(nodeMeta);
-        char uniqueId = AutoBuffer.decodeUniqueId(nodeMeta);
+        boolean isClient = AutoBuffer.decodeIsClient(timestamp);
         int sentinel = (0xFF) & bb.get();
         if(sentinel != 0xef) {
           if(H2O.SELF.getSecurityManager().securityEnabled) {
@@ -120,10 +119,10 @@ public class TCPReceiverThread extends Thread {
         // Pass off the TCP connection to a separate reader thread
         switch( chanType ) {
         case TCP_SMALL:
-          new UDP_TCP_ReaderThread(processNewNode(inetAddress, port, isClient, uniqueId), wrappedSocket).start();
+          new UDP_TCP_ReaderThread(processNewNode(inetAddress, port, isClient, timestamp), wrappedSocket).start();
           break;
         case TCP_BIG:
-          processNewNode(inetAddress, port, isClient, uniqueId);
+          processNewNode(inetAddress, port, isClient, timestamp);
           new TCPReaderThread(wrappedSocket, new AutoBuffer(wrappedSocket, inetAddress), inetAddress).start();
           break;
         case TCP_EXTERNAL:

--- a/h2o-core/src/main/java/water/UDPClientEvent.java
+++ b/h2o-core/src/main/java/water/UDPClientEvent.java
@@ -33,7 +33,6 @@ public class UDPClientEvent extends UDP {
             client._heartbeat = ce.clientHeartBeat;
 
             H2O.addNodeToFlatfile(ce.clientNode);
-            H2O.reportClient(ce.clientNode);
           }
           break;
         // Regular disconnect event also doesn't have any effect in multicast mode.

--- a/h2o-core/src/test/java/water/AutoBufferTest.java
+++ b/h2o-core/src/test/java/water/AutoBufferTest.java
@@ -34,6 +34,28 @@ public class AutoBufferTest extends TestUtil {
   }
 
   @Test
+  public void decodeClientInfoNotClient(){
+    long bootTime = 1540375717281L;
+    char uniqueId = AutoBuffer.createUniqueId(bootTime);
+    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
+    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, false);
+    assertEquals(meta, 9633);
+    assertFalse(AutoBuffer.decodeIsClient(meta));
+    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+  }
+
+  @Test
+  public void decodeClientInfoClient(){
+    long bootTime = 1540375717281L;
+    char uniqueId = AutoBuffer.createUniqueId(bootTime);
+    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
+    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, true);
+    assertEquals(meta, 42401);
+    assertTrue(AutoBuffer.decodeIsClient(meta));
+    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+  }
+
+  @Test
   public void testOutputStreamBigDataSmallChunks() {
     final int dataSize = 100 * 1024;
     byte[] data = new byte[dataSize - 1];

--- a/h2o-core/src/test/java/water/AutoBufferTest.java
+++ b/h2o-core/src/test/java/water/AutoBufferTest.java
@@ -34,45 +34,6 @@ public class AutoBufferTest extends TestUtil {
   }
 
   @Test
-  public void decodeClientInfoNotClient(){
-    long bootTime = 1540375717281L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
-    assertEquals(timestamp, 9633);
-    assertFalse(AutoBuffer.decodeIsClient(timestamp));
-  }
-
-  @Test
-  public void decodeClientInfoClient(){
-    long bootTime = 1540375717281L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
-    assertEquals(timestamp, -9633);
-    assertTrue(AutoBuffer.decodeIsClient(timestamp));
-  }
-
-  @Test
-  public void decodeNotClientZeroTimestamp(){
-    long bootTime = 0L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
-    assertEquals(timestamp, 1);
-    assertFalse(AutoBuffer.decodeIsClient(timestamp));
-  }
-  @Test
-  public void decodeClientZeroTimestamp(){
-    long bootTime = 0L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
-    assertEquals(timestamp, -1);
-    assertTrue(AutoBuffer.decodeIsClient(timestamp));
-  }
-
-  @Test
   public void testOutputStreamBigDataSmallChunks() {
     final int dataSize = 100 * 1024;
     byte[] data = new byte[dataSize - 1];
@@ -103,7 +64,7 @@ public class AutoBufferTest extends TestUtil {
 
   @Test
   public void testNameOfClass() throws Exception {
-    
+
     byte[] bytes = AutoBuffer.javaSerializeWritePojo(new XYZZY());
     assertEquals("water.AutoBufferTest$XYZZY", AutoBuffer.nameOfClass(bytes));
     bytes[7] = 127;

--- a/h2o-core/src/test/java/water/AutoBufferTest.java
+++ b/h2o-core/src/test/java/water/AutoBufferTest.java
@@ -36,23 +36,40 @@ public class AutoBufferTest extends TestUtil {
   @Test
   public void decodeClientInfoNotClient(){
     long bootTime = 1540375717281L;
-    char uniqueId = AutoBuffer.createUniqueId(bootTime);
-    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
-    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, false);
-    assertEquals(meta, 9633);
-    assertFalse(AutoBuffer.decodeIsClient(meta));
-    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
+    assertEquals(timestamp, 9633);
+    assertFalse(AutoBuffer.decodeIsClient(timestamp));
   }
 
   @Test
   public void decodeClientInfoClient(){
     long bootTime = 1540375717281L;
-    char uniqueId = AutoBuffer.createUniqueId(bootTime);
-    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
-    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, true);
-    assertEquals(meta, 42401);
-    assertTrue(AutoBuffer.decodeIsClient(meta));
-    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
+    assertEquals(timestamp, -9633);
+    assertTrue(AutoBuffer.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeNotClientZeroTimestamp(){
+    long bootTime = 0L;
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
+    assertEquals(timestamp, 1);
+    assertFalse(AutoBuffer.decodeIsClient(timestamp));
+  }
+  @Test
+  public void decodeClientZeroTimestamp(){
+    long bootTime = 0L;
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
+    assertEquals(timestamp, -1);
+    assertTrue(AutoBuffer.decodeIsClient(timestamp));
   }
 
   @Test

--- a/h2o-core/src/test/java/water/H2OTest.java
+++ b/h2o-core/src/test/java/water/H2OTest.java
@@ -1,0 +1,37 @@
+package water;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class H2OTest {
+
+  @Test
+  public void decodeClientInfoNotClient(){
+    short timestamp = H2O.calculateNodeTimestamp(1540375717281L, false);
+    assertEquals(timestamp, 9633);
+    assertFalse(H2O.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeClientInfoClient(){
+    short timestamp = H2O.calculateNodeTimestamp(1540375717281L, true);
+    assertEquals(timestamp, -9633);
+    assertTrue(H2O.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeNotClientZeroTimestamp(){
+    short timestamp = H2O.calculateNodeTimestamp(0L, false);
+    assertEquals(timestamp, 1);
+    assertFalse(H2O.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeClientZeroTimestamp(){
+    short timestamp = H2O.calculateNodeTimestamp(0L, true);
+    assertEquals(timestamp, -1);
+    assertTrue(H2O.decodeIsClient(timestamp));
+  }
+
+}

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -14,7 +14,7 @@ public class UnknownHeartbeatTest extends TestUtil{
 
   @Test
   public void testIgnoreUnknownHeartBeat() {
-    final int clientsCountBefore = H2O.getClients().size();
+    final int clientsCountBefore = H2O.getClients().length;
     HeartBeat hb = new HeartBeat();
     hb._cloud_name_hash = 777;
     hb._client = true;
@@ -26,7 +26,7 @@ public class UnknownHeartbeatTest extends TestUtil{
     ab.close();
 
     // Verify that we don't have a new client
-    assertEquals(clientsCountBefore, H2O.getClients().size());
+    assertEquals(clientsCountBefore, H2O.getClients().length);
   }
 
   @Test


### PR DESCRIPTION
## The Issue

The original issue was that when a client disconnected and connected to the cluster before the cluster discovered the original client is gone, it blocked the connection of the new client because of previously opened connections

This was caused by using the old client entry in the Client hash map as the cluster was still trying to  contact the old client on the old sockets. We need to make sure the new sockets are created.

##  The Fix
In order to fix this, we needed to add a new entry the the `AutoBuffer` head. This entry contains the information whether the node is client and the unique id. This entry is of size 2 bytes to minimize to communication overhead. The 1. bit is info whether we are client or not and the last 15 bits are the unique id.

This is needed because we need to be able to discover whether the node is client and if it is, different one, before we call `INTERN.put` of this newly created node.

## Implications

In the future, this additional info can help us separate client from the H2O core as we can now tell early whether the node is client or not

Also as part of this PR, the Client hash map was removed as it was duplication information already available in INTERN. 

The method `reportClient` was also removed. The information about the connected client is now printed as part of the `intern` method as that is always the first place where the new node is created. So the code is not scattered around.
