### PR TITLE
PUBDEV-5996: Eliminate unused param "nclasses" from mojo traversal code

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/CompressedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/CompressedTree.java
@@ -29,28 +29,26 @@ public class CompressedTree extends Keyed<CompressedTree> {
   private static final String KEY_PREFIX = "tree_";
 
   final byte [] _bits;
-  final int _nclass;     // Number of classes being predicted (for an integer prediction tree)
   final long _seed;
 
-  public CompressedTree(byte[] bits, int nclass, long seed, int tid, int cls) {
+  public CompressedTree(byte[] bits, long seed, int tid, int cls) {
     super(makeTreeKey(tid, cls));
     _bits = bits;
-    _nclass = nclass;
     _seed = seed;
   }
 
   public double score(final double row[], final String[][] domains) {
-    return SharedTreeMojoModel.scoreTree(_bits, row, _nclass, false, domains);
+    return SharedTreeMojoModel.scoreTree(_bits, row, false, domains);
   }
 
   @Deprecated
   public String getDecisionPath(final double row[], final String[][] domains) {
-    double d = SharedTreeMojoModel.scoreTree(_bits, row, _nclass, true, domains);
+    double d = SharedTreeMojoModel.scoreTree(_bits, row, true, domains);
     return SharedTreeMojoModel.getDecisionPath(d);
   }
 
   public <T> T getDecisionPath(final double row[], final String[][] domains, final SharedTreeMojoModel.DecisionPathTracker<T> tr) {
-    double d = SharedTreeMojoModel.scoreTree(_bits, row, _nclass, true, domains);
+    double d = SharedTreeMojoModel.scoreTree(_bits, row, true, domains);
     return SharedTreeMojoModel.getDecisionPath(d, tr);
   }
 
@@ -58,7 +56,7 @@ public class CompressedTree extends Keyed<CompressedTree> {
                                                  final String[] colNames, final String[][] domains) {
     TreeCoords tc = getTreeCoords();
     String treeName = SharedTreeMojoModel.treeName(tc._treeId, tc._clazz, domains[domains.length - 1]);
-    return SharedTreeMojoModel.computeTreeGraph(tc._treeId, treeName, _bits, auxTreeInfo._bits, _nclass, colNames, domains);
+    return SharedTreeMojoModel.computeTreeGraph(tc._treeId, treeName, _bits, auxTreeInfo._bits, colNames, domains);
   }
 
   public Random rngForChunk(int cidx) {

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -27,7 +27,6 @@ import java.util.*;
 public class DTree extends Iced {
   final String[] _names; // Column names
   final int _ncols;      // Active training columns
-  final char _nclass;    // #classes, or 1 for regression trees
   final long _seed;      // RNG seed; drives sampling seeds if necessary
   private Node[] _ns;    // All the nodes in the tree.  Node 0 is the root.
   public int _len;       // Resizable array
@@ -46,11 +45,10 @@ public class DTree extends Iced {
     return Math.min(Math.max(1,(int)((double)_mtrys * Math.pow(_parms._col_sample_rate_change_per_level, _depth))),_ncols);
   }
 
-  public DTree(Frame fr, int ncols, char nclass, int mtrys, int mtrys_per_tree, long seed, SharedTreeModel.SharedTreeParameters parms) {
+  public DTree(Frame fr, int ncols, int mtrys, int mtrys_per_tree, long seed, SharedTreeModel.SharedTreeParameters parms) {
     _names = fr.names();
     _ncols = ncols;
     _parms = parms;
-    _nclass=nclass;
     _ns = new Node[1];
     _mtrys = mtrys;
     _mtrys_per_tree = mtrys_per_tree;
@@ -757,7 +755,7 @@ public class DTree extends Iced {
       ab.put1(0).put2((char)65535); // Flag it special so the decompress doesn't look for top-level decision
     root().compress(ab, _abAux);      // Compress whole tree
     assert ab.position() == sz;
-    return new CompressedTree(ab.buf(),_nclass,_seed,tid,cls);
+    return new CompressedTree(ab.buf(), _seed,tid,cls);
   }
 
   static Split findBestSplitPoint(DHistogram hs, int col, double min_rows) {

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -201,7 +201,7 @@ public abstract class SharedTreeModel<
         DKV.put(keys[i]=ct._key,ct,fs);
         _treeStats.updateBy(trees[i]); // Update tree shape stats
 
-        CompressedTree ctAux = new CompressedTree(trees[i]._abAux.buf(),-1,-1,-1,-1);
+        CompressedTree ctAux = new CompressedTree(trees[i]._abAux.buf(),-1,-1,-1);
         keysAux[i] = ctAux._key = Key.make(createAuxKey(ct._key.toString()));
         DKV.put(ctAux);
       }
@@ -382,7 +382,7 @@ public abstract class SharedTreeModel<
       CompressedTree auxTree = _auxTreeKeys[tidx][cls].get();
       assert auxTree != null;
 
-      final double d = SharedTreeMojoModel.scoreTree(tree._bits, input, _nclasses, true, _domains);
+      final double d = SharedTreeMojoModel.scoreTree(tree._bits, input, true, _domains);
       final int nodeId = SharedTreeMojoModel.getLeafNodeId(d, auxTree._bits);
 
       out.addNum(nodeId, 0);

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeMojoWriter.java
@@ -45,7 +45,6 @@ public abstract class SharedTreeMojoWriter<
         if (ctVal == null)
           continue; //throw new H2OKeyNotFoundArgumentException("CompressedTree " + key + " not found");
         CompressedTree ct = ctVal.get();
-        assert ct._nclass == nclasses;
         // assume ct._seed is useless and need not be persisted
         writeblob(String.format("trees/t%02d_%03d.bin", j, i), ct._bits);
 
@@ -54,7 +53,6 @@ public abstract class SharedTreeMojoWriter<
           ctVal = key != null ? DKV.get(key) : null;
           if (ctVal != null) {
             ct = ctVal.get();
-            assert ct._nclass == -1;
             writeblob(String.format("trees/t%02d_%03d_aux.bin", j, i), ct._bits);
           }
         }

--- a/h2o-algos/src/main/java/hex/tree/TreeVisitor.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeVisitor.java
@@ -59,7 +59,6 @@ public abstract class TreeVisitor<T extends Exception> {
     case 1:  skip = _ts.get2();  break;
     case 2:  skip = _ts.get3();  break;
     case 3:  skip = _ts.get4();  break;
-    case 16: skip = _ct._nclass < 256?1:2;  break; // Small leaf
     case 48: skip =  4;  break; // skip is always 4 for direct leaves (see DecidedNode.size() and LeafNode.size() methods)
     default: assert false:"illegal lmask value " + lmask;
     }

--- a/h2o-algos/src/main/java/hex/tree/drf/DRF.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRF.java
@@ -187,7 +187,7 @@ public class DRF extends SharedTree<hex.tree.drf.DRFModel, hex.tree.drf.DRFModel
           // This optimization assumes the 2nd tree of a 2-class system is the
           // inverse of the first (and that the same columns were picked)
           if( k==1 && _nclass==2 && _model.binomialOpt()) continue;
-          ktrees[k] = new DTree(_train, _ncols, (char)_nclass, _mtry, _mtry_per_tree, rseed, _parms);
+          ktrees[k] = new DTree(_train, _ncols, _mtry, _mtry_per_tree, rseed, _parms);
           new UndecidedNode(ktrees[k], -1, DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalQuantilesKeys())); // The "root" node
         }
       }

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -425,7 +425,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
       for (int k = 0; k < numClassTrees(); k++) {
         // Initially setup as-if an empty-split had just happened
         if (_model._output._distribution[k] != 0) {
-          ktrees[k] = new DTree(_train, _ncols, (char)_nclass, _mtry, _mtry_per_tree, rseed, _parms);
+          ktrees[k] = new DTree(_train, _ncols, _mtry, _mtry_per_tree, rseed, _parms);
           DHistogram[] hist = DHistogram.initialHist(_train, _ncols, adj_nbins, hcs[k][0], rseed, _parms, getGlobalQuantilesKeys());
           new UndecidedNode(ktrees[k], DTree.NO_PARENT, hist); // The "root" node
         }

--- a/h2o-algos/src/test/java/hex/tree/CompressedTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/CompressedTreeTest.java
@@ -71,7 +71,7 @@ public class CompressedTreeTest extends TestUtil  {
 
         for (double[] row : data) {
           final double leafAssignment = SharedTreeMojoModel.scoreTree(tree._bits, row,
-                  2, true, model._output._domains);
+                  true, model._output._domains);
           final String nodePath = SharedTreeMojoModel.getDecisionPath(leafAssignment);
           final int nodeId = SharedTreeMojoModel.getLeafNodeId(leafAssignment, auxTreeInfo._bits);
 
@@ -94,7 +94,7 @@ public class CompressedTreeTest extends TestUtil  {
   public void testMakeTreeKey() {
     try {
       Scope.enter();
-      CompressedTree ct = new CompressedTree(new byte[0], 7, 123, 42, 17);
+      CompressedTree ct = new CompressedTree(new byte[0], 123, 42, 17);
       Scope.track_generic(ct);
       DKV.put(ct);
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree.java
@@ -4,6 +4,6 @@ import java.io.Serializable;
 
 public interface ScoreTree extends Serializable {
 
-  double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains);
+  double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains);
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree0.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree0.java
@@ -3,8 +3,8 @@ package hex.genmodel.algos.tree;
 public final class ScoreTree0 implements ScoreTree {
 
   @Override
-  public final double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains) {
-    return SharedTreeMojoModel.scoreTree0(tree, row, nclasses, computeLeafAssignment);
+  public final double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains) {
+    return SharedTreeMojoModel.scoreTree0(tree, row, computeLeafAssignment);
   }
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree1.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree1.java
@@ -3,8 +3,8 @@ package hex.genmodel.algos.tree;
 public final class ScoreTree1 implements ScoreTree {
 
   @Override
-  public final double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains) {
-    return SharedTreeMojoModel.scoreTree1(tree, row, nclasses, computeLeafAssignment);
+  public final double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains) {
+    return SharedTreeMojoModel.scoreTree1(tree, row, computeLeafAssignment);
   }
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree2.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree2.java
@@ -3,8 +3,8 @@ package hex.genmodel.algos.tree;
 public final class ScoreTree2 implements ScoreTree {
 
   @Override
-  public final double scoreTree(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment, String[][] domains) {
-    return SharedTreeMojoModel.scoreTree(tree, row, nclasses, computeLeafAssignment, domains);
+  public final double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains) {
+    return SharedTreeMojoModel.scoreTree(tree, row, computeLeafAssignment, domains);
   }
 
 }

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/tree/SharedTreeMojoModelTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/tree/SharedTreeMojoModelTest.java
@@ -18,11 +18,11 @@ public class SharedTreeMojoModelTest {
     bb.putFloat(4.2f);
 
     // Root Node Prediction
-    final double score = SharedTreeMojoModel.scoreTree(tree, null, -1, false, null);
+    final double score = SharedTreeMojoModel.scoreTree(tree, null, false, null);
     assertEquals(4.2f, score, 0.0);
 
     // Leaf Node Assignment
-    final double path = SharedTreeMojoModel.scoreTree(tree, null, -1, true, null);
+    final double path = SharedTreeMojoModel.scoreTree(tree, null, true, null);
     assertEquals("", SharedTreeMojoModel.getDecisionPath(path));
   }
 


### PR DESCRIPTION
The `_nclass` field/parameter has no effect during traversal of compressed trees, so this patch eliminates it where possible.

No functionality should be impacted at all. The only goal here is to remove dead code and increase readability. Performance improvement is possible, but unlikely measurable.

As part of these changes, a line like following is removed from all `scoreTree*` methods (and other tree traversals):

```java
...
case 16: ab.skip(nclasses < 256? 1 : 2);  break;  // Small leaf
...
```

In all cases, this line is unreachable - or more precisely, only reachable by traversing invalid binary mojo tree.

To prove this statement, let's see the result of extensive jenkins tests.