### PR TITLE
Extract version-specific implementations out of ScoreTreeMojoModel 

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree0.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree0.java
@@ -1,10 +1,87 @@
 package hex.genmodel.algos.tree;
 
+import hex.genmodel.utils.ByteBufferWrapper;
+import hex.genmodel.utils.GenmodelBitSet;
+
+import java.util.Arrays;
+
 public final class ScoreTree0 implements ScoreTree {
+  private static final int NsdNaVsRest = NaSplitDir.NAvsREST.value();
+  private static final int NsdNaLeft = NaSplitDir.NALeft.value();
+  private static final int NsdLeft = NaSplitDir.Left.value();
 
   @Override
   public final double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains) {
-    return SharedTreeMojoModel.scoreTree0(tree, row, computeLeafAssignment);
-  }
+    ByteBufferWrapper ab = new ByteBufferWrapper(tree);
+    GenmodelBitSet bs = null;  // Lazily set on hitting first group test
+    long bitsRight = 0;
+    int level = 0;
+    while (true) {
+      int nodeType = ab.get1U();
+      int colId = ab.get2();
+      if (colId == 65535) return ab.get4f();
+      int naSplitDir = ab.get1U();
+      boolean naVsRest = naSplitDir == NsdNaVsRest;
+      boolean leftward = naSplitDir == NsdNaLeft || naSplitDir == NsdLeft;
+      int lmask = (nodeType & 51);
+      int equal = (nodeType & 12);  // Can be one of 0, 8, 12
+      assert equal != 4;  // no longer supported
 
+      float splitVal = -1;
+      if (!naVsRest) {
+        // Extract value or group to split on
+        if (equal == 0) {
+          // Standard float-compare test (either < or ==)
+          splitVal = ab.get4f();  // Get the float to compare
+        } else {
+          // Bitset test
+          if (bs == null) bs = new GenmodelBitSet(0);
+          if (equal == 8)
+            bs.fill2(tree, ab);
+          else
+            bs.fill3_1(tree, ab);
+        }
+      }
+
+      double d = row[colId];
+      if (Double.isNaN(d) ? !leftward : !naVsRest && (equal == 0 ? d >= splitVal : bs.contains0((int) d))) {
+        // go RIGHT
+        switch (lmask) {
+          case 0:
+            ab.skip(ab.get1U());
+            break;
+          case 1:
+            ab.skip(ab.get2());
+            break;
+          case 2:
+            ab.skip(ab.get3());
+            break;
+          case 3:
+            ab.skip(ab.get4());
+            break;
+          case 48:
+            ab.skip(4);
+            break;  // skip the prediction
+          default:
+            assert false : "illegal lmask value " + lmask + " in tree " + Arrays.toString(tree);
+        }
+        if (computeLeafAssignment && level < 64) bitsRight |= 1 << level;
+        lmask = (nodeType & 0xC0) >> 2;  // Replace leftmask with the rightmask
+      } else {
+        // go LEFT
+        if (lmask <= 3)
+          ab.skip(lmask + 1);
+      }
+
+      level++;
+      if ((lmask & 16) != 0) {
+        if (computeLeafAssignment) {
+          bitsRight |= 1 << level;  // mark the end of the tree
+          return Double.longBitsToDouble(bitsRight);
+        } else {
+          return ab.get4f();
+        }
+      }
+    }
+  }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree1.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree1.java
@@ -1,10 +1,88 @@
 package hex.genmodel.algos.tree;
 
+import hex.genmodel.utils.ByteBufferWrapper;
+import hex.genmodel.utils.GenmodelBitSet;
+
+import java.util.Arrays;
+
 public final class ScoreTree1 implements ScoreTree {
+  private static final int NsdNaVsRest = NaSplitDir.NAvsREST.value();
+  private static final int NsdNaLeft = NaSplitDir.NALeft.value();
+  private static final int NsdLeft = NaSplitDir.Left.value();
 
   @Override
   public final double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains) {
-    return SharedTreeMojoModel.scoreTree1(tree, row, computeLeafAssignment);
-  }
+    ByteBufferWrapper ab = new ByteBufferWrapper(tree);
+    GenmodelBitSet bs = null;
+    long bitsRight = 0;
+    int level = 0;
+    while (true) {
+      int nodeType = ab.get1U();
+      int colId = ab.get2();
+      if (colId == 65535) return ab.get4f();
+      int naSplitDir = ab.get1U();
+      boolean naVsRest = naSplitDir == NsdNaVsRest;
+      boolean leftward = naSplitDir == NsdNaLeft || naSplitDir == NsdLeft;
+      int lmask = (nodeType & 51);
+      int equal = (nodeType & 12);  // Can be one of 0, 8, 12
+      assert equal != 4;  // no longer supported
 
+      float splitVal = -1;
+      if (!naVsRest) {
+        // Extract value or group to split on
+        if (equal == 0) {
+          // Standard float-compare test (either < or ==)
+          splitVal = ab.get4f();  // Get the float to compare
+        } else {
+          // Bitset test
+          if (bs == null) bs = new GenmodelBitSet(0);
+          if (equal == 8)
+            bs.fill2(tree, ab);
+          else
+            bs.fill3_1(tree, ab);
+        }
+      }
+
+      double d = row[colId];
+      if (Double.isNaN(d) || (equal != 0 && bs != null && !bs.isInRange((int) d))
+          ? !leftward : !naVsRest && (equal == 0 ? d >= splitVal : bs.contains((int) d))) {
+        // go RIGHT
+        switch (lmask) {
+          case 0:
+            ab.skip(ab.get1U());
+            break;
+          case 1:
+            ab.skip(ab.get2());
+            break;
+          case 2:
+            ab.skip(ab.get3());
+            break;
+          case 3:
+            ab.skip(ab.get4());
+            break;
+          case 48:
+            ab.skip(4);
+            break;  // skip the prediction
+          default:
+            assert false : "illegal lmask value " + lmask + " in tree " + Arrays.toString(tree);
+        }
+        if (computeLeafAssignment && level < 64) bitsRight |= 1 << level;
+        lmask = (nodeType & 0xC0) >> 2;  // Replace leftmask with the rightmask
+      } else {
+        // go LEFT
+        if (lmask <= 3)
+          ab.skip(lmask + 1);
+      }
+
+      level++;
+      if ((lmask & 16) != 0) {
+        if (computeLeafAssignment) {
+          bitsRight |= 1 << level;  // mark the end of the tree
+          return Double.longBitsToDouble(bitsRight);
+        } else {
+          return ab.get4f();
+        }
+      }
+    }
+  }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree2.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ScoreTree2.java
@@ -1,10 +1,136 @@
 package hex.genmodel.algos.tree;
 
+import hex.genmodel.utils.ByteBufferWrapper;
+import hex.genmodel.utils.GenmodelBitSet;
+
+import java.util.Arrays;
+
 public final class ScoreTree2 implements ScoreTree {
+  private static final int NsdNaVsRest = NaSplitDir.NAvsREST.value();
+  private static final int NsdNaLeft = NaSplitDir.NALeft.value();
+  private static final int NsdLeft = NaSplitDir.Left.value();
 
   @Override
   public final double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains) {
-    return SharedTreeMojoModel.scoreTree(tree, row, computeLeafAssignment, domains);
-  }
+    ByteBufferWrapper ab = new ByteBufferWrapper(tree);
+    GenmodelBitSet bs = null;
+    long bitsRight = 0;
+    int level = 0;
+    while (true) {
+      int nodeType = ab.get1U();
+      int colId = ab.get2();
+      if (colId == 65535) {
+        if (computeLeafAssignment) {
+          bitsRight |= 1 << level;  // mark the end of the tree
+          return Double.longBitsToDouble(bitsRight);
+        } else {
+          return ab.get4f();
+        }
+      }
+      int naSplitDir = ab.get1U();
+      boolean naVsRest = naSplitDir == NsdNaVsRest;
+      boolean leftward = naSplitDir == NsdNaLeft || naSplitDir == NsdLeft;
+      int lmask = (nodeType & 51);
+      int equal = (nodeType & 12);  // Can be one of 0, 8, 12
+      assert equal != 4;  // no longer supported
 
+      float splitVal = -1;
+      if (!naVsRest) {
+        // Extract value or group to split on
+        if (equal == 0) {
+          // Standard float-compare test (either < or ==)
+          splitVal = ab.get4f();  // Get the float to compare
+        } else {
+          // Bitset test
+          if (bs == null) bs = new GenmodelBitSet(0);
+          if (equal == 8)
+            bs.fill2(tree, ab);
+          else
+            bs.fill3(tree, ab);
+        }
+      }
+      /*
+      This logic:
+      //
+             double d = row[colId];
+             if (Double.isNaN(d) || ( equal != 0 && bs != null && !bs.isInRange((int)d) ) || (domains != null && domains[colId] != null && domains[colId].length <= (int)d)
+                   ? !leftward : !naVsRest && (equal == 0? d >= splitVal : bs.contains((int)d))) {
+
+      Really does this:
+      //
+             if (value is NaN or value is not in the range of the bitset or is outside the domain map length (but an integer) ) {
+                 if (leftward) {
+                     go left
+                 }
+                 else {
+                     go right
+                 }
+             }
+             else {
+                 if (naVsRest) {
+                     go left
+                 }
+                 else {
+                     if (numeric) {
+                         if (value < split value) {
+                             go left
+                         }
+                         else {
+                             go right
+                         }
+                     }
+                     else {
+                         if (value not in bitset) {
+                             go left
+                         }
+                         else {
+                             go right
+                         }
+                     }
+                 }
+             }
+      */
+
+      double d = row[colId];
+      if (Double.isNaN(d) || (equal != 0 && bs != null && !bs.isInRange((int) d)) || (domains != null && domains[colId] != null && domains[colId].length <= (int) d)
+          ? !leftward : !naVsRest && (equal == 0 ? d >= splitVal : bs.contains((int) d))) {
+        // go RIGHT
+        switch (lmask) {
+          case 0:
+            ab.skip(ab.get1U());
+            break;
+          case 1:
+            ab.skip(ab.get2());
+            break;
+          case 2:
+            ab.skip(ab.get3());
+            break;
+          case 3:
+            ab.skip(ab.get4());
+            break;
+          case 48:
+            ab.skip(4);
+            break;  // skip the prediction
+          default:
+            assert false : "illegal lmask value " + lmask + " in tree " + Arrays.toString(tree);
+        }
+        if (computeLeafAssignment && level < 64) bitsRight |= 1 << level;
+        lmask = (nodeType & 0xC0) >> 2;  // Replace leftmask with the rightmask
+      } else {
+        // go LEFT
+        if (lmask <= 3)
+          ab.skip(lmask + 1);
+      }
+
+      level++;
+      if ((lmask & 16) != 0) {
+        if (computeLeafAssignment) {
+          bitsRight |= 1 << level;  // mark the end of the tree
+          return Double.longBitsToDouble(bitsRight);
+        } else {
+          return ab.get4f();
+        }
+      }
+    }
+  }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoModel.java
@@ -69,23 +69,24 @@ public abstract class SharedTreeMojoModel extends MojoModel implements SharedTre
       return _ntrees_per_group;
     }
 
-
+    private static final ScoreTree SCORE_TREE_IMPL_V0 = new ScoreTree0();
     /**
-     * @deprecated use {@link #scoreTree0(byte[], double[], boolean)} instead.
+     * @deprecated use {@link ScoreTree0#scoreTree(byte[], double[], boolean, String[][])} instead.
      */
     @Deprecated
     public static double scoreTree0(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment) {
       // note that nclasses is ignored (and in fact, always was)
-      return scoreTree0(tree, row, computeLeafAssignment);
+      return SCORE_TREE_IMPL_V0.scoreTree(tree, row, computeLeafAssignment, new String[0][]);
     }
 
+    private static final ScoreTree SCORE_TREE_IMPL_V1 = new ScoreTree1();
     /**
-     * @deprecated use {@link #scoreTree1(byte[], double[], boolean)} instead.
+     * @deprecated use {@link ScoreTree1#scoreTree(byte[], double[], boolean, String[][])} instead.
      */
     @Deprecated
     public static double scoreTree1(byte[] tree, double[] row, int nclasses, boolean computeLeafAssignment) {
       // note that nclasses is ignored (and in fact, always was)
-      return scoreTree1(tree, row, computeLeafAssignment);
+      return SCORE_TREE_IMPL_V1.scoreTree(tree, row, computeLeafAssignment, new String[0][]);
     }
 
     /**
@@ -97,126 +98,10 @@ public abstract class SharedTreeMojoModel extends MojoModel implements SharedTre
       return scoreTree(tree, row, computeLeafAssignment, domains);
     }
 
-  /**
-   * Highly efficient (critical path) tree scoring
-   *
-   * Given a tree (in the form of a byte array) and the row of input data, compute either this tree's
-   * predicted value when `computeLeafAssignment` is false, or the the decision path within the tree (but no more
-   * than 64 levels) when `computeLeafAssignment` is true.
-   *
-   * Note: this function is also used from the `hex.tree.CompressedTree` class in `h2o-algos` project.
-   */
-  @SuppressWarnings("ConstantConditions")  // Complains that the code is too complex. Well duh!
+    private static final ScoreTree SCORE_TREE_IMPL_PREFERRED = new ScoreTree2();
+
     public static double scoreTree(byte[] tree, double[] row, boolean computeLeafAssignment, String[][] domains) {
-        ByteBufferWrapper ab = new ByteBufferWrapper(tree);
-        GenmodelBitSet bs = null;
-        long bitsRight = 0;
-        int level = 0;
-        while (true) {
-            int nodeType = ab.get1U();
-            int colId = ab.get2();
-            if (colId == 65535) {
-              if (computeLeafAssignment) {
-                bitsRight |= 1 << level;  // mark the end of the tree
-                return Double.longBitsToDouble(bitsRight);
-              } else {
-                return ab.get4f();
-              }
-            }
-            int naSplitDir = ab.get1U();
-            boolean naVsRest = naSplitDir == NsdNaVsRest;
-            boolean leftward = naSplitDir == NsdNaLeft || naSplitDir == NsdLeft;
-            int lmask = (nodeType & 51);
-            int equal = (nodeType & 12);  // Can be one of 0, 8, 12
-            assert equal != 4;  // no longer supported
-
-            float splitVal = -1;
-            if (!naVsRest) {
-                // Extract value or group to split on
-                if (equal == 0) {
-                    // Standard float-compare test (either < or ==)
-                    splitVal = ab.get4f();  // Get the float to compare
-                } else {
-                    // Bitset test
-                    if (bs == null) bs = new GenmodelBitSet(0);
-                    if (equal == 8)
-                        bs.fill2(tree, ab);
-                    else
-                        bs.fill3(tree, ab);
-                }
-            }
-
-          // This logic:
-          //
-          //        double d = row[colId];
-          //        if (Double.isNaN(d) || ( equal != 0 && bs != null && !bs.isInRange((int)d) ) || (domains != null && domains[colId] != null && domains[colId].length <= (int)d)
-          //              ? !leftward : !naVsRest && (equal == 0? d >= splitVal : bs.contains((int)d))) {
-
-          // Really does this:
-          //
-          //        if (value is NaN or value is not in the range of the bitset or is outside the domain map length (but an integer) ) {
-          //            if (leftward) {
-          //                go left
-          //            }
-          //            else {
-          //                go right
-          //            }
-          //        }
-          //        else {
-          //            if (naVsRest) {
-          //                go left
-          //            }
-          //            else {
-          //                if (numeric) {
-          //                    if (value < split value) {
-          //                        go left
-          //                    }
-          //                    else {
-          //                        go right
-          //                    }
-          //                }
-          //                else {
-          //                    if (value not in bitset) {
-          //                        go left
-          //                    }
-          //                    else {
-          //                        go right
-          //                    }
-          //                }
-          //            }
-          //        }
-
-            double d = row[colId];
-            if (Double.isNaN(d) || ( equal != 0 && bs != null && !bs.isInRange((int)d) ) || (domains != null && domains[colId] != null && domains[colId].length <= (int)d)
-                    ? !leftward : !naVsRest && (equal == 0? d >= splitVal : bs.contains((int)d))) {
-                // go RIGHT
-                switch (lmask) {
-                    case 0:  ab.skip(ab.get1U());  break;
-                    case 1:  ab.skip(ab.get2());  break;
-                    case 2:  ab.skip(ab.get3());  break;
-                    case 3:  ab.skip(ab.get4());  break;
-                    case 48: ab.skip(4);  break;  // skip the prediction
-                    default:
-                        assert false : "illegal lmask value " + lmask + " in tree " + Arrays.toString(tree);
-                }
-                if (computeLeafAssignment && level < 64) bitsRight |= 1 << level;
-                lmask = (nodeType & 0xC0) >> 2;  // Replace leftmask with the rightmask
-            } else {
-                // go LEFT
-                if (lmask <= 3)
-                    ab.skip(lmask + 1);
-            }
-
-            level++;
-            if ((lmask & 16) != 0) {
-                if (computeLeafAssignment) {
-                    bitsRight |= 1 << level;  // mark the end of the tree
-                    return Double.longBitsToDouble(bitsRight);
-                } else {
-                    return ab.get4f();
-                }
-            }
-        }
+        return SCORE_TREE_IMPL_PREFERRED.scoreTree(tree, row, computeLeafAssignment, domains);
     }
 
     public interface DecisionPathTracker<T> {
@@ -778,150 +663,6 @@ public abstract class SharedTreeMojoModel extends MojoModel implements SharedTre
   // DO NOT CHANGE THE CODE BELOW THIS LINE
   // DO NOT CHANGE THE CODE BELOW THIS LINE
   /////////////////////////////////////////////////////
-  /**
-   * SET IN STONE FOR MOJO VERSION "1.00" - DO NOT CHANGE
-   * @param tree
-   * @param row
-   * @param computeLeafAssignment
-   * @return
-   */
-  @SuppressWarnings("ConstantConditions")  // Complains that the code is too complex. Well duh!
-  public static double scoreTree0(byte[] tree, double[] row, boolean computeLeafAssignment) {
-    ByteBufferWrapper ab = new ByteBufferWrapper(tree);
-    GenmodelBitSet bs = null;  // Lazily set on hitting first group test
-    long bitsRight = 0;
-    int level = 0;
-    while (true) {
-      int nodeType = ab.get1U();
-      int colId = ab.get2();
-      if (colId == 65535) return ab.get4f();
-      int naSplitDir = ab.get1U();
-      boolean naVsRest = naSplitDir == NsdNaVsRest;
-      boolean leftward = naSplitDir == NsdNaLeft || naSplitDir == NsdLeft;
-      int lmask = (nodeType & 51);
-      int equal = (nodeType & 12);  // Can be one of 0, 8, 12
-      assert equal != 4;  // no longer supported
-
-      float splitVal = -1;
-      if (!naVsRest) {
-        // Extract value or group to split on
-        if (equal == 0) {
-          // Standard float-compare test (either < or ==)
-          splitVal = ab.get4f();  // Get the float to compare
-        } else {
-          // Bitset test
-          if (bs == null) bs = new GenmodelBitSet(0);
-          if (equal == 8)
-            bs.fill2(tree, ab);
-          else
-            bs.fill3_1(tree, ab);
-        }
-      }
-
-      double d = row[colId];
-      if (Double.isNaN(d)? !leftward : !naVsRest && (equal == 0? d >= splitVal : bs.contains0((int)d))) {
-        // go RIGHT
-        switch (lmask) {
-          case 0:  ab.skip(ab.get1U());  break;
-          case 1:  ab.skip(ab.get2());  break;
-          case 2:  ab.skip(ab.get3());  break;
-          case 3:  ab.skip(ab.get4());  break;
-          case 48: ab.skip(4);  break;  // skip the prediction
-          default:
-            assert false : "illegal lmask value " + lmask + " in tree " + Arrays.toString(tree);
-        }
-        if (computeLeafAssignment && level < 64) bitsRight |= 1 << level;
-        lmask = (nodeType & 0xC0) >> 2;  // Replace leftmask with the rightmask
-      } else {
-        // go LEFT
-        if (lmask <= 3)
-          ab.skip(lmask + 1);
-      }
-
-      level++;
-      if ((lmask & 16) != 0) {
-        if (computeLeafAssignment) {
-          bitsRight |= 1 << level;  // mark the end of the tree
-          return Double.longBitsToDouble(bitsRight);
-        } else {
-          return ab.get4f();
-        }
-      }
-    }
-  }
-
-  /**
-   * SET IN STONE FOR MOJO VERSION "1.10" - DO NOT CHANGE
-   * @param tree
-   * @param row
-   * @param computeLeafAssignment
-   * @return
-   */
-  @SuppressWarnings("ConstantConditions")  // Complains that the code is too complex. Well duh!
-  public static double scoreTree1(byte[] tree, double[] row, boolean computeLeafAssignment) {
-    ByteBufferWrapper ab = new ByteBufferWrapper(tree);
-    GenmodelBitSet bs = null;
-    long bitsRight = 0;
-    int level = 0;
-    while (true) {
-      int nodeType = ab.get1U();
-      int colId = ab.get2();
-      if (colId == 65535) return ab.get4f();
-      int naSplitDir = ab.get1U();
-      boolean naVsRest = naSplitDir == NsdNaVsRest;
-      boolean leftward = naSplitDir == NsdNaLeft || naSplitDir == NsdLeft;
-      int lmask = (nodeType & 51);
-      int equal = (nodeType & 12);  // Can be one of 0, 8, 12
-      assert equal != 4;  // no longer supported
-
-      float splitVal = -1;
-      if (!naVsRest) {
-        // Extract value or group to split on
-        if (equal == 0) {
-          // Standard float-compare test (either < or ==)
-          splitVal = ab.get4f();  // Get the float to compare
-        } else {
-          // Bitset test
-          if (bs == null) bs = new GenmodelBitSet(0);
-          if (equal == 8)
-            bs.fill2(tree, ab);
-          else
-            bs.fill3_1(tree, ab);
-        }
-      }
-
-      double d = row[colId];
-      if (Double.isNaN(d) || ( equal != 0 && bs != null && !bs.isInRange((int)d) )
-              ? !leftward : !naVsRest && (equal == 0? d >= splitVal : bs.contains((int)d))) {
-        // go RIGHT
-        switch (lmask) {
-          case 0:  ab.skip(ab.get1U());  break;
-          case 1:  ab.skip(ab.get2());  break;
-          case 2:  ab.skip(ab.get3());  break;
-          case 3:  ab.skip(ab.get4());  break;
-          case 48: ab.skip(4);  break;  // skip the prediction
-          default:
-            assert false : "illegal lmask value " + lmask + " in tree " + Arrays.toString(tree);
-        }
-        if (computeLeafAssignment && level < 64) bitsRight |= 1 << level;
-        lmask = (nodeType & 0xC0) >> 2;  // Replace leftmask with the rightmask
-      } else {
-        // go LEFT
-        if (lmask <= 3)
-          ab.skip(lmask + 1);
-      }
-
-      level++;
-      if ((lmask & 16) != 0) {
-        if (computeLeafAssignment) {
-          bitsRight |= 1 << level;  // mark the end of the tree
-          return Double.longBitsToDouble(bitsRight);
-        } else {
-          return ab.get4f();
-        }
-      }
-    }
-  }
 
   @Override
   public boolean calibrateClassProbabilities(double[] preds) {


### PR DESCRIPTION
Class `ScoreTreeMojoModel` is a mix of various functionalities, and various versions of them, in single source file.
Here I am trying to logically divide the code so that each version is in separate java class. These separate classes were even there already, so doing this looks like a next natural step.
**This brings no changes in functionality**.

The interface `ScoreTree` is used for the tree scoring functionality which is implemented in all mojo versions.

Methods related to `_aux.bin` and `computeGraph()` were moved to `ScoreTree2` class where they logically belong, but they are still static. Further refactoring steps seem useful there.