### PR TITLE
PUBDEV-5971: CSV/ARFF Parser handles blank lines as data lines with NAs

### DIFF
--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -47,11 +47,8 @@ class CsvParser extends Parser {
       // Starting state.  Are we skipping the first (partial) line, or not?  Skip
       // a header line, or a partial line if we're in the 2nd and later chunks.
       if (_setup._check_header == ParseSetup.HAS_HEADER || cidx > 0) state = SKIP_LINE;
-      else state = WHITESPACE_BEFORE_TOKEN;
+      else state = POSSIBLE_EMPTY_LINE;
     }
-
-    // For parsing ARFF
-    if (_setup._parse_type.equals(ARFF_INFO) && _setup._check_header == ParseSetup.HAS_HEADER) state = WHITESPACE_BEFORE_TOKEN;
 
     int quotes = 0;
     byte quoteCount = 0;
@@ -68,7 +65,7 @@ class CsvParser extends Parser {
     byte[] nonDataLineMarkers = nonDataLineMarkers();
     if( cidx == 0 ) {
       while (ArrayUtils.contains(nonDataLineMarkers, c) || isEOL(c)) {
-        while ((offset   < bits.length) && (bits[offset] != CHAR_CR) && (bits[offset  ] != CHAR_LF)) {
+        while ((offset < bits.length) && (bits[offset] != CHAR_CR) && (bits[offset  ] != CHAR_LF)) {
 //          System.out.print(String.format("%c",bits[offset]));
           ++offset;
         }
@@ -225,7 +222,6 @@ MAIN_LOOP:
             state = SKIP_LINE;
             break;
           }
-          state = WHITESPACE_BEFORE_TOKEN;
           // fallthrough to WHITESPACE_BEFORE_TOKEN
         // ---------------------------------------------------------------------
         case WHITESPACE_BEFORE_TOKEN:
@@ -234,6 +230,7 @@ MAIN_LOOP:
           } else if (c == CHAR_SEPARATOR) {
             // we have empty token, store as NaN
             dout.addInvalidCol(colIdx++);
+            state = WHITESPACE_BEFORE_TOKEN;
             break;
           } else if (isEOL(c)) {
             dout.addInvalidCol(colIdx++);

--- a/h2o-core/src/test/java/water/parser/CsvParserTest.java
+++ b/h2o-core/src/test/java/water/parser/CsvParserTest.java
@@ -1,6 +1,5 @@
 package water.parser;
 
-import org.junit.Assert;
 import org.junit.Test;
 import water.fvec.Vec;
 import water.util.StringUtils;

--- a/h2o-core/src/test/java/water/parser/ParserTest2.java
+++ b/h2o-core/src/test/java/water/parser/ParserTest2.java
@@ -74,6 +74,47 @@ public class ParserTest2 extends TestUtil {
     fr.delete();
   }
 
+  /**
+   * there's no official grammar for CSV, and especially no directive on how to handle blank lines.
+   * but common parsers (e.g. Python CSV parser) ignores them.
+   * Useful to consider anyway, especially for trailing lines
+   */
+  @Test public void testIgnoreBlankLines() {
+    //the data chunks are intentionally cut at some various edge cases (cut before data not currently supported)
+    String [] data = new String[]{
+        "'C1', 'C2', 'C3', "+" 'C4'\n"+         //chunk1&2
+        " \t\n"+
+        "1,       1,","         1,        1\n"+ //chunk3
+        "2,       2,         ","2,        2\n"+ //chunk4
+        "3,       3,         3",",        3\n"+ //chunk5
+        " ,        ,          ,      ","   \n"+ //chunk6
+        "\n"+
+        "  \n",
+        " \n"+                                  //chunk7
+        "\t\n"+
+        "  "+"  \n"+                            //chunk8
+        "\t\t\t\n"+
+        " \t"+"\n",
+    };
+    Key dataKey = ParserTest.makeByteVec(data);
+    ParseSetup ps = new ParseSetup(CSV_INFO, (byte)',', false, ParseSetup.HAS_HEADER, 4,
+        new String[]{"'C1'","'C2'", "'C3'", "'C4'"},
+        ParseSetup.strToColumnTypes(new String[]{"Numeric", "Numeric", "Numeric", "Numeric"}),
+        null, null, null);
+    Frame fr = null;
+    try {
+      fr = ParseDataset.parse(Key.make("blank_lines_test.hex"), new Key[]{dataKey}, true, ps);
+      Assert.assertEquals(4, fr.numRows());
+      Assert.assertTrue(fr.hasNAs());
+      Assert.assertEquals(4, fr.naCount());
+      for (int i = 0; i < 4; i++) { //only last=4th row contains NAs
+        Assert.assertTrue(fr.vec(i).isNA(3));
+      }
+    } finally {
+      if (fr != null) fr.delete();
+    }
+  }
+
   
  @Test public void testSingleQuotes(){
     String[] data  = new String[]{"'Tomass,test,first,line'\n'Tomas''s,test2',test2\nlast,'line''","s, trailing, piece'"};

--- a/h2o-core/src/test/java/water/parser/ParserTestARFF.java
+++ b/h2o-core/src/test/java/water/parser/ParserTestARFF.java
@@ -868,16 +868,51 @@ public class ParserTestARFF extends TestUtil {
     }
   }
 
+  @Test public void testIgnoreBlankLines() {
+    String[] arff = new String[] {
+        "% comment",
+        " ",
+        "\t",
+        "  ",
+        " \t",
+        "\t ",
+        "\t\t",
+        "@relation test_nas",
+        " ",
+        "@attribute y {'0', '1'}",
+        "@attribute x1 numeric",
+        "@attribute x2 string",
+        " ",
+        "@data",
+        "  ",
+        "\t ",
+        "'0',42,\"foo\"",
+        "'1',24,\"bar\"",
+        "  ",
+    };
+    byte[] expected_types = new byte[]{Vec.T_CAT, Vec.T_NUM, Vec.T_STR};
+    String[] expected_names = new String[]{"y", "x1", "x2"};
+    int expected_data_length = 2;
+
+    testTypes(arff, expected_types, expected_data_length, "\n", 1);
+    testColNames(arff, expected_names, expected_data_length, "\n", 1);
+  }
+
 
   @Test public void testMultiChunkHeader() {
     final int col_count = 51;
     final int cat_length = 10_000;
     final int data_count = 10_000;
+    final int header_comment_length = 1_000;
 
     byte[] expected_types = new byte[col_count];
     String[] expected_names = new String[col_count];
 
     List<String> arff = new ArrayList<>();
+    for (int i = 0; i < header_comment_length; i++) {
+      arff.add("%%%% comment comment comment");
+      if (i % 50 == 0) arff.add("");
+    }
     arff.add("@relation test_large_header");
     arff.add("@attribute y numeric");
     expected_types[0] = Vec.T_NUM;


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5971

CSV/Arff parser: keep the state machine in POSSIBLE_EMPTY_LINE state until a separator or token is reached