### PR TITLE
added EditorConfig metafile to reduce growth of the indentation mess

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# newline ending every file; no trailing space
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,json,py,xml,java,R}]
+charset = utf-8
+
+# 4 space indentation
+[*.{py,R,xml,js}]
+indent_style = space
+indent_size = 4
+
+# 2 space indentation
+[*.{java}]
+indent_style = space
+indent_size = 2
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
The codebase contains a lot of java, python and R sources that is often hard to read, for variety of reasons.
One day, it would be nice to prettify, and maybe even refactor these sources, but it's unlikely to happen anytime soon.

But there are still simple ways that have zero cost and can help us with, at least, avoiding some of the problems to *spread and grow*. One such helper is EditorConfig - [read about it here](http://EditorConfig.org).

This tool configures very simple rules telling how code editors should handle files - line endings, trailing spaces, final newline, and primarily: *indentation*.
And yes, current state of indentation is very annoying. When we try to contribute minimalistic changes, and want the new code to be properly indented, and place the new code into something where indentation is broken, it's really a headache. And causes authors to waste time with stuff completely unrelated to the domain they are fixing. At least, those who hate their code chaotically scattered.

I prepared the configuration in a way that tries to be best matching the style currently used in the codebase; here are some decisions I placed into the file. If you have a different strong opinion on any, please share.
Most frequent files are:

* `*.java` - indentation with 2 spaces; I personally dislike it, as the widely accepted standard is to use 4 spaces, but nevermind, 2sp is definitely the most used java style here; better than growing the current style mix of tabs, 4sp, 2sp, and even totally spilled code
* `*.py` - at first glance there seems to be similar number of 2sp and 4sp indented code, so I chose 4sp
* `*.R` - dtto

Note that this configuration affects only newly added and newly edited files; none of the editors will use it to implicitly bulk-apply the rules on every file in the project. There is no impact on build at all, and it is somewhat annoying to people who need the freedom to write every file in a style different from the standard (which this thing declares, to some extent).

[Supported by many editors](https://editorconfig.org/#download) - by some natively (like IntelliJ IDEA) and by others via plugins and extensions.
In IDEA, go to settings and search for "editorconfig", then check it on to activate the support.
