### PR TITLE
Doc updates to H2O-3 docs after reviewing release notes

### DIFF
--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -46,7 +46,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help="Whether to keep the predictions of the cross-validation predictions.  This needs to be set to TRUE if running the same AutoML object for repeated runs because CV predictions are required to build additional Stacked Ensemble models in AutoML.", direction=API.Direction.INPUT)
     public boolean keep_cross_validation_predictions;
 
-    @API(help="Whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster.", direction=API.Direction.INPUT)
+    @API(help="Whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster.", direction=API.Direction.INPUT, gridable = true)
     public boolean keep_cross_validation_models;
 
     @API(help="Whether to keep cross-validation assignments.", direction=API.Direction.INPUT)

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -106,9 +106,9 @@ Optional Miscellaneous Parameters
     - ``DRF`` (This includes both the Random Forest and Extremely Randomized Trees (XRT) models. Refer to the :ref:`xrt` section in the DRF chapter and the `histogram_type <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/histogram_type.html>`__ parameter description for more information.)
     - ``StackedEnsemble``
 
-- **keep_cross_validation_predictions**: Specify whether to keep the predictions of the cross-validation predictions. This needs to be set to TRUE if running the same AutoML object for repeated runs because CV predictions are required to build additional Stacked Ensemble models in AutoML. This option defaults to FALSE.
+- `keep_cross_validation_predictions <data-science/algo-params/keep_cross_validation_predictions.html>`__: Specify whether to keep the predictions of the cross-validation predictions. This needs to be set to TRUE if running the same AutoML object for repeated runs because CV predictions are required to build additional Stacked Ensemble models in AutoML. This option defaults to FALSE.
 
-- **keep_cross_validation_models**: Specify whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option defaults to FALSE.
+- `keep_cross_validation_models <data-science/algo-params/keep_cross_validation_models.html>`__: Specify whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option defaults to FALSE.
 
 - `keep_cross_validation_fold_assignment <data-science/algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment.  Defaults to FALSE.
 

--- a/h2o-docs/src/product/data-science/algo-params/keep_cross_validation_fold_assignment.rst
+++ b/h2o-docs/src/product/data-science/algo-params/keep_cross_validation_fold_assignment.rst
@@ -1,7 +1,7 @@
 ``keep_cross_validation_fold_assignment``
 -----------------------------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost
+- Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost, AutoML
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/keep_cross_validation_models.rst
+++ b/h2o-docs/src/product/data-science/algo-params/keep_cross_validation_models.rst
@@ -2,7 +2,7 @@
 -------------------------------------
 
 - Available in: GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost, AutoML
-- Hyperparameter: no
+- Hyperparameter: yes for AutoML, no for other algorithms
 
 Description
 ~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/coxph.rst
+++ b/h2o-docs/src/product/data-science/coxph.rst
@@ -15,6 +15,8 @@ where :math:`\lambda(t)` is the baseline hazard function shared by all observati
 
 This combination of a non-parametric baseline hazard function and a parametric risk score results in Cox proportional hazards models being described as *semi-parametric*. In addition, a simple rearrangement of terms shows that unlike generalized linear models, an intercept (constant) term in the risk score adds no value to the model fit, due to the inclusion of a baseline hazard function.
 
+`An R demo is available here <https://github.com/h2oai/h2o-3/blob/master/h2o-r/demos/rdemo.word2vec.craigslistjobtitles.R>`__. This uses the CoxPH algorithm along with the craigslistJobTitles.csv dataset. 
+
 Defining a CoxPH Model
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -850,10 +850,6 @@ The available options vary depending on the selected model. If an option is only
     - ``AUC``
     - ``mean_per_class_error``
 
--  **keep_cross_validation_predictions** (AutoML): Specify whether to keep the predictions of the cross-validation predictions. This needs to be set to TRUE if running the same AutoML object for repeated runs because CV predictions are required to build additional Stacked Ensemble models in AutoML. This option defaults to FALSE.
-
--  **keep_cross_validation_models** (AutoML): Specify whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option defaults to FALSE.
-
 -  **build_tree_one_node**: (DRF, GBM) To run on a single node, check this checkbox. This is suitable for small datasets as there is no network overhead but fewer CPUs are used. The default setting is disabled.
 
 -  **rate**: (DL) Specify the learning rate. Higher rates result in less stable models and lower rates result in slower convergence. Not applicable if **adaptive_rate** is enabled.
@@ -943,11 +939,11 @@ The available options vary depending on the selected model. If an option is only
 
 **Expert Options**
 
--  **keep_cross_validation_models**: (GLM, GBM, DL, DRF, K-Means, XGBoost) To keep the cross-validation models, check this checkbox.
+-  **keep_cross_validation_models**: (GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost, AutoML) To keep the cross-validation models, check this checkbox.
 
--  **keep_cross_validation_predictions**: (GLM, GBM, DL, DRF, K-Means, XGBoost) To keep the cross-validation predictions, check this checkbox.
+-  **keep_cross_validation_predictions**: (GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost, AutoML) To keep the cross-validation predictions, check this checkbox.
 
--  **keep_cross_validation_fold_assignment**: (GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost) Enable this option to preserve the cross-validation fold assignment.
+-  **keep_cross_validation_fold_assignment**: (GBM, DRF, Deep Learning, GLM, Naïve-Bayes, K-Means, XGBoost, AutoML) Enable this option to preserve the cross-validation fold assignment.
 
 -  **class_sampling_factors**: (DRF, GBM, DL, Naive-Bayes, AutoML) Specify the per-class (in lexicographical order) over/under-sampling ratios. By default, these ratios are automatically computed during training to obtain the class balance. This option is only applicable for classification problems and when **balance_classes** is enabled.
 
@@ -1674,8 +1670,6 @@ To access H2Ostream from Flow:
 4. Enter your question and click the red **Post** button. If you are requesting assistance for an error you experienced, be sure to include your logs. (Refer to `Downloading Logs`_.)
 
 You can also email your question to h2ostream@googlegroups.com.
-
---------------
 
 .. |Flow - Hide Sidebar| image:: images/Flow_SidebarHide.png
 .. |Flow - Display Sidebar| image:: images/Flow_SidebarDisplay.png

--- a/h2o-docs/src/product/grid-search.rst
+++ b/h2o-docs/src/product/grid-search.rst
@@ -757,7 +757,10 @@ XGBoost Hyperparameters
 -  ``skip_drop``
 
 
+AutoML Hyperparameters
+~~~~~~~~~~~~~~~~~~~~~~
 
+- ``keep_cross_validation_models``
 
 
 Grid Testing


### PR DESCRIPTION
- Added "gridable=true" to schema for keep_cross_validation_models.
- Updated grid search topic to include an AutoML heading with keep_cross_validation_models.
- Updated Flow topic for the keep_cross_validation* options.