### PR TITLE
PUBDEV-5988 - Experimental features flag

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
@@ -4,13 +4,18 @@ package ai.h2o.automl;
 // implementation of AutoML.algo can be safely removed once we get rid of this interface: current purpose
 // is to keep backward compatibility with {@link AutoML.algo}
 public enum Algo implements AutoML.algo {
-  GLM,
-  DRF,
-  GBM,
-  DeepLearning,
-  StackedEnsemble,
-  XGBoost,
-  ;
+  GLM(hex.glm.GLM.class.getSimpleName().toLowerCase()),
+  DRF(hex.tree.drf.DRF.class.getSimpleName().toLowerCase()),
+  GBM(hex.tree.gbm.GBM.class.getSimpleName().toLowerCase()),
+  DeepLearning(hex.deeplearning.DeepLearning.class.getSimpleName().toLowerCase()),
+  StackedEnsemble(hex.ensemble.StackedEnsemble.class.getSimpleName().toLowerCase()),
+  XGBoost(hex.tree.xgboost.XGBoost.class.getSimpleName().toLowerCase());
+
+  public final String _baseName;
+
+  Algo(String baseName) {
+    _baseName = baseName;
+  }
 
   String urlName() {
     return this.name().toLowerCase();

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -285,6 +285,13 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       skipAlgosList = ArrayUtils.append(skipAlgosList, Algo.XGBoost);
     }
 
+    for(Algo algo : Algo.values()){
+      final int i = ArrayUtils.find(ModelBuilder.SKIPPED_ALGORITHMS, algo._baseName);
+      if(i >= 0){
+        skipAlgosList = ArrayUtils.append(skipAlgosList, algo);
+      }
+    }
+
     // This is useful during debugging.
 //    skipAlgosList = ArrayUtils.append(skipAlgosList, Algo.GLM, Algo.DRF, Algo.GBM, Algo.DeepLearning, Algo.StackedEnsemble);
 

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -109,13 +109,13 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   /** gbm -> GBM, deeplearning -> DeepLearning */
   public static String algoName(String urlName) {
     final int algorithmIndex = ArrayUtils.find(ALGOBASES, urlName);
-    if (algorithmIndex < 0) throw new IllegalStateException("Unknown algorithm");
+    if (algorithmIndex < 0) throw new IllegalStateException(String.format("Algorithm not available: %s. Please review '-features' flag.", urlName));
     return BUILDERS[algorithmIndex]._parms.algoName();
   }
   /** gbm -> hex.tree.gbm.GBM, deeplearning -> hex.deeplearning.DeepLearning */
   public static String javaName(String urlName) {
     final int algorithmIndex = ArrayUtils.find(ALGOBASES, urlName);
-    if (algorithmIndex < 0) throw new IllegalStateException("Unknown algorithm");
+    if (algorithmIndex < 0) throw new IllegalStateException(String.format("Algorithm not available: %s. Please review '-features' flag.", urlName));
     return BUILDERS[algorithmIndex]._parms.javaName();
   }
   /** gbm -> GBMParameters */
@@ -123,7 +123,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   /** gbm -> "hex.schemas." ; custAlgo -> "org.myOrg.schemas." */
   public static String schemaDirectory(String urlName) {
     final int algorithmIndex = ArrayUtils.find(ALGOBASES, urlName);
-    if (algorithmIndex < 0) throw new IllegalStateException("Unknown algorithm");
+    if (algorithmIndex < 0) throw new IllegalStateException(String.format("Algorithm not available: %s. Please review '-features' flag.", urlName));
     return SCHEMAS[algorithmIndex];
   }
 

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -17,6 +17,7 @@ import java.util.*;
  *  Model builder parent class.  Contains the common interfaces and fields across all model builders.
  */
 abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Parameters, O extends Model.Output> extends Iced {
+  public static String[] SKIPPED_ALGORITHMS = new String[0];
 
   public ToEigenVec getToEigenVec() { return null; }
   public boolean shouldReorder(Vec v) { return _parms._categorical_encoding.needsResponse() && isSupervised(); }
@@ -84,10 +85,11 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
    *  default settings. */
   protected ModelBuilder(P parms, boolean startup_once) { this(parms,startup_once,"hex.schemas."); }
   protected ModelBuilder(P parms, boolean startup_once, String externalSchemaDirectory ) {
+    String base = getClass().getSimpleName().toLowerCase();
     if (H2O.ARGS.features_level.compareTo(builderVisibility()) > 0) {
+      SKIPPED_ALGORITHMS = ArrayUtils.append(SKIPPED_ALGORITHMS, base);
       return;
     }
-    String base = getClass().getSimpleName().toLowerCase();
     if (!startup_once)
       throw H2O.fail("Algorithm " + base + " registration issue. It can only be called at startup.");
     _job = null;

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1,5 +1,6 @@
 package water;
 
+import hex.ModelBuilder;
 import jsr166y.CountedCompleter;
 import jsr166y.ForkJoinPool;
 import jsr166y.ForkJoinWorkerThread;
@@ -34,11 +35,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import static water.util.JavaVersionUtils.JAVA_VERSION;
 
 /**
-* Start point for creating or joining an <code>H2O</code> Cloud.
-*
-* @author <a href="mailto:cliffc@h2o.ai"></a>
-* @version 1.0
-*/
+ * Start point for creating or joining an <code>H2O</code> Cloud.
+ *
+ * @author <a href="mailto:cliffc@h2o.ai"></a>
+ * @version 1.0
+ */
 final public class H2O {
   public static final String DEFAULT_JKS_PASS = "h2oh2o";
 
@@ -56,127 +57,127 @@ final public class H2O {
       // H2O doesn't know how to guess a good one.
       // user.home doesn't make sense.
       defaultFlowDirMessage =
-      "          (The default is none; saving flows not available.)\n";
+              "          (The default is none; saving flows not available.)\n";
     }
     else {
       defaultFlowDirMessage =
-      "          (The default is '" + DEFAULT_FLOW_DIR() + "'.)\n";
+              "          (The default is '" + DEFAULT_FLOW_DIR() + "'.)\n";
     }
 
     String s =
             "\n" +
-            "Usage:  java [-Xmx<size>] -jar h2o.jar [options]\n" +
-            "        (Note that every option has a default and is optional.)\n" +
-            "\n" +
-            "    -h | -help\n" +
-            "          Print this help.\n" +
-            "\n" +
-            "    -version\n" +
-            "          Print version info and exit.\n" +
-            "\n" +
-            "    -name <h2oCloudName>\n" +
-            "          Cloud name used for discovery of other nodes.\n" +
-            "          Nodes with the same cloud name will form an H2O cloud\n" +
-            "          (also known as an H2O cluster).\n" +
-            "\n" +
-            "    -flatfile <flatFileName>\n" +
-            "          Configuration file explicitly listing H2O cloud node members.\n" +
-            "\n" +
-            "    -ip <ipAddressOfNode>\n" +
-            "          IP address of this node.\n" +
-            "\n" +
-            "    -port <port>\n" +
-            "          Port number for this node (note: port+1 is also used by default).\n" +
-            "          (The default port is " + ARGS.port + ".)\n" +
-            "\n" +
-            "    -network <IPv4network1Specification>[,<IPv4network2Specification> ...]\n" +
-            "          The IP address discovery code will bind to the first interface\n" +
-            "          that matches one of the networks in the comma-separated list.\n" +
-            "          Use instead of -ip when a broad range of addresses is legal.\n" +
-            "          (Example network specification: '10.1.2.0/24' allows 256 legal\n" +
-            "          possibilities.)\n" +
-            "\n" +
-            "    -ice_root <fileSystemPath>\n" +
-            "          The directory where H2O spills temporary data to disk.\n" +
-            "\n" +
-            "    -log_dir <fileSystemPath>\n" +
-            "          The directory where H2O writes logs to disk.\n" +
-            "          (This usually has a good default that you need not change.)\n" +
-            "\n" +
-            "    -log_level <TRACE,DEBUG,INFO,WARN,ERRR,FATAL>\n" +
-            "          Write messages at this logging level, or above.  Default is INFO." +
-            "\n" +
-            "\n" +
-            "    -flow_dir <server side directory or HDFS directory>\n" +
-            "          The directory where H2O stores saved flows.\n" +
-            defaultFlowDirMessage +
-            "\n" +
-            "    -nthreads <#threads>\n" +
-            "          Maximum number of threads in the low priority batch-work queue.\n" +
-            "          (The default is " + (char)Runtime.getRuntime().availableProcessors() + ".)\n" +
-            "\n" +
-            "    -client\n" +
-            "          Launch H2O node in client mode.\n" +
-            "\n" +
-            "    -notify_local <fileSystemPath>" +
-            "          Specifies a file to write when the node is up. The file contains one line with the IP and" +
-            "          port of the embedded web server. e.g. 192.168.1.100:54321" +
-            "\n" +
-            "    -context_path <context_path>\n" +
-            "          The context path for jetty.\n" +
-            "\n" +
-            "Authentication options:\n" +
-            "\n" +
-            "    -jks <filename>\n" +
-            "          Java keystore file\n" +
-            "\n" +
-            "    -jks_pass <password>\n" +
-            "          (Default is '" + DEFAULT_JKS_PASS + "')\n" +
-            "\n" +
-            "    -hash_login\n" +
-            "          Use Jetty HashLoginService\n" +
-            "\n" +
-            "    -ldap_login\n" +
-            "          Use Jetty LdapLoginService\n" +
-            "\n" +
-            "    -kerberos_login\n" +
-            "          Use Kerberos LoginService\n" +
-            "\n" +
-            "    -pam_login\n" +
-            "          Use PAM LoginService\n" +
-            "\n" +
-            "    -login_conf <filename>\n" +
-            "          LoginService configuration file\n" +
-            "\n" +
-            "    -form_auth\n" +
-            "          Enables Form-based authentication for Flow (default is Basic authentication)\n" +
-            "\n" +
-            "    -session_timeout <minutes>\n" +
-            "          Specifies the number of minutes that a session can remain idle before the server invalidates\n" +
-            "          the session and requests a new login. Requires '-form_auth'. Default is no timeout\n" +
-            "\n" +
-            "    -internal_security_conf <filename>\n" +
-            "          Path (absolute or relative) to a file containing all internal security related configurations\n" +
-            "\n" +
-            "Cloud formation behavior:\n" +
-            "\n" +
-            "    New H2O nodes join together to form a cloud at startup time.\n" +
-            "    Once a cloud is given work to perform, it locks out new members\n" +
-            "    from joining.\n" +
-            "\n" +
-            "Examples:\n" +
-            "\n" +
-            "    Start an H2O node with 4GB of memory and a default cloud name:\n" +
-            "        $ java -Xmx4g -jar h2o.jar\n" +
-            "\n" +
-            "    Start an H2O node with 6GB of memory and a specify the cloud name:\n" +
-            "        $ java -Xmx6g -jar h2o.jar -name MyCloud\n" +
-            "\n" +
-            "    Start an H2O cloud with three 2GB nodes and a default cloud name:\n" +
-            "        $ java -Xmx2g -jar h2o.jar &\n" +
-            "        $ java -Xmx2g -jar h2o.jar &\n" +
-            "        $ java -Xmx2g -jar h2o.jar &\n" +
-            "\n";
+                    "Usage:  java [-Xmx<size>] -jar h2o.jar [options]\n" +
+                    "        (Note that every option has a default and is optional.)\n" +
+                    "\n" +
+                    "    -h | -help\n" +
+                    "          Print this help.\n" +
+                    "\n" +
+                    "    -version\n" +
+                    "          Print version info and exit.\n" +
+                    "\n" +
+                    "    -name <h2oCloudName>\n" +
+                    "          Cloud name used for discovery of other nodes.\n" +
+                    "          Nodes with the same cloud name will form an H2O cloud\n" +
+                    "          (also known as an H2O cluster).\n" +
+                    "\n" +
+                    "    -flatfile <flatFileName>\n" +
+                    "          Configuration file explicitly listing H2O cloud node members.\n" +
+                    "\n" +
+                    "    -ip <ipAddressOfNode>\n" +
+                    "          IP address of this node.\n" +
+                    "\n" +
+                    "    -port <port>\n" +
+                    "          Port number for this node (note: port+1 is also used by default).\n" +
+                    "          (The default port is " + ARGS.port + ".)\n" +
+                    "\n" +
+                    "    -network <IPv4network1Specification>[,<IPv4network2Specification> ...]\n" +
+                    "          The IP address discovery code will bind to the first interface\n" +
+                    "          that matches one of the networks in the comma-separated list.\n" +
+                    "          Use instead of -ip when a broad range of addresses is legal.\n" +
+                    "          (Example network specification: '10.1.2.0/24' allows 256 legal\n" +
+                    "          possibilities.)\n" +
+                    "\n" +
+                    "    -ice_root <fileSystemPath>\n" +
+                    "          The directory where H2O spills temporary data to disk.\n" +
+                    "\n" +
+                    "    -log_dir <fileSystemPath>\n" +
+                    "          The directory where H2O writes logs to disk.\n" +
+                    "          (This usually has a good default that you need not change.)\n" +
+                    "\n" +
+                    "    -log_level <TRACE,DEBUG,INFO,WARN,ERRR,FATAL>\n" +
+                    "          Write messages at this logging level, or above.  Default is INFO." +
+                    "\n" +
+                    "\n" +
+                    "    -flow_dir <server side directory or HDFS directory>\n" +
+                    "          The directory where H2O stores saved flows.\n" +
+                    defaultFlowDirMessage +
+                    "\n" +
+                    "    -nthreads <#threads>\n" +
+                    "          Maximum number of threads in the low priority batch-work queue.\n" +
+                    "          (The default is " + (char) Runtime.getRuntime().availableProcessors() + ".)\n" +
+                    "\n" +
+                    "    -client\n" +
+                    "          Launch H2O node in client mode.\n" +
+                    "\n" +
+                    "    -notify_local <fileSystemPath>" +
+                    "          Specifies a file to write when the node is up. The file contains one line with the IP and" +
+                    "          port of the embedded web server. e.g. 192.168.1.100:54321" +
+                    "\n" +
+                    "    -context_path <context_path>\n" +
+                    "          The context path for jetty.\n" +
+                    "\n" +
+                    "Authentication options:\n" +
+                    "\n" +
+                    "    -jks <filename>\n" +
+                    "          Java keystore file\n" +
+                    "\n" +
+                    "    -jks_pass <password>\n" +
+                    "          (Default is '" + DEFAULT_JKS_PASS + "')\n" +
+                    "\n" +
+                    "    -hash_login\n" +
+                    "          Use Jetty HashLoginService\n" +
+                    "\n" +
+                    "    -ldap_login\n" +
+                    "          Use Jetty LdapLoginService\n" +
+                    "\n" +
+                    "    -kerberos_login\n" +
+                    "          Use Kerberos LoginService\n" +
+                    "\n" +
+                    "    -pam_login\n" +
+                    "          Use PAM LoginService\n" +
+                    "\n" +
+                    "    -login_conf <filename>\n" +
+                    "          LoginService configuration file\n" +
+                    "\n" +
+                    "    -form_auth\n" +
+                    "          Enables Form-based authentication for Flow (default is Basic authentication)\n" +
+                    "\n" +
+                    "    -session_timeout <minutes>\n" +
+                    "          Specifies the number of minutes that a session can remain idle before the server invalidates\n" +
+                    "          the session and requests a new login. Requires '-form_auth'. Default is no timeout\n" +
+                    "\n" +
+                    "    -internal_security_conf <filename>\n" +
+                    "          Path (absolute or relative) to a file containing all internal security related configurations\n" +
+                    "\n" +
+                    "Cloud formation behavior:\n" +
+                    "\n" +
+                    "    New H2O nodes join together to form a cloud at startup time.\n" +
+                    "    Once a cloud is given work to perform, it locks out new members\n" +
+                    "    from joining.\n" +
+                    "\n" +
+                    "Examples:\n" +
+                    "\n" +
+                    "    Start an H2O node with 4GB of memory and a default cloud name:\n" +
+                    "        $ java -Xmx4g -jar h2o.jar\n" +
+                    "\n" +
+                    "    Start an H2O node with 6GB of memory and a specify the cloud name:\n" +
+                    "        $ java -Xmx6g -jar h2o.jar -name MyCloud\n" +
+                    "\n" +
+                    "    Start an H2O cloud with three 2GB nodes and a default cloud name:\n" +
+                    "        $ java -Xmx2g -jar h2o.jar &\n" +
+                    "        $ java -Xmx2g -jar h2o.jar &\n" +
+                    "        $ java -Xmx2g -jar h2o.jar &\n" +
+                    "\n";
 
     System.out.print(s);
 
@@ -194,7 +195,7 @@ final public class H2O {
    * A class containing all of the authentication arguments for H2O.
    */
   public static class
-    BaseArgs {
+  BaseArgs {
 
     //-----------------------------------------------------------------------------------
     // Authentication & Security
@@ -268,7 +269,7 @@ final public class H2O {
    * A class containing all of the arguments for H2O.
    */
   public static class
-    OptArgs extends BaseArgs {
+  OptArgs extends BaseArgs {
     // Prefix of hidden system properties
     public static final String SYSTEM_PROP_PREFIX = "sys.ai.h2o.";
     public static final String SYSTEM_DEBUG_CORS = H2O.OptArgs.SYSTEM_PROP_PREFIX + "debug.cors";
@@ -349,6 +350,8 @@ final public class H2O {
 
     /** Timeout specifying how long to wait before we check if the client has disconnected from this node */
     public long clientDisconnectTimeout = HeartBeatThread.CLIENT_TIMEOUT * 20;
+
+    public ModelBuilder.BuilderVisibility features_level = ModelBuilder.BuilderVisibility.Experimental;
 
     @Override public String toString() {
       StringBuilder result = new StringBuilder();
@@ -517,9 +520,9 @@ final public class H2O {
         i = s.incrementAndCheck(i, args);
         String value = args[i];
         trgt.context_path = value.startsWith("/")
-                            ? value.trim().length() == 1
-                              ? "" : value
-                            : "/" + value;
+                ? value.trim().length() == 1
+                ? "" : value
+                : "/" + value;
       }
       else if (s.matches("nthreads")) {
         i = s.incrementAndCheck(i, args);
@@ -618,8 +621,11 @@ final public class H2O {
         }
       else if(s.matches("useUDP")) {
           Log.warn("Support for UDP communication was removed from H2O, using TCP.");
-      }
-      else {
+      } else if (s.matches("features")) {
+        i = s.incrementAndCheck(i, args);
+        trgt.features_level = ModelBuilder.BuilderVisibility.valueOfIgnoreCase(args[i]);
+        Log.info(String.format("Limiting algorithms available to level: %s", trgt.features_level.name()));
+      } else {
         parseFailed("Unknown argument (" + s + ")");
       }
     }


### PR DESCRIPTION
## Description
https://0xdata.atlassian.net/browse/PUBDEV-5988


There are three levels of visibility defined in `BuilderVisibility` enum.

1. Experimental
2. Beta
3. Stable

Users should be able to define which "level" of algorithms do they want. E.g. whether they want to include everything (default), or exclude `experimental` but use `beta` and `stable`, or use only `stable`.

## Usage

Stable-only features
```plain
java -jar h2o.jar -features stable
```

Stable and beta features
```plain
java -jar h2o.jar -features beta
```

Stable, beta and experimental features.
```plain
java -jar h2o.jar -features experimental
```

By default, everything is allowed - feature level is by default set to `experimental`.

## AutoML

AutoML uses stable algos which are probably never going to be marked as beta or experimental again :rofl: . Yet `XGBoost` might be considered experimental in some cases:

```java
    if(ExtensionManager.getInstance().isCoreExtensionsEnabled(XGBoostExtension.NAME)){
      return BuilderVisibility.Stable;
    } else {
      return BuilderVisibility.Experimental;
    }
```
.

To prepare AutoML for new algos in future which might be experimental, the last commit named `Support for algorithm/feature flag in AutoML` with hash `b46d0da9f4c9d68335a6bdf2626fb075d5097be3` contains changes to provide generic support for excluded features. A binding between base algorithm name used in ModelBuilder and names used in AutoML's `Algo` enum was established in the most simple way by having the baseName in the `Algo` enum.

In case we'd like to delay this change or even completely discard it, the last commit may just be deleted.

Of course, any comments/reviews welcome.