### PR TITLE
PUBDEV-5777 Enable H2OXGBoost and native XGBoost comparison

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/schemas/XGBoostModelV3.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/schemas/XGBoostModelV3.java
@@ -21,6 +21,9 @@ public class XGBoostModelV3 extends ModelSchemaV3<
 
     @API(help="XGBoost Native Parameters", direction=API.Direction.OUTPUT, level = API.Level.secondary)
     TwoDimTableV3 native_parameters;
+
+    @API(help="Sparse", direction=API.Direction.OUTPUT, level = API.Level.secondary)
+    boolean sparse;
   }
 
   public XGBoostV3.XGBoostParametersV3 createParametersSchema() { return new XGBoostV3.XGBoostParametersV3(); }

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -19,6 +19,9 @@ from io import StringIO
 from types import FunctionType
 
 import requests
+import pandas as pd
+import numpy as np
+import math
 
 import h2o
 from h2o.display import H2ODisplay
@@ -2564,6 +2567,88 @@ class H2OFrame(object):
         if max_cardinality <= 0: raise H2OValueError("max_cardinality must be greater than 0")
         return H2OFrame._expr(expr=ExprNode("isax", self, num_words, max_cardinality, optimize_card))
 
+    def convert_H2OFrame_2_DMatrix(self, predictors, yresp, h2oXGBoostModel):
+        '''
+        This method will convert an H2OFrame to a DMatrix that can be used by native XGBoost.  The H2OFrame contains
+        numerical and enum columns alone.  Note that H2O one-hot-encoding introduces a missing(NA)
+        column. There can be NAs in any columns.
+
+        Follow the steps below to compare H2OXGBoost and native XGBoost:
+
+        1. Train the H2OXGBoost model with H2OFrame trainFile and generate a prediction:
+        h2oModelD = H2OXGBoostEstimator(**h2oParamsD) # parameters specified as a dict()
+        h2oModelD.train(x=myX, y=y, training_frame=trainFile) # train with H2OFrame trainFile
+        h2oPredict = h2oPredictD = h2oModelD.predict(trainFile)
+
+        2. Derive the DMatrix from H2OFrame:
+        nativeDMatrix = trainFile.convert_H2OFrame_2_DMatrix(myX, y, h2oModelD)
+
+        3. Derive the parameters for native XGBoost:
+        nativeParams = h2oModelD.convert_H2OXGBoostParams_2_XGBoostParams()
+
+        4. Train your native XGBoost model and generate a prediction:
+        nativeModel = xgb.train(params=nativeParams[0], dtrain=nativeDMatrix, num_boost_round=nativeParams[1])
+        nativePredict = nativeModel.predict(data=nativeDMatrix, ntree_limit=nativeParams[1].
+
+        5. Compare the predictions h2oPredict from H2OXGBoost, nativePredict from native XGBoost.
+
+        :param h2oFrame: H2OFrame to be converted to DMatrix for native XGBoost
+        :param predictors: List of predictor columns, can be column names or indices
+        :param yresp: response column, can be column index or name
+        :param h2oXGBoostModel: H2OXGboost model that are built with the same H2OFrame as input earlier
+        :return: DMatrix that can be an input to a native XGBoost model
+        '''
+        import xgboost as xgb
+        from scipy.sparse import csr_matrix
+
+        assert isinstance(predictors, list) or isinstance(predictors, tuple)
+        assert h2oXGBoostModel._model_json['algo'] == 'xgboost', \
+            "convert_H2OFrame_2_DMatrix is used for H2OXGBoost model only."
+
+        colnames = self.names
+        if type(predictors[0])=='int': # convert integer indices to column names
+            temp = []
+            for colInd in predictors:
+                temp.append(colnames[colInd])
+            predictors = temp
+
+        if (type(yresp) == 'int'):
+            tempy = colnames[yresp]
+            yresp = tempy
+
+        enumCols = [] # extract enum columns out to process them
+        typeDict = self.types
+        for predName in predictors:
+            if str(typeDict[predName])=='enum':
+                enumCols.append(predName)
+
+        pandaFtrain = self.as_data_frame(use_pandas=True, header=True)
+        nrows = self.nrow
+
+        # convert H2OFrame to DMatrix starts here
+        if len(enumCols) > 0:   # start with first enum column
+            pandaTrainPart = generatePandaEnumCols(pandaFtrain, enumCols[0], nrows)
+            pandaFtrain.drop([enumCols[0]], axis=1, inplace=True)
+
+            for colInd in range(1, len(enumCols)):
+                cname=enumCols[colInd]
+                ctemp = generatePandaEnumCols(pandaFtrain, cname,  nrows)
+                pandaTrainPart=pd.concat([pandaTrainPart, ctemp], axis=1)
+                pandaFtrain.drop([cname], axis=1, inplace=True)
+
+            pandaFtrain = pd.concat([pandaTrainPart, pandaFtrain], axis=1)
+
+        c0= self[yresp].asnumeric().as_data_frame(use_pandas=True, header=True)
+        pandaFtrain.drop([yresp], axis=1, inplace=True)
+        pandaF = pd.concat([c0, pandaFtrain], axis=1)
+        pandaF.rename(columns={c0.columns[0]:yresp}, inplace=True)
+        newX = list(pandaFtrain.columns.values)
+        data = pandaF.as_matrix(newX)
+        label = pandaF.as_matrix([yresp])
+
+        return xgb.DMatrix(data=csr_matrix(data), label=label) \
+            if h2oXGBoostModel._model_json['output']['sparse'] else xgb.DMatrix(data=data, label=label)
+
     def pivot(self, index, column, value):
         """
         Pivot the frame designated by the three columns: index, column, and value. Index and column should be
@@ -3330,3 +3415,45 @@ def _binop(lhs, op, rhs, rtype=None):
     if rtype is not None and res._ex._cache._names is not None:
         res._ex._cache._types = {name: rtype for name in res._ex._cache._names}
     return res
+
+
+
+
+def generatePandaEnumCols(pandaFtrain, cname, nrows):
+    """
+    For an H2O Enum column, we perform one-hot-encoding here and add one more column, "missing(NA)" to it.
+
+    :param pandaFtrain: panda frame derived from H2OFrame
+    :param cname: column name of enum col
+    :param nrows: number of rows of enum col
+    :return: panda frame with enum col encoded correctly for native XGBoost
+    """
+    cmissingNames=[cname+".missing(NA)"]
+    tempnp = np.zeros((nrows,1), dtype=np.int)
+    # check for nan and assign it correct value
+    colVals = pandaFtrain[cname]
+    for ind in range(nrows):
+        try:
+            float(colVals[ind])
+            if math.isnan(colVals[ind]):
+                tempnp[ind]=1
+        except ValueError:
+            pass
+    zeroFrame = pd.DataFrame(tempnp)
+    zeroFrame.columns=cmissingNames
+    temp = pd.get_dummies(pandaFtrain[cname], prefix=cname, drop_first=False)
+    tempNames = list(temp)  # get column names
+    colLength = len(tempNames)
+    newNames = ['a']*colLength
+    newIndics = [0]*colLength
+    header = tempNames[0].split('.')[0]
+
+    for ind in range(colLength):
+        newIndics[ind] = int(tempNames[ind].split('.')[1][1:])
+    newIndics.sort()
+
+    for ind in range(colLength):
+        newNames[ind] = header+'.l'+str(newIndics[ind])  # generate correct order of names
+    ftemp = temp[newNames]
+    ctemp = pd.concat([ftemp, zeroFrame], axis=1)
+    return ctemp

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_dense_comparisons.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_dense_comparisons.py
@@ -1,0 +1,110 @@
+import xgboost as xgb
+import time
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+
+'''
+PUBDEV-5777: enable H2OXGBoost and native XGBoost comparison.
+
+To ensure that H2OXGBoost and native XGBoost performance provide the same result, we propose to do the following:
+1. run H2OXGBoost with H2OFrame and parameter setting, save model and result
+2. Call Python API to convert H2OFrame to XGBoost frame and H2OXGBoost parameter to XGBoost parameters.
+3. Run native XGBoost with data frame and parameters from 2.  Should get the same result as in 1.
+
+Parameters in native XGBoost:
+booster default to gbtree
+silent default to 0
+nthread default to maximum number of threads available if not specified
+disable_default_eval_metric default to 0
+num_pbuffer automatically set
+num_feature automatically set
+eta/learning_rate default to 0.3
+max_depth default to 6
+min_child_weight default to 1
+max_delta_step default to 0
+subsample default to 1
+colsample_bytree default to 1
+colsample_by_level default to 1
+lambda/reg_lambda default to 1
+alpha/reg_alpha default to 0
+tree_method default to auto
+sketch_eps default to 0.03
+scale_pos_weight default to 1
+updater default to grow_colmaker, prune
+refresh_leaf default to 1
+process_type default to default
+grow_policy default depthwise
+max_leaves default to 0
+max_bin default to 256
+predictor default to cpu_predictor
+
+Addition ones for DART booster
+smaple_type default to uniform
+normalize_type default to tree
+rate_drop default to 0.0
+one_drop default to 0.0
+skip_drop default to 0.0
+
+For Linear Booster
+lambda/reg_lambda default to 0
+alpha/reg_alpha default to 0
+updater default to shotgun
+feature_selector default to cyclic
+top_k default to 0
+
+Parameters for Tweedie Regression objective=reg:tweedie
+tweedie_variance_power default to 1.5
+
+learning Task parameters:
+objective default to reg:linear
+base_score default to 0.5
+eval_metric default according to objective
+seed default to 0
+'''
+def comparison_test():
+    assert H2OXGBoostEstimator.available() is True
+    ret = h2o.cluster()
+    if len(ret.nodes) == 1:
+        runSeed = 1
+        dataSeed = 17
+        ntrees = 17
+        maxdepth = 5
+        nrows = 10000
+        ncols = 12
+        factorL = 20
+        numCols = 11
+        enumCols = ncols-numCols
+        responseL = 4
+        # CPU Backend is forced for the results to be comparable
+        h2oParamsD = {"ntrees":ntrees, "max_depth":maxdepth, "seed":runSeed, "learn_rate":0.7, "col_sample_rate_per_tree" : 0.9,
+                     "min_rows" : 5, "score_tree_interval": ntrees+1, "tree_method": "exact", "backend":"cpu"}
+
+        trainFile = pyunit_utils.genTrainFrame(nrows, numCols, enumCols=enumCols, enumFactors=factorL,
+                                               responseLevel=responseL, miscfrac=0.01,randseed=dataSeed)
+        myX = trainFile.names
+        y='response'
+        myX.remove(y)
+
+        h2oModelD = H2OXGBoostEstimator(**h2oParamsD)
+        # gather, print and save performance numbers for h2o model
+        h2oModelD.train(x=myX, y=y, training_frame=trainFile)
+        h2oPredictD = h2oModelD.predict(trainFile)
+
+        # derive native XGBoost parameter and DMatrx from h2oXGBoost model and H2OFrame
+        nativeXGBoostParam = h2oModelD.convert_H2OXGBoostParams_2_XGBoostParams()
+        nativeXGBoostInput = trainFile.convert_H2OFrame_2_DMatrix(myX, y, h2oModelD)
+
+        nativeModel = xgb.train(params=nativeXGBoostParam[0],
+                                dtrain=nativeXGBoostInput, num_boost_round=nativeXGBoostParam[1])
+        nativePred = nativeModel.predict(data=nativeXGBoostInput, ntree_limit=nativeXGBoostParam[1])
+        pyunit_utils.summarizeResult_multinomial(h2oPredictD, nativePred, -1, -1, -1,
+                                              -1, tolerance=1e-6)
+    else:
+        print("********  Test skipped.  This test cannot be performed in multinode environment.")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(comparison_test)
+else:
+    comparison_test()

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_sparse_comparisons.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_sparse_comparisons.py
@@ -1,0 +1,111 @@
+import xgboost as xgb
+import time
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+
+'''
+PUBDEV-5777: enable H2OXGBoost and native XGBoost comparison.
+
+To ensure that H2OXGBoost and native XGBoost performance provide the same result, we propose to do the following:
+1. run H2OXGBoost with H2OFrame and parameter setting, save model and result
+2. Call Python API to convert H2OFrame to XGBoost frame and H2OXGBoost parameter to XGBoost parameters.
+3. Run native XGBoost with data frame and parameters from 2.  Should get the same result as in 1.
+
+Parameters in native XGBoost:
+booster default to gbtree
+silent default to 0
+nthread default to maximum number of threads available if not specified
+disable_default_eval_metric default to 0
+num_pbuffer automatically set
+num_feature automatically set
+eta/learning_rate default to 0.3
+max_depth default to 6
+min_child_weight default to 1
+max_delta_step default to 0
+subsample default to 1
+colsample_bytree default to 1
+colsample_by_level default to 1
+lambda/reg_lambda default to 1
+alpha/reg_alpha default to 0
+tree_method default to auto
+sketch_eps default to 0.03
+scale_pos_weight default to 1
+updater default to grow_colmaker, prune
+refresh_leaf default to 1
+process_type default to default
+grow_policy default depthwise
+max_leaves default to 0
+max_bin default to 256
+predictor default to cpu_predictor
+
+Addition ones for DART booster
+smaple_type default to uniform
+normalize_type default to tree
+rate_drop default to 0.0
+one_drop default to 0.0
+skip_drop default to 0.0
+
+For Linear Booster
+lambda/reg_lambda default to 0
+alpha/reg_alpha default to 0
+updater default to shotgun
+feature_selector default to cyclic
+top_k default to 0
+
+Parameters for Tweedie Regression objective=reg:tweedie
+tweedie_variance_power default to 1.5
+
+learning Task parameters:
+objective default to reg:linear
+base_score default to 0.5
+eval_metric default according to objective
+seed default to 0
+'''
+def comparison_test():
+    assert H2OXGBoostEstimator.available() is True
+    ret = h2o.cluster()
+    if len(ret.nodes) == 1:
+        runSeed = 1
+        dataSeed = 17
+        ntrees = 17
+        maxdepth = 5
+        nrows = 10000
+        ncols = 12
+        factorL = 20
+        numCols = 1
+        enumCols = ncols-numCols
+        responseL = 4
+        # CPU Backend is forced for the results to be comparable
+        h2oParamsD = {"ntrees":ntrees, "max_depth":maxdepth, "seed":runSeed, "learn_rate":0.7,
+                      "col_sample_rate_per_tree" : 0.9, "min_rows" : 5, "score_tree_interval": ntrees+1,
+                      "tree_method": "exact", "backend":"cpu"}
+
+        trainFile = pyunit_utils.genTrainFrame(nrows, numCols, enumCols=enumCols, enumFactors=factorL,
+                                               responseLevel=responseL, miscfrac=0.01,randseed=dataSeed)
+        myX = trainFile.names
+        y='response'
+        myX.remove(y)
+
+        h2oModelD = H2OXGBoostEstimator(**h2oParamsD)
+        # gather, print and save performance numbers for h2o model
+        h2oModelD.train(x=myX, y=y, training_frame=trainFile)
+        h2oPredictD = h2oModelD.predict(trainFile)
+
+        # derive native XGBoost parameter and DMatrx from h2oXGBoost model and H2OFrame
+        nativeXGBoostParam = h2oModelD.convert_H2OXGBoostParams_2_XGBoostParams()
+        nativeXGBoostInput = trainFile.convert_H2OFrame_2_DMatrix(myX, y, h2oModelD)
+
+        nativeModel = xgb.train(params=nativeXGBoostParam[0],
+                                dtrain=nativeXGBoostInput, num_boost_round=nativeXGBoostParam[1])
+        nativePred = nativeModel.predict(data=nativeXGBoostInput, ntree_limit=nativeXGBoostParam[1])
+        pyunit_utils.summarizeResult_multinomial(h2oPredictD, nativePred, -1, -1, -1,
+                                              -1, tolerance=1e-6)
+    else:
+        print("********  Test skipped.  This test cannot be performed in multinode environment.")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(comparison_test)
+else:
+    comparison_test()


### PR DESCRIPTION
This PR completes the work in: https://0xdata.atlassian.net/browse/PUBDEV-5777?filter=-1

I have implemented two Python APIs to enable easy comparison between H2OXGBoost and native XGBoost.

I have added two python unit tests to enable that the APIs function correctly. 

Angela:  Here is a description I have to teach people how to compare the two algorithms.  Please find a proper home for this if you do not like where I put it.  While you are at it, please check the grammar and clarity of the description.  Thank you so much!  Wendy
---------------------------------------------------------------------------------------
Follow the following steps to compare H2OXGBoost and native XGBoost:

        1. Train the H2OXGBoost model with H2OFrame trainFile and generate a prediction
        h2oModelD = H2OXGBoostEstimator(**h2oParamsD) # parameters specified as a dict()
        h2oModelD.train(x=myX, y=y, training_frame=trainFile) # train with H2OFrame trainFile
        h2oPredict = h2oPredictD = h2oModelD.predict(trainFile)

        2. derive the DMatrix from H2OFrame
        nativeDMatrix = trainFile.convert_H2OFrame_2_DMatrix(myX, y, h2oModelD)

        3. derive the parameters for native XGBoost:
        nativeParams = h2oModelD.convert_H2OXGBoostParams_2_XGBoostParams()

        4. train your native XGBoost model and generate a prediction
        nativeModel = xgb.train(params=nativeParams[0], dtrain=nativeDMatrix, num_boost_round=nativeParams[1])
        nativePredict = nativeModel.predict(data=nativeDMatrix, ntree_limit=nativeParams[1].

        5. Compare the predictions h2oPredict, nativePredict