### PR TITLE
PUBDEV-6006: Deprecate Scala API before moving it to Sparkling Water

### DIFF
--- a/h2o-scala/src/main/scala/water/fvec/FrameOps.scala
+++ b/h2o-scala/src/main/scala/water/fvec/FrameOps.scala
@@ -7,7 +7,10 @@ import scala.util.{Failure, Success, Try}
 /**
  * High-level DSL proving user-friendly operations
  * on top of H2O Frame.
+ *
+ * @deprecated Scala API will be moved to the Sparkling Water project - https://github.com/h2oai/sparkling-water
  */
+@Deprecated
 trait FrameOps { self: H2OFrame =>  // Mix only with H2OFrame types
 
   /** Functional type to transform vectors. */

--- a/h2o-scala/src/main/scala/water/fvec/H2OFrame.scala
+++ b/h2o-scala/src/main/scala/water/fvec/H2OFrame.scala
@@ -15,7 +15,10 @@ import water.parser.DefaultParserProviders.GUESS_INFO
  * @param frameKey  reference of new frame
  * @param names  column names for new frame
  * @param vecs  vectors composing new frame
+ *
+ * @deprecated Scala API will be moved to the Sparkling Water project - https://github.com/h2oai/sparkling-water
  */
+@Deprecated
 class H2OFrame private (frameKey: Key[Frame], names: Array[String], vecs: Array[Vec])
   extends Frame(frameKey, names, vecs) with FrameOps {
 
@@ -105,7 +108,9 @@ class H2OFrame private (frameKey: Key[Frame], names: Array[String], vecs: Array[
 
 /** Companion object providing factory methods to create frame
   * from different sources.
+  * @deprecated Scala API will be moved to the Sparkling Water project - https://github.com/h2oai/sparkling-water
   */
+@Deprecated
 object H2OFrame {
   def apply(key : Key[Frame]) = new H2OFrame(key)
   def apply(f : Frame) = new H2OFrame(f)

--- a/h2o-scala/src/main/scala/water/udf/MoreColumns.scala
+++ b/h2o-scala/src/main/scala/water/udf/MoreColumns.scala
@@ -10,6 +10,10 @@ import water.util.{fp => F}
 
 import scala.collection.JavaConverters._
 
+/**
+  * @deprecated Scala API will be moved to the Sparkling Water project - https://github.com/h2oai/sparkling-water
+  */
+@Deprecated
 trait ScalaFactory[JavaType,ScalaType] extends Serializable { self: BaseFactory[JavaType] =>
 
   import collection.JavaConverters._
@@ -27,6 +31,10 @@ trait ScalaFactory[JavaType,ScalaType] extends Serializable { self: BaseFactory[
   }
 }
 
+/**
+  * @deprecated Scala API will be moved to the Sparkling Water project - https://github.com/h2oai/sparkling-water
+  */
+@Deprecated
 object ScalaDoubles extends Doubles with ScalaFactory[java.lang.Double, Double] {
   def newColumn(size: Long, f: Long => Double) = super.newColumn(size, ff1LD(f))
   def newColumnOpt(size: Long, f: Long => Option[Double]) = super.newColumn(size, ff1LDO(f))
@@ -47,7 +55,10 @@ object ScalaDoubles extends Doubles with ScalaFactory[java.lang.Double, Double] 
 
 /**
   * Scala adapters for h2o3 udf (which is currently in Java)
+  *
+  * @deprecated Scala API will be moved to the Sparkling Water project - https://github.com/h2oai/sparkling-water
   */
+@Deprecated
 object MoreColumns extends DataColumns {
   
   private[MoreColumns] def ff1L[Y](f: Long => Y): UFunction[lang.Long, Y] =


### PR DESCRIPTION
After discussion with @jakubhava it seems that Scala API in H2O is not used by people who directly use `h2o.jar`.

It somewhat complicates build and especially IDE integration, the way it is currently wired (due to reused source roots).

It is probably best to first deprecate the API, before we move scala h2o-3 codebase directly to SparklingWater.

I believe that either this, or #2955 should be merged before next major release.

Note: #2955 is the expected follow-up in the next major version.