### PR TITLE
[PUBDEV-6005] added XGBoost to list of algos that can be excluded in Flow.

### DIFF
--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.8.9"
+    "h2o-flow": "0.8.10"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Update Flow to 0.8.10.