### PR TITLE
Fixed ignored custom JVM args in R client when starting new JVM.

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -579,6 +579,7 @@ h2o.clusterStatus <- function() {
   nums <- paste0(sample(0:9, 3,  replace = TRUE),     collapse="")
   name <- paste0("H2O_started_from_R_", gsub("\\s", "_", Sys.info()["user"]),"_",ltrs,nums)
   if(enable_assertions) args <- c(args, "-ea")
+  if(!is.null(jvm_custom_args)) args <- c(args,jvm_custom_args)
   
   class_path <- paste0(c(jar_file, extra_classpath), collapse=.Platform$path.sep)
   args <- c(args, "-cp", class_path, "water.H2OApp")


### PR DESCRIPTION
Custom print at the beginning to demonstrate what was going on in the args really. The print is not part of the committed code.
```
> h2o.init(jvm_custom_args = "-XX:+PrintGCDetails")

H2O is not running yet, starting it now...
[1] "-ea"                 "-XX:+PrintGCDetails"

Note:  In case of errors look at the following log files:
    /tmp/RtmpP2Mq4p/h2o_pavel_started_from_r.out
    /tmp/RtmpP2Mq4p/h2o_pavel_started_from_r.err

java version "1.8.0_181"
Java(TM) SE Runtime Environment (build 1.8.0_181-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.181-b13, mixed mode)

Starting H2O JVM and connecting: . Connection successful!

R is connected to the H2O cluster: 
    H2O cluster uptime:         918 milliseconds 
    H2O cluster timezone:       Europe/Prague 
    H2O data parsing timezone:  UTC 
    H2O cluster version:        3.21.0.99999 
    H2O cluster version age:    8 minutes  
    H2O cluster name:           H2O_started_from_R_pavel_ihk741 
    H2O cluster total nodes:    1 
    H2O cluster total memory:   6.95 GB 
    H2O cluster total cores:    12 
    H2O cluster allowed cores:  12 
    H2O cluster healthy:        TRUE 
    H2O Connection ip:          localhost 
    H2O Connection port:        54321 
    H2O Connection proxy:       NA 
    H2O Internal Security:      FALSE 
    H2O API Extensions:         XGBoost, Algos, AutoML, Core V3, Core V4 
    R Version:                  R version 3.4.4 (2018-03-15) 
```