### PR TITLE
PUBDEV-5949: Second attempt at adding Tree to python docs

### DIFF
--- a/h2o-py/docs/tree.rst
+++ b/h2o-py/docs/tree.rst
@@ -3,7 +3,7 @@ Tree Class in H2O
 
 :mod:`H2O Tree Class`
 -------------------------------
-.. automodule:: h2o.tree.H2OTree
+.. autoclass:: h2o.backened.H2OTree
   :members:
   :undoc-members:
   :show-inheritance:


### PR DESCRIPTION
Creating another pull requests. This uses:

Tree Class in H2O
=================

:mod:`H2O Tree Class`
-------------------------------
.. autoclass:: h2o.backened.H2OTree
:members:
:undoc-members:
:show-inheritance: