### PR TITLE
Adds name parameter to Python and R init methods

### DIFF
--- a/h2o-py/h2o/backend/connection.py
+++ b/h2o-py/h2o/backend/connection.py
@@ -70,7 +70,7 @@ class H2OConnectionConf(object):
     """List of allowed property names exposed by this class"""
     allowed_properties = ["ip", "port", "https", "context_path", "verify_ssl_certificates",
                           "proxy", "auth", "cookies", "verbose"]
-    
+
     def _fill_from_config(self, config):
         """
         Fill this instance from given dictionary.
@@ -209,7 +209,7 @@ class H2OConnection(backwards_compatible()):
     url_pattern = r"^(https?)://((?:[\w-]+\.)*[\w-]+):(\d+)/?((/[\w-]+)+)?$"
 
     @staticmethod
-    def open(server=None, url=None, ip=None, port=None, https=None, auth=None, verify_ssl_certificates=True,
+    def open(server=None, url=None, ip=None, port=None, name=None, https=None, auth=None, verify_ssl_certificates=True,
              proxy=None, cookies=None, verbose=True, _msgs=None):
         r"""
         Establish connection to an existing H2O server.
@@ -233,6 +233,7 @@ class H2OConnection(backwards_compatible()):
         :param url: full url of the server to connect to.
         :param ip: target server's IP address or hostname (default "localhost").
         :param port: H2O server's port (default 54321).
+        :param name: H2O cloud name.
         :param https: if True then connect using https instead of http (default False).
         :param verify_ssl_certificates: if False then SSL certificate checking will be disabled (default True). This
             setting should rarely be disabled, as it makes your connection vulnerable to man-in-the-middle attacks. When
@@ -257,7 +258,8 @@ class H2OConnection(backwards_compatible()):
         if server is not None:
             assert_is_type(server, H2OLocalServer)
             assert_is_type(ip, None, "`ip` should be None when `server` parameter is supplied")
-            assert_is_type(url, None, "`ip` should be None when `server` parameter is supplied")
+            assert_is_type(url, None, "`url` should be None when `server` parameter is supplied")
+            assert_is_type(name, None, "`name` should be None when `server` parameter is supplied")
             if not server.is_running():
                 raise H2OConnectionError("Unable to connect to server because it is not running")
             ip = server.ip
@@ -267,6 +269,7 @@ class H2OConnection(backwards_compatible()):
         elif url is not None:
             assert_is_type(url, str)
             assert_is_type(ip, None, "`ip` should be None when `url` parameter is supplied")
+            assert_is_type(name, str, None)
             # We don't allow any Unicode characters in the URL. Maybe some day we will...
             match = assert_matches(url, H2OConnection.url_pattern)
             scheme = match.group(1)
@@ -280,6 +283,7 @@ class H2OConnection(backwards_compatible()):
             if is_type(port, str) and port.isdigit(): port = int(port)
             assert_is_type(ip, str)
             assert_is_type(port, int)
+            assert_is_type(name, str, None)
             assert_is_type(https, bool)
             assert_matches(ip, r"(?:[\w-]+\.)*[\w-]+")
             assert_satisfies(port, 1 <= port <= 65535)
@@ -297,6 +301,7 @@ class H2OConnection(backwards_compatible()):
         conn._verbose = bool(verbose)
         conn._local_server = server
         conn._base_url = "%s://%s:%d%s" % (scheme, ip, port, context_path)
+        conn._name = server.name if server else name
         conn._verify_ssl_cert = bool(verify_ssl_certificates)
         conn._auth = auth
         conn._cookies = cookies
@@ -464,6 +469,10 @@ class H2OConnection(backwards_compatible()):
         return self._base_url
 
     @property
+    def name(self):
+        return self._name
+
+    @property
     def proxy(self):
         """URL of the proxy server used for the connection (or None if there is no proxy)."""
         if self._proxies is None: return None
@@ -523,6 +532,7 @@ class H2OConnection(backwards_compatible()):
         self._stage = 0             # 0 = not connected, 1 = connected, -1 = disconnected
         self._session_id = None     # Rapids session id; issued upon request only
         self._base_url = None       # "{scheme}://{ip}:{port}"
+        self._name = None
         self._verify_ssl_cert = None
         self._auth = None           # Authentication token
         self._proxies = None        # `proxies` dictionary in the format required by the requests module
@@ -558,6 +568,11 @@ class H2OConnection(backwards_compatible()):
                 raise H2OServerError("Local server was unable to start")
             try:
                 cld = self.request("GET /3/Cloud")
+
+                if self.name and cld.cloud_name != self.name:
+                    raise H2OConnectionError(
+                        "Connected to cloud %s but requested %s." % (cld.cloud_name, self.name)
+                    )
                 if cld.consensus and cld.cloud_healthy:
                     self._print(" " + messages[1])
                     return cld

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oinit.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oinit.py
@@ -4,13 +4,13 @@ sys.path.insert(1,"../../../")
 from tests import pyunit_utils
 import h2o
 from h2o.utils.typechecks import assert_is_type
-from h2o.exceptions import H2OConnectionError
+from h2o.exceptions import H2OConnectionError, H2OServerError
 
 def h2oinit():
     """
-    Python API test: h2o.init(url=None, ip=None, port=None, https=None, insecure=None, username=None, password=None,
-     cookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None, enable_assertions=True,
-      max_mem_size=None, min_mem_size=None, strict_version_check=None, **kwargs)
+    Python API test: h2o.init(url=None, ip=None, port=None, name = None, https=None, insecure=None,
+    username=None, password=None, ookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None,
+    enable_assertions=True, max_mem_size=None, min_mem_size=None, strict_version_check=None, **kwargs)
     """
     start_h2o = False
     strict_version_check = False
@@ -45,7 +45,40 @@ def h2oinit():
         print("error message type is {0} and the error message is \n".format(e.__class__.__name__, e.args[0]))
         assert_is_type(e, H2OConnectionError)
 
+def h2oinitname():
+    """
+    Python API test for h2o.init
+    :return:
+    """
+    try:
+        h2o.init(strict_version_check=False, name="test")  # Should initialize
+        h2o.init(strict_version_check=False, name="test")  # Should just connect
+        assert h2o.cluster().cloud_name == "test"
+    except H2OConnectionError as e:  # some errors are okay like version mismatch
+        print("error message type is {0} and the error message is {1}\n".format(e.__class__.__name__, e.args[0]))
+
+    try:
+        h2o.init(strict_version_check=False, port=54321, name="test2", as_port=True)
+        assert False, "Should fail to connect and the port should be used by previous invocation."
+    except H2OServerError as e:
+        print("error message type is {0} and the error message is {1}\n".format(e.__class__.__name__, e.args[0]))
+
+    try:
+        h2o.init(strict_version_check=False, port=54321, name="test2")  # Should bump the port to next one
+        assert h2o.cluster().cloud_name == "test2"
+    except H2OConnectionError as e:
+        print("error message type is {0} and the error message is {1}\n".format(e.__class__.__name__, e.args[0]))
+
+    try:
+        h2o.init(strict_version_check=False, port=54327, name="test3", as_port=True)
+        assert h2o.cluster().cloud_name == "test3"
+    except H2OConnectionError as e:
+        print("error message type is {0} and the error message is {1}\n".format(e.__class__.__name__, e.args[0]))
+        assert_is_type(e, H2OConnectionError)
+
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oinit)
+    h2oinitname()
 else:
     h2oinit()
+    h2oinitname()

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -54,6 +54,7 @@ setRefClass("H2OConnectionMutableState",
 #' is not found at port 54321.
 #' @slot ip A \code{character} string specifying the IP address of the H2O cloud.
 #' @slot port A \code{numeric} value specifying the port number of the H2O cloud.
+#' @slot name A \code{character} value specifying the cloud name of the H2O cloud.
 #' @slot proxy A \code{character} specifying the proxy path of the H2O cloud.
 #' @slot https Set this to TRUE to use https instead of http.
 #' @slot insecure Set this to TRUE to disable SSL certificate checking.
@@ -65,7 +66,7 @@ setRefClass("H2OConnectionMutableState",
 #' @aliases H2OConnection
 #' @export
 setClass("H2OConnection",
-         representation(ip="character", port="numeric", proxy="character",
+         representation(ip="character", port="numeric", name="character", proxy="character",
                         https="logical", insecure="logical",
                         username="character", password="character",
                         cookies="character",
@@ -73,6 +74,7 @@ setClass("H2OConnection",
                         mutable="H2OConnectionMutableState"),
          prototype(ip           = NA_character_,
                    port         = NA_integer_,
+                   name         = NA_character_,
                    proxy        = NA_character_,
                    https        = FALSE,
                    insecure     = FALSE,
@@ -90,6 +92,7 @@ setClassUnion("H2OConnectionOrNULL", c("H2OConnection", "NULL"))
 setMethod("show", "H2OConnection", function(object) {
   cat("IP Address:", object@ip,                 "\n")
   cat("Port      :", object@port,               "\n")
+  cat("Name      :", object@name,               "\n")
   cat("Session ID:", object@mutable$session_id, "\n")
   cat("Key Count :", object@mutable$key_count,  "\n")
 })

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -11,6 +11,7 @@
 #'
 #' @param ip Object of class \code{character} representing the IP address of the server where H2O is running.
 #' @param port Object of class \code{numeric} representing the port number of the H2O server.
+#' @param name (Optional) A \code{character} string representing the H2O cloud name.
 #' @param startH2O (Optional) A \code{logical} value indicating whether to try to start H2O from R if no connection with H2O is detected. This is only possible if \code{ip = "localhost"} or \code{ip = "127.0.0.1"}.  If an existing connection is detected, R does not start H2O.
 #' @param forceDL (Optional) A \code{logical} value indicating whether to force download of the H2O executable. Defaults to FALSE, so the executable will only be downloaded if it does not already exist in the h2o R library resources directory \code{h2o/java/h2o.jar}.  This value is only used when R starts H2O.
 #' @param enable_assertions (Optional) A \code{logical} value indicating whether H2O should be launched with assertions enabled. Used mainly for error checking and debugging purposes.  This value is only used when R starts H2O.
@@ -55,7 +56,7 @@
 #' h2o.init(max_mem_size = "5g")
 #' }
 #' @export
-h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = FALSE,
+h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, startH2O = TRUE, forceDL = FALSE,
                      enable_assertions = TRUE, license = NULL, nthreads = -1,
                      max_mem_size = NULL, min_mem_size = NULL,
                      ice_root = tempdir(), strict_version_check = TRUE, proxy = NA_character_,
@@ -101,6 +102,8 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
     stop("`ip` must be a non-empty character string")
   if(!is.numeric(port) || length(port) != 1L || is.na(port) || port < 0 || port > 65536)
     stop("`port` must be an integer ranging from 0 to 65536")
+  if(!is.character(name) && !nzchar(name))
+    stop("`name` must be a character string or NA_character_")
   if(!is.logical(startH2O) || length(startH2O) != 1L || is.na(startH2O))
     stop("`startH2O` must be TRUE or FALSE")
   if(!is.logical(forceDL) || length(forceDL) != 1L || is.na(forceDL))
@@ -159,7 +162,7 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
   if (nchar(doc_port)) port <- as.numeric(doc_port)
 
   warnNthreads <- FALSE
-  tmpConn <- new("H2OConnection", ip = ip, port = port, proxy = proxy, https = https, insecure = insecure,
+  tmpConn <- new("H2OConnection", ip = ip, port = port, name = name, proxy = proxy, https = https, insecure = insecure,
     username = username, password = password,cookies = cookies, context_path = context_path)
   if (!h2o.clusterIsUp(tmpConn)) {
     if (!startH2O)
@@ -172,7 +175,8 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
         nthreads <- 2
       }
       stdout <- .h2o.getTmpFile("stdout")
-      .h2o.startJar(ip = ip, port = port, nthreads = nthreads, max_memory = max_mem_size, min_memory = min_mem_size,
+      .h2o.startJar(ip = ip, port = port, name = name, nthreads = nthreads,
+                    max_memory = max_mem_size, min_memory = min_mem_size,
                     enable_assertions = enable_assertions, forceDL = forceDL, license = license,
                     extra_classpath = extra_classpath, ice_root = ice_root, stdout = stdout,
                     jvm_custom_args = jvm_custom_args, bind_to_localhost = bind_to_localhost)
@@ -200,7 +204,7 @@ h2o.init <- function(ip = "localhost", port = 54321, startH2O = TRUE, forceDL = 
       stop("Can only start H2O launcher if IP address is localhost.")
   }
 
-  conn <- new("H2OConnection", ip = ip, port = port, proxy = proxy, https = https, insecure = insecure,
+  conn <- new("H2OConnection", ip = ip, port = port, name = .h2o.jar.env$name, proxy = proxy, https = https, insecure = insecure,
     username = username, password = password,cookies = cookies, context_path = context_path)
   assign("SERVER", conn, .pkg.env)
   cat(" Connection successful!\n\n")
@@ -515,7 +519,8 @@ h2o.clusterStatus <- function() {
   return(NULL)
 }
 
-.h2o.startJar <- function(ip = "localhost", port = 54321, nthreads = -1, max_memory = NULL, min_memory = NULL,
+.h2o.startJar <- function(ip = "localhost", port = 54321, name = NULL, nthreads = -1,
+                          max_memory = NULL, min_memory = NULL,
                           enable_assertions = TRUE, forceDL = FALSE, license = NULL, extra_classpath = NULL,
                           ice_root, stdout, jvm_custom_args = NULL, bind_to_localhost) {
   command <- .h2o.checkJava()
@@ -580,10 +585,13 @@ h2o.clusterStatus <- function() {
   args <- mem_args
   ltrs <- paste0(sample(letters,3, replace = TRUE), collapse="")
   nums <- paste0(sample(0:9, 3,  replace = TRUE),     collapse="")
-  name <- paste0("H2O_started_from_R_", gsub("\\s", "_", Sys.info()["user"]),"_",ltrs,nums)
+
+  if(is.na(name)) name <- paste0("H2O_started_from_R_", gsub("\\s", "_", Sys.info()["user"]),"_",ltrs,nums)
+  .h2o.jar.env$name <- name
+
   if(enable_assertions) args <- c(args, "-ea")
   if(!is.null(jvm_custom_args)) args <- c(args,jvm_custom_args)
-  
+
   class_path <- paste0(c(jar_file, extra_classpath), collapse=.Platform$path.sep)
   args <- c(args, "-cp", class_path, "water.H2OApp")
   args <- c(args, "-name", name)


### PR DESCRIPTION
Adds the option to specify `cloud_name` in the `h2o.init()` methods in Python and R. Main motivation is because we are using the `-name` parameter in MLI and would like to move from bootstrapping via `java -jar h2o.jar` to `h2o.init()` calls.

Proposed logic:

* If there is an instance under given address:port with the same cloud name - connect as normal
* If there is an instance with a different cloud name - fail in case of R, in case of Python fail if port passed explicitly and as_port=True passed, otherwise try to bootstrap on consecutive ports
* If no instance then try to start an H2O-3 instance using name as cloud name.

Added also `as_port` to the `kwargs` so the `port` argument acts like the actual `-port` parameter instead of `-base_port`. 

Comments?

I also would like to add the `log_dir` parameter if this one looks good in the next PR.