### PR TITLE
Fix model export issue

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -234,7 +234,11 @@ public final class AutoBuffer {
     _firstPage = true;
     _persist = 0;
 
-    if( persist ) put1(0x1C).put1(0xED).putStr(H2O.ABV.projectVersion()).putAStr(TypeMap.CLAZZES);
+    if( persist ) {
+      String[] typeMap = (H2O.CLOUD.leader() == H2O.SELF) ?
+              TypeMap.CLAZZES : FetchClazzes.fetchClazzes();
+      put1(0x1C).put1(0xED).putStr(H2O.ABV.projectVersion()).putAStr(typeMap);
+    }
     else put1(0);
   }
 

--- a/h2o-core/src/main/java/water/FetchClazzes.java
+++ b/h2o-core/src/main/java/water/FetchClazzes.java
@@ -1,0 +1,16 @@
+package water;
+
+class FetchClazzes extends DTask<FetchClazzes> {
+  // OUT
+  String[] _clazzes;
+  private FetchClazzes() { super(); }
+  public static String[] fetchClazzes() {
+    String[] clazzes = RPC.call(H2O.CLOUD.leader(), new FetchClazzes()).get()._clazzes;
+    assert clazzes != null;
+    return clazzes;
+  }
+  @Override public void compute2() {
+    _clazzes = TypeMap.CLAZZES;
+    tryComplete();
+  }
+}


### PR DESCRIPTION
Fixes an issue when a model is exported by an H2O node that didn't participate in the model building (typical the client node or a case of a small dataset stored on a single node of a multinode cluster). This node might not have some classes in its TypeMap (eg. CompressedTrees for GBM). We need to use the leader's TypeMap when exporting the model because this TypeMap is always authoritative for the whole cluster.

What happens is: when the client writes the binary model it writes its own TypeMap to the exported file first. Then the keys are being fetched from the nodes and if the client doesn't have the class in its own TypeMap it fetches it from the Leader. So the typemap gets updated on the fly after it was already written to the file. The fix is to fetch the typemap from the leader first before the export starts.