### PR TITLE
PUBDEV-5705: added skipped column to csv parsers

### DIFF
--- a/h2o-bindings/src/main/java/water/bindings/examples/Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/Example.java
@@ -1,16 +1,16 @@
 package water.bindings.examples;
 
+import com.google.gson.*;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 import water.bindings.pojos.*;
 import water.bindings.proxies.retrofit.*;
-import com.google.gson.*;
-import retrofit2.*;
-import retrofit2.http.*;
-import retrofit2.converter.gson.GsonConverterFactory;
-import retrofit2.Call;
+
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Example of using generated Java bindings for REST API.
@@ -103,6 +103,7 @@ public class Example {
                                                                   null,
                                                                   null,
                                                                   null,
+                                                                  null,
                                                                   0,
                                                                   0,
                                                                   0,
@@ -124,6 +125,7 @@ public class Example {
                                                    parseSetupBody.numberColumns,
                                                    parseSetupBody.columnNames,
                                                    parseSetupBody.columnTypes,
+                                                   parseSetupBody.skippedColumns,
                                                    null, // domains
                                                    parseSetupBody.naStrings,
                                                    parseSetupBody.chunkSize,

--- a/h2o-core/src/main/java/water/api/ParseSetupHandler.java
+++ b/h2o-core/src/main/java/water/api/ParseSetupHandler.java
@@ -1,10 +1,5 @@
 package water.api;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import water.DKV;
 import water.Key;
 import water.api.schemas3.ParseSetupV3;
@@ -13,6 +8,11 @@ import water.parser.ParseDataset;
 import water.parser.ParseSetup;
 import water.util.DistributedException;
 import water.util.PojoUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static water.parser.DefaultParserProviders.GUESS_INFO;
 
@@ -46,6 +46,8 @@ public class ParseSetupHandler extends Handler {
         throw new H2OIllegalArgumentException(ex2.getMessage());
       throw ex;
     }
+    ps.setSkippedColumns(p.skipped_columns);  // setup the skipped_columns here
+    ps.setParseColumnIndices(ps.getNumberColumns(), ps.getSkippedColumns());
     if(ps.errs() != null && ps.errs().length > 0) {
       p.warnings = new String[ps.errs().length];
       for (int i = 0; i < ps.errs().length; ++i)

--- a/h2o-core/src/main/java/water/api/schemas3/ParseSetupV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ParseSetupV3.java
@@ -33,6 +33,9 @@ public class ParseSetupV3 extends RequestSchemaV3<ParseSetup, ParseSetupV3> {
   @API(help="Column names", direction=API.Direction.INOUT)
   public String[] column_names = null;
 
+  @API(help="Skipped columns indices", direction=API.Direction.INOUT)
+  public int[] skipped_columns = null;
+
   @API(help="Value types for columns", direction=API.Direction.INOUT)
   public String[] column_types = null;
 

--- a/h2o-core/src/main/java/water/api/schemas3/ParseV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ParseV3.java
@@ -35,6 +35,9 @@ public class ParseV3 extends RequestSchemaV3<Iced, ParseV3> {
   @API(help="Value types for columns")
   public String[] column_types;
 
+  @API(help="Skipped columns indices", direction=API.Direction.INOUT)
+  public int[] skipped_columns;
+
   @API(help="Domains for categorical columns")
   public String[][] domains;
 

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -11,7 +11,10 @@ import water.fvec.*;
 import water.fvec.Vec.VectorGroup;
 import water.nbhm.NonBlockingHashMap;
 import water.nbhm.NonBlockingSetInt;
-import water.util.*;
+import water.util.ArrayUtils;
+import water.util.FrameUtils;
+import water.util.Log;
+import water.util.PrettyPrint;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,20 +24,32 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static water.parser.DefaultParserProviders.*;
+import static water.parser.DefaultParserProviders.SVMLight_INFO;
 
 public final class ParseDataset {
   public Job<Frame> _job;
   private MultiFileParseTask _mfpt; // Access to partially built vectors for cleanup after parser crash
 
   // Keys are limited to ByteVec Keys and Frames-of-1-ByteVec Keys
-  public static Frame parse(Key okey, Key... keys) { return parse(okey,keys,true, false, ParseSetup.GUESS_HEADER); }
+  public static Frame parse(Key okey, Key... keys) {
+    return parse(null, okey, keys);
+  }
+  public static Frame parse(int[] skippedColumns, Key okey, Key... keys) {
+    return parse(okey,keys,true, false, ParseSetup.GUESS_HEADER,skippedColumns); }
 
+  public static Frame parse(Key okey, Key[] keys, boolean deleteOnDone, boolean singleQuote, int checkHeader) {
+    return parse(okey, keys, deleteOnDone, singleQuote, checkHeader, null);
+  }
   // Guess setup from inspecting the first Key only, then parse.
   // Suitable for e.g. testing setups, where the data is known to be sane.
   // NOT suitable for random user input!
-  public static Frame parse(Key okey, Key[] keys, boolean deleteOnDone, boolean singleQuote, int checkHeader) {
-    return parse(okey,keys,deleteOnDone,ParseSetup.guessSetup(keys, singleQuote, checkHeader));
+  public static Frame parse(Key okey, Key[] keys, boolean deleteOnDone, boolean singleQuote, int checkHeader, int[] skippedColumns) {
+    ParseSetup guessParseSetup = ParseSetup.guessSetup(keys, singleQuote, checkHeader);
+    if (skippedColumns!=null) {
+      guessParseSetup.setSkippedColumns(skippedColumns);
+      guessParseSetup.setParseColumnIndices(guessParseSetup.getNumberColumns(), skippedColumns);
+    }
+    return parse(okey,keys,deleteOnDone,guessParseSetup);
   }
   public static Frame parse(Key okey, Key[] keys, boolean deleteOnDone, ParseSetup globalSetup) {
     return parse(okey,keys,deleteOnDone,globalSetup,true)._job.get();
@@ -243,24 +258,53 @@ public final class ParseDataset {
     Log.trace("Done ingesting files.");
     if( job.stop_requested() ) return pds;
 
-    final AppendableVec [] avs = mfpt.vecs();
-    setup._column_names = getColumnNames(avs.length, setup._column_names);
-
+    final AppendableVec [] avs = mfpt.vecs(); // with skipped_columns excluded
     Frame fr = null;
     // Calculate categorical domain
     // Filter down to columns with some categoricals
     int n = 0;
-    int[] ecols2 = new int[avs.length];
-    for( int i = 0; i < avs.length; ++i )
-      if( avs[i].get_type()==Vec.T_CAT  ) // Intended type is categorical (even though no domain has been set)?
+    int parseCols = setup._parse_columns_indices.length;
+    boolean sameParseColumns = setup._number_columns == parseCols; // _number_columns represent number of columns parsed
+
+    String[] parse_column_names;
+    byte[] parse_column_types;
+    if (setup._column_names == null)
+      setup._column_names = getColumnNames(setup._column_types.length, null);
+
+    boolean typesSameParseColumns = setup._column_types.length==parseCols;
+    boolean namesSameparseColumns = setup._column_names.length==parseCols;
+
+    if (sameParseColumns) {
+      parse_column_names = setup._column_names;
+    } else {
+      parse_column_names = new String[parseCols];
+      parse_column_types = new byte[parseCols];
+
+
+      for (int cindex = 0; cindex < parseCols; cindex++) {
+        parse_column_names[cindex] = namesSameparseColumns?setup._column_names[cindex]:
+                setup._column_names[setup._parse_columns_indices[cindex]];
+        parse_column_types[cindex] = typesSameParseColumns?setup._column_types[cindex]:
+                setup._column_types[setup._parse_columns_indices[cindex]];
+      }
+
+      setup._column_types=parse_column_types;
+    }
+    setup._column_names = getColumnNames(avs.length, parse_column_names);
+
+    int[] ecols2 = new int[parseCols];
+    for (int i = 0; i < parseCols; i++) {
+      if (avs[i].get_type() == Vec.T_CAT) // Intended type is categorical (even though no domain has been set)?
         ecols2[n++] = i;
-    final int[] ecols = Arrays.copyOf(ecols2, n);
+    }
+    final int[] ecols = Arrays.copyOf(ecols2, n); // skipped columns are excluded already
     // If we have any, go gather unified categorical domains
     if( n > 0 ) {
       if (!setup.getParseType().isDomainProvided) { // Domains are not provided via setup we need to collect them
         job.update(0, "Collecting categorical domains across nodes.");
         {
-          GatherCategoricalDomainsTask gcdt = new GatherCategoricalDomainsTask(mfpt._cKey, ecols).doAllNodes();
+          GatherCategoricalDomainsTask gcdt = new GatherCategoricalDomainsTask(mfpt._cKey, ecols,
+                  mfpt._parseSetup._parse_columns_indices).doAllNodes();
           //Test domains for excessive length.
           List<String> offendingColNames = new ArrayList<>();
           for (int i = 0; i < ecols.length; i++) {
@@ -271,7 +315,9 @@ public final class ParseDataset {
               offendingColNames.add(setup._column_names[ecols[i]]);
           }
           if (offendingColNames.size() > 0)
-            throw new H2OParseException("Exceeded categorical limit on columns "+ offendingColNames+".   Consider reparsing these columns as a string.");
+            throw new H2OParseException("Exceeded categorical limit on columns "+ offendingColNames+".   " +
+                    "Consider reparsing these columns as a string or skip parsing the offending columns by setting" +
+                    " the skipped_columns list in Python/R/Java APIs.");
         }
         Log.trace("Done collecting categorical domains across nodes.");
       } else {
@@ -282,6 +328,7 @@ public final class ParseDataset {
       }
 
       job.update(0, "Compressing data.");
+
       fr = new Frame(job._result, setup._column_names, AppendableVec.closeAll(avs));
       fr.update(job);
       Log.trace("Done compressing data.");
@@ -297,7 +344,7 @@ public final class ParseDataset {
           RPC[] rpcs = new RPC[H2O.CLOUD.size()];
           for (int i = 0; i < fcdt.length; i++){
             H2ONode[] nodes = H2O.CLOUD.members();
-            fcdt[i] = new CreateParse2GlobalCategoricalMaps(mfpt._cKey, fr._key, ecols);
+            fcdt[i] = new CreateParse2GlobalCategoricalMaps(mfpt._cKey, fr._key, ecols, mfpt._parseSetup._parse_columns_indices);
             rpcs[i] = new RPC<>(nodes[i], fcdt[i]).call();
           }
           for (RPC rpc : rpcs)
@@ -372,31 +419,34 @@ public final class ParseDataset {
     private final Key   _parseCatMapsKey;
     private final Key   _frKey;
     private final int[] _ecol;
+    private final int[] _parseColumns;
 
-    private CreateParse2GlobalCategoricalMaps(Key parseCatMapsKey, Key key, int[] ecol) {
+    private CreateParse2GlobalCategoricalMaps(Key parseCatMapsKey, Key key, int[] ecol, int[] parseColumns) {
       _parseCatMapsKey = parseCatMapsKey;
       _frKey = key;
-      _ecol = ecol;
+      _ecol = ecol; // contains the categoricals column indices only
+      _parseColumns = parseColumns;
     }
 
     @Override public void compute2() {
-      Frame _fr = DKV.getGet(_frKey);
+      Frame _fr = DKV.getGet(_frKey); // does not contain skipped columns
       // get the node local category->ordinal maps for each column from initial parse pass
       if( !MultiFileParseTask._categoricals.containsKey(_parseCatMapsKey) ) {
         tryComplete();
         return;
       }
-        final Categorical[] parseCatMaps = MultiFileParseTask._categoricals.get(_parseCatMapsKey);
+        final Categorical[] parseCatMaps = MultiFileParseTask._categoricals.get(_parseCatMapsKey); // include skipped columns
         int[][] _nodeOrdMaps = new int[_ecol.length][];
 
         // create old_ordinal->new_ordinal map for each cat column
         for (int eColIdx = 0; eColIdx < _ecol.length; eColIdx++) {
-          int colIdx = _ecol[eColIdx];
+          int colIdx = _parseColumns[_ecol[eColIdx]];
           if (parseCatMaps[colIdx].size() != 0) {
             _nodeOrdMaps[eColIdx] = MemoryManager.malloc4(parseCatMaps[colIdx].maxId() + 1);
             Arrays.fill(_nodeOrdMaps[eColIdx], -1);
             //Bulk String->BufferedString conversion is slightly faster, but consumes memory
-            final BufferedString[] unifiedDomain = BufferedString.toBufferedString(_fr.vec(colIdx).domain());
+            final BufferedString[] unifiedDomain = _fr.vec(_ecol[eColIdx]).isCategorical()?
+                    BufferedString.toBufferedString(_fr.vec(_ecol[eColIdx]).domain()):new BufferedString[0];
             //final String[] unifiedDomain = _fr.vec(colIdx).domain();
             for (int i = 0; i < unifiedDomain.length; i++) {
               //final BufferedString cat = new BufferedString(unifiedDomain[i]);
@@ -467,10 +517,12 @@ public final class ParseDataset {
     private final Key _k;
     private final int[] _catColIdxs;
     private byte[][] _packedDomains;
+    private final int[] _parseColumns;
 
-    private GatherCategoricalDomainsTask(Key k, int[] ccols) {
+    private GatherCategoricalDomainsTask(Key k, int[] ccols, int[] parseColumns) {
       _k = k;
       _catColIdxs = ccols;
+      _parseColumns = parseColumns;
     }
 
     @Override
@@ -478,11 +530,11 @@ public final class ParseDataset {
       if (!MultiFileParseTask._categoricals.containsKey(_k)) return;
       _packedDomains = new byte[_catColIdxs.length][];
       final BufferedString[][] _perColDomains = new BufferedString[_catColIdxs.length][];
-      final Categorical[] _colCats = MultiFileParseTask._categoricals.get(_k);
+      final Categorical[] _colCats = MultiFileParseTask._categoricals.get(_k); // still refer to all columns
       int i = 0;
       for (int col : _catColIdxs) {
-        _colCats[col].convertToUTF8(col + 1);
-        _perColDomains[i] = _colCats[col].getColumnDomain();
+        _colCats[_parseColumns[col]].convertToUTF8(_parseColumns[col] + 1);
+        _perColDomains[i] = _colCats[_parseColumns[col]].getColumnDomain();
         Arrays.sort(_perColDomains[i]);
         _packedDomains[i] = PackedDomains.pack(_perColDomains[i]);
         i++;
@@ -642,8 +694,12 @@ public final class ParseDataset {
         _parseSetup._column_types = new byte[res.length];
         Arrays.fill(_parseSetup._column_types,Vec.T_NUM);
       }
-      for(int i = 0; i < res.length; ++i)
-        res[i] = new AppendableVec(_vg.vecKey(_vecIdStart + i), espc, _parseSetup._column_types[i], 0);
+      boolean columnsSkipped = nCols<_parseSetup._number_columns;
+      for(int i = 0; i < res.length; ++i) {
+        byte columnTypes = columnsSkipped ? _parseSetup._column_types[_parseSetup._parse_columns_indices[i]] : _parseSetup._column_types[i];
+        int vecIDStartPI = columnsSkipped?(_vecIdStart+_parseSetup._parse_columns_indices[i]):_vecIdStart + i;
+        res[i] = new AppendableVec(_vg.vecKey(vecIDStartPI), espc, columnTypes, 0);
+      }
       // Load the global ESPC from the file-local ESPCs
       for( FVecParseWriter fvpw : _dout ) {
         AppendableVec[] avs = fvpw._vecs;
@@ -696,10 +752,13 @@ public final class ParseDataset {
       final long [] espc = MemoryManager.malloc8(nchunks);
       final byte[] ctypes = localSetup._column_types; // SVMLight only uses numeric types, sparsely represented as a null
       for(int i = 0; i < avs.length; ++i)
-        avs[i] = new AppendableVec(_vg.vecKey(i + _vecIdStart), espc, ctypes==null ? /*SVMLight*/Vec.T_NUM : ctypes[i], chunkOff);
+        avs[i] = new AppendableVec(_vg.vecKey(i + _vecIdStart), espc, ctypes==null ? /*SVMLight*/Vec.T_NUM :
+                ctypes[i], chunkOff);
       return localSetup._parse_type.equals(SVMLight_INFO)
-        ? new SVMLightFVecParseWriter(_vg, _vecIdStart,chunkOff, _parseSetup._chunk_size, avs)
-        : new FVecParseWriter(_vg, chunkOff, categoricals(_cKey, localSetup._number_columns), localSetup._column_types, _parseSetup._chunk_size, avs);
+        ? new SVMLightFVecParseWriter(_vg, _vecIdStart,chunkOff, _parseSetup._chunk_size, avs,
+              _parseSetup._parse_columns_indices)
+        : new FVecParseWriter(_vg, chunkOff, categoricals(_cKey, localSetup._number_columns),
+              localSetup._column_types, _parseSetup._chunk_size, avs, _parseSetup._parse_columns_indices);
     }
 
     // Called once per file
@@ -867,12 +926,17 @@ public final class ParseDataset {
       }
       @Override public void map( Chunk in ) {
         if( _jobKey.get().stop_requested() ) throw new Job.JobCancelledException();
-        AppendableVec [] avs = new AppendableVec[_setup._number_columns];
-        for(int i = 0; i < avs.length; ++i)
-          if (_setup._column_types == null) // SVMLight
-            avs[i] = new AppendableVec(_vg.vecKey(_vecIdStart + i), _espc, Vec.T_NUM, _startChunkIdx);
-          else
-            avs[i] = new AppendableVec(_vg.vecKey(_vecIdStart + i), _espc, _setup._column_types[i], _startChunkIdx);
+        AppendableVec [] avs = new AppendableVec[_setup._parse_columns_indices.length];
+        boolean notShrunkColumns = _setup._parse_columns_indices.length==_setup._number_columns;
+          for (int i = 0; i < avs.length; ++i)
+            if (_setup._column_types == null) // SVMLight which does not support skip columns anyway
+              avs[i] = new AppendableVec(_vg.vecKey(_vecIdStart + i), _espc, Vec.T_NUM, _startChunkIdx);
+            else
+              avs[i] = notShrunkColumns?
+                      new AppendableVec(_vg.vecKey(_vecIdStart + i), _espc, _setup._column_types[i], _startChunkIdx)
+                      :new AppendableVec(_vg.vecKey(_vecIdStart + _setup._parse_columns_indices[i]),
+                      _espc, _setup._column_types[_setup._parse_columns_indices[i]], _startChunkIdx);
+
         // Break out the input & output vectors before the parse loop
         FVecParseReader din = new FVecParseReader(in);
         FVecParseWriter dout;
@@ -884,21 +948,33 @@ public final class ParseDataset {
         case "PARQUET":
           Categorical [] categoricals = categoricals(_cKey, _setup._number_columns);
           dout = new FVecParseWriter(_vg,_startChunkIdx + in.cidx(), categoricals, _setup._column_types,
-                  _setup._chunk_size, avs); //TODO: use _setup._domains instead of categoricals
+                  _setup._chunk_size, avs, _setup._parse_columns_indices); //TODO: use _setup._domains instead of categoricals
           break;
         case "SVMLight":
-          dout = new SVMLightFVecParseWriter(_vg, _vecIdStart, in.cidx() + _startChunkIdx, _setup._chunk_size, avs);
+          dout = new SVMLightFVecParseWriter(_vg, _vecIdStart, in.cidx() + _startChunkIdx, _setup._chunk_size,
+                  avs, _setup._parse_columns_indices);
           break;
         case "ORC":  // setup special case for ORC
           Categorical [] orc_categoricals = categoricals(_cKey, _setup._number_columns);
           dout = new FVecParseWriter(_vg, in.cidx() + _startChunkIdx, orc_categoricals, _setup._column_types,
-                  _setup._chunk_size, avs);
+                  _setup._chunk_size, avs, _setup._parse_columns_indices);
           break;
         default: // FIXME: should not be default and creation strategy should be forwarded to ParserProvider
           dout = new FVecParseWriter(_vg, in.cidx() + _startChunkIdx, null, _setup._column_types,
-                  _setup._chunk_size, avs);
+                  _setup._chunk_size, avs, _setup._parse_columns_indices);
           break;
         }
+        if ((_setup.getParseType().name().toLowerCase().equals("svmlight") ||
+                (_setup.getParseType().name().toLowerCase().equals("avro") ))
+                && ((_setup.getSkippedColumns() != null) && (_setup.getSkippedColumns().length >0)))
+          throw new H2OIllegalArgumentException("Parser: skipped_columns are not supported for " +
+                  "SVMlight or Avro parsers.");
+
+        if (_setup.getSkippedColumns() !=null &&
+                ((_setup.get_parse_columns_indices()==null) || (_setup.get_parse_columns_indices().length==0)))
+          throw new H2OIllegalArgumentException("Parser:  all columns in the file are skipped and no H2OFrame" +
+                  " can be returned."); // Need this to send error message to R
+
         p.parseChunk(in.cidx(), din, dout);
         (_dout = dout).close(_fs);
         Job.update(in._len, _jobKey); // Record bytes parsed
@@ -979,7 +1055,7 @@ public final class ParseDataset {
   // Log information about the dataset we just parsed.
   public static void logParseResults(Frame fr) {
     long numRows = fr.anyVec().length();
-    Log.info("Parse result for " + fr._key + " (" + Long.toString(numRows) + " rows):");
+    Log.info("Parse result for " + fr._key + " (" + Long.toString(numRows) + " rows, "+Integer.toString(fr.numCols())+" columns):");
     // get all rollups started in parallell, otherwise this takes ages!
     Futures fs = new Futures();
     Vec[] vecArr = fr.vecs();

--- a/h2o-core/src/main/java/water/parser/Parser.java
+++ b/h2o-core/src/main/java/water/parser/Parser.java
@@ -80,6 +80,9 @@ public abstract class Parser extends Iced {
         for (int colIdx : _setup._skipped_columns)
           if (colIdx < _setup._number_columns)
             _keepColumns[colIdx] = false;
+          else
+            throw new IllegalArgumentException("Skipped column index "+colIdx+" is illegal.  It exceeds the actual" +
+                    " number of columns in your file.");
       }
     }
   }

--- a/h2o-core/src/main/java/water/parser/SVMLightFVecParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/SVMLightFVecParseWriter.java
@@ -12,13 +12,14 @@ public class SVMLightFVecParseWriter extends FVecParseWriter {
   protected final Vec.VectorGroup _vg;
   int _vecIdStart;
 
-  public SVMLightFVecParseWriter(Vec.VectorGroup vg, int vecIdStart, int cidx, int chunkSize, AppendableVec[] avs){
-    super(vg, cidx, null, null, chunkSize, avs);
+  public SVMLightFVecParseWriter(Vec.VectorGroup vg, int vecIdStart, int cidx, int chunkSize, AppendableVec[] avs, int[] parse_columns_indices){
+    super(vg, cidx, null, null, chunkSize, avs, parse_columns_indices);
     _vg = vg;
     _vecIdStart = vecIdStart;
-    _nvs = new NewChunk[avs.length];
-    for(int i = 0; i < _nvs.length; ++i)
-      _nvs[i] = new NewChunk(_vecs[i], _cidx, true);
+    int numParseCols = parse_columns_indices.length;
+    _nvs = new NewChunk[numParseCols];
+    for(int i = 0; i < numParseCols; ++i)
+      _nvs[i] = new NewChunk(_vecs[_parse_columns_indices[i]], _cidx, true);
     _col = 0;
   }
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -56,7 +56,7 @@ class H2OFrame(object):
     #-------------------------------------------------------------------------------------------------------------------
 
     def __init__(self, python_obj=None, destination_frame=None, header=0, separator=",",
-                 column_names=None, column_types=None, na_strings=None):
+                 column_names=None, column_types=None, na_strings=None, skipped_columns=None):
         """
         Create a new H2OFrame object, possibly from some other object.
 
@@ -103,7 +103,7 @@ class H2OFrame(object):
         self._is_frame = True  # Indicate that this is an actual frame, allowing typechecks to be made
         if python_obj is not None:
             self._upload_python_object(python_obj, destination_frame, header, separator,
-                                       column_names, column_types, na_strings)
+                                       column_names, column_types, na_strings, skipped_columns)
 
     @staticmethod
     def _expr(expr, cache=None):
@@ -116,7 +116,7 @@ class H2OFrame(object):
 
 
     def _upload_python_object(self, python_obj, destination_frame=None, header=0, separator=",",
-                              column_names=None, column_types=None, na_strings=None):
+                              column_names=None, column_types=None, na_strings=None, skipped_columns=None):
         assert_is_type(python_obj, list, tuple, dict, numpy_ndarray, pandas_dataframe, scipy_sparse)
         if is_type(python_obj, scipy_sparse):
             self._upload_sparse_matrix(python_obj, destination_frame=destination_frame)
@@ -144,7 +144,7 @@ class H2OFrame(object):
         else:
             csv_writer.writerows(data_to_write)
         tmp_file.close()  # close the streams
-        self._upload_parse(tmp_path, destination_frame, 1, separator, column_names, column_types, na_strings)
+        self._upload_parse(tmp_path, destination_frame, 1, separator, column_names, column_types, na_strings, skipped_columns)
         os.remove(tmp_path)  # delete the tmp file
 
 
@@ -309,24 +309,24 @@ class H2OFrame(object):
         raise H2OValueError("Column '%r' does not exist in the frame" % col)
 
 
-    def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings):
+    def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings, skipped_columns=None):
         if H2OFrame.__LOCAL_EXPANSION_ON_SINGLE_IMPORT__ and is_type(path, str) and "://" not in path:  # fixme: delete those 2 lines, cf. PUBDEV-5717
             path = os.path.abspath(path)
         rawkey = h2o.lazy_import(path, pattern)
-        self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings)
+        self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings, skipped_columns)
         return self
 
 
-    def _upload_parse(self, path, destination_frame, header, sep, column_names, column_types, na_strings):
+    def _upload_parse(self, path, destination_frame, header, sep, column_names, column_types, na_strings, skipped_columns=None):
         ret = h2o.api("POST /3/PostFile", filename=path)
         rawkey = ret["destination_frame"]
-        self._parse(rawkey, destination_frame, header, sep, column_names, column_types, na_strings)
+        self._parse(rawkey, destination_frame, header, sep, column_names, column_types, na_strings, skipped_columns)
         return self
 
 
     def _parse(self, rawkey, destination_frame="", header=None, separator=None, column_names=None, column_types=None,
-               na_strings=None):
-        setup = h2o.parse_setup(rawkey, destination_frame, header, separator, column_names, column_types, na_strings)
+               na_strings=None, skipped_columns=None):
+        setup = h2o.parse_setup(rawkey, destination_frame, header, separator, column_names, column_types, na_strings, skipped_columns)
         return self._parse_raw(setup)
 
 
@@ -342,6 +342,7 @@ class H2OFrame(object):
              "delete_on_done": True,
              "blocking": False,
              "column_types": None,
+             "skipped_columns":None
              }
 
         if setup["column_names"]: p["column_names"] = None

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -294,7 +294,7 @@ def _import_multi(paths, pattern):
 
 
 def upload_file(path, destination_frame=None, header=0, sep=None, col_names=None, col_types=None,
-                na_strings=None):
+                na_strings=None, skipped_columns=None):
     """
     Upload a dataset from the provided local path to the H2O cluster.
 
@@ -323,6 +323,7 @@ def upload_file(path, destination_frame=None, header=0, sep=None, col_names=None
           Times can also contain "AM" or "PM".
     :param na_strings: A list of strings, or a list of lists of strings (one list per column), or a dictionary
         of column names to strings which are to be interpreted as missing values.
+    :param skipped_columns: an integer lists of column indices to skip and not parsed into the final frame from the import file.
 
     :returns: a new :class:`H2OFrame` instance.
 
@@ -339,14 +340,17 @@ def upload_file(path, destination_frame=None, header=0, sep=None, col_names=None
     assert_is_type(col_names, [str], None)
     assert_is_type(col_types, [coltype], {str: coltype}, None)
     assert_is_type(na_strings, [natype], {str: natype}, None)
+    assert (skipped_columns==None) or isinstance(skipped_columns, list), \
+        "The skipped_columns should be an list of column names!"
+
     check_frame_id(destination_frame)
     if path.startswith("~"):
         path = os.path.expanduser(path)
-    return H2OFrame()._upload_parse(path, destination_frame, header, sep, col_names, col_types, na_strings)
+    return H2OFrame()._upload_parse(path, destination_frame, header, sep, col_names, col_types, na_strings, skipped_columns)
 
 
 def import_file(path=None, destination_frame=None, parse=True, header=0, sep=None, col_names=None, col_types=None,
-                na_strings=None, pattern=None):
+                na_strings=None, pattern=None, skipped_columns=None):
     """
     Import a dataset that is already on the cluster.
 
@@ -382,6 +386,7 @@ def import_file(path=None, destination_frame=None, parse=True, header=0, sep=Non
         of column names to strings which are to be interpreted as missing values.
     :param pattern: Character string containing a regular expression to match file(s) in the folder if `path` is a
         directory.
+    :param skipped_columns: an integer list of column indices to skip and not parsed into the final frame from the import file.
 
     :returns: a new :class:`H2OFrame` instance.
 
@@ -404,6 +409,8 @@ def import_file(path=None, destination_frame=None, parse=True, header=0, sep=Non
     assert_is_type(col_names, [str], None)
     assert_is_type(col_types, [coltype], {str: coltype}, None)
     assert_is_type(na_strings, [natype], {str: natype}, None)
+    assert (skipped_columns==None) or isinstance(skipped_columns, list), \
+        "The skipped_columns should be an list of column names!"
     check_frame_id(destination_frame)
     patharr = path if isinstance(path, list) else [path]
     if any(os.path.split(p)[0] == "~" for p in patharr):
@@ -412,7 +419,7 @@ def import_file(path=None, destination_frame=None, parse=True, header=0, sep=Non
     if not parse:
         return lazy_import(path, pattern)
     else:
-        return H2OFrame()._import_parse(path, pattern, destination_frame, header, sep, col_names, col_types, na_strings)
+        return H2OFrame()._import_parse(path, pattern, destination_frame, header, sep, col_names, col_types, na_strings, skipped_columns)
 
 
 def import_sql_table(connection_url, table, username, password, columns=None, optimize=True, fetch_mode=None):
@@ -508,7 +515,7 @@ def import_sql_select(connection_url, select_query, username, password, optimize
 
 
 def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, column_names=None,
-                column_types=None, na_strings=None):
+                column_types=None, na_strings=None, skipped_columns=None):
     """
     Retrieve H2O's best guess as to what the structure of the data file is.
 
@@ -541,6 +548,7 @@ def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, co
 
     :param na_strings: A list of strings, or a list of lists of strings (one list per column), or a dictionary
         of column names to strings which are to be interpreted as missing values.
+    :param skipped_columns: an integer lists of column indices to skip and not parsed into the final frame from the import file.
 
     :returns: a dictionary containing parse parameters guessed by the H2O backend.
     """
@@ -572,13 +580,36 @@ def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, co
     # TODO: clean up all this
     if destination_frame:
         j["destination_frame"] = destination_frame
+
+    parse_column_len = len(j["column_types"]) if skipped_columns is None else (len(j["column_types"])-len(skipped_columns))
+    tempColumnNames = j["column_names"] if j["column_names"] is not None else gen_header(j["number_columns"])
+    useType = [True]*len(tempColumnNames)
+    if skipped_columns is not None:
+        useType = [True]*len(tempColumnNames)
+
+        for ind in range(len(tempColumnNames)):
+            if ind in skipped_columns:
+                useType[ind]=False
+
     if column_names is not None:
         if not isinstance(column_names, list): raise ValueError("col_names should be a list")
-        if len(column_names) != len(j["column_types"]): raise ValueError(
-            "length of col_names should be equal to the number of columns: %d vs %d"
-            % (len(column_names), len(j["column_types"])))
+        if (skipped_columns is not None) and len(skipped_columns)>0:
+            if (len(column_names)) != parse_column_len:
+                raise ValueError(
+                    "length of col_names should be equal to the number of columns parsed: %d vs %d"
+                    % (len(column_names), parse_column_len))
+        else:
+            if len(column_names) != len(j["column_types"]): raise ValueError(
+                "length of col_names should be equal to the number of columns: %d vs %d"
+                % (len(column_names), len(j["column_types"])))
         j["column_names"] = column_names
-    if column_types is not None:
+        counter = 0
+        for ind in range(len(tempColumnNames)):
+            if useType[ind]:
+                tempColumnNames[ind]=column_names[counter]
+                counter=counter+1
+
+    if (column_types is not None): # keep the column types to include all columns
         if isinstance(column_types, dict):
             # overwrite dictionary to ordered list of column types. if user didn't specify column type for all names,
             # use type provided by backend
@@ -588,18 +619,28 @@ def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, co
                 "names specified in col_types is not a subset of the column names")
             idx = 0
             column_types_list = []
-            for name in j["column_names"]:
+
+            for name in tempColumnNames: # column_names may have already been changed
                 if name in column_types:
                     column_types_list.append(column_types[name])
                 else:
                     column_types_list.append(j["column_types"][idx])
                 idx += 1
+
             column_types = column_types_list
+
         elif isinstance(column_types, list):
-            if len(column_types) != len(j["column_types"]): raise ValueError(
-                "length of col_types should be equal to the number of columns")
-            column_types = [column_types[i] if column_types[i] else j["column_types"][i] for i in
-                            range(len(column_types))]
+            if len(column_types) != parse_column_len: raise ValueError(
+                "length of col_types should be equal to the number of parsed columns")
+            # need to expand it out to all columns, not just the parsed ones
+            column_types_list = j["column_types"]
+            counter = 0
+            for ind in range(len(j["column_types"])):
+                if useType[ind] and (column_types[counter]!=None):
+                    column_types_list[ind]=column_types[counter]
+                    counter=counter+1
+
+            column_types = column_types_list
         else:  # not dictionary or list
             raise ValueError("col_types should be a list of types or a dictionary of column names to types")
         j["column_types"] = column_types
@@ -624,6 +665,13 @@ def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, co
             raise ValueError(
                 "na_strings should be a list, a list of lists (one list per column), or a dictionary of column "
                 "names to strings which are to be interpreted as missing values")
+
+    if skipped_columns is not None:
+        if isinstance(skipped_columns, list):
+            j["skipped_columns"] = []
+            for colidx in skipped_columns:
+                if (colidx < 0): raise ValueError("skipped column index cannot be negative")
+                j["skipped_columns"].append(colidx)
 
     # quote column names and column types also when not specified by user
     if j["column_names"]: j["column_names"] = list(map(quoted, j["column_names"]))

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -409,8 +409,7 @@ def import_file(path=None, destination_frame=None, parse=True, header=0, sep=Non
     assert_is_type(col_names, [str], None)
     assert_is_type(col_types, [coltype], {str: coltype}, None)
     assert_is_type(na_strings, [natype], {str: natype}, None)
-    assert (skipped_columns==None) or isinstance(skipped_columns, list), \
-        "The skipped_columns should be an list of column names!"
+    assert isinstance(skipped_columns, (type(None), list)), "The skipped_columns should be an list of column names!"
     check_frame_id(destination_frame)
     patharr = path if isinstance(path, list) else [path]
     if any(os.path.split(p)[0] == "~" for p in patharr):
@@ -577,7 +576,6 @@ def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, co
         for w in j["warnings"]:
             warnings.warn(w)
     # TODO: really should be url encoding...
-    # TODO: clean up all this
     if destination_frame:
         j["destination_frame"] = destination_frame
 

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -45,6 +45,32 @@ import math
 from random import shuffle
 import scipy.special
 from h2o.utils.typechecks import assert_is_type
+import datetime
+import time # needed to randomly generate time
+import uuid # call uuid.uuid4() to generate unique uuid numbers
+
+def gen_random_uuid(numberUUID):
+    uuidVec = numberUUID*[None]
+
+    for uindex in range(numberUUID):
+        uuidVec[uindex] = uuid.uuid4()
+    return uuidVec
+
+def gen_random_time(numberTimes, maxtime= datetime.datetime(2080, 8,6,8,14,59), mintime=datetime.datetime(1980, 8,6,6,14,59)):
+    '''
+    Simple method that I shameless copied from the internet.
+    :param numberTimes:
+    :param maxtime:
+    :param mintime:
+    :return:
+    '''
+    mintime_ts = int(time.mktime(mintime.timetuple()))
+    maxtime_ts = int(time.mktime(maxtime.timetuple()))
+    randomTimes = numberTimes*[None]
+    for tindex in range(numberTimes):
+        temptime = random.randint(mintime_ts, maxtime_ts)
+        randomTimes[tindex] = datetime.datetime.fromtimestamp(temptimes)
+    return randomTimes
 
 
 def check_models(model1, model2, use_cross_validation=False, op='e'):
@@ -3402,34 +3428,90 @@ def compute_frame_diff(f1, f2):
     return frameDiff
 
 def compare_frames_local(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
+    '''
+    Compare two h2o frames and make sure they are equal.  However, we do not compare uuid column at this point
+    :param f1:
+    :param f2:
+    :param prob:
+    :param tol:
+    :param returnResult:
+    :return:
+    '''
+    assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "The two frames are of different sizes."
+    typeDict = f1.types
+    frameNames = f1.names
+
+    for colInd in range(f1.ncol):
+        if (typeDict[frameNames[colInd]]==u'enum'):
+            if returnResult:
+                result = compare_frames_local_onecolumn_NA_enum(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
+                if not(result):
+                    return False;
+            else:
+                result = compare_frames_local_onecolumn_NA_enum(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
+                if not(result):
+                    return False;
+        elif (typeDict[frameNames[colInd]]==u'string'):
+            if returnResult:
+                result =  compare_frames_local_onecolumn_NA_string(f1[colInd], f2[colInd], prob=prob, returnResult=returnResult)
+                if not(result):
+                    return False
+            else:
+                compare_frames_local_onecolumn_NA_string(f1[colInd], f2[colInd], prob=prob, returnResult=returnResult)
+        elif (typeDict[frameNames[colInd]]==u'uuid'):
+            continue    # do nothing here
+        else:
+            if returnResult:
+                result = compare_frames_local_onecolumn_NA(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
+                if not(result):
+                    return False
+            else:
+                compare_frames_local_onecolumn_NA(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
+
+    if returnResult:
+        return True
+
+def compare_frames_local_svm(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
+    '''
+    compare f1 and f2 but with f2 parsed from svmlight parser.  Here, the na's should be replaced with 0.0
+
+    :param f1: normal h2oFrame
+    :param f2: h2oFrame parsed from a svmlight parser.
+    :param prob:
+    :param tol:
+    :param returnResult:
+    :return:
+    '''
+    assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "The two frames are of different sizes."
     temp1 = f1.as_data_frame(use_pandas=False)
     temp2 = f2.as_data_frame(use_pandas=False)
-    assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "The two frames are of different sizes."
-    for colInd in range(f1.ncol):
-        for rowInd in range(1,f2.nrow):
-            if (random.uniform(0,1) < prob):
-                if (math.isnan(float(temp1[rowInd][colInd]))):
-                    if returnResult:
-                        if not(math.isnan(float(temp2[rowInd][colInd]))):
-                            return False
-                    assert math.isnan(float(temp2[rowInd][colInd])), "Failed frame values check at row {2} and column {3}! " \
-                                                              "frame1 value: {0}, frame2 value: " \
-                                                              "{1}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd)
-                else:
-                    v1 = float(temp1[rowInd][colInd])
-                    v2 = float(temp2[rowInd][colInd])
-                    diff = abs(v1-v2)/max(1.0, abs(v1), abs(v2))
-                    if returnResult:
-                        if diff > tol:
-                            return False
-                    assert diff<=tol, "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                      "{1}".format(v1, v2, rowInd, colInd)
+    for rowInd in range(1, f1.nrow):
+        for colInd in range(f1.ncol):
+            if (len(temp1[rowInd][colInd]))==0: # encounter NAs
+                if returnResult:
+                    if (abs(float(temp2[rowInd][colInd]))) > tol:
+                        return False
+                assert (abs(float(temp2[rowInd][colInd]))) <= tol, \
+                    "Expected: 0.0 but received: {0} for row: {1}, col: " \
+                    "{2}".format(temp2[rowInd][colInd], rowInd, colInd)
+            else:
+                if returnResult:
+                    if abs(float(temp1[rowInd][colInd])-float(temp2[rowInd][colInd]))>tol:
+                        return False
+                assert abs(float(temp1[rowInd][colInd])-float(temp2[rowInd][colInd]))<=tol, \
+                    "Expected: {1} but received: {0} for row: {2}, col: " \
+                    "{3}".format(temp2[rowInd][colInd], temp1[rowInd][colInd], rowInd, colInd)
+
+
     if returnResult:
         return True
 
 
 # frame compare with NAs in column
-def compare_frames_local_onecolumn_NA(f1, f2, prob=0.5, tol=1e-6):
+def compare_frames_local_onecolumn_NA(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
+    if (f1.types[f1.names[0]] == u'time'):   # we have to divide by 1000 before converting back and forth between ms and time format
+        tol = 10
+
     temp1 = f1.as_data_frame(use_pandas=False)
     temp2 = f2.as_data_frame(use_pandas=False)
     assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "The two frames are of different sizes."
@@ -3437,33 +3519,28 @@ def compare_frames_local_onecolumn_NA(f1, f2, prob=0.5, tol=1e-6):
         for rowInd in range(1,f2.nrow):
             if (random.uniform(0,1) < prob):
                 if len(temp1[rowInd]) == 0 or len(temp2[rowInd]) == 0:
-                    assert len(temp1[rowInd]) == len(temp2[rowInd]), "Failed frame values check at row {2} ! " \
+                    if returnResult:
+                        if not(len(temp1[rowInd]) == len(temp2[rowInd])):
+                            return False
+                    else:
+                        assert len(temp1[rowInd]) == len(temp2[rowInd]), "Failed frame values check at row {2} ! " \
                                                                      "frame1 value: {0}, frame2 value: " \
                                                                      "{1}".format(temp1[rowInd], temp2[rowInd], rowInd)
                 else:
                     v1 = float(temp1[rowInd][colInd])
                     v2 = float(temp2[rowInd][colInd])
                     diff = abs(v1-v2)/max(1.0, abs(v1), abs(v2))
-                    assert diff<=tol, "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                      "{1}".format(v1, v2, rowInd, colInd)
-# frame compare with NAs in column
-def compare_frames_local_onecolumn_NA_enum(f1, f2, prob=0.5, tol=1e-6):
-    temp1 = f1.as_data_frame(use_pandas=False)
-    temp2 = f2.as_data_frame(use_pandas=False)
-    assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "The two frames are of different sizes."
-    for colInd in range(f1.ncol):
-        for rowInd in range(1,f2.nrow):
-            if (random.uniform(0,1) < prob):
-                if len(temp1[rowInd]) == 0 or len(temp2[rowInd]) == 0:
-                    assert len(temp1[rowInd]) == len(temp2[rowInd]), "Failed frame values check at row {2} ! " \
-                                                                     "frame1 value: {0}, frame2 value: " \
-                                                                     "{1}".format(temp1[rowInd], temp2[rowInd], rowInd)
-                else:
-                    assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                      "{1}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd)
+                    if returnResult:
+                        if (diff > tol):
+                            return False
+                    else:
+                        assert diff<=tol, "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
+                                      "{1} and the difference/max(v1,v2) is {4}.  Column type is {5}".format(v1, v2, rowInd, colInd, diff, f1.types)
+    if returnResult:
+        return True
 
 # frame compare with NAs in column
-def compare_frames_local_onecolumn_NA_string(f1, f2, prob=0.5):
+def compare_frames_local_onecolumn_NA_enum(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
     temp1 = f1.as_data_frame(use_pandas=False)
     temp2 = f2.as_data_frame(use_pandas=False)
     assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "The two frames are of different sizes."
@@ -3471,13 +3548,50 @@ def compare_frames_local_onecolumn_NA_string(f1, f2, prob=0.5):
         for rowInd in range(1,f2.nrow):
             if (random.uniform(0,1) < prob):
                 if len(temp1[rowInd]) == 0 or len(temp2[rowInd]) == 0:
-                    assert len(temp1[rowInd]) == len(temp2[rowInd]), "Failed frame values check at row {2} ! " \
+                    if returnResult:
+                        if not(len(temp1[rowInd]) == len(temp2[rowInd])):
+                            return False
+                    else:
+                        assert len(temp1[rowInd]) == len(temp2[rowInd]), "Failed frame values check at row {2} ! " \
                                                                      "frame1 value: {0}, frame2 value: " \
                                                                      "{1}".format(temp1[rowInd], temp2[rowInd], rowInd)
                 else:
-                    assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
+                    if returnResult:
+                        if not(temp1[rowInd][colInd]==temp2[rowInd][colInd]):
+                            return False
+                    else:
+                        assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
+                                      "{1}".format(temp1[rowInd][colInd], temp1[rowInd][colInd], rowInd, colInd)
+
+    if returnResult:
+        return True
+
+# frame compare with NAs in column
+def compare_frames_local_onecolumn_NA_string(f1, f2, prob=0.5, returnResult=False):
+    temp1 = f1.as_data_frame(use_pandas=False)
+    temp2 = f2.as_data_frame(use_pandas=False)
+    assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "The two frames are of different sizes."
+    for colInd in range(f1.ncol):
+        for rowInd in range(1,f2.nrow):
+            if (random.uniform(0,1) < prob):
+                if len(temp1[rowInd]) == 0 or len(temp2[rowInd]) == 0:
+                    if returnResult:
+                        if not(len(temp1[rowInd]) == len(temp2[rowInd])):
+                            return False
+                    else:
+                        assert len(temp1[rowInd]) == len(temp2[rowInd]), "Failed frame values check at row {2} ! " \
+                                                                     "frame1 value: {0}, frame2 value: " \
+                                                                     "{1}".format(temp1[rowInd], temp2[rowInd], rowInd)
+                else:
+                    if returnResult:
+                        if not(temp1[rowInd][colInd]==temp2[rowInd][colInd]):
+                            return False
+                    else:
+                        assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
                                                                          "{1}".format(temp1[rowInd][colInd], temp1[rowInd][colInd], rowInd, colInd)
 
+    if returnResult:
+        return True
 
 def build_save_model_GLM(params, x, train, respName):
     # build a model
@@ -3558,6 +3672,16 @@ def random_dataset_strings_only(nrow, ncol, seed=None):
     fractions["string_fraction"] = 1  # Right now we are dropping string columns, so no point in having them.
     fractions["binary_fraction"] = 0
     return h2o.create_frame(rows=nrow, cols=ncol, missing_fraction=0, has_response=False, seed=seed, **fractions)
+
+def random_dataset_all_types(nrow, ncol, seed=None):
+    fractions=dict()
+    fractions['real_fraction']=0.16,
+    fractions['categorical_fraction']=0.16,
+    fractions['integer_fraction']=0.16,
+    fractions['binary_fraction']=0.16,
+    fractions['time_fraction']=0.16,
+    fractions['string_fraction']=0.2
+    return h2o.create_frame(rows=nrow, cols=ncol, missing_fraction=0.1, has_response=False, seed=seed)
 
 # generate random dataset of ncolumns of enums only, copied from Pasha
 def random_dataset_enums_only(nrow, ncol, factorL=10, misFrac=0.01, randSeed=None):
@@ -3908,3 +4032,114 @@ def compare_frames_equal_names(frame1, frame2):
             compare_frames_local_onecolumn_NA_string(frame1[name1], frame2[name1], prob=1)
         else:
             compare_frames_local_onecolumn_NA(frame1[name1], frame2[name1], prob=1, tol=1e-10)
+
+def write_H2OFrame_2_SVMLight(filename, h2oFrame):
+    '''
+    The function will write a h2oFrame into svmlight format and save it to a file.  However, it only supports
+    column types of real/integer and nothing else
+    :param filename:
+    :param h2oFrame:
+    :return:
+    '''
+    fwriteFile = open(filename, 'w')
+    ncol = h2oFrame.ncol
+    nrow = h2oFrame.nrow
+    fdataframe = h2oFrame.as_data_frame(use_pandas=False)
+    for rowindex in range(1, nrow+1):
+        if len(fdataframe[rowindex][0])==0:   # special treatment for response column
+            writeWords = ""    # convert na response to 0.0
+        else:
+            writeWords = fdataframe[rowindex][0]
+
+        for colindex in range(1, ncol):
+            if not(len(fdataframe[rowindex][colindex])==0):
+                writeWords = writeWords + " "+str(colindex) + ":"+fdataframe[rowindex][colindex]
+        fwriteFile.write(writeWords)
+        fwriteFile.write('\n')
+    fwriteFile.close()
+
+def write_H2OFrame_2_ARFF(filenameWithPath, filename, h2oFrame, uuidVecs, uuidNames):
+    '''
+    This function will write a H2OFrame into arff format and save it to a text file in ARFF format.
+    :param filename:
+    :param h2oFrame:
+    :return:
+    '''
+
+    fwriteFile = open(filenameWithPath, 'w')
+    nrow = h2oFrame.nrow
+
+    # write the arff headers here
+    writeWords = "@RELATION "+filename+'\n\n'
+    fwriteFile.write(writeWords)
+
+    typesDict = h2oFrame.types
+    colnames = h2oFrame.names
+    uuidtypes = len(uuidNames)*["UUID"]
+
+    for cname in colnames:
+        writeWords = "@ATTRIBUTE "+cname
+
+        if typesDict[cname]==u'int':
+            writeWords = writeWords + " integer"
+        elif typesDict[cname]==u'time':
+            writeWords = writeWords + " date"
+        else:
+            writeWords = writeWords + " "+typesDict[cname]
+        fwriteFile.write(writeWords)
+        fwriteFile.write('\n')
+
+    for cindex in range(len(uuidNames)):
+        writeWords = "@ATTRIBUTE " +uuidNames[cindex]+" uuid"
+        fwriteFile.write(writeWords)
+        fwriteFile.write('\n')
+    fwriteFile.write("\n@DATA\n")
+
+    # write the arff body as csv
+    fdataframe = h2oFrame.as_data_frame(use_pandas=False)
+
+    for rowindex in range(1,nrow+1):
+        writeWords = ""
+        for cindex in range(h2oFrame.ncol):
+            if len(fdataframe[rowindex][cindex])>0:
+                if typesDict[colnames[cindex]]==u'time':
+                    writeWords = writeWords+\
+                                 str(datetime.datetime.fromtimestamp(float(fdataframe[rowindex][cindex])/1000.0))+","
+                elif typesDict[colnames[cindex]] in [u'enum', u'string']:
+                    writeWords=writeWords+fdataframe[rowindex][cindex]+","
+                else:
+                    writeWords=writeWords+fdataframe[rowindex][cindex]+","
+            else:
+                writeWords = writeWords + ","
+
+        # process the uuid ones
+        for cindex in range(len(uuidVecs)-1):
+            writeWords=writeWords+str(uuidVecs[cindex][rowindex-1])+","
+        writeWords=writeWords+str(uuidVecs[-1][rowindex-1])+'\n'
+        fwriteFile.write(writeWords)
+    fwriteFile.close()
+
+def checkCorrectSkips(originalFullFrame, csvfile, skipped_columns):
+    skippedFrameUF = h2o.upload_file(csvfile, skipped_columns=skipped_columns)
+    skippedFrameIF = h2o.import_file(csvfile, skipped_columns=skipped_columns)  # this two frames should be the same
+    compare_frames_local(skippedFrameUF, skippedFrameIF, prob=0.5)
+
+    skipCounter = 0
+    typeDict = originalFullFrame.types
+    frameNames = originalFullFrame.names
+    for cindex in range(len(frameNames)):
+        if cindex not in skipped_columns:
+            print("Checking column {0}...".format(cindex))
+            if typeDict[frameNames[cindex]] == u'enum':
+                compare_frames_local_onecolumn_NA_enum(originalFullFrame[cindex],
+                                                                    skippedFrameIF[skipCounter], prob=1, tol=1e-10,
+                                                                    returnResult=False)
+            elif typeDict[frameNames[cindex]] == u'string':
+                compare_frames_local_onecolumn_NA_string(originalFullFrame[cindex],
+                                                                      skippedFrameIF[skipCounter], prob=1,
+                                                                      returnResult=False)
+            else:
+                compare_frames_local_onecolumn_NA(originalFullFrame[cindex], skippedFrameIF[skipCounter],
+                                                               prob=1, tol=1e-10, returnResult=False)
+            skipCounter = skipCounter + 1
+

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+from tests import pyunit_utils
+import os
+import random
+
+
+def test_csv_parser_column_skip():
+    # generate a big frame with all datatypes and save it to csv.  Load it back with different skipped_columns settings
+    nrow = 10000
+    ncol = 100
+    seed = 12345
+    frac1 = 0.16
+    frac2 = 0.2
+    f1 = h2o.create_frame(rows=nrow, cols=ncol, real_fraction=frac1, categorical_fraction=frac1, integer_fraction=frac1,
+                          binary_fraction=frac1, time_fraction=frac1, string_fraction=frac2, missing_fraction=0.1,
+                          has_response=False, seed=seed)
+    tmpdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results"))
+    if not (os.path.isdir(tmpdir)):
+        os.mkdir(tmpdir)
+    savefilenamewithpath = os.path.join(tmpdir, 'in.csv')
+    h2o.download_csv(f1, savefilenamewithpath)
+
+    # load in whole dataset
+    skip_all = list(range(f1.ncol))
+    skip_even = list(range(0, f1.ncol, 2))
+    skip_odd = list(range(1, f1.ncol, 2))
+    skip_start_end = [0, f1.ncol - 1]
+    skip_except_last = list(range(0, f1.ncol - 2))
+    skip_except_first = list(range(1, f1.ncol))
+    temp = list(range(0, f1.ncol))
+    random.shuffle(temp)
+    skip_random = []
+    for index in range(0, f1.ncol // 2):
+        skip_random.append(temp[index])
+    skip_random.sort()
+
+    try:
+        loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns=skip_all)
+        sys.exit(1)  # should have failed here
+    except:
+        pass
+
+    try:
+        importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
+        sys.exit(1)  # should have failed here
+    except:
+        pass
+
+    # skip even columns
+    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_even)
+
+    # skip odd columns
+    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_odd)
+
+    # skip the very beginning and the very end.
+    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_start_end)
+
+    # skip all except the last column
+    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_except_last)
+
+    # skip all except the very first column
+    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_except_first)
+
+    # randomly skipped half the columns
+    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_random)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_csv_parser_column_skip)
+else:
+    test_csv_parser_column_skip()

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_csv_large.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_csv_large.R
@@ -1,0 +1,63 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Tests parsing with skipped columns
+test.parseSkippedColumns<- function() {
+  nrow <- 10000
+  ncol <- 500
+  seed <- 987654321
+  frac1 <- 0.16
+  f1 <-
+    h2o.createFrame(
+      rows = nrow,
+      cols = ncol,
+      randomize = TRUE,
+      categorical_fraction = frac1,
+      integer_fraction = frac1,
+      binary_fraction = frac1,
+      time_fraction = frac1,
+      string_fraction = frac1,
+      seed = seed,
+      missing_fraction = 0.1
+    )
+  filePath <- getwd()
+  fileName <- paste0(filePath, '/tempFrame.csv')
+  
+  h2o.downloadCSV(f1, fileName) # save generated file into csv
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- seed
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+  
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE),
+      error = function(x)
+        x
+    )
+  print(e2)
+  
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+
+  if (file.exists(fileName))
+    file.remove(fileName)
+}
+
+doTest("Test CSV Parse with skipped columns", test.parseSkippedColumns)


### PR DESCRIPTION
This PR completes part of the work for JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-5705?filter=myopenissues.

I have done the following:
1. added skipped_column support for csv parser;
2. added client interface in R and Python;
3. added R/Python tests.

The most heavy duty work is in CsvParser.java.

=======================================================================
Tips for code review:

To enable skipping columns during parse, introduced two parameters to ParseSetup.java

_skipped_columns (int[] with inputs from user listing column indices to skip)
_parse_columns_indices (int[] representing columns indices to be included in the final frame). Size of this array is number of columns in file minus number of skipped columns.
Added one parameter to parser.java
boolean[] _keepColumns with size = number of columns in file. For skipped columns indices, its value is false.

During guessSetup or when users did not specify skipped_columns, _parse_columns_indices will contain all column indices and _keepColumns will contain all True. Remember that the various parsers associated with the different parsers will be called once to attempt to parse the file with that parser type. Hence, whatever change I made MUST NOT affect this process. By setting up the _parse_columns_indices and _keepColumns the way I did will guarantee this process will run smoothly.

I have not changed anything associate with reading the input file because all the columns must be read even though not all of them will be included in the final parse file.

The major change is in method makedout in ParseDataset.java. Inside method FVecParseWriter of FVecParseWriter.java, the following parameters will have dimension equals to the parse_column_indices: _ctypes, _categoricals, _vec, _nvs.

There are special cases to setting them when they are called from gzip files.

The stage is now set for parseChunk method. Basically, we use two indices to refer to the columns. One is to index through all the columns in the input file, the other one refers only to the columns that are to be written to dout.

After parsing and during reconciliation of categorical levels, the same thing apply. We only look at column indices that are inside parse_column_indices even though the Categorical variable contains all the column indices. Only the columns that are being parsed will have non-empty hashmap representing the categorical value and integer levels.

Hope this helps, Wendy
