### PR TITLE
PUBDEV-6052: Replace `.as_matrix()` with `.values` in shared_utils.py

### DIFF
--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -174,7 +174,7 @@ def _handle_numpy_array(python_obj, header):
 
 
 def _handle_pandas_data_frame(python_obj, header):
-    data = _handle_python_lists(python_obj.as_matrix().tolist(), -1)[1]
+    data = _handle_python_lists(python_obj.values.tolist(), -1)[1]
     return list(python_obj.columns), data
 
 def _handle_python_dicts(python_obj, check_header):


### PR DESCRIPTION
`.as_matrix()` is being deprecated as documented [here](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.as_matrix.html). Use `.values` instead.