### PR TITLE
Log dir and log level Python/R parameters

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -144,8 +144,8 @@ def version_check():
 
 
 def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, username=None, password=None,
-         cookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None, enable_assertions=True,
-         max_mem_size=None, min_mem_size=None, strict_version_check=None, ignore_config=False,
+         cookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None, log_dir=None, log_level=None,
+         enable_assertions=True, max_mem_size=None, min_mem_size=None, strict_version_check=None, ignore_config=False,
          extra_classpath=None, jvm_custom_args=None, bind_to_localhost=True, **kwargs):
     """
     Attempt to connect to a local server, or if not successful start a new server and connect to it.
@@ -165,6 +165,9 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     :param start_h2o: If False, do not attempt to start an h2o server when connection to an existing one failed.
     :param nthreads: "Number of threads" option when launching a new h2o server.
     :param ice_root: Directory for temporary files for the new h2o server.
+    :param log_dir: Directory for H2O logs to be stored if a new instance is started. Ignored if connecting to an existing node.
+    :param log_level: The logger level for H2O if a new instance is started. One of TRACE,DEBUG,INFO,WARN,ERRR,FATA.
+    Default is INFO. Ignored if connecting to an existing node.
     :param enable_assertions: Enable assertions in Java for the new h2o server.
     :param max_mem_size: Maximum memory to use for the new h2o server. Integer input will be evaluated as gigabytes.  Other units can be specified by passing in a string (e.g. "160M" for 160 megabytes).
     :param min_mem_size: Minimum memory to use for the new h2o server. Integer input will be evaluated as gigabytes.  Other units can be specified by passing in a string (e.g. "160M" for 160 megabytes).
@@ -188,6 +191,9 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     assert_is_type(start_h2o, bool, None)
     assert_is_type(nthreads, int)
     assert_is_type(ice_root, str, None)
+    assert_is_type(log_dir, str, None)
+    assert_is_type(log_level, str, None)
+    assert_satisfies(log_level, log_level in [None, "TRACE", "DEBUG", "INFO", "WARN", "ERRR", "FATA"])
     assert_is_type(enable_assertions, bool)
     assert_is_type(max_mem_size, int, str, None)
     assert_is_type(min_mem_size, int, str, None)
@@ -265,7 +271,8 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
         if ip and not (ip == "localhost" or ip == "127.0.0.1"):
             raise H2OConnectionError('Can only start H2O launcher if IP address is localhost.')
         hs = H2OLocalServer.start(nthreads=nthreads, enable_assertions=enable_assertions, max_mem_size=mmax,
-                                  min_mem_size=mmin, ice_root=ice_root, port=port, name=name,
+                                  min_mem_size=mmin, ice_root=ice_root, log_dir=log_dir, log_level=log_level,
+                                  port=port, name=name,
                                   extra_classpath=extra_classpath, jvm_custom_args=jvm_custom_args,
                                   bind_to_localhost=bind_to_localhost)
         h2oconn = H2OConnection.open(server=hs, https=https, verify_ssl_certificates=not insecure,

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -265,8 +265,9 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
         if ip and not (ip == "localhost" or ip == "127.0.0.1"):
             raise H2OConnectionError('Can only start H2O launcher if IP address is localhost.')
         hs = H2OLocalServer.start(nthreads=nthreads, enable_assertions=enable_assertions, max_mem_size=mmax,
-                                  min_mem_size=mmin, ice_root=ice_root, port=port, name=name, extra_classpath=extra_classpath,
-                                  jvm_custom_args=jvm_custom_args, bind_to_localhost=bind_to_localhost)
+                                  min_mem_size=mmin, ice_root=ice_root, port=port, name=name,
+                                  extra_classpath=extra_classpath, jvm_custom_args=jvm_custom_args,
+                                  bind_to_localhost=bind_to_localhost)
         h2oconn = H2OConnection.open(server=hs, https=https, verify_ssl_certificates=not insecure,
                                      auth=auth, proxy=proxy,cookies=cookies, verbose=True)
     if check_version:

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -20,6 +20,8 @@
 #' @param max_mem_size (Optional) A \code{character} string specifying the maximum size, in bytes, of the memory allocation pool to H2O. This value must a multiple of 1024 greater than 2MB. Append the letter m or M to indicate megabytes, or g or G to indicate gigabytes.  This value is only used when R starts H2O.
 #' @param min_mem_size (Optional) A \code{character} string specifying the minimum size, in bytes, of the memory allocation pool to H2O. This value must a multiple of 1024 greater than 2MB. Append the letter m or M to indicate megabytes, or g or G to indicate gigabytes.  This value is only used when R starts H2O.
 #' @param ice_root (Optional) A directory to handle object spillage. The defaul varies by OS.
+#' @param log_dir (Optional) A directory where H2O server logs are stored. The default varies by OS.
+#' @param log_level (Optional) The level of logging of H2O server. The default is INFO.
 #' @param strict_version_check (Optional) Setting this to FALSE is unsupported and should only be done when advised by technical support.
 #' @param proxy (Optional) A \code{character} string specifying the proxy path.
 #' @param https (Optional) Set this to TRUE to use https instead of http.
@@ -59,7 +61,8 @@
 h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, startH2O = TRUE, forceDL = FALSE,
                      enable_assertions = TRUE, license = NULL, nthreads = -1,
                      max_mem_size = NULL, min_mem_size = NULL,
-                     ice_root = tempdir(), strict_version_check = TRUE, proxy = NA_character_,
+                     ice_root = tempdir(), log_dir = NA_character_, log_level = NA_character_,
+                     strict_version_check = TRUE, proxy = NA_character_,
                      https = FALSE, insecure = FALSE, username = NA_character_, password = NA_character_,
                      cookies = NA_character_, context_path = NA_character_, ignore_config = FALSE,
                      extra_classpath = NULL, jvm_custom_args = NULL,
@@ -126,6 +129,10 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
     stop("`license` must be of class character")
   if(!is.character(ice_root) || length(ice_root) != 1L || is.na(ice_root) || !nzchar(ice_root))
     stop("`ice_root` must be a non-empty character string")
+  if(!is.character(log_dir) && !nzchar(log_dir))
+    stop("`log_dir` must be a character string or NA_character_")
+  if(!is.character(log_level) && !nzchar(log_level))
+    stop("`log_level` must be a character string or NA_character_")
   if(!is.logical(strict_version_check) || length(strict_version_check) != 1L || is.na(strict_version_check))
     stop("`strict_version_check` must be TRUE or FALSE")
   if(!is.character(proxy) || !nzchar(proxy))
@@ -179,6 +186,7 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
                     max_memory = max_mem_size, min_memory = min_mem_size,
                     enable_assertions = enable_assertions, forceDL = forceDL, license = license,
                     extra_classpath = extra_classpath, ice_root = ice_root, stdout = stdout,
+                    log_dir = log_dir, log_level = log_level,
                     jvm_custom_args = jvm_custom_args, bind_to_localhost = bind_to_localhost)
 
       count <- 0L
@@ -522,7 +530,7 @@ h2o.clusterStatus <- function() {
 .h2o.startJar <- function(ip = "localhost", port = 54321, name = NULL, nthreads = -1,
                           max_memory = NULL, min_memory = NULL,
                           enable_assertions = TRUE, forceDL = FALSE, license = NULL, extra_classpath = NULL,
-                          ice_root, stdout, jvm_custom_args = NULL, bind_to_localhost) {
+                          ice_root, stdout, log_dir, log_level, jvm_custom_args = NULL, bind_to_localhost) {
   command <- .h2o.checkJava()
 
   if (! is.null(license)) {
@@ -601,6 +609,10 @@ h2o.clusterStatus <- function() {
   }
   args <- c(args, "-port", port)
   args <- c(args, "-ice_root", slashes_fixed_ice_root)
+
+  if(!is.na(log_dir)) args <- c(args, "-log_dir", log_dir)
+  if(!is.na(log_level)) args <- c(args, "-log_level", log_level)
+
   if(nthreads > 0L) args <- c(args, "-nthreads", nthreads)
   if(!is.null(license)) args <- c(args, "-license", license)
 


### PR DESCRIPTION
Adds the option to pass `log_dir` and `log_level` to both Python and R APIs during `h2o.init`. If connecting to an existing cluster/node they are skipped. No special validations performed assuming H2O-3's behaviour should take care of it all.