### PR TITLE
PUBDEV-5820: Prepare Jetty-dependent classes for isolation

### DIFF
--- a/h2o-core/src/main/java/water/AbstractHTTPD.java
+++ b/h2o-core/src/main/java/water/AbstractHTTPD.java
@@ -1,7 +1,13 @@
 package water;
 
 import org.eclipse.jetty.plus.jaas.JAASLoginService;
-import org.eclipse.jetty.security.*;
+import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.DefaultIdentityService;
+import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.IdentityService;
+import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.security.authentication.FormAuthenticator;
 import org.eclipse.jetty.server.Connector;

--- a/h2o-core/src/main/java/water/DelegatingAuthenticator.java
+++ b/h2o-core/src/main/java/water/DelegatingAuthenticator.java
@@ -11,7 +11,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * DelegatingAuthenticator dynamically switches between Form-based authentication
+ * Dynamically switches between Form-based authentication
  * and Basic Access authentication.
  * The decision is made based on user's "User-Agent". Browser clients will use Form based
  * authentication, all other clients will use basic auth.

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -10,12 +10,20 @@ import water.UDPRebooted.ShutdownTsk;
 import water.api.RequestServer;
 import water.exceptions.H2OFailException;
 import water.exceptions.H2OIllegalArgumentException;
-import water.init.*;
+import water.init.AbstractBuildVersion;
+import water.init.AbstractEmbeddedH2OConfig;
+import water.init.JarHash;
+import water.init.NetworkInit;
+import water.init.NodePersistentStorage;
 import water.nbhm.NonBlockingHashMap;
 import water.parser.DecryptionTool;
 import water.parser.ParserService;
 import water.persist.PersistManager;
-import water.util.*;
+import water.server.ServletUtils;
+import water.util.Log;
+import water.util.NetworkUtils;
+import water.util.OSUtils;
+import water.util.PrettyPrint;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -24,8 +32,23 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
-import java.net.*;
-import java.util.*;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.net.NetworkInterface;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -453,7 +476,7 @@ final public class H2O {
     parseH2OArgumentsTo(args, ARGS);
   }
 
-  static OptArgs parseH2OArgumentsTo(String[] args, OptArgs trgt) {
+  public static OptArgs parseH2OArgumentsTo(String[] args, OptArgs trgt) {
     for (int i = 0; i < args.length; i++) {
       OptString s = new OptString(args[i]);
       if (s.matches("h") || s.matches("help")) {
@@ -898,7 +921,7 @@ final public class H2O {
     sb.append(desc).append("_model_");
 
     // Append user agent string if we can figure it out.
-    String source = JettyHTTPD.getUserAgent();
+    String source = ServletUtils.getUserAgent();
     if (source != null) {
       StringBuilder ua = new StringBuilder();
 

--- a/h2o-core/src/main/java/water/JettyHTTPD.java
+++ b/h2o-core/src/main/java/water/JettyHTTPD.java
@@ -11,81 +11,25 @@ import water.api.NpsBinServlet;
 import water.api.PostFileServlet;
 import water.api.PutKeyServlet;
 import water.api.RequestServer;
-import water.api.schemas3.H2OErrorV3;
-import water.exceptions.H2OAbstractRuntimeException;
-import water.exceptions.H2OFailException;
 import water.server.RequestAuthExtension;
-import water.util.HttpResponseStatus;
-import water.util.Log;
-import water.util.StringUtils;
+import water.server.ServletUtils;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.*;
-import java.net.MalformedURLException;
-import java.net.URLDecoder;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Embedded Jetty instance inside H2O.
  * This is intended to be a singleton per H2O node.
  */
 public class JettyHTTPD extends AbstractHTTPD {
-  //------------------------------------------------------------------------------------------
-  // Thread-specific things.
-  //------------------------------------------------------------------------------------------
-
-  private static final ThreadLocal<Long> _startMillis = new ThreadLocal<>();
-  private static final ThreadLocal<Integer> _status = new ThreadLocal<>();
-
-  private static final ThreadLocal<String> _userAgent = new ThreadLocal<>();
-
-  private static void startRequestLifecycle() {
-    _startMillis.set(System.currentTimeMillis());
-    _status.set(999);
-  }
-
-  private static void setStatus(int sc) {
-    _status.set(sc);
-  }
-
-  private static int getStatus() {
-    return _status.get();
-  }
-
-  protected static long getStartMillis() {
-    return _startMillis.get();
-  }
-
-  public static void startTransaction(String userAgent) {
-    _userAgent.set(userAgent);
-  }
-
-  public static void endTransaction() {
-    _userAgent.remove();
-  }
-
-  /**
-   * @return Thread-local User-Agent for this transaction.
-   */
-  public static String getUserAgent() {
-    return _userAgent.get();
-  }
-
-  //------------------------------------------------------------------------------------------
-  //------------------------------------------------------------------------------------------
-
-  public static void setResponseStatus(HttpServletResponse response, int sc) {
-    setStatus(sc);
-    response.setStatus(sc);
-  }
-
-  public static void sendResponseError(HttpServletResponse response, int sc, String msg) throws java.io.IOException {
-    setStatus(sc);
-    response.sendError(sc, msg);
-  }
-
   //------------------------------------------------------------------------------------------
   // Object-specific things.
   //------------------------------------------------------------------------------------------
@@ -117,7 +61,6 @@ public class JettyHTTPD extends AbstractHTTPD {
     context.addServlet(PutKeyServlet.class,   "/3/PutKey.bin");
     context.addServlet(PutKeyServlet.class,   "/3/PutKey");
     context.addServlet(RequestServer.class,   "/");
-
 
     final List<Handler> extHandlers = new ArrayList<Handler>();
     extHandlers.add(new AuthenticationHandler());
@@ -154,7 +97,7 @@ public class JettyHTTPD extends AbstractHTTPD {
   public class GateHandler extends AbstractHandler {
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
-      startRequestLifecycle();
+      ServletUtils.startRequestLifecycle();
       while (!_acceptRequests) {
         try { Thread.sleep(100); }
         catch (Exception ignore) {}
@@ -170,7 +113,7 @@ public class JettyHTTPD extends AbstractHTTPD {
 
   @Override
   protected void sendUnauthorizedResponse(HttpServletResponse response, String message) throws IOException {
-    sendResponseError(response, HttpServletResponse.SC_UNAUTHORIZED, message);
+    ServletUtils.sendResponseError(response, HttpServletResponse.SC_UNAUTHORIZED, message);
   }
 
   public class LoginHandler extends HandlerWrapper {
@@ -187,7 +130,7 @@ public class JettyHTTPD extends AbstractHTTPD {
         if (isPageRequest(request))
           sendLoginForm(request, response);
         else
-          sendResponseError(response, HttpServletResponse.SC_UNAUTHORIZED, "Access denied. Please login.");
+          ServletUtils.sendResponseError(response, HttpServletResponse.SC_UNAUTHORIZED, "Access denied. Please login.");
         baseRequest.setHandled(true);
       } else {
         // not for us, invoke wrapped handler
@@ -195,7 +138,7 @@ public class JettyHTTPD extends AbstractHTTPD {
       }
     }
     private void sendLoginForm(HttpServletRequest request, HttpServletResponse response) {
-      String uri = JettyHTTPD.getDecodedUri(request);
+      String uri = ServletUtils.getDecodedUri(request);
       try {
         byte[] bytes;
         try (InputStream resource = water.init.JarHash.getResource2("/login.html")) {
@@ -207,13 +150,13 @@ public class JettyHTTPD extends AbstractHTTPD {
         }
         response.setContentType(RequestServer.MIME_HTML);
         response.setContentLength(bytes.length);
-        setResponseStatus(response, HttpServletResponse.SC_OK);
+        ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
         OutputStream os = response.getOutputStream();
         water.util.FileUtils.copyStream(new ByteArrayInputStream(bytes), os, 2048);
       } catch (Exception e) {
-        sendErrorResponse(response, e, uri);
+        ServletUtils.sendErrorResponse(response, e, uri);
       } finally {
-        logRequest("GET", request, response);
+        ServletUtils.logRequest("GET", request, response);
       }
     }
     private boolean isPageRequest(HttpServletRequest request) {
@@ -222,96 +165,6 @@ public class JettyHTTPD extends AbstractHTTPD {
     }
     private boolean isLoginTarget(String target) {
       return target.equals(_loginTarget) || target.equals(_errorTarget);
-    }
-  }
-
-  public static InputStream extractPartInputStream (HttpServletRequest request, HttpServletResponse response) throws
-      IOException {
-    String ct = request.getContentType();
-    if (! ct.startsWith("multipart/form-data")) {
-      setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
-      response.getWriter().write("Content type must be multipart/form-data");
-      return null;
-    }
-
-    String boundaryString;
-    int idx = ct.indexOf("boundary=");
-    if (idx < 0) {
-      setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
-      response.getWriter().write("Boundary missing");
-      return null;
-    }
-
-    boundaryString = ct.substring(idx + "boundary=".length());
-    byte[] boundary = StringUtils.bytesOf(boundaryString);
-
-    // Consume headers of the mime part.
-    InputStream is = request.getInputStream();
-    String line = readLine(is);
-    while ((line != null) && (line.trim().length()>0)) {
-      line = readLine(is);
-    }
-
-    return new InputStreamWrapper(is, boundary);
-  }
-
-  public static void sendErrorResponse(HttpServletResponse response, Exception e, String uri) {
-    if (e instanceof H2OFailException) {
-      H2OFailException ee = (H2OFailException) e;
-      H2OError error = ee.toH2OError(uri);
-
-      Log.fatal("Caught exception (fatal to the cluster): " + error.toString());
-      throw(H2O.fail(error.toString()));
-    }
-    else if (e instanceof H2OAbstractRuntimeException) {
-      H2OAbstractRuntimeException ee = (H2OAbstractRuntimeException) e;
-      H2OError error = ee.toH2OError(uri);
-
-      Log.warn("Caught exception: " + error.toString());
-      setResponseStatus(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-
-      // Note: don't use Schema.schema(version, error) because we have to work at bootstrap:
-      try {
-        @SuppressWarnings("unchecked")
-        String s = new H2OErrorV3().fillFromImpl(error).toJsonString();
-        response.getWriter().write(s);
-      }
-      catch (Exception ignore) {
-        ignore.printStackTrace();
-      }
-    }
-    else { // make sure that no Exception is ever thrown out from the request
-      H2OError error = new H2OError(e, uri);
-
-      // some special cases for which we return 400 because it's likely a problem with the client request:
-      if (e instanceof IllegalArgumentException)
-        error._http_status = HttpResponseStatus.BAD_REQUEST.getCode();
-      else if (e instanceof FileNotFoundException)
-        error._http_status = HttpResponseStatus.BAD_REQUEST.getCode();
-      else if (e instanceof MalformedURLException)
-        error._http_status = HttpResponseStatus.BAD_REQUEST.getCode();
-      setResponseStatus(response, error._http_status);
-
-      Log.warn("Caught exception: " + error.toString());
-
-      // Note: don't use Schema.schema(version, error) because we have to work at bootstrap:
-      try {
-        @SuppressWarnings("unchecked")
-        String s = new H2OErrorV3().fillFromImpl(error).toJsonString();
-        response.getWriter().write(s);
-      }
-      catch (Exception ignore) {
-        ignore.printStackTrace();
-      }
-    }
-  }
-
-  public static String getDecodedUri(HttpServletRequest request) {
-    try {
-      return URLDecoder.decode(request.getRequestURI(), "UTF-8");
-    }
-    catch (Exception e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -341,154 +194,4 @@ public class JettyHTTPD extends AbstractHTTPD {
 
   //--------------------------------------------------
 
-  @SuppressWarnings("unused")
-  public static void logRequest(String method, HttpServletRequest request, HttpServletResponse response) {
-    Log.httpd(method, request.getRequestURI(), getStatus(), System.currentTimeMillis() - getStartMillis());
-  }
-
-  private static String readLine(InputStream in) throws IOException {
-    StringBuilder sb = new StringBuilder();
-    byte[] mem = new byte[1024];
-    while (true) {
-      int sz = readBufOrLine(in,mem);
-      sb.append(new String(mem,0,sz));
-      if (sz < mem.length)
-        break;
-      if (mem[sz-1]=='\n')
-        break;
-    }
-    if (sb.length()==0)
-      return null;
-    String line = sb.toString();
-    if (line.endsWith("\r\n"))
-      line = line.substring(0,line.length()-2);
-    else if (line.endsWith("\n"))
-      line = line.substring(0,line.length()-1);
-    return line;
-  }
-
-  @SuppressWarnings("all")
-  private static int readBufOrLine(InputStream in, byte[] mem) throws IOException {
-    byte[] bb = new byte[1];
-    int sz = 0;
-    while (true) {
-      byte b;
-      byte b2;
-      if (sz==mem.length)
-        break;
-      try {
-        in.read(bb,0,1);
-        b = bb[0];
-        mem[sz++] = b;
-      } catch (EOFException e) {
-        break;
-      }
-      if (b == '\n')
-        break;
-      if (sz==mem.length)
-        break;
-      if (b == '\r') {
-        try {
-          in.read(bb,0,1);
-          b2 = bb[0];
-          mem[sz++] = b2;
-        } catch (EOFException e) {
-          break;
-        }
-        if (b2 == '\n')
-          break;
-      }
-    }
-    return sz;
-  }
-
-  @SuppressWarnings("all")
-  private static final class InputStreamWrapper extends InputStream {
-    static final byte[] BOUNDARY_PREFIX = { '\r', '\n', '-', '-' };
-    final InputStream _wrapped;
-    final byte[] _boundary;
-    final byte[] _lookAheadBuf;
-    int _lookAheadLen;
-
-    public InputStreamWrapper(InputStream is, byte[] boundary) {
-      _wrapped = is;
-      _boundary = Arrays.copyOf(BOUNDARY_PREFIX, BOUNDARY_PREFIX.length + boundary.length);
-      System.arraycopy(boundary, 0, _boundary, BOUNDARY_PREFIX.length, boundary.length);
-      _lookAheadBuf = new byte[_boundary.length];
-      _lookAheadLen = 0;
-    }
-
-    @Override public void close() throws IOException { _wrapped.close(); }
-    @Override public int available() throws IOException { return _wrapped.available(); }
-    @Override public long skip(long n) throws IOException { return _wrapped.skip(n); }
-    @Override public void mark(int readlimit) { _wrapped.mark(readlimit); }
-    @Override public void reset() throws IOException { _wrapped.reset(); }
-    @Override public boolean markSupported() { return _wrapped.markSupported(); }
-
-    @Override public int read() throws IOException { throw new UnsupportedOperationException(); }
-    @Override public int read(byte[] b) throws IOException { return read(b, 0, b.length); }
-    @Override public int read(byte[] b, int off, int len) throws IOException {
-      if(_lookAheadLen == -1)
-        return -1;
-      int readLen = readInternal(b, off, len);
-      if (readLen != -1) {
-        int pos = findBoundary(b, off, readLen);
-        if (pos != -1) {
-          _lookAheadLen = -1;
-          return pos - off;
-        }
-      }
-      return readLen;
-    }
-
-    private int readInternal(byte b[], int off, int len) throws IOException {
-      if (len < _lookAheadLen ) {
-        System.arraycopy(_lookAheadBuf, 0, b, off, len);
-        _lookAheadLen -= len;
-        System.arraycopy(_lookAheadBuf, len, _lookAheadBuf, 0, _lookAheadLen);
-        return len;
-      }
-
-      if (_lookAheadLen > 0) {
-        System.arraycopy(_lookAheadBuf, 0, b, off, _lookAheadLen);
-        off += _lookAheadLen;
-        len -= _lookAheadLen;
-        int r = Math.max(_wrapped.read(b, off, len), 0) + _lookAheadLen;
-        _lookAheadLen = 0;
-        return r;
-      } else {
-        return _wrapped.read(b, off, len);
-      }
-    }
-
-    private int findBoundary(byte[] b, int off, int len) throws IOException {
-      int bidx = -1; // start index of boundary
-      int idx = 0; // actual index in boundary[]
-      for(int i = off; i < off+len; i++) {
-        if (_boundary[idx] != b[i]) { // reset
-          idx = 0;
-          bidx = -1;
-        }
-        if (_boundary[idx] == b[i]) {
-          if (idx == 0) bidx = i;
-          if (++idx == _boundary.length) return bidx; // boundary found
-        }
-      }
-      if (bidx != -1) { // it seems that there is boundary but we did not match all boundary length
-        assert _lookAheadLen == 0; // There should not be not read lookahead
-        _lookAheadLen = _boundary.length - idx;
-        int readLen = _wrapped.read(_lookAheadBuf, 0, _lookAheadLen);
-        if (readLen < _boundary.length - idx) { // There is not enough data to match boundary
-          _lookAheadLen = readLen;
-          return -1;
-        }
-        for (int i = 0; i < _boundary.length - idx; i++)
-          if (_boundary[i+idx] != _lookAheadBuf[i])
-            return -1; // There is not boundary => preserve lookahead buffer
-        // Boundary found => do not care about lookAheadBuffer since all remaining data are ignored
-      }
-
-      return bidx;
-    }
-  }
 }

--- a/h2o-core/src/main/java/water/api/DatasetServlet.java
+++ b/h2o-core/src/main/java/water/api/DatasetServlet.java
@@ -1,16 +1,14 @@
 package water.api;
 
 import water.DKV;
-import water.JettyHTTPD;
 import water.fvec.Frame;
+import water.server.ServletUtils;
 import water.util.FileUtils;
 import water.util.Log;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -20,7 +18,7 @@ public class DatasetServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
-    String uri = JettyHTTPD.getDecodedUri(request);
+    String uri = ServletUtils.getDecodedUri(request);
     try {
       boolean use_hex = false;
       String f_name = request.getParameter("frame_id");
@@ -48,7 +46,7 @@ public class DatasetServlet extends HttpServlet {
         suggested_fname = suggested_fname + ".csv";
       f_name = suggested_fname;
       response.addHeader("Content-Disposition", "attachment; filename=" + f_name);
-      JettyHTTPD.setResponseStatus(response, HttpServletResponse.SC_OK);
+      ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
       OutputStream os = null;
       try {
         os = response.getOutputStream();
@@ -64,9 +62,9 @@ public class DatasetServlet extends HttpServlet {
         }
       }
     } catch (Exception e) {
-      JettyHTTPD.sendErrorResponse(response, e, uri);
+      ServletUtils.sendErrorResponse(response, e, uri);
     } finally {
-      JettyHTTPD.logRequest("GET", request, response);
+      ServletUtils.logRequest("GET", request, response);
     }
   }
 

--- a/h2o-core/src/main/java/water/api/NpsBinServlet.java
+++ b/h2o-core/src/main/java/water/api/NpsBinServlet.java
@@ -1,8 +1,8 @@
 package water.api;
 
 import water.H2O;
-import water.JettyHTTPD;
 import water.init.NodePersistentStorage;
+import water.server.ServletUtils;
 import water.util.FileUtils;
 import water.util.Log;
 
@@ -21,13 +21,13 @@ public class NpsBinServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
-    String uri = JettyHTTPD.getDecodedUri(request);
+    String uri = ServletUtils.getDecodedUri(request);
     try {
       Pattern p = Pattern.compile(".*/NodePersistentStorage.bin/([^/]+)/([^/]+)");
       Matcher m = p.matcher(uri);
       boolean b = m.matches();
       if (!b) {
-        JettyHTTPD.setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
+        ServletUtils.setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
         response.getWriter().write("Improperly formatted URI");
         return;
       }
@@ -43,7 +43,7 @@ public class NpsBinServlet extends HttpServlet {
       response.setContentType("application/octet-stream");
       response.setContentLength((int) length.get());
       response.addHeader("Content-Disposition", "attachment; filename=" + keyName + ".flow");
-      JettyHTTPD.setResponseStatus(response, HttpServletResponse.SC_OK);
+      ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
       OutputStream os = null;
       try {
         os = response.getOutputStream();
@@ -59,21 +59,21 @@ public class NpsBinServlet extends HttpServlet {
         }
       }
     } catch (Exception e) {
-      JettyHTTPD.sendErrorResponse(response, e, uri);
+      ServletUtils.sendErrorResponse(response, e, uri);
     } finally {
-      JettyHTTPD.logRequest("GET", request, response);
+      ServletUtils.logRequest("GET", request, response);
     }
   }
 
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    String uri = JettyHTTPD.getDecodedUri(request);
+    String uri = ServletUtils.getDecodedUri(request);
     try {
       Pattern p = Pattern.compile(".*NodePersistentStorage.bin/([^/]+)/([^/]+)");
       Matcher m = p.matcher(uri);
       boolean b = m.matches();
       if (!b) {
-        JettyHTTPD.setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
+        ServletUtils.setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
         response.getWriter().write("Improperly formatted URI");
         return;
       }
@@ -81,7 +81,7 @@ public class NpsBinServlet extends HttpServlet {
       String categoryName = m.group(1);
       String keyName = m.group(2);
 
-      InputStream is = JettyHTTPD.extractPartInputStream(request, response);
+      InputStream is = ServletUtils.extractPartInputStream(request, response);
       if (is == null) {
         return;
       }
@@ -96,9 +96,9 @@ public class NpsBinServlet extends HttpServlet {
       response.setContentType("application/json");
       response.getWriter().write(responsePayload);
     } catch (Exception e) {
-      JettyHTTPD.sendErrorResponse(response, e, uri);
+      ServletUtils.sendErrorResponse(response, e, uri);
     } finally {
-      JettyHTTPD.logRequest("POST", request, response);
+      ServletUtils.logRequest("POST", request, response);
     }
   }
 }

--- a/h2o-core/src/main/java/water/api/PostFileServlet.java
+++ b/h2o-core/src/main/java/water/api/PostFileServlet.java
@@ -1,8 +1,8 @@
 package water.api;
 
-import water.JettyHTTPD;
 import water.Key;
 import water.fvec.UploadFileVec;
+import water.server.ServletUtils;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -15,7 +15,7 @@ public class PostFileServlet extends HttpServlet {
 
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    String uri = JettyHTTPD.getDecodedUri(request);
+    String uri = ServletUtils.getDecodedUri(request);
 
     try {
       String destination_frame = request.getParameter("destination_frame");
@@ -31,7 +31,7 @@ public class PostFileServlet extends HttpServlet {
       // JSON Payload returned is:
       //     { "destination_frame": "key_name", "total_bytes": nnn }
       //
-      InputStream is = JettyHTTPD.extractPartInputStream(request, response);
+      InputStream is = ServletUtils.extractPartInputStream(request, response);
       if (is == null) {
         return;
       }
@@ -45,9 +45,9 @@ public class PostFileServlet extends HttpServlet {
       response.setContentType("application/json");
       response.getWriter().write(responsePayload);
     } catch (Exception e) {
-      JettyHTTPD.sendErrorResponse(response, e, uri);
+      ServletUtils.sendErrorResponse(response, e, uri);
     } finally {
-      JettyHTTPD.logRequest("POST", request, response);
+      ServletUtils.logRequest("POST", request, response);
     }
   }
 }

--- a/h2o-core/src/main/java/water/api/PutKeyServlet.java
+++ b/h2o-core/src/main/java/water/api/PutKeyServlet.java
@@ -2,9 +2,9 @@ package water.api;
 
 import org.apache.commons.io.IOUtils;
 import water.DKV;
-import water.JettyHTTPD;
 import water.Key;
 import water.Value;
+import water.server.ServletUtils;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -24,7 +24,7 @@ public class PutKeyServlet extends HttpServlet {
 
   @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-    String uri = JettyHTTPD.getDecodedUri(request);
+    String uri = ServletUtils.getDecodedUri(request);
     
     try {
       String destKey = paramDestinationKey(request, response);
@@ -33,7 +33,7 @@ public class PutKeyServlet extends HttpServlet {
         return;
       }
 
-      InputStream is = JettyHTTPD.extractPartInputStream(request, response);
+      InputStream is = ServletUtils.extractPartInputStream(request, response);
       if (is == null) {
         return;
       }
@@ -57,9 +57,9 @@ public class PutKeyServlet extends HttpServlet {
       response.setContentType("application/json");
       response.getWriter().write(responsePayload);
     } catch (Exception e) {
-      JettyHTTPD.sendErrorResponse(response, e, uri);
+      ServletUtils.sendErrorResponse(response, e, uri);
     } finally {
-      JettyHTTPD.logRequest("POST", request, response);
+      ServletUtils.logRequest("POST", request, response);
     }
   }
 
@@ -75,7 +75,7 @@ public class PutKeyServlet extends HttpServlet {
 
   private boolean validate(String destKey, Boolean overwrite, HttpServletResponse response) throws IOException {
     if (destKey == null) {
-      JettyHTTPD.sendResponseError(response, HttpServletResponse.SC_BAD_REQUEST, "The field 'destination_frame` is compulsory!");
+      ServletUtils.sendResponseError(response, HttpServletResponse.SC_BAD_REQUEST, "The field 'destination_frame` is compulsory!");
       return false;
     }
     return true;

--- a/h2o-core/src/main/java/water/api/PutKeyServlet.java
+++ b/h2o-core/src/main/java/water/api/PutKeyServlet.java
@@ -1,21 +1,16 @@
 package water.api;
 
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jetty.server.Response;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.UUID;
-
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import water.DKV;
 import water.JettyHTTPD;
 import water.Key;
 import water.Value;
-import water.fvec.UploadFileVec;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Upload any value to K/V store.
@@ -80,7 +75,7 @@ public class PutKeyServlet extends HttpServlet {
 
   private boolean validate(String destKey, Boolean overwrite, HttpServletResponse response) throws IOException {
     if (destKey == null) {
-      JettyHTTPD.sendResponseError(response, Response.SC_BAD_REQUEST, "The field 'destination_frame` is compulsory!");
+      JettyHTTPD.sendResponseError(response, HttpServletResponse.SC_BAD_REQUEST, "The field 'destination_frame` is compulsory!");
       return false;
     }
     return true;

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -7,12 +7,29 @@ import water.util.Log;
 import water.util.NetworkUtils;
 import water.util.StringUtils;
 
-import java.io.*;
-import java.net.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.DatagramPacket;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MulticastSocket;
+import java.net.NetworkInterface;
+import java.net.ServerSocket;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.security.GeneralSecurityException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Data structure for holding network info specified by the user on the command line.

--- a/h2o-core/src/main/java/water/server/ServletUtils.java
+++ b/h2o-core/src/main/java/water/server/ServletUtils.java
@@ -1,0 +1,342 @@
+package water.server;
+
+import water.H2O;
+import water.H2OError;
+import water.api.schemas3.H2OErrorV3;
+import water.exceptions.H2OAbstractRuntimeException;
+import water.exceptions.H2OFailException;
+import water.util.HttpResponseStatus;
+import water.util.Log;
+import water.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+
+/**
+ * Utilities supporting HTTP server-side functionality, without depending on specific version of Jetty, or on Jetty at all.
+ */
+public class ServletUtils {
+  private static final ThreadLocal<Long> _startMillis = new ThreadLocal<>();
+  private static final ThreadLocal<Integer> _status = new ThreadLocal<>();
+  public static final ThreadLocal<String> _userAgent = new ThreadLocal<>();
+
+  private ServletUtils() {
+    // not instantiable
+  }
+
+  /**
+   * Called from {@link water.JettyHTTPD}.
+   */
+  public static void startRequestLifecycle() {
+    _startMillis.set(System.currentTimeMillis());
+    _status.set(999);
+  }
+
+  private static void setStatus(int sc) {
+    _status.set(sc);
+  }
+
+  private static int getStatus() {
+    return _status.get();
+  }
+
+  protected static long getStartMillis() {
+    return _startMillis.get();
+  }
+
+  public static void startTransaction(String userAgent) {
+    _userAgent.set(userAgent);
+  }
+
+  public static void endTransaction() {
+    _userAgent.remove();
+  }
+
+  /**
+   * @return Thread-local User-Agent for this transaction.
+   */
+  public static String getUserAgent() {
+    return _userAgent.get();
+  }
+
+  public static void setResponseStatus(HttpServletResponse response, int sc) {
+    setStatus(sc);
+    response.setStatus(sc);
+  }
+
+  public static void sendResponseError(HttpServletResponse response, int sc, String msg) throws java.io.IOException {
+    setStatus(sc);
+    response.sendError(sc, msg);
+  }
+
+  public static InputStream extractPartInputStream (HttpServletRequest request, HttpServletResponse response) throws
+      IOException {
+    String ct = request.getContentType();
+    if (! ct.startsWith("multipart/form-data")) {
+      setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
+      response.getWriter().write("Content type must be multipart/form-data");
+      return null;
+    }
+
+    String boundaryString;
+    int idx = ct.indexOf("boundary=");
+    if (idx < 0) {
+      setResponseStatus(response, HttpServletResponse.SC_BAD_REQUEST);
+      response.getWriter().write("Boundary missing");
+      return null;
+    }
+
+    boundaryString = ct.substring(idx + "boundary=".length());
+    byte[] boundary = StringUtils.bytesOf(boundaryString);
+
+    // Consume headers of the mime part.
+    InputStream is = request.getInputStream();
+    String line = readLine(is);
+    while ((line != null) && (line.trim().length()>0)) {
+      line = readLine(is);
+    }
+
+    return new InputStreamWrapper(is, boundary);
+  }
+
+  public static void sendErrorResponse(HttpServletResponse response, Exception e, String uri) {
+    if (e instanceof H2OFailException) {
+      H2OFailException ee = (H2OFailException) e;
+      H2OError error = ee.toH2OError(uri);
+
+      Log.fatal("Caught exception (fatal to the cluster): " + error.toString());
+      throw(H2O.fail(error.toString()));
+    }
+    else if (e instanceof H2OAbstractRuntimeException) {
+      H2OAbstractRuntimeException ee = (H2OAbstractRuntimeException) e;
+      H2OError error = ee.toH2OError(uri);
+
+      Log.warn("Caught exception: " + error.toString());
+      setResponseStatus(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+      // Note: don't use Schema.schema(version, error) because we have to work at bootstrap:
+      try {
+        @SuppressWarnings("unchecked")
+        String s = new H2OErrorV3().fillFromImpl(error).toJsonString();
+        response.getWriter().write(s);
+      }
+      catch (Exception ignore) {
+        ignore.printStackTrace();
+      }
+    }
+    else { // make sure that no Exception is ever thrown out from the request
+      H2OError error = new H2OError(e, uri);
+
+      // some special cases for which we return 400 because it's likely a problem with the client request:
+      if (e instanceof IllegalArgumentException)
+        error._http_status = HttpResponseStatus.BAD_REQUEST.getCode();
+      else if (e instanceof FileNotFoundException)
+        error._http_status = HttpResponseStatus.BAD_REQUEST.getCode();
+      else if (e instanceof MalformedURLException)
+        error._http_status = HttpResponseStatus.BAD_REQUEST.getCode();
+      setResponseStatus(response, error._http_status);
+
+      Log.warn("Caught exception: " + error.toString());
+
+      // Note: don't use Schema.schema(version, error) because we have to work at bootstrap:
+      try {
+        @SuppressWarnings("unchecked")
+        String s = new H2OErrorV3().fillFromImpl(error).toJsonString();
+        response.getWriter().write(s);
+      }
+      catch (Exception ignore) {
+        ignore.printStackTrace();
+      }
+    }
+  }
+
+  public static String getDecodedUri(HttpServletRequest request) {
+    try {
+      return URLDecoder.decode(request.getRequestURI(), "UTF-8");
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static boolean isXhrRequest(final HttpServletRequest request) {
+    final String requestedWithHeader = request.getHeader("X-Requested-With");
+    return "XMLHttpRequest".equals(requestedWithHeader);
+  }
+
+  public static void setCommonResponseHttpHeaders(HttpServletResponse response, final boolean xhrRequest) {
+    if (xhrRequest) {
+      response.setHeader("Cache-Control", "no-cache");
+    }
+    response.setHeader("X-h2o-build-project-version", H2O.ABV.projectVersion());
+    response.setHeader("X-h2o-rest-api-version-max", Integer.toString(water.api.RequestServer.H2O_REST_API_VERSION));
+    response.setHeader("X-h2o-cluster-id", Long.toString(H2O.CLUSTER_ID));
+    response.setHeader("X-h2o-cluster-good", Boolean.toString(H2O.CLOUD.healthy()));
+    response.setHeader("X-h2o-context-path", sanatizeContextPath(H2O.ARGS.context_path));
+  }
+
+  private static String sanatizeContextPath(String context_path) {
+    if(null == context_path || context_path.isEmpty()) {
+      return "/";
+    }
+    return context_path + "/";
+  }
+
+  @SuppressWarnings("unused")
+  public static void logRequest(String method, HttpServletRequest request, HttpServletResponse response) {
+    Log.httpd(method, request.getRequestURI(), getStatus(), System.currentTimeMillis() - getStartMillis());
+  }
+
+  private static String readLine(InputStream in) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    byte[] mem = new byte[1024];
+    while (true) {
+      int sz = readBufOrLine(in,mem);
+      sb.append(new String(mem,0,sz));
+      if (sz < mem.length)
+        break;
+      if (mem[sz-1]=='\n')
+        break;
+    }
+    if (sb.length()==0)
+      return null;
+    String line = sb.toString();
+    if (line.endsWith("\r\n"))
+      line = line.substring(0,line.length()-2);
+    else if (line.endsWith("\n"))
+      line = line.substring(0,line.length()-1);
+    return line;
+  }
+
+  @SuppressWarnings("all")
+  private static int readBufOrLine(InputStream in, byte[] mem) throws IOException {
+    byte[] bb = new byte[1];
+    int sz = 0;
+    while (true) {
+      byte b;
+      byte b2;
+      if (sz==mem.length)
+        break;
+      try {
+        in.read(bb,0,1);
+        b = bb[0];
+        mem[sz++] = b;
+      } catch (EOFException e) {
+        break;
+      }
+      if (b == '\n')
+        break;
+      if (sz==mem.length)
+        break;
+      if (b == '\r') {
+        try {
+          in.read(bb,0,1);
+          b2 = bb[0];
+          mem[sz++] = b2;
+        } catch (EOFException e) {
+          break;
+        }
+        if (b2 == '\n')
+          break;
+      }
+    }
+    return sz;
+  }
+
+  @SuppressWarnings("all")
+  private static final class InputStreamWrapper extends InputStream {
+    static final byte[] BOUNDARY_PREFIX = { '\r', '\n', '-', '-' };
+    final InputStream _wrapped;
+    final byte[] _boundary;
+    final byte[] _lookAheadBuf;
+    int _lookAheadLen;
+
+    public InputStreamWrapper(InputStream is, byte[] boundary) {
+      _wrapped = is;
+      _boundary = Arrays.copyOf(BOUNDARY_PREFIX, BOUNDARY_PREFIX.length + boundary.length);
+      System.arraycopy(boundary, 0, _boundary, BOUNDARY_PREFIX.length, boundary.length);
+      _lookAheadBuf = new byte[_boundary.length];
+      _lookAheadLen = 0;
+    }
+
+    @Override public void close() throws IOException { _wrapped.close(); }
+    @Override public int available() throws IOException { return _wrapped.available(); }
+    @Override public long skip(long n) throws IOException { return _wrapped.skip(n); }
+    @Override public void mark(int readlimit) { _wrapped.mark(readlimit); }
+    @Override public void reset() throws IOException { _wrapped.reset(); }
+    @Override public boolean markSupported() { return _wrapped.markSupported(); }
+
+    @Override public int read() throws IOException { throw new UnsupportedOperationException(); }
+    @Override public int read(byte[] b) throws IOException { return read(b, 0, b.length); }
+    @Override public int read(byte[] b, int off, int len) throws IOException {
+      if(_lookAheadLen == -1)
+        return -1;
+      int readLen = readInternal(b, off, len);
+      if (readLen != -1) {
+        int pos = findBoundary(b, off, readLen);
+        if (pos != -1) {
+          _lookAheadLen = -1;
+          return pos - off;
+        }
+      }
+      return readLen;
+    }
+
+    private int readInternal(byte b[], int off, int len) throws IOException {
+      if (len < _lookAheadLen ) {
+        System.arraycopy(_lookAheadBuf, 0, b, off, len);
+        _lookAheadLen -= len;
+        System.arraycopy(_lookAheadBuf, len, _lookAheadBuf, 0, _lookAheadLen);
+        return len;
+      }
+
+      if (_lookAheadLen > 0) {
+        System.arraycopy(_lookAheadBuf, 0, b, off, _lookAheadLen);
+        off += _lookAheadLen;
+        len -= _lookAheadLen;
+        int r = Math.max(_wrapped.read(b, off, len), 0) + _lookAheadLen;
+        _lookAheadLen = 0;
+        return r;
+      } else {
+        return _wrapped.read(b, off, len);
+      }
+    }
+
+    private int findBoundary(byte[] b, int off, int len) throws IOException {
+      int bidx = -1; // start index of boundary
+      int idx = 0; // actual index in boundary[]
+      for(int i = off; i < off+len; i++) {
+        if (_boundary[idx] != b[i]) { // reset
+          idx = 0;
+          bidx = -1;
+        }
+        if (_boundary[idx] == b[i]) {
+          if (idx == 0) bidx = i;
+          if (++idx == _boundary.length) return bidx; // boundary found
+        }
+      }
+      if (bidx != -1) { // it seems that there is boundary but we did not match all boundary length
+        assert _lookAheadLen == 0; // There should not be not read lookahead
+        _lookAheadLen = _boundary.length - idx;
+        int readLen = _wrapped.read(_lookAheadBuf, 0, _lookAheadLen);
+        if (readLen < _boundary.length - idx) { // There is not enough data to match boundary
+          _lookAheadLen = readLen;
+          return -1;
+        }
+        for (int i = 0; i < _boundary.length - idx; i++)
+          if (_boundary[i+idx] != _lookAheadBuf[i])
+            return -1; // There is not boundary => preserve lookahead buffer
+        // Boundary found => do not care about lookAheadBuffer since all remaining data are ignored
+      }
+
+      return bidx;
+    }
+  }
+}

--- a/h2o-core/src/main/java/water/util/FileUtils.java
+++ b/h2o-core/src/main/java/water/util/FileUtils.java
@@ -1,10 +1,13 @@
 package water.util;
 
-import org.eclipse.jetty.io.EofException;
 import water.Key;
-import water.fvec.NFSFileVec;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 
 /**
@@ -32,7 +35,7 @@ public class FileUtils {
         os.write(bytes, 0, count);
       }
     }
-    catch(EofException eofe) {
+    catch(EOFException eofe) {
       // no problem
     }
     catch(Exception ex) {

--- a/h2o-core/src/main/java/water/util/JStackCollectorTask.java
+++ b/h2o-core/src/main/java/water/util/JStackCollectorTask.java
@@ -1,9 +1,13 @@
 package water.util;
 
-import java.util.*;
-import java.util.Map.Entry;
+import water.H2O;
+import water.Iced;
+import water.MRTask;
 
-import water.*;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 
 public class JStackCollectorTask extends MRTask<JStackCollectorTask> {
   JStackCollectorTask() { super(H2O.MIN_HI_PRIORITY); }
@@ -60,7 +64,7 @@ public class JStackCollectorTask extends MRTask<JStackCollectorTask> {
   // bruteforce search for H2O Servlet, don't call until other obvious cases were filtered out
   private int isH2OHTTPRequestThread(StackTraceElement [] elms){
     for(int i = 0; i < elms.length; ++i)
-      if(elms[i].getClassName().equals("water.JettyHTTPD$H2oDefaultServlet"))
+      if(elms[i].getClassName().equals("....JettyHTTPD$H2oDefaultServlet")) //TODO FIXME! No such class(H2oDefaultServlet) exists there now! Use class comparison if another one took the role.
         return i;
     return elms.length;
   }

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
@@ -1,5 +1,6 @@
 package water;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
@@ -10,18 +11,15 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.ProxyServlet;
 import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.security.Credential;
+import water.network.SecurityUtils;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.io.IOUtils;
-import java.io.IOException;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
-
-import water.network.SecurityUtils;
 
 public class JettyProxy extends AbstractHTTPD {
 

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/ProxyStarter.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/ProxyStarter.java
@@ -1,14 +1,12 @@
 package water;
 
 import water.init.HostnameGuesser;
-import water.init.NetworkInit;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
-import java.security.UnrecoverableKeyException;
 
 public class ProxyStarter {
 


### PR DESCRIPTION
This is part of the effort to isolate support for Jetty 8 and add support for other versions, namely Jetty 9.

In this step, the generic code (= code actually not dependent on Jetty library) is moved to a separate class `ServletUtils`, mostly from class `JettyHTTPD`. The rest of changes is basically fixing references.

The reason is, that isolation of Jetty 8 which originally included this (see #2976) causes mysterious errors in `testMultiNode.sh`. So this is an attempt to make even smaller step, and get some more confidence that the changes are harmless.

