### PR TITLE
Eliminate generating another extra jar which is not used for each h2o-hadoop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     //noinspection GroovyAssignabilityCheck
     dependencies {
         classpath 'org.ow2.asm:asm:5.1'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.2'
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
         classpath 'com.github.townsfolk:gradle-release:1.2'
         classpath 'com.adaptc.gradle:nexus-workflow:0.6'

--- a/h2o-hadoop/assemblyjar.gradle
+++ b/h2o-hadoop/assemblyjar.gradle
@@ -96,7 +96,7 @@ artifacts {
 
 // We just need Shadow Jar
 jar {
-enabled = false
+  enabled = false
 }
 
 build.dependsOn shadowJar

--- a/h2o-hadoop/assemblyjar.gradle
+++ b/h2o-hadoop/assemblyjar.gradle
@@ -94,4 +94,9 @@ artifacts {
   archives shadowJar
 }
 
-jar.finalizedBy shadowJar
+// We just need Shadow Jar
+jar {
+enabled = false
+}
+
+build.dependsOn shadowJar

--- a/settings.gradle
+++ b/settings.gradle
@@ -85,7 +85,6 @@ if (System.getProperty("user.name").equals("jenkins")
   // Include selected/all Hadoop targets
   if (System.getenv("BUILD_HADOOP") != "false") {
     targets.each { name ->
-      include "h2o-hadoop:h2o-${name}"
       include "h2o-hadoop:h2o-${name}-assembly"
     }
   }


### PR DESCRIPTION
We use just the shadow JAR. The `jar` provided by `java` plugin is generated and never used. Less artifacts and should also speed the build a bit