### PR TITLE
PUBDEV-5820: extracted class Credentials out of JettyProxy

### DIFF
--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   compile "gov.nist.math:jama:1.0.3"
   compile 'org.javassist:javassist:3.23.1-GA'
   compile "org.apache.commons:commons-math3:3.3"
+  compile "commons-codec:commons-codec:1.9"
   compile "commons-io:commons-io:2.4"
   compile "org.eclipse.jetty.aggregate:jetty-servlet:8.1.17.v20150415"
   compile "org.eclipse.jetty:jetty-plus:8.1.17.v20150415"

--- a/h2o-core/src/main/java/water/server/Credentials.java
+++ b/h2o-core/src/main/java/water/server/Credentials.java
@@ -1,0 +1,102 @@
+package water.server;
+
+import org.apache.commons.codec.binary.Base64;
+import water.network.SecurityUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * Representation of the User-Password pair
+ */
+public class Credentials {
+  private static final int GEN_PASSWORD_LENGTH = 16;
+
+  private final String _user;
+  private final String _password;
+
+  private Credentials(String _user, String _password) {
+    this._user = _user;
+    this._password = _password;
+  }
+
+  public String toBasicAuth() {
+    return "Basic " + base64EncodeToString(_user + ":" + _password);
+  }
+
+  public String toHashFileEntry() {
+    return _user + ": " + credentialMD5digest(_password) + "\n";
+  }
+
+  public String toDebugString() {
+    return "Credentials[_user='" + _user + "', _password='" + _password + "']";
+  }
+
+  public static Credentials make(String user, String password) {
+    return new Credentials(user, password);
+  }
+
+  public static Credentials make(String user) {
+    return make(user, SecurityUtils.passwordGenerator(GEN_PASSWORD_LENGTH));
+  }
+
+  /**
+   * This replaces Jetty's B64Code.encode().
+   */
+  private static String base64EncodeToString(String s) {
+    final byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
+    return Base64.encodeBase64String(bytes);
+  }
+
+  // following part is copied out of Jetty's class org.eclipse.jetty.util.security.Credential$MD5, because we cannot depend on the library
+
+  private static final String __TYPE = "MD5:";
+  private static final Object __md5Lock = new Object();
+
+  private static MessageDigest __md;
+
+  /**
+   * This replaces Jetty's Credential.MD5.digest().
+   */
+  private static String credentialMD5digest(String password) {
+    try {
+      byte[] digest;
+      synchronized (__md5Lock) {
+        if (__md == null) {
+          try {
+            __md = MessageDigest.getInstance("MD5");
+          } catch (Exception e) {
+            throw new IllegalStateException(e);
+          }
+        }
+
+        __md.reset();
+        __md.update(password.getBytes(StandardCharsets.ISO_8859_1));
+        digest = __md.digest();
+      }
+
+      return __TYPE + toString(digest, 16);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static String toString(byte[] bytes, int base)
+  {
+    StringBuilder buf = new StringBuilder();
+    for (byte b : bytes)
+    {
+      int bi=0xff&b;
+      int c='0'+(bi/base)%base;
+      if (c>'9')
+        c= 'a'+(c-'0'-10);
+      buf.append((char)c);
+      c='0'+bi%base;
+      if (c>'9')
+        c= 'a'+(c-'0'-10);
+      buf.append((char)c);
+    }
+    return buf.toString();
+  }
+
+}

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/JettyProxy.java
@@ -9,9 +9,7 @@ import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.ProxyServlet;
-import org.eclipse.jetty.util.B64Code;
-import org.eclipse.jetty.util.security.Credential;
-import water.network.SecurityUtils;
+import water.server.Credentials;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -73,41 +71,6 @@ public class JettyProxy extends AbstractHTTPD {
     @Override
     protected void customizeExchange(HttpExchange exchange, HttpServletRequest request) {
       exchange.setRequestHeader("Authorization", _basicAuth);
-    }
-  }
-
-  /**
-   * Representation of the User-Password pair
-   */
-  public static class Credentials {
-    private static final int GEN_PASSWORD_LENGTH = 16;
-
-    private final String _user;
-    private final String _password;
-
-    private Credentials(String _user, String _password) {
-      this._user = _user;
-      this._password = _password;
-    }
-
-    public String toBasicAuth() {
-      return "Basic " + B64Code.encode(_user + ":" + _password);
-    }
-
-    public String toHashFileEntry() {
-      return _user + ": " + Credential.MD5.digest(_password) + "\n";
-    }
-
-    public String toDebugString() {
-      return "Credentials[_user='" + _user + "', _password='" + _password + "']";
-    }
-
-    public static Credentials make(String user, String password) {
-      return new Credentials(user, password);
-    }
-
-    public static Credentials make(String user) {
-      return make(user, SecurityUtils.passwordGenerator(GEN_PASSWORD_LENGTH));
     }
   }
 

--- a/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/ProxyStarter.java
+++ b/h2o-hadoop/h2o-mapreduce-generic/src/main/java/water/ProxyStarter.java
@@ -1,6 +1,7 @@
 package water;
 
 import water.init.HostnameGuesser;
+import water.server.Credentials;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -10,7 +11,7 @@ import java.security.GeneralSecurityException;
 
 public class ProxyStarter {
 
-  public static String start(String[] args, JettyProxy.Credentials credentials, String proxyTo,
+  public static String start(String[] args, Credentials credentials, String proxyTo,
                              boolean useHostname) {
     if (! proxyTo.endsWith("/"))
       proxyTo = proxyTo + "/";
@@ -39,7 +40,7 @@ public class ProxyStarter {
     return hostname;
   }
 
-  private static JettyProxy initializeProxy(H2O.BaseArgs args, JettyProxy.Credentials credentials, String proxyTo) {
+  private static JettyProxy initializeProxy(H2O.BaseArgs args, Credentials credentials, String proxyTo) {
     int proxyPort = args.port == 0 ? args.baseport : args.port;
 
     JettyProxy proxy = new JettyProxy(args, credentials, proxyTo);
@@ -91,7 +92,7 @@ public class ProxyStarter {
 
   // just for local testing
   public static void main(String[] args) {
-    JettyProxy.Credentials cred = JettyProxy.Credentials.make(System.getProperty("user.name"), "Heslo123");
+    Credentials cred = Credentials.make(System.getProperty("user.name"), "Heslo123");
     String url = start(args, cred, "https://localhost:54321/", false);
     System.out.println("Proxy started on " + url + " " + cred.toDebugString());
   }


### PR DESCRIPTION
It will later be shared by multiple implementations of the `H2OServletContainerFacade`, i.e. by Jetty 8 and Jetty 9 support.

This is yet another independent piece of the PUBDEV-5820 task, helping to keep the [remaining part]( https://github.com/h2oai/h2o-3/pull/2976) of Jetty 8 isolation change as small as possible.