### PR TITLE
PUBDEV-5705: add skip column support to ARFF parser.

### DIFF
--- a/h2o-core/src/test/java/water/parser/ParseFolderTest.java
+++ b/h2o-core/src/test/java/water/parser/ParseFolderTest.java
@@ -1,13 +1,16 @@
 package water.parser;
 
-import java.io.File;
-import org.junit.*;
-
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import water.Key;
+import water.Scope;
 import water.TestUtil;
 import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.util.FileUtils;
+
+import java.io.File;
 
 public class ParseFolderTest extends TestUtil {
   @BeforeClass static public void setup() { stall_till_cloudsize(5); }
@@ -21,6 +24,45 @@ public class ParseFolderTest extends TestUtil {
     } finally {
       if( k1 != null ) k1.delete();
       if( k2 != null ) k2.delete();
+    }
+  }
+
+  // test skipped some columns
+  @Test public void testFolderSkipColumnsSome() {
+    Scope.enter();
+    Frame k1 = null, k2 = null, k3=null, k4=null;
+    int[] skippedColumns = new int[] {0,1};
+
+    try {
+      k1 = parse_test_file  ("smalldata/junit/parse_folder_gold.csv");
+      k2 = parse_test_folder("smalldata/junit/parse_folder" );
+      Scope.track(k1,k2);
+      Assert.assertTrue("parsed values do not match!", TestUtil.isBitIdentical(k1,k2));
+
+      k3 = parse_test_file  ("smalldata/junit/parse_folder_gold.csv", skippedColumns);
+      k4 = parse_test_folder("smalldata/junit/parse_folder", skippedColumns);
+      Scope.track(k3,k4);
+      Assert.assertTrue("parsed values do not match!", TestUtil.isBitIdentical(k3,k4));
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
+  // test skipped some columns
+  @Test public void testFolderSkipColumnsAll() {
+    Scope.enter();
+    Frame k1 = null;
+    int[] skippedColumns = new int[] {0,1,2,3,4,5,6,7,8};
+
+    try {
+      k1 = parse_test_folder("smalldata/junit/parse_folder", skippedColumns);
+      Assert.assertTrue("Error:  Should have thrown an exception but did not!", 1 == 2);
+    } catch (Exception ex) {
+      System.out.println(ex);
+    } finally {
+      Scope.exit();
     }
   }
 

--- a/h2o-core/src/test/java/water/parser/ParserTestARFF.java
+++ b/h2o-core/src/test/java/water/parser/ParserTestARFF.java
@@ -4,20 +4,17 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import water.DKV;
-import water.H2O;
-import water.Key;
-import water.TestUtil;
+import water.*;
 import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.fvec.Vec;
-
-import static water.parser.ParserTest.makeByteVec;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+
+import static water.parser.ParserTest.makeByteVec;
 
 public class ParserTestARFF extends TestUtil {
   @BeforeClass static public void setup() { stall_till_cloudsize(1); }
@@ -136,6 +133,46 @@ public class ParserTestARFF extends TestUtil {
     } finally {
       if( k1 != null ) k1.delete();
       if( k2 != null ) k2.delete();
+    }
+  }
+
+  // test some skipped_columns
+  @Test public void testSimpleSkippedColumns() {
+    Scope.enter();
+    Frame k1 = null, k2 = null, k3=null, k4=null;
+    try {
+      int[] skipped_columns = new int[] {0,2};
+      k2 = parse_test_file("smalldata/junit/arff/iris.arff");
+      k3 = parse_test_file("smalldata/junit/arff/iris.arff", skipped_columns);
+      k4 = parse_test_file("smalldata/junit/iris.csv", skipped_columns);
+      k1 = parse_test_file("smalldata/junit/iris.csv");
+      Assert.assertTrue("parsed values do not match!", TestUtil.isBitIdentical(k1, k2));
+      Assert.assertTrue("parsed values do not match!", TestUtil.isBitIdentical(k3, k4));
+      Assert.assertTrue("parsed values do not match!", !(TestUtil.isBitIdentical(k1, k4)));
+      Assert.assertTrue("column names do not match!", Arrays.equals(k2.names(), k1.names()));
+      Scope.track(k1, k2, k3, k4);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test all skipped_columns
+  @Test public void testSimpleSkippedColumnsAll() {
+    Scope.enter();
+    Frame k1 = null, k2 = null;
+    try {
+      k2 = parse_test_file("smalldata/junit/arff/iris.arff");
+      Scope.track(k2);
+      int[] skipped_columns = new int[k2.numCols()];
+      for (int cindex=0; cindex<k2.numCols(); cindex++)
+        skipped_columns[cindex]=cindex;
+      k1 = parse_test_file("smalldata/junit/iris.csv", skipped_columns);
+      Assert.assertTrue("Exception should have been thrown!", 1 == 2);
+      Assert.assertTrue("parsed values do not match!", TestUtil.isBitIdentical(k1, k2));
+    } catch(Exception ex) {
+      System.out.println(ex);
+    } finally {
+      Scope.exit();
     }
   }
 

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -533,10 +533,12 @@ def parse_setup(raw_frames, destination_frame=None, header=0, separator=None, co
     :param header: -1 means the first line is data, 0 means guess, 1 means first line is header.
     :param separator: The field separator character. Values on each line of the file are separated by
         this character. If not provided, the parser will automatically detect the separator.
-    :param column_names: A list of column names for the file.
+    :param column_names: A list of column names for the file. If skipped_columns are specified, only list column names
+         of columns that are not skipped.
     :param column_types: A list of types or a dictionary of column names to types to specify whether columns
         should be forced to a certain type upon import parsing. If a list, the types for elements that are
-        one will be guessed. The possible types a column may have are:
+        one will be guessed. If skipped_columns are specified, only list column types of columns that are not skipped.
+        The possible types a column may have are:
 
         - "unknown" - this will force the column to be parsed as all NA
         - "uuid"    - the values in the column must be true UUID or will be parsed as NA

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -4143,3 +4143,24 @@ def checkCorrectSkips(originalFullFrame, csvfile, skipped_columns):
                                                                prob=1, tol=1e-10, returnResult=False)
             skipCounter = skipCounter + 1
 
+
+def checkCorrectSkipsFolder(originalFullFrame, csvfile, skipped_columns):
+    skippedFrameIF = h2o.import_file(csvfile, skipped_columns=skipped_columns)  # this two frames should be the same
+    skipCounter = 0
+    typeDict = originalFullFrame.types
+    frameNames = originalFullFrame.names
+    for cindex in range(len(frameNames)):
+        if cindex not in skipped_columns:
+            print("Checking column {0}...".format(cindex))
+            if typeDict[frameNames[cindex]] == u'enum':
+                compare_frames_local_onecolumn_NA_enum(originalFullFrame[cindex],
+                                                                    skippedFrameIF[skipCounter], prob=1, tol=1e-10,
+                                                                    returnResult=False)
+            elif typeDict[frameNames[cindex]] == u'string':
+                compare_frames_local_onecolumn_NA_string(originalFullFrame[cindex],
+                                                                      skippedFrameIF[skipCounter], prob=1,
+                                                                      returnResult=False)
+            else:
+                compare_frames_local_onecolumn_NA(originalFullFrame[cindex], skippedFrameIF[skipCounter],
+                                                               prob=1, tol=1e-10, returnResult=False)
+            skipCounter = skipCounter + 1

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_high_enums_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_high_enums_large.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import os
+
+def test_column_skip_high_cardinality():
+  # generate a big frame with all datatypes and save it to csv.  Load it back with different skipped_columns settings
+    tmpdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results"))
+    if not(os.path.isdir(tmpdir)):
+        os.mkdir(tmpdir)
+    savefilenamewithpath = os.path.join(tmpdir, 'in.csv')
+    fwriteFile = open(savefilenamewithpath, 'w')
+
+    nrow = 10000000
+
+    for rowindex in range(nrow):
+        writeWords = 'a'+str(rowindex)+','+str(rowindex)+"\n"
+        fwriteFile.write(writeWords)
+
+    fwriteFile.close()
+    try:
+        parseFile = h2o.upload_file(savefilenamewithpath, col_types=["enum","int"])
+        sys.exit(1) # should have failed here
+    except Exception as ex:
+        print(ex) # print out the error message
+        parseFile = h2o.upload_file(savefilenamewithpath, col_types=["int"], skipped_columns=[0]) # should pass here.
+        print("Test passed! Parsed with large enum columns skipped!")
+        pass
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_column_skip_high_cardinality)
+else:
+    test_column_skip_high_cardinality()

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_import_folder.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_import_folder.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+from tests import pyunit_utils
+import random
+
+# note that import folder can only be done with import_file
+def import_folder_skipped_columns():
+    # checking out zip file
+    originalFull = h2o.import_file(path=pyunit_utils.locate("smalldata/synthetic_perfect_separation"))
+    filePath = pyunit_utils.locate("smalldata/synthetic_perfect_separation")
+
+    skip_all = list(range(originalFull.ncol))
+    skip_even = list(range(0, originalFull.ncol, 2))
+    skip_odd = list(range(1, originalFull.ncol, 2))
+    skip_start_end = [0, originalFull.ncol - 1]
+    skip_except_last = list(range(0, originalFull.ncol - 2))
+    skip_except_first = list(range(1, originalFull.ncol))
+    temp = list(range(0, originalFull.ncol))
+    random.shuffle(temp)
+    skip_random = []
+    for index in range(0, originalFull.ncol//2):
+        skip_random.append(temp[index])
+    skip_random.sort()
+
+    try:
+        bad = h2o.import_file(filePath, skipped_columns=skip_all)  # skipped all
+        sys.exit(1)
+    except Exception as ex:
+        print(ex)
+        pass
+
+    # skip even columns
+    pyunit_utils.checkCorrectSkipsFolder(originalFull, filePath, skip_even)
+
+    # skip odd columns
+    pyunit_utils.checkCorrectSkipsFolder(originalFull, filePath, skip_odd)
+
+    # skip the very beginning and the very end.
+    pyunit_utils.checkCorrectSkipsFolder(originalFull, filePath, skip_start_end)
+
+    # skip all except the last column
+    pyunit_utils.checkCorrectSkipsFolder(originalFull, filePath, skip_except_last)
+
+    # skip all except the very first column
+    pyunit_utils.checkCorrectSkipsFolder(originalFull, filePath, skip_except_first)
+
+    # randomly skipped half the columns
+    pyunit_utils.checkCorrectSkipsFolder(originalFull, filePath, skip_random)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(import_folder_skipped_columns)
+else:
+    import_folder_skipped_columns()

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_arff_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_arff_large.py
@@ -1,0 +1,114 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+from tests import pyunit_utils
+import os
+import datetime
+import random
+
+MINTIME = datetime.datetime(1980, 8, 6, 6, 14, 59)
+MAXTIME = datetime.datetime(2080, 8, 6, 8, 14, 59)
+
+
+def test_arff_parser_column_skip():
+    # generate a big frame with all datatypes and save it to svmlight
+    nrow = 10000
+    ncol = 98
+    seed = 12345
+    frac1 = 0.16
+    frac2 = 0.2
+    f1 = h2o.create_frame(rows=nrow, cols=ncol, real_fraction=frac1, categorical_fraction=frac1, integer_fraction=frac1,
+                          binary_fraction=frac1, time_fraction=frac1, string_fraction=frac2, missing_fraction=0.1,
+                          has_response=False, seed=seed)
+    uuidVecs = [pyunit_utils.gen_random_uuid(nrow), pyunit_utils.gen_random_uuid(nrow)]  # generate the uuid vectos
+    tmpdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results"))
+    if not (os.path.isdir(tmpdir)):
+        os.mkdir(tmpdir)
+    savefilenamewithpath = os.path.join(tmpdir, 'out.arff')
+    uuidNames = ["uuidVec1", "uuidVec2"]
+    pyunit_utils.write_H2OFrame_2_ARFF(savefilenamewithpath, "out.arff", f1, uuidVecs,
+                                       uuidNames)  # write h2o frame to svm format
+
+    ncol = f1.ncol + len(uuidVecs)
+    skip_all = list(range(ncol))
+    skip_even = list(range(0, ncol, 2))
+    skip_odd = list(range(1, ncol, 2))
+    skip_start_end = [0, ncol - 1]
+    skip_except_last = list(range(0, ncol - 2))
+    skip_except_first = list(range(1, ncol))
+    temp = list(range(0, ncol))
+    random.shuffle(temp)
+    skip_random = []
+    for index in range(0, ncol // 2):
+        skip_random.append(temp[index])
+    skip_random.sort()
+
+    try:
+        loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns=skip_all)
+        sys.exit(1)  # should have failed here
+    except:
+        pass
+
+    try:
+        importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
+        sys.exit(1)  # should have failed here
+    except:
+        pass
+
+    # skip even columns
+    checkCorrectSkips(f1, savefilenamewithpath, skip_even, uuidNames)
+
+    # skip odd columns
+    checkCorrectSkips(f1, savefilenamewithpath, skip_odd, uuidNames)
+
+    # skip the very beginning and the very end.
+    checkCorrectSkips(f1, savefilenamewithpath, skip_start_end, uuidNames)
+
+    # skip all except the last column
+    checkCorrectSkips(f1, savefilenamewithpath, skip_except_last, uuidNames)
+
+    # skip all except the very first column
+    checkCorrectSkips(f1, savefilenamewithpath, skip_except_first, uuidNames)
+
+    # randomly skipped half the columns
+    checkCorrectSkips(f1, savefilenamewithpath, skip_random, uuidNames)
+
+
+def checkCorrectSkips(originalFullFrame, csvfile, skipped_columns, uuidNames):
+    skippedFrameUF = h2o.upload_file(csvfile, skipped_columns=skipped_columns)
+    skippedFrameIF = h2o.import_file(csvfile, skipped_columns=skipped_columns)  # this two frames should be the same
+    pyunit_utils.compare_frames_local(skippedFrameUF, skippedFrameIF, prob=0.5)
+
+    skipCounter = 0
+    typeDict = originalFullFrame.types
+    frameNames = originalFullFrame.names
+    for cindex in range(len(frameNames)):
+        if cindex not in skipped_columns:
+            if typeDict[frameNames[cindex]] == u'enum':
+                pyunit_utils.compare_frames_local_onecolumn_NA_enum(originalFullFrame[cindex],
+                                                                    skippedFrameIF[skipCounter], prob=1, tol=1e-10,
+                                                                    returnResult=False)
+            elif typeDict[frameNames[cindex]] == u'string':
+                pyunit_utils.compare_frames_local_onecolumn_NA_string(originalFullFrame[cindex],
+                                                                      skippedFrameIF[skipCounter], prob=1,
+                                                                      returnResult=False)
+            else:
+                pyunit_utils.compare_frames_local_onecolumn_NA(originalFullFrame[cindex], skippedFrameIF[skipCounter],
+                                                               prob=1, tol=1e-10, returnResult=False)
+            skipCounter = skipCounter + 1
+
+    # since we cannot check uuid contents, we at least need to know that the return frame contains the correct column names
+    frameNames.extend(uuidNames)
+    skippedFrameNames = skippedFrameIF.names
+
+    for skipIndex in skipped_columns:
+        assert frameNames[skipIndex] not in skippedFrameNames, \
+            "This column: {0}/{1} should have been skipped but is not!".format(frameNames[skipIndex], skipIndex)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_arff_parser_column_skip)
+else:
+    test_arff_parser_column_skip()

--- a/h2o-r/h2o-package/R/parse.R
+++ b/h2o-r/h2o-package/R/parse.R
@@ -16,9 +16,10 @@
 #'        the file are separated by this character. If \code{sep = ""}, the
 #'        parser will automatically detect the separator.
 #' @param col.names (Optional) An H2OFrame object containing a
-#'        single delimited line with the column names for the file.
+#'        single delimited line with the column names for the file.  If skipped_columns are specified,
+#'        only list column names of columns that are not skipped.
 #' @param col.types (Optional) A vector specifying the types to attempt to force
-#'        over columns.
+#'        over columns.  If skipped_columns are specified, only list column types of columns that are not skipped.
 #' @param na.strings (Optional) H2O will interpret these strings as missing.
 #' @param blocking (Optional) Tell H2O parse call to block synchronously instead
 #'        of polling.  This can be faster for small datasets but loses the

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_import_folder.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_import_folder.R
@@ -1,0 +1,33 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Tests parsing with skipped columns
+test.parseSkippedColumnsFolder <- function() {
+  originalFull <- h2o.importFile(locate("smalldata/synthetic_perfect_separation"))
+  allColnames <- h2o.names(originalFull)
+  allTypeDict <- h2o.getTypes(originalFull)
+  pathHeader <- locate("smalldata/synthetic_perfect_separation")
+  
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(originalFull))
+  skipall <- onePermute
+  skip50Per <- onePermute[1:floor(h2o.ncol(originalFull) * 0.5)]
+  skipAll <- c(1:h2o.ncol(originalFull))
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(pathHeader, originalFull, skipall, TRUE, h2o.getTypes(originalFull)),
+      error = function(x)
+        x
+    )
+  print(e)
+  
+  # skip 50% of the columns randomly
+  print("Testing skipping 50% of columns")
+  assertCorrectSkipColumns( pathHeader, as.data.frame(originalFull), skip50Per,TRUE, h2o.getTypes(originalFull)) 
+}
+
+doTest("Test parsing a folder", test.parseSkippedColumnsFolder)

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_arff_large.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_arff_large.R
@@ -1,0 +1,368 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)
+# Tests parsing with skipped columns
+test.parseSkippedColumnsARFF<- function() {
+  f1 <-
+    h2o.importFile(locate("bigdata/laptop/parser/anARFFFile.csv"))
+  fileName <- locate("bigdata/laptop/parser/anARFFFile.txt")
+
+  fullFrameR <- as.data.frame(f1)
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip99Per <- onePermute[1:floor(h2o.ncol(f1) * 0.99)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 99% of the columns randomly
+  print("Testing skipping 99% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+
+doTest("Test ARFF Parse with skipped columns", test.parseSkippedColumnsARFF)


### PR DESCRIPTION
This PR is related to JIRA: https://0xdata.atlassian.net/browse/PUBDEV-5705?filter=-1

It completes the following:
1. Added tests to verify that columns can be skipped with ARFF files in R and Python.
2. Added skip column capability to parse_test_file in testUtils.java.  This is mainly for testing only.

In addition, more tests are added to:
1. Verify that skipped columns are supported correctly when importing folders in Java/R/Python.
2. Test pyunit_PUBDEV_5705_drop_columns_high_enums_large.py contains columns with cardinality > 10000000.  When the column with high cardinality is skipped, the file was parsed successfully.