### PR TITLE
Get more useful results from testMultiNode on failure

### DIFF
--- a/h2o-core/src/test/java/water/junit/FatalCrashListener.java
+++ b/h2o-core/src/test/java/water/junit/FatalCrashListener.java
@@ -1,0 +1,19 @@
+package water.junit;
+
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+class FatalCrashListener extends RunListener {
+
+  @Override
+  public void testFailure(Failure failure) throws Exception {
+    final Throwable exception = failure.getException();
+
+    // ignore recoverable exceptions
+    if (exception instanceof AssertionError) return;
+
+    // any other causes JVM exit
+    exception.printStackTrace();
+    System.exit(-1);
+  }
+}

--- a/h2o-core/src/test/java/water/junit/H2OTestRunner.java
+++ b/h2o-core/src/test/java/water/junit/H2OTestRunner.java
@@ -40,6 +40,10 @@ public class H2OTestRunner {
     jcore.addListener(new TextListener(jsystem));
     // Add XML generator listener
     jcore.addListener(new XMLTestReporter());
+
+    // Add listener that kills JVM when there is an unhandled exception
+    jcore.addListener(new FatalCrashListener());
+    //
     Result result = jcore.run(classes.toArray(new Class[0]));
     for (Failure each : missingClasses) {
       System.err.println("FAIL Missing class in H2OTestRunner: " + each);


### PR DESCRIPTION
When running `testMultiNode` task, the case when it fails gives no useful information in the log, because the testrunner keeps running the suite no matter what happens.

This fix changes the behavior quite significantly, to match the way how tests are typically executed. That is:
- if test passes, next one can execute
- if test fails on assertion (or other "recoverable" error), failure is reported and next test can execute
- if any other (= non-recoverable) exception happens, the testsuite gets killed; which, in this specific test runner, means forced JVM exit (I found no other "gentle" way to break execution). 

That causes the stacktrace and the causing exception to be exposed in the console.

It is critical that tests provide richer information than just PASSED/FAILED. Please consider approving this or proposing better way to achieve something like this.