### PR TITLE
PUBDEV-5705: added skipped column support to gzip/gz parsers.

### DIFF
--- a/h2o-parsers/h2o-avro-parser/src/test/java/water/parser/ParseTestAvro.java
+++ b/h2o-parsers/h2o-avro-parser/src/test/java/water/parser/ParseTestAvro.java
@@ -2,7 +2,6 @@ package water.parser;
 
 
 import com.google.common.io.Files;
-
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
@@ -12,17 +11,16 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import water.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.*;
-
-import water.TestUtil;
-import water.fvec.Frame;
-import water.fvec.Vec;
-import water.util.StringUtils;
 
 /**
  * Test suite for Avro parser.
@@ -33,6 +31,16 @@ public class ParseTestAvro extends TestUtil {
 
   @BeforeClass
   static public void setup() { TestUtil.stall_till_cloudsize(5); }
+
+  @Test
+  public void testSkippedColumns() {
+    try { // specify skipped columns, not allowed!
+      Frame f1 = parse_test_file("smalldata/parser/avro/sequence100k.avro", new int[]{0,1});
+      assert 1==2:"Parser should have thrown an exception but did not!";
+    } catch(Exception ex) { // this should fail
+      System.out.println("Done, Avro parsers should not specify skipped_columns");
+    }
+  }
 
   @Test
   public void testParseSimple() {

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_column_names_types.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_column_names_types.py
@@ -1,0 +1,102 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+from tests import pyunit_utils
+import random
+
+# This test will test skipped columns while at the same time setting the column names and column types
+def import_with_column_names_types():
+    # upload file with headers in the csv
+    csvWithHeader = h2o.import_file(pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip"), header=1)
+    allColnames = csvWithHeader.names
+    allTypeDict = csvWithHeader.types
+
+    # upload file with  no header but fixed column types.
+    csvWithNoHeader = h2o.upload_file(pyunit_utils.locate("smalldata/airlines/allyears2k.zip"), header=-1)
+    allNewColnames = csvWithNoHeader.names
+    allNewTypeDict = csvWithNoHeader.types
+    pathNoHeader=pyunit_utils.locate("smalldata/airlines/allyears2k.zip")
+
+    # load in whole dataset
+    skip_even = list(range(0, csvWithHeader.ncol, 2))
+    skip_odd = list(range(1, csvWithHeader.ncol, 2))
+    skip_start_end = [0, csvWithHeader.ncol-1]
+    skip_except_last = list(range(0, csvWithHeader.ncol-2))
+    skip_except_first = list(range(1, csvWithHeader.ncol))
+    temp = list(range(0, csvWithHeader.ncol))
+    random.shuffle(temp)
+    skip_random = []
+    for index in range(0,csvWithHeader.ncol//2):
+        skip_random.append(temp[index])
+    skip_random.sort()
+
+    # skip even
+    checkCorrectSkipAndNameTypes(csvWithHeader, pathNoHeader, skip_even, allColnames, allTypeDict, 0, 0)
+
+    # skip odd
+    checkCorrectSkipAndNameTypes(csvWithNoHeader, pathNoHeader, skip_odd, allNewColnames, allNewTypeDict, 1, 0)
+
+    # skip start and end
+    checkCorrectSkipAndNameTypes(csvWithHeader, pathNoHeader, skip_start_end, allColnames, allTypeDict, 2, 0)
+
+    # keep last
+    checkCorrectSkipAndNameTypes(csvWithNoHeader, pathNoHeader, skip_except_last, allNewColnames, allNewTypeDict, 0, 0)
+
+    # keep first
+    checkCorrectSkipAndNameTypes(csvWithHeader, pathNoHeader, skip_except_first, allColnames, allTypeDict, 1, 0)
+
+    # random skip
+    checkCorrectSkipAndNameTypes(csvWithNoHeader, pathNoHeader, skip_random, allNewColnames, allNewTypeDict, 2, 0)
+
+def checkCorrectSkipAndNameTypes(originalFullFrame, csvfile, skipped_columns, all_column_names, all_column_types, modes, headerValue):
+    colnames = []
+    coltypes = dict()
+    coltypelist = []
+
+    for ind in range(len(all_column_names)):
+        if ind not in skipped_columns:
+            colnames.append(all_column_names[ind])
+            coltypes[all_column_names[ind]]=all_column_types[all_column_names[ind]]
+            coltypelist.append(all_column_types[all_column_names[ind]])
+
+    if modes==0: # include both names and types
+        skippedFrameUF = h2o.upload_file(csvfile, skipped_columns=skipped_columns, col_names=colnames, col_types=coltypes, header=headerValue)
+        skippedFrameIF = h2o.import_file(csvfile, skipped_columns=skipped_columns, col_names=colnames, col_types=coltypes, header=headerValue)
+    elif modes==1: # includes only names
+        skippedFrameUF = h2o.upload_file(csvfile, skipped_columns=skipped_columns, col_names=colnames, header=headerValue)
+        skippedFrameIF = h2o.import_file(csvfile, skipped_columns=skipped_columns, col_names=colnames, header=headerValue)
+    else: # includes only types
+        skippedFrameUF = h2o.upload_file(csvfile, skipped_columns=skipped_columns, col_types=coltypelist, header=headerValue)
+        skippedFrameIF = h2o.import_file(csvfile, skipped_columns=skipped_columns, col_types=coltypelist, header=headerValue)
+    pyunit_utils.compare_frames_local(skippedFrameUF, skippedFrameIF, prob=0.5)
+
+    skipCounter = 0
+    typeDict = originalFullFrame.types
+    frameNames = originalFullFrame.names
+    for cindex in range(len(frameNames)):
+        if cindex not in skipped_columns:
+            print("Checking column {0}...".format(cindex))
+            if typeDict[frameNames[cindex]] == u'enum':
+                pyunit_utils.compare_frames_local_onecolumn_NA_enum(originalFullFrame[cindex],
+                                                       skippedFrameIF[skipCounter], prob=1, tol=1e-10,
+                                                       returnResult=False)
+            elif typeDict[frameNames[cindex]] == u'string':
+                pyunit_utils.compare_frames_local_onecolumn_NA_string(originalFullFrame[cindex],
+                                                         skippedFrameIF[skipCounter], prob=1,
+                                                         returnResult=False)
+            else:
+                pyunit_utils.compare_frames_local_onecolumn_NA(originalFullFrame[cindex], skippedFrameIF[skipCounter],
+                                                  prob=1, tol=1e-10, returnResult=False)
+            skipCounter = skipCounter + 1
+
+
+
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(import_with_column_names_types)
+else:
+    import_with_column_names_types()

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gz_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gz_large.py
@@ -1,0 +1,90 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+from tests import pyunit_utils
+import random
+
+def import_zip_skipped_columns():
+    # checking out zip file
+    airlineFull = h2o.import_file(path=pyunit_utils.locate("smalldata/jira/adult.gz"))
+    filePath = pyunit_utils.locate("smalldata/jira/adult.gz")
+
+    skip_all = list(range(airlineFull.ncol))
+    skip_even = list(range(0, airlineFull.ncol, 2))
+    skip_odd = list(range(1, airlineFull.ncol, 2))
+    skip_start_end = [0, airlineFull.ncol - 1]
+    skip_except_last = list(range(0, airlineFull.ncol - 2))
+    skip_except_first = list(range(1, airlineFull.ncol))
+    temp = list(range(0, airlineFull.ncol))
+    random.shuffle(temp)
+    skip_random = []
+    for index in range(0, airlineFull.ncol // 2):
+        skip_random.append(temp[index])
+    skip_random.sort()
+
+    try:
+        bad = h2o.import_file(filePath, skipped_columns=skip_all)  # skipped all
+        sys.exit(1)
+    except Exception as ex:
+        print(ex)
+        pass
+
+    try:
+        bad = h2o.upload_file(filePath, skipped_columns=skip_all)   # skipped all
+        sys.exit(1)
+    except Exception as ex:
+        print(ex)
+        pass
+
+        # skip odd columns
+    pyunit_utils.checkCorrectSkips(airlineFull, filePath, skip_odd)
+
+    # skip even columns
+    pyunit_utils.checkCorrectSkips(airlineFull, filePath, skip_even)
+
+    # skip the very beginning and the very end.
+    pyunit_utils.checkCorrectSkips(airlineFull, filePath, skip_start_end)
+
+    # skip all except the last column
+    pyunit_utils.checkCorrectSkips(airlineFull, filePath, skip_except_last)
+
+    # skip all except the very first column
+    pyunit_utils.checkCorrectSkips(airlineFull, filePath, skip_except_first)
+
+    # randomly skipped half the columns
+    pyunit_utils.checkCorrectSkips(airlineFull, filePath, skip_random)
+
+
+def checkCorrectSkips(originalFullFrame, csvfile, skipped_columns):
+    skippedFrameUF = h2o.upload_file(csvfile, skipped_columns=skipped_columns)
+    skippedFrameIF = h2o.import_file(csvfile, skipped_columns=skipped_columns)  # this two frames should be the same
+    pyunit_utils.compare_frames_local(skippedFrameUF, skippedFrameIF, prob=0.5)
+
+    skipCounter = 0
+    typeDict = originalFullFrame.types
+    frameNames = originalFullFrame.names
+    for cindex in range(len(frameNames)):
+        if cindex not in skipped_columns:
+            print("Checking column {0}...".format(cindex))
+            if typeDict[frameNames[cindex]] == u'enum' and cindex==10: # look at original frame
+                continue
+
+            elif typeDict[frameNames[cindex]] == u'enum' and not(skipCounter==10):
+                pyunit_utils.compare_frames_local_onecolumn_NA_enum(originalFullFrame[cindex],
+                                                                    skippedFrameIF[skipCounter], prob=1, tol=1e-10,
+                                                                    returnResult=False)
+            elif typeDict[frameNames[cindex]] == u'string':
+                pyunit_utils.compare_frames_local_onecolumn_NA_string(originalFullFrame[cindex],
+                                                         skippedFrameIF[skipCounter], prob=1,
+                                                         returnResult=False)
+            elif typeDict[frameNames[cindex]] == u'int':
+                pyunit_utils.compare_frames_local_onecolumn_NA(originalFullFrame[cindex], skippedFrameIF[skipCounter].asnumeric(),
+                                                  prob=1, tol=1e-10, returnResult=False)
+            skipCounter = skipCounter + 1
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(import_zip_skipped_columns)
+else:
+    import_zip_skipped_columns()

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gzip_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gzip_large.py
@@ -1,0 +1,63 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+from tests import pyunit_utils
+import random
+
+def import_gzip_skipped_columns():
+    # checking out zip file
+    airlineCSV = h2o.import_file(path=pyunit_utils.locate("smalldata/airlines/AirlinesTrain.csv"))
+    filePath = pyunit_utils.locate("smalldata/airlines/AirlinesTrain.csv.zip")
+
+    skip_all = list(range(airlineCSV.ncol))
+    skip_even = list(range(0, airlineCSV.ncol, 2))
+    skip_odd = list(range(1, airlineCSV.ncol, 2))
+    skip_start_end = [0, airlineCSV.ncol - 1]
+    skip_except_last = list(range(0, airlineCSV.ncol - 2))
+    skip_except_first = list(range(1, airlineCSV.ncol))
+    temp = list(range(0, airlineCSV.ncol))
+    random.shuffle(temp)
+    skip_random = []
+    for index in range(0, airlineCSV.ncol//2):
+        skip_random.append(temp[index])
+    skip_random.sort()
+
+    try:
+        bad = h2o.import_file(filePath, skipped_columns=skip_all)  # skipped all
+        sys.exit(1)
+    except Exception as ex:
+        print(ex)
+        pass
+
+    try:
+        bad = h2o.upload_file(filePath, skipped_columns=skip_all)   # skipped all
+        sys.exit(1)
+    except Exception as ex:
+        print(ex)
+        pass
+
+    # skip even columns
+    pyunit_utils.checkCorrectSkips(airlineCSV, filePath, skip_even)
+
+    # skip odd columns
+    pyunit_utils.checkCorrectSkips(airlineCSV, filePath, skip_odd)
+
+    # skip the very beginning and the very end.
+    pyunit_utils.checkCorrectSkips(airlineCSV, filePath, skip_start_end)
+
+    # skip all except the last column
+    pyunit_utils.checkCorrectSkips(airlineCSV, filePath, skip_except_last)
+
+    # skip all except the very first column
+    pyunit_utils.checkCorrectSkips(airlineCSV, filePath, skip_except_first)
+
+    # randomly skipped half the columns
+    pyunit_utils.checkCorrectSkips(airlineCSV, filePath, skip_random)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(import_gzip_skipped_columns)
+else:
+    import_gzip_skipped_columns()

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_svmlight_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_svmlight_large.py
@@ -1,0 +1,74 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import os
+
+def test_parser_svmlight_column_skip():
+  # generate a big frame with all datatypes and save it to svmlight
+  nrow = 10000
+  ncol = 50
+  seed=12345
+
+  f1 = h2o.create_frame(rows=nrow, cols=ncol, real_fraction=0.5, integer_fraction=0.5, missing_fraction=0.2,
+                         has_response=False, seed=seed)
+  f2 = h2o.create_frame(rows=nrow, cols=1, real_fraction=1, integer_fraction=0, missing_fraction=0,
+                         has_response=False, seed=seed)
+  f2.set_name(0,"target")
+  f1 = f2.cbind(f1)
+
+  tmpdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results"))
+  if not(os.path.isdir(tmpdir)):
+    os.mkdir(tmpdir)
+  savefilenamewithpath = os.path.join(tmpdir, 'out.svm')
+  pyunit_utils.write_H2OFrame_2_SVMLight(savefilenamewithpath, f1) # write h2o frame to svm format
+
+  skip_all = list(range(ncol))
+  skip_even = list(range(0, ncol, 2))
+
+  try:
+    loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns = skip_all)
+    sys.exit(1) # should have failed here
+  except:
+    pass
+
+  try:
+    importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns = skip_all)
+    sys.exit(1) # should have failed here
+  except:
+    pass
+
+  try:
+    importFileSkipSome = h2o.import_file(savefilenamewithpath, skipped_columns = skip_even)
+    sys.exit(1) # should have failed here
+  except:
+    pass
+
+  # check for correct parsing only
+  checkCorrectSkips(savefilenamewithpath, f1)
+
+
+def checkCorrectSkips(csvfile, originalFrame):
+  skippedFrameUF = h2o.upload_file(csvfile)
+  skippedFrameIF = h2o.import_file(csvfile) # this two frames should be the same
+  pyunit_utils.compare_frames_local(skippedFrameUF, skippedFrameIF, prob=1)
+
+  # test with null skipped_column list
+  skippedFrameUF2 = h2o.upload_file(csvfile, skipped_columns=[])
+  skippedFrameIF2 = h2o.import_file(csvfile, skipped_columns=[]) # this two frames should be the same
+  pyunit_utils.compare_frames_local(skippedFrameUF2, skippedFrameIF2, prob=1)
+
+  # frame from not skipped_columns specification and empty skipped_columns should return same result
+  pyunit_utils.compare_frames_local(skippedFrameUF2, skippedFrameIF, prob=1)
+
+  # compare skipped frame with originalFrame
+  assert originalFrame.ncol==skippedFrameUF.ncol, \
+    "Expected return frame column number: {0}, actual frame column number: " \
+    "{1}".format((originalFrame.ncol, skippedFrameUF.ncol))
+  pyunit_utils.compare_frames_local_svm(originalFrame, skippedFrameIF2, prob=1)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_parser_svmlight_column_skip)
+else:
+  test_parser_svmlight_column_skip()

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_column_names_types_large.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_column_names_types_large.R
@@ -1,0 +1,35 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Tests parsing with skipped columns
+test.parseSkippedColumnsNameType <- function() {
+  csvWithHeader <-
+    h2o.importFile(locate("smalldata/airlines/allyears2k_headers.zip"))
+  allColnames <- h2o.names(csvWithHeader)
+  allTypeDict <- h2o.getTypes(csvWithHeader)
+  pathHeader <- locate("smalldata/airlines/allyears2k_headers.zip")
+
+  # upload file with  no header but fixed column types.
+  csvWithNoHeader <-
+    h2o.uploadFile(locate("smalldata/airlines/allyears2k.zip"))
+  allNewColnames <- h2o.names(csvWithNoHeader)
+  allNewTypeDict <- h2o.getTypes(csvWithNoHeader)
+  pathNoHeader <- locate("smalldata/airlines/allyears2k.zip")
+
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(csvWithHeader))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(csvWithHeader))
+  skipall <- onePermute
+  skip90Per <- onePermute[1:floor(h2o.ncol(csvWithHeader) * 0.9)]
+
+  # skip 90% of the columns randomly
+  print("Testing skipping 90% of columns")
+  assertCorrectSkipColumnsNamesTypes(csvWithHeader, pathNoHeader, skip90Per, allColnames, allTypeDict,0, h2o.getTypes(csvWithHeader))
+  assertCorrectSkipColumnsNamesTypes(csvWithHeader, pathNoHeader, skip90Per, allColnames, allTypeDict,1, h2o.getTypes(csvWithHeader))
+  assertCorrectSkipColumnsNamesTypes(csvWithHeader, pathNoHeader, skip90Per, allColnames, allTypeDict,2, h2o.getTypes(csvWithHeader))
+}
+
+doTest("Test Parse with column names and column types specified with skipped columns", test.parseSkippedColumnsNameType)

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_gz.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_gz.R
@@ -1,0 +1,43 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Tests parsing with skipped columns
+test.parseSkippedColumnsgz<- function() {
+  f1 <-
+    h2o.importFile(locate("smalldata/airlines/year2005.csv"))
+  fileName <- locate("smalldata/airlines/year2005.csv.gz")
+
+  fullFrameR <- as.data.frame(f1) # takes too long
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip90Per <- onePermute[1:floor(h2o.ncol(f1) * 0.9)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 90% of the columns randomly
+  print("Testing skipping 90% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip90Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip90Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+doTest("Test gz parser with skipped columns", test.parseSkippedColumnsgz)

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_gzip_large.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_gzip_large.R
@@ -1,0 +1,43 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+# Tests parsing with skipped columns
+test.parseSkippedColumnsgzip<- function() {
+  f1 <-
+    h2o.importFile(locate("smalldata/airlines/AirlinesTrain.csv"))
+  fileName <- locate("smalldata/airlines/AirlinesTrain.csv.zip")
+
+  fullFrameR <- as.data.frame(f1) # takes too long
+  skip_front <- c(1)
+  skip_end <- c(h2o.ncol(f1))
+  set.seed <- 12345
+  onePermute <- sample(h2o.ncol(f1))
+  skipall <- onePermute
+  skip90Per <- onePermute[1:floor(h2o.ncol(f1) * 0.9)]
+
+  # test skipall for h2o.importFile
+  e <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, TRUE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e)
+  # test skipall for h2o.uploadFile
+  e2 <-
+    tryCatch(
+      assertCorrectSkipColumns(fileName, fullFrameR, skipall, FALSE, h2o.getTypes(f1)),
+      error = function(x)
+        x
+    )
+  print(e2)
+
+  # skip 90% of the columns randomly
+  print("Testing skipping 90% of columns")
+  assertCorrectSkipColumns(fileName, fullFrameR, skip90Per, TRUE, h2o.getTypes(f1)) # test importFile
+  assertCorrectSkipColumns(fileName, fullFrameR, skip90Per, FALSE, h2o.getTypes(f1)) # test uploadFile
+}
+
+doTest("Test Orc Parse with skipped columns", test.parseSkippedColumnsgzip)


### PR DESCRIPTION
This PR covers the work for JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-5705?filter=myopenissues.

Work done:
1. Implemented skipped column support for gzip/gz parsers.
2. Discussed with Michalk that SVMlight and Avro will not support skipped columns.
3. Added Junit/R/Python unit tests to ensure correct implementation.
4. Added R/Python unit tests to make sure that users can set column names and types with skipped columns.