### PR TITLE
PUBDEV-6036: Fix `offset_column` parameter in the Python client while initializing an estimator

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/offset_column.rst
+++ b/h2o-docs/src/product/data-science/algo-params/offset_column.rst
@@ -95,7 +95,7 @@ Example
 
 	# try using the `offset_column` parameter:
 	# initialize the estimator then train the model
-	boston_gbm = H2OGradientBoostingEstimator(offset_column = "offset_column", seed = 1234)
+	boston_gbm = H2OGradientBoostingEstimator(offset_column = "offset", seed = 1234)
 	boston_gbm.train(x=predictors, y=response, training_frame=train, validation_frame=valid)
 
 	# print the mse for validation set

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -182,10 +182,9 @@ class H2OEstimator(ModelBase):
                             raise H2OValueError("Column %s not in the training frame" % xi)
                         xset.add(xi)
             x = list(xset)
-
-            parms["offset_column"] = offset_column
-            parms["fold_column"] = fold_column
-            parms["weights_column"] = weights_column
+            self._check_and_save_parm(parms, "offset_column", offset_column)
+            self._check_and_save_parm(parms, "weights_column", weights_column)
+            self._check_and_save_parm(parms, "fold_column", fold_column)
 
         if max_runtime_secs is not None: parms["max_runtime_secs"] = max_runtime_secs
 
@@ -450,3 +449,16 @@ class H2OEstimator(ModelBase):
         paramsSet = self.full_parameters
 
         return nativeXGBoostParams, paramsSet['ntrees']['actual_value']
+
+    def _check_and_save_parm(self, parms, parameter_name, parameter_value):
+        """
+        If a parameter is not stored in parms dict save them there (even though the value is None).
+        Else check if the parameter has been already set during initialization of estimator. If yes, check the new value is the same or not. If the values are different, set the last passed value to params dict and throw UserWarning.
+        """
+        if parameter_name not in parms:
+            parms[parameter_name] = parameter_value
+        elif parameter_value is not None and parms[parameter_name] != parameter_value:
+            parms[parameter_name] = parameter_value
+            warnings.warn("\n\n\t`%s` parameter has been already set and had a different value in `train` method. The last passed value \"%s\" is used." % (parameter_name, parameter_value), UserWarning, stacklevel=2)
+
+


### PR DESCRIPTION
The issue was focused on `offset_column` parameter, but it is the same problem for `weights_column` and `fold_column` parameters. Now there is a check if the parameters have been already set during initialization of estimator. If yes, it checks the new value is the same, if the values are different, it sets the last passed value to `params` dictionary and throws `UserWarning`.

There was also a bug in the documentation about the `offset_column` parameter (the wrong name of the column was assigned to the parameter), so I also fix that.

https://0xdata.atlassian.net/browse/PUBDEV-6036