### PR TITLE
PUBDEV-6046: Failed to get metric: auc from ModelMetrics type BinomialGLM

### DIFF
--- a/h2o-core/src/main/java/hex/AUC2.java
+++ b/h2o-core/src/main/java/hex/AUC2.java
@@ -165,7 +165,16 @@ public class AUC2 extends Iced {
     _gini = 2*_auc-1;
     _max_idx = DEFAULT_CM.max_criterion_idx(this);
   }
-  
+
+  // empty AUC, helps avoid NPE in edge cases
+  AUC2() {
+    _nBins = 0;
+    _ths = _tps = _fps = new double[0];
+    _p =_n = 0;
+    _auc = _gini = _pr_auc = Double.NaN;
+    _max_idx = -1;
+  }
+
   public double pr_auc() {
     checkRecallValidity();
     return Functions.integrate(forCriterion(recall), forCriterion(precision), 0, _nBins-1);

--- a/h2o-core/src/main/java/hex/AUC2.java
+++ b/h2o-core/src/main/java/hex/AUC2.java
@@ -175,7 +175,14 @@ public class AUC2 extends Iced {
     _max_idx = -1;
   }
 
+  private boolean isEmpty() {
+    return _nBins == 0;
+  }
+
   public double pr_auc() {
+    if (isEmpty()) {
+      return Double.NaN;
+    }
     checkRecallValidity();
     return Functions.integrate(forCriterion(recall), forCriterion(precision), 0, _nBins-1);
   }

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -154,16 +154,15 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     if (null == method)
       throw new H2OIllegalArgumentException("Failed to find ModelMetrics for criterion: " + criterion);
 
-    double c;
     try {
-      c = (double) method.invoke(obj);
+      return (double) method.invoke(obj);
     } catch (Exception e) {
+      Log.err(e);
       throw new H2OIllegalArgumentException(
               "Failed to get metric: " + criterion + " from ModelMetrics object: " + mm,
-              "Failed to get metric: " + criterion + " from ModelMetrics object: " + mm + ", criterion: " + method, e
+              "Failed to get metric: " + criterion + " from ModelMetrics object: " + mm + ", criterion: " + method + ", exception: " + e.getMessage()
       );
     }
-    return c;
   }
 
 

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -127,8 +127,9 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   }
 
   static public double getMetricFromModelMetric(ModelMetrics mm, String criterion) {
-    if (null == criterion || criterion.equals(""))
+    if (null == criterion || criterion.equals("")) {
       throw new H2OIllegalArgumentException("Need a valid criterion, but got '" + criterion + "'.");
+    }
 
     Method method = null;
     Object obj = null;

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -210,12 +210,14 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
       double mse = Double.NaN;
       double logloss = Double.NaN;
       double sigma = Double.NaN;
-      AUC2 auc = null;
+      final AUC2 auc;
       if (_wcount > 0) {
         sigma = weightedSigma();
         mse = _sumsqe / _wcount;
         logloss = _logloss / _wcount;
         auc = new AUC2(_auc);
+      } else {
+        auc = new AUC2();
       }
       ModelMetricsBinomial mm = new ModelMetricsBinomial(m, f, _count, mse, _domain, sigma, auc,  logloss, gl, _customMetric);
       if (m!=null) m.addModelMetrics(mm);

--- a/h2o-core/src/test/java/hex/ModelMetricsTest.java
+++ b/h2o-core/src/test/java/hex/ModelMetricsTest.java
@@ -1,0 +1,20 @@
+package hex;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ModelMetricsTest {
+
+  @Test
+  public void testEmptyModelAUC() {
+    ModelMetricsBinomial.MetricBuilderBinomial mbb =
+            new ModelMetricsBinomial.MetricBuilderBinomial(new String[]{"yes", "yes!!"});
+    ModelMetrics mm = mbb.makeModelMetrics(null, null, null, null);
+
+    assertTrue(mm instanceof ModelMetricsBinomial);
+    assertTrue(Double.isNaN(((ModelMetricsBinomial) mm).auc()));
+    assertTrue(Double.isNaN(ModelMetrics.getMetricFromModelMetric(mm, "auc")));
+  }
+
+}


### PR DESCRIPTION
This PR makes sure the AUC2 object is created even in edge cases when the data have 0 total weight. This prevents possible NPEs.