### PR TITLE
Pubdev-3451: add quiet argument to init

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -174,7 +174,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     :param strict_version_check: If True, an error will be raised if the client and server versions don't match.
     :param ignore_config: Indicates whether a processing of a .h2oconfig file should be conducted or not. Default value is False.
     :param extra_classpath: List of paths to libraries that should be included on the Java classpath when starting H2O from Python.
-    :param quiet: If True, the connection will not show messages when starting up. Default value is False.
+    :param quiet: If True, the connection will not show connection status messages. Default value is False.
     :param kwargs: (all other deprecated attributes)
     :param jvm_custom_args Customer, user-defined argument's for the JVM H2O is instantiated in. Ignored if there is an instance of H2O already running and the client connects to it.
     """

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -174,7 +174,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     :param strict_version_check: If True, an error will be raised if the client and server versions don't match.
     :param ignore_config: Indicates whether a processing of a .h2oconfig file should be conducted or not. Default value is False.
     :param extra_classpath: List of paths to libraries that should be included on the Java classpath when starting H2O from Python.
-    :param quiet: Surpress all output from the initialization. Default value is False.
+    :param quiet: If True, the connection will not show messages when starting up. Default value is False.
     :param kwargs: (all other deprecated attributes)
     :param jvm_custom_args Customer, user-defined argument's for the JVM H2O is instantiated in. Ignored if there is an instance of H2O already running and the client connects to it.
     """
@@ -282,7 +282,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     if check_version:
         version_check()
     h2oconn.cluster.timezone = "UTC"
-    h2oconn.cluster.show_status()
+    if not quiet: h2oconn.cluster.show_status()
 
 def lazy_import(path, pattern=None):
     """

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -146,7 +146,7 @@ def version_check():
 def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, username=None, password=None,
          cookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None, log_dir=None, log_level=None,
          enable_assertions=True, max_mem_size=None, min_mem_size=None, strict_version_check=None, ignore_config=False,
-         extra_classpath=None, jvm_custom_args=None, bind_to_localhost=True, **kwargs):
+         extra_classpath=None, jvm_custom_args=None, bind_to_localhost=True, quiet=False, **kwargs):
     """
     Attempt to connect to a local server, or if not successful start a new server and connect to it.
 
@@ -174,6 +174,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     :param strict_version_check: If True, an error will be raised if the client and server versions don't match.
     :param ignore_config: Indicates whether a processing of a .h2oconfig file should be conducted or not. Default value is False.
     :param extra_classpath: List of paths to libraries that should be included on the Java classpath when starting H2O from Python.
+    :param quiet: Surpress all output from the initialization. Default value is False.
     :param kwargs: (all other deprecated attributes)
     :param jvm_custom_args Customer, user-defined argument's for the JVM H2O is instantiated in. Ignored if there is an instance of H2O already running and the client connects to it.
     """
@@ -201,6 +202,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     assert_is_type(extra_classpath, [str], None)
     assert_is_type(jvm_custom_args, [str], None)
     assert_is_type(bind_to_localhost, bool)
+    assert_is_type(quiet, bool)
     assert_is_type(kwargs, {"proxies": {str: str}, "max_mem_size_GB": int, "min_mem_size_GB": int,
                             "force_connect": bool, "as_port": bool})
 
@@ -255,12 +257,12 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
             else:
                 verify_ssl_certificates = not insecure
 
-    if not start_h2o:
+    if not start_h2o and not quiet:
         print("Warning: if you don't want to start local H2O server, then use of `h2o.connect()` is preferred.")
     try:
         h2oconn = H2OConnection.open(url=url, ip=ip, port=port, name=name, https=https,
                                      verify_ssl_certificates=verify_ssl_certificates,
-                                     auth=auth, proxy=proxy,cookies=cookies, verbose=True,
+                                     auth=auth, proxy=proxy,cookies=cookies, verbose=not quiet,
                                      _msgs=("Checking whether there is an H2O instance running at {url}",
                                             "connected.", "not found."))
     except H2OConnectionError:
@@ -274,9 +276,9 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
                                   min_mem_size=mmin, ice_root=ice_root, log_dir=log_dir, log_level=log_level,
                                   port=port, name=name,
                                   extra_classpath=extra_classpath, jvm_custom_args=jvm_custom_args,
-                                  bind_to_localhost=bind_to_localhost)
+                                  bind_to_localhost=bind_to_localhost, verbose=not quiet)
         h2oconn = H2OConnection.open(server=hs, https=https, verify_ssl_certificates=not insecure,
-                                     auth=auth, proxy=proxy,cookies=cookies, verbose=True)
+                                     auth=auth, proxy=proxy,cookies=cookies, verbose=not quiet)
     if check_version:
         version_check()
     h2oconn.cluster.timezone = "UTC"

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_3451_quiet_init.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_3451_quiet_init.py
@@ -11,17 +11,17 @@ def pubdev_3451():
     # In a normal test, h2o.init will have been called before, but the output 
     # the first and the second time this function gets called is comparable
     
-	# Setup a trap
-	stdout_backup = sys.stdout
-	text_trap = io.StringIO()
-	sys.stdout = text_trap
+    # Setup a trap
+    stdout_backup = sys.stdout
+    text_trap = io.StringIO()
+    sys.stdout = text_trap
     
-	# Run function, expecting no output
-	#h2o.init(quiet = True)
-	init(quiet = True, strict_version_check = False)
-	
-	# Restore stdout
-	sys.stdout = stdout_backup
+    # Run function, expecting no output
+    #h2o.init(quiet = True)
+    init(quiet = True, strict_version_check = False)
+    
+    # Restore stdout
+    sys.stdout = stdout_backup
 
     assert text_trap.getvalue() == ""
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_3451_quiet_init.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_3451_quiet_init.py
@@ -1,0 +1,29 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import io
+import sys
+
+def pubdev_3451():
+
+    # We don't reinitialize h2o, but instead call h2o.init again, and see if there is any output.
+    
+	# Setup a trap
+	stdout_backup = sys.stdout
+	text_trap = io.StringIO()
+	sys.stdout = text_trap
+    
+	# Run function, expecting no output
+	h2o.init(quiet = True)
+	
+	# Restore stdout
+	sys.stdout = stdout_backup
+
+    assert text_trap.getvalue() == ""
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_3451)
+else:
+    pubdev_3451()

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_3451_quiet_init.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_3451_quiet_init.py
@@ -7,7 +7,9 @@ import sys
 
 def pubdev_3451():
 
-    # We don't reinitialize h2o, but instead call h2o.init again, and see if there is any output.
+    # We call h2o.init, and see if there is any output.
+    # In a normal test, h2o.init will have been called before, but the output 
+    # the first and the second time this function gets called is comparable
     
 	# Setup a trap
 	stdout_backup = sys.stdout
@@ -15,7 +17,8 @@ def pubdev_3451():
 	sys.stdout = text_trap
     
 	# Run function, expecting no output
-	h2o.init(quiet = True)
+	#h2o.init(quiet = True)
+	init(quiet = True, strict_version_check = False)
 	
 	# Restore stdout
 	sys.stdout = stdout_backup

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -206,9 +206,7 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
           cat(paste(readLines(stdout), collapse="\n"), "\n")
           print(tmpConn@ip)
           print(tmpConn@port)
-        }
-        rv <- .h2o.doRawGET(conn = tmpConn, urlSuffix = "")
-        if (!quiet) {
+          rv <- .h2o.doRawGET(conn = tmpConn, urlSuffix = "")
           print(rv$curlError)
           print(rv$httpStatusCode)
           print(rv$curlErrorMessage)
@@ -223,10 +221,12 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
   conn <- new("H2OConnection", ip = ip, port = port, name = .h2o.jar.env$name, proxy = proxy, https = https, insecure = insecure,
     username = username, password = password,cookies = cookies, context_path = context_path)
   assign("SERVER", conn, .pkg.env)
-  if (!quiet) cat(" Connection successful!\n\n")
   .h2o.jar.env$port <- port #Ensure right port is called when quitting R
-  if (!quiet) h2o.clusterInfo()
-  if (!quiet) cat("\n")
+  if (!quiet) {
+    cat(" Connection successful!\n\n")
+    h2o.clusterInfo()
+    cat("\n")
+  }
 
   if( strict_version_check && !nchar(Sys.getenv("H2O_DISABLE_STRICT_VERSION_CHECK"))) {
     verH2O <- h2o.getVersion()

--- a/h2o-r/tests/testdir_jira/runit_pubdev_3451_quiet_init.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_3451_quiet_init.R
@@ -4,9 +4,11 @@ source("../../scripts/h2o-r-test-setup.R")
 
 test.quiet.init <- function() {
   
-  # We don't reinitialize h2o, but instead call h2o.init again, and see if there is any output.
+  # We call h2o.init, and see if there is any output.
+  # In a normal test, h2o.init will have been called before, but the output 
+  # the first and the second time this function gets called is comparable
   
-  expect_silent(h2o.init(quiet = T))
+  expect_silent(h2o.init(quiet = TRUE))
   
 }
 

--- a/h2o-r/tests/testdir_jira/runit_pubdev_3451_quiet_init.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_3451_quiet_init.R
@@ -1,0 +1,13 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+test.quiet.init <- function() {
+  
+  # We don't reinitialize h2o, but instead call h2o.init again, and see if there is any output.
+  
+  expect_silent(h2o.init(quiet = T))
+  
+}
+
+doTest("h2o.init with quiet option", test.quiet.init)


### PR DESCRIPTION
Hello h2o people,

Jira here: https://0xdata.atlassian.net/browse/PUBDEV-3451

This is my first contribution to h2o, so if I did anything wrong, just point it out. I hope I followed all the guidelines.

This is a new feature, that adds an option to the 'h2o.init' function, to surpress output. As mentioned in the Jira, this has advantages for R, because the outputs interfere with knitr documents, making it hard to use h2o in latex. Furthermore, the output can interfere with certain unit test or build pipelines. 
The progress bars can be disabled with "h2o.no_progress()". It would be nice if the startup connection messages could be disabled too.

The option is implemented slightly differently for R and Python. In Python, 'verbose' is set to False, meaning no connection messages are printed at all, including when shutting down, etcetera. In R, there is no such verbose mode, so only the messages during init are hidden, to match the Jira ticket.