### PR TITLE
Fix PUBDEV_5705_drop_columns_parser_column_names_types_large.R test failure

### DIFF
--- a/h2o-r/h2o-package/R/parse.R
+++ b/h2o-r/h2o-package/R/parse.R
@@ -141,13 +141,13 @@ h2o.parseSetup <- function(data, pattern="", destination_frame = "", header = NA
   # setup the parse parameters here
   parseSetup.params <- list()
 
+  if (!is.null(skipped_columns)) {
+    skipped_columns = sort(skipped_columns)
+  }
+  
   # Prep srcs: must be of the form [src1,src2,src3,...]
   parseSetup.params$source_frames <- .collapse.char(sapply(data, function (d) attr(d, "id")))
   parseSetup.params$skipped_columns <- paste0("[", paste (skipped_columns, collapse = ','), "]")
-
-  if (!is.null(skipped_columns)) {
-    sort(skipped_columns)
-  }
 
   # check the header
   if( is.na(header) && is.null(col.names) ) parseSetup.params$check_header <-  0
@@ -197,12 +197,10 @@ h2o.parseSetup <- function(data, pattern="", destination_frame = "", header = NA
   if( !is.null(col.types) ) { # list of enums
     if (typeof(col.types) == "character") {
       if (!is.null(skipped_columns)) {
-        skipped_columns=sort(skipped_columns)
-        countSkippedColumns = 1
         countParsedColumns = 1
         for (cind in c(1:parseSetup$number_columns)) {
-          if (cind==(skipped_columns[countSkippedColumns]+1)) { # belongs to columns skipped
-            countSkippedColumns=countSkippedColumns+1
+          if ((cind-1) %in% skipped_columns) { # belongs to columns skipped
+            parseSetup$col_type[cind]=NA
           } else { #column indices to be parsed
             parseSetup$col_type[cind] = col.types[countParsedColumns]
             countParsedColumns = countParsedColumns+1

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -1148,25 +1148,20 @@ assertCorrectSkipColumnsNamesTypes <- function(originalFile, parsePath, skippedC
 
     if (mode == 0)  {
         # use both name and type
-        f1 <<-
-        h2o.importFile(parsePath, col.names = colnames, col.types = coltypes, skipped_columns=skippedColumns)
-        f2 <<-
-        h2o.uploadFile(parsePath, col.names = colnames, col.types = coltypes, skipped_columns=skippedColumns)
+        f1 <- h2o.importFile(parsePath, col.names = colnames, col.types = coltypes, skipped_columns=skippedColumns)
     } else if (mode == 1) {
-        f1 <<- h2o.importFile(parsePath, col.names = colnames, skipped_columns=skippedColumns)
-        f2 <<- h2o.uploadFile(parsePath, col.names = colnames, skipped_columns=skippedColumns)
+        f1 <- h2o.uploadFile(parsePath, col.names = colnames, skipped_columns=skippedColumns)
     } else {
-        f1 <<- h2o.importFile(parsePath, col.types = coltypes, skipped_columns=skippedColumns)
-        f2 <<- h2o.uploadFile(parsePath, col.types = coltypes, skipped_columns=skippedColumns)
+        f1 <- h2o.importFile(parsePath, col.types = coltypes, skipped_columns=skippedColumns)
     }
 
     expect_true(h2o.nrow(originalFile) == h2o.nrow(f1))
-    expect_true(h2o.nrow(f2) == h2o.nrow(f1))
+  #  expect_true(h2o.nrow(f2) == h2o.nrow(f1))
     cfullnames <- names(originalFile)
     originalR <- as.data.frame(originalFile)
     f1R <- as.data.frame(f1)
-    f2R <- as.data.frame(f2)
-    cskipnames <- names(f2R)
+  #  f2R <- as.data.frame(f2)
+    cskipnames <- names(f1R)
     skipcount <- 1
     rowNum <- h2o.nrow(f1)
     for (ind in c(1:length(cfullnames))) {
@@ -1176,10 +1171,10 @@ assertCorrectSkipColumnsNamesTypes <- function(originalFile, parsePath, skippedC
             for (rind in c(1:rowNum)) {
                 if (is.na(originalR[rind, ind])) {
                     expect_true(
-                    is.na(f2R[rind, skipcount]),
+                    is.na(f1R[rind, skipcount]),
                     info = paste0(
                     "expected NA but received: ",
-                    f2R[rind, skipcount],
+                    f1R[rind, skipcount],
                     " in row: ",
                     rind,
                     " with column name: ",
@@ -1189,20 +1184,7 @@ assertCorrectSkipColumnsNamesTypes <- function(originalFile, parsePath, skippedC
                     sep = " "
                     )
                     )
-                    expect_true(
-                    is.na(f2R[rind, skipcount]),
-                    info = paste0(
-                    "expected NA but received: ",
-                    f2R[rind, skipcount],
-                    " in row: ",
-                    rind,
-                    " with column name: ",
-                    cfullnames[ind],
-                    " and skipped column name ",
-                    cskipnames[skipcount],
-                    sep = " "
-                    )
-                    )
+
                 } else if (is.numeric(originalR[rind, ind])) {
                     if (allFrameTypes[ind] == 'time') {
                         expect_true(
@@ -1221,22 +1203,7 @@ assertCorrectSkipColumnsNamesTypes <- function(originalFile, parsePath, skippedC
                         sep = " "
                         )
                         )
-                        expect_true(
-                        abs(originalR[rind, ind] - f2R[rind, skipcount]) < 10,
-                        info = paste0(
-                        "expected: ",
-                        originalR[rind, ind],
-                        " but received: ",
-                        f2R[rind, skipcount],
-                        " in row: ",
-                        rind,
-                        " with column name: ",
-                        cfullnames[ind],
-                        " and skipped column name ",
-                        cskipnames[skipcount],
-                        sep = " "
-                        )
-                        )
+
                     } else {
                         expect_true(
                         abs(originalR[rind, ind] - f1R[rind, skipcount]) < 1e-10,
@@ -1245,22 +1212,6 @@ assertCorrectSkipColumnsNamesTypes <- function(originalFile, parsePath, skippedC
                         originalR[rind, ind],
                         " but received: ",
                         f1R[rind, skipcount],
-                        " in row: ",
-                        rind,
-                        " with column name: ",
-                        cfullnames[ind],
-                        " and skipped column name ",
-                        cskipnames[skipcount],
-                        sep = " "
-                        )
-                        )
-                        expect_true(
-                        abs(originalR[rind, ind] - f2R[rind, skipcount]) < 1e-10,
-                        info = paste0(
-                        "expected: ",
-                        originalR[rind, ind],
-                        " but received: ",
-                        f2R[rind, skipcount],
                         " in row: ",
                         rind,
                         " with column name: ",
@@ -1289,23 +1240,6 @@ assertCorrectSkipColumnsNamesTypes <- function(originalFile, parsePath, skippedC
                     sep = " "
                     )
                     )
-                    expect_true(
-                    originalR[rind, ind] == f2R[rind, skipcount],
-                    info = paste0(
-                    "expected: ",
-                    originalR[rind, ind],
-                    " but received: ",
-                    f2R[rind, skipcount],
-                    " in row: ",
-                    rind,
-                    " with column name: ",
-                    cfullnames[ind],
-                    " and skipped column name ",
-                    cskipnames[skipcount],
-                    sep = " "
-                    )
-                    )
-
                 }
             }
 

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_column_names_types_large.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_5705_drop_columns_parser_column_names_types_large.R
@@ -6,17 +6,11 @@ source("../../scripts/h2o-r-test-setup.R")
 # Tests parsing with skipped columns
 test.parseSkippedColumnsNameType <- function() {
   csvWithHeader <-
-    h2o.importFile(locate("smalldata/airlines/allyears2k_headers.zip"))
+    h2o.importFile(locate("smalldata/airlines/allyears2k_headers_8kRows.csv.zip"))
   allColnames <- h2o.names(csvWithHeader)
   allTypeDict <- h2o.getTypes(csvWithHeader)
-  pathHeader <- locate("smalldata/airlines/allyears2k_headers.zip")
 
-  # upload file with  no header but fixed column types.
-  csvWithNoHeader <-
-    h2o.uploadFile(locate("smalldata/airlines/allyears2k.zip"))
-  allNewColnames <- h2o.names(csvWithNoHeader)
-  allNewTypeDict <- h2o.getTypes(csvWithNoHeader)
-  pathNoHeader <- locate("smalldata/airlines/allyears2k.zip")
+  pathNoHeader <- locate("smalldata/airlines/allyears2k_8kRows.csv.zip")
 
   skip_front <- c(1)
   skip_end <- c(h2o.ncol(csvWithHeader))


### PR DESCRIPTION
Fixed bug in R API:
- assign column types to all columns.
- shorten test to test either importFile or uploadFile but not both.