### PR TITLE
PUBDEV-6062: fix multinomial coefficient names

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -31,6 +31,8 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
     @API(help="Lambda best + 1 standard error. Only applicable with lambda search and cross-validation")
     double lambda_1se;
 
+    int _responseColumn; // indicates the response column index, do not use, internal only
+
     private GLMModelOutputV3 fillMultinomial(GLMOutput impl) {
       if(impl.get_global_beta_multinomial() == null)
         return this; // no coefificients yet
@@ -42,9 +44,10 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       if(impl.isStandardized()){
         int n = impl.nclasses();
         String [] cols = new String[n*2];
+        String[] classNames = impl._domains[_responseColumn];
         for(int i = 0; i < n; ++i) {
-          cols[i] = "Coefs_class_" + i;
-          cols[n+i] = "Std_Coefs_class_" + i;
+          cols[i] = "Coefs_class_" + classNames[i];
+          cols[n+i] = "Std_Coefs_class_" + classNames[i];
         }
         String [] colTypes = new String[cols.length];
         Arrays.fill(colTypes, "double");

--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -22,6 +22,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
     @API(help="Table of Coefficients")
     TwoDimTableV3 coefficients_table;
 
+    @API(help="Table of Coefficients with coefficients denoted with class names for GLM multinonimals only.")
+    TwoDimTableV3 coefficients_table_multinomials_with_class_names;  // same as coefficients_table but with real class names.
+
     @API(help="Standardized Coefficient Magnitudes")
     TwoDimTableV3 standardized_coefficient_magnitudes;
 
@@ -31,8 +34,6 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
     @API(help="Lambda best + 1 standard error. Only applicable with lambda search and cross-validation")
     double lambda_1se;
 
-    int _responseColumn; // indicates the response column index, do not use, internal only
-
     private GLMModelOutputV3 fillMultinomial(GLMOutput impl) {
       if(impl.get_global_beta_multinomial() == null)
         return this; // no coefificients yet
@@ -41,14 +42,26 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       String [] ns = ArrayUtils.append(new String[]{"Intercept"},Arrays.copyOf(names,names.length-1));
 
       coefficients_table = new TwoDimTableV3();
+      if (impl.nclasses() > 2) // only change coefficient names for multinomials
+        coefficients_table_multinomials_with_class_names = new TwoDimTableV3();
+
       if(impl.isStandardized()){
         int n = impl.nclasses();
-        String [] cols = new String[n*2];
-        String[] classNames = impl._domains[_responseColumn];
-        for(int i = 0; i < n; ++i) {
-          cols[i] = "Coefs_class_" + classNames[i];
-          cols[n+i] = "Std_Coefs_class_" + classNames[i];
+        String[] cols = new String[n*2];
+        String[] cols2=null;
+        if (n>2) {
+          cols2 = new String[n*2];
+          String[] classNames = impl._domains[impl.responseIdx()];
+          for (int i = 0; i < n; ++i) {
+            cols2[i] = "coefs_class_" + classNames[i];
+            cols2[n + i] = "std_coefs_class_" + classNames[i];
+          }
         }
+        for (int i = 0; i < n; ++i) {
+          cols[i] = "coefs_class_" +i;
+          cols[n + i] = "std_coefs_class_" +i;
+        }
+
         String [] colTypes = new String[cols.length];
         Arrays.fill(colTypes, "double");
         String [] colFormats = new String[cols.length];
@@ -67,6 +80,11 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
             }
           }
           coefficients_table.fillFromImpl(tdt);
+
+          if (n>2) {  // restore column names from pythonized ones
+            coefficients_table_multinomials_with_class_names.fillFromImpl(tdt);
+            revertCoeffNames(cols2, n, coefficients_table_multinomials_with_class_names);
+          }
           final double [] magnitudes = new double[betaNorm[0].length];
           for(int i = 0; i < betaNorm.length; ++i) {
             for (int j = 0; j < betaNorm[i].length; ++j) {
@@ -99,9 +117,18 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       } else {
         int n = impl.nclasses();
         String [] cols = new String[n];
-        for(int i = 0; i < n; ++i) {
-          cols[i] = "Coefs_class_" + i;
+        String [] cols2 = null;
+        if (n>2) {
+          String[] classNames = impl._domains[impl.responseIdx()];
+          cols2 = new String[n];
+          for (int i = 0; i < n; ++i) {
+            cols2[i] = "coefs_class_" + classNames[i];
+          }
         }
+          for (int i = 0; i < n; ++i) {
+            cols[i] = "coefs_class_" +i;
+          }
+
         String [] colTypes = new String[cols.length];
         Arrays.fill(colTypes, "double");
         String [] colFormats = new String[cols.length];
@@ -116,9 +143,26 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
             tdt.set(i + 1, c, beta[i]);
         }
         coefficients_table.fillFromImpl(tdt);
+        if (n>2) {  // restore column names from pythonized ones
+          coefficients_table_multinomials_with_class_names.fillFromImpl(tdt);
+          revertCoeffNames(cols2, n, coefficients_table_multinomials_with_class_names);
+        }
       }
+
       return this;
     }
+
+    public void revertCoeffNames(String[] colNames, int nclass, TwoDimTableV3 coeffs_table) {
+      String newName = coeffs_table.name+" with class names";
+      coeffs_table.name = newName;
+      boolean bothCoeffStd = colNames.length==(2*nclass);
+      for (int tableIndex = 1; tableIndex <= nclass;  tableIndex++) {
+        coeffs_table.columns[tableIndex].name = new String(colNames[tableIndex-1]);
+        if (bothCoeffStd)
+          coeffs_table.columns[tableIndex+nclass].name = new String(colNames[tableIndex-1+nclass]);
+      }
+    }
+
     @Override
     public GLMModelOutputV3 fillFromImpl(GLMModel.GLMOutput impl) {
       super.fillFromImpl(impl);

--- a/h2o-core/src/main/java/water/api/schemas3/TwoDimTableV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/TwoDimTableV3.java
@@ -19,7 +19,7 @@ public class TwoDimTableV3 extends SchemaV3<TwoDimTable, TwoDimTableV3> {
 
   public static class ColumnSpecsBase extends SchemaV3<Iced, ColumnSpecsBase> {
     @API(help="Column Name", direction=API.Direction.OUTPUT)
-    String name;
+    public String name; // allow reset of col header names so that I can undo the pythonize for GLM multinomial coeff names
     @API(help="Column Type", direction=API.Direction.OUTPUT)
     String type;
     @API(help="Column Format (printf)", direction=API.Direction.OUTPUT)

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_6062_multinomial_coeffNames.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_6062_multinomial_coeffNames.py
@@ -1,0 +1,42 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+def test_glm_multinomial_coeffs():
+    trainF = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    y = "species"
+    x = [0,1,2,3]
+    bin_LS = glm(family='multinomial', seed=12345)
+    bin_LS.train(x=x, y=y, training_frame=trainF)
+    print(bin_LS.summary())
+    coefficient_table_original = bin_LS._model_json["output"]["coefficients_table"]
+    coefficient_table = bin_LS._model_json["output"]["coefficients_table_multinomials_with_class_names"]
+
+    coeffNamesOld = coefficient_table_original.col_header
+    coeffNames = coefficient_table.col_header
+    validCoefficientNames = [u"names", u"coefs_class_Iris-setosa", u"coefs_class_Iris-versicolor",
+                             u"coefs_class_Iris-virginica", u"std_coefs_class_Iris-setosa",
+                             u"std_coefs_class_Iris-versicolor", u"std_coefs_class_Iris-virginica"]
+    oldCoefficientNames = [u"names", u"coefs_class_0", u"coefs_class_1",
+                             u"coefs_class_2", u"std_coefs_class_0",
+                             u"std_coefs_class_1", u"std_coefs_class_2"]
+    print(coefficient_table)
+    print(coefficient_table_original)
+
+    # compare coefficient names
+    assert len(set(coeffNames).intersection(validCoefficientNames))==len(coeffNames),\
+        "Expected coefficient names: {0}.  Actual coefficient names: {1}".format(validCoefficientNames, coeffNames)
+    assert len(set(coeffNamesOld).intersection(oldCoefficientNames))==len(coeffNames), \
+        "Expected original coefficient names: {0}.  Actual original coefficient names: " \
+        "{1}".format(oldCoefficientNames, coeffNamesOld)
+
+    # compare table contents to make sure they contain the same values
+    pyunit_utils.assert_H2OTwoDimTable_equal_upto(coefficient_table_original, coefficient_table, [u'coefs_class_0'],
+                                                  tolerance=1e-10)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_multinomial_coeffs)
+else:
+    test_glm_multinomial_coeffs()

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_PUBDEV_6062_cat_coeff_names.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_PUBDEV_6062_cat_coeff_names.R
@@ -1,0 +1,17 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.multinomial.coeff.names <- function() {
+  trainF <- h2o.importFile(locate("smalldata/iris/iris_train.csv"))
+  my_model <- h2o.glm(x = 1:4,y = "species",training_frame = trainF,family = "multinomial",model_id = "my_model",seed = 1,lambda = 0)
+  my_model
+
+  cold <-my_model@model$coefficients_table
+  cnew <- my_model@model$coefficients_table_multinomials_with_class_names
+  
+  # spot check values, complete check is already done in Python
+  expect_equal(cold[[2]], cnew[[2]], tolerance=1e-10, info= "Return numerical values are different.")
+}
+
+doTest("Test GLM coefficient names", test.multinomial.coeff.names)
+


### PR DESCRIPTION
This PR completes the work demanded in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6062?filter=-1.

Work done:
1. In Java backend, force coefficient name to contain the actual class name instead of 0, 1, 2,...
2. Added R/Python unit test to verify correct coefficient names are returned. 