### PR TITLE
Cleanup - move temporary directory 'lib' under the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ pytest_flatfile-*
 sandbox*/
 syn_datasets
 build/
-lib/
 classes/
 h2o-web/src/main/resources/www/steam
 h2o-web/src/main/resources/www/flow

--- a/gradle/cp.gradle
+++ b/gradle/cp.gradle
@@ -7,6 +7,6 @@ task cpLibs(type:Sync) {
     from { project.configurations.runtime.minus(skipFiles()) }
     from { project.configurations.testRuntime.minus(skipFiles()) }
     
-    into "$rootDir/lib"
+    into "$rootDir/build/lib"
 }
 

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -6,8 +6,8 @@ description = "H2O Algorithms"
 dependencies {
   compile project(":h2o-core")
   // Include ad-hoc dependency represented by deepwater fat jar
-  if (file("${rootDir}/lib/deepwater-all.jar").exists()) {
-      compile files("${rootDir}/lib/deepwater-all.jar")
+  if (file("${rootDir}/build/lib/deepwater-all.jar").exists()) {
+      compile files("${rootDir}/build/lib/deepwater-all.jar")
   }
 
   // Jama dependencies

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -5,10 +5,6 @@ description = "H2O Algorithms"
 
 dependencies {
   compile project(":h2o-core")
-  // Include ad-hoc dependency represented by deepwater fat jar
-  if (file("${rootDir}/build/lib/deepwater-all.jar").exists()) {
-      compile files("${rootDir}/build/lib/deepwater-all.jar")
-  }
 
   // Jama dependencies
   compile "gov.nist.math:jama:1.0.3"

--- a/h2o-algos/testSSL.sh
+++ b/h2o-algos/testSSL.sh
@@ -108,7 +108,7 @@ pwd
 tshark -i ${INTERFACE} -T fields -e data -w ${OUTDIR}/h2o-nonSSL.pcap 1> /dev/null 2>&1 & PID_4=$!
 
 java -Dai.h2o.name=$CLUSTER_NAME -ea \
-    -cp "build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*" \
+    -cp "build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../build/lib/*" \
     water.network.SSLEncryptionTest
 
 echo After test cleanup...
@@ -127,7 +127,7 @@ echo Running SSL test...
 tshark -i ${INTERFACE} -T fields -e data -w ${OUTDIR}/h2o-SSL.pcap 1> /dev/null 2>&1 & PID_4=$!
 
 java -Dai.h2o.name=$CLUSTER_NAME -ea \
-    -cp "build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../lib/*" \
+    -cp "build/libs/h2o-algos-test.jar${SEP}build/libs/h2o-algos.jar${SEP}../h2o-core/build/libs/h2o-core.jar${SEP}../h2o-core/build/libs/h2o-core-test.jar${SEP}../h2o-genmodel/build/libs/h2o-genmodel.jar${SEP}../build/lib/*" \
     water.network.SSLEncryptionTest src/test/resources/ssl.properties
 
 echo After test cleanup...

--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -76,7 +76,7 @@ jar {
 // complete cluster of free-running JVMs and redirect all output (at the OS
 // level) to files - then scrape the files later for test results.
 test {
-  dependsOn smalldataCheck, cpLibs, testMultiNode, testJar
+  dependsOn smalldataCheck, testMultiNode, testJar
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-extensions/jython-cfunc/build.gradle
+++ b/h2o-extensions/jython-cfunc/build.gradle
@@ -15,7 +15,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 test {
     dependsOn ":h2o-core:testJar"
     // Note: multi node tests are ignored right now!
-    dependsOn smalldataCheck, cpLibs, jar, testJar, testSingleNode, testMultiNode
+    dependsOn smalldataCheck, jar, testJar, testSingleNode, testMultiNode
 
     // Defeat task 'test' by running no tests.
     exclude '**'

--- a/h2o-extensions/xgboost/build.gradle
+++ b/h2o-extensions/xgboost/build.gradle
@@ -18,7 +18,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 test {
     dependsOn ":h2o-core:testJar"
     // Note: multi node tests are ignored right now!
-    dependsOn smalldataCheck, cpLibs, jar, testJar, testSingleNode //, testMultiNode
+    dependsOn smalldataCheck, jar, testJar, testSingleNode //, testMultiNode
 
     // Defeat task 'test' by running no tests.
     exclude '**'

--- a/h2o-parsers/h2o-avro-parser/build.gradle
+++ b/h2o-parsers/h2o-avro-parser/build.gradle
@@ -18,7 +18,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 
 test {
   dependsOn ":h2o-core:testJar"
-  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+  dependsOn smalldataCheck, jar, testJar, testMultiNode
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-parsers/h2o-orc-parser/build.gradle
+++ b/h2o-parsers/h2o-orc-parser/build.gradle
@@ -67,7 +67,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 
 test {
   dependsOn ":h2o-core:testJar"
-  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+  dependsOn smalldataCheck, jar, testJar, testMultiNode
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-parsers/h2o-parquet-compat/h2o-parquet-v17-compat/build.gradle
+++ b/h2o-parsers/h2o-parquet-compat/h2o-parquet-v17-compat/build.gradle
@@ -36,7 +36,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 test {
   dependsOn ":h2o-core:testJar"
   dependsOn ":h2o-parquet-parser:testJar"
-  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+  dependsOn smalldataCheck, jar, testJar, testMultiNode
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-parsers/h2o-parquet-parser/build.gradle
+++ b/h2o-parsers/h2o-parquet-parser/build.gradle
@@ -49,7 +49,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 
 test {
   dependsOn ":h2o-core:testJar"
-  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+  dependsOn smalldataCheck, jar, testJar, testMultiNode
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-persist-gcs/build.gradle
+++ b/h2o-persist-gcs/build.gradle
@@ -14,7 +14,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 
 test {
     dependsOn ":h2o-core:testJar"
-    dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+    dependsOn smalldataCheck, jar, testJar, testMultiNode
 
     // Defeat task 'test' by running no tests.
     exclude '**'

--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -35,7 +35,7 @@ task s3CredentialsCheck(group: "S3") {
 
 test {
     dependsOn ":h2o-core:testJar"
-    dependsOn smalldataCheck, s3CredentialsCheck, cpLibs, jar, testJar, testMultiNode
+    dependsOn smalldataCheck, s3CredentialsCheck, jar, testJar, testMultiNode
 
     // Defeat task 'test' by running no tests.
     exclude '**'

--- a/h2o-persist-http/build.gradle
+++ b/h2o-persist-http/build.gradle
@@ -22,7 +22,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 // level) to files - then scrape the files later for test results.
 test {
   dependsOn ":h2o-core:testJar"
-  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+  dependsOn smalldataCheck, jar, testJar, testMultiNode
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-persist-s3/build.gradle
+++ b/h2o-persist-s3/build.gradle
@@ -31,7 +31,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 // level) to files - then scrape the files later for test results.
 test {
   dependsOn ":h2o-core:testJar"
-  dependsOn smalldataCheck, cpLibs, jar, testJar, testMultiNode
+  dependsOn smalldataCheck, jar, testJar, testMultiNode
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-scala/build.gradle
+++ b/h2o-scala/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 // complete cluster of free-running JVMs and redirect all output (at the OS
 // level) to files - then scrape the files later for test results.
 test {
-  dependsOn cpLibs, testMultiNode, testJar
+  dependsOn testMultiNode, testJar
 
   // Defeat task 'test' by running no tests.
   exclude '**'

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -100,13 +100,6 @@ task copyGenModelJarToWebRoot(type: Copy) {
   rename { filename -> "h2o-genmodel.jar"}
 }
 
-task copyDeepWaterJarToWebRoot(type: Copy) {
-  from {
-      file("${rootDir}/build/lib/deepwater-all.jar")
-  }
-  into "src/main/resources/www/${h2oRESTApiVersion}/"
-}
-
 task deleteBowerModules(type: Delete) {
   delete 'lib'
 }
@@ -189,7 +182,6 @@ processResources.dependsOn copyExampleFlows
 processResources.dependsOn compileHelpFiles
 processResources.dependsOn copyHelpImages
 processResources.dependsOn copyGenModelJarToWebRoot
-processResources.dependsOn copyDeepWaterJarToWebRoot
 
 compileAndInstallDocFiles.dependsOn installNpmPackages
 compileAndInstallDocFiles.dependsOn ":h2o-bindings:runGenerateRESTAPIBindingsSrc"

--- a/h2o-web/build.gradle
+++ b/h2o-web/build.gradle
@@ -102,7 +102,7 @@ task copyGenModelJarToWebRoot(type: Copy) {
 
 task copyDeepWaterJarToWebRoot(type: Copy) {
   from {
-      file("${rootDir}/lib/deepwater-all.jar")
+      file("${rootDir}/build/lib/deepwater-all.jar")
   }
   into "src/main/resources/www/${h2oRESTApiVersion}/"
 }


### PR DESCRIPTION
Temporary directories should always be under a `build` dir.

This PR does this for toplevel `lib` which is now `build/lib` instead.