### PR TITLE
PUBDEV-5236 add the missing transform method

### DIFF
--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -559,9 +559,12 @@ def class_extra_for(algo):
 
             :returns: H2OPCA object
             \"\"\"
-            
+            import inspect
             from h2o.transforms.decomposition import H2OPCA
-            return H2OPCA(**self._parms)
+            # check which parameters can be passed to H2OPCA init
+            var_names = list(dict(inspect.getmembers(H2OPCA.__init__.__code__))['co_varnames'])
+            parameters = {k: v for k, v in self._parms.items() if k in var_names}
+            return H2OPCA(**parameters)
         """
 
 

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -552,18 +552,24 @@ def class_extra_for(algo):
         """
     elif algo == "pca":
         return """
-        def fit_transform(self, X, y=None, **params):
+        def init_for_pipeline(self):
             \"\"\"
-            Fit and transform the given H2OFrame with the fitted PCA model.
-            This method has to be implemented to be used with sklearn.pipeline module.
+            Returns H2OPCA object which implements fit and transform method to be used in sklearn.Pipeline properly.
 
-            :param H2OFrame X: May contain NAs and/or categorical data.
-            :param H2OFrame y: Ignored for PCA. Should be None.
-            :param params: Ignored.
-
-            :returns: The input H2OFrame transformed by the Principal Components.
+            :returns: H2OPCA object
             \"\"\"
-            return self.fit(X, y, **params).predict(X)
+            from h2o.transforms.decomposition import H2OPCA
+            return H2OPCA(model_id=self.model_id,
+                            k=self.k,
+                            max_iterations=self.max_iterations,
+                            seed=self.seed,
+                            transform="None" if self.transform is None else self.transform,
+                            use_all_factor_levels=False if self.use_all_factor_levels is None else self.use_all_factor_levels,
+                            pca_method="GramSVD" if self.pca_method is None else self.pca_method,
+                            pca_impl="mtj_evd_symmmatrix" if self.pca_impl is None else self.pca_impl,
+                            ignore_const_cols=True if self.ignore_const_cols is None else self.ignore_const_cols,
+                            impute_missing=False if self.impute_missing is None else self.impute_missing,
+                            compute_metrics=True if self.compute_metrics is None else self.compute_metrics)
         """
 
 

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -552,9 +552,9 @@ def class_extra_for(algo):
         """
     elif algo == "pca":
         return """
-        def transform(self, X, y=None, **params):
+        def fit_transform(self, X, y=None, **params):
             \"\"\"
-            Transform the given H2OFrame with the fitted PCA model.
+            Fit and transform the given H2OFrame with the fitted PCA model.
             This method has to be implemented to be used with sklearn.pipeline module.
 
             :param H2OFrame X: May contain NAs and/or categorical data.
@@ -563,7 +563,7 @@ def class_extra_for(algo):
 
             :returns: The input H2OFrame transformed by the Principal Components.
             \"\"\"
-            return self.predict(X)
+            return self.fit(X, y, **params).predict(X)
         """
 
 

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -555,21 +555,13 @@ def class_extra_for(algo):
         def init_for_pipeline(self):
             \"\"\"
             Returns H2OPCA object which implements fit and transform method to be used in sklearn.Pipeline properly.
+            All parameters defined in self.__params, should be input parameters in H2OPCA.__init__ method.
 
             :returns: H2OPCA object
             \"\"\"
+            
             from h2o.transforms.decomposition import H2OPCA
-            return H2OPCA(model_id=self.model_id,
-                            k=self.k,
-                            max_iterations=self.max_iterations,
-                            seed=self.seed,
-                            transform="None" if self.transform is None else self.transform,
-                            use_all_factor_levels=False if self.use_all_factor_levels is None else self.use_all_factor_levels,
-                            pca_method="GramSVD" if self.pca_method is None else self.pca_method,
-                            pca_impl="mtj_evd_symmmatrix" if self.pca_impl is None else self.pca_impl,
-                            ignore_const_cols=True if self.ignore_const_cols is None else self.ignore_const_cols,
-                            impute_missing=False if self.impute_missing is None else self.impute_missing,
-                            compute_metrics=True if self.compute_metrics is None else self.compute_metrics)
+            return H2OPCA(**self._parms)
         """
 
 

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -555,6 +555,7 @@ def class_extra_for(algo):
         def transform(self, X, y=None, **params):
             \"\"\"
             Transform the given H2OFrame with the fitted PCA model.
+            This method has to be implemented to be used with sklearn.pipeline module.
 
             :param H2OFrame X: May contain NAs and/or categorical data.
             :param H2OFrame y: Ignored for PCA. Should be None.

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -550,6 +550,21 @@ def class_extra_for(algo):
 
             self.vec_size = self.pre_trained.dim[1] - 1;
         """
+    elif algo == "pca":
+        return """
+        def transform(self, X, y=None, **params):
+            \"\"\"
+            Transform the given H2OFrame with the fitted PCA model.
+
+            :param H2OFrame X: May contain NAs and/or categorical data.
+            :param H2OFrame y: Ignored for PCA. Should be None.
+            :param params: Ignored.
+
+            :returns: The input H2OFrame transformed by the Principal Components.
+            \"\"\"
+            return self.predict(X)
+        """
+
 
 def module_extra_for(algo):
     if algo == "deeplearning":

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -286,9 +286,9 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
 
 
 
-    def transform(self, X, y=None, **params):
+    def fit_transform(self, X, y=None, **params):
         """
-        Transform the given H2OFrame with the fitted PCA model.
+        Fit and transform the given H2OFrame with the fitted PCA model.
         This method has to be implemented to be used with sklearn.pipeline module.
 
         :param H2OFrame X: May contain NAs and/or categorical data.
@@ -297,4 +297,4 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
 
         :returns: The input H2OFrame transformed by the Principal Components.
         """
-        return self.predict(X)
+        return self.fit(X, y, **params).predict(X)

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -272,6 +272,7 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     def transform(self, X, y=None, **params):
         """
         Transform the given H2OFrame with the fitted PCA model.
+        This method has to be implemented to be used with sklearn.pipeline module.
 
         :param H2OFrame X: May contain NAs and/or categorical data.
         :param H2OFrame y: Ignored for PCA. Should be None.

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -269,18 +269,6 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
         assert_is_type(max_runtime_secs, None, numeric)
         self._parms["max_runtime_secs"] = max_runtime_secs
 
-    def transform(self, X, y=None, **params):
-        """
-        Transform the given H2OFrame with the fitted PCA model.
-
-        :param H2OFrame X: May contain NAs and/or categorical data.
-        :param H2OFrame y: Ignored for PCA. Should be None.
-        :param params: Ignored.
-
-        :returns: The input H2OFrame transformed by the Principal Components.
-        """
-        return self.predict(X)
-
 
     @property
     def export_checkpoints_dir(self):

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -269,19 +269,14 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
         assert_is_type(max_runtime_secs, None, numeric)
         self._parms["max_runtime_secs"] = max_runtime_secs
 
-
-    @property
-    def export_checkpoints_dir(self):
+    def transform(self, X, y=None, **params):
         """
-        Automatically export generated models to this directory.
+        Transform the given H2OFrame with the fitted PCA model.
 
-        Type: ``str``.
+        :param H2OFrame X: May contain NAs and/or categorical data.
+        :param H2OFrame y: Ignored for PCA. Should be None.
+        :param params: Ignored.
+
+        :returns: The input H2OFrame transformed by the Principal Components.
         """
-        return self._parms.get("export_checkpoints_dir")
-
-    @export_checkpoints_dir.setter
-    def export_checkpoints_dir(self, export_checkpoints_dir):
-        assert_is_type(export_checkpoints_dir, None, str)
-        self._parms["export_checkpoints_dir"] = export_checkpoints_dir
-
-
+        return self.predict(X)

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -286,15 +286,21 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
 
 
 
-    def fit_transform(self, X, y=None, **params):
+    def init_for_pipeline(self):
         """
-        Fit and transform the given H2OFrame with the fitted PCA model.
-        This method has to be implemented to be used with sklearn.pipeline module.
+        Returns H2OPCA object which implements fit and transform method to be used in sklearn.Pipeline properly.
 
-        :param H2OFrame X: May contain NAs and/or categorical data.
-        :param H2OFrame y: Ignored for PCA. Should be None.
-        :param params: Ignored.
-
-        :returns: The input H2OFrame transformed by the Principal Components.
+        :returns: H2OPCA object
         """
-        return self.fit(X, y, **params).predict(X)
+        from h2o.transforms.decomposition import H2OPCA
+        return H2OPCA(model_id=self.model_id,
+                        k=self.k,
+                        max_iterations=self.max_iterations,
+                        seed=self.seed,
+                        transform="None" if self.transform is None else self.transform,
+                        use_all_factor_levels=False if self.use_all_factor_levels is None else self.use_all_factor_levels,
+                        pca_method="GramSVD" if self.pca_method is None else self.pca_method,
+                        pca_impl="mtj_evd_symmmatrix" if self.pca_impl is None else self.pca_impl,
+                        ignore_const_cols=True if self.ignore_const_cols is None else self.ignore_const_cols,
+                        impute_missing=False if self.impute_missing is None else self.impute_missing,
+                        compute_metrics=True if self.compute_metrics is None else self.compute_metrics)

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -293,6 +293,9 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
 
         :returns: H2OPCA object
         """
-
+        import inspect
         from h2o.transforms.decomposition import H2OPCA
-        return H2OPCA(**self._parms)
+        # check which parameters can be passed to H2OPCA init
+        var_names = list(dict(inspect.getmembers(H2OPCA.__init__.__code__))['co_varnames'])
+        parameters = {k: v for k, v in self._parms.items() if k in var_names}
+        return H2OPCA(**parameters)

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -289,18 +289,10 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     def init_for_pipeline(self):
         """
         Returns H2OPCA object which implements fit and transform method to be used in sklearn.Pipeline properly.
+        All parameters defined in self.__params, should be input parameters in H2OPCA.__init__ method.
 
         :returns: H2OPCA object
         """
+
         from h2o.transforms.decomposition import H2OPCA
-        return H2OPCA(model_id=self.model_id,
-                        k=self.k,
-                        max_iterations=self.max_iterations,
-                        seed=self.seed,
-                        transform="None" if self.transform is None else self.transform,
-                        use_all_factor_levels=False if self.use_all_factor_levels is None else self.use_all_factor_levels,
-                        pca_method="GramSVD" if self.pca_method is None else self.pca_method,
-                        pca_impl="mtj_evd_symmmatrix" if self.pca_impl is None else self.pca_impl,
-                        ignore_const_cols=True if self.ignore_const_cols is None else self.ignore_const_cols,
-                        impute_missing=False if self.impute_missing is None else self.impute_missing,
-                        compute_metrics=True if self.compute_metrics is None else self.compute_metrics)
+        return H2OPCA(**self._parms)

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -269,6 +269,18 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
         assert_is_type(max_runtime_secs, None, numeric)
         self._parms["max_runtime_secs"] = max_runtime_secs
 
+    def transform(self, X, y=None, **params):
+        """
+        Transform the given H2OFrame with the fitted PCA model.
+
+        :param H2OFrame X: May contain NAs and/or categorical data.
+        :param H2OFrame y: Ignored for PCA. Should be None.
+        :param params: Ignored.
+
+        :returns: The input H2OFrame transformed by the Principal Components.
+        """
+        return self.predict(X)
+
 
     @property
     def export_checkpoints_dir(self):

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -269,6 +269,23 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
         assert_is_type(max_runtime_secs, None, numeric)
         self._parms["max_runtime_secs"] = max_runtime_secs
 
+
+    @property
+    def export_checkpoints_dir(self):
+        """
+        Automatically export generated models to this directory.
+
+        Type: ``str``.
+        """
+        return self._parms.get("export_checkpoints_dir")
+
+    @export_checkpoints_dir.setter
+    def export_checkpoints_dir(self, export_checkpoints_dir):
+        assert_is_type(export_checkpoints_dir, None, str)
+        self._parms["export_checkpoints_dir"] = export_checkpoints_dir
+
+
+
     def transform(self, X, y=None, **params):
         """
         Transform the given H2OFrame with the fitted PCA model.

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -17,13 +17,7 @@ class H2OPCA(H2OEstimator):
                  pca_impl="mtj_evd_symmmatrix",
                  ignore_const_cols=True,
                  impute_missing=False,
-                 compute_metrics=True,
-                 training_frame=None,
-                 validation_frame=None,
-                 ignored_columns=None,
-                 score_each_iteration=False,
-                 max_runtime_secs=0,
-                 export_checkpoints_dir=None):
+                 compute_metrics=True):
         """
         Principal Components Analysis
 
@@ -71,14 +65,6 @@ class H2OPCA(H2OEstimator):
         :param bool ignore_const_cols: If true, will ignore constant columns.  Default is True.
         :param bool impute_missing:  whether to impute NA/missing values.
         :param bool compute_metrics: whether to compute metrics on training data.  Default is True.
-        :param Frame training_frame: Id of the training data frame.
-        :param Frame validation_frame: Id of the validation data frame.
-        :param List[str] ignored_columns: names of columns to ignore for training.
-        :param bool score_each_iteration: Whether to score during each iteration of model training. Default is False.
-        :param numeric max_runtime_secs: Maximum allowed runtime in seconds for model training. Use 0 to disable.
-            Default is 0.
-        :param str export_checkpoints_dir: Automatically export generated models to this directory.
-
 
         :returns: A new instance of H2OPCA.
 
@@ -93,18 +79,6 @@ class H2OPCA(H2OEstimator):
         self._parms["pca_impl"] = pca_impl
         assert_is_type(transform, Enum("NONE", "DEMEAN", "DESCALE", "STANDARDIZE", "NORMALIZE"))
         self._parms["transform"] = transform
-        assert_is_type(training_frame, None, H2OFrame)
-        self._parms["training_frame"] = training_frame
-        assert_is_type(validation_frame, None, H2OFrame)
-        self._parms["validation_frame"] = validation_frame
-        assert_is_type(ignored_columns, None, [str])
-        self._parms["ignored_columns"] = ignored_columns
-        assert_is_type(score_each_iteration, None, bool)
-        self._parms["score_each_iteration"] = score_each_iteration
-        assert_is_type(max_runtime_secs, None, numeric)
-        self._parms["max_runtime_secs"] = max_runtime_secs
-        assert_is_type(export_checkpoints_dir, None, str)
-        self._parms["export_checkpoints_dir"] = export_checkpoints_dir
 
     def fit(self, X, y=None, **params):
         return super(H2OPCA, self).fit(X)

--- a/h2o-py/h2o/transforms/decomposition.py
+++ b/h2o-py/h2o/transforms/decomposition.py
@@ -1,7 +1,8 @@
 from ..estimators.estimator_base import H2OEstimator
 from h2o.utils.typechecks import Enum
 from h2o.utils.typechecks import assert_is_type
-
+from h2o.frame import H2OFrame
+from h2o.utils.typechecks import assert_is_type, Enum, numeric
 
 class H2OPCA(H2OEstimator):
     """
@@ -16,7 +17,13 @@ class H2OPCA(H2OEstimator):
                  pca_impl="mtj_evd_symmmatrix",
                  ignore_const_cols=True,
                  impute_missing=False,
-                 compute_metrics=True):
+                 compute_metrics=True,
+                 training_frame=None,
+                 validation_frame=None,
+                 ignored_columns=None,
+                 score_each_iteration=False,
+                 max_runtime_secs=0,
+                 export_checkpoints_dir=None):
         """
         Principal Components Analysis
 
@@ -63,7 +70,15 @@ class H2OPCA(H2OEstimator):
             ``"mtj_evd_symmmatrix"``, ``"mtj_svd_densematrix"``, ``"jama"``  (default: ``"mtj_evd_symmmatrix"``).
         :param bool ignore_const_cols: If true, will ignore constant columns.  Default is True.
         :param bool impute_missing:  whether to impute NA/missing values.
-        :param bool compute_metrics: whether to compute metrics on training data.  Default to True
+        :param bool compute_metrics: whether to compute metrics on training data.  Default is True.
+        :param Frame training_frame: Id of the training data frame.
+        :param Frame validation_frame: Id of the validation data frame.
+        :param List[str] ignored_columns: names of columns to ignore for training.
+        :param bool score_each_iteration: Whether to score during each iteration of model training. Default is False.
+        :param numeric max_runtime_secs: Maximum allowed runtime in seconds for model training. Use 0 to disable.
+            Default is 0.
+        :param str export_checkpoints_dir: Automatically export generated models to this directory.
+
 
         :returns: A new instance of H2OPCA.
 
@@ -78,6 +93,18 @@ class H2OPCA(H2OEstimator):
         self._parms["pca_impl"] = pca_impl
         assert_is_type(transform, Enum("NONE", "DEMEAN", "DESCALE", "STANDARDIZE", "NORMALIZE"))
         self._parms["transform"] = transform
+        assert_is_type(training_frame, None, H2OFrame)
+        self._parms["training_frame"] = training_frame
+        assert_is_type(validation_frame, None, H2OFrame)
+        self._parms["validation_frame"] = validation_frame
+        assert_is_type(ignored_columns, None, [str])
+        self._parms["ignored_columns"] = ignored_columns
+        assert_is_type(score_each_iteration, None, bool)
+        self._parms["score_each_iteration"] = score_each_iteration
+        assert_is_type(max_runtime_secs, None, numeric)
+        self._parms["max_runtime_secs"] = max_runtime_secs
+        assert_is_type(export_checkpoints_dir, None, str)
+        self._parms["export_checkpoints_dir"] = export_checkpoints_dir
 
     def fit(self, X, y=None, **params):
         return super(H2OPCA, self).fit(X)

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -24,7 +24,7 @@ def scale_pca_rf_pipe():
 def scale_pca_rf_pipe_new_import():
 
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
 
@@ -34,7 +34,7 @@ def scale_pca_rf_pipe_new_import():
   # it should fail
   try:
     pipe = Pipeline([("standardize", H2OScaler()),
-                     ("pca", H2OPCA(k=2)),
+                     ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
                      ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
     pipe.fit(iris[:4], iris[4])
     print(pipe)
@@ -44,13 +44,13 @@ def scale_pca_rf_pipe_new_import():
 
   # build transformation pipeline using sklearn's Pipeline and H2O estimators with H2OPCA.init_for_pipeline()
   pipe = Pipeline([("standardize", H2OScaler()),
-                   ("pca", H2OPCA(k=2).init_for_pipeline()),
+                   ("pca", H2OPrincipalComponentAnalysisEstimator(k=2).init_for_pipeline()),
                    ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
   pipe.fit(iris[:4], iris[4])
   print(pipe)
 
   # set H2OPCA transform property
-  pca = H2OPCA(k=2)
+  pca = H2OPrincipalComponentAnalysisEstimator(k=2)
   pca.transform = "standardize"
   pipe = Pipeline([("standardize", H2OScaler()),
                    ("pca", pca.init_for_pipeline()),

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -4,13 +4,10 @@ import h2o
 from tests import pyunit_utils
 
 
-
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
   from h2o.transforms.decomposition import H2OPCA
-  # this should work below, but it's not yet: https://0xdata.atlassian.net/browse/PUBDEV-5236
-  #from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
 
@@ -23,8 +20,25 @@ def scale_pca_rf_pipe():
   pipe.fit(iris[:4],iris[4])
 
 
+def scale_pca_rf_pipe_new_import():
+
+  from h2o.transforms.preprocessing import H2OScaler
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+  from h2o.estimators.random_forest import H2ORandomForestEstimator
+  from sklearn.pipeline import Pipeline
+
+  iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+
+  # build transformation pipeline using sklearn's Pipeline and H2O transforms
+  pipe = Pipeline([("standardize", H2OScaler()),
+                     ("pca", H2OPCA(k=2)),
+                     ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
+  pipe.fit(iris[:4],iris[4])
+
 
 if __name__ == "__main__":
-    pyunit_utils.standalone_test(scale_pca_rf_pipe)
+  pyunit_utils.standalone_test(scale_pca_rf_pipe)
+  pyunit_utils.standalone_test(scale_pca_rf_pipe_new_import)
 else:
-    scale_pca_rf_pipe()
+  scale_pca_rf_pipe()
+  scale_pca_rf_pipe_new_import()

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -32,31 +32,35 @@ def scale_pca_rf_pipe_new_import():
 
   # build transformation pipeline using sklearn's Pipeline and H2O estimators without H2OPCA.init_for_pipeline()
   # it should fail
+  # Note: if you use PCA algo in a different combination of pipeline tasks, it could not fail, for example
+  #     if you comment line with H2ORandomForestEstimator task, the fit method doesn't fail because the pipeline doesn't
+  #     use _fit_transform_one method thus does not use H2OPrincipalComponentAnalysisEstimator.transform method
   try:
-    pipe = Pipeline([("standardize", H2OScaler()),
+    pipe = Pipeline([
+                     ("standardize", H2OScaler()),
                      ("pca", H2OPrincipalComponentAnalysisEstimator(k=2)),
-                     ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
+                     ("rf", H2ORandomForestEstimator(seed=42,ntrees=5))
+                    ])
     pipe.fit(iris[:4], iris[4])
-    print(pipe)
-    assert True, "Pipeline should fail without using H2OPCA.init_for_pipeline()"
-  except:
-    pass
+    assert False, "Pipeline should fail without using H2OPrincipalComponentAnalysisEstimator.init_for_pipeline()"
+  except TypeError:
+     pass
+
 
   # build transformation pipeline using sklearn's Pipeline and H2O estimators with H2OPCA.init_for_pipeline()
   pipe = Pipeline([("standardize", H2OScaler()),
                    ("pca", H2OPrincipalComponentAnalysisEstimator(k=2).init_for_pipeline()),
-                   ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
+                   ("rf", H2ORandomForestEstimator(seed=42,ntrees=5))])
   pipe.fit(iris[:4], iris[4])
-  print(pipe)
+  #print(pipe)
 
   # set H2OPCA transform property
   pca = H2OPrincipalComponentAnalysisEstimator(k=2)
   pca.transform = "standardize"
   pipe = Pipeline([("standardize", H2OScaler()),
                    ("pca", pca.init_for_pipeline()),
-                   ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
+                   ("rf", H2ORandomForestEstimator(seed=42,ntrees=5))])
   pipe.fit(iris[:4], iris[4])
-  print(pipe)
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
+++ b/h2o-py/tests/testdir_pipeline/pyunit_scale_pca_rf.py
@@ -18,6 +18,7 @@ def scale_pca_rf_pipe():
                    ("pca", H2OPCA(k=2)),
                    ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
   pipe.fit(iris[:4],iris[4])
+  print(pipe)
 
 
 def scale_pca_rf_pipe_new_import():
@@ -29,11 +30,33 @@ def scale_pca_rf_pipe_new_import():
 
   iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
 
-  # build transformation pipeline using sklearn's Pipeline and H2O transforms
-  pipe = Pipeline([("standardize", H2OScaler()),
+  # build transformation pipeline using sklearn's Pipeline and H2O estimators without H2OPCA.init_for_pipeline()
+  # it should fail
+  try:
+    pipe = Pipeline([("standardize", H2OScaler()),
                      ("pca", H2OPCA(k=2)),
                      ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
-  pipe.fit(iris[:4],iris[4])
+    pipe.fit(iris[:4], iris[4])
+    print(pipe)
+    assert True, "Pipeline should fail without using H2OPCA.init_for_pipeline()"
+  except:
+    pass
+
+  # build transformation pipeline using sklearn's Pipeline and H2O estimators with H2OPCA.init_for_pipeline()
+  pipe = Pipeline([("standardize", H2OScaler()),
+                   ("pca", H2OPCA(k=2).init_for_pipeline()),
+                   ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
+  pipe.fit(iris[:4], iris[4])
+  print(pipe)
+
+  # set H2OPCA transform property
+  pca = H2OPCA(k=2)
+  pca.transform = "standardize"
+  pipe = Pipeline([("standardize", H2OScaler()),
+                   ("pca", pca.init_for_pipeline()),
+                   ("rf", H2ORandomForestEstimator(seed=42,ntrees=50))])
+  pipe.fit(iris[:4], iris[4])
+  print(pipe)
 
 
 if __name__ == "__main__":

--- a/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
+++ b/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
@@ -5,7 +5,6 @@ import h2o
 from tests import pyunit_utils
 
 
-
 def scale_pca_rf_pipe():
 
   from h2o.transforms.preprocessing import H2OScaler
@@ -17,7 +16,6 @@ def scale_pca_rf_pipe():
   from h2o.model.regression import h2o_r2_score
   from sklearn.metrics.scorer import make_scorer
   from scipy.stats import randint
-
 
   iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
 
@@ -47,8 +45,47 @@ def scale_pca_rf_pipe():
   print(random_search.best_estimator_)
 
 
+def scale_pca_rf_pipe_new_import():
+  from h2o.transforms.preprocessing import H2OScaler
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+  from h2o.estimators.random_forest import H2ORandomForestEstimator
+  from sklearn.pipeline import Pipeline
+  from sklearn.grid_search import RandomizedSearchCV
+  from h2o.cross_validation import H2OKFold
+  from h2o.model.regression import h2o_r2_score
+  from sklearn.metrics.scorer import make_scorer
+  from scipy.stats import randint
+
+  iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+
+  # build  transformation pipeline using sklearn's Pipeline and H2O transforms
+  pipe = Pipeline([("standardize", H2OScaler()),
+                 ("pca", H2OPCA()),
+                 ("rf", H2ORandomForestEstimator())])
+
+  params = {"standardize__center":    [True, False],             # Parameters to test
+          "standardize__scale":     [True, False],
+          "pca__k":                 randint(2, iris[1:].shape[1]),
+          "rf__ntrees":             randint(50,60),
+          "rf__max_depth":          randint(4,8),
+          "rf__min_rows":           randint(5,10),}
+
+  custom_cv = H2OKFold(iris, n_folds=5, seed=42)
+  random_search = RandomizedSearchCV(pipe, params,
+                                   n_iter=5,
+                                   scoring=make_scorer(h2o_r2_score),
+                                   cv=custom_cv,
+                                   random_state=42,
+                                   n_jobs=1)
+
+  random_search.fit(iris[1:],iris[0])
+
+  print(random_search.best_estimator_)
+
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(scale_pca_rf_pipe)
+    pyunit_utils.standalone_test(scale_pca_rf_pipe_new_import)
 else:
     scale_pca_rf_pipe()
+    scale_pca_rf_pipe_new_import()

--- a/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
+++ b/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
@@ -11,7 +11,7 @@ def scale_pca_rf_pipe():
   from h2o.transforms import H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
-  from sklearn.grid_search import RandomizedSearchCV
+  from sklearn.model_selection import RandomizedSearchCV
   from h2o.cross_validation import H2OKFold
   from h2o.model.regression import h2o_r2_score
   from sklearn.metrics.scorer import make_scorer
@@ -49,10 +49,10 @@ def scale_pca_rf_pipe():
 
 def scale_pca_rf_pipe_new_import():
   from h2o.transforms.preprocessing import H2OScaler
-  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+  from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
-  from sklearn.grid_search import RandomizedSearchCV
+  from sklearn.model_selection import RandomizedSearchCV
   from h2o.cross_validation import H2OKFold
   from h2o.model.regression import h2o_r2_score
   from sklearn.metrics.scorer import make_scorer
@@ -62,7 +62,7 @@ def scale_pca_rf_pipe_new_import():
 
   # build  transformation pipeline using sklearn's Pipeline and H2O transforms
   pipe = Pipeline([("standardize", H2OScaler()),
-                 ("pca", H2OPCA().init_for_pipeline()),
+                 ("pca", H2OPrincipalComponentAnalysisEstimator().init_for_pipeline()),
                  ("rf", H2ORandomForestEstimator())])
 
   params = {"standardize__center":    [True, False],             # Parameters to test

--- a/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
+++ b/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
@@ -11,7 +11,7 @@ def scale_pca_rf_pipe():
   from h2o.transforms import H2OPCA
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
-  from sklearn.model_selection import RandomizedSearchCV
+  from sklearn.grid_search import RandomizedSearchCV
   from h2o.cross_validation import H2OKFold
   from h2o.model.regression import h2o_r2_score
   from sklearn.metrics.scorer import make_scorer
@@ -52,7 +52,7 @@ def scale_pca_rf_pipe_new_import():
   from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator
   from h2o.estimators.random_forest import H2ORandomForestEstimator
   from sklearn.pipeline import Pipeline
-  from sklearn.model_selection import RandomizedSearchCV
+  from sklearn.grid_search import RandomizedSearchCV
   from h2o.cross_validation import H2OKFold
   from h2o.model.regression import h2o_r2_score
   from sklearn.metrics.scorer import make_scorer

--- a/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
+++ b/h2o-py/tests/testdir_scikit_grid/pyunit_scal_pca_rf_grid.py
@@ -29,7 +29,9 @@ def scale_pca_rf_pipe():
             "pca__k":                 randint(2, iris[1:].shape[1]),
             "rf__ntrees":             randint(50,60),
             "rf__max_depth":          randint(4,8),
-            "rf__min_rows":           randint(5,10),}
+            "rf__min_rows":           randint(5,10),
+            "pca__transform":         ["none", "standardize"],
+            }
 
   custom_cv = H2OKFold(iris, n_folds=5, seed=42)
   random_search = RandomizedSearchCV(pipe, params,
@@ -60,7 +62,7 @@ def scale_pca_rf_pipe_new_import():
 
   # build  transformation pipeline using sklearn's Pipeline and H2O transforms
   pipe = Pipeline([("standardize", H2OScaler()),
-                 ("pca", H2OPCA()),
+                 ("pca", H2OPCA().init_for_pipeline()),
                  ("rf", H2ORandomForestEstimator())])
 
   params = {"standardize__center":    [True, False],             # Parameters to test
@@ -68,7 +70,9 @@ def scale_pca_rf_pipe_new_import():
           "pca__k":                 randint(2, iris[1:].shape[1]),
           "rf__ntrees":             randint(50,60),
           "rf__max_depth":          randint(4,8),
-          "rf__min_rows":           randint(5,10),}
+          "rf__min_rows":           randint(5,10),
+          "pca__transform":         ["none", "standardize"],
+          }
 
   custom_cv = H2OKFold(iris, n_folds=5, seed=42)
   random_search = RandomizedSearchCV(pipe, params,


### PR DESCRIPTION
In the `H2OPrincipalComponentAnalysisEstimator` (`pca.py`) the method `transform` is missing and the `@property transform` was called instead. It caused `None` was returned. The H2OPCA works well because it doesn't have `@property transform` (the parameter `transform` is set in the `init `method and cannot be changed). 

JIRA: https://0xdata.atlassian.net/browse/PUBDEV-5236

**The first idea**
- generate transform method into `pca.py`
- problem: overloading doesn't work even though the tests passed. When the user sets the transform property, a pipeline uses this property method when is running. 

**The second idea**
- rename the  `@property transform` to `@property transformation`
- problem: it is not user-friendly, it breaks all estimators usage, the doc should be changed, etc...

**The third idea**
- use in pipeline different object (adapter or wrapper) which implement `fit` and `transform` method properly
- problem: user have to use this object instead of estimator object
- solution: use in `sklearn.Pipeline` the old implementation of `H2OPCA` which works well, but can't be customized after initialization -> implement method `init_for_pipeline` in 'H2OPrincipalComponentAnalysisEstimator' which return `H2OPCA` initialized from 'H2OPrincipalComponentAnalysisEstimator' properties. 

The final solution is not so pretty, but enable to users to use a transform estimator in `sklearn.Pipeline` with a little change. 

**This is not the problem only with PCA but also with GLRM, SVD and Aggregator.**
