### PR TITLE
PUBDEV-5937 - XGBoost error handling changes

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2436,7 +2436,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       is.close();
       return model;
     } finally {
-      FileUtils.close(is);
+      FileUtils.closeSilently(is);
     }
   }
 
@@ -2457,7 +2457,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       os.close();
       return targetUri;
     } finally {
-      FileUtils.close(os);
+      FileUtils.closeSilently(os);
     }
   }
 
@@ -2479,7 +2479,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       os.close();
       return targetUri;
     } finally {
-      FileUtils.close(os);
+      FileUtils.closeSilently(os);
     }
   }
 

--- a/h2o-core/src/main/java/water/util/FileUtils.java
+++ b/h2o-core/src/main/java/water/util/FileUtils.java
@@ -16,10 +16,24 @@ public class FileUtils {
    *
    * @param closeable files to close
    */
-  public static void close(Closeable...closeable) {
+  public static void closeSilently(Closeable...closeable) {
     for(Closeable c : closeable)
       try { if( c != null ) c.close(); } catch( IOException xe ) { }
   }
+
+  /**
+   * Closes given files, logging exceptions thrown during the process of closing.
+   *
+   * @param closeable files to close
+   */
+  public static void close(Closeable...closeable) {
+    for(Closeable c : closeable)
+      try { if( c != null ) c.close(); } catch( IOException ex ) {
+        Log.err(ex);
+      }
+  }
+
+
 
   public static void copyStream(InputStream is, OutputStream os, final int buffer_size) {
     try {

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -238,7 +238,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     // Per driver instance
     final private String featureMapFileName = "featureMap" + UUID.randomUUID().toString() + ".txt";
     // Shared file to write list of features
-    private File featureMapFile = null;
+    private String featureMapFileAbsolutePath = null;
 
     @Override
     public void computeImpl() {
@@ -294,7 +294,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
         assert dataInfo != null;
         String featureMap = XGBoostUtils.makeFeatureMap(_train, dataInfo);
         model.model_info().setFeatureMap(featureMap);
-        featureMapFile = createFeatureMapFile(featureMap);
+        featureMapFileAbsolutePath = createFeatureMapFile(featureMap);
 
         BoosterParms boosterParms = XGBoostModel.createParams(_parms, model._output.nclasses());
         model._output._native_parameters = boosterParms.toTwoDimTable();
@@ -366,7 +366,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     }
 
     // For feature importances - write out column info
-    private File createFeatureMapFile(String featureMap) {
+    private String createFeatureMapFile(String featureMap) {
       OutputStream os = null;
       try {
         File tmpModelDir = java.nio.file.Files.createTempDirectory("xgboost-model-" + _result.toString()).toFile();
@@ -374,7 +374,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
         os = new FileOutputStream(fmFile);
         os.write(featureMap.getBytes());
         os.close();
-        return fmFile;
+        return fmFile.getAbsolutePath();
       } catch (IOException e) {
         throw new RuntimeException("Cannot generate feature map file " + featureMapFileName, e);
       } finally {
@@ -486,7 +486,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
           varimp = BoosterHelper.doWithLocalRabit(new BoosterHelper.BoosterOp<Map<String, Integer>>() {
             @Override
             public Map<String, Integer> apply(Booster booster) throws XGBoostError {
-              return booster.getFeatureScore(featureMapFile.getAbsolutePath());
+              return booster.getFeatureScore(featureMapFileAbsolutePath);
             }
           }, booster);
         } finally {

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
@@ -81,8 +81,13 @@ public class XGBoostUpdater extends Thread {
     SynchronousQueue<?> outQ;
     while ((outQ = _out) != null) {
       T result = (T) outQ.poll(INACTIVE_CHECK_INTERVAL_SECS, TimeUnit.SECONDS);
-      if (result != null)
+      if (result != null) {
         return result;
+      } else {
+        throw new IllegalStateException(
+                String.format("Exceeded waiting interval of %d seconds for a task of type '%s' to finish on node '%s'. ",
+                        INACTIVE_CHECK_INTERVAL_SECS, callable, H2O.SELF));
+      }
     }
     throw new IllegalStateException("Cannot perform booster operation: updater is inactive on node " + H2O.SELF);
   }

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
@@ -23,8 +23,8 @@ public class XGBoostUpdater extends Thread {
   private final BoosterParms _boosterParms;
   private final Map<String, String> _rabitEnv;
 
-  private SynchronousQueue<BoosterCallable<?>> _in;
-  private SynchronousQueue<Object> _out;
+  private volatile SynchronousQueue<BoosterCallable<?>> _in;
+  private volatile SynchronousQueue<Object> _out;
 
   private Booster _booster;
 

--- a/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
+++ b/h2o-persist-hdfs/src/main/java/water/persist/PersistHdfs.java
@@ -185,7 +185,7 @@ public final class PersistHdfs extends Persist {
           assert v.isPersisted();
         } finally {
           s.getWrappedStream().close();
-          FileUtils.close(s);
+          FileUtils.closeSilently(s);
         }
         return null;
       }


### PR DESCRIPTION
While attempting to reproduce https://0xdata.atlassian.net/browse/PUBDEV-5937, I came across two places in the code where error handling and logging should be more refined.

Goal is to provide better chance in future for us to decrypt errors from logs sent by users.

## First commit (FileUtils.close)
The first commit is unrelated to the JIRA issue. When saving a feature map, I believe we definitely want to log when closing the file fails, and not fail silently, as resources might hang.

As FileUtils.close() method was used and this particular method closes the file sliently, I changed the existing close() method's name to `closeSilently` and introduced a new one named `close`, which logs the error during the  closing operation. This way, it is even more readable and obvious in the code which method is doing what.

## Second commit (IllegalStateException thrown)
This is directly related to the PR. A "finer" exception in case timeout is hit while waiting for a BoosterCallable task to be inserted into the queue by another thread. Besides printing basic info about the node this happened on, it also prints type of task it had been waiting for.

## Third commit (volatile in & out synced queues)

The `XGBoostUpdaterTask has the following fields:

```java
  private SynchronousQueue<BoosterCallable<?>> _in;
  private SynchronousQueue<Object> _out;
```
It might be potentially set to null during interruption of XGBoostUpdater thread:

```java
  } finally {
      _in = null; // Will throw NPE if used wrong
      _out = null;
```

These two props `_in` & `_out` are then checked to be null from another thread in `invoke()` method (approx. line 75) of `XGBoostUpdater`, yet called from different thread.

```java
if (inQ == null)
      throw new IllegalStateException("Updater is inactive on node " + H2O.SELF);
```

```java
    while ((outQ = _out) != null) {
      T result = (T) outQ.poll(INACTIVE_CHECK_INTERVAL_SECS, TimeUnit.SECONDS);
```

May result in shadow reads and result in various errors, e.g. continue and not throw IllegalStateException when it really should or vice-versa.


