### PR TITLE
PUBDEV-6064: Add default value for max_depth in IsoFor

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/max_depth.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_depth.rst
@@ -13,6 +13,13 @@ In general, deeper trees can seem to provide better accuracy on a training set b
 
 One way to determine an appropriate value for ``max_depth`` is to run a quick Cartesian grid search. Each model in the grid search will use early stopping to tune the number of trees using the validation set AUC, as before. The examples below are also available in the `GBM Tuning Tutorials <https://github.com/h2oai/h2o-3/tree/master/h2o-docs/src/product/tutorials/gbm>`__  folder on GitHub.
 
+The ``max_depth`` default value varies depending on the algorithm.
+
+- GBM: default is 5.
+- DRF: default is 20.
+- XGBoost: default is 6.
+- Isolation Forest: default is 8.
+
 
 Related Parameters
 ~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/sample_size.rst
+++ b/h2o-docs/src/product/data-science/algo-params/sample_size.rst
@@ -1,0 +1,84 @@
+``sample_size``
+---------------
+
+- Available in: Isolation Forest
+- Hyperparameter: yes
+
+Description
+~~~~~~~~~~~
+
+This option specifies the number of randomly sampled observations used to train each Isolation Forest tree. If set to -1, ``sample_rate`` will be used instead. This value defaults to 256.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- none
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+	# import the ecg discord datasets:
+	train <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/anomaly/ecg_discord_train.csv")
+	test <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/anomaly/ecg_discord_test.csv")
+
+	# train using the `sample_size` parameter:
+	isofor_model <- h2o.isolationForest(training_frame=train, sample_size=5, ntrees=7)
+
+	# test the prediction
+	anomaly_score <- h2o.predict(isofor_model, test)
+	anomaly_score
+	      predict mean_length
+	1 -0.16666667    2.857143
+	2 -0.16666667    2.857143
+	3 -0.08333333    2.714286
+	4  0.16666667    2.285714
+	5  0.00000000    2.571429
+	6  0.33333333    2.000000
+
+	[23 rows x 2 columns] 
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.isolation_forest import H2OIsolationForestEstimator
+	h2o.init()
+
+	# import the ecg discord datasets:
+	train = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/anomaly/ecg_discord_train.csv")
+	test = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/anomaly/ecg_discord_test.csv")
+
+	# try using the `sample_size` parameter:
+	isofor_model = H2OIsolationForestEstimator(sample_size = 5, ntrees=7) 
+
+	# then train your model
+	isofor_model.train(training_frame = train)
+
+	perf = isofor_model.model_performance()
+    perf
+      ModelMetricsAnomaly: isolationforest
+      ** Reported on train data. **
+      
+      Anomaly Score: 1.1392230576441102
+      Normalized Anomaly Score: 0.3631578947368421
+
+    test_pred = isofor_model.predict(test)
+    test_pred
+      predict    mean_length
+    ---------  -------------
+         -0.1        1.57143
+         -0.1        1.57143
+          0          1.42857
+          0          1.42857
+          0          1.42857
+         -0.1        1.57143
+          0.1        1.28571
+          0          1.42857
+          0.2        1.14286
+         -0.1        1.57143
+
+    [23 rows x 2 columns]

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -109,7 +109,7 @@ Defining a DRF Model
 
 -  `ntrees <algo-params/ntrees.html>`__: Specify the number of trees.
 
--  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth.
+-  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth. Higher values will make the model more complex and can lead to overfitting. Setting this value to 0 specifies no limit. This value defaults to 20. 
 
 -  `min_rows <algo-params/min_rows.html>`__: Specify the minimum number of observations for a leaf
    (``nodesize`` in R).

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -59,7 +59,7 @@ Defining a GBM Model
 
 -  `ntrees <algo-params/ntrees.html>`__: Specify the number of trees to build.
 
--  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth.
+-  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth. Higher values will make the model more complex and can lead to overfitting. Setting this value to 0 specifies no limit. This value defaults to 5.
 
 -  `min_rows <algo-params/min_rows.html>`__: Specify the minimum number of observations for a leaf
    (``nodesize`` in R).

--- a/h2o-docs/src/product/data-science/if.rst
+++ b/h2o-docs/src/product/data-science/if.rst
@@ -30,7 +30,7 @@ Defining an Isolation Forest Model
 
 -  `ntrees <algo-params/ntrees.html>`__: Specify the number of trees.
 
--  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth. This value defaults to 8.
+-  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth. Higher values will make the model more complex and can lead to overfitting. Setting this value to 0 specifies no limit. This value defaults to 8.
 
 -  `min_rows <algo-params/min_rows.html>`__: Specify the minimum number of observations for a leaf (``nodesize`` in R).
 

--- a/h2o-docs/src/product/data-science/if.rst
+++ b/h2o-docs/src/product/data-science/if.rst
@@ -30,7 +30,7 @@ Defining an Isolation Forest Model
 
 -  `ntrees <algo-params/ntrees.html>`__: Specify the number of trees.
 
--  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth.
+-  `max_depth <algo-params/max_depth.html>`__: Specify the maximum tree depth. This value defaults to 8.
 
 -  `min_rows <algo-params/min_rows.html>`__: Specify the minimum number of observations for a leaf (``nodesize`` in R).
 
@@ -42,9 +42,9 @@ Defining an Isolation Forest Model
 
 -  `mtries <algo-params/mtries.html>`__: Specify the columns to randomly select at each level. If the default value of ``-1`` is used, the number of variables is the square root of the number of columns for classification and p/3 for regression (where p is the number of predictors). The range is -1 to >=1.
 
--  **sample_size**: The number of randomly sampled observations used to train each Isolation Forest tree. If set to -1, ``sample_rate`` will be used instead.
+-  `sample_size <algo-params/sample_size.html>`__: The number of randomly sampled observations used to train each Isolation Forest tree. If set to -1, ``sample_rate`` will be used instead. This value defaults to 256.
 
--  `sample_rate <algo-params/sample_rate.html>`__: Specify the row sampling rate (x-axis). (Note that this method is sample without replacement.) The range is 0.0 to 1.0, and this value defaults to 0.6320000291. Higher values may improve training accuracy. Test accuracy improves when either columns or rows are sampled. For details, refer to "Stochastic Gradient Boosting" (`Friedman, 1999 <https://statweb.stanford.edu/~jhf/ftp/stobst.pdf>`__).
+-  `sample_rate <algo-params/sample_rate.html>`__: Specify the row sampling rate (x-axis). (Note that this method is sample without replacement.) The range is 0.0 to 1.0, and this value defaults to 0.6320000291. Higher values may improve training accuracy. Test accuracy improves when either columns or rows are sampled. For details, refer to "Stochastic Gradient Boosting" (`Friedman, 1999 <https://statweb.stanford.edu/~jhf/ftp/stobst.pdf>`__). If set to -1 (default), then ``sample_size`` will be used instead.
 
 -  `col_sample_rate_change_per_level <algo-params/col_sample_rate_change_per_level.html>`__: This option specifies to change the column sampling rate as a function of the depth in the tree. This can be a value > 0.0 and <= 2.0 and defaults to 1. (Note that this method is sample without replacement.) For example:
 

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -91,6 +91,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/remove_collinear_columns
    data-science/algo-params/sample_rate
    data-science/algo-params/sample_rate_per_class
+   data-science/algo-params/sample_size
    data-science/algo-params/score_each_iteration
    data-science/algo-params/score_tree_interval
    data-science/algo-params/seed

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -151,6 +151,7 @@ reference:
       - h2o.ischaracter
       - h2o.isfactor
       - h2o.isnumeric
+      - h2o.isolationForest
       - h2o.kfold_column
       - h2o.killMinus3
       - h2o.kmeans
@@ -311,7 +312,6 @@ reference:
       - is.factor 
       - is.h2o 
       - is.numeric
-      - h2o.isolationForest
       - Logical-or
       - ModelAccessors
       - names.H2OFrame


### PR DESCRIPTION
Note that the default value for max_depth in Isolation Forest is 8.
Driveby fixes:
- Added defauilt values for sample_size and sample_rate.
- Added a parameter description entry for sample_size.
- Fixed location of isolation_forest in the R HTML documentation (alphabetize).