### PR TITLE
Fix NPE when DataInfo#coefNames are accessed in XGBoost on a deserialized instance

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -231,6 +231,8 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
       if (nClasses == 1)
         dinfo.updateWeightedSigmaAndMeanForResponse(ymt.responseSDs(), ymt.responseMeans());
     }
+    dinfo.coefNames(); // cache the coefficient names
+    assert dinfo._coefNames != null;
     return dinfo;
   }
 

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -187,8 +187,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
     final DataInfo dinfo = makeDataInfo(train, valid, _parms, output.nclasses());
     DKV.put(dinfo);
     setDataInfoToOutput(dinfo);
-    model_info = new XGBoostModelInfo(parms);
-    model_info._dataInfoKey = dinfo._key;
+    model_info = new XGBoostModelInfo(parms, dinfo);
   }
 
   public static BoosterParms createParams(XGBoostParameters p, int nClasses, String[] coefNames) {

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostModelInfo.java
@@ -16,8 +16,20 @@ import java.util.Arrays;
  * This will be shared: one per node
  */
 final public class XGBoostModelInfo extends Iced {
+  public final XGBoostModel.XGBoostParameters _parameters; // not used, kept for debugging purposes
+  public final Key<DataInfo> _dataInfoKey;
+
   public String _featureMap;
   public byte[] _boosterBytes; // internal state of native backend
+
+  /**
+   * Main constructor
+   * @param origParams Model parameters
+   */
+  public XGBoostModelInfo(final XGBoostModel.XGBoostParameters origParams, DataInfo dinfo) {
+    _parameters = (XGBoostModel.XGBoostParameters) origParams.clone(); //make a copy, don't change model's parameters
+    _dataInfoKey = dinfo._key;
+  }
 
   public String getFeatureMap() {
     return _featureMap;
@@ -26,8 +38,6 @@ final public class XGBoostModelInfo extends Iced {
   public void setFeatureMap(String featureMap) {
     _featureMap = featureMap;
   }
-
-  public Key<DataInfo> _dataInfoKey;
 
   public void setBoosterBytes(byte[] boosterBytes) {
     _boosterBytes = boosterBytes;
@@ -61,16 +71,6 @@ final public class XGBoostModelInfo extends Iced {
 
   public DataInfo dataInfo() {
     return _dataInfoKey.get();
-  }
-
-  public XGBoostModel.XGBoostParameters parameters;
-
-  /**
-   * Main constructor
-   * @param origParams Model parameters
-   */
-  public XGBoostModelInfo(final XGBoostModel.XGBoostParameters origParams) {
-    parameters = (XGBoostModel.XGBoostParameters) origParams.clone(); //make a copy, don't change model's parameters
   }
 
 }

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -1450,6 +1450,24 @@ public class XGBoostTest extends TestUtil {
     }
   }
 
+  @Test
+  public void testMakeDataInfo() {
+    Scope.enter();
+    try {
+      Frame f = parse_test_file("smalldata/junit/cars.csv");
+      Scope.track(f);
+
+      XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
+      parms._response_column = "year";
+      parms._train = f._key;
+
+      DataInfo dinfo = hex.tree.xgboost.XGBoost.makeDataInfo(f, null, parms, 1);
+      assertNotNull(dinfo._coefNames);
+    } finally {
+      Scope.exit();
+    }
+  }
+
   private static XGBoostModel trainWithConstraints(XGBoostModel.XGBoostParameters p, KeyValue... constraints) {
     XGBoostModel.XGBoostParameters parms = (XGBoostModel.XGBoostParameters) p.clone();
     parms._monotone_constraints = constraints;


### PR DESCRIPTION
Test runit_XGBoostRandomGrid_airlines_large.R is failing on NPE.

    Caused by: java.lang.NullPointerException
        at hex.DataInfo.coefNames(DataInfo.java:704)
        at hex.tree.xgboost.XGBoostModel.setupBigScorePredictNative(XGBoostModel.java:465)
        at hex.tree.xgboost.XGBoostModel.setupBigScorePredict(XGBoostModel.java:459)
        at hex.Model$BigScore.setupLocal(Model.java:1572)