### PR TITLE
PUBDEV-6076 keep timestamp format after group_by

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
@@ -465,7 +465,9 @@ public class AstGroup extends AstPrimitive {
     }
     Vec v = Vec.makeZero(ngrps); // dummy layout vec
     // Convert the output arrays into a Frame, also doing the post-pass work
-    return mrfill.doAll(types, new Frame(v)).outputFrame(names, domains);
+    Frame f =  mrfill.doAll(types, new Frame(v)).outputFrame(names, domains);
+    v.remove();
+    return f;
   }
 
   // Description of a single aggregate, including the reduction function, the

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
@@ -450,8 +450,6 @@ public class AstGroup extends AstPrimitive {
 
     // Build the output!
     // the names of columns
-    // Build the output!
-    // the names of columns
     final int nCols = gbCols.length + noutCols;
     String[] names = new String[nCols];
     String[][] domains = new String[nCols][];

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
@@ -450,21 +450,24 @@ public class AstGroup extends AstPrimitive {
 
     // Build the output!
     // the names of columns
+    // Build the output!
+    // the names of columns
     final int nCols = gbCols.length + noutCols;
     String[] names = new String[nCols];
     String[][] domains = new String[nCols][];
+    byte[] types = new byte[nCols];
     for (int i = 0; i < gbCols.length; i++) {
       names[i] = fr.name(gbCols[i]);
       domains[i] = fr.domains()[gbCols[i]];
+      types[i] = fr.vec(names[i]).get_type();
     }
-    for (int i = 0; i < fcnames.length; i++)
+    for (int i = 0; i < fcnames.length; i++) {
       names[i + gbCols.length] = fcnames[i];
+      types[i + gbCols.length] = Vec.T_NUM;
+    }
     Vec v = Vec.makeZero(ngrps); // dummy layout vec
-
     // Convert the output arrays into a Frame, also doing the post-pass work
-    Frame f = mrfill.doAll(nCols, Vec.T_NUM, new Frame(v)).outputFrame(names, domains);
-    v.remove();
-    return f;
+    return mrfill.doAll(types, new Frame(v)).outputFrame(names, domains);
   }
 
   // Description of a single aggregate, including the reduction function, the

--- a/h2o-py/tests/testdir_munging/pyunit_groupby_types.py
+++ b/h2o-py/tests/testdir_munging/pyunit_groupby_types.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+
+
+def h2o_group_by_types():
+    """
+    This test checks that if the returned frame after a group_by operation returns correct type of group_by column.
+    """
+
+    data = h2o.H2OFrame([["4/1/07", 1, "A", 2.2],
+                         ["5/1/07", 23, "B", 223.4],
+                         ["6/1/07", 3, "A", 224.5]],
+                        column_names=["date", "int", "string", "double"])
+
+    group_by_column = "date"
+    grouped_type = get_group_by_type(data, group_by_column)
+    assert data[group_by_column].types == grouped_type, \
+        "The type of group by column should be the same before and after group by."
+
+    group_by_column = "int"
+    grouped_type = get_group_by_type(data, group_by_column)
+    assert data[group_by_column].types == grouped_type, \
+        "The type of group by column should be the same before and after group by."
+
+    group_by_column = "double"
+    grouped_type = get_group_by_type(data, group_by_column)
+    assert data[group_by_column].types == grouped_type, \
+        "The type of group by column should be the same before and after group by."
+
+
+def get_group_by_type(data, group_by_column):
+    grouped = data.group_by(by=[group_by_column]).mean('int')
+    grouped_frame = grouped.get_frame()
+    return grouped_frame[group_by_column].types
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(h2o_group_by_types)
+else:
+    h2o_group_by_types()


### PR DESCRIPTION
**Problem:** 
The type of group_by column is changed to `int` even though there is `time` type before group by operation. The problem is the new calculated group by vectors are saved in the DKV with default type `int`. The original type is decoded from values in the vector to write it to a schema. But `timestamp` type is `int` by default and can't be easily decoded back to a `timestamp`. 

**Solution:** 
Don't use the default `int` type when the new vectors are created. Group by columns are not changed during calculation so that its type can be preserved.