### PR TITLE
PUBDEV-6030 get reconstruction error for auto encoders from easy wrapper

### DIFF
--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderCategoricalTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderCategoricalTest.java
@@ -100,7 +100,11 @@ public class DeepLearningAutoEncoderCategoricalTest extends TestUtil {
       }
       double mojoMeanError = calcNormMse/train.numRows();
       sb.append("Mojo mean reconstruction error (train): ").append(mojoMeanError).append("\n");
-      Assert.assertTrue("Mean reconstruction error should be the same from model and mojo model.", mojoMeanError == mymodel.mse());
+      sb.append("Mean reconstruction error should be the same from model compare to mojo model " +
+              "reconstruction error: ");
+      sb.append(mymodel.mse()).append(" == ").append(mojoMeanError).append("\n");
+      Assert.assertEquals(mymodel.mse(), mojoMeanError, 1e-7);
+
     } catch (IOException error) {
       sb.append("IOError: ").append(error.toString()).append("\n");
     } catch (PredictException error){

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderCategoricalTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderCategoricalTest.java
@@ -29,121 +29,127 @@ public class DeepLearningAutoEncoderCategoricalTest extends TestUtil {
   public void run() {
     long seed = 0xDECAF;
 
-    NFSFileVec  nfs = TestUtil.makeNfsFileVec(PATH);
-    Frame train = ParseDataset.parse(Key.make("train.hex"), nfs._key);
+    Frame train=null;
 
-    DeepLearningParameters p = new DeepLearningParameters();
-    p._train = train._key;
-    p._autoencoder = true;
-    p._response_column = train.names()[train.names().length-1];
-    p._seed = seed;
-    p._hidden = new int[]{10, 5, 3};
-    p._adaptive_rate = true;
+    try {
+      NFSFileVec nfs = TestUtil.makeNfsFileVec(PATH);
+      train = ParseDataset.parse(Key.make("train.hex"), nfs._key);
+
+      DeepLearningParameters p = new DeepLearningParameters();
+      p._train = train._key;
+      p._autoencoder = true;
+      p._response_column = train.names()[train.names().length - 1];
+      p._seed = seed;
+      p._hidden = new int[]{10, 5, 3};
+      p._adaptive_rate = true;
 //    String[] n = train.names();
 //    p._ignored_columns = new String[]{n[0],n[1],n[2],n[3],n[6],n[7],n[8],n[10]}; //Optional: ignore all categoricals
 //    p._ignored_columns = new String[]{train.names()[4], train.names()[5], train.names()[9]}; //Optional: ignore all numericals
-    p._l1 = 1e-4;
-    p._activation = DeepLearningParameters.Activation.Tanh;
-    p._max_w2 = 10;
-    p._train_samples_per_iteration = -1;
-    p._loss = DeepLearningParameters.Loss.Huber;
-    p._epochs = 0.2;
-    p._force_load_balance = true;
-    p._score_training_samples = 0;
-    p._score_validation_samples = 0;
-    p._reproducible = true;
+      p._l1 = 1e-4;
+      p._activation = DeepLearningParameters.Activation.Tanh;
+      p._max_w2 = 10;
+      p._train_samples_per_iteration = -1;
+      p._loss = DeepLearningParameters.Loss.Huber;
+      p._epochs = 0.2;
+      p._force_load_balance = true;
+      p._score_training_samples = 0;
+      p._score_validation_samples = 0;
+      p._reproducible = true;
 
-    DeepLearning dl = new DeepLearning(p);
-    DeepLearningModel mymodel = dl.trainModel().get();
+      Frame recon_train = null, l2 = null, df1 = null, df2 = null, df3 = null;
+      DeepLearningModel mymodel = null;
+      StringBuilder sb = new StringBuilder();
 
-    // Verification of results
-    StringBuilder sb = new StringBuilder();
-    sb.append("Verifying results.\n");
-    sb.append("Reported mean reconstruction error: " + mymodel.mse() + "\n");
+      try {
+        DeepLearning dl = new DeepLearning(p);
+        mymodel = dl.trainModel().get();
 
-    // Training data
-    // Reconstruct data using the same helper functions and verify that self-reported MSE agrees
-    final Frame rec = mymodel.scoreAutoEncoder(train, Key.make(), true);
-    sb.append("Reconstruction error per feature: " + rec.toString() + "\n");
-    rec.remove();
+        // Verification of results
+        sb.append("Verifying results.\n");
+        sb.append("Reported mean reconstruction error: " + mymodel.mse() + "\n");
 
-    final Frame l2 = mymodel.scoreAutoEncoder(train, Key.make(), false);
-    final Vec l2vec = l2.anyVec();
-    sb.append("Actual   mean reconstruction error: " + l2vec.mean() + "\n");
+        // Training data
+        // Reconstruct data using the same helper functions and verify that self-reported MSE agrees
+        final Frame rec = mymodel.scoreAutoEncoder(train, Key.make(), true);
+        sb.append("Reconstruction error per feature: " + rec.toString() + "\n");
+        rec.remove();
 
-    // print stats and potential outliers
-    double quantile = 1 - 5. / train.numRows();
-    sb.append("The following training points are reconstructed with an error above the "
-            + quantile * 100 + "-th percentile - potential \"outliers\" in testing data.\n");
-    double thresh = mymodel.calcOutlierThreshold(l2vec, quantile);
-    for (long i = 0; i < l2vec.length(); i++) {
-      if (l2vec.at(i) > thresh) {
-        sb.append(String.format("row %d : l2vec error = %5f\n", i, l2vec.at(i)));
-      }
-    }
-    Log.info(sb.toString());
+        l2 = mymodel.scoreAutoEncoder(train, Key.make(), false);
+        final Vec l2vec = l2.anyVec();
+        sb.append("Actual   mean reconstruction error: " + l2vec.mean() + "\n");
 
-    Assert.assertEquals(l2vec.mean(), mymodel.mse(), 1e-8*mymodel.mse());
-
-    // Create reconstruction
-    Log.info("Creating full reconstruction.");
-    final Frame recon_train = mymodel.score(train);
-    Assert.assertTrue(mymodel.testJavaScoring(train,recon_train,1e-5));
-
-    Frame df1 = mymodel.scoreDeepFeatures(train, 0);
-    Assert.assertTrue(df1.numCols() == 10);
-    Assert.assertTrue(df1.numRows() == train.numRows());
-    df1.delete();
-
-    Frame df2 = mymodel.scoreDeepFeatures(train, 1);
-    Assert.assertTrue(df2.numCols() == 5);
-    Assert.assertTrue(df2.numRows() == train.numRows());
-    df2.delete();
-
-    Frame df3 = mymodel.scoreDeepFeatures(train, 2);
-    Assert.assertTrue(df3.numCols() == 3);
-    Assert.assertTrue(df3.numRows() == train.numRows());
-    df3.delete();
-
-    // check if reconstruction error is the same from model and mojo model too. Testcase for PUBDEV-6030.
-    try {
-      DeeplearningMojoModel mojoModel = (DeeplearningMojoModel) mymodel.toMojo();
-      EasyPredictModelWrapper model = new EasyPredictModelWrapper(mojoModel);
-      AutoEncoderModelPrediction tmpPrediction;
-      RowData tmpRow;
-      BufferedString bStr;
-      double calcNormMse = 0;
-      for (int r = 0; r < train.numRows(); r++) {
-        tmpRow = new RowData();
-        bStr = new BufferedString();
-        for (int c = 0; c < train.numCols(); c++) {
-          if (train.vec(c).isCategorical()) {
-            tmpRow.put(train.names()[c], train.vec(c).atStr(bStr, r).toString());
-          } else {
-            tmpRow.put(train.names()[c],  train.vec(c).at(r));
+        // print stats and potential outliers
+        double quantile = 1 - 5. / train.numRows();
+        sb.append("The following training points are reconstructed with an error above the "
+                + quantile * 100 + "-th percentile - potential \"outliers\" in testing data.\n");
+        double thresh = mymodel.calcOutlierThreshold(l2vec, quantile);
+        for (long i = 0; i < l2vec.length(); i++) {
+          if (l2vec.at(i) > thresh) {
+            sb.append(String.format("row %d : l2vec error = %5f\n", i, l2vec.at(i)));
           }
         }
-        tmpPrediction = model.predictAutoEncoder(tmpRow);
-        calcNormMse += tmpPrediction.mse;
-      }
-      double mojoMeanError = calcNormMse/train.numRows();
-      sb.append("Mojo mean reconstruction error (train): ").append(mojoMeanError).append("\n");
-      sb.append("Mean reconstruction error should be the same from model compare to mojo model " +
-              "reconstruction error: ");
-      sb.append(mymodel.mse()).append(" == ").append(mojoMeanError).append("\n");
-      Assert.assertEquals(mymodel.mse(), mojoMeanError, 1e-7);
+        Log.info(sb.toString());
 
-    } catch (IOException error) {
-      Assert.fail(error.getStackTrace().toString());
-    } catch (PredictException error){
-      Assert.fail(error.getStackTrace().toString());
+        Assert.assertEquals(l2vec.mean(), mymodel.mse(), 1e-8 * mymodel.mse());
+
+        // Create reconstruction
+        Log.info("Creating full reconstruction.");
+        recon_train = mymodel.score(train);
+        Assert.assertTrue(mymodel.testJavaScoring(train, recon_train, 1e-5));
+
+        df1 = mymodel.scoreDeepFeatures(train, 0);
+        Assert.assertTrue(df1.numCols() == 10);
+        Assert.assertTrue(df1.numRows() == train.numRows());
+
+        df2 = mymodel.scoreDeepFeatures(train, 1);
+        Assert.assertTrue(df2.numCols() == 5);
+        Assert.assertTrue(df2.numRows() == train.numRows());
+
+        df3 = mymodel.scoreDeepFeatures(train, 2);
+        Assert.assertTrue(df3.numCols() == 3);
+        Assert.assertTrue(df3.numRows() == train.numRows());
+
+        // check if reconstruction error is the same from model and mojo model too. Testcase for PUBDEV-6030.
+        try {
+          DeeplearningMojoModel mojoModel = (DeeplearningMojoModel) mymodel.toMojo();
+          EasyPredictModelWrapper model = new EasyPredictModelWrapper(mojoModel);
+          AutoEncoderModelPrediction tmpPrediction;
+          double calcNormMse = 0;
+          for (int r = 0; r < train.numRows(); r++) {
+            RowData tmpRow = new RowData();
+            BufferedString bStr = new BufferedString();
+            for (int c = 0; c < train.numCols(); c++) {
+              if (train.vec(c).isCategorical()) {
+                tmpRow.put(train.names()[c], train.vec(c).atStr(bStr, r).toString());
+              } else {
+                tmpRow.put(train.names()[c], train.vec(c).at(r));
+              }
+            }
+            tmpPrediction = model.predictAutoEncoder(tmpRow);
+            calcNormMse += tmpPrediction.mse;
+          }
+          double mojoMeanError = calcNormMse / train.numRows();
+          sb.append("Mojo mean reconstruction error (train): ").append(mojoMeanError).append("\n");
+          sb.append("Mean reconstruction error should be the same from model compare to mojo model " +
+                  "reconstruction error: ");
+          sb.append(mymodel.mse()).append(" == ").append(mojoMeanError).append("\n");
+          Assert.assertEquals(mymodel.mse(), mojoMeanError, 1e-7);
+        } catch (IOException error) {
+          Assert.fail(error.getStackTrace().toString());
+        } catch (PredictException error) {
+          Assert.fail(error.getStackTrace().toString());
+        }
+      } finally {
+        Log.info(sb);
+        if(recon_train != null) recon_train.delete();
+        if(l2 != null) l2.delete();
+        if(mymodel != null) mymodel.delete();
+        if(df1 != null) df1.delete();
+        if(df2 != null) df2.delete();
+        if(df3 != null) df3.delete();
+      }
     } finally {
-      // cleanup
-      Log.info(sb);
-      recon_train.delete();
-      train.delete();
-      mymodel.delete();
-      l2.delete();
+      if(train != null)train.delete();
     }
   }
 }

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderCategoricalTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderCategoricalTest.java
@@ -98,16 +98,16 @@ public class DeepLearningAutoEncoderCategoricalTest extends TestUtil {
         Assert.assertTrue(mymodel.testJavaScoring(train, recon_train, 1e-5));
 
         df1 = mymodel.scoreDeepFeatures(train, 0);
-        Assert.assertTrue(df1.numCols() == 10);
-        Assert.assertTrue(df1.numRows() == train.numRows());
+        Assert.assertEquals(10, df1.numCols());
+        Assert.assertEquals(train.numRows(), df1.numRows());
 
         df2 = mymodel.scoreDeepFeatures(train, 1);
-        Assert.assertTrue(df2.numCols() == 5);
-        Assert.assertTrue(df2.numRows() == train.numRows());
+        Assert.assertEquals(5, df2.numCols());
+        Assert.assertEquals(train.numRows(), df2.numRows());
 
         df3 = mymodel.scoreDeepFeatures(train, 2);
-        Assert.assertTrue(df3.numCols() == 3);
-        Assert.assertTrue(df3.numRows() == train.numRows());
+        Assert.assertEquals(3, df3.numCols());
+        Assert.assertEquals(train.numRows(), df3.numRows());
 
         // check if reconstruction error is the same from model and mojo model too. Testcase for PUBDEV-6030.
         try {

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
@@ -10,13 +10,10 @@ import org.junit.Test;
 import water.*;
 import water.fvec.*;
 import water.parser.ParseDataset;
-import water.util.FileUtils;
 import water.util.Log;
 import hex.deeplearning.DeepLearningModel.DeepLearningParameters;
 import hex.genmodel.easy.EasyPredictModelWrapper;
-import hex.deeplearning.DeepLearningModel;
 
-import java.io.IOError;
 import java.io.IOException;
 import java.util.HashSet;
 

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
@@ -164,12 +164,10 @@ public class DeepLearningAutoEncoderTest extends TestUtil {
             DeeplearningMojoModel mojoModel = (DeeplearningMojoModel) mymodel.toMojo();
             EasyPredictModelWrapper model = new EasyPredictModelWrapper(mojoModel);
             AutoEncoderModelPrediction tmpPrediction;
-            RowData tmpRow;
-            BufferedString bStr;
             double calcNormMse = 0;
             for (int r = 0; r < train.numRows(); r++) {
-              tmpRow = new RowData();
-              bStr = new BufferedString();
+              RowData tmpRow = new RowData();
+              BufferedString bStr = new BufferedString();
               for (int c = 0; c < train.numCols(); c++) {
                 if (train.vec(c).isCategorical()) {
                   tmpRow.put(train.names()[c], train.vec(c).atStr(bStr, r).toString());

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
@@ -9,6 +9,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import water.*;
 import water.fvec.*;
+import water.parser.BufferedString;
 import water.parser.ParseDataset;
 import water.util.Log;
 import hex.deeplearning.DeepLearningModel.DeepLearningParameters;
@@ -164,11 +165,17 @@ public class DeepLearningAutoEncoderTest extends TestUtil {
             EasyPredictModelWrapper model = new EasyPredictModelWrapper(mojoModel);
             AutoEncoderModelPrediction tmpPrediction;
             RowData tmpRow;
+            BufferedString bStr;
             double calcNormMse = 0;
             for (int r = 0; r < train.numRows(); r++) {
               tmpRow = new RowData();
+              bStr = new BufferedString();
               for (int c = 0; c < train.numCols(); c++) {
-                tmpRow.put(train.names()[c], train.vec(c).at(r));
+                if (train.vec(c).isCategorical()) {
+                  tmpRow.put(train.names()[c], train.vec(c).atStr(bStr, r).toString());
+                } else {
+                  tmpRow.put(train.names()[c],  train.vec(c).at(r));
+                }
               }
               tmpPrediction = model.predictAutoEncoder(tmpRow);
               calcNormMse += tmpPrediction.mse;

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
@@ -142,7 +142,8 @@ public class DeepLearningAutoEncoderTest extends TestUtil {
 
 
           // print stats and potential outliers
-          sb.append("The following test points are reconstructed with an error greater than ").append(mult).append(" times the mean reconstruction error of the training data:\n");
+          sb.append("The following test points are reconstructed with an error greater than ").append(mult)
+                  .append(" times the mean reconstruction error of the training data:\n");
           HashSet<Long> outliers = new HashSet<>();
           for (long i = 0; i < l2_test.length(); i++) {
             if (l2_test.at(i) > thresh_test) {
@@ -157,6 +158,7 @@ public class DeepLearningAutoEncoderTest extends TestUtil {
           Assert.assertTrue(outliers.contains(new Long(22)));
           Assert.assertTrue(outliers.size() == 3);
 
+          // check if reconstruction error is the same from model and mojo model too. Testcase for PUBDEV-6030.
           try {
             DeeplearningMojoModel mojoModel = (DeeplearningMojoModel) mymodel.toMojo();
             EasyPredictModelWrapper model = new EasyPredictModelWrapper(mojoModel);
@@ -173,11 +175,12 @@ public class DeepLearningAutoEncoderTest extends TestUtil {
             }
             double mojoMeanError = calcNormMse/train.numRows();
             sb.append("Mojo mean reconstruction error (train): ").append(mojoMeanError).append("\n");
-            Assert.assertTrue("Mean reconstruction error should be the same from model and mojo model.", mojoMeanError == mean_l2);
+            Assert.assertTrue("Mean reconstruction error should be the same from model compate to mojo model " +
+                    "reconstruction error.", mojoMeanError == mean_l2);
           } catch (IOException error) {
-            sb.append("IOError: ").append(error.toString()).append("\n");
+            Assert.fail("IOException when testing mojo mean reconstruction error: "+error.toString());
           } catch (PredictException error){
-            sb.append("PredictException: ").append(error.toString()).append("\n");
+            Assert.fail("PredictException when testing mojo mean reconstruction error: "+error.toString());
           }
         } finally {
           Log.info(sb);

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningAutoEncoderTest.java
@@ -175,8 +175,10 @@ public class DeepLearningAutoEncoderTest extends TestUtil {
             }
             double mojoMeanError = calcNormMse/train.numRows();
             sb.append("Mojo mean reconstruction error (train): ").append(mojoMeanError).append("\n");
-            Assert.assertTrue("Mean reconstruction error should be the same from model compate to mojo model " +
-                    "reconstruction error.", mojoMeanError == mean_l2);
+            sb.append("Mean reconstruction error should be the same from model compare to mojo model " +
+                    "reconstruction error: ");
+            sb.append(mean_l2).append(" == ").append(mojoMeanError).append("\n");
+            Assert.assertEquals( mean_l2, mojoMeanError, 1e-7);
           } catch (IOException error) {
             Assert.fail("IOException when testing mojo mean reconstruction error: "+error.toString());
           } catch (PredictException error){

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/deeplearning/DeeplearningMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/deeplearning/DeeplearningMojoModel.java
@@ -135,22 +135,19 @@ public class DeeplearningMojoModel extends MojoModel {
   }
 
   /**
-   * Calculates average reconstruction error (MSE). Only from numerical features.
+   * Calculates average reconstruction error (MSE).
+   * Uses a normalization defined for the numerical features of the trained model.
    * @return average reconstruction error = ||original - reconstructed||^2 / length(original)
    */
   public double calculateReconstructionErrorPerRowData(double [] original, double [] reconstructed){
-    if (this._nums == 0) {
-      return 1;
-    }
-    double l2 = 0;
-    int numIndex;
+    int numStartIndex = original.length - this._nums;
     double norm;
-    for (int i = 0; i < this._nums; i++) {
-      numIndex = i + (original.length - this._nums);
-      norm = (this._normmul != null) ? this._normmul[i] : 1;
-      l2 += Math.pow((reconstructed[numIndex] - original[numIndex]) * norm, 2);
+    double l2 = 0;
+    for (int i = 0; i < original.length; i++) {
+      norm = (this._normmul != null) && (this._nums > 0) && (i >= (numStartIndex)) ? this._normmul[i-numStartIndex] : 1;
+      l2 += Math.pow((reconstructed[i] - original[i]) * norm, 2);
     }
-    return  l2 / this._nums;
+    return  l2 / original.length;
   }
 
   // class to store weight or bias for one neuron layer

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/deeplearning/DeeplearningMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/deeplearning/DeeplearningMojoModel.java
@@ -134,6 +134,25 @@ public class DeeplearningMojoModel extends MojoModel {
     return (mc == ModelCategory.AutoEncoder)? _units[0]: (isClassifier()?nclasses()+1 :2);
   }
 
+  /**
+   * Calculates average reconstruction error (MSE). Only from numerical features.
+   * @return average reconstruction error = ||original - reconstructed||^2 / length(original)
+   */
+  public double calculateReconstructionErrorPerRowData(double [] original, double [] reconstructed){
+    if (this._nums == 0) {
+      return 1;
+    }
+    double l2 = 0;
+    int numIndex;
+    double norm;
+    for (int i = 0; i < this._nums; i++) {
+      numIndex = i + (original.length - this._nums);
+      norm = (this._normmul != null) ? this._normmul[i] : 1;
+      l2 += Math.pow((reconstructed[numIndex] - original[numIndex]) * norm, 2);
+    }
+    return  l2 / this._nums;
+  }
+
   // class to store weight or bias for one neuron layer
   public static class StoreWeightsBias implements Serializable {
     float[] _wValues; // store weight or bias arrays

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -6,6 +6,7 @@ import hex.genmodel.IClusteringModel;
 import hex.genmodel.algos.deepwater.DeepwaterMojoModel;
 import hex.genmodel.algos.tree.SharedTreeMojoModel;
 import hex.genmodel.algos.glrm.GlrmMojoModel;
+import hex.genmodel.algos.deeplearning.DeeplearningMojoModel;
 import hex.genmodel.algos.word2vec.WordEmbeddingModel;
 import hex.genmodel.easy.error.VoidErrorConsumer;
 import hex.genmodel.easy.exception.PredictException;
@@ -326,7 +327,10 @@ public class EasyPredictModelWrapper implements Serializable {
     p.original = expandRawData(rawData, output.length);
     p.reconstructed = output;
     p.reconstructedRowData = reconstructedToRowData(output);
-
+    p.mse = 1;
+    if (m instanceof DeeplearningMojoModel){
+      p.mse =  calculateReconstructionError(p.original, p.reconstructed, ((DeeplearningMojoModel)m)._normmul);
+    }
     return p;
   }
 
@@ -381,6 +385,13 @@ public class EasyPredictModelWrapper implements Serializable {
     }
     result.put(null, reconstructed[offset + cats.length]);
     return result;
+  }
+
+  private double calculateReconstructionError(double [] original, double [] reconstructed, double [] normmul){
+    double l2 = 0;
+    for (int i = 0; i < original.length; i++)
+      l2 += Math.pow((reconstructed[i] - original[i]) * normmul[i], 2);
+    return  l2 / original.length;
   }
 
   /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -329,7 +329,7 @@ public class EasyPredictModelWrapper implements Serializable {
     p.reconstructedRowData = reconstructedToRowData(output);
     if (m instanceof DeeplearningMojoModel){
       DeeplearningMojoModel mojoModel = ((DeeplearningMojoModel)m);
-      p.mse =  calculateReconstructionError(p.original, p.reconstructed, mojoModel._normmul, mojoModel._nums);
+      p.mse =  mojoModel.calculateReconstructionErrorPerRowData(p.original, p.reconstructed);
     }
     return p;
   }
@@ -385,18 +385,6 @@ public class EasyPredictModelWrapper implements Serializable {
     }
     result.put(null, reconstructed[offset + cats.length]);
     return result;
-  }
-
-  private double calculateReconstructionError(double [] original, double [] reconstructed, double [] normmul, int numNumeric){
-    double l2 = 0;
-    int numIndex = 0;
-    double norm = 0;
-    for (int i = 0; i < numNumeric; i++) {
-      numIndex = i + (original.length - numNumeric);
-      norm = (normmul != null) ? normmul[i] : 1;
-      l2 += Math.pow((reconstructed[numIndex] - original[numIndex]) * norm, 2);
-    }
-    return  l2 / numNumeric;
   }
 
   /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -327,9 +327,9 @@ public class EasyPredictModelWrapper implements Serializable {
     p.original = expandRawData(rawData, output.length);
     p.reconstructed = output;
     p.reconstructedRowData = reconstructedToRowData(output);
-    p.mse = 1;
     if (m instanceof DeeplearningMojoModel){
-      p.mse =  calculateReconstructionError(p.original, p.reconstructed, ((DeeplearningMojoModel)m)._normmul);
+      DeeplearningMojoModel mojoModel = ((DeeplearningMojoModel)m);
+      p.mse =  calculateReconstructionError(p.original, p.reconstructed, mojoModel._normmul, mojoModel._nums);
     }
     return p;
   }
@@ -387,11 +387,16 @@ public class EasyPredictModelWrapper implements Serializable {
     return result;
   }
 
-  private double calculateReconstructionError(double [] original, double [] reconstructed, double [] normmul){
+  private double calculateReconstructionError(double [] original, double [] reconstructed, double [] normmul, int numNumeric){
     double l2 = 0;
-    for (int i = 0; i < original.length; i++)
-      l2 += Math.pow((reconstructed[i] - original[i]) * normmul[i], 2);
-    return  l2 / original.length;
+    int numIndex = 0;
+    double norm = 0;
+    for (int i = 0; i < numNumeric; i++) {
+      numIndex = i + (original.length - numNumeric);
+      norm = (normmul != null) ? normmul[i] : 1;
+      l2 += Math.pow((reconstructed[numIndex] - original[numIndex]) * norm, 2);
+    }
+    return  l2 / numNumeric;
   }
 
   /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
@@ -24,4 +24,16 @@ public class AutoEncoderModelPrediction extends AbstractPrediction {
    * Example: input RowData([sex: "Male", ..]) will produce output RowData([sex: [Male: 0.9, Female: 0.1], ..]
    */
   public RowData reconstructedRowData;
+
+  /**
+   * Calculates average reconstruction error (MSE).
+   * @return average reconstruction error = ||original - reconstructed||^2 / length(original)
+   */
+  public double calcMSE() {
+    double l2 = 0;
+    for (int i = 0; i < original.length; i++)
+      l2 += Math.pow((reconstructed[i] - original[i]), 2);
+    return l2 / original.length;
+  }
+
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
@@ -26,7 +26,8 @@ public class AutoEncoderModelPrediction extends AbstractPrediction {
   public RowData reconstructedRowData;
 
   /**
-   * Reconstruction mean squared error calculated from original and reconstructed normalized data.
+   * Reconstruction mean squared error calculated from original and reconstructed data.
+   * Uses a normalization defined for the numerical features of the trained model.
    * average reconstruction error = ||original - reconstructed||^2 / length(original)
    */
   public double mse;

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
@@ -25,15 +25,5 @@ public class AutoEncoderModelPrediction extends AbstractPrediction {
    */
   public RowData reconstructedRowData;
 
-  /**
-   * Calculates average reconstruction error (MSE).
-   * @return average reconstruction error = ||original - reconstructed||^2 / length(original)
-   */
-  public double calcMSE() {
-    double l2 = 0;
-    for (int i = 0; i < original.length; i++)
-      l2 += Math.pow((reconstructed[i] - original[i]), 2);
-    return l2 / original.length;
-  }
-
+  public double mse;
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/AutoEncoderModelPrediction.java
@@ -25,5 +25,9 @@ public class AutoEncoderModelPrediction extends AbstractPrediction {
    */
   public RowData reconstructedRowData;
 
+  /**
+   * Reconstruction mean squared error calculated from original and reconstructed normalized data.
+   * average reconstruction error = ||original - reconstructed||^2 / length(original)
+   */
   public double mse;
 }


### PR DESCRIPTION
Edit `EasyPredictModelWrapper` to be able to calculate reconstruction error for autoencoder. Edit `DeepLearningAutoEncoderTest` to test if the error from model and mojo model is the same. 

Cherry pick [commit ](https://github.com/h2oai/h2o-3/pull/3102/commits/915ce9399ecee905ec764eb7b76150e48406a422) of @michalkurka, but find a slightly different solution.

JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6030