### PR TITLE
 [PUBDEV-5959] PySparking client is hanging after re-connecting to the H2O external backend

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -120,7 +120,10 @@ public final class AutoBuffer {
    *  remoteAddress set to null means that the communication is originating from non-h2o node, non-null value
    *  represents the case where the communication is coming from h2o node.
    *  */
-  public AutoBuffer( ByteChannel sock, InetAddress remoteAddress  ) throws IOException {
+  public AutoBuffer(ByteChannel sock ) {
+    this(sock, null, (short) 0);
+  }
+  public AutoBuffer( ByteChannel sock, InetAddress remoteAddress, short timestamp ) {
     _chan = sock;
     raisePriority();            // Make TCP priority high
     _bb = BBP_BIG.make();       // Get a big / TPC-sized ByteBuffer
@@ -129,7 +132,8 @@ public final class AutoBuffer {
     _firstPage = true;
     // Read Inet from socket, port from the stream, figure out H2ONode
     if(remoteAddress!=null) {
-      _h2o = H2ONode.intern(remoteAddress, getPort());
+      assert timestamp != 0;
+      _h2o = H2ONode.intern(remoteAddress, getPort(), timestamp);
     }else{
       // In case the communication originates from non-h2o node, we set _h2o node to null.
       // It is done for 2 reasons:
@@ -183,9 +187,7 @@ public final class AutoBuffer {
     _read = true;
     _firstPage = true;
     _chan = null;
-    boolean isClient = H2O.decodeIsClient(getTimestamp());
-    short timestamp = getTimestamp();
-    _h2o = TCPReceiverThread.processNewNode(pack.getAddress(), getPort(), isClient, timestamp);
+    _h2o = H2ONode.intern(pack.getAddress(), getPort(), getTimestamp());
     _persist = 0;               // No persistance
   }
 

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -146,10 +146,10 @@ public final class AutoBuffer {
 
   /** Make an AutoBuffer to write to an H2ONode.  Requests for full buffer will
    *  open a TCP socket and roll through writing to the target.  Smaller
-   *  requests will send via UDP.  Small requests get ordered by priority, so 
+   *  requests will send via UDP.  Small requests get ordered by priority, so
    *  that e.g. NACK and ACKACK messages have priority over most anything else.
    *  This helps in UDP floods to shut down flooding senders. */
-  private byte _msg_priority; 
+  private byte _msg_priority;
   AutoBuffer( H2ONode h2o, byte priority ) {
     // If UDP goes via TCP, we write into a HBB up front, because this will be copied again
     // into a large outgoing buffer.
@@ -186,7 +186,6 @@ public final class AutoBuffer {
     boolean isClient = H2O.decodeIsClient(getTimestamp());
     short timestamp = getTimestamp();
     _h2o = TCPReceiverThread.processNewNode(pack.getAddress(), getPort(), isClient, timestamp);
-    _h2o.timestamp = timestamp;
     _persist = 0;               // No persistance
   }
 
@@ -326,7 +325,7 @@ public final class AutoBuffer {
     ByteBuffer make() {
       while( true ) {             // Repeat loop for DBB OutOfMemory errors
         ByteBuffer bb=null;
-        synchronized(_bbs) { 
+        synchronized(_bbs) {
           int sz = _bbs.size();
           if( sz > 0 ) { bb = _bbs.remove(sz-1); _cached++; _numer++; }
         }
@@ -348,7 +347,7 @@ public final class AutoBuffer {
       // Heuristic: keep the ratio of BB's made to cache-hits at a fixed level.
       // Free to GC if ratio is high, free to internal cache if low.
       long ratio = _numer/(_denom+1);
-      synchronized(_bbs) { 
+      synchronized(_bbs) {
         if( ratio < 100 || _bbs.size() < _goal ) { // low hit/miss ratio or below goal
           bb.clear();           // Clear-before-add
           _bbs.add(bb);
@@ -778,10 +777,10 @@ public final class AutoBuffer {
     put(kd);
     return kd == null ? this : kd.writeAll_impl(this);
   }
-  public Keyed getKey(Key k, Futures fs) { 
+  public Keyed getKey(Key k, Futures fs) {
     return k==null ? null : getKey(fs); // Key is null ==> read nothing
   }
-  public Keyed getKey(Futures fs) { 
+  public Keyed getKey(Futures fs) {
     Keyed kd = get(Keyed.class);
     if( kd == null ) return null;
     DKV.put(kd,fs);
@@ -1004,7 +1003,7 @@ public final class AutoBuffer {
     assert _bb.position() == 0;
     putSp(_bb.position()+1+2+2);
     _bb.put    ((byte)type.ordinal());
-    _bb.putShort(H2O.SELF.timestamp);
+    _bb.putShort(H2O.SELF._timestamp);
     _bb.putChar((char)senderPort);
     return this;
   }
@@ -1027,7 +1026,7 @@ public final class AutoBuffer {
   AutoBuffer putTask(int ctrl, int tasknum) {
     assert _bb.position() == 0;
     putSp(_bb.position()+1+2+2+4);
-    _bb.put((byte)ctrl).putShort(H2O.SELF.timestamp).putChar((char)H2O.H2O_PORT).putInt(tasknum);
+    _bb.put((byte)ctrl).putShort(H2O.SELF._timestamp).putChar((char)H2O.H2O_PORT).putInt(tasknum);
     return this;
   }
 

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -115,14 +115,19 @@ public final class AutoBuffer {
   static final java.nio.charset.Charset UTF_8 = java.nio.charset.Charset.forName("UTF-8");
 
   /** Incoming TCP request.  Make a read-mode AutoBuffer from the open Channel,
+   *  in this case without additional arguments, the requests comes from outside the H2O cluster
+   *
+   *  */
+  public AutoBuffer(ByteChannel sock ) {
+    this(sock, null, (short) 0);
+  }
+
+  /** Incoming TCP request.  Make a read-mode AutoBuffer from the open Channel,
    *  figure the originating H2ONode from the first few bytes read.
    *
    *  remoteAddress set to null means that the communication is originating from non-h2o node, non-null value
    *  represents the case where the communication is coming from h2o node.
    *  */
-  public AutoBuffer(ByteChannel sock ) {
-    this(sock, null, (short) 0);
-  }
   public AutoBuffer( ByteChannel sock, InetAddress remoteAddress, short timestamp ) {
     _chan = sock;
     raisePriority();            // Make TCP priority high

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -1007,10 +1007,14 @@ public final class AutoBuffer {
    * @param senderPort port of the sender of the datagram
    */
   AutoBuffer putUdp(UDP.udp type, int senderPort){
+    return putUdp(type, senderPort, H2O.SELF._timestamp);
+  }
+
+  AutoBuffer putUdp(UDP.udp type, int senderPort, short timestamp){
     assert _bb.position() == 0;
     putSp(_bb.position()+1+2+2);
     _bb.put    ((byte)type.ordinal());
-    _bb.putShort(H2O.SELF._timestamp);
+    _bb.putShort(timestamp);
     _bb.putChar((char)senderPort);
     return this;
   }

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -980,6 +980,10 @@ public final class AutoBuffer {
   // Get the 1st control byte
   int  getCtrl( ) { return getSz(1).get(0)&0xFF; }
   // Get node timestamp in next 2 bytes
+
+  // the timestamp is on purpose where port was previously.
+  // In code, getPort is used to skip bytes before the value and the bytes for port itself.
+  // This ensures getPort will still have the same side-effect except we skip also the timestamp which is desired
   short getTimestamp() { return getSz(1+2).getShort(1);}
   // Get the port in next 2 bytes
   int getPort( ) { return getSz(1+2+2).getChar(1+2); }

--- a/h2o-core/src/main/java/water/ClientDisconnectCheckThread.java
+++ b/h2o-core/src/main/java/water/ClientDisconnectCheckThread.java
@@ -17,13 +17,15 @@ class ClientDisconnectCheckThread extends Thread {
    * This method checks whether the client is disconnected from this node due to some problem such as client or network
    * is unreachable.
    */
-  private void handleClientDisconnect(H2ONode node) {
-    if(node != H2O.SELF) {
-      Log.warn("Client " + node + " disconnected!");
+  private void handleClientDisconnect(H2ONode client) {
+    if(client != H2O.SELF) {
       if (H2O.isFlatfileEnabled()) {
-        H2O.removeNodeFromFlatfile(node);
+        H2O.removeNodeFromFlatfile(client);
       }
-      H2O.removeClient(node);
+      boolean removed = H2O.removeClient(client);
+      if (removed) {
+        Log.warn("Client " + client + " disconnected!");
+      }
     }
   }
 

--- a/h2o-core/src/main/java/water/ClientDisconnectCheckThread.java
+++ b/h2o-core/src/main/java/water/ClientDisconnectCheckThread.java
@@ -22,10 +22,7 @@ class ClientDisconnectCheckThread extends Thread {
       if (H2O.isFlatfileEnabled()) {
         H2O.removeNodeFromFlatfile(client);
       }
-      boolean removed = H2O.removeClient(client);
-      if (removed) {
-        Log.warn("Client " + client + " disconnected!");
-      }
+      H2O.removeClient(client);
     }
   }
 

--- a/h2o-core/src/main/java/water/ExternalFrameHandlerThread.java
+++ b/h2o-core/src/main/java/water/ExternalFrameHandlerThread.java
@@ -39,7 +39,7 @@ class ExternalFrameHandlerThread extends Thread {
                 new ExternalFrameHandler().process(_sock, _ab);
                 // Reuse open sockets for the next task
                 if (!_sock.isOpen()) break;
-                _ab = new AutoBuffer(_sock, null);
+                _ab = new AutoBuffer(_sock);
             } catch (Exception e) {
                 // Exceptions here are *normal*, this is an idle TCP connection and
                 // either the OS can time it out, or the cloud might shutdown.  We

--- a/h2o-core/src/main/java/water/ExternalFrameReaderClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderClient.java
@@ -188,7 +188,7 @@ final public class ExternalFrameReaderClient {
         sentAb.putA1(expectedTypes);
         sentAb.putA4(selectedColumnIndices);
         writeToChannel(sentAb, channel);
-        AutoBuffer receiveAb = new AutoBuffer(channel, null);
+        AutoBuffer receiveAb = new AutoBuffer(channel);
         // once we send H2O all information it needs to prepare for reading, it sends us back number of rows
         this.numRows = receiveAb.getInt();
         return receiveAb;

--- a/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
@@ -159,20 +159,16 @@ final public class ExternalFrameWriterClient {
      * @throws ExternalFrameConfirmationException
      */
     public void waitUntilAllWritten(int timeout) throws ExternalFrameConfirmationException {
+        final AutoBuffer confirmAb = new AutoBuffer(channel);
         try {
-            final AutoBuffer confirmAb = new AutoBuffer(channel, null);
-            try {
-                byte flag = ExternalFrameConfirmationCheck.getConfirmation(confirmAb, timeout);
-                assert (flag == ExternalFrameHandler.CONFIRM_WRITING_DONE);
-            } catch (TimeoutException ex) {
-                throw new ExternalFrameConfirmationException("Timeout for confirmation exceeded!");
-            } catch (InterruptedException e) {
-                throw new ExternalFrameConfirmationException("Confirmation thread interrupted!");
-            } catch (ExecutionException e) {
-                throw new ExternalFrameConfirmationException("Confirmation failed!");
-            }
-        } catch (IOException e) {
-            throw new ExternalFrameConfirmationException("Confirmation failed");
+            byte flag = ExternalFrameConfirmationCheck.getConfirmation(confirmAb, timeout);
+            assert (flag == ExternalFrameHandler.CONFIRM_WRITING_DONE);
+        } catch (TimeoutException ex) {
+            throw new ExternalFrameConfirmationException("Timeout for confirmation exceeded!");
+        } catch (InterruptedException e) {
+            throw new ExternalFrameConfirmationException("Confirmation thread interrupted!");
+        } catch (ExecutionException e) {
+            throw new ExternalFrameConfirmationException("Confirmation failed!");
         }
     }
 

--- a/h2o-core/src/main/java/water/FailedNodeWatchdogExtension.java
+++ b/h2o-core/src/main/java/water/FailedNodeWatchdogExtension.java
@@ -139,7 +139,7 @@ public class FailedNodeWatchdogExtension extends AbstractH2OExtension {
             try {
                 sleep(watchdogClientConnectTimeout);
                 boolean watchDogConnected = false;
-                HashSet<H2ONode> clients = H2O.getClients();
+                H2ONode[] clients = H2O.getClients();
 
                 if (Log.getLogLevel() == Log.DEBUG) {
                     Log.debug("Checking if watchdog client connected to the cluster, available clients at this moment are: ");
@@ -211,7 +211,7 @@ public class FailedNodeWatchdogExtension extends AbstractH2OExtension {
         @Override
         public void run() {
             while (true) {
-                HashSet<H2ONode> clients = H2O.getClients();
+                H2ONode[] clients = H2O.getClients();
 
                 if (Log.getLogLevel() == Log.DEBUG) {
                     Log.debug("Checking if watchdog client is connected, available clients are: ");

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2164,7 +2164,7 @@ final public class H2O {
    * Forgets H2O client
    */
   static boolean removeClient(H2ONode client){
-    return H2ONode.removeClient(client);
+    return client.removeClient();
   }
 
   public static H2ONode[] getClients(){

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1544,7 +1544,8 @@ final public class H2O {
     SELF._heartbeat._jar_md5 = JarHash.JARHASH;
     SELF._heartbeat._client = ARGS.client;
     SELF._heartbeat._cloud_name_hash = ARGS.name.hashCode();
-    SELF.timestamp = calculateNodeTimestamp();
+    SELF._client = ARGS.client;
+    SELF._timestamp = calculateNodeTimestamp();
   }
 
   /** Starts the worker threads, receiver threads, heartbeats and all other

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1955,7 +1955,6 @@ final public class H2O {
     // Validate arguments
     validateArguments();
 
-    // Create Timestamp for SELF
     Log.info("X-h2o-cluster-id: " + H2O.CLUSTER_ID);
     Log.info("User name: '" + H2O.ARGS.user_name + "'");
 

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1544,16 +1544,6 @@ final public class H2O {
     SELF._heartbeat._jar_md5 = JarHash.JARHASH;
     SELF._heartbeat._client = ARGS.client;
     SELF._heartbeat._cloud_name_hash = ARGS.name.hashCode();
-
-    if(ARGS.client){
-      reportClient(H2O.SELF); // report myself as the client to myself
-      // This is useful for the consistency and used, for example, in LogsHandler where, in case we couldn't find ip of
-      // regular worker node, we try to obtain the logs from the client.
-      //
-      // In case we wouldn't report the client to the client and the request for the logs would come to the client, we would
-      // need to handle that case differently. But since we handle this consistently like this, we do not need to worry about cases if the request
-      // came to the client node or not since we always report the client.
-    }
   }
 
   /** Starts the worker threads, receiver threads, heartbeats and all other
@@ -2169,25 +2159,19 @@ final public class H2O {
     return new HashSet<>(STATIC_H2OS);
   }
 
-  public static H2ONode reportClient(H2ONode client) {
-    H2ONode oldClient = CLIENTS_MAP.put(client.getIpPortString(), client);
-    if (oldClient == null) {
-        Log.info("New client discovered: " + client.toDebugString());
-    }
-    return oldClient;
+  /**
+   * Forgets H2O client
+   */
+  static boolean removeClient(H2ONode client){
+    return H2ONode.removeClient(client);
   }
 
-  public static H2ONode removeClient(H2ONode client){
-    client.stopSendThread();
-    return CLIENTS_MAP.remove(client.getIpPortString());
-  }
-
-  public static HashSet<H2ONode> getClients(){
-    return new HashSet<>(CLIENTS_MAP.values());
+  public static H2ONode[] getClients(){
+    return H2ONode.getClients();
   }
 
   public static H2ONode getClientByIPPort(String ipPort){
-    return CLIENTS_MAP.get(ipPort);
+    return H2ONode.getClientByIPPort(ipPort);
   }
 
   public static Key<DecryptionTool> defaultDecryptionTool() {

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2184,7 +2184,7 @@ final public class H2O {
    * Select last 15 bytes from the jvm boot start time and return it as short. If the timestamp is 0, we increment it by
    * 1 to be able to distinguish between client and node as -0 is the same as 0.
    */
-  private static short createTimestamp(long jvmStartTime){
+  private static short truncateTimestamp(long jvmStartTime){
     int bitMask = (1 << 15) - 1;
     // select the lower 15 bits
     short timestamp = (short) (jvmStartTime & bitMask);
@@ -2198,7 +2198,7 @@ final public class H2O {
    * we are client or not. We combine these 2 information and create a char(2 bytes) with this info in a single variable.
    */
   private static short calculateNodeTimestamp() {
-    return calculateNodeTimestamp(createTimestamp(TimeLine.JVM_BOOT_MSEC), H2O.ARGS.client);
+    return calculateNodeTimestamp(TimeLine.JVM_BOOT_MSEC, H2O.ARGS.client);
   }
 
   /**
@@ -2207,10 +2207,11 @@ final public class H2O {
    *
    * The negative timestamp represents a client node, the positive one a regular H2O node
    *
-   * @param timestamp  timestamp created by createTimestamp.
+   * @param bootTimestamp H2O node boot timestamp
    * @param amIClient true if this node is client, otherwise false
    */
-  private static short calculateNodeTimestamp(short timestamp, boolean amIClient) {
+  static short calculateNodeTimestamp(long bootTimestamp, boolean amIClient) {
+    short timestamp = truncateTimestamp(bootTimestamp);
     //if we are client, return negative timestamp, otherwise positive
     return amIClient ? (short) -timestamp : timestamp;
   }

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1544,8 +1544,6 @@ final public class H2O {
     SELF._heartbeat._jar_md5 = JarHash.JARHASH;
     SELF._heartbeat._client = ARGS.client;
     SELF._heartbeat._cloud_name_hash = ARGS.name.hashCode();
-    SELF._client = ARGS.client;
-    SELF._timestamp = calculateNodeTimestamp();
   }
 
   /** Starts the worker threads, receiver threads, heartbeats and all other
@@ -2198,7 +2196,7 @@ final public class H2O {
    * Calculate node timestamp from Current's node information. We use start of jvm boot time and information whether
    * we are client or not. We combine these 2 information and create a char(2 bytes) with this info in a single variable.
    */
-  private static short calculateNodeTimestamp() {
+  static short calculateNodeTimestamp() {
     return calculateNodeTimestamp(TimeLine.JVM_BOOT_MSEC, H2O.ARGS.client);
   }
 

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -1,6 +1,5 @@
 package water;
 
-import sun.util.resources.is.CalendarData_is;
 import water.nbhm.NonBlockingHashMap;
 import water.nbhm.NonBlockingHashMapLong;
 import water.network.SocketChannelFactory;

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -168,9 +168,10 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
 
   static boolean removeClient(H2ONode node){
       // Before we remove the Client, stop the sending thread
+      boolean ret = INTERN.remove(node._key, node);
       node.stopSendThread();
       Log.info("Removing client: " + node.toDebugString());
-      return INTERN.remove(node._key, node);
+      return ret;
   }
 
 

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -209,6 +209,10 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
         h2o.refreshClient(timestamp);
       }
       return h2o;
+    } else {
+      if (isClient) {
+        Log.info("New client connected, timestamp=" + timestamp);
+      }
     }
     final int idx = UNIQUE.getAndIncrement();
     assert idx < Short.MAX_VALUE;

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -318,7 +318,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert res && !sock2.isConnectionPending() && sock2.isBlocking() && sock2.isConnected() && sock2.isOpen();
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
     bb.put((byte)2);
-    bb.putShort(AutoBuffer.calculateNodeTimestamp());
+    bb.putShort(H2O.SELF.timestamp);
     bb.putChar((char)H2O.H2O_PORT);
     bb.put((byte)0xef);
     bb.flip();
@@ -369,7 +369,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert !sock.isConnectionPending() && sock.isBlocking() && sock.isConnected() && sock.isOpen();
     sock.socket().setTcpNoDelay(true);
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
-    bb.put(tcpType).putShort(AutoBuffer.calculateNodeTimestamp()).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
+    bb.put(tcpType).putShort(H2O.SELF.timestamp).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
 
     ByteChannel wrappedSocket = socketFactory.clientChannel(sock, isa.getHostName(), isa.getPort());
 

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -37,7 +37,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   transient public volatile HeartBeat _heartbeat;  // My health info.  Changes 1/sec.
   transient public int _tcp_readers;               // Count of started TCP reader threads
 
-  transient char uniqueMetaId;
+  transient short timestamp;
   public boolean _removed_from_cloud;
 
   public void stopSendThread(){
@@ -317,7 +317,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert res && !sock2.isConnectionPending() && sock2.isBlocking() && sock2.isConnected() && sock2.isOpen();
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
     bb.put((byte)2);
-    bb.putChar(AutoBuffer.calculateNodeUniqueMeta());
+    bb.putShort(AutoBuffer.calculateNodeTimestamp());
     bb.putChar((char)H2O.H2O_PORT);
     bb.put((byte)0xef);
     bb.flip();
@@ -368,7 +368,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert !sock.isConnectionPending() && sock.isBlocking() && sock.isConnected() && sock.isOpen();
     sock.socket().setTcpNoDelay(true);
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
-    bb.put(tcpType).putChar(AutoBuffer.calculateNodeUniqueMeta()).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
+    bb.put(tcpType).putShort(AutoBuffer.calculateNodeTimestamp()).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
 
     ByteChannel wrappedSocket = socketFactory.clientChannel(sock, isa.getHostName(), isa.getPort());
 

--- a/h2o-core/src/main/java/water/MRTask.java
+++ b/h2o-core/src/main/java/water/MRTask.java
@@ -300,7 +300,7 @@ public abstract class MRTask<T extends MRTask<T>> extends DTask<T> implements Fo
   /** Compute a permissible node index on which to launch remote work. */
   private int addShift( int x ) { x += _nlo; int sz = H2O.CLOUD.size(); return x < sz ? x : x-sz; }
   private int subShift( int x ) { x -= _nlo; int sz = H2O.CLOUD.size(); return x <  0 ? x+sz : x; }
-  private short selfidx() { int idx = H2O.SELF.index(); if( idx>= 0 ) return (short)idx; assert H2O.SELF._heartbeat._client; return 0; }
+  private short selfidx() { int idx = H2O.SELF.index(); if( idx>= 0 ) return (short)idx; assert H2O.SELF._client; return 0; }
 
   // Profiling support.  Time for each subpart of a single M/R task, plus any
   // nested MRTasks.  All numbers are CTM stamps or millisecond times.

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -71,23 +71,12 @@ public abstract class Paxos {
         // A new client was reported to this node so we propagate this information to all nodes in the cluster, to this
         // as well
         UDPClientEvent.ClientEvent.Type.CONNECT.broadcast(h2o);
-      } else if (!H2O.ARGS.client && h2o._heartbeat._client) {
-        // When we put the client ip:port to flatfile as well as the rest of the nodes, this client node is not in the
-        // client hash map. We need to handle this case to properly to handle client disconnects and add the client
-        // there as well for consistency
-        H2O.reportClient(h2o);
-      }
-      else if (H2O.ARGS.client && !H2O.isNodeInFlatfile(h2o)) {
+      } else if (H2O.ARGS.client && !H2O.isNodeInFlatfile(h2o)) {
         // This node is a client and using a flatfile to figure out a topology of the cluster. The flatfile passed to the
         // client is always modified at the start of H2O to contain only a single node. This node is used to propagate
         // information about the client to the cluster. Once the nodes have the information about the client, then propagate
         // themselves via heartbeat to the client
         H2O.addNodeToFlatfile(h2o);
-      }
-    }else{
-      // We are operating in the multicast mode and heard from the client, so we need to report the client on this node
-      if(h2o._heartbeat._client){
-        H2O.reportClient(h2o);
       }
     }
 

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -58,7 +58,7 @@ public abstract class Paxos {
         ListenerService.getInstance().report("client_wrong_md5", new Object[]{h2o._heartbeat._jar_md5});
       }
     }
-    
+
     if(h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash){
       // ignore requests from this node as they are coming from different cluster
       return 0;

--- a/h2o-core/src/main/java/water/RPC.java
+++ b/h2o-core/src/main/java/water/RPC.java
@@ -378,7 +378,7 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
 
           UDP.udp udp = dt.priority()==H2O.FETCH_ACK_PRIORITY ? UDP.udp.fetchack : UDP.udp.ack;
           ab = new AutoBuffer(_client,udp._prior).putTask(udp,_tsknum).put1(SERVER_UDP_SEND);
-          assert ab.position() == 1+2+4+1;
+          assert ab.position() == 1+2+2+4+1;
           dt.write(ab);         // Write the DTask - could be very large write
           dt._repliedTcp = ab.hasTCP(); // Resends do not need to repeat TCP result
           ab.close();                   // Then close; send final byte
@@ -421,7 +421,7 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
       if( wasTCP )  rab.put1(RPC.SERVER_TCP_SEND) ; // Original reply sent via TCP
       else {
         rab.put1(RPC.SERVER_UDP_SEND); // Original reply sent via UDP
-        assert rab.position() == 1+2+4+1;
+        assert rab.position() == 1+2+2+4+1;
         dt.write(rab);
       }
       assert sz_check(rab) : "Resend of " + _dt.getClass() + " changes size from "+_size+" to "+rab.size();

--- a/h2o-core/src/main/java/water/RPC.java
+++ b/h2o-core/src/main/java/water/RPC.java
@@ -150,7 +150,7 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
             _dt.setException(ex);
             // must be the last set before notify call cause the waiting thread
             // can wake up at any moment independently on notify
-            _done = true; 
+            _done = true;
             RPC.this.notifyAll();
           }
           doAllCompletions();
@@ -385,10 +385,10 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
           _computedAndReplied = true;   // After the final handshake, set computed+replied bit
           break;                        // Break out of retry loop
         } catch( AutoBuffer.AutoBufferException e ) {
-          if( !_client._heartbeat._client ) // Report on servers only; clients allowed to be flaky
+          if( !_client._client ) // Report on servers only; clients allowed to be flaky
             Log.info("IOException during ACK, "+e._ioe.getMessage()+", t#"+_tsknum+" AB="+ab+", waiting and retrying...");
           ab.drainClose();
-          if( _client._heartbeat._client ) // Dead client will not accept a TCP ACK response?
+          if( _client._client ) // Dead client will not accept a TCP ACK response?
             this.CAS_DT(dt,null);          // cancel the ACK
           try { Thread.sleep(100); } catch (InterruptedException ignore) {}
         } catch( Throwable e ) { // Custom serializer just barfed?

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -101,7 +101,7 @@ public class TCPReceiverThread extends Thread {
         int chanType = bb.get(); // 1 - small , 2 - big
         short timestamp = bb.getShort(); // read timestamp
         int port = bb.getChar(); // read port
-        boolean isClient = AutoBuffer.decodeIsClient(timestamp);
+        boolean isClient = H2O.decodeIsClient(timestamp);
         int sentinel = (0xFF) & bb.get();
         if(sentinel != 0xef) {
           if(H2O.SELF.getSecurityManager().securityEnabled) {

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -49,17 +49,17 @@ public class TCPReceiverThread extends Thread {
     this.socketChannelFactory = H2O.SELF.getSocketFactory();
   }
 
-  public static H2ONode processNewNode(InetAddress inetAddress, int port, boolean isClient, char uniqueId) {
+  public static H2ONode processNewNode(InetAddress inetAddress, int port, boolean isClient, short timestamp) {
     H2ONode node = H2O.getClientByIPPort(inetAddress.getHostAddress() + ":" + (port - 1));
-    if (!H2O.ARGS.client && isClient && node != null && node.uniqueMetaId != uniqueId) {
+    if (!H2O.ARGS.client && isClient && node != null && node.timestamp != timestamp) {
       // don't do this check in case we are the client
       H2ONode.removeClient(node);
     }
     H2ONode h2o = H2ONode.intern(inetAddress, port);
-    if(!H2O.ARGS.client && ((node == null && isClient) || (node != null && isClient && node.uniqueMetaId != uniqueId))){
+    if(!H2O.ARGS.client && ((node == null && isClient) || (node != null && isClient && node.timestamp != timestamp))){
       Log.info("New client discovered: " + h2o.toDebugString());
     }
-    h2o.uniqueMetaId = uniqueId;
+    h2o.timestamp = timestamp;
     return h2o;
   }
 
@@ -99,10 +99,9 @@ public class TCPReceiverThread extends Thread {
         }
         bb.flip();
         int chanType = bb.get(); // 1 - small , 2 - big
-        char nodeMeta = bb.getChar(); // read note id
+        short timestamp = bb.getShort(); // read timestamp
         int port = bb.getChar(); // read port
-        boolean isClient = AutoBuffer.decodeIsClient(nodeMeta);
-        char uniqueId = AutoBuffer.decodeUniqueId(nodeMeta);
+        boolean isClient = AutoBuffer.decodeIsClient(timestamp);
         int sentinel = (0xFF) & bb.get();
         if(sentinel != 0xef) {
           if(H2O.SELF.getSecurityManager().securityEnabled) {
@@ -120,10 +119,10 @@ public class TCPReceiverThread extends Thread {
         // Pass off the TCP connection to a separate reader thread
         switch( chanType ) {
         case TCP_SMALL:
-          new UDP_TCP_ReaderThread(processNewNode(inetAddress, port, isClient, uniqueId), wrappedSocket).start();
+          new UDP_TCP_ReaderThread(processNewNode(inetAddress, port, isClient, timestamp), wrappedSocket).start();
           break;
         case TCP_BIG:
-          processNewNode(inetAddress, port, isClient, uniqueId);
+          processNewNode(inetAddress, port, isClient, timestamp);
           new TCPReaderThread(wrappedSocket, new AutoBuffer(wrappedSocket, inetAddress), inetAddress).start();
           break;
         case TCP_EXTERNAL:

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -87,7 +87,6 @@ public class TCPReceiverThread extends Thread {
         int chanType = bb.get(); // 1 - small , 2 - big
         short timestamp = bb.getShort(); // read timestamp
         int port = bb.getChar(); // read port
-        boolean isClient = H2O.decodeIsClient(timestamp);
         int sentinel = (0xFF) & bb.get();
         if(sentinel != 0xef) {
           if(H2O.SELF.getSecurityManager().securityEnabled) {

--- a/h2o-core/src/main/java/water/UDPClientEvent.java
+++ b/h2o-core/src/main/java/water/UDPClientEvent.java
@@ -33,7 +33,6 @@ public class UDPClientEvent extends UDP {
             client._heartbeat = ce.clientHeartBeat;
 
             H2O.addNodeToFlatfile(ce.clientNode);
-            H2O.reportClient(ce.clientNode);
           }
           break;
         // Regular disconnect event also doesn't have any effect in multicast mode.

--- a/h2o-core/src/main/java/water/util/JStackCollectorTask.java
+++ b/h2o-core/src/main/java/water/util/JStackCollectorTask.java
@@ -67,7 +67,7 @@ public class JStackCollectorTask extends MRTask<JStackCollectorTask> {
 
   @Override public void setupLocal() {
     _traces = new DStackTrace[H2O.CLOUD.size()];
-    if( H2O.SELF._heartbeat._client ) return; // Clients are not in the cloud, and do not get stack traces
+    if( H2O.SELF._client ) return; // Clients are not in the cloud, and do not get stack traces
     Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
 
     // Known to be interesting

--- a/h2o-core/src/test/java/water/AutoBufferTest.java
+++ b/h2o-core/src/test/java/water/AutoBufferTest.java
@@ -34,6 +34,28 @@ public class AutoBufferTest extends TestUtil {
   }
 
   @Test
+  public void decodeClientInfoNotClient(){
+    long bootTime = 1540375717281L;
+    char uniqueId = AutoBuffer.createUniqueId(bootTime);
+    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
+    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, false);
+    assertEquals(meta, 9633);
+    assertFalse(AutoBuffer.decodeIsClient(meta));
+    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+  }
+
+  @Test
+  public void decodeClientInfoClient(){
+    long bootTime = 1540375717281L;
+    char uniqueId = AutoBuffer.createUniqueId(bootTime);
+    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
+    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, true);
+    assertEquals(meta, 42401);
+    assertTrue(AutoBuffer.decodeIsClient(meta));
+    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+  }
+
+  @Test
   public void testOutputStreamBigDataSmallChunks() {
     final int dataSize = 100 * 1024;
     byte[] data = new byte[dataSize - 1];

--- a/h2o-core/src/test/java/water/AutoBufferTest.java
+++ b/h2o-core/src/test/java/water/AutoBufferTest.java
@@ -34,45 +34,6 @@ public class AutoBufferTest extends TestUtil {
   }
 
   @Test
-  public void decodeClientInfoNotClient(){
-    long bootTime = 1540375717281L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
-    assertEquals(timestamp, 9633);
-    assertFalse(AutoBuffer.decodeIsClient(timestamp));
-  }
-
-  @Test
-  public void decodeClientInfoClient(){
-    long bootTime = 1540375717281L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
-    assertEquals(timestamp, -9633);
-    assertTrue(AutoBuffer.decodeIsClient(timestamp));
-  }
-
-  @Test
-  public void decodeNotClientZeroTimestamp(){
-    long bootTime = 0L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
-    assertEquals(timestamp, 1);
-    assertFalse(AutoBuffer.decodeIsClient(timestamp));
-  }
-  @Test
-  public void decodeClientZeroTimestamp(){
-    long bootTime = 0L;
-    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
-    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
-    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
-    assertEquals(timestamp, -1);
-    assertTrue(AutoBuffer.decodeIsClient(timestamp));
-  }
-
-  @Test
   public void testOutputStreamBigDataSmallChunks() {
     final int dataSize = 100 * 1024;
     byte[] data = new byte[dataSize - 1];
@@ -103,7 +64,7 @@ public class AutoBufferTest extends TestUtil {
 
   @Test
   public void testNameOfClass() throws Exception {
-    
+
     byte[] bytes = AutoBuffer.javaSerializeWritePojo(new XYZZY());
     assertEquals("water.AutoBufferTest$XYZZY", AutoBuffer.nameOfClass(bytes));
     bytes[7] = 127;

--- a/h2o-core/src/test/java/water/AutoBufferTest.java
+++ b/h2o-core/src/test/java/water/AutoBufferTest.java
@@ -36,23 +36,40 @@ public class AutoBufferTest extends TestUtil {
   @Test
   public void decodeClientInfoNotClient(){
     long bootTime = 1540375717281L;
-    char uniqueId = AutoBuffer.createUniqueId(bootTime);
-    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
-    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, false);
-    assertEquals(meta, 9633);
-    assertFalse(AutoBuffer.decodeIsClient(meta));
-    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
+    assertEquals(timestamp, 9633);
+    assertFalse(AutoBuffer.decodeIsClient(timestamp));
   }
 
   @Test
   public void decodeClientInfoClient(){
     long bootTime = 1540375717281L;
-    char uniqueId = AutoBuffer.createUniqueId(bootTime);
-    assertEquals(uniqueId,9633); // manually calculated -> took last 15 bits from bootTime
-    char meta = AutoBuffer.calculateNodeUniqueMeta(uniqueId, true);
-    assertEquals(meta, 42401);
-    assertTrue(AutoBuffer.decodeIsClient(meta));
-    assertEquals(AutoBuffer.decodeUniqueId(meta), uniqueId);
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 9633); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
+    assertEquals(timestamp, -9633);
+    assertTrue(AutoBuffer.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeNotClientZeroTimestamp(){
+    long bootTime = 0L;
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, false);
+    assertEquals(timestamp, 1);
+    assertFalse(AutoBuffer.decodeIsClient(timestamp));
+  }
+  @Test
+  public void decodeClientZeroTimestamp(){
+    long bootTime = 0L;
+    short timestampWithoutNodeInfo = AutoBuffer.createTimestamp(bootTime);
+    assertEquals(timestampWithoutNodeInfo, 1); // manually calculated -> took last 15 bits from bootTime
+    short timestamp = AutoBuffer.calculateNodeTimestamp(timestampWithoutNodeInfo, true);
+    assertEquals(timestamp, -1);
+    assertTrue(AutoBuffer.decodeIsClient(timestamp));
   }
 
   @Test

--- a/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
+++ b/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
@@ -1,0 +1,71 @@
+package water;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClientReconnectSimulationTest extends TestUtil{
+  @BeforeClass() public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void testClientReconnect() {
+    HeartBeat hb = new HeartBeat();
+    hb._cloud_name_hash = H2O.SELF._heartbeat._cloud_name_hash;
+    hb._client = true;
+    hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
+
+    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-100);
+    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-101);
+    // Verify number of clients
+    assertEquals(1, H2O.getClients().length);
+
+  }
+
+  @Test
+  public void testClientTimeout() {
+    // connect the client, wait for the timeout period and check that afterwards, the client is disconnected
+    HeartBeat hb = new HeartBeat();
+    hb._cloud_name_hash = H2O.SELF._heartbeat._cloud_name_hash;
+    hb._client = true;
+    hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
+
+    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-100);
+    // Verify number of clients
+    assertEquals(1, H2O.getClients().length);
+    waitForClientsDisconnect();
+    assertEquals(0, H2O.getClients().length);
+  }
+
+  @Test
+  public void testTwoClientsReconnect() {
+    HeartBeat hb = new HeartBeat();
+    hb._cloud_name_hash = H2O.SELF._heartbeat._cloud_name_hash;
+    hb._client = true;
+    hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
+
+    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-100);
+    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-101);
+
+    // second client from another node re-connects
+    H2ONode.intern(H2O.SELF_ADDRESS, 65458, (short)-100);
+    H2ONode.intern(H2O.SELF_ADDRESS, 65458, (short)-101);
+    // Verify number of clients
+    assertEquals(2, H2O.getClients().length);
+  }
+
+  @After
+  public void waitForClientsDisconnect(){
+    try {
+      Thread.sleep(H2O.ARGS.clientDisconnectTimeout *2); // sleep double the time the timeout for client disconnect is reached
+      // to be somehow sure the client is gone
+
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+}

--- a/h2o-core/src/test/java/water/H2OTest.java
+++ b/h2o-core/src/test/java/water/H2OTest.java
@@ -1,0 +1,37 @@
+package water;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class H2OTest {
+
+  @Test
+  public void decodeClientInfoNotClient(){
+    short timestamp = H2O.calculateNodeTimestamp(1540375717281L, false);
+    assertEquals(timestamp, 9633);
+    assertFalse(H2O.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeClientInfoClient(){
+    short timestamp = H2O.calculateNodeTimestamp(1540375717281L, true);
+    assertEquals(timestamp, -9633);
+    assertTrue(H2O.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeNotClientZeroTimestamp(){
+    short timestamp = H2O.calculateNodeTimestamp(0L, false);
+    assertEquals(timestamp, 1);
+    assertFalse(H2O.decodeIsClient(timestamp));
+  }
+
+  @Test
+  public void decodeClientZeroTimestamp(){
+    short timestamp = H2O.calculateNodeTimestamp(0L, true);
+    assertEquals(timestamp, -1);
+    assertTrue(H2O.decodeIsClient(timestamp));
+  }
+
+}

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -14,7 +14,7 @@ public class UnknownHeartbeatTest extends TestUtil{
 
   @Test
   public void testIgnoreUnknownHeartBeat() {
-    final int clientsCountBefore = H2O.getClients().size();
+    final int clientsCountBefore = H2O.getClients().length;
     HeartBeat hb = new HeartBeat();
     hb._cloud_name_hash = 777;
     hb._client = true;
@@ -26,7 +26,7 @@ public class UnknownHeartbeatTest extends TestUtil{
     ab.close();
 
     // Verify that we don't have a new client
-    assertEquals(clientsCountBefore, H2O.getClients().size());
+    assertEquals(clientsCountBefore, H2O.getClients().length);
   }
 
   @Test

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/communication/XGBoostAutoBuffer.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/communication/XGBoostAutoBuffer.java
@@ -16,7 +16,7 @@ public class XGBoostAutoBuffer {
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     public XGBoostAutoBuffer(SocketChannel channel) throws IOException {
-        this.ab = new AutoBuffer(channel, null);
+        this.ab = new AutoBuffer(channel);
     }
 
     public XGBoostAutoBuffer() {


### PR DESCRIPTION
This PR is for rel-xia to follow our current PR cycle, from https://github.com/h2oai/h2o-3/pull/3057.

Original comment:

## The Issue

The original issue was that when a client disconnected and connected to the cluster before the cluster discovered the original client is gone, it blocked the connection of the new client because of previously opened connections

This was caused by using the old client entry in the Client hash map as the cluster was still trying to  contact the old client on the old sockets. We need to make sure the new sockets are created.

##  The Fix
In order to fix this, we needed to add a new entry the the `AutoBuffer` head. This entry contains the information whether the node is client and the unique id. This entry is of size 2 bytes to minimize to communication overhead. The 1. bit is info whether we are client or not and the last 15 bits are the unique id.

This is needed because we need to be able to discover whether the node is client and if it is, different one, before we call `INTERN.put` of this newly created node.

## Implications

In the future, this additional info can help us separate client from the H2O core as we can now tell early whether the node is client or not

Also as part of this PR, the Client hash map was removed as it was duplication information already available in INTERN. 

The method `reportClient` was also removed. The information about the connected client is now printed as part of the `intern` method as that is always the first place where the new node is created. So the code is not scattered around.