### PR TITLE
PUBDEV-6101 fix StackedEnsembleMojoSubModel to be serializable

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/ensemble/StackedEnsembleMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/ensemble/StackedEnsembleMojoModel.java
@@ -2,6 +2,7 @@ package hex.genmodel.algos.ensemble;
 
 import hex.genmodel.MojoModel;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 public class StackedEnsembleMojoModel extends MojoModel {
@@ -47,7 +48,7 @@ public class StackedEnsembleMojoModel extends MojoModel {
      * internal order of features. Therefore, the scored row's values must be re-mapped to the internal order of each
      * model.
      */
-    static class StackedEnsembleMojoSubModel {
+    static class StackedEnsembleMojoSubModel implements Serializable {
 
         final MojoModel _mojoModel;
         final int[] _mapping; // Mapping. If null, no mapping is required.

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/ensemble/StackedEnsembleSerializableMojoTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/ensemble/StackedEnsembleSerializableMojoTest.java
@@ -1,0 +1,66 @@
+package hex.genmodel.algos.ensemble;
+
+import hex.genmodel.ModelMojoReader;
+import hex.genmodel.MojoModel;
+import hex.genmodel.MojoReaderBackend;
+import hex.genmodel.MojoReaderBackendFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.*;
+import java.net.URL;
+
+
+/**
+ * Test if StackedEnsembleMojoModel is serializable
+ */
+public class StackedEnsembleSerializableMojoTest {
+
+    private MojoModel deserialize(final byte[] buffer) {
+        final ByteArrayInputStream in = new ByteArrayInputStream(buffer);
+        try {
+            final ObjectInputStream objectIn = new ObjectInputStream(in);
+            return (MojoModel) objectIn.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        } finally {
+            try {
+                in.close();
+            } catch (IOException e) {
+                Assert.fail(e.toString());
+            }
+        }
+    }
+
+    private byte[] serialize(final Serializable input) {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            final ObjectOutputStream objectOutput = new ObjectOutputStream(out);
+            objectOutput.writeObject(input);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        } finally {
+            try {
+                out.close();
+            } catch (IOException e) {
+                Assert.fail(e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void testStackedEnsembleMojoSerialization() throws Exception {
+        URL mojoSource = StackedEnsembleRegressionMojoTest.class.getResource("binomial.zip");
+        Assert.assertNotNull(mojoSource);
+        MojoReaderBackend reader = MojoReaderBackendFactory.createReaderBackend(mojoSource, MojoReaderBackendFactory.CachingStrategy.MEMORY);
+        MojoModel model = ModelMojoReader.readFrom(reader);
+
+        try {
+            final byte[] buffer = serialize(model);
+            Assert.assertNotNull(deserialize(buffer));
+        } catch (IllegalStateException e){
+            Assert.fail(e.toString());
+        }
+    }
+}

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/ensemble/StackedEnsembleSerializableMojoTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/ensemble/StackedEnsembleSerializableMojoTest.java
@@ -16,36 +16,22 @@ import java.net.URL;
  */
 public class StackedEnsembleSerializableMojoTest {
 
-    private MojoModel deserialize(final byte[] buffer) {
+    private MojoModel deserialize(final byte[] buffer) throws IllegalStateException {
         final ByteArrayInputStream in = new ByteArrayInputStream(buffer);
-        try {
-            final ObjectInputStream objectIn = new ObjectInputStream(in);
+        try (final ObjectInputStream objectIn = new ObjectInputStream(in)){
             return (MojoModel) objectIn.readObject();
         } catch (IOException | ClassNotFoundException e) {
             throw new IllegalStateException(e);
-        } finally {
-            try {
-                in.close();
-            } catch (IOException e) {
-                Assert.fail(e.toString());
-            }
         }
     }
 
-    private byte[] serialize(final Serializable input) {
+    private byte[] serialize(final Serializable input) throws IllegalStateException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try {
-            final ObjectOutputStream objectOutput = new ObjectOutputStream(out);
+        try(final ObjectOutputStream objectOutput = new ObjectOutputStream(out)) {
             objectOutput.writeObject(input);
             return out.toByteArray();
         } catch (IOException e) {
             throw new IllegalStateException(e);
-        } finally {
-            try {
-                out.close();
-            } catch (IOException e) {
-                Assert.fail(e.toString());
-            }
         }
     }
 


### PR DESCRIPTION
The `StackedEnsembleMojoModel` has a static inner class `StackedEnsembleMojoSubModel` which is not serializable. This PR fixes the `StackedEnsembleMojoSubModel` implements the `Serializable` interface. 

JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6101