### PR TITLE
Rel-xia-PUBDEV-5990-arrange-OOM

### DIFF
--- a/h2o-core/src/main/java/water/MemoryManager.java
+++ b/h2o-core/src/main/java/water/MemoryManager.java
@@ -1,14 +1,15 @@
 package water;
 
+import jsr166y.ForkJoinPool;
+import jsr166y.ForkJoinPool.ManagedBlocker;
+import water.util.Log;
+import water.util.PrettyPrint;
+
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
 import java.lang.management.*;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.management.Notification;
-import javax.management.NotificationEmitter;
-import jsr166y.ForkJoinPool.ManagedBlocker;
-import jsr166y.ForkJoinPool;
-import water.util.Log;
-import water.util.PrettyPrint;
 
 /**
  * Manages memory assigned to key/value pairs. All byte arrays used in

--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -26,11 +26,12 @@ class BinaryMerge extends DTask<BinaryMerge> {
   private transient long _retLen[/*n2GB*/][];   // How many rows does it match to?
 
   final FFSB _leftSB, _riteSB;
+  final boolean _onlyLeftFrame;  // denote if only left frame is available which implies sorting.
   private transient KeyOrder _leftKO, _riteKO;
 
   private final int _numJoinCols;
   private transient long _leftFrom;
-  private transient int _retBatchSize;
+  private transient int _retBatchSize; // no need to match batchsize of RadixOrder.
 
   private final boolean _allLeft, _allRight;
   private boolean[] _stringCols;
@@ -65,7 +66,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
       _base = base;
       // Create fast lookups to go from chunk index to node index of that chunk
       Vec vec = _vec = frame.anyVec();
-      _chunkNode = vec==null ? null : new int[vec.nChunks()];
+      _chunkNode = vec==null ? null : MemoryManager.malloc4(vec.nChunks());
       if( vec == null ) return; // Zero-columns for Sort
       for( int i=0; i<_chunkNode.length; i++ )
         _chunkNode[i] = vec.chunkKey(i).home_node().index();
@@ -87,13 +88,14 @@ class BinaryMerge extends DTask<BinaryMerge> {
     assert riteSB._msb!=-1 || allLeft;
     _leftSB = leftSB;
     _riteSB = riteSB;
+    _onlyLeftFrame = (_leftSB._frame.numCols() > 0 && _riteSB._frame.numCols()==0);
     // the number of columns in the key i.e. length of _leftFieldSizes and _riteSB._fieldSizes
     _numJoinCols = Math.min(_leftSB._fieldSizes.length, _riteSB._fieldSizes.length);
     _allLeft = allLeft;
     _allRight = false;  // TODO: pass through
     int columnsInResult = (_leftSB._frame == null?0:_leftSB._frame.numCols()) +
             (_riteSB._frame == null?0:_riteSB._frame.numCols())-_numJoinCols;
-    _stringCols = new boolean[columnsInResult];
+    _stringCols = MemoryManager.mallocZ(columnsInResult);
     // check left frame first
     if (_leftSB._frame!=null) {
       for (int col = _numJoinCols; col < _leftSB._frame.numCols(); col++) {
@@ -114,7 +116,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
 
   @Override
   public void compute2() {
-    _timings = new double[20];
+    _timings = MemoryManager.malloc8d(20);
     long t0 = System.nanoTime();
 
     SingleThreadRadixOrder.OXHeader leftSortedOXHeader = DKV.getGet(getSortedOXHeaderKey(/*left=*/true, _leftSB._msb));
@@ -181,7 +183,8 @@ class BinaryMerge extends DTask<BinaryMerge> {
     long retSize = leftTo - _leftFrom - 1;   // since leftTo and leftFrom are 1 outside the extremes
     assert retSize >= 0;
     if (retSize==0) { tryComplete(); return; } // nothing can match, even when allLeft
-    _retBatchSize = 268435456;    // 2^31 / 8 since Java arrays are limited to 2^31 bytes
+
+    _retBatchSize = 1048576;   // must set to be the same from RadixOrder.java
     int retNBatch = (int)((retSize - 1) / _retBatchSize + 1);
     int retLastSize = (int)(retSize - (retNBatch - 1) * _retBatchSize);
 
@@ -224,7 +227,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
 
   // Holder for Key & Order info
   private static class KeyOrder {
-    private final transient long _batchSize;
+    public final transient long _batchSize;
     private final transient byte _key  [/*n2GB*/][/*i mod 2GB * _keySize*/];
     private final transient long _order[/*n2GB*/][/*i mod 2GB * _keySize*/];
     private final transient long _perNodeNumRowsToFetch[];
@@ -250,8 +253,8 @@ class BinaryMerge extends DTask<BinaryMerge> {
     // Do a mod/div long _order array lookup
     long at8order( long idx ) { return _order[(int)(idx / _batchSize)][(int)(idx % _batchSize)]; }
 
-    long[][] fillPerNodeRows( int i ) {
-      final int batchSizeLong = 256*1024*1024 / 16;  // 256GB DKV limit / sizeof(UUID)
+    long[][] fillPerNodeRows( int i, final int batchSizeLong) {
+     // final int batchSizeLong = 256*1024*1024 / 16;  // 256GB DKV limit / sizeof(UUID)
       if( _perNodeNumRowsToFetch[i] <= 0 ) return null;
       int nbatch  = (int) ((_perNodeNumRowsToFetch[i] - 1) / batchSizeLong + 1);  // TODO: wrap in class to avoid this boiler plate
       assert nbatch >= 1;
@@ -486,7 +489,6 @@ class BinaryMerge extends DTask<BinaryMerge> {
     // would run too much)
   }
 
-
   private void createChunksInDKV() {
     // Collect all matches
     // Create the final frame (part) for this MSB combination
@@ -496,25 +498,26 @@ class BinaryMerge extends DTask<BinaryMerge> {
     final int cloudSize = H2O.CLOUD.size();
     final long perNodeRightRows[][][] = new long[cloudSize][][];
     final long perNodeLeftRows [][][] = new long[cloudSize][][];
+
     // Allocate memory to split this MSB combn's left and right matching rows
     // into contiguous batches sent to the nodes they reside on
     for( int i = 0; i < cloudSize; i++ ) {
-      perNodeRightRows[i] = _riteKO.fillPerNodeRows(i);
-      perNodeLeftRows [i] = _leftKO.fillPerNodeRows(i);
+      perNodeRightRows[i] = _riteKO.fillPerNodeRows(i, (int) _riteKO._batchSize);
+      perNodeLeftRows [i] = _leftKO.fillPerNodeRows(i, (int) _leftKO._batchSize);
     }
     _timings[2] += ((t1=System.nanoTime()) - t0) / 1e9; t0=t1;
 
     // Loop over _ret1st and _retLen and populate the batched requests for
     // each node helper.  _ret1st and _retLen are the same shape
-    final long perNodeRightLoc[] = new long[cloudSize];
-    final long perNodeLeftLoc [] = new long[cloudSize];
+    final long perNodeRightLoc[] = MemoryManager.malloc8(cloudSize);
+    final long perNodeLeftLoc [] = MemoryManager.malloc8(cloudSize);
     chunksPopulatePerNode(perNodeLeftLoc,perNodeLeftRows,perNodeRightLoc,perNodeRightRows);
     _timings[3] += ((t1=System.nanoTime()) - t0) / 1e9; t0=t1;
 
     // Create the chunks for the final frame from this MSB pair.
     
     // 16 bytes for each UUID (biggest type). Enum will be long (8). TODO: How is non-Enum 'string' handled by H2O?
-    final int batchSizeUUID = 256*1024*1024 / 16;  // number of rows per chunk to fit in 256GB DKV limit.
+    final int batchSizeUUID = _retBatchSize;
     final int nbatch = (int) ((_numRowsInResult-1)/batchSizeUUID +1);  // TODO: wrap in class to avoid this boiler plate
     assert nbatch >= 1;
     final int lastSize = (int) (_numRowsInResult - (nbatch-1)*batchSizeUUID);
@@ -522,44 +525,98 @@ class BinaryMerge extends DTask<BinaryMerge> {
     final int numLeftCols = _leftSB._frame.numCols();
     final int numColsInResult = _leftSB._frame.numCols() + _riteSB._frame.numCols() - _numJoinCols;
     final double[][][] frameLikeChunks = new double[numColsInResult][nbatch][]; //TODO: compression via int types
-    BufferedString[][][] frameLikeChunks4Strings = new BufferedString[numColsInResult][nbatch][]; // cannot allocate before hand
+    final BufferedString[][][] frameLikeChunks4Strings = new BufferedString[numColsInResult][nbatch][]; // cannot allocate before hand
     _chunkSizes = new int[nbatch];
 
+    final GetRawRemoteRows grrrsLeft[][] = new GetRawRemoteRows[cloudSize][];
+    final GetRawRemoteRows grrrsRite[][] = new GetRawRemoteRows[cloudSize][];
+
+    if (_onlyLeftFrame) { // sorting only
+      long[] resultLeftLocPrevlPrevf = new long[4]; // element 0 store resultLoc, element 1 store leftLoc
+      resultLeftLocPrevlPrevf[1] = _leftFrom; // sweep through left table along the sorted row locations.
+      resultLeftLocPrevlPrevf[0] = 0;
+      resultLeftLocPrevlPrevf[2] = -1;
+      resultLeftLocPrevlPrevf[3] = -1;
+
+      for (int b = 0; b < nbatch; b++) {
+        allocateFrameLikeChunks(b, nbatch, lastSize, batchSizeUUID, frameLikeChunks, frameLikeChunks4Strings, numColsInResult);
+
+        // Now loop through _ret1st and _retLen and populate
+        chunksPopulateRetFirst(perNodeLeftRows, resultLeftLocPrevlPrevf, b, numColsInResult,
+                numLeftCols, perNodeLeftLoc, grrrsLeft, frameLikeChunks,
+                frameLikeChunks4Strings);
+        _timings[10] += ((t1 = System.nanoTime()) - t0) / 1e9;
+        t0 = t1;
+        // compress all chunks and store them
+        chunksCompressAndStore(b, numColsInResult, frameLikeChunks, frameLikeChunks4Strings);
+        if (nbatch > 1) {
+          cleanUpMemory(grrrsLeft, b);  // clean up memory used by grrrsLeft and grrrsRite
+        }
+      }
+    } else { // merging
+      for (int b = 0; b < nbatch; b++) { // allocate all frameLikeChunks in one shot
+        allocateFrameLikeChunks(b, nbatch, lastSize, batchSizeUUID, frameLikeChunks, frameLikeChunks4Strings,
+                numColsInResult); // allocate Frame is ok
+        _timings[6] += ((t1 = System.nanoTime()) - t0) / 1e9;
+        t0 = t1;  // all this time is expected to be in [5]
+      }
+
+      _timings[4] += ((t1 = System.nanoTime()) - t0) / 1e9;
+      t0 = t1;
+      chunksGetRawRemoteRows(perNodeLeftRows, perNodeRightRows, grrrsLeft, grrrsRite); // need this one
+
+      chunksPopulateRetFirst(batchSizeUUID, numColsInResult, numLeftCols, perNodeLeftLoc, grrrsLeft,
+              perNodeRightLoc, grrrsRite, frameLikeChunks, frameLikeChunks4Strings);
+      _timings[10] += ((t1 = System.nanoTime()) - t0) / 1e9;
+      t0 = t1;
+
+      chunksCompressAndStoreO(nbatch, numColsInResult, frameLikeChunks, frameLikeChunks4Strings);
+    }
+    _timings[11] += (System.nanoTime() - t0) / 1e9;
+  }
+
+  // compress all chunks and store them
+  private void chunksCompressAndStoreO(final int nbatch, final int numColsInResult, final double[][][] frameLikeChunks, BufferedString[][][] frameLikeChunks4String) {
+    // compress all chunks and store them
+    Futures fs = new Futures();
     for (int col = 0; col < numColsInResult; col++) {
       if (this._stringCols[col]) {
         for (int b = 0; b < nbatch; b++) {
-          frameLikeChunks4Strings[col][b] = new BufferedString[_chunkSizes[b] = (b == nbatch - 1 ? lastSize : batchSizeUUID)];
+          NewChunk nc = new NewChunk(null, 0);
+          for (int index = 0; index < frameLikeChunks4String[col][b].length; index++)
+            nc.addStr(frameLikeChunks4String[col][b][index]);
+          Chunk ck = nc.compress();
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          frameLikeChunks4String[col][b] = null; //free mem as early as possible (it's now in the store)
         }
       } else {
         for (int b = 0; b < nbatch; b++) {
-          frameLikeChunks[col][b] = MemoryManager.malloc8d(_chunkSizes[b] = (b == nbatch - 1 ? lastSize : batchSizeUUID));
-          Arrays.fill(frameLikeChunks[col][b], Double.NaN);
-          // NA by default to save filling with NA for nomatches when allLeft
+          Chunk ck = new NewChunk(frameLikeChunks[col][b]).compress();
+          DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
+          frameLikeChunks[col][b] = null; //free mem as early as possible (it's now in the store)
         }
       }
     }
+    fs.blockForPending();
+  }
 
-    _timings[4] += ((t1=System.nanoTime()) - t0) / 1e9; t0=t1;
-
-    // Get Raw Remote Rows
-    final GetRawRemoteRows grrrsLeft[][] = new GetRawRemoteRows[cloudSize][];
-    final GetRawRemoteRows grrrsRite[][] = new GetRawRemoteRows[cloudSize][];
-    chunksGetRawRemoteRows(perNodeLeftRows,perNodeRightRows,grrrsLeft,grrrsRite);
-    _timings[6] += ((t1=System.nanoTime()) - t0) / 1e9; t0=t1;  // all this time is expected to be in [5]
-
-    // Now loop through _ret1st and _retLen and populate
-    chunksPopulateRetFirst(numColsInResult, numLeftCols, perNodeLeftLoc, grrrsLeft, perNodeRightLoc, grrrsRite, frameLikeChunks, frameLikeChunks4Strings);
-    _timings[10] += ((t1=System.nanoTime()) - t0) / 1e9; t0=t1;
-
-    // compress all chunks and store them
-    chunksCompressAndStore(nbatch, numColsInResult, frameLikeChunks, frameLikeChunks4Strings);
-    _timings[11] += (System.nanoTime() - t0) / 1e9;
+  private void allocateFrameLikeChunks(final int b, final int nbatch, final int lastSize, final int batchSizeUUID, final double[][][] frameLikeChunks,
+                                       final BufferedString[][][] frameLikeChunks4Strings, final int numColsInResult) {
+    for (int col = 0; col < numColsInResult; col++) {  // allocate memory for frameLikeChunks for this batch
+      if (this._stringCols[col]) {
+        frameLikeChunks4Strings[col][b] = new BufferedString[_chunkSizes[b] = (b == nbatch - 1 ? lastSize : batchSizeUUID)];
+      } else {
+        frameLikeChunks[col][b] = MemoryManager.malloc8d(_chunkSizes[b] = (b == nbatch - 1 ? lastSize : batchSizeUUID));
+        Arrays.fill(frameLikeChunks[col][b], Double.NaN);
+        // NA by default to save filling with NA for nomatches when allLeft
+      }
+    }
   }
 
   // Loop over _ret1st and _retLen and populate the batched requests for
   // each node helper.  _ret1st and _retLen are the same shape
   private void chunksPopulatePerNode( final long perNodeLeftLoc[], final long perNodeLeftRows[][][], final long perNodeRightLoc[], final long perNodeRightRows[][][] ) {
-    final int batchSizeLong = 256*1024*1024 / 16;  // 256GB DKV limit / sizeof(UUID)
+    final int batchSizeLong = _retBatchSize;  // 256GB DKV limit / sizeof(UUID)
     long prevf = -1, prevl = -1;
     // TODO: hop back to original order here for [] syntax.
     long leftLoc=_leftFrom;  // sweep through left table along the sorted row locations.  
@@ -581,8 +638,8 @@ class BinaryMerge extends DTask<BinaryMerge> {
           // TODO could loop through batches rather than / and % wastefully
           long row = _leftKO.at8order(leftLoc);
           int chkIdx = _leftSB._vec.elem2ChunkIdx(row); //binary search in espc
-          int ni = _leftSB._chunkNode[chkIdx];
-          long pnl = perNodeLeftLoc[ni]++;   // pnl = per node location
+          int ni = _leftSB._chunkNode[chkIdx]; // node index
+          long pnl = perNodeLeftLoc[ni]++;    // pnl = per node location
           perNodeLeftRows[ni][(int)(pnl/batchSizeLong)][(int)(pnl%batchSizeLong)] = row;  // ask that node for global row number row
         }
         if (f==0) continue;
@@ -609,7 +666,6 @@ class BinaryMerge extends DTask<BinaryMerge> {
     Arrays.fill(perNodeRightLoc,0);
   }
 
-  // Get Raw Remote Rows
   private void chunksGetRawRemoteRows(final long perNodeLeftRows[][][], final long perNodeRightRows[][][], GetRawRemoteRows grrrsLeft[][], GetRawRemoteRows grrrsRite[][]) {
     RPC<GetRawRemoteRows> grrrsRiteRPC[][] = new RPC[H2O.CLOUD.size()][];
     RPC<GetRawRemoteRows> grrrsLeftRPC[][] = new RPC[H2O.CLOUD.size()][];
@@ -625,7 +681,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
       grrrsLeft[ni] = new GetRawRemoteRows[bUppLeft];
       for (int b = 0; b < bUppRite; b++) {
         // TODO try again now with better surrounding method
-        // Arrays.sort(perNodeRightRows[ni][b]);  Simple quick test of fetching in monotonic order. Doesn't seem to help so far. 
+        // Arrays.sort(perNodeRightRows[ni][b]);  Simple quick test of fetching in monotonic order. Doesn't seem to help so far.
         grrrsRiteRPC[ni][b] = new RPC<>(node, new GetRawRemoteRows(_riteSB._frame, perNodeRightRows[ni][b])).call();
       }
       for (int b = 0; b < bUppLeft; b++) {
@@ -645,16 +701,47 @@ class BinaryMerge extends DTask<BinaryMerge> {
     }
   }
 
+
+  // Get Raw Remote Rows
+  private void chunksGetRawRemoteRows(final long perNodeLeftRows[][][], GetRawRemoteRows grrrsLeft[][], int batchNumber) {
+    RPC<GetRawRemoteRows> grrrsRiteRPC[][] = new RPC[H2O.CLOUD.size()][];
+    RPC<GetRawRemoteRows> grrrsLeftRPC[][] = new RPC[H2O.CLOUD.size()][];
+
+    // Launch remote tasks left and right
+    for( H2ONode node : H2O.CLOUD._memary ) {
+      final int ni = node.index();
+      final int bUppLeft =  perNodeLeftRows[ni] == null ? 0 :  perNodeLeftRows[ni].length;  // denote nbatch
+      grrrsLeftRPC[ni] = new RPC[bUppLeft];
+      grrrsLeft[ni] = new GetRawRemoteRows[bUppLeft];
+      if (batchNumber < bUppLeft) {
+        grrrsLeftRPC[ni][batchNumber] = new RPC<>(node, new GetRawRemoteRows(_leftSB._frame, perNodeLeftRows[ni][batchNumber])).call();
+      }
+    }
+    for( H2ONode node : H2O.CLOUD._memary ) {
+      // TODO: just send and wait for first batch on each node and then .get() next batch as needed.
+      int ni = node.index();
+      final int bUppLeft = perNodeLeftRows[ni] == null ? 0 :  perNodeLeftRows[ni].length;
+      if (batchNumber < bUppLeft)
+        _timings[5] += (grrrsLeft[ni][batchNumber] = grrrsLeftRPC[ni][batchNumber].get()).timeTaken;
+    }
+  }
+
   // Now loop through _ret1st and _retLen and populate
-  private void chunksPopulateRetFirst(final int numColsInResult, final int numLeftCols, final long perNodeLeftLoc[], final GetRawRemoteRows grrrsLeft[][], final long perNodeRightLoc[], final GetRawRemoteRows grrrsRite[][], final double[][][] frameLikeChunks, BufferedString[][][] frameLikeChunks4String) {
+  private void chunksPopulateRetFirst(final long perNodeLeftRows[][][], 
+                                      long[] resultLeftLocPrevlPrevf, final int jb, final int numColsInResult,
+                                      final int numLeftCols, final long perNodeLeftLoc[],
+                                      final GetRawRemoteRows grrrsLeft[][], final double[][][] frameLikeChunks,
+                                      BufferedString[][][] frameLikeChunks4String) {
     // 16 bytes for each UUID (biggest type). Enum will be long (8). 
     // TODO: How is non-Enum 'string' handled by H2O?
-    final int batchSizeUUID = 256*1024*1024 / 16;  // number of rows per chunk to fit in 256GB DKV limit.
-    long resultLoc=0;   // sweep upwards through the final result, filling it in
+    final int batchSizeUUID = _retBatchSize;  // number of rows per chunk to fit in 256GB DKV limit.
     // TODO: hop back to original order here for [] syntax.
-    long leftLoc=_leftFrom; // sweep through left table along the sorted row locations.  
-    long prevf = -1, prevl = -1;
-    for (int jb=0; jb<_ret1st.length; ++jb) {              // jb = j batch
+    long resultLoc = resultLeftLocPrevlPrevf[0];
+    long leftLoc = resultLeftLocPrevlPrevf[1];
+    long prevl = resultLeftLocPrevlPrevf[2];
+    long prevf = resultLeftLocPrevlPrevf[3];
+
+    if (jb < _ret1st.length) {
       for (int jo=0; jo<_ret1st[jb].length; ++jo) {        // jo = j offset
         leftLoc++;  // to save jb*_ret1st[0].length + jo;
         long f = _ret1st[jb][jo];  // TODO: take _ret1st[jb] outside inner loop
@@ -670,8 +757,11 @@ class BinaryMerge extends DTask<BinaryMerge> {
         int chkIdx = _leftSB._vec.elem2ChunkIdx(row); //binary search in espc
         int ni = _leftSB._chunkNode[chkIdx];
         long pnl = perNodeLeftLoc[ni]++;   // pnl = per node location.  TODO: batch increment this rather than
-        int b = (int)(pnl / batchSizeUUID);
+        int b = (int)(pnl / batchSizeUUID);  // however, the batch number of remote nodes may not match with final batch number
         int o = (int)(pnl % batchSizeUUID);
+        if (grrrsLeft[ni]==null || grrrsLeft[ni][b] == null || grrrsLeft[ni][b]._chk==null) { // fetch chunk from remote nodes
+          chunksGetRawRemoteRows(perNodeLeftRows, grrrsLeft, b);
+        }
         double[][] chks = grrrsLeft[ni][b]._chk;
         BufferedString[][] chksString = grrrsLeft[ni][b]._chkString;
 
@@ -680,15 +770,15 @@ class BinaryMerge extends DTask<BinaryMerge> {
           long a = resultLoc + rep;
           // TODO: loop into batches to save / and % for each repeat and still
           // cater for crossing multiple batch boundaries
-          int whichChunk = (int) (a / batchSizeUUID);  
+          int whichChunk = (int) (a / batchSizeUUID);  // this actually points to batch number
           int offset = (int) (a % batchSizeUUID);
 
           for (int col=0; col<chks.length; col++) { // copy over left frame to frameLikeChunks
             if (this._stringCols[col]) {
-              if (chksString[col][o] != null)
                 frameLikeChunks4String[col][whichChunk][offset] = chksString[col][o];
-            } else
-              frameLikeChunks[col][whichChunk][offset] = chks[col][o];  // colForBatch.atd(row);
+            } else {
+                frameLikeChunks[col][whichChunk][offset] = chks[col][o];  // colForBatch.atd(row);
+            }
           }
         }
         if (f==0) { resultLoc++; continue; } // no match so just one row (NA for right table) to advance over
@@ -717,10 +807,90 @@ class BinaryMerge extends DTask<BinaryMerge> {
         }
         prevf = f;
         prevl = l;
+      }
+    }
+    resultLeftLocPrevlPrevf[0] = resultLoc;
+    resultLeftLocPrevlPrevf[1] = leftLoc;
+    resultLeftLocPrevlPrevf[2] = prevl;
+    resultLeftLocPrevlPrevf[3] = prevf;
+  }
+
+  // Now loop through _ret1st and _retLen and populate
+  private void chunksPopulateRetFirst(final int batchSizeUUID, final int numColsInResult, final int numLeftCols, final long perNodeLeftLoc[], final GetRawRemoteRows grrrsLeft[][], final long perNodeRightLoc[], final GetRawRemoteRows grrrsRite[][], final double[][][] frameLikeChunks, BufferedString[][][] frameLikeChunks4String) {
+    // 16 bytes for each UUID (biggest type). Enum will be long (8).
+    // TODO: How is non-Enum 'string' handled by H2O?
+
+    long resultLoc=0;   // sweep upwards through the final result, filling it in
+    // TODO: hop back to original order here for [] syntax.
+    long leftLoc=_leftFrom; // sweep through left table along the sorted row locations.
+    long prevf = -1, prevl = -1;
+    for (int jb=0; jb<_ret1st.length; ++jb) {              // jb = j batch
+      for (int jo=0; jo<_ret1st[jb].length; ++jo) {        // jo = j offset
+        leftLoc++;  // to save jb*_ret1st[0].length + jo;
+        long f = _ret1st[jb][jo];  // TODO: take _ret1st[jb] outside inner loop
+        long l = _retLen[jb][jo];
+        if (f==0 && !_allLeft) continue;  // f==0 => left row matches to no right row
+        // else insert the left row once and NA for the right columns i.e. left outer join
+
+        // Fetch the left rows and recycle it if more than 1 row in the right table is matched to.
+        // TODO could loop through batches rather than / and % wastefully
+        long row = _leftKO.at8order(leftLoc);
+        // TODO should leftOrder and retFirst/retLen have the same batch size to make this easier?
+        // TODO Can we not just loop through _leftKO._order only? Why jb and jo too through
+        int chkIdx = _leftSB._vec.elem2ChunkIdx(row); //binary search in espc
+        int ni = _leftSB._chunkNode[chkIdx];
+        long pnl = perNodeLeftLoc[ni]++;   // pnl = per node location.  TODO: batch increment this rather than
+        int b = (int)(pnl / batchSizeUUID);
+        int o = (int)(pnl % batchSizeUUID);
+        double[][] chks = grrrsLeft[ni][b]._chk;
+        BufferedString[][] chksString = grrrsLeft[ni][b]._chkString;
+
+        final int l1 = Math.max((int)l,1);
+        for (int rep = 0; rep < l1; rep++) {
+          long a = resultLoc + rep;
+          // TODO: loop into batches to save / and % for each repeat and still
+          // cater for crossing multiple batch boundaries
+          int whichChunk = (int) (a / batchSizeUUID);
+          int offset = (int) (a % batchSizeUUID);
+
+          for (int col=0; col<chks.length; col++) { // copy over left frame to frameLikeChunks
+            if (this._stringCols[col]) {
+              if (chksString[col][o] != null)
+                frameLikeChunks4String[col][whichChunk][offset] = chksString[col][o];
+            } else
+              frameLikeChunks[col][whichChunk][offset] = chks[col][o];  // colForBatch.atd(row);
+          }
+        }
+        if (f==0) { resultLoc++; continue; } // no match so just one row (NA for right table) to advance over
+        assert l > 0;
+        if (prevf == f && prevl == l) {
+          // just copy from previous batch in the result (populated by for()
+          // below).  Contiguous easy in-cache copy (other than batches).
+          for (int r=0; r<l; r++) {
+            // TODO: loop into batches to save / and % for each repeat and
+            // still cater for crossing multiple batch boundaries
+            int toChunk = (int) (resultLoc / batchSizeUUID);
+            int toOffset = (int) (resultLoc % batchSizeUUID);
+            int fromChunk = (int) ((resultLoc - l) / batchSizeUUID);
+            int fromOffset = (int) ((resultLoc - l) % batchSizeUUID);
+            for (int col=0; col<numColsInResult-numLeftCols; col++) {
+              int colIndex = numLeftCols + col;
+              if (this._stringCols[colIndex]) {
+                frameLikeChunks4String[colIndex][toChunk][toOffset] = frameLikeChunks4String[colIndex][fromChunk][fromOffset];
+              } else {
+                frameLikeChunks[colIndex][toChunk][toOffset] = frameLikeChunks[colIndex][fromChunk][fromOffset];
+              }
+            }
+            resultLoc++;
+          }
+          continue;
+        }
+        prevf = f;
+        prevl = l;
         for (int r=0; r<l; r++) {
           // TODO: loop into batches to save / and % for each repeat and still
           // cater for crossing multiple batch boundaries
-          int whichChunk = (int) (resultLoc / batchSizeUUID);  
+          int whichChunk = (int) (resultLoc / batchSizeUUID);
           int offset = (int) (resultLoc % batchSizeUUID);
           long loc = f+r-1;  // -1 because these are 0-based where 0 means no-match and 1 refers to the first row
           // TODO: could take / and % outside loop in cases where it doesn't span a batch boundary
@@ -747,26 +917,46 @@ class BinaryMerge extends DTask<BinaryMerge> {
     }
   }
 
+
+  private void cleanUpMemory(GetRawRemoteRows[][] grrr, int batchIdx) {
+    if (grrr != null) {
+      int nodeNum = grrr.length;
+      for (int nodeIdx = 0; nodeIdx < nodeNum; nodeIdx++) {
+        int batchLimit = Math.min(batchIdx+1, grrr[nodeIdx].length);
+        if ((grrr[nodeIdx] != null) && (grrr[nodeIdx].length > 0)) {
+          for (int bIdx = 0; bIdx < batchLimit; bIdx++) { // clean up memory
+              int chkLen = grrr[nodeIdx][bIdx] == null ? 0 :
+                      (grrr[nodeIdx][bIdx]._chk ==null?0:grrr[nodeIdx][bIdx]._chk.length);
+              for (int cindex = 0; cindex < chkLen; cindex++) {
+                grrr[nodeIdx][bIdx]._chk[cindex] = null;
+                grrr[nodeIdx][bIdx]._chkString[cindex] = null;
+              }
+              if (chkLen>0) {
+                grrr[nodeIdx][bIdx]._chk = null;
+                grrr[nodeIdx][bIdx]._chkString = null;
+              }
+          }
+        }
+      }
+    }
+  }
+
   // compress all chunks and store them
-  private void chunksCompressAndStore(final int nbatch, final int numColsInResult, final double[][][] frameLikeChunks, BufferedString[][][] frameLikeChunks4String) {
+  private void chunksCompressAndStore(final int b, final int numColsInResult, final double[][][] frameLikeChunks, BufferedString[][][] frameLikeChunks4String) {
     // compress all chunks and store them
     Futures fs = new Futures();
     for (int col = 0; col < numColsInResult; col++) {
       if (this._stringCols[col]) {
-        for (int b = 0; b < nbatch; b++) {
           NewChunk nc = new NewChunk(null, 0);
           for (int index = 0; index < frameLikeChunks4String[col][b].length; index++)
             nc.addStr(frameLikeChunks4String[col][b][index]);
           Chunk ck = nc.compress();
           DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
           frameLikeChunks4String[col][b] = null; //free mem as early as possible (it's now in the store)
-        }
       } else {
-        for (int b = 0; b < nbatch; b++) {
           Chunk ck = new NewChunk(frameLikeChunks[col][b]).compress();
           DKV.put(getKeyForMSBComboPerCol(_leftSB._msb, _riteSB._msb, col, b), ck, fs, true);
           frameLikeChunks[col][b] = null; //free mem as early as possible (it's now in the store)
-        }
       }
     }
     fs.blockForPending();

--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -48,7 +48,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     // it when aligning two keys in Merge()
     int keySize = ArrayUtils.sum(_bytesUsed);
     // 256MB is the DKV limit.  / 2 because we fit o and x together in one OXBatch.
-    int batchSize = 256*1024*1024 / Math.max(keySize, 8) / 2 ;
+    int batchSize = 1048576 ; // larger, requires more memory with less remote row fetch and vice versa for smaller
     // The Math.max ensures that batches of o and x are aligned, even for wide
     // keys.  To save % and / in deep iteration; e.g. in insert().
     System.out.println("Time to use rollup stats to determine biggestBit: " + ((t1=System.nanoTime()) - t0) / 1e9); t0=t1;

--- a/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
@@ -54,7 +54,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
 
   @Override
   public void compute2() {
-    keytmp = new byte[_keySize];
+    keytmp = MemoryManager.malloc1(_keySize);
     counts = new long[_keySize][256];
     Key k;
 
@@ -84,11 +84,11 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
     _x = new byte[nbatch][];
     int b;
     for (b = 0; b < nbatch-1; b++) {
-      _o[b] = new long[_batchSize];          // TO DO?: use MemoryManager.malloc8()
-      _x[b] = new byte[_batchSize * _keySize];
+      _o[b] = MemoryManager.malloc8(_batchSize);          // TO DO?: use MemoryManager.malloc8()
+      _x[b] = MemoryManager.malloc1(_batchSize * _keySize);
     }
-    _o[b] = new long[lastSize];
-    _x[b] = new byte[lastSize * _keySize];
+    _o[b] = MemoryManager.malloc8(lastSize);
+    _x[b] = MemoryManager.malloc1(lastSize * _keySize);
 
     SplitByMSBLocal.OXbatch ox[/*node*/] = new SplitByMSBLocal.OXbatch[H2O.CLOUD.size()];
     int oxBatchNum[/*node*/] = new int[H2O.CLOUD.size()];  // which batch of OX are we on from that node?  Initialized to 0.
@@ -98,8 +98,8 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
       ox[node] = DKV.getGet(k);   // get the first batch for each node for this MSB
       DKV.remove(k);
     }
-    int oxOffset[] = new int[H2O.CLOUD.size()];
-    int oxChunkIdx[] = new int[H2O.CLOUD.size()];  // that node has n chunks and which of those are we currently on?
+    int oxOffset[] = MemoryManager.malloc4(H2O.CLOUD.size());
+    int oxChunkIdx[] = MemoryManager.malloc4(H2O.CLOUD.size());  // that node has n chunks and which of those are we currently on?
 
     int targetBatch = 0, targetOffset = 0, targetBatchRemaining = _batchSize;
     final Vec vec = _fr.anyVec();

--- a/h2o-core/src/test/java/water/rapids/SortTest.java
+++ b/h2o-core/src/test/java/water/rapids/SortTest.java
@@ -1,5 +1,6 @@
 package water.rapids;
 
+import hex.CreateFrame;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import water.*;
@@ -309,6 +310,37 @@ public class SortTest extends TestUtil {
     }
   }
 
+  /***
+   * This simple test just want to test and make sure that processing the final frames by a batch does
+   * not leak memories.  The accuracy of the sort is tested elsewhere.
+   */
+  @Test public void testSortOOM() throws IOException {
+    Scope.enter();
+    Frame fr, sortedInt;
+    try {
+      CreateFrame cf = new CreateFrame();
+      cf.rows=9000000;
+      cf.cols = 2;
+      cf.categorical_fraction = 0;
+      cf.integer_fraction = 1;
+      cf.binary_fraction = 0;
+      cf.time_fraction = 0;
+      cf.string_fraction = 0;
+      cf.binary_ones_fraction = 0;
+      cf.integer_range = 1;
+      cf.has_response = false;
+      cf.seed = 1234;
+      fr = cf.execImpl().get();
+      sortedInt = fr.sort(new int[]{0}, new int[]{-1});
+      Scope.track(fr);
+      Scope.track(sortedInt);
+      
+      assert fr.numRows()==sortedInt.numRows();
+    } finally {
+      Scope.exit();
+    }
+  }
+  
   private static void testSort(Frame frSorted, Frame originalF, int colIndex) throws IOException {
     Scope.enter();
     Vec vec = frSorted.vec(colIndex);

--- a/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5990_arrange_OOM_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5990_arrange_OOM_large.py
@@ -1,0 +1,38 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import time
+import random
+
+def test_arrange_OOM():
+    '''
+    PUBDEV-5990 customer reported that h2o.arrange (sorting) takes way more memory than normal for sparse
+    datasets of 1G.
+
+    Thanks to Lauren DiPerna for finding the dataset to repo the problem.
+    '''
+
+    df = h2o.import_file(pyunit_utils.locate("bigdata/laptop/jira/sort_OOM.csv"))
+    t1 = time.time()
+    newFrame = df.sort("sort_col")
+    print(newFrame[0,0])
+    elapsed_time = time.time()-t1
+    print("time taken to perform sort is {0}".format(elapsed_time))
+
+    # check and make sure the sort columns contain the right value after sorting!
+    answerFrame = h2o.import_file(pyunit_utils.locate("bigdata/laptop/jira/sort_OOM_answer.csv"))
+
+    # compare sort_col from my sort with answer Frame
+    pyunit_utils.compare_frames_local(answerFrame["sort_col"], newFrame["sort_col"])
+
+    # compare 10 more columns with answer Frame.  Compare all columns will take too long
+    allColumns = list(range(0, df.ncols))
+    random.shuffle(allColumns)
+    pyunit_utils.compare_frames_local(answerFrame[allColumns[0:5]], newFrame[allColumns[0:5]])
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_arrange_OOM)
+else:
+    test_arrange_OOM()


### PR DESCRIPTION
This PR resolves JIRA: https://0xdata.atlassian.net/browse/PUBDEV-5990?filter=-1

Work done:
1. Instead of saving all the rows for a MSB in a RPC call, I have broken down the rows into batches.  Only one batch need to be saved at a time.  This reduces the memory requirement.  However, this can potentially increase the number of batches that need to be fetched from neighboring nodes and increase run time.  The batchsize decision is important in this case.  I will perform experiment to capture this.
2. Added R and Python unit tests to ensure that sorting is done correctly and no OOM message is received.  The datasets are generated from Lauren's parameters.