### PR TITLE
Rel-Xia-HEXDEV-715 spencer PR

### DIFF
--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -9,7 +9,11 @@ import water.util.PrettyPrint;
 import water.util.StringUtils;
 import water.util.UnsafeUtils;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.UUID;
+
 
 import static water.H2OConstants.MAX_STR_LEN;
 
@@ -1208,10 +1212,15 @@ public class NewChunk extends Chunk {
     boolean floatOverflow = false;
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
+    long min_l = Long.MAX_VALUE;
+    long max_l = Long.MIN_VALUE;
+    double longMax = (double) Long.MAX_VALUE;
+    double longMin = (double) Long.MIN_VALUE;
     int p10iLength = PrettyPrint.powers10i.length;
     long llo=Long   .MAX_VALUE, lhi=Long   .MIN_VALUE;
     int  xlo=Integer.MAX_VALUE, xhi=Integer.MIN_VALUE;
     boolean hasZero = sparse;
+    long ll;
     for(int i = 0; i< _sparseLen; i++ ) {
       if( isNA2(i) ) continue;
       long l = _ms.get(i);
@@ -1226,26 +1235,34 @@ public class NewChunk extends Chunk {
         hasZero = true;
         continue;
       }
-      if( d < min ) { min = d; llo=l; xlo=x; }
-      if( d > max ) { max = d; lhi=l; xhi=x; }
+      if (isInteger)  // once set to false don't want to reset back to true
+        isInteger = (x>=0) && (d<=longMax) && (d>=longMin);
+
+      if (isInteger) {
+        ll = l*PrettyPrint.pow10i(x); // only perform operation if still fit in Long and still integer
+        if( ll<min_l ) { min = d; min_l=ll; llo=l; xlo=x; } //
+        if( ll>max_l ) { max = d; max_l=ll; lhi=l; xhi=x; }
+      } else {
+        if (d < min) { min = d; llo = l; xlo = x; }
+        if (d > max) { max=d; lhi=l; xhi=x; }
+      }
       floatOverflow = l < Integer.MIN_VALUE+1 || l > Integer.MAX_VALUE;
       xmin = Math.min(xmin,x);
     }
     boolean hasNonZero = min != Double.POSITIVE_INFINITY && max != Double.NEGATIVE_INFINITY;
 
     if(hasZero){ // sparse?  then compare vs implied 0s
-      if( min > 0 ) { min = 0; llo=0; }
-      if( max < 0 ) { max = 0; lhi=0; }
+
+      if( min > 0 ) { min = 0; llo=0; min_l=0l; }
+      if( max < 0 ) { max = 0; lhi=0; max_l=0l; }
     }
     if(!hasNonZero) xlo = xhi = xmin = 0;
     // Constant column?
-    if( _naCnt==0 && (min==max)) {
-      if (llo == lhi && xlo == 0 && xhi == 0)
-        return new C0LChunk(llo, _len);
-      else if ((long)min == min)
-        return new C0LChunk((long)min, _len);
-      else
-        return new C0DChunk(min, _len);
+    if( _naCnt==0 && (min_l==max_l) && xmin >=0 && isInteger) {
+      return new C0LChunk(min_l, _len);
+    }
+    if( _naCnt==0 && (min==max) && (xmin<0 || !isInteger) ) {
+      return new C0DChunk(min, _len);
     }
     // Compute min & max, as scaled integers in the xmin scale.
     // Check for overflow along the way
@@ -1263,6 +1280,10 @@ public class NewChunk extends Chunk {
       if( (lemin/pow10lo) != llo ) overflow = true;
     }
     final long leRange = leRange(lemin,lemax);
+
+    // put min_l in xmin scale
+    if( xmin > 0 )
+      min_l = min_l/PrettyPrint.pow10i(xmin);
 
     // Boolean column?
     if (max == 1 && min == 0 && xmin == 0 && !overflow) {

--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -96,6 +96,10 @@ class BinaryMerge extends DTask<BinaryMerge> {
     _stringCols = new boolean[columnsInResult];
     // check left frame first
     if (_leftSB._frame!=null) {
+      for (int col=0; col <_numJoinCols; col++) {
+        if (_leftSB._frame.vec(col).isInt())
+          _intCols[col] = true;
+      }
       for (int col = _numJoinCols; col < _leftSB._frame.numCols(); col++) {
         if (_leftSB._frame.vec(col).isString())
           _stringCols[col] = true;

--- a/h2o-core/src/test/java/water/fvec/C1SChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/C1SChunkTest.java
@@ -1,11 +1,18 @@
 package water.fvec;
 
-import org.junit.*;
-
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
 import water.Futures;
+import water.MRTask;
+import water.Scope;
 import water.TestUtil;
+
+import java.io.IOException;
 import java.util.Arrays;
-import java.util.Iterator;
+
+import static junit.framework.TestCase.assertTrue;
 
 public class C1SChunkTest extends TestUtil {
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
@@ -227,4 +234,56 @@ public class C1SChunkTest extends TestUtil {
 
   }
 
+
+  @Test public void testOverflow() throws IOException {
+    Scope.enter();
+    final long min = 1485333188427000000L;
+    int len = 100;
+    try {
+      Vec dz = Vec.makeZero(len);
+      Vec z = dz.makeZero(); // make a vec consisting of C0LChunks
+      Vec v = new MRTask() {
+        @Override public void map(Chunk[] cs) {
+          for (Chunk c : cs)
+            for (int r = 0; r < c._len; r++)
+              c.set(r, r + min + c.start());
+        }
+      }.doAll(z)._fr.vecs()[0];
+      Scope.track(dz);
+      Scope.track(z);
+      Scope.track(v);
+
+      for(int i=0; i<len; i++)
+        assertTrue(v.at8(i)==min+i);
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test public void testOverflowConst() throws IOException {
+    Scope.enter();
+    final long min = 1485333188427000000L;
+    int len = 100;
+    try {
+      Vec dz = Vec.makeZero(len);
+      Vec z = dz.makeZero(); // make a vec consisting of C0LChunks
+      Vec v = new MRTask() {
+        @Override public void map(Chunk[] cs) {
+          for (Chunk c : cs)
+            for (int r = 0; r < c._len; r++)
+              c.set(r, min);
+        }
+      }.doAll(z)._fr.vecs()[0];
+      Scope.track(dz);
+      Scope.track(z);
+      Scope.track(v);
+
+      for(int i=0; i<len; i++)
+        assertTrue(v.at8(i)==min);
+
+    } finally {
+      Scope.exit();
+    }
+  }
 }

--- a/h2o-core/src/test/java/water/fvec/C2SChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/C2SChunkTest.java
@@ -1,13 +1,17 @@
 package water.fvec;
 
-import org.junit.*;
-
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import water.Futures;
+import water.MRTask;
+import water.Scope;
 import water.TestUtil;
 import water.util.PrettyPrint;
 
+import java.io.IOException;
 import java.util.Arrays;
-import java.util.Iterator;
+import static org.junit.Assert.assertTrue;
 
 public class C2SChunkTest extends TestUtil {
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
@@ -197,13 +201,41 @@ public class C2SChunkTest extends TestUtil {
           }
           assert j == nvals;
           Chunk c = nc.compress().deepCopy();
-          if (!(c instanceof C2SChunk))
-            System.out.println("exp = " + exponent + " b = " + bias + " c = " + c.getClass().getSimpleName());
-          Assert.assertTrue(c instanceof C2SChunk);
+          String msg = "exp = " + exponent + " b = " + bias + " c = " + c.getClass().getSimpleName();
+          Assert.assertTrue(msg, c instanceof C2SChunk);
           for (int i = 0; i < expected.length; ++i)
-            Assert.assertEquals(expected[i], c.atd(i), 0);
+            Assert.assertEquals(msg + " i: " + i, expected[i], c.atd(i), 0);
         }
       }
+    }
+  }
+
+  @Test public void testOverflow() throws IOException {
+    Scope.enter();
+    final long min = 1485333188427000000L;
+    int len = 10000;
+    try {
+      Vec dz = Vec.makeZero(len);
+      Vec z = dz.makeZero(); // make a vec consisting of C0LChunks
+      Vec v = new MRTask() {
+        @Override public void map(Chunk[] cs) {
+          for (Chunk c : cs)
+            for (int r = 0; r < c._len; r++)
+              c.set(r, r + min + c.start());
+        }
+      }.doAll(z)._fr.vecs()[0];
+      Scope.track(dz);
+      Scope.track(z);
+      Scope.track(v);
+
+      for(long i=0; i<len; i++) {
+        if( v.isNA(i) )
+          System.out.println("MISSING: " + i);
+        assertTrue("i/total: " + i + "/" + len + " min+i: " + (min+i) + " v.at8(i): " + v.at8(i) + " chk= " + v.elem2ChunkIdx(i), v.at8(i) == min + i);
+      }
+
+    } finally {
+      Scope.exit();
     }
   }
 }

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -11,8 +11,6 @@ import java.util.Set;
 
 import static org.junit.Assert.*;
 
-import static org.junit.Assert.assertTrue;
-
 /**
  * Tests for Frame.java
  */

--- a/h2o-core/src/test/java/water/fvec/NewChunkSpeedTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkSpeedTest.java
@@ -1,7 +1,6 @@
 package water.fvec;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import water.MRTask;
 import water.Scope;
@@ -97,7 +96,7 @@ public class NewChunkSpeedTest extends TestUtil {
 
 
   // todo: This should be changed to test after Spencer PR is in.
-  @Ignore
+  @Test
   public void testParseLong(){
     double startTime = System.currentTimeMillis();
     for (int index=0; index<numberLoops; index++)
@@ -108,7 +107,7 @@ public class NewChunkSpeedTest extends TestUtil {
             +PrettyPrint.msecs((long) endTime, false));
   }
 
-  @Ignore
+  @Test
   public void testParseLongConsts(){
     double startTime = System.currentTimeMillis();
     for (int index=0; index<numberLoops; index++)
@@ -117,6 +116,19 @@ public class NewChunkSpeedTest extends TestUtil {
     Log.info("New Chunk test for constant longs:", " time taken for "+numberLoops+" is "
             +PrettyPrint.msecs((long) endTime, false));
   }
+
+  @Test
+  public void testParseLongMAXMINV(){
+    double startTime = System.currentTimeMillis();
+    for (int index=0; index<numberLoops; index++) {
+      testsForLongsMaxMin(Long.MAX_VALUE); // read in Long.MAX_VALUE
+      testsForLongsMaxMin(Long.MIN_VALUE); // read in Long.MIN_VALUE
+    }
+    double endTime = System.currentTimeMillis()-startTime;  // change time to seconds
+    Log.info("New Chunk test for constant longs:", " time taken for "+numberLoops+" is "
+            +PrettyPrint.msecs((long) endTime, false));
+  }
+
 
   @Test
   public void testParseDataFromFiles() {
@@ -142,6 +154,39 @@ public class NewChunkSpeedTest extends TestUtil {
               +PrettyPrint.msecs((long) endTime, false));
     }
   }
+
+  // Added this test to make sure we can read in Long.MAX_VALUE and Long.MIN_VALUE and still get a
+  // C8Chunk back.
+  public void testsForLongsMaxMin(long base) {
+    Scope.enter();
+    final long baseD = base;
+
+    try {
+      Vec tVec = Vec.makeZero(rowNumber);
+      Vec v;
+      v = new MRTask() {
+        @Override
+        public void map(Chunk cs) {
+          for (int r = 0; r < cs._len; r++) {
+            cs.set(r, baseD);
+          }
+        }
+      }.doAll(tVec)._fr.vecs()[0];
+
+      Scope.track(tVec);
+      Scope.track(v);
+
+      assertTrue(v.chunkForChunkIdx(0)  instanceof C0LChunk);
+      for (int rowInd = 0; rowInd < rowNumber; rowInd = rowInd + rowInterval) {
+        assertTrue("rowIndex: " + rowInd + " rowInd+baseD: " + (rowInd + baseD) + " v.at(rowIndex): "
+                        + v.at8(rowInd) + " chk= " + v.elem2ChunkIdx(rowInd),
+                v.at8(rowInd) == baseD);
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
 
   public void testsForLongs(boolean forConstants) {
     Scope.enter();

--- a/h2o-core/src/test/java/water/fvec/NewChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkTest.java
@@ -79,7 +79,7 @@ public class NewChunkTest extends TestUtil {
     int missingSize()  {return _missing == null?0:_missing.size();}
   }
 
-  
+
   private void testIntegerChunk(long [] values, int mantissaSize) {
     Vec v = Vec.makeCon(0,0);
     // single bytes
@@ -485,22 +485,22 @@ public class NewChunkTest extends TestUtil {
       assertEquals("Wrong (3) at " + (K-4), 0, nc.atd(K-4), Math.ulp(0));
       assertEquals("Wrong (4) at " + (K-3), Double.NaN, nc.atd(K-3), Math.ulp(Double.NaN)); // this is weird: ulp(NaN) is NaN)
       for (int i = K-2; i < K; i++) assertEquals("Wrong (5) at " + i, 0, nc.atd(i), Math.ulp(0));
-      
+
       post();
       cc.set(K-5, 0);
       post_write();
       assertEquals(K, nc._len);
       assertEquals(0,cc.atd(K-5),Math.ulp(0));
       assertTrue(cc.chk2() instanceof CXIChunk);
-      
+
       for (int i = 0; i < K-3; i++) assertEquals(0, cc.atd(i), Math.ulp(0));
       assertEquals(Double.NaN, cc.atd(K-3), Math.ulp(Double.NaN));
       for (int i = K-2; i < K; i++) assertEquals(0, cc.atd(i), Math.ulp(0));
       assertEquals(1,cc.chk2().sparseLenZero());
-      
+
     } finally { remove();}
   }
-  
+
   @Test public void testCNAXDChunk_setPostSparse() {
     try {
       pre();
@@ -532,7 +532,7 @@ public class NewChunkTest extends TestUtil {
       assertEquals(4,cc.chk2().sparseLenNA());
     } finally {remove();}
   }
-  
+
   @Test public void testSparseCat() {
     try {
       av = new AppendableVec(Vec.newKey(), Vec.T_CAT);

--- a/h2o-core/src/test/java/water/rapids/SortTest.java
+++ b/h2o-core/src/test/java/water/rapids/SortTest.java
@@ -229,6 +229,42 @@ public class SortTest extends TestUtil {
   }
 
 
+  @Test public void testSortOverflows2() throws IOException {
+    Scope.enter();
+    Frame fr, sorted1, sorted2;
+    final long ts=1485333188427000000L;
+    try {
+
+      Vec dz = Vec.makeZero(1000);
+      Vec z = dz.makeZero(); // make a vec consisting of C0LChunks
+      Vec v = new MRTask() {
+        @Override public void map(Chunk[] cs) {
+          for (Chunk c : cs)
+            for (int r = 0; r < c._len; r++)
+              c.set(r, r + ts + c.start());
+        }
+      }.doAll(z)._fr.vecs()[0];
+      Scope.track(dz);
+      Scope.track(z);
+      Scope.track(v);
+      Vec rand = dz.makeRand(12345678);
+
+      fr = new Frame(v, rand);
+      sorted1 = fr.sort(new int[]{1});
+      sorted2 = sorted1.sort(new int[]{0});
+
+      for(long i=0; i < fr.numRows(); i++) {
+        assertTrue(fr.vec(0).at8(i) == sorted2.vec(0).at8(i));
+      }
+
+      Scope.track(fr);
+      Scope.track(sorted1);
+      Scope.track(sorted2);
+    } finally {
+      Scope.exit();
+    }
+  }
+  
   @Test public void testSortIntegersFloats() throws IOException {
     // test small integers sort
     testSortOneColumn("smalldata/synthetic/smallIntFloats.csv.zip", 0, false, false);


### PR DESCRIPTION
Review is being done on spencer_2309-2310.  This PR is here to make sure it runs with rel-xia branch.


Add final to variable declaration.
HEXDEV-715: Fixing new chunk.
HEXDEV0715: Fixed the error for testNumberFormat and C1 and C2 chunk tests are passing.
HEXDEV-715: Fixed sorting bug.
HEXDEV-715: Fixed bug in NewChunk.java when using double is not lossy but really should be using Long when the integer fits into Long format.
HEXDEV-715: Fixed NewChunk.java to only update long min/max when appropriate.
HEXDEV-715: This is a working version before any optimization.  Always come back here.
HEXDEV-715: Fixed speed tests.
HEXDEV-715: Replace BigInteger with long.
HEXDEV-715: Minor optimization and incorporate Michalk code review.
HEXDEV-715: Incorporate Michalk code reviews.
            Added parsing of Long.MAX_VALUE and Long.MIN_VALUE to make sure it works.