### PR TITLE
PUBDEV-6124: Use same default for L2 regularization as native XGBoost

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -115,7 +115,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
     public GrowPolicy _grow_policy = GrowPolicy.depthwise;
     public Booster _booster = Booster.gbtree;
     public DMatrixType _dmatrix_type = DMatrixType.auto;
-    public float _reg_lambda = 0;
+    public float _reg_lambda = 1;
     public float _reg_alpha = 0;
 
     // Dart specific (booster == dart)

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -1405,6 +1405,7 @@ public class XGBoostTest extends TestUtil {
       parms._train = f._key;
       parms._ignored_columns = new String[]{"name"};
       parms._seed = 42;
+      parms._reg_lambda = 0;
 
       XGBoostModel.XGBoostParameters noConstrParams = (XGBoostModel.XGBoostParameters) parms.clone();
       XGBoostModel noConstrModel = new hex.tree.xgboost.XGBoost(noConstrParams).trainModel().get();

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTreeConverterTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTreeConverterTest.java
@@ -53,6 +53,7 @@ public class XGBoostTreeConverterTest extends TestUtil {
             parms._max_depth = 3;
             parms._train = tfr._key;
             parms._response_column = response;
+            parms._reg_lambda = 0;
 
             model = new hex.tree.xgboost.XGBoost(parms).trainModel().get();
 
@@ -61,7 +62,6 @@ public class XGBoostTreeConverterTest extends TestUtil {
             final RegTreeNode[] nodes = tree.getNodes();
 
             final SharedTreeGraph sharedTreeGraph = model.convert(0, "down");
-            final String s = XGBoostUtils.makeFeatureMap(tfr, model.model_info()._dataInfoKey.get());
             assertNotNull(sharedTreeGraph);
             assertEquals(parms._ntrees, sharedTreeGraph.subgraphArray.size());
             final SharedTreeSubgraph sharedTreeSubgraph = sharedTreeGraph.subgraphArray.get(0);

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTreeConverterTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTreeConverterTest.java
@@ -60,6 +60,7 @@ public class XGBoostTreeConverterTest extends TestUtil {
             final GBTree booster = (GBTree) new Predictor(new ByteArrayInputStream(model.model_info()._boosterBytes)).getBooster();
             final RegTree tree = booster.getGroupedTrees()[0][0];
             final RegTreeNode[] nodes = tree.getNodes();
+            assertNotNull(nodes);
 
             final SharedTreeGraph sharedTreeGraph = model.convert(0, "down");
             assertNotNull(sharedTreeGraph);
@@ -91,12 +92,14 @@ public class XGBoostTreeConverterTest extends TestUtil {
             parms._ignored_columns = new String[]{"fYear","fMonth","fDayofMonth","fDayOfWeek","UniqueCarrier", "Dest"};
             parms._train = tfr._key;
             parms._response_column = response;
+            parms._reg_lambda = 0;
 
             model = new hex.tree.xgboost.XGBoost(parms).trainModel().get();
 
             final GBTree booster = (GBTree) new Predictor(new ByteArrayInputStream(model.model_info()._boosterBytes)).getBooster();
             final RegTree tree = booster.getGroupedTrees()[0][0];
             final RegTreeNode[] nodes = tree.getNodes();
+            assertNotNull(nodes);
 
             final SharedTreeGraph sharedTreeGraph = model.convert(0, "NO");
             assertNotNull(sharedTreeGraph);

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -890,7 +890,7 @@ class H2OXGBoostEstimator(H2OEstimator):
         """
         L2 regularization
 
-        Type: ``float``  (default: ``0``).
+        Type: ``float``  (default: ``1``).
         """
         return self._parms.get("reg_lambda")
 

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_binomial_compare_sparse_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_binomial_compare_sparse_singleNode.py
@@ -23,7 +23,6 @@ def comparison_test():
                        'seed': h2oParamsS["seed"],
                        'booster': 'gbtree',
                        'objective': 'binary:logistic',
-                       'lambda': 0.0,
                        'eta': h2oParamsS["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_multinomial_compare_sparse_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_enum_multinomial_compare_sparse_singleNode.py
@@ -24,7 +24,6 @@ def comparison_test():
                        'seed': h2oParamsS["seed"],
                        'booster': 'gbtree',
                        'objective': 'multi:softprob',
-                       'lambda': 0.0,
                        'eta': h2oParamsS["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_dense_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_dense_singleNode.py
@@ -27,7 +27,6 @@ def comparison_test_dense():
                        'seed': h2oParamsD["seed"],
                        'booster': 'gbtree',
                        'objective': 'binary:logistic',
-                       'lambda': 0.0,
                        'eta': h2oParamsD["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_sparse_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_binomial_compare_large_sparse_singleNode.py
@@ -25,7 +25,6 @@ def comparison_test_dense():
                        'seed': h2oParamsD["seed"],
                        'booster': 'gbtree',
                        'objective': 'binary:logistic',
-                       'lambda': 0.0,
                        'eta': h2oParamsD["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_dense_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_dense_singleNode.py
@@ -32,7 +32,6 @@ def comparison_test_dense():
                        'seed': h2oParamsD["seed"],
                        'booster': 'gbtree',
                        'objective': 'multi:softprob',
-                       'lambda': 0.0,
                        'eta': h2oParamsD["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_sparse_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_multinomial_compare_large_sparse_singleNode.py
@@ -25,7 +25,6 @@ def comparison_test_dense():
                        'seed': h2oParamsD["seed"],
                        'booster': 'gbtree',
                        'objective': 'multi:softprob',
-                       'lambda': 0.0,
                        'eta': h2oParamsD["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_dense_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_dense_singleNode.py
@@ -25,7 +25,6 @@ def comparison_test_dense():
                        'seed': h2oParamsD["seed"],
                        'booster': 'gbtree',
                        'objective': 'reg:linear',
-                       'lambda': 0.0,
                        'eta': h2oParamsD["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_sparse_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_mixed_regression_compare_large_sparse_singleNode.py
@@ -25,7 +25,6 @@ def comparison_test_dense():
                        'seed': h2oParamsD["seed"],
                        'booster': 'gbtree',
                        'objective': 'reg:linear',
-                       'lambda': 0.0,
                        'eta': h2oParamsD["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_numerical_binomial_compare_sparse_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_H2OXGBoost_native_XGBoost_numerical_binomial_compare_sparse_singleNode.py
@@ -22,7 +22,6 @@ def comparison_test():
                        'seed': h2oParamsS["seed"],
                        'booster': 'gbtree',
                        'objective': 'binary:logistic',
-                       'lambda': 0.0,
                        'eta': h2oParamsS["learn_rate"],
                        'grow_policy': 'depthwise',
                        'alpha': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_native_comparison.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_native_comparison.py
@@ -21,7 +21,7 @@ def arlines_test():
     dtrain = xgb.DMatrix(data=data, label=label)
     watchlist = [(dtrain, 'train')]
     param = {'eta': 0.7, 'silent': 1, 'objective': 'binary:logistic', 'booster': 'gbtree',
-             'max_depth': 2, 'seed': 1, 'lambda': 0, 'max_delta_step': 0, 'alpha': 0, 'nround': 5}
+             'max_depth': 2, 'seed': 1, 'max_delta_step': 0, 'alpha': 0, 'nround': 5}
     bst = xgb.train(params=param, dtrain=dtrain, num_boost_round=2, evals = watchlist)
     native_prediction = bst.predict(data=dtrain)
     print(native_prediction)

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_xgboost_zero_nan_handling_native_comparison.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_xgboost_zero_nan_handling_native_comparison.py
@@ -30,7 +30,7 @@ def xgboost_categorical_zero_nan_handling_sparse_vs_native():
     ntrees = 1
     h2oParamsS = {"ntrees":ntrees, "max_depth":4, "seed":runSeed, "learn_rate":1.0, "col_sample_rate_per_tree" : 1.0,
                   "min_rows": 1, "score_tree_interval": ntrees + 1, "dmatrix_type": "sparse", "tree_method": "exact",
-                  "backend": "cpu"}
+                  "backend": "cpu", "reg_lambda": 0.0}
     nativeParam = {'colsample_bytree': h2oParamsS["col_sample_rate_per_tree"],
                    'tree_method': 'exact',
                    'seed': h2oParamsS["seed"],
@@ -39,6 +39,7 @@ def xgboost_categorical_zero_nan_handling_sparse_vs_native():
                    'eta': h2oParamsS["learn_rate"],
                    'grow_policy': 'depthwise',
                    'alpha': 0.0,
+                   'lambda': h2oParamsS["reg_lambda"],
                    'subsample': 1.0,
                    'colsample_bylevel': 1.0,
                    'max_delta_step': 0.0,

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_xgboost_zero_nan_handling_native_comparison.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_xgboost_zero_nan_handling_native_comparison.py
@@ -36,7 +36,6 @@ def xgboost_categorical_zero_nan_handling_sparse_vs_native():
                    'seed': h2oParamsS["seed"],
                    'booster': 'gbtree',
                    'objective': 'reg:linear',
-                   'lambda': 0.0,
                    'eta': h2oParamsS["learn_rate"],
                    'grow_policy': 'depthwise',
                    'alpha': 0.0,

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -82,7 +82,7 @@
 #' @param grow_policy Grow policy - depthwise is standard GBM, lossguide is LightGBM Must be one of: "depthwise", "lossguide".
 #'        Defaults to depthwise.
 #' @param booster Booster type Must be one of: "gbtree", "gblinear", "dart". Defaults to gbtree.
-#' @param reg_lambda L2 regularization Defaults to 0.0.
+#' @param reg_lambda L2 regularization Defaults to 1.0.
 #' @param reg_alpha L1 regularization Defaults to 0.0.
 #' @param dmatrix_type Type of DMatrix. For sparse, NAs and 0 are treated equally. Must be one of: "auto", "dense", "sparse".
 #'        Defaults to auto.
@@ -145,7 +145,7 @@ h2o.xgboost <- function(x, y, training_frame,
                         tree_method = c("auto", "exact", "approx", "hist"),
                         grow_policy = c("depthwise", "lossguide"),
                         booster = c("gbtree", "gblinear", "dart"),
-                        reg_lambda = 0.0,
+                        reg_lambda = 1.0,
                         reg_alpha = 0.0,
                         dmatrix_type = c("auto", "dense", "sparse"),
                         backend = c("auto", "gpu", "cpu"),

--- a/h2o-r/tests/testdir_jira/runit_pubdev_4585.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_4585.R
@@ -1,6 +1,3 @@
-library(h2o)
-h2o.init()
-
 setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../scripts/h2o-r-test-setup.R")
 
@@ -42,20 +39,13 @@ test.pubdev_4585 <- function() {
     mfile <- h2o.saveModel(xgb, path = tempdir())
     rm("xgb", "train", "test")
 
-
-    print("about to start up / connect to a different instance")
-    h2o.init(ip="localhost", port=54319)
-
-    h2o.ls()
-    print("YO! connected to a new instance!")
+    h2o.removeAll()
 
     # Load xgb into the new instance
     xgb <- h2o.loadModel(path = mfile)
-    xgb
 
     test <- h2o.importFile(normalizePath(locate("smalldata/higgs/higgs_test_5k.csv")))
     test[,y] <- as.factor(test[,y])
-
 
     h2o.performance(xgb, newdata = test)
 
@@ -63,9 +53,6 @@ test.pubdev_4585 <- function() {
     print("pred_reloaded[1,3]: ")
     print(pred_reloaded[1,3])
     expect_true(abs(pred_orig_1_3 - pred_reloaded[1,3]) < 1e-5)
-
-    # we don't want old instances lying around on the machine, especially with old code versions
-    h2o.shutdown(prompt = FALSE)
 }
 
 doTest("PUBDEV-4585: XGBoost binary save/load", test.pubdev_4585)


### PR DESCRIPTION
Reverts back a mistake that was made to [change the default value](https://0xdata.atlassian.net/browse/PUBDEV-4794).