### PR TITLE
Fix code generators to no longer generate trailing spaces

### DIFF
--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -354,8 +354,8 @@ def gen_module(schema, algo, module):
     print_ln(paste0("Number of Base Models: ", length(baselearners)))
     print_ln("\nBase Models (count by algorithm type):")
     print(table(unlist(lapply(baselearners, function(baselearner) baselearner@algorithm))))
-    
-    
+
+
     print_ln("\nMetalearner:\n")
     print_ln(paste0(
       "Metalearner algorithm: ",
@@ -371,10 +371,10 @@ def gen_module(schema, algo, module):
         "  Fold column: ",
         ifelse(is.null(metalearner_fold_column), "NULL", metalearner_fold_column )))
     }
-    
+
     if (!missing(metalearner_params))
       print_ln(paste0("Metalearner hyperparameters: ", parms$metalearner_params))
-    
+
   })
   class(model@model$model_summary) <- "h2o.stackedEnsemble.summary"
         """

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -135,8 +135,8 @@ h2o.stackedEnsemble <- function(x, y, training_frame,
     print_ln("
 Base Models (count by algorithm type):")
     print(table(unlist(lapply(baselearners, function(baselearner) baselearner@algorithm))))
-    
-    
+
+
     print_ln("
 Metalearner:
 ")
@@ -154,10 +154,10 @@ Metalearner:
         "  Fold column: ",
         ifelse(is.null(metalearner_fold_column), "NULL", metalearner_fold_column )))
     }
-    
+
     if (!missing(metalearner_params))
       print_ln(paste0("Metalearner hyperparameters: ", parms$metalearner_params))
-    
+
   })
   class(model@model$model_summary) <- "h2o.stackedEnsemble.summary"
         


### PR DESCRIPTION
This is little part of the effort to bring our codebase closer to a canonical state, which will help us in producing minimal diffs. Currently, there is:

- 179 `.java` files,
- 289 `.py` files,
- 422 `.R` files

containing lines with trailing spaces. That's quite a lot, and it makes the chance of nonsenses in diffs pretty high. Before we do any other steps, it's good to start with generated files.
