### PR TITLE
[PUBDEV-6115] Fix output of rankTsv in Leaderboard

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -524,7 +524,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
     return new String[] {"unknown"};
   }
 
-  public String rankTsv() {
+  String rankTsv() {
     String lineSeparator = "\n";
 
     StringBuilder sb = new StringBuilder();

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -524,19 +524,17 @@ public class Leaderboard extends Keyed<Leaderboard> {
     return new String[] {"unknown"};
   }
 
-  String rankTsv() {
-    String fieldSeparator = "\\t";
-    String lineSeparator = "\\n";
+  public String rankTsv() {
+    String lineSeparator = "\n";
 
-    StringBuffer sb = new StringBuffer();
-//  sb.append("Rank").append(fieldSeparator).append("Error").append(lineSeparator);
+    StringBuilder sb = new StringBuilder();
     sb.append("Error").append(lineSeparator);
 
     Model[] models = getModels();
     for (int i = models.length - 1; i >= 0; i--) {
       // TODO: allow the metric to be passed in.  Note that this assumes the validation (or training) frame is the same.
       Model m = models[i];
-      sb.append(defaultMetricForModel(m));
+      sb.append(Arrays.toString(defaultMetricForModel(m)));
       sb.append(lineSeparator);
     }
     return sb.toString();

--- a/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
@@ -1,10 +1,15 @@
 package ai.h2o.automl;
 
+import hex.tree.gbm.GBM;
+import hex.tree.gbm.GBMModel;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import water.fvec.Frame;
+import water.util.Log;
 import water.util.TwoDimTable;
+
+import static hex.genmodel.utils.DistributionFamily.gaussian;
 
 public class LeaderboardTest extends water.TestUtil {
 
@@ -47,4 +52,38 @@ public class LeaderboardTest extends water.TestUtil {
     }
   }
 
+
+  @Test
+  public void test_rank_tsv() {
+    Leaderboard lb = null;
+    UserFeedback ufb = new UserFeedback(new AutoML());
+    GBMModel model = null;
+    Frame fr  = null;
+    try {
+      fr = parse_test_file("./smalldata/logreg/prostate_train.csv");
+      GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+      parms._train = fr._key;
+      parms._nfolds = 2;
+      parms._seed = 1;
+      parms._response_column = "CAPSULE";
+      GBM job = new GBM(parms);
+      model = job.trainModel().get();
+      
+      lb = Leaderboard.getOrMakeLeaderboard("dummy_rank_tsv", ufb, null, "mae");
+      lb.addModel(model);
+      Assert.assertEquals("Error\n[0.19959320678410908, 0.44675855535636816, 0.19959320678410908, 0.3448260574357465, 0.31468498072970547]\n", lb.rankTsv()); 
+    } finally {
+      if (lb != null){
+        lb.deleteWithChildren();
+      }
+      ufb.delete();
+      if (model != null) {
+        model.deleteCrossValidationModels();
+        model.delete();
+      }
+      if( fr != null) {
+        fr.delete();
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fix output of rankTsv in Leaderboard. Previously, it tried to print Arrays of metrics directly (`defaultMetricForModel(m)` returns array), however Java arrays don't have readable` toString` method. Just `hashcode` of that array was printed out