### PR TITLE
PUBDEV-6117: fixed python client code to enable XGBoost compare with anyH2O Frame

### DIFF
--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_dense_comparisons.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_dense_comparisons.py
@@ -86,6 +86,12 @@ def comparison_test():
         myX = trainFile.names
         y='response'
         myX.remove(y)
+        newNames = []
+        for ind in range(0, len(myX)):
+            myX[ind] = myX[ind]+"_"+str(ind) # avoid duplicated column names
+            newNames.append(myX[ind])
+        newNames.append(y)
+        trainFile.set_names(newNames)
 
         h2oModelD = H2OXGBoostEstimator(**h2oParamsD)
         # gather, print and save performance numbers for h2o model

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_sparse_comparisons.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_5777_XGBoost_sparse_comparisons.py
@@ -84,9 +84,16 @@ def comparison_test():
 
         trainFile = pyunit_utils.genTrainFrame(nrows, numCols, enumCols=enumCols, enumFactors=factorL,
                                                responseLevel=responseL, miscfrac=0.01,randseed=dataSeed)
+
         myX = trainFile.names
         y='response'
         myX.remove(y)
+        newNames = []
+        for ind in range(0, len(myX)):
+            myX[ind] = myX[ind]+"_"+str(ind) # avoid duplicated column names
+            newNames.append(myX[ind])
+        newNames.append(y)
+        trainFile.set_names(newNames)
 
         h2oModelD = H2OXGBoostEstimator(**h2oParamsD)
         # gather, print and save performance numbers for h2o model

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_6117_xgboost_compare.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_PUBDEV_6117_xgboost_compare.py
@@ -1,0 +1,43 @@
+import xgboost as xgb
+import time
+
+from h2o.estimators.xgboost import *
+from tests import pyunit_utils
+from h2o.frame import H2OFrame
+
+'''
+PUBDEV-6117: test H2OXGBoost and native XGBoost comparison.
+'''
+def comparison_test():
+    assert H2OXGBoostEstimator.available() is True
+    ret = h2o.cluster()
+    if len(ret.nodes) == 1:
+        data= h2o.import_file(pyunit_utils.locate("smalldata/jira/adult_data_modified.csv"))
+        data[14] = data[14].asfactor()
+        myX = list(range(0, 13)) # use column indices
+        print(myX)
+        y='income'
+        h2oParamsD = {"ntrees":30, "max_depth":4, "seed":2, "learn_rate":0.7,
+              "col_sample_rate_per_tree" : 0.9, "min_rows" : 5, "score_tree_interval": 30+1,
+              "tree_method": "exact", "backend":"cpu"}
+
+        h2oModelD = H2OXGBoostEstimator(**h2oParamsD)
+        # gather, print and save performance numbers for h2o model
+        h2oModelD.train(x=myX, y=y, training_frame=data)
+        h2oPredictD = h2oModelD.predict(data)
+
+        nativeXGBoostParam = h2oModelD.convert_H2OXGBoostParams_2_XGBoostParams()
+        nativeXGBoostInput = data.convert_H2OFrame_2_DMatrix(myX, y, h2oModelD)
+        
+        nativeModel = xgb.train(params=nativeXGBoostParam[0],
+                                dtrain=nativeXGBoostInput, num_boost_round=nativeXGBoostParam[1])
+        nativePred = nativeModel.predict(data=nativeXGBoostInput, ntree_limit=nativeXGBoostParam[1])
+        pyunit_utils.summarizeResult_binomial(h2oPredictD, nativePred, -1, -1, -1,
+                                              -1, tolerance=1e-10)
+    else:
+        print("********  Test skipped.  This test cannot be performed in multinode environment.")
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(comparison_test)
+else:
+    comparison_test()


### PR DESCRIPTION
This PR fixes the problem in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6117?filter=-1

Work done:
1.  Added Python test using the dataset provided by Nidhi.
2. Fixed method convert_H2OFrame_2_DMatrix in frame.py to accept any H2O frame and convert it to valid data for native XGBoost.