### PR TITLE
PUBDEV-6129 Added support for using indices when specifying columns in parameters of Target Encoding in Python's API

### DIFF
--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -28,7 +28,7 @@ class TargetEncoder(object):
 
     Sample usage:
 
-    >>> targetEncoder = TargetEncoder(x=te_columns, y=responseColumnName, blending_avg=True, inflection_point=3, smoothing=1)
+    >>> targetEncoder = TargetEncoder(x=te_columns, y=responseColumnName, blended_avg=True, inflection_point=3, smoothing=1)
     >>> targetEncoder.fit(trainFrame) 
     >>> encodedTrain = targetEncoder.transform(frame=trainFrame, holdout_type="kfold", seed=1234, is_train_or_valid=True)
     >>> encodedValid = targetEncoder.transform(frame=validFrame, holdout_type="none", noise=0.0, is_train_or_valid=True)

--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -43,7 +43,7 @@ class TargetEncoder(object):
         """
         Creates instance of the TargetEncoder class and setting parameters that will be used in both `train` and `transform` methods.
 
-        :param List[str] or List[int] x: List of categorical column names or indicess that we want apply target encoding to
+        :param List[str] or List[int] x: List of categorical column names or indices that we want apply target encoding to
 
         :param str or int y: response column name or index we will create encodings with
         :param str or int fold_column: fold column if we want to use 'kfold' holdout_type

--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -28,25 +28,26 @@ class TargetEncoder(object):
 
     Sample usage:
 
-    >>> targetEncoder = TargetEncoder(x=e_columns, y=responseColumnName, blending=True, inflection_point=3, smoothing=1)
-    >>> targetEncoder.fit(frame) 
-    >>> encodedValid = targetEncoder.transform(frame=frame, holdout_type="kfold", seed=1234, is_train_or_valid=True)
-    >>> encodedTest = targetEncoder.transform(frame=testFrame, holdout_type="none", noise=0.0, seed=1234, is_train_or_valid=False)
+    >>> targetEncoder = TargetEncoder(x=te_columns, y=responseColumnName, blending_avg=True, inflection_point=3, smoothing=1)
+    >>> targetEncoder.fit(trainFrame) 
+    >>> encodedTrain = targetEncoder.transform(frame=trainFrame, holdout_type="kfold", seed=1234, is_train_or_valid=True)
+    >>> encodedValid = targetEncoder.transform(frame=validFrame, holdout_type="none", noise=0.0, is_train_or_valid=True)
+    >>> encodedTest = targetEncoder.transform(frame=testFrame, holdout_type="none", noise=0.0, is_train_or_valid=False)
     """
 
     #-------------------------------------------------------------------------------------------------------------------
     # Construction
     #-------------------------------------------------------------------------------------------------------------------
 
-    def __init__(self, x=None, y=None, fold_column='', blending_avg=True, inflection_point=3, smoothing=1):
+    def __init__(self, x=None, y=None, fold_column='', blended_avg=True, inflection_point=3, smoothing=1):
         """
         Creates instance of the TargetEncoder class and setting parameters that will be used in both `train` and `transform` methods.
 
-        :param List[str] x: List of categorical column names that we want apply target encoding to
+        :param List[str] or List[int] x: List of categorical column names or indicess that we want apply target encoding to
 
-        :param str y: response column we will create encodings with
-        :param str fold_column: fold column if we want to use 'kfold' holdout_type
-        :param boolean blending_avg: whether to use blending or not
+        :param str or int y: response column name or index we will create encodings with
+        :param str or int fold_column: fold column if we want to use 'kfold' holdout_type
+        :param boolean blended_avg: whether to use blending or not
         :param double inflection_point: parameter for blending. Used to calculate `lambda`. Parameter determines half of the minimal sample size
             for which we completely trust the estimate based on the sample in the particular level of categorical variable.
         :param double smoothing: parameter for blending. Used to calculate `lambda`. The parameter f controls the rate of transition between
@@ -58,7 +59,7 @@ class TargetEncoder(object):
         self._teColumns = x
         self._responseColumnName = y
         self._foldColumnName = fold_column
-        self._blending = blending_avg
+        self._blending = blended_avg
         self._inflectionPoint = inflection_point
         self._smoothing = smoothing
 
@@ -69,6 +70,10 @@ class TargetEncoder(object):
 
         :param frame frame: frame you want to generate encoding map for target encoding based on.
         """
+        self._teColumns = list(map(lambda i: frame.names[i], self._teColumns)) if all(isinstance(n, int) for n in self._teColumns) else self._teColumns
+        self._responseColumnName = frame.names[self._responseColumnName] if isinstance(self._responseColumnName, int) else self._responseColumnName
+        self._foldColumnName = frame.names[self._foldColumnName] if isinstance(self._foldColumnName, int) else self._foldColumnName
+        
         self._encodingMap = ExprNode("target.encoder.fit", frame, self._teColumns, self._responseColumnName,
                                      self._foldColumnName)._eager_map_frame()
 

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
@@ -53,7 +53,7 @@ def titanic_with_te_kfoldstrategy(frame = None, seeds = None):
 
       teColumns = ["home.dest", "cabin", "embarked"]
       targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                    fold_column= foldColumnName, blending_avg= True, inflection_point = 3, smoothing = 1)
+                                    fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
       targetEncoder.fit(frame=ds['train'])
 
       encodedTrain = targetEncoder.transform(frame=ds['train'], holdout_type="kfold", seed=1234, is_train_or_valid=True)
@@ -93,7 +93,7 @@ def titanic_with_te_loostrategy(frame = None, seeds = None):
 
     teColumns = ["home.dest", "cabin", "embarked"]
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  fold_column= foldColumnName, blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
     targetEncoder.fit(frame=ds['train'])
 
     encodedTrain = targetEncoder.transform(frame=ds['train'], holdout_type="loo", seed=1234, is_train_or_valid=True)
@@ -133,7 +133,7 @@ def titanic_with_te_nonestrategy(frame = None, seeds = None):
 
     teColumns = ["home.dest", "cabin", "embarked"]
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  blended_avg= True, inflection_point = 3, smoothing = 1)
     targetEncoder.fit(frame=holdout)
 
     encodedTrain = targetEncoder.transform(frame=train, holdout_type="none", noise=0.0, seed=1234, is_train_or_valid=True)

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
@@ -23,7 +23,7 @@ def test_target_encoding_fit_method():
 
     teColumns = ["home.dest", "cabin", "embarked"]
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  fold_column= foldColumnName, blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
     trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
 
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
@@ -41,7 +41,7 @@ def test_target_encoding_transform_kfold():
 
     teColumns = ["home.dest", "cabin", "embarked"]
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  fold_column= foldColumnName, blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
     trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
 
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
@@ -62,7 +62,7 @@ def test_target_encoding_transform_loo():
 
     teColumns = ["home.dest", "cabin", "embarked"]
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  fold_column='', blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  fold_column='', blended_avg= True, inflection_point = 3, smoothing = 1)
     trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
 
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
@@ -82,7 +82,7 @@ def test_target_encoding_transform_none():
 
     teColumns = ["home.dest", "cabin", "embarked"]
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  blended_avg= True, inflection_point = 3, smoothing = 1)
     trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
 
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
@@ -105,7 +105,7 @@ def test_target_encoding_transform_none_blending():
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
     
     targetEncoderWithBlending = TargetEncoder(x= teColumns, y= targetColumnName,
-                                              blending_avg= True, inflection_point = 3, smoothing = 1)
+                                              blended_avg= True, inflection_point = 3, smoothing = 1)
     
     targetEncoderWithBlending.fit(frame=trainingFrame)
 
@@ -114,7 +114,7 @@ def test_target_encoding_transform_none_blending():
     frameWithBlendedEncodingsOnly = encodedFrameWithBlending[teColumnsEncoded]
 
     targetEncoderWithoutBlending = TargetEncoder(x= teColumns, y= targetColumnName,
-                                                 blending_avg= False, inflection_point = 3, smoothing = 1)
+                                                 blended_avg= False, inflection_point = 3, smoothing = 1)
 
     targetEncoderWithoutBlending.fit(frame=trainingFrame)
 
@@ -140,7 +140,7 @@ def test_target_encoding_seed_is_working():
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
 
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  blended_avg= True, inflection_point = 3, smoothing = 1)
 
     targetEncoder.fit(frame=trainingFrame)
 
@@ -178,7 +178,7 @@ def test_target_encoding_default_noise_is_applied():
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
 
     targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
-                                  blending_avg= True, inflection_point = 3, smoothing = 1)
+                                  blended_avg= True, inflection_point = 3, smoothing = 1)
 
     targetEncoder.fit(frame=trainingFrame)
 
@@ -205,6 +205,25 @@ def test_target_encoding_default_noise_is_applied():
     except AssertionError:
         print('Good, encodings are different as expected. Default noise is working')
 
+def test_ability_to_pass_column_parameters_as_indexes():
+    print("Check that we can pass indices for specifying columns")
+    targetColumnIdx = 1 
+    targetColumnName = "survived"
+    foldColumnIdx = 14
+    foldColumnName = "kfold_column" 
+
+    teColumns = [13] # 13 stands for `home.dest`
+    targetEncoder = TargetEncoder(x= teColumns, y= targetColumnIdx,
+                                  fold_column= foldColumnIdx, blended_avg= True, inflection_point = 3, smoothing = 1)
+    trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
+
+    trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
+    trainingFrame[foldColumnName] = trainingFrame.kfold_column(n_folds=5, seed=1234)
+    
+    encodingMap = targetEncoder.fit(frame=trainingFrame)
+    assert encodingMap.map_keys['string'] == ["home.dest"]
+    assert encodingMap.frames[0]['num_rows'] == 583
+
 testList = [
     test_target_encoding_parameters,
     test_target_encoding_fit_method,
@@ -213,7 +232,8 @@ testList = [
     test_target_encoding_transform_none,
     test_target_encoding_transform_none_blending,
     test_target_encoding_default_noise_is_applied,
-    test_target_encoding_seed_is_working
+    test_target_encoding_seed_is_working,
+    test_ability_to_pass_column_parameters_as_indexes
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
Purpose of PR is to unify R and Python's target encoding API's
1) added support for indices for specifying columns in parameters of TE ( adjust descriptions)
2) @angela0xdata found mismatch in naming https://0xdata.atlassian.net/browse/PUBDEV-6126  . Changed blending_avg -> blended_avg to match with the first version of R's TE.
3) correct example in description for target encoding