### PR TITLE
Remove -output hdfsOutputDirName when starting Hadoop

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -577,7 +577,7 @@
             <p class="terminal" id="to_copy7">
                 unzip h2o-SUBST_PROJECT_VERSION-*.zip<br/>
                 cd h2o-SUBST_PROJECT_VERSION-*<br/>
-                hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g -output hdfsOutputDirName<br/>
+                hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g<br/>
             </p>
             <p>3. Point your browser to H2O (see "Open H2O Flow in your web browser" in the output below):</p>
             <button class="btn copy_button" id="btnCopy5" data-copied-hint="Copied!" data-clipboard-target='to_copy5'>

--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -138,7 +138,7 @@ Install on Hadoop
 
 	unzip h2o-3.20.0.1-*.zip
 	cd h2o-3.20.0.1-*
-	hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g -output hdfsOutputDirName
+	hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g
 
 3. Point your browser to H2O. (See "Open H2O Flow in your web browser" in the output below.)
 


### PR DESCRIPTION
Removed this from the documentation and from the Install on Hadoop tab of the download site.