### PR TITLE
[PUBDEV-6059] Fix missing checks of NaN, MaxValue and Infinity for chunk add

### DIFF
--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -16,7 +16,7 @@ import static water.H2OConstants.MAX_STR_LEN;
 // An uncompressed chunk of data, supporting an append operation
 public class NewChunk extends Chunk {
 
-  private static final int[] EXP10s = new int[Double.MAX_EXPONENT - Double.MIN_EXPONENT];
+  private static final int[] EXP10s = new int[Double.MAX_EXPONENT - Double.MIN_EXPONENT + 1];
   private static final double[] INV_POW10s = new double[EXP10s.length];
 
   static {
@@ -521,6 +521,14 @@ public class NewChunk extends Chunk {
         addNum(0, 0);
       else // subnormal
         addNum(d);
+      return;
+    } else if (expIdx == Double.MAX_EXPONENT - Double.MIN_EXPONENT + 1) {
+      // NaN or infinity
+      if (d == Double.NaN) { // NaN
+        addNA();
+      } else {
+        addNum(d); // infinity
+      }
       return;
     }
 

--- a/h2o-core/src/test/java/water/fvec/NewChunkTest.java
+++ b/h2o-core/src/test/java/water/fvec/NewChunkTest.java
@@ -618,5 +618,16 @@ public class NewChunkTest extends TestUtil {
     }
   }
 
+  @Test public void testAddNumDecompose() {
+    nc = new NewChunk(av, 0);
+    nc.addNumDecompose(0.0);
+    nc.addNumDecompose(Math.PI);
+    nc.addNumDecompose(Double.NEGATIVE_INFINITY);
+    nc.addNumDecompose(Double.POSITIVE_INFINITY);
+    nc.addNumDecompose(Double.NaN);
+    nc.addNumDecompose(Double.MAX_VALUE);
+    nc.addNumDecompose(Double.MIN_VALUE);
+    nc.addNumDecompose(Double.MIN_NORMAL);
+  }
 }
 


### PR DESCRIPTION
This PR fixes the problem in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6059

Work done:
- Added testcase for function NewChunk.addNumDecompose()
- Fixed IndexOutOfBound exception when adding spetial double values:
    - NaN
    - +-Infinity
    - Large double with exponential > 1023