### PR TITLE
HEXDEV-725: fix bit order in explanatory comments for byte arrays

### DIFF
--- a/h2o-core/src/main/java/water/util/IcedBitSet.java
+++ b/h2o-core/src/main/java/water/util/IcedBitSet.java
@@ -1,6 +1,5 @@
 package water.util;
 
-import hex.genmodel.GenModel;
 import water.AutoBuffer;
 import water.Iced;
 
@@ -122,13 +121,21 @@ public class IcedBitSet extends Iced {
     int bytes = bytes(_nbits);
     for(int i = 0; i < bytes; i++) {
       if( i>0 && _bitoff + 8*i < size()) sb.p(' ');
-      for( int j=0; j<8; j++ ) {
-        if (_bitoff + 8*i + j >= size()) break;
-        sb.p((_val[_byteoff + i] >> j) & 1);
-      }
+      sb.p(byteTo8digitBinaryString(_val[_byteoff + i]));
     }
     return sb.p("}");
   }
+
+  /**
+   * Converts byte to binary 8-digit string.
+   * @param b  the byte to be converted
+   * @return binary representation, lowest bit (weight 1) goes last
+   */
+  static String byteTo8digitBinaryString(byte b) {
+    final String binaryString = "0000000" + Integer.toBinaryString(b);
+    return binaryString.substring(binaryString.length() - 8);
+  }
+
   public String toStrArray() {
     StringBuilder sb = new StringBuilder();
     sb.append("{").append(_val[_byteoff]);

--- a/h2o-core/src/test/java/water/util/IcedBitSetTest.java
+++ b/h2o-core/src/test/java/water/util/IcedBitSetTest.java
@@ -96,12 +96,6 @@ public class IcedBitSetTest extends TestUtil {
     check(bs, 0, idx);
   }
 
-  @Test (expected = AssertionError.class) public void outOfBounds() {
-    int len = 32 + (int) (10000 * new Random().nextDouble());
-    IcedBitSet bs = new IcedBitSet(len);
-    bs.set(len);
-  }
-
   @Test public void fillSparse() {
     int len = 10 + (int) (10000 * new Random().nextDouble());
     IcedBitSet bs = new IcedBitSet(len);

--- a/h2o-core/src/test/java/water/util/IcedBitSetUnitTest.java
+++ b/h2o-core/src/test/java/water/util/IcedBitSetUnitTest.java
@@ -1,0 +1,15 @@
+package water.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IcedBitSetUnitTest {
+
+  @Test
+  public void byteTo8digitBinaryString() {
+    Assert.assertEquals("00000001", IcedBitSet.byteTo8digitBinaryString((byte) 0x01));
+    Assert.assertEquals("01000001", IcedBitSet.byteTo8digitBinaryString((byte) 0x41));
+    Assert.assertEquals("11111110", IcedBitSet.byteTo8digitBinaryString((byte) -2));
+  }
+
+}

--- a/h2o-core/src/test/java/water/util/IcedBitSetUnitTest.java
+++ b/h2o-core/src/test/java/water/util/IcedBitSetUnitTest.java
@@ -3,7 +3,16 @@ package water.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Random;
+
 public class IcedBitSetUnitTest {
+
+  @Test (expected = AssertionError.class) 
+  public void outOfBounds() {
+    int len = 32 + (int) (10000 * new Random().nextDouble());
+    IcedBitSet bs = new IcedBitSet(len);
+    bs.set(len);
+  }
 
   @Test
   public void byteTo8digitBinaryString() {


### PR DESCRIPTION
Originally, the bit order in POJO generated comments was lowest to highest. The opposite order is correct.