### PR TITLE
PUBDEV-6123: fixed SQLManager import queries for MS SQLServer / Azure SQL

### DIFF
--- a/h2o-core/src/main/java/water/jdbc/SQLManager.java
+++ b/h2o-core/src/main/java/water/jdbc/SQLManager.java
@@ -280,7 +280,9 @@ public class SQLManager {
     switch(databaseType) {
       case SQL_SERVER_DB_TYPE:  // requires ORDER BY clause with OFFSET/FETCH NEXT clauses, syntax supported since SQLServer 2012
         sqlText += " ORDER BY ROW_NUMBER() OVER (ORDER BY (SELECT 0))";
-        //fall through oracle syntax for offset logic
+        sqlText += " OFFSET " + start + " ROWS FETCH NEXT " + length + " ROWS ONLY";
+        break;
+        
       case ORACLE_DB_TYPE:
         sqlText += " OFFSET " + start + " ROWS FETCH NEXT " + length + " ROWS ONLY";
         break;

--- a/h2o-core/src/main/java/water/jdbc/SQLManager.java
+++ b/h2o-core/src/main/java/water/jdbc/SQLManager.java
@@ -239,8 +239,10 @@ public class SQLManager {
   static String buildSelectSingleRowSql(String databaseType, String table, String columns) {
 
     switch(databaseType) {
+      case SQL_SERVER_DB_TYPE: //syntax supported since SQLServer 2008
+        return "SELECT TOP(1) " + columns + " FROM " + table;
+        
       case ORACLE_DB_TYPE:
-      case SQL_SERVER_DB_TYPE:
         return "SELECT " + columns + " FROM " + table + " FETCH NEXT 1 ROWS ONLY";
 
       case TERADATA_DB_TYPE:
@@ -276,8 +278,10 @@ public class SQLManager {
 
     String sqlText = "SELECT " + columns + " FROM " + table;
     switch(databaseType) {
+      case SQL_SERVER_DB_TYPE:  // requires ORDER BY clause with OFFSET/FETCH NEXT clauses, syntax supported since SQLServer 2012
+        sqlText += " ORDER BY ROW_NUMBER() OVER (ORDER BY (SELECT 0))";
+        //fall through oracle syntax for offset logic
       case ORACLE_DB_TYPE:
-      case SQL_SERVER_DB_TYPE:
         sqlText += " OFFSET " + start + " ROWS FETCH NEXT " + length + " ROWS ONLY";
         break;
 

--- a/h2o-core/src/test/java/water/jdbc/SQLManagerTest.java
+++ b/h2o-core/src/test/java/water/jdbc/SQLManagerTest.java
@@ -96,7 +96,7 @@ public class SQLManagerTest {
             SQLManager.buildSelectSingleRowSql("oracle","mytable","*"));
 
     // SQL Server
-    Assert.assertEquals("SELECT * FROM mytable FETCH NEXT 1 ROWS ONLY",
+    Assert.assertEquals("SELECT TOP(1) * FROM mytable",
             SQLManager.buildSelectSingleRowSql("sqlserver", "mytable", "*"));
 
     // Teradata
@@ -116,7 +116,7 @@ public class SQLManagerTest {
             SQLManager.buildSelectChunkSql("oracle", "mytable", 0, 1310, "*", null));
 
     // SQL Server
-    Assert.assertEquals("SELECT * FROM mytable OFFSET 0 ROWS FETCH NEXT 1310 ROWS ONLY",
+    Assert.assertEquals("SELECT * FROM mytable ORDER BY ROW_NUMBER() OVER (ORDER BY (SELECT 0)) OFFSET 0 ROWS FETCH NEXT 1310 ROWS ONLY",
             SQLManager.buildSelectChunkSql("sqlserver", "mytable", 0, 1310, "*", null));
 
     // Teradata


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6123

fixed import queries, now using following syntax, both fully supported from SQL Server 2012:

for column names retrieval (supported from SQLS 2008):
```sql
select top(1) <columns> from <table>;
```

for data chunks retrieval (supported from SQLS 2012):
```sql
select <columns> from <table> order by row_number() over (order by (select 0)) offset <start> rows fetch next <N> rows only;
```

see ticket comments for testing protocol