### PR TITLE
PUBDEV-6122 - Add a parameter to pdp to save the plot

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -901,7 +901,7 @@ class ModelBase(backwards_compatible()):
         :param server: ?
         :param include_na: A boolean specifying whether missing value should be included in the Feature values.
         :param user_splits: a dictionary containing column names as key and user defined split values as value in a list.
-        :param save_to_file Fully qualified name to an image file the resulting plot should be saved to, e.g. '/home/user/pdpplot.png'. The 'png' postfix might be omitted. If the file already exists, it will be overridden.
+        :param save_to_file Fully qualified name to an image file the resulting plot should be saved to, e.g. '/home/user/pdpplot.png'. The 'png' postfix might be omitted. If the file already exists, it will be overridden. Plot is only saved if plot = True.
         :returns: Plot and list of calculated mean response tables for each feature requested.
         """
 

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -884,7 +884,8 @@ class ModelBase(backwards_compatible()):
 
 
     def partial_plot(self, data, cols, destination_key=None, nbins=20, weight_column=None,
-                     plot=True, plot_stddev = True, figsize=(7, 10), server=False, include_na=False, user_splits=None):
+                     plot=True, plot_stddev = True, figsize=(7, 10), server=False, include_na=False, user_splits=None,
+                     save_to_file=None):
         """
         Create partial dependence plot which gives a graphical depiction of the marginal effect of a variable on the
         response. The effect of a variable is measured in change in the mean response.
@@ -900,6 +901,7 @@ class ModelBase(backwards_compatible()):
         :param server: ?
         :param include_na: A boolean specifying whether missing value should be included in the Feature values.
         :param user_splits: a dictionary containing column names as key and user defined split values as value in a list.
+        :param save_to_file Fully qualified name to an image file the resulting plot should be saved to, e.g. '/home/user/pdpplot.png'. The 'png' postfix might be omitted. If the file already exists, it will be overridden.
         :returns: Plot and list of calculated mean response tables for each feature requested.
         """
 
@@ -1027,6 +1029,8 @@ class ModelBase(backwards_compatible()):
                 axs[i, 0].yaxis.grid()
             if len(col) > 1:
                 fig.tight_layout(pad=0.4, w_pad=0.5, h_pad=1.0)
+            if(save_to_file is not None):
+                plt.savefig(save_to_file)
 
         return pps
 

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
@@ -1,7 +1,8 @@
 import sys
+import os
 sys.path.insert(1,"../../")
 import h2o
-import math
+import tempfile
 from tests import pyunit_utils
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 
@@ -31,9 +32,13 @@ def partial_plot_test_with_user_splits():
                           75.21052631578948, 77.10526315789474]
     user_splits['RACE'] = ["Black"]
     # pdp without weight or NA
-    pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True)
+    file, filename = tempfile.mkstemp(suffix=".png")
+    pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True, save_to_file=filename)
+    assert os.path.getsize(filename) > 0
+    os.unlink(filename)
+       
     pdpUserSplit = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True,
-                                          user_splits=user_splits)
+                                          user_splits=user_splits)  
 
     # compare results
     pyunit_utils.assert_H2OTwoDimTable_equal_upto(pdpUserSplit[0], pdpOrig[0], pdpUserSplit[0].col_header, tolerance=1e-10)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3081,7 +3081,7 @@ h2o.cross_validation_predictions <- function(object) {
 #' Inside each list, the first element is the column name followed by values defined by the user.
 #' @param save_to Fully qualified prefix of the image files the resulting plots should be saved to, e.g. '/home/user/pdp'.
 #'  Plots for each feature are saved separately in PNG format, each file receives a suffix equal to the corresponding feature name, e.g. `/home/user/pdp_AGE.png`.
-#'  If the files already exists, they will be overridden.
+#'  If the files already exists, they will be overridden. Files are only saves if plot argument is set to True.
 #' @return Plot and list of calculated mean response tables for each feature requested.
 #' @examples
 #' \donttest{

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3081,7 +3081,7 @@ h2o.cross_validation_predictions <- function(object) {
 #' Inside each list, the first element is the column name followed by values defined by the user.
 #' @param save_to Fully qualified prefix of the image files the resulting plots should be saved to, e.g. '/home/user/pdp'.
 #'  Plots for each feature are saved separately in PNG format, each file receives a suffix equal to the corresponding feature name, e.g. `/home/user/pdp_AGE.png`.
-#'  If the files already exists, they will be overridden.
+#'  If the files already exists, they will be overridden. Files are only saves if plot = TRUE (default).
 #' @return Plot and list of calculated mean response tables for each feature requested.
 #' @examples
 #' \donttest{
@@ -3231,7 +3231,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
 
   if(plot) lapply(pps, pp.plot)
   
-  if(!is.null(save_to)){
+  if(plot && !is.null(save_to)){
     lapply(pps, pp.plot.save)
   }
   

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3077,6 +3077,9 @@ h2o.cross_validation_predictions <- function(object) {
 #' @param user_splits A two-level nested list containing user defined split points for pdp plots for each column.
 #' If there are two columns using user defined split points, there should be two lists in the nested list.
 #' Inside each list, the first element is the column name followed by values defined by the user.
+#' @param save_to Fully qualified prefix of the image files the resulting plots should be saved to, e.g. '/home/user/pdp'.
+#'  Plots for each feature are saved separately in PNG format, each file receives a suffix equal to the corresponding feature name, e.g. `/home/user/pdp_AGE.png`.
+#'  If the files already exists, they will be overridden.
 #' @return Plot and list of calculated mean response tables for each feature requested.
 #' @examples
 #' \donttest{
@@ -3096,7 +3099,8 @@ h2o.cross_validation_predictions <- function(object) {
 #' }
 #' @export
 
-h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot = TRUE, plot_stddev = TRUE, weight_column=-1, include_na=FALSE, user_splits=NULL) {
+h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot = TRUE, plot_stddev = TRUE,
+                            weight_column=-1, include_na=FALSE, user_splits=NULL, save_to=NULL) {
   if(!is(object, "H2OModel")) stop("object must be an H2Omodel")
   if( is(object, "H2OMultinomialModel")) stop("object must be a regression model or binary classfier")
   if( is(object, "H2OOrdinalModel")) stop("object must be a regression model or binary classfier")
@@ -3208,6 +3212,14 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
         lines(pp[,1], upper, col = "blue", lty = 2) 
       } else {
         plot(pp[,1:2], type = "l", main = attr(x,"description") )
+      }
+      if(!is.null(save_to)){
+        # If user accidentally provides one of the most common suffixes in R, it is removed.
+        save_to <- gsub(replacement = "",pattern = "(\\.png)|(\\.jpg)|(\\.pdf)", x = save_to)
+        destination_file <- paste0(save_to,"_",names(pp)[1],'.png')
+        dev.copy(png, destination_file)
+        dev.off()
+        
       }
     } else {
       print("Partial Dependence not calculated--make sure nbins is as high as the level count")

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3081,7 +3081,7 @@ h2o.cross_validation_predictions <- function(object) {
 #' Inside each list, the first element is the column name followed by values defined by the user.
 #' @param save_to Fully qualified prefix of the image files the resulting plots should be saved to, e.g. '/home/user/pdp'.
 #'  Plots for each feature are saved separately in PNG format, each file receives a suffix equal to the corresponding feature name, e.g. `/home/user/pdp_AGE.png`.
-#'  If the files already exists, they will be overridden. Files are only saves if plot argument is set to True.
+#'  If the files already exists, they will be overridden.
 #' @return Plot and list of calculated mean response tables for each feature requested.
 #' @examples
 #' \donttest{
@@ -3215,20 +3215,26 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
       } else {
         plot(pp[,1:2], type = "l", main = attr(x,"description") )
       }
-      if(!is.null(save_to)){
-        # If user accidentally provides one of the most common suffixes in R, it is removed.
-        save_to <- gsub(replacement = "",pattern = "(\\.png)|(\\.jpg)|(\\.pdf)", x = save_to)
-        destination_file <- paste0(save_to,"_",names(pp)[1],'.png')
-        dev.copy(png, destination_file)
-        dev.off()
-        
-      }
     } else {
       print("Partial Dependence not calculated--make sure nbins is as high as the level count")
     }
   }
+  
+  pp.plot.save <- function(pp) {
+    # If user accidentally provides one of the most common suffixes in R, it is removed.
+    save_to <- gsub(replacement = "",pattern = "(\\.png)|(\\.jpg)|(\\.pdf)", x = save_to)
+    destination_file <- paste0(save_to,"_",names(pp)[1],'.png')
+    png(destination_file)
+    pp.plot(pp)
+    dev.off()
+  }
 
   if(plot) lapply(pps, pp.plot)
+  
+  if(!is.null(save_to)){
+    lapply(pps, pp.plot.save)
+  }
+  
   if(length( pps) == 1) {
     return(pps[[1]])
   } else {

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2,6 +2,8 @@
 #' H2O Model Related Functions
 #'
 #' @importFrom graphics strwidth par legend polygon
+#' @importFrom grDevices dev.copy dev.off png
+
 NULL
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6122.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6122.R
@@ -14,8 +14,8 @@ test.pdp.save <- function() {
     
     check_file <- function(feature){
       filepath <- paste0(temp_filename_no_extension,'_',feature,'.png')
-      print(filepath)
       expect_true(file.size(filepath) > 0)
+      unlink(filepath)
     }
     
     lapply(cols, check_file)

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6122.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6122.R
@@ -1,0 +1,24 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.pdp.save <- function() {
+    data <- h2o.importFile(path = locate('smalldata/prostate/prostate_cat_NA.csv'))
+    cols <- c("AGE","RACE","DCAPS")
+    model <- h2o.gbm(x=cols, y = "CAPSULE", training_frame = data)
+    
+    temp_filename_no_extension <- tempfile(pattern = "pdp", tmpdir = tempdir(), fileext = "")
+    plot <- h2o.partialPlot(object = model, data = data, save_to = temp_filename_no_extension)
+    expect_false(is.null(plot))
+    
+    check_file <- function(feature){
+      filepath <- paste0(temp_filename_no_extension,'_',feature,'.png')
+      print(filepath)
+      expect_true(file.size(filepath) > 0)
+    }
+    
+    lapply(cols, check_file)
+}
+
+doTest("Saving partial plot", test.pdp.save)


### PR DESCRIPTION
### About
[PUBDEV-6122](https://0xdata.atlassian.net/browse/PUBDEV-6122)
[SUPPORT PORTAL Ticket #93297](https://support.h2o.ai/helpdesk/tickets/93297)
### Python
- I rather chose to modify a current test (almost zero slowdown of test pipeline) that constructs PDPs anyway.
- Existing files are overwritten
- PNG output format (unified with R).

Example call:
```python
pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True, save_to_file="/home/pavel/pdps.png")
```

### R 
- Saves each plot to a separate file. Automatically adds posfix `${FEATURE_NAME}.png`, where `${FEATURE_NAME}` is obviously name of the feature the plot corresponds to. For `n` plots being generated in R, there are `n` files created.
- Plots can still be seen in R, `dev.copy()` is used.
- Existing files are overwritten
- PNG format (unified with Python)
- Test from scratch, uses temp files

Example call:

```R
    plot <- h2o.partialPlot(object = model, data = data, save_to = "/home/pavel/pdp")
```

If the user accidentally uses any of the following prefixes: [png,jpg,pdf], then those are automatically removed.

```R
    plot <- h2o.partialPlot(object = model, data = data, save_to = "/home/pavel/pdp.pdf)
```

Both calls would end in three files created on filesystem:

```plain
/home/pavel/pdp_AGE.png
/home/pavel/pdp_RACE.png
/home/pavel/pdp_DCAPS.png
```

Passing an empty string to `save_to` argument saves just the feature name with `.png` suffix in current workspace, e.g. `/home/pavel/RStudio/_AGE.png`