### PR TITLE
PUBDEV-6091 - expose timestamp in Python & R API (#3112)

### DIFF
--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -257,6 +257,9 @@ class H2OEstimator(ModelBase):
         m._metrics_class = metrics_class
         m._parms = self._parms
         m._estimator_type = self._estimator_type
+        m._start_time = model_json.get('output', {}).get('start_time', None)
+        m._end_time = model_json.get('output', {}).get('end_time', None)
+        m._run_time = model_json.get('output', {}).get('run_time', None)
 
         if model_id is not None and model_json is not None and metrics_class is not None:
             # build Metric objects out of each metrics

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -34,6 +34,9 @@ class ModelBase(backwards_compatible()):
         self._job = None  # used when _future is True
         self._have_pojo = False
         self._have_mojo = False
+        self._start_time = None
+        self._end_time = None
+        self._run_time = None
 
 
     @property
@@ -107,6 +110,21 @@ class ModelBase(backwards_compatible()):
     def have_mojo(self):
         """True, if export to MOJO is possible"""
         return self._have_mojo
+
+    @property
+    def start_time(self):
+        """Timestamp (milliseconds since 1970) when the model training was started."""
+        return self._start_time
+
+    @property
+    def end_time(self):
+        """Timestamp (milliseconds since 1970) when the model training was ended."""
+        return self._end_time
+
+    @property
+    def run_time(self):
+        """Model training time in milliseconds"""
+        return self._run_time
 
 
     def __repr__(self):

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5829_pubdev_6091_get_model_timestamp.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5829_pubdev_6091_get_model_timestamp.py
@@ -7,14 +7,10 @@ import numpy as np
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 
 
-def test_api_returns_the_same_timestamp():
+def test_api_timestamp():
     prostate_train = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate_train.csv"))
 
-    #Log.info("Converting CAPSULE and RACE columns to factors...\n")
     prostate_train["CAPSULE"] = prostate_train["CAPSULE"].asfactor()
-
-    # Import prostate_train.csv as numpy array for scikit comparison
-    trainData = np.loadtxt(pyunit_utils.locate("smalldata/logreg/prostate_train.csv"), delimiter=',', skiprows=1)
 
     ntrees = 1
     learning_rate = 0.1
@@ -33,7 +29,13 @@ def test_api_returns_the_same_timestamp():
     models = h2o.api("GET /3/Models")
     assert model._model_json['timestamp'] == models["models"][0]["timestamp"], "Timestamp should be the same."
 
+    assert gbm_h2o.start_time is not None and gbm_h2o.start_time > 0
+    assert gbm_h2o.end_time is not None and gbm_h2o.end_time > 0
+    assert gbm_h2o.run_time is not None and gbm_h2o.run_time > 0
+
+    assert gbm_h2o.end_time - gbm_h2o.start_time == gbm_h2o.run_time
+
 if __name__ == "__main__":
-    pyunit_utils.standalone_test(test_api_returns_the_same_timestamp)
+    pyunit_utils.standalone_test(test_api_timestamp)
 else:
-    test_api_returns_the_same_timestamp()
+    test_api_timestamp()


### PR DESCRIPTION
* PUBDEV-6091: expose timestamp of a model

* Reverted R API timestamp exposure

* Model training start time, end time and resulting runtime exposed in Python as in R API

(cherry picked from commit cf1e23e0b1b04def9fcfb80edb4adce9bbbd1003)