### PR TITLE
PUBDEV-6154: Add CDH 6.0 and 6.1 to list of supported Hadoop versions…

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -417,6 +417,8 @@ Supported Versions
 -  CDH 5.10
 -  CDH 5.13
 -  CDH 5.14
+-  CDH 6.0
+-  CDH 6.1
 -  HDP 2.2
 -  HDP 2.3
 -  HDP 2.4


### PR DESCRIPTION
… - DO NOT MERGE

Do not merge until PUBDEV-6153 is resolved.