### PR TITLE
PUBDEV-6048: New stopping_metric options

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -77,6 +77,8 @@ Optional Miscellaneous Parameters
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
+    - ``custom``
+    - ``custom_increasing``
 
 - `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping criterion to stop a grid search and the training of individual models within the AutoML run. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the non-NA-rate.  In that case, the value is computed as 1/sqrt(nrows * non-NA-rate).
 

--- a/h2o-docs/src/product/data-science/algo-params/stopping_metric.rst
+++ b/h2o-docs/src/product/data-science/algo-params/stopping_metric.rst
@@ -30,6 +30,8 @@ Available options for ``stopping_metric`` include the following:
 - ``lift_top_group``
 - ``misclassification``
 - ``mean_per_class_error``
+- ``custom`` (for custom metric functions where "less is better". It is expected that the lower bound is 0.)
+- ``custom_increasing`` (for custom metric functions where "more is better")
 
 **Note**: ``stopping_rounds`` must be enabled for ``stopping_metric`` or ``stopping_tolerance`` to work.
 
@@ -123,3 +125,34 @@ Example
 	# print the auc for the validation data
 	airlines_gbm.auc(valid=True)
 
+	# Example using a custom metric
+	# Create a custom RMSE Model metric and save as mm_rmse.py
+	# Note that this references a java class java.lang.Math
+	class CustomRmseFunc:
+	def map(self, pred, act, w, o, model):
+	    idx = int(act[0])
+	    err = 1 - pred[idx + 1] if idx + 1 < len(pred) else 1
+	    return [err * err, 1]
+
+	def reduce(self, l, r):
+	    return [l[0] + r[0], l[1] + r[1]]
+
+	def metric(self, l):
+	    # Use Java API directly
+	    import java.lang.Math as math
+	    return math.sqrt(l[0] / l[1])
+
+	# Upload the custom metric
+	custom_mm_func = h2o.upload_custom_metric(CustomRmseFunc, 
+	                                          func_name="rmse", 
+	                                          func_file="mm_rmse.py")
+
+	# Train the model
+	model = H2OGradientBoostingEstimator(ntrees=3, 
+	                                     max_depth=5,
+	                                     score_each_iteration=True,
+	                                     custom_metric_func=custom_mm_func,
+	                                     stopping_metric="custom",
+	                                     stopping_tolerance=0.1,
+	                                     stopping_rounds=3)
+	model.train(x=predictors, y=response, training_frame train, validation_frame = valid)

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -199,7 +199,9 @@ H2O Deep Learning models have many input parameters, many of which are only acce
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
-
+    - ``custom``
+    - ``custom_increasing``
+    
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less
    than this value.

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -159,7 +159,9 @@ Defining a DRF Model
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
-
+    - ``custom``
+    - ``custom_increasing``
+    
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less
    than this value.

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -206,6 +206,8 @@ Defining a GBM Model
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
+    - ``custom``
+    - ``custom_increasing``
 
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less

--- a/h2o-docs/src/product/data-science/xgboost.rst
+++ b/h2o-docs/src/product/data-science/xgboost.rst
@@ -75,6 +75,8 @@ Defining an XGBoost Model
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
+    - ``custom``
+    - ``custom_increasing``
 
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the metric-based stopping to stop training if the improvement is less than this value. This value defaults to 0.001.
 

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -829,6 +829,8 @@ The available options vary depending on the selected model. If an option is only
     - lift_top_group
     - misclassification
     - mean_per_class_error
+    - custom
+    - custom_increasing
 
 -  **stopping_rounds**: (GBM, DRF, DL, XGBoost, AutoML) Stops training when the option selected for **stopping_metric** doesn’t improve for the specified number of training rounds, based on a simple moving average. To disable this feature, specify 0. The metric is computed on the validation data (if provided); otherwise, training data is used.
 


### PR DESCRIPTION
- Added "custom" and "custom_increasing" to list of stopping_metric options in all supported algorithm sections and in flow.
- Added a Python example showing how to use this in the stopping_metric parameter appendix entry.