### PR TITLE
Doc update for custom metric in stopping_metric

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -77,8 +77,6 @@ Optional Miscellaneous Parameters
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
-    - ``custom``
-    - ``custom_increasing``
 
 - `stopping_tolerance <data-science/algo-params/stopping_tolerance.html>`__: This option specifies the relative tolerance for the metric-based stopping criterion to stop a grid search and the training of individual models within the AutoML run. This value defaults to 0.001 if the dataset is at least 1 million rows; otherwise it defaults to a bigger value determined by the size of the dataset and the non-NA-rate.  In that case, the value is computed as 1/sqrt(nrows * non-NA-rate).
 

--- a/h2o-docs/src/product/data-science/algo-params/stopping_metric.rst
+++ b/h2o-docs/src/product/data-science/algo-params/stopping_metric.rst
@@ -30,8 +30,8 @@ Available options for ``stopping_metric`` include the following:
 - ``lift_top_group``
 - ``misclassification``
 - ``mean_per_class_error``
-- ``custom`` (for custom metric functions where "less is better". It is expected that the lower bound is 0.)
-- ``custom_increasing`` (for custom metric functions where "more is better")
+- ``custom`` (for custom metric functions where "less is better". It is expected that the lower bound is 0.) Note that this is currently only supported in GBM and DRF. 
+- ``custom_increasing`` (for custom metric functions where "more is better".) Note that this is currently only supported in GBM and DRF. 
 
 **Note**: ``stopping_rounds`` must be enabled for ``stopping_metric`` or ``stopping_tolerance`` to work.
 

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -199,8 +199,6 @@ H2O Deep Learning models have many input parameters, many of which are only acce
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
-    - ``custom``
-    - ``custom_increasing``
     
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the
    metric-based stopping to stop training if the improvement is less

--- a/h2o-docs/src/product/data-science/xgboost.rst
+++ b/h2o-docs/src/product/data-science/xgboost.rst
@@ -75,8 +75,6 @@ Defining an XGBoost Model
     - ``lift_top_group``
     - ``misclassification``
     - ``mean_per_class_error``
-    - ``custom``
-    - ``custom_increasing``
 
 -  `stopping_tolerance <algo-params/stopping_tolerance.html>`__: Specify the relative tolerance for the metric-based stopping to stop training if the improvement is less than this value. This value defaults to 0.001.
 


### PR DESCRIPTION
The new custom and custom_increasing options can currently only be used in GBM and DRF.