### PR TITLE
PUBDEV-6167 XGBoost stress test timeout

### DIFF
--- a/h2o-py/tests/testdir_algos/xgboost/stress/pyunit_xgboost_airlines_stress.py
+++ b/h2o-py/tests/testdir_algos/xgboost/stress/pyunit_xgboost_airlines_stress.py
@@ -1,4 +1,5 @@
 import h2o
+from timeit import default_timer as timer
 from h2o.estimators import H2OXGBoostEstimator
 
 
@@ -7,12 +8,17 @@ from tests import pyunit_utils
 # Create many small models
 def models_stress_test():
     data = h2o.import_file(pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
-
-    for i in range(0,1000):
+    # Ulimit of stress tests should be set low enough, e.g. 100, in case of file descriptors leaks, this test should fail.
+    num_models = 1000 
+    start = timer()
+    
+    for i in range(0,num_models):
         xgb = H2OXGBoostEstimator(ntrees = 1, max_depth= 2)
         xgb.train(x = ["Origin","Distance"],y="IsDepDelayed", training_frame=data)
         h2o.remove(xgb)
 
+    end = timer()
+    print ('Trained {} models in {} seconds.'.format(num_models, end - start))
 if __name__ == "__main__":
     pyunit_utils.standalone_test(models_stress_test)
 else:

--- a/h2o-py/tests/testdir_algos/xgboost/stress/pyunit_xgboost_airlines_stress.py
+++ b/h2o-py/tests/testdir_algos/xgboost/stress/pyunit_xgboost_airlines_stress.py
@@ -11,6 +11,7 @@ def models_stress_test():
     for i in range(0,1000):
         xgb = H2OXGBoostEstimator(ntrees = 1, max_depth= 2)
         xgb.train(x = ["Origin","Distance"],y="IsDepDelayed", training_frame=data)
+        h2o.remove(xgb)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(models_stress_test)

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -320,7 +320,7 @@ def call(final pipelineContext) {
       timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [ // These run with reduced number of file descriptors for early detection of FD leaks
-      stageName: 'XGBoost Stress tests', target: 'test-pyunit-xgboost-stress', pythonVersion: '3.5', timeoutValue: 20,
+      stageName: 'XGBoost Stress tests', target: 'test-pyunit-xgboost-stress', pythonVersion: '3.5', timeoutValue: 40,
       component: pipelineContext.getBuildConfig().COMPONENT_PY, customDockerArgs: [ '--ulimit nofile=100:100' ]
     ]
   ]


### PR DESCRIPTION
## Description
[JIRA PUBDEV-6167](https://0xdata.atlassian.net/browse/PUBDEV-6167)

XGBoost stress tests have a time limit of 20 minutes, then those tests are terminated. Sometimes, the environment is slow to start. The stress tests (currently 1 stress test) otherwise take approx. 220 second to complete on a single local node.

There is a cloud of 5 nodes used to stress test XGBoost integration, with a limit of file descriptors to 100. The reason for current stress test is resource leaks detection.

This battery of tests (1 stress test in reality) has limited file descriptor resources.

```groovy
    [ // These run with reduced number of file descriptors for early detection of FD leaks
      stageName: 'XGBoost Stress tests', target: 'test-pyunit-xgboost-stress', pythonVersion: '3.5', timeoutValue: 40,
      component: pipelineContext.getBuildConfig().COMPONENT_PY, customDockerArgs: [ '--ulimit nofile=100:100' ]
    ]
```

## Resolution
1. Increased test timeout to 40 minutes (first commit)
1. Explicitly remove model - should not affect resource leaks at all (cleanup ASAP, second commit).
1. Add time measurement to the XGBoost stress test to compare performance among runs.
