### PR TITLE
[PUBDEV-6166] In External Backend, we need to explicitly pass timestamp from the Spark Driver node (#3194)

### DIFF
--- a/h2o-core/src/main/java/water/ExternalFrameUtils.java
+++ b/h2o-core/src/main/java/water/ExternalFrameUtils.java
@@ -43,16 +43,17 @@ public class ExternalFrameUtils {
 
     /**
      * Get connection to a specific h2o node. The caller of this method is usually non-H2O node who wants to read H2O
-     * frames or write to H2O frames from non-H2O environment, such as Spark executor.
+     * frames or write to H2O frames from non-H2O environment, such as Spark executor. 
+     * This node usually does not have H2O running.
      */
-    public static ByteChannel getConnection(String h2oNodeHostname, int h2oNodeApiPort) throws IOException{
+    public static ByteChannel getConnection(String h2oNodeHostname, int h2oNodeApiPort, short nodeTimeStamp) throws IOException{
         SocketChannelFactory socketFactory = SocketChannelFactory.instance(H2OSecurityManager.instance());
-        return H2ONode.openChan(TCPReceiverThread.TCP_EXTERNAL, socketFactory, h2oNodeHostname, h2oNodeApiPort +1);
+        return H2ONode.openChan(TCPReceiverThread.TCP_EXTERNAL, socketFactory, h2oNodeHostname, h2oNodeApiPort +1, nodeTimeStamp);
     }
 
-    public static ByteChannel getConnection(String ipPort) throws IOException{
+    public static ByteChannel getConnection(String ipPort, short nodeTimeStamp) throws IOException{
         String[] split = ipPort.split(":");
-        return getConnection(split[0], Integer.parseInt(split[1]));
+        return getConnection(split[0], Integer.parseInt(split[1]), nodeTimeStamp);
     }
 
     public static byte[] vecTypesFromExpectedTypes(byte[] expectedTypes, int[] vecElemSizes){

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -398,11 +398,17 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
    *   TCPReceiverThread.TCP_SMALL, TCPReceiverThread.TCP_BIG or
    *   TCPReceiverThread.TCP_EXTERNAL.
    *
+   * In case of TCPReceiverThread.TCP_EXTERNAL, we need to keep in mind that this method is executed in environment
+   * where H2O is not running, but it is just on the classpath so users can establish connection with the external H2O
+   * cluster.
+   * 
    * If socket channel factory is set, the communication will considered to be secured - this depends on the
    * configuration of the {@link SocketChannelFactory}. In case of the factory is null, the communication won't be secured.
    * @return new socket channel
    */
-  public static ByteChannel openChan(byte tcpType, SocketChannelFactory socketFactory, InetAddress originAddr, int originPort ) throws IOException {
+  public static ByteChannel openChan(byte tcpType, SocketChannelFactory socketFactory, InetAddress originAddr, int originPort, short nodeTimeStamp) throws IOException {
+    // This method can't internally use static fields which depends on initialized H2O cluster in case of 
+    //communication to the external H2O cluster
     // Must make a fresh socket
     SocketChannel sock = SocketChannel.open();
     sock.socket().setReuseAddress(true);
@@ -414,7 +420,10 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert !sock.isConnectionPending() && sock.isBlocking() && sock.isConnected() && sock.isOpen();
     sock.socket().setTcpNoDelay(true);
     ByteBuffer bb = ByteBuffer.allocate(6).order(ByteOrder.nativeOrder());
-    bb.put(tcpType).putShort(H2O.SELF._timestamp).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
+    // In Case of tcpType == TCPReceiverThread.TCP_EXTERNAL, H2O.H2O_PORT is 0 as it is undefined, because
+    // H2O cluster is not running in this case. However,
+    // it is fine as the receiver of the external backend does not use this value.
+    bb.put(tcpType).putShort(nodeTimeStamp).putChar((char)H2O.H2O_PORT).put((byte) 0xef).flip();
 
     ByteChannel wrappedSocket = socketFactory.clientChannel(sock, isa.getHostName(), isa.getPort());
 
@@ -424,8 +433,8 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     return wrappedSocket;
   }
 
-  public static ByteChannel openChan(byte tcpType, SocketChannelFactory socketFactory, String originAddr, int originPort) throws IOException {
-    return openChan(tcpType, socketFactory, InetAddress.getByName(originAddr), originPort);
+  public static ByteChannel openChan(byte tcpType, SocketChannelFactory socketFactory, String originAddr, int originPort, short nodeTimeStamp) throws IOException {
+    return openChan(tcpType, socketFactory, InetAddress.getByName(originAddr), originPort, nodeTimeStamp);
   }
 
   // Private thread serving (actually ships the bytes over) small msg Q.
@@ -528,7 +537,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
 
     // Open channel on first write attempt
     private ByteChannel openChan() throws IOException {
-      return H2ONode.openChan(TCPReceiverThread.TCP_SMALL, _socketFactory, _key.getAddress(), _key.getPort());
+      return H2ONode.openChan(TCPReceiverThread.TCP_SMALL, _socketFactory, _key.getAddress(), _key.getPort(), H2O.SELF._timestamp);
     }
   }
 

--- a/h2o-core/src/test/java/water/ExternalFrameReaderClientTest.java
+++ b/h2o-core/src/test/java/water/ExternalFrameReaderClientTest.java
@@ -60,7 +60,7 @@ public class ExternalFrameReaderClientTest extends TestUtil{
                     @Override
                     public void run() {
                         try {
-                            ByteChannel sock = ExternalFrameUtils.getConnection(nodes[currentChunkIdx % nodes.length]);
+                            ByteChannel sock = ExternalFrameUtils.getConnection(nodes[currentChunkIdx % nodes.length], H2O.SELF._timestamp);
                             ExternalFrameReaderClient reader = new ExternalFrameReaderClient(sock, frameName, currentChunkIdx, selectedColumnIndices, expectedTypes);
 
                             int rowsRead = 0;

--- a/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
+++ b/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
@@ -312,7 +312,7 @@ public class ExternalFrameWriterClientTest extends TestUtil {
                 @Override
                 public void run() {
                     try {
-                        ByteChannel sock = ExternalFrameUtils.getConnection(writeEndpoints[currentIndex]);
+                        ByteChannel sock = ExternalFrameUtils.getConnection(writeEndpoints[currentIndex], H2O.SELF._timestamp);
                         try {
                             ExternalFrameWriterClient writer = new ExternalFrameWriterClient(sock);
                             writer.createChunks(op.frameName(), op.colTypes(),  currentIndex, op.nrows(), op.maxVecSizes());


### PR DESCRIPTION
(cherry picked from commit 8fed43772bdec8ee039bf2ca4b4fd45f4ace3903)