### PR TITLE
PUBDEV-6165 Docs: Add support for HDP 3.0 and 3.1

### DIFF
--- a/h2o-docs/src/product/downloading.rst
+++ b/h2o-docs/src/product/downloading.rst
@@ -15,8 +15,8 @@ Download and Run
   ::
 
 	cd ~/Downloads
-	unzip h2o-3.20.0.1.zip
-	cd h2o-3.20.0.1
+	unzip h2o-3.22.1.2.zip
+	cd h2o-3.22.1.2
 	java -jar h2o.jar
 
 3. Point your browser to http://localhost:54321.
@@ -114,7 +114,7 @@ Open a terminal window and run the following command to install H2O on the Anaco
       
    ::
 
-     user$ conda install -c h2oai h2o=3.20.0.1
+     user$ conda install -c h2oai h2o=3.22.1.2
 
 **Note**: For Python 3.6 users, H2O has ``tabulate>=0.75`` as a dependency; however, there is no ``tabulate`` available in the default channels for Python 3.6. This is available in the conda-forge channel. As a result, Python 3.6 users must add the ``conda-forge`` channel in order to load the latest version of H2O. This can be done by performing the following steps:
 
@@ -132,12 +132,12 @@ Install on Hadoop
 
 1. Go to `http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html <http://h2o-release.s3.amazonaws.com/h2o/latest_stable.html>`__. Click on the **Install on Hadoop** tab, and download H2O for your version of Hadoop. This is a zip file that contains everything you need to get started.
 
-2. Unpack the zip file and launch a 6g instance of H2O. The example below describes how to unpack version 3.20.0.1. Replace this version with the version that you downloaded.
+2. Unpack the zip file and launch a 6g instance of H2O. The example below describes how to unpack version 3.22.1.2. Replace this version with the version that you downloaded.
 
  ::
 
-	unzip h2o-3.20.0.1-*.zip
-	cd h2o-3.20.0.1-*
+	unzip h2o-3.22.1.2-*.zip
+	cd h2o-3.22.1.2-*
 	hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g
 
 3. Point your browser to H2O. (See "Open H2O Flow in your web browser" in the output below.)

--- a/h2o-docs/src/product/starting-h2o.rst
+++ b/h2o-docs/src/product/starting-h2o.rst
@@ -58,7 +58,7 @@ Example
 
   R is connected to the H2O cluster: 
       H2O cluster uptime:         2 seconds 812 milliseconds 
-      H2O cluster version:        3.20.0.1 
+      H2O cluster version:        3.22.1.2 
       H2O cluster version age:    9 days  
       H2O cluster name:           H2O_started_from_R_techwriter_awt197 
       H2O cluster total nodes:    1 
@@ -115,7 +115,7 @@ Example
   Connecting to H2O server at http://127.0.0.1:54323... successful.
   --------------------------  ---------------------------------
   H2O cluster uptime:         02 secs
-  H2O cluster version:        3.20.0.1
+  H2O cluster version:        3.22.1.2
   H2O cluster version age:    9 days
   H2O cluster name:           H2O_from_python_techwriter_pu6lbs
   H2O cluster total nodes:    1

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -424,6 +424,8 @@ Supported Versions
 -  HDP 2.4
 -  HDP 2.5
 -  HDP 2.6
+-  HDP 3.0
+-  HDP 3.1
 -  MapR 4.0
 -  MapR 5.0
 -  MapR 5.1


### PR DESCRIPTION
driveby fixes: updated H2O version in examples to be 3.22.1.2.