### PR TITLE
ITA-362: move test lookups into Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ h2o-docs/src/booklets/source/PythonBooklet.tui
 *.gz(busy)
 
 h2o-web/package-lock.json
+
+h2o-*/tests/.lookup.txt

--- a/docker/scripts/build-h2o-3
+++ b/docker/scripts/build-h2o-3
@@ -23,7 +23,7 @@ cd h2o-3
 git checkout ${H2O_BRANCH}
 
 echo '###### Build H2O-3 ######'
-printenv
+printenv | sort
 make -f scripts/jenkins/Makefile.jenkins warmup-caches
 
 echo '###### Cleanup ######'

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -25,21 +25,36 @@ warmup-caches:
 	./gradlew cpLibs $$ADDITIONAL_GRADLE_OPTS
 
 test-package-py:
-	cd h2o-py/tests/ && rm -f -r testdir_hdfs
 	zip -q -r test-package-py.zip h2o-py/tests/ h2o-py/demos/ \
 	h2o-docs/src/booklets/v2_2015/source h2o-py/build/dist/*.whl \
 	h2o-genmodel/build/libs/h2o-genmodel.jar h2o-assemblies/genmodel/build/libs/genmodel.jar scripts/run.py \
 	$(JENKINS_MAKEFILE_PATH) tests/pyunit*List h2o-py/scripts/h2o-py-test-setup.py
 
 test-package-r:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
 	zip -q -r test-package-r.zip h2o-r h2o-docs/src/booklets/v2_2015/source \
 		h2o-assemblies/genmodel/build/libs/genmodel.jar scripts/run.py \
 		$(JENKINS_MAKEFILE_PATH) tests/runitSmokeTestList tests/runitAutoMLList \
 		scripts/validate_r_cmd_check_output.R scripts/validate_r_cmd_check_output.py h2o-3-DESCRIPTION
 
+init-lookup:
+	rm -f h2o-{r,py}/tests/.lookup.txt
+
+lookup-automl-tests: init-lookup
+	mkdir -p h2o-{r,py}/tests
+	find h2o-r/tests -name '*automl*.R' -exec basename {} \; >>h2o-r/tests/.lookup.txt
+	find h2o-py/tests -name '*automl*.py' -exec basename {} \; >>h2o-py/tests/.lookup.txt
+
+lookup-hdfs-tests: init-lookup
+	mkdir -p h2o-{r,py}/tests/testdir_hdfs
+	find h2o-r/tests/testdir_hdfs -name '*.R' -exec basename {} \; >>h2o-r/tests/.lookup.txt
+	find h2o-py/tests/testdir_hdfs -name '*.py' -exec basename {} \; >>h2o-py/tests/.lookup.txt
+
+lookup-demos-tests: init-lookup
+	mkdir -p h2o-{r,py}/tests/testdir_demos
+	find h2o-r/tests/testdir_demos -name '*.R' -exec basename {} \; >>h2o-r/tests/.lookup.txt
+	find h2o-py/tests/testdir_demos -name '*.py' -exec basename {} \; >>h2o-py/tests/.lookup.txt
+
 test-py-smoke:
-	cd h2o-py/tests/ && rm -f -r testdir_hdfs
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist ../../tests/pyunitSmokeTestList --numclouds 6 --jvm.xmx 3g
 
 test-py-init:
@@ -51,28 +66,23 @@ test-py-booklets:
 	cd h2o-docs/src/booklets/v2_2015/source && ../../../../../scripts/run.py --numclouds 1 --numnodes 3 --baseport 52524 --jvm.xmx 5g --test pybooklet.gbm.vignette.py
 	cd h2o-docs/src/booklets/v2_2015/source && ../../../../../scripts/run.py --numclouds 1 --numnodes 3 --baseport 53534 --jvm.xmx 5g --test pybooklet.glm.vignette.py
 
-test-pyunit-small:
-	cd h2o-py/tests/ && rm -f -r testdir_hdfs
-	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --numclouds 6 --jvm.xmx 3g --excludelist ../../tests/pyunitAutoMLList
+test-pyunit-small: lookup-hdfs-tests lookup-automl-tests
+	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --numclouds 6 --jvm.xmx 3g --excludelist .lookup.txt
 
 test-pyunit-single-node:
-	cd h2o-py/tests/ && rm -f -r testdir_hdfs
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --numclouds 1 --numnodes 1 --jvm.xmx 3g --testlist ../../tests/pyunitSingleNodeList
 
 test-pyunit-xgboost-stress:
-	cd h2o-py/tests/ && rm -f -r testdir_hdfs
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --numclouds 1 --numnodes 5 --jvm.xmx 3g --testlist ../../tests/pyunitXGBoostStressTestList
 
-test-pyunit-small-automl:
-	cd h2o-py/tests/ && rm -f -r testdir_hdfs
-	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --numclouds 6 --jvm.xmx 3g --testlist ../../tests/pyunitAutoMLList
+test-pyunit-small-automl: lookup-automl-tests
+	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --numclouds 6 --jvm.xmx 3g --testlist .lookup.txt
 
 test-py-demos:
 	export NO_GCE_CHECK=True && cd h2o-py/demos/ && ../../scripts/run.py --wipeall --numclouds 4 --baseport 56789 --jvm.xmx 10g
 
-test-pyunit-medium-large:
-	cd h2o-py/tests/ && rm -f -r testdir_hdfs
-	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize ml --numclouds 1 --numnodes 5 --jvm.xmx 15g
+test-pyunit-medium-large: lookup-hdfs-tests
+	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize ml --numclouds 1 --numnodes 5 --jvm.xmx 15g --excludelist .lookup.txt
 
 test-py-single-test:
 	@echo "test=$$SINGLE_TEST_PATH"
@@ -81,37 +91,27 @@ test-py-single-test:
 	export NO_GCE_CHECK=True && cd h2o-py/tests/ && ../../scripts/run.py --wipeall --geterrs --test $$SINGLE_TEST_PATH --numnodes $$SINGLE_TEST_NUM_NODES --jvm.xmx $$SINGLE_TEST_XMX
 
 test-r-smoke:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
 	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --geterrs --testlist ../../tests/runitSmokeTestList --numclouds 8 --jvm.xmx 3g
 
 test-r-init:
 	cd h2o-r/tests/testdir_jira && R -f h2o.init_test_HOQE-16.R
 
-test-r-small:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
-	cd h2o-r/tests/ && rm -f -r testdir_demos
-	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --geterrs --numclouds 4 --jvm.xmx 4g --excludelist ../../tests/runitAutoMLList
+test-r-small: lookup-automl-tests lookup-hdfs-tests lookup-demos-tests
+	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --geterrs --numclouds 4 --jvm.xmx 4g --excludelist .lookup.txt
 
-test-r-small-client-mode:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
-	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --client --testsize s --numclouds 4 --jvm.xmx 4g --excludelist ../../tests/runitAutoMLList
+test-r-small-client-mode: lookup-automl-tests lookup-hdfs-tests
+	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --client --testsize s --numclouds 4 --jvm.xmx 4g --excludelist .lookup.txt
 
-test-r-small-automl:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
-	cd h2o-r/tests/ && rm -f -r testdir_demos
-	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize s --geterrs --numclouds 4 --jvm.xmx 4g --testlist ../../tests/runitAutoMLList
+test-r-small-automl: lookup-automl-tests
+	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --testsize s --geterrs --numclouds 4 --jvm.xmx 4g --testlist .lookup.txt
 
-test-r-small-client-mode-automl:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
-	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --client --testsize s --numclouds 4 --jvm.xmx 4g --testlist ../../tests/runitAutoMLList
+test-r-small-client-mode-automl: lookup-automl-tests
+	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --client --testsize s --numclouds 4 --jvm.xmx 4g --testlist .lookup.txt
 
-test-r-medium-large:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
-	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize ml --numclouds 2 --numnodes 2 --jvm.xmx 20g
+test-r-medium-large: lookup-hdfs-tests
+	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --geterrs --testsize ml --numclouds 2 --numnodes 2 --jvm.xmx 20g --excludelist .lookup.txt
 
 test-r-datatable:
-	cd h2o-r/tests/ && rm -f -r testdir_hdfs
-	cd h2o-r/tests/ && rm -f -r testdir_demos
 	export NO_GCE_CHECK=True && cd h2o-r/tests/testdir_perf && ../../../scripts/run.py --wipeall --test runit_repeating_merge.R  --numclouds 1 --numnodes 2 --jvm.xmx 20g
 
 test-r-cmd-check:

--- a/scripts/jenkins/groovy/buildH2O3.groovy
+++ b/scripts/jenkins/groovy/buildH2O3.groovy
@@ -26,7 +26,6 @@ def call(final pipelineContext) {
                             makefilePath = pipelineContext.getBuildConfig().MAKEFILE_PATH
                             activatePythonEnv = true
                         }
-                        findAutoMLTests(pipelineContext, pipelineContext.getBuildConfig().COMPONENT_PY)
                         makeTarget(pipelineContext) {
                             target = 'test-package-py'
                             hasJUnit = false
@@ -34,7 +33,6 @@ def call(final pipelineContext) {
                             makefilePath = pipelineContext.getBuildConfig().MAKEFILE_PATH
                             activatePythonEnv = true
                         }
-                        findAutoMLTests(pipelineContext, pipelineContext.getBuildConfig().COMPONENT_R)
                         makeTarget(pipelineContext) {
                             target = 'test-package-r'
                             hasJUnit = false
@@ -106,20 +104,6 @@ def call(final pipelineContext) {
     } else {
         buildClosure()
     }
-}
-
-/**
- * Finds all AutoML tests for given component and writes them to "tests/${component}unitAutoMLList". Test is considered
- * AutoML-related, if its name contains *automl*.
- * @param pipelineContext
- * @param component component to find AutoML tests for
- */
-private def findAutoMLTests(final pipelineContext, final component) {
-    final def supportedComponents = [pipelineContext.getBuildConfig().COMPONENT_PY, pipelineContext.getBuildConfig().COMPONENT_R]
-    if (!supportedComponents.contains(component)) {
-        error "Component ${component} is not supported. Supported components are ${supportedComponents.join(', ')}"
-    }
-    sh "find h2o-3/h2o-${component}/tests -name '*automl*' -type f -exec basename {} \\; > h2o-3/tests/${component}unitAutoMLList"
 }
 
 return this

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -19,7 +19,7 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
         withCredentials([file(credentialsId: 'c096a055-bb45-4dac-ba5e-10e6e470f37e', variable: 'JUNIT_CORE_SITE_PATH'), [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS S3 Credentials', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
           docker.image(image).inside("--init --dns ${DEFAULT_DNS} -e AWS_ACCESS_KEY_ID=\${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=\${AWS_SECRET_ACCESS_KEY} -v /home/0xdiag:/home/0xdiag ${customArgs}") {
             sh 'id'
-            sh 'printenv'
+            sh 'printenv | sort'
             block()
           }
         }

--- a/scripts/jenkins/groovy/makeTarget.groovy
+++ b/scripts/jenkins/groovy/makeTarget.groovy
@@ -115,7 +115,7 @@ private void execMake(final String buildAction, final String h2o3dir) {
     unset CHANGE_AUTHOR_DISPLAY_NAME
     unset CHANGE_TITLE
 
-    printenv
+    printenv | sort
     ${buildAction}
   """
 }

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -20,7 +20,7 @@ try {
                 env.PYTHON_VERSION = '3.5'
                 env.R_VERSION = '3.4.1'
 
-                sh 'printenv'
+                sh 'printenv | sort'
 
                 final String CHECKOUT_STAGE_NAME = 'Checkout'
                 stage(CHECKOUT_STAGE_NAME) {


### PR DESCRIPTION
The goal is to maintain the same Makefile behavior in Jenkins and local execution.

This PR solves the problem for all affected targets - many R and python unit tests.
In addition to this, another problem is fixed: some exclusions were implemented by simply deleting certain tests from the filesystem, which is not such a problem on jenkins agents, but would be very dangerous when executed on developer's machine. Instead, cummulative exclussion is used now, see new helper targets `init-tests`, `lookup-*-tests` and usage of `.tests-*.txt` files.