### PR TITLE
PUBDEV-6198: Make sure H2ONode never loses a Sending Thread

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -1007,7 +1007,7 @@ public final class AutoBuffer {
    * @param senderPort port of the sender of the datagram
    */
   AutoBuffer putUdp(UDP.udp type, int senderPort){
-    return putUdp(type, senderPort, H2O.SELF._timestamp);
+    return putUdp(type, senderPort, H2O.SELF.getTimestamp());
   }
 
   AutoBuffer putUdp(UDP.udp type, int senderPort, short timestamp){
@@ -1037,7 +1037,7 @@ public final class AutoBuffer {
   AutoBuffer putTask(int ctrl, int tasknum) {
     assert _bb.position() == 0;
     putSp(_bb.position()+1+2+2+4);
-    _bb.put((byte)ctrl).putShort(H2O.SELF._timestamp).putChar((char)H2O.H2O_PORT).putInt(tasknum);
+    _bb.put((byte)ctrl).putShort(H2O.SELF.getTimestamp()).putChar((char)H2O.H2O_PORT).putInt(tasknum);
     return this;
   }
 

--- a/h2o-core/src/main/java/water/ClientDisconnectCheckThread.java
+++ b/h2o-core/src/main/java/water/ClientDisconnectCheckThread.java
@@ -1,7 +1,5 @@
 package water;
 
-import water.util.Log;
-
 class ClientDisconnectCheckThread extends Thread {
 
   public ClientDisconnectCheckThread() {
@@ -17,7 +15,7 @@ class ClientDisconnectCheckThread extends Thread {
    * This method checks whether the client is disconnected from this node due to some problem such as client or network
    * is unreachable.
    */
-  private void handleClientDisconnect(H2ONode client) {
+  static void handleClientDisconnect(H2ONode client) {
     if(client != H2O.SELF) {
       if (H2O.isFlatfileEnabled()) {
         H2O.removeNodeFromFlatfile(client);

--- a/h2o-core/src/main/java/water/ClientRandomDisconnectThread.java
+++ b/h2o-core/src/main/java/water/ClientRandomDisconnectThread.java
@@ -1,0 +1,41 @@
+package water;
+
+import water.util.Log;
+
+import java.util.Random;
+
+// Emulates Random Client disconnects
+public class ClientRandomDisconnectThread extends Thread {
+
+  public ClientRandomDisconnectThread() {
+    super("ClientRandomDisconnectThread");
+    setDaemon(true);
+  }
+
+  @Override
+  public void run() {
+    Log.warn("-----------------------------------------------------------");
+    Log.warn("| Random Client Disconnect Attack - for development only! |");
+    Log.warn("-----------------------------------------------------------");
+
+    try {
+      Thread.sleep(H2O.ARGS.clientDisconnectTimeout);
+    } catch (InterruptedException ignore) {}
+
+    Random r = new Random();
+    while (true) {
+      final int timeout = r.nextInt((int) H2O.ARGS.clientDisconnectTimeout / 10);
+      Log.warn("Random Attack: Clients will get killed in " + timeout + "ms.");
+      try {
+        Thread.sleep(timeout);
+      } catch (InterruptedException ignore) {}
+      for (H2ONode client: H2O.getClients()) {
+        if (client != H2O.SELF) {
+          Log.warn("Random Attack: Emulating client disconnect: " + client._key);
+          ClientDisconnectCheckThread.handleClientDisconnect(client);
+        }
+      }
+    }
+  }
+
+}

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2138,7 +2138,14 @@ final public class H2O {
     Log.info("Registered parsers: " + Arrays.toString(ParserService.INSTANCE.getAllProviderNames(true)));
 
     // Start thread checking client disconnections
-    new ClientDisconnectCheckThread().start();
+    if (Boolean.getBoolean(H2O.OptArgs.SYSTEM_PROP_PREFIX + "debug.clientDisconnectAttack")) {
+      // for development only!
+      Log.warn("Client Random Disconnect attack is enabled - use only for debugging! More warnings to follow ;)");
+      new ClientRandomDisconnectThread().start();
+    } else {
+      // regular mode of operation
+      new ClientDisconnectCheckThread().start();
+    }
 
     long time12 = System.currentTimeMillis();
     Log.debug("Timing within H2O.main():");

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -197,8 +197,6 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   }
 
   private void refreshClient(short timestamp) {
-    assert timestamp == 0 || H2O.decodeIsClient(timestamp); 
-
     boolean reconnected = _timestamp != 0 && timestamp != 0 && _timestamp != timestamp;
     if (reconnected) {
       Log.info("Client reconnected with a new timestamp=" + timestamp + ", old client: " + toDebugString());
@@ -214,12 +212,9 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   }
 
   boolean removeClient() {
-    assert _timestamp == 0 || H2O.decodeIsClient(_timestamp);
-
     Log.info("Removing client: " + toDebugString());
     boolean removed = !_removed_from_cloud;
     removeFromCloud();
-
     return removed;
   }
 

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -212,7 +212,8 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     assert _timestamp == 0 || H2O.decodeIsClient(_timestamp);
 
     Log.info("Removing client: " + toDebugString());
-    boolean removed = _sendThread != null;
+    boolean removed = !_removed_from_cloud;
+    _removed_from_cloud = true;
     stopSendThread();
 
     return removed;

--- a/h2o-core/src/main/java/water/MRTask.java
+++ b/h2o-core/src/main/java/water/MRTask.java
@@ -300,7 +300,7 @@ public abstract class MRTask<T extends MRTask<T>> extends DTask<T> implements Fo
   /** Compute a permissible node index on which to launch remote work. */
   private int addShift( int x ) { x += _nlo; int sz = H2O.CLOUD.size(); return x < sz ? x : x-sz; }
   private int subShift( int x ) { x -= _nlo; int sz = H2O.CLOUD.size(); return x <  0 ? x+sz : x; }
-  private short selfidx() { int idx = H2O.SELF.index(); if( idx>= 0 ) return (short)idx; assert H2O.SELF._client; return 0; }
+  private short selfidx() { int idx = H2O.SELF.index(); if( idx>= 0 ) return (short)idx; assert H2O.SELF.isClient(); return 0; }
 
   // Profiling support.  Time for each subpart of a single M/R task, plus any
   // nested MRTasks.  All numbers are CTM stamps or millisecond times.

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -161,7 +161,7 @@ public abstract class Paxos {
         for(H2ONode n: H2O.getFlatfile()){
           if(!n._heartbeat._client && !PROPOSED.containsKey(n._key)){
             Log.info("Flatile::" + n._key + " not active in this cloud. Removing it from the list.");
-            n.stopSendThread();
+            n.removeFromCloud();
           }
         }
       }

--- a/h2o-core/src/main/java/water/RPC.java
+++ b/h2o-core/src/main/java/water/RPC.java
@@ -385,10 +385,10 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
           _computedAndReplied = true;   // After the final handshake, set computed+replied bit
           break;                        // Break out of retry loop
         } catch( AutoBuffer.AutoBufferException e ) {
-          if( !_client._client ) // Report on servers only; clients allowed to be flaky
+          if( !_client.isClient() ) // Report on servers only; clients allowed to be flaky
             Log.info("IOException during ACK, "+e._ioe.getMessage()+", t#"+_tsknum+" AB="+ab+", waiting and retrying...");
           ab.drainClose();
-          if( _client._client ) // Dead client will not accept a TCP ACK response?
+          if( _client.isClient() ) // Dead client will not accept a TCP ACK response?
             this.CAS_DT(dt,null);          // cancel the ACK
           try { Thread.sleep(100); } catch (InterruptedException ignore) {}
         } catch( Throwable e ) { // Custom serializer just barfed?

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -294,7 +294,7 @@ public class TCPReceiverThread extends Thread {
     // Check cloud membership; stale ex-members are "fail-stop" - we mostly
     // ignore packets from them (except paxos packets).
     boolean is_member = cloud.contains(ab._h2o);
-    boolean is_client = ab._h2o._client;
+    boolean is_client = ab._h2o.isClient();
 
     // Some non-Paxos packet from a non-member.  Probably should record & complain.
     // Filter unknown-packet-reports.  In bad situations of poisoned Paxos

--- a/h2o-core/src/main/java/water/UDPClientEvent.java
+++ b/h2o-core/src/main/java/water/UDPClientEvent.java
@@ -29,8 +29,7 @@ public class UDPClientEvent extends UDP {
             Log.info("Client reported via broadcast message " + ce.clientNode + " from " + ab._h2o);
 
             // It is important to propagate Client's HeartBeat information to the rest of the nodes
-            H2ONode client = ce.clientNode;
-            client._heartbeat = ce.clientHeartBeat;
+            ce.clientNode.setHeartBeat(ce.clientHeartBeat);
 
             H2O.addNodeToFlatfile(ce.clientNode);
           }

--- a/h2o-core/src/main/java/water/UDPHeartbeat.java
+++ b/h2o-core/src/main/java/water/UDPHeartbeat.java
@@ -12,10 +12,12 @@ class UDPHeartbeat extends UDP {
       // Do not update self-heartbeat object
       // The self-heartbeat is the sole holder of racey cloud-concensus hashes
       // and if we update it here we risk dropping an update.
-      ab._h2o._heartbeat = new HeartBeat().read(ab);
-      if(ab._h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash){
+      HeartBeat hb = new HeartBeat().read(ab);
+      if (hb._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash) {
         return ab;
       }
+      assert ab._h2o != null;
+      ab._h2o.setHeartBeat(hb);
       Paxos.doHeartbeat(ab._h2o);
     }
     return ab;

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -331,7 +331,7 @@ public class NetworkInit {
       nodes.addAll(water.Paxos.PROPOSED.values());
       bb.mark();
       for( H2ONode h2o : nodes ) {
-        if(h2o.removedFromCloud()) {
+        if(h2o.isRemovedFromCloud()) {
           continue;
         }
         bb.reset();

--- a/h2o-core/src/main/java/water/init/NetworkInit.java
+++ b/h2o-core/src/main/java/water/init/NetworkInit.java
@@ -331,7 +331,7 @@ public class NetworkInit {
       nodes.addAll(water.Paxos.PROPOSED.values());
       bb.mark();
       for( H2ONode h2o : nodes ) {
-        if(h2o._removed_from_cloud) {
+        if(h2o.removedFromCloud()) {
           continue;
         }
         bb.reset();

--- a/h2o-core/src/main/java/water/util/JStackCollectorTask.java
+++ b/h2o-core/src/main/java/water/util/JStackCollectorTask.java
@@ -71,7 +71,7 @@ public class JStackCollectorTask extends MRTask<JStackCollectorTask> {
 
   @Override public void setupLocal() {
     _traces = new DStackTrace[H2O.CLOUD.size()];
-    if( H2O.SELF._client ) return; // Clients are not in the cloud, and do not get stack traces
+    if( H2O.SELF.isClient() ) return; // Clients are not in the cloud, and do not get stack traces
     Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
 
     // Known to be interesting

--- a/h2o-core/src/test/java/water/ClientJarMD5IgnoreTest.java
+++ b/h2o-core/src/test/java/water/ClientJarMD5IgnoreTest.java
@@ -1,5 +1,6 @@
 package water;
 
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -44,7 +45,17 @@ public class ClientJarMD5IgnoreTest extends TestUtil {
 
     byte[] received_hash= (byte[])client_wrong_md5.get(0)[0];
     assertArrayEquals(fake_hash, received_hash);
+  }
 
+  @After
+  public void waitForClientsDisconnect(){
+    try {
+      Thread.sleep(H2O.ARGS.clientDisconnectTimeout *2); // sleep double the time the timeout for client disconnect is reached
+      // to be somehow sure the client is gone
+
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
   }
 
 }

--- a/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
+++ b/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
@@ -1,8 +1,10 @@
 package water;
 
 import org.junit.*;
+import water.util.Log;
 
 import java.net.InetAddress;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -26,14 +28,14 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._cloud_name_hash = H2O.SELF._heartbeat._cloud_name_hash;
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
-
+    
     H2ONode node = H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
     node._heartbeat = hb;
-
+    
     assertSame(node, H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-101));
 
     // Verify number of clients
-    assertEquals(1, H2O.getClients().length);
+    assertEquals(1, getClients().length);
   }
 
   @Test
@@ -49,9 +51,9 @@ public class ClientReconnectSimulationTest extends TestUtil{
             ._heartbeat = hb;
 
     // Verify number of clients
-    assertEquals(1, H2O.getClients().length);
+    assertEquals(1, getClients().length);
     waitForClientsDisconnect();
-    assertEquals(0, H2O.getClients().length);
+    assertEquals(0, getClients().length);
   }
 
   @Test
@@ -69,7 +71,7 @@ public class ClientReconnectSimulationTest extends TestUtil{
             ._heartbeat = hb;
 
     // make sure H2O sees only one client node
-    assertEquals(1, H2O.getClients().length);
+    assertEquals(1, getClients().length);
 
     // second client from another node re-connects
     H2ONode
@@ -80,7 +82,13 @@ public class ClientReconnectSimulationTest extends TestUtil{
             ._heartbeat = hb;
 
     // we should see 2 clients nodes now
-    assertEquals(2, H2O.getClients().length);
+    assertEquals(2, getClients().length);
+  }
+
+  static H2ONode[] getClients() {
+    H2ONode[] clients = H2O.getClients();
+    Log.info("Current clients: " + Arrays.toString(clients));
+    return clients;
   }
 
   @After

--- a/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
+++ b/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
@@ -3,9 +3,9 @@ package water;
 import org.junit.*;
 
 import java.net.InetAddress;
-import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class ClientReconnectSimulationTest extends TestUtil{
 
@@ -19,7 +19,7 @@ public class ClientReconnectSimulationTest extends TestUtil{
   public void setupFakeAddress() throws Exception {
     FAKE_NODE_ADDRESS = InetAddress.getByAddress(new byte[]{(byte) 23, (byte) 185, (byte)0, (byte)4});
   }
-  
+
   @Test
   public void testClientReconnect() {
     HeartBeat hb = new HeartBeat();
@@ -27,10 +27,12 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
-    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-101);
+    H2ONode node = H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
+    node._heartbeat = hb;
+
+    assertSame(node, H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-101));
+
     // Verify number of clients
-    System.out.println(Arrays.toString(H2O.getClients()));
     assertEquals(1, H2O.getClients().length);
   }
 
@@ -42,11 +44,13 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
+    H2ONode
+            .intern(FAKE_NODE_ADDRESS, 65456, (short)-100)
+            ._heartbeat = hb;
+
     // Verify number of clients
     assertEquals(1, H2O.getClients().length);
     waitForClientsDisconnect();
-    System.out.println(Arrays.toString(H2O.getClients()));
     assertEquals(0, H2O.getClients().length);
   }
 
@@ -57,13 +61,25 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
-    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-101);
+    H2ONode
+            .intern(FAKE_NODE_ADDRESS, 65456, (short)-100)
+            ._heartbeat = hb;
+    H2ONode
+            .intern(FAKE_NODE_ADDRESS, 65456, (short)-101)
+            ._heartbeat = hb;
+
+    // make sure H2O sees only one client node
+    assertEquals(1, H2O.getClients().length);
 
     // second client from another node re-connects
-    H2ONode.intern(FAKE_NODE_ADDRESS, 65458, (short)-100);
-    H2ONode.intern(FAKE_NODE_ADDRESS, 65458, (short)-101);
-    // Verify number of clients
+    H2ONode
+            .intern(FAKE_NODE_ADDRESS, 65458, (short)-100)
+            ._heartbeat = hb;
+    H2ONode
+            .intern(FAKE_NODE_ADDRESS, 65458, (short)-101)
+            ._heartbeat = hb;
+
+    // we should see 2 clients nodes now
     assertEquals(2, H2O.getClients().length);
   }
 

--- a/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
+++ b/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
@@ -63,23 +63,19 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    H2ONode
-            .intern(FAKE_NODE_ADDRESS, 65456, (short)-100)
-            ._heartbeat = hb;
-    H2ONode
-            .intern(FAKE_NODE_ADDRESS, 65456, (short)-101)
-            ._heartbeat = hb;
+    H2ONode n1 = H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
+    n1._heartbeat = hb;
+    H2ONode n2 = H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-101);
+    assertSame(n1, n2);
 
     // make sure H2O sees only one client node
     assertEquals(1, getClients().length);
 
     // second client from another node re-connects
-    H2ONode
-            .intern(FAKE_NODE_ADDRESS, 65458, (short)-100)
-            ._heartbeat = hb;
-    H2ONode
-            .intern(FAKE_NODE_ADDRESS, 65458, (short)-101)
-            ._heartbeat = hb;
+    H2ONode n3 = H2ONode.intern(FAKE_NODE_ADDRESS, 65458, (short)-100);
+    n3._heartbeat = hb;
+    H2ONode n4 = H2ONode.intern(FAKE_NODE_ADDRESS, 65458, (short)-101);
+    assertSame(n3, n4);
 
     // we should see 2 clients nodes now
     assertEquals(2, getClients().length);

--- a/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
+++ b/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
@@ -1,16 +1,26 @@
 package water;
 
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+
+import java.net.InetAddress;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
+@Ignore
 public class ClientReconnectSimulationTest extends TestUtil{
+
+  private InetAddress FAKE_NODE_ADDRESS;
+
   @BeforeClass() public static void setup() {
     stall_till_cloudsize(1);
   }
 
+  @Before
+  public void setupFakeAddress() throws Exception {
+    FAKE_NODE_ADDRESS = InetAddress.getByAddress(new byte[]{(byte) 23, (byte) 185, (byte)0, (byte)4});
+  }
+  
   @Test
   public void testClientReconnect() {
     HeartBeat hb = new HeartBeat();
@@ -18,11 +28,11 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-100);
-    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-101);
+    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
+    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-101);
     // Verify number of clients
+    System.out.println(Arrays.toString(H2O.getClients()));
     assertEquals(1, H2O.getClients().length);
-
   }
 
   @Test
@@ -33,10 +43,11 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-100);
+    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
     // Verify number of clients
     assertEquals(1, H2O.getClients().length);
     waitForClientsDisconnect();
+    System.out.println(Arrays.toString(H2O.getClients()));
     assertEquals(0, H2O.getClients().length);
   }
 
@@ -47,12 +58,12 @@ public class ClientReconnectSimulationTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
-    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-100);
-    H2ONode.intern(H2O.SELF_ADDRESS, 65456, (short)-101);
+    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-100);
+    H2ONode.intern(FAKE_NODE_ADDRESS, 65456, (short)-101);
 
     // second client from another node re-connects
-    H2ONode.intern(H2O.SELF_ADDRESS, 65458, (short)-100);
-    H2ONode.intern(H2O.SELF_ADDRESS, 65458, (short)-101);
+    H2ONode.intern(FAKE_NODE_ADDRESS, 65458, (short)-100);
+    H2ONode.intern(FAKE_NODE_ADDRESS, 65458, (short)-101);
     // Verify number of clients
     assertEquals(2, H2O.getClients().length);
   }

--- a/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
+++ b/h2o-core/src/test/java/water/ClientReconnectSimulationTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
-@Ignore
 public class ClientReconnectSimulationTest extends TestUtil{
 
   private InetAddress FAKE_NODE_ADDRESS;

--- a/h2o-core/src/test/java/water/ExternalFrameReaderClientTest.java
+++ b/h2o-core/src/test/java/water/ExternalFrameReaderClientTest.java
@@ -60,7 +60,7 @@ public class ExternalFrameReaderClientTest extends TestUtil{
                     @Override
                     public void run() {
                         try {
-                            ByteChannel sock = ExternalFrameUtils.getConnection(nodes[currentChunkIdx % nodes.length], H2O.SELF._timestamp);
+                            ByteChannel sock = ExternalFrameUtils.getConnection(nodes[currentChunkIdx % nodes.length], H2O.SELF.getTimestamp());
                             ExternalFrameReaderClient reader = new ExternalFrameReaderClient(sock, frameName, currentChunkIdx, selectedColumnIndices, expectedTypes);
 
                             int rowsRead = 0;

--- a/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
+++ b/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
@@ -312,7 +312,7 @@ public class ExternalFrameWriterClientTest extends TestUtil {
                 @Override
                 public void run() {
                     try {
-                        ByteChannel sock = ExternalFrameUtils.getConnection(writeEndpoints[currentIndex], H2O.SELF._timestamp);
+                        ByteChannel sock = ExternalFrameUtils.getConnection(writeEndpoints[currentIndex], H2O.SELF.getTimestamp());
                         try {
                             ExternalFrameWriterClient writer = new ExternalFrameWriterClient(sock);
                             writer.createChunks(op.frameName(), op.colTypes(),  currentIndex, op.nrows(), op.maxVecSizes());

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -1,14 +1,13 @@
 package water;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
-@Ignore
+
 public class UnknownHeartbeatTest extends TestUtil{
   @BeforeClass() public static void setup() {
     stall_till_cloudsize(1);
@@ -22,10 +21,18 @@ public class UnknownHeartbeatTest extends TestUtil{
     hb._client = true;
     hb._jar_md5 = H2O.SELF._heartbeat._jar_md5;
 
+    // Multicast the Heart Beat 
     AutoBuffer ab = new AutoBuffer(H2O.SELF, UDP.udp.heartbeat._prior);
     ab.putUdp(UDP.udp.heartbeat, 65400); // put different port number to simulate heartbeat from fake node
     hb.write(ab);
     ab.close();
+
+    // Give it time so the packet can arrive
+    try {
+      Thread.sleep(2000);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
 
     // Verify that we don't have a new client
     assertEquals(clientsCountBefore, H2O.getClients().length);

--- a/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
+++ b/h2o-core/src/test/java/water/UnknownHeartbeatTest.java
@@ -1,12 +1,14 @@
 package water;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+@Ignore
 public class UnknownHeartbeatTest extends TestUtil{
   @BeforeClass() public static void setup() {
     stall_till_cloudsize(1);

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -98,6 +98,10 @@ test-r-small-client-mode:
 	cd h2o-r/tests/ && rm -f -r testdir_hdfs
 	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --client --testsize s --numclouds 4 --jvm.xmx 4g --excludelist ../../tests/runitAutoMLList
 
+test-r-small-client-mode-attack:
+	cd h2o-r/tests/ && rm -f -r testdir_hdfs
+	export NO_GCE_CHECK=True && cd h2o-r/tests/ && ../../scripts/run.py --wipeall --client --testsize s --numclouds 4 --jvm.opts '-Dsys.ai.h2o.debug.clientDisconnectAttack=true' --jvm.xmx 4g --excludelist ../../tests/runitAutoMLList
+
 test-r-small-automl:
 	cd h2o-r/tests/ && rm -f -r testdir_hdfs
 	cd h2o-r/tests/ && rm -f -r testdir_demos

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -124,6 +124,10 @@ def call(final pipelineContext) {
       timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],
     [
+      stageName: 'R3.4 Small Client Mode Disconnect Attack', target: 'test-r-small-client-mode-attack', rVersion: '3.4.1',
+      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R
+    ],
+    [
       stageName: 'R3.4 Small AutoML', target: 'test-r-small-automl', rVersion: '3.4.1',
       timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R
     ],


### PR DESCRIPTION
This PR addresses a race condition in the client mode: if a client is detected to be disconnected and at the same time we want to send a message back to the client we can kill the Sending Thread of the H2ONode instance that the sender wants to use to communicate back to the client. This results in NullPointerException.

This PR solves this by combining 2 approaches:
- `H2ONode#sendMessage` is modified to avoid communication using stale instances of Sending Threads
- decommissioned Sending Threads are kept around for a grace period - if the client is not actually disconnected (even though H2O thinks that) we will deliver the currently unsent messages and also any messages added before we realized the client is re-connected again and added back to the cluster. The grace period is 100s by default.

Relevant part of the logs capturing the failure we are fixing in this PR:

```
01-04 13:18:16.839 127.0.0.1:40008       219    FJ-2-15   INFO: Found categoricals with non-UTF-8 characters or NULL character in the 11th column. Converting unrecognized characters into hex:  N524A<0xE4>, N621A<0xE4>, N574<0xE4E2>, N825<0xE4E2>, N423<0xE4E2>, -N925<0xE5>, N623A<0xE4>, N122<0xE4E6>, N434<0xE4E2>, -N955<0xE5>, ...
01-04 13:18:18.855 127.0.0.1:40008       219    FJ-2-29   INFO: Building H2O Aggregator model with these parameters:
01-04 13:18:18.857 127.0.0.1:40008       219    FJ-2-29   INFO: {"_train":{"name":"allyears2k_headers_sid_b8b4_2","type":"Key"},"_valid":null,"_nfolds":0,"_keep_cross_validation_models":true,"_keep_cross_validation_predictions":false,"_keep_cross_validation_fold_assignment":false,"_parallelize_cross_validation":true,"_auto_rebalance":true,"_seed":-1,"_fold_assignment":"AUTO","_categorical_encoding":"Eigen","_max_categorical_levels":10,"_distribution":"AUTO","_tweedie_power":1.5,"_quantile_alpha":0.5,"_huber_alpha":0.9,"_ignored_columns":null,"_ignore_const_cols":false,"_weights_column":null,"_offset_column":null,"_fold_column":null,"_is_cv_model":false,"_score_each_iteration":false,"_max_runtime_secs":0.0,"_stopping_rounds":0,"_stopping_metric":"AUTO","_stopping_tolerance":0.001,"_response_column":null,"_balance_classes":false,"_max_after_balance_size":5.0,"_class_sampling_factors":null,"_max_confusion_matrix_size":20,"_checkpoint":null,"_pretrained_autoencoder":null,"_custom_metric_func":null,"_export_checkpoints_dir":null,"_transform":"STANDARDIZE","_pca_method":"Power","_k":1,"_target_num_exemplars":500,"_rel_tol_num_exemplars":0.3,"_use_all_factor_levels":false,"_save_mapping_frame":false,"_num_iteration_without_new_exemplar":500}
01-04 13:18:18.873 127.0.0.1:40008       219    FJ-2-29   INFO: Rebalancing train dataset into 40 chunks.
01-04 13:18:20.003 127.0.0.1:40008       219    FJ-3-113  INFO: Reducing the cardinality of a categorical column with 3501 levels to 1024
01-04 13:18:36.758 127.0.0.1:40008       219    #ckThread INFO: Removing client: localhost/127.0.0.1:40010(timestamp=-22737, watchdog=false, cloud_name_hash=2004151008)
01-04 13:18:36.763 127.0.0.1:40008       219    #ti-UDP-R INFO: New client connected, timestamp=-22737
java.lang.NullPointerException
        at water.H2ONode.sendMessage(H2ONode.java:394)
        at water.AutoBuffer.udpSend(AutoBuffer.java:565)
        at water.AutoBuffer.close(AutoBuffer.java:424)
        at water.RPC.call(RPC.java:204)
        at water.RPC.call(RPC.java:102)
        at water.TaskInvalidateKey.invalidate(TaskInvalidateKey.java:13)
        at water.Value.lockAndInvalidate(Value.java:539)
        at water.DKV.DputIfMatch(DKV.java:147)
        at water.DKV.DputIfMatch(DKV.java:96)
        at water.Atomic.compute2(Atomic.java:69)
        at water.Atomic.fork(Atomic.java:39)
        at water.Atomic.invoke(Atomic.java:31)
        at water.Job$JAtomic.apply(Job.java:368)
        at water.Job.update(Job.java:163)
        at hex.aggregator.Aggregator$AggregatorDriver.computeImpl(Aggregator.java:138)
        at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:218)
        at water.H2O$H2OCountedCompleter.compute(H2O.java:1395)
        at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
        at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
        at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
        at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
        at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR: java.lang.NullPointerException
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.H2ONode.sendMessage(H2ONode.java:394)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.AutoBuffer.udpSend(AutoBuffer.java:565)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.AutoBuffer.close(AutoBuffer.java:424)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.RPC.call(RPC.java:204)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.RPC.call(RPC.java:102)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.TaskInvalidateKey.invalidate(TaskInvalidateKey.java:13)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.Value.lockAndInvalidate(Value.java:539)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.DKV.DputIfMatch(DKV.java:147)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.DKV.DputIfMatch(DKV.java:96)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.Atomic.compute2(Atomic.java:69)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.Atomic.fork(Atomic.java:39)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.Atomic.invoke(Atomic.java:31)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.Job$JAtomic.apply(Job.java:368)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.Job.update(Job.java:163)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at hex.aggregator.Aggregator$AggregatorDriver.computeImpl(Aggregator.java:138)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:218)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at water.H2O$H2OCountedCompleter.compute(H2O.java:1395)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
01-04 13:18:37.548 127.0.0.1:40008       219    FJ-2-29   ERRR:         at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
java.lang.NullPointerException
        at water.H2ONode.sendMessage(H2ONode.java:394)
        at water.AutoBuffer.udpSend(AutoBuffer.java:565)
        at water.AutoBuffer.close(AutoBuffer.java:424)
        at water.RPC.call(RPC.java:204)
        at water.RPC.call(RPC.java:102)
        at water.TaskInvalidateKey.invalidate(TaskInvalidateKey.java:13)
        at water.Value.lockAndInvalidate(Value.java:539)
        at water.DKV.DputIfMatch(DKV.java:147)
        at water.DKV.DputIfMatch(DKV.java:96)
        at water.Atomic.compute2(Atomic.java:69)
        at water.Atomic.fork(Atomic.java:39)
        at water.Atomic.invoke(Atomic.java:31)
        at water.Job$JAtomic.apply(Job.java:368)
        at water.Job.update(Job.java:163)
        at hex.aggregator.Aggregator$AggregatorDriver.computeImpl(Aggregator.java:138)
        at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:218)
        at water.H2O$H2OCountedCompleter.compute(H2O.java:1395)
        at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
        at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
        at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
```