### PR TITLE
ITA-363: keep huge java logs in Jenkins archive, zipped

### DIFF
--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -24,6 +24,9 @@ warmup-caches:
 	@$(MAKE) -f $(THIS_FILE) build-h2o-3
 	./gradlew cpLibs $$ADDITIONAL_GRADLE_OPTS
 
+compress-huge-logfiles:
+	find * -type f -name 'java*.out.txt' -exec zip -jm {}.zip {} \;
+
 test-package-py:
 	zip -q -r test-package-py.zip h2o-py/tests/ h2o-py/demos/ \
 	h2o-docs/src/booklets/v2_2015/source h2o-py/build/dist/*.whl \

--- a/scripts/jenkins/groovy/benchmarkStage.groovy
+++ b/scripts/jenkins/groovy/benchmarkStage.groovy
@@ -23,7 +23,7 @@ def call(final pipelineContext, final stageConfig) {
   def prepareBenchmarkFolderConfig = pipelineContext.getPrepareBenchmarkDirStruct(this, ML_BENCHMARK_ROOT)
   def benchmarkFolderConfig = prepareBenchmarkFolderConfig(stageConfig.customData.algorithm, env.GIT_SHA, env.BRANCH_NAME)
   GString outputPath = "${env.workspace}/${pipelineContext.getUtils().stageNameToDirName(stageConfig.stageName)}/${benchmarkFolderConfig.getOutputDir()}"
-  sh "rm -rf ${outputPath} && mkdir -p ${outputPath}"
+  sh "rm -rfv ${outputPath} && mkdir -p ${outputPath}"
 
   def benchmarkEnv = [
           "PATH_PREFIX=${ML_BENCHMARK_ROOT}",

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -573,7 +573,7 @@ private void invokeStage(final pipelineContext, final body) {
                 if (healthCheckPassed) {
                   pipelineContext.getBuildSummary().setStageDetails(this, config.stageName, env.NODE_NAME, env.WORKSPACE)
 
-                  sh "rm -rf ${config.stageDir}"
+                  sh "rm -rfv ${config.stageDir}"
 
                   def script = load(config.executionScript)
                   script(pipelineContext, config)

--- a/scripts/jenkins/groovy/hadoopStage.groovy
+++ b/scripts/jenkins/groovy/hadoopStage.groovy
@@ -51,7 +51,7 @@ def call(final pipelineContext, final stageConfig) {
 
 private GString getH2OStartupCmd_hadoop(final stageConfig) {
     return """
-            rm -f h2o_one_node h2odriver.out
+            rm -fv h2o_one_node h2odriver.out
             hadoop jar h2o-hadoop-*/h2o-${stageConfig.customData.distribution}${stageConfig.customData.version}-assembly/build/libs/h2odriver.jar \\
                 -libjars "\$(cat /opt/hive-jars/hive-libjars)" -n 1 -mapperXmx 2g -baseport 54445 \\
                 -notify h2o_one_node -ea -proxy \\

--- a/scripts/jenkins/groovy/initPipelineContext.groovy
+++ b/scripts/jenkins/groovy/initPipelineContext.groovy
@@ -20,13 +20,7 @@ def call(final scmEnv, final String mode, final boolean ignoreChanges, final Lis
 }
 
 void clearStageDirs() {
-  def findCmd = "find . -maxdepth 1 -not -name 'h2o-3' -not -name h2o-3@tmp -not -name '.'"
-  def deleteCmd = " -exec rm -rf '{}' ';'"
-  def findDeleteCmd = findCmd + deleteCmd
-
-  echo "About to delete these files/folders:"
-  sh findCmd
-  sh findDeleteCmd
+  sh "find `pwd` -maxdepth 1 -not -name 'h2o-3' -not -name h2o-3@tmp -not -path `pwd` -exec rm -rfv '{}' ';'"
 }
 
 return this

--- a/scripts/jenkins/groovy/insideDocker.groovy
+++ b/scripts/jenkins/groovy/insideDocker.groovy
@@ -8,8 +8,10 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
 
   retryWithDelay(3 /* retries */, 120 /* delay in sec */) {
     withCredentials([usernamePassword(credentialsId: registry, usernameVariable: 'REGISTRY_USERNAME', passwordVariable: 'REGISTRY_PASSWORD')]) {
-      sh "docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD ${registry}"
-      sh "docker pull ${image}"
+      sh """
+        docker login -u $REGISTRY_USERNAME -p $REGISTRY_PASSWORD ${registry}
+        docker pull ${image}
+      """
     }
   }
 
@@ -18,8 +20,10 @@ def call(customEnv, image, registry, buildConfig, timeoutValue, timeoutUnit, cus
       docker.withRegistry("https://${registry}") {
         withCredentials([file(credentialsId: 'c096a055-bb45-4dac-ba5e-10e6e470f37e', variable: 'JUNIT_CORE_SITE_PATH'), [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS S3 Credentials', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
           docker.image(image).inside("--init --dns ${DEFAULT_DNS} -e AWS_ACCESS_KEY_ID=\${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=\${AWS_SECRET_ACCESS_KEY} -v /home/0xdiag:/home/0xdiag ${customArgs}") {
-            sh 'id'
-            sh 'printenv | sort'
+            sh """
+              id
+              printenv | sort
+            """
             block()
           }
         }

--- a/scripts/jenkins/groovy/makeTarget.groovy
+++ b/scripts/jenkins/groovy/makeTarget.groovy
@@ -106,10 +106,10 @@ private void execMake(final String buildAction, final String h2o3dir) {
 
     cd ${h2o3dir}
     echo "Linking small and bigdata"
-    rm -f smalldata
-    ln -s -f /home/0xdiag/smalldata
-    rm -f bigdata
-    ln -s -f /home/0xdiag/bigdata
+    rm -fv smalldata
+    ln -s -f -v /home/0xdiag/smalldata
+    rm -fv bigdata
+    ln -s -f -v /home/0xdiag/bigdata
 
     # The Gradle fails if there is a special character, in these variables
     unset CHANGE_AUTHOR_DISPLAY_NAME

--- a/scripts/jenkins/groovy/makeTarget.groovy
+++ b/scripts/jenkins/groovy/makeTarget.groovy
@@ -12,6 +12,8 @@ def call(final pipelineContext, final Closure body) {
           '**/results/failed/*.txt',
           '**/results/*.code',
           '**/results/failed/*.code',
+          '**/results/failed/*.code',
+          '**/java*_*.out.txt.zip',
   ]
 
   final List<String> FILES_TO_ARCHIVE_ON_SUCCESS = [
@@ -86,6 +88,7 @@ def call(final pipelineContext, final Closure body) {
       pipelineContext.getUtils().archiveJUnitResults(this, config.h2o3dir)
     }
     if (config.archiveFiles) {
+      execMake("make -f ${config.makefilePath} compress-huge-logfiles", config.h2o3dir)
       pipelineContext.getUtils().archiveStageFiles(this,
               config.h2o3dir,
               success ? FILES_TO_ARCHIVE_ON_SUCCESS : FILES_TO_ARCHIVE_ON_FAILURE,

--- a/scripts/jenkins/groovy/pipelineUtils.groovy
+++ b/scripts/jenkins/groovy/pipelineUtils.groovy
@@ -173,7 +173,7 @@ class PipelineUtils {
             unstashFiles(context, buildConfig.getStashNameForTestPackage(component))
             unstashFiles(context, buildConfig.H2O_JAR_STASH_NAME)
         }
-        context.sh "cd ${stageDir}/h2o-3 && unzip -q -o test-package-${component}.zip && rm test-package-${component}.zip"
+        context.sh "cd ${stageDir}/h2o-3 && unzip -q -o test-package-${component}.zip && rm -v test-package-${component}.zip"
     }
 
     void archiveStageFiles(final context, final String h2o3dir, final List<String> archiveFiles, final List<String> excludeFiles) {

--- a/scripts/jenkins/groovy/xgbGPUStage.groovy
+++ b/scripts/jenkins/groovy/xgbGPUStage.groovy
@@ -33,10 +33,10 @@ def call(final pipelineContext, final stageConfig) {
         ls -alh
         
         echo "Linking small and bigdata"
-        rm -f smalldata
-        ln -s -f /home/0xdiag/smalldata
-        rm -f bigdata
-        ln -s -f /home/0xdiag/bigdata
+        rm -fv smalldata
+        ln -s -f -v /home/0xdiag/smalldata
+        rm -fv bigdata
+        ln -s -f -v /home/0xdiag/bigdata
         
         if [ "${stageConfig.activatePythonEnv}" = 'true' ]; then
             echo "Activating Python ${stageConfig.pythonVersion}"

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -539,7 +539,7 @@ private setReleaseJobProperties(final pipelineContext) {
             env.DO_RELEASE = true
         }
     }
-    sh 'env'
+    sh "printenv | sort"
 }
 
 private printReleaseConfiguration(final pipelineContext) {


### PR DESCRIPTION
[ITA-363](https://0xdata.atlassian.net/browse/ITA-363)

Files matching `**/java*_*.out.txt` are now archived (rather than excluded), but right before archival, we move to zip those bigger than threshold (currently 400k). Extension `.zip` is added to them, and these files are archived, too.

Additionally, this PR comes with very minor improvements in groovy code.
Especially, every `rm` command is now equipped with flag `-v` so that we can see which files have been deleted.