### PR TITLE
ITA-362: always archive summary.txt on jenkins jobs

### DIFF
--- a/scripts/jenkins/groovy/makeTarget.groovy
+++ b/scripts/jenkins/groovy/makeTarget.groovy
@@ -1,12 +1,21 @@
 def call(final pipelineContext, final Closure body) {
   final List<String> FILES_TO_EXCLUDE = [
-    '**/rest.log', '**/*prediction*.csv', '**/java*_*.out.txt'
+          '**/rest.log', 
+          '**/*prediction*.csv', 
+          '**/java*_*.out.txt'
   ]
 
-  final List<String> FILES_TO_ARCHIVE = [
-    '**/*.log', '**/out.*',
-    '**/results/*.txt', '**/results/failed/*.txt',
-    '**/results/*.code', '**/results/failed/*.code',
+  final List<String> FILES_TO_ARCHIVE_ON_FAILURE = [
+          '**/*.log',
+          '**/out.*',
+          '**/results/*.txt',
+          '**/results/failed/*.txt',
+          '**/results/*.code',
+          '**/results/failed/*.code',
+  ]
+
+  final List<String> FILES_TO_ARCHIVE_ON_SUCCESS = [
+          '**/summary.txt'
   ]
 
   def config = [:]
@@ -76,8 +85,11 @@ def call(final pipelineContext, final Closure body) {
       sh replaceCmd
       pipelineContext.getUtils().archiveJUnitResults(this, config.h2o3dir)
     }
-    if (config.archiveFiles && !success) {
-      pipelineContext.getUtils().archiveStageFiles(this, config.h2o3dir, FILES_TO_ARCHIVE, FILES_TO_EXCLUDE)
+    if (config.archiveFiles) {
+      pipelineContext.getUtils().archiveStageFiles(this,
+              config.h2o3dir,
+              success ? FILES_TO_ARCHIVE_ON_SUCCESS : FILES_TO_ARCHIVE_ON_FAILURE,
+              FILES_TO_EXCLUDE)
     }
     if (config.archiveAdditionalFiles) {
       echo "###### Archiving additional files: ######"


### PR DESCRIPTION
The `summary.txt` contains list of executed tests, with results and timing, which is quite important and takes almost no diskspace. Such information can be used for basic comparison of tests.

Note: merging this is IMHO good by itself, but may be helpful for #3206 and #3212 