### PR TITLE
PUBDEV-6197 assign ignored_columns parameter in train method properly

### DIFF
--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -155,6 +155,8 @@ class H2OEstimator(ModelBase):
         if not training_frame_exists:
             assert_is_type(y, str, None)
             ignored_columns_set = set()
+            if ignored_columns is None and "ignored_columns" in parms:
+                ignored_columns = parms['ignored_columns']
             if ignored_columns is not None:
                 if x is not None:
                     raise H2OValueError("Properties x and ignored_columns cannot be specified simultaneously")

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_ignored_columns_gbm.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_ignored_columns_gbm.py
@@ -1,0 +1,53 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+def ignored_columns():
+    airlines = h2o.upload_file(pyunit_utils.locate("smalldata/airlines/allyears2k_headers.zip"))
+
+    # convert columns to factors
+    airlines["Year"]= airlines["Year"].asfactor()
+    airlines["Month"]= airlines["Month"].asfactor()
+    airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
+    airlines["Cancelled"] = airlines["Cancelled"].asfactor()
+    airlines['FlightNum'] = airlines['FlightNum'].asfactor()
+
+    # set the predictor names and the response column name
+    predictors = airlines.columns[:9]
+    response = "IsDepDelayed"
+
+    # split into train and validation sets
+    train, valid= airlines.split_frame(ratios=[.8], seed=1234)
+
+    # create a list of column names to ignore
+    col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
+
+    # initialize the estimator and train the model
+    airlines_gbm = H2OGradientBoostingEstimator(ignored_columns=col_list, seed=1234)
+
+    # throws H2OValueError: Properties x and ignored_columns cannot be specified simultaneously
+    message = "Properties x and ignored_columns cannot be specified simultaneously"
+    try:
+        airlines_gbm.train(x=predictors, y=response, training_frame=train, validation_frame=valid)
+        assert False, "It should throw H2OValueError: "+message
+    except Exception as e:
+        assert message in e.args, "It should throw H2OValueError: "+message
+        
+    airlines_gbm.train(y=response, training_frame=train, validation_frame=valid)
+
+    # get the ignored columns from the model JSON
+    ignored_cols_from_model = [param_dict["actual_value"] for param_dict in airlines_gbm._model_json["parameters"] if param_dict["name"] == "ignored_columns"][0]
+    assert set(col_list) <= set(ignored_cols_from_model)
+
+    # get the list of columns used by the model
+    used_columns = airlines_gbm._model_json['output']['names']
+    assert set(col_list).isdisjoint(set(used_columns))
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(ignored_columns)
+else:
+    ignored_columns()

--- a/h2o-py/tests/testdir_algos/kmeans/pyunit_parametersKmeans.py
+++ b/h2o-py/tests/testdir_algos/kmeans/pyunit_parametersKmeans.py
@@ -24,7 +24,8 @@ def parametersKmeans():
     del param_dict['validation_frame']
     del param_dict['max_runtime_secs']
     iris_km_again = H2OKMeansEstimator(**param_dict)  # not all parameters go here - invalid test
-    iris_km_again.train(x=list(range(4)), training_frame=iris, fold_column=fold_column)
+    # remove assigning the x parameter to prevent H2OValueError: Properties x and ignored_columns cannot be specified simultaneously
+    iris_km_again.train(training_frame=iris, fold_column=fold_column)
 
     print("wss")
     wss = iris_km.withinss().sort()


### PR DESCRIPTION
The parameter `ignored_columns` in train method replace the parameter set in Estimator constructor. 

The similar problem as in PUBDEV-6036 (https://github.com/h2oai/h2o-3/pull/3024). 

JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6197