### PR TITLE
PUBDEV-6074 Quantile local histograms POC

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -273,7 +273,8 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
         // top-level quantiles for all columns
         // non-numeric columns get a vector full of NAs
         if (_parms._histogram_type == SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal
-                || _parms._histogram_type == SharedTreeModel.SharedTreeParameters.HistogramType.RoundRobin) {
+                || _parms._histogram_type == SharedTreeModel.SharedTreeParameters.HistogramType.RoundRobin
+                || _parms._histogram_type == SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesLocal) {
           int N = _parms._nbins;
           QuantileModel.QuantileParameters p = new QuantileModel.QuantileParameters();
           Key rndKey = Key.make();

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -58,7 +58,7 @@ public abstract class SharedTreeModel<
 
     public double _min_split_improvement = 1e-5; // Minimum relative improvement in squared error reduction for a split to happen
 
-    public enum HistogramType { AUTO, UniformAdaptive, Random, QuantilesGlobal, RoundRobin }
+    public enum HistogramType { AUTO, UniformAdaptive, Random, QuantilesGlobal, RoundRobin, QuantilesLocal}
     public HistogramType _histogram_type = HistogramType.AUTO; // What type of histogram to use for finding optimal split points
 
     public double _r2_stopping = Double.MAX_VALUE; // Stop when the r^2 metric equals or exceeds this value

--- a/h2o-algos/src/test/java/hex/quantile/QuantileTest.java
+++ b/h2o-algos/src/test/java/hex/quantile/QuantileTest.java
@@ -697,117 +697,73 @@ public class QuantileTest extends TestUtil {
   
   @Test
   public void testInterpolate1Local() {
-    QuantileModel kmm = null;
-    Frame fr = null;
     QuantileModel kmml = null;
     Frame frl = null;
     try {
-      double[][] d = new double[][]{{1}, {1}, {2}, {2}};
-      fr = ArrayUtils.frame(d);
-      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
-      parms._train = fr._key;
-      parms._probs = new double[]{0.5};
-      Job<QuantileModel> job = new Quantile(parms).trainModel();
-      kmm = job.get();
-      job.remove();
-      Assert.assertTrue(kmm._output._quantiles[0][0] == 1.5);
-
       double[][] dl = new double[][]{{0}, {1}, {1}, {2}, {2}, {3}};
       frl = ArrayUtils.frame(dl);
-      parms = new QuantileModel.QuantileParameters();
+      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = frl._key;
       parms._probs = new double[]{0.5};
       parms._lo = 1; // inclusive
       parms._hi = 3; // exclusive
       parms._local_column_index = 0;
-      job = new Quantile(parms).trainModel();
+      Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmml = job.get();
       job.remove();
       Assert.assertTrue(kmml._output._quantiles[0][0] == 1.5);
 
     } finally {
-      if (fr != null) fr.remove();
       if (frl != null) frl.remove();
-      if (kmm != null) kmm.delete();
       if (kmml != null) kmml.delete();
     }
   }
 
   @Test
   public void testInterpolateHighWeightedLocal() {
-    QuantileModel kmm = null;
-    Frame fr = null;
     QuantileModel kmml = null;
     Frame frl = null;
     try {
-      double[][] d = new double[][]{{1, 0}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
-      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
-      parms._train = fr._key;
-      parms._weights_column = "weights";
-      parms._probs = new double[]{0.51};
-      Job<QuantileModel> job = new Quantile(parms).trainModel();
-      kmm = job.get();
-      job.remove();
-      Assert.assertTrue(kmm._output._quantiles[0][0] == 2.51);
-
       double[][] dl = new double[][]{{0, 1}, {1, 0}, {2, 1}, {3, 1},{4, 7}};
       frl = ArrayUtils.frame(new String[]{"x", "weights"}, dl);
-      parms = new QuantileModel.QuantileParameters();
+      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = frl._key;
       parms._weights_column = "weights";
       parms._probs = new double[]{0.51};
       parms._lo = 1; // inclusive
       parms._hi = 4; // exclusive
       parms._local_column_index = 0;
-      job = new Quantile(parms).trainModel();
+      Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmml = job.get();
       job.remove();
       Assert.assertTrue(kmml._output._quantiles[0][0] == 2.51);
       
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
       if (frl != null) frl.remove();
       if (kmml != null) kmml.delete();
     }
   }
   
   @Test
-  public void testInterpolateHighWeightedDoubleLocal() { 
-      QuantileModel kmm = null;
-      Frame fr = null;
+  public void testInterpolateHighWeightedDoubleLocal() {
       QuantileModel kmml = null;
       Frame frl = null;
-      try { 
-          double[][] d = new double[][]{{1e-100, 10}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}};
-          fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
-          QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
-          parms._train = fr._key;
-          parms._weights_column = "weights";
-          parms._probs = new double[]{0.5};
-          Job<QuantileModel> job = new Quantile(parms).trainModel();
-          kmm = job.get();
-          job.remove();
-          Assert.assertEquals(5.000005000000008E-5, kmm._output._quantiles[0][0], 1e-10);
-
+      try {
           double[][] dl = new double[][]{{1e-100, 10}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}, {2, 10}};
           frl = ArrayUtils.frame(new String[]{"x", "weights"}, dl);
-          parms = new QuantileModel.QuantileParameters();
+          QuantileModel.QuantileParameters parms  = new QuantileModel.QuantileParameters();
           parms._train = frl._key;
           parms._weights_column = "weights";
           parms._probs = new double[]{0.5};
           parms._lo = 1e-100; // inclusive
           parms._hi = 2; // exclusive
           parms._local_column_index = 0;
-          job = new Quantile(parms).trainModel();
+          Job<QuantileModel> job = new Quantile(parms).trainModel();
           kmml = job.get();
           job.remove();
           Assert.assertEquals(5.000005000000008E-5, kmml._output._quantiles[0][0],1e-10 );
 
       } finally {
-          if (fr != null) fr.remove();
-          if (kmm != null) kmm.delete();
           if (frl != null) frl.remove();
           if (kmml != null) kmml.delete(); 
       }

--- a/h2o-algos/src/test/java/hex/quantile/QuantileTest.java
+++ b/h2o-algos/src/test/java/hex/quantile/QuantileTest.java
@@ -12,9 +12,13 @@ import water.util.ArrayUtils;
 import java.util.Arrays;
 
 public class QuantileTest extends TestUtil {
-  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+  @BeforeClass()
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
 
-  @Test public void testIris() {
+  @Test
+  public void testIris() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -23,7 +27,7 @@ public class QuantileTest extends TestUtil {
       fr = parse_test_file("smalldata/iris/iris_wheader.csv");
       //fr = parse_test_file("../../datasets/UCI/UCI-large/covtype/covtype.data");
       //fr = parse_test_file("../../datasets/billion_rows.csv.gz");
-      System.out.println("Done Parse: "+(System.currentTimeMillis()-start));
+      System.out.println("Done Parse: " + (System.currentTimeMillis() - start));
 
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
@@ -34,12 +38,13 @@ public class QuantileTest extends TestUtil {
       job.remove();
 
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  
-  @Test public void testAllNAS() {
+
+  @Test
+  public void testAllNAS() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -70,21 +75,22 @@ public class QuantileTest extends TestUtil {
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      for (int i=0; i < 11; i++)
+      for (int i = 0; i < 11; i++)
         Assert.assertTrue(Double.isNaN(kmm._output._quantiles[0][i]));
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
-    }    
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
+    }
   }
 
-  @Test public void testInts() {
+  @Test
+  public void testInts() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       fr = ArrayUtils.frame(new double[][]{{0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0},
-                                            {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1},
-                                            {2}, {2}, {2}, {2}, {2}, {2}, {2}, {2}, {2}, {2}});
+              {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1}, {1},
+              {2}, {2}, {2}, {2}, {2}, {2}, {2}, {2}, {2}, {2}});
 
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
@@ -94,12 +100,13 @@ public class QuantileTest extends TestUtil {
       job.remove();
 
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
 
-  @Test public void test50pct() {
+  @Test
+  public void test50pct() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -113,12 +120,13 @@ public class QuantileTest extends TestUtil {
       Assert.assertTrue(kmm._output._quantiles[0][5] == d[3][0]);
 
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
 
-  @Test public void testDirectMatch() {
+  @Test
+  public void testDirectMatch() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -133,11 +141,13 @@ public class QuantileTest extends TestUtil {
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1);
 
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolate1() {
+
+  @Test
+  public void testInterpolate1() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -151,11 +161,13 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.5);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolate2() {
+
+  @Test
+  public void testInterpolate2() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -169,11 +181,13 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.5);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateLow() {
+
+  @Test
+  public void testInterpolateLow() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -187,11 +201,13 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.98);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHigh() {
+
+  @Test
+  public void testInterpolateHigh() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -205,16 +221,18 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 2.02);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted() {
+
+  @Test
+  public void testInterpolateHighWeighted() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 0}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -224,16 +242,19 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 2.51);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted2() {
+
+
+  @Test
+  public void testInterpolateHighWeighted2() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 2}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -243,16 +264,18 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.29);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted3() {
+
+  @Test
+  public void testInterpolateHighWeighted3() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 3}, {2, 2}, {3, 5}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -262,16 +285,18 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.79);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted4() {
+
+  @Test
+  public void testInterpolateHighWeighted4() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 1.005}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -279,18 +304,20 @@ public class QuantileTest extends TestUtil {
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      Assert.assertTrue("Got: " + kmm._output._quantiles[0][0], Math.abs(kmm._output._quantiles[0][0] - 2.42355)<1e-10);
+      Assert.assertTrue("Got: " + kmm._output._quantiles[0][0], Math.abs(kmm._output._quantiles[0][0] - 2.42355) < 1e-10);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted5() {
+
+  @Test
+  public void testInterpolateHighWeighted5() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 5}, {2, 4}, {3, 3}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -300,16 +327,18 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.73);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted6() {
+
+  @Test
+  public void testInterpolateHighWeighted6() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 2}, {2, 2}, {3, 2}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -319,73 +348,81 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.65);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted7() {
+
+  @Test
+  public void testInterpolateHighWeighted7() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 1}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0,0.25,0.5,0.75,1};
+      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1,1.5,2,2.5,3}));
+      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1, 1.5, 2, 2.5, 3}));
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateHighWeighted8() {
+
+  @Test
+  public void testInterpolateHighWeighted8() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 2}, {2, 2}, {3, 2}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0,0.25,0.5,0.75,1};
+      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1,1.25,2,2.75,3}));
+      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1, 1.25, 2, 2.75, 3}));
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateWideRangeWeighted() {
+
+  @Test
+  public void testInterpolateWideRangeWeighted() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1e-100, 1}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
       //parms._probs = new double[]{0,0.25,0.5,0.75,1};
-      parms._probs = new double[]{0.25,0.5,0.75,1};
+      parms._probs = new double[]{0.25, 0.5, 0.75, 1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
       //double[] exp = new double[]{1e-100,5e-5,1e-2,1e-1,1};
-      double[] exp = new double[]{5e-5,1e-2,1e-1,1};
+      double[] exp = new double[]{5e-5, 1e-2, 1e-1, 1};
       double[] act = kmm._output._quantiles[0];
-      for (int i=0;i<exp.length; ++i)
-        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i])/exp[i] < 1e-5);
+      for (int i = 0; i < exp.length; ++i)
+        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateWideRange() {
+
+  @Test
+  public void testInterpolateWideRange() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -393,65 +430,70 @@ public class QuantileTest extends TestUtil {
       fr = ArrayUtils.frame(new String[]{"x"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
-      parms._probs = new double[]{0,0.25,0.5,0.75,1};
+      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      double[] exp = new double[]{1e-100,2.5e-5,5.05e-3,7.75e-2,1};
+      double[] exp = new double[]{1e-100, 2.5e-5, 5.05e-3, 7.75e-2, 1};
       double[] act = kmm._output._quantiles[0];
-      for (int i=0;i<exp.length; ++i)
-        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i])/exp[i] < 1e-5);
+      for (int i = 0; i < exp.length; ++i)
+        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateWideRangeWeighted2() {
+
+  @Test
+  public void testInterpolateWideRangeWeighted2() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1e-100, 10}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0,0.25,0.5,0.75,1};
+      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      double[] exp = new double[]{1e-100,1e-100,5.000005e-5,1e-1,1};
+      double[] exp = new double[]{1e-100, 1e-100, 5.000005e-5, 1e-1, 1};
       double[] act = kmm._output._quantiles[0];
-      for (int i=0;i<exp.length; ++i)
+      for (int i = 0; i < exp.length; ++i)
         Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
-  @Test public void testInterpolateLargeWeights() {
+
+  @Test
+  public void testInterpolateLargeWeights() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{0, 10}, {1, 10}};
-      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0.475,0.48,0.49};
+      parms._probs = new double[]{0.475, 0.48, 0.49};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      double[] exp = new double[]{0.025,0.12,0.31};
+      double[] exp = new double[]{0.025, 0.12, 0.31};
       double[] act = kmm._output._quantiles[0];
-      for (int i=0;i<exp.length; ++i)
+      for (int i = 0; i < exp.length; ++i)
         Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
     } finally {
-      if( fr  != null ) fr .remove();
-      if( kmm != null ) kmm.delete();
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
     }
   }
 
-  @Test public void testShuffled() {
+  @Test
+  public void testShuffled() {
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -493,12 +535,13 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if( fr1  != null ) fr1.remove();
-      if( fr2  != null ) fr2.remove();
+      if (fr1 != null) fr1.remove();
+      if (fr2 != null) fr2.remove();
     }
   }
 
-  @Test public void testWeights0() {
+  @Test
+  public void testWeights0() {
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -542,12 +585,13 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if( fr1  != null ) fr1.remove();
-      if( fr2  != null ) fr2.remove();
+      if (fr1 != null) fr1.remove();
+      if (fr2 != null) fr2.remove();
     }
   }
 
-  @Test public void testWeights1() {
+  @Test
+  public void testWeights1() {
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -591,12 +635,14 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if( fr1  != null ) fr1.remove();
-      if( fr2  != null ) fr2.remove();
+      if (fr1 != null) fr1.remove();
+      if (fr2 != null) fr2.remove();
     }
   }
 
-  @Ignore @Test public void testWeights2() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=2 don't agree (unless normwt=TRUE)
+  @Ignore
+  @Test
+  public void testWeights2() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=2 don't agree (unless normwt=TRUE)
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -632,7 +678,7 @@ public class QuantileTest extends TestUtil {
         }
 
         try {
-          assert(Arrays.deepEquals(kmm1._output._quantiles, kmm2._output._quantiles));
+          assert (Arrays.deepEquals(kmm1._output._quantiles, kmm2._output._quantiles));
           Assert.assertTrue(Arrays.deepEquals(kmm1._output._quantiles, kmm2._output._quantiles));
         } finally {
           if (kmm1 != null) kmm1.delete();
@@ -641,12 +687,14 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if( fr1  != null ) fr1.remove();
-      if( fr2  != null ) fr2.remove();
+      if (fr1 != null) fr1.remove();
+      if (fr2 != null) fr2.remove();
     }
   }
 
-  @Ignore @Test public void testWeights3() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=epsilon don't agree (unless normwt=TRUE)
+  @Ignore
+  @Test
+  public void testWeights3() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=epsilon don't agree (unless normwt=TRUE)
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -690,8 +738,128 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if( fr1  != null ) fr1.remove();
-      if( fr2  != null ) fr2.remove();
+      if (fr1 != null) fr1.remove();
+      if (fr2 != null) fr2.remove();
     }
   }
+
+  @Test
+  public void testInterpolate1Local() {
+    QuantileModel kmm = null;
+    Frame fr = null;
+    QuantileModel kmml = null;
+    Frame frl = null;
+    try {
+      double[][] d = new double[][]{{1}, {1}, {2}, {2}};
+      fr = ArrayUtils.frame(d);
+      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
+      parms._train = fr._key;
+      parms._probs = new double[]{0.5};
+      Job<QuantileModel> job = new Quantile(parms).trainModel();
+      kmm = job.get();
+      job.remove();
+      Assert.assertTrue(kmm._output._quantiles[0][0] == 1.5);
+
+      double[][] dl = new double[][]{{0}, {1}, {1}, {2}, {2}, {3}};
+      frl = ArrayUtils.frame(dl);
+      parms = new QuantileModel.QuantileParameters();
+      parms._train = frl._key;
+      parms._probs = new double[]{0.5};
+      parms._lo = 1; // inclusive
+      parms._hi = 3; // exclusive
+      parms._local_column_index = 0;
+      job = new Quantile(parms).trainModel();
+      kmml = job.get();
+      job.remove();
+      Assert.assertTrue(kmml._output._quantiles[0][0] == 1.5);
+
+    } finally {
+      if (fr != null) fr.remove();
+      if (frl != null) frl.remove();
+      if (kmm != null) kmm.delete();
+      if (kmml != null) kmml.delete();
+    }
+  }
+
+  @Test
+  public void testInterpolateHighWeightedLocal() {
+    QuantileModel kmm = null;
+    Frame fr = null;
+    QuantileModel kmml = null;
+    Frame frl = null;
+    try {
+      double[][] d = new double[][]{{1, 0}, {2, 1}, {3, 1}};
+      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
+      parms._train = fr._key;
+      parms._weights_column = "weights";
+      parms._probs = new double[]{0.51};
+      Job<QuantileModel> job = new Quantile(parms).trainModel();
+      kmm = job.get();
+      job.remove();
+      Assert.assertTrue(kmm._output._quantiles[0][0] == 2.51);
+
+      double[][] dl = new double[][]{{0, 1}, {1, 0}, {2, 1}, {3, 1},{4, 7}};
+      frl = ArrayUtils.frame(new String[]{"x", "weights"}, dl);
+      parms = new QuantileModel.QuantileParameters();
+      parms._train = frl._key;
+      parms._weights_column = "weights";
+      parms._probs = new double[]{0.51};
+      parms._lo = 1; // inclusive
+      parms._hi = 4; // exclusive
+      parms._local_column_index = 0;
+      job = new Quantile(parms).trainModel();
+      kmml = job.get();
+      job.remove();
+      Assert.assertTrue(kmml._output._quantiles[0][0] == 2.51);
+      
+    } finally {
+      if (fr != null) fr.remove();
+      if (kmm != null) kmm.delete();
+      if (frl != null) frl.remove();
+      if (kmml != null) kmml.delete();
+    }
+  }
+  
+  @Test
+  public void testInterpolateHighWeightedDoubleLocal() { 
+      QuantileModel kmm = null;
+      Frame fr = null;
+      QuantileModel kmml = null;
+      Frame frl = null;
+      try { 
+          double[][] d = new double[][]{{1e-100, 10}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}};
+          fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+          QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
+          parms._train = fr._key;
+          parms._weights_column = "weights";
+          parms._probs = new double[]{0.5};
+          Job<QuantileModel> job = new Quantile(parms).trainModel();
+          kmm = job.get();
+          job.remove();
+          Assert.assertEquals(5.000005000000008E-5, kmm._output._quantiles[0][0], 1e-10);
+
+          double[][] dl = new double[][]{{1e-100, 10}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}, {2, 10}};
+          frl = ArrayUtils.frame(new String[]{"x", "weights"}, dl);
+          parms = new QuantileModel.QuantileParameters();
+          parms._train = frl._key;
+          parms._weights_column = "weights";
+          parms._probs = new double[]{0.5};
+          parms._lo = 1e-100; // inclusive
+          parms._hi = 2; // exclusive
+          parms._local_column_index = 0;
+          job = new Quantile(parms).trainModel();
+          kmml = job.get();
+          job.remove();
+          Assert.assertEquals(5.000005000000008E-5, kmml._output._quantiles[0][0],1e-10 );
+
+      } finally {
+          if (fr != null) fr.remove();
+          if (kmm != null) kmm.delete();
+          if (frl != null) frl.remove();
+          if (kmml != null) kmml.delete(); 
+      }
+  }
 }
+
+

--- a/h2o-algos/src/test/java/hex/quantile/QuantileTest.java
+++ b/h2o-algos/src/test/java/hex/quantile/QuantileTest.java
@@ -12,13 +12,9 @@ import water.util.ArrayUtils;
 import java.util.Arrays;
 
 public class QuantileTest extends TestUtil {
-  @BeforeClass()
-  public static void setup() {
-    stall_till_cloudsize(1);
-  }
+  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
 
-  @Test
-  public void testIris() {
+  @Test public void testIris() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -27,7 +23,7 @@ public class QuantileTest extends TestUtil {
       fr = parse_test_file("smalldata/iris/iris_wheader.csv");
       //fr = parse_test_file("../../datasets/UCI/UCI-large/covtype/covtype.data");
       //fr = parse_test_file("../../datasets/billion_rows.csv.gz");
-      System.out.println("Done Parse: " + (System.currentTimeMillis() - start));
+      System.out.println("Done Parse: "+(System.currentTimeMillis()-start));
 
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
@@ -38,13 +34,12 @@ public class QuantileTest extends TestUtil {
       job.remove();
 
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
 
-  @Test
-  public void testAllNAS() {
+  @Test public void testAllNAS() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -75,16 +70,15 @@ public class QuantileTest extends TestUtil {
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      for (int i = 0; i < 11; i++)
+      for (int i=0; i < 11; i++)
         Assert.assertTrue(Double.isNaN(kmm._output._quantiles[0][i]));
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
 
-  @Test
-  public void testInts() {
+  @Test public void testInts() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -100,13 +94,12 @@ public class QuantileTest extends TestUtil {
       job.remove();
 
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
 
-  @Test
-  public void test50pct() {
+  @Test public void test50pct() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -120,13 +113,12 @@ public class QuantileTest extends TestUtil {
       Assert.assertTrue(kmm._output._quantiles[0][5] == d[3][0]);
 
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
 
-  @Test
-  public void testDirectMatch() {
+  @Test public void testDirectMatch() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -141,13 +133,11 @@ public class QuantileTest extends TestUtil {
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1);
 
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolate1() {
+  @Test public void testInterpolate1() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -161,13 +151,11 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.5);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolate2() {
+  @Test public void testInterpolate2() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -181,13 +169,11 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.5);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateLow() {
+  @Test public void testInterpolateLow() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -201,13 +187,11 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.98);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHigh() {
+  @Test public void testInterpolateHigh() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -221,18 +205,16 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 2.02);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHighWeighted() {
+  @Test public void testInterpolateHighWeighted() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 0}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -242,19 +224,16 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 2.51);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-
-  @Test
-  public void testInterpolateHighWeighted2() {
+  @Test public void testInterpolateHighWeighted2() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 2}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -264,18 +243,16 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.29);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHighWeighted3() {
+  @Test public void testInterpolateHighWeighted3() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 3}, {2, 2}, {3, 5}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -285,18 +262,16 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.79);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHighWeighted4() {
+  @Test public void testInterpolateHighWeighted4() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 1.005}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -304,20 +279,18 @@ public class QuantileTest extends TestUtil {
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      Assert.assertTrue("Got: " + kmm._output._quantiles[0][0], Math.abs(kmm._output._quantiles[0][0] - 2.42355) < 1e-10);
+      Assert.assertTrue("Got: " + kmm._output._quantiles[0][0], Math.abs(kmm._output._quantiles[0][0] - 2.42355)<1e-10);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHighWeighted5() {
+  @Test public void testInterpolateHighWeighted5() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 5}, {2, 4}, {3, 3}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -327,18 +300,16 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.73);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHighWeighted6() {
+  @Test public void testInterpolateHighWeighted6() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 2}, {2, 2}, {3, 2}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
@@ -348,81 +319,73 @@ public class QuantileTest extends TestUtil {
       job.remove();
       Assert.assertTrue(kmm._output._quantiles[0][0] == 1.65);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHighWeighted7() {
+  @Test public void testInterpolateHighWeighted7() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 1}, {2, 1}, {3, 1}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
+      parms._probs = new double[]{0,0.25,0.5,0.75,1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1, 1.5, 2, 2.5, 3}));
+      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1,1.5,2,2.5,3}));
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateHighWeighted8() {
+  @Test public void testInterpolateHighWeighted8() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1, 2}, {2, 2}, {3, 2}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
+      parms._probs = new double[]{0,0.25,0.5,0.75,1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1, 1.25, 2, 2.75, 3}));
+      Assert.assertTrue(Arrays.equals(kmm._output._quantiles[0], new double[]{1,1.25,2,2.75,3}));
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateWideRangeWeighted() {
+  @Test public void testInterpolateWideRangeWeighted() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1e-100, 1}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
       //parms._probs = new double[]{0,0.25,0.5,0.75,1};
-      parms._probs = new double[]{0.25, 0.5, 0.75, 1};
+      parms._probs = new double[]{0.25,0.5,0.75,1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
       //double[] exp = new double[]{1e-100,5e-5,1e-2,1e-1,1};
-      double[] exp = new double[]{5e-5, 1e-2, 1e-1, 1};
+      double[] exp = new double[]{5e-5,1e-2,1e-1,1};
       double[] act = kmm._output._quantiles[0];
-      for (int i = 0; i < exp.length; ++i)
-        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
+      for (int i=0;i<exp.length; ++i)
+        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i])/exp[i] < 1e-5);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateWideRange() {
+  @Test public void testInterpolateWideRange() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
@@ -430,70 +393,65 @@ public class QuantileTest extends TestUtil {
       fr = ArrayUtils.frame(new String[]{"x"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
-      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
+      parms._probs = new double[]{0,0.25,0.5,0.75,1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      double[] exp = new double[]{1e-100, 2.5e-5, 5.05e-3, 7.75e-2, 1};
+      double[] exp = new double[]{1e-100,2.5e-5,5.05e-3,7.75e-2,1};
       double[] act = kmm._output._quantiles[0];
-      for (int i = 0; i < exp.length; ++i)
-        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
+      for (int i=0;i<exp.length; ++i)
+        Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i])/exp[i] < 1e-5);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateWideRangeWeighted2() {
+  @Test public void testInterpolateWideRangeWeighted2() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{1e-100, 10}, {1e-10, 4}, {1e-4, 2}, {1e-2, 4}, {1e-1, 5}, {1, 3}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0, 0.25, 0.5, 0.75, 1};
+      parms._probs = new double[]{0,0.25,0.5,0.75,1};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      double[] exp = new double[]{1e-100, 1e-100, 5.000005e-5, 1e-1, 1};
+      double[] exp = new double[]{1e-100,1e-100,5.000005e-5,1e-1,1};
       double[] act = kmm._output._quantiles[0];
-      for (int i = 0; i < exp.length; ++i)
+      for (int i=0;i<exp.length; ++i)
         Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
-
-  @Test
-  public void testInterpolateLargeWeights() {
+  @Test public void testInterpolateLargeWeights() {
     QuantileModel kmm = null;
     Frame fr = null;
     try {
       double[][] d = new double[][]{{0, 10}, {1, 10}};
-      fr = ArrayUtils.frame(new String[]{"x", "weights"}, d);
+      fr = ArrayUtils.frame(new String[]{"x","weights"}, d);
       QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
       parms._train = fr._key;
       parms._weights_column = "weights";
-      parms._probs = new double[]{0.475, 0.48, 0.49};
+      parms._probs = new double[]{0.475,0.48,0.49};
       Job<QuantileModel> job = new Quantile(parms).trainModel();
       kmm = job.get();
       job.remove();
-      double[] exp = new double[]{0.025, 0.12, 0.31};
+      double[] exp = new double[]{0.025,0.12,0.31};
       double[] act = kmm._output._quantiles[0];
-      for (int i = 0; i < exp.length; ++i)
+      for (int i=0;i<exp.length; ++i)
         Assert.assertTrue("Got " + act[i] + " but expected " + exp[i], Math.abs(act[i] - exp[i]) / exp[i] < 1e-5);
     } finally {
-      if (fr != null) fr.remove();
-      if (kmm != null) kmm.delete();
+      if( fr  != null ) fr .remove();
+      if( kmm != null ) kmm.delete();
     }
   }
 
-  @Test
-  public void testShuffled() {
+  @Test public void testShuffled() {
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -535,13 +493,12 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if (fr1 != null) fr1.remove();
-      if (fr2 != null) fr2.remove();
+      if( fr1  != null ) fr1.remove();
+      if( fr2  != null ) fr2.remove();
     }
   }
 
-  @Test
-  public void testWeights0() {
+  @Test public void testWeights0() {
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -585,13 +542,12 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if (fr1 != null) fr1.remove();
-      if (fr2 != null) fr2.remove();
+      if( fr1  != null ) fr1.remove();
+      if( fr2  != null ) fr2.remove();
     }
   }
 
-  @Test
-  public void testWeights1() {
+  @Test public void testWeights1() {
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -635,14 +591,12 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if (fr1 != null) fr1.remove();
-      if (fr2 != null) fr2.remove();
+      if( fr1  != null ) fr1.remove();
+      if( fr2  != null ) fr2.remove();
     }
   }
 
-  @Ignore
-  @Test
-  public void testWeights2() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=2 don't agree (unless normwt=TRUE)
+  @Ignore @Test public void testWeights2() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=2 don't agree (unless normwt=TRUE)
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -678,7 +632,7 @@ public class QuantileTest extends TestUtil {
         }
 
         try {
-          assert (Arrays.deepEquals(kmm1._output._quantiles, kmm2._output._quantiles));
+          assert(Arrays.deepEquals(kmm1._output._quantiles, kmm2._output._quantiles));
           Assert.assertTrue(Arrays.deepEquals(kmm1._output._quantiles, kmm2._output._quantiles));
         } finally {
           if (kmm1 != null) kmm1.delete();
@@ -687,14 +641,12 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if (fr1 != null) fr1.remove();
-      if (fr2 != null) fr2.remove();
+      if( fr1  != null ) fr1.remove();
+      if( fr2  != null ) fr2.remove();
     }
   }
 
-  @Ignore
-  @Test
-  public void testWeights3() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=epsilon don't agree (unless normwt=TRUE)
+  @Ignore @Test public void testWeights3() { //same behavior as wtd.quantile in R -> results with all weights=1 and all weights=epsilon don't agree (unless normwt=TRUE)
     QuantileModel kmm1;
     QuantileModel kmm2;
     Frame fr1 = null;
@@ -738,11 +690,11 @@ public class QuantileTest extends TestUtil {
       }
 
     } finally {
-      if (fr1 != null) fr1.remove();
-      if (fr2 != null) fr2.remove();
+      if( fr1  != null ) fr1.remove();
+      if( fr2  != null ) fr2.remove();
     }
   }
-
+  
   @Test
   public void testInterpolate1Local() {
     QuantileModel kmm = null;

--- a/h2o-algos/src/test/java/hex/tree/HistogramTest.java
+++ b/h2o-algos/src/test/java/hex/tree/HistogramTest.java
@@ -126,7 +126,7 @@ public class HistogramTest extends TestUtil {
       }
       Key k = Key.make();
       DKV.put(new DHistogram.HistoQuantiles(k,splitPts));
-      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,0,histoType,seed,k);
+      DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,0,histoType,seed,k, null);
       hist.init();
       int N=10000000;
       int bin=-1;
@@ -161,7 +161,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, 0, histoType, seed, null);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, 0, histoType, seed, null, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -177,7 +177,7 @@ public class HistogramTest extends TestUtil {
     double maxEx = 6.900000000000001;
     long seed = 1234;
     SharedTreeModel.SharedTreeParameters.HistogramType histoType = SharedTreeModel.SharedTreeParameters.HistogramType.Random;
-    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, 0, histoType, seed, null);
+    DHistogram hist = new DHistogram("myhisto", nbins, nbins_cats, isInt, min, maxEx, 0, histoType, seed, null, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);
@@ -196,7 +196,7 @@ public class HistogramTest extends TestUtil {
     double[] splitPts = new double[]{1,1.5,2,2.5,3,4,5,6.1,6.2,6.3,6.7,6.8,6.85};
     Key k = Key.make();
     DKV.put(new DHistogram.HistoQuantiles(k,splitPts));
-    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,0,histoType,seed,k);
+    DHistogram hist = new DHistogram("myhisto",nbins,nbins_cats,isInt,min,maxEx,0,histoType,seed,k, null);
     hist.init();
     assert(hist.binAt(0)==min);
     assert(hist.binAt(nbins-1)<maxEx);

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -3530,5 +3530,57 @@ public class GBMTest extends TestUtil {
     Scope.track(train);
     return train;
   }
+  
+  @Test
+  public void testLocalQuantiles(){
+    Scope.enter();
+    try {
+      final Key<Frame> target = Key.make();
+      Frame train = Scope.track(parse_test_file("/smalldata/higgs/higgs_train_10k.csv"));
+      int ci = train.find("response");
+      Scope.track(train.replace(ci, train.vecs()[ci].toCategoricalVec()));   // Convert response 'Angaus' to categorical
+      DKV.put(train);                    // Update frame after hacking it
+
+      GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+      parms._train = train._key;
+      parms._response_column = "response"; // Train on the outcome
+      parms._distribution = bernoulli;
+      parms._ntrees = 50;
+      parms._max_depth = 20;
+      
+      parms._histogram_type = SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesLocal;
+      GBMModel gbm_local = (GBMModel) Scope.track_generic(new GBM(parms).trainModel().get());
+
+      if(gbm_local!=null){ gbm_local.delete();}
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testGlobalQuantiles(){
+    Scope.enter();
+    try {
+      final Key<Frame> target = Key.make();
+      Frame train = Scope.track(parse_test_file("/smalldata/higgs/higgs_train_10k.csv"));
+      int ci = train.find("response");
+      Scope.track(train.replace(ci, train.vecs()[ci].toCategoricalVec()));   // Convert response 'Angaus' to categorical
+      DKV.put(train);                    // Update frame after hacking it
+
+      GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+      parms._train = train._key;
+      parms._response_column = "response"; // Train on the outcome
+      parms._distribution = bernoulli;
+      parms._ntrees = 50;
+      parms._max_depth = 20;
+
+      parms._histogram_type = SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal;
+      GBMModel gbm_global= (GBMModel) Scope.track_generic(new GBM(parms).trainModel().get());
+      
+      if(gbm_global!=null){ gbm_global.delete();}
+    } finally {
+      Scope.exit();
+    }
+  }
 
 }

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -2147,7 +2147,7 @@ public class GBMTest extends TestUtil {
       }
       int idx = ArrayUtils.minIndex(loglosses);
       Log.info("Optimal randomization: " + histoType[idx]);
-      assertTrue(4 == idx);
+      assertTrue(3 == idx);
     } finally {
       if (tfr!=null) tfr.delete();
       if (ksplits[0]!=null) ksplits[0].remove();
@@ -3545,8 +3545,8 @@ public class GBMTest extends TestUtil {
       parms._train = train._key;
       parms._response_column = "response"; // Train on the outcome
       parms._distribution = bernoulli;
-      parms._ntrees = 50;
-      parms._max_depth = 20;
+      parms._ntrees = 20;
+      parms._max_depth = 10;
       
       parms._histogram_type = SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesLocal;
       GBMModel gbm_local = (GBMModel) Scope.track_generic(new GBM(parms).trainModel().get());
@@ -3571,8 +3571,8 @@ public class GBMTest extends TestUtil {
       parms._train = train._key;
       parms._response_column = "response"; // Train on the outcome
       parms._distribution = bernoulli;
-      parms._ntrees = 50;
-      parms._max_depth = 20;
+      parms._ntrees = 20;
+      parms._max_depth = 10;
 
       parms._histogram_type = SharedTreeModel.SharedTreeParameters.HistogramType.QuantilesGlobal;
       GBMModel gbm_global= (GBMModel) Scope.track_generic(new GBM(parms).trainModel().get());

--- a/h2o-automl/src/main/java/ai/h2o/automl/collectors/MetaCollector.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/collectors/MetaCollector.java
@@ -128,7 +128,7 @@ public class MetaCollector {
       parms._nbins = nbins;
       parms._nbins_cats = nbins_cats;
 
-      return DHistogram.make(name, nbins, isInt, minIn, maxEx, 0, parms, null);
+      return DHistogram.make(name, nbins, isInt, minIn, maxEx, 0, parms, null, null);
     }
     public double binAt(int b) { return _h.binAt(b); }
 

--- a/h2o-core/src/main/java/hex/quantile/QuantileModel.java
+++ b/h2o-core/src/main/java/hex/quantile/QuantileModel.java
@@ -13,6 +13,10 @@ public class QuantileModel extends Model<QuantileModel,QuantileModel.QuantilePar
     // Set of probabilities to compute
     public double _probs[/*Q*/] = new double[]{0.001,0.01,0.1,0.25,0.333,0.50,0.667,0.75,0.9,0.99,0.999};
     public CombineMethod _combine_method = CombineMethod.INTERPOLATE;
+    
+    public double _lo,_hi = 0;
+    public int _local_column_index = -1;
+    
     protected boolean defaultDropConsCols() { return false; }
     public String algoName() { return "Quantiles"; }
     public String fullName() { return "Quantiles"; }


### PR DESCRIPTION
Try to implement Local Quantile Histogram approach which is described in [XGBoost paper](https://arxiv.org/pdf/1603.02754.pdf). 

JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-6074

**First implementation**
- Solution: 
recalculate split points for new histograms after every split in the tree in the same way how global splits are calculated
- Result: 
slower than Global Quantile Histograms and the MSE is worse
- Next step: 
inspect how split points are calculated in XGBoost -  they use approximation factor (to decide how many split points will be created) which H2O GBM does not use (in GBM we use the fixed number of probabilities and then normalize and pad new split points)