### PR TITLE
PUBDEV-6245: Add predict_leaf_node_assignment to User Guide

### DIFF
--- a/h2o-docs/src/product/data-science/if.rst
+++ b/h2o-docs/src/product/data-science/if.rst
@@ -10,6 +10,15 @@ Isolation Forest is similar in principle to Random Forest and is built on the ba
 
 Random partitioning produces noticeably shorter paths for anomalies. When a forest of random trees collectively produces shorter path lengths for particular samples, they are highly likely to be anomalies.
 
+Tutorials and Blogs
+~~~~~~~~~~~~~~~~~~~
+
+The following tutorials are available that describe how to use Isolation Forest to find anomalies in a dataset and how to interpret the results. 
+
+- `Isolation Forest Deep Dive <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/isolation-forest/isolation-forest.ipynb>`__: Describes how the Isolation Forest algorithm works and how to use it.
+- `Interpreting Isolation Forest Anomalies <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/isolation-forest/interpreting_isolation-forest.ipynb>`__: Describes how to understand why a particular feature is considered an anomaly.
+
+The `Anomaly Detection with Isolation Forests using H2O <https://www.h2o.ai/blog/anomaly-detection-with-isolation-forests-using-h2o/>`__ blog provides a summary and examples of the Isolation Forest algorithm in H2O. 
 
 Defining an Isolation Forest Model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,6 +80,68 @@ Defining an Isolation Forest Model
   - ``label_encoder`` or ``LabelEncoder``:  Convert every enum into the integer of its index (for example, level 0 -> 0, level 1 -> 1, etc.)
   - ``sort_by_response`` or ``SortByResponse``: Reorders the levels by the mean response (for example, the level with lowest response -> 0, the level with second-lowest response -> 1, etc.). This is useful in GBM/DRF, for example, when you have more levels than ``nbins_cats``, and where the top level splits now have a chance at separating the data with a split. Note that this requires a specified response column.
 
+Simple Example
+~~~~~~~~~~~~~~
+
+Below is a simple example showing Isolation Forest from model training through prediction and predicted leaf node assignment. 
+
+.. example-code::
+   .. code-block:: r
+
+    library(h2o)
+    h2o.init()
+
+    # Import the prostate dataset
+    prostate.hex <- h2o.importFile(path = "https://raw.github.com/h2oai/h2o/master/smalldata/logreg/prostate.csv", 
+                                   destination_frame = "prostate.hex")
+
+    # Split dataset giving the training dataset 75% of the data
+    prostate.split <- h2o.splitFrame(data=prostate.hex, ratios=0.75)
+
+    # Create a training set from the 1st dataset in the split
+    train <- prostate.split[[1]]
+
+    # Create a testing set from the 2nd dataset in the split
+    test <- prostate.split[[2]]
+
+    # Build an Isolation forest model
+    model <- h2o.isolationForest(training_frame=train, 
+                                 sample_rate = 0.1, 
+                                 max_depth = 20, 
+                                 ntrees = 10, 
+                                 score_each_iteration = TRUE)
+
+    # Calculate score
+    score <- h2o.predict(model, test)
+    result_pred <- as.data.frame(score)$predict
+
+    # Predict the leaf node assignment
+    ln_pred <- h2o.predict_leaf_node_assignment(model, test)
+
+   .. code-block:: python
+
+    import h2o
+    from h2o.estimators import H2OIsolationForestEstimator
+    h2o.init()
+    
+    # Import the prostate dataset
+    h2o_df = h2o.import_file("https://raw.github.com/h2oai/h2o/master/smalldata/logreg/prostate.csv")
+    
+    # Split the data into Train/Test/Validation with Train having 70% and test and validation 15% each
+    train,test,valid = h2o_df.split_frame(ratios=[.7, .15])
+
+    # Build an Isolation forest model
+    model = H2OIsolationForestEstimator(sample_rate = 0.1, 
+                                        max_depth = 20, 
+                                        ntrees = 10, 
+                                        score_each_iteration = True)
+    model.train(training_frame=train)
+
+    # Run prediction on the model
+    predict = model.predict(test)
+
+    # Predict the leaf node assigment
+    predict_lna = model.predict_leaf_node_assignment(test, "Path")
 
 References
 ~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/if.rst
+++ b/h2o-docs/src/product/data-science/if.rst
@@ -108,12 +108,11 @@ Below is a simple example showing Isolation Forest from model training through p
     model <- h2o.isolationForest(training_frame=train, 
                                  sample_rate = 0.1, 
                                  max_depth = 20, 
-                                 ntrees = 10, 
-                                 score_each_iteration = TRUE)
+                                 ntrees = 50)
 
     # Calculate score
     score <- h2o.predict(model, test)
-    result_pred <- as.data.frame(score)$predict
+    result_pred <- score$predict
 
     # Predict the leaf node assignment
     ln_pred <- h2o.predict_leaf_node_assignment(model, test)
@@ -127,21 +126,22 @@ Below is a simple example showing Isolation Forest from model training through p
     # Import the prostate dataset
     h2o_df = h2o.import_file("https://raw.github.com/h2oai/h2o/master/smalldata/logreg/prostate.csv")
     
-    # Split the data into Train/Test/Validation with Train having 70% and test and validation 15% each
-    train,test,valid = h2o_df.split_frame(ratios=[.7, .15])
+    # Split the data giving the training dataset 75% of the data
+    train,test = h2o_df.split_frame(ratios=[0.75])
 
     # Build an Isolation forest model
     model = H2OIsolationForestEstimator(sample_rate = 0.1, 
                                         max_depth = 20, 
-                                        ntrees = 10, 
-                                        score_each_iteration = True)
+                                        ntrees = 50)
     model.train(training_frame=train)
 
-    # Run prediction on the model
-    predict = model.predict(test)
+    # Calculate score
+    score = model.predict(test)
+    result_pred = score["predict"]
 
-    # Predict the leaf node assigment
-    predict_lna = model.predict_leaf_node_assignment(test, "Path")
+    # Predict the leaf node assignment
+    ln_pred = model.predict_leaf_node_assignment(test, "Path")
+
 
 References
 ~~~~~~~~~~

--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -465,7 +465,7 @@ Thus, the one-dimensional partial dependence of function :math:`g` on :math:`X_j
 Prediction
 ----------
 
-With H2O-3, you can generate predictions for a model based on samples in a test set using ``h2o.predict()`` or ``predict``(). This can be accomplished in memory or using MOJOs/POJOs.
+With H2O-3, you can generate predictions for a model based on samples in a test set using ``h2o.predict()`` or ``predict()``. This can be accomplished in memory or using MOJOs/POJOs.
 
 **Note**: MOJO/POJO predict cannot parse columns enclosed in double quotes (for example, ""2"").  
 

--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -465,9 +465,18 @@ Thus, the one-dimensional partial dependence of function :math:`g` on :math:`X_j
 Prediction
 ----------
 
-With H2O-3, you can generate predictions for a model based on samples in a test set. This can be accomplished in memory or using MOJOs/POJOs.  
+With H2O-3, you can generate predictions for a model based on samples in a test set using ``h2o.predict()`` or ``.predict()``. This can be accomplished in memory or using MOJOs/POJOs.  
 
 For classification problems, predicted probabilities and labels are compared against known results. (Note that for binary models, labels are based on the maximum F1 threshold from the model object.) For regression problems, predicted regression targets are compared against testing targets and typical error metrics.
+
+Predicting Leaf Node Assignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For tree-based models, including GBM, DRF, XGBoost, and Isolation Forest, the ``h2o.predict_leaf_node_assignment()`` function predicts the leaf assignment on an H2O model. 
+
+This function predicts against a test frame. For every row in the test frame, this function returns the leaf placements of the row in all the trees in the model. An optional Type can also be specified to define the placements. Placements can be represented either by paths to the leaf nodes from the tree root (``Path`` - default) or by H2O's internal identifiers (``Node_ID``). The order of the rows in the results is the same as the order in which the data was loaded.
+
+This function returns an H2OFrame object with categorical leaf assignment identifiers for each tree in the model.
 
 Prediction Threshold
 ~~~~~~~~~~~~~~~~~~~~
@@ -494,7 +503,6 @@ This section provides examples of performing predictions in Python and R. Refer 
     prostate.hex <- h2o.importFile(path = "https://raw.github.com/h2oai/h2o/master/smalldata/logreg/prostate.csv", 
                                    destination_frame = "prostate.hex")
 
-
     # Split dataset giving the training dataset 75% of the data
     prostate.split <- h2o.splitFrame(data=prostate.hex, ratios=0.75)
 
@@ -517,27 +525,42 @@ This section provides examples of performing predictions in Python and R. Refer 
                      learn_rate=0.1)
 
     # Predict using the GBM model and the testing dataset
-    pred = h2o.predict(object=model, newdata=prostate.test)
+    pred <- h2o.predict(object=model, newdata=prostate.test)
     pred
       predict         p0          p1
-    1       1 0.39080085 0.609199153
-    2       0 0.75531958 0.244680420
-    3       1 0.09730223 0.902697771
-    4       0 0.99386932 0.006130679
-    5       0 0.89263247 0.107367533
-    6       0 0.98590611 0.014093887
+    1       0 0.7414373 0.25856274
+    2       1 0.3114293 0.68857073
+    3       0 0.9852284 0.01477161
+    4       0 0.6647902 0.33520975
+    5       0 0.6075046 0.39249538
+    6       1 0.4065468 0.59345323
 
-    [38 rows x 3 columns] 
+    [88 rows x 3 columns] 
 
     # View a summary of the prediction with a probability of TRUE
     summary(pred$p1, exact_quantiles=TRUE)
      p1                
-     Min.   :0.006131  
-     1st Qu.:0.123465  
-     Median :0.375684  
-     Mean   :0.414250  
-     3rd Qu.:0.676742  
-     Max.   :0.971854  
+     Min.   :0.008925  
+     1st Qu.:0.160050  
+     Median :0.350236  
+     Mean   :0.451507  
+     3rd Qu.:0.818486  
+     Max.   :0.99040  
+
+    # Predict the leaf node assigment using the GBM model and test data.
+    # Predict based on the path from the root node of the tree.
+    predict_lna <- h2o.predict_leaf_node_assignment(model, prostate.test)
+
+    # View a summary of the leaf node assignment prediction
+    summary(predict_lna$T1.C1, exact_quantiles=TRUE)
+    T1.C1   
+    RRLR:15 
+    RRR :13 
+    LLLR:12 
+    LLLL:11 
+    LLRR: 8 
+    LLRL: 6 
+
 
    .. code-block:: python
 
@@ -580,6 +603,10 @@ This section provides examples of performing predictions in Python and R. Refer 
             0  0.642381  0.357619
 
     [10 rows x 3 columns]
+
+    # Predict the leaf node assigment using the GBM model and test data.
+    # Predict based on the path from the root node of the tree.
+    predict_lna = model.predict_leaf_node_assignment(test, "Path")
 
 
 Predict using MOJOs


### PR DESCRIPTION
- Added this in the Prediction topic, as it applies to predictions in GBM, DRF, XGBoost, and Isolation Forest.
- Added predict_leaf_node_assignment to the current example in the Prediction topic.
- In the Isolation Forest topic, added links to tutorials and blogs. Also added a simple example (in R and Python) showing model building, predict, and predict leaf node assignment.