### PR TITLE
PUBDEV-6183: Doc fix for Tweedie deviance equation

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/GLMBooklet.tex
@@ -535,7 +535,7 @@ where $\kappa(\mu,p) = \mu^{2-p}/(2-p)$ for $p \neq 2$ and $\kappa(\mu,p) = \log
 %Apart from the special cases, the density of the distribution does not have an analytic expression. The model likelihood to maximize is
 
 The corresponding deviance when $p \neq 1$ and $p\neq 2$ is equal to:
-$$D = -2 \sum_{i=1}^{N} y_i  (y_i^{1-p} - \hat{y}_i^{1-p} ) - \frac{(y_i^{2 - p} - \hat{y}_i^{2 - p})}{(2 - p)}. $$\\
+$$D = 2\sum_{i}^N \frac{y_{i}(y_{i}^{1-p} - \hat{y}_{i}^{1-p})}{(1-p)} - \frac{(y_{i}^{2-p} - \hat{y}_{i}^{2-p})}{(2-p)} $$\\
 
 %\waterExampleInR
 %This example loads the Insurance data from the HDtweedie library, imports it into H2O and runs a tweedie model that predicts the aggregate claim loss (in thousand dollars) based on 56 predictors including the car type, job class etc.
@@ -813,7 +813,7 @@ it is therefore less numerically stable and can be very slow as well due to slow
 
 \subsubsection{Offsets}
 
-\texttt{offset\_column} is an optional column name or index referring to a column in the training frame. This column specifies a prior known component to be included in the linear predictor during training. Offsets are per-row ``��bias values''�� that are used during model training. 
+\texttt{offset\_column} is an optional column name or index referring to a column in the training frame. This column specifies a prior known component to be included in the linear predictor during training. Offsets are per-row "bias values" that are used during model training. 
 
 For Gaussian distributions, they can be seen as simple corrections to the response (\texttt{y}) column. Instead of learning to predict the response (\texttt{y}-row), the model learns to predict the (row) offset of the response column. 
 
@@ -993,7 +993,7 @@ Various model statistics are available:
 
 \texttt{R\textasciicircum2} is the R squared: $R^2 = 1 - {MSE \over \sigma_y^2}$
 
-\texttt{LogLoss} is the log loss.  $LogLoss = {−1 \over N} \sum_i^N \sum_j^C y_{i}log(p_{i,j})$
+\texttt{LogLoss} is the log loss. $LogLoss = {-1 \over N} \sum_i^N \sum_j^C y_{i}log(p_{i,j})$
 
 \texttt{AUC} is available only for binomial models and is defined the area under ROC curve.
 

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -383,7 +383,7 @@ The Tweedie distribution is parametrized by variance power :math:`p`. It is defi
 - :math:`p = 1`: Poisson
 - :math:`p \in (1,2)`: Compound Poisson, non-negative with mass at zero
 - :math:`p = 2`: Gamma
-- :math:`p = 3`: Gaussian
+- :math:`p = 3`: Inverse-Gaussian
 - :math:`p > 2`: Stable, with support on the positive reals
 
 For :math:`p > 1`, the model likelood to maximize has the form:
@@ -398,7 +398,7 @@ The corresponding deviance when :math:`p \neq 1` and :math:`p \neq 2` is equal t
 
 .. math::
 
- D = -2 \sum_{i=1}^{N} y_i(y_i^{1-p} - \hat{y}_i^{1-p}) - \dfrac {(y_i^{2-p} - \hat{y}_i^{2-p})} {(2-p)}
+ D = 2\sum_{i}^N \frac{y_{i}(y_{i}^{1-p} - \hat{y}_{i}^{1-p})}{(1-p)} - \frac{(y_{i}^{2-p} - \hat{y}_{i}^{2-p})}{(2-p)}
 
 Links
 '''''


### PR DESCRIPTION
- Updated the equation for deviance in the Tweedie subsection in the user guide and GLM booklet
- p=3 is Inverse-Gaussian instead of Gaussian in the UG
- Fixed character issue in GLM booklet