### PR TITLE
PUBDEV-6254: AutoML basic support for blending

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -295,6 +295,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
         Log.warn("Failed to find base model; skipping: " + k);
         continue;
       }
+      Log.debug("Checking properties for model " + k);
       if (!aModel.isSupervised()) {
         throw new H2OIllegalArgumentException("Base model is not supervised: " + aModel._key.toString());
       }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -135,6 +135,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       
       StackedEnsemble.addModelPredictionsToLevelOneFrame(base, basePreds, levelOneFrame);
       DKV.remove(basePreds._key); //Cleanup
+      Frame.deleteTempFrameAndItsNonSharedVecs(basePreds, levelOneFrame);
     }
 
     // Add response column to level one frame
@@ -162,6 +163,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       ModelMetrics mmStackedEnsemble = lastComputedMetric.deepCloneWithDifferentModelAndFrame(this, fr);
       this.addModelMetrics(mmStackedEnsemble);
     }
+    Frame.deleteTempFrameAndItsNonSharedVecs(levelOneFrame, adaptFrm);
     return predictFr;
   }
 
@@ -182,7 +184,8 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
 
   ModelMetrics doScoreMetricsOneFrame(Frame frame, Job job) {
       Frame pred = this.predictScoreImpl(frame, new Frame(frame), null, job, true, CFuncRef.from(_parms._custom_metric_func));
-      pred.remove();
+//      Frame pred = this.score(frame, null, job, true,  CFuncRef.from(_parms._custom_metric_func));
+      pred.delete();
       return ModelMetrics.getFromDKV(this, frame);
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1298,7 +1298,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     } else if (allModels.length == 1) {
       this.job.update(seWork.consumeAll(), "One model built; StackedEnsemble builds skipped");
       userFeedback.info(Stage.ModelTraining, "StackedEnsemble builds skipped since there is only one model built");
-    } else if (buildSpec.build_control.nfolds == 0 && getBlendingFrame() == null) {
+    } else if (!isCVEnabled() && getBlendingFrame() == null) {
       this.job.update(seWork.consumeAll(), "Cross-validation disabled by the user and no blending frame provided; StackedEnsemble build skipped");
       userFeedback.info(Stage.ModelTraining,"Cross-validation disabled by the user and no blending frame provided; StackedEnsemble build skipped");
     } else {

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -309,7 +309,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
           this.leaderboardFrame = splits[1];
           this.didValidationSplit = false;
           this.didLeaderboardSplit = true;
-          userFeedback.info(Stage.DataImport, "Since nfolds == 0, automatically split the training data into training and leaderboard frame in the ratio 80/20");
+          userFeedback.info(Stage.DataImport, "Since nfolds == 0, automatically split the training data into training and leaderboard frame in the ratio 90/10");
         } else {
           // Leaderboard frame is already there, no need to do anything
           userFeedback.info(Stage.DataImport, "Since nfolds == 0 and leaderboard dataset was specified, no auto-splitting needed.");

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -65,6 +65,7 @@ public class AutoMLBuildSpec extends Iced {
 
     public Key<Frame> training_frame;
     public Key<Frame> validation_frame;
+    public Key<Frame> blending_frame;
     public Key<Frame> leaderboard_frame;
 
     public String response_column;

--- a/h2o-automl/src/main/java/ai/h2o/automl/UserFeedbackEvent.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/UserFeedbackEvent.java
@@ -7,10 +7,11 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class UserFeedbackEvent extends Iced {
+
   public enum Level {
-    Debug, Info, Warn;
+    Debug, Info, Warn
   }
-  public final int longestLevel = longestLevel(); // for formatting
+  private final int longestLevel = longestLevel(); // for formatting
 
 
   public enum Stage {
@@ -21,7 +22,7 @@ public class UserFeedbackEvent extends Iced {
     FeatureCreation,
     ModelTraining,
   }
-  public final int longestStage = longestStage(); // for formatting
+  private final int longestStage = longestStage(); // for formatting
 
   private long timestamp;
   transient private AutoML autoML;

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -75,7 +75,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help = "ID of the validation data frame (used for early stopping in grid searches and for early stopping of the AutoML process itself).", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 validation_frame;
 
-    @API(help = "ID of the actual blending frame used to train the Stacked Ensembles in the absence of cross-validated base models: when using this frame, it is recommended to set `nfolds=0` and provide a leaderboard frame for scoring.", direction = API.Direction.INPUT)
+    @API(help = "ID of the blending frame used to train the Stacked Ensembles in the absence of cross-validated base models. When provided, it is also recommended to disable cross validation by setting `nfolds=0` and to provide a leaderboard frame for scoring purposes.", direction = API.Direction.INPUT)
     public KeyV3.FrameKeyV3 blending_frame;
 
     @API(help = "ID of the leaderboard data frame (used to score models and rank them on the AutoML Leaderboard).", direction=API.Direction.INPUT)

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -75,6 +75,9 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help = "ID of the validation data frame (used for early stopping in grid searches and for early stopping of the AutoML process itself).", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 validation_frame;
 
+    @API(help = "ID of the actual blending frame used to train the Stacked Ensembles in the absence of cross-validated base models: when using this frame, it is recommended to set `nfolds=0` and provide a leaderboard frame for scoring.", direction = API.Direction.INPUT)
+    public KeyV3.FrameKeyV3 blending_frame;
+
     @API(help = "ID of the leaderboard data frame (used to score models and rank them on the AutoML Leaderboard).", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 leaderboard_frame;
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -75,7 +75,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help = "ID of the validation data frame (used for early stopping in grid searches and for early stopping of the AutoML process itself).", direction=API.Direction.INPUT)
     public KeyV3.FrameKeyV3 validation_frame;
 
-    @API(help = "ID of the blending frame used to train the Stacked Ensembles in the absence of cross-validated base models. When provided, it is also recommended to disable cross validation by setting `nfolds=0` and to provide a leaderboard frame for scoring purposes.", direction = API.Direction.INPUT)
+    @API(help = "ID of the H2OFrame used to train the the metalearning algorithm in Stacked Ensembles (instead of relying on cross-validated predicted values). When provided, it is also recommended to disable cross validation by setting `nfolds=0` and to provide a leaderboard frame for scoring purposes.", direction = API.Direction.INPUT)
     public KeyV3.FrameKeyV3 blending_frame;
 
     @API(help = "ID of the leaderboard data frame (used to score models and rank them on the AutoML Leaderboard).", direction=API.Direction.INPUT)

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
@@ -20,7 +20,7 @@ public class AutoMLV99 extends SchemaV3<AutoML,AutoMLV99> {
   @API(help="ID of the actual validation frame for this AutoML run after any automatic splitting", direction=API.Direction.OUTPUT)
   public KeyV3.FrameKeyV3 validation_frame;
 
-  @API(help="", direction = API.Direction.OUTPUT)
+  @API(help="ID of the actual blending frame used to train the Stacked Ensembles in blending mode", direction = API.Direction.OUTPUT)
   public KeyV3.FrameKeyV3 blending_frame;
   
   @API(help="ID of the actual leaderboard frame for this AutoML run after any automatic splitting", direction=API.Direction.OUTPUT)

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
@@ -20,6 +20,9 @@ public class AutoMLV99 extends SchemaV3<AutoML,AutoMLV99> {
   @API(help="ID of the actual validation frame for this AutoML run after any automatic splitting", direction=API.Direction.OUTPUT)
   public KeyV3.FrameKeyV3 validation_frame;
 
+  @API(help="", direction = API.Direction.OUTPUT)
+  public KeyV3.FrameKeyV3 blending_frame;
+  
   @API(help="ID of the actual leaderboard frame for this AutoML run after any automatic splitting", direction=API.Direction.OUTPUT)
   public KeyV3.FrameKeyV3 leaderboard_frame;
 
@@ -62,6 +65,10 @@ public class AutoMLV99 extends SchemaV3<AutoML,AutoMLV99> {
 
     if (null != autoML.getValidationFrame()) {
       this.validation_frame = new KeyV3.FrameKeyV3(autoML.getValidationFrame()._key);
+    }
+
+    if (null != autoML.getBlendingFrame()) {
+      this.blending_frame = new KeyV3.FrameKeyV3(autoML.getBlendingFrame()._key);
     }
 
     if (null != autoML.getLeaderboardFrame()) {

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -111,19 +111,19 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   public float[] hr() { return null; }
   public AUC2 auc_obj() { return null; }
 
-  static public double getMetricFromModel(Key<Model> key, String criterion) {
-    Model model = DKV.getGet(key);
-    if (null == model) throw new H2OIllegalArgumentException("Cannot find model " + key);
-    ModelMetrics mm =
-            model._output._cross_validation_metrics != null ?
-                    model._output._cross_validation_metrics :
-                    model._output._validation_metrics != null ?
-                            model._output._validation_metrics :
-                            model._output._training_metrics;
-    return getMetricFromModelMetric(mm, criterion);
+  public static ModelMetrics defaultModelMetrics(Model model) {
+    return model._output._cross_validation_metrics != null ? model._output._cross_validation_metrics
+        : model._output._validation_metrics != null ? model._output._validation_metrics
+        : model._output._training_metrics;
   }
 
-  static public double getMetricFromModelMetric(ModelMetrics mm, String criterion) {
+  public static double getMetricFromModel(Key<Model> key, String criterion) {
+    Model model = DKV.getGet(key);
+    if (null == model) throw new H2OIllegalArgumentException("Cannot find model " + key);
+    return getMetricFromModelMetric(defaultModelMetrics(model), criterion);
+  }
+
+  public static double getMetricFromModelMetric(ModelMetrics mm, String criterion) {
     if (null == criterion || criterion.equals("")) {
       throw new H2OIllegalArgumentException("Need a valid criterion, but got '" + criterion + "'.");
     }
@@ -234,12 +234,7 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     Set<String> res = new HashSet<>();
     Model model = DKV.getGet(key);
     if (null == model) throw new H2OIllegalArgumentException("Cannot find model " + key);
-    ModelMetrics m =
-            model._output._cross_validation_metrics != null ?
-                    model._output._cross_validation_metrics :
-                    model._output._validation_metrics != null ?
-                            model._output._validation_metrics :
-                            model._output._training_metrics;
+    ModelMetrics m = defaultModelMetrics(model);
     ConfusionMatrix cm = m.cm();
     Set<String> excluded = new HashSet<>();
     excluded.add("makeSchema");

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -128,6 +128,7 @@ public class TestUtil extends Iced {
     int leaked_keys = H2O.store_size() - _initial_keycnt;
     int cnt=0;
     if( leaked_keys > 0 ) {
+      int print_max = 10;
       for( Key k : H2O.localKeySet() ) {
         Value value = Value.STORE_get(k);
         // Ok to leak VectorGroups and the Jobs list
@@ -137,11 +138,11 @@ public class TestUtil extends Iced {
           leaked_keys--;
         } else {
           System.out.println(k + " -> " + (value.type() != TypeMap.PRIM_B ? value.get() : "byte[]"));
-          if( cnt++ < 10 )
+          if( cnt++ < print_max )
             System.err.println("Leaked key: " + k + " = " + TypeMap.className(value.type()));
         }
       }
-      if( 10 < leaked_keys ) System.err.println("... and "+(leaked_keys-10)+" more leaked keys");
+      if( print_max < leaked_keys ) System.err.println("... and "+(leaked_keys-print_max)+" more leaked keys");
     }
     assertTrue("Keys leaked: " + leaked_keys + ", cnt = " + cnt, leaked_keys <= 0 || cnt == 0);
     // Bulk brainless key removal.  Completely wipes all Keys without regard.

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -275,6 +275,9 @@ class H2OAutoML(object):
         :param leaderboard_frame: H2OFrame with test data for scoring the leaderboard.  This is optional and
             if this is set to None (the default), then cross-validation metrics will be used to generate the leaderboard 
             rankings instead.
+        :param blending_frame: H2OFrame used to train the Stacked Ensembles in the absence of cross-validated base models.
+            This is optional, but when provided, it is also recommended to disable cross validation 
+            by setting `nfolds=0` and to provide a leaderboard frame for scoring purposes.
 
         :returns: An H2OAutoML object.
 

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -254,7 +254,7 @@ class H2OAutoML(object):
     # Training AutoML
     #---------------------------------------------------------------------------
     def train(self, x = None, y = None, training_frame = None, fold_column = None, 
-              weights_column = None, validation_frame = None, leaderboard_frame = None):
+              weights_column = None, validation_frame = None, leaderboard_frame = None, blending_frame = None):
         """
         Begins an AutoML task, a background task that automatically builds a number of models
         with various algorithms and tracks their performance in a leaderboard. At any point 
@@ -323,12 +323,16 @@ class H2OAutoML(object):
             input_spec['weights_column'] = weights_column
 
         if validation_frame is not None:
-            assert_is_type(training_frame, H2OFrame)
+            assert_is_type(validation_frame, H2OFrame)
             input_spec['validation_frame'] = validation_frame.frame_id
 
         if leaderboard_frame is not None:
-            assert_is_type(training_frame, H2OFrame)
+            assert_is_type(leaderboard_frame, H2OFrame)
             input_spec['leaderboard_frame'] = leaderboard_frame.frame_id
+
+        if blending_frame is not None:
+            assert_is_type(blending_frame, H2OFrame)
+            input_spec['blending_frame'] = blending_frame.frame_id
 
         if self.sort_metric is not None:
             assert_is_type(self.sort_metric, str)

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -275,7 +275,7 @@ class H2OAutoML(object):
         :param leaderboard_frame: H2OFrame with test data for scoring the leaderboard.  This is optional and
             if this is set to None (the default), then cross-validation metrics will be used to generate the leaderboard 
             rankings instead.
-        :param blending_frame: H2OFrame used to train the Stacked Ensembles in the absence of cross-validated base models.
+        :param blending_frame: H2OFrame used to train the the metalearning algorithm in Stacked Ensembles (instead of relying on cross-validated predicted values).
             This is optional, but when provided, it is also recommended to disable cross validation 
             by setting `nfolds=0` and to provide a leaderboard frame for scoring purposes.
 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -16,7 +16,7 @@
 #'        validation_frame will be ignored.
 #' @param leaderboard_frame Leaderboard frame (H2OFrame or ID); Optional.  If provided, the Leaderboard will be scored using 
 #'        this data frame intead of using cross-validation metrics, which is the default.
-#' @param blending_frame Blending frame (H2OFrame or ID) used to train the Stacked Ensembles in the absence of cross-validated base models; Optional. 
+#' @param blending_frame Blending frame (H2OFrame or ID) used to train the the metalearning algorithm in Stacked Ensembles (instead of relying on cross-validated predicted values); Optional.
 #         When provided, it also is recommended to disable cross validation by setting `nfolds=0` and to provide a leaderboard frame for scoring purposes.
 #' @param nfolds Number of folds for k-fold cross-validation. Defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensemble (thus decreasing the overall model performance).
 #' @param fold_column Column with cross-validation fold index assignment per observation; used to override the default, randomized, 5-fold cross-validation scheme for individual models in the AutoML run.

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -377,16 +377,19 @@ function(testDesc, test) {
 }
 
 doSuite<-
-function(suiteDesc, suite, run_in_isolation=TRUE) {
+function(suiteDesc, suite, run_in_isolation=TRUE, time_monitor=FALSE) {
     suiteTest <- function() {
         warnings <- c()
         errors <- c()
+        call_func <- do.call
+        if(time_monitor)
+            call_func <- function(...) print(system.time(do.call(...)))
         lapply(suite$tests, function(test_name) {
           cat("\n")
           cat("Running", test_name, "\n")
           if(run_in_isolation) h2o.removeAll()
           tryCatch(
-              test_that(test_name, withWarnings(do.call(test_name, list(), envir=suite$envir))),
+              test_that(test_name, withWarnings(call_func(test_name, list(), envir=suite$envir))),
               warning = function(w) warnings <<- c(warnings, w),
               error = function(e) errors <<- c(errors, e$message)
           )  

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -2,403 +2,420 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
 automl.args.test <- function() {
-
-  # This test checks the following (for binomial classification):
-  #
-  # 1) That h2o.automl executes w/o errors
-  # 2) That the arguments are working properly
-
-  run_each_test_in_isolation <- TRUE      # can be disabled to minimize slowdown when running test suite in client mode on Jenkins
-  max_models <- 2
-
-  import_dataset <- function(cleanup = run_each_test_in_isolation) {
-    if (cleanup) h2o.removeAll()
-
-    y <- "CAPSULE"
-    y.idx <- 1
-
-    keys <- h2o.ls()$key
-    if ("rtest_automl_args_train" %in% keys) {
-      print("using existing dataset")
-      train <- h2o.getFrame("rtest_automl_args_train")
-      valid <- h2o.getFrame("rtest_automl_args_valid")
-      test <- h2o.getFrame("rtest_automl_args_test")
-    } else {
-      print("uploading dataset")
-      train <- h2o.importFile(locate("smalldata/testng/prostate_train.csv"), destination_frame = "prostate_full_train")
-      train[,y] <- as.factor(train[,y])
-      train <- as.h2o(train, "rtest_automl_args_train")
-      test <- h2o.importFile(locate("smalldata/testng/prostate_test.csv"), destination_frame = "prostate_full_test")
-      test[,y] <- as.factor(test[,y])
-      ss <- h2o.splitFrame(test, destination_frames=c("rtest_automl_args_valid", "rtest_automl_args_test"), seed = 1)
-      valid <- ss[[1]]
-      test <- ss[[2]]
+    
+    # This test checks the following (for binomial classification):
+    #
+    # 1) That h2o.automl executes w/o errors
+    # 2) That the arguments are working properly
+    
+    run_each_test_in_isolation <- TRUE      # can be disabled to minimize slowdown when running test suite in client mode on Jenkins
+    max_models <- 2
+    
+    import_dataset <- function(cleanup = run_each_test_in_isolation) {
+        if (cleanup) h2o.removeAll()
+        
+        y <- "CAPSULE"
+        y.idx <- 1
+        
+        keys <- h2o.ls()$key
+        if ("rtest_automl_args_train" %in% keys) {
+            print("using existing dataset")
+            train <- h2o.getFrame("rtest_automl_args_train")
+            valid <- h2o.getFrame("rtest_automl_args_valid")
+            test <- h2o.getFrame("rtest_automl_args_test")
+        } else {
+            print("uploading dataset")
+            train <- h2o.importFile(locate("smalldata/testng/prostate_train.csv"), destination_frame = "prostate_full_train")
+            train[,y] <- as.factor(train[,y])
+            train <- as.h2o(train, "rtest_automl_args_train")
+            test <- h2o.importFile(locate("smalldata/testng/prostate_test.csv"), destination_frame = "prostate_full_test")
+            test[,y] <- as.factor(test[,y])
+            ss <- h2o.splitFrame(test, destination_frames=c("rtest_automl_args_valid", "rtest_automl_args_test"), seed = 1)
+            valid <- ss[[1]]
+            test <- ss[[2]]
+        }
+        
+        x <- setdiff(names(train), y)
+        return(list(x=x, y=y, y.idx=y.idx, train=train, valid=valid, test=test))
     }
-
-    x <- setdiff(names(train), y)
-    return(list(x=x, y=y, y.idx=y.idx, train=train, valid=valid, test=test))
-  }
-
-  get_partitioned_models <- function(aml) {
-    model_ids <- as.character(as.data.frame(aml@leaderboard[,"model_id"])[,1])
-    ensemble_model_ids <- grep("StackedEnsemble", model_ids, value = TRUE, invert = FALSE)
-    non_ensemble_model_ids <- model_ids[!(model_ids %in% ensemble_model_ids)]
-    return(list(all=model_ids, se=ensemble_model_ids, non_se=non_ensemble_model_ids))
-  }
-
-
-  print("Check arguments to H2OAutoML class")
-
-  test_without_y <- function() {
-    print("Try without a y")
-    ds <- import_dataset()
-    expect_error(h2o.automl(training_frame = ds$train,
-                              max_models = max_models,
-                              project_name = "aml0"))
-  }
-
-  test_without_x <- function() {
-    print("Try without an x")
-    ds <- import_dataset()
-    h2o.automl(y = ds$y,
-              training_frame = ds$train,
-              max_models = max_models,
-              project_name = "aml1")
-  }
-
-  test_y_as_index_x_as_name <- function() {
-    print("Try with y as a column index, x as colnames")
-    ds <- import_dataset()
-    h2o.automl(x = ds$x, y = ds$y.idx,
-              training_frame = ds$train,
-              max_models = max_models,
-              project_name = "aml2",
-    )
-  }
-
-  test_single_training_frame <- function() {
-    print("Single training frame; x and y both specified")
-    ds <- import_dataset()
-    h2o.automl(x = ds$x, y = ds$y,
-              training_frame = ds$train,
-              max_models = max_models,
-              project_name = "aml3",
-    )
-  }
-
-  test_training_with_validation_frame <- function() {
-    print("Training & validation frame")
-    ds <- import_dataset()
-    h2o.automl(x = ds$x, y = ds$y,
-              training_frame = ds$train,
-              validation_frame = ds$valid,
-              max_models = max_models,
-              project_name = "aml4",
-    )
-  }
-
-  test_training_with_leaderboard_frame <- function() {
-    print("Training & leaderboard frame")
-    ds <- import_dataset()
-    h2o.automl(x = ds$x, y = ds$y,
-              training_frame = ds$train,
-              leaderboard_frame = ds$test,
-              max_models = max_models,
-              project_name = "aml5",
-    )
-  }
-
-  test_training_with_validation_and_leaderboard_frame <- function() {
-    print("Training, validation & leaderboard frame")
-    ds <- import_dataset()
-    h2o.automl(x = ds$x, y = ds$y,
-              training_frame = ds$train,
-              validation_frame = ds$valid,
-              leaderboard_frame = ds$test,
-              max_models = max_models,
-              project_name = "aml6",
-    )
-  }
-
-  test_early_stopping <- function() {
-    print("Early stopping args")
-    ds <- import_dataset()
-    h2o.automl(x = ds$x, y = ds$y,
-              training_frame = ds$train,
-              validation_frame = ds$valid,
-              leaderboard_frame = ds$test,
-              max_models = max_models,
-              stopping_metric = "AUC",
-              stopping_tolerance = 0.001,
-              stopping_rounds = 3,
-              project_name = "aml7",
-    )
-  }
-
-  test_leaderboard_growth <- function() {
-    print("Check max_models = 1")
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    max_models = 1,
-                    project_name = "aml8",
-    )
-    nrow_lb <- nrow(aml@leaderboard)
-    expect_equal(nrow_lb, 1)
-
-    print("Check max_models > 1; leaderboard continuity/growth")
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    max_models = max_models,
-                    project_name = "aml8",
-    )
-    expect_equal(nrow(aml@leaderboard) > nrow_lb, TRUE)
-  }
-
-  test_fold_column <- function() {
-    ds <- import_dataset()
-    fold_column <- "fold_id"
-    ds$train[,fold_column] <- as.h2o(data.frame(rep(seq(1:3), 2000)[1:nrow(ds$train)]))
-
-    print("Check fold_column")
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    fold_column = fold_column,
-                    max_models = max_models,
-                    keep_cross_validation_models = TRUE,
-                    project_name = "aml9",
-    )
-    models <- get_partitioned_models(aml)
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    base_model_fold_column <- base_model@parameters$fold_column$column_name
-    expect_equal(base_model_fold_column, fold_column)
-    ensemble <- h2o.getModel(models$se[1])
-    ensemble_fold_column <- ensemble@parameters$metalearner_fold_column$column_name
-    expect_equal(ensemble_fold_column, fold_column)
-    ensemble_meta <- h2o.getModel(ensemble@model$metalearner$name)
-    expect_equal(length(ensemble_meta@model$cross_validation_models), 3)
-  }
-
-
-  test_weights_column <- function() {
-    print("Check weights_column")
-    ds <- import_dataset()
-    weights_column <- "weight"
-    ds$train[,weights_column] <- as.h2o(data.frame(runif(n = nrow(ds$train), min = 0, max = 5)))
-
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    weights_column = weights_column,
-                    max_models = max_models,
-                    project_name = "aml10"
-    )
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    base_model_weights_column <- base_model@parameters$weights_column$column_name
-    expect_equal(base_model_weights_column, weights_column)
-  }
-
-  test_fold_column_with_weights_column <- function() {
-    print("Check fold_colum and weights_column")
-    ds <- import_dataset()
-    fold_column <- "fold_id"
-    ds$train[,fold_column] <- as.h2o(data.frame(rep(seq(1:3), 2000)[1:nrow(ds$train)]))
-    weights_column <- "weight"
-    ds$train[,weights_column] <- as.h2o(data.frame(runif(n = nrow(ds$train), min = 0, max = 5)))
-
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    fold_column = fold_column,
-                    weights_column = weights_column,
-                    max_models = max_models,
-                    project_name = "aml11",
-    )
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    base_model_fold_column <- base_model@parameters$fold_column$column_name
-    expect_equal(base_model_fold_column, fold_column)
-    base_model_weights_column <- base_model@parameters$weights_column$column_name
-    expect_equal(base_model_weights_column, weights_column)
-  }
-
-  test_nfolds_set_to_base_model <- function() {
-    print("Check that nfolds is piped through properly to base models (nfolds > 1)")
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    nfolds = 3,
-                    max_models = max_models,
-                    project_name = "aml12"
-    )
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    expect_equal(base_model@parameters$nfolds, 3)
-  }
-
-  test_nfolds_eq_0 <- function() {
-    print("Check that nfolds = 0 works properly")  #will need to change after xval leaderboard is implemented
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    nfolds = 0,
-                    max_models = max_models,
-                    project_name = "aml13",
-    )
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    expect_equal(base_model@allparameters$nfolds, 0)
-  }
-
-  test_stacked_ensembles_trained <- function() {
-    print("Check that two Stacked Ensembles are trained")
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    nfolds = 3,
-                    max_models = max_models,
-                    project_name = "aml14",
-    )
-    # Check that leaderboard contains exactly two SEs: all model ensemble & top model ensemble
-    expect_equal(length(get_partitioned_models(aml)$se), 2)
-  }
-
-  test_balance_classes <- function() {
-    print("Check that balance_classes is working")
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    nfolds = 3,
-                    max_models = max_models,
-                    balance_classes = TRUE,
-                    max_after_balance_size = 3.0,
-                    class_sampling_factors = c(0.2, 1.4),
-                    project_name = "aml15",
-    )
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    expect_equal(base_model@parameters$balance_classes, TRUE)
-    expect_equal(base_model@parameters$max_after_balance_size, 3.0)
-    expect_equal(base_model@parameters$class_sampling_factors, c(0.2, 1.4))
-  }
-
-  test_keep_cv_models_and_keep_cv_predictions <- function() {
-    print("Check that cv preds/models are deleted")
-    ds <- import_dataset()
-    nfolds <- 3
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                    training_frame = ds$train,
-                    nfolds = nfolds,
-                    max_models = max_models,
-                    project_name = "aml15",
-                    keep_cross_validation_models = FALSE,
-                    keep_cross_validation_predictions = FALSE,
-    )
-
-    model_ids <- as.character(as.data.frame(aml@leaderboard[,"model_id"])[,1])
-    model_ids <- setdiff(model_ids, grep("StackedEnsemble", model_ids, value = TRUE))
-    cv_model_ids <- list(NULL)
-    for(i in 1:nfolds) {
-      cv_model_ids[[i]] <- paste0(model_ids, "_cv_", i)
+    
+    get_partitioned_models <- function(aml) {
+        model_ids <- as.character(as.data.frame(aml@leaderboard[,"model_id"])[,1])
+        ensemble_model_ids <- grep("StackedEnsemble", model_ids, value = TRUE, invert = FALSE)
+        non_ensemble_model_ids <- model_ids[!(model_ids %in% ensemble_model_ids)]
+        return(list(all=model_ids, se=ensemble_model_ids, non_se=non_ensemble_model_ids))
     }
-    cv_model_ids <- unlist(cv_model_ids)
-    expect_equal(sum(sapply(cv_model_ids, function(i) grepl(i, h2o.ls()))), 0)
-  }
-
-  test_keep_cv_fold_assignment_defaults_with_nfolds_gt_0 <- function() {
-    print("Check that fold assignments were skipped by default and nfolds > 1")
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
+    
+    
+    print("Check arguments to H2OAutoML class")
+    
+    test_without_y <- function() {
+        print("Try without a y")
+        ds <- import_dataset()
+        expect_error(h2o.automl(training_frame = ds$train,
+                                max_models = max_models,
+                                project_name = "aml0"))
+    }
+    
+    test_without_x <- function() {
+        print("Try without an x")
+        ds <- import_dataset()
+        h2o.automl(y = ds$y,
                     training_frame = ds$train,
-                    nfolds = 3,
                     max_models = max_models,
-                    project_name = "aml16",
-    )
-    some_base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    expect_equal(some_base_model@parameters$keep_cross_validation_fold_assignment, NULL)
-    expect_equal(some_base_model@model$cross_validation_fold_assignment_frame_id, NULL)
-  }
-
-  test_keep_cv_fold_assignment_TRUE_with_nfolds_gt_0 <- function() {
-    print("Check that fold assignments were kept when `keep_cross_validation_fold_assignment`= TRUE and nfolds > 1")
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
+                    project_name = "aml1")
+    }
+    
+    test_y_as_index_x_as_name <- function() {
+        print("Try with y as a column index, x as colnames")
+        ds <- import_dataset()
+        h2o.automl(x = ds$x, y = ds$y.idx,
                     training_frame = ds$train,
-                    nfolds = 3,
                     max_models = max_models,
-                    project_name = "aml17",
-                    keep_cross_validation_fold_assignment = TRUE,
+                    project_name = "aml2",
+        )
+    }
+    
+    test_single_training_frame <- function() {
+        print("Single training frame; x and y both specified")
+        ds <- import_dataset()
+        h2o.automl(x = ds$x, y = ds$y,
+                    training_frame = ds$train,
+                    max_models = max_models,
+                    project_name = "aml3",
+        )
+    }
+    
+    test_training_with_validation_frame <- function() {
+        print("Training & validation frame")
+        ds <- import_dataset()
+        h2o.automl(x = ds$x, y = ds$y,
+                    training_frame = ds$train,
+                    validation_frame = ds$valid,
+                    max_models = max_models,
+                    project_name = "aml4",
+        )
+    }
+    
+    test_training_with_leaderboard_frame <- function() {
+        print("Training & leaderboard frame")
+        ds <- import_dataset()
+        h2o.automl(x = ds$x, y = ds$y,
+                    training_frame = ds$train,
+                    leaderboard_frame = ds$test,
+                    max_models = max_models,
+                    project_name = "aml5",
+        )
+    }
+    
+    test_training_with_validation_and_leaderboard_frame <- function() {
+        print("Training, validation & leaderboard frame")
+        ds <- import_dataset()
+        h2o.automl(x = ds$x, y = ds$y,
+                    training_frame = ds$train,
+                    validation_frame = ds$valid,
+                    leaderboard_frame = ds$test,
+                    max_models = max_models,
+                    project_name = "aml6",
+        )
+    }
+    
+    test_early_stopping <- function() {
+        print("Early stopping args")
+        ds <- import_dataset()
+        h2o.automl(x = ds$x, y = ds$y,
+                    training_frame = ds$train,
+                    validation_frame = ds$valid,
+                    leaderboard_frame = ds$test,
+                    max_models = max_models,
+                    stopping_metric = "AUC",
+                    stopping_tolerance = 0.001,
+                    stopping_rounds = 3,
+                    project_name = "aml7",
+        )
+    }
+    
+    test_leaderboard_growth <- function() {
+        print("Check max_models = 1")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            max_models = 1,
+                            project_name = "aml8",
+        )
+        nrow_lb <- nrow(aml@leaderboard)
+        expect_equal(nrow_lb, 1)
+        
+        print("Check max_models > 1; leaderboard continuity/growth")
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            max_models = max_models,
+                            project_name = "aml8",
+        )
+        expect_equal(nrow(aml@leaderboard) > nrow_lb, TRUE)
+    }
+    
+    test_fold_column <- function() {
+        ds <- import_dataset()
+        fold_column <- "fold_id"
+        ds$train[,fold_column] <- as.h2o(data.frame(rep(seq(1:3), 2000)[1:nrow(ds$train)]))
+        
+        print("Check fold_column")
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            fold_column = fold_column,
+                            max_models = max_models,
+                            keep_cross_validation_models = TRUE,
+                            project_name = "aml9",
+        )
+        models <- get_partitioned_models(aml)
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        base_model_fold_column <- base_model@parameters$fold_column$column_name
+        expect_equal(base_model_fold_column, fold_column)
+        ensemble <- h2o.getModel(models$se[1])
+        ensemble_fold_column <- ensemble@parameters$metalearner_fold_column$column_name
+        expect_equal(ensemble_fold_column, fold_column)
+        ensemble_meta <- h2o.getModel(ensemble@model$metalearner$name)
+        expect_equal(length(ensemble_meta@model$cross_validation_models), 3)
+    }
+    
+    
+    test_weights_column <- function() {
+        print("Check weights_column")
+        ds <- import_dataset()
+        weights_column <- "weight"
+        ds$train[,weights_column] <- as.h2o(data.frame(runif(n = nrow(ds$train), min = 0, max = 5)))
+        
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            weights_column = weights_column,
+                            max_models = max_models,
+                            project_name = "aml10"
+        )
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        base_model_weights_column <- base_model@parameters$weights_column$column_name
+        expect_equal(base_model_weights_column, weights_column)
+    }
+    
+    test_fold_column_with_weights_column <- function() {
+        print("Check fold_colum and weights_column")
+        ds <- import_dataset()
+        fold_column <- "fold_id"
+        ds$train[,fold_column] <- as.h2o(data.frame(rep(seq(1:3), 2000)[1:nrow(ds$train)]))
+        weights_column <- "weight"
+        ds$train[,weights_column] <- as.h2o(data.frame(runif(n = nrow(ds$train), min = 0, max = 5)))
+        
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            fold_column = fold_column,
+                            weights_column = weights_column,
+                            max_models = max_models,
+                            project_name = "aml11",
+        )
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        base_model_fold_column <- base_model@parameters$fold_column$column_name
+        expect_equal(base_model_fold_column, fold_column)
+        base_model_weights_column <- base_model@parameters$weights_column$column_name
+        expect_equal(base_model_weights_column, weights_column)
+    }
+    
+    test_nfolds_set_to_base_model <- function() {
+        print("Check that nfolds is piped through properly to base models (nfolds > 1)")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = 3,
+                            max_models = max_models,
+                            project_name = "aml12"
+        )
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        expect_equal(base_model@parameters$nfolds, 3)
+    }
+    
+    test_nfolds_eq_0 <- function() {
+        print("Check that nfolds = 0 works properly")  #will need to change after xval leaderboard is implemented
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = 0,
+                            max_models = max_models,
+                            project_name = "aml13",
+        )
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        expect_equal(base_model@allparameters$nfolds, 0)
+    }
+    
+    test_stacked_ensembles_trained <- function() {
+        print("Check that two Stacked Ensembles are trained")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = 3,
+                            max_models = max_models,
+                            project_name = "aml14",
+        )
+        # Check that leaderboard contains exactly two SEs: all model ensemble & top model ensemble
+        expect_equal(length(get_partitioned_models(aml)$se), 2)
+    }
+    
+    test_stacked_ensembles_trained_with_blending_frame_and_nfolds_eq_0 <- function() {
+        print("Check that Stacked Ensembles are trained using blending frame, even if cross-validation is disabled.")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y, 
+                            training_frame = ds$train,
+                            blending_frame = ds$valid,
+                            leaderboard_frame = ds$test,
+                            nfolds = 0,
+                            max_models = max_models,
+                            project_name = "aml_blending",
+        )
+        se <- get_partitioned_models(aml)$se
+        expect_equal(length(se), 2)
+        for (m in se) {
+            model <- h2o.getModel(m)
+            expect_equal(model@model$stacking_strategy, "blending")
+        }
+    }
+    
+    test_balance_classes <- function() {
+        print("Check that balance_classes is working")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = 3,
+                            max_models = max_models,
+                            balance_classes = TRUE,
+                            max_after_balance_size = 3.0,
+                            class_sampling_factors = c(0.2, 1.4),
+                            project_name = "aml15",
+        )
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        expect_equal(base_model@parameters$balance_classes, TRUE)
+        expect_equal(base_model@parameters$max_after_balance_size, 3.0)
+        expect_equal(base_model@parameters$class_sampling_factors, c(0.2, 1.4))
+    }
+    
+    test_keep_cv_models_and_keep_cv_predictions <- function() {
+        print("Check that cv preds/models are deleted")
+        ds <- import_dataset()
+        nfolds <- 3
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = nfolds,
+                            max_models = max_models,
+                            project_name = "aml15",
+                            keep_cross_validation_models = FALSE,
+                            keep_cross_validation_predictions = FALSE,
+        )
+        
+        model_ids <- as.character(as.data.frame(aml@leaderboard[,"model_id"])[,1])
+        model_ids <- setdiff(model_ids, grep("StackedEnsemble", model_ids, value = TRUE))
+        cv_model_ids <- list(NULL)
+        for(i in 1:nfolds) {
+            cv_model_ids[[i]] <- paste0(model_ids, "_cv_", i)
+        }
+        cv_model_ids <- unlist(cv_model_ids)
+        expect_equal(sum(sapply(cv_model_ids, function(i) grepl(i, h2o.ls()))), 0)
+    }
+    
+    test_keep_cv_fold_assignment_defaults_with_nfolds_gt_0 <- function() {
+        print("Check that fold assignments were skipped by default and nfolds > 1")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = 3,
+                            max_models = max_models,
+                            project_name = "aml16",
+        )
+        some_base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        expect_equal(some_base_model@parameters$keep_cross_validation_fold_assignment, NULL)
+        expect_equal(some_base_model@model$cross_validation_fold_assignment_frame_id, NULL)
+    }
+    
+    test_keep_cv_fold_assignment_TRUE_with_nfolds_gt_0 <- function() {
+        print("Check that fold assignments were kept when `keep_cross_validation_fold_assignment`= TRUE and nfolds > 1")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = 3,
+                            max_models = max_models,
+                            project_name = "aml17",
+                            keep_cross_validation_fold_assignment = TRUE,
+        )
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        expect_equal(base_model@parameters$keep_cross_validation_fold_assignment, TRUE)
+        expect_equal(length(base_model@model$cross_validation_fold_assignment_frame_id), 4)
+    }
+    
+    test_keep_cv_fold_assignment_TRUE_with_nfolds_eq_0 <- function() {
+        print("Check that fold assignments were skipped when `keep_cross_validation_fold_assignment`= TRUE and nfolds = 0")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                            training_frame = ds$train,
+                            nfolds = 0,
+                            max_models = max_models,
+                            project_name = "aml18",
+                            keep_cross_validation_fold_assignment = TRUE,
+        )
+        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        expect_equal(base_model@parameters$keep_cross_validation_fold_assignment, NULL)
+        expect_equal(base_model@model$cross_validation_fold_assignment_frame_id, NULL)
+    }
+    
+    test_max_runtime_secs <- function() {
+        print("Check that automl gets interrupted after `max_runtime_secs`")
+        ds <- import_dataset()
+        max_runtime_secs <- 60
+        cancel_tolerance_secs <- 6+5 # should be enough for most cases given job notification mechanism (adding 5 more ~=10% for SEs)
+        time <- system.time(aml <- h2o.automl(x=ds$x, y=ds$y,
+                            training_frame=ds$train,
+                            project_name="aml_max_runtime_secs",
+                            max_runtime_secs=max_runtime_secs)
+        )[['elapsed']]
+        print(paste("trained", length(get_partitioned_models(aml)$non_se), "models"))
+        expect_lte(abs(time - max_runtime_secs), cancel_tolerance_secs)
+        expect_equal(length(get_partitioned_models(aml)$se), 2)
+    }
+    
+    test_max_models <- function() {
+        print("Check that automl get interrupted after `max_models`")
+        ds <- import_dataset()
+        aml <- h2o.automl(x=ds$x, y=ds$y,
+                            training_frame=ds$train,
+                            project_name="aml_max_models",
+                            max_models=max_models,
+        )
+        models <- get_partitioned_models(aml)
+        expect_equal(length(models$non_se), max_models)
+        expect_equal(length(models$se), 2)
+    }
+    
+    
+    makeSuite(
+        test_without_y, 
+        test_without_x,
+        test_y_as_index_x_as_name,
+        test_single_training_frame,
+        test_training_with_validation_frame,
+        test_training_with_leaderboard_frame,
+        test_training_with_validation_and_leaderboard_frame,
+        test_early_stopping,
+        test_leaderboard_growth,
+        test_fold_column,
+        test_weights_column,
+        test_fold_column_with_weights_column,
+        test_nfolds_set_to_base_model,
+        test_nfolds_eq_0,
+        test_stacked_ensembles_trained,
+        test_stacked_ensembles_trained_with_blending_frame_and_nfolds_eq_0,
+        test_balance_classes,
+        test_keep_cv_models_and_keep_cv_predictions,
+        test_keep_cv_fold_assignment_defaults_with_nfolds_gt_0,
+        test_keep_cv_fold_assignment_TRUE_with_nfolds_gt_0,
+        test_keep_cv_fold_assignment_TRUE_with_nfolds_eq_0,
+        test_max_runtime_secs,
+        test_max_models
     )
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    expect_equal(base_model@parameters$keep_cross_validation_fold_assignment, TRUE)
-    expect_equal(length(base_model@model$cross_validation_fold_assignment_frame_id), 4)
-  }
-
-  test_keep_cv_fold_assignment_TRUE_with_nfolds_eq_0 <- function() {
-    print("Check that fold assignments were skipped when `keep_cross_validation_fold_assignment`= TRUE and nfolds = 0")
-    ds <- import_dataset()
-    aml <- h2o.automl(x = ds$x, y = ds$y,
-                        training_frame = ds$train,
-                        nfolds = 0,
-                        max_models = max_models,
-                        project_name = "aml18",
-                        keep_cross_validation_fold_assignment = TRUE,
-    )
-    base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
-    expect_equal(base_model@parameters$keep_cross_validation_fold_assignment, NULL)
-    expect_equal(base_model@model$cross_validation_fold_assignment_frame_id, NULL)
-  }
-
-  test_max_runtime_secs <- function() {
-    print("Check that automl gets interrupted after `max_runtime_secs`")
-    ds <- import_dataset()
-    max_runtime_secs <- 60
-    cancel_tolerance_secs <- 6+5 # should be enough for most cases given job notification mechanism (adding 5 more ~=10% for SEs)
-    time <- system.time(aml <- h2o.automl(x=ds$x, y=ds$y,
-                                           training_frame=ds$train,
-                                           project_name="aml_max_runtime_secs",
-                                           max_runtime_secs=max_runtime_secs)
-                        )[['elapsed']]
-    print(paste("trained", length(get_partitioned_models(aml)$non_se), "models"))
-    expect_lte(abs(time - max_runtime_secs), cancel_tolerance_secs)
-    expect_equal(length(get_partitioned_models(aml)$se), 2)
-  }
-
-  test_max_models <- function() {
-    print("Check that automl get interrupted after `max_models`")
-    ds <- import_dataset()
-    aml <- h2o.automl(x=ds$x, y=ds$y,
-                      training_frame=ds$train,
-                      project_name="aml_max_models",
-                      max_models=max_models,
-    )
-    models <- get_partitioned_models(aml)
-    expect_equal(length(models$non_se), max_models)
-    expect_equal(length(models$se), 2)
-  }
-
-
-  tests <- c(
-    test_without_y,
-    test_without_x,
-    test_y_as_index_x_as_name,
-    test_single_training_frame,
-    test_training_with_validation_frame,
-    test_training_with_leaderboard_frame,
-    test_training_with_validation_and_leaderboard_frame,
-    test_early_stopping,
-    test_leaderboard_growth,
-    test_fold_column,
-    test_weights_column,
-    test_fold_column_with_weights_column,
-    test_nfolds_set_to_base_model,
-    test_nfolds_eq_0,
-    test_stacked_ensembles_trained,
-    test_balance_classes,
-    test_keep_cv_models_and_keep_cv_predictions,
-    test_keep_cv_fold_assignment_defaults_with_nfolds_gt_0,
-    test_keep_cv_fold_assignment_TRUE_with_nfolds_gt_0,
-    test_keep_cv_fold_assignment_TRUE_with_nfolds_eq_0,
-    test_max_runtime_secs,
-    test_max_models
-  )
-
-  lapply(tests, function(test) print(system.time(test()))) #need to monitor why this test suite is taking so long in client mode
 }
 
-doTest("AutoML Args Test", automl.args.test)
-
+doSuite("AutoML Args Test", automl.args.test(), time_monitor=TRUE)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -169,7 +169,7 @@ automl.args.test <- function() {
                             project_name = "aml9",
         )
         models <- get_partitioned_models(aml)
-        base_model <- h2o.getModel(get_partitioned_models(aml)$non_se[1])
+        base_model <- h2o.getModel(models$non_se[1])
         base_model_fold_column <- base_model@parameters$fold_column$column_name
         expect_equal(base_model_fold_column, fold_column)
         ensemble <- h2o.getModel(models$se[1])


### PR DESCRIPTION
https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-6254

Exposing blending frame in AutoML..: expected behaviour when blending frame is provided, is that we don't enforce some CV-related params necessary for SE otherwise, and SE are still computed if nfolds=0 as we don't use cv predictions to train the SEs in this case.

When CV is disabled (common use-case when using blending for time series), we now force the creation of a validation frame to avoid overfitting of the base models.
Also made small changes to leaderboard so that it can do scoring based on validation metrics then, and not only by scoring the leaderboard frame, making this latter one potentially optional also internally.
