### PR TITLE
Allow to create sparse newchunk

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -980,10 +980,14 @@ public class Frame extends Lockable<Frame> {
   // Chunks in a Frame, before filling them.  This can be called in parallel
   // for different Chunk#'s (cidx); each Chunk can be filled in parallel.
   static NewChunk[] createNewChunks(String name, byte[] type, int cidx) {
+    return createNewChunks(name, type, cidx, false);
+  }
+
+  static NewChunk[] createNewChunks(String name, byte[] type, int cidx, boolean sparse) {
     Frame fr = (Frame) Key.make(name).get();
     NewChunk[] nchks = new NewChunk[fr.numCols()];
     for (int i = 0; i < nchks.length; i++) {
-      nchks[i] = new NewChunk(new AppendableVec(fr._keys[i], type[i]), cidx);
+      nchks[i] = new NewChunk(new AppendableVec(fr._keys[i], type[i]), cidx, sparse);
     }
     return nchks;
   }


### PR DESCRIPTION
In Sparkling Water, we would like to improve handling of sparse vectors. Ie we would like to use sparse new chunks when converting sparse spark vectors.

We use the `createNewChunks` method from H2O to create chunks. This PR just exposes the sparse option to this method.