### PR TITLE
[WIP-ITA] Rancher 2 support for Jenkins pipeline

### DIFF
--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -334,17 +334,14 @@ class BuildConfig {
   }
 
   static enum JenkinsMaster {
-    C1, // indicates we are running under mr-0xc1 master - master or nightly build
-    B4  // indicates we are running under mr-0xb4 master - PR build
+    C1, // indicates we are running under mr-0xc1 master
 
     private static JenkinsMaster findByName(final String name) {
       switch(name.toLowerCase()) {
         case 'c1':
           return C1
-        case 'b4':
-          return B4
         default:
-          throw new IllegalArgumentException(String.format("Master %s is unknown", name))
+          return C1 // assume default jenkins master
       }
     }
 
@@ -356,7 +353,6 @@ class BuildConfig {
 
   static enum NodeLabels {
     LABELS_C1('docker && !mr-0xc8', 'mr-0xc9', 'gpu && !2gpu'),
-    LABELS_B4('docker', 'docker', 'gpu && !2gpu')
 
     private final String defaultNodeLabel
     private final String benchmarkNodeLabel
@@ -380,12 +376,10 @@ class BuildConfig {
       return gpuNodeLabel
     }
 
-    private static findByJenkinsMaster(final JenkinsMaster master) {
+    private static NodeLabels findByJenkinsMaster(final JenkinsMaster master) {
       switch (master) {
         case JenkinsMaster.C1:
           return LABELS_C1
-        case JenkinsMaster.B4:
-          return LABELS_B4
         default:
           throw new IllegalArgumentException(String.format("Master %s is unknown", master))
       }

--- a/scripts/jenkins/groovy/defaultStage.groovy
+++ b/scripts/jenkins/groovy/defaultStage.groovy
@@ -1,52 +1,47 @@
 def call(final pipelineContext, final stageConfig) {
-    def insideDocker = load('h2o-3/scripts/jenkins/groovy/insideDocker.groovy')
     def makeTarget = load('h2o-3/scripts/jenkins/groovy/makeTarget.groovy')
 
-    def buildEnv = pipelineContext.getBuildConfig().getBuildEnv() + ["PYTHON_VERSION=${stageConfig.pythonVersion}", "R_VERSION=${stageConfig.rVersion}", "JAVA_VERSION=${stageConfig.javaVersion}"]
-
     echo "###### Changes for ${stageConfig.component} detected, starting ${stageConfig.stageName} ######"
-    insideDocker(buildEnv, stageConfig.image, pipelineContext.getBuildConfig().DOCKER_REGISTRY, pipelineContext.getBuildConfig(), stageConfig.timeoutValue, 'MINUTES', stageConfig.customDockerArgs.join(' ')) {
-        def h2oFolder = stageConfig.stageDir + '/h2o-3'
+    def h2oFolder = stageConfig.stageDir + '/h2o-3'
 
-        // pull the test package unless this is a COMPONENT_ANY stage
-        if (stageConfig.component != pipelineContext.getBuildConfig().COMPONENT_ANY) {
-            pipelineContext.getUtils().unpackTestPackage(this, pipelineContext.getBuildConfig(), stageConfig.component, stageConfig.stageDir)
-        }
-        // pull aditional test packages
-        for (additionalPackage in stageConfig.additionalTestPackages) {
-            echo "Pulling additional test-package-${additionalPackage}.zip"
-            pipelineContext.getUtils().unpackTestPackage(this, pipelineContext.getBuildConfig(), additionalPackage, stageConfig.stageDir)
-        }
+    // pull the test package unless this is a COMPONENT_ANY stage
+    if (stageConfig.component != pipelineContext.getBuildConfig().COMPONENT_ANY) {
+        pipelineContext.getUtils().unpackTestPackage(this, pipelineContext.getBuildConfig(), stageConfig.component, stageConfig.stageDir)
+    }
+    // pull aditional test packages
+    for (additionalPackage in stageConfig.additionalTestPackages) {
+        echo "Pulling additional test-package-${additionalPackage}.zip"
+        pipelineContext.getUtils().unpackTestPackage(this, pipelineContext.getBuildConfig(), additionalPackage, stageConfig.stageDir)
+    }
 
-        if (stageConfig.component == pipelineContext.getBuildConfig().COMPONENT_PY || stageConfig.additionalTestPackages.contains(pipelineContext.getBuildConfig().COMPONENT_PY)) {
-            installPythonPackage(h2oFolder)
-            dir(stageConfig.stageDir) {
-                pipelineContext.getUtils().pullXGBWheels(this)
-            }
-            installXGBWheel(pipelineContext.getBuildConfig().getCurrentXGBVersion(), h2oFolder)
+    if (stageConfig.component == pipelineContext.getBuildConfig().COMPONENT_PY || stageConfig.additionalTestPackages.contains(pipelineContext.getBuildConfig().COMPONENT_PY)) {
+        installPythonPackage(h2oFolder)
+        dir(stageConfig.stageDir) {
+            pipelineContext.getUtils().pullXGBWheels(this)
         }
+        installXGBWheel(pipelineContext.getBuildConfig().getCurrentXGBVersion(), h2oFolder)
+    }
 
-        if (stageConfig.installRPackage && (stageConfig.component == pipelineContext.getBuildConfig().COMPONENT_R || stageConfig.additionalTestPackages.contains(pipelineContext.getBuildConfig().COMPONENT_R))) {
-            installRPackage(h2oFolder)
-        }
+    if (stageConfig.installRPackage && (stageConfig.component == pipelineContext.getBuildConfig().COMPONENT_R || stageConfig.additionalTestPackages.contains(pipelineContext.getBuildConfig().COMPONENT_R))) {
+        installRPackage(h2oFolder)
+    }
 
-        makeTarget(pipelineContext) {
-            preBuildAction = stageConfig.preBuildAction
-            customBuildAction = stageConfig.customBuildAction
-            postSuccessfulBuildAction = stageConfig.postSuccessfulBuildAction
-            postFailedBuildAction = stageConfig.postFailedBuildAction
-            postSuccessfulBuildAction = stageConfig.postSuccessfulBuildAction
-            postBuildAction = stageConfig.postBuildAction
-            target = stageConfig.target
-            hasJUnit = stageConfig.hasJUnit
-            h2o3dir = h2oFolder
-            archiveAdditionalFiles = stageConfig.archiveAdditionalFiles
-            excludeAdditionalFiles = stageConfig.excludeAdditionalFiles
-            makefilePath = stageConfig.makefilePath
-            archiveFiles = stageConfig.archiveFiles
-            activatePythonEnv = stageConfig.activatePythonEnv
-            javaVersion = stageConfig.javaVersion
-        }
+    makeTarget(pipelineContext) {
+        preBuildAction = stageConfig.preBuildAction
+        customBuildAction = stageConfig.customBuildAction
+        postSuccessfulBuildAction = stageConfig.postSuccessfulBuildAction
+        postFailedBuildAction = stageConfig.postFailedBuildAction
+        postSuccessfulBuildAction = stageConfig.postSuccessfulBuildAction
+        postBuildAction = stageConfig.postBuildAction
+        target = stageConfig.target
+        hasJUnit = stageConfig.hasJUnit
+        h2o3dir = h2oFolder
+        archiveAdditionalFiles = stageConfig.archiveAdditionalFiles
+        excludeAdditionalFiles = stageConfig.excludeAdditionalFiles
+        makefilePath = stageConfig.makefilePath
+        archiveFiles = stageConfig.archiveFiles
+        activatePythonEnv = stageConfig.activatePythonEnv
+        javaVersion = stageConfig.javaVersion
     }
 }
 

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -25,32 +25,39 @@ def call(final pipelineContext) {
   def SMOKE_STAGES = [
     [
       stageName: 'Py2.7 Smoke', target: 'test-py-smoke', pythonVersion: '2.7',timeoutValue: 8,
-      component: pipelineContext.getBuildConfig().COMPONENT_PY
+      component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'R3.4 Smoke', target: 'test-r-smoke', rVersion: '3.4.1',timeoutValue: 8,
-      component: pipelineContext.getBuildConfig().COMPONENT_R
+      component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 27, cpu: 6
     ],
     [
       stageName: 'Flow Headless Smoke', target: 'test-flow-headless-smoke',timeoutValue: 20,
-      component: pipelineContext.getBuildConfig().COMPONENT_JS
+      component: pipelineContext.getBuildConfig().COMPONENT_JS,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'Java 7 Smoke', target: 'test-junit-7-smoke-jenkins', javaVersion: 7, timeoutValue: 20,
       component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
-      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-openjdk-7:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-openjdk-7:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'Java 8 Smoke', target: 'test-junit-smoke-jenkins', javaVersion: 8, timeoutValue: 20,
-      component: pipelineContext.getBuildConfig().COMPONENT_JAVA
+      component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
+      mem: 18, cpu: 6
     ],
      [
        stageName: 'Java 10 Smoke', target: 'test-junit-10-smoke-jenkins', javaVersion: 10, timeoutValue: 20,
-       component: pipelineContext.getBuildConfig().COMPONENT_JAVA
+       component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
+       mem: 18, cpu: 6
      ],
     [
       stageName: 'Java 11 Smoke', target: 'test-junit-11-smoke-jenkins', javaVersion: 11, timeoutValue: 20,
-      component: pipelineContext.getBuildConfig().COMPONENT_JAVA
+      component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
+      mem: 18, cpu: 6
     ]
   ]
 
@@ -58,149 +65,183 @@ def call(final pipelineContext) {
   def PR_STAGES = [
     [
       stageName: 'Py2.7 Booklets', target: 'test-py-booklets', pythonVersion: '2.7',
-      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 17, cpu: 6
     ],
     [
       stageName: 'Py3.5 Single Node', target: 'test-pyunit-single-node', pythonVersion: '3.5',
-      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 3, cpu: 4
     ],
     [
       stageName: 'Py2.7 Demos', target: 'test-py-demos', pythonVersion: '2.7',
-      timeoutValue: 30, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 30, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 44, cpu: 8
     ],
     [
       stageName: 'Py2.7 Init Java 7', target: 'test-py-init', pythonVersion: '2.7', javaVersion: 7,
       timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_PY,
-      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-openjdk-7:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-openjdk-7:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+      mem: 5, cpu: 4
     ],
     [
       stageName: 'Py2.7 Init Java 8', target: 'test-py-init', pythonVersion: '2.7', javaVersion: 8,
       timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_PY,
-      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-jdk-8:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-jdk-8:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+      mem: 5, cpu: 4
     ],
      [
        stageName: 'Py2.7 Init Java 10', target: 'test-py-init', pythonVersion: '2.7', javaVersion: 10,
        timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_PY,
-       image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-jdk-10:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+       image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-jdk-10:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+       mem: 5, cpu: 4
      ],
     [
       stageName: 'Py2.7 Init Java 11', target: 'test-py-init', pythonVersion: '2.7', javaVersion: 11,
       timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_PY,
-      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-jdk-11:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-jdk-11:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+      mem: 5, cpu: 4
     ],
     [
       stageName: 'Py3.5 Small', target: 'test-pyunit-small', pythonVersion: '3.5',
-      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'Py3.5 Small AutoML', target: 'test-pyunit-small-automl', pythonVersion: '3.5',
-      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'R3.4 Init Java 7', target: 'test-r-init', rVersion: '3.4.1', javaVersion: 7,
       timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
-      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-openjdk-7:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-openjdk-7:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+      mem: 5, cpu: 4
     ],
     [
       stageName: 'R3.4 Init Java 8', target: 'test-r-init', rVersion: '3.4.1', javaVersion: 8,
       timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
-      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-jdk-8:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-jdk-8:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+      mem: 5, cpu: 4
     ],
      [
        stageName: 'R3.4 Init Java 10', target: 'test-r-init', rVersion: '3.4.1', javaVersion: 10,
        timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
-       image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-jdk-10:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+       image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-jdk-10:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+       mem: 5, cpu: 4
      ],
     [
       stageName: 'R3.4 Init Java 11', target: 'test-r-init', rVersion: '3.4.1', javaVersion: 11,
       timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
-      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-jdk-11:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}"
+      image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3/dev-r-3.4.1-jdk-11:${pipelineContext.getBuildConfig().DEFAULT_IMAGE_VERSION_TAG}",
+      mem: 5, cpu: 4
     ],
     [
       stageName: 'R3.4 Small', target: 'test-r-small', rVersion: '3.4.1',
-      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.4 Small Client Mode', target: 'test-r-small-client-mode', rVersion: '3.4.1',
-      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.4 Small Client Mode Disconnect Attack', target: 'test-r-small-client-mode-attack', rVersion: '3.4.1',
-      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.4 Small AutoML', target: 'test-r-small-automl', rVersion: '3.4.1',
-      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.4 Small Client Mode AutoML', target: 'test-r-small-client-mode-automl', rVersion: '3.4.1',
-      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.4 CMD Check', target: 'test-r-cmd-check', rVersion: '3.4.1',
-      timeoutValue: 15, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 15, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 3, cpu: 4
     ],
     [
       stageName: 'R3.4 CMD Check as CRAN', target: 'test-r-cmd-check-as-cran', rVersion: '3.4.1',
-      timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 3, cpu: 4
     ],
     [
       stageName: 'R3.4 Booklets', target: 'test-r-booklets', rVersion: '3.4.1',
-      timeoutValue: 50, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 50, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 50, cpu: 8
     ],
     [
       stageName: 'R3.4 Demos Small', target: 'test-r-demos-small', rVersion: '3.4.1',
-      timeoutValue: 15, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 15, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 8, cpu: 6
     ],
     [
       stageName: 'Flow Headless', target: 'test-flow-headless',
-      timeoutValue: 75, component: pipelineContext.getBuildConfig().COMPONENT_JS
+      timeoutValue: 75, component: pipelineContext.getBuildConfig().COMPONENT_JS,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'Py3.6 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.5',
-      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 66, cpu: 10
     ],
     [
       stageName: 'R3.4 Medium-large', target: 'test-r-medium-large', rVersion: '3.4.1',
-      timeoutValue: 80, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 80, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 50, cpu: 8
     ],
     [
       stageName: 'R3.4 Demos Medium-large', target: 'test-r-demos-medium-large', rVersion: '3.4.1',
-      timeoutValue: 140, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 140, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 50, cpu: 8
     ],
     [
       stageName: 'INFO Check', target: 'test-info',
-      timeoutValue: 10, component: pipelineContext.getBuildConfig().COMPONENT_ANY, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R]
+      timeoutValue: 10, component: pipelineContext.getBuildConfig().COMPONENT_ANY, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
+      mem: 3, cpu: 4
     ],
     [
       stageName: 'Py3.6 Test Demos', target: 'test-demos', pythonVersion: '3.6',
-      timeoutValue: 10, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 10, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 44, cpu: 8
     ],
     [
       stageName: 'Java 8 JUnit', target: 'test-junit-jenkins', pythonVersion: '2.7', javaVersion: 8,
-      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
+      mem: 44, cpu: 8
     ],
     [
       stageName: 'Java 8 AutoML JUnit', target: 'test-junit-automl-jenkins', pythonVersion: '2.7', javaVersion: 8,
-      timeoutValue: 20, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      timeoutValue: 20, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
+      mem: 44, cpu: 8
     ],
     [
       stageName: 'Java 10 JUnit', target: 'test-junit-10-jenkins', pythonVersion: '2.7', javaVersion: 10,
-      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
+      mem: 44, cpu: 8
     ],
     [
       stageName: 'Java 11 JUnit', target: 'test-junit-11-jenkins', pythonVersion: '2.7', javaVersion: 11,
-      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
+      mem: 44, cpu: 8
     ],
     [
       stageName: 'R3.4 Generate Docs', target: 'r-generate-docs-jenkins', archiveFiles: false,
       timeoutValue: 10, component: pipelineContext.getBuildConfig().COMPONENT_R, hasJUnit: false,
-      archiveAdditionalFiles: ['r-generated-docs.zip'], installRPackage: false
+      archiveAdditionalFiles: ['r-generated-docs.zip'], installRPackage: false,
+      mem: 4, cpu: 4
     ],
     [
       stageName: 'MOJO Compatibility', target: 'test-mojo-compatibility',
       archiveFiles: false, timeoutValue: 20, pythonVersion: '3.6', hasJUnit: false,
-      component: pipelineContext.getBuildConfig().COMPONENT_ANY, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      component: pipelineContext.getBuildConfig().COMPONENT_ANY, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
+      mem: 17, cpu: 6
     ]
   ]
 
@@ -253,15 +294,18 @@ def call(final pipelineContext) {
   def MASTER_STAGES = [
     [
       stageName: 'R3.4 Datatable', target: 'test-r-datatable', rVersion: '3.4.1',
-      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 44, cpu: 8
     ],
     [
       stageName: 'Flow Headless Small', target: 'test-flow-headless-small',
-      timeoutValue: 75, component: pipelineContext.getBuildConfig().COMPONENT_JS
+      timeoutValue: 75, component: pipelineContext.getBuildConfig().COMPONENT_JS,
+      mem: 6, cpu: 4
     ],
     [
       stageName: 'Flow Headless Medium', target: 'test-flow-headless-medium',
-      timeoutValue: 75, component: pipelineContext.getBuildConfig().COMPONENT_JS
+      timeoutValue: 75, component: pipelineContext.getBuildConfig().COMPONENT_JS,
+      mem: 6, cpu: 4
     ]
   ]
 
@@ -269,67 +313,83 @@ def call(final pipelineContext) {
   def NIGHTLY_STAGES = [
     [
       stageName: 'Py2.7 Single Node', target: 'test-pyunit-single-node', pythonVersion: '2.7',
-      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 3, cpu: 4
     ],
     [
       stageName: 'Py3.6 Single Node', target: 'test-pyunit-single-node', pythonVersion: '3.6',
-      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'Py2.7 Small', target: 'test-pyunit-small', pythonVersion: '2.7',
-      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'Py3.6 Small', target: 'test-pyunit-small', pythonVersion: '3.6',
-      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'Py2.7 Small AutoML', target: 'test-pyunit-small-automl', pythonVersion: '2.7',
-      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'Py3.6 Small AutoML', target: 'test-pyunit-small-automl', pythonVersion: '3.6',
-      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 90, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 20, cpu: 6
     ],
     [
       stageName: 'Py2.7 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '2.7',
-      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 50, cpu: 8
     ],
     [
       stageName: 'Py3.5 Medium-large', target: 'test-pyunit-medium-large', pythonVersion: '3.5',
-      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_PY
+      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_PY,
+      mem: 50, cpu: 8
     ],
     [
       stageName: 'R3.3 Medium-large', target: 'test-r-medium-large', rVersion: '3.3.3',
-      timeoutValue: 70, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 70, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 50, cpu: 8
     ],
     [
       stageName: 'R3.3 Small', target: 'test-r-small', rVersion: '3.3.3',
-      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.3 Small Client Mode', target: 'test-r-small-client-mode', rVersion: '3.3.3',
-      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.3 Small AutoML', target: 'test-r-small-automl', rVersion: '3.3.3',
-      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 125, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.3 Small Client Mode AutoML', target: 'test-r-small-client-mode-automl', rVersion: '3.3.3',
-      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 155, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 18, cpu: 6
     ],
     [
       stageName: 'R3.3 CMD Check', target: 'test-r-cmd-check', rVersion: '3.3.3',
-      timeoutValue: 15, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 15, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 3, cpu: 4
     ],
     [
       stageName: 'R3.3 CMD Check as CRAN', target: 'test-r-cmd-check-as-cran', rVersion: '3.3.3',
-      timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R
+      timeoutValue: 10, hasJUnit: false, component: pipelineContext.getBuildConfig().COMPONENT_R,
+      mem: 3, cpu: 4
     ],
     [ // These run with reduced number of file descriptors for early detection of FD leaks
       stageName: 'XGBoost Stress tests', target: 'test-pyunit-xgboost-stress', pythonVersion: '3.5', timeoutValue: 40,
-      component: pipelineContext.getBuildConfig().COMPONENT_PY, customDockerArgs: [ '--ulimit nofile=100:100' ]
+      component: pipelineContext.getBuildConfig().COMPONENT_PY, customDockerArgs: [ '--ulimit nofile=100:100' ],
+      mem: 17, cpu: 6
     ]
   ]
 
@@ -497,6 +557,8 @@ private void executeInParallel(final jobs, final pipelineContext) {
           archiveFiles = c['archiveFiles']
           activatePythonEnv = c['activatePythonEnv']
 	      customDockerArgs = c['customDockerArgs']
+          mem = c['mem']
+          cpu = c['cpu']
         }
       }
     ]
@@ -511,6 +573,8 @@ private void invokeStage(final pipelineContext, final body) {
   final int DEFAULT_TIMEOUT = 60
   final String DEFAULT_EXECUTION_SCRIPT = 'h2o-3/scripts/jenkins/groovy/defaultStage.groovy'
   final int HEALTH_CHECK_RETRIES = 5
+  final int DEFAULT_MEM = 32
+  final int DEFAULT_CPU = 8000
 
   def config = [:]
 
@@ -530,6 +594,8 @@ private void invokeStage(final pipelineContext, final body) {
   }
   config.additionalTestPackages = config.additionalTestPackages ?: []
   config.nodeLabel = config.nodeLabel ?: pipelineContext.getBuildConfig().getDefaultNodeLabel()
+  config.mem = config.mem ?: DEFAULT_MEM
+  config.cpu = config.cpu ?: DEFAULT_CPU
   config.executionScript = config.executionScript ?: DEFAULT_EXECUTION_SCRIPT
   config.makefilePath = config.makefilePath ?: pipelineContext.getBuildConfig().MAKEFILE_PATH
   config.archiveAdditionalFiles = config.archiveAdditionalFiles ?: []
@@ -558,32 +624,48 @@ private void invokeStage(final pipelineContext, final body) {
           pipelineContext.getBuildSummary().setStageDetails(this, config.stageName, 'Skipped', 'N/A')
           pipelineContext.getBuildSummary().markStageSuccessful(this, config.stageName)
         } else {
-          boolean healthCheckPassed = false
-          int attempt = 0
-          String nodeLabel = config.nodeLabel
+          def stageImplClosure = {
+            def isolationArgs = [
+                    customEnv: pipelineContext.getBuildConfig().getBuildEnv() + ["PYTHON_VERSION=${config.pythonVersion}", "R_VERSION=${config.rVersion}", "JAVA_VERSION=${config.javaVersion}"],
+                    image: config.image,
+                    registry: pipelineContext.getBuildConfig().DOCKER_REGISTRY,
+                    buildConfig: pipelineContext.getBuildConfig(),
+                    timeoutValue: config.timeoutValue,
+                    customDockerArgs: config.customDockerArgs.join(' '),
+                    mem: config.mem,
+                    cpu: config.cpu
+            ]
+            pipelineContext.getIsolationProvider().withIsolation(this, pipelineContext.getStageIsolation(), isolationArgs) {
+              echo "###### Unstash scripts. ######"
+              pipelineContext.getUtils().unstashScripts(this)
+              pipelineContext.getBuildSummary().setStageDetails(this, config.stageName, env.NODE_NAME, env.WORKSPACE)
+              sh "rm -rf ${config.stageDir}"
+              def script = load(config.executionScript)
+              script(pipelineContext, config)
+              pipelineContext.getBuildSummary().markStageSuccessful(this, config.stageName)
+            }
+          }
           try {
-            while (!healthCheckPassed) {
-              attempt += 1
-              if (attempt > HEALTH_CHECK_RETRIES) {
-                error "Too many attempts to pass initial health check"
-              }
-              nodeLabel = pipelineContext.getHealthChecker().getHealthyNodesLabel(config.nodeLabel)
-              echo "######### NodeLabel: ${nodeLabel} #########"
-              node(nodeLabel) {
-                echo "###### Unstash scripts. ######"
-                pipelineContext.getUtils().unstashScripts(this)
-
-                healthCheckPassed = pipelineContext.getHealthChecker().checkHealth(this, env.NODE_NAME, config.image, pipelineContext.getBuildConfig().DOCKER_REGISTRY, pipelineContext.getBuildConfig())
-                if (healthCheckPassed) {
-                  pipelineContext.getBuildSummary().setStageDetails(this, config.stageName, env.NODE_NAME, env.WORKSPACE)
-
-                  sh "rm -rf ${config.stageDir}"
-
-                  def script = load(config.executionScript)
-                  script(pipelineContext, config)
-                  pipelineContext.getBuildSummary().markStageSuccessful(this, config.stageName)
+            if (pipelineContext.isHealthCheckEnabled()) {
+              boolean healthCheckPassed = false
+              int attempt = 0
+              String nodeLabel
+              while (!healthCheckPassed) {
+                attempt += 1
+                if (attempt > HEALTH_CHECK_RETRIES) {
+                  error "Too many attempts to pass initial health check"
+                }
+                nodeLabel = pipelineContext.getHealthChecker().getHealthyNodesLabel(config.nodeLabel)
+                echo "######### NodeLabel: ${nodeLabel} #########"
+                node(nodeLabel) {
+                  healthCheckPassed = pipelineContext.getHealthChecker().checkHealth(this, env.NODE_NAME, config.image, pipelineContext.getBuildConfig().DOCKER_REGISTRY, pipelineContext.getBuildConfig())
+                  if (healthCheckPassed) {
+                    stageImplClosure()
+                  }
                 }
               }
+            } else {
+              stageImplClosure()
             }
           } catch (Exception e) {
             pipelineContext.getBuildSummary().markStageFailed(this, config.stageName)

--- a/scripts/jenkins/groovy/healthChecker.groovy
+++ b/scripts/jenkins/groovy/healthChecker.groovy
@@ -1,5 +1,5 @@
-def call() {
-    return new HealthChecker()
+def call(final insideDockerScript) {
+    return new HealthChecker(insideDockerScript)
 }
 
 class HealthChecker {
@@ -11,6 +11,11 @@ class HealthChecker {
 
 
     private List<HealthProblem> healthProblems = []
+    private insideDockerScript
+    
+    private HealthChecker(final insideDockerScript) {
+        this.insideDockerScript = insideDockerScript
+    }
 
     boolean checkHealth(final context, final String node, final String dockerImage, final String dockerRegistry, final buildConfig) {
         boolean healthy = true
@@ -29,9 +34,8 @@ class HealthChecker {
             healthy = false
         }
 
-        def insideDocker = context.load('h2o-3/scripts/jenkins/groovy/insideDocker.groovy')
         try {
-            insideDocker([], dockerImage, dockerRegistry, buildConfig, 90, 'SECONDS') {
+            insideDockerScript.call([], dockerImage, dockerRegistry, buildConfig, 90, 'SECONDS') {
                 context.echo 'Docker health check passed'
             }
         } catch (Exception e) {

--- a/scripts/jenkins/groovy/initPipelineContext.groovy
+++ b/scripts/jenkins/groovy/initPipelineContext.groovy
@@ -3,11 +3,14 @@ def call(final scmEnv, final String mode, final boolean ignoreChanges) {
 }
 
 def call(final scmEnv, final String mode, final boolean ignoreChanges, final List<String> gradleOpts) {
+  return call(scmEnv, mode, ignoreChanges, gradleOpts, 'docker')
+}
 
+def call(final scmEnv, final String mode, final boolean ignoreChanges, final List<String> gradleOpts, final String isolationBackend) {
   clearStageDirs()
 
   def pipelineContextFactory = load('h2o-3/scripts/jenkins/groovy/pipelineContext.groovy')
-  def final pipelineContext = pipelineContextFactory('h2o-3', mode, scmEnv, ignoreChanges, gradleOpts)
+  def final pipelineContext = pipelineContextFactory('h2o-3', mode, scmEnv, ignoreChanges, gradleOpts, isolationBackend)
 
   pipelineContext.getBuildSummary().addDetailsSection(this, mode)
   pipelineContext.getBuildSummary().addChangesSectionIfNecessary(this)

--- a/scripts/jenkins/groovy/insidePod.groovy
+++ b/scripts/jenkins/groovy/insidePod.groovy
@@ -1,0 +1,64 @@
+def call(final customEnv, final timeoutValue, final mem, final cpu, final image, final Closure body) {
+    final def defaultPodContainer = 'h2o-3-container'
+    final def label = "h2o-3-pod-${mem}GB-${cpu}CPU-${UUID.randomUUID().toString()}"
+    def podSpec = """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${label}
+spec:
+  securityContext:
+    runAsUser: 2117
+    fsGroup: 2117
+  containers:
+  - args:
+    - cat
+    command:
+    - /bin/sh
+    - -c
+    image: ${image}
+    imagePullPolicy: Always
+    name: ${defaultPodContainer}
+    resources:
+      limits:
+        cpu: ${cpu}
+        memory: ${mem}Gi
+      requests:
+        cpu: ${cpu}
+        memory: ${mem}Gi
+    securityContext:
+      privileged: false
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+    - mountPath: /home/0xdiag
+      name: datasets
+  imagePullSecrets:
+  - name: regcred
+  volumes:
+  - hostPath:
+      path: /home/0xdiag
+      type: ""
+    name: datasets
+"""
+    podTemplate(label: label, name: label, yaml: podSpec) {
+        node(label) {
+            container(defaultPodContainer) {
+                withEnv(customEnv) {
+                    timeout(time: timeoutValue, unit: 'MINUTES') {
+                        withCredentials([file(credentialsId: 'c096a055-bb45-4dac-ba5e-10e6e470f37e', variable: 'JUNIT_CORE_SITE_PATH'), [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS S3 Credentials', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                            sh """
+                                id
+                                printenv | sort
+                            """
+                            body()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+return this

--- a/scripts/jenkins/groovy/makeTarget.groovy
+++ b/scripts/jenkins/groovy/makeTarget.groovy
@@ -119,6 +119,7 @@ private void execMake(final String buildAction, final String h2o3dir) {
     unset CHANGE_AUTHOR_DISPLAY_NAME
     unset CHANGE_TITLE
 
+    id
     printenv | sort
     ${buildAction}
   """

--- a/scripts/jenkins/groovy/withIsolation.groovy
+++ b/scripts/jenkins/groovy/withIsolation.groovy
@@ -1,0 +1,50 @@
+def call() {
+    IsolationProvider result =  new IsolationProvider()
+    result.initialize(this)
+    return result
+}
+
+class IsolationProvider {
+    
+    private insideDockerScript
+    private insidePod
+    
+    def initialize(final context) {
+        insideDockerScript = context.load('h2o-3/scripts/jenkins/groovy/insideDocker.groovy')
+        insidePod = context.load('h2o-3/scripts/jenkins/groovy/insidePod.groovy')
+    }
+
+    def withIsolation(final context, final isolationType, final args, final body) {
+        switch (isolationType) {
+            case 'docker':
+                context.echo "Running in docker container with args: ${args}"
+                insideDockerScript.call(args.customEnv, args.image, args.registry, args.buildConfig, args.timeoutValue, 'MINUTES', args.customDockerArgs, body)
+                break
+            case 'pod':
+                context.echo "Running in k8s pod with args: ${args}"
+                insidePod.call(args.customEnv, args.timeoutValue, args.mem, args.cpu, args.image, body)
+                break
+            case 'none':
+                context.withEnv(args.customEnv) {
+                    context.timeout(time: args.timeoutValue, unit: 'MINUTES') {
+                        context.sh """
+                            id
+                            printenv | sort
+                        """
+                        context.echo "Running without additional isolation"
+                        context.withCredentials([
+                                context.file(credentialsId: 'c096a055-bb45-4dac-ba5e-10e6e470f37e', variable: 'JUNIT_CORE_SITE_PATH'),
+                                [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AWS S3 Credentials', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                        ]) {
+                            body()
+                        }
+                    }
+                }
+                break
+            default:
+                error "Isolation type ${isolationType} not supported"
+        }
+    }
+}
+
+return this

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-k8s
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-k8s
@@ -1,0 +1,97 @@
+@Library('test-shared-library') _
+
+def defineTestStages = null
+def pipelineContext = null
+def result = 'FAILURE'
+def scmEnv = null
+
+final String buildPodYaml = """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: h2o-3-small
+spec:
+  securityContext:
+    runAsUser: 2117
+    fsGroup: 2117
+  containers:
+  - args:
+    - cat
+    command:
+    - /bin/sh
+    - -c
+    image: harbor.h2o.ai/opsh2oai/h2o-3/dev-release-gradle-4.10.1:8
+    imagePullPolicy: Always
+    name: h2o-3-container
+    resources:
+      limits:
+        cpu: "8"
+        memory: 16Gi
+      requests:
+        cpu: "8"
+        memory: 16Gi
+    securityContext:
+      privileged: false
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+    - mountPath: /home/0xdiag
+      name: datasets
+  imagePullSecrets:
+  - name: regcred
+  volumes:
+  - hostPath:
+      path: /home/0xdiag
+      type: ""
+    name: datasets
+"""
+
+ansiColor('xterm') {
+    timestamps {
+        stage('Checkout and Build') {
+            final def label = "h2o-3-pod-build-${UUID.randomUUID().toString()}"
+            echo "######### NodeLabel: ${label} #########"
+            podTemplate(label: label, name: 'h2o-3-pod-build', yaml: buildPodYaml) {
+                node(label) {
+                    container('h2o-3-container') {
+                        dir('h2o-3') {
+                            // clear the folder
+                            deleteDir()
+                            // checkout H2O-3
+                            retryWithTimeout(60, 3) {
+                                echo "###### Checkout H2O-3 ######"
+                                scmEnv = checkout scm
+                            }
+                        }
+
+                        if (pipelineContext == null) {
+                            def initPipelineContext = load('h2o-3/scripts/jenkins/groovy/initPipelineContext.groovy')
+                            pipelineContext = initPipelineContext(
+                                    scmEnv, 
+                                    'MODE_NIGHTLY', 
+                                    true, // ignore changes so all stages are executed 
+                                    null, // no additional gradle args
+                                    'k8s' // isolation backend
+                            )
+                            // Execute nightly for master at 22:XX, 0:XX, 2:XX, 4:XX and 6:XX
+                            // for rel- branches at 21:XX
+                            String scheduleString = 'H */4 * * *'
+                            if (env.BRANCH_NAME.startsWith('rel-')) {
+                                scheduleString = 'H 21 * * *'
+                            }
+                            pipelineContext.getBuildConfig().setJobProperties(this, pipelineTriggers([cron(scheduleString)]))
+                            // Load the defineTestStages script
+                            defineTestStages = load('h2o-3/scripts/jenkins/groovy/defineTestStages.groovy')
+                        }
+                        def buildH2O3 = load('h2o-3/scripts/jenkins/groovy/buildH2O3.groovy')
+                        buildH2O3(pipelineContext)
+                    }
+                }
+
+                defineTestStages(pipelineContext)
+                result = 'SUCCESS'
+            }
+        }
+    }
+}

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-k8s
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-k8s
@@ -74,13 +74,11 @@ ansiColor('xterm') {
                                     null, // no additional gradle args
                                     'k8s' // isolation backend
                             )
-                            // Execute nightly for master at 22:XX, 0:XX, 2:XX, 4:XX and 6:XX
-                            // for rel- branches at 21:XX
-                            String scheduleString = 'H */4 * * *'
+                            String scheduleString = 'H */6 * * *'
                             if (env.BRANCH_NAME.startsWith('rel-')) {
                                 scheduleString = 'H 21 * * *'
                             }
-                            pipelineContext.getBuildConfig().setJobProperties(this, pipelineTriggers([cron(scheduleString)]))
+                            pipelineContext.getBuildConfig().setJobProperties(this, [disableConcurrentBuilds(), pipelineTriggers([cron(scheduleString)])])
                             // Load the defineTestStages script
                             defineTestStages = load('h2o-3/scripts/jenkins/groovy/defineTestStages.groovy')
                         }


### PR DESCRIPTION
Adds minimal support for the Jenkins on Kubernetes implementation. It's possible to run nightly pipeline (without benchmarks) on both, the existing Jenkins and the new Jenkins on k8s. The idea is to compare results from these two a decide if we should pursue this path.

Notable changes:
- `scripts/jenkins/groovy/defaultStage.groovy` the `insideDocker` wrapper is removed from here, it's now responsibility of the `scripts/jenkins/groovy/defineTestStages.groovy` to ensure correct isolation
- `scripts/jenkins/groovy/defineTestStages.groovy` added `mem` and `cpu` specs for k8s pods, use the new `IsolationProvider`
- `scripts/jenkins/groovy/insidePod.groovy`implements isolation using k8s pods
- `scripts/jenkins/groovy/withIsolation.groovy` runs given `Closure` using specified isolation method (`docker`, `pod`, `none`)
- `scripts/jenkins/jenkinsfiles/Jenkinsfile-k8s` implements "nightly-like" pipeline using k8s as isolation mechanism