### PR TITLE
PUBDEV-6271 - IRF Mojo path length is of type integer and should be long

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
+++ b/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
@@ -13,8 +13,6 @@ import water.fvec.Frame;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
 import static org.junit.Assert.*;
 

--- a/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
+++ b/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
@@ -1,10 +1,20 @@
 package hex.tree.isofor;
 
+import hex.genmodel.MojoModel;
+import hex.genmodel.MojoReaderBackend;
+import hex.genmodel.MojoReaderBackendFactory;
+import hex.genmodel.algos.isofor.IsolationForestMojoReader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import water.Scope;
 import water.TestUtil;
 import water.fvec.Frame;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.Assert.*;
 
@@ -35,6 +45,67 @@ public class IsolationForestTest extends TestUtil {
       assertEquals(train.numRows(), preds.numRows());
 
       assertTrue(model.testJavaScoring(train, preds, 1e-8));
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testMojo() throws IOException {
+    try (final ByteArrayOutputStream mojoByteArrayOutputStream = new ByteArrayOutputStream()) {
+      Scope.enter();
+      Frame train = Scope.track(parse_test_file("smalldata/anomaly/ecg_discord_train.csv"));
+
+      IsolationForestModel.IsolationForestParameters p = new IsolationForestModel.IsolationForestParameters();
+      p._train = train._key;
+      p._seed = 0xDECAF;
+      p._ntrees = 100;
+      p._sample_size = 5;
+
+      IsolationForestModel model = new IsolationForest(p).trainModel().get();
+      assertNotNull(model);
+      Scope.track_generic(model);
+
+      model.getMojo().writeTo(mojoByteArrayOutputStream);
+
+      final MojoReaderBackend readerBackend = MojoReaderBackendFactory.
+              createReaderBackend(new ByteArrayInputStream(mojoByteArrayOutputStream.toByteArray()), MojoReaderBackendFactory.CachingStrategy.MEMORY);
+
+      final MojoModel mojoModel = IsolationForestMojoReader.readFrom(readerBackend);
+      assertNotNull(mojoModel);
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testMojo_largePathLength() throws IOException {
+    try (final ByteArrayOutputStream mojoByteArrayOutputStream = new ByteArrayOutputStream()) {
+      Scope.enter();
+      Frame train = Scope.track(parse_test_file("smalldata/anomaly/ecg_discord_train.csv"));
+
+      IsolationForestModel.IsolationForestParameters p = new IsolationForestModel.IsolationForestParameters();
+      p._train = train._key;
+      p._seed = 0xDECAF;
+      p._ntrees = 1;
+      p._sample_size = 5;
+
+      IsolationForestModel model = new IsolationForest(p).trainModel().get();
+      assertNotNull(model);
+      Scope.track_generic(model);
+
+      model._output._min_path_length = 9223372036854775807L;
+      model._output._max_path_length = 9223372036854775807L;
+
+      model.getMojo().writeTo(mojoByteArrayOutputStream);
+
+      final MojoReaderBackend readerBackend = MojoReaderBackendFactory.
+              createReaderBackend(new ByteArrayInputStream(mojoByteArrayOutputStream.toByteArray()), MojoReaderBackendFactory.CachingStrategy.MEMORY);
+
+      final MojoModel mojoModel = IsolationForestMojoReader.readFrom(readerBackend);
+      assertNotNull(mojoModel);
+
     } finally {
       Scope.exit();
     }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/isofor/IsolationForestMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/isofor/IsolationForestMojoModel.java
@@ -5,8 +5,8 @@ import hex.genmodel.algos.tree.SharedTreeMojoModel;
 
 public final class IsolationForestMojoModel extends SharedTreeMojoModel {
 
-  int _min_path_length;
-  int _max_path_length;
+  long _min_path_length;
+  long _max_path_length;
 
   public IsolationForestMojoModel(String[] columns, String[][] domains, String responseColumn) {
     super(columns, domains, responseColumn);

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/isofor/IsolationForestMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/isofor/IsolationForestMojoReader.java
@@ -14,8 +14,8 @@ public class IsolationForestMojoReader extends SharedTreeMojoReader<IsolationFor
   @Override
   protected void readModelData() throws IOException {
     super.readModelData();
-    _model._min_path_length = readkv("min_path_length", 0);
-    _model._max_path_length = readkv("max_path_length", 0);;
+    _model._min_path_length = readkv("min_path_length", 0L);
+    _model._max_path_length = readkv("max_path_length", 0L);
   }
 
   @Override

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -46,7 +46,7 @@ public class PrintMojo {
 
   private static void usage() {
     System.out.println("Emit a human-consumable graph of a model for use with dot (graphviz).");
-    System.out.println("The currently supported model types are DRF, GBM and XGBoost.");
+    System.out.println("The currently supported model types are DRF, GBM, XGBoost and IRF.");
     System.out.println("");
     System.out.println("Usage:  java [...java args...] hex.genmodel.tools.PrintMojo [--tree n] [--levels n] [--title sss] [-o outputFileName]");
     System.out.println("");


### PR DESCRIPTION
## Summary
JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6271
Support ticket: https://support.h2o.ai/helpdesk/tickets/93643

## Description

IRF has two variables of type **long** in model's output:

```java
  public static class IsolationForestOutput extends SharedTreeModel.SharedTreeOutput {
    public long _max_path_length;
    public long _min_path_length;

....
}
```

In IsolationForestMojoReader, these variables were red as Integers. Sometimes, the values can really go high with large number of trees and cause the value not to be parsed.

## Resolution

- Variable types have been changes in `IsolationForestMojoModel` from 32-bit integer to 64-bit long.
- Wrote two new tests - one general test for MOJO, one with these values (`_max_path_length`, `_min_path_length`) set artificially to a very high value not squeezable to 32-bits integer.
- Mentioned IRF is actually supported in PrintMojo's hints.

