### PR TITLE
Fix the new method allowing us to create sparse chunks from SW

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -980,14 +980,16 @@ public class Frame extends Lockable<Frame> {
   // Chunks in a Frame, before filling them.  This can be called in parallel
   // for different Chunk#'s (cidx); each Chunk can be filled in parallel.
   static NewChunk[] createNewChunks(String name, byte[] type, int cidx) {
-    return createNewChunks(name, type, cidx, false);
+    boolean[] sparse = new boolean[type.length];
+    Arrays.fill(sparse, false);
+    return createNewChunks(name, type, cidx, sparse);
   }
 
-  static NewChunk[] createNewChunks(String name, byte[] type, int cidx, boolean sparse) {
+  static NewChunk[] createNewChunks(String name, byte[] type, int cidx, boolean[] sparse) {
     Frame fr = (Frame) Key.make(name).get();
     NewChunk[] nchks = new NewChunk[fr.numCols()];
     for (int i = 0; i < nchks.length; i++) {
-      nchks[i] = new NewChunk(new AppendableVec(fr._keys[i], type[i]), cidx, sparse);
+      nchks[i] = new NewChunk(new AppendableVec(fr._keys[i], type[i]), cidx, sparse[i]);
     }
     return nchks;
   }


### PR DESCRIPTION
In a PR about a week ago I introduce method which would allow us to create sparse chunks from Sparkling Water. I passed single value for `sparse` however we need to pass array of booleans as different chunks in frame might be sparse and not sparse