### PR TITLE
[ITA-372] Check for leaked passwords and usernames in logs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ h2o-docs/src/booklets/source/PythonBooklet.tui
 h2o-web/package-lock.json
 
 h2o-*/tests/.lookup.txt
+
+# Ignore leak check output
+leak-check.out

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -377,8 +377,11 @@ endif
 	cd ../mojoland/mojo-py && python in_mojo_veritas.py
 
 check-leaks:
-	-find . -name '*.log' -or -name '*.out' -or -name 'out.*' | \
-		ack -x "`cat tests/leakCheckKeywords | tr '\n' '|' | sed 's/|\s*$$//'`" 2>&1 > leak-check.out
+	-find . \
+		-name '*.log' \
+		-or -name '*.out' \
+		-or -name 'out.*' \
+		-exec grep -E "`cat tests/leakCheckKeywords | tr '\n' '|' | sed 's/|\s*$$//'`" {} \; 2>&1 > leak-check.out
 	@if [ -n "`cat leak-check.out`" ]; then\
 		echo "Credentials leaked! Please check $(PWD)/leak-check.out"; \
 		exit 1; \

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -375,3 +375,11 @@ endif
 	cd ../mojoland && ./gradlew clean
 	cd ../mojoland && ./gradlew build
 	cd ../mojoland/mojo-py && python in_mojo_veritas.py
+
+check-leaks:
+	-find . -name '*.log' -or -name '*.out' | \
+		ack -x "`cat tests/leakCheckKeywords | tr '\n' '|' | sed 's/|\s*$$//'`" 2>&1 > leak-check.out
+	@if [ -n "`cat leak-check.out`" ]; then\
+		echo "Credentials leaked! Please check $(PWD)/leak-check.out"; \
+		exit 1; \
+	fi

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -345,7 +345,6 @@ test-package-hadoop:
 		h2o-hadoop-3/tests/python/ h2o-hadoop-3/h2o-*-assembly/build/libs/h2odriver.jar \
 		h2o-hadoop-common/tests/python/
 
-
 test-hadoop-common-smoke-ldap:
 	cd h2o-hadoop-common/tests/python && ../../../scripts/run.py --wipeall --usecloud "https://$$CLOUD_IP:$$CLOUD_PORT" --ldap.username $$LDAP_USERNAME --ldap.password $$LDAP_PASSWORD
 

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -29,12 +29,14 @@ compress-huge-logfiles:
 
 test-package-py:
 	zip -q -r test-package-py.zip h2o-py/tests/ h2o-py/demos/ \
+	tests/leakCheckKeywords \
 	h2o-docs/src/booklets/v2_2015/source h2o-py/build/dist/*.whl \
 	h2o-genmodel/build/libs/h2o-genmodel.jar h2o-assemblies/genmodel/build/libs/genmodel.jar scripts/run.py \
 	$(JENKINS_MAKEFILE_PATH) tests/pyunit*List h2o-py/scripts/h2o-py-test-setup.py
 
 test-package-r:
 	zip -q -r test-package-r.zip h2o-r h2o-docs/src/booklets/v2_2015/source \
+		tests/leakCheckKeywords \
 		h2o-assemblies/genmodel/build/libs/genmodel.jar scripts/run.py \
 		$(JENKINS_MAKEFILE_PATH) tests/runitSmokeTestList tests/runitAutoMLList \
 		scripts/validate_r_cmd_check_output.R scripts/validate_r_cmd_check_output.py h2o-3-DESCRIPTION
@@ -168,6 +170,7 @@ pack-r-generated-docs:
 
 test-package-js:
 	zip -q -r test-package-js \
+		tests/leakCheckKeywords \
 		$(JENKINS_MAKEFILE_PATH) tests/ignoreFlowSmokeTestList scripts/run.py \
 		h2o-web
 
@@ -197,6 +200,7 @@ test-demos:
 
 test-package-java:
 	zip -q -r test-package-java \
+		tests/leakCheckKeywords \
 		$(JENKINS_MAKEFILE_PATH) \
 		gradlew \
 		gradle.properties \
@@ -335,6 +339,7 @@ benchmark:
 
 test-package-hadoop:
 	zip -q -r test-package-hadoop \
+		tests/leakCheckKeywords \
 		scripts/jenkins/config/ \
 		h2o-hadoop-2/tests/python/ h2o-hadoop-2/h2o-*-assembly/build/libs/h2odriver.jar \
 		h2o-hadoop-3/tests/python/ h2o-hadoop-3/h2o-*-assembly/build/libs/h2odriver.jar \

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -377,7 +377,7 @@ endif
 	cd ../mojoland/mojo-py && python in_mojo_veritas.py
 
 check-leaks:
-	-find . -name '*.log' -or -name '*.out' | \
+	-find . -name '*.log' -or -name '*.out' -or -name 'out.*' | \
 		ack -x "`cat tests/leakCheckKeywords | tr '\n' '|' | sed 's/|\s*$$//'`" 2>&1 > leak-check.out
 	@if [ -n "`cat leak-check.out`" ]; then\
 		echo "Credentials leaked! Please check $(PWD)/leak-check.out"; \

--- a/scripts/jenkins/groovy/hadoopStage.groovy
+++ b/scripts/jenkins/groovy/hadoopStage.groovy
@@ -39,7 +39,7 @@ def call(final pipelineContext, final stageConfig) {
             echo "Cloud IP:PORT ----> \$CLOUD_IP:\$CLOUD_PORT"
 
             echo "Running Make"
-            make -f ${pipelineContext.getBuildConfig().MAKEFILE_PATH} ${stageConfig.target}${getMakeTargetSuffix(stageConfig)}
+            make -f ${pipelineContext.getBuildConfig().MAKEFILE_PATH} ${stageConfig.target}${getMakeTargetSuffix(stageConfig)} check-leaks
         """
         
         stageConfig.postFailedBuildAction = getPostFailedBuildAction(stageConfig.customData.mode)

--- a/scripts/jenkins/groovy/makeTarget.groovy
+++ b/scripts/jenkins/groovy/makeTarget.groovy
@@ -60,7 +60,7 @@ def call(final pipelineContext, final Closure body) {
 
       echo "Running Make"
       export ${makeVars.join(' ')}
-      make -f ${config.makefilePath} ${config.target}
+      make -f ${config.makefilePath} ${config.target} check-leaks
     """
   }
 

--- a/scripts/jenkins/groovy/makeTarget.groovy
+++ b/scripts/jenkins/groovy/makeTarget.groovy
@@ -6,6 +6,7 @@ def call(final pipelineContext, final Closure body) {
   ]
 
   final List<String> FILES_TO_ARCHIVE_ON_FAILURE = [
+          '**/leak-check.out',
           '**/*.log',
           '**/out.*',
           '**/results/*.txt',

--- a/tests/leakCheckKeywords
+++ b/tests/leakCheckKeywords
@@ -1,0 +1,2 @@
+password
+username


### PR DESCRIPTION
After each execution of Make target in pipeline additional target `check-leaks` is executed. This new target does the following:
- at first reads the `tests/leakCheckKeywords` which contains restricted keywords
- replace newlines with `|`, so it is usable in `grep` regexp
- check for presence of any of the keywords in files with `*.out`, `*.log` suffices and in files with `out.*` prefix (JUnit logs)
- all matches are logged to `leak-check.out`
- if this file is not empty, make call fails failing the stage