### PR TITLE
PUBDEV-6294: Expose check_constant_response for DRF and GBM

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/DRFV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DRFV3.java
@@ -68,5 +68,8 @@ public class DRFV3 extends SharedTreeV3<DRF, DRFV3, DRFV3.DRFParametersV3> {
 
         @API(help = "Row sample rate per tree (from 0.0 to 1.0)", gridable = true)
         public double sample_rate;
+
+        @API(help="Check for constant response", level = API.Level.expert, direction = API.Direction.INOUT)
+        public boolean check_constant_response;
     }
 }

--- a/h2o-algos/src/main/java/hex/schemas/DRFV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DRFV3.java
@@ -56,7 +56,8 @@ public class DRFV3 extends SharedTreeV3<DRF, DRFV3, DRFV3.DRFParametersV3> {
                 "calibration_frame",
                 "distribution",
                 "custom_metric_func",
-                "export_checkpoints_dir"
+                "export_checkpoints_dir",
+                "check_constant_response"
         };
 
         // Input fields
@@ -69,7 +70,5 @@ public class DRFV3 extends SharedTreeV3<DRF, DRFV3, DRFV3.DRFParametersV3> {
         @API(help = "Row sample rate per tree (from 0.0 to 1.0)", gridable = true)
         public double sample_rate;
 
-        @API(help="Check for constant response", level = API.Level.expert, direction = API.Direction.INOUT)
-        public boolean check_constant_response;
     }
 }

--- a/h2o-algos/src/main/java/hex/schemas/GBMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GBMV3.java
@@ -95,6 +95,9 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
     @API(help="Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions", level = API.Level.expert, gridable = true)
     public double pred_noise_bandwidth;
 
+    @API(help="Check for constant response", level = API.Level.expert, direction = API.Direction.INOUT)
+    public boolean check_constant_response;
+
 //    // TODO debug only, remove!
 //    @API(help="Internal flag, use new version of histo tsk if set", level = API.Level.expert, gridable = false)
 //    public boolean use_new_histo_tsk;

--- a/h2o-algos/src/main/java/hex/schemas/GBMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GBMV3.java
@@ -65,7 +65,8 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
       "calibration_frame",
       "custom_metric_func",
       "export_checkpoints_dir",
-      "monotone_constraints"
+      "monotone_constraints",
+      "check_constant_response"
 //      "use_new_histo_tsk",
 //      "col_block_sz",
 //      "min_threads",
@@ -94,9 +95,6 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
 
     @API(help="Bandwidth (sigma) of Gaussian multiplicative noise ~N(1,sigma) for tree node predictions", level = API.Level.expert, gridable = true)
     public double pred_noise_bandwidth;
-
-    @API(help="Check for constant response", level = API.Level.expert, direction = API.Direction.INOUT)
-    public boolean check_constant_response;
 
 //    // TODO debug only, remove!
 //    @API(help="Internal flag, use new version of histo tsk if set", level = API.Level.expert, gridable = false)

--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -95,5 +95,8 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
 
     @API(help="Calibration frame for Platt Scaling", level = API.Level.expert, direction = API.Direction.INOUT)
     public FrameKeyV3 calibration_frame;
+
+    @API(help="Check for constant response", level = API.Level.expert, direction = API.Direction.INOUT)
+    public boolean check_constant_response;
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -96,7 +96,8 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     @API(help="Calibration frame for Platt Scaling", level = API.Level.expert, direction = API.Direction.INOUT)
     public FrameKeyV3 calibration_frame;
 
-    @API(help="Check for constant response", level = API.Level.expert, direction = API.Direction.INOUT)
+    @API(help="Check if response column is constant. If enabled, then an exception is thrown if the response column is a constant value." +
+            "If disabled, then model will train regardless of the response column being constant or not.", level = API.Level.expert, direction = API.Direction.INOUT)
     public boolean check_constant_response;
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/SharedTreeV3.java
@@ -97,7 +97,7 @@ public class SharedTreeV3<B extends SharedTree, S extends SharedTreeV3<B,S,P>, P
     public FrameKeyV3 calibration_frame;
 
     @API(help="Check if response column is constant. If enabled, then an exception is thrown if the response column is a constant value." +
-            "If disabled, then model will train regardless of the response column being constant or not.", level = API.Level.expert, direction = API.Direction.INOUT)
+            "If disabled, then model will train regardless of the response column being a constant value or not.", level = API.Level.expert, direction = API.Direction.INOUT)
     public boolean check_constant_response;
   }
 }

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -80,8 +80,6 @@ public abstract class SharedTreeModel<
     public boolean _calibrate_model = false; // Use Platt Scaling
     public Key<Frame> _calibration_frame;
 
-    public boolean _check_constant_response = true; // Check for constant response
-
     public Frame calib() { return _calibration_frame == null ? null : _calibration_frame.get(); }
 
     @Override public long progressUnits() { return _ntrees + (_histogram_type==HistogramType.QuantilesGlobal || _histogram_type==HistogramType.RoundRobin ? 1 : 0); }

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -80,6 +80,8 @@ public abstract class SharedTreeModel<
     public boolean _calibrate_model = false; // Use Platt Scaling
     public Key<Frame> _calibration_frame;
 
+    public boolean _check_constant_response = true; // Check for constant response
+
     public Frame calib() { return _calibration_frame == null ? null : _calibration_frame.get(); }
 
     @Override public long progressUnits() { return _ntrees + (_histogram_type==HistogramType.QuantilesGlobal || _histogram_type==HistogramType.RoundRobin ? 1 : 0); }

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -40,7 +40,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
                       "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
                       "histogram_type", "max_abs_leafnode_pred", "pred_noise_bandwidth", "categorical_encoding",
                       "calibrate_model", "calibration_frame", "custom_metric_func", "export_checkpoints_dir",
-                      "monotone_constraints"}
+                      "monotone_constraints", "check_constant_response"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -895,5 +895,20 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     def monotone_constraints(self, monotone_constraints):
         assert_is_type(monotone_constraints, None, dict)
         self._parms["monotone_constraints"] = monotone_constraints
+
+
+    @property
+    def check_constant_response(self):
+        """
+        Check for constant response
+
+        Type: ``bool``  (default: ``True``).
+        """
+        return self._parms.get("check_constant_response")
+
+    @check_constant_response.setter
+    def check_constant_response(self, check_constant_response):
+        assert_is_type(check_constant_response, None, bool)
+        self._parms["check_constant_response"] = check_constant_response
 
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -900,7 +900,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @property
     def check_constant_response(self):
         """
-        Check for constant response
+        Check if response column is constant. If enabled, then an exception is thrown if the response column is a
+        constant value.If disabled, then model will train regardless of the response column being constant or not.
 
         Type: ``bool``  (default: ``True``).
         """

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -901,7 +901,8 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     def check_constant_response(self):
         """
         Check if response column is constant. If enabled, then an exception is thrown if the response column is a
-        constant value.If disabled, then model will train regardless of the response column being constant or not.
+        constant value.If disabled, then model will train regardless of the response column being a constant value or
+        not.
 
         Type: ``bool``  (default: ``True``).
         """

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -34,7 +34,7 @@ class H2ORandomForestEstimator(H2OEstimator):
                       "sample_rate_per_class", "binomial_double_trees", "checkpoint",
                       "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
                       "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame", "distribution",
-                      "custom_metric_func", "export_checkpoints_dir"}
+                      "custom_metric_func", "export_checkpoints_dir", "check_constant_response"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -784,5 +784,20 @@ class H2ORandomForestEstimator(H2OEstimator):
     def export_checkpoints_dir(self, export_checkpoints_dir):
         assert_is_type(export_checkpoints_dir, None, str)
         self._parms["export_checkpoints_dir"] = export_checkpoints_dir
+
+
+    @property
+    def check_constant_response(self):
+        """
+        Check for constant response
+
+        Type: ``bool``  (default: ``True``).
+        """
+        return self._parms.get("check_constant_response")
+
+    @check_constant_response.setter
+    def check_constant_response(self, check_constant_response):
+        assert_is_type(check_constant_response, None, bool)
+        self._parms["check_constant_response"] = check_constant_response
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -790,7 +790,8 @@ class H2ORandomForestEstimator(H2OEstimator):
     def check_constant_response(self):
         """
         Check if response column is constant. If enabled, then an exception is thrown if the response column is a
-        constant value.If disabled, then model will train regardless of the response column being constant or not.
+        constant value.If disabled, then model will train regardless of the response column being a constant value or
+        not.
 
         Type: ``bool``  (default: ``True``).
         """

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -789,7 +789,8 @@ class H2ORandomForestEstimator(H2OEstimator):
     @property
     def check_constant_response(self):
         """
-        Check for constant response
+        Check if response column is constant. If enabled, then an exception is thrown if the response column is a
+        constant value.If disabled, then model will train regardless of the response column being constant or not.
 
         Type: ``bool``  (default: ``True``).
         """

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_constant_response_gbm.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_constant_response_gbm.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+def constant_col_gbm():
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    train["constantCol"] = 1
+
+    # Run GBM, which should run successfully with constant response when check_constant_response is set to false
+    my_gbm = H2OGradientBoostingEstimator(check_constant_response=False)
+    my_gbm.train(x=list(range(1,5)), y="constantCol", training_frame=train)
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(constant_col_gbm)
+else:
+    constant_col_gbm()

--- a/h2o-py/tests/testdir_algos/rf/pyunit_constant_response_rf.py
+++ b/h2o-py/tests/testdir_algos/rf/pyunit_constant_response_rf.py
@@ -1,0 +1,20 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+
+def constant_col_rf():
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    train["constantCol"] = 1
+
+    # Run DRF, which should run successfully with constant response when check_constant_response is set to false
+    my_rf = H2ORandomForestEstimator(check_constant_response=False)
+    my_rf.train(x=list(range(1,5)), y="constantCol", training_frame=train)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(constant_col_rf)
+else:
+    constant_col_rf()

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -95,6 +95,7 @@
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
 #' @param monotone_constraints A mapping representing monotonic constraints. Use +1 to enforce an increasing constraint and -1 to specify a
 #'        decreasing constraint.
+#' @param check_constant_response \code{Logical}. Check for constant response Defaults to TRUE.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
@@ -165,6 +166,7 @@ h2o.gbm <- function(x, y, training_frame,
                     custom_metric_func = NULL,
                     export_checkpoints_dir = NULL,
                     monotone_constraints = NULL,
+                    check_constant_response = TRUE,
                     verbose = FALSE 
                     ) 
 {
@@ -310,6 +312,8 @@ h2o.gbm <- function(x, y, training_frame,
     parms$export_checkpoints_dir <- export_checkpoints_dir
   if (!missing(monotone_constraints))
     parms$monotone_constraints <- monotone_constraints
+  if (!missing(check_constant_response))
+    parms$check_constant_response <- check_constant_response
   # Error check and build model
   .h2o.modelJob('gbm', parms, h2oRestApiVersion = 3, verbose=verbose) 
 }

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -95,7 +95,9 @@
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
 #' @param monotone_constraints A mapping representing monotonic constraints. Use +1 to enforce an increasing constraint and -1 to specify a
 #'        decreasing constraint.
-#' @param check_constant_response \code{Logical}. Check for constant response Defaults to TRUE.
+#' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
+#'        column is a constant value.If disabled, then model will train regardless of the response column being constant
+#'        or not. Defaults to TRUE.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -96,8 +96,8 @@
 #' @param monotone_constraints A mapping representing monotonic constraints. Use +1 to enforce an increasing constraint and -1 to specify a
 #'        decreasing constraint.
 #' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
-#'        column is a constant value.If disabled, then model will train regardless of the response column being constant
-#'        or not. Defaults to TRUE.
+#'        column is a constant value.If disabled, then model will train regardless of the response column being a
+#'        constant value or not. Defaults to TRUE.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -84,6 +84,7 @@
 #' @param distribution Distribution. This argument is deprecated and has no use for Random Forest.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
+#' @param check_constant_response \code{Logical}. Check for constant response Defaults to TRUE.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
@@ -134,6 +135,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              distribution = c("AUTO", "bernoulli", "multinomial", "gaussian", "poisson", "gamma", "tweedie", "laplace", "quantile", "huber"),
                              custom_metric_func = NULL,
                              export_checkpoints_dir = NULL,
+                             check_constant_response = TRUE,
                              verbose = FALSE 
                              ) 
 {
@@ -264,6 +266,8 @@ h2o.randomForest <- function(x, y, training_frame,
     parms$custom_metric_func <- custom_metric_func
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
+  if (!missing(check_constant_response))
+    parms$check_constant_response <- check_constant_response
   # Error check and build model
   .h2o.modelJob('drf', parms, h2oRestApiVersion = 3, verbose=verbose) 
 }

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -84,7 +84,9 @@
 #' @param distribution Distribution. This argument is deprecated and has no use for Random Forest.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
-#' @param check_constant_response \code{Logical}. Check for constant response Defaults to TRUE.
+#' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
+#'        column is a constant value.If disabled, then model will train regardless of the response column being constant
+#'        or not. Defaults to TRUE.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -85,8 +85,8 @@
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
 #' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
-#'        column is a constant value.If disabled, then model will train regardless of the response column being constant
-#'        or not. Defaults to TRUE.
+#'        column is a constant value.If disabled, then model will train regardless of the response column being a
+#'        constant value or not. Defaults to TRUE.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction

--- a/h2o-r/tests/testdir_algos/gbm/runit_GBM_constant_response.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_GBM_constant_response.R
@@ -1,0 +1,15 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.GBM.constant_response <- function() {
+    train.hex <- h2o.uploadFile(locate("smalldata/iris/iris_train.csv"), "train.hex")
+    train.hex$constantCol <- 1
+    
+    # Build GBM model, which should run successfully with constant response when check_constant_response is set to false
+    iris.gbm.initial <- h2o.gbm(y = 6, x = 1:5, training_frame = train.hex, check_constant_response = F)
+}
+
+doTest("GBM test constant response", test.GBM.constant_response)
+
+
+

--- a/h2o-r/tests/testdir_algos/randomforest/runit_RF_constant_response.R
+++ b/h2o-r/tests/testdir_algos/randomforest/runit_RF_constant_response.R
@@ -1,0 +1,12 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.randomForest.constant_response <- function() {
+    train.hex <- h2o.uploadFile(locate("smalldata/iris/iris_train.csv"), "train.hex")
+    train.hex$constantCol <- 1
+
+    # Build DRF model, which should run succesfully with constant response when check_constant_response is set to false
+    iris.drf.initial <- h2o.randomForest(y = 6, x = 1:5, training_frame = train.hex, check_constant_response = F)
+}
+
+doTest("Random Forest test constant response", test.randomForest.constant_response)


### PR DESCRIPTION
* Expose `check_constant_response` for DRF and GBM
* This variable is set to `true` by default, which is behavior today, i.e., thrown an exception if response column is a constant value
* Added simple unit tests in R/Python client which basically ensures GBM and DRF respect this argument if set to `false`