### PR TITLE
PUBDEV-6304: fixed wrong categorical level error message

### DIFF
--- a/h2o-core/src/main/java/hex/CreateFrame.java
+++ b/h2o-core/src/main/java/hex/CreateFrame.java
@@ -55,7 +55,7 @@ public class CreateFrame extends Iced {
     if (categorical_fraction > 0 && factors <= 1) throw new IllegalArgumentException("Factors must be larger than 2 for categorical data.");
     if (response_factors < 1) throw new IllegalArgumentException("Response factors must be either 1 (real-valued response), or >=2 (factor levels).");
     if (response_factors > Model.Parameters.MAX_SUPPORTED_LEVELS) throw new IllegalArgumentException("Response factors must be <= " + Model.Parameters.MAX_SUPPORTED_LEVELS + ".");
-    if (factors > 1000000) throw new IllegalArgumentException("Number of factors must be <= 1,000,000).");
+    if (factors > 10000000) throw new IllegalArgumentException("Number of factors must be <= 10,000,000).");
     if (cols <= 0 || rows <= 0) throw new IllegalArgumentException("Must have number of rows > 0 and columns > 0.");
 
     // estimate byte size of the frame

--- a/h2o-core/src/main/java/hex/createframe/recipes/OriginalCreateFrameRecipe.java
+++ b/h2o-core/src/main/java/hex/createframe/recipes/OriginalCreateFrameRecipe.java
@@ -44,7 +44,7 @@ public class OriginalCreateFrameRecipe extends CreateFrameRecipe<OriginalCreateF
     check(categorical_fraction == 0 || factors >= 2, "Factors must be larger than 2 for categorical data");
     check(response_factors >= 1, "Response factors must be either 1 (real-valued response), or >=2 (factor levels)");
     check(response_factors <= 1024, "Response factors must be <= 1024");
-    check(factors <= 1000000, "Number of factors must be <= 1,000,000");
+    check(factors <= 10000000, "Number of factors must be <= 10,000,000");
     check(cols > 0 && rows > 0, "Must have number of rows and columns > 0");
     check(real_range >= 0, "Real range must be a nonnegative number");
     check(integer_range >= 0, "Integer range must be a nonnegative number");

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6304_cat_warn_large.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6304_cat_warn_large.py
@@ -1,0 +1,35 @@
+import h2o
+from tests import pyunit_utils
+import sys
+
+def pubdev_6304():
+    fractions = dict()
+    fractions["real_fraction"] = 0 # Right now we are dropping string columns, so no point in having them.
+    fractions["categorical_fraction"] = 1
+    fractions["integer_fraction"] = 0
+    fractions["time_fraction"] = 0
+    fractions["string_fraction"] = 0 # Right now we are dropping string columns, so no point in having them.
+    fractions["binary_fraction"] = 0
+    
+    # this used to get an error message
+    try: 
+        traindata = h2o.create_frame(rows=100, cols=2, missing_fraction=0, has_response=False, factors=9999999, seed=12345, **fractions)
+    except Exception as ex:
+        sys.exit(1)
+
+    # this get an error message
+    try:
+        traindata = h2o.create_frame(rows=100, cols=2, missing_fraction=0, has_response=False, factors=19999999, seed=12345, **fractions)
+        sys.exit(1) # should have thrown an error
+    except Exception as ex: # expect an error here
+        print(ex)
+        if 'Number of factors must be <= 10,000,000' in ex.args[0].dev_msg:
+            sys.exit(0) # correct error message
+        else:
+            sys.exit(1) # something else is wrong.
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_6304)
+else:
+    pubdev_6304()


### PR DESCRIPTION
This PR completes work required in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6304?filter=-1 .

H2O allows 10000000 categorical levels.  However, an error message was generated if we have categorical level > 1000000.  We are missing out on a zero here.

Fix:
1. Comparison threshold changed from 1000000 to 10000000.
2. Added pyunit test to make sure correct error message is returned.