### PR TITLE
PUBDEV-6287: Add documentation for check_constant_response in GBM and DRF

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/check_constant_response.rst
+++ b/h2o-docs/src/product/data-science/algo-params/check_constant_response.rst
@@ -1,0 +1,49 @@
+``check_constant_response``
+---------------------------
+
+- Available in: GBM, DRF
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+This option checks if a response column is a constant value. If this option is enabled (default), then an exception is thrown if the response column is a constant value. If this option is disabled, then the model will train regardless of the response column being a constant value or not.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- None
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# import the iris dataset: 
+	train.hex <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/iris/iris_train.csv")
+	train.hex$constantCol <- 1
+
+	# Build a GBM model. This should run successfully when 
+	# check_constant_response is set to false.
+	iris.gbm.initial <- h2o.gbm(y = 6, x = 1:5, training_frame = train.hex)
+
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.gbm import H2OGradientBoostingEstimator
+	h2o.init()
+
+	# import the iris dataset: 
+	train = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/iris/iris_train.csv")
+	train["constantCol"] = 1
+
+	# Build a GBM model. This should run successfully when 
+	# check_constant_response is set to false.
+	my_gbm = H2OGradientBoostingEstimator(check_constant_response=False)
+	my_gbm.train(x=list(range(1,5)), y="constantCol", training_frame=train)
+

--- a/h2o-docs/src/product/data-science/algo-params/custom_metric_func.rst
+++ b/h2o-docs/src/product/data-science/algo-params/custom_metric_func.rst
@@ -1,0 +1,96 @@
+.. _custom_metric_func:
+
+``custom_metric_func``
+----------------------
+
+- Available in: GBM, DRF, GLM 
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+Use this option to specify a custom evaluation function. A custom metric function can be used to produce adhoc scoring metrics if actuals are presented.
+
+**Note**: This option is only supported in the Python client.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `stopping_metric <stopping_metric.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.estimators.gbm import H2OGradientBoostingEstimator
+	h2o.init()
+	h2o.cluster().show_status()
+
+	# import the airlines dataset:
+	# This dataset is used to classify whether a flight will be delayed 'YES' or not "NO"
+	# original data can be found at http://www.transtats.bts.gov/
+	airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
+
+	# convert columns to factors
+	airlines["Year"]= airlines["Year"].asfactor()
+	airlines["Month"]= airlines["Month"].asfactor()
+	airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
+	airlines["Cancelled"] = airlines["Cancelled"].asfactor()
+	airlines['FlightNum'] = airlines['FlightNum'].asfactor()
+
+	# set the predictor names and the response column name
+	predictors = ["Origin", "Dest", "Year", "UniqueCarrier", "DayOfWeek", "Month", "Distance", "FlightNum"]
+	response = "IsDepDelayed"
+
+	# split into train and validation sets 
+	train, valid= airlines.split_frame(ratios = [.8], seed = 1234)
+
+	# try using the `stopping_metric` parameter: 
+	# since this is a classification problem we will look at the AUC
+	# you could also choose logloss, or misclassification, among other options
+	# train your model, where you specify the stopping_metric, stopping_rounds, 
+	# and stopping_tolerance
+	# initialize the estimator then train the model
+	airlines_gbm = H2OGradientBoostingEstimator(stopping_metric = "auc", stopping_rounds = 3,
+	                                            stopping_tolerance = 1e-2,
+	                                            seed =1234)
+	airlines_gbm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+
+	# print the auc for the validation data
+	airlines_gbm.auc(valid=True)
+
+	# Use a custom metric
+	# Create a custom RMSE Model metric and save as mm_rmse.py
+	# Note that this references a java class java.lang.Math
+	class CustomRmseFunc:
+	def map(self, pred, act, w, o, model):
+	    idx = int(act[0])
+	    err = 1 - pred[idx + 1] if idx + 1 < len(pred) else 1
+	    return [err * err, 1]
+
+	def reduce(self, l, r):
+	    return [l[0] + r[0], l[1] + r[1]]
+
+	def metric(self, l):
+	    # Use Java API directly
+	    import java.lang.Math as math
+	    return math.sqrt(l[0] / l[1])
+
+	# Upload the custom metric
+	custom_mm_func = h2o.upload_custom_metric(CustomRmseFunc, 
+	                                          func_name="rmse", 
+	                                          func_file="mm_rmse.py")
+
+	# Train the model
+	model = H2OGradientBoostingEstimator(ntrees=3, 
+	                                     max_depth=5,
+	                                     score_each_iteration=True,
+	                                     custom_metric_func=custom_mm_func,
+	                                     stopping_metric="custom",
+	                                     stopping_tolerance=0.1,
+	                                     stopping_rounds=3)
+	model.train(x=predictors, y=response, training_frame train, validation_frame = valid)

--- a/h2o-docs/src/product/data-science/deep-learning.rst
+++ b/h2o-docs/src/product/data-science/deep-learning.rst
@@ -263,6 +263,8 @@ H2O Deep Learning models have many input parameters, many of which are only acce
 
 -  **elastic_averaging_regularization**: Specify the elastic averaging regularization strength. This option is only available if ``elastic_averaging=True``. 
 
+-  **export_checkpoints_dir**: Optionally specify a path to a directory where every generated model will be stored when checkpointing models.
+
 -  **verbose**: Print scoring history to the console. For Deep Learning, metrics are per epoch. This value defaults to FALSE.
 
 

--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -238,6 +238,13 @@ Defining a DRF Model
 
 -  **verbose**: Print scoring history to the console. For DRF, metrics are per tree. This value defaults to FALSE.
 
+-  `custom_metric_func <algo-params/custom_metric_func.html>`__: Optionally specify a custom evaluation function.
+
+-  **export_checkpoints_dir**: Optionally specify a path to a directory where every generated model will be stored when checkpointing models.
+
+-  `check_constant_response <algo-params/check_constant_response.html>`__: Check if the response column is a constant value. If enabled (default), then an exception is thrown if the response column is a constant value. If disabled, then the model will train regardless of the response column being a constant value or not.
+
+
 Interpreting a DRF Model
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -258,9 +258,16 @@ Defining a GBM Model
 
 -  `calibration_frame <algo-params/calibration_frame.html>`__: Specifies the frame to be used for Platt scaling.
 
+-  `custom_metric_func <algo-params/custom_metric_func.html>`__: Optionally specify a custom evaluation function.
+
+-  **export_checkpoints_dir**: Optionally specify a path to a directory where every generated model will be stored when checkpointing models.
+
 -  **monotone_constraints**: A mapping representing monotonic constraints. Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint. Note that constraints can only be defined for numerical columns. A Python demo is available `here <https://github.com/h2oai/h2o-3/tree/master/h2o-py/demos/H2O_tutorial_gbm_monotonicity.ipynb>`__.
 
+-  `check_constant_response <algo-params/check_constant_response.html>`__: Check if the response column is a constant value. If enabled (default), then an exception is thrown if the response column is a constant value. If disabled, then the model will train regardless of the response column being a constant value or not.
+
 -  **verbose**: Print scoring history to the console. For GBM, metrics are per tree. This value defaults to FALSE.
+
 
 Interpreting a GBM Model
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -142,6 +142,8 @@ Defining a GLM Model
 
 -  **obj_reg**: Specifies the likelihood divider in objective value computation. This defaults to 1/nobs.
 
+-  `custom_metric_func <algo-params/custom_metric_func.html>`__: Optionally specify a custom evaluation function.
+
 
 Interpreting a GLM Model
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -95,11 +95,7 @@ Defining a Stacked Ensemble Model
 
 -  `seed <algo-params/seed.html>`__: (Optional) Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 
-
-Also in a `future release <https://0xdata.atlassian.net/browse/PUBDEV-5086>`__, there will be an additional ``metalearner_params`` argument which allows for full customization of the metalearner algorithm hyperparamters.  
-
 You can follow the progress of H2O's Stacked Ensemble development `here <https://0xdata.atlassian.net/issues/?filter=19301>`__.
-
 
 
 Example

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -942,6 +942,10 @@ The available options vary depending on the selected model. If an option is only
 
 -  **lre_min**: (CoxPH) A positive number to use as the minimum log-relative error (LRE) of subsequent log partial likelihood calculations to determine algorithmic convergence. The role this parameter plays in the stopping criteria of the model fitting algorithm is explained in the :ref:`coxph_algorithm` section below. This value defaults to 9.
 
+-  **export_checkpoints_dir**: (DL, DRF, GBM) Optionally specify a path to a directory where every generated model will be stored when checkpointing models.
+
+-  **custom_metric_func**: (GBM, DRF, GLM) Optionally specify a custom evaluation function.
+
 
 **Expert Options**
 
@@ -1065,7 +1069,9 @@ The available options vary depending on the selected model. If an option is only
 
 -  **interactions**: (GLM, CoxPH) Specify a list of predictor column indices to interact. All pairwise combinations will be computed for this list. 
 
--  **interaction_pairs** (GLM, CoxPH) When defining interactions, use this to specify a list of pairwise column interactions (interactions between two variables). Note that this is different than ``interactions``, which will compute all pairwise combinations of specified columns.
+-  **interaction_pairs**: (GLM, CoxPH) When defining interactions, use this to specify a list of pairwise column interactions (interactions between two variables). Note that this is different than ``interactions``, which will compute all pairwise combinations of specified columns.
+
+-  **check_constant_response**: (GBM, DRF) Check if the response column is a constant value. If enabled (default), then an exception is thrown if the response column is a constant value. If disabled, then the model will train regardless of the response column being a constant value or not.
 
 --------------
 

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -22,6 +22,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/calibrate_model
    data-science/algo-params/calibration_frame
    data-science/algo-params/categorical_encoding
+   data-science/algo-params/check_constant_response
    data-science/algo-params/checkpoint
    data-science/algo-params/class_sampling_factors
    data-science/algo-params/col_sample_rate
@@ -29,6 +30,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/col_sample_rate_per_tree
    data-science/algo-params/compute_metrics
    data-science/algo-params/compute_p_values
+   data-science/algo-params/custom_metric_func
    data-science/algo-params/distribution
    data-science/algo-params/early_stopping
    data-science/algo-params/eps_prob


### PR DESCRIPTION
- Added check_constant_response to list of parameters in GBM and DRF.
- Added an example of check_constant_response in the Parameters appendix.
- Added check_constant_response to Flow chapter
Driveby fixes:
- Added documentation for custom_metric_func, available in GBM, DRF, and GLM.
- Added export_checkpoints_dir option to DL, DRF, and GBM.
- Updated flow to include export_checkpoints_dir and custom_metric_func.