### PR TITLE
PUBDEV-6319: Test that shows that AstGroup can return unexpected values

### DIFF
--- a/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstMergeTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstMergeTest.java
@@ -20,30 +20,6 @@ public class AstMergeTest extends TestUtil {
     stall_till_cloudsize(1);
   }
 
-
-  @Test(timeout = 10000) // This merge is not going to finish in reasonable time. Check if it is n*log(n)
-  public void AutoMergeAllLeftStressTest() {
-
-    fr = new TestFrameBuilder()
-            .withName("leftFrame")
-            .withColNames("ColA", "ColB")
-            .withVecTypes(Vec.T_NUM, Vec.T_STR)
-            .withRandomIntDataForCol(0, 1000000, 0, 100)
-            .withRandomBinaryDataForCol(1, 1000000)
-            .build();
-
-    Frame frRight = new TestFrameBuilder()
-            .withName("rightFrame")
-            .withColNames("ColA_R", "ColB_R")
-            .withVecTypes(Vec.T_NUM, Vec.T_STR)
-            .withRandomIntDataForCol(0, 1000000, 0, 100)
-            .withRandomBinaryDataForCol(1, 1000000)
-            .build();
-
-    String tree = "(merge leftFrame rightFrame TRUE FALSE [0.0] [0.0] 'auto' )";
-    Rapids.exec(tree);
-  }
-
   @Test
   public void mergeWithNaOnTheRightMapsToEverythingTest4() {
     Scope.enter();


### PR DESCRIPTION
During Integration of target encoding( TE) into AutoML I have noticed some unexpected inconsistency in results for the same TE parameters. So I tracked it down to the method that is doing grouping for calculation of the frequencies. I checked out revision that was before my refactoring in AstGroup class to see if it was something that I had introduced when I was implementing TE. The bug was there before. 
Behaviour is quite interesting... only from time to time AstGroup returns only one line with different aggregated values( maybe it is specific for a titanic dataset...but still it seems that it is always one line with inconsistency).