### PR TITLE
PUBDEV-5801: Added column names and types to model output

### DIFF
--- a/h2o-algos/src/main/java/hex/api/MakeGLMModelHandler.java
+++ b/h2o-algos/src/main/java/hex/api/MakeGLMModelHandler.java
@@ -3,7 +3,6 @@ package hex.api;
 import hex.DataInfo;
 import hex.DataInfo.TransformType;
 import hex.Model;
-import hex.genmodel.utils.ArrayUtils;
 import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMOutput;
 import hex.gram.Gram;
@@ -14,11 +13,10 @@ import water.MRTask;
 import water.api.Handler;
 import water.api.schemas3.KeyV3;
 import water.fvec.*;
-import water.rapids.vals.ValFrame;
+import water.fvec.Vec.VectorGroup;
 
 import java.util.Arrays;
 import java.util.Map;
-import water.fvec.Vec.VectorGroup;
 
 /**
  * Created by tomasnykodym on 3/25/15.
@@ -39,7 +37,7 @@ public class MakeGLMModelHandler extends Handler {
     DataInfo dinfo = model.dinfo();
     dinfo.setPredictorTransform(TransformType.NONE);
     // GLMOutput(DataInfo dinfo, String[] column_names, String[][] domains, String[] coefficient_names, boolean binomial) {
-    m._output = new GLMOutput(model.dinfo(),model._output._names, model._output._domains, model._output.coefficientNames(), model._output._binomial, beta);
+    m._output = new GLMOutput(model.dinfo(),model._output._names,model._output._column_types,  model._output._domains, model._output.coefficientNames(), model._output._binomial, beta);
     DKV.put(m._key, m);
     GLMModelV3 res = new GLMModelV3();
     res.fillFromImpl(m);

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -204,7 +204,7 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
     makeWeightsBiases(destKey);
     _output._scoring_history = DeepLearningScoringInfo.createScoringHistoryTable(scoringInfo, (null != get_params()._valid), false, _output.getModelCategory(), _output.isAutoencoder());
     _output._variable_importances = calcVarImp(last_scored().variable_importances);
-    _output.setNames(dataInfo._adaptedFrame.names());
+    _output.setNames(dataInfo._adaptedFrame.names(), dataInfo._adaptedFrame.typesStr());
     _output._domains = dataInfo._adaptedFrame.domains();
     assert(Arrays.equals(_key._kb, destKey._kb));
   }
@@ -222,7 +222,7 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
     super(destKey, parms, output);
     final DataInfo dinfo = makeDataInfo(train, valid, _parms, nClasses);
     DKV.put(dinfo);
-    _output.setNames(dinfo._adaptedFrame.names());
+    _output.setNames(dinfo._adaptedFrame.names(), dinfo._adaptedFrame.typesStr());
     _output._domains = dinfo._adaptedFrame.domains();
     _output._origNames = parms._train.get().names();
     _output._origDomains = parms._train.get().domains();

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -375,7 +375,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
 
         // TODO: set _parms._train to aModel._parms.train()
 
-        _output.setNames(aModel._output._names);
+        _output.setNames(aModel._output._names, aModel._output._column_types);
         this.names = new NonBlockingHashSet<>();
         this.names.addAll(Arrays.asList(aModel._output._names));
 

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -969,10 +969,10 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       return MakeGLMModelHandler.oneHot(fr,interactions,useAll,standardize,false,skipMissing);
     }
 
-    public GLMOutput(DataInfo dinfo, String[] column_names, String[][] domains, String[] coefficient_names, boolean binomial) {
+    public GLMOutput(DataInfo dinfo, String[] column_names, String[] column_types, String[][] domains, String[] coefficient_names, boolean binomial) {
       super(dinfo._weights, dinfo._offset, dinfo._fold);
       _dinfo = dinfo.clone();
-      setNames(column_names);
+      setNames(column_names, column_types);
       _domains = domains;
       _coefficient_names = coefficient_names;
       _binomial = binomial;
@@ -983,8 +983,8 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       }
     }
 
-    public GLMOutput(DataInfo dinfo, String[] column_names, String[][] domains, String[] coefficient_names, boolean binomial, double[] beta) {
-      this(dinfo,column_names,domains,coefficient_names,binomial);
+    public GLMOutput(DataInfo dinfo, String[] column_names, String[] column_types, String[][] domains, String[] coefficient_names, boolean binomial, double[] beta) {
+      this(dinfo,column_names,column_types, domains,coefficient_names,binomial);
       assert !ArrayUtils.hasNaNsOrInfs(beta);
       _global_beta=beta;
       _submodels = new Submodel[]{new Submodel(0,beta,-1,Double.NaN,Double.NaN)};
@@ -1026,7 +1026,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         names = ns;
         domains = ds;
       }
-      setNames(names);
+      setNames(names, glm._dinfo._adaptedFrame.typesStr());
       _domains = domains;
       _coefficient_names = Arrays.copyOf(cnames, cnames.length + 1);
       _coefficient_names[_coefficient_names.length-1] = "Intercept";

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -620,9 +620,22 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     /** Columns used in the model and are used to match up with scoring data
      *  columns.  The last name is the response column name (if any). */
     public String _names[];
+    public String _column_types[];
 
+    /**
+     * @deprecated as of March 6, 2019, replaced by (@link #setNames(String[] names, String[] columnTypes))
+     * 
+     */
+    @Deprecated
     public void setNames(String[] names) {
       _names = names;
+      _column_types = new String[names.length];
+      Arrays.fill(_column_types, "NA");
+    }
+
+    public void setNames(String[] names, String[] columntypes) {
+      _names = names;
+      _column_types = columntypes;
     }
 
     public String _origNames[]; // only set if ModelBuilder.encodeFrameCategoricals() changes the training frame
@@ -669,7 +682,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       if (b.error_count() > 0)
         throw new IllegalArgumentException(b.validationErrors());
       // Capture the data "shape" the model is valid on
-      setNames(train != null ? train.names() : new String[0]);
+      setNames(train != null ? train.names() : new String[0], train!=null?train.typesStr():new String[0]);
       _domains = train != null ? train.domains() : new String[0][];
       _origNames = b._origNames;
       _origDomains = b._origDomains;

--- a/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
@@ -19,6 +19,9 @@ public class ModelOutputSchemaV3<O extends Model.Output, S extends ModelOutputSc
   @API(help="Column names", direction=API.Direction.OUTPUT)
   public String[] names;
 
+  @API(help="Column types", direction=API.Direction.OUTPUT)
+  public String[] column_types; // column type mappings can be found in Vec.java, around line 198.
+
   @API(help="Domains for categorical columns", direction=API.Direction.OUTPUT, level=API.Level.expert)
   public String[][] domains;
 

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -630,7 +630,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
   }
 
   private void setDataInfoToOutput(DataInfo dinfo) {
-    _output._names = dinfo._adaptedFrame.names();
+    _output.setNames(dinfo._adaptedFrame.names(), dinfo._adaptedFrame.typesStr());
     _output._domains = dinfo._adaptedFrame.domains();
     _output._origNames = _parms._train.get().names();
     _output._origDomains = _parms._train.get().domains();

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -4230,3 +4230,21 @@ def checkCorrectSkipsFolder(originalFullFrame, csvfile, skipped_columns):
                 compare_frames_local_onecolumn_NA(originalFullFrame[cindex], skippedFrameIF[skipCounter],
                                                                prob=1, tol=1e-10, returnResult=False)
             skipCounter = skipCounter + 1
+
+def assertModelColNamesTypesCorrect(modelNames, modelTypes, frameNames, frameTypesDict):
+    fName = list(frameNames)
+    mName = list(modelNames)
+    assert fName.sort() == mName.sort(), "Expected column names {0}, actual column names {1} and they" \
+                                                    " are different".format(frameNames, modelNames) 
+    for ind in range(len(frameNames)):  
+        if modelTypes[modelNames.index(frameNames[ind])].lower()=="numeric":
+            assert (frameTypesDict[frameNames[ind]].lower()=='real') or \
+                   (frameTypesDict[frameNames[ind]].lower()=='int'), \
+                "Expected training data types for column {0} is {1}.  Actual training data types for column {2} from " \
+                "model output is {3}".format(frameNames[ind], frameTypesDict[frameNames[ind]],
+                                             frameNames[ind], modelTypes[modelNames.index(frameNames[ind])])
+        else:
+            assert modelTypes[modelNames.index(frameNames[ind])].lower()==frameTypesDict[frameNames[ind]].lower(), \
+            "Expected training data types for column {0} is {1}.  Actual training data types for column {2} from " \
+            "model output is {3}".format(frameNames[ind], frameTypesDict[frameNames[ind]],
+                                         frameNames[ind], modelTypes[modelNames.index(frameNames[ind])])

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_regression.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_regression.py
@@ -53,13 +53,16 @@ def stackedensemble_gaussian():
 
     stack = H2OStackedEnsembleEstimator(base_models=[my_gbm.model_id, my_rf.model_id, my_glm.model_id])
     stack.train(model_id="my_ensemble", x=myX, y="runoffnew", training_frame=australia_hex)
+    
+    # check that model contains the correct names and types in model._model_json._output fields
+    pyunit_utils.assertModelColNamesTypesCorrect(stack._model_json["output"]["names"],  
+                                                 stack._model_json["output"]["column_types"], australia_hex.names,
+                                                 australia_hex.types)
+    
     # test ignore_columns parameter checking
     # stack.train(model_id="my_ensemble", y="runoffnew", training_frame=australia_hex, ignored_columns=["premax"])
     predictions = stack.predict(australia_hex)  # training data
     print("Predictions for australia ensemble are in: " + predictions.frame_id)
-
-
-
 
     # 
     # ecology.csv: Gaussian

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_insurance_poisson_small.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_insurance_poisson_small.py
@@ -16,6 +16,12 @@ def xgboost_insurance_poisson_small():
     model_2_trees = H2OXGBoostEstimator(training_frame=training_frame, learn_rate=0.1, max_depth=1,
                                         booster='gbtree', seed=1, ntrees=2, distribution='poisson');
     model_2_trees.train(x=x, y=y, training_frame=training_frame)
+
+    # check and make sure training frame column names and types info are returned correctly in model output
+    pyunit_utils.assertModelColNamesTypesCorrect(model_2_trees._model_json["output"]["names"],
+                                                 model_2_trees._model_json["output"]["column_types"],
+                                                 ['District', 'Group', 'Age', 'Holders', 'Claims'],training_frame.types)
+
     prediction_2_trees = model_2_trees.predict(test_frame)
 
     assert prediction_2_trees.nrows == test_frame.nrows

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5801_add_names_types_model.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5801_add_names_types_model.py
@@ -1,0 +1,111 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.deeplearning import H2ODeepLearningEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+from h2o.estimators.kmeans import H2OKMeansEstimator
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.word2vec import H2OWord2vecEstimator
+from h2o.estimators.deepwater import H2ODeepWaterEstimator
+from h2o.estimators.naive_bayes import H2ONaiveBayesEstimator
+
+def algo_max_runtime_secs():
+    '''
+    This pyunit test is written to ensure that column names and column types are returned in the model
+      output for every algorithm supported by H2O.  See PUBDEV-5801.
+    '''
+    seed = 12345
+    print("Checking GLM.....")
+    training1_data = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
+    model =  H2OGeneralizedLinearEstimator(family = "binomial", alpha  = 1.0, lambda_search = False,
+                                       max_iterations  = 2, seed = seed)
+    checkColumnNamesTypesReturned(training1_data, model, ["displacement","power","weight", "acceleration","year"],
+                              y_index= "economy_20mpg")
+
+    print("Checking GLRM.....")
+    irisH2O = h2o.upload_file(pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=3, loss="Quadratic", gamma_x=0.5, gamma_y=0.5, transform="STANDARDIZE")
+    checkColumnNamesTypesReturned(irisH2O, glrm_h2o, irisH2O.names)
+    
+    print("Checking NaiveBayes......")
+    model = H2ONaiveBayesEstimator(laplace=0.25)
+    x_indices = irisH2O.names
+    y_index = x_indices[-1]
+    x_indices.remove(y_index)
+    checkColumnNamesTypesReturned(irisH2O, model, x_indices, y_index=y_index)
+
+    # deeplearning
+    print("Checking deeplearning.....")
+    training1_data = h2o.import_file(path=pyunit_utils.locate("smalldata/gridsearch/gaussian_training1_set.csv"))
+    x_indices = training1_data.names
+    y_index = x_indices[-1]
+    x_indices.remove(y_index)
+    model = H2ODeepLearningEstimator(distribution='gaussian', seed=seed, hidden=[10, 10, 10])
+    checkColumnNamesTypesReturned(training1_data, model, x_indices, y_index=y_index)
+
+    # stack ensemble, stacking part is not iterative
+    print("******************** Skip testing stack ensemble.  Test done in pyunit_stackedensemble_regression.py.")
+
+    # GBM run
+    print("Checking GBM.....")
+    training1_data = h2o.import_file(path=pyunit_utils.locate("smalldata/gridsearch/multinomial_training1_set.csv"))
+    x_indices = training1_data.names
+    y_index = x_indices[-1]
+    x_indices.remove(y_index)
+    training1_data[y_index] = training1_data[y_index].round().asfactor()
+    model = H2OGradientBoostingEstimator(distribution="multinomial", seed=seed)
+    checkColumnNamesTypesReturned(training1_data, model, x_indices, y_index=y_index)
+
+    # random foreset
+    print("Checking Random Forest.....")
+    model = H2ORandomForestEstimator(ntrees=100, score_tree_interval=0)
+    checkColumnNamesTypesReturned(training1_data, model, x_indices, y_index=y_index)
+
+    # PCA
+    print("Checking PCA.....")
+    training1_data = h2o.import_file(path=pyunit_utils.locate("smalldata/gridsearch/pca1000by25.csv"))
+    x_indices = training1_data.names
+    model = H2OPCA(k=10, transform="STANDARDIZE", pca_method="Power", compute_metrics=True)
+    checkColumnNamesTypesReturned(training1_data, model, x_indices)
+
+    # kmeans
+    print("Checking kmeans....")
+    training1_data = h2o.import_file(path=pyunit_utils.locate("smalldata/gridsearch/kmeans_8_centers_3_coords.csv"))
+    x_indices = training1_data.names
+    model = H2OKMeansEstimator(k=10)
+    checkColumnNamesTypesReturned(training1_data, model, x_indices)
+
+    # word2vec
+    print("Checking word2vec....")
+    train = h2o.import_file(pyunit_utils.locate("bigdata/laptop/text8.gz"), header=1, col_types=["string"])
+    used = train[0:170000, 0]
+    w2v_model = H2OWord2vecEstimator()
+    checkColumnNamesTypesReturned(train,  w2v_model, [],0)
+
+
+def checkColumnNamesTypesReturned(training_data, model, x_indices, y_index=0):
+    unsupervised = ("glrm" in model.algo) or ("pca" in model.algo) or ("kmeans" in model.algo)
+    trainNames = []
+    if unsupervised:
+        model.train(x=x_indices, training_frame=training_data, max_runtime_secs=1)
+        trainNames = x_indices
+    else:
+        if ('word2vec' in model.algo):
+            model.train(training_frame=training_data, max_runtime_secs=1)
+        else:
+            model.train(x=x_indices, y=y_index, training_frame=training_data, max_runtime_secs=1)
+            trainNames = x_indices+[y_index]
+    trainTypes = training_data.types
+    
+    pyunit_utils.assertModelColNamesTypesCorrect(model._model_json["output"]['names'], 
+                                                 model._model_json["output"]["column_types"], trainNames, trainTypes)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(algo_max_runtime_secs)
+else:
+    algo_max_runtime_secs()


### PR DESCRIPTION
This PR completes the work described in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-5801?filter=-1 .

I have added the Java backend to copy the column types to model output.
I have added a pyunit test to check for all H2O algos that the column names and column types are correct.

For stackedensemble, I added the check to one existing pyunit test: pyunit_stackedensemble_regression.py

For xgboost, I added the check to one existing pyunit test: pyunit_insurance_poisson_small.py