### PR TITLE
PUBDEV-6271: Isolation Forest - Min-Max path is correctly calculated when OOB is empty

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/isofor/IsolationForestModel.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/IsolationForestModel.java
@@ -35,8 +35,8 @@ public class IsolationForestModel extends SharedTreeModel<IsolationForestModel, 
   }
 
   public static class IsolationForestOutput extends SharedTreeModel.SharedTreeOutput {
-    public long _max_path_length;
-    public long _min_path_length;
+    public int _max_path_length;
+    public int _min_path_length;
 
     public IsolationForestOutput(IsolationForest b) { super(b); }
 

--- a/h2o-algos/src/main/java/hex/tree/isofor/IsolationForestModel.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/IsolationForestModel.java
@@ -50,7 +50,7 @@ public class IsolationForestModel extends SharedTreeModel<IsolationForestModel, 
 
   @Override
   public ModelMetrics.MetricBuilder makeMetricBuilder(String[] domain) {
-    return new ModelMetricsAnomaly.MetricBuilderAnomaly();
+    return new ModelMetricsAnomaly.MetricBuilderAnomaly("Isolation Forest Metrics");
   }
 
   @Override

--- a/h2o-algos/src/main/java/hex/tree/isofor/ModelMetricsAnomaly.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/ModelMetricsAnomaly.java
@@ -9,8 +9,9 @@ public class ModelMetricsAnomaly extends ModelMetricsUnsupervised implements Sco
   public final double _mean_normalized_score;
 
   public ModelMetricsAnomaly(Model model, Frame frame, CustomMetric customMetric,
-                             long nobs, double totalScore, double totalNormScore) {
-    super(model, frame, nobs, Double.NaN, customMetric);
+                             long nobs, double totalScore, double totalNormScore,
+                             String description) {
+    super(model, frame, nobs, description, customMetric);
     _mean_score = totalScore / nobs;
     _mean_normalized_score = totalNormScore / nobs;
   }
@@ -21,13 +22,23 @@ public class ModelMetricsAnomaly extends ModelMetricsUnsupervised implements Sco
     sk._anomaly_score_normalized = _mean_normalized_score;
   }
 
+  @Override
+  protected StringBuilder appendToStringMetrics(StringBuilder sb) {
+    sb.append(" Number of Observations: ").append(_nobs).append("\n");
+    sb.append(" Mean Anomaly Score: ").append(_mean_score).append("\n");
+    sb.append(" Mean Normalized Anomaly Score: ").append(_mean_normalized_score).append("\n");
+    return sb;
+  }
+
   public static class MetricBuilderAnomaly extends MetricBuilderUnsupervised<MetricBuilderAnomaly> {
+    private transient String _description;
     private double _total_score = 0;
     private double _total_norm_score = 0;
     private long _nobs = 0;
 
-    public MetricBuilderAnomaly() {
+    public MetricBuilderAnomaly(String description) {
       _work = new double[2];
+      _description = description;
     }
 
     @Override
@@ -50,7 +61,7 @@ public class ModelMetricsAnomaly extends ModelMetricsUnsupervised implements Sco
 
     @Override
     public ModelMetrics makeModelMetrics(Model m, Frame f, Frame adaptedFrame, Frame preds) {
-      return m.addModelMetrics(new ModelMetricsAnomaly(m, f, _customMetric, _nobs, _total_score, _total_norm_score));
+      return m.addModelMetrics(new ModelMetricsAnomaly(m, f, _customMetric, _nobs, _total_score, _total_norm_score, _description));
     }
   }
 }

--- a/h2o-algos/src/main/java/hex/tree/isofor/PathTracker.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/PathTracker.java
@@ -1,0 +1,40 @@
+package hex.tree.isofor;
+
+import water.fvec.Chunk;
+
+/**
+ * Helper class - encodes lengths of paths for observations separately for OOB and when they were used for tree building.
+ */
+class PathTracker {
+
+  static int encodeNewPathLength(Chunk tree, int row, int depth, boolean wasOOB) {
+    final long old_len_enc = tree.at8(row);
+    final long len_enc = addNewPathLength(old_len_enc, depth, wasOOB);
+    tree.set(row, len_enc);
+    return decodeTotalPathLength(len_enc); 
+  }
+
+  static int decodeOOBPathLength(Chunk tree, int row) {
+    return decodeOOBPathLength(tree.at8(row));
+  }
+
+  private static int decodeTotalPathLength(long lengthEncoded) {
+    long total_len = (lengthEncoded >> 31) + (lengthEncoded & 0x7fffffff);
+    assert total_len == (int) total_len;
+    return (int) total_len;
+  }
+
+  static int decodeOOBPathLength(long lengthEncoded) {
+    return (int) (lengthEncoded >> 31);
+  }
+
+  static long addNewPathLength(long oldLengthEncoded, int depth, boolean wasOOB) {
+    if (wasOOB) {
+      return oldLengthEncoded + ((long) depth << 31);
+    } else {
+      return oldLengthEncoded + depth;
+    }
+  }
+
+
+}

--- a/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
+++ b/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
@@ -24,6 +24,7 @@ public class IsolationForestTest extends TestUtil {
       p._train = train._key;
       p._seed = 0xDECAF;
       p._ntrees = 7;
+      p._min_rows = 1;
       p._sample_size = 5;
 
       IsolationForestModel model = new IsolationForest(p).trainModel().get();
@@ -35,9 +36,40 @@ public class IsolationForestTest extends TestUtil {
       assertEquals(train.numRows(), preds.numRows());
 
       assertTrue(model.testJavaScoring(train, preds, 1e-8));
+
+      assertTrue(model._output._min_path_length < Integer.MAX_VALUE);
     } finally {
       Scope.exit();
     }
   }
+
+  @Test
+  public void testEmptyOOB() {
+    try {
+      Scope.enter();
+      Frame train = Scope.track(parse_test_file("smalldata/anomaly/ecg_discord_train.csv"));
+
+      IsolationForestModel.IsolationForestParameters p = new IsolationForestModel.IsolationForestParameters();
+      p._train = train._key;
+      p._seed = 0xDECAF;
+      p._ntrees = 7;
+      p._sample_size = train.numRows(); // => no OOB observations
+
+      IsolationForestModel model = new IsolationForest(p).trainModel().get();
+      assertNotNull(model);
+      Scope.track_generic(model);
+
+      Frame preds = Scope.track(model.score(train));
+      assertArrayEquals(new String[]{"predict", "mean_length"}, preds.names());
+      assertEquals(train.numRows(), preds.numRows());
+
+      assertTrue(model.testJavaScoring(train, preds, 1e-8));
+
+      assertTrue(model._output._min_path_length < Integer.MAX_VALUE);
+    } finally {
+      Scope.exit();
+    }
+  }
+
 
 }

--- a/h2o-algos/src/test/java/hex/tree/isofor/PathTrackerTest.java
+++ b/h2o-algos/src/test/java/hex/tree/isofor/PathTrackerTest.java
@@ -1,0 +1,94 @@
+package hex.tree.isofor;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Chunk;
+import water.fvec.Vec;
+
+import static org.junit.Assert.*;
+
+public class PathTrackerTest extends TestUtil {
+
+  @BeforeClass() public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void encodeNewPathLength() {
+    try {
+      Scope.enter();
+      Vec treeVec = Scope.track(Vec.makeZero(2)).makeVolatileDoubles(1)[0];
+      assertEquals(1, treeVec.nChunks());
+      Chunk treeChunk = treeVec.chunkForChunkIdx(0);
+
+      assertEquals(0L, PathTracker.encodeNewPathLength(treeChunk, 0,  0, true));
+      assertEquals(0L, PathTracker.decodeOOBPathLength(treeChunk, 0));
+      assertEquals(7L, PathTracker.encodeNewPathLength(treeChunk, 0,  7, true));
+      assertEquals(7L, PathTracker.decodeOOBPathLength(treeChunk, 0));
+      assertEquals(49L, PathTracker.encodeNewPathLength(treeChunk, 0,  42, true));
+      assertEquals(49L, PathTracker.decodeOOBPathLength(treeChunk, 0));
+      assertEquals(63L, PathTracker.encodeNewPathLength(treeChunk, 0,  14, false));
+      assertEquals(49L, PathTracker.decodeOOBPathLength(treeChunk, 0));
+
+      assertEquals(12345L+63L, PathTracker.encodeNewPathLength(treeChunk, 0,  12345, false));
+      assertEquals(49L, PathTracker.decodeOOBPathLength(treeChunk, 0));
+
+      assertEquals(54321L+12345L+63L, PathTracker.encodeNewPathLength(treeChunk, 0,  54321, true));
+      assertEquals(54321L+49L, PathTracker.decodeOOBPathLength(treeChunk, 0));
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void encodeNewPathLength_large() {
+    try {
+      Scope.enter();
+      Vec treeVec = Scope.track(Vec.makeZero(1)).makeVolatileDoubles(1)[0];
+      assertEquals(1, treeVec.nChunks());
+      Chunk treeChunk = treeVec.chunkForChunkIdx(0);
+
+      int total = 0;
+      int total_oob = 0;
+      for (int i = 0; i < 10000; i++) {
+        final boolean wasOOB = i % 3 == 0;
+        final int depth = 50 + (i % 50);
+        total += depth;
+        if (wasOOB)
+          total_oob += depth;
+        assertEquals(total, PathTracker.encodeNewPathLength(treeChunk, 0, depth, wasOOB));
+        assertEquals(total_oob, PathTracker.decodeOOBPathLength(treeChunk, 0));
+      }
+      assertEquals(745000, total);
+      assertEquals(248383, total_oob);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void addNewPathLength() {
+    assertEquals(0, PathTracker.addNewPathLength(0, 0, true));
+    assertEquals(7L << 31, PathTracker.addNewPathLength(0, 7, true));
+    assertEquals((7L << 31) + (42L << 31), PathTracker.addNewPathLength(7L << 31, 42, true));
+    assertEquals((7L << 31) + (42L << 31) + 14, PathTracker.addNewPathLength((7L << 31) + (42L << 31), 14, false));
+    
+    assertEquals(0, PathTracker.addNewPathLength(0, 0, false));
+    assertEquals(7, PathTracker.addNewPathLength(0, 7, false));
+    assertEquals(49, PathTracker.addNewPathLength(7, 42, false));
+    assertEquals((3L << 31) + 49, PathTracker.addNewPathLength(49, 3, true));
+  }
+
+  @Test
+  public void decodeOOBPathLength() {
+    assertEquals(0, PathTracker.decodeOOBPathLength(0));
+    assertEquals(7L, PathTracker.decodeOOBPathLength(7L << 31));
+    assertEquals(49, PathTracker.decodeOOBPathLength((7L << 31) + (42L << 31)));
+    assertEquals(49, PathTracker.decodeOOBPathLength((7L << 31) + (42L << 31) + 14));
+    assertEquals(0, PathTracker.decodeOOBPathLength(14));
+    assertEquals(0, PathTracker.decodeOOBPathLength(Integer.MAX_VALUE));
+    assertEquals(1, PathTracker.decodeOOBPathLength(Integer.MAX_VALUE + 1L));
+  }
+}

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -97,9 +97,13 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     sb.append(" Description: " + (_description == null ? "N/A" : _description) + "\n");
     sb.append(" model id: " + _modelKey + "\n");
     sb.append(" frame id: " + _frameKey + "\n");
-    sb.append(" MSE: " + (float)_MSE + "\n");
-    sb.append(" RMSE: " + (float)rmse() + "\n");
-    return sb.toString();
+    return appendToStringMetrics(sb).toString();
+  }
+
+  protected StringBuilder appendToStringMetrics(StringBuilder sb) {
+    sb.append(" MSE: ").append((float)_MSE).append("\n");
+    sb.append(" RMSE: ").append((float)rmse()).append("\n");
+    return sb;
   }
 
   public final Model model() { return _model==null ? (_model=DKV.getGet(_modelKey)) : _model; }

--- a/h2o-core/src/main/java/hex/ModelMetricsUnsupervised.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsUnsupervised.java
@@ -7,6 +7,10 @@ public class ModelMetricsUnsupervised extends ModelMetrics {
     super(model, frame, nobs, MSE, null, customMetric);
   }
 
+  public ModelMetricsUnsupervised(Model model, Frame frame, long nobs, String description, CustomMetric customMetric) {
+    super(model, frame, nobs, Double.NaN, description, customMetric);
+  }
+
   public static abstract class MetricBuilderUnsupervised<T extends MetricBuilderUnsupervised<T>>
           extends MetricBuilder<T> {}
 }


### PR DESCRIPTION
Fixes case when minimum and maximum path length is not correctly calculated in Isolation Forest when there are no OOB observations (this is an edge case - usually only small subset of records is used to build the trees).