### PR TITLE
[PUBDEV-6321] Fix resolution of h2o-algos by Spark ivy resolver

### DIFF
--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
   // Manually define all dependencies in com.github.fommil.netlib:all:1.1.2 to make Databricks maven resolver happy.
   // Also exclude arpack_combined_all dependency and manually add it later. The fommil libraries 
-  // references this dependency and also its javadoc way which may confuse some maven resolvers (Spark ivy resolver)
+  // reference this dependency and also its javadoc which confuses some maven resolvers (Spark ivy resolver)
   compile('com.github.fommil.netlib:core:1.1.2'){
     exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
   }

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -15,17 +15,37 @@ dependencies {
 
   // netlib-java / MTJ dependencies
 
-  // Manually define all dependencies in com.github.fommil.netlib:all:1.1.2 to make Databricks maven resolver happy
-  compile('com.github.fommil.netlib:core:1.1.2')
+  // Manually define all dependencies in com.github.fommil.netlib:all:1.1.2 to make Databricks maven resolver happy.
+  // Also exclude arpack_combined_all dependency and manually add it later. The fommil libraries 
+  // references this dependency and also its javadoc way which may confuse some maven resolvers (Spark ivy resolver)
+  compile('com.github.fommil.netlib:core:1.1.2'){
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
   compile('net.sourceforge.f2j:arpack_combined_all:0.1')
-  compile('com.github.fommil.netlib:netlib-native_ref-osx-x86_64:1.1:natives')
-  compile('com.github.fommil.netlib:netlib-native_ref-linux-x86_64:1.1:natives')
-  compile('com.github.fommil.netlib:netlib-native_ref-win-x86_64:1.1:natives')
-  compile('com.github.fommil.netlib:netlib-native_ref-linux-armhf:1.1:natives')
-  compile('com.github.fommil.netlib:netlib-native_system-osx-x86_64:1.1:natives')
-  compile('com.github.fommil.netlib:netlib-native_system-linux-x86_64:1.1:natives')
-  compile('com.github.fommil.netlib:netlib-native_system-linux-armhf:1.1:natives')
-  compile('com.github.fommil.netlib:netlib-native_system-win-x86_64:1.1:natives')
+  compile('com.github.fommil.netlib:netlib-native_ref-osx-x86_64:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
+  compile('com.github.fommil.netlib:netlib-native_ref-linux-x86_64:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
+  compile('com.github.fommil.netlib:netlib-native_ref-win-x86_64:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
+  compile('com.github.fommil.netlib:netlib-native_ref-linux-armhf:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
+  compile('com.github.fommil.netlib:netlib-native_system-osx-x86_64:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
+  compile('com.github.fommil.netlib:netlib-native_system-linux-x86_64:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
+  compile('com.github.fommil.netlib:netlib-native_system-linux-armhf:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
+  compile('com.github.fommil.netlib:netlib-native_system-win-x86_64:1.1:natives') {
+    exclude group: 'net.sourceforge.f2j', module: 'arpack_combined_all'
+  }
 
   compile('com.googlecode.matrix-toolkits-java:mtj:1.0.4'){
     exclude group: 'com.github.fommil.netlib', module: 'all'


### PR DESCRIPTION
When starting Spark with dependencies specified using --packages, such as:

`spark-shell --packages "ai.h2o:h2o-algos:3.22.1.4` ( usually people do `spark-shell --packages "ai.h2o:sparkling-water-package_2.11:2.4.6` ) but the problematic bit were the h2o-algos.

`h2o-algos` is using `com.github.fommil.netlib:core` dependency which has this pom file `http://central.maven.org/maven2/com/github/fommil/netlib/core/1.1.2/core-1.1.2.pom.

We can see that this pom file specifies dependency on `net.sourceforge.f2j:arpack_combined_all` for both jar and javadoc. 

This confuses spark ivy resolver. The solution here is to exclude this dependency and add it manually again, this time without javadoc.

JIRA on Spark side
Spark ivy resolver is confused if the maven coordinates 