### PR TITLE
PUBDEV-6292: remove NA row from GLM varimp

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -103,8 +103,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
               return 0;
             }
           });
-          String [] names2 = new String[names.length];
-          for(int i = 0; i < names2.length-1; ++i)
+          int len = names.length-1;
+          String [] names2 = new String[len]; // this one decides the length of standardized table length
+          for(int i = 0; i < len; ++i)
             names2[i] = names[indices[i]];
           tdt = new TwoDimTable("Standardized Coefficient Magnitudes", "standardized coefficient magnitudes", names2, new String[]{"Coefficients", "Sign"}, new String[]{"double", "string"}, new String[]{"%5f", "%s"}, "names");
           for (int i = 0; i < magnitudes.length - 1; ++i) {
@@ -235,8 +236,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
             return 0;
           }
         });
-        String[] names2 = new String[names.length];
-        for (int i = 0; i < names2.length - 1; ++i)
+        int len = names.length-1;
+        String[] names2 = new String[len];
+        for (int i = 0; i < len; ++i)
           names2[i] = names[indices[i]];
         tdt = new TwoDimTable("Standardized Coefficient Magnitudes", "standardized coefficient magnitudes", names2, new String[]{"Coefficients", "Sign"}, new String[]{"double", "string"}, new String[]{"%5f", "%s"}, "names");
         for (int i = 0; i < beta.length - 1; ++i) {

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_6292_varimp_check.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_6292_varimp_check.py
@@ -1,0 +1,43 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# check varimp for Binomial, Multinomial, Regression at least.
+
+def testvarimp():
+    print("Checking variable importance for binomials....")
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+    buildModelCheckVarimp(training_data, X, Y, "binomial")
+
+    print("Checking variable importance for multinomials....")
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    myY = "class"
+    mX = list(range(0,4))
+    buildModelCheckVarimp(train, mX, myY, "multinomial")
+
+    print("Checking variable importance for regression....")
+    h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate_complete.csv.zip"))
+    myY = "GLEASON"
+    myX = ["ID","AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS"]
+    buildModelCheckVarimp(h2o_data, myX, myY, "gaussian")
+ 
+
+def buildModelCheckVarimp(training_frame, x_indices, y_index, family):
+    model = H2OGeneralizedLinearEstimator(family=family)
+    model.train(training_frame=training_frame, x=x_indices, y=y_index)
+    varimp = model.varimp()
+    print(varimp)
+    assert len(varimp)==len(x_indices), "expected varimp length: {0}, actual varimp length:" \
+                                        " {1}".format(len(x_indices), len(varimp))
+    #model.varimp_plot()
+
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(testvarimp)
+else:
+    testvarimp()

--- a/h2o-r/tests/testdir_algos/glm/runit_pubdev_6292_varimp_check.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_pubdev_6292_varimp_check.R
@@ -1,0 +1,34 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+glmVarimpCheck <- function() {
+  # check for binomial
+  bhexFV <- h2o.uploadFile(locate("smalldata/logreg/benign.csv"), destination_frame="benignFV.hex")
+  maxX <- 11
+  Y <- 4
+  X   <- 3:maxX
+  X   <- X[ X != Y ] 
+  
+  Log.info("Checking varimp for GLM Binomial")
+  buildModelVarimpCheck("binomial",bhexFV,X,Y)
+  
+  # check for multinomial
+  Log.info("Checking varimp for GLM Multinomial")
+  buildModelVarimpCheck("multinomial", as.h2o(iris), x_indices=c(1,2,3,4), y_index=5)
+
+  # check regression
+  h2o.data = h2o.uploadFile(locate("smalldata/prostate/prostate_complete.csv.zip"), destination_frame="h2o.data")    
+  myY = "GLEASON"
+  myX = c("ID","AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS")
+  Log.info("Checking varimp for GLM Gaussian")
+  buildModelVarimpCheck("gaussian", h2o.data, x_indices=myX, y_index=myY)
+}
+
+buildModelVarimpCheck <- function(family, training_frame, x_indices, y_index) {
+  model <- h2o.glm(y=y_index, x=x_indices, training_frame=training_frame, family=family)
+  varimp <- h2o.varimp(model)
+  expect_true(sum(is.na(varimp$relative_importance))==0, "NA still appears in varimp")
+  h2o.varimp_plot(model)
+}
+
+doTest("GLM: Check variable importance values", glmVarimpCheck)


### PR DESCRIPTION
This work fixes the problem described in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6292?filter=-1

Tasked completed:
1. remove the intercept term from the standardized coefficient magnitude calculation from the backend.  The intercept term magnitude is assigned NA anyway.
2. Redirected model.R or model_base.py to look for standardized_coefficient_magnitudes when calculating variable importances.  GLM Binomial and GLM Multinomial have different coefficient fields.
3. Added Runit and pyunit tests to make sure varimp for GLM look the same as for other algos and varimp_plot works.