### PR TITLE
[PUBDEV-6305] fix context_path related bugs

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -23,7 +23,7 @@
   FALSE
 }
 
-.h2o.calcBaseURL <- function(conn,h2oRestApiVersion, urlSuffix) {
+.h2o.calcBaseURL <- function(conn, h2oRestApiVersion, urlSuffix) {
   if( missing(conn) ) conn <- h2o.getConnection()
   stopifnot(is(conn, "H2OConnection"))
   stopifnot(is.character(urlSuffix))
@@ -903,7 +903,7 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
 
 #------------------------------------ Utilities ------------------------------------#
 h2o.getBaseURL <- function(conn) {
-  .h2o.calcBaseURL( conn, urlSuffix = "")
+  .h2o.calcBaseURL(conn, urlSuffix = "")
 }
 
 #' Get h2o version

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -186,7 +186,7 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
                     max_memory = max_mem_size, min_memory = min_mem_size,
                     enable_assertions = enable_assertions, forceDL = forceDL, license = license,
                     extra_classpath = extra_classpath, ice_root = ice_root, stdout = stdout,
-                    log_dir = log_dir, log_level = log_level,
+                    log_dir = log_dir, log_level = log_level, context_path = context_path,
                     jvm_custom_args = jvm_custom_args, bind_to_localhost = bind_to_localhost)
 
       count <- 0L
@@ -530,7 +530,8 @@ h2o.clusterStatus <- function() {
 .h2o.startJar <- function(ip = "localhost", port = 54321, name = NULL, nthreads = -1,
                           max_memory = NULL, min_memory = NULL,
                           enable_assertions = TRUE, forceDL = FALSE, license = NULL, extra_classpath = NULL,
-                          ice_root, stdout, log_dir, log_level, jvm_custom_args = NULL, bind_to_localhost) {
+                          ice_root, stdout, log_dir, log_level, context_path, jvm_custom_args = NULL, 
+                          bind_to_localhost) {
   command <- .h2o.checkJava()
 
   if (! is.null(license)) {
@@ -612,6 +613,7 @@ h2o.clusterStatus <- function() {
 
   if(!is.na(log_dir)) args <- c(args, "-log_dir", log_dir)
   if(!is.na(log_level)) args <- c(args, "-log_level", log_level)
+  if(!is.na(context_path)) args <- c(args, "-context_path", context_path)
 
   if(nthreads > 0L) args <- c(args, "-nthreads", nthreads)
   if(!is.null(license)) args <- c(args, "-license", license)
@@ -822,6 +824,8 @@ h2o.networkTest <- function() {
 #'
 #' @importFrom utils browseURL
 #' @export
-h2o.flow <- function(){
-  browseURL(.h2o.calcBaseURL(urlSuffix=""))
+h2o.flow <- function() {
+  conn <- h2o.getConnection()
+  url <- .h2o.calcBaseURL(conn, urlSuffix = "flow/")
+  browseURL(url)
 }

--- a/h2o-r/h2o-package/R/export.R
+++ b/h2o-r/h2o-package/R/export.R
@@ -95,7 +95,8 @@ h2o.downloadCSV <- function(data, filename) {
     stop("`data` must be an H2OFrame object")
 
   conn = h2o.getConnection()
-  str <- paste0('http://', conn@ip, ':', conn@port, '/3/DownloadDataset?frame_id=', h2o.getId(data))
+  path <- paste0('3/DownloadDataset?frame_id=', h2o.getId(data))
+  str <- .h2o.calcBaseURL(conn, urlSuffix = path)
   has_wget <- nzchar(Sys.which('wget'))
   has_curl <- nzchar(Sys.which('curl'))
   if(!(has_wget || has_curl))

--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -188,7 +188,7 @@ h2o.downloadAllLogs <- function(dirname = ".", filename = NULL) {
     stop("`filename` must be a non-empty character string")
 
   conn <- h2o.getConnection()
-  url <- paste0("http://", conn@ip, ":", conn@port, "/", .h2o.__DOWNLOAD_LOGS)
+  url <- .h2o.calcBaseURL(conn, urlSuffix = .h2o.__DOWNLOAD_LOGS)
   if(!file.exists(dirname))
     dir.create(dirname)
 


### PR DESCRIPTION
- h2o.init now correctly respects context_path when starting new h2o instance
- h2o.downloadAllLogs now respects context_path
- h2o.downloadCSV now respects context_path