### PR TITLE
PUBDEV-6283 - Stratified split fails when ran on the same column twice

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstStratifiedSplit.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstStratifiedSplit.java
@@ -57,7 +57,7 @@ public class AstStratifiedSplit extends AstPrimitive {
     // Collect input vector domain
     final long[] classes = new VecUtils.CollectIntegerDomain().doAll(stratifyingColumn).domain();
     // Number of output classes
-    final int numClasses = stratifyingColumn.isNumeric() ? classes.length : stratifyingColumn.domain().length;
+    final int numClasses = classes.length;
     
     // Make a new column based on input column - this needs to follow layout of input vector!
     // Save vector into DKV

--- a/h2o-core/src/test/java/water/util/VecUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/VecUtilsTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import water.DKV;
 import water.TestUtil;
 import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
 
 /**
  * Test VecUtils interface.
@@ -30,6 +32,27 @@ public class VecUtilsTest extends TestUtil {
       Assert.assertEquals(categoricalCnt, f.vec(4).cardinality());
     } finally {
       f.delete();
+    }
+  }
+
+  @Test
+  public void collectIntegerDomain() {
+
+    String[] data = new String[]{"1", "2", "3", "4", "5", "6", "7", "8", "9", "11"};
+
+    Frame frame = null;
+    try {
+      frame = new TestFrameBuilder().withColNames("C1")
+              .withName("testFrame")
+              .withVecTypes(Vec.T_CAT)
+              .withDataForCol(0, data)
+              .build();
+      Assert.assertNotNull(frame);
+
+      final long[] levels = new VecUtils.CollectIntegerDomain().doAll(frame.vec(0)).domain();
+      Assert.assertEquals(levels.length, data.length);
+    } finally {
+      if (frame != null) frame.remove();
     }
   }
 }

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6283.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6283.py
@@ -1,0 +1,26 @@
+import h2o
+from tests import pyunit_utils
+
+
+def pubdev_6283():
+
+    data = h2o.import_file(pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    data['C3'] = data['C3'].asfactor()
+    stratified = data[54].stratified_split()
+    train = data[stratified=="train"]
+    test  = data[stratified=="test"]
+    assert train.nrows + test.nrows == data.nrows
+    
+    split=data['C3'].stratified_split(test_frac=0.3)
+    train=data[split=='train']
+    test=data[split=='test']
+    assert train.nrows + test.nrows == data.nrows
+    
+    split = train['C3'].stratified_split(test_frac=0.1)
+    split.show()
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_6283)
+else:
+    pubdev_6283()


### PR DESCRIPTION
## Jira
https://0xdata.atlassian.net/browse/PUBDEV-6283

## Reproducibility
Original script to reproduce the issue from the JIRA

```python
import h2o
h2o.init()
df_h2o = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/covtype/covtype.20k.data")
stratified = df_h2o[54].stratified_split()
train = df_h2o[stratified=="train"]
test  = df_h2o[stratified=="test"]
df_h2o['C3'] = df_h2o['C3'].asfactor()
col = 'C3'

split=df_h2o[col].stratified_split(test_frac=0.3)
train=df_h2o[split=='train']
test=df_h2o[split=='test']
print(len(train))
print(train[col].nacnt())
print(train[col].nlevels())
train['C3'].stratified_split(test_frac=0.1)
```