### PR TITLE
Avoid rounding errors in monotone GBMs by using split predictions directly

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -771,7 +771,7 @@ public class DTree extends Iced {
     public final double getSplitPrediction() {
       DTree.DecidedNode parent = (DTree.DecidedNode) _tree.node(_pid);
       boolean isLeft = parent._nids[0] == _nid;
-      return isLeft ? parent._split._p0 * parent._split._n0 : parent._split._p1 * parent._split._n1;
+      return isLeft ? parent._split._p0 : parent._split._p1;
     }
   }
 

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -573,7 +573,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
     }
 
     private void fitBestConstants(DTree[] ktrees, int[] leafs, GammaPass gp, Constraints cs) {
-      final boolean useBounds = cs != null && cs.useBounds();
+      final boolean useSplitPredictions = cs != null && cs.useBounds();
       double m1class = _nclass > 1 && _parms._distribution == DistributionFamily.multinomial ? (double) (_nclass - 1) / _nclass : 1.0; // K-1/K for multinomial
       for (int k = 0; k < _nclass; k++) {
         final DTree tree = ktrees[k];
@@ -582,9 +582,8 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
         for (int i = 0; i < tree._len - leafs[k]; i++) {
           LeafNode leafNode = (LeafNode) ktrees[k].node(leafs[k] + i);
           double gamma;
-          if (useBounds) {
-            double numerator = leafNode.getSplitPrediction();
-            gamma = gp.gamma(k, i, numerator);
+          if (useSplitPredictions) {
+            gamma = leafNode.getSplitPrediction();
           } else {
             gamma = gp.gamma(k, i);
           }


### PR DESCRIPTION
We currently only support Gaussian distribution which lets us use split node predictions from tree building directly and avoid using values from GammaPass. This fixes rounding errors introduced in GammaPass summation.