### PR TITLE
PUBDEV-6334 update sort javadoc

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1612,9 +1612,9 @@ public class Frame extends Lockable<Frame> {
   @Override public Class<KeyV3.FrameKeyV3> makeSchema() { return KeyV3.FrameKeyV3.class; }
 
   /** Sort rows of a frame, using the set of columns as keys.  User can specify sorting direction for each sorting
-   * column in a boolean array.  For example, if we want to sort columns 0, 1, 2 and want to sort 0 in ascending
-   * direction, 1 and 2 in descending direction for frame fr, the call to make is fr.sort(new int[2]{0,1,2},
-   * new boolean[2]{true, false, false}.
+   * column in a integer array.  For example, if we want to sort columns 0, 1, 2 and want to sort 0 in ascending
+   * direction, 1 and 2 in descending direction for frame fr, the call to make is fr.sort(new int[]{0,1,2},
+   * new int[]{1, -1, -1}.
    *
    *  @return Copy of frame, sorted */
   public Frame sort( int[] cols ) {


### PR DESCRIPTION
The work in this PR completes the work  requested in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6334?filter=-1

I corrected the error in Javadoc for Frame.java sort function.  Thanks to Andrey for catching it.

The sorting function itself is implemented in the rapids framework and that is why the sort tests are under the rapids folder as well.

The whole rapids design came about before I joined H2O so I have no idea why things are organized the way it is.

For anything that I have implemented, I made sure to add thorough tests in Java, R and Python clients. I have done the following for sort:
1. enable sorting of doubles;
2. add sorting directions support;
3. allow string columns in the frame as long as we do not sort with it.
4. fixed memory issue with sort when there are many columns of duplicated sort values.