### PR TITLE
PUBDEV-6208: SE Model deletion can lead to removal of shared vecs

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -169,8 +169,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     if (keepLevelOneFrame) {
       levelOneFrame.write_lock(_job);
       levelOneFrame = levelOneFrame.deepCopy(levelOneFrame._key.toString());
+      levelOneFrame.update(_job);
       levelOneFrame.unlock(_job);
-      DKV.put(levelOneFrame);
     }
     return levelOneFrame;
   }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -167,10 +167,11 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     boolean keepLevelOneFrame = isTraining && _parms._keep_levelone_frame;
     Frame levelOneFrame = prepareLevelOneFrame(levelOneKey, baseModels.toArray(new Model[0]), baseModelPredictions.toArray(new Frame[0]), actuals);
     if (keepLevelOneFrame) {
-      levelOneFrame.write_lock(_job);
       levelOneFrame = levelOneFrame.deepCopy(levelOneFrame._key.toString());
+      levelOneFrame.write_lock(_job);
       levelOneFrame.update(_job);
       levelOneFrame.unlock(_job);
+      Scope.untrack(levelOneFrame.keysList());
     }
     return levelOneFrame;
   }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -66,20 +66,25 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     return true;
   }
 
-  static void addModelPredictionsToLevelOneFrame(Model aModel, Frame aModelsPredictions, Frame levelOneFrame) {
+  static void addModelPredictionsToLevelOneFrame(Model aModel, Frame aModelsPredictions, Frame levelOneFrame, boolean keepLevelOneFrame) {
     if (aModel._output.isBinomialClassifier()) {
       // GLM uses a different column name than the other algos
-      Vec preds = aModelsPredictions.vec(2); // Predictions column names have been changed. . .
+      Vec preds = aModelsPredictions.vec(2); // Predictions column names have been changed...
+      if (keepLevelOneFrame) preds = preds.makeCopy();
       levelOneFrame.add(aModel._key.toString(), preds);
     } else if (aModel._output.isMultinomialClassifier()) { //Multinomial
       //Need to remove 'predict' column from multinomial since it contains outcome
-      levelOneFrame.add(aModelsPredictions.subframe(ArrayUtils.remove(aModelsPredictions.names(), "predict")));
+      Frame probabilities = aModelsPredictions.subframe(ArrayUtils.remove(aModelsPredictions.names(), "predict"));
+      if (keepLevelOneFrame) probabilities = probabilities.deepCopy(aModelsPredictions._key.toString() + "_probabilities");
+      levelOneFrame.add(probabilities);
     } else if (aModel._output.isAutoencoder()) {
       throw new H2OIllegalArgumentException("Don't yet know how to stack autoencoders: " + aModel._key);
     } else if (!aModel._output.isSupervised()) {
       throw new H2OIllegalArgumentException("Don't yet know how to stack unsupervised models: " + aModel._key);
     } else {
-      levelOneFrame.add(aModel._key.toString(), aModelsPredictions.vec("predict"));
+      Vec preds = aModelsPredictions.vec("predict");
+      if (keepLevelOneFrame) preds = preds.makeCopy();
+      levelOneFrame.add(aModel._key.toString(), preds);
     }
   }
 
@@ -90,7 +95,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
      * training and validation frames for the metalearning step, and could also be used for bulk predictions for
      * a StackedEnsemble.
      */
-    private Frame prepareLevelOneFrame(String levelOneKey, Model[] baseModels, Frame[] baseModelPredictions, Frame actuals) {
+    private Frame prepareLevelOneFrame(String levelOneKey, Model[] baseModels, Frame[] baseModelPredictions, Frame actuals, boolean keepResultFrame) {
       if (null == baseModels) throw new H2OIllegalArgumentException("Base models array is null.");
       if (null == baseModelPredictions) throw new H2OIllegalArgumentException("Base model predictions array is null.");
       if (baseModels.length == 0) throw new H2OIllegalArgumentException("Base models array is empty.");
@@ -102,46 +107,50 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       if (null == levelOneKey) levelOneKey = "levelone_" + _model._key.toString();
       Frame levelOneFrame = new Frame(Key.<Frame>make(levelOneKey));
 
-    for (int i = 0; i < baseModels.length; i++) {
-      Model baseModel = baseModels[i];
-      Frame baseModelPreds = baseModelPredictions[i];
+      for (int i = 0; i < baseModels.length; i++) {
+        Model baseModel = baseModels[i];
+        Frame baseModelPreds = baseModelPredictions[i];
 
-      if (null == baseModel) {
-        Log.warn("Failed to find base model; skipping: " + baseModels[i]);
-        continue;
+        if (null == baseModel) {
+          Log.warn("Failed to find base model; skipping: " + baseModels[i]);
+          continue;
+        }
+        if (null == baseModelPreds) {
+          Log.warn("Failed to find base model " + baseModel + " predictions; skipping: " + baseModelPreds._key);
+          continue;
+        }
+        StackedEnsemble.addModelPredictionsToLevelOneFrame(baseModel, baseModelPreds, levelOneFrame, keepResultFrame);
       }
-      if (null == baseModelPreds) {
-        Log.warn("Failed to find base model " + baseModel + " predictions; skipping: " + baseModelPreds._key);
-        continue;
+      // Add metalearner_fold_column to level one frame if it exists
+      if (_model._parms._metalearner_fold_column != null) {
+        Vec foldColumn = actuals.vec(_model._parms._metalearner_fold_column);
+        if (keepResultFrame) foldColumn = foldColumn.makeCopy();
+        levelOneFrame.add(_model._parms._metalearner_fold_column, foldColumn);
       }
-      StackedEnsemble.addModelPredictionsToLevelOneFrame(baseModel, baseModelPreds, levelOneFrame);
-    }
-    // Add metalearner_fold_column to level one frame if it exists
-    if (_model._parms._metalearner_fold_column != null) {
-      levelOneFrame.add(_model._parms._metalearner_fold_column, actuals.vec(_model._parms._metalearner_fold_column));
-    }
-    // Add response column to level one frame
-    levelOneFrame.add(_model.responseColumn, actuals.vec(_model.responseColumn));
+      // Add response column to level one frame
+      Vec responseColumn = actuals.vec(_model.responseColumn);
+      if (keepResultFrame) responseColumn = responseColumn.makeCopy();
+      levelOneFrame.add(_model.responseColumn, responseColumn);
 
-    // TODO: what if we're running multiple in parallel and have a name collision?
+      // TODO: what if we're running multiple in parallel and have a name collision?
 
-    Frame old = DKV.getGet(levelOneFrame._key);
-    if (old != null && old instanceof Frame) {
-      Frame oldFrame = (Frame) old;
-      // Remove ALL the columns so we don't delete them in remove_impl.  Their
-      // lifetime is controlled by their model.
-      oldFrame.removeAll();
-      oldFrame.write_lock(_job);
-      oldFrame.update(_job);
-      oldFrame.unlock(_job);
+      Frame old = DKV.getGet(levelOneFrame._key);
+      if (old != null && old instanceof Frame) {
+        Frame oldFrame = (Frame) old;
+        // Remove ALL the columns so we don't delete them in remove_impl.  Their
+        // lifetime is controlled by their model.
+        oldFrame.removeAll();
+        oldFrame.write_lock(_job);
+        oldFrame.update(_job);
+        oldFrame.unlock(_job);
+      }
+
+      levelOneFrame.delete_and_lock(_job);
+      levelOneFrame.unlock(_job);
+      Log.info("Finished creating \"level one\" frame for stacking: " + levelOneFrame.toString());
+      DKV.put(levelOneFrame);
+      return levelOneFrame;
     }
-
-    levelOneFrame.delete_and_lock(_job);
-    levelOneFrame.unlock(_job);
-    Log.info("Finished creating \"level one\" frame for stacking: " + levelOneFrame.toString());
-    DKV.put(levelOneFrame);
-    return levelOneFrame;
-  }
 
   /**
    * Prepare a "level one" frame for a given set of models and actuals.
@@ -160,8 +169,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       baseModels.add(aModel);
       baseModelPredictions.add(predictions);
     }
-
-    return prepareLevelOneFrame(levelOneKey, baseModels.toArray(new Model[0]), baseModelPredictions.toArray(new Frame[0]), actuals);
+    boolean keepLevelOneFrame = isTraining && _parms._keep_levelone_frame;
+    return prepareLevelOneFrame(levelOneKey, baseModels.toArray(new Model[0]), baseModelPredictions.toArray(new Frame[0]), actuals, keepLevelOneFrame);
   }
 
   protected Frame buildPredictionsForBaseModel(Model model, Frame frame) {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -133,7 +133,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
           false
       );
       
-      StackedEnsemble.addModelPredictionsToLevelOneFrame(base, basePreds, levelOneFrame);
+      StackedEnsemble.addModelPredictionsToLevelOneFrame(base, basePreds, levelOneFrame, false);
       DKV.remove(basePreds._key); //Cleanup
       Frame.deleteTempFrameAndItsNonSharedVecs(basePreds, levelOneFrame);
     }
@@ -418,6 +418,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       _output._metalearner.remove(fs);
     if (_output._levelone_frame_id != null)
       _output._levelone_frame_id.remove(fs);
+//        DKV.remove(_output._levelone_frame_id._key);
 
     return super.remove_impl(fs);
   }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -133,7 +133,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
           false
       );
       
-      StackedEnsemble.addModelPredictionsToLevelOneFrame(base, basePreds, levelOneFrame, false);
+      StackedEnsemble.addModelPredictionsToLevelOneFrame(base, basePreds, levelOneFrame);
       DKV.remove(basePreds._key); //Cleanup
       Frame.deleteTempFrameAndItsNonSharedVecs(basePreds, levelOneFrame);
     }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -418,7 +418,6 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       _output._metalearner.remove(fs);
     if (_output._levelone_frame_id != null)
       _output._levelone_frame_id.remove(fs);
-//        DKV.remove(_output._levelone_frame_id._key);
 
     return super.remove_impl(fs);
   }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -596,10 +596,13 @@ public class StackedEnsembleTest extends TestUtil {
 
             if (keepLevelOneFrame) {
                 Assert.assertEquals(gridModels.length + 1, se1._output._levelone_frame_id.numCols());
-                if (blending)
+                if (blending) {
                     Assert.assertEquals(test.numRows(), se1._output._levelone_frame_id.numRows());
-                else
+                    TestUtil.isBitIdentical(new Frame(test.vec(target)), new Frame(se1._output._levelone_frame_id.vec(target)));
+                } else {
                     Assert.assertEquals(train.numRows(), se1._output._levelone_frame_id.numRows());
+                    TestUtil.isBitIdentical(new Frame(train.vec(target)), new Frame(se1._output._levelone_frame_id.vec(target)));
+                }
             } else {
                 Assert.assertNull(se1._output._levelone_frame_id);
             }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -536,6 +536,85 @@ public class StackedEnsembleTest extends TestUtil {
       }
     }
 
+    @Test public void testKeepLevelOneFrameCVMode() {
+        testSEModelCanBeSafelyRemoved(true, false);
+    }
+
+    @Test public void testDoNotKeepLevelOneFrameCVMode() {
+        testSEModelCanBeSafelyRemoved(false, false);
+    }
+
+    @Test public void testKeepLevelOneFrameBlendingMode() {
+        testSEModelCanBeSafelyRemoved(true, true);
+    }
+
+    @Test public void testDoNotKeepLevelOneFrameBlendingMode() {
+        testSEModelCanBeSafelyRemoved(false, true);
+    }
+
+    private void testSEModelCanBeSafelyRemoved(boolean keepLevelOneFrame, boolean blending) {
+        List<Lockable> deletables = new ArrayList<>();
+        try {
+            final int seed = 1;
+            final Frame train = parse_test_file("./smalldata/logreg/prostate_train.csv"); deletables.add(train);
+            final Frame test = parse_test_file("./smalldata/logreg/prostate_test.csv"); deletables.add(test);
+
+            final String target = "CAPSULE";
+            int tidx = train.find(target);
+            train.replace(tidx, train.vec(tidx).toCategoricalVec()).remove(); DKV.put(train);
+            test.replace(tidx, test.vec(tidx).toCategoricalVec()).remove(); DKV.put(test);
+
+            //generate a few base models
+            GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+            params._train = train._key;
+            params._response_column = target;
+            params._seed = seed;
+            if (!blending) {
+                params._nfolds = 3;
+                params._keep_cross_validation_models = false;
+                params._keep_cross_validation_predictions = true;
+                params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+            }
+
+            Job<Grid> gridSearch = GridSearch.startGridSearch(null, params, new HashMap<String, Object[]>() {{
+                put("_ntrees", new Integer[]{3, 5});
+                put("_learn_rate", new Double[]{0.1, 0.2});
+            }});
+            Grid grid = gridSearch.get(); deletables.add(grid);
+            Model[] gridModels = grid.getModels(); deletables.addAll(Arrays.asList(gridModels));
+            Assert.assertEquals(4, gridModels.length);
+
+            StackedEnsembleModel.StackedEnsembleParameters seParams = new StackedEnsembleModel.StackedEnsembleParameters();
+            seParams._train = train._key;
+            seParams._response_column = target;
+            seParams._base_models = grid.getModelKeys();
+            seParams._seed = seed;
+            seParams._keep_levelone_frame = keepLevelOneFrame;
+            if (blending) seParams._blending = test._key;
+            StackedEnsembleModel se1 = new StackedEnsemble(seParams).trainModel().get(); deletables.add(se1);
+            Frame predictions = se1.score(test); deletables.add(predictions);
+
+            if (keepLevelOneFrame) {
+                Assert.assertEquals(gridModels.length + 1, se1._output._levelone_frame_id.numCols());
+                if (blending)
+                    Assert.assertEquals(test.numRows(), se1._output._levelone_frame_id.numRows());
+                else
+                    Assert.assertEquals(train.numRows(), se1._output._levelone_frame_id.numRows());
+            } else {
+                Assert.assertNull(se1._output._levelone_frame_id);
+            }
+            se1.delete();
+
+//            building a new model would throw an exception if we deleted too much when deleting s1
+            GBMModel gbm = new GBM(params).trainModel().get(); deletables.add(gbm);
+            StackedEnsembleModel se2 = new StackedEnsemble(seParams).trainModel().get(); deletables.add(se2);
+        } finally {
+            for (Lockable l: deletables) {
+                if (l instanceof Model) ((Model)l).deleteCrossValidationPreds();
+                l.delete();
+            }
+        }
+    }
 
     // ==========================================================================
     public StackedEnsembleModel.StackedEnsembleOutput basicEnsemble(String training_file,


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6208

Not sure it covers the specific use-case mentioned in the ticket, but I was able to reproduce a similar behaviour when deleting a SE after AutoML run in Flow.
Note that AutoML has always `keep_level_one_frame=true`, which is the reason why this issue occurs more often there.