### PR TITLE
PUBDEV-6362: Replaced "h2o cloud" with "h2o cluster" in end-user docs

### DIFF
--- a/h2o-docs/devel/h2o_clouding.rst
+++ b/h2o-docs/devel/h2o_clouding.rst
@@ -1,7 +1,7 @@
-H2O Clouding Behaviour
-----------------------
+H2O Clustering Behaviour
+------------------------
 
-The purpose of this document is to document the behaviour of H2O clouding process. In H2O, there are two ways how a
+The purpose of this document is to document the behaviour of H2O clustering process. In H2O, there are two ways how a
 cluster can be created:
 
 - **multicast discovery**
@@ -39,7 +39,7 @@ cluster isolation.
 This also applies to stopping the H2O cluster, which means that it is not possible for a node from different cluster to kill
 different cluster. The kill request needs to come from the same cluster.
 
-The H2O cloud consist of H2O worker nodes, which needs to remain available during the whole lifetime of the cluster. The cluster
+The H2O cluster consist of H2O worker nodes, which needs to remain available during the whole lifetime of the cluster. The cluster
 can also have H2O clients connected to it. They are not part of the cluster and are not used for the distributed computations.
 The clients can be used to drive the computation on the worker nodes. For example, the major usage of H2O client is in Sparkling Water.
 
@@ -64,14 +64,14 @@ The network initialization is specified in the ``H2O.startLocalNode`` static met
 
 The ``startLocalNode`` method further:
 
-- initializes the heartbeat with cloud name and bunch of other required properties so we can be sure we communicate only with the nodes in the same cluster
+- initializes the heartbeat with cluster name and bunch of other required properties so we can be sure we communicate only with the nodes in the same cluster
 - in case of the node is client (``-client``), we report ourselves as the client to ourselves. This is important for the consistency in cases
   we need perform some operations on all the clients, including me.
 
 The network communication is initialized in the ``H2O.startNetworkServices`` method. This method starts the sockets and starts listening on
 the defined ports. However we still don't send any heartbeats so the different nodes can't still hear from us. The next step is to announce ourselves
  in the ``Paxos.doHeartbeat`` method which, at this point, creates a cluster of size 1. The final step
-is to start the heartbeat thread so the rest of the nodes can hear from us and the cloud can be created.
+is to start the heartbeat thread so the rest of the nodes can hear from us and the cluster can be created.
 
 Clouding
 ~~~~~~~~

--- a/h2o-docs/src/booklets/v2_2015/source/RBooklet.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/RBooklet.tex
@@ -326,7 +326,7 @@ hadoop jar h2odriver.jar -nodes 1 -mapperXmx 6g -output hdfsOutputDirName
 \item The above command launches exactly one 6g node of H2O; however,  we recommend launching the cluster with 4 times the memory of your data file.
 \item{\texttt{mapperXmx}} is the mapper size or the amount of memory allocated to each node.
 \item{\texttt{nodes}} is the number of nodes requested to form the cluster.
-\item{\texttt{output}} is the name of the directory created each time a H2O cloud is created so it is necessary for the name to be unique each time it is launched.
+\item{\texttt{output}} is the name of the directory created each time a H2O cluster is created so it is necessary for the name to be unique each time it is launched.
 \end{itemize}
 
 

--- a/h2o-docs/src/booklets/v2_2015/source/sw/sections/backends.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/sw/sections/backends.tex
@@ -125,15 +125,15 @@ conf = H2OConf(spark)
 hc = H2OContext.getOrCreate(spark, conf)
 \end{lstlisting}
 
-We can see that in this case we are using extra call \texttt{setH2OCluster} in Scala and \texttt{set\_h2o\_cluster} in Python. When the external cluster is started via the flatfile approach, we need to give Sparkling Water ip address and port of arbitrary node inside the H2O cloud in order to connect to the cluster. The ip and port of this node are passed as arguments to \texttt{setH2OCluster/set\_h2o\_cluster} method.
+We can see that in this case we are using extra call \texttt{setH2OCluster} in Scala and \texttt{set\_h2o\_cluster} in Python. When the external cluster is started via the flatfile approach, we need to give Sparkling Water ip address and port of arbitrary node inside the H2O cluster in order to connect to the cluster. The ip and port of this node are passed as arguments to \texttt{setH2OCluster/set\_h2o\_cluster} method.
 
-It's possible in both cases that node on which want to start Sparkling Watter shell is connected to more networks. In this case it can happen that H2O cloud decides to use addresses from network A, whilst Spark decides to use addresses for its executors and driver from network B. Later, when we start \texttt{H2OContext}, the special H2O client, running inside of the Spark Driver, can get the same IP address as the Spark driver and thus the rest of the H2O cloud can't see it. This shouldn't happen in environments where the nodes are connected to only one network, however we provide configuration how to deal with this case as well.
+It's possible in both cases that node on which want to start Sparkling Watter shell is connected to more networks. In this case it can happen that H2O cluster decides to use addresses from network A, whilst Spark decides to use addresses for its executors and driver from network B. Later, when we start \texttt{H2OContext}, the special H2O client, running inside of the Spark Driver, can get the same IP address as the Spark driver and thus the rest of the H2O cluster can't see it. This shouldn't happen in environments where the nodes are connected to only one network, however we provide configuration how to deal with this case as well.
 
-We can use method \texttt{setClientIp} in Scala and \texttt{set\_client\_ip} in Python available on \texttt{H2OConf} which expects IP address and sets this IP address for the H2O client running inside the Spark driver. The IP address passed to this method should be address of the node where Spark driver is about to run and should be from the same network as the rest of H2O cloud.
+We can use method \texttt{setClientIp} in Scala and \texttt{set\_client\_ip} in Python available on \texttt{H2OConf} which expects IP address and sets this IP address for the H2O client running inside the Spark driver. The IP address passed to this method should be address of the node where Spark driver is about to run and should be from the same network as the rest of the H2O cluster.
 
 Let's say we have two H2O nodes on addresses 192.168.0.1 and 192.168.0.2 and also assume that Spark driver is available on 172.16.1.1 and the only executor is available on 172.16.1.2. The node with Spark driver is also connected to 192.168.0.x network with address 192.168.0.3.
 
-In this case there is a chance that H2O client will use the address from 172.168.x.x network instead of the 192.168.0.x one, which can lead to the problem that H2O cloud and H2O client can't see each other.
+In this case there is a chance that H2O client will use the address from 172.168.x.x network instead of the 192.168.0.x one, which can lead to the problem that H2O cluster and H2O client can't see each other.
 
 We can force the client to use the correct address using the following configuration:
 

--- a/h2o-docs/src/booklets/v2_2015/source/sw/sections/deployment.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/sw/sections/deployment.tex
@@ -175,7 +175,7 @@ This will allow you to use the Flow UI.
 \item The jar file is located in the sparkling water zip file at the following location: `assembly/build/libs/sparkling-water-assembly\_*-all.jar`
 \item Attach the Sparkling Water library to the cluster.
 \item Create a new Scala notebook.
-\item Create an H2O cloud inside the Spark cluster:
+\item Create an H2O cluster inside the Spark cluster:
 \begin{lstlisting}[style=Scala]
 import org.apache.spark.h2o._
 val h2oConf = new H2OConf(spark).set("spark.ui.enabled", "false")
@@ -204,7 +204,7 @@ You can access Flow by going to localhost:54321.
 \item Create libraries for the following python modules: request, tabulate, future and colorama.
 \item Attach the PySparkling library and python modules to the cluster.
 \item Create a new python notebook.
-\item Create an H2O cloud inside the Spark cluster:
+\item Create an H2O cluster inside the Spark cluster:
 \begin{lstlisting}[style=Python]
 from pysparkling import *
 h2oConf = H2OConf(spark).set("spark.ui.enabled", "false")

--- a/h2o-docs/src/booklets/v2_2015/source/sw/sections/pysparkling.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/sw/sections/pysparkling.tex
@@ -2,8 +2,8 @@
 
 PySparkling Water is an integration of Python with Sparkling water. It allows the user to start H2O services on a spark cluster from Python API.
 
-In the PySparkling Water driver program, the \texttt{SparkContext} or \texttt{SparkSession} uses Py4J to start the driver JVM, and the JAVA \texttt{SparkContext}/\texttt{SparkSession} is used to create \texttt{H2OContext} (hc). This in turn starts the H2O cloud in the Spark ecosystem. (In Internal backend only. In external backend, the H2O cloud is running outside of the Spark cluster.)
-Once the H2O cluster is up, the H2O-Python package is used to interact with the cloud and run H2O algorithms. All pure H2O calls are executed via H2O's REST API interface. Users can easily integrate their regular PySpark workflow with H2O algorithms using PySparkling Water.
+In the PySparkling Water driver program, the \texttt{SparkContext} or \texttt{SparkSession} uses Py4J to start the driver JVM, and the JAVA \texttt{SparkContext}/\texttt{SparkSession} is used to create \texttt{H2OContext} (hc). This in turn starts the H2O cluster in the Spark ecosystem. (In Internal backend only. In external backend, the H2O cluster is running outside of the Spark cluster.)
+Once the H2O cluster is up, the H2O-Python package is used to interact with the cluster and run H2O algorithms. All pure H2O calls are executed via H2O's REST API interface. Users can easily integrate their regular PySpark workflow with H2O algorithms using PySparkling Water.
 
 PySparkling Water programs can be launched as an application, or in an interactive shell, or notebook environment.
 
@@ -46,7 +46,7 @@ Or start a notebook:
 PYSPARK_DRIVER_PYTHON="ipython" PYSPARK_DRIVER_PYTHON_OPTS="notebook" bin/pysparkling
 \end{lstlisting}
 
-\item Create an H2O cloud inside the Spark cluster and import H2O-Python package:
+\item Create an H2O cluster inside the Spark cluster and import H2O-Python package:
 
 \begin{lstlisting}[style=Python]
 from pysparkling import *
@@ -71,7 +71,7 @@ export SPARKLING_HOME="/path/to/SparklingWater/installation"
 $SPARKLING_HOME/bin/pysparkling --num-executors 3 --executor-memory 20g --executor-cores 10 --driver-memory 20g --master yarn --deploy-mode client
 \end{lstlisting}
     
-Then create an H2O cloud inside the Spark cluster and import H2O-Python package:
+Then create an H2O cluster inside the Spark cluster and import H2O-Python package:
 \begin{lstlisting}[style=Python]
 from pysparkling import *
 hc = H2OContext.getOrCreate(spark)

--- a/h2o-docs/src/booklets/v2_2015/source/sw/sections/usecase.tex
+++ b/h2o-docs/src/booklets/v2_2015/source/sw/sections/usecase.tex
@@ -44,7 +44,7 @@ addFiles(spark.sparkContext,
 val wrawdata = spark.sparkContext.textFile(SparkFiles.get("Chicago_Ohare_International_Airport.csv"), 3).cache()
 val weatherTable = wrawdata.map(_.split(",")).map(row => WeatherParse(row)).filter(!_.isWrongRow())
 
-// Load H2O from zipped CSV file (i.e., access directly H2O cloud)
+// Load H2O from zipped CSV file (i.e., access directly H2O cluster)
 val airlinesData = new H2OFrame(new File(SparkFiles.get("allyears2k_headers.zip")))
 
 val airlinesTable: RDD[Airlines] = asRDD[Airlines](airlinesData)

--- a/h2o-docs/src/product/architecture.rst
+++ b/h2o-docs/src/product/architecture.rst
@@ -48,7 +48,7 @@ All REST API clients communicate with H2O over a socket connection.
 JVM Components
 ~~~~~~~~~~~~~~
 
-An H2O cloud consists of one or more nodes. Each node is a single JVM
+An H2O cluster consists of one or more nodes. Each node is a single JVM
 process. Each JVM process is split into three layers: language,
 algorithms, and core infrastructure.
 
@@ -135,7 +135,7 @@ The following diagram shows the different software layers involved when
 a user runs an R program that starts a GLM on H2O.
 
 The left side shows the steps that run the the R process and the right
-side shows the steps that run in the H2O cloud. The top layer is the
+side shows the steps that run in the H2O cluster. The top layer is the
 TCP/IP network code that enables the two processes to communicate with
 each other.
 

--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -340,7 +340,7 @@ XGBoost
 AutoML now includes `XGBoost <data-science/xgboost.html>`__ GBMs (Gradient Boosting Machines) among its set of algorithms. This feature is currently provided with the following restrictions:
 
 - XGBoost is used only if it is available globally and if it hasn't been explicitly `disabled <data-science/xgboost.html#disabling-xgboost>`__.
-- XGBoost is disabled by default in AutoML when running H2O-3 in multi-node due to current `limitations <data-science/xgboost.html#limitations>`__.  XGBoost can however be enabled experimentally in multi-node by setting the environment variable ``-Dsys.ai.h2o.automl.xgboost.multinode.enabled=true`` (when launching the H2O process from the command line) for every node of the H2O cloud.
+- XGBoost is disabled by default in AutoML when running H2O-3 in multi-node due to current `limitations <data-science/xgboost.html#limitations>`__.  XGBoost can however be enabled experimentally in multi-node by setting the environment variable ``-Dsys.ai.h2o.automl.xgboost.multinode.enabled=true`` (when launching the H2O process from the command line) for every node of the H2O cluster.
 - You can check if XGBoost is available by using the ``h2o.xgboost.available()`` in R or ``h2o.estimators.xgboost.H2OXGBoostEstimator.available()`` in Python.
 
 

--- a/h2o-docs/src/product/data-munging/combining-columns.rst
+++ b/h2o-docs/src/product/data-munging/combining-columns.rst
@@ -85,8 +85,8 @@ The ``cbind`` function allows you to combine datasets by adding columns from one
 
 	[10 rows x 4 columns]
 	
-	# Generate a second random dataset with 10 rows and 1 column. 
-	# Label the columns, Y and D.
+	# Generate a second random dataset with 10 rows and 2 columns. 
+	# Label the columns, Y and Z.
 	cols2_df = h2o.H2OFrame.from_python(np.random.randn(10,2).tolist(), column_names=list('YZ'))
 	cols2_df.describe
 	         Y           Z

--- a/h2o-docs/src/product/data-science/xgboost.rst
+++ b/h2o-docs/src/product/data-science/xgboost.rst
@@ -297,7 +297,7 @@ FAQs
 
   By default, XGBoost will create N+1 new cols for categorical features with N levels (i.e., ``categorical_encoding="one_hot_internal"``). 
 
--  **Why does my H2O cloud on Hadoop became unresponsive when running XGBoost even when I supplied 4 times the datasize memory?**
+-  **Why does my H2O cluster on Hadoop became unresponsive when running XGBoost even when I supplied 4 times the datasize memory?**
 
   XGBoost uses memory outside the Java heap, and when that memory is not available, Hadoop kills the h2o job and the h2o cluster becomes unresponsive. Please set ``-extramempercent`` argument to a much higher value (120% recommended) when starting H2O. This argument configures the extra memory for internal JVM use outside of the Java heap and is a percentage of mapperXmx. For example:
 

--- a/h2o-docs/src/product/faq/java.rst
+++ b/h2o-docs/src/product/faq/java.rst
@@ -67,33 +67,3 @@ If you are running OS X 10.8 or later, modify the launchd.plist by entering the 
     </dict>
     </plist>
     EOF
-
---------------
-
-**I recently upgraded to Java 9, and now H2O no longer works. How can I switch to a supported version of Java?**
-
-Java 9 is not yet supported but will be in an upcoming release. In the meantime, you can tell H2O which version of Java you'd like to use by setting the ``JAVA_HOME`` environment variable. 
-
- **On Mac OS X**
-
- First, run the following to get the location of a previous version of Java (for example, 1.8).
-
- ::
-  
-   /usr/libexec/java_home -v 1.8
-
- This will return the path for Java. For example:
-
- ::
-
-   /Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home
-
- Next, add the path to your ``.bash_profile``.
-
- :: 
-
-   export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home
-
- **In RStudio**
-
- In some cases, after you've set your JAVA_HOME environment variable to a supported version, H2O still fails in RStudio. If this is the case, add the path (for example, ``JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_25.jdk/Contents/Home``) to ``~/.Renviron``, and then restart RStudio.

--- a/h2o-docs/src/product/hadoop.rst
+++ b/h2o-docs/src/product/hadoop.rst
@@ -103,8 +103,8 @@ and the parameters involved in launching H2O from the command line.
 
    -  *nodes* is the number of nodes requested to form the cluster.
 
-   -  *output* is the name of the directory created each time a H2O
-      cloud is created so it is necessary for the name to be unique each
+   -  *output* is the name of the directory created each time an H2O
+      cluster is created so it is necessary for the name to be unique each
       time it is launched.
 
 4. To monitor your job, direct your web browser to your standard job
@@ -161,7 +161,7 @@ Hadoop Launch Parameters
 -  ``-notify <notification file name>``: Specify a file to write when
    the cluster is up. The file contains the IP and port of the embedded
    web server for one of the nodes in the cluster. All mappers must
-   start before the H2O cloud is considered "up".
+   start before the H2O cluster is considered "up".
 -  ``-mapperXmx <per mapper Java Xmx heap size>``: Specify the amount of
    memory to allocate to H2O (at least 6g).
 -  ``-extramempercent <0-20>``: Specify the extra memory for internal

--- a/h2o-docs/src/product/starting-h2o.rst
+++ b/h2o-docs/src/product/starting-h2o.rst
@@ -212,7 +212,7 @@ H2O.
 When you launch from the command line, you can include
 additional instructions to H2O 3.0, such as how many nodes to launch,
 how much memory to allocate for each node, assign names to the nodes in
-the cloud, and more.
+the cluster, and more.
 
     **Note**: H2O requires some space in the ``/tmp`` directory to
     launch. If you cannot launch H2O, try freeing up some space in the
@@ -244,8 +244,8 @@ H2O Options
 
 -	``-h`` or ``-help``: Display this information in the command line output.
 - ``-version``: Specify to print version information and exit.
--	``-name <H2OCloudName>``: Assign a name to the H2O instance in the cloud (where ``<H2OCloudName>`` is the name of the cloud). Nodes with the same cloud name will form an H2O cloud (also known as an H2O cluster).
--	``-flatfile <FileName>``: Specify a flatfile of IP address for faster cloud formation (where ``<FileName>`` is the name of the flatfile).
+-	``-name <H2OClusterName>``: Assign a name to the H2O instance in the cluster (where ``<H2OClusterName>`` is the name of the cluster). Nodes with the same cluster name will form an H2O cluster (also known as an H2O cloud).
+-	``-flatfile <FileName>``: Specify a flatfile of IP address for faster cluster formation (where ``<FileName>`` is the name of the flatfile).
 -	``-ip <IPnodeAddress>``: Specify an IP for the machine other than the default ``localhost``, for example:
     
     - IPv4: ``-ip 178.16.2.223`` 
@@ -311,19 +311,19 @@ By default, H2O selects the IP and PORT for internal communication automatically
   - ``-baseport`` 
 
 
-Cloud Formation Behavior
-^^^^^^^^^^^^^^^^^^^^^^^^
+Cluster Formation Behavior
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-New H2O nodes join to form a cloud during launch. After a job has
-started on the cloud, it prevents new members from joining.
+New H2O nodes join to form a cluster during launch. After a job has
+started on the cluster, it prevents new members from joining.
 
--  To start an H2O node with 4GB of memory and a default cloud name:
+-  To start an H2O node with 4GB of memory and a default cluster name:
    ``java -Xmx4g -jar h2o.jar``
 
--  To start an H2O node with 6GB of memory and a specific cloud name:
-   ``java -Xmx6g -jar h2o.jar -name MyCloud``
+-  To start an H2O node with 6GB of memory and a specific cluster name:
+   ``java -Xmx6g -jar h2o.jar -name MyCluster``
 
--  To start an H2O cloud with three 2GB nodes using the default cloud
+-  To start an H2O cluster with three 2GB nodes using the default cluster
    names: ``java -Xmx2g -jar h2o.jar &   java -Xmx2g -jar h2o.jar &   java -Xmx2g -jar h2o.jar &``
 
 Wait for the ``INFO: Registered: # schemas in: #mS`` output before
@@ -341,8 +341,8 @@ H2O provides two modes for cluster creation:
 Multicast
 '''''''''
 
-In this mode, H2O is using IP multicast to announce existence of H2O nodes. Each node selects the same multicast group and port based on specified shared cloud name (see ``-name`` option). For example, for IPv4/PORT a generated multicast group is ``228.246.114.236:58614`` (for cloud name ``michal``), 
-for IPv6/PORT a generated multicast group is ``ff05:0:3ff6:72ec:0:0:3ff6:72ec:58614`` (for cloud name ``michal`` and link-local address which enforce link-local scope).
+In this mode, H2O is using IP multicast to announce existence of H2O nodes. Each node selects the same multicast group and port based on specified shared cluster name (see ``-name`` option). For example, for IPv4/PORT a generated multicast group is ``228.246.114.236:58614`` (for cluster name ``michal``), 
+for IPv6/PORT a generated multicast group is ``ff05:0:3ff6:72ec:0:0:3ff6:72ec:58614`` (for cluster name ``michal`` and link-local address which enforce link-local scope).
 
 For IPv6 the scope of multicast address is enforced by a selected node IP. For example, if IP the selection process selects link-local address, then the scope of multicast will be link-local. This can be modified by specifying JVM variable ``sys.ai.h2o.network.ipv6.scope`` which enforces addressing scope use in multicast group address (for example, ``-Dsys.ai.h2o.network.ipv6.scope=0x0005000000000000`` enforces the site local scope. For more details please consult the
 class ``water.util.NetworkUtils``).

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -348,7 +348,7 @@ REST APIs are generated immediately out of the code, allowing users to implement
 Java Users
 --------------
 
-For Java developers, the following resources will help you create your own custom app that uses H2O.
+H2O-3 is supported with Java 7 and later. For Java developers, the following resources will help you create your own custom app that uses H2O.
 
 -  `H2O Core Java Developer Documentation <../h2o-core/javadoc/index.html>`_: The definitive Java API guide
    for the core components of H2O.
@@ -488,9 +488,9 @@ The following steps show you how to download or build H2O with Hadoop and the pa
 
    -  *nodes* is the number of nodes requested to form the cluster.
 
-   -  *output* is the name of the directory created each time a H2O cloud is created so it is necessary for the name to be unique each time it is launched.
+   -  *output* is the name of the directory created each time a H2O cluster is created so it is necessary for the name to be unique each time it is launched.
 
-4. To monitor your job, direct your web browser to your standard job tracker Web UI. To access H2O's Web UI, direct your web browser to one of the launched instances. If you are unsure where your JVM is launched, review the output from your command after the nodes has clouded up and formed a cluster. Any of the nodes' IP addresses will work as there is no master node.
+4. To monitor your job, direct your web browser to your standard job tracker Web UI. To access H2O's Web UI, direct your web browser to one of the launched instances. If you are unsure where your JVM is launched, review the output from your command after the nodes have clouded up and formed a cluster. Any of the nodes' IP addresses will work as there is no master node.
 
    ::
 
@@ -523,7 +523,7 @@ Hadoop Launch Parameters
 
     **Note**: For Qubole users who include the ``-disown`` flag, if your cluster is dying right after launch, add ``-Dmapred.jobclient.killjob.onexit=false`` as a launch parameter.
 
--  ``-notify <notification file name>``: Specify a file to write when the cluster is up. The file contains the IP and port of the embedded web server for one of the nodes in the cluster. All mappers must start before the H2O cloud is considered "up".
+-  ``-notify <notification file name>``: Specify a file to write when the cluster is up. The file contains the IP and port of the embedded web server for one of the nodes in the cluster. All mappers must start before the H2O cluster is considered "up".
 -  ``-mapperXmx <per mapper Java Xmx heap size>``: Specify the amount of memory to allocate to H2O (at least 6g).
 -  ``-extramempercent``: Specify the extra memory for internal JVM use outside of the Java heap. This is a percentage of ``mapperXmx``. **Recommendation**: Set this to a high value when running XGBoost, for example, 120. 
 -  ``-n | -nodes <number of H2O nodes>``: Specify the number of nodes.

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -536,12 +536,12 @@ Hadoop Launch Parameters
 -  ``-proxy``: Enables Proxy mode.
 -  ``-report_hostname``: This flag allows the user to specify the machine hostname instead of the IP address when launching H2O Flow. This option can only be used when H2O on Hadoop is started in Proxy mode (with ``-proxy``).
 
-    **JVM arguments**
+**JVM arguments**
 
--  ``-ea``: Enable assertions to verify boolean expressions for error detection.
--  ``-verbose:gc``: Include heap and garbage collection information in the logs. Deprecated in Java 9, removed in Java 10.
--  ``-XX:+PrintGCDetails``: Include a short message after each garbage collection. Deprecated in Java 9, removed in Java 10.
--  ``-Xlog:gc=info``: Prints garbage collection information into the logs. Introduced in Java 9. Usage enforced since Java 10. A replacement for ``-verbose:gc`` and ``-XX:+PrintGCDetails`` tags which are deprecated in Java 9 and removed in Java 10.
+ -  ``-ea``: Enable assertions to verify boolean expressions for error detection.
+ -  ``-verbose:gc``: Include heap and garbage collection information in the logs. Deprecated in Java 9, removed in Java 10.
+ -  ``-XX:+PrintGCDetails``: Include a short message after each garbage collection. Deprecated in Java 9, removed in Java 10.
+ -  ``-Xlog:gc=info``: Prints garbage collection information into the logs. Introduced in Java 9. Usage enforced since Java 10. A replacement for ``-verbose:gc`` and ``-XX:+PrintGCDetails`` tags which are deprecated in Java 9 and removed in Java 10.
 
 Accessing S3 Data from Hadoop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -859,15 +859,15 @@ You can also view the IP address (``192.168.99.100`` in the example below) by sc
 After obtaining the IP address, point your browser to the specified ip address and port to open Flow. In R and Python, you can access the instance by installing the latest version of the H2O R or Python package and then initializing H2O:
 
 
-  .. example-code::
-     .. code-block:: r
+.. example-code::
+   .. code-block:: r
 
-      # Initialize H2O
-      library(h2o)
-      dockerH2O <- h2o.init(ip = "192.168.59.103", port = 54321)
+    # Initialize H2O
+    library(h2o)
+    dockerH2O <- h2o.init(ip = "192.168.59.103", port = 54321)
 
-     .. code-block:: python
+   .. code-block:: python
 
-      # Initialize H2O 
-      import h2o
-      docker_h2o = h2o.init(ip = "192.168.59.103", port = 54321) 
+    # Initialize H2O 
+    import h2o
+    docker_h2o = h2o.init(ip = "192.168.59.103", port = 54321) 

--- a/h2o-py/docs/intro.rst
+++ b/h2o-py/docs/intro.rst
@@ -61,7 +61,7 @@ various objects of the H2O ecosystem. Some shared objects are mutable by the cli
 some shared objects are read-only by the client, but are mutable by H2O (e.g. a model
 being constructed will change over time); and actions by the client may have side-effects
 on other clients (multi-tenancy is not a supported model of use, but it is possible for
-multiple clients to attach to a single H2O cloud).
+multiple clients to attach to a single H2O cluster).
 
 Briefly, these objects are:
 
@@ -88,7 +88,7 @@ manipulation of a distributed system.
 H2O Cluster Inspection
 ----------------------
 
-There are many tools for directly interacting with user-visible objects in the H2O cloud.
+There are many tools for directly interacting with user-visible objects in the H2O cluster.
 Every new python session begins by initializing a connection between the python client and
 the H2O cluster:
 
@@ -208,7 +208,7 @@ The set of operations on an H2OFrame is described in a dedicated chapter, but
 in general, this set of operations closely resembles those that may be
 performed on an R data.frame. This includes all types of slicing (with complex
 conditionals), broadcasting operations, and a slew of math operations for transforming and
-mutating a Frame -- all the while the actual Big Data is sitting in the H2O cloud. The
+mutating a Frame -- all the while the actual Big Data is sitting in the H2O cluster. The
 semantics for modifying a Frame closely resemble R's copy-on-modify semantics, except
 when it comes to mutating a Frame in place. For example, it's possible to assign all
 occurrences of the number `0` in a column to missing (or `NA` in R parlance) as
@@ -244,7 +244,7 @@ all dependent subparts composing `a` are also evaluated.
 
 This module relies on reference counting of python objects to dispose of
 out-of-scope objects. The ExprNode class destroys objects and their big data
-counterparts in the H2O cloud using a remove call:
+counterparts in the H2O cluster using a remove call:
 
   >>> fr = h2o.import_file(path="smalldata/logreg/prostate.csv")   # import prostate data
   >>>

--- a/h2o-py/h2o/backend/connection.py
+++ b/h2o-py/h2o/backend/connection.py
@@ -233,7 +233,7 @@ class H2OConnection(backwards_compatible()):
         :param url: full url of the server to connect to.
         :param ip: target server's IP address or hostname (default "localhost").
         :param port: H2O server's port (default 54321).
-        :param name: H2O cloud name.
+        :param name: H2O cluster name.
         :param https: if True then connect using https instead of http (default False).
         :param verify_ssl_certificates: if False then SSL certificate checking will be disabled (default True). This
             setting should rarely be disabled, as it makes your connection vulnerable to man-in-the-middle attacks. When
@@ -450,7 +450,7 @@ class H2OConnection(backwards_compatible()):
         Return the session id of the current connection.
 
         The session id is issued (through an API request) the first time it is requested, but no sooner. This is
-        because generating a session id puts it into the DKV on the server, which effectively locks the cloud. Once
+        because generating a session id puts it into the DKV on the server, which effectively locks the cluster. Once
         issued, the session id will stay the same until the connection is closed.
         """
         if self._session_id is None:
@@ -460,7 +460,7 @@ class H2OConnection(backwards_compatible()):
 
     @property
     def cluster(self):
-        """H2OCluster object describing the underlying cloud."""
+        """H2OCluster object describing the underlying cluster."""
         return self._cluster
 
     @property
@@ -550,11 +550,11 @@ class H2OConnection(backwards_compatible()):
 
     def _test_connection(self, max_retries=5, messages=None):
         """
-        Test that the H2O cluster can be reached, and retrieve basic cloud status info.
+        Test that the H2O cluster can be reached, and retrieve basic cluster status info.
 
-        :param max_retries: Number of times to try to connect to the cloud (with 0.2s intervals).
+        :param max_retries: Number of times to try to connect to the cluster (with 0.2s intervals).
 
-        :returns: Cloud information (an H2OCluster object)
+        :returns: Cluster information (an H2OCluster object)
         :raises H2OConnectionError, H2OServerError:
         """
         if messages is None:

--- a/h2o-py/h2o/backend/server.py
+++ b/h2o-py/h2o/backend/server.py
@@ -81,7 +81,7 @@ class H2OLocalServer(object):
             tempfile.mkdtemp().
         :param port: Port where to start the new server. This could be either an integer, or a string of the form
             "DDDDD+", indicating that the server should start looking for an open port starting from DDDDD and up.
-        :param name: name of the h2o cloud to be started
+        :param name: name of the h2o cluster to be started
         :param extra_classpath List of paths to libraries that should be included on the Java classpath.
         :param verbose: If True, then connection info will be printed to the stdout.
         :param jvm_custom_args Custom, user-defined arguments for the JVM H2O is instantiated in
@@ -186,7 +186,7 @@ class H2OLocalServer(object):
 
     @property
     def name(self):
-        """H2O cloud name."""
+        """H2O cluster name."""
         return self._name
 
     #-------------------------------------------------------------------------------------------------------------------

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -155,9 +155,9 @@ def init(url=None, ip=None, port=None, name=None, https=None, insecure=None, use
     :param url: Full URL of the server to connect to (can be used instead of `ip` + `port` + `https`).
     :param ip: The ip address (or host name) of the server where H2O is running.
     :param port: Port number that H2O service is listening to.
-    :param name: cloud name. If None while connecting to an existing cluster it will not check the cloud name.
-                 If set then will connect only if the target cloud name matches. If no instance is found and decides to start a local
-                 one then this will be used as the cloud name or a random one will be generated if set to None.
+    :param name: Cluster name. If None while connecting to an existing cluster it will not check the cluster name.
+                 If set then will connect only if the target cluster name matches. If no instance is found and decides to start a local
+                 one then this will be used as the cluster name or a random one will be generated if set to None.
     :param https: Set to True to connect via https:// instead of http://.
     :param insecure: When using https, setting this to True will disable SSL certificates verification.
     :param username: Username and
@@ -1109,7 +1109,7 @@ def export_file(frame, path, force=False, parts=1):
 
 
 def cluster():
-    """Return :class:`H2OCluster` object describing the backend H2O cloud."""
+    """Return :class:`H2OCluster` object describing the backend H2O cluster."""
     return h2oconn.cluster if h2oconn else None
 
 

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -24,7 +24,7 @@ if (inherits(try(getRefClass("H2OConnectionMutableState"), silent = TRUE), "try-
 #'
 #' The H2OConnectionMutableState class
 #'
-#' This class represents the mutable aspects of a connection to an H2O cloud.
+#' This class represents the mutable aspects of a connection to an H2O cluster.
 #'
 #' @name H2OConnectionMutableState
 #' @slot session_id A \code{character} string specifying the H2O session identifier.
@@ -43,7 +43,7 @@ setRefClass("H2OConnectionMutableState",
 #'
 #' The H2OConnection class.
 #'
-#' This class represents a connection to an H2O cloud.
+#' This class represents a connection to an H2O cluster.
 #'
 #' Because H2O is not a master-slave architecture, there is no restriction on which H2O node
 #' is used to establish the connection between R (the client) and H2O (the server).
@@ -52,10 +52,10 @@ setRefClass("H2OConnectionMutableState",
 #' the `ip` and `port` of the machine running an instance to connect with. The default behavior
 #' is to connect with a local instance of H2O at port 54321, or to boot a new local instance if one
 #' is not found at port 54321.
-#' @slot ip A \code{character} string specifying the IP address of the H2O cloud.
-#' @slot port A \code{numeric} value specifying the port number of the H2O cloud.
-#' @slot name A \code{character} value specifying the cloud name of the H2O cloud.
-#' @slot proxy A \code{character} specifying the proxy path of the H2O cloud.
+#' @slot ip A \code{character} string specifying the IP address of the H2O cluster.
+#' @slot port A \code{numeric} value specifying the port number of the H2O cluster.
+#' @slot name A \code{character} value specifying the name of the H2O cluster.
+#' @slot proxy A \code{character} specifying the proxy path of the H2O cluster.
 #' @slot https Set this to TRUE to use https instead of http.
 #' @slot insecure Set this to TRUE to disable SSL certificate checking.
 #' @slot username Username to login with.
@@ -102,10 +102,10 @@ setMethod("show", "H2OConnection", function(object) {
 #'
 #' This virtual class represents a model built by H2O.
 #'
-#' This object has slots for the key, which is a character string that points to the model key existing in the H2O cloud,
+#' This object has slots for the key, which is a character string that points to the model key existing in the H2O cluster,
 #' the data used to build the model (an object of class H2OFrame).
 #'
-#' @slot model_id A \code{character} string specifying the key for the model fit in the H2O cloud's key-value store.
+#' @slot model_id A \code{character} string specifying the key for the model fit in the H2O cluster's key-value store.
 #' @slot algorithm A \code{character} string specifying the algorithm that were used to fit the model.
 #' @slot parameters A \code{list} containing the parameter settings that were used to fit the model that differ from the defaults.
 #' @slot allparameters A \code{list} containg all parameters used to fit the model.
@@ -265,10 +265,10 @@ setClass("H2ORegressionModel",  contains="H2OModel")
 #'
 #' This virtual class represents a clustering model built by H2O.
 #'
-#' This object has slots for the key, which is a character string that points to the model key existing in the H2O cloud,
+#' This object has slots for the key, which is a character string that points to the model key existing in the H2O cluster,
 #' the data used to build the model (an object of class H2OFrame).
 #'
-#' @slot model_id A \code{character} string specifying the key for the model fit in the H2O cloud's key-value store.
+#' @slot model_id A \code{character} string specifying the key for the model fit in the H2O cluster's key-value store.
 #' @slot algorithm A \code{character} string specifying the algorithm that was used to fit the model.
 #' @slot parameters A \code{list} containing the parameter settings that were used to fit the model that differ from the defaults.
 #' @slot allparameters A \code{list} containing all parameters used to fit the model.

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -11,7 +11,7 @@
 #'
 #' @param ip Object of class \code{character} representing the IP address of the server where H2O is running.
 #' @param port Object of class \code{numeric} representing the port number of the H2O server.
-#' @param name (Optional) A \code{character} string representing the H2O cloud name.
+#' @param name (Optional) A \code{character} string representing the H2O cluster name.
 #' @param startH2O (Optional) A \code{logical} value indicating whether to try to start H2O from R if no connection with H2O is detected. This is only possible if \code{ip = "localhost"} or \code{ip = "127.0.0.1"}.  If an existing connection is detected, R does not start H2O.
 #' @param forceDL (Optional) A \code{logical} value indicating whether to force download of the H2O executable. Defaults to FALSE, so the executable will only be downloaded if it does not already exist in the h2o R library resources directory \code{h2o/java/h2o.jar}.  This value is only used when R starts H2O.
 #' @param enable_assertions (Optional) A \code{logical} value indicating whether H2O should be launched with assertions enabled. Used mainly for error checking and debugging purposes.  This value is only used when R starts H2O.
@@ -353,7 +353,7 @@ h2o.getConnection <- function() {
 #' @note Users must call h2o.shutdown explicitly in order to shut down the local H2O instance started by R. If R is closed before H2O, then an attempt will be made to automatically shut down H2O. This only applies to local instances started with h2o.init, not remote H2O servers.
 #' @seealso \code{\link{h2o.init}}
 #' @examples
-#' # Don't run automatically to prevent accidentally shutting down a cloud
+#' # Don't run automatically to prevent accidentally shutting down a cluster
 #' \dontrun{
 #' library(h2o)
 #' h2o.init()
@@ -387,7 +387,7 @@ h2o.shutdown <- function(prompt = TRUE) {
 # **** TODO: This isn't really a cluster status... it's a node status check for the node we're connected to.
 # This is possibly confusing because this can come back without warning,
 # but if a user tries to do any remoteSend, they will get a "cloud sick warning"
-# Suggest cribbing the code from Internal.R that checks cloud status (or just call it here?)
+# Suggest cribbing the code from Internal.R that checks cluster status (or just call it here?)
 
 #' Return the status of the cluster
 #'

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1340,19 +1340,19 @@ h2o.as_date <- function(x, format, ...) {
 #' @export
 as.Date.H2OFrame <- h2o.as_date
 
-#' Set the Time Zone on the H2O Cloud
+#' Set the Time Zone on the H2O cluster
 #'
 #' @param tz The desired timezone.
 #' @export
 h2o.setTimezone <- function(tz) .eval.scalar(.newExpr("setTimeZone",.quote(tz)))
 
-#' Get the Time Zone on the H2O Cloud
+#' Get the Time Zone on the H2O cluster
 #' Returns a string
 #'
 #' @export
 h2o.getTimezone <- function() .eval.scalar(.newExpr("getTimeZone"))
 
-#' List all of the Time Zones Acceptable by the H2O Cloud.
+#' List all of the Time Zones Acceptable by the H2O cluster.
 #'
 #' @export
 h2o.listTimezones <- function() .fetch.data(.newExpr("listTimeZones"),1000L)
@@ -3192,7 +3192,7 @@ use.package <- function(package,
 #'
 #' Create H2OFrame
 #'
-#' Import R object to the H2O cloud.
+#' Import R object to the H2O cluster.
 #'
 #' @param x An \code{R} object.
 #' @param destination_frame A string with the desired name for the H2OFrame.

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -8,7 +8,7 @@
 #'
 #' Import Files into H2O
 #'
-#' Imports files into an H2O cloud. The default behavior is to pass-through to the parse phase
+#' Imports files into an H2O cluster. The default behavior is to pass-through to the parse phase
 #' automatically.
 #'
 #' \code{h2o.importFile} is a parallelized reader and pulls information from the server from a location specified
@@ -186,7 +186,7 @@ h2o.uploadFile <- function(path, destination_frame = "",
 #'
 #' Import SQL Table into H2O
 #'
-#' Imports SQL table into an H2O cloud. Assumes that the SQL table is not being updated and is stable.
+#' Imports SQL table into an H2O cluster. Assumes that the SQL table is not being updated and is stable.
 #' Runs multiple SELECT SQL queries concurrently for parallel ingestion.
 #' Be sure to start the h2o.jar in the terminal with your downloaded JDBC driver in the classpath:
 #'    `java -cp <path_to_h2o_jar>:<path_to_jdbc_driver_jar> water.H2OApp`

--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -9,7 +9,7 @@
 #'}
 NULL
 
-#' Shutdown H2O cloud after examples run
+#' Shutdown H2O cluster after examples run
 #'
 #' @name zzz
 #' @examples

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -124,7 +124,7 @@ def grab_java_message(node_list, curr_testname):
     Parameters
     ----------
     :param node_list:  list of H2O nodes
-      List of H2o nodes associated with a H2OCloud that are performing the test specified in curr_testname.
+      List of H2o nodes associated with an H2OCloud (cluster) that are performing the test specified in curr_testname.
     :param curr_testname: str
       Store the unit test name (can be R unit or Py unit) that has been completed and failed.
     :return: a string object that is either empty or the java messages that associated with the test in curr_testname.
@@ -180,11 +180,11 @@ def grab_java_message(node_list, curr_testname):
 
 class H2OUseCloudNode(object):
     """
-    A class representing one node in an H2O cloud which was specified by the user.
+    A class representing one node in an H2O cluster that was specified by the user.
     Don't try to build or tear down this kind of node.
 
-    use_ip: The given ip of the cloud.
-    use_port: The given port of the cloud.
+    use_ip: The given ip of the cluster.
+    use_port: The given port of the cluster.
     """
 
     def __init__(self, use_ip, use_port):
@@ -201,18 +201,18 @@ class H2OUseCloudNode(object):
         """Not implemented."""
 
     def get_ip(self):
-        """Cloud's IP-address."""
+        """Cluster's IP-address."""
         return self.use_ip
 
     def get_port(self):
-        """Cloud's port number."""
+        """Cluster's port number."""
         return self.use_port
 
 
 class H2OUseCloud(object):
     """
-    A class representing an H2O clouds which was specified by the user.
-    Don't try to build or tear down this kind of cloud.
+    A class representing an H2O cluster that was specified by the user.
+    Don't try to build or tear down this kind of cluster.
     """
 
     def __init__(self, cloud_num, use_ip, use_port):
@@ -237,22 +237,22 @@ class H2OUseCloud(object):
         """Not implemented."""
 
     def get_ip(self):
-        """Cloud's IP-address."""
+        """Cluster's IP-address."""
         node = self.nodes[0]
         return node.get_ip()
 
     def get_port(self):
-        """Cloud's port number."""
+        """Cluster's port number."""
         node = self.nodes[0]
         return node.get_port()
 
 
 class H2OCloudNode(object):
     """
-    A class representing one node in an H2O cloud.
+    A class representing one node in an H2O cluster.
     Note that the base_port is only a request for H2O.
     H2O may choose to ignore our request and pick any port it likes.
-    So we have to scrape the real port number from stdout as part of cloud startup.
+    So we have to scrape the real port number from stdout as part of cluster startup.
 
     port: The actual port chosen at run time.
     pid: The process id of the node.
@@ -267,8 +267,8 @@ class H2OCloudNode(object):
         Create a node in a cloud.
 
         :param is_client: Whether this node is an H2O client node (vs a worker node) or not.
-        :param cloud_num: Dense 0-based cloud index number.
-        :param nodes_per_cloud: How many H2O java instances are in a cloud.  Clouds are symmetric.
+        :param cloud_num: Dense 0-based cluster index number.
+        :param nodes_per_cloud: How many H2O java instances are in a cluster. Clustes are symmetric.
         :param node_num: This node's dense 0-based node index number.
         :param cloud_name: The H2O -name command-line argument.
         :param h2o_jar: Path to H2O jar file.
@@ -446,7 +446,7 @@ class H2OCloudNode(object):
 
     def scrape_cloudsize_from_stdout(self, nodes_per_cloud):
         """
-        Look at the stdout log and wait until the cloud of proper size is formed.
+        Look at the stdout log and wait until the cluster of proper size is formed.
         This call is blocking.
         Exit if this fails.
 
@@ -525,16 +525,16 @@ class H2OCloudNode(object):
 
 class H2OCloud(object):
     """
-    A class representing one of the H2O clouds.
+    A class representing one of the H2O clusters.
     """
 
     def __init__(self, cloud_num, use_client, nodes_per_cloud, h2o_jar, base_port, xmx, cp, output_dir, test_ssl,
                  ldap_config_path, jvm_opts=None):
         """
-        Create a cloud.
+        Create a cluster.
         See node definition above for argument descriptions.
 
-        :return The cloud object.
+        :return The cluster object.
         """
         self.use_client = use_client
         self.cloud_num = cloud_num
@@ -548,7 +548,7 @@ class H2OCloud(object):
         self.ldap_config_path = ldap_config_path
         self.jvm_opts = jvm_opts
 
-        # Randomly choose a seven digit cloud number.
+        # Randomly choose a seven digit cluster number.
         n = random.randint(1000000, 9999999)
         user = getpass.getuser()
         user = ''.join(user.split())
@@ -590,8 +590,8 @@ class H2OCloud(object):
 
     def start(self):
         """
-        Start H2O cloud.
-        The cloud is not up until wait_for_cloud_to_be_up() is called and returns.
+        Start H2O cluster.
+        The cluster is not up until wait_for_cloud_to_be_up() is called and returns.
 
         :return none
         """
@@ -603,7 +603,7 @@ class H2OCloud(object):
 
     def wait_for_cloud_to_be_up(self):
         """
-        Blocking call ensuring the cloud is available.
+        Blocking call ensuring the cluster is available.
 
         :return none
         """
@@ -612,7 +612,7 @@ class H2OCloud(object):
 
     def stop(self):
         """
-        Normal cloud shutdown.
+        Normal cluster shutdown.
 
         :return none
         """
@@ -624,7 +624,7 @@ class H2OCloud(object):
 
     def terminate(self):
         """
-        Terminate a running cloud.  (Due to a signal.)
+        Terminate a running cluster.  (Due to a signal.)
 
         :return none
         """
@@ -635,7 +635,7 @@ class H2OCloud(object):
             node.terminate()
 
     def get_ip(self):
-        """ Return an ip to use to talk to this cloud. """
+        """ Return an ip to use to talk to this cluster. """
         if len(self.client_nodes) > 0:
             node = self.client_nodes[0]
         else:
@@ -643,7 +643,7 @@ class H2OCloud(object):
         return node.get_ip()
 
     def get_port(self):
-        """ Return a port to use to talk to this cloud. """
+        """ Return a port to use to talk to this cluster. """
         if len(self.client_nodes) > 0:
             node = self.client_nodes[0]
         else:
@@ -682,8 +682,8 @@ class Test(object):
     terminated: Test killed due to signal.
     returncode: Exit code of child.
     pid: Process id of the test.
-    ip: IP of cloud to run test.
-    port: Port of cloud to run test.
+    ip: IP of cluster to run test.
+    port: Port of cluster to run test.
     child: subprocess.Popen object.
     """
 
@@ -728,8 +728,8 @@ class Test(object):
         """
         Start the test in a non-blocking fashion.
 
-        :param ip: IP address of cloud to run on.
-        :param port: Port of cloud to run on.
+        :param ip: IP address of cluster to run on.
+        :param port: Port of cluster to run on.
         :return none
         """
 
@@ -836,13 +836,13 @@ class Test(object):
 
     def get_ip(self):
         """
-        :return IP of the cloud where this test ran.
+        :return IP of the cluster where this test ran.
         """
         return self.ip
 
     def get_port(self):
         """
-        :return Integer port number of the cloud where this test ran.
+        :return Integer port number of the cluster where this test ran.
         """
         return int(self.port)
 
@@ -965,7 +965,7 @@ class Test(object):
         else:
             cmd += ["--pyBooklet"]
         if g_jacoco_include:
-            # When using JaCoCo we don't want the test to return an error if a cloud reports as unhealthy
+            # When using JaCoCo we don't want the test to return an error if a cluster reports as unhealthy
             cmd += ["--forceConnect"]
         if g_ldap_username:
             cmd += ['--ldapUsername', g_ldap_username]
@@ -1024,13 +1024,13 @@ class TestRunner(object):
         Create a runner.
 
         :param test_root_dir: h2o/R/tests directory.
-        :param use_cloud: Use this one user-specified cloud.  Overrides num_clouds.
-        :param use_cloud2: Use the cloud_config to define the list of H2O clouds.
-        :param cloud_config: (if use_cloud2) the config file listing the H2O clouds.
-        :param use_ip: (if use_cloud) IP of one cloud to use.
-        :param use_port: (if use_cloud) Port of one cloud to use.
-        :param num_clouds: Number of H2O clouds to start.
-        :param nodes_per_cloud: Number of H2O nodes to start per cloud.
+        :param use_cloud: Use this one user-specified cluster.  Overrides num_clouds.
+        :param use_cloud2: Use the cloud_config to define the list of H2O clusters.
+        :param cloud_config: (if use_cloud2) the config file listing the H2O clusters.
+        :param use_ip: (if use_cloud) IP of one cluster to use.
+        :param use_port: (if use_cloud) Port of one cluster to use.
+        :param num_clouds: Number of H2O clusters to start.
+        :param nodes_per_cloud: Number of H2O nodes to start per cluster.
         :param h2o_jar: Path to H2O jar file to run.
         :param base_port: Base H2O port (e.g. 54321) to start choosing from.
         :param xmx: Java -Xmx parameter.
@@ -1354,7 +1354,7 @@ class TestRunner(object):
 
     def start_clouds(self):
         """
-        Start all H2O clouds.
+        Start all H2O clusters.
         :return none
         """
         if self.terminated: return
@@ -1454,7 +1454,7 @@ class TestRunner(object):
 
     def check_clouds(self):
         """
-        for all clouds, check if connection to h2o exists, and that h2o is healthy.
+        For all clusters, check if connection to h2o exists, and that h2o is healthy.
         """
         time.sleep(3)
         print("Checking cloud health...")
@@ -1467,7 +1467,7 @@ class TestRunner(object):
 
     def stop_clouds(self):
         """
-        Stop all H2O clouds.
+        Stop all H2O clusters.
         :return: none
         """
         if self.terminated: return
@@ -1575,7 +1575,7 @@ class TestRunner(object):
 
     def terminate(self):
         """
-        Terminate all running clouds.  (Due to a signal.)
+        Terminate all running clusters.  (Due to a signal.)
         :return none
         """
         self.terminated = True
@@ -1747,8 +1747,8 @@ class TestRunner(object):
 
     def _wait_for_available_cloud(self, nopass, timeout=60):
         """
-        Waits for an available cloud to appear by either a test completing or by a cloud on the suspicious_clouds list
-        reporting as healthy, and then returns a tuple containing its ip and port. If no tests are running and no clouds
+        Waits for an available cluster to appear by either a test completing or by a cluster on the suspicious_clouds list
+        reporting as healthy, and then returns a tuple containing its ip and port. If no tests are running and no clusters
         are reporting as healthy, then the function will wait until the designated timeout time expires before returning
         None.
         """
@@ -1960,8 +1960,8 @@ class TestRunner(object):
 
     def _remove_cloud(self, ip, port):
         """
-        add the ip, port to TestRunner's bad cloud list. remove the bad cloud from the TestRunner's cloud list.
-        terminate TestRunner if no good clouds remain.
+        add the ip, port to TestRunner's bad clusters list. Remove the bad cluster from the TestRunner's cluster list.
+        Terminate TestRunner if no good clusters remain.
         """
         if not [ip, str(port)] in self.bad_clouds: self.bad_clouds.append([ip, str(port)])
         cidx = 0
@@ -1978,9 +1978,9 @@ class TestRunner(object):
 
     def _suspect_cloud(self, ip, port):
         """
-        add the ip, port to TestRunner's suspicious cloud list. This way the cloud is considered to have the potential
-        to report as being healthy sometime in the future. Unlike _remove_cloud(), the suspicious cloud is not removed
-        from the TestRunner's cloud list.
+        add the ip, port to TestRunner's suspicious clusters list. This way the cluster is considered to have the potential
+        to report as being healthy sometime in the future. Unlike _remove_cloud(), the suspicious cluster is not removed
+        from the TestRunner's cluster list.
         """
         if not [ip, str(port)] in self.suspicious_clouds: self.suspicious_clouds.append([ip, str(port)])
 
@@ -2108,10 +2108,10 @@ def usage():
     print("")
     print("    --baseport       The first port at which H2O starts searching for free ports.")
     print("")
-    print("    --numclouds      The number of clouds to start.")
-    print("                     Each test is randomly assigned to a cloud.")
+    print("    --numclouds      The number of clusters to start.")
+    print("                     Each test is randomly assigned to a cluster.")
     print("")
-    print("    --numnodes       The number of nodes in the cloud.")
+    print("    --numnodes       The number of nodes in the cluster.")
     print("                     When this is specified, numclouds must be 1.")
     print("")
     print("    --test           If you only want to run one test, specify it like this.")
@@ -2127,10 +2127,10 @@ def usage():
     print("                     s=small (seconds), m=medium (a minute or two), l=large (longer), x=xlarge (very big)")
     print("                     (Default is to run all tests.)")
     print("")
-    print("    --usecloud       ip:port of cloud to send tests to instead of starting clouds.")
+    print("    --usecloud       ip:port of cluster to send tests to instead of starting clusters.")
     print("                     (When this is specified, numclouds is ignored.)")
     print("")
-    print("    --usecloud2      cloud.cfg: Use a set clouds defined in cloud.config to run tests on.")
+    print("    --usecloud2      cloud.cfg: Use a set clusters defined in cloud.config to run tests on.")
     print("                     (When this is specified, numclouds, numnodes, and usecloud are ignored.)")
     print("")
     print("    --client         Send REST API commands through client mode.")


### PR DESCRIPTION
Updated User Guide, booklets, R, and Python docs.
Driveby fix: Removed FAQ indicating that Java 9 isn't supported. Fixed combining columns example.