### PR TITLE
PUBDEV-6319 astgroup inconsistent

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
@@ -514,7 +514,7 @@ public class AstGroup extends AstPrimitive {
   // Main worker MRTask.  Makes 1 pass over the data, and accumulates both all
   // groups and all aggregates
   public static class GBTask extends MRTask<GBTask> {
-    IcedHashMap<G, String> _gss; // each thread will have its own IcedHashMap
+    IcedHashMap<G, String> _gss = new IcedHashMap<>(); // each thread will have its own IcedHashMap
     private final int[] _gbCols; // Columns used to define group
     private final AGG[] _aggs;   // Aggregate descriptions
     private final int _medianCounts;
@@ -529,19 +529,22 @@ public class AstGroup extends AstPrimitive {
     @Override
     public void map(Chunk[] cs) {
       // Groups found in this Chunk
-      _gss = new IcedHashMap<>();
       G gWork = new G(_gbCols.length, _aggs, _medianCounts); // Working Group
       G gOld;                   // Existing Group to be filled in
       for (int row = 0; row < cs[0]._len; row++) {
         // Find the Group being worked on
         gWork.fill(row, cs, _gbCols);            // Fill the worker Group for the hashtable lookup
-        if (_gss.putIfAbsent(gWork, "") == null) { // Insert if not absent (note: no race, no need for atomic)
-          gOld = gWork;                          // Inserted 'gWork' into table
-          gWork = new G(_gbCols.length, _aggs, _medianCounts);   // need entirely new G
-        } else gOld = _gss.getk(gWork);            // Else get existing group
 
-        for (int i = 0; i < _aggs.length; i++) // Accumulate aggregate reductions
-          _aggs[i].op(gOld._dss, gOld._ns, i, cs[_aggs[i]._col].atd(row));
+        synchronized (_gss) {
+          String s = _gss.putIfAbsent(gWork, "");
+          if (s == null) { // Insert if not absent (note: no race, no need for atomic) 
+            gOld = gWork;                          // Inserted 'gWork' into table
+            gWork = new G(_gbCols.length, _aggs, _medianCounts);   // need entirely new G
+          } else gOld = _gss.getk(gWork);          // Else get existing group
+        
+          for (int i = 0; i < _aggs.length; i++) // Accumulate aggregate reductions
+            _aggs[i].op(gOld._dss, gOld._ns, i, cs[_aggs[i]._col].atd(row));
+        }
       }
     }
 

--- a/h2o-core/src/test/java/water/rapids/GroupByTest.java
+++ b/h2o-core/src/test/java/water/rapids/GroupByTest.java
@@ -277,8 +277,8 @@ public class GroupByTest extends TestUtil {
         int teColumnIndex = fr.find(teColumnName);
         int responseColumnIndex = fr.find(responseColumn);
 
-        String tree = String.format("(GB %s [%d] median %s \"all\" sum %s \"all\" nrow %s \"all\")", fr._key,
-                teColumnIndex, responseColumnIndex, responseColumnIndex, responseColumnIndex);
+        String tree = String.format("(GB %s [%d]  sum %s \"all\" nrow %s \"all\")", fr._key,
+                teColumnIndex, responseColumnIndex, responseColumnIndex);
         Val val = Rapids.exec(tree);
         Frame groupedFrame = val.getFrame();
         groupedFrame._key = Key.make();


### PR DESCRIPTION
This PR fixes the race condition caught by Andrey Spiridonov in this JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6319?filter=-1

I fixed the race condition by giving each thread its own IcedHashMap instead of sharing one per node.

I copied over Andrey Spiridonov's groupby test to make sure the fix actually works.