### PR TITLE
PUBDEV-6331: Add parameter appendix entries for new AutoML options

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -32,7 +32,7 @@ One of the following stopping strategies (time or number-of-model based) must be
 
 - `max_runtime_secs <data-science/algo-params/max_runtime_secs.html>`__: This argument controls how long the AutoML will run at the most, before training the final Stacked Ensemble models. Defaults to 3600 seconds (1 hour).
 
-- **max_models**: Specify the maximum number of models to build in an AutoML run, excluding the Stacked Ensemble models.  Defaults to ``NULL/None``. 
+- `max_models <data-science/algo-params/max_models.html>`__: Specify the maximum number of models to build in an AutoML run, excluding the Stacked Ensemble models.  Defaults to ``NULL/None``. 
 
 
 Optional Parameters
@@ -45,7 +45,7 @@ Optional Data Parameters
 
 - `validation_frame <data-science/algo-params/validation_frame.html>`__: This argument is ignored unless ``nfolds == 0``, in which a validation frame can be specified and used for early stopping of individual models and early stopping of the grid searches (unless ``max_models`` or ``max_runtime_secs`` overrides metric-based early stopping).  By default and when ``nfolds > 1``, cross-validation metrics will be used for early stopping and thus ``validation_frame`` will be ignored.
 
-- **leaderboard_frame**: This argument allows the user to specify a particular data frame use to score & rank models on the leaderboard. This frame will not be used for anything besides leaderboard scoring. If a leaderboard frame is not specified by the user, then the leaderboard will use cross-validation metrics instead (or if cross-validation is turned off by setting ``nfolds = 0``, then a leaderboard frame will be generated automatically from the training frame).
+- **leaderboard_frame**: This argument allows the user to specify a particular data frame to use to score and rank models on the leaderboard. This frame will not be used for anything besides leaderboard scoring. If a leaderboard frame is not specified by the user, then the leaderboard will use cross-validation metrics instead, or if cross-validation is turned off by setting ``nfolds = 0``, then a leaderboard frame will be generated automatically from the training frame.
 
 - `fold_column <data-science/algo-params/fold_column.html>`__: Specifies a column with cross-validation fold index assignment per observation. This is used to override the default, randomized, 5-fold cross-validation scheme for individual models in the AutoML run.
 
@@ -64,7 +64,7 @@ Optional Miscellaneous Parameters
 
 - `max_after_balance_size <data-science/algo-params/max_after_balance_size.html>`__: Specify the maximum relative size of the training data after balancing class counts (**balance\_classes** must be enabled). Defaults to 5.0.  (The value can be less than 1.0).
 
-- **max_runtime_secs_per_model**: Specify the max amount of time dedicated to the training of each individual model in the AutoML run. Defaults to 0 (disabled). Note that setting this parameter can affect AutoML reproducibility.
+- `max_runtime_secs_per_model <data-science/algo-params/max_runtime_secs_per_model.html>`__: Specify the max amount of time dedicated to the training of each individual model in the AutoML run. Defaults to 0 (disabled). Note that setting this parameter can affect AutoML reproducibility.
 
 - `stopping_metric <data-science/algo-params/stopping_metric.html>`__: Specifies the metric to use for early stopping of the grid searches and individual models. Defaults to ``"AUTO"``.  The available options are:
 
@@ -100,7 +100,7 @@ Optional Miscellaneous Parameters
 
 - **project_name**: Character string to identify an AutoML project. Defaults to ``NULL/None``, which means a project name will be auto-generated based on the training frame ID.  More models can be trained and added to an existing AutoML project by specifying the same project name in muliple calls to the AutoML function (as long as the same training frame is used in subsequent runs).
 
-- **exclude_algos**: List/vector of character strings naming the algorithms to skip during the model-building phase.  An example use is ``exclude_algos = ["GLM", "DeepLearning", "DRF"]`` in Python or ``exclude_algos = c("GLM", "DeepLearning", "DRF")`` in R.  Defaults to ``None/NULL``, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow.  The algorithm names are:
+- `exclude_algos <data-science/algo-params/exclude_algos.html>`__: A list/vector of character strings naming the algorithms to skip during the model-building phase.  An example use is ``exclude_algos = ["GLM", "DeepLearning", "DRF"]`` in Python or ``exclude_algos = c("GLM", "DeepLearning", "DRF")`` in R.  Defaults to ``None/NULL``, which means that all appropriate H2O algorithms will be used if the search stopping criteria allows and if the ``include_algos`` option is not specified. This option is mutually exclusive with ``include_algos``. The available algorithms are:
 
     - ``DRF`` (This includes both the Random Forest and Extremely Randomized Trees (XRT) models. Refer to the :ref:`xrt` section in the DRF chapter and the `histogram_type <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/histogram_type.html>`__ parameter description for more information.)
     - ``GLM``
@@ -109,7 +109,14 @@ Optional Miscellaneous Parameters
     - ``DeepLearning``  (Fully-connected multi-layer artificial neural network)
     - ``StackedEnsemble``
 
-- **include_algos**: List/vector of character strings naming the algorithms to restrict to during the model-building phase. This can't be used in combination with ``exclude_algos`` param. Defaults to ``None/NULL``: all algorithms are included, except if ``exclude_algos`` parameter is provided.
+- `include_algos <data-science/algo-params/include_algos.html>`__: A list/vector of character strings naming the algorithms to include during the model-building phase.  An example use is ``include_algos = ["GLM", "DeepLearning", "DRF"]`` in Python or ``include_algos = c("GLM", "DeepLearning", "DRF")`` in R.  Defaults to ``None/NULL``, which means that all appropriate H2O algorithms will be used if the search stopping criteria allows and if no algorithms are specified in ``exclude_algos``. This option is mutually exclusive with ``exclude_algos``. The available algorithms are:
+
+    - ``DRF`` (This includes both the Random Forest and Extremely Randomized Trees (XRT) models. Refer to the :ref:`xrt` section in the DRF chapter and the `histogram_type <http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/algo-params/histogram_type.html>`__ parameter description for more information.)
+    - ``GLM``
+    - ``XGBoost``  (XGBoost GBM)
+    - ``GBM``  (H2O GBM)
+    - ``DeepLearning``  (Fully-connected multi-layer artificial neural network)
+    - ``StackedEnsemble``
 
 - `keep_cross_validation_predictions <data-science/algo-params/keep_cross_validation_predictions.html>`__: Specify whether to keep the predictions of the cross-validation predictions. This needs to be set to TRUE if running the same AutoML object for repeated runs because CV predictions are required to build additional Stacked Ensemble models in AutoML. This option defaults to FALSE.
 

--- a/h2o-docs/src/product/data-science/algo-params/exclude_algos.rst
+++ b/h2o-docs/src/product/data-science/algo-params/exclude_algos.rst
@@ -1,0 +1,113 @@
+``exclude_algos``
+-----------------
+
+- Available in: AutoML
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+This option allows you to specify a list of algorithms that should not be included in an AutoML run during the model-building phase. This option defaults to None/Null, which means that  all algorithms are included. However, if the ``include_algos`` option is used, then the AutoML run will include only those specified algorithms. Note that these two options cannot both be specified.
+
+The algorithms that can be specified include:
+
+- DRF (including both the Random Forest and Extremely Randomized Trees (XRT) models)
+- GLM
+- XGBoost (XGBoost GBM)
+- GBM (H2O GBM)
+- DeepLearning (Fully-connected multi-layer artificial neural network)
+- StackedEnsemble
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `include-algos <include_algos.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+   
+
+	library(h2o)
+	h2o.init()
+
+	# Import a sample binary outcome training set into H2O
+	train <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
+
+	# Identify predictors and response
+	x <- setdiff(names(train), y)
+	y <- "response"
+
+	# For binary classification, response should be a factor
+	train[,y] <- as.factor(train[,y])
+
+	# Train AutoML, omitting DeepLearning and DRF
+	aml <- h2o.automl(x = x, y = y,
+	                  training_frame = train,
+	                  max_runtime_secs = 30,
+	                  sort_metric = "logloss",
+	                  exclude_algos = c("DeepLearning", "DRF"))
+
+	# View the AutoML Leaderboard
+	lb <- aml@leaderboard
+	lb
+
+	                                             model_id       auc   logloss
+	1    StackedEnsemble_AllModels_AutoML_20190321_095825 0.7866967 0.5550255
+	2 StackedEnsemble_BestOfFamily_AutoML_20190321_095825 0.7848515 0.5569458
+	3                    XGBoost_1_AutoML_20190321_095825 0.7846668 0.5578654
+	4                    XGBoost_2_AutoML_20190321_095825 0.7820392 0.5586830
+	5           GLM_grid_1_AutoML_20190321_095825_model_1 0.6826481 0.6385205
+	  mean_per_class_error      rmse       mse
+	1            0.3309041 0.4338530 0.1882284
+	2            0.3231440 0.4346720 0.1889397
+	3            0.3324049 0.4349659 0.1891953
+	4            0.3269806 0.4356756 0.1898132
+	5            0.3972341 0.4726827 0.2234290
+
+	[5 rows x 6 columns] 
+
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.automl import H2OAutoML
+	h2o.init()
+
+	# Import a sample binary outcome training set into H2O
+	train = h2o.import_file("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
+
+	# Identify predictors and response
+	x = train.columns
+	y = "response"
+	x.remove(y)
+
+	# For binary classification, response should be a factor
+	train[y] = train[y].asfactor()
+
+	# Train AutoML, omitting DeepLearning and DRF
+	aml = H2OAutoML(max_runtime_secs = 30, sort_metric = "logloss",
+	                exclude_algos = ["DeepLearning", "DRF"])
+	aml.train(x = x, y = y, training_frame = train)
+
+	# View the AutoML Leaderboard
+	lb = aml.leaderboard
+	lb
+
+	model_id                                                 auc    logloss    mean_per_class_error      rmse       mse
+	--------------------------------------------------  --------  ---------  ----------------------  --------  --------
+	DRF_1_AutoML_20190321_100107                        0.744882   0.597348                0.360293  0.452093  0.204388
+	XRT_1_AutoML_20190321_095341                        0.741603   0.60012                 0.342847  0.453342  0.205519
+	XRT_1_AutoML_20190321_100107                        0.740636   0.600695                0.356075  0.453646  0.205795
+	DRF_1_AutoML_20190321_095341                        0.740674   0.60294                 0.375423  0.453271  0.205454
+	DeepLearning_grid_1_AutoML_20190321_095341_model_1  0.711473   0.620394                0.387857  0.463987  0.215284
+	DeepLearning_1_AutoML_20190321_100107               0.703753   0.628472                0.401192  0.467294  0.218363
+	GLM_grid_1_AutoML_20190321_095341_model_1           0.682648   0.63852                 0.397234  0.472683  0.223429
+	GLM_grid_1_AutoML_20190321_100107_model_1           0.682648   0.63852                 0.397234  0.472683  0.223429
+	DeepLearning_1_AutoML_20190321_095341               0.684733   0.639195                0.418683  0.472425  0.223185
+	DeepLearning_grid_1_AutoML_20190321_100107_model_1  0.670713   0.643133                0.434458  0.475507  0.226107
+
+	[10 rows x 6 columns]
+

--- a/h2o-docs/src/product/data-science/algo-params/include_algos.rst
+++ b/h2o-docs/src/product/data-science/algo-params/include_algos.rst
@@ -1,0 +1,107 @@
+``include_algos``
+-----------------
+
+- Available in: AutoML
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+This option allows you to specify a list of algorithms to include in an AutoML run during the model-building phase. This option defaults to None/Null, which means that  all algorithms are included unless any algorithms are specified in the ``exclude_algos`` option. Note that these two options cannot both be specified.
+
+The algorithms that can be specified include:
+
+- DRF (including both the Random Forest and Extremely Randomized Trees (XRT) models)
+- GLM
+- XGBoost (XGBoost GBM)
+- GBM (H2O GBM)
+- DeepLearning (Fully-connected multi-layer artificial neural network)
+- StackedEnsemble
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `exclude-algos <exclude_algos.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+   
+
+	library(h2o)
+	h2o.init()
+
+	# Import a sample binary outcome training set into H2O
+	train <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
+
+	# Identify predictors and response
+	x <- setdiff(names(train), y)
+	y <- "response"
+
+	# For binary classification, response should be a factor
+	train[,y] <- as.factor(train[,y])
+
+	# Train AutoML using only GLM, DeepLearning, and DRF
+	aml <- h2o.automl(x = x, y = y,
+	                  training_frame = train,
+	                  max_runtime_secs = 30,
+	                  sort_metric = "logloss",
+	                  include_algos = c("GLM", "DeepLearning", "DRF"))
+
+	# View the AutoML Leaderboard
+	lb <- aml@leaderboard
+	lb
+
+	                                            model_id       auc   logloss
+	1                       XRT_1_AutoML_20190321_094944 0.7402090 0.6051397
+	2                       DRF_1_AutoML_20190321_094944 0.7431221 0.6057202
+	3              DeepLearning_1_AutoML_20190321_094944 0.6994255 0.6309644
+	4          GLM_grid_1_AutoML_20190321_094944_model_1 0.6826481 0.6385205
+	5 DeepLearning_grid_1_AutoML_20190321_094944_model_1 0.6707953 0.7042976
+	  mean_per_class_error      rmse       mse
+	1            0.3545519 0.4539312 0.2060535
+	2            0.3683363 0.4527405 0.2049739
+	3            0.3892368 0.4687153 0.2196940
+	4            0.3972341 0.4726827 0.2234290
+	5            0.4385448 0.4911634 0.2412415
+
+	[5 rows x 6 columns] 
+
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.automl import H2OAutoML
+	h2o.init()
+
+	# Import a sample binary outcome training set into H2O
+	train = h2o.import_file("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
+
+	# Identify predictors and response
+	x = train.columns
+	y = "response"
+	x.remove(y)
+
+	# For binary classification, response should be a factor
+	train[y] = train[y].asfactor()
+
+	# Train AutoML using only GLM, DeepLearning, and DRF
+	aml = H2OAutoML(max_runtime_secs = 30, sort_metric = "logloss",
+	                include_algos = ["GLM", "DeepLearning", "DRF"])
+	aml.train(x = x, y = y, training_frame = train)
+
+	# View the AutoML Leaderboard
+	lb = aml.leaderboard
+	lb
+
+	model_id                                                 auc    logloss    mean_per_class_error      rmse       mse
+	--------------------------------------------------  --------  ---------  ----------------------  --------  --------
+	XRT_1_AutoML_20190321_095341                        0.741603   0.60012                 0.342847  0.453342  0.205519
+	DRF_1_AutoML_20190321_095341                        0.740674   0.60294                 0.375423  0.453271  0.205454
+	DeepLearning_grid_1_AutoML_20190321_095341_model_1  0.711473   0.620394                0.387857  0.463987  0.215284
+	GLM_grid_1_AutoML_20190321_095341_model_1           0.682648   0.63852                 0.397234  0.472683  0.223429
+	DeepLearning_1_AutoML_20190321_095341               0.684733   0.639195                0.418683  0.472425  0.223185
+
+	[5 rows x 6 columns]

--- a/h2o-docs/src/product/data-science/algo-params/max_models.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_models.rst
@@ -1,0 +1,97 @@
+``max_models``
+--------------
+
+- Available in: AutoML
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+Use this option to specify the maximum number of models to build in the AutoML run, excluding the Stacked Ensemble models. This option defaults to Null/None.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `max_runtime_secs <max_runtime_secs.html>`__
+- `max_runtime_secs_per_model <max_runtime_secs_per_model.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# Import the prostate dataset
+	prostate <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip")
+
+	# Set the predictor names and the response column name
+	y <- "CAPSULE"
+	x <- setdiff(names(prostate), c(p_y, "ID"))
+
+	# Train AutoML
+	aml <- h2o.automl(x = x,
+	                  y = y,
+	                  training_frame = prostate,
+	                  seed = 1234,
+	                  max_models = 5,
+	                  max_runtime_secs = 200,
+	                  max_runtime_secs_per_model = 40)
+
+	# View the AutoML Leaderboard
+	lb <- aml@leaderboard
+	lb
+
+		                                             model_id mean_residual_deviance
+	1 StackedEnsemble_BestOfFamily_AutoML_20190321_110032           0.0009730593
+	2    StackedEnsemble_AllModels_AutoML_20190321_110032           0.0009730593
+	3                        DRF_1_AutoML_20190321_110032           0.0012766064
+	4                        XRT_1_AutoML_20190321_110032           0.0038347775
+	5                    XGBoost_2_AutoML_20190321_110032           0.0064206276
+	6                    XGBoost_1_AutoML_20190321_110032           0.0544174809
+	        rmse          mse        mae      rmsle
+	1 0.03119390 0.0009730593 0.02086672 0.02368844
+	2 0.03119390 0.0009730593 0.02086672 0.02368844
+	3 0.03572963 0.0012766064 0.01406001 0.02661268
+	4 0.06192558 0.0038347775 0.03330358 0.04958889
+	5 0.08012882 0.0064206276 0.06873394 0.06112533
+	6 0.23327555 0.0544174809 0.18390358 0.16640402
+
+	[7 rows x 6 columns] 
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.automl import H2OAutoML
+	h2o.init()
+
+	# Import a sample binary outcome training set into H2O
+	prostate = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip")
+
+	# Set the predictor names and the response column name
+	response = "CAPSULE"
+	predictor = prostate.names[2:9]
+
+	# Train AutoML
+	aml = H2OAutoML(max_models = 5,
+	                max_runtime_secs = 200,
+	                max_runtime_secs_per_model = 40,
+	                seed = 1234)
+	aml.train(x = predictor, y = response, training_frame = prostate)
+
+	# View the AutoML Leaderboard
+	lb = aml.leaderboard
+	lb
+	model_id                                               mean_residual_deviance       rmse          mse        mae      rmsle
+	---------------------------------------------------  ------------------------  ---------  -----------  ---------  ---------
+	StackedEnsemble_AllModels_AutoML_20190321_111608                  0.000282073  0.016795   0.000282073  0.0103226  0.0129982
+	StackedEnsemble_BestOfFamily_AutoML_20190321_111608               0.000282073  0.016795   0.000282073  0.0103226  0.0129982
+	DRF_1_AutoML_20190321_111608                                      0.000334287  0.0182835  0.000334287  0.0076525  0.0140754
+	XRT_1_AutoML_20190321_111608                                      0.0015397    0.039239   0.0015397    0.0217268  0.0293752
+	XGBoost_2_AutoML_20190321_111608                                  0.0118094    0.108671   0.0118094    0.0888375  0.0804565
+	XGBoost_1_AutoML_20190321_111608                                  0.0675672    0.259937   0.0675672    0.213536   0.184793
+	GLM_grid_1_AutoML_20190321_111608_model_1                         0.193551     0.439944   0.193551     0.397327   0.306996
+
+	[7 rows x 6 columns]

--- a/h2o-docs/src/product/data-science/algo-params/max_runtime_secs_per_model.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_runtime_secs_per_model.rst
@@ -1,0 +1,104 @@
+``max_runtime_secs_per_model``
+------------------------------
+
+- Available in: AutoML
+- Hyperparameter: no
+
+Description
+~~~~~~~~~~~
+
+Use this option to specify the maximum amount of seconds dedicated to the training of each individual model in the AutoML run. This option defaults to 0 (disabled). Note that setting this parameter can affect AutoML reproducibility.
+
+Related Parameters
+~~~~~~~~~~~~~~~~~~
+
+- `max_runtime_secs <max_runtime_secs.html>`__
+- `max_models <max_models.html>`__
+
+Example
+~~~~~~~
+
+.. example-code::
+   .. code-block:: r
+
+	library(h2o)
+	h2o.init()
+
+	# Import the prostate dataset
+	prostate <- h2o.importFile("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip")
+
+	# Set the predictor names and the response column name
+	y <- "CAPSULE"
+	x <- setdiff(names(prostate), c(p_y, "ID"))
+
+	# Train AutoML
+	aml <- h2o.automl(x = x,
+	                  y = y,
+	                  training_frame = prostate,
+	                  seed = 1234,
+	                  max_models = 5,
+	                  max_runtime_secs = 200,
+	                  max_runtime_secs_per_model = 40)
+
+	# View the AutoML Leaderboard
+	lb <- aml@leaderboard
+	lb
+
+		                                             model_id mean_residual_deviance
+	1 StackedEnsemble_BestOfFamily_AutoML_20190321_110032           0.0009730593
+	2    StackedEnsemble_AllModels_AutoML_20190321_110032           0.0009730593
+	3                        DRF_1_AutoML_20190321_110032           0.0012766064
+	4                        XRT_1_AutoML_20190321_110032           0.0038347775
+	5                    XGBoost_2_AutoML_20190321_110032           0.0064206276
+	6                    XGBoost_1_AutoML_20190321_110032           0.0544174809
+	        rmse          mse        mae      rmsle
+	1 0.03119390 0.0009730593 0.02086672 0.02368844
+	2 0.03119390 0.0009730593 0.02086672 0.02368844
+	3 0.03572963 0.0012766064 0.01406001 0.02661268
+	4 0.06192558 0.0038347775 0.03330358 0.04958889
+	5 0.08012882 0.0064206276 0.06873394 0.06112533
+	6 0.23327555 0.0544174809 0.18390358 0.16640402
+
+	[7 rows x 6 columns] 
+
+   .. code-block:: python
+
+	import h2o
+	from h2o.automl import H2OAutoML
+	h2o.init()
+
+	# Import a sample binary outcome training set into H2O
+	prostate = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip")
+
+	# Set the predictor names and the response column name
+	response = "CAPSULE"
+	predictor = prostate.names[2:9]
+
+	# Train AutoML
+	aml = H2OAutoML(max_models = 5,
+	                max_runtime_secs = 200,
+	                max_runtime_secs_per_model = 40,
+	                seed = 1234)
+	aml.train(x = predictor, y = response, training_frame = prostate)
+
+	# View the AutoML Leaderboard
+	lb = aml.leaderboard
+	lb
+	model_id                                               mean_residual_deviance       rmse          mse        mae      rmsle
+	---------------------------------------------------  ------------------------  ---------  -----------  ---------  ---------
+	StackedEnsemble_AllModels_AutoML_20190321_111608                  0.000282073  0.016795   0.000282073  0.0103226  0.0129982
+	StackedEnsemble_BestOfFamily_AutoML_20190321_111608               0.000282073  0.016795   0.000282073  0.0103226  0.0129982
+	DRF_1_AutoML_20190321_111608                                      0.000334287  0.0182835  0.000334287  0.0076525  0.0140754
+	XRT_1_AutoML_20190321_111608                                      0.0015397    0.039239   0.0015397    0.0217268  0.0293752
+	XGBoost_2_AutoML_20190321_111608                                  0.0118094    0.108671   0.0118094    0.0888375  0.0804565
+	XGBoost_1_AutoML_20190321_111608                                  0.0675672    0.259937   0.0675672    0.213536   0.184793
+	GLM_grid_1_AutoML_20190321_111608_model_1                         0.193551     0.439944   0.193551     0.397327   0.306996
+
+	[7 rows x 6 columns]
+
+
+
+
+
+
+

--- a/h2o-docs/src/product/data-science/algo-params/sort_metric.rst
+++ b/h2o-docs/src/product/data-science/algo-params/sort_metric.rst
@@ -33,16 +33,15 @@ Example
    .. code-block:: r
    
 
-	library(h2o)
-
+	library(h2o)\
 	h2o.init()
 
 	# Import a sample binary outcome training set into H2O
 	train <- h2o.importFile("https://s3.amazonaws.com/erin-data/higgs/higgs_train_10k.csv")
 
 	# Identify predictors and response
-	y <- "response"
 	x <- setdiff(names(train), y)
+	y <- "response"
 
 	# For binary classification, response should be a factor
 	train[,y] <- as.factor(train[,y])
@@ -78,7 +77,6 @@ Example
 
 	import h2o
 	from h2o.automl import H2OAutoML
-
 	h2o.init()
 
 	# Import a sample binary outcome training set into H2O

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -38,6 +38,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/eps_prob
    data-science/algo-params/eps_sdev
    data-science/algo-params/estimate_k
+   data-science/algo-params/exclude_algos
    data-science/algo-params/family
    data-science/algo-params/fold_assignment
    data-science/algo-params/fold_column
@@ -47,6 +48,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/ignore_const_cols
    data-science/algo-params/ignored_columns
    data-science/algo-params/impute_missing
+   data-science/algo-params/include_algos
    data-science/algo-params/init
    data-science/algo-params/interaction_pairs
    data-science/algo-params/interactions
@@ -68,7 +70,9 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/max_depth
    data-science/algo-params/max_hit_ratio_k
    data-science/algo-params/max_iterations
+   data-science/algo-params/max_models
    data-science/algo-params/max_runtime_secs
+   data-science/algo-params/max_runtime_secs_per_model
    data-science/algo-params/metalearner_algorithm
    data-science/algo-params/metalearner_params
    data-science/algo-params/min_prob


### PR DESCRIPTION
- Added examples for include_algos, exclude_algos, max_models, and max_runtime_secs_per_model.
- Added links to these new topics in the AutoML chapter