### PR TITLE
Standardisation investigation

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -926,6 +926,7 @@ public class DataInfo extends Keyed<DataInfo> {
     }
     public void setResponse(int i, double z) {response[i] = z;}
 
+    // TODO this method is not being used
     public void standardize(double[] normSub, double[] normMul) {
       if(numIds == null){
         for(int i = 0; i < numVals.length; ++i)
@@ -1058,6 +1059,8 @@ public class DataInfo extends Keyed<DataInfo> {
         double d = chunks[_cats + i].atd(rid); // can be NA if skipMissing() == false
         if (Double.isNaN(d))
           d = _numMeans[numValsIdx];
+        
+        // Here is where standardisation happens
         if (_normMul != null && _normSub != null)
           d = (d - _normSub[numValsIdx]) * _normMul[numValsIdx];
         row.numVals[numValsIdx++] = d;

--- a/h2o-algos/src/main/java/hex/api/MakeGLMModelHandler.java
+++ b/h2o-algos/src/main/java/hex/api/MakeGLMModelHandler.java
@@ -14,6 +14,7 @@ import water.api.Handler;
 import water.api.schemas3.KeyV3;
 import water.fvec.*;
 import water.fvec.Vec.VectorGroup;
+import water.util.TwoDimTable;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -63,6 +64,7 @@ public class MakeGLMModelHandler extends Handler {
 
   public static Frame oneHot(Frame fr, Model.InteractionSpec interactions, boolean useAll, boolean standardize, final boolean interactionsOnly, final boolean skipMissing) {
     final DataInfo dinfo = new DataInfo(fr,null,1,useAll,standardize?TransformType.STANDARDIZE:TransformType.NONE,TransformType.NONE,skipMissing,false,false,false,false,false, interactions);
+    
     Frame res;
     if( interactionsOnly ) {
       if( null==dinfo._interactionVecs ) throw new IllegalArgumentException("no interactions");
@@ -120,6 +122,7 @@ public class MakeGLMModelHandler extends Handler {
         }
       }.doAll(types, dinfo._adaptedFrame.vecs()).outputFrame(Key.make("OneHot"+Key.make().toString()), dinfo.coefNames(), null);
     }
+     printOutFrameAsTable(res, true, 20);
     dinfo.dropInteractions();
     dinfo.remove();
     return res;
@@ -163,5 +166,20 @@ public class MakeGLMModelHandler extends Handler {
     input.destination_frame.fillFromImpl(k);
     DKV.put(new Frame(k, names,vecs));
     return input;
+  }
+
+
+  public static void printOutFrameAsTable(Frame fr, boolean rollups, long limit) {
+    assert limit <= Integer.MAX_VALUE;
+    TwoDimTable twoDimTable = fr.toTwoDimTable(0, (int) limit, rollups);
+    System.out.println(twoDimTable.toString(2, true));
+  }
+
+  public void printOutColumnsMetadata(Frame fr) {
+    for (String header : fr.toTwoDimTable().getColHeaders()) {
+      String type = fr.vec(header).get_type_str();
+      int cardinality = fr.vec(header).cardinality();
+      System.out.println(header + " - " + type + String.format("; Cardinality = %d", cardinality));
+    }
   }
 }

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1127,8 +1127,10 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           DataInfo activeData = _state.activeData();
           double [] beta_nostd = activeData.denormalizeBeta(beta);
           DataInfo.TransformType transform = activeData._predictor_transform;
+          // TODO Why are we disabling Transform in the block where we want to standardize?
           activeData.setPredictorTransform(DataInfo.TransformType.NONE);
           Gram g = new GLMIterationTask(_job._key,activeData,new GLMWeightsFun(_parms),beta_nostd).doAll(activeData._adaptedFrame)._gram;
+          // TODO enabling it back...see hotfix comments to the commit affd062d9d842a4f5a7d7fa9908107ef7b9e0e34
           activeData.setPredictorTransform(transform); // just in case, restore the trasnform
           g.mul(_parms._obj_reg);
           chol = g.cholesky(null);

--- a/h2o-algos/src/test/java/hex/DataInfoTest.java
+++ b/h2o-algos/src/test/java/hex/DataInfoTest.java
@@ -11,6 +11,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static org.junit.Assert.*;
+
 
 // test cases:
 // skipMissing = TRUE/FALSE
@@ -32,7 +34,7 @@ public class DataInfoTest extends TestUtil {
               null,        // valid
               1,           // num responses
               true,        // use all factor levels
-              DataInfo.TransformType.STANDARDIZE,  // predictor transform
+              DataInfo.TransformType.NONE,  // predictor transform
               DataInfo.TransformType.NONE,         // response  transform
               true,        // skip missing
               false,       // impute missing
@@ -64,7 +66,7 @@ public class DataInfoTest extends TestUtil {
               null,        // valid
               1,           // num responses
               true,        // use all factor levels
-              DataInfo.TransformType.STANDARDIZE,  // predictor transform
+              DataInfo.TransformType.DEMEAN,  // predictor transform
               DataInfo.TransformType.NONE,         // response  transform
               true,        // skip missing
               false,       // impute missing
@@ -84,7 +86,7 @@ public class DataInfoTest extends TestUtil {
               null,        // valid
               1,           // num responses
               true,        // use all factor levels
-              DataInfo.TransformType.STANDARDIZE,  // predictor transform
+              DataInfo.TransformType.NONE,  // predictor transform
               DataInfo.TransformType.NONE,         // response  transform
               true,        // skip missing
               false,       // impute missing
@@ -118,7 +120,7 @@ public class DataInfoTest extends TestUtil {
               null,        // valid
               1,           // num responses
               false,        // use all factor levels
-              DataInfo.TransformType.STANDARDIZE,  // predictor transform
+              DataInfo.TransformType.DEMEAN,  // predictor transform
               DataInfo.TransformType.NONE,         // response  transform
               true,        // skip missing
               false,       // impute missing
@@ -611,5 +613,43 @@ public class DataInfoTest extends TestUtil {
         }
       }
     }.doAll(di._adaptedFrame);
+  }
+
+  @Test
+  public void dataInfoTransformsDataTest() {
+    
+    Frame fr = new TestFrameBuilder()
+            .withName("testFrame")
+            .withColNames("ColA", "response")
+            .withVecTypes(Vec.T_NUM, Vec.T_NUM)
+            .withDataForCol(0, ar(1, 3, 6))
+            .withDataForCol(1, ar(5, 10, 7))
+            .build();
+    try {
+      DataInfo di = new DataInfo(
+              fr.clone(),
+              null,
+              1, //nResponses
+              true,
+              DataInfo.TransformType.STANDARDIZE, //do not standardize
+              DataInfo.TransformType.NONE, //do not standardize response
+              false, //whether to skip missing
+              false, // do not replace NAs in numeric cols with mean
+              false,  // always add a bucket for missing values
+              false, // observation weights
+              false,
+              false,
+              false
+      );
+//      DKV.put(di._key, di._adaptedFrame);
+      
+      printOutFrameAsTable(fr, true, 10);
+      printOutFrameAsTable(di._adaptedFrame, true, 10);
+      assertTrue(isBitIdentical(fr, di._adaptedFrame));
+      fail();
+    } catch (AssertionError ex) {
+      System.out.println("!!!!!!!!!!! Frames are identical. Is it expected here? ");
+      fr.delete();
+    }
   }
 }

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestRegression.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestRegression.java
@@ -124,7 +124,7 @@ public class GLMBasicTestRegression extends TestUtil {
     parms._ignored_columns = new String[]{"C1"};
 //    parms._remove_collinear_columns = true;
     parms._response_column = "IsDepDelayed";
-    parms._standardize = true;
+    parms._standardize = true; // if we change here then it will fail
     parms._objective_epsilon = 0;
     parms._gradient_epsilon = 1e-10;
     parms._max_iterations = 1000;
@@ -145,7 +145,7 @@ public class GLMBasicTestRegression extends TestUtil {
     parms._train = _weighted._key;
     parms._ignored_columns = new String[]{_weighted.name(0)};
     parms._response_column = _weighted.name(1);
-    parms._standardize = true;
+    parms._standardize = false;
     parms._objective_epsilon = 0;
     parms._gradient_epsilon = 1e-10;
     parms._max_iterations = 1000;
@@ -189,7 +189,7 @@ public class GLMBasicTestRegression extends TestUtil {
     parms._train = _weighted._key;
     parms._ignored_columns = new String[]{_weighted.name(0)};
     parms._response_column = _weighted.name(1);
-    parms._standardize = true;
+    parms._standardize = false;
     parms._objective_epsilon = 0;
     parms._gradient_epsilon = 1e-10;
     parms._max_iterations = 1000;
@@ -201,7 +201,7 @@ public class GLMBasicTestRegression extends TestUtil {
       parms._solver = s;
       parms._offset_column = "C20";
       parms._compute_p_values = true;
-      parms._standardize = false;
+      parms._standardize = true;
       model1 = new GLM(parms).trainModel().get();
       HashMap<String, Double> coefs1 = model1.coefficients();
       System.out.println("coefs1 = " + coefs1);
@@ -341,7 +341,7 @@ public class GLMBasicTestRegression extends TestUtil {
     parms._ignored_columns = new String[]{};
     // "response_column":"Claims","offset_column":"logInsured"
     parms._response_column = "Infections";
-    parms._standardize = false;
+    parms._standardize = true;
     parms._lambda = new double[]{0};
     parms._alpha = new double[]{0};
     parms._gradient_epsilon = 1e-10;
@@ -404,7 +404,7 @@ public class GLMBasicTestRegression extends TestUtil {
       // "response_column":"Claims","offset_column":"logInsured"
       parms._response_column = "Claims";
       parms._offset_column = "logInsured";
-      parms._standardize = false;
+      parms._standardize = true;
       parms._lambda = new double[]{0};
       parms._alpha = new double[]{0};
       parms._objective_epsilon = 0;
@@ -486,7 +486,7 @@ public class GLMBasicTestRegression extends TestUtil {
     parms._tweedie_variance_power = 1.5;
     parms._tweedie_link_power = 1 - parms._tweedie_variance_power;
     parms._train = _earinf._key;
-    parms._standardize = false;
+    parms._standardize = true;
     parms._lambda = new double[]{0};
     parms._alpha = new double[]{0};
     parms._response_column = "Infections";
@@ -558,7 +558,7 @@ public class GLMBasicTestRegression extends TestUtil {
 
     GLMParameters parms = new GLMParameters(Family.poisson);
     parms._train = _canCarTrain._key;
-    parms._standardize = false;
+    parms._standardize = true;
     parms._lambda = new double[]{0};
     parms._alpha = new double[]{0};
     parms._response_column = "Claims";
@@ -641,7 +641,7 @@ public class GLMBasicTestRegression extends TestUtil {
 //    Number of Fisher Scoring iterations: 2
     GLMParameters params = new GLMParameters(Family.gaussian);
     params._response_column = "CAPSULE";
-    params._standardize = false;
+    params._standardize = true;
     params._train = _prostateTrain._key;
     params._compute_p_values = true;
     params._lambda = new double[]{0};
@@ -762,10 +762,12 @@ public class GLMBasicTestRegression extends TestUtil {
 //    VOL         -0.18129997  0.1620383 -1.11887108 2.631951e-01
 //    GLEASON      0.91750972  0.1963285  4.67333842 2.963429e-06
 
-    params._standardize = true;
+    //TODO Comment above says that following section is about STANDARDIZED case but when we disable it test still passes. Looks like tolerance is not small enough
+    params._standardize = false;
 
     try {
-      model = new GLM(params).trainModel().get();
+      GLM glm1 = new GLM(params);
+      model = glm1.trainModel().get();
       String[] names_expected = new String[]{"Intercept", "ID", "AGE", "RACE.R2", "RACE.R3", "DPROS.b", "DPROS.c", "DPROS.d", "DCAPS.b", "PSA", "VOL", "GLEASON"};
       // do not compare std_err here, depends on the coefficients
 //      double[] stder_expected = new double[]{1.5687858,   0.1534062,   0.1449847,   1.5423974, 1.5827190,   0.3950883,   0.4161974,  0.5426512,   0.5179591,   0.2244733, 0.1620383,   0.1963285};
@@ -782,7 +784,7 @@ public class GLMBasicTestRegression extends TestUtil {
       double[] pvals_actual = model._output.pValues();
       for (int i = 0; i < zvals_expected.length; ++i) {
         int id = coefMap.get(names_actual[i]);
-        assertEquals(zvals_expected[id], zvals_actual[i], Math.abs(zvals_expected[id]) * 1e-5);
+        assertEquals(zvals_expected[id], zvals_actual[i], Math.abs(zvals_expected[id]) * 1e-7);
         assertEquals(pvals_expected[id], pvals_actual[i], pvals_expected[id] * 1e-3);
       }
       predict = model.score(params._train.get());
@@ -797,7 +799,7 @@ public class GLMBasicTestRegression extends TestUtil {
     }
 
     // Airlines (has collinear columns)
-    params._standardize = true;
+    params._standardize = false;
     params._remove_collinear_columns = true;
     params._train = _airlines._key;
     params._response_column = "IsDepDelayed";

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -160,7 +160,7 @@ public class GLMTest  extends TestUtil {
       // params._response = 1;
       params._response_column = fr._names[1];
       params._lambda = new double[]{0};
-      params._standardize = false;
+      params._standardize = true;
       model = new GLM(params).trainModel().get();
       for (double c : model.beta())
         assertEquals(Math.log(2), c, 1e-2); // only 1e-2 precision cause the perfect solution is too perfect -> will trigger grid search
@@ -176,7 +176,7 @@ public class GLMTest  extends TestUtil {
       // params2._response = 1;
       params2._response_column = fr._names[1];
       params2._lambda = new double[]{0};
-      params2._standardize = true;
+      params2._standardize = false;
       params2._beta_epsilon = 1e-5;
       model = new GLM(params2).trainModel().get();
       assertEquals(0.3396, model.beta()[1], 1e-1);
@@ -624,7 +624,7 @@ public class GLMTest  extends TestUtil {
     try {
       // H2O differs on intercept and race, same residual deviance though
       GLMParameters params = new GLMParameters();
-      params._standardize = true;
+      params._standardize = false;
       params._family = Family.binomial;
       params._beta_constraints = betaConstraints._key;
       params._response_column = "CAPSULE";
@@ -692,7 +692,7 @@ public class GLMTest  extends TestUtil {
     try {
       // H2O differs on intercept and race, same residual deviance though
       GLMParameters params = new GLMParameters();
-      params._standardize = true;
+      params._standardize = false;
       params._family = Family.binomial;
       params._solver = Solver.COORDINATE_DESCENT_NAIVE;
       params._response_column = "IsDepDelayed";
@@ -721,7 +721,7 @@ public class GLMTest  extends TestUtil {
     try {
       // H2O differs on intercept and race, same residual deviance though
       GLMParameters params = new GLMParameters();
-      params._standardize = true;
+      params._standardize = false;
       params._family = Family.binomial;
       params._solver = Solver.COORDINATE_DESCENT;
       params._response_column = "IsDepDelayed";
@@ -748,7 +748,7 @@ public class GLMTest  extends TestUtil {
     try {
       // H2O differs on intercept and race, same residual deviance though
       GLMParameters params = new GLMParameters();
-      params._standardize = true;
+      params._standardize = false;
       params._family = Family.gaussian;
       params._solver = Solver.COORDINATE_DESCENT_NAIVE;
       params._response_column = "C1";


### PR DESCRIPTION
I was looking for a way to standardise frames in Java, found DataInfo class but there is no usages for method `standardise`. What I found out is that `DataInfo._adaptedFrame` does not contain data with applied transformations(e.g. standardisation). We need to use `extractDenseRow()` method to get it.

But what is strange is that most of the tests that look like they have to depend on standardised parameter pass regardless of whether we enabled it or not. 

PS don't pay attention to the name of the branch. It is probably working but tests are not checking this