### PR TITLE
PUBDEV-6367 - Overridable non-data line markers

### DIFF
--- a/h2o-bindings/src/main/java/water/bindings/examples/Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/Example.java
@@ -108,6 +108,7 @@ public class Example {
                                                                   0,
                                                                   0,
                                                                   null,
+                                                                  null,
                                                                   null).execute().body();
             System.out.println("parseSetupBody: " + parseSetupBody);
 
@@ -131,6 +132,7 @@ public class Example {
                                                    parseSetupBody.chunkSize,
                                                    true,
                                                    true,
+                                                   null,
                                                    null, null).execute().body();
             System.out.println("parseBody: " + parseBody);
 

--- a/h2o-core/src/main/java/water/api/ParseHandler.java
+++ b/h2o-core/src/main/java/water/api/ParseHandler.java
@@ -22,7 +22,8 @@ class ParseHandler extends Handler {
                                       parse.domains, parse.na_strings,
                                       null,
                                       new ParseWriter.ParseErr[0], parse.chunk_size,
-                                      parse.decrypt_tool != null ? parse.decrypt_tool.key() : null, parse.skipped_columns);
+                                      parse.decrypt_tool != null ? parse.decrypt_tool.key() : null, parse.skipped_columns,
+                                      parse.custom_non_data_line_markers != null ? parse.custom_non_data_line_markers.getBytes(): null);
 
     if (parse.source_frames == null) throw new H2OIllegalArgumentException("Data for Frame '" + parse.destination_frame.name + "' is not available. Please check that the path is valid (for all H2O nodes).'");
     Key[] srcs = new Key[parse.source_frames.length];

--- a/h2o-core/src/main/java/water/api/schemas3/ParseSetupV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ParseSetupV3.java
@@ -73,6 +73,9 @@ public class ParseSetupV3 extends RequestSchemaV3<ParseSetup, ParseSetupV3> {
   @API(help="Total number of columns we would return with no column pagination", direction=API.Direction.INOUT)
   public int total_filtered_column_count;
 
+  @API(help="Custom characters to be treated as non-data line markers", direction=API.Direction.INOUT)
+  public String custom_non_data_line_markers;
+
   @API(help="Key-reference to an initialized instance of a Decryption Tool")
   public KeyV3.DecryptionToolKeyV3 decrypt_tool;
 

--- a/h2o-core/src/main/java/water/api/schemas3/ParseV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ParseV3.java
@@ -56,6 +56,9 @@ public class ParseV3 extends RequestSchemaV3<Iced, ParseV3> {
   @API(help="Key-reference to an initialized instance of a Decryption Tool")
   public KeyV3.DecryptionToolKeyV3 decrypt_tool;
 
+  @API(help="Custom characters to be treated as non-data line markers", direction=API.Direction.INPUT)
+  public String custom_non_data_line_markers;
+
   // Output fields
   @API(help="Parse job", direction=API.Direction.OUTPUT)
   public JobV3 job;

--- a/h2o-core/src/main/java/water/parser/ARFFParser.java
+++ b/h2o-core/src/main/java/water/parser/ARFFParser.java
@@ -31,7 +31,8 @@ class ARFFParser extends CsvParser {
   static ParseSetup guessSetup(ByteVec bv, byte[] bits, byte sep, boolean singleQuotes, String[] columnNames, String[][] naStrings,
                                byte[] nonDataLineMarkers) {
     if (columnNames != null) throw new UnsupportedOperationException("ARFFParser doesn't accept columnNames.");
-    if(nonDataLineMarkers == null) nonDataLineMarkers = NON_DATA_LINE_MARKERS_DEFAULT;
+    if (nonDataLineMarkers == null)
+      nonDataLineMarkers = NON_DATA_LINE_MARKERS_DEFAULT;
 
     // Parse all lines starting with @ until EOF or @DATA
     boolean haveData = false;
@@ -134,7 +135,7 @@ class ARFFParser extends CsvParser {
     naStrings = addDefaultNAs(naStrings, ncols);
 
     // Return the final setup
-    return new ParseSetup(ARFF_INFO, sep, singleQuotes, ParseSetup.NO_HEADER, ncols, labels, ctypes, domains, naStrings, data);
+    return new ParseSetup(ARFF_INFO, sep, singleQuotes, ParseSetup.NO_HEADER, ncols, labels, ctypes, domains, naStrings, data, nonDataLineMarkers);
   }
 
   private static String[][] addDefaultNAs(String[][] naStrings, int nCols) {

--- a/h2o-core/src/main/java/water/parser/ARFFParser.java
+++ b/h2o-core/src/main/java/water/parser/ARFFParser.java
@@ -19,13 +19,7 @@ class ARFFParser extends CsvParser {
   private static final byte GUESS_SEP = ParseSetup.GUESS_SEP;
   private static final byte[] NON_DATA_LINE_MARKERS_DEFAULT = {'%', '@'};
 
-  ARFFParser(ParseSetup ps, Key jobKey) { super(ps, jobKey); }
-
-  @Override
-  protected byte[] nonDataLineMarkersDefault() {
-    return NON_DATA_LINE_MARKERS_DEFAULT;
-  }
-
+  ARFFParser(ParseSetup ps, Key jobKey) { super(ps, NON_DATA_LINE_MARKERS_DEFAULT, jobKey); }
 
   /** Try to parse the bytes as ARFF format  */
   static ParseSetup guessSetup(ByteVec bv, byte[] bits, byte sep, boolean singleQuotes, String[] columnNames, String[][] naStrings,

--- a/h2o-core/src/main/java/water/parser/ARFFParser.java
+++ b/h2o-core/src/main/java/water/parser/ARFFParser.java
@@ -17,18 +17,21 @@ class ARFFParser extends CsvParser {
   private static final String TAG_ATTRIBUTE = "@ATTRIBUTE";
   private static final String NA = "?"; //standard NA in Arff format
   private static final byte GUESS_SEP = ParseSetup.GUESS_SEP;
-  private static final byte[] NON_DATA_LINE_MARKERS = {'%', '@'};
+  private static final byte[] NON_DATA_LINE_MARKERS_DEFAULT = {'%', '@'};
 
   ARFFParser(ParseSetup ps, Key jobKey) { super(ps, jobKey); }
 
   @Override
-  protected byte[] nonDataLineMarkers() {
-    return NON_DATA_LINE_MARKERS;
+  protected byte[] nonDataLineMarkersDefault() {
+    return NON_DATA_LINE_MARKERS_DEFAULT;
   }
 
+
   /** Try to parse the bytes as ARFF format  */
-  static ParseSetup guessSetup(ByteVec bv, byte[] bits, byte sep, boolean singleQuotes, String[] columnNames, String[][] naStrings) {
+  static ParseSetup guessSetup(ByteVec bv, byte[] bits, byte sep, boolean singleQuotes, String[] columnNames, String[][] naStrings,
+                               byte[] nonDataLineMarkers) {
     if (columnNames != null) throw new UnsupportedOperationException("ARFFParser doesn't accept columnNames.");
+    if(nonDataLineMarkers == null) nonDataLineMarkers = NON_DATA_LINE_MARKERS_DEFAULT;
 
     // Parse all lines starting with @ until EOF or @DATA
     boolean haveData = false;
@@ -87,7 +90,7 @@ class ARFFParser extends CsvParser {
         ++offset;
         // For Windoze, skip a trailing LF after CR
         if ((offset < bits.length) && (bits[offset] == CsvParser.CHAR_LF)) ++offset;
-        if (ArrayUtils.contains(NON_DATA_LINE_MARKERS, bits[lineStart])) continue;
+        if (ArrayUtils.contains(nonDataLineMarkers, bits[lineStart])) continue;
         if (lineEnd > lineStart) {
           String str = new String(bits, lineStart, lineEnd - lineStart).trim();
           if (!str.isEmpty()) datablock.add(str);

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -22,7 +22,6 @@ public class CsvParser extends Parser {
 
   CsvParser( ParseSetup ps, Key jobKey ) {
     super(ps, jobKey);
-    if(_setup._nonDataLineMarkers == null) _setup._nonDataLineMarkers = nonDataLineMarkersDefault();
   }
 
   protected byte[] nonDataLineMarkersDefault() {

--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -18,13 +18,18 @@ public class CsvParser extends Parser {
   private static final int NO_HEADER = ParseSetup.NO_HEADER;
   private static final int GUESS_HEADER = ParseSetup.GUESS_HEADER;
   private static final int HAS_HEADER = ParseSetup.HAS_HEADER;
-  private static final byte[] NON_DATA_LINE_MARKERS = {'#'};
+  private static final byte[] NON_DATA_LINE_MARKERS_DEFAULT = {'#'};
 
-  CsvParser( ParseSetup ps, Key jobKey ) { super(ps, jobKey); }
-
-  protected byte[] nonDataLineMarkers() {
-    return NON_DATA_LINE_MARKERS;
+  CsvParser( ParseSetup ps, Key jobKey ) {
+    super(ps, jobKey);
+    if(_setup._nonDataLineMarkers == null) _setup._nonDataLineMarkers = nonDataLineMarkersDefault();
   }
+
+  protected byte[] nonDataLineMarkersDefault() {
+    return NON_DATA_LINE_MARKERS_DEFAULT;
+  }
+
+
 
   // Parse this one Chunk (in parallel with other Chunks)
   @SuppressWarnings("fallthrough")
@@ -62,9 +67,8 @@ public class CsvParser extends Parser {
     int colIdx = 0; // count each actual column in the dataset including the skipped columns
     byte c = bits[offset];
     // skip comments for the first chunk (or if not a chunk)
-    byte[] nonDataLineMarkers = nonDataLineMarkers();
     if( cidx == 0 ) {
-      while (ArrayUtils.contains(nonDataLineMarkers, c) || isEOL(c)) {
+      while (ArrayUtils.contains(_setup._nonDataLineMarkers, c) || isEOL(c)) {
         while ((offset < bits.length) && (bits[offset] != CHAR_CR) && (bits[offset  ] != CHAR_LF)) {
 //          System.out.print(String.format("%c",bits[offset]));
           ++offset;
@@ -231,7 +235,7 @@ MAIN_LOOP:
               state = EXPECT_COND_LF;
             break;
           }
-          if (ArrayUtils.contains(nonDataLineMarkers, c)) {
+          if (ArrayUtils.contains(_setup._nonDataLineMarkers, c)) {
             state = SKIP_LINE;
             break;
           }
@@ -524,7 +528,7 @@ MAIN_LOOP:
 
   @Override protected int fileHasHeader(byte[] bits, ParseSetup ps) {
     boolean hasHdr = true;
-    String[] lines = getFirstLines(bits, ps._single_quotes, nonDataLineMarkers());
+    String[] lines = getFirstLines(bits, ps._single_quotes, ps._nonDataLineMarkers);
     if (lines != null && lines.length > 0) {
       String[] firstLine = determineTokens(lines[0], _setup._separator, _setup._single_quotes);
       if (_setup._column_names != null) {
@@ -682,11 +686,13 @@ MAIN_LOOP:
    *  singleQuotes is honored in all cases (and not guessed).
    *
    */
-  static ParseSetup guessSetup(byte[] bits, byte sep, int ncols, boolean singleQuotes, int checkHeader, String[] columnNames, byte[] columnTypes, String[][] naStrings) {
+  static ParseSetup guessSetup(byte[] bits, byte sep, int ncols, boolean singleQuotes, int checkHeader,
+                               String[] columnNames, byte[] columnTypes, String[][] naStrings, byte[] nonDataLineMarkers) {
+    if(nonDataLineMarkers == null) nonDataLineMarkers = NON_DATA_LINE_MARKERS_DEFAULT;
     int lastNewline = bits.length-1;
     while(lastNewline > 0 && !CsvParser.isEOL(bits[lastNewline]))lastNewline--;
     if(lastNewline > 0) bits = Arrays.copyOf(bits,lastNewline+1);
-    String[] lines = getFirstLines(bits, singleQuotes, NON_DATA_LINE_MARKERS);
+    String[] lines = getFirstLines(bits, singleQuotes, nonDataLineMarkers);
     if(lines.length==0 )
       throw new ParseDataset.H2OParseException("No data!");
 
@@ -715,7 +721,8 @@ MAIN_LOOP:
             }
           }
           //FIXME should set warning message and let fall through
-          return new ParseSetup(CSV_INFO, GUESS_SEP, singleQuotes, checkHeader, 1, null, ctypes, domains, naStrings, data, new ParseWriter.ParseErr[0],FileVec.DFLT_CHUNK_SIZE);
+          return new ParseSetup(CSV_INFO, GUESS_SEP, singleQuotes, checkHeader, 1, null, ctypes, domains, naStrings, data, new ParseWriter.ParseErr[0],FileVec.DFLT_CHUNK_SIZE,
+                  nonDataLineMarkers);
         }
       }
       data[0] = determineTokens(lines[0], sep, singleQuotes);
@@ -774,7 +781,8 @@ MAIN_LOOP:
     }
 
     // Assemble the setup understood so far
-    ParseSetup resSetup = new ParseSetup(CSV_INFO, sep, singleQuotes, checkHeader, ncols, labels, null, null /*domains*/, naStrings, data);
+    ParseSetup resSetup = new ParseSetup(CSV_INFO, sep, singleQuotes, checkHeader, ncols, labels, null, null /*domains*/, naStrings, data,
+            nonDataLineMarkers);
 
     // now guess the types
     if (columnTypes == null || ncols != columnTypes.length) {

--- a/h2o-core/src/main/java/water/parser/DefaultParserProviders.java
+++ b/h2o-core/src/main/java/water/parser/DefaultParserProviders.java
@@ -39,10 +39,9 @@ public final class DefaultParserProviders {
     }
 
     @Override
-    public ParseSetup guessSetup(ByteVec bv, byte[] bits, byte sep, int ncols, boolean singleQuotes,
-                                 int checkHeader, String[] columnNames, byte[] columnTypes,
-                                 String[][] domains, String[][] naStrings) {
-      return ARFFParser.guessSetup(bv, bits, sep, singleQuotes, columnNames, naStrings);
+    public ParseSetup guessInitSetup(ByteVec v, byte[] bits, ParseSetup ps) {
+      return ARFFParser.guessSetup(v, bits, ps._separator, ps._single_quotes, ps._column_names, ps._na_strings,
+              ps._nonDataLineMarkers);
     }
   }
 
@@ -99,11 +98,11 @@ public final class DefaultParserProviders {
     }
 
     @Override
-    public ParseSetup guessSetup(ByteVec bv, byte[] bits, byte sep, int ncols, boolean singleQuotes,
-                                 int checkHeader, String[] columnNames, byte[] columnTypes,
-                                 String[][] domains, String[][] naStrings) {
-      return CsvParser.guessSetup(bits, sep, ncols, singleQuotes, checkHeader, columnNames, columnTypes, naStrings);
+    public ParseSetup guessInitSetup(ByteVec v, byte[] bits, ParseSetup ps) {
+      return CsvParser.guessSetup(bits, ps._separator, ps._number_columns, ps._single_quotes, ps._check_header,
+              ps._column_names, ps._column_types, ps._na_strings, ps._nonDataLineMarkers);
     }
+    
   }
 
   public final static class GuessParserProvider extends AbstractParserProvide {

--- a/h2o-core/src/main/java/water/parser/ParseSetup.java
+++ b/h2o-core/src/main/java/water/parser/ParseSetup.java
@@ -562,6 +562,7 @@ public class ParseSetup extends Iced {
       else if (setupA._parse_type.equals(CSV_INFO) && setupB._parse_type.equals(ARFF_INFO)) {
         mergedSetup._parse_type = ARFF_INFO;
         mergedSetup._column_types = setupB._column_types;
+        mergedSetup._nonDataLineMarkers = setupB._nonDataLineMarkers;
       } else if (setupA.isCompatible(setupB)) {
         mergedSetup._column_previews = PreviewParseWriter.unifyColumnPreviews(setupA._column_previews, setupB._column_previews);
       } else

--- a/h2o-core/src/main/java/water/parser/ParserProvider.java
+++ b/h2o-core/src/main/java/water/parser/ParserProvider.java
@@ -78,7 +78,6 @@ public abstract class ParserProvider {
   }
 
   /** Returns parser setup of throws exception if input is not recognized */
-  // FIXME: should be more flexible
   public ParseSetup guessSetup(ByteVec v, byte[] bits, byte sep, int ncols, boolean singleQuotes, int checkHeader, String[] columnNames, byte[] columnTypes, String[][] domains, String[][] naStrings) {
     throw new UnsupportedOperationException("Not implemented. This method is kept only for backwards compatibility. " +
             "Override methods guessInitSetup & guessFinalSetup if you are implementing a new parser.");

--- a/h2o-core/src/test/java/water/parser/ARFFParserTest.java
+++ b/h2o-core/src/test/java/water/parser/ARFFParserTest.java
@@ -72,6 +72,7 @@ public class ARFFParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 5;
     parseSetup._single_quotes = false;
+    parseSetup._nonDataLineMarkers = new byte[]{'%', '@'};
     final ARFFParser parser = new ARFFParser(parseSetup, null);
 
     final NFSFileVec data = TestUtil.makeNfsFileVec("./smalldata/arff-examples/dataWeka/iris.arff");

--- a/h2o-core/src/test/java/water/parser/CsvParserTest.java
+++ b/h2o-core/src/test/java/water/parser/CsvParserTest.java
@@ -39,6 +39,7 @@ public class CsvParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 1;
     parseSetup._single_quotes = false;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\"\"abcd\"\"\""), 0);
@@ -60,6 +61,7 @@ public class CsvParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 1;
     parseSetup._single_quotes = true;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("'''abcd'''"), 0);
@@ -81,6 +83,7 @@ public class CsvParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 1;
     parseSetup._single_quotes = true;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("'''''abcd'''''"), 0);
@@ -102,6 +105,7 @@ public class CsvParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 1;
     parseSetup._single_quotes = false;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"'abcd'\""), 0);
@@ -123,6 +127,7 @@ public class CsvParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 1;
     parseSetup._single_quotes = false;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"\"\"\"\"abcd\"\"\"\"\""), 0);
@@ -144,6 +149,7 @@ public class CsvParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 1;
     parseSetup._single_quotes = false;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\",\""), 0);
@@ -164,6 +170,7 @@ public class CsvParserTest {
     parseSetup._column_types = new byte[]{Vec.T_STR};
     parseSetup._column_names = new String[]{"IsDepDelayed","fYear","fMonth","fDayofMonth","fDayOfWeek","UniqueCarrier","Origin","Dest","Distance"};
     parseSetup._number_columns = 9;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final Parser.ByteAryData byteAryData = new Parser.ByteAryData(StringUtils.bytesOf("\"YES\",\"f1987\",\"f10\",\"f14\",\"f3\",\"PS\",\"SAN\",\"SFO\",447\n" +
@@ -193,6 +200,7 @@ public class CsvParserTest {
     parseSetup._column_types = new byte[]{Vec.T_STR};
     parseSetup._column_names = new String[]{"PassengerId","Survived","Pclass","Name","Sex","Age","SibSp","Parch","Ticket","Fare","Cabin","Embarked"};
     parseSetup._number_columns = 12;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final String parsedString = "102,0,3,\"Petroff, Mr. Pastcho (\"\"Pentcho\"\")\",male,,0,0,349215,7.8958,,S";
@@ -229,6 +237,7 @@ public class CsvParserTest {
     parseSetup._column_types = new byte[]{Vec.T_STR};
     parseSetup._column_names = new String[]{"PassengerId","Survived","Pclass","Name","Sex","Age","SibSp","Parch","Ticket","Fare","Cabin","Embarked"};
     parseSetup._number_columns = 12;
+    parseSetup._nonDataLineMarkers = new byte[0];
     CsvParser csvParser = new CsvParser(parseSetup, null);
 
     final String parsedString = "1,0,3,\"Braund, Mr. Owen Harris\",male,22,1,0,A/5 21171,7.25,,S\r\n"
@@ -240,8 +249,6 @@ public class CsvParserTest {
     assertEquals(2, outWriter.lineNum());
     assertEquals(0, outWriter._invalidLines);
     assertFalse(outWriter.hasErrors());
-
-    final StringTokenizer stringTokenizer = new StringTokenizer(parsedString, ",");
 
     for (int lineIndex = 1; lineIndex < 3; lineIndex++) {
       for (int colIndex = 0; colIndex < parseSetup._number_columns; colIndex++) {
@@ -272,7 +279,7 @@ public class CsvParserTest {
     parseSetup._column_names = new String[]{"Name"};
     parseSetup._number_columns = 3;
     parseSetup._single_quotes = false;
-    parseSetup._nonDataLineMarkers = null; // Non data line markers are set to null, thus defaults should be used
+    parseSetup._nonDataLineMarkers = new byte[]{'#'};
     CsvParser parser = new CsvParser(parseSetup, null);
 
     final String parsedString = "C1,C2,C3\n"

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -309,11 +309,13 @@ class H2OFrame(object):
         raise H2OValueError("Column '%r' does not exist in the frame" % col)
 
 
-    def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings, skipped_columns=None):
+    def _import_parse(self, path, pattern, destination_frame, header, separator, column_names, column_types, na_strings,
+                      skipped_columns=None, custom_non_data_line_markers = None):
         if H2OFrame.__LOCAL_EXPANSION_ON_SINGLE_IMPORT__ and is_type(path, str) and "://" not in path:  # fixme: delete those 2 lines, cf. PUBDEV-5717
             path = os.path.abspath(path)
         rawkey = h2o.lazy_import(path, pattern)
-        self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings, skipped_columns)
+        self._parse(rawkey, destination_frame, header, separator, column_names, column_types, na_strings,
+                    skipped_columns, custom_non_data_line_markers)
         return self
 
 
@@ -325,8 +327,9 @@ class H2OFrame(object):
 
 
     def _parse(self, rawkey, destination_frame="", header=None, separator=None, column_names=None, column_types=None,
-               na_strings=None, skipped_columns=None):
-        setup = h2o.parse_setup(rawkey, destination_frame, header, separator, column_names, column_types, na_strings, skipped_columns)
+               na_strings=None, skipped_columns=None, custom_non_data_line_markers = None):
+        setup = h2o.parse_setup(rawkey, destination_frame, header, separator, column_names, column_types, na_strings,
+                                skipped_columns, custom_non_data_line_markers)
         return self._parse_raw(setup)
 
 
@@ -342,7 +345,8 @@ class H2OFrame(object):
              "delete_on_done": True,
              "blocking": False,
              "column_types": None,
-             "skipped_columns":None
+             "skipped_columns":None,
+             "custom_non_data_line_markers": setup["custom_non_data_line_markers"]
              }
 
         if setup["column_names"]: p["column_names"] = None

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6367.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6367.py
@@ -1,0 +1,29 @@
+
+import h2o
+import pandas as pd
+import tempfile
+from tests import pyunit_utils
+
+
+def pubdev_5394():
+    l = list(range(100))
+    l.append("#")
+    tmp = tempfile.NamedTemporaryFile(suffix='.tsv')
+    try:
+        df = pd.DataFrame({1: l, 2: l, 3: l, 4: l, 5: l})
+        df.to_csv(tmp.name, sep="\t", index=False)
+
+        # One line ignored in default settings
+        df = h2o.import_file(tmp.name, header=1)
+        assert df.nrows == len(l) - 1
+
+        # No lines ignored, as non-data line markers are overridden/empty
+        df = h2o.import_file(tmp.name, header=1, custom_non_data_line_markers='')
+        assert df.nrows == len(l)
+    finally:
+        tmp.close()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_5394)
+else:
+    pubdev_5394()

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -55,6 +55,7 @@
 #' @param decrypt_tool (Optional) Specify a Decryption Tool (key-reference
 #'        acquired by calling \link{h2o.decryptionSetup}.
 #' @param skipped_columns a list of column indices to be skipped during parsing.
+#' @param custom_non_data_line_markers (Optional) If a line in imported file starts with any character in given string it will NOT be imported. Empty string means all lines are imported, NULL means that default behaviour for given format will be used
 #' @seealso \link{h2o.import_sql_select}, \link{h2o.import_sql_table}, \link{h2o.parseRaw}
 #' @examples
 #' \donttest{
@@ -76,16 +77,19 @@
 #' @name h2o.importFile
 #' @export
 h2o.importFile <- function(path, destination_frame = "", parse = TRUE, header=NA, sep = "", col.names=NULL,
-                           col.types=NULL, na.strings=NULL, decrypt_tool=NULL, skipped_columns=NULL) {
+                           col.types=NULL, na.strings=NULL, decrypt_tool=NULL, skipped_columns=NULL,
+                           custom_non_data_line_markers=NULL) {
   h2o.importFolder(path, pattern = "", destination_frame=destination_frame, parse, header, sep, col.names, col.types,
-                   na.strings=na.strings, decrypt_tool=decrypt_tool, skipped_columns=skipped_columns)
+                   na.strings=na.strings, decrypt_tool=decrypt_tool, skipped_columns=skipped_columns,
+                   custom_non_data_line_markers=custom_non_data_line_markers)
 }
 
 
 #' @rdname h2o.importFile
 #' @export
 h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse = TRUE, header = NA, sep = "",
-                             col.names = NULL, col.types=NULL, na.strings=NULL, decrypt_tool=NULL, skipped_columns=NULL) {
+                             col.names = NULL, col.types=NULL, na.strings=NULL, decrypt_tool=NULL, skipped_columns=NULL,
+                             custom_non_data_line_markers=NULL) {
   if(!is.character(path) || is.na(path) || !nzchar(path)) stop("`path` must be a non-empty character string")
   if(!is.character(pattern) || length(pattern) != 1L || is.na(pattern)) stop("`pattern` must be a character string")
   .key.validate(destination_frame)
@@ -111,7 +115,7 @@ h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse =
   } else {
     res <- .h2o.__remoteSend(.h2o.__IMPORT, path=path,pattern=pattern)
   }
-
+  
   if(length(res$fails) > 0L) {
     for(i in seq_len(length(res$fails)))
       cat(res$fails[[i]], "failed to import")
@@ -121,7 +125,8 @@ h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse =
 if(parse) {
     srcKey <- res$destination_frames
     return( h2o.parseRaw(data=.newH2OFrame(op="ImportFolder",id=srcKey,-1,-1),pattern=pattern, destination_frame=destination_frame,
-            header=header, sep=sep, col.names=col.names, col.types=col.types, na.strings=na.strings, decrypt_tool=decrypt_tool, skipped_columns=skipped_columns) )
+            header=header, sep=sep, col.names=col.names, col.types=col.types, na.strings=na.strings, decrypt_tool=decrypt_tool,
+             skipped_columns=skipped_columns, custom_non_data_line_markers=custom_non_data_line_markers) )
 }
   myData <- lapply(res$destination_frames, function(x) .newH2OFrame( op="ImportFolder", id=x,-1,-1))  # do not gc, H2O handles these nfs:// vecs
   if(length(res$destination_frames) == 1L)

--- a/h2o-r/h2o-package/R/parse.R
+++ b/h2o-r/h2o-package/R/parse.R
@@ -30,22 +30,25 @@
 #'        acquired by calling \link{h2o.decryptionSetup}.
 #' @param chunk_size size of chunk of (input) data in bytes
 #' @param skipped_columns a list of column indices to be excluded from parsing
+#' @param custom_non_data_line_markers (Optional) If a line in imported file starts with any character in given string it will NOT be imported. Empty string means all lines are imported, NULL means that default behaviour for given format will be used
 #' @seealso \link{h2o.importFile}, \link{h2o.parseSetup}
 #' @export
 h2o.parseRaw <- function(data, pattern="", destination_frame = "", header=NA, sep = "", col.names=NULL,
                          col.types=NULL, na.strings=NULL, blocking=FALSE, parse_type = NULL, chunk_size = NULL,
-                         decrypt_tool = NULL, skipped_columns = NULL) {
+                         decrypt_tool = NULL, skipped_columns = NULL, custom_non_data_line_markers = NULL) {
   # Check and parse col.types in case col.types is supplied col.name = col.type vec
   if( length(names(col.types)) > 0 & typeof(col.types) != "list" ) {
     parse.params <- h2o.parseSetup(data, pattern="", destination_frame, header, sep, col.names, col.types = NULL,
                                    na.strings = na.strings, parse_type = parse_type, chunk_size = chunk_size,
-                                   decrypt_tool = decrypt_tool, skipped_columns=skipped_columns)
+                                   decrypt_tool = decrypt_tool, skipped_columns=skipped_columns,
+                                   custom_non_data_line_markers = custom_non_data_line_markers)
     idx = match(names(col.types), parse.params$column_names)
     parse.params$column_types[idx] = as.character(col.types)
   } else {
     parse.params <- h2o.parseSetup(data, pattern="", destination_frame, header, sep, col.names, col.types,
                                    na.strings = na.strings, parse_type = parse_type, chunk_size = chunk_size,
-                                   decrypt_tool = decrypt_tool, skipped_columns=skipped_columns)
+                                   decrypt_tool = decrypt_tool, skipped_columns=skipped_columns,
+                                   custom_non_data_line_markers = custom_non_data_line_markers)
   }
   for(w in parse.params$warnings){
     cat('WARNING:',w,'\n')
@@ -67,6 +70,9 @@ h2o.parseRaw <- function(data, pattern="", destination_frame = "", header=NA, se
             decrypt_tool = .decrypt_tool_id(parse.params$decrypt_tool),
             skipped_columns = paste0("[", paste(parse.params$skipped_columns, collapse=','), "]")
             )
+  if(!is.null(custom_non_data_line_markers)){
+    parse.params <- append(parse.params,list(custom_non_data_line_markers = custom_non_data_line_markers))
+  }
 
   # Perform the parse
   res <- .h2o.__remoteSend(.h2o.__PARSE, method = "POST", .params = parse.params)
@@ -127,7 +133,8 @@ h2o.parseRaw <- function(data, pattern="", destination_frame = "", header=NA, se
 #' @seealso \link{h2o.parseRaw}
 #' @export
 h2o.parseSetup <- function(data, pattern="", destination_frame = "", header = NA, sep = "", col.names = NULL, col.types = NULL,
-                           na.strings = NULL, parse_type = NULL, chunk_size = NULL, decrypt_tool = NULL, skipped_columns=NULL) {
+                           na.strings = NULL, parse_type = NULL, chunk_size = NULL, decrypt_tool = NULL, skipped_columns = NULL,
+                           custom_non_data_line_markers = NULL) {
 
   # Allow single frame or list of frames; turn singleton into a list
   if( is.H2OFrame(data) ) data <- list(data)
@@ -140,6 +147,10 @@ h2o.parseSetup <- function(data, pattern="", destination_frame = "", header = NA
   # begin the setup
   # setup the parse parameters here
   parseSetup.params <- list()
+  
+  if(!is.null(custom_non_data_line_markers)) {
+    parseSetup.params$custom_non_data_line_markers = custom_non_data_line_markers
+  }
 
   if (!is.null(skipped_columns)) {
     skipped_columns = sort(skipped_columns)
@@ -267,7 +278,8 @@ h2o.parseSetup <- function(data, pattern="", destination_frame = "", header = NA
         delete_on_done     = TRUE,
         warnings           = parseSetup$warnings,
         decrypt_tool       = parseSetup$decrypt_tool,
-        skipped_columns    = parseSetup$skipped_columns
+        skipped_columns    = parseSetup$skipped_columns,
+        custom_non_data_line_markers = parseSetup$custom_non_data_line_markers
         )
 }
 

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6339.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6339.R
@@ -77,8 +77,7 @@ calculateChunkSize <- function() {
     filePaths = c(locate("smalldata/arcene/arcene_train.data"),
     locate("smalldata/census_income/adult_data.csv"),
     locate("smalldata/chicago/chicagoAllWeather.csv"),
-    locate("smalldata/gbm_test/alphabet_cattest.csv"),
-    locate("smalldata/wa_cannabis/raw/Dashboard_Usable_Sales_w_Weight_Daily.csv")
+    locate("smalldata/gbm_test/alphabet_cattest.csv")
     )
 
     info <- capture.output(h2o.clusterInfo())

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6367.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6367.R
@@ -1,0 +1,35 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.nondatalinemarkers <- function() {
+  
+  # Use default
+  tmp = tempfile(fileext = ".tsv")
+  data <- data.frame("C1" = c(1,2,'3',4,5), "C2" = c(6:10), "C3" = c(11:15))
+  write.table(data, file=tmp, quote=FALSE, sep='\t', col.names = FALSE, row.names = FALSE)
+  imported <- h2o.importFile(tmp, col.types = c("String", "Numeric", "Numeric"))
+  expect_equal(5, h2o.nrow(imported))
+  
+  #Override default with empty list
+  tmp = tempfile(fileext = ".tsv")
+  data <- data.frame("C1" = c(1,2,'#3',4,5), "C2" = c(6:10), "C3" = c(11:15))
+  write.table(data, file=tmp, quote=FALSE, sep='\t', col.names = FALSE, row.names = FALSE)
+  imported <- h2o.importFile(tmp, col.types = c("String", "Numeric", "Numeric"), custom_non_data_line_markers = '')
+  expect_equal(5, h2o.nrow(imported))
+  
+  # Non-default single non-data line marker
+  data <- data.frame("C1" = c(1,2,'@3',4,5), "C2" = c(6:10), "C3" = c(11:15))
+  write.table(data, file=tmp, quote=FALSE, sep='\t', col.names = FALSE, row.names = FALSE)
+  imported <- h2o.importFile(tmp, col.types = c("String", "Numeric", "Numeric"), custom_non_data_line_markers = '@')
+  expect_equal(4, h2o.nrow(imported))
+  
+  # Multiple non-default non-data line markers 
+  data <- data.frame("C1" = c(1,2,'@3','#4',5), "C2" = c(6:10), "C3" = c(11:15))
+  write.table(data, file=tmp, quote=FALSE, sep='\t', col.names = FALSE, row.names = FALSE)
+  imported <- h2o.importFile(tmp, col.types = c("String", "Numeric", "Numeric"), custom_non_data_line_markers = '@#')
+  expect_equal(3, h2o.nrow(imported))
+}
+
+doTest("Setting non-data line markers", test.nondatalinemarkers)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6367

By default, some parsers are skipping lines beginning with some characters. Those defaults are implemented per each parser. The main point of this PR is to fulfill all the following conditions:

1. Make the defaults overridable,
1. Preserve the original behavior(defaults) when non-data line markers are not specified.

As a positive side-effect of this API, I made `CsvParser` and `ArffParser` use the new generic methods passing the whole `ParseSetup` object (reference to it of course), instead of pin-pointing only the necessary stuff. This old method has even been deprecated by @michalkurka some time ago. :)