### PR TITLE
PUBDEV-6374: Allow users to define custom HTTP headers

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -294,8 +294,19 @@ final public class H2O {
 
     /** -context_path=jetty_context_path; the context path for jetty */
     public String context_path = "";
+
+    public KeyValueArg[] extra_headers = new KeyValueArg[0];
   }
 
+  public static class KeyValueArg {
+    public final String _key;
+    public final String _value;
+    private KeyValueArg(String key, String value) {
+      _key = key;
+      _value = value;
+    }
+  } 
+  
   /**
    * A class containing all of the arguments for H2O.
    */
@@ -663,6 +674,12 @@ final public class H2O {
         i = s.incrementAndCheck(i, args);
         trgt.features_level = ModelBuilder.BuilderVisibility.valueOfIgnoreCase(args[i]);
         Log.info(String.format("Limiting algorithms available to level: %s", trgt.features_level.name()));
+      } else if (s.matches("add_http_header")) {
+        i = s.incrementAndCheck(i, args);
+        String key = args[i];
+        i = s.incrementAndCheck(i, args);
+        String value = args[i];
+        trgt.extra_headers = ArrayUtils.append(trgt.extra_headers, new KeyValueArg(key, value));
       } else {
         parseFailed("Unknown argument (" + s + ")");
       }

--- a/h2o-core/src/main/java/water/server/ServletUtils.java
+++ b/h2o-core/src/main/java/water/server/ServletUtils.java
@@ -193,7 +193,10 @@ public class ServletUtils {
     response.setHeader("Content-Security-Policy", "default-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:");
     // Note: ^^^ unsafe-eval/-inline are essential for Flow to work
     //           this will also kill the component "Star H2O on Github" in Flow - see HEXDEV-739
-
+    // Custom headers - using addHeader - can be multi-value and cannot overwrite the security headers
+    for (H2O.KeyValueArg header : H2O.ARGS.extra_headers) {
+      response.addHeader(header._key, header._value);
+    }
   }
 
   public static String sanatizeContextPath(String context_path) {


### PR DESCRIPTION
Example:

java -jarh2o.jar -add_http_header 'Strict-Transport-Security' 'max-age=3600' -jks ../mykeystore.jks