### PR TITLE
PUBDEV-6376: StackedEnsemble prediction fails when applied to a test dataset without response column

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1431,10 +1431,10 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       adaptFrm.remove(responseId);
     }
     // Build up the names & domains.
-    final boolean computeMetrix = computeMetrics && (adaptFrm.vec(_output.responseName()) != null && !adaptFrm.vec(_output.responseName()).isBad());
-    String [] domain = _output.nclasses()<=1 ? null : !computeMetrix ? _output._domains[_output._domains.length-1] : adaptFrm.lastVec().domain();
+    final boolean detectedComputeMetrics = computeMetrics && (adaptFrm.vec(_output.responseName()) != null && !adaptFrm.vec(_output.responseName()).isBad());
+    String [] domain = _output.nclasses()<=1 ? null : !detectedComputeMetrics ? _output._domains[_output._domains.length-1] : adaptFrm.lastVec().domain();
     // Score the dataset, building the class distribution & predictions
-    return new GLMScore(j, this, _output._dinfo.scoringInfo(_output._names,adaptFrm),domain,computeMetrix, generatePredictions);
+    return new GLMScore(j, this, _output._dinfo.scoringInfo(_output._names,adaptFrm),domain,detectedComputeMetrics, generatePredictions);
   }
   /** Score an already adapted frame.  Returns a new Frame with new result
    *  vectors, all in the DKV.  Caller responsible for deleting.  Input is

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1452,7 +1452,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     GLMScore gs = makeScoringTask(adaptFrm,true,j);// doAll(names.length,Vec.T_NUM,adaptFrm);
     assert gs._dinfo._valid:"_valid flag should be set on data info when doing scoring";
     gs.doAll(names.length,Vec.T_NUM,gs._dinfo._adaptedFrame);
-    if (gs._computeMetrics)
+    if (computeMetrics && gs._computeMetrics)
       gs._mb.makeModelMetrics(this, fr, adaptFrm, gs.outputFrame());
     domains[0] = gs._domain;
     return gs.outputFrame(Key.<Frame>make(destination_key),names, domains);

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1424,17 +1424,17 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
 
 
-  private GLMScore makeScoringTask(Frame adaptFrm, boolean generatePredictions, Job j){
+  private GLMScore makeScoringTask(Frame adaptFrm, boolean generatePredictions, Job j, boolean computeMetrics){
     int responseId = adaptFrm.find(_output.responseName());
     if(responseId > -1 && adaptFrm.vec(responseId).isBad()) { // remove inserted invalid response
       adaptFrm = new Frame(adaptFrm.names(),adaptFrm.vecs());
       adaptFrm.remove(responseId);
     }
     // Build up the names & domains.
-    final boolean computeMetrics = adaptFrm.vec(_output.responseName()) != null && !adaptFrm.vec(_output.responseName()).isBad();
-    String [] domain = _output.nclasses()<=1 ? null : !computeMetrics ? _output._domains[_output._domains.length-1] : adaptFrm.lastVec().domain();
+    final boolean computeMetrix = computeMetrics && (adaptFrm.vec(_output.responseName()) != null && !adaptFrm.vec(_output.responseName()).isBad());
+    String [] domain = _output.nclasses()<=1 ? null : !computeMetrix ? _output._domains[_output._domains.length-1] : adaptFrm.lastVec().domain();
     // Score the dataset, building the class distribution & predictions
-    return new GLMScore(j, this, _output._dinfo.scoringInfo(_output._names,adaptFrm),domain,computeMetrics, generatePredictions);
+    return new GLMScore(j, this, _output._dinfo.scoringInfo(_output._names,adaptFrm),domain,computeMetrix, generatePredictions);
   }
   /** Score an already adapted frame.  Returns a new Frame with new result
    *  vectors, all in the DKV.  Caller responsible for deleting.  Input is
@@ -1449,10 +1449,10 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
   protected Frame predictScoreImpl(Frame fr, Frame adaptFrm, String destination_key, Job j, boolean computeMetrics, CFuncRef customMetricFunc) {
     String [] names = makeScoringNames();
     String [][] domains = new String[names.length][];
-    GLMScore gs = makeScoringTask(adaptFrm,true,j);// doAll(names.length,Vec.T_NUM,adaptFrm);
+    GLMScore gs = makeScoringTask(adaptFrm,true,j, computeMetrics);// doAll(names.length,Vec.T_NUM,adaptFrm);
     assert gs._dinfo._valid:"_valid flag should be set on data info when doing scoring";
     gs.doAll(names.length,Vec.T_NUM,gs._dinfo._adaptedFrame);
-    if (computeMetrics && gs._computeMetrics)
+    if (gs._computeMetrics)
       gs._mb.makeModelMetrics(this, fr, adaptFrm, gs.outputFrame());
     domains[0] = gs._domain;
     return gs.outputFrame(Key.<Frame>make(destination_key),names, domains);
@@ -1469,7 +1469,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
    */
   @Override
   protected ModelMetrics.MetricBuilder scoreMetrics(Frame adaptFrm) {
-    GLMScore gs = makeScoringTask(adaptFrm,false,null);// doAll(names.length,Vec.T_NUM,adaptFrm);
+    GLMScore gs = makeScoringTask(adaptFrm,false,null, true);// doAll(names.length,Vec.T_NUM,adaptFrm);
     assert gs._dinfo._valid:"_valid flag should be set on data info when doing scoring";
     return gs.doAll(gs._dinfo._adaptedFrame)._mb;
   }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -4,6 +4,7 @@ import hex.GLMHelper;
 import hex.Model;
 import hex.ModelMetrics;
 import hex.SplitFrame;
+import hex.ensemble.Metalearner.Algorithm;
 import hex.ensemble.StackedEnsembleModel.StackedEnsembleParameters;
 import hex.genmodel.utils.DistributionFamily;
 import hex.glm.GLM;
@@ -24,6 +25,7 @@ import water.fvec.Frame;
 import water.fvec.NewChunk;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
+import water.util.Log;
 
 import java.util.*;
 
@@ -44,7 +46,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
             null,
             new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-            false, DistributionFamily.gaussian, Metalearner.Algorithm.AUTO, false);
+            false, DistributionFamily.gaussian, Algorithm.AUTO, false);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -52,19 +54,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.AUTO, false);
+                false, DistributionFamily.bernoulli, Algorithm.AUTO, false);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, Metalearner.Algorithm.AUTO, false);
+                false, DistributionFamily.multinomial, Algorithm.AUTO, false);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.AUTO, false);
+                false, DistributionFamily.bernoulli, Algorithm.AUTO, false);
     }
 
 
@@ -73,7 +75,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, DistributionFamily.gaussian, Metalearner.Algorithm.gbm, false);
+                false, DistributionFamily.gaussian, Algorithm.gbm, false);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -81,19 +83,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.gbm, false);
+                false, DistributionFamily.bernoulli, Algorithm.gbm, false);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, Metalearner.Algorithm.gbm, false);
+                false, DistributionFamily.multinomial, Algorithm.gbm, false);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.gbm, false);
+                false, DistributionFamily.bernoulli, Algorithm.gbm, false);
     }
 
     @Test public void testBasicEnsembleDRFMetalearner() {
@@ -101,7 +103,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, DistributionFamily.gaussian, Metalearner.Algorithm.drf, false);
+                false, DistributionFamily.gaussian, Algorithm.drf, false);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -109,19 +111,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.drf, false);
+                false, DistributionFamily.bernoulli, Algorithm.drf, false);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, Metalearner.Algorithm.drf, false);
+                false, DistributionFamily.multinomial, Algorithm.drf, false);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.drf, false);
+                false, DistributionFamily.bernoulli, Algorithm.drf, false);
     }
 
     @Test public void testBasicEnsembleDeepLearningMetalearner() {
@@ -129,7 +131,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, DistributionFamily.gaussian, Metalearner.Algorithm.deeplearning, false);
+                false, DistributionFamily.gaussian, Algorithm.deeplearning, false);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -137,19 +139,19 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.deeplearning, false);
+                false, DistributionFamily.bernoulli, Algorithm.deeplearning, false);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, Metalearner.Algorithm.deeplearning, false);
+                false, DistributionFamily.multinomial, Algorithm.deeplearning, false);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.deeplearning, false);
+                false, DistributionFamily.bernoulli, Algorithm.deeplearning, false);
     }
 
     
@@ -160,32 +162,32 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-                false, DistributionFamily.gaussian, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.gaussian, Algorithm.glm, false);
 
         // Binomial tests
         basicEnsemble("./smalldata/junit/test_tree_minmax.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("response"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.bernoulli, Algorithm.glm, false);
 
         basicEnsemble("./smalldata/logreg/prostate.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("ID").remove(); return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.bernoulli, Algorithm.glm, false);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
                 "./smalldata/logreg/prostate_test.csv",
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.bernoulli, Algorithm.glm, false);
 
         basicEnsemble("./smalldata/gbm_test/alphabet_cattest.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("y"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.bernoulli, Algorithm.glm, false);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
                 null,
@@ -193,26 +195,26 @@ public class StackedEnsembleTest extends TestUtil {
                     for( String s : ignored_aircols ) fr.remove(s).remove();
                     return fr.find("IsArrDelayed"); }
                 },
-                false, DistributionFamily.bernoulli, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.bernoulli, Algorithm.glm, false);
 
         // Multinomial tests
         basicEnsemble("./smalldata/logreg/prostate.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("ID").remove(); return fr.find("RACE"); }
                 },
-                false, DistributionFamily.multinomial, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.multinomial, Algorithm.glm, false);
 
         basicEnsemble("./smalldata/junit/cars.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) { fr.remove("name").remove(); return fr.find("cylinders"); }
                 },
-                false, DistributionFamily.multinomial, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.multinomial, Algorithm.glm, false);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
                 null,
                 new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                 },
-                false, DistributionFamily.multinomial, Metalearner.Algorithm.glm, false);
+                false, DistributionFamily.multinomial, Algorithm.glm, false);
 
     }
 
@@ -280,7 +282,7 @@ public class StackedEnsembleTest extends TestUtil {
                     null,
                     new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
                     },
-                    false, DistributionFamily.multinomial, Metalearner.Algorithm.glm, false);
+                    false, DistributionFamily.multinomial, Algorithm.glm, false);
         } finally {
             Scope.exit();
         }
@@ -290,7 +292,7 @@ public class StackedEnsembleTest extends TestUtil {
         basicEnsemble("./smalldata/junit/cars.csv",
             null,
             new StackedEnsembleTest.PrepData() { int prep(Frame fr ) {fr.remove("name").remove(); return ~fr.find("economy (mpg)"); }},
-            false, DistributionFamily.gaussian, Metalearner.Algorithm.AUTO, true);
+            false, DistributionFamily.gaussian, Algorithm.AUTO, true);
 
         basicEnsemble("./smalldata/airlines/allyears2k_headers.zip",
             null,
@@ -298,19 +300,19 @@ public class StackedEnsembleTest extends TestUtil {
                 for( String s : ignored_aircols ) fr.remove(s).remove();
                 return fr.find("IsArrDelayed"); }
             },
-            false, DistributionFamily.bernoulli, Metalearner.Algorithm.AUTO, true);
+            false, DistributionFamily.bernoulli, Algorithm.AUTO, true);
 
         basicEnsemble("./smalldata/iris/iris_wheader.csv",
             null,
             new StackedEnsembleTest.PrepData() { int prep(Frame fr) {return fr.find("class"); }
             },
-            false, DistributionFamily.multinomial, Metalearner.Algorithm.AUTO, true);
+            false, DistributionFamily.multinomial, Algorithm.AUTO, true);
 
         basicEnsemble("./smalldata/logreg/prostate_train.csv",
             "./smalldata/logreg/prostate_test.csv",
             new StackedEnsembleTest.PrepData() { int prep(Frame fr) { return fr.find("CAPSULE"); }
             },
-            false, DistributionFamily.bernoulli, Metalearner.Algorithm.AUTO, true);
+            false, DistributionFamily.bernoulli, Algorithm.AUTO, true);
     }
 
     @Test
@@ -625,7 +627,7 @@ public class StackedEnsembleTest extends TestUtil {
                                                                     StackedEnsembleTest.PrepData prep,
                                                                     boolean dupeTrainingFrameToValidationFrame,
                                                                     DistributionFamily family,
-                                                                    Metalearner.Algorithm metalearner_algo,
+                                                                    Algorithm metalearner_algo,
                                                                     boolean blending_mode) {
         Set<Frame> framesBefore = new HashSet<>();
         framesBefore.addAll(Arrays.asList( Frame.fetchAll()));
@@ -796,5 +798,84 @@ public class StackedEnsembleTest extends TestUtil {
             }
             Scope.exit();
         }
+    }
+
+
+    @Test public void test_SE_scoring_with_missing_response_column() {
+        for (Algorithm algo: Algorithm.values()) {
+            try {
+                test_SE_scoring_with_missing_response_column(algo);
+            } catch (Exception e) {
+                Log.err(e);
+                Assert.fail("StackedEnsemble scoring failed with algo "+algo+": "+e.getMessage());
+            }
+        }
+    }
+
+    private void test_SE_scoring_with_missing_response_column(Algorithm algo) {
+        // test for PUBDEV-6376
+        List<Lockable> deletables = new ArrayList<>();
+        try {
+            final int seed = 1;
+            final Frame train = parse_test_file("./smalldata/testng/prostate_train.csv"); deletables.add(train);
+            final Frame test = parse_test_file("./smalldata/testng/prostate_test.csv"); deletables.add(test);
+            final String target = "CAPSULE";
+            int target_idx = train.find(target);
+            train.replace(target_idx, train.vec(target_idx).toCategoricalVec()).remove();
+            DKV.put(train);
+            test.remove(target_idx).remove();
+            DKV.put(test);
+
+            //generate a few base models
+            GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+            params._train = train._key;
+            params._response_column = target;
+            params._seed = seed;
+            params._keep_cross_validation_models = false;
+            params._keep_cross_validation_predictions = true;
+            params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+            params._nfolds = 5;
+
+            Job<Grid> gridSearch = GridSearch.startGridSearch(null, params, new HashMap<String, Object[]>() {{
+                put("_ntrees", new Integer[]{3, 5});
+                put("_learn_rate", new Double[]{0.1, 0.2});
+            }});
+            Grid grid = gridSearch.get(); deletables.add(grid);
+            Model[] gridModels = grid.getModels(); deletables.addAll(Arrays.asList(gridModels));
+            Assert.assertEquals(4, gridModels.length);
+
+            GLMModel.GLMParameters glm_params = new GLMModel.GLMParameters();
+            glm_params._train = train._key;
+            glm_params._response_column = target;
+            glm_params._family = GLMModel.GLMParameters.Family.binomial;
+            glm_params._seed = seed;
+            glm_params._keep_cross_validation_models = false;
+            glm_params._keep_cross_validation_predictions = true;
+            glm_params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+            glm_params._nfolds = 5;
+            glm_params._alpha = new double[]{0.1, 0.2, 0.4};
+            glm_params._lambda_search = true;
+            GLMModel glm = new GLM(glm_params).trainModel().get(); deletables.add(glm);
+            Frame glmPredictions = glm.score(test); deletables.add(glmPredictions);
+
+            StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+            seParams._train = train._key;
+            seParams._response_column = target;
+            seParams._base_models = ArrayUtils.append(grid.getModelKeys());
+            seParams._seed = seed;
+            StackedEnsembleModel se = new StackedEnsemble(seParams).trainModel().get(); deletables.add(se);
+
+            // mainly ensuring that no exception is thrown due to unmet categorical in test dataset.
+            Frame predictions = se.score(test); deletables.add(predictions);
+            List<Double> allowedResponses = Arrays.asList(0.0, 1.0);
+            double lastPrediction = predictions.vec(0).at(test.vec(0).length() - 1);
+            Assert.assertTrue(allowedResponses.indexOf(lastPrediction) >= 0);
+        } finally {
+            for (Lockable l: deletables) {
+                if (l instanceof Model) ((Model)l).deleteCrossValidationPreds();
+                l.delete();
+            }
+        }
+
     }
 }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -862,6 +862,7 @@ public class StackedEnsembleTest extends TestUtil {
             seParams._train = train._key;
             seParams._response_column = target;
             seParams._base_models = ArrayUtils.append(grid.getModelKeys());
+            seParams._metalearner_algorithm = algo;
             seParams._seed = seed;
             StackedEnsembleModel se = new StackedEnsemble(seParams).trainModel().get(); deletables.add(se);
 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6376

ensured that GLM respect computeMetrics parameter when it doesn't have direct access to original frame (like in SE scoring)