### PR TITLE
PUBDEV-6382: Extend Py API for TargetEncoder with convenient method for getting encoding maps

### DIFF
--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from h2o.expr import ExprNode
 from h2o.frame import H2OFrame
 from h2o.utils.typechecks import (assert_is_type)
+from h2o import get_frame
 import warnings
 
 __all__ = ("TargetEncoder", )
@@ -115,3 +116,6 @@ class TargetEncoder(object):
                                             self._responseColumnName, self._foldColumnName,
                                             self._blending, self._inflectionPoint, self._smoothing,
                                             noise, seed))
+
+    def encoding_map_frames(self):
+        return list(map(lambda x: get_frame(x['key']['name']), self._encodingMap.frames))

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
@@ -4,7 +4,6 @@ from tests import pyunit_utils
 from h2o.targetencoder import TargetEncoder
 import random
 
-
 def split_data(frame = None, seed = None):
   splits = frame.split_frame(ratios=[.8,.1], seed=seed)
   targetColumnName = "survived"
@@ -39,7 +38,6 @@ def titanic_without_te(frame = None, seeds = None):
       print("AUC without te: " + str(current_seed) + " = " + str(auc))
     return sum_of_aucs / len(seeds)
 
-
 def titanic_with_te_kfoldstrategy(frame = None, seeds = None):
     sum_of_aucs = 0
     for current_seed in seeds:
@@ -54,6 +52,12 @@ def titanic_with_te_kfoldstrategy(frame = None, seeds = None):
       targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
                                     fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
       targetEncoder.fit(frame=ds['train'])
+
+      encodingMapFramesKeys = list(map(lambda x: h2o.get_frame(x['key']['name']), targetEncoder._encodingMap.frames))
+
+      encodingMapFramesKeys[0].describe()
+      encodingMapFramesKeys[1].describe()
+      encodingMapFramesKeys[2].describe()
 
       encodedTrain = targetEncoder.transform(frame=ds['train'], holdout_type="kfold", seed=1234)
       encodedValid = targetEncoder.transform(frame=ds['valid'], holdout_type="none", noise=0.0)

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
@@ -53,12 +53,6 @@ def titanic_with_te_kfoldstrategy(frame = None, seeds = None):
                                     fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
       targetEncoder.fit(frame=ds['train'])
 
-      encodingMapFramesKeys = list(map(lambda x: h2o.get_frame(x['key']['name']), targetEncoder._encodingMap.frames))
-
-      encodingMapFramesKeys[0].describe()
-      encodingMapFramesKeys[1].describe()
-      encodingMapFramesKeys[2].describe()
-
       encodedTrain = targetEncoder.transform(frame=ds['train'], holdout_type="kfold", seed=1234)
       encodedValid = targetEncoder.transform(frame=ds['valid'], holdout_type="none", noise=0.0)
       encodedTest = targetEncoder.transform(frame=ds['test'], holdout_type="none", noise=0.0)


### PR DESCRIPTION
It will make it easier to access encoding maps on the client side