### PR TITLE
PUBDEV-6381: monotone_constraints available with Bernoulli distribution

### DIFF
--- a/h2o-docs/src/product/data-science/gbm.rst
+++ b/h2o-docs/src/product/data-science/gbm.rst
@@ -262,7 +262,7 @@ Defining a GBM Model
 
 -  **export_checkpoints_dir**: Optionally specify a path to a directory where every generated model will be stored when checkpointing models.
 
--  **monotone_constraints**: A mapping representing monotonic constraints. Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint. Note that constraints can only be defined for numerical columns. Also note that this option can only be used when ``distribution="gaussian"``.A Python demo is available `here <https://github.com/h2oai/h2o-3/tree/master/h2o-py/demos/H2O_tutorial_gbm_monotonicity.ipynb>`__.
+-  **monotone_constraints**: A mapping representing monotonic constraints. Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint. Note that constraints can only be defined for numerical columns. Also note that this option can only be used when the distribution is either ``gaussian`` or ``bernoulli``. A Python demo is available `here <https://github.com/h2oai/h2o-3/tree/master/h2o-py/demos/H2O_tutorial_gbm_monotonicity.ipynb>`__.
 
 -  `check_constant_response <algo-params/check_constant_response.html>`__: Check if the response column is a constant value. If enabled (default), then an exception is thrown if the response column is a constant value. If disabled, then the model will train regardless of the response column being a constant value or not.
 

--- a/h2o-docs/src/product/flow.rst
+++ b/h2o-docs/src/product/flow.rst
@@ -911,7 +911,7 @@ The available options vary depending on the selected model. If an option is only
 
 -  **col_sample_rate_per_tree**: (XGBoost) Specify the column subsampling rate per tree.
 
--  **monotone_constraints**: (XGBoost, GBM) A mapping representing `monotonic constraints <https://xiaoxiaowang87.github.io/monotonicity_constraint/>`__. Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint. Note that constraints can only be defined for numerical columns. Also note that in GBM, this option can only be used when ``distribution="gaussian"``. 
+-  **monotone_constraints**: (XGBoost, GBM) A mapping representing `monotonic constraints <https://xiaoxiaowang87.github.io/monotonicity_constraint/>`__. Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint. Note that constraints can only be defined for numerical columns. Also note that in GBM, this option can only be used when the distribution is either ``gaussian`` or ``bernoulli``. 
 
 -  **score_tree_interval**: (XGBoost) Score the model after every so many trees.
 


### PR DESCRIPTION
In the Flow and GBM chapters, added that monotone_constraints can be used when the distribution is set to bernoulli. Previously, this stated that monontone_constraints was only available for gaussian distributions.