### PR TITLE
PUBDEV-6386: XGBoost MOJO should use Java predictor by default

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostMojoWriter.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostMojoWriter.java
@@ -29,6 +29,7 @@ public class XGBoostMojoWriter extends ModelMojoWriter<XGBoostModel, XGBoostMode
     writekv("cat_offsets", model._output._catOffsets);
     writekv("use_all_factor_levels", model._output._useAllFactorLevels);
     writekv("sparse", model._output._sparse);
+    writekv("booster", model._parms._booster.toString());
     writeblob("feature_map", model.model_info().getFeatureMap().getBytes(Charset.forName("UTF-8")));
   }
 }

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/DefaultMojoImplTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/DefaultMojoImplTest.java
@@ -1,0 +1,103 @@
+package hex.tree.xgboost;
+
+import hex.ModelMetricsRegression;
+import hex.SplitFrame;
+import hex.genmodel.MojoModel;
+import hex.genmodel.algos.xgboost.XGBoostJavaMojoModel;
+import hex.genmodel.algos.xgboost.XGBoostMojoReader;
+import hex.genmodel.algos.xgboost.XGBoostNativeMojoModel;
+import hex.genmodel.utils.DistributionFamily;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.Parameterized;
+import water.DKV;
+import water.Key;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.util.Log;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import hex.tree.xgboost.XGBoostModel.XGBoostParameters.Booster;
+
+public class DefaultMojoImplTest extends TestUtil {
+
+  @BeforeClass
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Before
+  public void setupMojoJavaScoring() {
+    System.clearProperty("sys.ai.h2o.xgboost.scoring.java.enable"); // force default behavior
+
+    assertNull(XGBoostMojoReader.getJavaScoringConfig()); // check that MOJO scoring config is not present
+  }
+
+  @Test
+  public void testGBTree() throws IOException {
+    Scope.enter();
+    try {
+      XGBoostModel model = trainModel(Booster.gbtree);
+      MojoModel mojo = model.toMojo();
+      assertEquals(XGBoostJavaMojoModel.class.getName(), mojo.getClass().getName());
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testDART() throws IOException {
+    Scope.enter();
+    try {
+      XGBoostModel model = trainModel(Booster.dart);
+      MojoModel mojo = model.toMojo();
+      assertEquals(XGBoostNativeMojoModel.class.getName(), mojo.getClass().getName());
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  /* FIXME: PUBDEV-6387: gblinear causes a segmenation fault
+  @Test
+  public void testGBLinear() throws IOException {
+    Scope.enter();
+    try {
+      XGBoostModel model = trainModel(Booster.gblinear);
+      MojoModel mojo = model.toMojo();
+      assertEquals(XGBoostNativeMojoModel.class.getName(), mojo.getClass().getName());
+    } finally {
+      Scope.exit();
+    }
+  }
+  */
+
+  private static XGBoostModel trainModel(Booster booster) {
+    Frame tfr = parse_test_file("./smalldata/prostate/prostate.csv");
+    Scope.track(tfr);
+    Scope.track(tfr.replace(1, tfr.vecs()[1].toCategoricalVec()));   // Convert CAPSULE to categorical
+    Scope.track(tfr.replace(3, tfr.vecs()[3].toCategoricalVec()));   // Convert RACE to categorical
+    DKV.put(tfr);
+
+    XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
+    parms._train = tfr._key;
+    parms._response_column = "AGE";
+    parms._ignored_columns = new String[]{"ID"};
+    parms._booster = booster;
+    if (! Booster.gblinear.equals(booster)) {
+      parms._ntrees = 5;
+    }
+
+    XGBoostModel model = new hex.tree.xgboost.XGBoost(parms).trainModel().get();
+    Scope.track_generic(model);
+    Log.info(model);
+    return model;
+  }
+
+}

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -56,7 +56,7 @@ public class XGBoostTest extends TestUtil {
   @Before
   public void setupMojoJavaScoring() {
     System.setProperty("sys.ai.h2o.xgboost.scoring.java.enable", confMojoJavaScoring); // mojo scoring
-    System.setProperty("sys.ai.h2o.xgboost.predict.java.enable", confMojoJavaScoring); // in-h2o predict
+    System.setProperty("sys.ai.h2o.xgboost.predict.java.enable", confJavaPredict); // in-h2o predict
   }
 
   public static final class FrameMetadata {

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -57,6 +57,8 @@ public class XGBoostTest extends TestUtil {
   public void setupMojoJavaScoring() {
     System.setProperty("sys.ai.h2o.xgboost.scoring.java.enable", confMojoJavaScoring); // mojo scoring
     System.setProperty("sys.ai.h2o.xgboost.predict.java.enable", confJavaPredict); // in-h2o predict
+
+    assertEquals(Boolean.valueOf(confMojoJavaScoring), XGBoostMojoReader.getJavaScoringConfig()); // check that MOJO scoring config was applied
   }
 
   public static final class FrameMetadata {
@@ -1380,11 +1382,9 @@ public class XGBoostTest extends TestUtil {
     }
   }
 
-
-
   @Test
   public void testMojoBoosterDump() throws IOException {
-    Assume.assumeTrue(! XGBoostMojoReader.useJavaScoring());
+    Assume.assumeFalse(XGBoostMojoReader.getJavaScoringConfig());
     Scope.enter();
     try {
       Frame tfr = Scope.track(parse_test_file("./smalldata/prostate/prostate.csv"));

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
@@ -53,7 +53,7 @@ public abstract class XGBoostMojoModel extends MojoModel implements SharedTreeGr
   public int[] _catOffsets;
   public boolean _useAllFactorLevels;
   public boolean _sparse;
-    public String _featureMap;
+  public String _featureMap;
 
   public XGBoostMojoModel(String[] columns, String[][] domains, String responseColumn) {
     super(columns, domains, responseColumn);

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoReader.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoReader.java
@@ -35,15 +35,29 @@ public class XGBoostMojoReader extends ModelMojoReader<XGBoostMojoModel> {
     } catch (IOException e) {
       throw new IllegalStateException("MOJO is corrupted: cannot read the serialized Booster", e);
     }
-    if (useJavaScoring()) {
+    Boolean conf = getJavaScoringConfig();
+    if (useJavaScoring(conf)) {
       return new XGBoostJavaMojoModel(boosterBytes, columns, domains, responseColumn);
     } else {
       return new XGBoostNativeMojoModel(boosterBytes, columns, domains, responseColumn);
     }
   }
 
-  public static boolean useJavaScoring() {
-    return Boolean.getBoolean("sys.ai.h2o.xgboost.scoring.java.enable");
+  private boolean useJavaScoring(Boolean conf) {
+    if (conf != null) {
+      // user set the property - respect the decision
+      return conf;
+    }
+    String booster = readkv("booster");
+    return "gbtree".equals(booster); // use java scoring for `gbtree` (well tested); `native` for dart & gblinear
+  }
+
+  public static Boolean getJavaScoringConfig() {
+    String javaScoringEnabled = System.getProperty("sys.ai.h2o.xgboost.scoring.java.enable");
+    if (javaScoringEnabled == null) {
+      return null;
+    }
+    return Boolean.valueOf(javaScoringEnabled);
   }
 
   @Override public String mojoVersion() {


### PR DESCRIPTION
Java predict is now proven and should be used as the default implementation for MOJO scoring. This also gives people access to TreeSHAP by default.