### PR TITLE
PUBDEV-6221 h2o.getTypes bug

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -287,7 +287,7 @@ h2o.getId <- function(x) attr( .eval.frame(x), "id")
 #' @param x An H2OFrame
 #' @return A list of types per column
 #' @export
-h2o.getTypes <- function(x) attr( .eval.frame(x), "types")
+h2o.getTypes <- function(x){.eval.frame(x); .fetch.data(x, 10L); attr(x, "types")}
 
 #'
 #' Rename an H2O object.

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6221_get_types.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6221_get_types.R
@@ -1,0 +1,12 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+test_get_types <- function() {
+    h2o_test_frame <- h2o.uploadFile(locate("smalldata/junit/cars.csv"))
+    h2o_test_frame["name"] <- h2o.asfactor(h2o_test_frame["name"])
+    types <- h2o.getTypes(h2o_test_frame)
+    expect_false(all(is.na(types)))
+}
+
+doTest("Test h2o.getTypes returns always types not NULL", test_get_types)


### PR DESCRIPTION
Fetch H2oFrame before get the 'types' attribute.