### PR TITLE
PUBDEV-6399: AUCBuilder doesn't always correctly merge histograms

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -522,7 +522,7 @@ public class GBMTest extends TestUtil {
     Scope.enter();
     try {
       final Key<Frame> target = Key.make();
-      Frame train = Scope.track(parse_test_file("/smalldata/logreg/prostate.csv"));
+      Frame train = Scope.track(parse_test_file("./smalldata/logreg/prostate.csv"));
       train.remove("ID").remove();     // Remove unique ID
       int ci = train.find("RACE");
       Scope.track(train.replace(ci, train.vecs()[ci].toCategoricalVec()));   // Convert response 'Angaus' to categorical

--- a/h2o-core/src/main/java/hex/AUC2.java
+++ b/h2o-core/src/main/java/hex/AUC2.java
@@ -387,9 +387,22 @@ public class AUC2 extends Iced {
     // tried the original: merge bins with the least distance between bin
     // centers.  Same problem for sorted data.
     private int find_smallest() {
-      if( _ssx == -1 ) return (_ssx = find_smallest_impl());
+      if( _ssx == -1 ) {
+        _ssx = find_smallest_impl();
+        assert _ssx != -1 : toDebugString();
+      }
       return _ssx;
     }
+
+    private String toDebugString() {
+      return "_ssx = " + _ssx + 
+              "; n = " + _n +
+              "; ths = " + Arrays.toString(_ths) +
+              "; tps = " + Arrays.toString(_tps) +
+              "; fps = " + Arrays.toString(_fps) + 
+              "; sqe = " + Arrays.toString(_sqe);
+    }
+
     private int find_smallest_impl() {
       double minSQE = Double.MAX_VALUE;
       int minI = -1;

--- a/h2o-core/src/main/java/hex/AUC2.java
+++ b/h2o-core/src/main/java/hex/AUC2.java
@@ -350,6 +350,7 @@ public class AUC2 extends Iced {
         if( self_is_larger ) x--; else y--;
       }
       _n += bldr._n;
+      _ssx = -1; // We no longer know what bin has the smallest error
 
       // Merge elements with least squared-error increase until we get fewer
       // than _nBins and no duplicates.  May require many merges.

--- a/h2o-core/src/test/java/hex/AUCBuilderTest.java
+++ b/h2o-core/src/test/java/hex/AUCBuilderTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 
 import static org.junit.Assert.*;
@@ -56,6 +57,27 @@ public class AUCBuilderTest {
     }
 
     System.out.println("Total time with speedup: " + t + "ms; orginal time: " + t_old + "ms.");
+  }
+
+  @Test
+  public void testPubDev6399ReduceDoesntUsePreviousKnownSSX() {
+    AUC2.AUCBuilder abL = new AUC2.AUCBuilder(10);
+    for (int i = 0; i < abL._nBins; i++) {
+      abL.perRow(i, 1, 1);
+    }
+    abL.perRow(5.5, 1, 1); // insert something in the middle and cause a bin merge
+    assertEquals(0, abL._ssx); // bin with smallest error is known but shouldn't be used!
+    
+    AUC2.AUCBuilder abR = new AUC2.AUCBuilder(10);
+    abR.perRow(9, 1, 1); // single element, should be appended at the end when merging and then de-duped
+
+    double[] expected = Arrays.copyOf(abL._ths, abL._n);
+
+    // reduce!
+    abL.reduce(abR);
+
+    double[] ths = Arrays.copyOf(abL._ths, abL._n);
+    assertArrayEquals(expected, ths, 0);
   }
 
 }


### PR DESCRIPTION
It sometimes fails to find the first bin to merge when merging per-chunk histograms
because it reuses invalid internal state