### PR TITLE
PUBDEV-6401: Fix links to Sparkling Water topics in FAQ

### DIFF
--- a/h2o-docs/src/product/faq/sparkling-water.rst
+++ b/h2o-docs/src/product/faq/sparkling-water.rst
@@ -1,6 +1,8 @@
 Sparkling Water
 ---------------
 
+**Note**: This topic is deprecated and will be removed in a later release. Refer to the `Sparkling Water User Guide <http://docs.h2o.ai/#sparkling-water>`__ for Sparkling Water FAQs. 
+
 **What is Sparkling Water?**
 
 Sparkling Water allows users to combine the fast, scalable machine
@@ -207,7 +209,7 @@ The "magic" behind ``run-example.sh`` is a regular Spark Submit:
 
 **How do I use Sparkling Water with Databricks?**
 
-Refer to `Using H2O Sparking Water with Databricks <../cloud-integration/databricks.html>`__ for information on how to use Sparkling Water with Databricks.
+Refer to the "Running Sparkling Water on Databricks Azure Cluster" in the `Sparkling Water User Guide <http://docs.h2o.ai/#sparkling-water>`__ for information on how to use Sparkling Water with Databricks. 
 
 --------------
 
@@ -223,8 +225,8 @@ the app needs to initialize ``H2OServices`` via ``H2OContext``:
     import org.apache.spark.h2o._
     val h2oContext = new H2OContext(sc).start()
 
-For more information, refer to the `Sparkling Water development
-documentation <https://github.com/h2oai/sparkling-water/blob/master/DEVEL.md>`__.
+For more information, refer to the Sparkling Water Development
+documentation in the `Sparkling Water User Guide <http://docs.h2o.ai/#sparkling-water>`__.
 
 --------------
 

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -295,6 +295,17 @@ PySparkling documentation is available for `2.1 <http://docs.h2o.ai/sparkling-wa
 
 PySparkling can be installed by downloading and running the PySparkling shell or using ``pip``. PySparkling can also be installed from the PyPi repository. Follow the instructions on the `Download page <http://h2o.ai/download>`__ for Sparkling Water.
 
+RSparkling
+~~~~~~~~~~
+
+The rsparkling R package is an extension package for sparklyr that creates an R front-end for the Sparkling Water package from H2O. This provides an interface to H2O’s high performance, distributed machine learning algorithms on Spark using R.
+
+This package implements basic functionality (creating an H2OContext, showing the H2O Flow interface, and converting between Spark DataFrames and H2O Frames). The main purpose of this package is to provide a connector between sparklyr and H2O’s machine learning algorithms.
+
+The rsparkling package uses sparklyr for Spark job deployment and initialization of Sparkling Water. After that, users can use the regular H2O R package for modeling. 
+
+Refer to the `Sparkling Water User Guide <http://docs.h2o.ai/#sparkling-water>`__ for more information.
+
 Python Users
 --------------
 


### PR DESCRIPTION
- Sparkling Water links now point to the SW user guide.
- Noted that the SW FAQ is deprecated and will be removed, and users should refer to the FAQ in the SW UG.
Driveby fix: Added summary of RSparkling in the welcome topic.