### PR TITLE
Add six to Python setuptools install requirements

### DIFF
--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -80,7 +80,13 @@ setup(
     ]},
 
     # run-time dependencies
-    install_requires=["requests", "tabulate", "future", "colorama>=0.3.8"],
+    install_requires=[
+        "requests",
+        "tabulate",
+        "future",
+        "colorama>=0.3.8",
+        "six",
+    ],
 
     # optional dependencies
     extras_require={


### PR DESCRIPTION
Currently, if you install h2o using pip in an empty virtual environment,
'import h2o' will fail due to lack of the six library.  This resolves the
issue.