### PR TITLE
PUBDEV-6393 - Rapids as.factor operation converts non-ASCII strings to sanitized forms

### DIFF
--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -84,7 +84,12 @@ public class VecUtils {
             nc.addNA();
           } else {
             c.atStr(bs, row);
-            nc.addNum(lookupTable.get(bs.toSanitizedString()), 0);
+            String strRepresentation = bs.toString();
+            if (strRepresentation.contains("\uFFFD")) {
+              nc.addNum(lookupTable.get(bs.toSanitizedString()), 0);
+            } else {
+              nc.addNum(lookupTable.get(strRepresentation), 0);
+            }
           }
         }
       }
@@ -607,7 +612,6 @@ public class VecUtils {
 
   private static class CollectStringVecDomain extends MRTask<CollectStringVecDomain> {
 
-    private static String PLACEHOLDER = "nothing";
 
     private IcedHashMap<String, IcedInt> _uniques = null;
 
@@ -623,7 +627,12 @@ public class VecUtils {
       for (int i = 0; i < c.len(); i++) {
         if (!c.isNA(i)) {
           c.atStr(bs, i);
-          _uniques.put(bs.toSanitizedString(), _placeHolder);
+          final String strRepresentation = bs.toString();
+          if (strRepresentation.contains("\uFFFD")) {
+            _uniques.put(bs.toSanitizedString(), _placeHolder);
+          } else {
+            _uniques.put(strRepresentation, _placeHolder);
+          }
         }
       }
     }

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6393.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6393.py
@@ -1,0 +1,32 @@
+from h2o import H2OFrame
+from tests import pyunit_utils
+
+
+def pubdev_6393():
+    locations = [['location'],
+             ['�Ｘ県 Ａ市 '], # First observation contains replacement character for unknown char
+             ['Ｘ県 Ｂ市']]
+
+    frame = H2OFrame(locations, header=True, column_types=['enum'])
+    assert frame.ncols == 1
+    assert frame.nrows == len(locations) - 1
+    
+    frame_categories= frame['location'].categories()
+    print(frame_categories)
+    
+    frame_converted = frame['location'].ascharacter().asfactor()
+    assert frame_converted.ncols == 1
+    assert frame_converted.nrows == len(locations) - 1
+    
+    frame_converted_categories = frame_converted.categories();
+    print(frame_converted_categories)
+    
+    # Check for the representation of categoricals to be exactly the same
+    # No explicit check for any specific behavior, the behavior of Categorical and asFactor should be the same
+    for i in range(0,len(frame_converted_categories)):
+        assert frame_categories[i] == frame_converted_categories[i]
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_6393)
+else:
+    pubdev_6393()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6393

My assumption was that the behavior of `asFactor` should be the same as in `Categorical` class. Rules for conversion to categoricals should be the same.