### PR TITLE
PUBDEV-6418: H2O shouldn't just shutdown when an older H2O is trying to connect to it

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2081,7 +2081,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
           return true;
         } catch (Exception e) {
           e.printStackTrace();
-          throw H2O.fail("Internal POJO compilation failed",e);
+          throw new IllegalStateException("Internal POJO compilation failed",e);
         }
 
         // Check that POJO has the expected interfaces
@@ -2131,7 +2131,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
             features = MemoryManager.malloc8d(genmodel._names.length);
           } catch (IOException e1) {
             e1.printStackTrace();
-            throw H2O.fail("Internal MOJO loading failed", e1);
+            throw new IllegalStateException("Internal MOJO loading failed", e1);
           } finally {
             boolean deleted = new File(filename).delete();
             if (!deleted) Log.warn("Failed to delete the file");

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1073,6 +1073,20 @@ final public class H2O {
   private static final ExtensionManager extManager = ExtensionManager.getInstance();
 
   /**
+   * Retrieves a value of an H2O system property
+   * @param name property name
+   * @param def default value
+   * @return value of the system property or default value if property was not defined
+   */
+  public static String getSysProperty(String name, String def) {
+    return System.getProperty(H2O.OptArgs.SYSTEM_PROP_PREFIX + name, def);
+  }
+
+  public static boolean getSysBoolProperty(String name, boolean def) {
+    return Boolean.parseBoolean(getSysProperty(name, String.valueOf(def)));
+  }
+
+  /**
    * Throw an exception that will cause the request to fail, but the cluster to continue.
    * @see #fail(String, Throwable)
    * @return never returns

--- a/h2o-core/src/test/java/water/H2OTest.java
+++ b/h2o-core/src/test/java/water/H2OTest.java
@@ -34,4 +34,19 @@ public class H2OTest {
     assertTrue(H2O.decodeIsClient(timestamp));
   }
 
+  @Test
+  public void testGetSysProperty() {
+    assertEquals("default1", H2O.getSysProperty("test.testGetSysProperty", "default1"));
+    System.setProperty(H2O.ARGS.SYSTEM_PROP_PREFIX + "test.testGetSysProperty", "value1");
+    assertEquals("value1", H2O.getSysProperty("test.testGetSysProperty", "default1"));
+  }
+
+  @Test
+  public void testGetSysBoolProperty() {
+    assertFalse(H2O.getSysBoolProperty("test.testGetSysBoolProperty", false));
+    assertTrue(H2O.getSysBoolProperty("test.testGetSysBoolProperty", true));
+    System.setProperty(H2O.ARGS.SYSTEM_PROP_PREFIX + "test.testGetSysBoolProperty", "true");
+    assertTrue(H2O.getSysBoolProperty("test.testGetSysBoolProperty", false));
+  }
+
 }

--- a/h2o-core/src/test/java/water/NodeLocalEventCollectingListener.java
+++ b/h2o-core/src/test/java/water/NodeLocalEventCollectingListener.java
@@ -3,10 +3,11 @@ package water;
 import org.junit.Ignore;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 
 @Ignore
-public class NodeLocalEventCollectingListener implements H2OListenerExtension{
+public class NodeLocalEventCollectingListener implements H2OListenerExtension {
 
   private HashMap<String, ArrayList<Object[]>> reports;
   @Override
@@ -34,4 +35,12 @@ public class NodeLocalEventCollectingListener implements H2OListenerExtension{
   public void clear(){
     reports = new HashMap<>();
   }
+
+  public static NodeLocalEventCollectingListener getFreshInstance() {
+    Collection<H2OListenerExtension> listenerExtensions = ExtensionManager.getInstance().getListenerExtensions();
+    NodeLocalEventCollectingListener ext = (NodeLocalEventCollectingListener) listenerExtensions.iterator().next();
+    ext.clear();
+    return ext;
+  }
+
 }

--- a/h2o-core/src/test/java/water/TCPReceiverThreadTest.java
+++ b/h2o-core/src/test/java/water/TCPReceiverThreadTest.java
@@ -1,0 +1,38 @@
+package water;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+public class TCPReceiverThreadTest extends TestUtil {
+
+  @BeforeClass()
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void testDontShutdownOnGarbageRequests() throws Exception {
+    NodeLocalEventCollectingListener ext = NodeLocalEventCollectingListener.getFreshInstance(); 
+
+    // make a bogus request to our H2O PORT (NOT the API PORT!!!)
+    // using HTTP is just a cheap trick to send some garbage data that H2O won't recognize
+    URL apiURL = new URL("http:/" + H2O.SELF_ADDRESS + ":" + H2O.H2O_PORT + "/");
+    try (InputStream is = apiURL.openStream()) {
+      assertNull(is); // should never happen
+    } catch (IOException e) {
+      assertEquals("Connection reset", e.getMessage());
+    }
+
+    ArrayList<Object[]> protocolFailure = ext.getData("protocol-failure");
+    assertEquals(1, protocolFailure.size());
+    assertArrayEquals(new Object[]{"handshake"}, protocolFailure.get(0));
+  }
+
+}


### PR DESCRIPTION
Instead of shutting down logs will have this message:

    java.io.IOException: Communication protocol failure (source: '/192.168.1.64'): Missing EOM sentinel     when opening new TCP channel.
    	at water.TCPReceiverThread.run(TCPReceiverThread.java:98)
    04-10 17:27:08.637 192.168.1.64:54321    87637  #P-Accept ERRR: IO error on TCP port 54322:     java.io.IOException: Communication protocol failure (source: '/192.168.1.64'): Missing EOM sentinel     when opening new TCP channel.

The message includes the originator of the request. Users can go ahead and kill the misbehaving H2O.