### PR TITLE
PUBDEV-6421: Get rid off `six` library from the python client

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -168,7 +168,7 @@ At this point, determine whether you want to complete this quick start in either
     h2o-3 user$ [sudo] pip install -U requests
     h2o-3 user$ [sudo] pip install -U tabulate
     h2o-3 user$ [sudo] pip install -U future
-    h2o-3 user$ [sudo] pip install -U six
+    h2o-3 user$ [sudo] pip install -U colorama
 
     # Start python
     h2o-3 user$ python

--- a/h2o-py/conda/h2o/meta.yaml
+++ b/h2o-py/conda/h2o/meta.yaml
@@ -43,7 +43,6 @@ requirements:
     - patsy >= 0.5.0
     - sklearn
     - scikit-learn >= 0.19.1
-    - six >= 1.11.0
     - seaborn >= 0.8.1
     - matplotlib >= 2.1.1
     - sphinx >= 1.6.6

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -12,8 +12,7 @@ from h2o.utils.backward_compatibility import backwards_compatible
 from h2o.utils.compatibility import *  # NOQA
 from h2o.utils.compatibility import viewitems
 from h2o.utils.shared_utils import can_use_pandas
-from h2o.utils.typechecks import I, assert_is_type, assert_satisfies, Enum
-from six import string_types
+from h2o.utils.typechecks import I, assert_is_type, assert_satisfies, Enum, is_type
 
 
 class ModelBase(backwards_compatible()):
@@ -1003,7 +1002,7 @@ class ModelBase(backwards_compatible()):
                     data_ncol = data.ncol
                     column_names = data.names
                     for colKey,val in user_splits.items():
-                        if isinstance(colKey, string_types) and colKey in column_names:
+                        if is_type(colKey, str) and colKey in column_names:
                             user_cols.append(colKey)
                         elif isinstance(colKey, int) and colKey < data_ncol:
                             user_cols.append(column_names[colKey])

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -7,7 +7,6 @@ from functools import reduce
 from scipy.sparse import csr_matrix
 import sys, os
 import pandas as pd
-from six import string_types
 
 try:        # works with python 2.7 not 3
     from StringIO import StringIO
@@ -45,7 +44,7 @@ import json
 import math
 from random import shuffle
 import scipy.special
-from h2o.utils.typechecks import assert_is_type
+from h2o.utils.typechecks import is_type
 import datetime
 import time # needed to randomly generate time
 import uuid # call uuid.uuid4() to generate unique uuid numbers
@@ -4048,7 +4047,7 @@ def manual_partial_dependence(model, dataframe, xlist, xname, weightV):
         cons = [xval]*nRows
         if xname in dataframe.names:
             dataframe=dataframe.drop(xname)
-        if not((isinstance(xval, string_types) and xval=='NA') or (isinstance(xval, float) and math.isnan(xval))):
+        if not((is_type(xval, str) and xval=='NA') or (isinstance(xval, float) and math.isnan(xval))):
             dataframe = dataframe.cbind(h2o.H2OFrame(cons))
             dataframe.set_name(nCols, xname)
 

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5761_pdp_NA.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5761_pdp_NA.py
@@ -5,7 +5,7 @@ import math
 from tests import pyunit_utils
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 import random
-from six import string_types
+from h2o.utils.typechecks import is_type
 
 
 '''
@@ -90,7 +90,7 @@ def manual_partial_dependence(model, datafile, xlist, xname, weightV):
         cons = [xval]*nRows
         if xname in dataframe.names:
             dataframe=dataframe.drop(xname)
-        if not((isinstance(xval, string_types) and xval=='NA') or (isinstance(xval, float) and math.isnan(xval))):
+        if not((is_type(xval, str) and xval=='NA') or (isinstance(xval, float) and math.isnan(xval))):
             dataframe = dataframe.cbind(h2o.H2OFrame(cons))
             dataframe.set_name(nCols, xname)
 


### PR DESCRIPTION
Same can be accomplished using our own functions