### PR TITLE
PUBDEV-6411: Improve error message when model fails to load

### DIFF
--- a/h2o-core/src/main/java/water/api/ModelsHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelsHandler.java
@@ -209,7 +209,7 @@ public class ModelsHandler<I extends ModelsHandler.Models, S extends SchemaV3<I,
       Model<?, ?, ?> model = Model.importBinaryModel(mimport.dir);
       s.models = new ModelSchemaV3[]{(ModelSchemaV3) SchemaServer.schema(version, model).fillFromImpl(model)};
     } catch (IOException | FSIOException e) {
-      throw new H2OIllegalArgumentException("dir", "importModel", mimport.dir);
+      throw new H2OIllegalArgumentException("dir", "importModel", e);
     }
     return s;
   }

--- a/h2o-core/src/test/java/water/api/ModelsHandlerTest.java
+++ b/h2o-core/src/test/java/water/api/ModelsHandlerTest.java
@@ -1,0 +1,29 @@
+package water.api;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import water.TestUtil;
+import water.api.schemas3.ModelImportV3;
+
+public class ModelsHandlerTest extends TestUtil {
+
+  @Rule
+  public ExpectedException ee = ExpectedException.none();
+  
+  @BeforeClass
+  static public void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void testImportModelWithException() {
+    ModelImportV3 importSpec = new ModelImportV3();
+    importSpec.dir = "/definitely/invalid/directory";
+    // the message should show what went wrong
+    ee.expectMessage("Illegal argument: dir of function: importModel: water.api.FSIOException: FS IO Failure: \n" +
+            " accessed path : file:/definitely/invalid/directory msg: File not found");
+    new ModelsHandler().importModel(3, importSpec);
+  }
+}


### PR DESCRIPTION
Messages like

    Illegal argument: dir of function: importModel: /path/to/model

Are not helpful, instead include whole exception message