### PR TITLE
[PUBDEV-6432] Added Py API support for single column name or column index for target encoding.

### DIFF
--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -58,6 +58,9 @@ class TargetEncoder(object):
             threshold between the posterior and the prior probability.
 
         """
+
+        if(type(x) == str or type(x) == int):
+            x = [x]
         self._teColumns = x
         self._responseColumnName = y
         self._foldColumnName = fold_column

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
@@ -245,7 +245,8 @@ def test_that_both_deprecated_and_new_parameters_are_working_together():
         assert issubclass(w[-1].category, DeprecationWarning)
         assert "Parameter blending_avg is deprecated; use blended_avg instead" == str(w[-1].message)
 
-def test_teColumns_parameter_as_single_element():
+
+def test_teColumns_parameter_as_single_column_name():
     print("Check fit method can accept non-array single column to encode")
     targetColumnName = "survived"
     foldColumnName = "kfold_column" # it is strange that we can't set name for generated kfold
@@ -261,7 +262,28 @@ def test_teColumns_parameter_as_single_element():
     encodingMap = targetEncoder.fit(frame=trainingFrame)
     assert encodingMap.map_keys['string'] == [teColumns]
     assert encodingMap.frames[0]['num_rows'] == 583
+    
+    trainingFrame = targetEncoder.transform(trainingFrame, holdout_type="kfold", seed=1234)
+    assert "home.dest_te" in trainingFrame.columns
 
+
+def test_teColumns_parameter_as_single_column_index():
+    print("Check fit method can accept non-array single column to encode")
+    targetColumnName = "survived"
+    foldColumnName = "kfold_column" # it is strange that we can't set name for generated kfold
+
+    teColumns = 13 # stands for "home.dest" column
+    targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
+                                  fold_column= foldColumnName, blending_avg= True, inflection_point = 3, smoothing = 1)
+    trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
+
+    trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
+    trainingFrame[foldColumnName] = trainingFrame.kfold_column(n_folds=5, seed=1234)
+
+    encodingMap = targetEncoder.fit(frame=trainingFrame)
+    assert encodingMap.map_keys['string'] == [trainingFrame.columns[teColumns]]
+    trainingFrame = targetEncoder.transform(trainingFrame, holdout_type="kfold", seed=1234)
+    assert "home.dest_te" in trainingFrame.columns 
 
 
 testList = [
@@ -275,7 +297,8 @@ testList = [
     test_target_encoding_seed_is_working,
     test_ability_to_pass_column_parameters_as_indexes,
     test_that_both_deprecated_and_new_parameters_are_working_together,
-    test_teColumns_parameter_as_single_element
+    test_teColumns_parameter_as_single_column_name,
+    test_teColumns_parameter_as_single_column_index
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before there was a support for :
```
teColumns = ["home.dest"]
    targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,blended_avg= True, inflection_point = 3, smoothing = 1)
```
with this PR it will be possible to pass column as string:
```
teColumns = "home.dest"
    targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
```
or as index of the column:
```
teColumns = 13
    targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
```