### PR TITLE
PUBDEV-6394 - Rapids replace operations on categoricals do not respect reduced categorical domains

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -469,7 +469,22 @@ public class Vec extends Keyed<Vec> {
     return v;
   }
 
-  public Vec remapDomain(final String[] newDomainValues) {
+  /**
+   * Remaps vec's current domain levels to a new set of values. The cardinality of the new set of domain values might be
+   * less than or equal to the cardinality of current domain values. The new domain set is automatically extracted from
+   * the given mapping array.
+   * <p>
+   * Changes are made to this very vector, no copying is done. If you need the original vector to remain unmodified,
+   * please make sure to copy it first.
+   *
+   * @param newDomainValues An array of new domain values. For each old domain value, there must be a new value in
+   *                        this array. The value at each index of newDomainValues array represents the new mapping for
+   *                        this very index. May not be null.
+   * @throws UnsupportedOperationException When invoked on non-categorical vector
+   * @throws IllegalArgumentException      Length of newDomainValues must be equal to length of current domain values of
+   *                                       this vector
+   */
+  public void remapDomain(final String[] newDomainValues) throws UnsupportedOperationException, IllegalArgumentException {
     // Sanity checks
     Objects.requireNonNull(newDomainValues);
     if (_domain == null)
@@ -506,11 +521,9 @@ public class Vec extends Keyed<Vec> {
       reducedDomainIdx++;
     }
 
-    final Vec copy = makeCopy();
     new RemapDomainTask(indicesMap)
-            .doAll(copy);
-    copy.setMeta(Vec.T_CAT, reducedDomain);
-    return copy;
+            .doAll(this);
+    this.setMeta(Vec.T_CAT, reducedDomain);
   }
 
   /**

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -5,7 +5,9 @@ import water.nbhm.NonBlockingHashMap;
 import water.parser.BufferedString;
 import water.util.*;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.UUID;
 
 /** A distributed vector/array/column of uniform data.
  *
@@ -467,83 +469,6 @@ public class Vec extends Keyed<Vec> {
     v.setMeta(type,domain);
     DKV.put(v);
     return v;
-  }
-
-  /**
-   * Remaps vec's current domain levels to a new set of values. The cardinality of the new set of domain values might be
-   * less than or equal to the cardinality of current domain values. The new domain set is automatically extracted from
-   * the given mapping array.
-   * <p>
-   * Changes are made to this very vector, no copying is done. If you need the original vector to remain unmodified,
-   * please make sure to copy it first.
-   *
-   * @param newDomainValues An array of new domain values. For each old domain value, there must be a new value in
-   *                        this array. The value at each index of newDomainValues array represents the new mapping for
-   *                        this very index. May not be null.
-   * @throws UnsupportedOperationException When invoked on non-categorical vector
-   * @throws IllegalArgumentException      Length of newDomainValues must be equal to length of current domain values of
-   *                                       this vector
-   */
-  public void remapDomain(final String[] newDomainValues) throws UnsupportedOperationException, IllegalArgumentException {
-    // Sanity checks
-    Objects.requireNonNull(newDomainValues);
-    if (_domain == null)
-      throw new UnsupportedOperationException("Unable to remap domain values on a non-categorical vector.");
-    if (newDomainValues.length != _domain.length) {
-      throw new IllegalArgumentException(String.format("For each of original domain levels, there must be a new mapping." +
-              "There are %o domain levels, however %o mappings were supplied.", _domain.length, newDomainValues.length));
-    }
-
-    // Create a map of new domain values pointing to indices in the array of old domain values in this vec
-    final Map<String, Set<Integer>> map = new HashMap<>();
-    for (int i = 0; i < newDomainValues.length; i++) {
-      Set<Integer> indices = map.get(newDomainValues[i]);
-      if (indices == null) {
-        indices = new HashSet<>(1);
-        indices.add(i);
-        map.put(newDomainValues[i], indices);
-      } else {
-        indices.add(i);
-      }
-    }
-
-    // Map from the old domain to the new domain
-    // There might actually be less domain levels after the transformation
-    final int[] indicesMap = MemoryManager.malloc4(_domain.length);
-    final String[] reducedDomain = new String[map.size()];
-    int reducedDomainIdx = 0;
-    for (String e : map.keySet()) {
-      final Set<Integer> oldDomainIndices = map.get(e);
-      reducedDomain[reducedDomainIdx] = e;
-      for (int idx : oldDomainIndices) {
-        indicesMap[idx] = reducedDomainIdx;
-      }
-      reducedDomainIdx++;
-    }
-
-    new RemapDomainTask(indicesMap)
-            .doAll(this);
-    this.setMeta(Vec.T_CAT, reducedDomain);
-  }
-
-  /**
-   * Maps old categorical values (indices to old array of domain levels) to new categorical values
-   * (indices to a new array with new domain levels). Uses a simple array for mapping, 
-   */
-  private class RemapDomainTask extends MRTask<RemapDomainTask> {
-
-    private final int[] _domainIndicesMap;
-
-    public RemapDomainTask(int[] domainIndicesMap) {
-      _domainIndicesMap = domainIndicesMap;
-    }
-
-    @Override
-    public void map(Chunk c) {
-      for (int i = 0; i < c.len(); i++) {
-        c.set(i, _domainIndicesMap[(int) c.at8(i)]);
-      }
-    }
   }
 
   public Vec doCopy() {

--- a/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceAll.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceAll.java
@@ -1,5 +1,6 @@
 package water.rapids.ast.prims.string;
 
+import water.Key;
 import water.MRTask;
 import water.fvec.*;
 import water.parser.BufferedString;
@@ -8,6 +9,7 @@ import water.rapids.Val;
 import water.rapids.vals.ValFrame;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
+import water.util.VecUtils;
 
 import java.util.*;
 import java.util.regex.Pattern;
@@ -82,9 +84,7 @@ public class AstReplaceAll extends AstPrimitive {
       return vec.makeCopy(doms);
     } else {
       newDomainSet = null;
-      final Vec copy = vec.makeCopy();
-      copy.remapDomain(doms);
-      return copy;
+      return VecUtils.remapDomain(doms, vec);
     }
   }
 

--- a/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceAll.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceAll.java
@@ -82,7 +82,9 @@ public class AstReplaceAll extends AstPrimitive {
       return vec.makeCopy(doms);
     } else {
       newDomainSet = null;
-      return vec.remapDomain(doms);
+      final Vec copy = vec.makeCopy();
+      copy.remapDomain(doms);
+      return copy;
     }
   }
 

--- a/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceFirst.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceFirst.java
@@ -9,7 +9,10 @@ import water.rapids.vals.ValFrame;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
 
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Accepts a frame with a single string column, a regex pattern string, a replacement substring,
@@ -65,13 +68,26 @@ public class AstReplaceFirst extends AstPrimitive {
   }
 
   private Vec replaceFirstCategoricalCol(Vec vec, String pattern, String replacement, boolean ignoreCase) {
+    final Pattern compiledPattern = Pattern.compile(pattern); // Compile the pattern once before replacement
     String[] doms = vec.domain().clone();
-    for (int i = 0; i < doms.length; ++i)
+    Set<String> newDomainSet = new HashSet<>(); // The pattern might create multiple domains with the same name
+    for (int i = 0; i < doms.length; ++i) {
       doms[i] = ignoreCase
-          ? doms[i].toLowerCase(Locale.ENGLISH).replaceFirst(pattern, replacement)
-          : doms[i].replaceFirst(pattern, replacement);
+              ? compiledPattern.matcher(doms[i].toLowerCase(Locale.ENGLISH)).replaceFirst(replacement)
+              : compiledPattern.matcher(doms[i]).replaceFirst(replacement);
+      newDomainSet.add(doms[i]);
+    }
 
-    return vec.makeCopy(doms);
+    if (newDomainSet.size() == doms.length) {
+      // Avoid remapping if cardinality is the same
+      newDomainSet = null;
+      return vec.makeCopy(doms);
+    } else {
+      newDomainSet = null;
+      final Vec copy = vec.makeCopy();
+      copy.remapDomain(doms);
+      return copy;
+    }
   }
 
   private Vec replaceFirstStringCol(Vec vec, String pat, String rep, boolean ic) {
@@ -89,14 +105,15 @@ public class AstReplaceFirst extends AstPrimitive {
 //          ((CStrChunk) chk).asciiReplaceFirst(newChk);
 //        } else { //UTF requires Java string methods for accuracy
           BufferedString tmpStr = new BufferedString();
+          final Pattern compiledPattern = Pattern.compile(pattern);
           for (int i = 0; i < chk._len; i++) {
             if (chk.isNA(i))
               newChk.addNA();
             else {
               if (ignoreCase)
-                newChk.addStr(chk.atStr(tmpStr, i).toString().toLowerCase(Locale.ENGLISH).replaceFirst(pattern, replacement));
+                newChk.addStr(compiledPattern.matcher(chk.atStr(tmpStr, i).toString().toLowerCase(Locale.ENGLISH)).replaceFirst(replacement));
               else
-                newChk.addStr(chk.atStr(tmpStr, i).toString().replaceFirst(pattern, replacement));
+                newChk.addStr(compiledPattern.matcher(chk.atStr(tmpStr, i).toString()).replaceFirst(replacement));
             }
           }
         }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceFirst.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/string/AstReplaceFirst.java
@@ -8,6 +8,7 @@ import water.rapids.Val;
 import water.rapids.vals.ValFrame;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
+import water.util.VecUtils;
 
 import java.util.HashSet;
 import java.util.Locale;
@@ -84,10 +85,9 @@ public class AstReplaceFirst extends AstPrimitive {
       return vec.makeCopy(doms);
     } else {
       newDomainSet = null;
-      final Vec copy = vec.makeCopy();
-      copy.remapDomain(doms);
-      return copy;
+      return VecUtils.remapDomain(doms, vec);
     }
+    
   }
 
   private Vec replaceFirstStringCol(Vec vec, String pat, String rep, boolean ic) {

--- a/h2o-core/src/test/java/water/rapids/RapidsTest.java
+++ b/h2o-core/src/test/java/water/rapids/RapidsTest.java
@@ -11,10 +11,7 @@ import water.rapids.ast.AstRoot;
 import water.rapids.ast.params.AstNumList;
 import water.rapids.ast.params.AstStr;
 import water.rapids.vals.ValFrame;
-import water.util.ArrayUtils;
-import water.util.FileUtils;
-import water.util.FrameUtils;
-import water.util.Log;
+import water.util.*;
 
 import java.io.File;
 import java.util.Arrays;
@@ -749,5 +746,67 @@ public class RapidsTest extends TestUtil {
       Rapids.parse(expr);
       fail("Expression " + expr + " expected to fail, however it did not.");
     } catch (IllegalASTException ignored) {}
+  }
+
+  @Test
+  public void testAstReplaceFirst() {
+    try {
+      Scope.enter();
+
+      final Frame frame = new TestFrameBuilder().
+              withVecTypes(Vec.T_CAT)
+              .withColNames("location")
+              .withDataForCol(0, ar("ab", "ac", "ad"))
+              .withName("fr")
+              .build();
+      Scope.track(frame);
+
+      final Frame transformedFrame = Rapids.exec("(replacefirst (cols_py fr 'location') 'a' '' 0)").getFrame();
+      assertNotNull(transformedFrame);
+
+      assertEquals(frame.numRows(), transformedFrame.numRows());
+      assertEquals(frame.numCols(), transformedFrame.numCols());
+      final Vec vec = transformedFrame.vec(0);
+      assertEquals("b", vec.stringAt(0));
+      assertEquals("c", vec.stringAt(1));
+      assertEquals("d", vec.stringAt(2));
+
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testAstReplaceFirst_cardinalityChange() {
+    try {
+      Scope.enter();
+
+      final Frame frame = new TestFrameBuilder().
+              withVecTypes(Vec.T_CAT)
+              .withColNames("location")
+              .withDataForCol(0, ar("Ｘ県 Ａ市", "Ｘ県 Ｂ市", "Ｘ県 Ｂ市", "Ｙ県 Ｃ市", "Ｙ県 Ｃ市"))
+              .withName("fr")
+              .build();
+      Scope.track(frame);
+
+      final Frame transformedFrame = Rapids.exec("(replacefirst (cols_py fr 'location') ' .*' '' 0)").getFrame();
+      assertNotNull(transformedFrame);
+
+      assertEquals(frame.numRows(), transformedFrame.numRows());
+      assertEquals(frame.numCols(), transformedFrame.numCols());
+      final Vec vec = transformedFrame.vec(0);
+      assertEquals("Ｘ県", vec.stringAt(0));
+      assertEquals("Ｘ県", vec.stringAt(1));
+      assertEquals("Ｘ県", vec.stringAt(2));
+      assertEquals("Ｙ県", vec.stringAt(3));
+      assertEquals("Ｙ県", vec.stringAt(4));
+      
+      assertEquals(2, vec.cardinality());
+      assertArrayEquals(new String[]{"Ｘ県", "Ｙ県"}, vec.domain());
+
+    } finally {
+      Scope.exit();
+    }
   }
 }

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6394.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6394.py
@@ -1,0 +1,33 @@
+from h2o import H2OFrame
+from tests import pyunit_utils
+
+
+def pubdev_6394():
+    data = [['location'],
+             ['Ｘ県 Ａ市'],
+             ['Ｘ県 Ｂ市'],
+             ['Ｘ県 Ｂ市'],
+             ['Ｙ県 Ｃ市'],
+             ['Ｙ県 Ｃ市']]
+
+
+    originalFrame = H2OFrame(data, header=True, column_types=['enum'])
+    
+    assert originalFrame.type('location') == 'enum'
+    assert originalFrame.categories() ==  ['Ｘ県 Ａ市', 'Ｘ県 Ｂ市', 'Ｙ県 Ｃ市']
+    
+    # Reduce cardinality of 'location' column to 2 by reducing existing categorical values to ['Ｘ県','Y県']
+    expectedCategories = ['Ｘ県', 'Ｙ県']
+    transformedFrame = originalFrame['location'].gsub(' .*', '')
+    print(transformedFrame)
+    
+    assert transformedFrame.ncols == 1
+    assert transformedFrame.nrows == originalFrame.nrows
+    assert transformedFrame.type('C1') == 'enum'
+    assert transformedFrame.type('C1') == 'enum'
+    assert transformedFrame['C1'].categories() == expectedCategories
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_6394)
+else:
+    pubdev_6394()

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6394.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6394.py
@@ -24,6 +24,27 @@ def pubdev_6394():
     assert transformedFrame.ncols == 1
     assert transformedFrame.nrows == originalFrame.nrows
     assert transformedFrame.type('C1') == 'enum'
+    assert transformedFrame['C1'].categories() == expectedCategories
+    
+    # Test gsub without changing the cardinality
+
+    data = [['location'],
+            ['ab'],
+            ['ac'],
+            ['ad'],
+            ['ae'],
+            ['af']]
+
+    originalFrame = H2OFrame(data, header=True, column_types=['enum'])
+    assert originalFrame.type('location') == 'enum'
+    assert originalFrame.categories() ==  ['ab', 'ac','ad', 'ae', 'af']
+
+    expectedCategories = ['b', 'c', 'd', 'e', 'f']
+    transformedFrame = originalFrame['location'].gsub('a', '')
+    print(transformedFrame)
+    
+    assert transformedFrame.ncols == 1
+    assert transformedFrame.nrows == originalFrame.nrows
     assert transformedFrame.type('C1') == 'enum'
     assert transformedFrame['C1'].categories() == expectedCategories
     

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6394.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6394.py
@@ -1,8 +1,9 @@
 from h2o import H2OFrame
 from tests import pyunit_utils
 
-
 def pubdev_6394():
+    # JUnit tests are to be found in RapidsTest class
+    
     data = [['location'],
              ['Ｘ県 Ａ市'],
              ['Ｘ県 Ｂ市'],


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6394

When applying replacement on parts of categorical string, a duplicate categorical levels might be created, effectively reducing the cardinality of the set.

In this PR, the proposed way to deal with it is to change the categorical mapping (only if cardinality changes !) to the new domain by gathering the categorical ordinals which now map to the same index in string domain levels array.

For example, if the following frame named `originalFrame`, containing one column only with five categoricals and three categorical levels ( `["Ｘ県 Ａ市", "Ｘ県 Ｂ市", "Ｙ県 Ｃ市"]` ): 

```plain
location
-----------
Ｘ県 Ａ市
Ｘ県 Ｂ市
Ｘ県 Ｂ市
Ｙ県 Ｃ市
Ｙ県 Ｃ市
```

and everything after the space was removed/replaced by calling `originalFrame['location'].gsub(' .*', '')`. The result should be

```plain
```plain
location
-----------
Ｘ県
Ｘ県
Ｘ県
Ｙ県
Ｙ県
```

and there should be only two categorical levels in the domain: `["Ｘ県", "Ｙ県"]`.



Created two JUnit tests and a kind-of duplicate Python test (really quick though) to demonstrate the result on what the reported provided us.

Note: `AstStrSplit`  has it's own way to deal with changes in categorical values already coded inside.