### PR TITLE
Removed duplicate stack trace log in TCPReceiverThread

### DIFF
--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -123,7 +123,6 @@ public class TCPReceiverThread extends Thread {
         if (wrappedSocket != null) {
           try { wrappedSocket.close(); } catch (Exception e2) { Log.trace(e2); }
         }
-        e.printStackTrace();
         // On any error from anybody, close all sockets & re-open
         Log.err("IO error on TCP port "+H2O.H2O_PORT+": ",e);
         saw_error = true;


### PR DESCRIPTION
Discovered while investigating: [rel-yates build 17](http://mr-0xc1:8080/view/H2O-3/job/h2o-3-nightly-pipeline/job/rel-yates/17/testReport/junit/water/TCPReceiverThreadTest/Java_11_JUnit___testDontShutdownOnGarbageRequests/)