### PR TITLE
[PUBDEV-6431] fix exception for job list with replaced keys

### DIFF
--- a/h2o-core/src/main/java/water/api/schemas3/JobV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/JobV3.java
@@ -3,6 +3,8 @@ package water.api.schemas3;
 import water.*;
 import water.api.API;
 import water.api.schemas3.KeyV3.JobKeyV3;
+import water.exceptions.H2OIllegalArgumentException;
+import water.util.Log;
 import water.util.PojoUtils;
 
 import java.io.PrintWriter;
@@ -91,8 +93,17 @@ public class JobV3 extends SchemaV3<Job, JobV3> {
     msec = job.msec();
     ready_for_view = job.readyForView();
 
-    Keyed dest_type = (Keyed)TypeMap.theFreezable(job._typeid);
-    dest = job._result == null ? null : KeyV3.make(dest_type.makeSchema(),job._result);
+    Keyed dest_type;
+    Value value = null;
+    if (job._result != null) {
+      value = DKV.get(job._result);
+    }
+    if (value != null) {
+      dest_type = (Keyed) TypeMap.theFreezable(value.type());
+    } else {
+      dest_type = (Keyed) TypeMap.theFreezable(job._typeid);
+    }
+    dest = job._result == null ? null : KeyV3.make(dest_type.makeSchema(), job._result);
     return this;
   }
 

--- a/h2o-py/h2o/backend/cluster.py
+++ b/h2o-py/h2o/backend/cluster.py
@@ -263,7 +263,17 @@ class H2OCluster(object):
         res = h2o.api("GET /3/NetworkTest")
         res["table"].show()
 
-
+    def list_jobs(self):
+        """List all jobs performed by the cluster."""
+        res = h2o.api("GET /3/Jobs")
+        table = [["type"], ["dest"], ["description"], ["status"]]
+        for job in res["jobs"]:
+            job_dest = job["dest"]
+            table[0].append(self._translate_job_type(job_dest["type"]))
+            table[1].append(job_dest["name"])
+            table[2].append(job["description"])
+            table[3].append(job["status"])
+        return table
 
     def list_all_extensions(self):
         """List all available extensions on the h2o backend"""
@@ -315,6 +325,22 @@ class H2OCluster(object):
         res = h2o.api("GET /3/" + endpoint)["capabilities"]
         return [x["name"] for x in res]
 
+    def _translate_job_type(self, type):
+        if type is None:
+            return ('Removed')
+        type_mapping = dict([
+            ('Key<Frame>', 'Frame'),
+            ('Key<Model>', 'Model'),
+            ('Key<Grid>', 'Grid'),
+            ('Key<PartialDependence>', 'PartialDependence'),
+            ('Key<AutoML>', 'Auto Model'),
+            ('Key<ScalaCodeResult>', 'Scala Code Execution'),
+            ('Key<KeyedVoid>', 'Void')
+        ])
+        if type in type_mapping:
+            return type_mapping[type]
+        else:
+            return 'Unknown'
 
 _cloud_v3_valid_keys = {"is_client", "build_number", "cloud_name", "locked", "node_idx", "consensus", "branch_name",
                         "version", "cloud_uptime_millis", "cloud_internal_timezone", "datafile_parser_timezone", "cloud_healthy", "bad_nodes", "cloud_size", "skip_ticks",

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5023_rm_metalearner.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5023_rm_metalearner.py
@@ -1,7 +1,6 @@
 
 import h2o
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
-from h2o.grid.grid_search import H2OGridSearch
 
 from tests import pyunit_utils
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6431_deleted_key.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6431_deleted_key.py
@@ -1,0 +1,30 @@
+import h2o
+
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from h2o.grid.grid_search import H2OGridSearch
+from tests import pyunit_utils
+
+
+def pubdev_6431_deleted_key():
+    frame = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+    model = H2OGeneralizedLinearEstimator(family="binomial", alpha=0, Lambda=1e-5)
+    model.train(x=X, y=Y, training_frame=frame)
+    assert 3 == len(h2o.cluster().list_jobs()[0])
+
+    h2o.rm(model)
+    assert 3 == len(h2o.cluster().list_jobs()[0])
+
+    hyper_parameters = {
+        'alpha': [0, 0.3],
+    }
+    grid_search = H2OGridSearch(H2OGeneralizedLinearEstimator, hyper_params=hyper_parameters)
+    grid_search.train(x=X, y=Y, training_frame=frame)
+    assert 3 == len(h2o.cluster().list_jobs()[0])
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_6431_deleted_key)
+else:
+    pubdev_6431_deleted_key()

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -749,6 +749,40 @@ h2o.clusterInfo <- function() {
   }
 }
 
+.h2o.translateJobType <- function(type) {
+    if (is.null(type)) {
+      return('Removed')
+    }
+    switch (type,
+      'Key<Frame>' = 'Frame',
+      'Key<Model>' = 'Model',
+      'Key<Grid>' = 'Grid',
+      'Key<PartialDependence>' = 'PartialDependence',
+      'Key<AutoML>' = 'Auto Model',
+      'Key<ScalaCodeResult>' = 'Scala Code Execution',
+      'Key<KeyedVoid>' = 'Void',
+      'Unknown'
+    )
+}
+
+#' Return list of jobs performed by the H2O cluster
+#' @export
+h2o.list_jobs <- function() {
+  myJobUrlSuffix <- paste0(.h2o.__JOBS)
+  rawResponse <- .h2o.doSafeGET(urlSuffix = myJobUrlSuffix)
+  jsonObject <- .h2o.fromJSON(jsonlite::fromJSON(rawResponse, simplifyDataFrame=FALSE))
+  df <- data.frame()
+  for (job in jsonObject$jobs) {
+    df <- rbind(df, data.frame(
+      type=.h2o.translateJobType(job$dest$type),
+      dest=job$dest$name,
+      description=job$description,
+      status=job$status
+    ))
+  }
+  df
+}
+
 #' Check H2O Server Health
 #'
 #' Warn if there are sick nodes.

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6431_deleted_key.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6431_deleted_key.R
@@ -1,0 +1,19 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.getJobsWithDeletedKeys <- function() {
+
+  input <- h2o.importFile("https://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/abalone.csv.gz")
+  model <- h2o.glm(model_id = "MyModel", y = "C9", training_frame = input, validation_frame = input, alpha = 0.3)
+  expect_equal(2, nrow(h2o.list_jobs()))
+
+  h2o.rm(model)
+  expect_equal(2, nrow(h2o.list_jobs()))
+
+  grid <- h2o.grid(algorithm = "glm", grid_id = "MyModel", y = "C9", training_frame = input, validation_frame = input, alpha = 0.3)
+  expect_equal(3, nrow(h2o.list_jobs()))
+}
+
+doTest("List of jobs with deleted keys", test.getJobsWithDeletedKeys)


### PR DESCRIPTION
- when listing jobs use the actual value type for job result rather than the one stored in the job
- this fixes exception case when one job result is overwritten by another job result of different type