### PR TITLE
Explicitly re-map domains in prediction frames if necessary (PUBDEV-6449)

### DIFF
--- a/h2o-algos/src/main/java/hex/generic/Generic.java
+++ b/h2o-algos/src/main/java/hex/generic/Generic.java
@@ -27,15 +27,11 @@ public class Generic extends ModelBuilder<GenericModel, GenericModelParameters, 
 
     public Generic(GenericModelParameters genericParameters){
         super(genericParameters);
+        init(false);
     }
 
     public Generic(boolean startup_once) {
         super(new GenericModelParameters(), startup_once);
-    }
-
-    @Override
-    public void init(boolean expensive) {
-        super.init(expensive);
     }
 
     @Override

--- a/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
+++ b/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
@@ -107,7 +107,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -154,7 +154,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -201,7 +201,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -248,7 +248,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -295,7 +295,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -341,7 +341,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -389,7 +389,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -436,7 +436,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
@@ -483,7 +483,7 @@ public class GenericModelTest extends TestUtil {
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
-            assertEquals(2691, predictions.anyVec().length());
+            assertEquals(2691, predictions.numRows());
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);

--- a/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
+++ b/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
@@ -58,7 +58,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -105,7 +104,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -153,7 +151,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -201,7 +198,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -249,7 +245,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -297,7 +292,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -344,7 +338,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -393,7 +386,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -441,7 +433,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -489,7 +480,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             predictions = genericModel.score(testFrame);
@@ -541,7 +531,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
             
             // Compare the two MOJOs byte-wise
@@ -591,7 +580,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             // Compare the two MOJOs byte-wise
@@ -641,7 +629,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             // Compare the two MOJOs byte-wise
@@ -690,7 +677,6 @@ public class GenericModelTest extends TestUtil {
             final GenericModelParameters genericModelParameters = new GenericModelParameters();
             genericModelParameters._model_key = mojo;
             final Generic generic = new Generic(genericModelParameters);
-            generic.init(false);
             genericModel = generic.trainModel().get();
 
             // Compare the two MOJOs byte-wise

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1413,7 +1413,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       if( actual != null ) {  // Predict does not have an actual, scoring does
         String sdomain[] = actual.domain(); // Scored/test domain; can be null
         if (sdomain != null && mdomain != sdomain && !Arrays.equals(mdomain, sdomain))
-          output.replace(0, new CategoricalWrappedVec(actual.group().addVec(), actual._rowLayout, sdomain, predicted._key));
+          CategoricalWrappedVec.updateDomain(output.vec(0), sdomain);
       }
     }
     Frame.deleteTempFrameAndItsNonSharedVecs(adaptFr, fr);

--- a/h2o-core/src/main/java/water/fvec/CategoricalWrappedVec.java
+++ b/h2o-core/src/main/java/water/fvec/CategoricalWrappedVec.java
@@ -3,6 +3,7 @@ package water.fvec;
 import water.AutoBuffer;
 import water.Key;
 import water.DKV;
+import water.MRTask;
 import water.util.ArrayUtils;
 
 import java.util.Arrays;
@@ -38,13 +39,50 @@ public class CategoricalWrappedVec extends WrappedVec {
   /** Constructor just to generate the map and domain; used in tests or when
    *  mixing categorical columns */
   private CategoricalWrappedVec(Key key) { super(key, ESPC.rowLayout(key, new long[]{0}), null, null); }
-  public static int[] computeMap(String[] from, String[] to) {
+  private static CategoricalWrappedVec makeTransientVec(String[] from, String[] to) {
     Key key = Vec.newKey();
     CategoricalWrappedVec tmp = new CategoricalWrappedVec(key);
     tmp.computeMap(from, to, false);
-    return tmp._map;
+    return tmp;
+  }
+  public static int[] computeMap(String[] from, String[] to) {
+    return makeTransientVec(from, to)._map;
   }
 
+  /**
+   * Updates Vec's domain in-place (instead of creating a wrapper Vec)
+   * @param source source Vec
+   * @param toDomain target domain
+   * @return updated instance of Vec
+   */
+  public static Vec updateDomain(Vec source, String[] toDomain) {
+    CategoricalWrappedVec tv = makeTransientVec(source.domain(), toDomain);
+    new RemapTask(tv).doAll(source);
+    source.setDomain(tv.domain());
+    DKV.put(source);
+    return source;
+  }
+
+  private static class RemapTask extends MRTask<RemapTask> {
+    private final int[] _map;
+    private final int _p;
+
+    private RemapTask(CategoricalWrappedVec vec) {
+      _map = vec._map; _p = vec._p;
+    }
+
+    @Override
+    public void map(Chunk c) {
+      Chunk wc = new CategoricalWrappedChunk(c, c._vec, _map, _p);
+      assert wc._len == c._len;
+      for (int i = 0; i < wc._len; i++) {
+        if (c.isNA(i))
+          continue;;
+        c.set(i, wc.at8(i));
+      }
+    }
+  }
+  
   @Override public Chunk chunkForChunkIdx(int cidx) {
     return new CategoricalWrappedChunk(masterVec().chunkForChunkIdx(cidx), this);
   }
@@ -67,7 +105,7 @@ public class CategoricalWrappedVec extends WrappedVec {
    *  Extra values in the 'from' domain appear, in-order in the 'from' domain, at the end.
    *  @return mapping
    */
-  void computeMap( String[] from, String[] to, boolean fromIsBad ) {
+  private void computeMap( String[] from, String[] to, boolean fromIsBad ) {
     // Identity? Build the cheapo non-map
     if( from==to || Arrays.equals(from,to) ) {
       _map = ArrayUtils.seq(0,to.length);
@@ -147,9 +185,13 @@ public class CategoricalWrappedVec extends WrappedVec {
     final transient int   _p;
 
     CategoricalWrappedChunk(Chunk c, CategoricalWrappedVec vec) {
+      this(c, vec, vec._map, vec._p);
+    }
+
+    private CategoricalWrappedChunk(Chunk c, Vec vec, int[] map, int p) {
       _c  = c; set_len(_c._len);
       _start = _c._start; _vec = vec; _cidx = _c._cidx;
-      _map = vec._map; _p = vec._p;
+      _map = map; _p = p;
     }
 
     // Returns the mapped value.  {@code _map} covers all the values in the
@@ -190,8 +232,10 @@ public class CategoricalWrappedVec extends WrappedVec {
     @Override protected final void initFromBytes () { throw water.H2O.fail(); }
     @Override public boolean hasNA() { return _c.hasNA(); }
 
+    @Override
     public Chunk deepCopy() {
       return extractRows(new NewChunk(this),0,_c._len).compress();
     }
   }
+
 }

--- a/h2o-core/src/test/java/water/fvec/CategoricalWrappedVecTest.java
+++ b/h2o-core/src/test/java/water/fvec/CategoricalWrappedVecTest.java
@@ -2,10 +2,7 @@ package water.fvec;
 
 import org.junit.*;
 
-import water.Keyed;
-import water.Lockable;
-import water.Scope;
-import water.TestUtil;
+import water.*;
 import water.util.Log;
 import water.util.PrettyPrint;
 import water.util.RandomUtils;
@@ -13,6 +10,10 @@ import water.util.RandomUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class CategoricalWrappedVecTest extends TestUtil {
   @BeforeClass static public void setup() {  stall_till_cloudsize(1); }
@@ -103,4 +104,25 @@ public class CategoricalWrappedVecTest extends TestUtil {
     int[] mapping = CategoricalWrappedVec.computeMap(colDomain, modelDomain);
     Assert.assertArrayEquals("Mapping differs",  expectedMapping, mapping);
   }
+
+  @Test
+  public void testUpdateDomain() {
+    try {
+      Scope.enter();
+      Frame f = new TestFrameBuilder().withVecTypes(Vec.T_CAT)
+              .withDataForCol(0, ar("a", "c", "c"))
+              .build();
+      Vec vec = f.anyVec();
+      String[] toDomain = new String[]{"a", "b", "c"}; 
+      CategoricalWrappedVec.updateDomain(vec, toDomain);
+      assertArrayEquals(toDomain, vec.domain());
+      assertEquals(0, vec.at8(0));
+      assertEquals(2, vec.at8(1));
+      assertEquals(2, vec.at8(2));
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
 }


### PR DESCRIPTION
Instead of using CategoricalWrappedVec: update is more expensive than
wrapping a Vec but the benefit is that it is straightforward to work further
with a materialized Vec. Modifying a CategoricalWrappedVec might not always
work.