### PR TITLE
Failing Iced serialization/writing into autobuffer

### DIFF
--- a/h2o-core/src/test/java/water/IcedSerializationTest.java
+++ b/h2o-core/src/test/java/water/IcedSerializationTest.java
@@ -1,0 +1,47 @@
+package water;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class IcedSerializationTest extends TestUtil {
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtil.stall_till_cloudsize(1);
+    }
+
+    private static final class Outer extends Lockable<Outer> {
+        
+        private Inner f;
+        
+        public final class Inner extends Iced<Inner>{
+            
+        }
+        
+        /**
+         * Create a Lockable object, if it has a {@link Key}.
+         *
+         * @param key
+         */
+        public Outer(Key<Outer> key) {
+            super(key);
+            f = new Inner();
+        }
+    }
+
+    @Test
+    public void test() {
+        try {
+            Scope.enter();
+            final Key<Outer> key = Key.make();
+            final Outer outer = new Outer(key);
+            Scope.track_generic(outer);
+
+            outer.write_lock();
+            outer.unlock();
+        } finally {
+            Scope.exit();
+        }
+    }
+}


### PR DESCRIPTION
In case of a non-static inner class, the serialization runs in cycles, resulting in stack overflow.

Same effect is achieved with `Serializable`, only the serialization goes through different route. Means the problem probably lies somewhere else.

The cycle makes sense - the instance of non-static inner class needs the outer class instance. However, the outer class contains a field with the inner class. This creates the infinite loop.