### PR TITLE
We need to update the reference to a possibly stale Vec in Vec#chunkForCIdx

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -1091,12 +1091,10 @@ public class Vec extends Keyed<Vec> {
     long cstart = c._start;             // Read once, since racily filled in
     Vec v = c._vec;
     int tcidx = c._cidx;
-    if( cstart == start && v != null && tcidx == cidx)
-      return c;                       // Already filled-in
-    if (cstart != -1 && v != null && tcidx != -1)
-      throw new RuntimeException("Was not filled in (everybody racily writes the same start value:  cstart = " + cstart + " v = " + v + " cidx = " + tcidx + ", chunk = " + c.getClass().getName());
-    c._vec = this;             // Fields not filled in by unpacking from Value
-    c._start = start;          // Fields not filled in by unpacking from Value
+    if( cstart == start && v == this && tcidx == cidx)
+      return c;                         // Already filled-in
+    c._vec = this;                      // Fields not filled in by unpacking from Value
+    c._start = start;
     c._cidx = cidx;
     return c;
   }

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -1093,9 +1093,8 @@ public class Vec extends Keyed<Vec> {
     int tcidx = c._cidx;
     if( cstart == start && v != null && tcidx == cidx)
       return c;                       // Already filled-in
-    if(!(cstart == -1 || v == null || tcidx == -1))
-      throw new RuntimeException("Was not filled in (everybody racily writes the same start value:  cstart = " + cstart + " v == null? " + (v == null) + " cidx = " + tcidx + ", chunk = " + c.getClass().getName());
-    assert cstart == -1 || v == null || tcidx == -1:" cstart = " + cstart + " v == null? " + (v == null) + " cidx = " + tcidx + ", chunk = " + c.getClass().getName(); // Was not filled in (everybody racily writes the same start value)
+    if (cstart != -1 && v != null && tcidx != -1)
+      throw new RuntimeException("Was not filled in (everybody racily writes the same start value:  cstart = " + cstart + " v = " + v + " cidx = " + tcidx + ", chunk = " + c.getClass().getName());
     c._vec = this;             // Fields not filled in by unpacking from Value
     c._start = start;          // Fields not filled in by unpacking from Value
     c._cidx = cidx;


### PR DESCRIPTION
The assumption of `Vec#chunkForCIdx` was that Vec is set only once at the beginning and then it never changes. This works fine in most of the cases but breaks if you mutate the Vec on a different node which is not the home node of the Vec and send an MRTask that accesses Chunk#_vec.

This is WIP because any call to chunkForChunkIdx will now update the Vec even when it is a temporary change that won't be propagated to DKV.

cc: @deil87 