### PR TITLE
PUBDEV-6440 - Unable to parse files from s3 [using s3's directory url with s3 protocol]

### DIFF
--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -180,7 +180,8 @@ public final class PersistS3 extends Persist {
   }
 
 
-  private static void processListing(ObjectListing listing, final String pattern, ArrayList<String> succ, ArrayList<String> fail, boolean doImport) {
+  private static void processListing(ObjectListing listing, String pattern, ArrayList<String> succ, ArrayList<String> fail, boolean doImport) {
+    if( pattern != null && pattern.isEmpty()) pattern = null;
     for( S3ObjectSummary obj : listing.getObjectSummaries() ) {
       if (obj.getKey().endsWith("/")) continue;
       if (pattern != null && !obj.getKey().matches(pattern)) continue;


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6440

In **S3**, everything is an object. Including folders. Which means H2O was trying to parse folders, as these were not filtered out.

- Filtering folders based on `/` postfix.
- Current logic also walks all the subfolders, This behavior has not been changed.
- Pattern was not taken into account when `importFiles` was invoked. This has been fixed, as users might need to filter the files in the subdirectories (for example).
- Flow tested

![FireShot Capture 001 - H2O Flow - 192 168 59 179](https://user-images.githubusercontent.com/8769110/57309434-5c9c9500-70e8-11e9-8cd0-585c5eafa9a7.png)

Note: This PR is only about S3. S3A has different handling of everything.
