### PR TITLE
PUBDEV-6476: Experimenting with Rabit.init in order to speed-up scoring

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -221,23 +221,6 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     return dinfo;
   }
 
-  public static byte[] getRawArray(Booster booster) {
-    if(null == booster) {
-      return null;
-    }
-
-    byte[] rawBooster;
-    try {
-      Map<String, String> localRabitEnv = new HashMap<>();
-      Rabit.init(localRabitEnv);
-      rawBooster = booster.toByteArray();
-      Rabit.shutdown();
-    } catch (XGBoostError xgBoostError) {
-      throw new IllegalStateException("Failed to initialize Rabit or serialize the booster.", xgBoostError);
-    }
-    return rawBooster;
-  }
-
   // ----------------------
   class XGBoostDriver extends Driver {
 

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -464,8 +464,14 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
               (timeToScore && _parms._score_tree_interval == 0) || // use time-based duty-cycle heuristic only if the user didn't specify _score_tree_interval
               manualInterval) {
         _timeLastScoreStart = now;
+        long ub_start = System.currentTimeMillis();
         boosterProvider.updateBooster(); // retrieve booster, expensive!
+        long ub_end = System.currentTimeMillis();
+        long ds_start = System.currentTimeMillis();
         model.doScoring(_train, _parms.train(), _valid, _parms.valid());
+        long ds_end = System.currentTimeMillis();
+        System.out.println("Timer UB:" + (ub_end - ub_start));
+        System.out.println("Timer DS:" + (ds_end - ds_start));
         _timeLastScoreEnd = System.currentTimeMillis();
         XGBoostOutput out = model._output;
         final Map<String, XGBoostUtils.FeatureScore> varimp;

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
@@ -155,10 +155,8 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
         DMatrix data = null;
         Booster booster = null;
         try {
-            Map<String, String> rabitEnv = new HashMap<>();
             // Rabit has to be initialized as parts of booster.predict() are using Rabit
             // This might be fixed in future versions of XGBoost
-            Rabit.init(rabitEnv);
 
             data = XGBoostUtils.convertChunksToDMatrix(
                     dataInfo,
@@ -195,11 +193,6 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
             throw new IllegalStateException("Failed to score with XGBoost.", xgBoostError);
         } finally {
             BoosterHelper.dispose(booster, data);
-            try {
-                Rabit.shutdown();
-            } catch (XGBoostError xgBoostError) {
-                throw new IllegalStateException("Failed Rabit shutdown. A hanging RabitTracker task might be present on the driver node.", xgBoostError);
-            }
         }
     }
 

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
@@ -26,7 +26,7 @@ public class XGBoostUpdateTask extends AbstractXGBoostTask<XGBoostUpdateTask> {
         final H2ONode boosterNode = getBoosterNode();
         final byte[] boosterBytes;
         if (H2O.SELF.equals(boosterNode)) {
-            boosterBytes = XGBoost.getRawArray(XGBoostUpdater.getUpdater(_modelKey).getBooster());
+            boosterBytes = XGBoostUpdater.getUpdater(_modelKey).getBoosterBytes();
         } else {
             Log.debug("Booster will be retrieved from a remote node, node=" + boosterNode);
             FetchBoosterTask t = new FetchBoosterTask(_modelKey);

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
@@ -111,14 +111,22 @@ public class XGBoostUpdater extends Thread {
       if ((_booster == null) && _tid == 0) {
         HashMap<String, DMatrix> watches = new HashMap<>();
         // Create empty Booster
+        long bg_start = System.currentTimeMillis();
         _booster = ml.dmlc.xgboost4j.java.XGBoost.train(_trainMat,
                 _boosterParms.get(),
                 0,
                 watches,
                 null,
                 null);
+        long bg_end = System.currentTimeMillis();
         // Force Booster initialization; we can call any method that does "lazy init"
+        long bs_start = System.currentTimeMillis();
         byte[] boosterBytes = _booster.toByteArray();
+        long bs_end = System.currentTimeMillis();
+
+        System.out.println("Timer BG:" + (bg_end - bg_start));
+        System.out.println("Timer BS:" + (bs_end - bs_start));
+
         Log.info("Initial (0 tree) Booster created, size=" + boosterBytes.length);
       } else {
         // Do one iteration
@@ -137,7 +145,11 @@ public class XGBoostUpdater extends Thread {
   private class SerializeBooster implements BoosterCallable<byte[]> {
     @Override
     public byte[] call() throws XGBoostError {
-      return _booster.toByteArray();
+      long sb_start = System.currentTimeMillis();
+      byte[] result = _booster.toByteArray();
+      long sb_end = System.currentTimeMillis();
+      System.out.println("Timer SB:" + (sb_end - sb_start));
+      return result;
     }
     @Override
     public String toString() {

--- a/h2o-genmodel-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/BoosterHelper.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/BoosterHelper.java
@@ -53,24 +53,8 @@ public class BoosterHelper {
   }
 
   public static <X> X doWithLocalRabit(BoosterOp<X> op, Booster booster) throws XGBoostError {
-    boolean shutdownRabit = true;
-    try {
-      Map<String, String> rabitEnv = new HashMap<>();
-      rabitEnv.put("DMLC_TASK_ID", "0");
-      Rabit.init(rabitEnv);
-      shutdownRabit = true;
       X result = op.apply(booster);
-      Rabit.shutdown();
-      shutdownRabit = false;
       return result;
-    } finally {
-      if (shutdownRabit)
-        try {
-          Rabit.shutdown();
-        } catch (XGBoostError e) {
-          e.printStackTrace(); // don't rely on logging support in genmodel
-        }
-    }
   }
 
 }


### PR DESCRIPTION
@honzasterba the first commit can go in, the second one is just experimental

This PR shows that killing all calls to Rabit.init/shutdown significantly speeds-up scoring and brings it to performance pre-xgboost upgrade. I think it is conclusive that this is the cause of the slowdown reported in PUBDEV-6476. 