### PR TITLE
PUBDEV-6475 - h2o.getModelTree throws invalid object for slot 'nas'

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3604,7 +3604,15 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
     )
 
   res$thresholds[is.nan(res$thresholds)] <- NA
+  
+  if(length(res$left_children) < 1) stop("Tree does not contain any nodes.")
 
+  if(res$left_children[1] == -1){ # If the root node has no children
+    res$nas <- c("NA")
+    res$levels <- list(NULL)
+    res$thresholds <- c(as.double(NA))
+  }
+  
   tree <- new(
     "H2OTree",
     left_children = res$left_children,

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6475.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6475.R
@@ -1,0 +1,22 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.tree.rootnode_only <- function() {
+  
+  data <- h2o.importFile(locate("smalldata/iris/iris_wheader.csv"))
+  model <- h2o.gbm(x= c("sepal_len", "sepal_wid"), y = "class", training_frame = data)
+  # Artificially create an XGBoost model with root node only
+  model <- h2o.xgboost(x= c("sepal_len", "sepal_wid"), y = "class", training_frame = data, max_depth = 0)
+  tree <- h2o.getModelTree(model, 1, "Iris-setosa")
+  expect_false(is.null(tree))
+  expect_equal(-1, tree@left_children[1])
+  expect_equal( -1, tree@right_children[1])
+  expect_true(is.null(tree@levels[[1]]))
+  expect_true(is.na(tree@thresholds))
+  
+
+}
+
+doTest("Decision tree with root node only", test.tree.rootnode_only)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6475

Details are hidden in the support portal, as the model may not be published: https://support.h2o.ai/helpdesk/tickets/94341

## Description

It is possible for XGBoost to produce a root-node only decision tree. Our API couldn't handle this case, as it relied on max_depth parameters to be required > 0. This is not the case of XGBoost. 

Submitting `max_depth = 0` to XGBoost is not the only way XGBoost will produce a root-node only graph. The customer used a valid (at first sight) set of arguments (details in the support ticket). Also, there were bugs found in history that made XGBoost produce the same result: https://github.com/dmlc/xgboost/issues/8

**Sample output after the code adjustments:**

```R
> tree@thresholds
[1] NA
> tree@levels
[[1]]
NULL

> tree@nas
[1] "NA"
> tree@left_children
[1] -1
> tree@right_children
[1] -1
```

Let me also share what is inside H2O's response once a tree for a root-node only XGBoost model is fetched:

```R
$model$`__meta`$schema_name
[1] "ModelKeyV3"

$model$`__meta`$schema_type
[1] "Key<Model>"


$model$name
[1] "XGBoost_model_R_1555615412037_230835"

$model$type
[1] "Key<Model>"

$model$URL
[1] "/3/Models/XGBoost_model_R_1555615412037_230835"


$tree_number
[1] 0

$tree_class
[1] "0"

$left_children
[1] -1

$right_children
[1] -1

$root_node_id
[1] 0

$thresholds
[1] NaN

$features
[1] "attr07_h1"

$nas
[1] NA

$descriptions
[1] "Root node has id 0. "

$levels
[1] NA

$predictions
[1] 0
```

### Python API

Python API remains **unaffected** :heavy_check_mark: , due to its handling of types. The only malfunctioning code was R.

```
from h2o.tree import *
tree = H2OTree(model, 0, "Iris-setosa")
tree
Out[11]: <h2o.tree.tree.H2OTree at 0x7f8de803f278>
tree.nas
Out[12]: [None]
tree.features
Out[13]: ['sepal_len']
tree.thresholds
Out[14]: [nan]
```