### PR TITLE
PUBDEV-6490: GBM models with monotone constraints inflate variable importance

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -192,8 +192,8 @@ public final class DHistogram extends Iced {
   public DHistogram(String name, final int nbins, int nbins_cats, byte isInt, double min, double maxEx,
                     double minSplitImprovement, SharedTreeModel.SharedTreeParameters.HistogramType histogramType, long seed, Key globalQuantilesKey,
                     Constraints cs) {
-    assert nbins > 1;
-    assert nbins_cats > 1;
+    assert nbins >= 1;
+    assert nbins_cats >= 1;
     assert maxEx > min : "Caller ensures "+maxEx+">"+min+", since if max==min== the column "+name+" is all constants";
     if (cs != null) {
       _pred1 = cs._min;

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -81,6 +81,17 @@ public final class DHistogram extends Iced {
   public double wNA()   { return _vals[_vals_dim*_nbin+0]; }
   public double wYNA()  { return _vals[_vals_dim*_nbin+1]; }
   public double wYYNA() { return _vals[_vals_dim*_nbin+2]; }
+
+  /**
+   * Squared Error for NA bucket and prediction value _pred1
+   * @return se
+   */
+  public double seP1NA() { return _vals[_vals_dim*_nbin+3]; }
+  /**
+   * Squared Error for NA bucket and prediction value _pred2
+   * @return se
+   */
+  public double seP2NA() { return _vals[_vals_dim*_nbin+4]; }
   public double denNA() { return _vals[_vals_dim*_nbin+5]; }
 
   final boolean hasPreds() {

--- a/h2o-algos/src/main/java/hex/tree/DTree.java
+++ b/h2o-algos/src/main/java/hex/tree/DTree.java
@@ -140,7 +140,8 @@ public class DTree extends Iced {
     public Split(int col, int bin, DHistogram.NASplitDir nasplit, IcedBitSet bs, byte equal, double se, double se0, double se1, double n0, double n1, double p0, double p1, double tree_p0, double tree_p1) {
       assert(nasplit!= DHistogram.NASplitDir.None);
       assert(equal!=1); //no longer done
-      assert se > se0+se1 || se==Double.MAX_VALUE; // No point in splitting unless error goes down
+      // FIXME: Disabled for testing PUBDEV-6495:
+      // assert se > se0+se1 || se==Double.MAX_VALUE; // No point in splitting unless error goes down
       assert(col>=0);
       assert(bin>=0);
       _col = col;  _bin = bin; _nasplit = nasplit; _bs = bs;  _equal = equal;  _se = se;
@@ -803,7 +804,7 @@ public class DTree extends Iced {
       return null; // TODO: there are empty leafs?
     }
     final int nbins = hs.nbins();
-    assert nbins > 1;
+    assert nbins >= 1;
 
     final boolean hasPreds = hs.hasPreds();
     final boolean hasDenom = hs.hasDenominator();

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -624,6 +624,10 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
           if (dn._split == null)
             continue;
           int constraint = cs.getColumnConstraint(dn._split._col);
+          if (dn._split.naSplitDir() == DHistogram.NASplitDir.NAvsREST) {
+            // NAs are not subject to constraints, we don't have to check the monotonicity on "NA vs REST" type of splits
+            continue;
+          }
           if (constraint > 0) {
             if (maxs[dn._nids[0]] > mins[dn._nids[1]]) {
               throw new IllegalStateException("Monotonicity constraint " + constraint + " violated on column '" + _train.name(dn._split._col) + "' (max(left) > min(right)): " + 

--- a/h2o-algos/src/test/java/hex/tree/DTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeTest.java
@@ -16,7 +16,7 @@ public class DTreeTest {
     double[] ys = new double[]{0,          1,          0,   1  };
     int[] rows  = new int[]   {0,          1,          2,   3  };
 
-    DHistogram hs = new DHistogram("test_hs", 2, 0, (byte) 0, 0, 2, 0.01,
+    DHistogram hs = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, 0.01,
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null);
     hs.init();
     hs.updateHisto(ws, null, cs, ys,rows, rows.length, 0);
@@ -24,14 +24,13 @@ public class DTreeTest {
     // 1. min_rows = #NAs
     DTree.Split s1 = DTree.findBestSplitPoint(hs, 0, 20, 0, Double.NaN, Double.NaN, false);
     assertNotNull(s1);
-    final double se = s1._se; 
 
     // 2. min_rows = #NAs + 1
     DTree.Split s2 = DTree.findBestSplitPoint(hs, 0, 21, 0, Double.NaN, Double.NaN, false);
     assertNull(s2); // not enough improvement => no split
 
     // 3. allow negative (!!!) split improvement, min_rows = #NAs + 1
-    DHistogram hsN = new DHistogram("test_hs", 2, 0, (byte) 0, 0, 2, -9,
+    DHistogram hsN = new DHistogram("test_hs", 2, 2, (byte) 0, 0, 2, -9,
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null);
     hsN.init();
     hsN.updateHisto(ws, null, cs, ys,rows, rows.length, 0);
@@ -69,12 +68,12 @@ public class DTreeTest {
   }
 
   private static DHistogram makeHisto(int nbins, double min_pred, double max_pred) {
-    Constraints c = new Constraints(new int[1], DistributionFamily.gaussian, true)
-            .withNewConstraint(0, 0, min_pred)
-            .withNewConstraint(0, 1, max_pred);
+    Constraints c = new Constraints(new int[]{1}, DistributionFamily.gaussian, true)
+            .withNewConstraint(0, 1, min_pred)
+            .withNewConstraint(0, 0, max_pred);
     assertEquals(min_pred, c._min, 0);
     assertEquals(max_pred, c._max, 0);
-    return new DHistogram("test_hs", nbins, 0, (byte) 0, 0, 10, 0.01,
+    return new DHistogram("test_hs", nbins, 2, (byte) 0, 0, 10, 0.01,
             SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, c);
   }
   

--- a/h2o-algos/src/test/java/hex/tree/DTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeTest.java
@@ -1,0 +1,124 @@
+package hex.tree;
+
+import hex.tree.DHistogram.NASplitDir;
+import hex.genmodel.utils.DistributionFamily;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DTreeTest {
+
+  @Test // check that bounds constrained "NA vs REST" splits have correct Square Errors
+  public void testFindBestSplitPoint_bounds_NAvsREST() {
+    final double min_pred = 0.3;
+    final double max_pred = 0.4;
+
+    DHistogram hs = makeHisto(1, min_pred, max_pred);
+    ExpectedSplitInfo expectedSplitInfo = updateHisto(hs, min_pred, max_pred, 1.0);
+    
+    DTree.Split split = DTree.findBestSplitPoint(hs, 0, 0, 0, min_pred, max_pred, true);
+    
+    expectedSplitInfo.checkSplit(split);
+  }
+
+  @Test // check that bounds constrained splits include the error of NAs in the Square Error
+  public void testFindBestSplitPoint_bounds_NAs() {
+    final double min_pred = 0.3;
+    final double max_pred = 0.4;
+
+    DHistogram hs = makeHisto(100, min_pred, max_pred);
+    ExpectedSplitInfo expectedSplitInfo = updateHisto(hs, min_pred, max_pred,0.1);
+
+    DTree.Split split = DTree.findBestSplitPoint(hs, 0, 100, 0, min_pred, max_pred, true);
+
+    expectedSplitInfo.checkSplit(split);
+  }
+
+  private static DHistogram makeHisto(int nbins, double min_pred, double max_pred) {
+    Constraints c = new Constraints(new int[1], DistributionFamily.gaussian, true)
+            .withNewConstraint(0, 0, min_pred)
+            .withNewConstraint(0, 1, max_pred);
+    assertEquals(min_pred, c._min, 0);
+    assertEquals(max_pred, c._max, 0);
+    return new DHistogram("test_hs", nbins, 0, (byte) 0, 0, 10, 0.01,
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, c);
+  }
+  
+  private static ExpectedSplitInfo updateHisto(DHistogram hs, final double min_pred, final double max_pred, double na_percent) {
+    hs.init();
+    final int N = 1000;
+    final int S = 600;
+    final int NA = (int) (S * na_percent);
+    double[] ws = new double[N];
+    double[] cs = new double[N];
+    double[] ys = new double[N];
+    int[] rows = new int[N];
+    double p0 = 0.25; // < min_pred
+    double p1 = 0.45; // > max_pred 
+    double ys_mean = (S * p0 + (N - S) * p1) / N;
+    double se = 0;
+    double se_min_pred = 0;
+    double se_max_pred = 0;
+    for (int i = 0; i < N; i++) {
+      ws[i] = 1.0;
+      rows[i] = i;
+      cs[i] = i < NA ? Double.NaN : i / (N / 10.0);
+      ys[i] = i < S ? p0 : p1;
+      se += (ys_mean - ys[i]) * (ys_mean - ys[i]);
+      if (i < S) {
+        se_min_pred += (min_pred - ys[i]) * (min_pred - ys[i]);
+      } else {
+        se_max_pred += (max_pred - ys[i]) * (max_pred - ys[i]);
+      }
+    }
+    hs.updateHisto(ws, null, cs, ys, rows, N, 0);
+    
+    if (na_percent == 1.0) {
+      return new ExpectedSplitInfo(NASplitDir.NAvsREST, se, se_max_pred, se_min_pred);
+    } else {
+      // ignore actual SE and use non-NA SE
+      double nna_se = seNonNA(cs, ys); 
+      return new ExpectedSplitInfo(NASplitDir.NALeft, nna_se, se_min_pred, se_max_pred);
+    }
+  }
+  
+  private static double seNonNA(double[] cs, double[] ys) {
+    double nna_y_sum = 0;
+    int nna_y_cnt = 0;
+    for (int i = 0; i < ys.length; i++) {
+      if (Double.isNaN(cs[i]))
+        continue;
+      nna_y_cnt++;
+      nna_y_sum += ys[i];
+    }
+    double nna_y_mean = nna_y_sum / nna_y_cnt;
+    double nna_se = 0;
+    for (int i = 0; i < ys.length; i++) {
+      if (Double.isNaN(cs[i]))
+        continue;
+      nna_se += (ys[i] - nna_y_mean) * (ys[i] - nna_y_mean);
+    }
+    return nna_se;
+  }
+  
+  private static class ExpectedSplitInfo {
+    NASplitDir _nasplit;
+    double _se, _se0, _se1;
+
+    ExpectedSplitInfo(NASplitDir nasplit, double se, double se0, double se1) {
+      _nasplit = nasplit;
+      _se = se;
+      _se0 = se0;
+      _se1 = se1;
+    }
+
+    void checkSplit(DTree.Split split) {
+      assertNotNull(split);
+      assertEquals(_nasplit, split._nasplit);
+      assertEquals(_se, split._se, 1e-8);
+      assertEquals(_se0, split._se0, 1e-8);
+      assertEquals(_se1, split._se1, 1e-8);
+    }
+  }
+  
+}

--- a/h2o-algos/src/test/java/hex/tree/DTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/DTreeTest.java
@@ -8,6 +8,40 @@ import static org.junit.Assert.*;
 
 public class DTreeTest {
 
+  @Test
+  public void testFindBestSplitPoint_pubdev6495() {
+
+    double[] ws = new double[]{10,         10,         100, 1  };
+    double[] cs = new double[]{Double.NaN, Double.NaN, 0.5, 1.5};
+    double[] ys = new double[]{0,          1,          0,   1  };
+    int[] rows  = new int[]   {0,          1,          2,   3  };
+
+    DHistogram hs = new DHistogram("test_hs", 2, 0, (byte) 0, 0, 2, 0.01,
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null);
+    hs.init();
+    hs.updateHisto(ws, null, cs, ys,rows, rows.length, 0);
+
+    // 1. min_rows = #NAs
+    DTree.Split s1 = DTree.findBestSplitPoint(hs, 0, 20, 0, Double.NaN, Double.NaN, false);
+    assertNotNull(s1);
+    final double se = s1._se; 
+
+    // 2. min_rows = #NAs + 1
+    DTree.Split s2 = DTree.findBestSplitPoint(hs, 0, 21, 0, Double.NaN, Double.NaN, false);
+    assertNull(s2); // not enough improvement => no split
+
+    // 3. allow negative (!!!) split improvement, min_rows = #NAs + 1
+    DHistogram hsN = new DHistogram("test_hs", 2, 0, (byte) 0, 0, 2, -9,
+            SharedTreeModel.SharedTreeParameters.HistogramType.UniformAdaptive, 123, null, null);
+    hsN.init();
+    hsN.updateHisto(ws, null, cs, ys,rows, rows.length, 0);
+    DTree.Split s3 = DTree.findBestSplitPoint(hsN, 0, 21, 0, Double.NaN, Double.NaN, false);
+    assertNotNull(s3); // split was made thanks to the negative split improvement
+    assertEquals(s3._se, seNonNA(ws, cs, ys), 0); // SE is actually the non-NA SE
+    assertTrue(s3._se < s1._se); // SE is different because the SE of NAs is not accounted for
+    // case (2) shows that we would abandon the split if it was not for the negative minimum split improvement 
+  }
+
   @Test // check that bounds constrained "NA vs REST" splits have correct Square Errors
   public void testFindBestSplitPoint_bounds_NAvsREST() {
     final double min_pred = 0.3;
@@ -77,26 +111,26 @@ public class DTreeTest {
       return new ExpectedSplitInfo(NASplitDir.NAvsREST, se, se_max_pred, se_min_pred);
     } else {
       // ignore actual SE and use non-NA SE
-      double nna_se = seNonNA(cs, ys); 
+      double nna_se = seNonNA(ws, cs, ys); 
       return new ExpectedSplitInfo(NASplitDir.NALeft, nna_se, se_min_pred, se_max_pred);
     }
   }
   
-  private static double seNonNA(double[] cs, double[] ys) {
+  private static double seNonNA(double ws[], double[] cs, double[] ys) {
     double nna_y_sum = 0;
-    int nna_y_cnt = 0;
+    double nna_y_weight = 0;
     for (int i = 0; i < ys.length; i++) {
       if (Double.isNaN(cs[i]))
         continue;
-      nna_y_cnt++;
-      nna_y_sum += ys[i];
+      nna_y_weight += ws[i];
+      nna_y_sum += ws[i] * ys[i];
     }
-    double nna_y_mean = nna_y_sum / nna_y_cnt;
+    double nna_y_mean = nna_y_sum / nna_y_weight;
     double nna_se = 0;
     for (int i = 0; i < ys.length; i++) {
       if (Double.isNaN(cs[i]))
         continue;
-      nna_se += (ys[i] - nna_y_mean) * (ys[i] - nna_y_mean);
+      nna_se += ws[i] * (ys[i] - nna_y_mean) * (ys[i] - nna_y_mean);
     }
     return nna_se;
   }

--- a/h2o-r/tests/testdir_algos/gbm/runit_gbm_monotone_varimp_large.R
+++ b/h2o-r/tests/testdir_algos/gbm/runit_gbm_monotone_varimp_large.R
@@ -1,0 +1,26 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+
+
+test_varimp_monotone_gbm <- function(){
+    loans <- h2o.importFile(locate("bigdata/laptop/lending-club/loan.csv"))
+    loans$bad_loan <- as.factor(loans$bad_loan)
+
+    gbm_regular <- h2o.gbm(y = "bad_loan", training_frame = loans, nfold = 5, seed = 1234)
+    auc_regular <- h2o.auc(gbm_regular, xval = T)
+    varimp_regular <- h2o.varimp(gbm_regular)[,c("variable", "percentage")]
+
+    gbm_constrained <- h2o.gbm(y = "bad_loan", training_frame = loans, nfold = 5, seed = 1234,
+    monotone_constraints = list(int_rate = 1))
+    auc_constrained <- h2o.auc(gbm_constrained, xval = T)
+    varimp_constrained <- h2o.varimp(gbm_constrained)[,c("variable", "percentage")]
+
+    varimps <- merge(varimp_regular, varimp_constrained, by="variable")
+    print(varimps)
+    expect_equal(varimps$percentage.x, varimps$percentage.y, tolerance = 0.01, scale = 1)
+    
+    expect_equal(auc_regular, auc_constrained, tolerance = 0.01, scale = 1)
+}
+
+doTest("GBM Test: Check that adding a monotone constraint to an almost-monotonic variable doesn't affect model performance and variable importace", test_varimp_monotone_gbm)


### PR DESCRIPTION
For columns with NAs - this is mainly due to incorrect attribution of squared error improvement for splits "NA vs rest".