### PR TITLE
PUBDEV-6476: XGBoost - better (faster) way of extracting booster bytes

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -221,23 +221,6 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
     return dinfo;
   }
 
-  public static byte[] getRawArray(Booster booster) {
-    if(null == booster) {
-      return null;
-    }
-
-    byte[] rawBooster;
-    try {
-      Map<String, String> localRabitEnv = new HashMap<>();
-      Rabit.init(localRabitEnv);
-      rawBooster = booster.toByteArray();
-      Rabit.shutdown();
-    } catch (XGBoostError xgBoostError) {
-      throw new IllegalStateException("Failed to initialize Rabit or serialize the booster.", xgBoostError);
-    }
-    return rawBooster;
-  }
-
   // ----------------------
   class XGBoostDriver extends Driver {
 

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdateTask.java
@@ -26,7 +26,7 @@ public class XGBoostUpdateTask extends AbstractXGBoostTask<XGBoostUpdateTask> {
         final H2ONode boosterNode = getBoosterNode();
         final byte[] boosterBytes;
         if (H2O.SELF.equals(boosterNode)) {
-            boosterBytes = XGBoost.getRawArray(XGBoostUpdater.getUpdater(_modelKey).getBooster());
+            boosterBytes = XGBoostUpdater.getUpdater(_modelKey).getBoosterBytes();
         } else {
             Log.debug("Booster will be retrieved from a remote node, node=" + boosterNode);
             FetchBoosterTask t = new FetchBoosterTask(_modelKey);


### PR DESCRIPTION
Avoid using Rabit.init/shutdown - it is causing slowdown with new XGB