### PR TITLE
PUBDEV-6486: Add support for CDH 6.2 to User Guide

### DIFF
--- a/h2o-docs/src/product/faq/hadoop.rst
+++ b/h2o-docs/src/product/faq/hadoop.rst
@@ -81,7 +81,7 @@ Here is another example:
 
 ::
 
-    # pathToAirlines <- "hdfs://mr-0xd6.0xdata.loc/datasets/airlines_all.csv"
+    # pathToAirlines <- "http://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip"
     # airlines.hex <- h2o.importFile(path = pathToAirlines, destination_frame = "airlines.hex")
 
 In Flow, the easiest way is to let the auto-suggestion feature in the

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -430,6 +430,7 @@ Supported Versions
 -  CDH 5.14
 -  CDH 6.0
 -  CDH 6.1
+-  CDH 6.2
 -  HDP 2.2
 -  HDP 2.3
 -  HDP 2.4


### PR DESCRIPTION
driveby fix: updated path to airlines file in Hadoop FAQ