### PR TITLE
PUBDEV-6474: Fix for the issue with more than two columns to encode in Py TargetEncoder

### DIFF
--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -102,8 +102,6 @@ class TargetEncoder(object):
         """
         assert_is_type(holdout_type, "kfold", "loo", "none")
 
-        # We need to make sure that frames are being sent in the same order
-        assert self._encodingMap.map_keys['string'] == self._teColumns
         encodingMapKeys = self._encodingMap.map_keys['string']
         encodingMapFramesKeys = list(map(lambda x: x['key']['name'], self._encodingMap.frames))
         return H2OFrame._expr(expr=ExprNode("target.encoder.transform", encodingMapKeys, encodingMapFramesKeys, frame, self._teColumns, holdout_type,

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
@@ -261,7 +261,33 @@ def test_teColumns_parameter_as_single_element():
     encodingMap = targetEncoder.fit(frame=trainingFrame)
     assert encodingMap.map_keys['string'] == [teColumns]
     assert encodingMap.frames[0]['num_rows'] == 583
+    
 
+def pubdev_6474_test_more_than_two_columns_to_encode_case():
+    import pandas as pd
+    import random
+
+    runs = 10
+    seeds = random.sample(range(1, 10000), runs)
+    for current_seed in seeds:
+        df = pd.DataFrame({
+            'x_0': ['a'] * 5 + ['b'] * 5,
+            'x_1': ['c'] * 9 + ['d'] * 1,
+            'x_2': ['e'] * 2 + ['f'] * 8,
+            'x_3': ['h'] * 4 + ['i'] * 6,
+            'x_4': ['g'] * 7 + ['k'] * 3,
+            'x_5': ['l'] * 1 + ['m'] * 9,
+            'y_0': [1, 1, 1, 1, 0, 1, 0, 0, 0, 0]
+        })
+        
+        hf = h2o.H2OFrame(df)
+        hf['cv_fold_te'] = hf.kfold_column(n_folds=2, seed=current_seed)
+        hf['y_0'] = hf['y_0'].asfactor()
+    
+        full_features = ['x_0','x_1','x_2', 'x_3', 'x_4', 'x_5']
+        target_encoder = TargetEncoder(x=full_features, y='y_0', fold_column = 'cv_fold_te')
+        target_encoder.fit(hf)
+        hf = target_encoder.transform(frame=hf, holdout_type='kfold', seed=current_seed, noise=0.0)
 
 
 testList = [
@@ -275,7 +301,8 @@ testList = [
     test_target_encoding_seed_is_working,
     test_ability_to_pass_column_parameters_as_indexes,
     test_that_both_deprecated_and_new_parameters_are_working_together,
-    test_teColumns_parameter_as_single_element
+    test_teColumns_parameter_as_single_element,
+    pubdev_6474_test_more_than_two_columns_to_encode_case
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
The issue was only in Py client. There was an assert that checks that order of columns to encode and order in response from the server are matching. 

Removed unnecessary assertion. As long as we sent to the server column names and frame keys from our encoding map in the same order we don't have to worry about the fact that order is different from what user had passed to the argument x.
