### PR TITLE
PUBDEV-6476: Fix slow XGBoost scoring on OS X

### DIFF
--- a/h2o-genmodel-extensions/xgboost/build.gradle
+++ b/h2o-genmodel-extensions/xgboost/build.gradle
@@ -11,17 +11,17 @@ dependencies {
 
     // XGBoost dependencies published into Maven central by H2O
     // Versioning rules may differ for XGBoost artifacts published by H2O
-    compile("ai.h2o:xgboost4j:0.82.18") {
+    compile("ai.h2o:xgboost4j:0.82.19") {
         exclude group: 'org.scala-lang', module: 'scala-compiler'
         exclude group: 'org.scala-lang', module: 'scala-reflect'
         exclude group: 'org.scala-lang', module: 'scala-library'
         exclude group: 'com.typesafe.akka', module: 'akka-actor_2.11'
         exclude group: 'com.esotericsoftware.kryo', module: 'kryo'
     }
-    compile "ai.h2o:xgboost4j-linux-gpuv4:0.82.18"
-    compile "ai.h2o:xgboost4j-linux-minimal:0.82.18"
-    compile "ai.h2o:xgboost4j-osx-minimal:0.82.18"
-    compile "ai.h2o:xgboost4j-linux-ompv3:0.82.18"
+    compile "ai.h2o:xgboost4j-linux-gpuv4:0.82.19"
+    compile "ai.h2o:xgboost4j-linux-minimal:0.82.19"
+    compile "ai.h2o:xgboost4j-osx-minimal:0.82.19"
+    compile "ai.h2o:xgboost4j-linux-ompv3:0.82.19"
     compileOnly 'com.esotericsoftware.kryo:kryo:2.21'
 
     testCompile 'com.esotericsoftware.kryo:kryo:2.21'


### PR DESCRIPTION
This PR incorporates XGBoost version with a patched Rabit module: https://github.com/h2oai/xgboost/pull/71 (this patch improves performance H2OXGBoost on OS X)