### PR TITLE
PUBDEV-6503: Allow specifying an external IP for h2odriver callback

### DIFF
--- a/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -104,7 +104,8 @@ public class h2odriver extends Configured implements Tool {
   static String mapperXmx = null;
   static int extraMemPercent = -1;            // Between 0 and 10, typically.  Cannot be negative.
   static String mapperPermSize = null;
-  static String driverCallbackIp = null;
+  static String driverCallbackBindIp = null;
+  static String driverCallbackPublicIp = null;
   static int driverCallbackPort = 0;          // By default, let the system pick the port.
   static PortRange driverCallbackPortRange = null;
   static String network = null;
@@ -640,6 +641,7 @@ public class h2odriver extends Configured implements Tool {
                     "          [-driverif <ip address of mapper->driver callback interface>]\n" +
                     "          [-driverport <port of mapper->driver callback interface>]\n" +
                     "          [-driverportrange <range portX-portY of mapper->driver callback interface>; eg: 50000-55000]\n" +
+                    "          [-extdriverif <external ip address of mapper->driver callback interface>\n" +
                     "          [-network <IPv4network1Specification>[,<IPv4network2Specification> ...]\n" +
                     "          [-timeout <seconds>]\n" +
                     "          [-disown]\n" +
@@ -673,6 +675,11 @@ public class h2odriver extends Configured implements Tool {
                     "          o  -driverif and -driverport/-driverportrange let the user optionally\n" +
                     "             specify the network interface and port/port range (on the driver host)\n" +
                     "             for callback messages from the mapper to the driver.\n" +
+                    "          o  -extdriverif lets the user optionally specify external (=not present on the host)\n" +
+                    "             IP address to be used for callback messages from mappers to the driver. This can be\n" +
+                    "             used when driver is running in an isolated environment (eg. Docker container)\n" +
+                    "             and communication to the driver port is forwarded from outside of the host/container.\n" +
+                    "             Should be used in conjunction with -driverport option.\n" +
                     "          o  -network allows the user to specify a list of networks that the\n" +
                     "             H2O nodes can bind to.  Use this if you have multiple network\n" +
                     "             interfaces on the hosts in your Hadoop cluster and you want to\n" +
@@ -856,9 +863,13 @@ public class h2odriver extends Configured implements Tool {
         i++; if (i >= args.length) { usage(); }
         mapperPermSize = args[i];
       }
+      else if (s.equals("-extdriverif")) {
+        i++; if (i >= args.length) { usage(); }
+        driverCallbackPublicIp = args[i];
+      }
       else if (s.equals("-driverif")) {
         i++; if (i >= args.length) { usage(); }
-        driverCallbackIp = args[i];
+        driverCallbackBindIp = args[i];
       }
       else if (s.equals("-driverport")) {
         i++; if (i >= args.length) { usage(); }
@@ -1185,17 +1196,17 @@ public class h2odriver extends Configured implements Tool {
     }
   }
 
-  static String calcMyIp() throws Exception {
+  private static String calcMyIp(String externalIp) throws Exception {
     Enumeration nis = NetworkInterface.getNetworkInterfaces();
 
-    System.out.println("Determining driver host interface for mapper->driver callback...");
+    System.out.println("Determining driver " + (externalIp != null ? "(internal) " : "") +  "host interface for mapper->driver callback...");
     while (nis.hasMoreElements()) {
       NetworkInterface ni = (NetworkInterface) nis.nextElement();
       Enumeration ias = ni.getInetAddresses();
       while (ias.hasMoreElements()) {
         InetAddress ia = (InetAddress) ias.nextElement();
         String s = ia.getHostAddress();
-        System.out.println("    [Possible callback IP address: " + s + "]");
+        System.out.println("    [Possible callback IP address: " + s +  (externalIp != null ? "; external IP specified: " + externalIp : "") + "]");
       }
     }
 
@@ -1371,7 +1382,7 @@ public class h2odriver extends Configured implements Tool {
     for (int p = driverCallbackPortRange.from; (result == null) && (p <= driverCallbackPortRange.to); p++) {
       ServerSocket ss = new ServerSocket();
       ss.setReuseAddress(true);
-      InetSocketAddress sa = new InetSocketAddress(driverCallbackIp, p);
+      InetSocketAddress sa = new InetSocketAddress(driverCallbackBindIp, p);
       try {
         int backlog = Math.max(50, numNodes * 3); // minimum 50 (bind's default) or numNodes * 3 (safety constant, arbitrary)
         ss.bind(sa, backlog);
@@ -1419,8 +1430,11 @@ public class h2odriver extends Configured implements Tool {
 
     // Set up callback address and port.
     // ---------------------------------
-    if (driverCallbackIp == null) {
-      driverCallbackIp = calcMyIp();
+    if (driverCallbackBindIp == null) {
+      driverCallbackBindIp = calcMyIp(driverCallbackPublicIp);
+    }
+    if (driverCallbackPublicIp == null) {
+      driverCallbackPublicIp = driverCallbackBindIp;
     }
     if (driverCallbackPortRange == null) {
       driverCallbackPortRange = new PortRange(driverCallbackPort, driverCallbackPort);
@@ -1430,8 +1444,9 @@ public class h2odriver extends Configured implements Tool {
     CallbackManager cm = new CallbackManager();
     cm.setServerSocket(driverCallbackSocket);
     cm.start();
-    System.out.println("Using mapper->driver callback IP address and port: " + driverCallbackIp + ":" + actualDriverCallbackPort);
-    System.out.println("(You can override these with -driverif and -driverport/-driverportrange.)");
+    System.out.println("Using mapper->driver callback IP address and port: " + driverCallbackPublicIp + ":" + actualDriverCallbackPort + 
+            (!driverCallbackBindIp.equals(driverCallbackPublicIp) ? " (internal callback address: " + driverCallbackBindIp + ":" + actualDriverCallbackPort + ")" : ""));
+    System.out.println("(You can override these with -driverif and -driverport/-driverportrange and/or specify external IP using -extdriverif.)");
 
     // Set up configuration.
     // ---------------------
@@ -1535,7 +1550,7 @@ public class h2odriver extends Configured implements Tool {
       conf.set("mapred.job.reuse.jvm.num.tasks", "1");
     }
 
-    conf.set(h2omapper.H2O_DRIVER_IP_KEY, driverCallbackIp);
+    conf.set(h2omapper.H2O_DRIVER_IP_KEY, driverCallbackPublicIp);
     conf.set(h2omapper.H2O_DRIVER_PORT_KEY, Integer.toString(actualDriverCallbackPort));
 
     // Arguments.


### PR DESCRIPTION
Use case: h2odriver running in a docker contain or somehow isolated from data nodes (data nodes cannot reach the driver node), we need to give an outside IP address to the H2O nodes to use for a callback instead of the one detected in the container/isolated environment.

This would be used in Cloudera Data Science Workbench.

The user run starts the h2odriver in a container and specifies a known external IP for the callback using the `-extdriverif` parameter. It is expected the port doesn't have to be re-mapped like this because the outside port would be known and the container port can be chosen to be the same.

Example (a bit contrived, only for demo purposes):

1. Run ssh tunnel forwarding 172.16.2.204:40000 to 172.16.2.181:40000: `michalk@172.16.2.204:~$ ssh -L \*:40000:localhost:40000 michalk@172.16.2.181`
2. On 172.16.2.181 run h2odriver with mapper->driver callback routed through 172.16.2.204:
    `michalk@172.16.2.181:~$ hadoop jar h2odriver.jar -extdriverif 172.16.2.204 -driverif 127.0.0.1 -driverport 40000 -n 2 -mapperXmx 4g`

Driver prints:

    Using mapper->driver callback IP address and port: 172.16.2.204:40000 (internal callback address: 127.0.0.1:40000)
