### PR TITLE
PUBDEV-648 - NA threshold not properly shown in tree node's description

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -207,7 +207,7 @@ public class TreeHandler extends Handler {
                 if (nodeLevelsindex != nodeLevels.length - 1) nodeDescriptionBuilder.append(",");
             }
         } else {
-            nodeDescriptionBuilder.append("NA only");
+            nodeDescriptionBuilder.append("Split value is NA.");
         }
 
         nodeDescriptions[pointer] = nodeDescriptionBuilder.toString();


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6489

The "NA only" sentence is indeed confusing. The threshold values are all NA,s which seems to be a valid outcome from the underlying SharedTree* structures.

```R
> tree <- h2o.getModelTree(gbm, tree_number = 1, tree_class = 0)
> tree@thresholds
[1] NA NA NA
```
The logic on backend is here (look into the else block): https://github.com/h2oai/h2o-3/blob/3ae9f57b68d715f4956dc090decdcc2fbe5438b9/h2o-algos/src/main/java/hex/tree/TreeHandler.java#L195

I propose changing the sentence about the split value, otherwise there is not much we can do in Tree API - this is a real valid outcome from the algorithm.
