### PR TITLE
XGBoost: Clean-up + speed-up of Sparse Matrix allocation

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
@@ -67,10 +67,8 @@ public class XGBoostSetupTask extends AbstractXGBoostTask<XGBoostSetupTask> {
       return XGBoostUtils.convertFrameToDMatrix(
               _sharedModel.dataInfo(),
               _trainFrame,
-              true,
               _parms._response_column,
               _parms._weights_column,
-              _parms._fold_column,
               _sparse);
   }
 

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
@@ -194,8 +194,6 @@ public class XGBoostUtilsTest extends TestUtil {
         }
         final int nrows = (int) vec.length();
 
-        int actualRows = 0;
-
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(3);
         // Calculate sparse matrix dimensions
         final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, vecs, null, di);
@@ -210,8 +208,8 @@ public class XGBoostUtilsTest extends TestUtil {
                 nrows);
 
         // Initialize allocated matrices with actual data
-        actualRows = XGBoostUtils.initalizeFromChunkIds(
-                frame, chunksIds, vecs, null, di, actualRows, sparseMatrix._rowHeaders,
+        int actualRows = XGBoostUtils.initalizeFromChunkIds(
+                frame, chunksIds, vecs, null, di, sparseMatrix._rowHeaders,
                 sparseMatrix._sparseData, sparseMatrix._colIndices,
                 respReader, resp, weights);
 
@@ -257,8 +255,6 @@ public class XGBoostUtilsTest extends TestUtil {
         }
         final int nrows = (int) vec.length();
 
-        int actualRows = 0;
-
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(3);
         // Calculate sparse matrix dimensions
         final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, vecs, null, di);
@@ -273,8 +269,8 @@ public class XGBoostUtilsTest extends TestUtil {
                 nrows);
 
         // Initialize allocated matrices with actual data
-        actualRows = XGBoostUtils.initalizeFromChunkIds(
-                frame, chunksIds, vecs, null, di, actualRows, sparseMatrix._rowHeaders,
+        int actualRows = XGBoostUtils.initalizeFromChunkIds(
+                frame, chunksIds, vecs, null, di, sparseMatrix._rowHeaders,
                 sparseMatrix._sparseData, sparseMatrix._colIndices,
                 respReader, resp, weights);
 
@@ -323,8 +319,6 @@ public class XGBoostUtilsTest extends TestUtil {
         }
         final int nrows = (int) vec.length();
 
-        int actualRows = 0;
-
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(1); // 3 arrays in each direction for colIndices and data, 4 for rowHeaders
 
         // Calculate sparse matrix dimensions
@@ -340,8 +334,8 @@ public class XGBoostUtilsTest extends TestUtil {
                 nrows);
 
         // Initialize allocated matrices with actual data
-        actualRows = XGBoostUtils.initalizeFromChunkIds(
-                frame, chunksIds, vecs, null, di, actualRows, sparseMatrix._rowHeaders,
+        int actualRows = XGBoostUtils.initalizeFromChunkIds(
+                frame, chunksIds, vecs, null, di, sparseMatrix._rowHeaders,
                 sparseMatrix._sparseData, sparseMatrix._colIndices,
                 respReader, resp, weights);
 
@@ -390,8 +384,6 @@ public class XGBoostUtilsTest extends TestUtil {
         }
         final int nrows = (int) vec.length();
 
-        int actualRows = 0;
-
         // Force the internal representation to utilize both dimensions
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(1);
 
@@ -408,8 +400,8 @@ public class XGBoostUtilsTest extends TestUtil {
                 nrows);
 
         // Initialize allocated matrices with actual data
-        actualRows = XGBoostUtils.initalizeFromChunkIds(
-                frame, chunksIds, vecs, null, di, actualRows, sparseMatrix._rowHeaders,
+        int actualRows = XGBoostUtils.initalizeFromChunkIds(
+                frame, chunksIds, vecs, null, di, sparseMatrix._rowHeaders,
                 sparseMatrix._sparseData, sparseMatrix._colIndices,
                 respReader, resp, weights);
 

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
@@ -196,7 +196,7 @@ public class XGBoostUtilsTest extends TestUtil {
 
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(3);
         // Calculate sparse matrix dimensions
-        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, vecs, null, di);
+        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, null, di);
         assertNotNull(sparseMatrixDimensions);
         assertEquals(3, sparseMatrixDimensions._nonZeroElementsCount);
         assertEquals(4, sparseMatrixDimensions._rowHeadersCount); // 3 rows + 1 final index
@@ -257,7 +257,7 @@ public class XGBoostUtilsTest extends TestUtil {
 
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(3);
         // Calculate sparse matrix dimensions
-        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, vecs, null, di);
+        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, null, di);
         assertNotNull(sparseMatrixDimensions);
         assertEquals(3, sparseMatrixDimensions._nonZeroElementsCount);
         assertEquals(4, sparseMatrixDimensions._rowHeadersCount); // 3 rows + 1 final index
@@ -322,7 +322,7 @@ public class XGBoostUtilsTest extends TestUtil {
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(1); // 3 arrays in each direction for colIndices and data, 4 for rowHeaders
 
         // Calculate sparse matrix dimensions
-        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, vecs, null, di);
+        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, null, di);
         assertNotNull(sparseMatrixDimensions);
         assertEquals(3, sparseMatrixDimensions._nonZeroElementsCount);
         assertEquals(4, sparseMatrixDimensions._rowHeadersCount); // 3 rows + 1 final index
@@ -388,7 +388,7 @@ public class XGBoostUtilsTest extends TestUtil {
         XGBoostUtilsTest.setSparseMatrixMaxDimensions(1);
 
         // Calculate sparse matrix dimensions
-        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, vecs, null, di);
+        final XGBoostUtils.SparseMatrixDimensions sparseMatrixDimensions = XGBoostUtils.calculateCSRMatrixDimensions(frame, chunksIds, null, di);
         assertNotNull(sparseMatrixDimensions);
         assertEquals(5, sparseMatrixDimensions._nonZeroElementsCount);
         assertEquals(4, sparseMatrixDimensions._rowHeadersCount); // 3 rows + 1 final index

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
@@ -157,7 +157,7 @@ public class XGBoostUtilsTest extends TestUtil {
                 .withDataForCol(2, ard(0, 3, 0))
                 .build());
         final DMatrix response = XGBoostUtils.convertFrameToDMatrix(new DataInfo(frame, null, true, DataInfo.TransformType.NONE, false, false, false),
-                frame, true, "C3", null, null, true);
+                frame, "C3", null, true);
         assertNotNull(response);
         assertEquals(3, response.rowNum());
         assertArrayEquals(arf(0, 3, 0), response.getLabel(), 0f);


### PR DESCRIPTION
@Pscheidl I noticed we spend a significant amount of time calculating dimensions of the CSR sparse matrix (see attached screenshot - 4 minutes no progress and the code is just calculating the matrix size) on larger dataset. Only single thread is doing something.

This PR makes the calculation parallel.