### PR TITLE
[PUBDEV-5937] make java predictor default for XGBoost

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/util/PredictConfiguration.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/util/PredictConfiguration.java
@@ -1,0 +1,22 @@
+package hex.tree.xgboost.util;
+
+import static water.H2O.OptArgs.SYSTEM_PROP_PREFIX;
+
+public class PredictConfiguration {
+
+  public static final String PREDICT_JAVA_PROP = SYSTEM_PROP_PREFIX + "xgboost.predict.java.enable";
+  public static final String PREDICT_NATIVE_PROP = SYSTEM_PROP_PREFIX + "xgboost.predict.native.enable";
+
+  public static boolean useJavaScoring() {
+    String predictNativePropValue = System.getProperty(PREDICT_NATIVE_PROP);
+    String predictJavaPropValue = System.getProperty(PREDICT_JAVA_PROP);
+    if (predictNativePropValue != null) {
+      return !Boolean.valueOf(predictNativePropValue);
+    } if (predictJavaPropValue != null) {
+      return Boolean.valueOf(predictJavaPropValue);
+    } else {
+      return true;
+    }
+  }
+
+}

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PredictorFactory.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/PredictorFactory.java
@@ -5,7 +5,7 @@ import biz.k11i.xgboost.config.PredictorConfiguration;
 import biz.k11i.xgboost.tree.RegTree;
 import biz.k11i.xgboost.tree.RegTreeFactory;
 import biz.k11i.xgboost.util.ModelReader;
-import water.util.Log;
+import hex.genmodel.algos.xgboost.XGBoostJavaObjFunRegistration;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -13,7 +13,11 @@ import java.io.InputStream;
 import java.nio.ByteOrder;
 
 public class PredictorFactory {
-
+  
+  static {
+    XGBoostJavaObjFunRegistration.register();
+  }
+  
   public static Predictor makePredictor(byte[] boosterBytes) {
     return makePredictor(boosterBytes, true);
   }
@@ -21,7 +25,6 @@ public class PredictorFactory {
   public static Predictor makePredictor(byte[] boosterBytes, boolean scoringOnly) {
     PredictorConfiguration.Builder bldr = PredictorConfiguration.builder();
     if (scoringOnly && unsafeTreesSupported()) {
-      Log.warn("XGBoost Predictor is using EXPERIMENTAL scoring implementation!");
       bldr.regTreeFactory(UnsafeRegTreeFactory.INSTANCE);
     }
     PredictorConfiguration cfg = bldr.build();

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostScoreTask.java
@@ -164,8 +164,6 @@ public class XGBoostScoreTask extends MRTask<XGBoostScoreTask> {
                     dataInfo,
                     cs,
                     fr.find(parms._response_column),
-                    -1, // not used for preds
-                    fr.find(parms._fold_column),
                     output._sparse);
 
             // No local chunks for this frame

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostSetupTask.java
@@ -69,7 +69,8 @@ public class XGBoostSetupTask extends AbstractXGBoostTask<XGBoostSetupTask> {
               _trainFrame,
               _parms._response_column,
               _parms._weights_column,
-              _sparse);
+              _sparse
+      );
   }
 
   /**

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/DefaultMojoImplTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/DefaultMojoImplTest.java
@@ -1,30 +1,23 @@
 package hex.tree.xgboost;
 
-import hex.ModelMetricsRegression;
-import hex.SplitFrame;
 import hex.genmodel.MojoModel;
 import hex.genmodel.algos.xgboost.XGBoostJavaMojoModel;
 import hex.genmodel.algos.xgboost.XGBoostMojoReader;
 import hex.genmodel.algos.xgboost.XGBoostNativeMojoModel;
-import hex.genmodel.utils.DistributionFamily;
-import org.junit.*;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import hex.tree.xgboost.XGBoostModel.XGBoostParameters.Booster;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import water.DKV;
-import water.Key;
 import water.Scope;
 import water.TestUtil;
 import water.fvec.Frame;
 import water.util.Log;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import hex.tree.xgboost.XGBoostModel.XGBoostParameters.Booster;
 
 public class DefaultMojoImplTest extends TestUtil {
 
@@ -35,7 +28,7 @@ public class DefaultMojoImplTest extends TestUtil {
 
   @Before
   public void setupMojoJavaScoring() {
-    System.clearProperty("sys.ai.h2o.xgboost.scoring.java.enable"); // force default behavior
+    System.clearProperty(XGBoostMojoReader.SCORE_JAVA_PROP); // force default behavior
 
     assertNull(XGBoostMojoReader.getJavaScoringConfig()); // check that MOJO scoring config is not present
   }

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostUtilsTest.java
@@ -156,8 +156,10 @@ public class XGBoostUtilsTest extends TestUtil {
                 .withDataForCol(1, ard(0, 2, 0))
                 .withDataForCol(2, ard(0, 3, 0))
                 .build());
-        final DMatrix response = XGBoostUtils.convertFrameToDMatrix(new DataInfo(frame, null, true, DataInfo.TransformType.NONE, false, false, false),
-                frame, "C3", null, true);
+        final DMatrix response = XGBoostUtils.convertFrameToDMatrix(
+            new DataInfo(frame, null, true, DataInfo.TransformType.NONE, false, false, false),
+            frame, "C3", null, true
+        );
         assertNotNull(response);
         assertEquals(3, response.rowNum());
         assertArrayEquals(arf(0, 3, 0), response.getLabel(), 0f);

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/util/PredictConfigurationTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/util/PredictConfigurationTest.java
@@ -1,0 +1,27 @@
+package hex.tree.xgboost.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PredictConfigurationTest {
+  
+  @Test
+  public void testUseJavaPredict() {
+    assertTrue(PredictConfiguration.useJavaScoring());
+    System.setProperty(PredictConfiguration.PREDICT_NATIVE_PROP, "true");
+    assertFalse(PredictConfiguration.useJavaScoring());
+
+    System.setProperty(PredictConfiguration.PREDICT_NATIVE_PROP, "false");
+    assertTrue(PredictConfiguration.useJavaScoring());
+
+    System.setProperty(PredictConfiguration.PREDICT_JAVA_PROP, "false");
+    assertTrue(PredictConfiguration.useJavaScoring()); // still respecting native prop
+
+    System.clearProperty(PredictConfiguration.PREDICT_NATIVE_PROP);
+    assertFalse(PredictConfiguration.useJavaScoring());
+
+    System.setProperty(PredictConfiguration.PREDICT_JAVA_PROP, "true");
+    assertTrue(PredictConfiguration.useJavaScoring());
+  }
+}

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostJavaMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostJavaMojoModel.java
@@ -29,9 +29,7 @@ public final class XGBoostJavaMojoModel extends XGBoostMojoModel implements Pred
   private OneHotEncoderFactory _1hotFactory;
 
   static {
-    ObjFunction.register("reg:gamma", new RegObjFunction());
-    ObjFunction.register("reg:tweedie", new RegObjFunction());
-    ObjFunction.register("count:poisson", new RegObjFunction());
+    XGBoostJavaObjFunRegistration.register();
   }
 
   public XGBoostJavaMojoModel(byte[] boosterBytes, String[] columns, String[][] domains, String responseColumn) {
@@ -112,22 +110,6 @@ public final class XGBoostJavaMojoModel extends XGBoostMojoModel implements Pred
   public SharedTreeGraph convert(final int treeNumber, final String treeClass) {
     GradBooster booster = _predictor.getBooster();
     return _computeGraph(booster, treeNumber);
-  }
-
-  private static class RegObjFunction extends ObjFunction {
-    @Override
-    public float[] predTransform(float[] preds) {
-      if (preds.length != 1)
-        throw new IllegalStateException("Regression problem is supposed to have just a single predicted value, got " +
-                preds.length + " instead.");
-      preds[0] = (float) Math.exp(preds[0]);
-      return preds;
-    }
-
-    @Override
-    public float predTransform(float pred) {
-      return (float) Math.exp(pred);
-    }
   }
 
   private class OneHotEncoderFactory {

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostJavaObjFunRegistration.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostJavaObjFunRegistration.java
@@ -1,0 +1,30 @@
+package hex.genmodel.algos.xgboost;
+
+import biz.k11i.xgboost.learner.ObjFunction;
+
+public class XGBoostJavaObjFunRegistration {
+
+  public static void register() {
+    ObjFunction.register("reg:gamma", new RegObjFunction());
+    ObjFunction.register("reg:tweedie", new RegObjFunction());
+    ObjFunction.register("count:poisson", new RegObjFunction());
+  }
+
+  private static class RegObjFunction extends ObjFunction {
+    @Override
+    public float[] predTransform(float[] preds) {
+      if (preds.length != 1)
+        throw new IllegalStateException(
+            "Regression problem is supposed to have just a single predicted value, got " + preds.length + " instead."
+        );
+      preds[0] = (float) Math.exp(preds[0]);
+      return preds;
+    }
+
+    @Override
+    public float predTransform(float pred) {
+      return (float) Math.exp(pred);
+    }
+  }
+
+}

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoReader.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoReader.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 /**
  */
 public class XGBoostMojoReader extends ModelMojoReader<XGBoostMojoModel> {
+  
+  public static final String SCORE_JAVA_PROP = "sys.ai.h2o.xgboost.scoring.java.enable";
 
   @Override
   public String getModelName() {
@@ -53,7 +55,7 @@ public class XGBoostMojoReader extends ModelMojoReader<XGBoostMojoModel> {
   }
 
   public static Boolean getJavaScoringConfig() {
-    String javaScoringEnabled = System.getProperty("sys.ai.h2o.xgboost.scoring.java.enable");
+    String javaScoringEnabled = System.getProperty(SCORE_JAVA_PROP);
     if (javaScoringEnabled == null) {
       return null;
     }

--- a/h2o-genmodel-extensions/xgboost/src/test/java/hex/genmodel/algos/xgboost/XGBoostJavaMojoModelTest.java
+++ b/h2o-genmodel-extensions/xgboost/src/test/java/hex/genmodel/algos/xgboost/XGBoostJavaMojoModelTest.java
@@ -1,6 +1,5 @@
 package hex.genmodel.algos.xgboost;
 
-import biz.k11i.xgboost.learner.ObjFunction;
 import org.junit.Test;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
- add new property xgboost.predict.native.enable
- move logic for determining predictor impl into separate file
- cleanup a little bit of dead code from xgboostutils