### PR TITLE
PUBDEV-6488  h2o.getModelTree failing

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3613,6 +3613,29 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
     res$thresholds <- c(as.double(NA))
   }
   
+  # Protection against NA only arrays being evaluated as logical
+  if(is.logical(res$features)){
+    res$features <- as.character(res$features)
+  }
+  
+  if(is.logical(res$nas)){
+    res$nas <- as.character(res$nas)
+  }
+  
+  if(is.logical(res$thresholds)){
+    res$thresholds <- as.numeric(res$thresholds)
+  }
+  
+  if(is.logical(res$predictions)){
+    res$predictions <- as.numeric(res$predictions)
+  }
+  
+  if(is.logical(res$predictions)){
+    res$predictions <- as.numeric(res$predictions)
+  }
+  
+  
+  # Start of the tree-building process
   tree <- new(
     "H2OTree",
     left_children = res$left_children,

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3458,7 +3458,7 @@ setMethod('show', 'H2ONode',
 print.H2ONode <- function(node){
   cat("Node ID", node@id, "\n\n")
   if(class(node) == "H2OLeafNode"){
-    cat("Terminal node. Prediction is")
+    cat("Terminal node. Prediction is", node@prediction)
     return()
   }
 

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6488.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6488.R
@@ -1,0 +1,22 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.tree.fetch <- function() {
+  
+  data <- as.h2o(data.frame(
+    x1 = c(1, NA, 2),
+    x2 = c(2, NA, 1),
+    y = c(1, 2,3)
+  ))
+  
+  # A simple model to test prediction the correctly printed by delegating to print.H2ONode.
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "y", training_frame = data, max_depth = 0, ntrees = 1)
+  tree <- h2o.getModelTree(model, 1)
+  expect_false(is.null(tree))
+  expect_equal(3, grep("Prediction is 0", capture.output(print(tree@root_node))))
+  
+}
+
+doTest("Tree API fetch & parse test", test.tree.fetch)

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6488.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6488.R
@@ -4,6 +4,9 @@ source("../../scripts/h2o-r-test-setup.R")
 
 
 test.tree.fetch <- function() {
+  seed <- sample.int(1e+9, 1)
+  set.seed(seed)
+  cat("Using seed:", seed)
   
   data <- as.h2o(data.frame(
     x1 = c(1, NA, 2),
@@ -12,7 +15,7 @@ test.tree.fetch <- function() {
   ))
   
   # A simple model to test prediction the correctly printed by delegating to print.H2ONode.
-  model <- h2o.xgboost(x= c("x1", "x2"), y = "y", training_frame = data, max_depth = 0, ntrees = 1)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "y", training_frame = data, max_depth = 0, ntrees = 1, seed = seed)
   tree <- h2o.getModelTree(model, 1)
   expect_false(is.null(tree))
   expect_equal(3, grep("Prediction is 0", capture.output(print(tree@root_node))))
@@ -30,7 +33,7 @@ test.tree.fetch <- function() {
   )
   
   data <- as.h2o(data)
-  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees, seed = seed)
   for (i in seq(1,ntrees)) {
     tree <- h2o.getModelTree(model, i)
     expect_false(is.null(tree))
@@ -51,7 +54,7 @@ test.tree.fetch <- function() {
   data <- as.h2o(data)
   data$x1 <- h2o.asfactor(data$x1)
   data$x2 <- h2o.asfactor(data$x2)
-  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees, seed = seed)
   for (i in seq(1,ntrees)) {
     tree <- h2o.getModelTree(model, i)
     expect_false(is.null(tree))
@@ -71,7 +74,7 @@ test.tree.fetch <- function() {
   
   data <- as.h2o(data)
   data$response <- h2o.asfactor(data$response)
-  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees, seed = seed)
   for (i in seq(1,ntrees)) {
     for(clazz in domain){
     tree <- h2o.getModelTree(model, i,as.character(clazz))
@@ -96,7 +99,7 @@ test.tree.fetch <- function() {
   
   data <- as.h2o(data)
   data$response <- h2o.asfactor(data$response)
-  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees, seed = seed)
   for (i in seq(1,ntrees)) {
     for(clazz in states){
       tree <- h2o.getModelTree(model, i,as.character(clazz))
@@ -121,17 +124,13 @@ test.tree.fetch <- function() {
   }
   
   data <- as.h2o(data)
-  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees, max_depth = 0)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees, max_depth = 0, seed = seed)
   for (i in seq(1,ntrees)) {
     tree <- h2o.getModelTree(model, i)
     expect_false(is.null(tree))
     
   }
-  
-  
-  
-  
-  
+
 }
 
 doTest("Tree API fetch & parse test", test.tree.fetch)

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6488.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6488.R
@@ -17,6 +17,121 @@ test.tree.fetch <- function() {
   expect_false(is.null(tree))
   expect_equal(3, grep("Prediction is 0", capture.output(print(tree@root_node))))
   
+  # Random Tree API test with a randomly generated matrix
+  nrows <- 1000
+  ntrees <- 50
+  response <- sample(0:1,nrows,replace = TRUE)
+  domain <- unique(response)
+  data <- data.frame(
+    x1 = rnorm(nrows),
+    x2 = rbinom(nrows, 1, 0.5),
+    x3 = rbinom(nrows, 10, 0.5),
+    response = response # Binomial response
+  )
+  
+  data <- as.h2o(data)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  for (i in seq(1,ntrees)) {
+    tree <- h2o.getModelTree(model, i)
+    expect_false(is.null(tree))
+  
+  }
+  
+  
+  
+  # Random Tree API test with a randomly generated matrix - categorical only
+  nrows <- 1000
+  ntrees <- 50
+  data <- data.frame(
+    x1 = rbinom(nrows, 1, 0.5),
+    x2 = rbinom(nrows, 1, 0.5),
+    response = rbinom(nrows, 1, 0.5) # Binomial response
+  )
+  
+  data <- as.h2o(data)
+  data$x1 <- h2o.asfactor(data$x1)
+  data$x2 <- h2o.asfactor(data$x2)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  for (i in seq(1,ntrees)) {
+    tree <- h2o.getModelTree(model, i)
+    expect_false(is.null(tree))
+  }
+  
+  
+  # Random Tree API test with a randomly generated matrix - multinomial response
+  nrows <- 1000
+  ntrees <- 50
+  response <- sample(1:10,nrows,replace = TRUE)
+  domain <- unique(response)
+  data <- data.frame(
+    x1 = rnorm(nrows),
+    x2 = rbinom(nrows, 1, 0.5),
+    response = response # Multinomial response
+  )
+  
+  data <- as.h2o(data)
+  data$response <- h2o.asfactor(data$response)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  for (i in seq(1,ntrees)) {
+    for(clazz in domain){
+    tree <- h2o.getModelTree(model, i,as.character(clazz))
+    expect_false(is.null(tree))
+    }
+  }
+  
+  # Random Tree API test with a randomly generated matrix with NAs - multinomial response
+  nrows <- 1000
+  ntrees <- 50
+  states <- sample(state.name, 10)
+  data <- data.frame(
+    x1 = rnorm(nrows),
+    x2 = rbinom(nrows, 1, 0.5),
+    response = states # Multinomial response
+  )
+  
+  # 10 percent of NAs
+  for(i in sample(1:nrows, nrows / 10)){
+    data$x1[i] <- NA
+  }
+  
+  data <- as.h2o(data)
+  data$response <- h2o.asfactor(data$response)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees)
+  for (i in seq(1,ntrees)) {
+    for(clazz in states){
+      tree <- h2o.getModelTree(model, i,as.character(clazz))
+      expect_false(is.null(tree))
+    }
+  }
+  
+  
+  # Random Tree API test - stumps
+  nrows <- 1000
+  ntrees <- 100
+  data <- data.frame(
+    x1 = rnorm(nrows),
+    x2 = rbinom(nrows, 1, 0.5),
+    x3 = rbinom(nrows, 10, 0.5),
+    response = rbinom(nrows, 1, 0.5) # Binomial response
+  )
+  
+  # 30 percent of NAs
+  for(i in sample(1:nrows, nrows / 30)){
+    data$x1[i] <- NA
+  }
+  
+  data <- as.h2o(data)
+  model <- h2o.xgboost(x= c("x1", "x2"), y = "response", training_frame = data, ntrees = ntrees, max_depth = 0)
+  for (i in seq(1,ntrees)) {
+    tree <- h2o.getModelTree(model, i)
+    expect_false(is.null(tree))
+    
+  }
+  
+  
+  
+  
+  
 }
 
 doTest("Tree API fetch & parse test", test.tree.fetch)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6488

There are three commits in this PR, each representing one improvement.

- https://github.com/h2oai/h2o-3/pull/3511/commits/950494734d72c0de4d1ccbd51b21530153817119 Fixes prediction printing in R (Python is OK)
- https://github.com/h2oai/h2o-3/pull/3511/commits/927aa8ce28ae536d5079a1d8342b5abedcf2f7cf Randomized tests for Tree API
- https://github.com/h2oai/h2o-3/pull/3511/commits/a2aa61a9efa3aee4df7b1c80ea6e44e839abdaf0 Protection against NA only arrays being evaluated as logical in R

The last commit unfortunately has no direct test, as we were unable to reproduce. It was the original issue, @meganjkurka managed to force XGBoost to produce a tree with split features all being NA. But we don't have the code to reproduce it. In future, we're shielded against that.

