### PR TITLE
PUBDEV-6454: Fixed Tweedie Regression and Standard Error Calculation

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -28,6 +28,8 @@ import java.util.NoSuchElementException;
  */
 public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLMOutput> {
 
+  final static public double _EPS = 1e-6;
+  final static public double _OneOEPS = 1e6;
   public GLMModel(Key selfKey, GLMParameters parms, GLM job, double [] ymu, double ySigma, double lambda_max, long nobs) {
     super(selfKey, parms, job == null?new GLMOutput():new GLMOutput(job));
     // modelKey, parms, null, Double.NaN, Double.NaN, Double.NaN, -1
@@ -450,7 +452,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case logit:
 //        case multinomial:
           double div = (x * (1 - x));
-          if(div < 1e-6) return 1e6; // avoid numerical instability
+          if(div < _EPS) return _OneOEPS; // avoid numerical instability
           return 1.0 / div;
         case identity:
           return 1;
@@ -461,7 +463,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case ologlog:
           double oneMx = 1.0-x;
           double divsor = -1.0*oneMx*Math.log(oneMx);
-          return (divsor<1e-6)?1e6:(1.0/divsor);
+          return (divsor<_EPS)?_OneOEPS:(1.0/divsor);
         case tweedie:
 //          double res = _tweedie_link_power == 0
 //            ?Math.max(2e-16,Math.exp(x))
@@ -539,8 +541,16 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     final Link _link;
     final double _var_power;
     final double _link_power;
+    final double _oneOoneMinusVarPower;
+    final double _oneOtwoMinusVarPower;
+    final double _oneMinusVarPower;
+    final double _twoMinusVarPower;
+    final double _oneOLinkPower;
+    final double _oneOLinkPowerSquare;
     double _theta;  // used by negative binomial, 0 < _theta <= 1
     double _invTheta;
+    double _oneOeta;
+    double _oneOetaSquare;
 
     final NormalDistribution _dprobit = new NormalDistribution(0,1);  // get the normal distribution
     
@@ -552,6 +562,12 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       _link = link;
       _var_power = var_power;
       _link_power = link_power;
+      _oneMinusVarPower = 1-_var_power;
+      _twoMinusVarPower = 2-_var_power;
+      _oneOoneMinusVarPower = _var_power==1?1:1.0/(1-_var_power);
+      _oneOtwoMinusVarPower = _var_power==2?1:1.0/(2-_var_power);
+      _oneOLinkPower = 1.0/_link_power;
+      _oneOLinkPowerSquare = _oneOLinkPower*_oneOLinkPower;
       _theta = theta;
       _invTheta = 1/theta;
     }
@@ -596,9 +612,8 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case inverse:
           double xx = (x < 0) ? Math.min(-1e-5, x) : Math.max(1e-5, x);
           return -1 / (xx * xx);
-//        case tweedie:
-//          double vp = (1. - _tweedie_link_power) / _tweedie_link_power;
-//          return (1/ _tweedie_link_power) * Math.pow(x, vp);
+        case tweedie:
+          return _link_power==0?Math.max(x, Double.MIN_NORMAL):x*_oneOLinkPower*_oneOeta;
         default:
           throw new RuntimeException("unexpected link function id  " + this);
       }
@@ -611,6 +626,8 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
           return 0;
         case log:
           return Math.max(x, Double.MIN_NORMAL);
+        case tweedie:
+          return _link_power==0?Math.max(x, Double.MIN_NORMAL):x*_oneOLinkPower*(_oneOLinkPower-1)*_oneOetaSquare;
         default:
           throw new RuntimeException("unexpected link function id  " + this);
       }
@@ -624,12 +641,12 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case logit:
 //        case multinomial:
           double div = (x * (1 - x));
-          if(div < 1e-6) return 1e6; // avoid numerical instability
+          if(div < _EPS) return _OneOEPS; // avoid numerical instability
           return 1.0 / div;
         case ologlog:
           double oneMx = 1.0-x;
           double divsor = -1.0*oneMx*Math.log(oneMx);
-          return (divsor<1e-6)?1e6:(1.0/divsor);
+          return (divsor<_EPS)?_OneOEPS:(1.0/divsor);
         case identity:
           return 1;
         case log:
@@ -666,7 +683,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case tweedie:
           return _link_power == 0
             ?Math.max(2e-16,Math.exp(x))
-            :Math.pow(x, 1/ _link_power);
+            :Math.pow(x, _oneOLinkPower);
         default:
           throw new RuntimeException("unexpected link function id  " + _link);
       }
@@ -678,7 +695,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case quasibinomial:
         case binomial:
           double res = mu * (1 - mu);
-          return res < 1e-6?1e-6:res;
+          return res < _EPS?_EPS:res;
         case poisson:
           return mu;
         case negativebinomial:
@@ -693,7 +710,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     }
 
     public final double deviance(double yr, double ym){
-      double y1 = yr == 0?.1:yr;
+      double y1 = yr == 0?hex.glm.GLMTask.EPS:yr;
       switch(_family){
         case gaussian:
           return (yr - ym) * (yr - ym);
@@ -713,13 +730,16 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
           if( yr == 0 ) return -2;
           return -2 * (Math.log(yr / ym) - (yr - ym) / ym);
         case tweedie:
-          double theta = _var_power == 1
-            ?Math.log(y1/ym)
-            :(Math.pow(y1,1.-_var_power) - Math.pow(ym,1 - _var_power))/(1-_var_power);
-          double kappa = _var_power == 2
-            ?Math.log(y1/ym)
-            :(Math.pow(yr,2-_var_power) - Math.pow(ym,2-_var_power))/(2 - _var_power);
-          return 2 * (yr * theta - kappa);
+          double val;
+          if (_var_power==1) {
+            val = yr*Math.log(y1/ym)-(yr-ym);
+          } else if (_var_power==2) {
+            val = yr*(1/ym-1/y1)-Math.log(y1/ym);
+          } else {
+            val = yr*_oneOoneMinusVarPower*(Math.pow(yr,_oneMinusVarPower)-Math.pow(ym, _oneMinusVarPower))-
+                    (Math.pow(yr,_twoMinusVarPower)-Math.pow(ym, _twoMinusVarPower))*_oneOtwoMinusVarPower;
+          }
+          return 2 * val;
         default:
           throw new RuntimeException("unknown family " + _family);
       }
@@ -749,7 +769,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case gamma:
         case tweedie:
           x.dev = w*deviance(yr,ym);
-          x.l = x.dev; // todo: verify that this is not true for Poisson distribution
+          x.l = likelihood(w, yr, ym); // todo: verify that this is not true for Poisson distribution
           break;
         case negativebinomial:
           x.dev = w*deviance(yr,ym); // CHECKED-log/CHECKED-identity
@@ -785,8 +805,11 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         case gamma:
           if (yr == 0) return -2;
           return -2 * (Math.log(yr / ym) - (yr - ym) / ym);
-        case tweedie:
-          return deviance(yr, ym); //fixme: not really correct, not sure what the likelihood is right now
+        case tweedie: // we ignore the a(y,phi,p) term in the likelihood calculation here since we are not optimizing over them
+          double temp = 0;
+          temp += _var_power==2?Math.log(ym):Math.pow(ym,_twoMinusVarPower)*_oneOtwoMinusVarPower;
+          temp -= yr*(_var_power==1?Math.log(ym):Math.pow(ym,_oneMinusVarPower)*_oneOoneMinusVarPower);
+          return temp; // ignored the a(y,phi,p) term as it is a constant for us
         default:
           throw new RuntimeException("unknown family " + _family);
       }
@@ -799,26 +822,42 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       double var = variance(x.mu);//Math.max(1e-5, variance(x.mu)); // avoid numerical problems with 0 variance
       double d = linkDeriv(x.mu);
       if (_family.equals(Family.negativebinomial)) {
-        double invSum = 1.0/(1+_theta*x.mu);
+        double invSum = 1.0 / (1 + _theta * x.mu);
         double d2 = linkInvDeriv(x.mu);
-        if (y>0 && (x.mu>0)) {
-          double sumr = 1.0+_theta*y;
-          d = (y/(x.mu*x.mu)-_theta*sumr*invSum*invSum) * d2 * d2 + (sumr*invSum-y/x.mu) * linkInvDeriv2(x.mu); //CHECKED-log/CHECKED-identity
-          x.w = w*d;
-          x.z = eta + (y-x.mu) *invSum * d2/(d*x.mu); // CHECKED-identity
-        } else if (y==0 && x.mu > 0) {
-          d = linkInvDeriv2(x.mu)*invSum-_theta*invSum*invSum*d2*d2; // CHECKED
-          x.w = w*d;
-          x.z = eta - invSum*d2/d;
+        if (y > 0 && (x.mu > 0)) {
+          double sumr = 1.0 + _theta * y;
+          d = (y / (x.mu * x.mu) - _theta * sumr * invSum * invSum) * d2 * d2 + (sumr * invSum - y / x.mu) * linkInvDeriv2(x.mu); //CHECKED-log/CHECKED-identity
+          x.w = w * d;
+          x.z = eta + (y - x.mu) * invSum * d2 / (d * x.mu); // CHECKED-identity
+        } else if (y == 0 && x.mu > 0) {
+          d = linkInvDeriv2(x.mu) * invSum - _theta * invSum * invSum * d2 * d2; // CHECKED
+          x.w = w * d;
+          x.z = eta - invSum * d2 / d;
         } else {
           x.w = 0;
           x.z = 0;
         }
+      } else if (_family.equals(Family.tweedie)) {
+        double oneOxmu = x.mu==0?_OneOEPS:1.0/x.mu;
+        double oneOxmuSquare = oneOxmu*oneOxmu;
+        _oneOeta = etaOff==0?_OneOEPS:1.0/etaOff;;
+        _oneOetaSquare = _oneOeta*_oneOeta;
+        double diffOneSquare = linkInvDeriv(x.mu)*linkInvDeriv(x.mu);
+        double xmuPowMP = Math.pow(x.mu, -_var_power);
+        x.w = _var_power==1?(y*oneOxmuSquare*diffOneSquare-(y*oneOxmu-1)*linkInvDeriv2(x.mu)):(_var_power==2?
+                ((oneOxmu-y*xmuPowMP)*linkInvDeriv2(x.mu)+
+                        (y*2*Math.pow(x.mu, -3)-oneOxmuSquare)*diffOneSquare)
+                :(_var_power*y*Math.pow(x.mu, -_var_power-1)+_oneMinusVarPower*xmuPowMP)*diffOneSquare-
+                (y*xmuPowMP-Math.pow(x.mu, _oneMinusVarPower))*linkInvDeriv2(x.mu));
+        x.z = etaOff+(_var_power==1?(y*oneOxmu-1):
+                (_var_power==2?(y*Math.pow(x.mu, -_var_power)-oneOxmu):
+                        (y*Math.pow(x.mu, -_var_power)-Math.pow(x.mu, _oneMinusVarPower))))*linkInvDeriv(x.mu)/x.w;
+        x.w *= w;
       } else {
         x.w = w / (var * d * d);  // formula did not quite work with negative binomial
         x.z = eta + (y - x.mu) * d;
       }
-      likelihoodAndDeviance(y,x,w);
+      likelihoodAndDeviance(y, x, w);
       return x;
     }
   }

--- a/h2o-algos/src/main/java/hex/gram/Gram.java
+++ b/h2o-algos/src/main/java/hex/gram/Gram.java
@@ -158,10 +158,10 @@ public final class Gram extends Iced<Gram> {
    * QR computation:
    * QR is computed using Gram-Schmidt elimination, using Gram matrix instead of the underlying dataset.
    *
-   * Gram-schmidt decomposition can be computed as follows: (from "The Eelements of Statistical Learning")
+   * Gram-schmidt decomposition can be computed as follows: (from "The Eelements of Statistical Learning", Algorithm 3.1)
    * 1. set z0 = x0 = 1 (Intercept)
    * 2. for j = 1:p
-   *      for l = 1:j-1
+   *      for l = 0:j-1
    *        gamma_jl = dot(x_l,x_j)/dot(x_l,x_l)
    *      zj = xj - sum(gamma_j[l]*x_l)
    *      if(zj ~= 0) xj was redundant (collinear)
@@ -176,7 +176,7 @@ public final class Gram extends Iced<Gram> {
    * When doing that, we need to replace dot(xi,xk) with dot(xi,zk) for all i.
    * There are two cases,
    *   1)  dot(xk,xk) -> dot(zk,zk)
-   *       dot(xk - sum(gamma_l*x_l,xk - sum(gamma_l*x_l)
+   *       dot(xk - sum(gamma_l*x_l),xk - sum(gamma_l*x_l))
    *       = dot(xk,xk) - 2* sum(gamma_l*dot(x_i,x_k) + sum(gamma_l*sum(gamma_k*dot(x_l,x_k)))
    *       (can be simplified using the fact that dot(zi,zj) == 0 for i != j
    *   2)  dot(xi,xk) -> dot(xi,zk) for i != k
@@ -216,7 +216,9 @@ public final class Gram extends Iced<Gram> {
       double rs_tot = standardized
               ?ZdiagInv[j]
               :1.0/(Zdiag[j]-Z[j][0]*ZdiagInv[0]*Z[j][0]);
-      if(j > 0 && zjj*rs_tot  < r2_eps) { // collinear column, drop it!
+      double temp = zjj*rs_tot;
+      temp = temp < 0?-temp:temp;
+      if(j > 0 && temp  < r2_eps) { // collinear column, drop it!
         zjj = 0;
         dropped_cols.add(j-1);
         ZdiagInv[j] = 0;

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestRegression.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestRegression.java
@@ -1,5 +1,6 @@
 package hex.glm;
 
+import hex.DataInfo;
 import hex.GLMMetrics;
 import hex.ModelMetricsRegressionGLM;
 import hex.deeplearning.DeepLearningModel;
@@ -12,6 +13,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import water.DKV;
 import water.Key;
+import water.Scope;
 import water.TestUtil;
 import water.exceptions.H2OIllegalArgumentException;
 import water.exceptions.H2OModelBuilderIllegalArgumentException;
@@ -19,11 +21,13 @@ import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.fvec.Vec;
 import water.parser.ParseDataset;
+import water.util.ArrayUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 import static org.junit.Assert.*;
 import static water.util.FileUtils.getFile;
@@ -601,6 +605,8 @@ public class GLMBasicTestRegression extends TestUtil {
     0.0520203427103241, 0.0629693638202253, 0.054824519906118, 0.0664522679377852, 0.0709937504956703, 0.0522528199125061, 0.116792628883851, 0.127959068214529, 0.0588829864765987, 0.0938071273144982, 0.0638448982296692, 0.095474139348608, 0.0636920146973271, 0.102824928294982, 0.0546954905581237, 0.0957477006105716, 0.0516295701222635, 0.0679538008921464, 0.067911254988675, 0.11772719691146, 0.0626934169760874, 0.0755070350639548, 0.0581558616336498, 0.0873377370618371, 0.0654538358047351, 0.0693235931850606, 0.0962317603498954, 0.0552842877956681, 0.077459867942534, 0.0626998557114978, 0.0531665050182605, 0.0495451968026518, 0.0531904147974664, 0.0773863775170239, 0.0570467158542459, 0.0615088358357168, 0.0653655052453002, 0.0958225208725932, 0.0821004080317487, 0.0554118772903184, 0.062705388445474, 0.115252227824609, 0.0930756784532364, 0.0856558971929684, 0.0976473251692103, 0.0710701529636323, 0.050750991917379, 0.0564411256187975, 0.0775449777496427, 0.115494288850098,0.0682381145402218, 0.0515555125627838, 0.0670040023710206, 0.0712685707513018, 0.0532727639007648, 0.0546917068101745, 0.0717446129579534, 0.0801494525268998, 0.0472679272457015, 0.0730855772596969, 0.0656353433724242, 0.0670760966162116, 0.086126622468753, 0.0867455394873098, 0.117762705091036, 0.0552308514888129, 0.0567599016061833, 0.0761215691699384, 0.0699603827190508, 0.0611526828602172, 0.0665649473386548, 0.068400044275874, 0.052851970203728, 0.0947351046167158, 0.075626919466335, 0.0986954326552911, 0.158600667788559, 0.0997971513046435, 0.0558735275034329, 0.055050981781157, 0.0543870270651114, 0.0885427466948035, 0.0912282011735491, 0.0501764251426058, 0.065519936856806, 0.126597731978782, 0.0571871738429555, 0.0601312366784372, 0.134633469314707, 0.0636293392600048, 0.0822701720606341, 0.0998238113866312, 0.264894832552688, 0.0649884289638972, 0.0708677960760423, 0.0806790608308702, 0.101119270743047, 0.0550422649696084, 0.0648419030353994, 0.0558608594291732,
     0.0526453344402306, 0.0610806341536575, 0.0609287420297426, 0.092034974197124, 0.0654686061501201, 0.0876869833195622, 0.0632671529428891, 0.0537964056797385, 0.0578936987690603, 0.0610938723761382, 0.0639353712535906, 0.168259497679141, 0.0962447000659448, 0.0651311057869981, 0.057491792983237, 0.0833792244616626, 0.086830040351315, 0.0774225857956364, 0.0664132437698603, 0.0574733178794812, 0.0647095391454638, 0.0608749267574728, 0.0534737593003958, 0.0864207446374423, 0.0630820817777617, 0.07226313326455, 0.0657499714305992, 0.121316445806293, 0.05853768423366, 0.0768645928103155, 0.0561109648914227, 0.0746288344339693, 0.0657484453780335, 0.0969340921119936, 0.0794439588324644, 0.0748828899207881, 0.100497037474176, 0.10675969143369, 0.0684810175839798, 0.0824837244664557, 0.0892814658999665, 0.0573638625958212, 0.0646309493356802, 0.0940910063257154, 0.0673435846353654, 0.0957497261909759, 0.0664402337808255, 0.0781546316899442, 0.0742122328375746, 0.0582089765051909,0.0781545857991108, 0.104152580875285, 0.0711435121130216, 0.0983829670734453, 0.0815684611863238, 0.102263743443002, 0.0936000092997729, 0.128533232616524, 0.0641557720833701, 0.111115887875877, 0.0638681893568514, 0.101074063878806, 0.06424466347809, 0.064441266436105, 0.110618016393452, 0.0712315373586064, 0.0657094575123701, 0.0705967310833688, 0.068439218729386, 0.103666086457174, 0.0787150533390872, 0.107851546439191, 0.142558987347935, 0.0756230725139849, 0.0812011758847381, 0.0710836161067677, 0.0662009215101577, 0.130219300771016, 0.0951028456739751, 0.0774634922652527, 0.100986990070013, 0.0810216431052252, 0.0836836265752558, 0.0897897867952456, 0.174853086617412, 0.0750505478534531, 0.105468755484224, 0.102115887997378, 0.102894682905793, 0.0651020673618454
   };
+  
+  
 
   @Test
   public void testPValuesGaussian(){
@@ -921,6 +927,394 @@ public class GLMBasicTestRegression extends TestUtil {
     }
 
   }
+
+  @Test
+  public void testTweedieGradient(){
+    Scope.enter();
+    Frame fr, f1, f2, f3;
+    // get new coefficients, 7 classes and 53 predictor+intercept
+    Random rand = new Random();
+    rand.setSeed(12345);
+    int nclass = 4;
+    double threshold = 1e-10;
+    int numRows = 1000;
+
+    try {
+      long seed = 1234;
+      f1 = TestUtil.generate_enum_only(2, numRows, nclass, 0, seed);
+      Scope.track(f1);
+      f2 = TestUtil.generate_real_only(4, numRows, 0, seed);
+      Scope.track(f2);
+      f3 = TestUtil.generate_int_only(1, numRows, 10, 0, seed);
+      Scope.track(f3);
+      fr = f1.add(f2).add(f3);  // complete frame generation
+      Scope.track(fr);
+      // test different var_power, link_power settings
+      testTweedieVarLinkPower(1,0,fr, threshold);
+      testTweedieVarLinkPower(1,1,fr, threshold);
+      testTweedieVarLinkPower(2,0,fr, threshold);
+      testTweedieVarLinkPower(2,3,fr, threshold);
+      testTweedieVarLinkPower(3,0,fr, threshold);
+      testTweedieVarLinkPower(3,1,fr, threshold);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  public void testTweedieVarLinkPower(double var_power, double link_power, Frame fr, double threshold) {
+    Scope.enter();
+    Random rand = new Random();
+    rand.setSeed(12345);
+    DataInfo dinfo = null;
+    try {
+      GLMParameters params = new GLMParameters(Family.tweedie);
+      params._response_column = fr._names[fr.numCols() - 1];
+      params._ignored_columns = new String[]{};
+      params._train = fr._key;
+      params._lambda = new double[]{0.5};
+      params._alpha = new double[]{0.5};
+      params._standardize = true;
+      params._tweedie_link_power = link_power;
+      params._tweedie_variance_power = var_power;
+      GLMModel.GLMWeightsFun glmw = new GLMModel.GLMWeightsFun(params);
+
+      dinfo = new DataInfo(fr, null, 1, true, DataInfo.TransformType.STANDARDIZE,
+              DataInfo.TransformType.NONE, true, false, false, false,
+              false, false);
+      int ncoeffPClass = dinfo.fullN() + 1;
+      double[] beta = new double[ncoeffPClass];
+      for (int ind = 0; ind < beta.length; ind++) {
+        beta[ind] = rand.nextDouble();
+      }
+      double l2pen = (1.0 - params._alpha[0]) * params._lambda[0];
+      GLMTask.GLMGradientTask gmt = new GLMTask.GLMGenericGradientTask(null, dinfo, params, l2pen, beta).doAll(dinfo._adaptedFrame);
+      // calculate gradient and likelihood manually
+      double[] manualGrad = new double[beta.length];
+      double manualLLH = manualLikelihoodGradient(beta, manualGrad, 1, l2pen, dinfo,
+              ncoeffPClass, params, glmw);
+      // check likelihood calculation;
+      
+      if (Double.isNaN(manualLLH))
+        assertTrue(Double.isNaN(gmt._likelihood));
+      assertEquals(manualLLH, gmt._likelihood, threshold);
+      // check gradient
+      TestUtil.checkArrays(gmt._gradient, manualGrad, threshold);
+    } finally {
+      if (dinfo != null)
+        dinfo.remove();
+      Scope.exit();
+    }
+  }
+
+
+  public double manualLikelihoodGradient(double[] initialBeta, double[] gradient, double reg, double l2pen,
+                                         DataInfo dinfo, int ncoeffPClass, GLMParameters params,
+                                         GLMModel.GLMWeightsFun glmw) {
+    double likelihood = 0;
+    int numRows = (int) dinfo._adaptedFrame.numRows();
+    int respInd = dinfo._adaptedFrame.numCols() - 1;
+    double etas;
+
+    // calculate the etas for each class
+    for (int rowInd = 0; rowInd < numRows; rowInd++) {
+      etas = getInnerProduct(rowInd, initialBeta, dinfo);
+      double xmu = glmw.linkInv(etas);
+      glmw._oneOeta = 1.0/etas;
+      glmw._oneOetaSquare = glmw._oneOeta*glmw._oneOeta;
+      int yresp = (int) dinfo._adaptedFrame.vec(respInd).at(rowInd);
+      // calculate the gradient multiplier
+      double multiplier = calGradMultiplier(yresp, xmu, glmw, etas);
+      // apply the multiplier and update the gradient accordingly
+      updateGradient(gradient, ncoeffPClass, dinfo, rowInd, multiplier);
+      
+      if (params._tweedie_variance_power == 1) {
+        likelihood -= yresp*Math.log(xmu)-Math.pow(xmu, 2-params._tweedie_variance_power)/(2-params._tweedie_variance_power);
+      } else if (params._tweedie_variance_power == 2) {
+        likelihood -= yresp*Math.pow(xmu, 1-params._tweedie_variance_power)/(1-params._tweedie_variance_power)-Math.log(xmu);
+      } else {
+        likelihood -= yresp*Math.pow(xmu, 1-params._tweedie_variance_power)/(1-params._tweedie_variance_power)-
+                Math.pow(xmu, 2-params._tweedie_variance_power)/(2-params._tweedie_variance_power);
+      }
+    }
+    // apply learning rate and regularization constant
+    if (l2pen > 0) {
+      for (int predInd = 0; predInd < dinfo.fullN(); predInd++) {  // loop through all coefficients for predictors only
+        gradient[predInd] += l2pen * initialBeta[predInd];
+      }
+    }
+    return likelihood;
+  }
+  
+  public double calGradMultiplier(double yresp, double xmu, GLMModel.GLMWeightsFun glmw, double eta) {
+    if (glmw._var_power==1) {
+      if (glmw._link_power == 0) {
+        return (xmu-yresp);
+      } else {
+        return (xmu-yresp)/(glmw._link_power*eta);
+      }
+    } else if (glmw._var_power==2) {
+      if (glmw._link_power == 0) {
+        return (1-yresp/xmu);
+      } else {
+        return (1-yresp/xmu)/(glmw._link_power*eta);
+      }
+    } else {
+      if (glmw._link_power == 0) {
+        return Math.pow(xmu, 2-glmw._var_power)-yresp*Math.pow(xmu, 1-glmw._var_power);
+      } else {
+        return (Math.pow(xmu, 2-glmw._var_power)-yresp*Math.pow(xmu, 1-glmw._var_power))/(glmw._link_power*eta);
+      }
+    }
+  }
+
+  public void updateGradient(double[] gradient, int ncoeffPclass, DataInfo dinfo, int rowInd,
+                             double multiplier) {
+      for (int cid = 0; cid < dinfo._cats; cid++) {
+        int id = dinfo.getCategoricalId(cid, dinfo._adaptedFrame.vec(cid).at(rowInd));
+        gradient[id] += multiplier;
+      }
+      int numOff = dinfo.numStart();
+      int cidOff = dinfo._cats;
+      for (int cid = 0; cid < dinfo._nums; cid++) {
+        double scale = dinfo._normMul != null ? dinfo._normMul[cid] : 1;
+        double off = dinfo._normSub != null ? dinfo._normSub[cid] : 0;
+        gradient[numOff + cid] += multiplier *
+                (dinfo._adaptedFrame.vec(cid + cidOff).at(rowInd)-off)*scale;
+      }
+      // fix the intercept term
+      gradient[ ncoeffPclass - 1] += multiplier;
+  }
+
+  public double getInnerProduct(int rowInd, double[] coeffs, DataInfo dinfo) {
+    double innerP = coeffs[coeffs.length-1];  // add the intercept term;
+
+    for (int predInd = 0; predInd < dinfo._cats; predInd++) { // categorical columns
+      int id = dinfo.getCategoricalId(predInd, (int) dinfo._adaptedFrame.vec(predInd).at(rowInd));
+      innerP += coeffs[id];
+    }
+
+    int numOff = dinfo.numStart();
+    int cidOff = dinfo._cats;
+    for (int cid=0; cid < dinfo._nums; cid++) {
+      double scale = dinfo._normMul!=null?dinfo._normMul[cid]:1;
+      double off = dinfo._normSub != null?dinfo._normSub[cid]:0;
+      innerP += coeffs[cid+numOff]*(dinfo._adaptedFrame.vec(cid+cidOff).at(rowInd)-off)*scale;
+    }
+
+    return innerP;
+  }
+
+  /**
+   * Verify Tweedie Hessian, z and XY calculations with various var_power and link_power settings.
+   */
+  @Test
+  public void testTweedieHessian(){
+    Scope.enter();
+    Frame fr, f1, f2, f3;
+    // get new coefficients, 7 classes and 53 predictor+intercept
+    Random rand = new Random();
+    rand.setSeed(12345);
+    int nclass = 4;
+    double threshold = 1e-10;
+    int numRows = 1000;
+
+    try {
+      long seed = 1234;
+      f1 = TestUtil.generate_enum_only(2, numRows, nclass, 0, seed);
+      Scope.track(f1);
+      f2 = TestUtil.generate_real_only(4, numRows, 0, seed);
+      Scope.track(f2);
+      f3 = TestUtil.generate_int_only(1, numRows, 10, 0, seed);
+      Scope.track(f3);
+      fr = f1.add(f2).add(f3);  // complete frame generation
+      Scope.track(fr);
+      checkHessianXYTweedie(fr, rand, threshold, 1, 0);
+      checkHessianXYTweedie(fr, rand, threshold, 1, 1);
+      checkHessianXYTweedie(fr, rand, threshold, 2, 0);
+      checkHessianXYTweedie(fr, rand, threshold, 2, 3);
+      checkHessianXYTweedie(fr, rand, threshold, 3, 0);
+      checkHessianXYTweedie(fr, rand, threshold, 3, 1);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
+  public void checkHessianXYTweedie(Frame fr, Random rand, double threshold, double var_power, double link_power) {
+    Scope.enter();
+    DataInfo dinfo=null;
+    try {
+      GLMParameters params = new GLMParameters(Family.tweedie);
+      params._response_column = fr._names[fr.numCols()-1];
+      params._ignored_columns = new String[]{};
+      params._train = fr._key;
+      params._lambda = new double[]{0.5};
+      params._alpha = new double[]{0.5};
+      params._tweedie_link_power = link_power;
+      params._tweedie_variance_power = var_power;
+
+      GLMModel.GLMWeightsFun glmw = new GLMModel.GLMWeightsFun(params);
+      dinfo = new DataInfo(fr, null, 1, true, DataInfo.TransformType.STANDARDIZE,
+              DataInfo.TransformType.NONE, true, false, false, false,
+              false, false);
+      int ncoeffPClass = dinfo.fullN()+1;
+      double[] beta = new double[ncoeffPClass];
+      for (int ind = 0; ind < beta.length; ind++) {
+        beta[ind] = rand.nextDouble();
+      }
+      // calculate Hessian, xy and likelihood manually
+      double[][] hessian = new double[beta.length][beta.length];
+      double[] xy = new double[beta.length];
+      GLMTask.GLMIterationTask gmt = new GLMTask.GLMIterationTask(null, dinfo, glmw, beta,
+              -1).doAll(dinfo._adaptedFrame);
+      double manualLLH = manualHessianXYLLH(beta, hessian, xy, dinfo, ncoeffPClass, fr.numCols()-1,
+              glmw, params);
+      
+      // check likelihood calculation;
+      assertEquals(manualLLH, gmt._likelihood, threshold*Math.max(Math.abs(manualLLH), Math.abs(gmt._likelihood)));
+      // check hessian
+      double[][] glmHessian = gmt.getGram().getXX();
+      checkDoubleArrays(glmHessian, hessian, threshold);
+      // check xy
+      TestUtil.checkArrays(xy, gmt._xy, threshold);
+    } finally {
+      if (dinfo!=null)
+        dinfo.remove();
+      Scope.exit();
+    }
+  }
+
+  public double manualHessianXYLLH(double[] initialBetas, double[][] hessian, double[] xy, DataInfo dinfo,
+                                   int ncoeffPClass, int respInd, GLMModel.GLMWeightsFun glmw, GLMParameters params) {
+    double likelihood = 0;
+    int numRows = (int) dinfo._adaptedFrame.numRows();
+    double etas;
+    double w; // reuse for each row
+    double grad;
+    double[][] xtx = new double[ncoeffPClass][ncoeffPClass];
+
+    // calculate the etas for each class
+    for (int rowInd = 0; rowInd < numRows; rowInd++) { // work through each row
+      etas = getInnerProduct(rowInd, initialBetas, dinfo);
+      int yresp = (int) dinfo._adaptedFrame.vec(respInd).at(rowInd);
+      double xmu = glmw.linkInv(etas);
+      glmw._oneOeta = 1/etas;
+      glmw._oneOetaSquare = glmw._oneOeta*glmw._oneOeta;
+      double xmu2OneMP = Math.pow(xmu, 1-params._tweedie_variance_power);
+      double xmu2TwoMP = Math.pow(xmu, 2-params._tweedie_variance_power);
+      double oneOqetasquare = 1/(params._tweedie_link_power*etas*etas);
+      double oneMp = 1-params._tweedie_variance_power;
+      double twoMp = 2-params._tweedie_variance_power;
+      double oneOqM1 = 1/params._tweedie_link_power-1;
+      // calculate w, grad in order to calculate the Hessian and xy
+      if (params._tweedie_variance_power==1) {
+        likelihood -= yresp*Math.log(xmu)-xmu2TwoMP/twoMp;
+        if (params._tweedie_link_power==0) {
+          w = xmu;
+          grad = yresp-xmu;
+        } else {
+          w = (yresp-(yresp-xmu)*oneOqM1)*oneOqetasquare;
+          grad = (yresp-xmu)/(params._tweedie_link_power*etas);
+        }
+      } else if (params._tweedie_variance_power==2) {
+        likelihood -= yresp*xmu2OneMP/oneMp-Math.log(xmu);
+        if (params._tweedie_link_power==0) {
+          w = yresp/xmu;
+          grad = yresp/xmu-1;
+        } else {
+          w = (yresp/(xmu*params._tweedie_link_power)+yresp/xmu-1)*oneOqetasquare;
+          grad = (yresp/xmu-1)/(params._tweedie_link_power*etas);
+        }        
+      } else {
+        likelihood -= yresp*xmu2OneMP/oneMp-xmu2TwoMP/twoMp;
+        if (params._tweedie_link_power==0) {
+          w = params._tweedie_variance_power*yresp*xmu2OneMP+oneMp*xmu2TwoMP-(yresp*xmu2OneMP-xmu2TwoMP);
+          grad = yresp*xmu2OneMP-xmu2TwoMP;
+        } else {
+          w = ((params._tweedie_variance_power*yresp*xmu2OneMP+oneMp*xmu2TwoMP)/params._tweedie_link_power-
+                  (yresp*xmu2OneMP-xmu2TwoMP)*oneOqM1)*oneOqetasquare;
+          grad = (yresp*xmu2OneMP-xmu2TwoMP)/(params._tweedie_link_power*etas);
+        }
+      }
+      // Add predictors to hessian to generate transpose(X)*W*X
+      addX2W(xtx, hessian, w, dinfo, rowInd, ncoeffPClass); // checked out okay
+      // add predictors to wz to form XY
+      addX2XY(xy, dinfo, rowInd, ncoeffPClass, w, grad,etas); // checked out okay
+    }
+    return likelihood;
+  }
+
+
+  public void addX2W(double[][] xtx, double[][] hessian, double w, DataInfo dinfo, int rowInd, int coeffPClass) {
+    int numOff = dinfo._cats; // start of numerical columns
+    int interceptInd = coeffPClass - 1;
+    // generate XTX first
+    ArrayUtils.mult(xtx, 0.0); // generate xtx
+    for (int predInd = 0; predInd < dinfo._cats; predInd++) {
+      int rid = dinfo.getCategoricalId(predInd, (int) dinfo._adaptedFrame.vec(predInd).at(rowInd));
+      for (int predInd2 = 0; predInd2 <= predInd; predInd2++) { // cat x cat
+        int cid = dinfo.getCategoricalId(predInd2, (int) dinfo._adaptedFrame.vec(predInd2).at(rowInd));
+        xtx[rid][cid] = 1;
+      }
+      // intercept x cat
+      xtx[interceptInd][rid] = 1;
+    }
+    for (int predInd = 0; predInd < dinfo._nums; predInd++) {
+      int rid = predInd + numOff;
+      double scale = dinfo._normMul != null ? dinfo._normMul[predInd] : 1;
+      double off = dinfo._normSub != null ? dinfo._normSub[predInd] : 0;
+      double d = (dinfo._adaptedFrame.vec(rid).at(rowInd) - off) * scale;
+      for (int predInd2 = 0; predInd2 < dinfo._cats; predInd2++) {   // num x cat
+        int cid = dinfo.getCategoricalId(predInd2, (int) dinfo._adaptedFrame.vec(predInd2).at(rowInd));
+        xtx[dinfo._numOffsets[predInd]][cid] = d;
+      }
+    }
+    for (int predInd = 0; predInd < dinfo._nums; predInd++) { // num x num
+      int rid = predInd + numOff;
+      double scale = dinfo._normMul != null ? dinfo._normMul[predInd] : 1;
+      double off = dinfo._normSub != null ? dinfo._normSub[predInd] : 0;
+      double d = (dinfo._adaptedFrame.vec(rid).at(rowInd) - off) * scale;
+      // intercept x num
+      xtx[interceptInd][dinfo._numOffsets[predInd]] = d;
+      for (int predInd2 = 0; predInd2 <= predInd; predInd2++) {
+        scale = dinfo._normMul != null ? dinfo._normMul[predInd2] : 1;
+        off = dinfo._normSub != null ? dinfo._normSub[predInd2] : 0;
+        int cid = predInd2 + numOff;
+        xtx[dinfo._numOffsets[predInd]][dinfo._numOffsets[predInd2]] = d * (dinfo._adaptedFrame.vec(cid).at(rowInd) - off) * scale;
+      }
+    }
+    xtx[interceptInd][interceptInd] = 1;
+    // copy the lower triangle to the uppder triangle of xtx
+    for (int rInd = 0; rInd < coeffPClass; rInd++) {
+      for (int cInd = rInd + 1; cInd < coeffPClass; cInd++) {
+        xtx[rInd][cInd] = xtx[cInd][rInd];
+      }
+    }
+    // xtx generation checkout out with my manual calculation
+    for (int rpredInd = 0; rpredInd < coeffPClass; rpredInd++) {
+      for (int cpredInd = 0; cpredInd < coeffPClass; cpredInd++) {
+        if (Math.abs(xtx[rpredInd][cpredInd]) > 0)
+          hessian[rpredInd][cpredInd] += w * xtx[rpredInd][cpredInd];
+      }
+    }
+  }
+
+  public void addX2XY(double[] xy, DataInfo dinfo, int rowInd, int coeffPClass, double w, double grad, double etas) {
+    double wz = w*(etas + grad/w);  // same calculation order as GLM
+    for (int predInd = 0; predInd < dinfo._cats; predInd++) { // cat
+      int cid = dinfo.getCategoricalId(predInd, (int) dinfo._adaptedFrame.vec(predInd).at(rowInd));
+      xy[cid] += wz;
+    }
+    for (int predInd = 0; predInd < dinfo._nums; predInd++) { // num
+      double scale = dinfo._normMul != null ? dinfo._normMul[predInd] : 1;
+      double off = dinfo._normSub != null ? dinfo._normSub[predInd] : 0;
+      int cid = predInd + dinfo._cats;
+      double d = (dinfo._adaptedFrame.vec(cid).at(rowInd) - off) * scale;
+      xy[dinfo._numOffsets[predInd]] += wz * d;
+    }
+    xy[coeffPClass - 1] += wz;
+  }
+  
   private static String removeDot(String s) {
     int id = s.indexOf(".");
     if(id ==-1) return s;

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -151,6 +151,23 @@ public class TestUtil extends Iced {
     _initial_keycnt = H2O.store_size();
   }
 
+  public static void checkArrays(double[] expected, double[] actual, double threshold) {
+    for(int i = 0; i < actual.length; i++) {
+      if (!Double.isNaN(expected[i]) && !Double.isNaN(actual[i])) // only compare when both are not NaN
+        assertEquals(expected[i], actual[i], threshold*Math.max(Math.abs(expected[i]),Math.abs(actual[i])));
+    }
+  }
+
+  public static void checkDoubleArrays(double[][] expected, double[][] actual, double threshold) {
+    int len1 = expected.length;
+    assertEquals(len1, actual.length);
+
+    for (int ind=0; ind < len1; ind++) {
+      assertEquals(expected[ind].length, actual[ind].length);
+      checkArrays(expected[ind], actual[ind], threshold);
+    }
+  }
+
   /**
    * generate random frames containing enum columns only
    * @param numCols
@@ -159,6 +176,12 @@ public class TestUtil extends Iced {
    * @return
    */
   protected static Frame generate_enum_only(int numCols, int numRows, int num_factor, double missingfrac) {
+    long seed = System.currentTimeMillis();
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+seed);
+    return generate_enum_only(numCols, numRows, num_factor, missingfrac, seed);
+  }
+
+  protected static Frame generate_enum_only(int numCols, int numRows, int num_factor, double missingfrac, long seed) {
     CreateFrame cf = new CreateFrame();
     cf.rows= numRows;
     cf.cols = numCols;
@@ -168,7 +191,52 @@ public class TestUtil extends Iced {
     cf.categorical_fraction = 1;
     cf.has_response=false;
     cf.missing_fraction = missingfrac;
-    cf.seed = System.currentTimeMillis();
+    cf.seed =seed;
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
+    return cf.execImpl().get();
+  }
+
+  protected static Frame generate_real_only(int numCols, int numRows, double missingfrac) {
+    long seed = System.currentTimeMillis();
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+seed);
+    return generate_real_only(numCols, numRows, missingfrac, seed);
+  }
+
+  protected static Frame generate_real_only(int numCols, int numRows, double missingfrac, long seed) {
+    CreateFrame cf = new CreateFrame();
+    cf.rows= numRows;
+    cf.cols = numCols;
+    cf.binary_fraction = 0;
+    cf.integer_fraction = 0;
+    cf.categorical_fraction = 0;
+    cf.time_fraction = 0;
+    cf.string_fraction = 0;
+    cf.has_response=false;
+    cf.missing_fraction = missingfrac;
+    cf.seed = seed;
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
+    return cf.execImpl().get();
+  }
+
+  protected static Frame generate_int_only(int numCols, int numRows, int integer_range, double missingfrac) {
+    long seed = System.currentTimeMillis();
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+seed);
+    return generate_int_only(numCols, numRows, integer_range, missingfrac, seed);
+  }
+
+  protected static Frame generate_int_only(int numCols, int numRows, int integer_range, double missingfrac, long seed) {
+    CreateFrame cf = new CreateFrame();
+    cf.rows= numRows;
+    cf.cols = numCols;
+    cf.binary_fraction = 0;
+    cf.integer_fraction = 1;
+    cf.categorical_fraction = 0;
+    cf.time_fraction = 0;
+    cf.string_fraction = 0;
+    cf.has_response=false;
+    cf.missing_fraction = missingfrac;
+    cf.integer_range = integer_range;
+    cf.seed = seed;
     System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
     return cf.execImpl().get();
   }
@@ -190,26 +258,6 @@ public class TestUtil extends Iced {
       sortDir[index] = dirs[rand.nextInt(2)];
     }
     return sortDir;
-  }
-  /**
-   * generate random frames containing enum columns only
-   * @param numCols
-   * @param numRows
-   * @return
-   */
-  protected static Frame generate_int_only(int numCols, int numRows, int iRange, double missingfrac) {
-    CreateFrame cf = new CreateFrame();
-    cf.rows= numRows;
-    cf.cols = numCols;
-    cf.binary_fraction = 0;
-    cf.integer_fraction = 1;
-    cf.categorical_fraction = 0;
-    cf.has_response=false;
-    cf.missing_fraction = missingfrac;
-    cf.integer_range=iRange;
-    cf.seed = System.currentTimeMillis();
-    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
-    return cf.execImpl().get();
   }
 
   private static class DKVCleaner extends MRTask<DKVCleaner> {

--- a/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gaussian_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gaussian_large.py
@@ -135,7 +135,7 @@ class TestGLMGaussian:
     nan_fraction = 0.2          # denote maximum fraction of NA's to be inserted into a column
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     enum_col = 0                # set maximum number of categorical columns in predictor
     enum_level_vec = []         # vector containing number of levels for each categorical column

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3774,6 +3774,21 @@ def random_dataset_numeric_only(nrow, ncol, integerR=100, misFrac=0.01, randSeed
                           seed=randSeed, **fractions)
     return df
 
+# generate random dataset of ncolumns of integer and reals, copied from Pasha
+def random_dataset_real_only(nrow, ncol, realR=100, misFrac=0.01, randSeed=None):
+    """Create and return a random dataset."""
+    fractions = dict()
+    fractions["real_fraction"] = 1  # Right now we are dropping string columns, so no point in having them.
+    fractions["categorical_fraction"] = 0
+    fractions["integer_fraction"] = 0
+    fractions["time_fraction"] = 0
+    fractions["string_fraction"] = 0  # Right now we are dropping string columns, so no point in having them.
+    fractions["binary_fraction"] = 0
+
+    df = h2o.create_frame(rows=nrow, cols=ncol, missing_fraction=misFrac, has_response=False, integer_range=realR,
+                          seed=randSeed, **fractions)
+    return df
+
 def getMojoName(modelID):
     regex = re.compile("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]")
     return regex.sub("_", modelID)

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_link_functions_tweedie_basic.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_link_functions_tweedie_basic.R
@@ -5,16 +5,12 @@ source("../../../scripts/h2o-r-test-setup.R")
 # Link functions: tweedie (canonical link)
 ##
 
-
-
-
-
 test_linkFunctions <- function() {
 
   # Use prostate_complete to test tweedie in R glm vs h2o.glm
   # Note that the outcome in this dataset has a bernoulli distribution
   require(statmod)
-
+  browser()
   print("Read in prostate data.")
   hdf <- h2o.uploadFile("../../../../smalldata/prostate/prostate_complete.csv.zip", destination_frame = "hdf")
   df <- as.data.frame(hdf)
@@ -34,7 +30,7 @@ test_linkFunctions <- function() {
                                        link = "tweedie",
                                        alpha = 0.5,
                                        lambda = 0,
-                                       nfolds = 0)
+                                       nfolds = 0, compute_p_values=TRUE)
   model.R.tweedie.tweedie <- glm(formula = formula,
                                  #data = df[,4:10],
                                  data = df[,x],
@@ -50,16 +46,6 @@ test_linkFunctions <- function() {
   if (difference > 0.01) {
     checkTrue(difference <= 0.01, "h2o's model's residualDeviance/nullDeviance is more than 0.01 lower than R's model's")
   }
-
-  
 }
 
 doTest("Comparison of H2O to R with varying link functions for the TWEEDIE family", test_linkFunctions)
-
-
-
-
-
-
-
-

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_tweedie_PUBDEV_6457.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_tweedie_PUBDEV_6457.R
@@ -1,0 +1,65 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+##
+# Comparison of H2O to R for the TWEEDIE family on prostate dataset
+# In particular, we want to compare the coefficients and their standard error calculations.
+##
+
+test_linkFunctions <- function() {
+
+  # Use prostate_complete to test tweedie in R glm vs h2o.glm
+  # Note that the outcome in this dataset has a bernoulli distribution
+  require(statmod)
+  print("Read in prostate data.")
+   hdf <- h2o.uploadFile("../../../../smalldata/prostate/prostate_complete.csv.zip", destination_frame = "hdf")
+   df <- as.data.frame(hdf)
+   
+   print("Testing for family: TWEEDIE")
+   print("Set variables for h2o.")
+   y <- "CAPSULE"
+   x <- c("AGE","RACE","DCAPS","PSA","VOL","DPROS","GLEASON")
+  print("Compare H2O, R GLM model coefficients and standard error for var_power=1, link_power=0")
+  compareH2ORGLM(1, 0, x, y, hdf, df)
+  print("Compare H2O, R GLM model coefficients and standard error for var_power=0, link_power=1")
+  compareH2ORGLM(0, 1, x, y, hdf, df)
+  hdf$CAPSULE <- hdf$CAPSULE+1 # add 1 to avoid NaN
+  df <- as.data.frame(hdf)
+  print("Compare H2O, R GLM model coefficients and standard error for var_power=2, link_power=0")
+  compareH2ORGLM(2, 0, x, y, hdf, df)
+}
+
+compareH2ORGLM<-function(vpower, lpower, x, y, hdf, df, tolerance=5e-6) {
+  print("Define formula for R")
+  formula <- (df[,"CAPSULE"]~.)
+  rmodel <- glm(formula = formula, data = df[,x],
+                                 family=tweedie(var.power=vpower,link.power=lpower),na.action = na.omit)
+  h2omodel <- h2o.glm(x = x, y = y, training_frame = hdf, family = "tweedie", link = "tweedie", 
+                      tweedie_variance_power = vpower, tweedie_link_power = lpower, alpha = 0.5, lambda = 0, 
+                      nfolds = 0, compute_p_values=TRUE)
+  print("H2O GLM model....")
+  print(h2omodel)
+  print("R GLM model....")
+  print(summary(rmodel))
+  
+  print("Comparing H2O and R GLM model coefficients....")
+  h2oCoeff <- h2omodel@model$coefficients
+  rCoeff <- coef(rmodel)
+  for (ind in c(1:length(x))) {
+    expect_true(abs(h2oCoeff[x[ind]]-rCoeff[x[ind]]) < tolerance, info = paste0(
+      "R coefficient: ",
+      rCoeff[x[ind]],
+      " but h2o Coefficient: ",
+      h2oCoeff[x[ind]],
+      sep = " "
+    ))
+  }
+  expect_true(abs(h2oCoeff[x[ind]]-rCoeff[x[ind]]) < tolerance, info = paste0(
+    "R coefficient: ",
+    rCoeff["(Intercept)"],
+    " but h2o Coefficient: ",
+    h2oCoeff["(Intercept)"],
+    sep = " "
+  ))
+}
+
+doTest("Comparison of H2O to R TWEEDIE family coefficients and standard errors", test_linkFunctions)


### PR DESCRIPTION
This PR completes the work in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6457?filter=-1

I have completed the following:
1. Fixed Hessian/gradient calculation for Tweedie family and added Junit tests to verify the hessian/gradient fix.
2. Add Runit to run Tweedie regression on prostrate data.  Both H2O and R models are built.  Their coefficients are compared and found to be within tolerance.
3. However, the standard error of coefficients only agree between the two model if variance_power=1 and link_power = 0.  They do not agree with the other cases.

I used the standard error calculation using Pearson chi-squared statistic to estimate the dispersion factor.  You can find the standard error calculation on page 28 of this doc: http://statmath.wu.ac.at/courses/heather_turner/glmCourse_001.pdf.  Estimation of the dispersion factor can be found on page 3 of this doc: http://people.stat.sfu.ca/~raltman/stat402/402L25.pdf
