### PR TITLE
PUBDEV-6457: Fixed Tweedie hessian/gradient and standard error calculation

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -509,7 +509,7 @@ public final class ComputationState {
     _beta = beta;
     _ginfo = null;
     _likelihood = likelihood;
-    return (_relImprovement = (objOld - objective())/objOld);
+    return (_relImprovement = (objOld - objective())/Math.abs(objOld));
   }
   private double _betaDiff;
   private double _relImprovement;
@@ -536,7 +536,7 @@ public final class ComputationState {
     else System.arraycopy(beta,0,_beta,0,beta.length);
     _ginfo = ginfo;
     _likelihood = ginfo._likelihood;
-    return (_relImprovement = (objOld - objective())/objOld);
+    return (_relImprovement = (objOld - objective())/Math.abs(objOld));
   }
 
   public double [] expandBeta(double [] beta) {

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1119,7 +1119,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         if(_parms._family != Family.binomial && _parms._family != Family.poisson) {
           seEst = true;
           ComputeSETsk ct = new ComputeSETsk(null, _state.activeData(), _job._key, beta, _parms).doAll(_state.activeData()._adaptedFrame);
-          se = ct._sumsqe / (_nobs - 1 - _state.activeData().fullN());
+          se = ct._sumsqe / (_nobs - 1 - _state.activeData().fullN());  // this is the dispersion parameter estimate
         }
         double [] zvalues = MemoryManager.malloc8d(_state.activeData().fullN()+1);
         Cholesky chol = _chol;
@@ -1153,10 +1153,14 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       Frame train = DKV.<Frame>getGet(_parms._train);
       _model.score(train).delete();
       ModelMetrics mtrain = ModelMetrics.getFromDKV(_model, train); // updated by model.scoreAndUpdateModel
-      _model._output._training_metrics = mtrain;
       long t2 = System.currentTimeMillis();
+      if (!(mtrain==null)) {
+        _model._output._training_metrics = mtrain;
+        Log.info(LogMsg(mtrain.toString()));
+      } else {
+        Log.info(LogMsg("ModelMetrics mtrain is null"));
+      }
       Log.info(LogMsg("Training metrics computed in " + (t2-t1) + "ms"));
-      Log.info(LogMsg(mtrain.toString()));
       if(_valid != null) {
         Frame valid = DKV.<Frame>getGet(_parms._valid);
         _model.score(valid).delete();

--- a/h2o-algos/src/main/java/hex/gram/Gram.java
+++ b/h2o-algos/src/main/java/hex/gram/Gram.java
@@ -158,10 +158,10 @@ public final class Gram extends Iced<Gram> {
    * QR computation:
    * QR is computed using Gram-Schmidt elimination, using Gram matrix instead of the underlying dataset.
    *
-   * Gram-schmidt decomposition can be computed as follows: (from "The Eelements of Statistical Learning")
+   * Gram-schmidt decomposition can be computed as follows: (from "The Eelements of Statistical Learning", Algorithm 3.1)
    * 1. set z0 = x0 = 1 (Intercept)
    * 2. for j = 1:p
-   *      for l = 1:j-1
+   *      for l = 0:j-1
    *        gamma_jl = dot(x_l,x_j)/dot(x_l,x_l)
    *      zj = xj - sum(gamma_j[l]*x_l)
    *      if(zj ~= 0) xj was redundant (collinear)
@@ -176,7 +176,7 @@ public final class Gram extends Iced<Gram> {
    * When doing that, we need to replace dot(xi,xk) with dot(xi,zk) for all i.
    * There are two cases,
    *   1)  dot(xk,xk) -> dot(zk,zk)
-   *       dot(xk - sum(gamma_l*x_l,xk - sum(gamma_l*x_l)
+   *       dot(xk - sum(gamma_l*x_l),xk - sum(gamma_l*x_l))
    *       = dot(xk,xk) - 2* sum(gamma_l*dot(x_i,x_k) + sum(gamma_l*sum(gamma_k*dot(x_l,x_k)))
    *       (can be simplified using the fact that dot(zi,zj) == 0 for i != j
    *   2)  dot(xi,xk) -> dot(xi,zk) for i != k

--- a/h2o-algos/src/main/java/hex/optimization/L_BFGS.java
+++ b/h2o-algos/src/main/java/hex/optimization/L_BFGS.java
@@ -1,10 +1,12 @@
 package hex.optimization;
 
-import hex.optimization.OptimizationUtils.*;
+import hex.optimization.OptimizationUtils.GradientInfo;
+import hex.optimization.OptimizationUtils.GradientSolver;
+import hex.optimization.OptimizationUtils.LineSearchSolver;
+import hex.optimization.OptimizationUtils.MoreThuente;
 import water.Iced;
 import water.MemoryManager;
 import water.util.ArrayUtils;
-import water.util.Log;
 import water.util.MathUtils;
 
 import java.util.Arrays;
@@ -190,7 +192,7 @@ public final class L_BFGS extends Iced {
       lineSearch.setInitialStep(Math.max(minStep, lineSearch.step()));
       GradientInfo newGinfo = lineSearch.ginfo();
       _hist.update(pk, newGinfo._gradient, ginfo._gradient);
-      rel_improvement = (ginfo._objVal - newGinfo._objVal)/ginfo._objVal;
+      rel_improvement = (ginfo._objVal - newGinfo._objVal)/Math.abs(ginfo._objVal);
       ginfo = newGinfo;
       if(!pm.progress(lineSearch.getX(), ginfo))break;
     }

--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -34,6 +34,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
     @API(help="Lambda best + 1 standard error. Only applicable with lambda search and cross-validation")
     double lambda_1se;
 
+    @API(help="Dispersion parameter, only applicable to Tweedie family")
+    double dispersion;
+
     private GLMModelOutputV3 fillMultinomial(GLMOutput impl) {
       if(impl.get_global_beta_multinomial() == null)
         return this; // no coefificients yet
@@ -169,6 +172,7 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       super.fillFromImpl(impl);
       lambda_1se = impl.lambda_1se();
       lambda_best = impl.lambda_best();
+      dispersion = impl.dispersion();
       if(impl._multinomial || impl._ordinal)
         return fillMultinomial(impl);
       String [] names = impl.coefficientNames().clone();

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -151,6 +151,23 @@ public class TestUtil extends Iced {
     _initial_keycnt = H2O.store_size();
   }
 
+  public static void checkArrays(double[] expected, double[] actual, double threshold) {
+    for(int i = 0; i < actual.length; i++) {
+      if (!Double.isNaN(expected[i]) && !Double.isNaN(actual[i])) // only compare when both are not NaN
+        assertEquals(expected[i], actual[i], threshold*Math.min(Math.abs(expected[i]),Math.abs(actual[i])));
+    }
+  }
+
+  public static void checkDoubleArrays(double[][] expected, double[][] actual, double threshold) {
+    int len1 = expected.length;
+    assertEquals(len1, actual.length);
+
+    for (int ind=0; ind < len1; ind++) {
+      assertEquals(expected[ind].length, actual[ind].length);
+      checkArrays(expected[ind], actual[ind], threshold);
+    }
+  }
+
   /**
    * generate random frames containing enum columns only
    * @param numCols
@@ -159,6 +176,12 @@ public class TestUtil extends Iced {
    * @return
    */
   protected static Frame generate_enum_only(int numCols, int numRows, int num_factor, double missingfrac) {
+    long seed = System.currentTimeMillis();
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+seed);
+    return generate_enum_only(numCols, numRows, num_factor, missingfrac, seed);
+  }
+
+  protected static Frame generate_enum_only(int numCols, int numRows, int num_factor, double missingfrac, long seed) {
     CreateFrame cf = new CreateFrame();
     cf.rows= numRows;
     cf.cols = numCols;
@@ -168,7 +191,52 @@ public class TestUtil extends Iced {
     cf.categorical_fraction = 1;
     cf.has_response=false;
     cf.missing_fraction = missingfrac;
-    cf.seed = System.currentTimeMillis();
+    cf.seed =seed;
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
+    return cf.execImpl().get();
+  }
+
+  protected static Frame generate_real_only(int numCols, int numRows, double missingfrac) {
+    long seed = System.currentTimeMillis();
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+seed);
+    return generate_real_only(numCols, numRows, missingfrac, seed);
+  }
+
+  protected static Frame generate_real_only(int numCols, int numRows, double missingfrac, long seed) {
+    CreateFrame cf = new CreateFrame();
+    cf.rows= numRows;
+    cf.cols = numCols;
+    cf.binary_fraction = 0;
+    cf.integer_fraction = 0;
+    cf.categorical_fraction = 0;
+    cf.time_fraction = 0;
+    cf.string_fraction = 0;
+    cf.has_response=false;
+    cf.missing_fraction = missingfrac;
+    cf.seed = seed;
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
+    return cf.execImpl().get();
+  }
+
+  protected static Frame generate_int_only(int numCols, int numRows, int integer_range, double missingfrac) {
+    long seed = System.currentTimeMillis();
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+seed);
+    return generate_int_only(numCols, numRows, integer_range, missingfrac, seed);
+  }
+
+  protected static Frame generate_int_only(int numCols, int numRows, int integer_range, double missingfrac, long seed) {
+    CreateFrame cf = new CreateFrame();
+    cf.rows= numRows;
+    cf.cols = numCols;
+    cf.binary_fraction = 0;
+    cf.integer_fraction = 1;
+    cf.categorical_fraction = 0;
+    cf.time_fraction = 0;
+    cf.string_fraction = 0;
+    cf.has_response=false;
+    cf.missing_fraction = missingfrac;
+    cf.integer_range = integer_range;
+    cf.seed = seed;
     System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
     return cf.execImpl().get();
   }
@@ -190,26 +258,6 @@ public class TestUtil extends Iced {
       sortDir[index] = dirs[rand.nextInt(2)];
     }
     return sortDir;
-  }
-  /**
-   * generate random frames containing enum columns only
-   * @param numCols
-   * @param numRows
-   * @return
-   */
-  protected static Frame generate_int_only(int numCols, int numRows, int iRange, double missingfrac) {
-    CreateFrame cf = new CreateFrame();
-    cf.rows= numRows;
-    cf.cols = numCols;
-    cf.binary_fraction = 0;
-    cf.integer_fraction = 1;
-    cf.categorical_fraction = 0;
-    cf.has_response=false;
-    cf.missing_fraction = missingfrac;
-    cf.integer_range=iRange;
-    cf.seed = System.currentTimeMillis();
-    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
-    return cf.execImpl().get();
   }
 
   private static class DKVCleaner extends MRTask<DKVCleaner> {

--- a/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gaussian_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gaussian_large.py
@@ -135,7 +135,7 @@ class TestGLMGaussian:
     nan_fraction = 0.2          # denote maximum fraction of NA's to be inserted into a column
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     enum_col = 0                # set maximum number of categorical columns in predictor
     enum_level_vec = []         # vector containing number of levels for each categorical column

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3774,6 +3774,21 @@ def random_dataset_numeric_only(nrow, ncol, integerR=100, misFrac=0.01, randSeed
                           seed=randSeed, **fractions)
     return df
 
+# generate random dataset of ncolumns of integer and reals, copied from Pasha
+def random_dataset_real_only(nrow, ncol, realR=100, misFrac=0.01, randSeed=None):
+    """Create and return a random dataset."""
+    fractions = dict()
+    fractions["real_fraction"] = 1  # Right now we are dropping string columns, so no point in having them.
+    fractions["categorical_fraction"] = 0
+    fractions["integer_fraction"] = 0
+    fractions["time_fraction"] = 0
+    fractions["string_fraction"] = 0  # Right now we are dropping string columns, so no point in having them.
+    fractions["binary_fraction"] = 0
+
+    df = h2o.create_frame(rows=nrow, cols=ncol, missing_fraction=misFrac, has_response=False, integer_range=realR,
+                          seed=randSeed, **fractions)
+    return df
+
 def getMojoName(modelID):
     regex = re.compile("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]")
     return regex.sub("_", modelID)

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_interactions_valid_large.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_interactions_valid_large.R
@@ -2,7 +2,6 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
 test.glm.interactions_pubdev5277 <- function() {
-
     df <- h2o.importFile(locate("smalldata/airlines/allyears2k_headers.zip"))
     df[is.na(df$Distance), "Distance"] <- h2o.mean(df$Distance, na.rm = TRUE)
     df[is.na(df$CRSElapsedTime), "CRSElapsedTime"] <- h2o.mean(df$CRSElapsedTime, na.rm = TRUE)
@@ -26,17 +25,29 @@ test.glm.interactions_pubdev5277 <- function() {
                   early_stopping = FALSE, seed = 1234)
 
     # Performance is similar
+    print("comparing AUC of m1 and m2")
+    print(m1@model$training_metrics@metrics$AUC- m2@model$training_metrics@metrics$AUC)
     expect_equal(m1@model$training_metrics@metrics$AUC, m2@model$training_metrics@metrics$AUC, tolerance = 0.001, scale = 1)
+    print("Comparing logloss of m1 and m2")
+    print(m1@model$training_metrics@metrics$logloss-m2@model$training_metrics@metrics$logloss)
     expect_equal(m1@model$training_metrics@metrics$logloss, m2@model$training_metrics@metrics$logloss, tolerance = 0.001, scale = 1)
 
     # Coefficients of numeric features from the orginal dataset are reasonably similar in both models
     simple.coef <- setdiff(m1@model$coefficients_table$names[grep('\\.', m1@model$coefficients_table$names, invert = TRUE)], "Intercept")
+    print("Comparing intercept of m1 and m2")
+    print(m1@model$coefficients["Intercept"]-m2@model$coefficients["Intercept"])
     expect_equal(m1@model$coefficients["Intercept"], m2@model$coefficients["Intercept"], tolerance = 0.01, scale = m1@model$coefficients["Intercept"])
+    print("Comparing coefficients of m1 and m2")
+    print(m1@model$coefficients[simple.coef]-m2@model$coefficients[simple.coef])
     expect_equal(m1@model$coefficients[simple.coef], m2@model$coefficients[simple.coef], tolerance = 5e-4, scale = 1)
 
     # Coefficients for interactions don't match (one example:) - needs to be fixed in PUBDEV-5277
-    expect_true(abs(0.346 - m1@model$coefficients["UniqueCarrier_Origin.AA_ABQ"]) < 0.001)
-    expect_true(abs(7.456 - m2@model$coefficients["UniqueCarrier_Origin.AA_ABQ"]) < 0.001)
+    print("Comparing coefficients of m1 and 0.346")
+    print(abs(0.346 - m1@model$coefficients["UniqueCarrier_Origin.AA_ABQ"]))
+    expect_true(abs(0.346 - m1@model$coefficients["UniqueCarrier_Origin.AA_ABQ"]) < 0.01)
+    print("Comparing coefficients of m2 and 7.456")
+    print(abs(7.456 - m2@model$coefficients["UniqueCarrier_Origin.AA_ABQ"]))
+    expect_true(abs(7.456 - m2@model$coefficients["UniqueCarrier_Origin.AA_ABQ"]) < 0.01)
 }
 
 doTest("Demonstrates that 2 GLM runs with implicit interactions and explicit interactions differ", test.glm.interactions_pubdev5277)

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_tweedie_PUBDEV_6457.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_tweedie_PUBDEV_6457.R
@@ -1,0 +1,91 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+##
+# Comparison of H2O to R for the TWEEDIE family on prostate dataset
+# In particular, we want to compare the coefficients and their standard error calculations.
+##
+
+test_linkFunctions <- function() {
+
+  # Use prostate_complete to test tweedie in R glm vs h2o.glm
+  # Note that the outcome in this dataset has a bernoulli distribution
+  require(statmod)
+  print("Read in prostate data.")
+   hdf <- h2o.uploadFile("../../../../smalldata/prostate/prostate_complete.csv.zip", destination_frame = "hdf")
+   weightOffFrame <- ((h2o.createFrame(rows=h2o.nrow(hdf), cols=2, categorical_fraction=0, integer_fraction=0,
+                                     real_range=1, binary_fraction=0, binary_ones_fraction = 0, 
+                                     time_fraction = 0, string_fraction = 0, missing_fraction=0, seed = 12345))+1.1)*0.5
+   colnames(weightOffFrame) <- c("offset", "weight")
+   hdf <- h2o.cbind(hdf, weightOffFrame)
+   df <- as.data.frame(hdf)
+   
+   print("Testing for family: TWEEDIE")
+   print("Set variables for h2o.")
+   y <- "CAPSULE"
+   x <- c("AGE","RACE","DCAPS","PSA","VOL","DPROS","GLEASON")
+  print("Compare H2O, R GLM model coefficients and standard error for var_power=1, link_power=0")
+  compareH2ORGLM(1, 0, x, y, hdf, df)
+  print("Compare H2O, R GLM model coefficients and standard error for var_power=0, link_power=1")
+  compareH2ORGLM(0, 1, x, y, hdf, df)
+  hdf$CAPSULE <- hdf$CAPSULE+1 # add 1 to avoid NaN
+  df <- as.data.frame(hdf)
+  print("Compare H2O, R GLM model coefficients and standard error for var_power=2, link_power=0")
+  compareH2ORGLM(2, 0, x, y, hdf, df)
+  
+  # check calculation with offset/weight columns
+  
+}
+
+compareH2ORGLM<-function(vpower, lpower, x, y, hdf, df, tolerance=5e-6) {
+  print("Define formula for R")
+  formula <- (df[,"CAPSULE"]~.)
+  rmodel <- glm(formula = formula,  data = df[,x],
+                        family=tweedie(var.power=vpower,link.power=lpower),na.action = na.omit)
+  rmodelWWeights <- glm(CAPSULE~.-weight-offset-C1-ID, data = df, weights=weight,
+                        family=tweedie(var.power=vpower,link.power=lpower),na.action = na.omit)
+  rmodelWOffsets <- glm(CAPSULE~.-weight-offset-C1-ID+offset(offset), data = df, weights=weight,
+                        family=tweedie(var.power=vpower,link.power=lpower),na.action = na.omit)
+  h2omodel <- h2o.glm(x = x, y = y, training_frame = hdf, family = "tweedie", link = "tweedie", 
+                      tweedie_variance_power = vpower, tweedie_link_power = lpower, alpha = 0.5, lambda = 0, 
+                      nfolds = 0, compute_p_values=TRUE)
+  h2omodelWWeights <- h2o.glm(x = x, y = y, training_frame = hdf, family = "tweedie", link = "tweedie", 
+                              tweedie_variance_power = vpower, tweedie_link_power = lpower, alpha = 0.5, lambda = 0, 
+                              nfolds = 0, compute_p_values=TRUE, weights_column="weight")
+  h2omodelWOffsets <- h2o.glm(x = x, y = y, training_frame = hdf, family = "tweedie", link = "tweedie", 
+                              tweedie_variance_power = vpower, tweedie_link_power = lpower, alpha = 0.5, lambda = 0, 
+                              nfolds = 0, compute_p_values=TRUE, offset_column="offset")
+
+  print("Comparing H2O and R GLM model coefficients....")
+  compareCoeffs(rmodel, h2omodel, tolerance, x)
+  print("Comparing H2O and R GLM model coefficients with weights....")
+  compareCoeffs(rmodelWWeights, h2omodelWWeights, tolerance, x)
+  print("Comparing H2O and R GLM model coefficients with offsets")
+  compareCoeffs(rmodelWOffsets, h2omodelWOffsets, 2, x) # accuracy is lower for some reason
+}
+
+compareCoeffs <- function(rmodel, h2omodel, tolerance, x) {
+  print("H2O GLM model....")
+  print(h2omodel)
+  print("R GLM model....")
+  print(summary(rmodel))
+  h2oCoeff <- h2omodel@model$coefficients
+  rCoeff <- coef(rmodel)
+  for (ind in c(1:length(x))) {
+    expect_true(abs(h2oCoeff[x[ind]]-rCoeff[x[ind]]) < tolerance, info = paste0(
+      "R coefficient: ",
+      rCoeff[x[ind]],
+      " but h2o Coefficient: ",
+      h2oCoeff[x[ind]],
+      sep = " "
+    ))
+  }
+  expect_true(abs(h2oCoeff[x[ind]]-rCoeff[x[ind]]) < tolerance, info = paste0(
+    "R coefficient: ",
+    rCoeff["(Intercept)"],
+    " but h2o Coefficient: ",
+    h2oCoeff["(Intercept)"],
+    sep = " "
+  ))
+}
+
+doTest("Comparison of H2O to R TWEEDIE family coefficients and standard errors", test_linkFunctions)


### PR DESCRIPTION
This PR completes the work in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6457?filter=-1 and https://0xdata.atlassian.net/browse/PUBDEV-6472?filter=-1

I have completed the following:

1. Fixed Hessian/gradient calculation for Tweedie family and added Junit tests to verify the hessian/gradient fix.
2. Add Runit to run Tweedie regression on prostrate data. Both H2O and R models are built. Their coefficients are compared and found to be within tolerance.
However, the standard error of coefficients only agree between the two model if variance_power=1 and link_power = 0. They do not agree with the other cases.
3. I used the standard error calculation using Pearson chi-squared statistic to estimate the dispersion factor. You can find the standard error calculation on page 28 of this doc: http://statmath.wu.ac.at/courses/heather_turner/glmCourse_001.pdf. Estimation of the dispersion factor can be found on page 3 of this doc: http://people.stat.sfu.ca/~raltman/stat402/402L25.pdf
4. A junit test is added to verify the dispersion parameter estimation is correct.