### PR TITLE
PUBDEV-6511 - add missing functions to _pkgdown.yml file

### DIFF
--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -139,6 +139,8 @@ reference:
       - h2o.hit_ratio_table
       - h2o.hour
       - h2o.ifelse
+      - h2o.import_hive_table
+      - h2o.import_mojo
       - h2o.import_sql_select
       - h2o.import_sql_table
       - h2o.importFile


### PR DESCRIPTION
Added import_hive_table and import_mojo to _pkgdown.yml file so that these functions are included in the generated html output.