### PR TITLE
PUBDEV-6458 - Categorical splits represented as numerical (SharedTree solution)

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/PrintMojoTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/PrintMojoTreeTest.java
@@ -1,0 +1,198 @@
+package hex.tree;
+
+import hex.genmodel.tools.PrintMojo;
+import hex.tree.isofor.IsolationForest;
+import hex.tree.isofor.IsolationForestModel;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.Permission;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class PrintMojoTreeTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private SecurityManager originalSecurityManager;
+
+  @Before
+  public void setUp() throws Exception {
+    TestUtil.stall_till_cloudsize(1);
+    originalSecurityManager = System.getSecurityManager();
+    System.setSecurityManager(new PreventExitSecurityManager());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    System.setSecurityManager(originalSecurityManager);
+  }
+
+  @Test
+  public void testMojoCategoricalPrint() throws IOException {
+    try {
+      Scope.enter();
+      Frame train = Scope.track(TestUtil.parse_test_file("smalldata/iris/iris.csv"));
+
+      IsolationForestModel.IsolationForestParameters p = new IsolationForestModel.IsolationForestParameters();
+      p._train = train._key;
+      p._ignored_columns = new String[]{"C1", "C2", "C3", "C4"};
+      p._seed = 0xFEED;
+      p._ntrees = 1;
+
+      IsolationForestModel model = new IsolationForest(p).trainModel().get();
+      final File modelFile = folder.newFile();
+      model.exportMojo(modelFile.getAbsolutePath(), true);
+
+      final File treeOutput = folder.newFile();
+      try {
+        PrintMojo.main(new String[]{"--input", modelFile.getAbsolutePath(), "--output", treeOutput.getAbsolutePath()});
+        fail("Expected PrintMojo to call System.exit()");
+      } catch (PreventedExitException e) {
+      }
+
+      final String treeDotz = FileUtils.readFileToString(treeOutput);
+      System.out.println(treeDotz);
+      assertFalse(treeDotz.isEmpty());
+
+
+      final Pattern labelPattern = Pattern.compile("label{1}=\\\"(.*?)\\\"");
+      final Pattern labelContentPattern = Pattern.compile(".*[<>=].*"); // Contains < or > or =
+      final Matcher matcher = labelPattern.matcher(treeDotz);
+
+      assertEquals(1, matcher.groupCount());
+
+      while (matcher.find()){
+        assertFalse(labelContentPattern.matcher(matcher.group(1)).matches());
+      }
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testMojoCategoricalPrint_limitedLevels() throws IOException {
+    try {
+      Scope.enter();
+      Frame train = Scope.track(TestUtil.parse_test_file("smalldata/iris/iris.csv"));
+
+      IsolationForestModel.IsolationForestParameters p = new IsolationForestModel.IsolationForestParameters();
+      p._train = train._key;
+      p._ignored_columns = new String[]{"C1", "C2", "C3", "C4"};
+      p._seed = 0xFEED;
+      p._ntrees = 1;
+
+      IsolationForestModel model = new IsolationForest(p).trainModel().get();
+      final File modelFile = folder.newFile();
+      model.exportMojo(modelFile.getAbsolutePath(), true);
+
+      final File treeOutput = folder.newFile();
+      try {
+        PrintMojo.main(new String[]{"--input", modelFile.getAbsolutePath(), "--output", treeOutput.getAbsolutePath(), "--levels", "1"});
+        fail("Expected PrintMojo to call System.exit()");
+      } catch (PreventedExitException e) {
+      }
+
+      final String treeDotz = FileUtils.readFileToString(treeOutput);
+      assertFalse(treeDotz.isEmpty());
+
+      assertTrue(treeDotz.contains("/* Edges */\n" +
+              "\"SG_0_Node_0\" -> \"SG_0_Node_1\" [fontsize=14, label=\"[NA]\\n2 levels\\n\"]\n" +
+              "\"SG_0_Node_0\" -> \"SG_0_Node_4\" [fontsize=14, label=\"Iris-virginica\\n\"]\n" +
+              "\"SG_0_Node_1\" -> \"SG_0_Node_5\" [fontsize=14, label=\"2 levels\\n\"]\n" +
+              "\"SG_0_Node_1\" -> \"SG_0_Node_6\" [fontsize=14, label=\"[NA]\\nIris-setosa\\n\"]"));
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  /**
+   * Tests if internal split representation is present in the graph. Labels contain real numbers as split and
+   * edge labels contain lesser than/equals/greater than signs.
+   */
+  @Test
+  public void testMojoCategoricalPrint_internalRepresentationOutput() throws IOException {
+    try {
+      Scope.enter();
+      Frame train = Scope.track(TestUtil.parse_test_file("smalldata/iris/iris.csv"));
+
+      IsolationForestModel.IsolationForestParameters p = new IsolationForestModel.IsolationForestParameters();
+      p._train = train._key;
+      p._ignored_columns = new String[]{"C1", "C2", "C3", "C4"};
+      p._seed = 0xFEED;
+      p._ntrees = 1;
+
+      IsolationForestModel model = new IsolationForest(p).trainModel().get();
+      final File modelFile = folder.newFile();
+      model.exportMojo(modelFile.getAbsolutePath(), true);
+
+      final File treeOutput = folder.newFile();
+      try {
+        PrintMojo.main(new String[]{"--input", modelFile.getAbsolutePath(), "--output", treeOutput.getAbsolutePath(), "--internal"});
+        fail("Expected PrintMojo to call System.exit()");
+      } catch (PreventedExitException e) {
+      }
+
+      final String treeDotz = FileUtils.readFileToString(treeOutput);
+      assertFalse(treeDotz.isEmpty());
+
+      final Pattern labelPattern = Pattern.compile("label{1}=\\\"(.*?)\\\"");
+      final Pattern labelContentPattern = Pattern.compile(".*[<>=].*"); // Contains < or > or =
+      final Matcher matcher = labelPattern.matcher(treeDotz);
+
+      assertEquals(1, matcher.groupCount());
+
+      int matches = 0;
+      while (matcher.find()){
+        if(labelContentPattern.matcher(matcher.group(1)).matches()){
+          matches++; // Find labels with '<>=' inside. In non-internal representation, there should be none in a graph with purely categorical splits
+        }
+      }
+
+      assertTrue(matches > 0);
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  protected static class PreventedExitException extends SecurityException {
+    public final int status;
+
+    public PreventedExitException(int status) {
+      this.status = status;
+    }
+  }
+
+  /**
+   * Security managers that prevents PrintMojo from exiting.
+   */
+  private static class PreventExitSecurityManager extends SecurityManager {
+    @Override
+    public void checkPermission(Permission perm) {
+    }
+
+    @Override
+    public void checkPermission(Permission perm, Object context) {
+    }
+
+    @Override
+    public void checkExit(int status) {
+      throw new PreventedExitException(status);
+    }
+  }
+}

--- a/h2o-algos/src/test/java/hex/tree/PrintMojoTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/PrintMojoTreeTest.java
@@ -109,10 +109,9 @@ public class PrintMojoTreeTest {
       final String treeDotz = FileUtils.readFileToString(treeOutput);
       assertFalse(treeDotz.isEmpty());
 
-      assertTrue(treeDotz.contains("/* Edges */\n" +
-              "\"SG_0_Node_0\" -> \"SG_0_Node_1\" [fontsize=14, label=\"[NA]\\n2 levels\\n\"]\n" +
+      assertTrue(treeDotz.contains("\"SG_0_Node_0\" -> \"SG_0_Node_1\" [fontsize=14, label=\"[NA]\\n2 levels\\n\"]\n" +
               "\"SG_0_Node_0\" -> \"SG_0_Node_4\" [fontsize=14, label=\"Iris-virginica\\n\"]\n" +
-              "\"SG_0_Node_1\" -> \"SG_0_Node_5\" [fontsize=14, label=\"2 levels\\n\"]\n" +
+              "\"SG_0_Node_1\" -> \"SG_0_Node_5\" [fontsize=14, label=\"Iris-versicolor\\n\"]\n" +
               "\"SG_0_Node_1\" -> \"SG_0_Node_6\" [fontsize=14, label=\"[NA]\\nIris-setosa\\n\"]"));
 
     } finally {
@@ -149,6 +148,7 @@ public class PrintMojoTreeTest {
 
       final String treeDotz = FileUtils.readFileToString(treeOutput);
       assertFalse(treeDotz.isEmpty());
+      System.out.println(treeDotz);
 
       final Pattern labelPattern = Pattern.compile("label{1}=\\\"(.*?)\\\"");
       final Pattern labelContentPattern = Pattern.compile(".*[<>=].*"); // Contains < or > or =

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoModel.java
@@ -337,9 +337,13 @@ public abstract class SharedTreeMojoModel extends MojoModel implements SharedTre
         if (!naVsRest) {
             // Extract value or group to split on
             if (equal == 0) {
+              float splitVal = ab.get4f();
+
+              if (domains[colId] != null) {
+                node.setDomainValues(domains[colId]);
+              }
                 // Standard float-compare test (either < or ==)
-                float splitVal = ab.get4f();  // Get the float to compare
-                node.setSplitValue(splitVal);
+              node.setSplitValue(splitVal);
             } else {
                 // Bitset test
                 GenmodelBitSet bs = new GenmodelBitSet(0);

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
@@ -300,8 +300,7 @@ public class SharedTreeNode implements INode<double[]>, INodeStat {
       os.print("fontsize="+treeOptions._fontSize+", label=\"");
       float predv = treeOptions._setDecimalPlace?treeOptions.roundNPlace(predValue):predValue;
       os.print(predv);
-    }
-    else if (isBitset()) {
+    } else if (isBitset() && (Float.isNaN(splitValue) || !treeOptions._internal)) {
       os.print("shape=box, fontsize="+treeOptions._fontSize+", label=\"");
       os.print(escapeQuotes(colName));
     }
@@ -364,7 +363,7 @@ public class SharedTreeNode implements INode<double[]>, INodeStat {
   private void printDotEdgesCommon(PrintStream os, int maxLevelsToPrintPerEdge, ArrayList<String> arr,
                                    SharedTreeNode child, float totalWeight, boolean detail,
                                    PrintMojo.PrintTreeOptions treeOptions) {
-    if (isBitset()) {
+    if (isBitset() || (!Float.isNaN(splitValue) && treeOptions._internal)) { // Print categorical levels even in case of internal numerical representation
       BitSet childInclusiveLevels = child.getInclusiveLevels();
       int total = childInclusiveLevels.cardinality();
       if ((total > 0) && (total <= maxLevelsToPrintPerEdge)) {
@@ -420,7 +419,7 @@ public class SharedTreeNode implements INode<double[]>, INodeStat {
         arr.add("[Not NA]");
       }
       else {
-        if (! isBitset()) {
+        if (!isBitset() || (!Float.isNaN(splitValue) && treeOptions._internal)) {
           arr.add("<");
         }
       }
@@ -437,7 +436,7 @@ public class SharedTreeNode implements INode<double[]>, INodeStat {
       }
 
       if (! naVsRest) {
-        if (! isBitset()) {
+        if (!isBitset() || (!Float.isNaN(splitValue) && treeOptions._internal)) {
           arr.add(">=");
         }
       }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
@@ -177,21 +177,19 @@ public class SharedTreeNode implements INode<double[]>, INodeStat {
     BitSet inheritedInclusiveLevels = findInclusiveLevels(colId);
     BitSet childInclusiveLevels = new BitSet();
 
-    int splitPoint = Float.isNaN(splitValue) ? -1 : (int) Math.ceil(splitValue);
 
     for (int i = 0; i < domainValues.length; i++) {
       // Calculate whether this level should flow into this child node.
       boolean includeThisLevel = false;
       {
-        if (splitPoint != -1) {
-          includeThisLevel = splitPoint > i ^ nodeBitsetDoesContain;
-        } else if (discardAllLevels) {
+        if (discardAllLevels) {
           includeThisLevel = false;
-        }
-        else if (includeAllLevels) {
+        } else if (includeAllLevels) {
           includeThisLevel = calculateIncludeThisLevel(inheritedInclusiveLevels, i);
-        }
-        else if (bs.isInRange(i) && bs.contains(i) == nodeBitsetDoesContain) {
+        } else if (!Float.isNaN(splitValue)) {
+          // This branch is only used if categorical split is represented numerically
+          includeThisLevel = splitValue < i ^ !nodeBitsetDoesContain;
+        } else if (bs.isInRange(i) && bs.contains(i) == nodeBitsetDoesContain) {
           includeThisLevel = calculateIncludeThisLevel(inheritedInclusiveLevels, i);
         }
       }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeNode.java
@@ -177,11 +177,15 @@ public class SharedTreeNode implements INode<double[]>, INodeStat {
     BitSet inheritedInclusiveLevels = findInclusiveLevels(colId);
     BitSet childInclusiveLevels = new BitSet();
 
+    int splitPoint = Float.isNaN(splitValue) ? -1 : (int) Math.ceil(splitValue);
+
     for (int i = 0; i < domainValues.length; i++) {
       // Calculate whether this level should flow into this child node.
       boolean includeThisLevel = false;
       {
-        if (discardAllLevels) {
+        if (splitPoint != -1) {
+          includeThisLevel = splitPoint > i ^ nodeBitsetDoesContain;
+        } else if (discardAllLevels) {
           includeThisLevel = false;
         }
         else if (includeAllLevels) {

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -71,9 +71,9 @@ public class PrintMojo {
     System.out.println("");
     System.out.println("    --fontsize | -f    Set font sizes of strings.");
     System.out.println("");
-    System.out.println("    --raw    Print raw graph representation to standard output.");
+    System.out.println("    --raw    Print raw, human-readable graph representation to standard output. Together with graphviz representation.");
     System.out.println("");
-    System.out.println("    --internal    Internal H2O representation of the graph (splits etc.) is used for generating the GRAPHVIZ format.");
+    System.out.println("    --internal    Internal H2O representation of the decision tree (splits etc.) is used for generating the GRAPHVIZ format.");
     System.out.println("");
     System.out.println("");
     System.out.println("Example:");

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -71,8 +71,6 @@ public class PrintMojo {
     System.out.println("");
     System.out.println("    --fontsize | -f    Set font sizes of strings.");
     System.out.println("");
-    System.out.println("    --raw    Print raw, human-readable graph representation to standard output. Together with graphviz representation.");
-    System.out.println("");
     System.out.println("    --internal    Internal H2O representation of the decision tree (splits etc.) is used for generating the GRAPHVIZ format.");
     System.out.println("");
     System.out.println("");

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -9,6 +9,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Print dot (graphviz) representation of one or more trees in a DRF or GBM model.
@@ -22,6 +24,7 @@ public class PrintMojo {
   private static String outputFileName = null;
   private static String optionalTitle = null;
   private static PrintTreeOptions pTreeOptions;
+  private static boolean internal;
 
   public static void main(String[] args) {
     // Parse command line arguments
@@ -67,6 +70,10 @@ public class PrintMojo {
     System.out.println("    --decimalplaces | -d    Set decimal places of all numerical values.");
     System.out.println("");
     System.out.println("    --fontsize | -f    Set font sizes of strings.");
+    System.out.println("");
+    System.out.println("    --raw    Print raw graph representation to standard output.");
+    System.out.println("");
+    System.out.println("    --internal    Internal H2O representation of the graph (splits etc.) is used for generating the GRAPHVIZ format.");
     System.out.println("");
     System.out.println("");
     System.out.println("Example:");
@@ -151,6 +158,9 @@ public class PrintMojo {
           case "--raw":
             printRaw = true;
             break;
+          case "--internal":
+            internal = true;
+            break;
 
           case "-o":
           case "--output":
@@ -165,7 +175,7 @@ public class PrintMojo {
             break;
         }
       }
-      pTreeOptions = new PrintTreeOptions(setDecimalPlaces, nPlaces, fontSize);
+      pTreeOptions = new PrintTreeOptions(setDecimalPlaces, nPlaces, fontSize, internal);
     } catch (Exception e) {
       e.printStackTrace();
       usage();
@@ -207,11 +217,13 @@ public class PrintMojo {
     public boolean _setDecimalPlace = false;
     public int _nPlaces = -1;
     public int _fontSize = 14;  // default
+    public boolean _internal;
 
-    public PrintTreeOptions(boolean setdecimalplaces, int nplaces, int fontsize) {
+    public PrintTreeOptions(boolean setdecimalplaces, int nplaces, int fontsize, boolean internal) {
       _setDecimalPlace = setdecimalplaces;
       _nPlaces = _setDecimalPlace?nplaces:_nPlaces;
       _fontSize = fontsize;
+      _internal = internal;
     }
 
     public float roundNPlace(float value) {


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6458

As discovered in : https://github.com/h2oai/h2o-3/pull/3530

- It is best to fix it once and for all
- There is a strong suspicion our inherited categorical levels calculations are wrong.

### Categorical representation

Hide internal categorical splits represented in a numerical way.

![tree_representation](https://user-images.githubusercontent.com/8769110/58706143-79f41480-83b1-11e9-865d-dd5c3da6b87e.png)


### Internal representation
Print the numerical representation of the categorical split, but keep the categorical levels calculated for **each edge printed as well**, for better verifiability and readability.

![tree_representation_internal](https://user-images.githubusercontent.com/8769110/58706138-7791ba80-83b1-11e9-82ee-933f2912a1fa.png)

