### PR TITLE
PUBDEV-6532 - XGBoost should not use grouping in parameter localization

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
@@ -1,15 +1,11 @@
 package hex.tree.xgboost;
 
-import sun.misc.FloatingDecimal;
 import water.Iced;
 import water.util.IcedHashMapGeneric;
 import water.util.TwoDimTable;
 
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 /**

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
@@ -1,5 +1,6 @@
 package hex.tree.xgboost;
 
+import sun.misc.FloatingDecimal;
 import water.Iced;
 import water.util.IcedHashMapGeneric;
 import water.util.TwoDimTable;
@@ -42,13 +43,13 @@ public class BoosterParms extends Iced<BoosterParms> {
    */
   private static Map<String, Object> localizeDecimalParams(final Map<String, Object> params) {
     Map<String, Object> localized = new HashMap<>(params.size());
-    final NumberFormat localizedNumberFormatter = DecimalFormat.getNumberInstance(Locale.ENGLISH);
-    localizedNumberFormatter.setGroupingUsed(false);
     for (String key : params.keySet()) {
       final Object value = params.get(key);
       final Object newValue;
-      if (value instanceof Float || value instanceof Double) {
-        newValue = localizedNumberFormatter.format(value);
+      if (value instanceof Float) {
+        newValue = FloatingDecimal.toJavaFormatString((Float) value);
+      } else if (value instanceof Double) {
+        newValue = FloatingDecimal.toJavaFormatString((Double) value);
       } else
         newValue = value;
       localized.put(key, newValue);

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
@@ -46,10 +46,8 @@ public class BoosterParms extends Iced<BoosterParms> {
     for (String key : params.keySet()) {
       final Object value = params.get(key);
       final Object newValue;
-      if (value instanceof Float) {
-        newValue = FloatingDecimal.toJavaFormatString((Float) value);
-      } else if (value instanceof Double) {
-        newValue = FloatingDecimal.toJavaFormatString((Double) value);
+      if (value instanceof Float || value instanceof Double) {
+        newValue = value.toString();
       } else
         newValue = value;
       localized.put(key, newValue);

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
@@ -5,7 +5,6 @@ import water.util.IcedHashMapGeneric;
 import water.util.TwoDimTable;
 
 import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.HashMap;

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/BoosterParms.java
@@ -5,6 +5,7 @@ import water.util.IcedHashMapGeneric;
 import water.util.TwoDimTable;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,6 +44,7 @@ public class BoosterParms extends Iced<BoosterParms> {
   private static Map<String, Object> localizeDecimalParams(final Map<String, Object> params) {
     Map<String, Object> localized = new HashMap<>(params.size());
     final NumberFormat localizedNumberFormatter = DecimalFormat.getNumberInstance(Locale.ENGLISH);
+    localizedNumberFormatter.setGroupingUsed(false);
     for (String key : params.keySet()) {
       final Object value = params.get(key);
       final Object newValue;

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/BoosterParmsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/BoosterParmsTest.java
@@ -2,7 +2,6 @@ package hex.tree.xgboost;
 
 import org.junit.Test;
 
-import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,8 +20,8 @@ public class BoosterParmsTest {
     }});
     Map<String, Object> expected = Collections.unmodifiableMap(new HashMap<String, Object>() {{
       put("integer", 42);
-      put("float", DecimalFormat.getNumberInstance().format(0.5f));
-      put("double", DecimalFormat.getNumberInstance().format(Math.E));
+      put("float", new Float(0.5F).toString());
+      put("double", new Double(Math.E).toString());
       put("boolean", true);
     }});
 

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostParamsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostParamsTest.java
@@ -1,6 +1,5 @@
 package hex.tree.xgboost;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import water.Scope;

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostParamsTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostParamsTest.java
@@ -35,6 +35,7 @@ public class XGBoostParamsTest extends TestUtil {
       XGBoostModel.XGBoostParameters parms = new XGBoostModel.XGBoostParameters();
       parms._ntrees = 1;
       parms._max_depth = 5;
+      parms._min_rows = 5000000;
       parms._ignored_columns = new String[]{"fYear", "fMonth", "fDayofMonth", "fDayOfWeek", "UniqueCarrier", "Dest"};
       parms._train = traningFrame._key;
       parms._response_column = response;


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6532



XGBoost formats non-integer numbers (doubles, floats) using Locale.ENGLISH to ensure a decimal point "." is used instead of a comma ",".

This locale setting groups large numbers by thousands and splits the groups with ",", which is unparseable to XGBoost.

https://github.com/dmlc/dmlc-core/blob/3943914eed66470bd010df581e29e4dca4f7df6f/include/dmlc/parameter.h#L1011
