### PR TITLE
Added nirvana-msu patch.

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -2072,7 +2072,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         for (int i = 0; i < v.length(); ++i) {
           if (!v.isNA(i) && map[i] != -1) {
             int idx = map == null ? i : map[i];
-            if (idx > _dinfo.numStart() && idx < _dinfo.fullN()) {
+            if (idx >= _dinfo.numStart() && idx < _dinfo.fullN()) {
               _dinfo._normSub[idx - _dinfo.numStart()] = v.at(i);
             } else {
               // categorical or Intercept, will be ignored
@@ -2086,7 +2086,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         for (int i = 0; i < v.length(); ++i) {
           if (!v.isNA(i) && map[i] != -1) {
             int idx = map == null ? i : map[i];
-            if (idx > _dinfo.numStart() && idx < _dinfo.fullN()) {
+            if (idx >= _dinfo.numStart() && idx < _dinfo.fullN()) {
               _dinfo._normMul[idx - _dinfo.numStart()] = 1.0 / v.at(i);
             } else {
               // categorical or Intercept, will be ignored


### PR DESCRIPTION
A patch from our wonderful user: nirvana-msu.

I will merge his PR after Jenkins tests passed here.  This branch will not be merged.

There is currently a bug where mean and std_dev standardization overrides, provided via beta_constraints, are ignored for the first numerical feature. The check should be idx >= _dinfo.numStart() rather than idx > _dinfo.numStart(). This is very easy to verify - just train a simple GLM model with all numerical features and provide mean override of 0 and std_dev override of e.g. 1 for all the features. You will see in the result that normalized and non-normalized coefficients match for all the features apart from the first one. They should match for all features (only intercept can differ).

In Python, beta_constraints for the test case described above would look something like:

beta_constraints = h2o.H2OFrame(dict(
    names=features,
    mean=[0] * len(features),
    std_dev=[1] * len(features),
))
P.S. I'm sorry if that's not your preferred way of logging issues, I just thought such PR is the quick and easy way to show where the bug is.