### PR TITLE
PUBDEV-6501: Disable examples in R package

### DIFF
--- a/h2o-bindings/bin/gen_R.py
+++ b/h2o-bindings/bin/gen_R.py
@@ -548,7 +548,7 @@ def help_references_for(algo):
 
 def help_example_for(algo):
     if algo == "aggregator":
-        return """\donttest{
+        return """\dontrun{
             library(h2o)
             h2o.init()
             df <- h2o.createFrame(rows=100, cols=5, categorical_fraction=0.6, integer_fraction=0,
@@ -562,7 +562,7 @@ def help_example_for(algo):
                                  categorical_encoding=encoding)
             }"""
     if algo == "deeplearning":
-        return """\donttest{
+        return """\dontrun{
             library(h2o)
             h2o.init()
             iris_hf <- as.h2o(iris)
@@ -572,7 +572,7 @@ def help_example_for(algo):
             predictions <- h2o.predict(iris_dl, iris_hf)
             }"""
     if algo == "gbm":
-        return """\donttest{
+        return """\dontrun{
         library(h2o)
         h2o.init()
 
@@ -586,7 +586,7 @@ def help_example_for(algo):
                 ntrees = 3, max_depth = 3, min_rows = 2)
         }"""
     if algo == "glm":
-        return """\donttest{
+        return """\dontrun{
         h2o.init()
 
         # Run GLM of CAPSULE ~ AGE + RACE + PSA + DCAPS
@@ -613,7 +613,7 @@ def help_example_for(algo):
         h2o.std_coef_plot(glm, num_of_features = 20)
         }"""
     if algo == "glrm":
-        return """\donttest{
+        return """\dontrun{
             library(h2o)
             h2o.init()
             australia_path <- system.file("extdata", "australia.csv", package = "h2o")
@@ -622,7 +622,7 @@ def help_example_for(algo):
                      gamma_x = 0.5, gamma_y = 0, max_iterations = 1000)
             }"""
     if algo == "kmeans":
-        return """\donttest{
+        return """\dontrun{
         library(h2o)
         h2o.init()
         prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -630,14 +630,14 @@ def help_example_for(algo):
         h2o.kmeans(training_frame = prostate, k = 10, x = c("AGE", "RACE", "VOL", "GLEASON"))
         }"""
     if algo == "naivebayes":
-        return """\donttest{
+        return """\dontrun{
         h2o.init()
         votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
         votes <- h2o.uploadFile(path = votes_path, header = TRUE)
         h2o.naiveBayes(x = 2:17, y = 1, training_frame = votes, laplace = 3)
         }"""
     if algo == "pca":
-        return """\donttest{
+        return """\dontrun{
         library(h2o)
         h2o.init()
         australia_path <- system.file("extdata", "australia.csv", package = "h2o")
@@ -645,7 +645,7 @@ def help_example_for(algo):
         h2o.prcomp(training_frame = australia, k = 8, transform = "STANDARDIZE")
         }"""
     if algo == "svd":
-        return """\donttest{
+        return """\dontrun{
         library(h2o)
         h2o.init()
         australia_path <- system.file("extdata", "australia.csv", package = "h2o")
@@ -819,7 +819,7 @@ def help_afterword_for(algo):
             #'
             #' @param model an \linkS4class{H2OClusteringModel} corresponding from a \code{h2o.aggregator} call.
             #' @examples
-            #' \donttest{
+            #' \dontrun{
             #' library(h2o)
             #' h2o.init()
             #' df <- h2o.createFrame(rows=100, cols=5, categorical_fraction=0.6, integer_fraction=0,
@@ -855,7 +855,7 @@ def help_afterword_for(algo):
             #'         reconstruction MSE or the per-feature squared error.
             #' @seealso \code{\link{h2o.deeplearning}} for making an H2OAutoEncoderModel.
             #' @examples
-            #' \donttest{
+            #' \dontrun{
             #' library(h2o)
             #' h2o.init()
             #' prostate_path = system.file("extdata", "prostate.csv", package = "h2o")
@@ -1061,7 +1061,7 @@ def help_afterword_for(algo):
             #'         training data;
             #' @seealso \code{\link{h2o.glrm}} for making an H2ODimReductionModel.
             #' @examples
-            #' \donttest{
+            #' \dontrun{
             #' library(h2o)
             #' h2o.init()
             #' iris_hf <- as.h2o(iris)
@@ -1093,7 +1093,7 @@ def help_afterword_for(algo):
             #'         down into the original feature space, where each row is one archetype.
             #' @seealso \code{\link{h2o.glrm}} for making an H2ODimReductionModel.
             #' @examples
-            #' \donttest{
+            #' \dontrun{
             #' library(h2o)
             #' h2o.init()
             #' iris_hf <- as.h2o(iris)

--- a/h2o-r/h2o-package.template
+++ b/h2o-r/h2o-package.template
@@ -25,7 +25,7 @@ H2O supports a number of standard statistical models, such as GLM, K-means, and 
 
 Note that no actual data is stored in the R workspace; and no actual work is carried out by R. R only saves the named objects, which uniquely identify the data set, model, etc on the server. When the user makes a request, R queries the server via the REST API, which returns a JSON file with the relevant information that R then displays in the console.
 
-If you are using an older version of H2O, use the following porting guide to update your scripts: \href{https://github.com/h2oai/h2o-dev/blob/master/h2o-docs/src/product/upgrade/H2ODevPortingRScripts.md}{Porting Scripts}
+If you are using an older version of H2O, use the following porting guide to update your scripts: \href{https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/upgrade/H2ODevPortingRScripts.md}{Porting Scripts}
 }
 \author{
 Maintainer: Erin LeDell <erin@h2o.ai>

--- a/h2o-r/h2o-package/R/aggregator.R
+++ b/h2o-r/h2o-package/R/aggregator.R
@@ -22,7 +22,7 @@
 #'        Defaults to 500.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' df <- h2o.createFrame(rows=100, cols=5, categorical_fraction=0.6, integer_fraction=0,
@@ -93,7 +93,7 @@ h2o.aggregator <- function(training_frame, x,
 #'
 #' @param model an \linkS4class{H2OClusteringModel} corresponding from a \code{h2o.aggregator} call.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' df <- h2o.createFrame(rows=100, cols=5, categorical_fraction=0.6, integer_fraction=0,

--- a/h2o-r/h2o-package/R/aggregator.R
+++ b/h2o-r/h2o-package/R/aggregator.R
@@ -22,7 +22,7 @@
 #'        Defaults to 500.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' df <- h2o.createFrame(rows=100, cols=5, categorical_fraction=0.6, integer_fraction=0,
@@ -93,7 +93,7 @@ h2o.aggregator <- function(training_frame, x,
 #'
 #' @param model an \linkS4class{H2OClusteringModel} corresponding from a \code{h2o.aggregator} call.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' df <- h2o.createFrame(rows=100, cols=5, categorical_fraction=0.6, integer_fraction=0,

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -58,7 +58,7 @@
 #'          which contains a leaderboard of all the models that were trained in the process, ranked by a default model performance metric.
 #' @return An \linkS4class{H2OAutoML} object.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
@@ -322,7 +322,7 @@ predict.H2OAutoML <- function(object, newdata, ...) {
 #' @param project_name A string indicating the project_name of the automl instance to retrieve.
 #' @return Returns an object that is a subclass of \linkS4class{H2OAutoML}.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -395,7 +395,7 @@ h2o.shutdown <- function(prompt = TRUE) {
 #'
 #' @seealso \linkS4class{H2OConnection}, \code{\link{h2o.init}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' h2o.clusterStatus()
 #' }

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -38,7 +38,7 @@
 #' @note Users may wish to manually upgrade their package (rather than waiting until being prompted), which requires
 #' that they fully uninstall and reinstall the H2O package, and the H2O client package. You must unload packages running
 #' in the environment before upgrading. It's recommended that users restart R or R studio after upgrading
-#' @seealso \href{http://h2o-release.s3.amazonaws.com/h2o-dev/rel-shannon/2/docs-website/h2o-r/h2o_package.pdf}{H2O R package documentation} for more details. \code{\link{h2o.shutdown}} for shutting down from R.
+#' @seealso \href{http://docs.h2o.ai/h2o/latest-stable/h2o-r/h2o_package.pdf}{H2O R package documentation} for more details. \code{\link{h2o.shutdown}} for shutting down from R.
 #' @examples
 #' \dontrun{
 #' # Try to connect to a local H2O instance that is already running.

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -139,7 +139,7 @@
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -465,7 +465,7 @@ h2o.deeplearning <- function(x, y, training_frame,
 #'         reconstruction MSE or the per-feature squared error.
 #' @seealso \code{\link{h2o.deeplearning}} for making an H2OAutoEncoderModel.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path = system.file("extdata", "prostate.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -139,7 +139,7 @@
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -465,7 +465,7 @@ h2o.deeplearning <- function(x, y, training_frame,
 #'         reconstruction MSE or the per-feature squared error.
 #' @seealso \code{\link{h2o.deeplearning}} for making an H2OAutoEncoderModel.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path = system.file("extdata", "prostate.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/export.R
+++ b/h2o-r/h2o-package/R/export.R
@@ -79,7 +79,7 @@ h2o.exportHDFS <- function(object, path, force=FALSE) { h2o.exportFile(object,pa
 #' @param filename A string indicating the name that the CSV file should be
 #'        should be saved to.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -368,7 +368,7 @@ h2o.assign <- function(data, key) {
 #' @param seed_for_column_types A seed used to generate random column types when \code{randomize = TRUE}.
 #' @return Returns an H2OFrame object.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' hf <- h2o.createFrame(rows = 1000, cols = 100, categorical_fraction = 0.1,
@@ -431,7 +431,7 @@ h2o.createFrame <- function(rows = 10000, cols = 10, randomize = TRUE,
 #' @param min_occurrence Min. occurrence threshold for factor levels in pair-wise interaction terms
 #' @return Returns an H2OFrame object.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -550,7 +550,7 @@ h2o.rep_len <- function(x, length.out) {
 #' @section WARNING: This will modify the original dataset. Unless this is intended,
 #' this function should only be called on a subset of the original.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' 
@@ -593,7 +593,7 @@ h2o.insertMissingValues <- function(data, fraction=0.1, seed=-1) {
 #' @param seed Random seed.
 #' @return Returns a list of split H2OFrame's
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -691,7 +691,7 @@ h2o.filterNACols <- function(data, frac=0.2) .eval.scalar(.newExpr("filterNACols
 #'        FALSE to expand counts across all combinations.  
 #' @return Returns a tabulated H2OFrame object.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -745,7 +745,7 @@ h2o.unique <- function(x) .newExpr("unique", x)
 #' @param ... Further arguments passed to or from other methods.
 #' @return Returns an H2OFrame object containing the factored data with intervals as levels.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -783,7 +783,7 @@ cut.H2OFrame <- h2o.cut
 #' @return Returns a vector of the positions of (first) matches of its first argument in its second
 #' @seealso \code{\link[base]{match}} for base R implementation.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' h2o.match(iris_hf[, 5], c("setosa", "versicolor"))
@@ -834,7 +834,7 @@ na.omit.H2OFrame <- h2o.na_omit
 #' @param ... Ignored
 #' @return A list of column indices that correspond to "type"
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -867,7 +867,7 @@ h2o.columns_by_type <- function(object,coltype="numeric",...){
 #' @param inverse Whether to perform the inverse transform
 #' @return Returns an H2OFrame object.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #'   library(h2o)
 #'   h2o.init()
 #'   df <- h2o.createFrame(rows = 1000, cols = 8 * 16 * 24,
@@ -909,7 +909,7 @@ h2o.dct <- function(data, destination_frame, dimensions, inverse=FALSE) {
 #' @param seed A random seed used to generate draws from the uniform distribution.
 #' @return A vector of random, uniformly distributed numbers. The elements are between 0 and 1.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -947,7 +947,7 @@ h2o.kfold_column <- function(data,nfolds,seed=-1) .eval.frame(.newExpr("kfold_co
 #' @param x An \code{H2OFrame} object.
 #' @return Returns a logical value indicating whether any of the columns in \code{x} are factors.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -973,7 +973,7 @@ h2o.anyFactor <- function(x) as.logical(.eval.scalar(.newExpr("any.factor", x)))
 #' @param ... Further arguments passed to or from other methods.
 #' @return A vector describing the percentiles at the given cutoffs for the \code{H2OFrame} object.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # Request quantiles for an H2O parsed data set:
 #' library(h2o)
 #' h2o.init()
@@ -1061,7 +1061,7 @@ quantile.H2OFrame <- h2o.quantile
 #' @param values A vector of impute values (one per column). NaN indicates to skip the column
 #' @return an H2OFrame with imputed values
 #' @examples
-#' \donttest{
+#' \dontrun{
 #'  h2o.init()
 #'  iris_hf <- as.h2o(iris)
 #'  iris_hf[sample(nrow(iris_hf), 40), 5] <- NA  # randomly replace 50 values with NA
@@ -1666,7 +1666,7 @@ trunc <- function(x, ...) {
 #' @return Returns an H2OFrame object.
 #' @seealso \code{\link[base]{which}} for the base R method.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' h2o.which(iris_hf[, 1] == 4.4)
@@ -1724,7 +1724,7 @@ which.min.H2OFrame <- h2o.which_min
 #' @param x An H2OFrame object.
 #' @return Returns a list containing the count of NAs per column
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' h2o.nacnt(iris_hf)  # should return all 0s
@@ -1742,7 +1742,7 @@ h2o.nacnt <- function(x)
 #' @param x An H2OFrame object.
 #' @seealso \code{\link[base]{dim}} for the base R method.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' dim(iris_hf)
@@ -1763,7 +1763,7 @@ ncol.H2OFrame <- function(x) { .fetch.data(x,10L); attr(.eval.frame(x), "ncol") 
 #' Set column names of an H2O Frame
 #' @param x An H2OFrame
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' n <- 2000
 #' #  Generate variables V1, ... V10
@@ -1788,7 +1788,7 @@ names.H2OFrame <- function(x) .Primitive("names")(.fetch.data(x,1L))
 #' @param do.NULL logical. If FALSE and names are NULL, names are created.
 #' @param prefix for created names.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' colnames(iris_hf)  # Returns "Sepal.Length" "Sepal.Width"  "Petal.Length" "Petal.Width"  "Species"
@@ -1823,7 +1823,7 @@ h2o.length <- length.H2OFrame
 #' @param i Optional, the index of the column whose domain is to be returned.
 #' @seealso \code{\link[base]{levels}} for the base R method.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' iris_hf <- as.h2o(iris)
 #' h2o.levels(iris_hf, 5)  # returns "setosa"     "versicolor" "virginica"
 #' }
@@ -1868,7 +1868,7 @@ h2o.nlevels <- function(x) {
 #'        of the column will be created with the given domain levels.
 #' @export
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' new.levels <- c("setosa", "versicolor", "caroliniana")
@@ -1889,7 +1889,7 @@ h2o.setLevels <- function(x, levels, in.place = TRUE) .newExpr("setDomain", chk.
 #' @param ... Ignored.
 #' @return An H2OFrame containing the first or last n rows of an H2OFrame object.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init(ip <- "localhost", port = 54321, startH2O = TRUE)
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")
@@ -2138,7 +2138,7 @@ str.H2OFrame <- function(object, ..., cols=FALSE) {
 #' @return A table displaying the minimum, 1st quartile, median, mean, 3rd quartile and maximum for each
 #' numeric column, and the levels and category counts of the levels in each categorical column.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -2286,7 +2286,7 @@ h2o.summary <- function(object, factors=6L, exact_quantiles=FALSE, ...) {
 #' @param frame An H2OFrame object.
 #' @return A table with the Frame stats.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -2331,7 +2331,7 @@ summary.H2OFrame <- h2o.summary
 #' @param na.rm a logical, indicating whether na's are omitted.
 #' @return Returns a list containing the median for each column (NaN for non-numeric columns)
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2358,7 +2358,7 @@ median.H2OFrame <- h2o.median
 #' @return Returns a list containing the mean for each column (NaN for non-numeric columns) if return_frame is set to FALSE.
 #'         If return_frame is set to TRUE, then it will return an H2O frame with means per column or row (depends on axis argument).
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2392,7 +2392,7 @@ mean.H2OFrame <- h2o.mean
 #' @param na.rm A logical value indicating whether \code{NA} or missing values should be stripped before the computation.
 #' @return Returns a list containing the skewness for each column (NaN for non-numeric columns).
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2416,7 +2416,7 @@ skewness.H2OFrame <- h2o.skewness
 #' @param na.rm A logical value indicating whether \code{NA} or missing values should be stripped before the computation.
 #' @return Returns a list containing the kurtosis for each column (NaN for non-numeric columns).
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2456,7 +2456,7 @@ kurtosis.H2OFrame <- h2o.kurtosis
 #'   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
 #' @seealso \code{\link[stats]{var}} for the base R implementation. \code{\link{h2o.sd}} for standard deviation.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2498,7 +2498,7 @@ var <- function(x, y = NULL, na.rm = FALSE, use)  {
 #'   "all.obs"               - presence of missing observations will throw an error
 #'   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2530,7 +2530,7 @@ h2o.cor <- function(x, y=NULL,na.rm = FALSE, use){
 #'   "cosine"               - Cosine similarity (-1...1)
 #'   "cosine_sq"            - Squared Cosine similarity (0...1)
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2564,7 +2564,7 @@ cor <- function (x, ...)
 #' @param na.rm \code{logical}. Should missing values be removed?
 #' @seealso \code{\link{h2o.var}} for variance, and \code{\link[stats]{sd}} for the base R implementation.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2630,7 +2630,7 @@ round <- function(x, digits=0) {
 #' @param center either a \code{logical} value or numeric vector of length equal to the number of columns of x.
 #' @param scale either a \code{logical} value or numeric vector of length equal to the number of columns of x.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -2861,7 +2861,7 @@ h2o.sin <- function(x) {
 #' @param x An H2OFrame object.
 #' @seealso \code{\link[base]{acos}} for the base R implementation.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -2946,7 +2946,7 @@ h2o.sqrt <- function(x) {
 #' @param x An H2OFrame object.
 #' @seealso \code{\link[base]{abs}} for the base R implementation.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' url <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/smtrees.csv"
 #' smtrees_hf <- h2o.importFile(url)
@@ -3233,7 +3233,7 @@ use.package <- function(package,
 #' @param \dots arguments passed to method arguments.
 #' @export
 #' @examples 
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' euro_hf <- as.h2o(euro)
@@ -3420,7 +3420,7 @@ as.h2o.Matrix <- function(x, destination_frame="", ...) {
 #' Method \code{as.data.frame.H2OFrame} will use \code{\link[data.table]{fread}} if data.table package is installed in required version.
 #' @seealso \code{\link{use.package}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -3519,7 +3519,7 @@ as.data.frame.H2OFrame <- function(x, ...) {
 #' @param x An H2OFrame object
 #' @param ... Further arguments to be passed down from other methods.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' describe <- h2o.describe(iris_hf)
@@ -3545,7 +3545,7 @@ as.matrix.H2OFrame <- function(x, ...) {
 #' @usage \method{as.vector}{H2OFrame}(x,mode)
 #' @method as.vector H2OFrame
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' cor_R <- cor(as.matrix(iris[, 1]))
@@ -3588,7 +3588,7 @@ as.logical.H2OFrame <- function(x, ...) as.vector.H2OFrame(x, "logical")
 #' @param x a column from an H2OFrame data set.
 #' @seealso \code{\link{as.factor}}.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -3606,7 +3606,7 @@ as.factor <- function(x) {
 #' @param x An H2OFrame object
 #' @param ... Further arguments to be passed from or to other methods.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' pretrained <- as.h2o(data.frame(
 #'        C1 = c("a", "b"), C2 = c(0, 1), C3 = c(1, 0), C4 = c(0.2, 0.8),
@@ -3627,7 +3627,7 @@ as.character.H2OFrame <- function(x, ...) {
 #' @param x a column from an H2OFrame data set.
 #' @param ... Further arguments to be passed from or to other methods.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -3671,7 +3671,7 @@ h2o.removeVecs <- function(data, cols) {
 #' @param no The value to return if the condition is FALSE.
 #' @return Returns a vector of new values matching the conditions stated in the ifelse call.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")
 #' australia <- h2o.importFile(path = australia_path)
@@ -3719,7 +3719,7 @@ ifelse <- function(test, yes, no) {
 #' @return An H2OFrame object containing the combined \dots arguments column-wise.
 #' @seealso \code{\link[base]{cbind}} for the base \code{R} method.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -3749,7 +3749,7 @@ h2o.cbind <- function(...) {
 #' @return An H2OFrame object containing the combined \dots arguments row-wise.
 #' @seealso \code{\link[base]{rbind}} for the base \code{R} method.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -3797,7 +3797,7 @@ checkMatch = function(x,y) {
 #' @param all.y see all.x
 #' @param method auto(default), radix, hash
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' left <- data.frame(fruit = c('apple', 'orange', 'banana', 'lemon', 'strawberry', 'blueberry'),
 #' color <- c('red', 'orange', 'yellow', 'yellow', 'red', 'blue'))
@@ -4009,7 +4009,7 @@ h2o.rank_within_group_by <- function(x, group_by_cols, sort_cols, ascending=NULL
 #' @param y reference level (string)
 #' @return new reordered factor column
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -4213,7 +4213,7 @@ h2o.groupedPermute <- function(fr, permCol, permByCol, groupByCols, keepCol) {
 #          row-by-row
 #' @seealso \code{\link[plyr]{ddply}} for the plyr library implementation.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -4300,7 +4300,7 @@ h2o.ddply <- function (X, .variables, FUN, ..., .progress = 'none') {
 #'         subsequent H2O processes.
 #' @seealso \link[base]{apply} for the base generic
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
 #' summary(apply(iris_hf, 2, sum))
@@ -4447,7 +4447,7 @@ h2o.isax <- function(x, num_words, max_cardinality, optimize_card = FALSE){
 #' @param maxlen An Integer for maximum number of consecutive NA's to fill
 #' @return An H2OFrame after filling missing values
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' fr_with_nas = h2o.createFrame(categorical_fraction = 0.0, missing_fraction = 0.7, rows = 6,
@@ -4473,7 +4473,7 @@ h2o.fillna <- function(x, method="forward", axis=1, maxlen=1L) {
 #' @param x The column whose strings must be split.
 #' @param split The pattern to split on.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_split <- as.h2o("Split at every character.")
@@ -4492,7 +4492,7 @@ h2o.strsplit <- function(x, split) { .newExpr("strsplit", x, .quote(split)) }
 #' @param x The column or columns whose strings to tokenize.
 #' @param split The regular expression to split on.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_tokenize <- as.h2o("Split at every character and tokenize.")
@@ -4507,7 +4507,7 @@ h2o.tokenize <- function(x, split) { .newExpr("tokenize", x, .quote(split)) }
 #'
 #' @param x An H2OFrame object whose strings should be lower cased
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_lower <- as.h2o("ABCDE")
@@ -4522,7 +4522,7 @@ h2o.tolower <- function(x) .newExpr("tolower", x)
 #'
 #' @param x An H2OFrame object whose strings should be upper cased
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_upper <- as.h2o("abcde")
@@ -4551,7 +4551,7 @@ h2o.toupper <- function(x) .newExpr("toupper", x)
 #' @return H2OFrame holding the matching positions or a logical vector
 #' if `output.logical` is enabled.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' addresses <- as.h2o(c("2307", "Leghorn St", "Mountain View", "CA", "94043"))
@@ -4576,7 +4576,7 @@ h2o.grep <- function(pattern, x, ignore.case = FALSE, invert = FALSE, output.log
 #' @param x The column on which to operate.
 #' @param ignore.case Case sensitive or not
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_sub <- as.h2o("r tutorial")
@@ -4596,7 +4596,7 @@ h2o.sub <- function(pattern,replacement,x,ignore.case=FALSE) .newExpr("replacefi
 #' @param x The column on which to operate.
 #' @param ignore.case Case sensitive or not
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_gsub <- as.h2o("r tutorial")
@@ -4610,7 +4610,7 @@ h2o.gsub <- function(pattern,replacement,x,ignore.case=FALSE) .newExpr("replacea
 #'
 #' @param x The column whose strings should be trimmed.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_trim <- as.h2o("r tutorial")
@@ -4624,7 +4624,7 @@ h2o.trim <- function(x) .newExpr("trim", x)
 #'
 #' @param x The column whose string lengths will be returned.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_nchar <- as.h2o("r tutorial")
@@ -4647,7 +4647,7 @@ h2o.nchar <- function(x) .newExpr("strlen", x)
 #' @param start The index of the first element to be included in the substring.
 #' @param stop Optional, The index of the last element to be included in the substring.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_substring <- as.h2o("1234567890")
@@ -4669,7 +4669,7 @@ h2o.substr <- h2o.substring
 #' @param x   The column whose strings should be lstrip-ed.
 #' @param set string of characters to be removed
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_lstrip <- as.h2o("1234567890")
@@ -4688,7 +4688,7 @@ h2o.lstrip <- function(x, set = " ") .newExpr("lstrip", x, .quote(set))
 #' @param x   The column whose strings should be rstrip-ed.
 #' @param set string of characters to be removed
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' string_to_rstrip <- as.h2o("1234567890")
@@ -4705,7 +4705,7 @@ h2o.rstrip <- function(x, set = " ") .newExpr("rstrip", x, .quote(set))
 #'
 #' @param x   The column on which to calculate the entropy.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' buys <- as.h2o(c("no", "no", "yes", "yes", "yes", "no", "yes", "no", "yes", "yes","no"))
@@ -4740,7 +4740,7 @@ h2o.num_valid_substrings <- function(x, path) .newExpr("num_valid_substrings", x
 #'   "jw"                   - Jaro, or Jaro-Winker distance
 #'   "soundex"              - Distance based on soundex encoding
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' x <- as.h2o(c("Martha", "Dwayne", "Dixon"))
 #' y <- as.character(as.h2o(c("Marhta", "Duane", "Dicksonx")))
@@ -4768,7 +4768,7 @@ h2o.stringdist <- function(x, y, method = c("lv", "lcs", "qgram", "jaccard", "jw
 #' @return Returns a list of H2OFrame objects containing the target encoding mapping for each column in `x`.
 #' @seealso \code{\link{h2o.target_encode_apply}} for applying the target encoding mapping to a frame.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' 
@@ -4869,7 +4869,7 @@ h2o.target_encode_create <- function(data, x, y, fold_column = NULL){
 #' @return Returns an H2OFrame object containing the target encoding per record.
 #' @seealso \code{\link{h2o.target_encode_create}} for creating the target encoding map
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' 

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -101,7 +101,7 @@
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' 

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -101,7 +101,7 @@
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree for GBM, DRF, & XGBoost. Metrics per epoch for Deep Learning). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' 

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -113,7 +113,7 @@
 #'          \code{\link{h2o.confusionMatrix}}, \code{\link{h2o.performance}}, \code{\link{h2o.giniCoef}},
 #'          \code{\link{h2o.logloss}}, \code{\link{h2o.varimp}}, \code{\link{h2o.scoreHistory}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' 
 #' # Run GLM of CAPSULE ~ AGE + RACE + PSA + DCAPS

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -113,7 +113,7 @@
 #'          \code{\link{h2o.confusionMatrix}}, \code{\link{h2o.performance}}, \code{\link{h2o.giniCoef}},
 #'          \code{\link{h2o.logloss}}, \code{\link{h2o.varimp}}, \code{\link{h2o.scoreHistory}}
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' h2o.init()
 #' 
 #' # Run GLM of CAPSULE ~ AGE + RACE + PSA + DCAPS

--- a/h2o-r/h2o-package/R/glrm.R
+++ b/h2o-r/h2o-package/R/glrm.R
@@ -51,7 +51,7 @@
 #' @references M. Udell, C. Horn, R. Zadeh, S. Boyd (2014). {Generalized Low Rank Models}[http://arxiv.org/abs/1410.0342]. Unpublished manuscript, Stanford Electrical Engineering Department
 #'             N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")
@@ -238,7 +238,7 @@ h2o.glrm <- function(training_frame, cols = NULL,
 #'         training data;
 #' @seealso \code{\link{h2o.glrm}} for making an H2ODimReductionModel.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -270,7 +270,7 @@ h2o.getFrame(key)
 #'         down into the original feature space, where each row is one archetype.
 #' @seealso \code{\link{h2o.glrm}} for making an H2ODimReductionModel.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)

--- a/h2o-r/h2o-package/R/glrm.R
+++ b/h2o-r/h2o-package/R/glrm.R
@@ -51,7 +51,7 @@
 #' @references M. Udell, C. Horn, R. Zadeh, S. Boyd (2014). {Generalized Low Rank Models}[http://arxiv.org/abs/1410.0342]. Unpublished manuscript, Stanford Electrical Engineering Department
 #'             N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")
@@ -238,7 +238,7 @@ h2o.glrm <- function(training_frame, cols = NULL,
 #'         training data;
 #' @seealso \code{\link{h2o.glrm}} for making an H2ODimReductionModel.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)
@@ -270,7 +270,7 @@ h2o.getFrame(key)
 #'         down into the original feature space, where each row is one archetype.
 #' @seealso \code{\link{h2o.glrm}} for making an H2ODimReductionModel.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' iris_hf <- as.h2o(iris)

--- a/h2o-r/h2o-package/R/grid.R
+++ b/h2o-r/h2o-package/R/grid.R
@@ -34,7 +34,7 @@
 #'        or  \code{list(strategy = "RandomDiscrete", stopping_metric = "misclassification", stopping_tolerance = 0.00001, stopping_rounds = 5)}.
 #' @importFrom jsonlite toJSON
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' library(jsonlite)
 #' h2o.init()
@@ -173,7 +173,7 @@ h2o.grid <- function(algorithm,
 #' @param sort_by Sort the models in the grid space by a metric. Choices are "logloss", "residual_deviance", "mse", "auc", "accuracy", "precision", "recall", "f1", etc.
 #' @param decreasing Specify whether sort order should be decreasing
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' library(jsonlite)
 #' h2o.init()

--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -58,7 +58,7 @@
 #' @param custom_non_data_line_markers (Optional) If a line in imported file starts with any character in given string it will NOT be imported. Empty string means all lines are imported, NULL means that default behaviour for given format will be used
 #' @seealso \link{h2o.import_sql_select}, \link{h2o.import_sql_table}, \link{h2o.parseRaw}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init(ip = "localhost", port = 54321, startH2O = TRUE)
 #' prostate_path = system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate = h2o.importFile(path = prostate_path)

--- a/h2o-r/h2o-package/R/kmeans.R
+++ b/h2o-r/h2o-package/R/kmeans.R
@@ -41,7 +41,7 @@
 #'          \code{\link{h2o.betweenss}}, \code{\link{h2o.tot_withinss}}, \code{\link{h2o.withinss}},
 #'          \code{\link{h2o.centersSTD}}, \code{\link{h2o.centers}}
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/kmeans.R
+++ b/h2o-r/h2o-package/R/kmeans.R
@@ -41,7 +41,7 @@
 #'          \code{\link{h2o.betweenss}}, \code{\link{h2o.tot_withinss}}, \code{\link{h2o.withinss}},
 #'          \code{\link{h2o.centersSTD}}, \code{\link{h2o.centers}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -30,7 +30,7 @@
 #'
 #' @return Returns a list of hex keys in the current H2O instance.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -51,7 +51,7 @@ h2o.ls <- function() {
 #' @param timeout_secs Timeout in seconds. Default is no timeout.
 #' @seealso \code{\link{h2o.rm}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -124,7 +124,7 @@ h2o.getFrame <- function(id) {
 #' @param model_id A string indicating the unique model_id of the model to retrieve.
 #' @return Returns an object that is a subclass of \linkS4class{H2OModel}.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -227,7 +227,7 @@ h2o.getModel <- function(model_id) {
 #' @return If path is NULL, then pretty print the POJO to the console.
 #'         Otherwise save it to the specified directory and return POJO file name.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h <- h2o.init()
 #' fr <- as.h2o(iris)
@@ -312,7 +312,7 @@ h2o.download_pojo <- function(model, path=NULL, getjar=NULL, get_jar=TRUE, jar_n
 #' @return Name of the MOJO file written to the path.
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h <- h2o.init()
 #' fr <- as.h2o(iris)

--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -53,7 +53,7 @@ h2o.logIt <- function(m, tmp, commandOrErr, isPost = TRUE) {
 #' @seealso \code{\link{h2o.stopLogging}, \link{h2o.clearLog},
 #'          \link{h2o.openLog}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' h2o.startLogging()
@@ -82,7 +82,7 @@ h2o.startLogging <- function(file) {
 #' @seealso \code{\link{h2o.startLogging}, \link{h2o.clearLog},
 #'          \link{h2o.openLog}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' h2o.startLogging()
@@ -104,7 +104,7 @@ h2o.stopLogging <- function() {
 #' @seealso \code{\link{h2o.startLogging}, \link{h2o.stopLogging},
 #'          \link{h2o.openLog}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' h2o.startLogging()
@@ -176,7 +176,7 @@ h2o.logAndEcho <- function(message) {
 #' @param dirname (Optional) A character string indicating the directory that the log file should be saved in.
 #' @param filename (Optional) A character string indicating the name that the log file should be saved to. Note that the saved format is .zip, so the file name must include the .zip extension.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.downloadAllLogs(dirname='./your_directory_name/', filename = 'autoh2o_log.zip')
 #' }
 #' @export

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -498,7 +498,7 @@ h2o.predict <- function(object, newdata, ...){
 #' @seealso \code{\link{h2o.gbm}} and  \code{\link{h2o.randomForest}} for model
 #'          generation in h2o.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -587,7 +587,7 @@ h2o.crossValidate <- function(model, nfolds, model.type = c("gbm", "glm", "deepl
 #' @seealso \code{\link{h2o.gbm}} and  \code{\link{h2o.randomForest}} for model
 #'          generation in h2o.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -632,7 +632,7 @@ h2o.staged_predict_proba <- staged_predict_proba.H2OModel
 #' @seealso \code{\link{h2o.gbm}} and  \code{\link{h2o.randomForest}} for model
 #'          generation in h2o.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -678,7 +678,7 @@ h2o.predict_contributions <- predict_contributions.H2OModel
 #' @param data (DEPRECATED) An H2OFrame. This argument is now called `newdata`.
 #' @return Returns an object of the \linkS4class{H2OModelMetrics} subclass.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -760,7 +760,7 @@ h2o.performance <- function(model, newdata=NULL, train=FALSE, valid=FALSE, xval=
 #' @param distribution Distribution for regression.
 #' @return Returns an object of the \linkS4class{H2OModelMetrics} subclass.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -819,7 +819,7 @@ h2o.make_metrics <- function(predicted, actuals, domain=NULL, distribution=NULL)
 #'          various threshold metrics. See \code{\link{h2o.performance}} for
 #'          creating H2OModelMetrics objects.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -885,7 +885,7 @@ h2o.auc <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #'          various threshold metrics. See \code{\link{h2o.performance}} for
 #'          creating H2OModelMetrics objects.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -950,7 +950,7 @@ h2o.pr_auc <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #'          various threshold metrics. See \code{\link{h2o.performance}} for
 #'          creating H2OModelMetrics objects.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -1014,7 +1014,7 @@ h2o.mean_per_class_error <- function(object, train=FALSE, valid=FALSE, xval=FALS
 #' @param valid Retrieve the validation AIC
 #' @param xval Retrieve the cross-validation AIC
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
 #' prostate <- h2o.uploadFile(path = prostate_path)
@@ -1076,7 +1076,7 @@ h2o.aic <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' @param valid  Retrieve the validation set R2 if a validation set was passed in during model build time.
 #' @param xval Retrieve the cross-validation R2
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #'
 #' h <- h2o.init()
@@ -1137,7 +1137,7 @@ h2o.r2 <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' @param valid Retrieve the validation Mean Residual Deviance
 #' @param xval Retrieve the cross-validation Mean Residual Deviance
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #'
 #' h <- h2o.init()
@@ -1201,7 +1201,7 @@ h2o.mean_residual_deviance <- function(object, train=FALSE, valid=FALSE, xval=FA
 #'          threshold metrics. See \code{\link{h2o.performance}} for creating 
 #'          H2OModelMetrics objects.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -1308,7 +1308,7 @@ h2o.coef_norm <- function(object) {
 #'          \code{\link{h2o.metric}} for the various threshold metrics. See
 #'          \code{\link{h2o.performance}} for creating H2OModelMetrics objects.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -1381,7 +1381,7 @@ h2o.mse <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #'          \code{\link{h2o.metric}} for the various threshold metrics. See
 #'          \code{\link{h2o.performance}} for creating H2OModelMetrics objects.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -1448,7 +1448,7 @@ h2o.rmse <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' @param valid  Retrieve the validation set MAE if a validation set was passed in during model build time.
 #' @param xval Retrieve the cross-validation MAE
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #'
 #' h <- h2o.init()
@@ -1509,7 +1509,7 @@ h2o.mae <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #' @param valid  Retrieve the validation set rmsle if a validation set was passed in during model build time.
 #' @param xval Retrieve the cross-validation rmsle
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #'
 #' h <- h2o.init()
@@ -1767,7 +1767,7 @@ h2o.hit_ratio_table <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #'          GINI coefficient, and \code{\link{h2o.mse}} for MSE. See
 #'          \code{\link{h2o.performance}} for creating H2OModelMetrics objects.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -2378,7 +2378,7 @@ h2o.null_dof <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
 #'          \code{\link{h2o.performance}} for creating
 #'          \linkS4class{H2OModelMetrics}.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -2465,7 +2465,7 @@ setMethod("h2o.gainsLift", "H2OModelMetrics", function(object) {
 #'          \code{\link{h2o.performance}} for creating
 #'          \linkS4class{H2OModelMetrics}.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -2600,7 +2600,7 @@ setMethod("h2o.confusionMatrix", "H2OModelMetrics", function(object, thresholds=
 #'          \code{\link{h2o.glm}}, \code{\link{h2o.randomForest}} for model
 #'          generation in h2o.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' if (requireNamespace("mlbench", quietly=TRUE)) {
 #'     library(h2o)
 #'     h2o.init()
@@ -2734,7 +2734,7 @@ plot.H2OModel <- function(x, timestep = "AUTO", metric = "AUTO", ...) {
 #' @param num_of_features The number of features shown in the plot (default is 10 or all if less than 10).
 #' @seealso \code{\link{h2o.std_coef_plot}} for GLM.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -2806,7 +2806,7 @@ h2o.varimp_plot <- function(model, num_of_features = NULL){
 #' @seealso \code{\link{h2o.varimp_plot}} for variable importances plot of
 #'          random forest, GBM, deep learning.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #'
@@ -3013,7 +3013,7 @@ h2o.sdev <- function(object) {
 #'        count_table:    X     Y counts
 #'        response_table: X meanY counts
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' df <- as.h2o(iris)
@@ -3059,7 +3059,7 @@ h2o.tabulate <- function(data, x, y,
 #' @return Returns a ggplot2-based heatmap of co-occurance.
 #' @seealso \code{\link{h2o.tabulate}}
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' df <- as.h2o(iris)
@@ -3186,7 +3186,7 @@ h2o.cross_validation_predictions <- function(object) {
 #'  If the files already exists, they will be overridden. Files are only saves if plot = TRUE (default).
 #' @return Plot and list of calculated mean response tables for each feature requested.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -3357,7 +3357,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
 #' @seealso \code{\link{h2o.deeplearning}} for making H2O Deep Learning models.
 #' @seealso \code{\link{h2o.deepwater}} for making H2O DeepWater models.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path = system.file("extdata", "prostate.csv", package = "h2o")
@@ -3747,7 +3747,7 @@ print.h2o.stackedEnsemble.summary <- function(x, ...) cat(x, sep = "\n")
 #' @param object a fitted \linkS4class{H2OModel} object.
 #' @return Returns seed to be used during training a model. Could be numeric or string.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' prostate_path <- system.file("extdata", "prostate.csv", package = "h2o")
@@ -3776,7 +3776,7 @@ h2o.get_seed <- get_seed.H2OModel
 #' @return Returns H2O Generic Model based on given embedded model
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #'
 #' # Import default Iris dataset as H2O frame
 #' data <- as.h2o(iris)
@@ -3811,7 +3811,7 @@ h2o.genericModel <- function(model_file_path){
 #' @return Returns H2O Generic Model embedding given MOJO model
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #'
 #' # Import default Iris dataset as H2O frame
 #' data <- as.h2o(iris)
@@ -3849,7 +3849,7 @@ h2o.import_mojo <- function(mojo_file_path){
 #' @return Returns H2O Generic Model embedding given MOJO model
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #'
 #' # Import default Iris dataset as H2O frame
 #' data <- as.h2o(iris)

--- a/h2o-r/h2o-package/R/naivebayes.R
+++ b/h2o-r/h2o-package/R/naivebayes.R
@@ -59,7 +59,7 @@
 #' @return Returns an object of class \linkS4class{H2OBinomialModel} if the response has two categorical levels,
 #'         and \linkS4class{H2OMultinomialModel} otherwise.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' h2o.init()
 #' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
 #' votes <- h2o.uploadFile(path = votes_path, header = TRUE)

--- a/h2o-r/h2o-package/R/naivebayes.R
+++ b/h2o-r/h2o-package/R/naivebayes.R
@@ -59,7 +59,7 @@
 #' @return Returns an object of class \linkS4class{H2OBinomialModel} if the response has two categorical levels,
 #'         and \linkS4class{H2OMultinomialModel} otherwise.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #' votes_path <- system.file("extdata", "housevotes.csv", package = "h2o")
 #' votes <- h2o.uploadFile(path = votes_path, header = TRUE)

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -40,7 +40,7 @@
 #' @seealso \code{\link{h2o.svd}}, \code{\link{h2o.glrm}}
 #' @references N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/pca.R
+++ b/h2o-r/h2o-package/R/pca.R
@@ -40,7 +40,7 @@
 #' @seealso \code{\link{h2o.svd}}, \code{\link{h2o.glrm}}
 #' @references N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/predict.R
+++ b/h2o-r/h2o-package/R/predict.R
@@ -13,7 +13,7 @@
 #' @return Returns an object with the prediction result
 #' @importFrom jsonlite fromJSON
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.predict_json('~/GBM_model_python_1473313897851_6.zip', '{"C7":1}')
 #' h2o.predict_json('~/GBM_model_python_1473313897851_6.zip', '{"C7":1}', c(".", "lib"))

--- a/h2o-r/h2o-package/R/svd.R
+++ b/h2o-r/h2o-package/R/svd.R
@@ -29,7 +29,7 @@
 #' @return Returns an object of class \linkS4class{H2ODimReductionModel}.
 #' @references N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/svd.R
+++ b/h2o-r/h2o-package/R/svd.R
@@ -29,7 +29,7 @@
 #' @return Returns an object of class \linkS4class{H2ODimReductionModel}.
 #' @references N. Halko, P.G. Martinsson, J.A. Tropp. {Finding structure with randomness: Probabilistic algorithms for constructing approximate matrix decompositions}[http://arxiv.org/abs/0909.4061]. SIAM Rev., Survey and Review section, Vol. 53, num. 2, pp. 217-288, June 2011.
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(h2o)
 #' h2o.init()
 #' australia_path <- system.file("extdata", "australia.csv", package = "h2o")

--- a/h2o-r/h2o-package/R/w2vutils.R
+++ b/h2o-r/h2o-package/R/w2vutils.R
@@ -28,7 +28,7 @@ h2o.findSynonyms <- function(word2vec, word, count = 20) {
 #'    Each word of a sequences is internally mapped to a vector and vectors belonging to
 #'    the same sentence are averaged and returned in the result.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #'
 #' # Build a dummy word2vec model
@@ -64,7 +64,7 @@ h2o.transform <- function(word2vec, words, aggregate_method = c("NONE", "AVERAGE
 #'
 #' @param word2vec A word2vec model.
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' h2o.init()
 #'
 #' # Build a dummy word2vec model


### PR DESCRIPTION
Replaces: https://github.com/h2oai/h2o-3/pull/3543

Changes all the `\donttest` to `\dontrun` in the R examples so we don't run into issues with CRAN servers.
https://0xdata.atlassian.net/browse/PUBDEV-6501