### PR TITLE
Remove unsuported link function for GLM ordinal from R/Python API.

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -142,7 +142,7 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     public double obj_reg;
 
     @API(help = "", level = Level.secondary, values = {"family_default", "identity", "logit", "log", "inverse",
-            "tweedie", "ologit", "oprobit", "ologlog"})
+            "tweedie", "ologit"}) //"oprobit", "ologlog": will be supported.
     public GLMParameters.Link link;
 
     @API(help="Include constant term in the model", level = Level.expert)

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -602,14 +602,14 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         """
         
 
-        One of: ``"family_default"``, ``"identity"``, ``"logit"``, ``"log"``, ``"inverse"``, ``"tweedie"``,
-        ``"ologit"``, ``"oprobit"``, ``"ologlog"``  (default: ``"family_default"``).
+        One of: ``"family_default"``, ``"identity"``, ``"logit"``, ``"log"``, ``"inverse"``, ``"tweedie"``, ``"ologit"``
+        (default: ``"family_default"``).
         """
         return self._parms.get("link")
 
     @link.setter
     def link(self, link):
-        assert_is_type(link, None, Enum("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit", "oprobit", "ologlog"))
+        assert_is_type(link, None, Enum("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit"))
         self._parms["link"] = link
 
 

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -73,8 +73,8 @@
 #'        indicates: If lambda_search is set to False and lambda is equal to zero, the default value of gradient_epsilon
 #'        is equal to .000001, otherwise the default value is .0001. If lambda_search is set to True, the conditional
 #'        values above are 1E-8 and 1E-6 respectively. Defaults to -1.
-#' @param link  Must be one of: "family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit", "oprobit",
-#'        "ologlog". Defaults to family_default.
+#' @param link  Must be one of: "family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit". Defaults to
+#'        family_default.
 #' @param prior Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
 #'        of response does not reflect reality. Defaults to -1.
 #' @param lambda_min_ratio Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all
@@ -174,7 +174,7 @@ h2o.glm <- function(x, y, training_frame,
                     objective_epsilon = -1,
                     beta_epsilon = 0.0001,
                     gradient_epsilon = -1,
-                    link = c("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit", "oprobit", "ologlog"),
+                    link = c("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit"),
                     prior = -1,
                     lambda_min_ratio = -1,
                     beta_constraints = NULL,


### PR DESCRIPTION
Many users have complained about using ologlog and oprobit for GLM ordinal regression link function only to encounter an error later.

I have removed the ologlog/oprobit link from R/Python API so that user will not think it is a valid function.  However, we will be adding support to these two soon.