### PR TITLE
PUBDEV-6382: Extend Py API for TargetEncoder with convenient method for getting encoding maps

### DIFF
--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from h2o.expr import ExprNode
 from h2o.frame import H2OFrame
 from h2o.utils.typechecks import (assert_is_type)
+from h2o import get_frame
 import warnings
 
 __all__ = ("TargetEncoder", )
@@ -122,3 +123,6 @@ class TargetEncoder(object):
                                             self._responseColumnName, self._foldColumnName,
                                             self._blending, self._inflectionPoint, self._smoothing,
                                             noise, seed))
+
+    def encoding_map_frames(self):
+        return list(map(lambda x: get_frame(x['key']['name']), self._encodingMap.frames))

--- a/h2o-py/h2o/targetencoder.py
+++ b/h2o-py/h2o/targetencoder.py
@@ -56,6 +56,9 @@ class TargetEncoder(object):
         """
         Creates instance of the TargetEncoder class and setting parameters that will be used in both `train` and `transform` methods.
         """
+
+        if(type(x) == str or type(x) == int):
+            x = [x]
         self._teColumns = x
         self._responseColumnName = y
         self._foldColumnName = fold_column

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
@@ -4,7 +4,6 @@ from tests import pyunit_utils
 from h2o.targetencoder import TargetEncoder
 import random
 
-
 def split_data(frame = None, seed = None):
   splits = frame.split_frame(ratios=[.8,.1], seed=seed)
   targetColumnName = "survived"
@@ -39,7 +38,6 @@ def titanic_without_te(frame = None, seeds = None):
       print("AUC without te: " + str(current_seed) + " = " + str(auc))
     return sum_of_aucs / len(seeds)
 
-
 def titanic_with_te_kfoldstrategy(frame = None, seeds = None):
     sum_of_aucs = 0
     for current_seed in seeds:
@@ -54,6 +52,12 @@ def titanic_with_te_kfoldstrategy(frame = None, seeds = None):
       targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
                                     fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
       targetEncoder.fit(frame=ds['train'])
+
+      encodingMapFramesKeys = list(map(lambda x: h2o.get_frame(x['key']['name']), targetEncoder._encodingMap.frames))
+
+      encodingMapFramesKeys[0].describe()
+      encodingMapFramesKeys[1].describe()
+      encodingMapFramesKeys[2].describe()
 
       encodedTrain = targetEncoder.transform(frame=ds['train'], holdout_type="kfold", seed=1234)
       encodedValid = targetEncoder.transform(frame=ds['valid'], holdout_type="none", noise=0.0)

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_gbm_target_encoding.py
@@ -53,12 +53,6 @@ def titanic_with_te_kfoldstrategy(frame = None, seeds = None):
                                     fold_column= foldColumnName, blended_avg= True, inflection_point = 3, smoothing = 1)
       targetEncoder.fit(frame=ds['train'])
 
-      encodingMapFramesKeys = list(map(lambda x: h2o.get_frame(x['key']['name']), targetEncoder._encodingMap.frames))
-
-      encodingMapFramesKeys[0].describe()
-      encodingMapFramesKeys[1].describe()
-      encodingMapFramesKeys[2].describe()
-
       encodedTrain = targetEncoder.transform(frame=ds['train'], holdout_type="kfold", seed=1234)
       encodedValid = targetEncoder.transform(frame=ds['valid'], holdout_type="none", noise=0.0)
       encodedTest = targetEncoder.transform(frame=ds['test'], holdout_type="none", noise=0.0)

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_automl_target_encoding.py
@@ -381,6 +381,26 @@ def test_that_warning_will_be_shown_if_we_add_noise_for_none_strategy():
         assert "Attempt to apply noise with holdout_type=`none` strategy" == str(w[-1].message)
 
 
+def test_that_encoding_maps_are_accessible_as_frames():
+    print("Check that we can access encoding maps as data frames")
+    targetColumnName = "survived"
+    foldColumnName = "kfold_column" # it is strange that we can't set name for generated kfold
+
+    teColumns = "home.dest"
+    targetEncoder = TargetEncoder(x= teColumns, y= targetColumnName,
+                                  fold_column= foldColumnName, blending_avg= True, inflection_point = 3, smoothing = 1)
+    trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
+
+    trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
+    trainingFrame[foldColumnName] = trainingFrame.kfold_column(n_folds=5, seed=1234)
+
+    targetEncoder.fit(frame=trainingFrame)
+
+    encodingMapFramesKeys = targetEncoder.encoding_map_frames()
+
+    assert len([value for value in encodingMapFramesKeys[0].columns if value in teColumns]) > 0
+
+
 testList = [
     test_target_encoding_parameters,
     test_target_encoding_fit_method,
@@ -397,7 +417,8 @@ testList = [
     pubdev_6474_test_more_than_two_columns_to_encode_case,
     test_blending_params_are_within_valid_range,
     test_that_error_will_be_thrown_if_user_has_not_used_fold_column,
-    test_that_warning_will_be_shown_if_we_add_noise_for_none_strategy
+    test_that_warning_will_be_shown_if_we_add_noise_for_none_strategy,
+    test_that_encoding_maps_are_accessible_as_frames
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is a cherry-pick from [PR](https://github.com/h2oai/h2o-3/pull/3393) to make it available in fix release 3.24.0.5