### PR TITLE
PUBDEV-6515 - MOJO loading fails when categorical values contain a newline character

### DIFF
--- a/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
+++ b/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
@@ -11,7 +11,6 @@ import water.fvec.Frame;
 import water.fvec.TestFrameBuilder;
 import water.fvec.Vec;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
+++ b/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
@@ -116,6 +116,8 @@ public class MojoIntegrationTest {
   /**
    * Custom Mojo writer with categorical levels serialized "the old way" - one categorical per row.
    * This approach made it impossible to represent multi-level categoricals.
+   * 
+   * No need to override `writekv("multiline_categoricals", true);` to false, as the DFA should be able to recognize a line not beginning with a quote.
    */
   private static final class OldDomainSerializationGBMMojoWriter extends GbmMojoWriter {
 

--- a/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
+++ b/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
@@ -31,8 +31,8 @@ public class MojoIntegrationTest {
     try {
       Scope.enter();
 
-      final Frame trainingFrame = new TestFrameBuilder().withDataForCol(0, new String[]{"L1\n \"\"L1", "L2\n\r", "\nL3\n", "L4\r", "\\"})
-              .withDataForCol(1, new String[]{"\"R1", "R2", "R3", "", "   "})
+      final Frame trainingFrame = new TestFrameBuilder().withDataForCol(0, new String[]{"L1\n \"\"L1", "L2\n\r", "\nL3\n", "L4\r", "\\", "L6\f", "\rL7\b"})
+              .withDataForCol(1, new String[]{"\"R1", "R2", "R3", "", "   ", "R6\t", "R7\b"})
               .withUniformVecTypes(2, Vec.T_CAT)
               .build();
 

--- a/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
+++ b/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
@@ -51,9 +51,7 @@ public class MojoIntegrationTest {
       final GBMModel gbmModel = gbm.trainModel().get();
       assertNotNull(gbmModel);
 
-      final ByteArrayOutputStream originalModelMojo = new ByteArrayOutputStream();
       final File originalModelMojoFile = File.createTempFile("mojo", "zip");
-      gbmModel.getMojo().writeTo(originalModelMojo);
       gbmModel.getMojo().writeTo(new FileOutputStream(originalModelMojoFile));
 
       MojoModel mojoModel = MojoModel.load(originalModelMojoFile.getAbsolutePath());
@@ -94,9 +92,7 @@ public class MojoIntegrationTest {
       final GBMModel gbmModel = gbm.trainModel().get();
       assertNotNull(gbmModel);
 
-      final ByteArrayOutputStream originalModelMojo = new ByteArrayOutputStream();
       final File originalModelMojoFile = File.createTempFile("mojo", "zip");
-      gbmModel.getMojo().writeTo(originalModelMojo);
       new OldDomainSerializationGBMMojoWriter(gbmModel).writeTo(new FileOutputStream(originalModelMojoFile));
 
 

--- a/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
+++ b/h2o-algos/src/test/java/hex/mojo/MojoIntegrationTest.java
@@ -1,0 +1,146 @@
+package hex.mojo;
+
+import hex.genmodel.MojoModel;
+import hex.tree.gbm.GBM;
+import hex.tree.gbm.GBMModel;
+import hex.tree.gbm.GbmMojoWriter;
+import org.junit.Before;
+import org.junit.Test;
+import water.*;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class MojoIntegrationTest {
+
+  @Before
+  public void setUp() throws Exception {
+    TestUtil.stall_till_cloudsize(1);
+  }
+
+
+  @Test
+  public void testMojo_MultilineCategoricals() throws IOException {
+    try {
+      Scope.enter();
+
+      final Frame trainingFrame = new TestFrameBuilder().withDataForCol(0, new String[]{"L1\n \"\"L1", "L2\n\r", "\nL3\n", "L4\r", "\\"})
+              .withDataForCol(1, new String[]{"\"R1", "R2", "R3", "", "   "})
+              .withUniformVecTypes(2, Vec.T_CAT)
+              .build();
+
+      Scope.track(trainingFrame);
+
+      GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
+      parameters._train = trainingFrame._key;
+      parameters._response_column = trainingFrame._names[trainingFrame.numCols()-1];
+      parameters._seed = 0XFEED;
+      parameters._max_depth = 1;
+      parameters._ntrees = 1;
+      parameters._min_rows = 1;
+      
+      
+      GBM gbm = new GBM(parameters);
+      final GBMModel gbmModel = gbm.trainModel().get();
+      assertNotNull(gbmModel);
+
+      final ByteArrayOutputStream originalModelMojo = new ByteArrayOutputStream();
+      final File originalModelMojoFile = File.createTempFile("mojo", "zip");
+      gbmModel.getMojo().writeTo(originalModelMojo);
+      gbmModel.getMojo().writeTo(new FileOutputStream(originalModelMojoFile));
+
+      MojoModel mojoModel = MojoModel.load(originalModelMojoFile.getAbsolutePath());
+      assertNotNull(mojoModel);
+      
+      for (int i = 0; i < gbmModel._output._domains.length; i++) {
+        assertArrayEquals(gbmModel._output._domains[i], mojoModel._domains[i]);
+      }
+
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testMojo_parseUnquoted() throws IOException {
+    try {
+      Scope.enter();
+
+      final Frame trainingFrame = new TestFrameBuilder().withDataForCol(0, new String[]{"LVL1", " LVL2  ", "LVL 3 ", " LVL4 "}) // Third with space in the middle
+              .withDataForCol(1, new String[]{"RLVL1", "RLVL2", "", "RLVL4"}).
+                      withUniformVecTypes(2, Vec.T_CAT)
+              .build();
+
+      Scope.track(trainingFrame);
+
+      GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
+      parameters._train = trainingFrame._key;
+      parameters._response_column = trainingFrame._names[trainingFrame.numCols() - 1];
+      parameters._seed = 0XFEED;
+      parameters._max_depth = 1;
+      parameters._ntrees = 1;
+      parameters._min_rows = 1;
+
+
+      GBM gbm = new GBM(parameters);
+      final GBMModel gbmModel = gbm.trainModel().get();
+      assertNotNull(gbmModel);
+
+      final ByteArrayOutputStream originalModelMojo = new ByteArrayOutputStream();
+      final File originalModelMojoFile = File.createTempFile("mojo", "zip");
+      gbmModel.getMojo().writeTo(originalModelMojo);
+      new OldDomainSerializationGBMMojoWriter(gbmModel).writeTo(new FileOutputStream(originalModelMojoFile));
+
+
+      MojoModel mojoModel = MojoModel.load(originalModelMojoFile.getAbsolutePath());
+      assertNotNull(mojoModel);
+
+      for (int i = 0; i < gbmModel._output._domains.length; i++) {
+        assertArrayEquals(gbmModel._output._domains[i], mojoModel._domains[i]);
+      }
+
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  /**
+   * Custom Mojo writer with categorical levels serialized "the old way" - one categorical per row.
+   * This approach made it impossible to represent multi-level categoricals.
+   */
+  private static final class OldDomainSerializationGBMMojoWriter extends GbmMojoWriter {
+
+    public OldDomainSerializationGBMMojoWriter(GBMModel model) {
+      super(model);
+    }
+
+    /**
+     * Provide categorical levels output "the old way"
+     *
+     * @throws IOException
+     */
+    @Override
+    protected void writeDomains() throws IOException {
+      int domIndex = 0;
+      for (String[] domain : model._output._domains) {
+        if (domain == null) continue;
+        startWritingTextFile(String.format("domains/d%03d.txt", domIndex++));
+        for (String category : domain) {
+          writeln(category.replaceAll("\n", "\\n"));  // replace newlines with "\n" escape sequences
+        }
+        finishWritingTextFile();
+      }
+    }
+  }
+
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
@@ -246,10 +246,7 @@ public abstract class AbstractMojoWriter {
       if (domain == null) continue;
       startWritingTextFile(String.format("domains/d%03d.txt", domIndex++));
       for (String category : domain) {
-        StringBuilder stringBuilder = new StringBuilder("\"");
-        stringBuilder.append(QUOTE_PATTERN.matcher(category).replaceAll(QUOTE_ESCAPING_REPLACEMENT));
-        stringBuilder.append("\"");
-        writeln(stringBuilder.toString());  // replace newlines with "\n" escape sequences
+        writeln(StringEscapeUtils.escapeNewlines(category));
       }
       finishWritingTextFile();
     }

--- a/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
@@ -185,7 +185,7 @@ public abstract class AbstractMojoWriter {
     writekv("prior_class_distrib", Arrays.toString(model.priorClassDist()));
     writekv("model_class_distrib", Arrays.toString(model.modelClassDist()));
     writekv("timestamp", model.timestamp());
-    writekv("multiline_categoricals", true);
+    writekv("escape_domain_values", true); // Without escaping, there is no way to represent multiline categoricals as one-line values.
   }
 
   /**
@@ -235,8 +235,6 @@ public abstract class AbstractMojoWriter {
     finishWritingTextFile();
   }
 
-  private static final Pattern QUOTE_PATTERN = Pattern.compile("[\"]{1}"); // Escape quotes
-  private static final String QUOTE_ESCAPING_REPLACEMENT = "\"\"";
   /**
    * Create files containing domain definitions for each categorical column.
    */

--- a/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
@@ -185,6 +185,7 @@ public abstract class AbstractMojoWriter {
     writekv("prior_class_distrib", Arrays.toString(model.priorClassDist()));
     writekv("model_class_distrib", Arrays.toString(model.modelClassDist()));
     writekv("timestamp", model.timestamp());
+    writekv("multiline_categoricals", true);
   }
 
   /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
@@ -8,7 +8,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -233,16 +234,21 @@ public abstract class AbstractMojoWriter {
     finishWritingTextFile();
   }
 
+  private static final Pattern QUOTE_PATTERN = Pattern.compile("[\"]{1}"); // Escape quotes
+  private static final String QUOTE_ESCAPING_REPLACEMENT = "\"\"";
   /**
    * Create files containing domain definitions for each categorical column.
    */
-  private void writeDomains() throws IOException {
+  protected void writeDomains() throws IOException {
     int domIndex = 0;
     for (String[] domain : model.scoringDomains()) {
       if (domain == null) continue;
       startWritingTextFile(String.format("domains/d%03d.txt", domIndex++));
       for (String category : domain) {
-        writeln(category.replaceAll("\n", "\\n"));  // replace newlines with "\n" escape sequences
+        StringBuilder stringBuilder = new StringBuilder("\"");
+        stringBuilder.append(QUOTE_PATTERN.matcher(category).replaceAll(QUOTE_ESCAPING_REPLACEMENT));
+        stringBuilder.append("\"");
+        writeln(stringBuilder.toString());  // replace newlines with "\n" escape sequences
       }
       finishWritingTextFile();
     }

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
@@ -268,14 +268,10 @@ public abstract class ModelMojoReader<M extends MojoModel> {
       try (BufferedReader br = _reader.getTextFile("domains/" + domfile)) {
         String line;
         int id = 0;  // domain elements counter
-        while (true) {
-          final String str = br.readLine();
-          if (str == null) break;
+        while ((line = br.readLine()) != null) {
+          if (line == null) break;
           if (escapeDomainValues) {
-            line = StringEscapeUtils.unescapeNewlines(str);
-          } else {
-            // Older MOJOs did not escape new line in categoricals. Support for backwards compatibility.
-            line = str;
+            line = StringEscapeUtils.unescapeNewlines(line);
           }
           domain[id++] = line;
         }

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
@@ -269,7 +269,6 @@ public abstract class ModelMojoReader<M extends MojoModel> {
         String line;
         int id = 0;  // domain elements counter
         while ((line = br.readLine()) != null) {
-          if (line == null) break;
           if (escapeDomainValues) {
             line = StringEscapeUtils.unescapeNewlines(line);
           }

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
@@ -115,11 +115,7 @@ public abstract class ModelMojoReader<M extends MojoModel> {
       return val != null ? (T) val : defVal;
     return ((RawValue) val).parse(defVal);
   }
-
-  protected boolean existsInKV(final String key) {
-    return _lkv.containsKey(key);
-  }
-
+  
   /**
    * Retrieve binary data previously saved to the mojo file using `writeblob(key, blob)`.
    */
@@ -256,7 +252,7 @@ public abstract class ModelMojoReader<M extends MojoModel> {
   }
 
   private String[][] parseModelDomains(int n_columns) throws IOException {
-    final boolean multilineCategoricals = existsInKV("multiline_categoricals") && (boolean) readkv("multiline_categoricals"); // The key might not exist in older MOJOs
+    final boolean escapeDomainValues = Boolean.TRUE.equals(readkv("escape_domain_values")); // The key might not exist in older MOJOs
     String[][] domains = new String[n_columns][];
     // noinspection unchecked
     Map<Integer, String> domass = (Map<Integer, String>) _lkv.get("[domains]");
@@ -275,9 +271,10 @@ public abstract class ModelMojoReader<M extends MojoModel> {
         while (true) {
           final String str = br.readLine();
           if (str == null) break;
-          if (multilineCategoricals) {
+          if (escapeDomainValues) {
             line = StringEscapeUtils.unescapeNewlines(str);
           } else {
+            // Older MOJOs did not escape new line in categoricals. Support for backwards compatibility.
             line = str;
           }
           domain[id++] = line;

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
@@ -251,6 +251,29 @@ public abstract class ModelMojoReader<M extends MojoModel> {
     return info;
   }
 
+  private static final char CR = '\r';
+  private static final char LF = '\n';
+  private static final char QUOTES = '"';
+
+  /**
+   * States of Model Domains parser DFA
+   */
+  private enum States {
+    CATEGORICAL_END, // For unquoted categorical levels, one of {\r,\n} is reached. For quoted, the terminal quote is reached. 
+    QUOTES_DETECTED, // Quotes parsed
+    CHECK_ESC_QUOTES, // After quotes are parsed, check if those were escaping quotes or ending quotes
+    QUOTED_CATEGORICAL, // A categorical level enclosed in QUOTES
+    UNQUOTED_CATEGORICAL, // Old MOJO versions used to save categorical levels not enclosed in quotes - for backwards compatibility
+    NEW_CATEGORICAL // Decide quoted/unquoted categorical level
+  }
+
+  /**
+   * Parses domain levels from inside the MOJO for each categorical column
+   *
+   * @param n_columns Number of categorical columns
+   * @return A two-dimensional array of {@link String}, each level representing domain for the respective column
+   * @throws IOException
+   */
   private String[][] parseModelDomains(int n_columns) throws IOException {
     String[][] domains = new String[n_columns][];
     // noinspection unchecked
@@ -263,25 +286,94 @@ public abstract class ModelMojoReader<M extends MojoModel> {
       int n_elements = Integer.parseInt(info[0]);
       String domfile = info[1];
       String[] domain = new String[n_elements];
-      BufferedReader br = _reader.getTextFile("domains/" + domfile);
-      try {
-        String line;
-        int id = 0;  // domain elements counter
+
+
+      try (BufferedReader br = _reader.getTextFile("domains/" + domfile)) {
+        States state = States.NEW_CATEGORICAL;
+        StringBuilder stringBuilder = new StringBuilder();
+        int quoteCount = 0;
+        int domainIdx = 0;
+        int c;
+        parsingLoop:
         while (true) {
-          line = br.readLine();
-          if (line == null) break;
-          domain[id++] = line;
+          c = br.read();
+
+          states:
+          while (true) {
+            switch (state) {
+              case NEW_CATEGORICAL:
+                if (c == -1) break parsingLoop;
+                if (c == QUOTES) { // Quotes at the beginning imply quoted categorical.
+                  state = States.QUOTED_CATEGORICAL;
+                  quoteCount++;
+                  break states;
+                } else if (c == CR || c == LF) {
+                  state = States.CATEGORICAL_END;
+                  continue states;
+                } else {
+                  state = States.UNQUOTED_CATEGORICAL;
+                  continue states;
+                }
+                
+              case CATEGORICAL_END:
+                quoteCount = 0;
+                domain[domainIdx++] = stringBuilder.toString();
+                stringBuilder = new StringBuilder();
+                state = States.NEW_CATEGORICAL;
+                break states;
+                
+              case QUOTES_DETECTED:
+                quoteCount++;
+                state = States.CHECK_ESC_QUOTES;
+                break states;
+                
+              case CHECK_ESC_QUOTES:
+                if (c == QUOTES) {
+                  quoteCount--;
+                  state = States.QUOTED_CATEGORICAL;
+                  stringBuilder.append(QUOTES);
+                  break states;
+                } else if (quoteCount == 2) {
+                  state = States.CATEGORICAL_END;
+                  continue states;
+                }
+
+                state = States.QUOTED_CATEGORICAL;
+                continue states;
+                
+              case UNQUOTED_CATEGORICAL:
+                if (c == CR || c == LF || c == -1) {
+                  state = States.CATEGORICAL_END;
+                  continue states;
+                }
+                stringBuilder.append((char) c);
+                break states;
+                
+              case QUOTED_CATEGORICAL:
+                if (c == QUOTES) {
+                  state = States.QUOTES_DETECTED;
+                  continue states;
+                }
+                if ((c == CR || c == LF) && quoteCount == 0) {
+                  state = States.CATEGORICAL_END;
+                  continue states;
+                }
+                stringBuilder.append((char) c);
+                break states;
+            }
+          }
+
         }
-        if (id != n_elements)
+        
+        domains[col_index] = domain;
+        if (domain.length != n_elements)
           throw new IOException("Not enough elements in the domain file");
-        br.close();
-      } finally {
-        try { br.close(); } catch (IOException ioe) { /* ignored */ }
+        
       }
-      domains[col_index] = domain;
     }
     return domains;
   }
+
 
   private static class RawValue {
     private final String _val;

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
@@ -116,6 +116,10 @@ public abstract class ModelMojoReader<M extends MojoModel> {
     return ((RawValue) val).parse(defVal);
   }
 
+  protected boolean existsInKV(final String key) {
+    return _lkv.containsKey(key);
+  }
+
   /**
    * Retrieve binary data previously saved to the mojo file using `writeblob(key, blob)`.
    */
@@ -275,6 +279,7 @@ public abstract class ModelMojoReader<M extends MojoModel> {
    * @throws IOException
    */
   private String[][] parseModelDomains(int n_columns) throws IOException {
+    final boolean multilineCategoricals = existsInKV("multiline_categoricals") && (boolean) readkv("multiline_categoricals"); // The key might not exist in older MOJOs
     String[][] domains = new String[n_columns][];
     // noinspection unchecked
     Map<Integer, String> domass = (Map<Integer, String>) _lkv.get("[domains]");
@@ -303,7 +308,7 @@ public abstract class ModelMojoReader<M extends MojoModel> {
             switch (state) {
               case NEW_CATEGORICAL:
                 if (c == -1) break parsingLoop;
-                if (c == QUOTES) { // Quotes at the beginning imply quoted categorical.
+                if (c == QUOTES && multilineCategoricals) { // Quotes at the beginning imply quoted categorical.
                   state = States.QUOTED_CATEGORICAL;
                   quoteCount++;
                   break states;

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/StringEscapeUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/StringEscapeUtils.java
@@ -24,6 +24,10 @@ public class StringEscapeUtils {
           out.write('\\');
           out.write('n');
           break;
+        case '\r':
+          out.write('\\');
+          out.write('r');
+          break;
         default:
           out.write(c);
       }
@@ -46,6 +50,9 @@ public class StringEscapeUtils {
         switch (c) {
           case 'n':
             out.write('\n');
+            break;
+          case 'r':
+            out.write('\r');
             break;
           case '\\':
             out.write('\\');


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6515

The problem is simple, we're reading the input by lines. And if a categorical value has a new line at the end, it will be parsed as a new empty categorical levels.

The solution is simple: one categorical per line, with harmful characters escaped (new line chars).