### PR TITLE
PUBDEV-6550 - TestFrameBuilder BAD Vec support

### DIFF
--- a/h2o-core/src/test/java/water/fvec/TestFrameBuilder.java
+++ b/h2o-core/src/test/java/water/fvec/TestFrameBuilder.java
@@ -316,6 +316,9 @@ public class TestFrameBuilder {
             else
               nchunks[colIdx].addNA();
             break;
+          case Vec.T_BAD:
+            nchunks[colIdx].addNum(numericData.get(colIdx)[i]);
+            break;
           default:
             throw new UnsupportedOperationException("Unsupported Vector type for the builder");
 
@@ -342,6 +345,7 @@ public class TestFrameBuilder {
       switch (vecTypes[i]){
         case Vec.T_TIME:
         case Vec.T_NUM:
+        case Vec.T_BAD:
           if(numericData.get(i)==null){
             numericData.put(i, new double[0]); // init with no data as default
           }
@@ -410,6 +414,13 @@ public class TestFrameBuilder {
             numRows = stringData.get(colIdx).length;
           } else {
             throwIf(numRows != stringData.get(colIdx).length, "Columns have different number of elements");
+          }
+          break;
+        case Vec.T_BAD:
+          final double[] data = numericData.get(colIdx);
+          numRows = data.length;
+          for (int i = 0; i < data.length; i++) {
+            throwIf(!Double.isNaN(data[i]), "All elements in a bad column must be NAs or zeros");
           }
           break;
         default:

--- a/h2o-core/src/test/java/water/fvec/TestFrameBuilderTest.java
+++ b/h2o-core/src/test/java/water/fvec/TestFrameBuilderTest.java
@@ -1,9 +1,13 @@
 package water.fvec;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import water.Scope;
 import water.TestUtil;
 import water.parser.BufferedString;
+import water.rapids.Rapids;
+import water.rapids.Val;
 import water.util.TwoDimTable;
 
 import java.util.Random;
@@ -228,4 +232,33 @@ public class TestFrameBuilderTest extends TestUtil {
 
     fr.delete();
   }
+
+  @Test
+  public void testBadVec(){
+    try {
+      Scope.enter();
+
+      Frame frame = new TestFrameBuilder()
+              .withVecTypes(Vec.T_BAD)
+              .withDataForCol(0, ard(Float.NaN, Float.NaN, Float.NaN)) // All NaN column
+              .withName("fr")
+              .build();
+      Scope.track(frame);
+      
+      assertNotNull(frame);
+      assertEquals(1, frame.numCols());
+
+      final Vec badVec = frame.vec(0);
+      assertEquals(Vec.T_BAD, badVec._type);
+      assertEquals(3, badVec.length());
+      assertTrue(badVec.isBad());
+
+      for (int i = 0; i < badVec.length(); i++) {
+        assertEquals(Float.NaN, badVec.at(i), 0D);
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+  
 }

--- a/h2o-core/src/test/java/water/fvec/TestFrameBuilderTest.java
+++ b/h2o-core/src/test/java/water/fvec/TestFrameBuilderTest.java
@@ -243,7 +243,6 @@ public class TestFrameBuilderTest extends TestUtil {
               .withDataForCol(0, ard(Float.NaN, Float.NaN, Float.NaN)) // All NaN column
               .withName("fr")
               .build();
-      Scope.track(frame);
       
       assertNotNull(frame);
       assertEquals(1, frame.numCols());


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6550

During the review of https://github.com/h2oai/h2o-3/pull/3562/files , I've discovered the `TestFrameBuilder` class does not allow us to create Frames with BAD vectors. 

This PR does the bare minimum (an all-NaN column inside a frame) and tries to prepare the ground for future PRs. 