### PR TITLE
PUBDEV-6566 HDP S3 import/export test output files removal

### DIFF
--- a/h2o-hadoop-2/tests/python/pyunit_s3_import_export.py
+++ b/h2o-hadoop-2/tests/python/pyunit_s3_import_export.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import h2o
 import uuid
 from pandas.util.testing import assert_frame_equal
+import boto3
 
 def s3_import_export():
     local_frame = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
@@ -18,6 +19,11 @@ def s3_import_export():
         h2o.export_file(local_frame, s3_path)
         s3_frame = h2o.import_file(s3_path)
         assert_frame_equal(local_frame.as_data_frame(), s3_frame.as_data_frame())
+        
+        #Delete the file afterwards
+        s3 = boto3.resource('s3')
+        s3.Object(bucket_name='test.0xdata.com', key="h2o-hadoop-tests/test-export/" + scheme + "/exported." + \
+                                                     timestamp + "." + unique_suffix + ".csv.zip").delete()
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(s3_import_export)

--- a/h2o-hadoop-3/tests/python/pyunit_s3_import_export.py
+++ b/h2o-hadoop-3/tests/python/pyunit_s3_import_export.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import h2o
 import uuid
 from pandas.util.testing import assert_frame_equal
+import boto3
 
 def s3_import_export():
     local_frame = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
@@ -18,6 +19,11 @@ def s3_import_export():
         h2o.export_file(local_frame, s3_path)
         s3_frame = h2o.import_file(s3_path)
         assert_frame_equal(local_frame.as_data_frame(), s3_frame.as_data_frame())
+        
+        #Delete the file afterwards
+        s3 = boto3.resource('s3')
+        s3.Object(bucket_name='test.0xdata.com', key="h2o-hadoop-tests/test-export/" + scheme + "/exported." + \
+                                                     timestamp + "." + unique_suffix + ".csv.zip").delete()
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(s3_import_export)

--- a/h2o-py/test-requirements.txt
+++ b/h2o-py/test-requirements.txt
@@ -29,3 +29,4 @@ recommonmark==0.4.0
 sphinx_rtd_theme==0.2.4
 git+https://github.com/svx/sphinxcontrib-osexample#egg=1cc4afcc6089083256aa642d9faa12352ef45d68
 shap==0.28.3
+boto3>=1.7.50


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6556 

The pyunit_s3_import_export.py tests (one for HDP 2 and one fore HDP 3 based distros) generate a lot of dummy files which are not being deleted afterwards, residing in our AWS.

This does not directly solve the reason why this test fails non-deterministically.

http://mr-0xc1:8080/job/h2o-3-kerberos-smoke-pipeline/job/pavel%252Fpubdev-6556-file-removal/