### PR TITLE
PUBDEV-6565: Enable XGBoost Junit tests in multi-node

### DIFF
--- a/h2o-extensions/xgboost/build.gradle
+++ b/h2o-extensions/xgboost/build.gradle
@@ -19,7 +19,7 @@ apply from: "${rootDir}/gradle/dataCheck.gradle"
 test {
     dependsOn ":h2o-core:testJar"
     // Note: multi node tests are ignored right now!
-    dependsOn smalldataCheck, cpLibs, jar, testJar, testSingleNode //, testMultiNode
+    dependsOn smalldataCheck, cpLibs, jar, testJar, testSingleNode, testMultiNode
 
     // Defeat task 'test' by running no tests.
     exclude '**'

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostTest.java
@@ -807,6 +807,7 @@ public class XGBoostTest extends TestUtil {
 
   @Test
   public void testBinomialTrainingWeights() {
+    Assume.assumeTrue(H2O.getCloudSize() == 1); // FIXME: PUBDEV-6565
     XGBoostModel model = null;
     XGBoostModel noWeightsModel = null;
     Scope.enter();
@@ -857,6 +858,7 @@ public class XGBoostTest extends TestUtil {
 
   @Test
   public void testRegressionTrainingWeights() {
+    Assume.assumeTrue(H2O.getCloudSize() == 1); // FIXME: PUBDEV-6565
     XGBoostModel model = null;
     XGBoostModel noWeightsModel = null;
     Scope.enter();
@@ -907,6 +909,7 @@ public class XGBoostTest extends TestUtil {
 
   @Test
   public void testMultinomialTrainingWeights() {
+    Assume.assumeTrue(H2O.getCloudSize() == 1); // FIXME: PUBDEV-6565
     XGBoostModel model = null;
     XGBoostModel noWeightsModel = null;
     Scope.enter();
@@ -1460,6 +1463,7 @@ public class XGBoostTest extends TestUtil {
 
   @Test
   public void testMonotoneConstraints() {
+    Assume.assumeTrue(H2O.getCloudSize() == 1); // FIXME: PUBDEV-6565
     Scope.enter();
     try {
       final String response = "power (hp)";

--- a/h2o-extensions/xgboost/testMultiNode.sh
+++ b/h2o-extensions/xgboost/testMultiNode.sh
@@ -31,10 +31,10 @@ function cleanup () {
   RC="`paste $OUTDIR/status.* | sed 's/[[:blank:]]//g'`"
   if [ "$RC" != "00000" ]; then
     cat $OUTDIR/out.*
-    echo h2o-algos junit tests FAILED
+    echo h2o-ext-xgboost junit tests FAILED
     exit 1
   else
-    echo h2o-algos junit tests PASSED
+    echo h2o-ext-xgboost junit tests PASSED
     exit 0
   fi
 }
@@ -65,7 +65,7 @@ MAX_MEM=${H2O_JVM_XMX:-2500m}
 if [ $JACOCO_ENABLED = true ]
 then
     AGENT="../jacoco/jacocoagent.jar"
-    COVERAGE="-javaagent:$AGENT=destfile=build/jacoco/h2o-algos.exec"
+    COVERAGE="-javaagent:$AGENT=destfile=build/jacoco/h2o-ext-xgboost.exec"
     MAX_MEM=${H2O_JVM_XMX:-8g}
 else
     COVERAGE=""
@@ -87,7 +87,7 @@ JUNIT_RUNNER="water.junit.H2OTestRunner"
 # Cut the   "water/MRThrow.java" down to "water/MRThrow"
 # Slash/dot "water/MRThrow"      becomes "water.MRThrow"
 
-# On this h2o-algos testMultiNode.sh only, force the tests.txt to be in the same order for all machines.
+# On this h2o-ext-xgboost testMultiNode.sh only, force the tests.txt to be in the same order for all machines.
 # If sorted, the result of the cd/grep varies by machine. 
 # If randomness is desired, replace sort with the unix 'shuf'
 # Use /usr/bin/sort because of cygwin on windows. 

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -262,7 +262,7 @@ test-junit-jenkins:
 	@$(MAKE) -f $(THIS_FILE) test-junit
 
 test-junit:
-	./gradlew test -x :h2o-ext-mojo-pipeline:test -x h2o-automl:test $$ADDITIONAL_GRADLE_OPTS
+	./gradlew test -x h2o-ext-mojo-pipeline:test -x h2o-automl:test -x h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-automl-jenkins:
 	$(call sed_test_scripts)
@@ -271,26 +271,33 @@ test-junit-automl-jenkins:
 test-junit-automl:
 	./gradlew h2o-automl:test $$ADDITIONAL_GRADLE_OPTS
 
+test-junit-xgb-multi-jenkins:
+	$(call sed_test_scripts)
+	@$(MAKE) -f $(THIS_FILE) test-junit-xgb-multi
+
+test-junit-xgb-multi:
+	./gradlew h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
+
 test-junit-10-jenkins:
 	$(call sed_test_scripts)
 	@$(MAKE) -f $(THIS_FILE) test-junit-10
 
 test-junit-10:
-	./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test -x :h2o-ext-mojo-pipeline:test -x h2o-automl:test  $$ADDITIONAL_GRADLE_OPTS
+	./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test -x h2o-ext-mojo-pipeline:test -x h2o-automl:test -x h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-11-jenkins:
 	$(call sed_test_scripts)
 	@$(MAKE) -f $(THIS_FILE) test-junit-11
 
 test-junit-11:
-	./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test -x :h2o-ext-mojo-pipeline:test -x h2o-automl:test $$ADDITIONAL_GRADLE_OPTS
+	./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test -x h2o-ext-mojo-pipeline:test -x h2o-automl:test -x h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-12-jenkins:
 	$(call sed_test_scripts)
 	@$(MAKE) -f $(THIS_FILE) test-junit-12
 
 test-junit-12:
-	./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test -x :h2o-ext-mojo-pipeline:test -x h2o-automl:test $$ADDITIONAL_GRADLE_OPTS
+	./gradlew test -x h2o-scala_2.11:test -x h2o-scala_2.10:test -x h2o-ext-mojo-pipeline:test -x h2o-automl:test -x h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-smoke-jenkins:
 	$(call sed_test_scripts)
@@ -340,11 +347,11 @@ test-xgb-smoke-gpu-jenkins:
 	@$(MAKE) -f $(THIS_FILE) test-xgb-smoke-gpu
 
 test-xgb-smoke-minimal:
-	./gradlew h2o-ext-xgboost:test -x :h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
+	./gradlew h2o-ext-xgboost:test -x h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 	$(call check_xgb_backend,'xgboost4j_minimal')
 
 test-xgb-smoke-omp:
-	./gradlew h2o-ext-xgboost:test -x :h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
+	./gradlew h2o-ext-xgboost:test -x h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 	$(call check_xgb_backend,'xgboost4j_\(omp\|gpu\)')
 
 test-xgb-smoke-gpu:

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -340,11 +340,11 @@ test-xgb-smoke-gpu-jenkins:
 	@$(MAKE) -f $(THIS_FILE) test-xgb-smoke-gpu
 
 test-xgb-smoke-minimal:
-	./gradlew h2o-ext-xgboost:test $$ADDITIONAL_GRADLE_OPTS
+	./gradlew h2o-ext-xgboost:test -x :h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 	$(call check_xgb_backend,'xgboost4j_minimal')
 
 test-xgb-smoke-omp:
-	./gradlew h2o-ext-xgboost:test $$ADDITIONAL_GRADLE_OPTS
+	./gradlew h2o-ext-xgboost:test -x :h2o-ext-xgboost:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 	$(call check_xgb_backend,'xgboost4j_\(omp\|gpu\)')
 
 test-xgb-smoke-gpu:

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -232,8 +232,10 @@ test-package-java:
 		h2o-persist-hdfs/build/libs/h2o-persist-hdfs-*.jar \
 		h2o-persist-s3/src/ \
 		h2o-persist-s3/build/libs/h2o-persist-s3-*.jar \
-		h2o-extensions/xgboost/ \
-		h2o-genmodel-extensions/ \
+		h2o-extensions/xgboost/src/ \
+		h2o-extensions/xgboost/build/libs/h2o-ext-xgboost*.jar \
+		h2o-genmodel-extensions/xgboost/src/ \
+		h2o-genmodel-extensions/xgboost/build/libs/h2o-genmodel-ext-xgboost*.jar \
 		h2o-jaas-pam/build/libs/h2o-jaas-pam-*.jar \
 		h2o-scala/src/ \
 		h2o-scala/build/h2o-scala_2.*/libs/h2o-scala_2.*.jar \

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -191,6 +191,10 @@ def call(final pipelineContext) {
       timeoutValue: 20, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ],
     [
+      stageName: 'Java 8 XGBoost Multinode JUnit', target: 'test-junit-xgb-multi-jenkins', pythonVersion: '2.7', javaVersion: 8,
+      timeoutValue: 20, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+    ],
+    [
       stageName: 'Java 10 JUnit', target: 'test-junit-10-jenkins', pythonVersion: '2.7', javaVersion: 10,
       timeoutValue: 180, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ],

--- a/scripts/test-xgb-gpu-smoke.sh
+++ b/scripts/test-xgb-gpu-smoke.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+michalk_xgb-enable#! /bin/bash
 
 set -e
 
@@ -21,7 +21,7 @@ function finish {
     set -e
 }
 
-./gradlew h2o-ext-xgboost:test &
+./gradlew h2o-ext-xgboost:test -x h2o-ext-xgboost:testMultiNode &
 gradlewPID=$!
 i=1
 checkPassed=


### PR DESCRIPTION
This PR introduces a new stage for XGBoost Multinode Junit tests. The purpose of having it separate for now is to have very good visibility that these tests are actually run and to be able to quickly fix remaining issues. I had to ignore 4 tests in XGBoostTest, these tests should be fixed as a part of PUBDEV-6565.

@michal-raska please look into the changes in the makefile, especially those that modify the artifacts to be archived (without these changes the test directories were empty).