### PR TITLE
PUBDEV-6112 StackEnsemble verification of fold column presence in training/validation dataset

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -70,9 +70,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
   public void init(boolean expensive) {
     super.init(expensive);
 
-    checkFoldColumnPresent(_parms._metalearner_fold_column, _parms._train != null ? _parms._train.get() : null,
-            _parms._valid != null ? _parms._valid.get() : null,
-            _parms._blending != null ? _parms._blending.get() : null);
+    checkFoldColumnPresent(_parms._metalearner_fold_column, train(), valid(), _parms.blending());
   }
 
   /**
@@ -87,8 +85,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     for (Frame frame : frames) {
       if (frame == null) continue; // No frame provided, no checks required
       if (frame.vec(foldColumnName) == null) {
-        throw new IllegalArgumentException(String.format("Specified fold column '%s' not found in the data frame: '%s'. Available column names are: %s",
-                foldColumnName, frame._key, Arrays.toString(frame.names())));
+        throw new IllegalArgumentException(String.format("Specified fold column '%s' not found in one of the supplied data frames. Available column names are: %s",
+                foldColumnName, Arrays.toString(frame.names())));
       }
     }
   }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -16,7 +16,6 @@ import water.fvec.Vec;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Objects;
 
 import water.util.ArrayUtils;
 import water.util.Log;

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -242,54 +242,51 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     init(true);
     if (error_count() > 0)
         throw H2OModelBuilderIllegalArgumentException.makeFromBuilder(StackedEnsemble.this);
-      try {
-        _model = new StackedEnsembleModel(dest(), _parms, new StackedEnsembleModel.StackedEnsembleOutput(StackedEnsemble.this));
-        _model._output._stacking_strategy = strategy();
-        _model.delete_and_lock(_job); // and clear & write-lock it (smashing any prior)
 
-        _model.checkAndInheritModelProperties();
+      _model = new StackedEnsembleModel(dest(), _parms, new StackedEnsembleModel.StackedEnsembleOutput(StackedEnsemble.this));
+      _model._output._stacking_strategy = strategy();
+      _model.delete_and_lock(_job); // and clear & write-lock it (smashing any prior)
 
-        String levelOneTrainKey = "levelone_training_" + _model._key.toString();
-        Frame levelOneTrainingFrame = prepareLevelOneFrame(levelOneTrainKey, _model._parms._base_models, getActualTrainingFrame(), true);
-        Frame levelOneValidationFrame = null;
-        if (_model._parms.valid() != null) {
-          String levelOneValidKey = "levelone_validation_" + _model._key.toString();
-          levelOneValidationFrame = prepareLevelOneFrame(levelOneValidKey, _model._parms._base_models, _model._parms.valid(), false);
-        }
+      _model.checkAndInheritModelProperties();
 
-        Metalearner.Algorithm metalearnerAlgoSpec = _model._parms._metalearner_algorithm;
-        Metalearner.Algorithm metalearnerAlgoImpl = Metalearner.getActualMetalearnerAlgo(metalearnerAlgoSpec);
+      String levelOneTrainKey = "levelone_training_" + _model._key.toString();
+      Frame levelOneTrainingFrame = prepareLevelOneFrame(levelOneTrainKey, _model._parms._base_models, getActualTrainingFrame(), true);
+      Frame levelOneValidationFrame = null;
+      if (_model._parms.valid() != null) {
+        String levelOneValidKey = "levelone_validation_" + _model._key.toString();
+        levelOneValidationFrame = prepareLevelOneFrame(levelOneValidKey, _model._parms._base_models, _model._parms.valid(), false);
+      }
 
-        // Compute metalearner
-        if (metalearnerAlgoImpl != null) {
-          Key<Model> metalearnerKey = Key.<Model>make("metalearner_" + metalearnerAlgoSpec + "_" + _model._key);
+      Metalearner.Algorithm metalearnerAlgoSpec = _model._parms._metalearner_algorithm;
+      Metalearner.Algorithm metalearnerAlgoImpl = Metalearner.getActualMetalearnerAlgo(metalearnerAlgoSpec);
 
-          Job metalearnerJob = new Job<>(metalearnerKey, ModelBuilder.javaName(metalearnerAlgoImpl.toString()),
-                  "StackingEnsemble metalearner (" + metalearnerAlgoSpec + ")");
-          //Check if metalearner_params are passed in
-          boolean hasMetaLearnerParams = _model._parms._metalearner_parameters != null;
-          long metalearnerSeed = _model._parms._seed;
+      // Compute metalearner
+      if(metalearnerAlgoImpl != null) {
+        Key<Model> metalearnerKey = Key.<Model>make("metalearner_" + metalearnerAlgoSpec + "_" + _model._key);
 
-          Metalearner metalearner = Metalearner.createInstance(metalearnerAlgoSpec);
-          metalearner.init(
-                  levelOneTrainingFrame,
-                  levelOneValidationFrame,
-                  _model._parms._metalearner_parameters,
-                  _model,
-                  _job,
-                  metalearnerKey,
-                  metalearnerJob,
-                  _parms,
-                  hasMetaLearnerParams,
-                  metalearnerSeed
-          );
-          metalearner.compute();
-        } else {
-          throw new H2OIllegalArgumentException("Invalid `metalearner_algorithm`. Passed in " + metalearnerAlgoSpec +
-                  " but must be one of " + Arrays.toString(Metalearner.Algorithm.values()));
-        }
-      } finally{
-        _model.unlock(_job);
+        Job metalearnerJob = new Job<>(metalearnerKey, ModelBuilder.javaName(metalearnerAlgoImpl.toString()),
+                "StackingEnsemble metalearner (" + metalearnerAlgoSpec + ")");
+        //Check if metalearner_params are passed in
+        boolean hasMetaLearnerParams = _model._parms._metalearner_parameters != null;
+        long metalearnerSeed = _model._parms._seed;
+
+        Metalearner metalearner = Metalearner.createInstance(metalearnerAlgoSpec);
+        metalearner.init(
+          levelOneTrainingFrame,
+          levelOneValidationFrame,
+          _model._parms._metalearner_parameters,
+          _model,
+          _job,
+          metalearnerKey,
+          metalearnerJob,
+          _parms,
+          hasMetaLearnerParams,
+          metalearnerSeed
+        );
+        metalearner.compute();
+      } else {
+        throw new H2OIllegalArgumentException("Invalid `metalearner_algorithm`. Passed in " + metalearnerAlgoSpec +
+            " but must be one of " + Arrays.toString(Metalearner.Algorithm.values()));
       }
     } // computeImpl
   }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -283,8 +283,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
                   " but must be one of " + Arrays.toString(Metalearner.Algorithm.values()));
         }
       } finally{
-        // If there is an exception during model training or validation, remove the model before exiting
-        _model.remove();
+        _model.unlock(_job);
       }
     } // computeImpl
   }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -919,8 +919,7 @@ public class StackedEnsembleTest extends TestUtil {
       seParams._metalearner_fold_column = "class";
 
       expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
-              + partialFrame._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
+      expectedException.expectMessage("Specified fold column 'class' not found in one of the supplied data frames. Available column names are: [sepal_len, sepal_wid, petal_wid, petal_len]");
       final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
       fail("Expected the Stack Ensemble Model never to be initialized successfully.");
 
@@ -949,6 +948,7 @@ public class StackedEnsembleTest extends TestUtil {
 
       GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
       parameters._train = trainingFrame._key;
+      parameters._valid = trainingFrame._key;
       parameters._fold_column = "class";
       parameters._seed = 0xFEED;
       parameters._response_column = "petal_len";
@@ -961,6 +961,7 @@ public class StackedEnsembleTest extends TestUtil {
 
 
       final StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = trainingFrame._key;
       seParams._valid = partialFrame._key;
       seParams._response_column = "petal_len";
       seParams._metalearner_algorithm = Algorithm.AUTO;
@@ -969,8 +970,7 @@ public class StackedEnsembleTest extends TestUtil {
       seParams._metalearner_fold_column = "class";
 
       expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
-              + partialFrame._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
+      expectedException.expectMessage("Specified fold column 'class' not found in one of the supplied data frames. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
       final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
       fail("Expected the Stack Ensemble Model never to be initialized successfully.");
 
@@ -1011,6 +1011,7 @@ public class StackedEnsembleTest extends TestUtil {
 
 
       final StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = trainingFrame._key;
       seParams._blending = partialFrame._key;
       seParams._response_column = "petal_len";
       seParams._metalearner_algorithm = Algorithm.AUTO;
@@ -1019,8 +1020,7 @@ public class StackedEnsembleTest extends TestUtil {
       seParams._metalearner_fold_column = "class";
 
       expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
-              + partialFrame._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
+      expectedException.expectMessage("Specified fold column 'class' not found in one of the supplied data frames. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
       final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
       fail("Expected the Stack Ensemble Model never to be initialized successfully.");
 
@@ -1072,8 +1072,7 @@ public class StackedEnsembleTest extends TestUtil {
       seParams._metalearner_fold_column = "class";
 
       expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
-              + seTrain._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
+      expectedException.expectMessage("Specified fold column 'class' not found in one of the supplied data frames. Available column names are: [sepal_len, sepal_wid, petal_wid, petal_len]");
 
       new StackedEnsemble(seParams);
       fail("Expected the Stack Ensemble Model never to be initialized successfully.");

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -18,7 +18,9 @@ import hex.tree.gbm.GBM;
 import hex.tree.gbm.GBMModel;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import water.*;
 import water.fvec.Chunk;
 import water.fvec.Frame;
@@ -30,10 +32,14 @@ import water.util.Log;
 import java.util.*;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class StackedEnsembleTest extends TestUtil {
 
     @BeforeClass public static void stall() { stall_till_cloudsize(1); }
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
     private abstract class PrepData { abstract int prep(Frame fr); }
 
@@ -879,4 +885,56 @@ public class StackedEnsembleTest extends TestUtil {
         }
 
     }
+
+  @Test
+  public void testMissingValidationColumn() {
+    GBMModel gbmModel = null;
+    try {
+      Scope.enter();
+
+      final Frame trainingFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv");
+      Scope.track(trainingFrame);
+      final Frame partialFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv", new int[]{4}); // Missing fold column
+      Scope.track(partialFrame);
+
+      GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
+      parameters._train = trainingFrame._key;
+      parameters._fold_column = "class";
+      parameters._seed = 0xFEED;
+      parameters._response_column = "petal_len";
+      parameters._ntrees = 1;
+      parameters._keep_cross_validation_predictions = true;
+
+      GBM gbm = new GBM(parameters);
+      gbmModel = gbm.trainModel().get();
+      assertNotNull(gbmModel);
+      
+
+      final StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = partialFrame._key;
+      seParams._response_column = "petal_len";
+      seParams._metalearner_algorithm = Algorithm.AUTO;
+      seParams._base_models = new Key[]{gbmModel._key};
+      seParams._seed = 0xFEED;
+      seParams._metalearner_fold_column = "class";
+
+      final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
+
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
+              + partialFrame._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
+      final StackedEnsembleModel stackedEnsembleModel = stackedEnsemble.trainModel().get();
+      fail("Expected the Stack Ensemble Model never to be trained successfully.");
+    } finally {
+      Scope.exit();
+      
+     
+      if(gbmModel != null){
+        gbmModel.deleteCrossValidationModels();
+        gbmModel.deleteCrossValidationPreds();
+        gbmModel.remove();
+      }
+    }
+
+  }
 }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -1035,5 +1035,57 @@ public class StackedEnsembleTest extends TestUtil {
       }
     }
   }
-  
+
+  @Test
+  public void testInvalidFoldColumn_trainingFrame() {
+    GBMModel gbmModel = null;
+    try {
+      Scope.enter();
+
+      final Frame trainingFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv");
+      Scope.track(trainingFrame);
+
+      GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
+      parameters._train = trainingFrame._key;
+      parameters._fold_column = "class";
+      parameters._seed = 0xFEED;
+      parameters._response_column = "petal_len";
+      parameters._ntrees = 1;
+      parameters._keep_cross_validation_predictions = true;
+
+      GBM gbm = new GBM(parameters);
+      gbmModel = gbm.trainModel().get();
+      assertNotNull(gbmModel);
+
+      final Frame seTrain = new Frame(Key.<Frame>make(), trainingFrame.names(), trainingFrame.vecs());
+      Vec foldVec = seTrain.remove("class");
+      seTrain.add("class", foldVec.toStringVec());
+      DKV.put(seTrain);
+      Scope.track(seTrain);
+
+      final StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = seTrain._key;
+      seParams._response_column = "petal_len";
+      seParams._metalearner_algorithm = Algorithm.AUTO;
+      seParams._base_models = new Key[]{gbmModel._key};
+      seParams._seed = 0x5EED;
+      seParams._metalearner_fold_column = "class";
+
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
+              + seTrain._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
+
+      new StackedEnsemble(seParams);
+      fail("Expected the Stack Ensemble Model never to be initialized successfully.");
+    } finally {
+      Scope.exit();
+      if(gbmModel != null){
+        gbmModel.deleteCrossValidationModels();
+        gbmModel.deleteCrossValidationPreds();
+        gbmModel.remove();
+      }
+    }
+  }
+
+
 }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -919,7 +919,7 @@ public class StackedEnsembleTest extends TestUtil {
       seParams._metalearner_fold_column = "class";
 
       expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Specified fold column 'class' not found in the training data frame: '"
+      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
               + partialFrame._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
       final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
       fail("Expected the Stack Ensemble Model never to be initialized successfully.");
@@ -969,7 +969,57 @@ public class StackedEnsembleTest extends TestUtil {
       seParams._metalearner_fold_column = "class";
 
       expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Specified fold column 'class' not found in the validation data frame: '"
+      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
+              + partialFrame._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
+      final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
+      fail("Expected the Stack Ensemble Model never to be initialized successfully.");
+
+    } finally {
+      Scope.exit();
+
+
+      if(gbmModel != null){
+        gbmModel.deleteCrossValidationModels();
+        gbmModel.deleteCrossValidationPreds();
+        gbmModel.remove();
+      }
+    }
+  }
+
+  @Test
+  public void testMissingFoldColumn_blendingFrame() {
+    GBMModel gbmModel = null;
+    try {
+      Scope.enter();
+
+      final Frame trainingFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv");
+      Scope.track(trainingFrame);
+      final Frame partialFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv", new int[]{4}); // Missing fold column
+      Scope.track(partialFrame);
+
+      GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
+      parameters._train = trainingFrame._key;
+      parameters._fold_column = "class";
+      parameters._seed = 0xFEED;
+      parameters._response_column = "petal_len";
+      parameters._ntrees = 1;
+      parameters._keep_cross_validation_predictions = true;
+
+      GBM gbm = new GBM(parameters);
+      gbmModel = gbm.trainModel().get();
+      assertNotNull(gbmModel);
+
+
+      final StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._blending = partialFrame._key;
+      seParams._response_column = "petal_len";
+      seParams._metalearner_algorithm = Algorithm.AUTO;
+      seParams._base_models = new Key[]{gbmModel._key};
+      seParams._seed = 0xFEED;
+      seParams._metalearner_fold_column = "class";
+
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Specified fold column 'class' not found in the data frame: '"
               + partialFrame._key.toString() + "'. Available column names are: [sepal_len, sepal_wid, petal_len, petal_wid]");
       final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
       fail("Expected the Stack Ensemble Model never to be initialized successfully.");


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6112

## The cause

The exception provided by the reporter in the JIRA can be reproduced by training a GBM model on a dataset with fold column specified (and of course, the CV models kept). The `GBMModel` parameters are:

```java
      GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
      parameters._train = trainingFrame._key;
      parameters._fold_column = "class";
      parameters._seed = 0xFEED;
      parameters._response_column = "petal_len";
      parameters._ntrees = 1;
      parameters._keep_cross_validation_predictions = true;
```

 Afterwards, the `StackEnsembleModel` is created with the previously mentioned base GBM model inside:

```java
      final StackedEnsembleParameters seParams = new StackedEnsembleParameters();
      seParams._train = partialFrame._key;
      seParams._response_column = "petal_len";
      seParams._metalearner_algorithm = Algorithm.AUTO;
      seParams._base_models = new Key[]{gbmModel._key};
      seParams._seed = 0xFEED;
      seParams._metalearner_fold_column = "class";
```

In `StackEnsemble` class, once line `123` (sic!) is reached:

```java
      if (_model._parms._metalearner_fold_column != null) {
        Vec foldColumn = actuals.vec(_model._parms._metalearner_fold_column);
        levelOneFrame.add(_model._parms._metalearner_fold_column, foldColumn);
      }
```

the property `foldColumn` is filled with null, as the fold column does not exist in the training dataset, but it did exist in the training dataset of the GBM. This might also happen during validation.

## Resolution

This is considered to be user's fault. However, we should prevent nullpointer once the user provides dataset with missing fold column (or renamed). That is why an exception with human-readable error message about fold column missing (while printing the columns available) is thrown.

This is the case of the JIRA reporter, as he's constantly changing the data and chances are the validation data frame he provided does not have the right column (or with a bad name). His example is not runnable (demo only) and we do not have access to the data the reporter used.

## Additional changes

- The StackEnsemble driver's `computeImpl` method is not very fault tolerant. It creates a model at the beginning and does not delete the model if there is an exception inside, effectively creating a key leak. The test constructed tests this as well (as a side effect). A mechanism to remove the model created and to rethrow the exception afterwards has been introduced. See my comments.