### PR TITLE
PUBDEV-6569: AutoML, set `score_tree_interval` for DRF+XRT

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1042,6 +1042,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     DRFParameters drfParameters = new DRFParameters();
     setCommonModelBuilderParams(drfParameters);
+    drfParameters._score_tree_interval = 5;
     drfParameters._stopping_tolerance = this.buildSpec.build_control.stopping_criteria.stopping_tolerance();
 
     Job randomForestJob = trainModel(null, work, drfParameters);
@@ -1056,6 +1057,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     DRFParameters drfParameters = new DRFParameters();
     setCommonModelBuilderParams(drfParameters);
+    drfParameters._score_tree_interval = 5;
     drfParameters._histogram_type = SharedTreeParameters.HistogramType.Random;
     drfParameters._stopping_tolerance = this.buildSpec.build_control.stopping_criteria.stopping_tolerance();
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -908,7 +908,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     commonXGBoostParameters._score_tree_interval = 5;
     commonXGBoostParameters._stopping_rounds = 5;
-//    commonXGBoostParameters._stopping_tolerance = Math.min(1e-2, RandomDiscreteValueSearchCriteria.default_stopping_tolerance_for_frame(this.trainingFrame));
 
     commonXGBoostParameters._ntrees = 10000;
     commonXGBoostParameters._learn_rate = 0.05;
@@ -991,7 +990,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     xgBoostParameters._score_tree_interval = 5;
     xgBoostParameters._stopping_rounds = 5;
-//    xgBoostParameters._stopping_tolerance = Math.min(1e-2, RandomDiscreteValueSearchCriteria.default_stopping_tolerance_for_frame(this.trainingFrame));
 
     xgBoostParameters._ntrees = 10000;
     xgBoostParameters._learn_rate = 0.05;
@@ -1147,7 +1145,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     // NOTE: removed MissingValuesHandling.Skip for now because it's crashing.  See https://0xdata.atlassian.net/browse/PUBDEV-4974
     searchParams.put("_missing_values_handling", new DeepLearningParameters.MissingValuesHandling[] {
             DeepLearningParameters.MissingValuesHandling.MeanImputation,
-            DeepLearningParameters.MissingValuesHandling.Skip
+//            DeepLearningParameters.MissingValuesHandling.Skip
     });
 
     Job<Grid> glmJob = hyperparameterSearch(gridKey, work, glmParameters, searchParams);

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -2,6 +2,10 @@ package ai.h2o.automl;
 
 import hex.Model;
 import hex.SplitFrame;
+import hex.tree.SharedTreeModel;
+import hex.tree.SharedTreeModel.SharedTreeParameters;
+import hex.tree.xgboost.XGBoostModel;
+import hex.tree.xgboost.XGBoostModel.XGBoostParameters;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import water.DKV;
@@ -517,26 +521,71 @@ public class AutoMLTest extends water.TestUtil {
     Frame fr=null;
     try {
       int maxModels = 20;
+      int seed = 0;
+      int nfolds = 0;  //this test currently fails if CV is enabled due to PUBDEV-6385 (the final model gets its `stopping_rounds` param reset to 0)
       AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
       fr = parse_test_file("./smalldata/logreg/prostate.csv");
       autoMLBuildSpec.input_spec.training_frame = fr._key;
       autoMLBuildSpec.input_spec.response_column = "CAPSULE";
 
       autoMLBuildSpec.build_control.stopping_criteria.set_max_models(maxModels);
-      autoMLBuildSpec.build_control.nfolds = 0;
+      autoMLBuildSpec.build_control.nfolds = nfolds;
+      autoMLBuildSpec.build_control.stopping_criteria.set_seed(seed);
 
       aml = AutoML.startAutoML(autoMLBuildSpec);
       aml.get();
-      assertEquals(maxModels, aml.leaderboard().getModelCount());
+      assertEquals(maxModels+(nfolds > 0 ? 2 : 0), aml.leaderboard().getModelCount());
 
       Key[] modelKeys = aml.leaderboard().getModelKeys();
-      int count_se = 0, count_non_se = 0;
-      Map<Algo, List<Key>> modelsByAlgo = new HashMap<>();
-      for (Algo algo : Algo.values()) modelsByAlgo.put(algo, new ArrayList<Key>());
-      for (Key k : modelKeys) if (k.toString().startsWith("StackedEnsemble")) count_se++; else count_non_se++;
+      Map<Algo, List<Key<Model>>> keysByAlgo = new HashMap<>();
+      for (Algo algo : Algo.values()) keysByAlgo.put(algo, new ArrayList<Key<Model>>());
+      for (Key k : modelKeys) {
+        if (k.toString().startsWith("XRT")) {
+          keysByAlgo.get(Algo.DRF).add(k);
+        } else for (Algo algo: Algo.values()) {
+          if (k.toString().startsWith(algo.name())) {
+            keysByAlgo.get(algo).add(k);
+            break;
+          }
+        }
+      }
 
-      assertEquals("wrong amount of standard models", 3, count_non_se);
-      assertEquals("no Stacked Ensemble expected if cross-validation is disabled", 0, count_se);
+      // verify that all keys were categorized
+      int count = 0; for (List<Key<Model>> keys : keysByAlgo.values()) count += keys.size();
+      assertEquals(aml.leaderboard().getModelCount(), count);
+
+      // check parameters constraints that should be set for all models
+      for (Algo algo: Algo.values()) {
+        Set<Long> collectedSeeds = new HashSet<>(); // according to AutoML logic, no model for same algo should have the same seed.
+        List<Key<Model>> keys = keysByAlgo.get(algo);
+        for (Key<Model> key : keys) {
+          Model.Parameters parameters = key.get()._parms;
+          assertTrue(parameters._seed != -1);
+          assertTrue(key+":"+parameters._seed, Math.abs(parameters._seed - seed) < maxModels);
+          collectedSeeds.add(parameters._seed);
+          assertTrue(key+" has `stopping_rounds` param set to "+parameters._stopping_rounds,
+                  parameters._stopping_rounds == 3 || algo == Algo.XGBoost);  // currently only enforced to different value for XGB (AutoML hardcoded)
+        }
+        assertTrue(collectedSeeds.size() > 1 || keys.size() < 2);  // we should have built enough models to guarantee this
+      }
+
+      //check model specific constraints
+      for (Algo algo : Arrays.asList(Algo.XGBoost)) {
+        List<Key<Model>> keys = keysByAlgo.get(algo);
+        for (Key<Model> key : keys) {
+          XGBoostParameters parameters = (XGBoostParameters)key.get()._parms;
+          assertEquals(5, parameters._score_tree_interval);
+          assertEquals(5, parameters._stopping_rounds); //should probably not be left enforced/hardcoded for XGB?
+        }
+      }
+
+      for (Algo algo : Arrays.asList(Algo.DRF, Algo.GBM)) {
+        List<Key<Model>> keys = keysByAlgo.get(algo);
+        for (Key<Model> key : keys) {
+          SharedTreeParameters parameters = (SharedTreeParameters)key.get()._parms;
+          assertEquals(5, parameters._score_tree_interval);
+        }
+      }
     } finally {
       // Cleanup
       if(aml!=null) aml.deleteWithChildren();

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -2,9 +2,7 @@ package ai.h2o.automl;
 
 import hex.Model;
 import hex.SplitFrame;
-import hex.tree.SharedTreeModel;
 import hex.tree.SharedTreeModel.SharedTreeParameters;
-import hex.tree.xgboost.XGBoostModel;
 import hex.tree.xgboost.XGBoostModel.XGBoostParameters;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -520,7 +518,7 @@ public class AutoMLTest extends water.TestUtil {
     AutoML aml=null;
     Frame fr=null;
     try {
-      int maxModels = 20;
+      int maxModels = 20; // generating enough models so that we can check every algo x every mode (single model + grid models)
       int seed = 0;
       int nfolds = 0;  //this test currently fails if CV is enabled due to PUBDEV-6385 (the final model gets its `stopping_rounds` param reset to 0)
       AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -509,8 +509,7 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
               // ToDo: This implementation only works for sequential model building.
               if (_set_model_seed_from_search_seed) {
                 // set model seed = search_criteria.seed+(0, 1, 2,..., model number)
-                params._seed=((HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria) _search_criteria).seed()+
-                        (model_number++);
+                params._seed = _search_criteria.seed() + (model_number++);
               }
 
               // set max_runtime_secs

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -209,8 +209,7 @@ def test_AUTO_stopping_metric_with_no_sorting_metric_binomial():
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     first = [m for m in non_se if 'XGBoost_1' in m]
     others = [m for m in non_se if m not in first]
-    # check_model_property(first, 'stopping_metric', True, "AUTO")  # disabling due to bug PUBDEV-6385
-    check_model_property(first, 'stopping_metric', True, "logloss") # should fail and replace by above once PUBDEV-6385 is fixed
+    check_model_property(first, 'stopping_metric', True, "AUTO")
     check_model_property(others, 'stopping_metric', True, "logloss")
 
 
@@ -228,8 +227,7 @@ def test_AUTO_stopping_metric_with_no_sorting_metric_regression():
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     first = [m for m in non_se if 'XGBoost_1' in m]
     others = [m for m in non_se if m not in first]
-    # check_model_property(first, 'stopping_metric', True, "AUTO")  # disabling due to bug PUBDEV-6385
-    check_model_property(first, 'stopping_metric', True, "deviance") # should fail and replace by above once PUBDEV-6385 is fixed
+    check_model_property(first, 'stopping_metric', True, "AUTO")
     check_model_property(others, 'stopping_metric', True, "deviance")
 
 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6569

Also added a test verifying that parameters required for reproducibility are set or propagated by default.
When writing this test, discovered that same seed was always reused for hardcoded GBM and XGB, so, as it was not designed to behave this way, made it work by fixing the AutoML part of https://0xdata.atlassian.net/browse/PUBDEV-6385 (ie cloning parameters instead of reusing them).