### PR TITLE
PUBDEV:6596 - Add new -jks_alias option to Starting H2O section

### DIFF
--- a/h2o-docs/src/product/starting-h2o.rst
+++ b/h2o-docs/src/product/starting-h2o.rst
@@ -277,6 +277,7 @@ Authentication Options
 
 -  ``-jks <filename>``: Specify a Java keystore file.
 -  ``-jks_pass <password>``: Specify the Java keystore password.
+-  ``-jks_alias <alias>``: Optional, use if the keystore has multiple certificates and you want to use a specific one.
 -  ``-hash_login``: Specify to use Jetty HashLoginService. This defaults to False.
 -  ``-ldap_login``: Specify to use Jetty LdapLoginService. This defaults to False.
 -  ``-kerberos_login``: Specify to use Kerberos LoginService. This defaults to False.


### PR DESCRIPTION
New -jks_alias option added to H2O-3 documentation. This option allows the user to specify certificate alias when starting H2O with SSL.

See: https://github.com/h2oai/h2o-3/pull/3564