### PR TITLE
hotfix: disable last two examples from R package

### DIFF
--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -5,7 +5,7 @@
 #' \dontrun{
 #' if (Sys.info()['sysname'] == "Darwin" && Sys.info()['release'] == '13.4.0') {
 #'   quit(save="no")
-#' } else{
+#' } else {
 #'  h2o.init(nthreads = 2)
 #' }
 #'}

--- a/h2o-r/h2o-package/R/logging.R
+++ b/h2o-r/h2o-package/R/logging.R
@@ -2,10 +2,12 @@
 #'
 #' @name aaa
 #' @examples
-#'if(Sys.info()['sysname'] == "Darwin" && Sys.info()['release'] == '13.4.0'){
-#'  quit(save="no")
-#'}else{
+#' \dontrun{
+#' if (Sys.info()['sysname'] == "Darwin" && Sys.info()['release'] == '13.4.0') {
+#'   quit(save="no")
+#' } else{
 #'  h2o.init(nthreads = 2)
+#' }
 #'}
 NULL
 
@@ -13,10 +15,12 @@ NULL
 #'
 #' @name zzz
 #' @examples
+#' \dontrun{
 #' library(h2o)
 #' h2o.init()
 #' h2o.shutdown(prompt = FALSE)
 #' Sys.sleep(3)
+#' }
 NULL
 
 # Initialize functions for R logging


### PR DESCRIPTION
These two functions should also have a `\dontrun` around them because they still start up the H2O cluster upon CRAN submission (which we don't want) because of reasons cited [here](https://0xdata.atlassian.net/browse/PUBDEV-6501).  Follow-up to: https://github.com/h2oai/h2o-3/pull/3544