### PR TITLE
PUBDEV-6410: Isolation Forest - early stopping on mean anomaly score

### DIFF
--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -508,7 +508,7 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
           stopped_early = true;
         }
         if (ScoreKeeper.stopEarly(ScoringInfo.scoreKeepers(scoring_history()),
-                get_params()._stopping_rounds, _output.isClassifier(), get_params()._stopping_metric, get_params()._stopping_tolerance, "model's last", true
+                get_params()._stopping_rounds, ScoreKeeper.ProblemType.forSupervised(_output.isClassifier()), get_params()._stopping_metric, get_params()._stopping_tolerance, "model's last", true
         )) {
           Log.info("Convergence detected based on simple moving average of the loss function for the past " + get_params()._stopping_rounds + " scoring events. Model building completed.");
           stopped_early = true;

--- a/h2o-algos/src/main/java/hex/deepwater/DeepWaterModel.java
+++ b/h2o-algos/src/main/java/hex/deepwater/DeepWaterModel.java
@@ -460,7 +460,7 @@ public class DeepWaterModel extends Model<DeepWaterModel,DeepWaterParameters,Dee
         if (keep_running && printme)
           Log.info(toString());
         if (ScoreKeeper.stopEarly(ScoringInfo.scoreKeepers(scoring_history()),
-                get_params()._stopping_rounds, _output.isClassifier(), get_params()._stopping_metric, get_params()._stopping_tolerance, "model's last", true
+                get_params()._stopping_rounds, ScoreKeeper.ProblemType.forSupervised(_output.isClassifier()), get_params()._stopping_metric, get_params()._stopping_tolerance, "model's last", true
         )) {
           Log.info("Convergence detected based on simple moving average of the loss function for the past " + get_params()._stopping_rounds + " scoring events. Model building completed.");
           stopped_early = true;

--- a/h2o-algos/src/main/java/hex/schemas/IsolationForestV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/IsolationForestV3.java
@@ -26,6 +26,9 @@ public class IsolationForestV3 extends SharedTreeV3<IsolationForest, IsolationFo
                 "col_sample_rate_change_per_level",
                 "col_sample_rate_per_tree",
                 "categorical_encoding",
+                "stopping_rounds",
+                "stopping_metric",
+                "stopping_tolerance",
                 "export_checkpoints_dir"
         };
 

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -431,7 +431,7 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
       for( int tid=0; tid< _ntrees; tid++) {
         // During first iteration model contains 0 trees, then 1-tree, ...
         boolean scored = doScoringAndSaveModel(false, oob, _parms._build_tree_one_node);
-        if (scored && ScoreKeeper.stopEarly(_model._output.scoreKeepers(), _parms._stopping_rounds, _nclass > 1, _parms._stopping_metric, _parms._stopping_tolerance, "model's last", true)) {
+        if (scored && ScoreKeeper.stopEarly(_model._output.scoreKeepers(), _parms._stopping_rounds, getProblemType(), _parms._stopping_metric, _parms._stopping_tolerance, "model's last", true)) {
           doScoringAndSaveModel(true, oob, _parms._build_tree_one_node);
           _job.update(_ntrees-_model._output._ntrees); //finish
           return;
@@ -454,6 +454,11 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
     }
   }
 
+  protected ScoreKeeper.ProblemType getProblemType() {
+    assert isSupervised();
+    return ScoreKeeper.ProblemType.forSupervised(_nclass > 1);
+  }
+  
   // --------------------------------------------------------------------------
   // Build an entire layer of all K trees
   protected DHistogram[][][] buildLayer(final Frame fr, final int nbins, int nbins_cats, final DTree ktrees[], final int leafs[], final DHistogram hcs[][][], boolean build_tree_one_node) {

--- a/h2o-algos/src/main/java/hex/tree/isofor/IsolationForest.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/IsolationForest.java
@@ -51,6 +51,8 @@ public class IsolationForest extends SharedTree<IsolationForestModel, IsolationF
 
   @Override public boolean isSupervised() { return false; }
 
+  @Override protected ScoreKeeper.ProblemType getProblemType() { return ScoreKeeper.ProblemType.anomaly_detection; }
+
   @Override public void init(boolean expensive) {
     super.init(expensive);
     // Initialize local variables

--- a/h2o-algos/src/main/java/hex/tree/isofor/IsolationForestModel.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/IsolationForestModel.java
@@ -2,6 +2,7 @@ package hex.tree.isofor;
 
 import hex.ModelCategory;
 import hex.ModelMetrics;
+import hex.ScoreKeeper;
 import hex.genmodel.utils.DistributionFamily;
 import hex.tree.SharedTreeModel;
 import water.Key;
@@ -31,6 +32,9 @@ public class IsolationForestModel extends SharedTreeModel<IsolationForestModel, 
       // _nbins_top_level = 2;
       _histogram_type = HistogramType.Random;
       _distribution = DistributionFamily.gaussian;
+
+      // early stopping
+      _stopping_tolerance = 0.01; // (default 0.001 is too low for the default criterion anomaly_score)
     }
   }
 

--- a/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
+++ b/h2o-algos/src/test/java/hex/tree/isofor/IsolationForestTest.java
@@ -45,6 +45,32 @@ public class IsolationForestTest extends TestUtil {
   }
 
   @Test
+  public void testEarlyStopping() {
+    try {
+      Scope.enter();
+      Frame train = Scope.track(parse_test_file("smalldata/anomaly/ecg_discord_train.csv"));
+
+      IsolationForestModel.IsolationForestParameters p = new IsolationForestModel.IsolationForestParameters();
+      p._train = train._key;
+      p._seed = 0xDECAF;
+      p._ntrees = 1000;
+      p._min_rows = 1;
+      p._sample_size = 5;
+      p._stopping_rounds = 3;
+      p._score_each_iteration = true;
+      p._stopping_tolerance = 0.05;
+
+      IsolationForestModel model = new IsolationForest(p).trainModel().get();
+      assertNotNull(model);
+      Scope.track_generic(model);
+
+      assertEquals(0, model._output._ntrees, 20); // stops in 20 trees or less
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
   public void testEmptyOOB() {
     try {
       Scope.enter();

--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -132,6 +132,10 @@ def gen_module(schema, algo):
             enum_values.remove(u'quasibinomial')
         if (pname==u'distribution') and (not(algo==u'glm')):    # ordinal only in glm
             enum_values.remove(u'ordinal')
+        if (pname==u'stopping_metric') and (not(algo==u'isolationforest')):    # anomaly_score only in Isolation Forest
+            enum_values.remove(u'anomaly_score')
+        if (pname == u'stopping_metric') and (algo == u'isolationforest'):
+            enum_values = [u'AUTO', u'anomaly_score']
         if pname in reserved_words: pname += "_"
         param_names.append(pname)
         param["pname"] = pname

--- a/h2o-core/src/main/java/hex/ScoringInfo.java
+++ b/h2o-core/src/main/java/hex/ScoringInfo.java
@@ -91,16 +91,12 @@ public class ScoringInfo extends Iced<ScoringInfo> {
    * @param criterion scalar model metric / stopping criterion by which to sort
    * @return a Comparator on a stopping criterion / metric
    */
-  public static final Comparator<ScoringInfo> comparator(final ScoreKeeper.StoppingMetric criterion) {
+  public static Comparator<ScoringInfo> comparator(final ScoreKeeper.StoppingMetric criterion) {
+    final int direction = criterion.direction();
     return new Comparator<ScoringInfo>() {
       @Override
       public int compare(ScoringInfo o1, ScoringInfo o2) {
-        boolean moreIsBetter = ScoreKeeper.moreIsBetter(criterion);
-
-        if (!moreIsBetter)
-          return (int)Math.signum(o2.metric(criterion) - o1.metric(criterion));
-        else
-          return (int)Math.signum(o1.metric(criterion) - o2.metric(criterion));
+        return direction * (int)Math.signum(o1.metric(criterion) - o2.metric(criterion));
       }
     };
   }

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -466,7 +466,7 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
     public boolean stopEarly(Model model, ScoringInfo[] sk) {
       return ScoreKeeper.stopEarly(ScoringInfo.scoreKeepers(sk),
                                    search_criteria().stopping_rounds(),
-                                   model._output.isClassifier(),
+                                    ScoreKeeper.ProblemType.forSupervised(model._output.isClassifier()),
                                    search_criteria().stopping_metric(),
                                    search_criteria().stopping_tolerance(), "grid's best", true);
     }

--- a/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
@@ -161,8 +161,7 @@ public class ModelParametersSchemaV3<P extends Model.Parameters, S extends Model
   /**
    * Metric to use for convergence checking, only for _stopping_rounds > 0
    */
-//  @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression)", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "r2"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
-  @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom and custom_increasing can only be used in GBM and DRF with the Python client.", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
+  @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python client.", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
   public ScoreKeeper.StoppingMetric stopping_metric;
 
   @API(help = "Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)", level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)

--- a/h2o-core/src/test/java/hex/ScoreKeeperTest.java
+++ b/h2o-core/src/test/java/hex/ScoreKeeperTest.java
@@ -1,8 +1,9 @@
 package hex;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import water.TestUtil;
 import water.util.Log;
 
@@ -10,12 +11,22 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Random;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+import static org.junit.Assert.assertTrue;
+
 public class ScoreKeeperTest extends TestUtil {
   @BeforeClass
   public static void stall() { stall_till_cloudsize(1); }
 
   // implement early stopping logic from scratch
-  static boolean stopEarly(double[] val, int k, double tolerance, boolean moreIsBetter, boolean verbose) {
+  private static boolean stopEarly(double[] val, int k, double tolerance, boolean moreIsBetter, boolean verbose) {
     if (val.length-1 < 2*k) return false; //need 2k scoring events (+1 to skip the very first one, which might be full of NaNs)
     double[] moving_avg = new double[k+1]; //one moving avg for the last k+1 scoring events (1 is reference, k consecutive attempts to improve)
 
@@ -84,7 +95,7 @@ public class ScoreKeeperTest extends TestUtil {
       Log.info("relative tolerance: " + tol);
       for (int k=values.length-1;k>0;k--) {
         boolean c = stopEarly(values, k, tol, moreIsBetter, false /*verbose*/);
-        boolean d = ScoreKeeper.stopEarly(sk, k, true /*classification*/, metric, tol, "JUnit's", false /*verbose*/);
+        boolean d = ScoreKeeper.stopEarly(sk, k, ScoreKeeper.ProblemType.classification, metric, tol, "JUnit's", false /*verbose*/);
         // for debugging
 //        Log.info("Checking for stopping condition with k=" + k + ": " + c + " " + d);
         if (c || d) Log.info("Stopped for k=" + k);
@@ -96,7 +107,7 @@ public class ScoreKeeperTest extends TestUtil {
 //          stopEarly(values, k, tol, moreIsBetter, true /*verbose*/);
 //          ScoreKeeper.stopEarly(sk, k, true /*classification*/, metric, tol, "JUnit", true /*verbose*/);
 //        }
-        Assert.assertTrue("For k="+k+", JUnit: " + c + ", ScoreKeeper: " + d, c == d);
+        assertTrue("For k="+k+", JUnit: " + c + ", ScoreKeeper: " + d, c == d);
       }
     }
   }
@@ -140,10 +151,79 @@ public class ScoreKeeperTest extends TestUtil {
         ScoreKeeper.StoppingMetric metric = moreIsBetter ? ScoreKeeper.StoppingMetric.AUC : ScoreKeeper.StoppingMetric.logloss;
         ScoreKeeper[] sk = fillScoreKeeperArray(values, moreIsBetter);
         boolean c = stopEarly(values, k, tol, moreIsBetter, true /*verbose*/);
-        boolean d = ScoreKeeper.stopEarly(sk, k, true /*classification*/, metric, tol, "JUnit's", true /*verbose*/);
-        Assert.assertTrue("For k=" + k + ", JUnit: " + c + ", ScoreKeeper: " + d, c == d);
+        boolean d = ScoreKeeper.stopEarly(sk, k, ScoreKeeper.ProblemType.classification, metric, tol, "JUnit's", true /*verbose*/);
+        assertTrue("For k=" + k + ", JUnit: " + c + ", ScoreKeeper: " + d, c == d);
       }
     }
+  }
+
+  @Test
+  public void testHitLowerBound() {
+    ScoreKeeper[] sks = new ScoreKeeper[]{
+            new ScoreKeeper(0.3),
+            new ScoreKeeper(0.2),
+            new ScoreKeeper(0.1),
+            new ScoreKeeper(0.0),
+            new ScoreKeeper(0.0)
+    };
+    
+    boolean stopEarly = ScoreKeeper.stopEarly(sks, 1, ScoreKeeper.ProblemType.regression, ScoreKeeper.StoppingMetric.MSE, 0.01, "MSE", true);
+    assertTrue(stopEarly);
+  }
+
+  @Test
+  public void testQueryConvergenceStrategy() { // ConvergenceStrategy gets the right input to make the decision
+    ScoreKeeper.IConvergenceStrategy mockConvergence = mock(ScoreKeeper.IConvergenceStrategy.class);
+    ScoreKeeper.IStoppingMetric mockMetric = mock(ScoreKeeper.IStoppingMetric.class);
+    when(mockMetric.getConvergenceStrategy()).thenReturn(mockConvergence);
+    when(mockMetric.metricValue(any(ScoreKeeper.class))).thenAnswer(new Answer<Double>() {
+      @Override
+      public Double answer(InvocationOnMock invocation)  {
+        return ((ScoreKeeper) invocation.getArgument(0))._mse;
+      }
+    });
+    when(mockConvergence.extremePoint(anyDouble(), anyDouble(), anyDouble())).thenReturn(0.1);
+
+    ScoreKeeper[] sks = new ScoreKeeper[]{
+            new ScoreKeeper(0.6),
+            new ScoreKeeper(0.5),
+            new ScoreKeeper(0.4),
+            new ScoreKeeper(0.3),
+            new ScoreKeeper(0.2),
+            new ScoreKeeper(0.1)
+    };
+
+    ScoreKeeper.stopEarly(sks, 2, ScoreKeeper.ProblemType.regression, mockMetric, 0.01, "Mock", true);
+
+    verify(mockConvergence).extremePoint(0.35d, 0.15000000000000002d, 0.25);
+    verify(mockConvergence).stopEarly(0.35d, 0.15000000000000002d, 0.25, 0.01);
+  }
+
+  @Test
+  public void testConvergenceStrategy_extremePoint() {
+    assertEquals(0.2, ScoreKeeper.ConvergenceStrategy.MORE_IS_BETTER.extremePoint(0, 0.1, 0.2), 0);
+    assertEquals(0.1, ScoreKeeper.ConvergenceStrategy.LESS_IS_BETTER.extremePoint(0, 0.1, 0.2), 0);
+    assertEquals(0.1, ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.extremePoint(0.16, 0.1, 0.2), 0);
+    assertEquals(0.2, ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.extremePoint(0.14, 0.1, 0.2), 0);
+  }
+
+  @Test
+  public void testConvergenceStrategy_stopEarly() {
+    assertFalse(ScoreKeeper.ConvergenceStrategy.MORE_IS_BETTER.stopEarly(0.1, 0.1, 0.2, 0.01));
+    assertFalse(ScoreKeeper.ConvergenceStrategy.MORE_IS_BETTER.stopEarly(0.1, 0.1, 0.2, 0.1));
+    assertTrue(ScoreKeeper.ConvergenceStrategy.MORE_IS_BETTER.stopEarly(0.1, 0.1, 0.2, 1.0));
+
+    assertFalse(ScoreKeeper.ConvergenceStrategy.LESS_IS_BETTER.stopEarly(0.2, 0.1, 0.3, 0.01));
+    assertFalse(ScoreKeeper.ConvergenceStrategy.LESS_IS_BETTER.stopEarly(0.2, 0.1, 0.3, 0.1));
+    assertTrue(ScoreKeeper.ConvergenceStrategy.LESS_IS_BETTER.stopEarly(0.2, 0.1, 0.3, 1.0));
+
+    assertFalse(ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.stopEarly(0.14, 0.1, 0.2, 0.01));
+    assertFalse(ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.stopEarly(0.14, 0.1, 0.2, 0.1));
+    assertTrue(ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.stopEarly(0.14, 0.1, 0.2, 1.0));
+
+    assertFalse(ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.stopEarly(0.16, 0.1, 0.2, 0.01));
+    assertFalse(ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.stopEarly(0.16, 0.1, 0.2, 0.1));
+    assertTrue(ScoreKeeper.ConvergenceStrategy.NON_DIRECTIONAL.stopEarly(0.16, 0.1, 0.2, 1.0));
   }
 
 }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -377,7 +377,7 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
       for( int tid=0; tid< _parms._ntrees; tid++) {
         // During first iteration model contains 0 trees, then 1-tree, ...
         boolean scored = doScoring(model, boosterProvider, false);
-        if (scored && ScoreKeeper.stopEarly(model._output.scoreKeepers(), _parms._stopping_rounds, _nclass > 1, _parms._stopping_metric, _parms._stopping_tolerance, "model's last", true)) {
+        if (scored && ScoreKeeper.stopEarly(model._output.scoreKeepers(), _parms._stopping_rounds, ScoreKeeper.ProblemType.forSupervised(_nclass > 1), _parms._stopping_metric, _parms._stopping_tolerance, "model's last", true)) {
           Log.info("Early stopping triggered - stopping XGBoost training");
           break;
         }

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1005,14 +1005,14 @@ class H2ODeepLearningEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
-        ``"custom_increasing"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
+        (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1000,18 +1000,19 @@ class H2ODeepLearningEstimator(H2OEstimator):
     @property
     def stopping_metric(self):
         """
-        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-        and custom_increasing can only be used in GBM and DRF with the Python client.
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -637,18 +637,19 @@ class H2ODeepWaterEstimator(H2OEstimator):
     @property
     def stopping_metric(self):
         """
-        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-        and custom_increasing can only be used in GBM and DRF with the Python client.
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -642,14 +642,14 @@ class H2ODeepWaterEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
-        ``"custom_increasing"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
+        (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -487,18 +487,19 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @property
     def stopping_metric(self):
         """
-        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-        and custom_increasing can only be used in GBM and DRF with the Python client.
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -492,14 +492,14 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
-        ``"custom_increasing"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
+        (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/isolation_forest.py
+++ b/h2o-py/h2o/estimators/isolation_forest.py
@@ -326,15 +326,13 @@ class H2OIsolationForestEstimator(H2OEstimator):
         for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
         client.
 
-        One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
-        ``"custom_increasing"``  (default: ``"auto"``).
+        One of: ``"AUTO"``, ``"anomaly_score"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("AUTO", "anomaly_score"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/isolation_forest.py
+++ b/h2o-py/h2o/estimators/isolation_forest.py
@@ -31,7 +31,8 @@ class H2OIsolationForestEstimator(H2OEstimator):
         names_list = {"model_id", "training_frame", "score_each_iteration", "score_tree_interval", "ignored_columns",
                       "ignore_const_cols", "ntrees", "max_depth", "min_rows", "max_runtime_secs", "seed",
                       "build_tree_one_node", "mtries", "sample_size", "sample_rate", "col_sample_rate_change_per_level",
-                      "col_sample_rate_per_tree", "categorical_encoding", "export_checkpoints_dir"}
+                      "col_sample_rate_per_tree", "categorical_encoding", "stopping_rounds", "stopping_metric",
+                      "stopping_tolerance", "export_checkpoints_dir"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
@@ -300,6 +301,56 @@ class H2OIsolationForestEstimator(H2OEstimator):
     def categorical_encoding(self, categorical_encoding):
         assert_is_type(categorical_encoding, None, Enum("auto", "enum", "one_hot_internal", "one_hot_explicit", "binary", "eigen", "label_encoder", "sort_by_response", "enum_limited"))
         self._parms["categorical_encoding"] = categorical_encoding
+
+
+    @property
+    def stopping_rounds(self):
+        """
+        Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
+        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable)
+
+        Type: ``int``  (default: ``0``).
+        """
+        return self._parms.get("stopping_rounds")
+
+    @stopping_rounds.setter
+    def stopping_rounds(self, stopping_rounds):
+        assert_is_type(stopping_rounds, None, int)
+        self._parms["stopping_rounds"] = stopping_rounds
+
+
+    @property
+    def stopping_metric(self):
+        """
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
+
+        One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
+        """
+        return self._parms.get("stopping_metric")
+
+    @stopping_metric.setter
+    def stopping_metric(self, stopping_metric):
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
+        self._parms["stopping_metric"] = stopping_metric
+
+
+    @property
+    def stopping_tolerance(self):
+        """
+        Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)
+
+        Type: ``float``  (default: ``0.01``).
+        """
+        return self._parms.get("stopping_tolerance")
+
+    @stopping_tolerance.setter
+    def stopping_tolerance(self, stopping_tolerance):
+        assert_is_type(stopping_tolerance, None, numeric)
+        self._parms["stopping_tolerance"] = stopping_tolerance
 
 
     @property

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -486,14 +486,14 @@ class H2ORandomForestEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
-        ``"custom_increasing"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
+        (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -481,18 +481,19 @@ class H2ORandomForestEstimator(H2OEstimator):
     @property
     def stopping_metric(self):
         """
-        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-        and custom_increasing can only be used in GBM and DRF with the Python client.
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -282,18 +282,19 @@ class H2OXGBoostEstimator(H2OEstimator):
     @property
     def stopping_metric(self):
         """
-        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-        and custom_increasing can only be used in GBM and DRF with the Python client.
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -287,14 +287,14 @@ class H2OXGBoostEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"anomaly_score"``, ``"custom"``,
-        ``"custom_increasing"``  (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
+        (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -99,8 +99,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
-#'        Defaults to AUTO.
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
+#'        AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -209,7 +209,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              classification_stop = 0,
                              regression_stop = 1e-06,
                              stopping_rounds = 5,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                              stopping_tolerance = 0,
                              max_runtime_secs = 0,
                              score_validation_sampling = c("Uniform", "Stratified"),

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -96,10 +96,11 @@
 #' @param regression_stop Stopping criterion for regression error (MSE) on training data (-1 to disable). Defaults to 1e-06.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 5.
-#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-#'        and custom_increasing can only be used in GBM and DRF with the Python client. Must be one of: "AUTO",
-#'        "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error", "custom", "custom_increasing". Defaults to AUTO.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -208,7 +209,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              classification_stop = 0,
                              regression_stop = 1e-06,
                              stopping_rounds = 5,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
                              stopping_tolerance = 0,
                              max_runtime_secs = 0,
                              score_validation_sampling = c("Uniform", "Stratified"),

--- a/h2o-r/h2o-package/R/deepwater.R
+++ b/h2o-r/h2o-package/R/deepwater.R
@@ -66,10 +66,11 @@
 #' @param regression_stop Stopping criterion for regression error (MSE) on training data (-1 to disable). Defaults to 0.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 5.
-#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-#'        and custom_increasing can only be used in GBM and DRF with the Python client. Must be one of: "AUTO",
-#'        "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error", "custom", "custom_increasing". Defaults to AUTO.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -141,7 +142,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           classification_stop = 0,
                           regression_stop = 0,
                           stopping_rounds = 5,
-                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
                           stopping_tolerance = 0,
                           max_runtime_secs = 0,
                           ignore_const_cols = TRUE,

--- a/h2o-r/h2o-package/R/deepwater.R
+++ b/h2o-r/h2o-package/R/deepwater.R
@@ -69,8 +69,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
-#'        Defaults to AUTO.
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
+#'        AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -142,7 +142,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           classification_stop = 0,
                           regression_stop = 0,
                           stopping_rounds = 5,
-                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
+                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                           stopping_tolerance = 0,
                           max_runtime_secs = 0,
                           ignore_const_cols = TRUE,

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -59,8 +59,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
-#'        Defaults to AUTO.
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
+#'        AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -142,7 +142,7 @@ h2o.gbm <- function(x, y, training_frame,
                     nbins_cats = 1024,
                     r2_stopping = 1.797693135e+308,
                     stopping_rounds = 0,
-                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
+                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                     stopping_tolerance = 0.001,
                     max_runtime_secs = 0,
                     seed = -1,

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -56,10 +56,11 @@
 #'        exceeds this Defaults to 1.797693135e+308.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
-#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-#'        and custom_increasing can only be used in GBM and DRF with the Python client. Must be one of: "AUTO",
-#'        "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error", "custom", "custom_increasing". Defaults to AUTO.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -141,7 +142,7 @@ h2o.gbm <- function(x, y, training_frame,
                     nbins_cats = 1024,
                     r2_stopping = 1.797693135e+308,
                     stopping_rounds = 0,
-                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
                     stopping_tolerance = 0.001,
                     max_runtime_secs = 0,
                     seed = -1,

--- a/h2o-r/h2o-package/R/isolationforest.R
+++ b/h2o-r/h2o-package/R/isolationforest.R
@@ -34,9 +34,7 @@
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
-#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
-#'        Defaults to AUTO.
+#'        with the Python client. Must be one of: "AUTO", "anomaly_score". Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.01.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
@@ -59,7 +57,7 @@ h2o.isolationForest <- function(training_frame, x,
                                 col_sample_rate_per_tree = 1,
                                 categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
                                 stopping_rounds = 0,
-                                stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
+                                stopping_metric = c("AUTO", "anomaly_score"),
                                 stopping_tolerance = 0.01,
                                 export_checkpoints_dir = NULL
                                 ) 

--- a/h2o-r/h2o-package/R/isolationforest.R
+++ b/h2o-r/h2o-package/R/isolationforest.R
@@ -30,6 +30,15 @@
 #' @param col_sample_rate_per_tree Column sample rate per tree (from 0.0 to 1.0) Defaults to 1.
 #' @param categorical_encoding Encoding scheme for categorical features Must be one of: "AUTO", "Enum", "OneHotInternal", "OneHotExplicit",
 #'        "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited". Defaults to AUTO.
+#' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
+#'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
+#'        Defaults to AUTO.
+#' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
+#'        much) Defaults to 0.01.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
 #' @export
 h2o.isolationForest <- function(training_frame, x,
@@ -49,6 +58,9 @@ h2o.isolationForest <- function(training_frame, x,
                                 col_sample_rate_change_per_level = 1,
                                 col_sample_rate_per_tree = 1,
                                 categorical_encoding = c("AUTO", "Enum", "OneHotInternal", "OneHotExplicit", "Binary", "Eigen", "LabelEncoder", "SortByResponse", "EnumLimited"),
+                                stopping_rounds = 0,
+                                stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
+                                stopping_tolerance = 0.01,
                                 export_checkpoints_dir = NULL
                                 ) 
 {
@@ -93,6 +105,12 @@ h2o.isolationForest <- function(training_frame, x,
     parms$col_sample_rate_per_tree <- col_sample_rate_per_tree
   if (!missing(categorical_encoding))
     parms$categorical_encoding <- categorical_encoding
+  if (!missing(stopping_rounds))
+    parms$stopping_rounds <- stopping_rounds
+  if (!missing(stopping_metric))
+    parms$stopping_metric <- stopping_metric
+  if (!missing(stopping_tolerance))
+    parms$stopping_tolerance <- stopping_tolerance
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
   # Error check and build model

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -53,10 +53,11 @@
 #'        exceeds this Defaults to 1.797693135e+308.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
-#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-#'        and custom_increasing can only be used in GBM and DRF with the Python client. Must be one of: "AUTO",
-#'        "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error", "custom", "custom_increasing". Defaults to AUTO.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -117,7 +118,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              nbins_cats = 1024,
                              r2_stopping = 1.797693135e+308,
                              stopping_rounds = 0,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
                              stopping_tolerance = 0.001,
                              max_runtime_secs = 0,
                              seed = -1,

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -56,8 +56,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
-#'        Defaults to AUTO.
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
+#'        AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -118,7 +118,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              nbins_cats = 1024,
                              r2_stopping = 1.797693135e+308,
                              stopping_rounds = 0,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                              stopping_tolerance = 0.001,
                              max_runtime_secs = 0,
                              seed = -1,

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -35,8 +35,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
-#'        Defaults to AUTO.
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
+#'        AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -107,7 +107,7 @@ h2o.xgboost <- function(x, y, training_frame,
                         offset_column = NULL,
                         weights_column = NULL,
                         stopping_rounds = 0,
-                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
+                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
                         stopping_tolerance = 0.001,
                         max_runtime_secs = 0,
                         seed = -1,

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -32,10 +32,11 @@
 #'        well. During training, rows with higher weights matter more, due to the larger loss function pre-factor.
 #' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
 #'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
-#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression). Note that custom
-#'        and custom_increasing can only be used in GBM and DRF with the Python client. Must be one of: "AUTO",
-#'        "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification",
-#'        "mean_per_class_error", "custom", "custom_increasing". Defaults to AUTO.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -106,7 +107,7 @@ h2o.xgboost <- function(x, y, training_frame,
                         offset_column = NULL,
                         weights_column = NULL,
                         stopping_rounds = 0,
-                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"),
                         stopping_tolerance = 0.001,
                         max_runtime_secs = 0,
                         seed = -1,


### PR DESCRIPTION
This PR adds support for early stopping on mean `anomaly_score` in Isolation Forest. In order to do that, I had to refactor ScoreKeeper quite a bit: adding both @wendycwong and @maurever to the review.