### PR TITLE
Early detectuion of no numerical columns in the scaled frame. Added a test for that case.

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstScale.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstScale.java
@@ -10,6 +10,7 @@ import water.rapids.vals.ValFrame;
 import water.rapids.ast.AstPrimitive;
 import water.rapids.ast.AstRoot;
 import water.rapids.ast.params.AstNumList;
+import water.util.Log;
 
 import java.util.Arrays;
 
@@ -42,6 +43,11 @@ public class AstScale extends AstPrimitive {
       if (v.get_type() == Vec.T_NUM) {
         numericFrame.add(originalFrame.name(i), v);
       }
+    }
+
+    if (numericFrame.numCols() == 0) {
+      Log.info("Nothing scaled in frame '%s'. There are no numeric columns.");
+      return new ValFrame(originalFrame);
     }
 
     final double[] means = calcMeans(env, asts[2], numericFrame);

--- a/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstScaleTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstScaleTest.java
@@ -76,6 +76,31 @@ public class AstScaleTest extends TestUtil {
   }
 
   @Test
+  public void testScaleNoNumeric() {
+    Scope.enter();
+    try {
+      Frame fr = new TestFrameBuilder()
+              .withColNames("C1", "C2")
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "c", "d"))
+              .withDataForCol(1, ar("a", "b", "c", "d"))
+              .build();
+      Frame expected = new TestFrameBuilder()
+              .withColNames("C1", "C2")
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "c", "d"))
+              .withDataForCol(1, ar("a", "b", "c", "d"))
+              .build();
+
+      ValFrame v = (ValFrame) Rapids.exec("(scale " + fr._key + " 1 1)");
+
+      compareFrames(expected, v.getFrame(), 1e-10);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
   public void testCalcMeans_invalidCols() {
     Frame fr = mock(Frame.class);
     AstRoot meanSpec = mock(AstNumList.class);


### PR DESCRIPTION
Just a quick 5 minute adjustment. Merge it or throw it away. Your call @michalkurka .

Test the case with no numerical column for `AstScale`. Also, do not do all the computation if there is no numerical column to apply it to. Just return the original frame and print info about no-op/identity operation was done.