### PR TITLE
[HOTFIX] Fix h2o.scale, H2OScaler provides "means" even for non-numerical columns

### DIFF
--- a/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstScaleTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstScaleTest.java
@@ -94,7 +94,7 @@ public class AstScaleTest extends TestUtil {
 
       ValFrame v = (ValFrame) Rapids.exec("(scale " + fr._key + " 1 1)");
 
-      compareFrames(expected, v.getFrame(), 1e-10);
+      compareFrames(expected, v.getFrame());
     } finally {
       Scope.exit();
     }
@@ -102,28 +102,32 @@ public class AstScaleTest extends TestUtil {
 
   @Test
   public void testCalcMeans_invalidCols() {
+    Frame origFr = mock(Frame.class);
     Frame fr = mock(Frame.class);
     AstRoot meanSpec = mock(AstNumList.class);
 
     when(fr.numCols()).thenReturn(43);
     when(((AstNumList) meanSpec).expand()).thenReturn(new double[4]);
 
-    ee.expectMessage("Numlist must be the same length as the numeric columns of the Frame");
+    ee.expectMessage("Values must be the same length as is the number of columns of the Frame to scale" +
+            " (fill 0 for non-numeric columns).");
     
-    AstScale.calcMeans(null, meanSpec, fr);
+    AstScale.calcMeans(null, meanSpec, fr, origFr);
   }
 
   @Test
   public void testCalcMults_invalidCols() {
+    Frame origFr = mock(Frame.class);
     Frame fr = mock(Frame.class);
     AstRoot multSpec = mock(AstNumList.class);
 
     when(fr.numCols()).thenReturn(43);
     when(((AstNumList) multSpec).expand()).thenReturn(new double[4]);
 
-    ee.expectMessage("Numlist must be the same length as the numeric columns of the Frame");
+    ee.expectMessage("Values must be the same length as is the number of columns of the Frame to scale" +
+            " (fill 0 for non-numeric columns).");
 
-    AstScale.calcMults(null, multSpec, fr);
+    AstScale.calcMults(null, multSpec, fr, origFr);
   }
 
 }

--- a/h2o-py/tests/testdir_munging/pyunit_h2oscaler.py
+++ b/h2o-py/tests/testdir_munging/pyunit_h2oscaler.py
@@ -1,0 +1,23 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.transforms.preprocessing import H2OScaler
+
+
+def test_scaler():
+    iris = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris.csv"))
+
+    scaler = H2OScaler()
+    scaler.fit(iris)
+
+    iris_transformed = scaler.transform(iris)
+
+    assert [[u'Iris-setosa', u'Iris-versicolor', u'Iris-virginica']] == iris_transformed["C5"].levels()
+    assert max(iris_transformed[["C1", "C2", "C3", "C4"]].mean().as_data_frame().transpose()[0].tolist()) < 1e-10
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_scaler)
+else:
+    test_scaler()


### PR DESCRIPTION
It makes more sense to get the array for the whole Frame, this way
it is easier to map desired mean valus to the columns that should be
scaled.