### PR TITLE
PUBDEV-6619: Remove Deep Water booklet from download page & docs gradlew build

### DIFF
--- a/h2o-dist/buildinfo.json
+++ b/h2o-dist/buildinfo.json
@@ -256,11 +256,6 @@
             "name" : "Sparkling Water",
             "id"   : "booklet-sparklingwater",
             "path" : "docs-website/h2o-docs/booklets/SparklingWaterBooklet.pdf"
-        },
-        {
-            "name" : "Deep Water",
-            "id"   : "booklet-deepwater",
-            "path" : "docs-website/h2o-docs/booklets/DeepWaterBooklet.pdf"
         }
     ]
 }

--- a/h2o-docs/build.gradle
+++ b/h2o-docs/build.gradle
@@ -13,8 +13,7 @@ def bookletList = [
             "DeepLearningBooklet",
             "SparklingWaterBooklet",
             "RBooklet",
-            "PythonBooklet",
-            "DeepWaterBooklet"]
+            "PythonBooklet"]
 
 task(createBuildInfoTex) {
     doLast {


### PR DESCRIPTION
Deep Water no longer being maintained - changes made to buildinfo.json and build.grade to remove Deep Water booklet content.

See https://0xdata.atlassian.net/browse/PUBDEV-6619