### PR TITLE
Mark AutoML tests checking time constraints tests as NOPASS

### DIFF
--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -3,6 +3,7 @@ package ai.h2o.automl;
 import hex.Model;
 import hex.SplitFrame;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import water.DKV;
 import water.Key;
@@ -193,6 +194,7 @@ public class AutoMLTest extends water.TestUtil {
   }
 
 
+  @Ignore
   @Test public void test_individual_model_max_runtime() {
     AutoML aml=null;
     Frame fr=null;

--- a/h2o-py/tests/testdir_algos/automl/pyunit_NOPASS_automl_timing.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_NOPASS_automl_timing.py
@@ -1,0 +1,59 @@
+from __future__ import print_function
+import sys, os, time
+
+from h2o.exceptions import H2OTypeError
+
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils
+from h2o.automl import H2OAutoML
+
+"""
+Those tests check time constraints on AutoML runs.
+"""
+
+
+def import_dataset(seed=0, larger=False):
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/{}".format("prostate_complete.csv.zip" if larger else "prostate.csv")))
+    target = "CAPSULE"
+    df[target] = df[target].asfactor()
+    #Split frames
+    fr = df.split_frame(ratios=[.8,.1], seed=seed)
+    #Set up train, validation, and test sets
+    return dict(train=fr[0], valid=fr[1], test=fr[2], target=target, target_idx=1)
+
+
+def test_automl_stops_after_max_runtime_secs():
+    print("Check that automl gets interrupted after `max_runtime_secs`")
+    max_runtime_secs = 30
+    cancel_tolerance_secs = 5+5   # should work for most cases given current mechanism, +5 due to SE which currently ignore max_runtime_secs
+    ds = import_dataset()
+    aml = H2OAutoML(project_name="py_aml_max_runtime_secs", seed=1, max_runtime_secs=max_runtime_secs)
+    start = time.time()
+    aml.train(y=ds['target'], training_frame=ds['train'])
+    end = time.time()
+    assert abs(end-start - max_runtime_secs) < cancel_tolerance_secs, end-start
+
+
+def test_no_model_takes_more_than_max_runtime_secs_per_model():
+    print("Check that individual model get interrupted after `max_runtime_secs_per_model`")
+    ds = import_dataset(seed=1, larger=True)
+    max_runtime_secs = 30
+    models_count = {}
+    for max_runtime_secs_per_model in [0, 3, max_runtime_secs]:
+        aml = H2OAutoML(project_name="py_aml_max_runtime_secs_per_model_{}".format(max_runtime_secs_per_model), seed=1,
+                        max_runtime_secs_per_model=max_runtime_secs_per_model,
+                        max_runtime_secs=max_runtime_secs)
+        aml.train(y=ds['target'], training_frame=ds['train'])
+        models_count[max_runtime_secs_per_model] = len(aml.leaderboard)
+        # print(aml.leaderboard)
+    # there may be one model difference as reproducibility is not perfectly guaranteed in time-bound runs
+    assert abs(models_count[0] - models_count[max_runtime_secs]) <= 1
+    assert abs(models_count[0] - models_count[3]) > 1
+    # TODO: add assertions about single model timing once 'automl event_log' is available on client side
+
+
+pyunit_utils.run_tests([
+    test_automl_stops_after_max_runtime_secs,
+    test_no_model_takes_more_than_max_runtime_secs_per_model,
+])

--- a/h2o-r/tests/testdir_algos/automl/runit_NOPASS_automl_timing.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_NOPASS_automl_timing.R
@@ -1,0 +1,84 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+automl.timing.test <- function() {
+
+    # This test checks the following (for binomial classification):
+    #
+    # 1) That h2o.automl executes w/o errors
+    # 2) That the arguments are working properly
+
+    max_models <- 2
+
+    import_dataset <- function() {
+        y <- "CAPSULE"
+        y.idx <- 1
+
+        keys <- h2o.ls()$key
+        if ("rtest_automl_args_train" %in% keys) {
+            print("using existing dataset")
+            train <- h2o.getFrame("rtest_automl_args_train")
+            valid <- h2o.getFrame("rtest_automl_args_valid")
+            test <- h2o.getFrame("rtest_automl_args_test")
+        } else {
+            print("uploading dataset")
+            train <- h2o.importFile(locate("smalldata/testng/prostate_train.csv"), destination_frame = "prostate_full_train")
+            train[,y] <- as.factor(train[,y])
+            train <- as.h2o(train, "rtest_automl_args_train")
+            test <- h2o.importFile(locate("smalldata/testng/prostate_test.csv"), destination_frame = "prostate_full_test")
+            test[,y] <- as.factor(test[,y])
+            ss <- h2o.splitFrame(test, destination_frames=c("rtest_automl_args_valid", "rtest_automl_args_test"), seed = 1)
+            valid <- ss[[1]]
+            test <- ss[[2]]
+        }
+
+        x <- setdiff(names(train), y)
+        return(list(x=x, y=y, y.idx=y.idx, train=train, valid=valid, test=test))
+    }
+
+    test_max_runtime_secs <- function() {
+        print("Check that automl gets interrupted after `max_runtime_secs`")
+        ds <- import_dataset()
+        max_runtime_secs <- 60
+        cancel_tolerance_secs <- 6+5 # should be enough for most cases given job notification mechanism (adding 5 more ~=10% for SEs)
+        time <- system.time(aml <- h2o.automl(x=ds$x, y=ds$y,
+                            training_frame=ds$train,
+                            project_name="aml_max_runtime_secs",
+                            max_runtime_secs=max_runtime_secs)
+        )[['elapsed']]
+        print(paste("trained", length(get_partitioned_models(aml)$non_se), "models"))
+        expect_lte(abs(time - max_runtime_secs), cancel_tolerance_secs)
+        expect_equal(length(get_partitioned_models(aml)$se), 2)
+    }
+
+    test_max_runtime_secs_per_model <- function() {
+      print("Check that individual model get interrupted after `max_runtime_secs_per_model`")
+      # need a larger dataset to obtain significant differences in behaviour
+      train <- h2o.importFile(locate("smalldata/prostate/prostate_complete.csv.zip"), destination_frame="prostate_complete")
+      y <- 'CAPSULE'
+      x <- setdiff(names(train), y)
+      ds <- list(train=train, x=x, y=y)
+
+      max_runtime_secs <- 30
+      models_count <- list()
+      for (max_runtime_secs_per_model in c(0, 3, max_runtime_secs)) {
+        aml <- h2o.automl(x=ds$x, y=ds$y,
+                          training_frame=ds$train,
+                          seed=1,
+                          project_name=paste0("aml_max_runtime_secs_per_model_", max_runtime_secs_per_model),
+                          max_runtime_secs_per_model=max_runtime_secs_per_model,
+                          max_runtime_secs=max_runtime_secs)
+        models_count[paste0(max_runtime_secs_per_model)] = nrow(aml@leaderboard)
+      }
+      expect_lte(abs(models_count[[paste0(0)]] - models_count[[paste0(max_runtime_secs)]]), 1)
+      expect_gt(abs(models_count[[paste0(0)]] - models_count[[paste0(3)]]), 1)
+      # TODO: add assertions about single model timing once 'automl event_log' is available on client side
+    }
+
+    makeSuite(
+        test_max_runtime_secs,
+        test_max_runtime_secs_per_model,
+    )
+}
+
+doSuite("AutoML Timing Test", automl.timing.test(), time_monitor=TRUE)

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -860,7 +860,7 @@ class Test(object):
 
     def get_nopass(self, nopass):
         """
-        Some tests are known not to fail and even if they don't pass we don't want
+        Some tests are known to fail often and even if they don't pass we don't want
         to fail the overall regression PASS/FAIL status.
 
         :param nopass:
@@ -871,7 +871,7 @@ class Test(object):
 
     def get_nofeature(self, nopass):
         """
-        Some tests are known not to fail and even if they don't pass we don't want
+        Some tests are known to fail often and even if they don't pass we don't want
         to fail the overall regression PASS/FAIL status.
 
         :param nopass:


### PR DESCRIPTION
For the sake of green-washing Jenkins, let's not fail the build when those tests fail as it's easy for them to fail, especially when machine is using full CPU.

@michalkurka FYI