### PR TITLE
PUBDEV-6590: support for AutoML deletion (including models and other dependencies)

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -180,7 +180,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
     Key<Frame> predsKey = buildPredsKey(model, frame);
     Frame preds = DKV.getGet(predsKey);
     if (preds == null) {
-      preds =  model.score(frame, predsKey.toString());
+      preds =  model.score(frame, predsKey.toString(), null, false);  // no need for metrics here (leaks in client mode)
       Scope.untrack(preds.keysList());
     }
     if (_model._output._base_model_predictions_keys == null)

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -446,5 +446,9 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     _output._metalearner.deleteCrossValidationPreds();
   }
 
+  @Override
+  public void deleteCrossValidationFoldAssignment() {
+    _output._metalearner.deleteCrossValidationFoldAssignment();
+  }
 }
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -159,6 +159,10 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       ModelMetrics lastComputedMetric = mms[mms.length - 1].get();
       ModelMetrics mmStackedEnsemble = lastComputedMetric.deepCloneWithDifferentModelAndFrame(this, fr);
       this.addModelMetrics(mmStackedEnsemble);
+      //now that we have the metric set on the SE model, removing the one we just computed on metalearner (otherwise it leaks in client mode)
+      for (Key<ModelMetrics> mm : metalearner._output.clearModelMetrics(true)) {
+        DKV.remove(mm);
+      }
     }
     Frame.deleteTempFrameAndItsNonSharedVecs(levelOneFrame, adaptFrm);
     return predictFr;

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -569,7 +569,7 @@ public abstract class SharedTreeModel<
     M newModel = IcedUtils.deepCopy(self());
     newModel._key = result;
     // Do not clone model metrics
-    newModel._output.clearModelMetrics();
+    newModel._output.clearModelMetrics(false);
     newModel._output._training_metrics = null;
     newModel._output._validation_metrics = null;
     // Clone trees

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -389,16 +389,16 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     return DKV.getGet(this.job._key);
   }
 
-  public Model leader() { return (leaderboard() == null ? null : leaderboard.getLeader()); }
+  public Model leader() {
+    return leaderboard() == null ? null : leaderboard.getLeader();
+  }
 
   public Leaderboard leaderboard() {
-    if (leaderboard != null) leaderboard = leaderboard._key.get();
-    return leaderboard;
+    return leaderboard == null ? null : (leaderboard = leaderboard._key.get());
   }
 
   public EventLog eventLog() {
-    if (eventLog != null) eventLog = eventLog._key.get();
-    return eventLog;
+    return eventLog == null ? null : (eventLog = eventLog._key.get());
   }
 
   public String projectName() {

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -389,11 +389,17 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     return DKV.getGet(this.job._key);
   }
 
-  public Leaderboard leaderboard() { return (leaderboard == null ? null : leaderboard._key.get()); }
+  public Model leader() { return (leaderboard() == null ? null : leaderboard.getLeader()); }
 
-  public Model leader() { return (leaderboard() == null ? null : leaderboard().getLeader()); }
+  public Leaderboard leaderboard() {
+    if (leaderboard != null) leaderboard = leaderboard._key.get();
+    return leaderboard;
+  }
 
-  public EventLog eventLog() { return eventLog == null ? null : eventLog._key.get(); }
+  public EventLog eventLog() {
+    if (eventLog != null) eventLog = eventLog._key.get();
+    return eventLog;
+  }
 
   public String projectName() {
     return buildSpec == null ? null : buildSpec.project();
@@ -1344,8 +1350,8 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     if (trainingFrame != null && origTrainingFrame != null)
       Frame.deleteTempFrameAndItsNonSharedVecs(trainingFrame, origTrainingFrame);
-    if (leaderboard != null) leaderboard.remove(fs);
-    if (eventLog != null) eventLog.remove(fs);
+    if (leaderboard() != null) leaderboard().remove(fs);
+    if (eventLog() != null) eventLog().remove(fs);
 
     return super.remove_impl(fs);
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1333,10 +1333,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   @Override
   protected Futures remove_impl(Futures fs) {
     Key<Job> jobKey = job == null ? null : job._key;
-
-    if (gridKeys != null)
-      for (Key<Grid> gridKey : gridKeys) gridKey.remove(fs);
-
+    Log.debug("Cleaning up AutoML "+jobKey);
     // If the Frame was made here (e.g. buildspec contained a path, then it will be deleted
     if (buildSpec.input_spec.training_frame == null && origTrainingFrame != null) {
       origTrainingFrame.delete(jobKey, fs);
@@ -1352,6 +1349,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       Frame.deleteTempFrameAndItsNonSharedVecs(trainingFrame, origTrainingFrame);
     if (leaderboard() != null) leaderboard().remove(fs);
     if (eventLog() != null) eventLog().remove(fs);
+
+    // grid should be removed after leaderboard cleanup
+    if (gridKeys != null)
+      for (Key<Grid> gridKey : gridKeys) gridKey.remove(fs);
 
     return super.remove_impl(fs);
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
@@ -3,6 +3,7 @@ package ai.h2o.automl;
 import ai.h2o.automl.EventLogEntry.Level;
 import ai.h2o.automl.EventLogEntry.Stage;
 import water.DKV;
+import water.Futures;
 import water.Key;
 import water.Keyed;
 import water.util.Log;
@@ -81,11 +82,12 @@ public class EventLog extends Keyed<EventLog> {
   } // addEvent
 
   /**
-   * Delete everything in the DKV that this points to.  We currently need to be able to call this after deleteWithChildren().
+   * Delete object and its dependencies from DKV, including models.
    */
-  public void delete() {
+  @Override
+  protected Futures remove_impl(Futures fs) {
     _events = new EventLogEntry[0];
-    remove();
+    return super.remove_impl(fs);
   }
 
   public TwoDimTable toTwoDimTable() {

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -434,7 +434,7 @@ public class Leaderboard extends Keyed<Leaderboard> {
    */
   @Override
   protected Futures remove_impl(Futures fs) {
-    for (Model m : getModels())
+    for (Key<Model> m : models)
       m.remove(fs);
     for (Key k : leaderboard_set_metrics.keySet())
       k.remove(fs);

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -434,8 +434,15 @@ public class Leaderboard extends Keyed<Leaderboard> {
    */
   @Override
   protected Futures remove_impl(Futures fs) {
-    for (Key<Model> m : models)
+    for (Key<Model> m : models) {
+      Model model = m.get();
+      if (model != null) {
+        model.deleteCrossValidationPreds();
+        model.deleteCrossValidationModels();
+        model.deleteCrossValidationFoldAssignment();
+      }
       m.remove(fs);
+    }
     for (Key k : leaderboard_set_metrics.keySet())
       k.remove(fs);
     return super.remove_impl(fs);

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -430,18 +430,15 @@ public class Leaderboard extends Keyed<Leaderboard> {
   }
 
   /**
-   * Delete everything in the DKV that this points to.  We currently need to be able to call this after deleteWithChildren().
+   * Delete object and its dependencies from DKV, including models.
    */
-  void delete() {
-    for (Key k : leaderboard_set_metrics.keySet())
-      k.remove();
-    remove();
-  }
-
-  void deleteWithChildren() {
+  @Override
+  protected Futures remove_impl(Futures fs) {
     for (Model m : getModels())
-      m.delete();
-    delete();
+      m.remove(fs);
+    for (Key k : leaderboard_set_metrics.keySet())
+      k.remove(fs);
+    return super.remove_impl(fs);
   }
 
   private static double[] defaultMetricForModel(Model m) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -240,7 +240,6 @@ public class Leaderboard extends Keyed<Leaderboard> {
             mm = ModelMetrics.getFromDKV(model, leaderboardFrame);
             if (mm == null) {
               //scores and magically stores the metrics where we're looking for it on the next line
-//              model.scoreOnH20Node(leaderboardFrame).delete();  // immediately delete the resulting frame to avoid leaks
               model.score(leaderboardFrame).delete();
               mm = ModelMetrics.getFromDKV(model, leaderboardFrame);
             }

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -240,7 +240,8 @@ public class Leaderboard extends Keyed<Leaderboard> {
             mm = ModelMetrics.getFromDKV(model, leaderboardFrame);
             if (mm == null) {
               //scores and magically stores the metrics where we're looking for it on the next line
-              model.score(leaderboardFrame).delete();  // immediately delete the resulting frame to avoid leaks
+//              model.scoreOnH20Node(leaderboardFrame).delete();  // immediately delete the resulting frame to avoid leaks
+              model.score(leaderboardFrame).delete();
               mm = ModelMetrics.getFromDKV(model, leaderboardFrame);
             }
           }

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -434,12 +434,15 @@ public class Leaderboard extends Keyed<Leaderboard> {
    */
   @Override
   protected Futures remove_impl(Futures fs) {
+    Log.debug("Cleaning up leaderboard from models "+Arrays.toString(models));
     for (Key<Model> m : models) {
       Model model = m.get();
       if (model != null) {
+        model.deleteCrossValidationFoldAssignment();
         model.deleteCrossValidationPreds();
         model.deleteCrossValidationModels();
-        model.deleteCrossValidationFoldAssignment();
+      } else {
+        Log.info("Model "+m+" was already removed");
       }
       m.remove(fs);
     }

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -251,10 +251,6 @@ public class AutoMLTest extends water.TestUtil {
     } finally {
       if(aml!=null) aml.delete();
       if(fr != null) fr.remove();
-      if(leader!=null) {
-        Frame cvFoldAssignmentFrame = DKV.getGet(leader._output._cross_validation_fold_assignment_frame_id);
-        cvFoldAssignmentFrame.delete();
-      }
     }
   }
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -48,7 +48,7 @@ public class AutoMLTest extends water.TestUtil {
       assertEquals(3+2, aml.leaderboard().getModelCount());
     } finally {
       // Cleanup
-      if(aml!=null) aml.deleteWithChildren();
+      if(aml!=null) aml.delete();
       if(fr != null) fr.delete();
     }
   }
@@ -80,7 +80,7 @@ public class AutoMLTest extends water.TestUtil {
       assertEquals(3, aml.leaderboard().getModelCount());
     } finally {
       // Cleanup
-      if(aml!=null) aml.deleteWithChildren();
+      if(aml!=null) aml.delete();
       if(fr != null) fr.delete();
     }
   }
@@ -126,7 +126,6 @@ public class AutoMLTest extends water.TestUtil {
     } finally {
       // Cleanup
       for (Lockable l: deletables) {
-        if (l instanceof AutoML) ((AutoML)l).deleteWithChildren();
         l.delete();
       }
     }
@@ -158,7 +157,7 @@ public class AutoMLTest extends water.TestUtil {
       // no assertion, we just want to check leaked keys
     } finally {
       // Cleanup
-      if(aml!=null) aml.deleteWithChildren();
+      if(aml!=null) aml.delete();
       if(fr != null) fr.delete();
     }
   }
@@ -184,7 +183,7 @@ public class AutoMLTest extends water.TestUtil {
       // no assertion, we just want to check leaked keys
     } finally {
       // Cleanup
-      if(aml!=null) aml.deleteWithChildren();
+      if(aml!=null) aml.delete();
       if(fr != null) fr.delete();
     }
   }
@@ -222,7 +221,7 @@ public class AutoMLTest extends water.TestUtil {
       }
     } finally {
       // Cleanup
-      if(aml!=null) aml.deleteWithChildren();
+      if(aml!=null) aml.delete();
       if(fr != null) fr.delete();
     }
   }
@@ -250,7 +249,7 @@ public class AutoMLTest extends water.TestUtil {
       assertNotNull(leader._output._cross_validation_fold_assignment_frame_id);
 
     } finally {
-      if(aml!=null) aml.deleteWithChildren();
+      if(aml!=null) aml.delete();
       if(fr != null) fr.remove();
       if(leader!=null) {
         Frame cvFoldAssignmentFrame = DKV.getGet(leader._output._cross_validation_fold_assignment_frame_id);
@@ -281,7 +280,7 @@ public class AutoMLTest extends water.TestUtil {
       assertNull(leader._output._cross_validation_fold_assignment_frame_id);
 
     } finally {
-      if(aml!=null) aml.deleteWithChildren();
+      if(aml!=null) aml.delete();
       if(fr != null) fr.delete();
     }
   }
@@ -321,7 +320,7 @@ public class AutoMLTest extends water.TestUtil {
       assertEquals(workPlan.remainingWork(), maxTotalWork - defaultAllocs.get(Algo.DeepLearning) - defaultAllocs.get(Algo.DRF));
 
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
     }
   }
@@ -347,7 +346,7 @@ public class AutoMLTest extends water.TestUtil {
       assertEquals(0.1, (double)aml.getValidationFrame().numRows() / fr.numRows(), tolerance);
       assertEquals(test.numRows(), aml.getLeaderboardFrame().numRows());
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
       if (test != null) test.remove();
     }
@@ -374,7 +373,7 @@ public class AutoMLTest extends water.TestUtil {
       assertEquals(test.numRows(), aml.getValidationFrame().numRows());
       assertEquals(0.1, (double)aml.getLeaderboardFrame().numRows() / fr.numRows(), tolerance);
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
       if (test != null) test.remove();
     }
@@ -400,7 +399,7 @@ public class AutoMLTest extends water.TestUtil {
       assertEquals(0.1, (double)aml.getValidationFrame().numRows() / fr.numRows(), tolerance);
       assertEquals(0.1, (double)aml.getLeaderboardFrame().numRows() / fr.numRows(), tolerance);
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
     }
   }
@@ -423,7 +422,7 @@ public class AutoMLTest extends water.TestUtil {
       assertNull(aml.getValidationFrame());
       assertNull(aml.getLeaderboardFrame());
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
     }
   }
@@ -452,7 +451,7 @@ public class AutoMLTest extends water.TestUtil {
         }
       }
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
     }
   }
@@ -486,7 +485,7 @@ public class AutoMLTest extends water.TestUtil {
         }
       }
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
     }
   }
@@ -508,7 +507,7 @@ public class AutoMLTest extends water.TestUtil {
         assertTrue(e.getMessage().startsWith("Parameters `exclude_algos` and `include_algos` are mutually exclusive"));
       }
     } finally {
-      if (aml != null) aml.deleteWithChildren();
+      if (aml != null) aml.delete();
       if (fr != null) fr.remove();
     }
   }

--- a/h2o-automl/src/test/java/ai/h2o/automl/EventLogTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/EventLogTest.java
@@ -51,7 +51,7 @@ public class EventLogTest extends water.TestUtil {
             Assert.assertEquals("foo", events.get(3, 4));
             Assert.assertEquals(Integer.toString(777), events.get(4, 5));
         } finally {
-            eventLog.delete();
+            eventLog.remove();
         }
 
     }

--- a/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
@@ -23,32 +23,32 @@ public class LeaderboardTest extends water.TestUtil {
   @Test
   public void test_toTwoDimTable_with_empty_models_and_without_sort_metric() {
     Leaderboard lb = null;
-    EventLog ufb = EventLog.make(dummy);
+    EventLog eventLog = EventLog.make(dummy);
     try {
-      lb = Leaderboard.getOrMake("dummy_lb_no_sort_metric", ufb, new Frame(), null);
+      lb = Leaderboard.getOrMake("dummy_lb_no_sort_metric", eventLog, new Frame(), null);
 
       TwoDimTable table = lb.toTwoDimTable();
       Assert.assertNotNull("empty leaderboard should also produce a TwoDimTable", table);
       Assert.assertEquals("no models in this leaderboard", table.getTableDescription());
     } finally {
-      if (lb != null) lb.deleteWithChildren();
-      ufb.delete();
+      if (lb != null) lb.remove();
+      eventLog.remove();
     }
   }
 
   @Test
   public void test_toTwoDimTable_with_empty_models_and_with_sort_metric() {
     Leaderboard lb = null;
-    EventLog ufb = EventLog.make(dummy);
+    EventLog eventLog = EventLog.make(dummy);
     try {
-      lb = Leaderboard.getOrMake("dummy_lb_logloss_sort_metric", ufb, new Frame(), "logloss");
+      lb = Leaderboard.getOrMake("dummy_lb_logloss_sort_metric", eventLog, new Frame(), "logloss");
 
       TwoDimTable table = lb.toTwoDimTable();
       Assert.assertNotNull("empty leaderboard should also produce a TwoDimTable", table);
       Assert.assertEquals("no models in this leaderboard", table.getTableDescription());
     } finally {
-      if (lb != null) lb.deleteWithChildren();
-      ufb.delete();
+      if (lb != null) lb.remove();
+      eventLog.remove();
     }
   }
 
@@ -56,7 +56,7 @@ public class LeaderboardTest extends water.TestUtil {
   @Test
   public void test_rank_tsv() {
     Leaderboard lb = null;
-    EventLog ufb = EventLog.make(dummy);
+    EventLog eventLog = EventLog.make(dummy);
     GBMModel model = null;
     Frame fr  = null;
     try {
@@ -69,14 +69,14 @@ public class LeaderboardTest extends water.TestUtil {
       GBM job = new GBM(parms);
       model = job.trainModel().get();
       
-      lb = Leaderboard.getOrMake("dummy_rank_tsv", ufb, null, "mae");
+      lb = Leaderboard.getOrMake("dummy_rank_tsv", eventLog, null, "mae");
       lb.addModel(model);
       Assert.assertEquals("Error\n[0.19959320678410908, 0.44675855535636816, 0.19959320678410908, 0.3448260574357465, 0.31468498072970547]\n", lb.rankTsv()); 
     } finally {
       if (lb != null){
-        lb.deleteWithChildren();
+        lb.remove();
       }
-      ufb.delete();
+      eventLog.remove();
       if (model != null) {
         model.deleteCrossValidationModels();
         model.delete();

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2359,6 +2359,12 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     }
   }
 
+  public void deleteCrossValidationFoldAssignment() {
+    if (_output._cross_validation_fold_assignment_frame_id != null) {
+      _output._cross_validation_fold_assignment_frame_id.remove();
+    }
+  }
+
   @Override public String toString() {
     return _output.toString();
   }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2357,7 +2357,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
    */
   public void deleteCrossValidationModels() {
     if (_output._cross_validation_models != null) {
-      Log.info("Cleaning up CV Models for " + this._key.toString());
+      Log.info("Cleaning up CV Models for " + _key);
       int count = deleteAll(_output._cross_validation_models);
       Log.info(count+" CV models were removed");
     }
@@ -2368,7 +2368,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
    */
   public void deleteCrossValidationPreds() {
     if (_output._cross_validation_predictions != null) {
-      Log.info("Cleaning up CV Predictions for " + this._key.toString());
+      Log.info("Cleaning up CV Predictions for " + _key);
       int count = deleteAll(_output._cross_validation_predictions);
       Log.info(count+" CV predictions were removed");
     }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1363,32 +1363,6 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
   }
 
 
-  private static class ScoreRunnable extends H2O.RemoteRunnable<ScoreRunnable> {
-    private Key<Model> _modelKey;
-    private Key<Frame> _frameKey;
-    private Key<Frame> _result;
-
-    public ScoreRunnable(Model m, Frame fr) {
-      _modelKey = m._key;
-      _frameKey = fr._key;
-    }
-
-    @Override
-    public void run() {
-      Model m = _modelKey.get();
-      Frame fr = _frameKey.get();
-      Frame predictions = m.score(fr);
-      _result = predictions._key;
-    }
-  }
-
-  public Frame scoreOnH20Node(Frame fr) throws IllegalArgumentException {
-    ScoreRunnable runnable = new ScoreRunnable(this, fr);
-    H2O.runOnH2ONode(runnable);
-    return runnable._result == null ? null : runnable._result.get();
-  }
-
-
   /**
    * Bulk score the frame, and auto-name the resulting predictions frame.
    * @see #score(Frame, String)

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -698,7 +698,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
               || _parms._keep_cross_validation_predictions
               || (_parms._distribution== DistributionFamily.huber /*need to compute quantiles on abs error of holdout predictions*/)) {
         String predName = cvModelBuilders[i].getPredictionKey();
-        cvModel.predictScoreImpl(cvValid, adaptFr, predName, _job, true, CFuncRef.NOP);
+        cvModel.predictScoreImpl(cvValid, adaptFr, predName, _job, false, CFuncRef.NOP); //no need for metrics here, we just need predictions
         DKV.put(cvModel);
       }
       // free resources as early as possible

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -698,7 +698,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
               || _parms._keep_cross_validation_predictions
               || (_parms._distribution== DistributionFamily.huber /*need to compute quantiles on abs error of holdout predictions*/)) {
         String predName = cvModelBuilders[i].getPredictionKey();
-        cvModel.predictScoreImpl(cvValid, adaptFr, predName, _job, false, CFuncRef.NOP); //no need for metrics here, we just need predictions
+        cvModel.predictScoreImpl(cvValid, adaptFr, predName, _job, true, CFuncRef.NOP);
         DKV.put(cvModel);
       }
       // free resources as early as possible

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -2,14 +2,15 @@
 import functools as ft
 
 import h2o
-from h2o.estimators import H2OEstimator
+from h2o.base import Keyed
 from h2o.exceptions import H2OValueError
-from h2o.job import H2OJob
 from h2o.frame import H2OFrame
-from h2o.utils.typechecks import assert_is_type, is_type
+from h2o.job import H2OJob
 from h2o.model.model_base import ModelBase
+from h2o.utils.typechecks import assert_is_type, is_type
 
-class H2OAutoML(object):
+
+class H2OAutoML(Keyed):
     """
     Automatic Machine Learning
 
@@ -251,6 +252,10 @@ class H2OAutoML(object):
     #---------------------------------------------------------------------------
     # Basic properties
     #---------------------------------------------------------------------------
+    @property
+    def key(self):
+        return self.project_name
+
     @property
     def leader(self):
         """
@@ -500,6 +505,14 @@ class H2OAutoML(object):
         """
 
         return ModelBase.download_mojo(self.leader, path, get_genmodel_jar, genmodel_name)
+
+    #-------------------------------------------------------------------------------------------------------------------
+    # Overrides
+    #-------------------------------------------------------------------------------------------------------------------
+    def detach(self):
+        self.project_name = None
+        h2o.remove(self.leaderboard)
+        h2o.remove(self.event_log)
 
     #-------------------------------------------------------------------------------------------------------------------
     # Private

--- a/h2o-py/h2o/base.py
+++ b/h2o-py/h2o/base.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf-8 -*-
+# Copyright: (c) 2019 H2O.ai
+# License:   Apache License Version 2.0 (see LICENSE for details)
+"""
+:mod:`abstract` -- abstract H2O classes used internally.
+"""
+
+
+class Keyed(object):
+
+    @property
+    def id(self):
+        raise NotImplementedError

--- a/h2o-py/h2o/base.py
+++ b/h2o-py/h2o/base.py
@@ -2,12 +2,21 @@
 # Copyright: (c) 2019 H2O.ai
 # License:   Apache License Version 2.0 (see LICENSE for details)
 """
-:mod:`abstract` -- abstract H2O classes used internally.
+:mod:`abstract` -- base/abstract H2O classes used internally.
 """
 
 
 class Keyed(object):
 
     @property
-    def id(self):
-        raise NotImplementedError
+    def key(self):
+        """
+        :return: the unique key representing the object on the backend
+        """
+        raise NotImplementedError("Keyed classes should have a `key` property.")
+
+    def detach(self):
+        """
+        Detach the Python object from the backend, usually by clearing its key
+        """
+        raise NotImplementedError("Keyed classes should implement `detach`.")

--- a/h2o-py/h2o/base.py
+++ b/h2o-py/h2o/base.py
@@ -2,7 +2,7 @@
 # Copyright: (c) 2019 H2O.ai
 # License:   Apache License Version 2.0 (see LICENSE for details)
 """
-:mod:`abstract` -- base/abstract H2O classes used internally.
+:mod:`base` -- base/abstract H2O classes used internally.
 """
 
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -18,10 +18,8 @@ import warnings
 from io import StringIO
 from types import FunctionType
 
-import requests
-import math
-
 import h2o
+from h2o.base import Keyed
 from h2o.display import H2ODisplay
 from h2o.exceptions import H2OTypeError, H2OValueError
 from h2o.expr import ExprNode
@@ -39,7 +37,7 @@ from h2o.utils.typechecks import (assert_is_type, assert_satisfies, Enum, I, is_
 __all__ = ("H2OFrame", )
 
 
-class H2OFrame(object):
+class H2OFrame(Keyed):
     """
     Primary data store for H2O.
 
@@ -235,6 +233,11 @@ class H2OFrame(object):
     #-------------------------------------------------------------------------------------------------------------------
     # Frame properties
     #-------------------------------------------------------------------------------------------------------------------
+
+    @property
+    def key(self):
+        return None if self._ex is None else self._ex._cache._id
+
 
     @property
     def names(self):
@@ -514,6 +517,9 @@ class H2OFrame(object):
                 res["distribution_summary"].show()
             print("\n")
         self.summary()
+
+    def detach(self):
+        self._ex = None
 
 
     def _frame(self, rows=10, rows_offset=0, cols=-1, cols_offset=0, fill_cache=False):

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -924,7 +924,6 @@ def remove(x):
             xi.detach()
         else:
             # string may be a Frame key name part of a rapids session... need to call rm thru rapids here
-            assert isinstance(xi, str)
             try:
                 rapids("(rm {})".format(xi))
             except:

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -6,6 +6,7 @@ import traceback
 import warnings
 
 import h2o
+from h2o.base import Keyed
 from h2o.exceptions import H2OValueError
 from h2o.job import H2OJob
 from h2o.utils.backward_compatibility import backwards_compatible
@@ -15,7 +16,7 @@ from h2o.utils.shared_utils import can_use_pandas
 from h2o.utils.typechecks import I, assert_is_type, assert_satisfies, Enum, is_type
 
 
-class ModelBase(backwards_compatible()):
+class ModelBase(Keyed, backwards_compatible()):
     """Base class for all models."""
 
     def __init__(self):
@@ -37,6 +38,10 @@ class ModelBase(backwards_compatible()):
         self._end_time = None
         self._run_time = None
 
+
+    @property
+    def key(self):
+        return self._id
 
     @property
     def model_id(self):
@@ -256,6 +261,10 @@ class ModelBase(backwards_compatible()):
         :returns: A list of models.
         """
         return self.get_xval_models()
+
+
+    def detach(self):
+        self._id = None
 
 
     def deepfeatures(self, test_data, layer):

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -16,7 +16,7 @@ from h2o.utils.shared_utils import can_use_pandas
 from h2o.utils.typechecks import I, assert_is_type, assert_satisfies, Enum, is_type
 
 
-class ModelBase(Keyed, backwards_compatible()):
+class ModelBase(backwards_compatible(Keyed)):
     """Base class for all models."""
 
     def __init__(self):

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -6,6 +6,7 @@ import re
 import h2o
 from tests import pyunit_utils
 from h2o.automl import H2OAutoML
+from h2o.frame import H2OFrame
 
 
 def get_partitioned_model_names(leaderboard):
@@ -29,34 +30,53 @@ def check_model_property(model_names, prop_name, present=True, actual_value=None
             assert prop_name not in model.params.keys(), "unexpected {prop} in model {model}".format(prop=prop_name, model=mn)
 
 
-def list_keys_in_memory():
+def list_keys_in_memory(project_name=None):
     mem_keys = h2o.ls().key
-    automl_keys = [k for k in mem_keys if re.search(r'_AutoML_', k)]
-    pred_keys = [k for k in mem_keys if re.search(r'(^|_)prediction_', k)]
+    automl_keys = [k for k in mem_keys if re.search(r'_AutoML_', k) and (project_name is None or project_name not in k)]
+    automl_frame_keys = [k for k in mem_keys if re.search(r'^levelone_', k)]
+    prediction_keys = [k for k in mem_keys if re.search(r'(^|_)prediction_', k)]
     metrics_keys = [k for k in mem_keys if re.search(r'^modelmetrics_', k)]
-    model_keys = [k for k in automl_keys if k not in pred_keys and k not in metrics_keys]
+    metalearner_keys = [k for k in mem_keys if re.search(r'^metalearner', k)]
+    fold_keys = [k for k in mem_keys if re.search(r'_fold_', k)]
+    all_model_keys = [k for k in automl_keys
+                      if k not in automl_frame_keys
+                      and k not in prediction_keys
+                      and k not in metrics_keys
+                      and k not in fold_keys]
     cv_keys = [k for k in mem_keys if re.search(r'(^|_)cv_', k)]
-    cv_pred_keys = [k for k in cv_keys if k in pred_keys]
+    cv_prediction_keys = [k for k in cv_keys if k in prediction_keys]
     cv_metrics_keys = [k for k in cv_keys if k in metrics_keys]
-    cv_mod_keys = [k for k in cv_keys if k in model_keys]
+    cv_fold_assignment = [k for k in cv_keys if k in fold_keys]
+    cv_model_keys = [k for k in cv_keys
+                     if k in all_model_keys
+                     and k not in cv_fold_assignment]
+    base_model_keys = [k for k in all_model_keys
+                       if k not in cv_keys
+                       and k not in metalearner_keys]
     return dict(
         all=mem_keys,
-        models=model_keys,
-        predictions=pred_keys,
+        models_all=all_model_keys,
+        models_base=base_model_keys,
+        predictions=prediction_keys,
         metrics=metrics_keys,
         automl=automl_keys,
         cv_all=cv_keys,
-        cv_models=cv_mod_keys,
-        cv_predictions=cv_pred_keys,
-        cv_metrics=cv_metrics_keys
+        cv_models=cv_model_keys,
+        cv_predictions=cv_prediction_keys,
+        cv_metrics=cv_metrics_keys,
+        cv_fold_assignment=cv_fold_assignment
     )
 
 
 def prepare_data(seed=1):
-    df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    name = 'amldataset'
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"), destination_frame=name)
     target = "CAPSULE"
     df[target] = df[target].asfactor()
-    fr = df.split_frame(ratios=[.8, .1], seed=seed)
+    h2o.assign(df, name)
+    fr = df.split_frame(ratios=[.8, .1],
+                        destination_frames=[name+'_'+f for f in ['training', 'validation', 'leaderboard']],
+                        seed=seed)
     train, valid, test = fr[0], fr[1], fr[2]
     return target, train, valid, test
 
@@ -220,7 +240,7 @@ def test_suite_clean_cv_models():
         check_model_property(se, kcvm, False)
         check_model_property(non_se, kcvm, True, False, True)
         keys = list_keys_in_memory()
-        tot, cv = len(keys['models']), len(keys['cv_models'])
+        tot, cv = len(keys['models_all']), len(keys['cv_models'])
         print("total models in memory = {tot}, among which {cv} CV models".format(tot=tot, cv=cv))
         assert tot > 0, "no models left in memory"
         assert cv == 0, "{cv} CV models were not cleaned from memory".format(cv=cv)
@@ -237,7 +257,7 @@ def test_suite_clean_cv_models():
         check_model_property(se, kcvm, False)
         check_model_property(non_se, kcvm, True, True, True)
         keys = list_keys_in_memory()
-        tot, cv = len(keys['models']), len(keys['cv_models'])
+        tot, cv = len(keys['models_all']), len(keys['cv_models'])
         print("total models in memory = {tot}, among which {cv} CV models".format(tot=tot, cv=cv))
         assert tot > 0, "no models left in memory"
         expected = len(models) * nfolds
@@ -255,7 +275,7 @@ def test_suite_clean_cv_models():
         check_model_property(se, kcvm, False)
         check_model_property(non_se, kcvm, True, False, True)
         keys = list_keys_in_memory()
-        tot, cv = len(keys['models']), len(keys['cv_models'])
+        tot, cv = len(keys['models_all']), len(keys['cv_models'])
         print("total models in memory = {tot}, among which {cv} CV models".format(tot=tot, cv=cv))
         assert tot > 0, "no models left in memory"
         assert cv == 0, "{cv} CV models were not cleaned from memory".format(cv=cv)
@@ -272,13 +292,192 @@ def test_suite_clean_cv_models():
     ]
 
 
-tests = list(iter.chain.from_iterable([
+def test_suite_remove_automl():
+
+    def contains_leaderboard(project_name, keys):
+        return "AutoML_Leaderboard_{}".format(project_name) in keys['all'].values
+
+    def contains_event_log(project_name, keys):
+        return "AutoML_Events_{}".format(project_name) in keys['all'].values
+
+    def frame_in_cluster(frame):
+        # reload the first row of the frame to verify that no vec has been removed
+        return frame.key is not None and H2OFrame.get_frame(frame.key, rows=1) is not None
+
+
+    def test_remove_automl_with_xval():
+        target, train, valid, test = prepare_data()
+        project_name = 'aml_with_xval_remove_test'
+        max_models = 3
+        nfolds = 5
+        aml = H2OAutoML(project_name=project_name,
+                        nfolds=nfolds,
+                        max_models=max_models,
+                        seed=1)
+        aml.train(y=target, training_frame=train, validation_frame=valid, leaderboard_frame=test)
+
+        keys = list_keys_in_memory()
+        # print(keys['all'].values)
+        assert contains_leaderboard(project_name, keys)
+        assert contains_event_log(project_name, keys)
+        expectations = dict(
+            models_base=max_models + 2,  # 2 SEs
+            cv_models=0,
+            predictions=0,
+            metrics=(max_models * 3  # for each non-SE model, 1 on training_frame, 1 on validation_frame, 1 on leaderboard_frame
+                     + (2 * 2)  # for each SE model, 1 on training frame, 1 on leaderboard frame
+                     + (2 * 4)  # for each SE metalearner, 1+1 on levelone training+validation, 1+1 for final scoring (preds_levelone training+leaderbird)
+                     )
+        )
+        for k, v in expectations.items():
+            assert len(keys[k]) == v, "expected {} {}, but got {}".format(v, k, len(keys[k]))
+
+        h2o.remove(aml)
+        clean = list_keys_in_memory()
+        # print(clean['all'].values)
+        assert not contains_leaderboard(project_name, clean)
+        assert not contains_event_log(project_name, clean)
+        assert len(clean['models_base']) == 0
+        assert len(clean['cv_models']) == 0
+        assert len(clean['models_all']) == 0
+        assert len(clean['predictions']) == 0
+        assert len(clean['metrics']) == 0
+        assert len(clean['automl']) == 0
+        for frame in [train, valid, test]:
+            assert frame_in_cluster(frame), "frame {} has been removed from cluster".format(frame.frame_id)
+
+
+    def test_remove_automl_with_xval_when_keeping_all_cv_details():
+        target, train, valid, test = prepare_data()
+        project_name = 'aml_with_xval_remove_test'
+        max_models = 3
+        nfolds = 5
+        aml = H2OAutoML(project_name=project_name,
+                        nfolds=nfolds,
+                        max_models=max_models,
+                        seed=1,
+                        keep_cross_validation_predictions=True,
+                        keep_cross_validation_fold_assignment=True,
+                        keep_cross_validation_models=True)
+        aml.train(y=target, training_frame=train)
+
+        keys = list_keys_in_memory()
+        # print(keys['all'].values)
+        assert contains_leaderboard(project_name, keys)
+        assert contains_event_log(project_name, keys)
+        expectations = dict(
+            models_base=max_models + 2,  # 2 SEs
+            cv_models=(max_models+2) * nfolds,  # 1 cv model per fold for all models, incl. SEs
+            predictions=(len(keys['cv_models'])  # cv predictions
+                         + len(keys['models_base'])  # cv holdout predictions
+                         ),
+            metrics=(len(keys['cv_models']) * 3  # for each cv model, 1 on training frame, 1 on validation frame (=training for cv), 1 on frame with null key (what is this?)
+                     + len(keys['models_base'])  # for each model, 1 on training_frame
+                     + (2 * 2)  # for each SE, 1 on levelone training, 1 for final scoring (preds_levelone)
+                     )
+        )
+        for k, v in expectations.items():
+            assert len(keys[k]) == v, "expected {} {}, but got {}".format(v, k, len(keys[k]))
+
+        h2o.remove(aml)
+        clean = list_keys_in_memory()
+        # print(clean['all'].values)
+        assert not contains_leaderboard(project_name, clean)
+        assert not contains_event_log(project_name, clean)
+        assert len(clean['models_base']) == 0
+        assert len(clean['cv_models']) == 0
+        assert len(clean['models_all']) == 0
+        assert len(clean['predictions']) == 0
+        assert len(clean['metrics']) == 0
+        assert len(clean['automl']) == 0
+        for frame in [train, valid, test]:
+            assert frame_in_cluster(frame), "frame {} has been removed from cluster".format(frame.frame_id)
+
+
+    def test_remove_automl_no_xval():
+        target, train, blend, test = prepare_data()
+        project_name='aml_no_xval_remove_test'
+        max_models = 3
+        aml = H2OAutoML(project_name=project_name,
+                        nfolds=0,
+                        max_models=max_models,
+                        seed=1)
+        aml.train(y=target, training_frame=train, blending_frame=blend)
+
+        keys = list_keys_in_memory()
+        # print(keys['all'].values)
+        assert contains_leaderboard(project_name, keys)
+        assert contains_event_log(project_name, keys)
+        expectations = dict(
+            models_base=max_models + 2,  # 2 SEs
+            cv_models=0,
+            predictions=0,
+            metrics=(len(keys['models_base']) * 2  # for each model, 1 on training_frame, 1 on leaderboard frame (those are extracted from original training_frame)
+                     + max_models * 2  # for each non-SE model, 1 on blending frame, 1 on validation frame
+                     + (2 * 4)  # for each SE metalearner, 1 on levelone training, 1 on levelone validation, 2 for final scoring (1 on training, 1 on leaderboard)
+                     )
+        )
+        for k, v in expectations.items():
+            assert len(keys[k]) == v, "expected {} {}, but got {}".format(v, k, len(keys[k]))
+
+        h2o.remove(aml)
+        clean = list_keys_in_memory()
+        # print(clean['all'].values)
+        assert not contains_leaderboard(project_name, clean)
+        assert not contains_event_log(project_name, clean)
+        assert len(clean['models_base']) == 0
+        assert len(clean['cv_models']) == 0
+        assert len(clean['models_all']) == 0
+        assert len(clean['metrics']) == 0
+        assert len(clean['predictions']) == 0
+        assert len(clean['automl']) == 0
+        for frame in [train, blend, test]:
+            assert frame_in_cluster(frame), "frame {} has been removed from cluster".format(frame.frame_id)
+
+
+    def test_remove_automl_after_individual_manual_deletions():
+        target, train, blend, test = prepare_data()
+        project_name='aml_no_xval_remove_test'
+        max_models = 3
+        aml = H2OAutoML(project_name=project_name,
+                        nfolds=0,
+                        max_models=max_models,
+                        seed=1)
+        aml.train(y=target, training_frame=train, blending_frame=blend)
+
+        keys = list_keys_in_memory()
+        # manually remove the first item for each category to verify robustness of global automl deletion
+        for k, v in keys.items():
+            if k == 'all': continue
+            if len(v) > 0:
+                h2o.remove(v[0])
+
+        h2o.remove(aml)
+        clean = list_keys_in_memory()
+        # print(clean['all'].values)
+        assert not contains_leaderboard(project_name, clean)
+        assert not contains_event_log(project_name, clean)
+        assert len(clean['models_base']) == 0
+        assert len(clean['cv_models']) == 0
+        assert len(clean['models_all']) == 0
+        assert len(clean['metrics']) == 0
+        assert len(clean['predictions']) == 0
+        assert len(clean['automl']) == 0
+        for frame in [train, blend, test]:
+            assert frame_in_cluster(frame), "frame {} has been removed from cluster".format(frame.frame_id)
+
+
+    return [
+        test_remove_automl_with_xval,
+        test_remove_automl_with_xval_when_keeping_all_cv_details,
+        test_remove_automl_no_xval,
+        test_remove_automl_after_individual_manual_deletions
+    ]
+
+
+
+pyunit_utils.run_tests(list(iter.chain.from_iterable([
     test_suite_clean_cv_predictions(),
     test_suite_clean_cv_models(),
-]))
-
-
-if __name__ == "__main__":
-    for test in tests: pyunit_utils.standalone_test(test)
-else:
-    for test in tests: test()
+    test_suite_remove_automl()
+])))

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -447,6 +447,7 @@ def test_suite_remove_automl():
 
         keys = list_keys_in_memory()
         # manually remove the first item for each category to verify robustness of global automl deletion
+        # for example, to verify that exceptions (if any) are handled correctly when automl is trying to remove a base model that was already removed
         for k, v in keys.items():
             if k == 'all': continue
             if len(v) > 0:

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -371,7 +371,7 @@ def test_suite_remove_automl():
             predictions=(len(keys['cv_models'])  # cv predictions
                          + len(keys['models_base'])  # cv holdout predictions
                          ),
-            metrics=(len(keys['cv_models']) * 2  # for each cv model, 1 on training frame, 1 on validation frame (=training for cv)
+            metrics=(len(keys['cv_models']) * 3  # for each cv model, 1 on training frame, 1 on validation frame (=training for cv), one on adapted frame (to be removed with PUBDEV-6638)
                      + len(keys['models_base'])  # for each model, 1 on training_frame
                      + (2 * 1)  # for each SE, 1 on levelone training
                      )
@@ -405,7 +405,7 @@ def test_suite_remove_automl():
         aml.train(y=target, training_frame=train, blending_frame=blend)
 
         keys = list_keys_in_memory()
-        print(keys['all'].values)
+        # print(keys['all'].values)
         assert contains_leaderboard(project_name, keys)
         assert contains_event_log(project_name, keys)
         expectations = dict(
@@ -478,7 +478,7 @@ def test_suite_remove_automl():
 
 
 pyunit_utils.run_tests(list(iter.chain.from_iterable([
-    # test_suite_clean_cv_predictions(),
-    # test_suite_clean_cv_models(),
+    test_suite_clean_cv_predictions(),
+    test_suite_clean_cv_models(),
     test_suite_remove_automl()
 ])))

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -326,7 +326,7 @@ def test_suite_remove_automl():
             predictions=0,
             metrics=(max_models * 3  # for each non-SE model, 1 on training_frame, 1 on validation_frame, 1 on leaderboard_frame
                      + (2 * 2)  # for each SE model, 1 on training frame, 1 on leaderboard frame
-                     + (2 * 4)  # for each SE metalearner, 1+1 on levelone training+validation, 1+1 for final scoring (preds_levelone training+leaderbird)
+                     + (2 * 2)  # for each SE metalearner, 1+1 on levelone training+validation
                      )
         )
         for k, v in expectations.items():
@@ -334,7 +334,7 @@ def test_suite_remove_automl():
 
         h2o.remove(aml)
         clean = list_keys_in_memory()
-        # print(clean['all'].values)
+        print(clean['all'].values)
         assert not contains_leaderboard(project_name, clean)
         assert not contains_event_log(project_name, clean)
         assert len(clean['models_base']) == 0
@@ -371,9 +371,9 @@ def test_suite_remove_automl():
             predictions=(len(keys['cv_models'])  # cv predictions
                          + len(keys['models_base'])  # cv holdout predictions
                          ),
-            metrics=(len(keys['cv_models']) * 3  # for each cv model, 1 on training frame, 1 on validation frame (=training for cv), 1 on frame with null key (what is this?)
+            metrics=(len(keys['cv_models']) * 2  # for each cv model, 1 on training frame, 1 on validation frame (=training for cv)
                      + len(keys['models_base'])  # for each model, 1 on training_frame
-                     + (2 * 2)  # for each SE, 1 on levelone training, 1 for final scoring (preds_levelone)
+                     + (2 * 1)  # for each SE, 1 on levelone training
                      )
         )
         for k, v in expectations.items():
@@ -381,7 +381,7 @@ def test_suite_remove_automl():
 
         h2o.remove(aml)
         clean = list_keys_in_memory()
-        # print(clean['all'].values)
+        print(clean['all'].values)
         assert not contains_leaderboard(project_name, clean)
         assert not contains_event_log(project_name, clean)
         assert len(clean['models_base']) == 0
@@ -396,7 +396,7 @@ def test_suite_remove_automl():
 
     def test_remove_automl_no_xval():
         target, train, blend, test = prepare_data()
-        project_name='aml_no_xval_remove_test'
+        project_name = 'aml_no_xval_remove_test'
         max_models = 3
         aml = H2OAutoML(project_name=project_name,
                         nfolds=0,
@@ -405,7 +405,7 @@ def test_suite_remove_automl():
         aml.train(y=target, training_frame=train, blending_frame=blend)
 
         keys = list_keys_in_memory()
-        # print(keys['all'].values)
+        print(keys['all'].values)
         assert contains_leaderboard(project_name, keys)
         assert contains_event_log(project_name, keys)
         expectations = dict(
@@ -413,8 +413,8 @@ def test_suite_remove_automl():
             cv_models=0,
             predictions=0,
             metrics=(len(keys['models_base']) * 2  # for each model, 1 on training_frame, 1 on leaderboard frame (those are extracted from original training_frame)
-                     + max_models * 2  # for each non-SE model, 1 on blending frame, 1 on validation frame
-                     + (2 * 4)  # for each SE metalearner, 1 on levelone training, 1 on levelone validation, 2 for final scoring (1 on training, 1 on leaderboard)
+                     + max_models * 1  # for each non-SE model, 1 on validation frame
+                     + (2 * 2)  # for each SE metalearner, 1 on levelone training, 1 on levelone validation
                      )
         )
         for k, v in expectations.items():
@@ -422,7 +422,7 @@ def test_suite_remove_automl():
 
         h2o.remove(aml)
         clean = list_keys_in_memory()
-        # print(clean['all'].values)
+        print(clean['all'].values)
         assert not contains_leaderboard(project_name, clean)
         assert not contains_event_log(project_name, clean)
         assert len(clean['models_base']) == 0
@@ -455,7 +455,7 @@ def test_suite_remove_automl():
 
         h2o.remove(aml)
         clean = list_keys_in_memory()
-        # print(clean['all'].values)
+        print(clean['all'].values)
         assert not contains_leaderboard(project_name, clean)
         assert not contains_event_log(project_name, clean)
         assert len(clean['models_base']) == 0
@@ -478,7 +478,7 @@ def test_suite_remove_automl():
 
 
 pyunit_utils.run_tests(list(iter.chain.from_iterable([
-    test_suite_clean_cv_predictions(),
-    test_suite_clean_cv_models(),
+    # test_suite_clean_cv_predictions(),
+    # test_suite_clean_cv_models(),
     test_suite_remove_automl()
 ])))

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -105,15 +105,15 @@ h2o.rm <- function(ids) {
   for (xi in x_list) {
     if( is.null(xi) ) stop("h2o.rm with NULL object is not supported")
     if( is.H2OFrame(xi) ) {
-      xi_id <- attr(xi, "id")       # String or None
-      if( is.null(xi_id) ) return() # Lazy frame, never evaluated, nothing in cluster
-      .h2o.__remoteSend(.h2o.__RAPIDS, h2oRestApiVersion = 99, ast=paste0("(rm ",xi_id[[1]],")"), session_id=h2o.getConnection()@mutable$session_id, method = "POST")
-    } else if( is(xi, "H2OModel") ) {
-      .h2o.__remoteSend(paste0(.h2o.__DKV, "/",xi@model_id), method = "DELETE")
+      key <- h2o.keyof(xi) # String or None
+      if( is.null(key) ) return() # Lazy frame, never evaluated, nothing in cluster
+      .h2o.__remoteSend(.h2o.__RAPIDS, h2oRestApiVersion = 99, ast=paste0("(rm ",key,")"), session_id=h2o.getConnection()@mutable$session_id, method = "POST")
+    } else if( is(xi, "Keyed") ) {
+      .h2o.__remoteSend(paste0(.h2o.__DKV, "/",h2o.keyof(xi)), method = "DELETE")
     } else if( is.character(xi) ) {
       .h2o.__remoteSend(paste0(.h2o.__DKV, "/",xi), method = "DELETE")
     } else {
-      stop("input to h2o.rm must be one of: H2OFrame, H2OModel, or character")
+      stop("input to h2o.rm must be a Keyed instance (e.g. H2OFrame, H2OModel) or character")
     }
   }
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_memory_cleanup.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_memory_cleanup.R
@@ -1,0 +1,51 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+automl.cleanup.suite <- function() {
+
+  max_models <- 3
+
+  import_dataset <- function() {
+    y <- "CAPSULE"
+
+    train <- h2o.importFile(locate("smalldata/testng/prostate_train.csv"), destination_frame = "aml_r_train_dataset")
+    train[,y] <- as.factor(train[,y])
+    train <- as.h2o(train, "aml_r_train_dataset")
+    test <- h2o.importFile(locate("smalldata/testng/prostate_test.csv"), destination_frame = "aml_r_test_dataset")
+    test[,y] <- as.factor(test[,y])
+    ss <- h2o.splitFrame(test, destination_frames=c("aml_r_test_valid", "aml_r_test_dataset"), seed = 1)
+    valid <- ss[[1]]
+    test <- ss[[2]]
+
+    x <- setdiff(names(train), y)
+    return(list(x=x, y=y, train=train, valid=valid, test=test))
+  }
+
+  test_remove_automl_instance <- function() {
+    ds <- import_dataset()
+    aml <- h2o.automl(project_name="test_remove_R_automl_instance",
+                      x=ds$x, y=ds$y,
+                      training_frame=ds$train,
+                      validation_frame=ds$valid,
+                      leaderboard_frame=ds$test,
+                      max_models=max_models)
+
+    keys <- h2o.ls()$key
+    expect_gt(length(grep("_AutoML_", keys)), nrow(aml@leaderboard))
+
+    h2o.rm(aml)
+    clean <- h2o.ls()$key
+    expect_equal(length(grep("_AutoML_", clean)), 0)
+    # verify that the original frames were not deleted
+    for (frame in c(ds$train, ds$valid, ds$test)) {
+      expect_true(any(grepl(paste0("^",h2o.getId(frame),"$"), clean)))
+    }
+  }
+
+  makeSuite(test_remove_automl_instance)
+}
+
+doSuite("AutoML Memory Cleanup Test", automl.cleanup.suite())
+
+
+


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6590

User should be able to delete AutoML instance and all its dependencies from any client.
Especially, all dependencies should be removed from DKV.
This includes:
- trained models (including cross-validation models, SE…).
- metrics.
- predictions.
- frames generated and referenced by AutoML (those created outside AutoML but used during training should remain though).
- …


WIP: still need to implement R support