### PR TITLE
PUBDEV-6598: Update documentation for partial plots for 2D

### DIFF
--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -464,7 +464,7 @@ Thus, the one-dimensional partial dependence of function :math:`g` on :math:`X_j
 
 - The partial dependence of a given feature is :math:`Xj` (where :math:`j` is the column index)
 - You can also change the equation to sum from 1 to N instead of 0 to N-1
-- Use the `col_pairs_2dpdp` option along with a list containing pairs of column names to generate 2D partial dependence plots
+- Use the ``col_pairs_2dpdp`` option along with a list containing pairs of column names to generate 2D partial dependence plots
 
 .. figure:: images/pdp_summary.png
     :alt: Partial Dependence Summary

--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -464,6 +464,7 @@ Thus, the one-dimensional partial dependence of function :math:`g` on :math:`X_j
 
 - The partial dependence of a given feature is :math:`Xj` (where :math:`j` is the column index)
 - You can also change the equation to sum from 1 to N instead of 0 to N-1
+- Use the `col_pairs_2dpdp` option along with a list containing pairs of column names to generate 2D partial dependence plots
 
 .. figure:: images/pdp_summary.png
     :alt: Partial Dependence Summary

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -957,12 +957,12 @@ class ModelBase(backwards_compatible()):
         :param plot: A boolean specifying whether to plot partial dependence table.
         :param plot_stddev: A boolean specifying whether to add std err to partial dependence plot.
         :param figsize: Dimension/size of the returning plots, adjust to fit your output cells.
-        :param server: ?
+        :param server: Specify whether to activate matplotlib "server" mode. In this case, the plots are saved to a file instead of being rendered.
         :param include_na: A boolean specifying whether missing value should be included in the Feature values.
         :param user_splits: a dictionary containing column names as key and user defined split values as value in a list.
         :param col_pairs_2dpdp: list containing pairs of column names for 2D pdp
-        :param save_to_file Fully qualified name to an image file the resulting plot should be saved to, e.g. '/home/user/pdpplot.png'. The 'png' postfix might be omitted. If the file already exists, it will be overridden. Plot is only saved if plot = True.
-        :param row_index Row for which partial dependence will be calculated instead of the whole input frame.
+        :param save_to_file: Fully qualified name to an image file the resulting plot should be saved to, e.g. '/home/user/pdpplot.png'. The 'png' postfix might be omitted. If the file already exists, it will be overridden. Plot is only saved if plot = True.
+        :param row_index: Row for which partial dependence will be calculated instead of the whole input frame.
         :returns: Plot and list of calculated mean response tables for each feature requested.
         """
 


### PR DESCRIPTION
Updated the notes in H2O userguide to indicate support for 2-D pdps.
Driveby fixes to the Python documentation.

See: https://0xdata.atlassian.net/browse/PUBDEV-6598
https://0xdata.atlassian.net/browse/PUBDEV-6438