### PR TITLE
PUBDEV-6639: adding cascade param to remove API

### DIFF
--- a/h2o-algos/src/main/java/hex/aggregator/AggregatorModel.java
+++ b/h2o-algos/src/main/java/hex/aggregator/AggregatorModel.java
@@ -64,10 +64,9 @@ public class AggregatorModel extends Model<AggregatorModel,AggregatorModel.Aggre
   }
 
   @Override
-  protected Futures remove_impl(Futures fs) {
-    if (_exemplar_assignment_vec_key!=null)
-      _exemplar_assignment_vec_key.remove();
-    return super.remove_impl(fs);
+  protected Futures remove_impl(Futures fs, boolean cascade) {
+    Keyed.remove(_exemplar_assignment_vec_key);
+    return super.remove_impl(fs, cascade);
   }
 
   @Override

--- a/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
@@ -340,11 +340,11 @@ public class CoxPHModel extends Model<CoxPHModel,CoxPHParameters,CoxPHOutput> {
     throw new UnsupportedOperationException("CoxPHModel.score0 should never be called");
   }
 
-  protected Futures remove_impl( Futures fs ) {
+  protected Futures remove_impl(Futures fs, boolean cascade) {
     Frame varCumhaz2 = _output._var_cumhaz_2 != null ? _output._var_cumhaz_2.get() : null;
     if (varCumhaz2 != null)
       varCumhaz2.remove(fs);
-    super.remove_impl(fs);
+    super.remove_impl(fs, cascade);
     return fs;
   }
 

--- a/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
+++ b/h2o-algos/src/main/java/hex/deeplearning/DeepLearningModel.java
@@ -929,15 +929,15 @@ public class DeepLearningModel extends Model<DeepLearningModel,DeepLearningModel
     assert (bestModel.compareTo(this) <= 0);
   }
 
-  @Override protected Futures remove_impl(Futures fs) {
+  @Override protected Futures remove_impl(Futures fs, boolean cascade) {
     if (_output.weights != null && _output.biases != null) {
-      for (Key k : _output.weights) if (k!=null) k.remove(fs);
-      for (Key k : _output.biases) if (k!=null) k.remove(fs);
+      for (Key k : _output.weights) Keyed.remove(k, fs, true);
+      for (Key k : _output.biases) Keyed.remove(k, fs, true);
     }
     if (actual_best_model_key!=null) DKV.remove(actual_best_model_key);
     DKV.remove(model_info().data_info()._key, fs);
     deleteElasticAverageModels();
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   void deleteElasticAverageModels() {

--- a/h2o-algos/src/main/java/hex/deepwater/DeepWaterModel.java
+++ b/h2o-algos/src/main/java/hex/deepwater/DeepWaterModel.java
@@ -991,14 +991,14 @@ public class DeepWaterModel extends Model<DeepWaterModel,DeepWaterParameters,Dee
   }
 
   @Override
-  protected Futures remove_impl(Futures fs) {
+  protected Futures remove_impl(Futures fs, boolean cascade) {
     cleanUpCache(fs);
     removeNativeState();
     if (actual_best_model_key!=null)
       DKV.remove(actual_best_model_key);
     if (model_info()._dataInfo !=null)
       model_info()._dataInfo.remove(fs);
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   void exportNativeModel(String path, int iteration) {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -399,20 +399,20 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
         if (_output._levelone_frame_id != null && key.get() != null)
           Frame.deleteTempFrameAndItsNonSharedVecs(key.get(), _output._levelone_frame_id);
         else
-          key.remove();
+          Keyed.remove(key);
       }
       _output._base_model_predictions_keys = null;
     }
   }
 
-  @Override protected Futures remove_impl(Futures fs ) {
+  @Override protected Futures remove_impl(Futures fs, boolean cascade) {
     deleteBaseModelPredictions(); 
     if (_output._metalearner != null)
       _output._metalearner.remove(fs);
     if (_output._levelone_frame_id != null)
       _output._levelone_frame_id.remove(fs);
 
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   /** Write out models (base + metalearner) */

--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -187,12 +187,12 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     super(selfKey, parms, output);
   }
 
-  @Override protected Futures remove_impl( Futures fs ) {
-    if (_output._init_key != null) _output._init_key.remove(fs);
-    if (_output._x_factor_key !=null) _output._x_factor_key.remove(fs);
-    if (_output._representation_key != null) _output._representation_key.remove(fs);
+  @Override protected Futures remove_impl(Futures fs, boolean cascade) {
+    Keyed.remove(_output._init_key, fs, true);
+    Keyed.remove(_output._x_factor_key, fs, true);
+    Keyed.remove(_output._representation_key, fs, true);
 
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   @Override protected AutoBuffer writeAll_impl(AutoBuffer ab) {

--- a/h2o-algos/src/main/java/hex/psvm/PSVMModel.java
+++ b/h2o-algos/src/main/java/hex/psvm/PSVMModel.java
@@ -10,6 +10,7 @@ import hex.psvm.psvm.KernelFactory;
 import hex.psvm.psvm.PrimalDualIPM;
 import water.Futures;
 import water.Key;
+import water.Keyed;
 import water.fvec.Chunk;
 import water.fvec.Frame;
 import water.util.Log;
@@ -186,10 +187,9 @@ public class PSVMModel extends Model<PSVMModel, PSVMModel.PSVMParameters, PSVMMo
   }
 
   @Override
-  protected Futures remove_impl(Futures fs) {
-    if (_output._alpha_key != null)
-      _output._alpha_key.remove(fs);
-    return super.remove_impl(fs);
+  protected Futures remove_impl(Futures fs, boolean cascade) {
+    Keyed.remove(_output._alpha_key, fs, true);
+    return super.remove_impl(fs, cascade);
   }
 
 }

--- a/h2o-algos/src/main/java/hex/svd/SVDModel.java
+++ b/h2o-algos/src/main/java/hex/svd/SVDModel.java
@@ -96,12 +96,10 @@ public class SVDModel extends Model<SVDModel, SVDModel.SVDParameters, SVDModel.S
 
   public SVDModel(Key<SVDModel> selfKey, SVDParameters parms, SVDOutput output) { super(selfKey, parms, output); }
 
-  @Override protected Futures remove_impl( Futures fs ) {
-    if (null != _output._u_key)
-      _output._u_key.remove(fs);
-    if (null != _output._v_key)
-      _output._v_key.remove(fs);
-    return super.remove_impl(fs);
+  @Override protected Futures remove_impl(Futures fs, boolean cascade) {
+    Keyed.remove(_output._u_key, fs, true);
+    Keyed.remove(_output._v_key, fs, true);
+    return super.remove_impl(fs, cascade);
   }
 
   /** Write out K/V pairs */

--- a/h2o-algos/src/main/java/hex/tree/SharedTree.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTree.java
@@ -361,7 +361,7 @@ public abstract class SharedTree<M extends SharedTreeModel<M,P,O>, P extends Sha
 
       } finally {
         if( _model!=null ) _model.unlock(_job);
-        for (Key k : getGlobalQuantilesKeys()) if (k!=null) k.remove();
+        for (Key k : getGlobalQuantilesKeys()) Keyed.remove(k);
         if (_validWorkspace != null) {
           _validWorkspace.remove();
           _validWorkspace = null;

--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -599,16 +599,16 @@ public abstract class SharedTreeModel<
     return newModel;
   }
 
-  @Override protected Futures remove_impl( Futures fs ) {
+  @Override protected Futures remove_impl(Futures fs, boolean cascade) {
     for (Key[] ks : _output._treeKeys)
       for (Key k : ks)
-        if( k != null ) k.remove(fs);
+        Keyed.remove(k, fs, true);
     for (Key[] ks : _output._treeKeysAux)
       for (Key k : ks)
-        if( k != null ) k.remove(fs);
+        Keyed.remove(k, fs, true);
     if (_output._calib_model != null)
       _output._calib_model.remove(fs);
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   /** Write out K/V pairs */

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -1341,30 +1341,30 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
    * Delete the AutoML-related objects, but leave the grids and models that it built.
    */
   @Override
-  protected Futures remove_impl(Futures fs) {
+  protected Futures remove_impl(Futures fs, boolean cascade) {
     Key<Job> jobKey = job == null ? null : job._key;
     Log.debug("Cleaning up AutoML "+jobKey);
     // If the Frame was made here (e.g. buildspec contained a path, then it will be deleted
     if (buildSpec.input_spec.training_frame == null && origTrainingFrame != null) {
-      origTrainingFrame.delete(jobKey, fs);
+      origTrainingFrame.delete(jobKey, fs, true);
     }
     if (buildSpec.input_spec.validation_frame == null && validationFrame != null) {
-      validationFrame.delete(jobKey, fs);
+      validationFrame.delete(jobKey, fs, true);
     }
     if (buildSpec.input_spec.leaderboard_frame == null && leaderboardFrame != null) {
-      leaderboardFrame.delete(jobKey, fs);
+      leaderboardFrame.delete(jobKey, fs, true);
     }
 
     if (trainingFrame != null && origTrainingFrame != null)
       Frame.deleteTempFrameAndItsNonSharedVecs(trainingFrame, origTrainingFrame);
-    if (leaderboard() != null) leaderboard().remove(fs);
-    if (eventLog() != null) eventLog().remove(fs);
+    if (leaderboard() != null) leaderboard().remove(fs, cascade);
+    if (eventLog() != null) eventLog().remove(fs, cascade);
 
     // grid should be removed after leaderboard cleanup
     if (gridKeys != null)
-      for (Key<Grid> gridKey : gridKeys) gridKey.remove(fs);
+      for (Key<Grid> gridKey : gridKeys) Keyed.remove(gridKey, fs, true);
 
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   // If we have multiple AutoML engines running on the same project they will be updating the Leaderboard concurrently,

--- a/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
@@ -85,9 +85,9 @@ public class EventLog extends Keyed<EventLog> {
    * Delete object and its dependencies from DKV, including models.
    */
   @Override
-  protected Futures remove_impl(Futures fs) {
+  protected Futures remove_impl(Futures fs, boolean cascade) {
     _events = new EventLogEntry[0];
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   public TwoDimTable toTwoDimTable() {

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -433,22 +433,16 @@ public class Leaderboard extends Keyed<Leaderboard> {
    * Delete object and its dependencies from DKV, including models.
    */
   @Override
-  protected Futures remove_impl(Futures fs) {
+  protected Futures remove_impl(Futures fs, boolean cascade) {
     Log.debug("Cleaning up leaderboard from models "+Arrays.toString(models));
-    for (Key<Model> m : models) {
-      Model model = m.get();
-      if (model != null) {
-        model.deleteCrossValidationFoldAssignment();
-        model.deleteCrossValidationPreds();
-        model.deleteCrossValidationModels();
-      } else {
-        Log.info("Model "+m+" was already removed");
+    if (cascade) {
+      for (Key<Model> m : models) {
+        Keyed.remove(m, fs, true);
       }
-      m.remove(fs);
     }
     for (Key k : leaderboard_set_metrics.keySet())
-      k.remove(fs);
-    return super.remove_impl(fs);
+      Keyed.remove(k, fs, true);
+    return super.remove_impl(fs, cascade);
   }
 
   private static double[] defaultMetricForModel(Model m) {

--- a/h2o-core/src/main/java/hex/FrameSplitter.java
+++ b/h2o-core/src/main/java/hex/FrameSplitter.java
@@ -99,7 +99,7 @@ public class FrameSplitter extends H2OCountedCompleter<FrameSplitter> {
     if (splits!=null)
       for (Frame s : splits)
         if (s!=null)
-          s.unlock(jobKey).delete(jobKey,fs);
+          s.unlock(jobKey).delete(jobKey,fs, true);
     fs.blockForPending();
     return true;
   }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1805,12 +1805,17 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     return _output.nclasses() == 1 ? pred[0] /* regression */ : ArrayUtils.maxIndex(pred) /*classification?*/; 
   }
 
-  @Override protected Futures remove_impl( Futures fs ) {
+  @Override protected Futures remove_impl(Futures fs, boolean cascade) {
     if (_output._model_metrics != null)
       for( Key k : _output._model_metrics )
-        k.remove(fs);
+        Keyed.remove(k, fs, true);
+    if (cascade) {
+      deleteCrossValidationFoldAssignment();
+      deleteCrossValidationPreds();
+      deleteCrossValidationModels();
+    }
     cleanUp(_toDelete);
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   /** Write out K/V pairs, in this case model metrics. */
@@ -2377,16 +2382,11 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       int count = deleteAll(_output._cross_validation_predictions);
       Log.info(count+" CV predictions were removed");
     }
-
-    if (_output._cross_validation_holdout_predictions_frame_id != null) {
-      _output._cross_validation_holdout_predictions_frame_id.remove();
-    }
+    Keyed.remove(_output._cross_validation_holdout_predictions_frame_id);
   }
 
   public void deleteCrossValidationFoldAssignment() {
-    if (_output._cross_validation_fold_assignment_frame_id != null) {
-      _output._cross_validation_fold_assignment_frame_id.remove();
-    }
+    Keyed.remove(_output._cross_validation_fold_assignment_frame_id);
   }
 
   @Override public String toString() {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -317,12 +317,10 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
                         @Override
                         public boolean onExceptionalCompletion(Throwable ex, CountedCompleter caller) {
                           Log.warn("Model training job "+_job._description+" completed with exception: "+ex);
-                          if (_job._result != null) {
-                            try {
-                              _job._result.remove(); //ensure there's no incomplete model left for manipulation after crash or cancellation
-                            } catch (Exception logged) {
-                              Log.warn("Exception thrown when removing result from job "+ _job._description, logged);
-                            }
+                          try {
+                            Keyed.remove(_job._result); //ensure there's no incomplete model left for manipulation after crash or cancellation
+                          } catch (Exception logged) {
+                            Log.warn("Exception thrown when removing result from job "+ _job._description, logged);
                           }
                           return true;
                         }
@@ -474,7 +472,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
           DKV.remove(mb._parms._train, fs);
           DKV.remove(mb._parms._valid, fs);
           DKV.remove(Key.make(mb.getPredictionKey()), fs);
-          mb._result.remove(fs);
+          Keyed.remove(mb._result, fs, true);
         }
         fs.blockForPending();
       }

--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -390,11 +390,13 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> {
 
   // Cleanup models and grid
   @Override
-  protected Futures remove_impl(final Futures fs) {
-    for (Key<Model> k : _models.values())
-      k.remove(fs);
+  protected Futures remove_impl(final Futures fs, boolean cascade) {
+    if (cascade) {
+      for (Key<Model> k : _models.values())
+        Keyed.remove(k, fs, true);
+    }
     _models.clear();
-    return fs;
+    return super.remove_impl(fs, cascade);
   }
 
   /**

--- a/h2o-core/src/main/java/water/Key.java
+++ b/h2o-core/src/main/java/water/Key.java
@@ -360,13 +360,17 @@ final public class Key<T extends Keyed> extends Iced<Key<T>> implements Comparab
     return make(Arrays.copyOf(ab.buf(),ab.position()),rf);
   }
 
-  /** Remove a Key from the DKV, including any embedded Keys.
+  /**
+   * Remove a Key from the DKV, including any embedded Keys.
+   * @deprecated use {@link Keyed#remove(Key)} instead. Will be removed from version 3.30.
    */
-  public void remove() { remove(new Futures()).blockForPending(); }
+  public void remove() { Keyed.remove(this); }
+
+  /**
+   * @deprecated use {@link Keyed#remove(Key, Futures)} instead. Will be removed from version 3.30.
+   */
   public Futures remove(Futures fs) {
-    Value val = DKV.get(this);
-    if( val!=null ) ((Keyed)val.get()).remove(fs);
-    return fs;
+    return Keyed.remove(this, fs, true);
   }
 
   /** True if a {@link #USER_KEY} and not a system key.

--- a/h2o-core/src/main/java/water/Keyed.java
+++ b/h2o-core/src/main/java/water/Keyed.java
@@ -12,29 +12,40 @@ public abstract class Keyed<T extends Keyed> extends Iced<T> {
 
   // ---
   /** Remove this Keyed object, and all subparts; blocking. */
-  public final void remove( ) { remove(new Futures()).blockForPending(); }
+  public final void remove() {
+    remove(true);
+  }
+
+  /** Remove this Keyed object, including all subparts if cascade = true; blocking. */
+  public final void remove(boolean cascade) { remove(new Futures(), cascade).blockForPending(); }
   /** Remove this Keyed object, and all subparts.  */
   public final Futures remove( Futures fs ) {
+    return remove(fs, true);
+  }
+  /** Remove this Keyed object, including all subparts if cascade = true.  */
+  public final Futures remove( Futures fs, boolean cascade ) {
     if( _key != null ) DKV.remove(_key,fs);
-    return remove_impl(fs);
+    return remove_impl(fs, cascade);
   }
 
   /** Override to remove subparts, but not self, of composite Keyed objects.  
    *  Examples include {@link Vec} (removing associated {@link Chunk} keys)
    *  and {@link Frame} (removing associated {@link Vec} keys.) */
-  protected Futures remove_impl( Futures fs ) { return fs; }
+  protected Futures remove_impl(Futures fs, boolean cascade) { return fs; }
 
-  /** Remove this Keyed object, and all subparts; blocking. */
+  /** Removes the Keyed object associated to the key, and all subparts; blocking. */
   public static void remove( Key k ) {
+    if (k==null) return;
     Value val = DKV.get(k);
-    if( val==null ) return;
+    if (val==null) return;
     ((Keyed)val.get()).remove();
   }
-  /** Remove this Keyed object, and all subparts. */
-  public static void remove( Key k, Futures fs ) {
+  /** Remove the Keyed object associated to the key, and all subparts. */
+  public static Futures remove( Key k, Futures fs, boolean cascade) {
+    if (k==null) return fs;
     Value val = DKV.get(k);
-    if( val==null ) return;
-    ((Keyed)val.get()).remove(fs);
+    if (val==null) return fs;
+    return ((Keyed)val.get()).remove(fs, cascade);
   }
 
   // ---

--- a/h2o-core/src/main/java/water/Lockable.java
+++ b/h2o-core/src/main/java/water/Lockable.java
@@ -70,7 +70,7 @@ public abstract class Lockable<T extends Lockable<T>> extends Keyed<T> {
     Lockable old =  write_lock(job_key);
     if( old != null ) {
       Log.debug("lock-then-clear "+_key+" by job "+job_key);
-      old.remove_impl(new Futures()).blockForPending();
+      old.remove_impl(new Futures(), true).blockForPending();
     }
     return (T)this;
   }
@@ -86,22 +86,23 @@ public abstract class Lockable<T extends Lockable<T>> extends Keyed<T> {
   /** Write-lock 'this' and delete; blocking.
    *  Throws IAE if the _key is already locked.
    *
-   *  Subclasses that need custom deletion logic should override {@link #remove_impl(Futures)}
+   *  Subclasses that need custom deletion logic should override {@link Keyed#remove_impl(Futures, boolean)}
    *  as by contract, the only difference between {@link #delete()} and {@link #remove()}
    *  is that `delete` first write-locks `this`.
    */
-  public final void delete( ) { delete(null,new Futures()).blockForPending(); }
-  /** Write-lock 'this' and delete. 
+  public final void delete( ) { delete(true); }
+  public final void delete(boolean cascade) { delete(null, new Futures(), cascade).blockForPending(); }
+  /** Write-lock 'this' and delete.
    *  Throws IAE if the _key is already locked.
    *
-   *  Subclasses that need custom deletion logic should override {@link #remove_impl(Futures)}.
+   *  Subclasses that need custom deletion logic should override {@link Keyed#remove_impl(Futures, boolean)}.
    */
-  public final Futures delete( Key<Job> job_key, Futures fs ) {
+  public final Futures delete(Key<Job> job_key, Futures fs, boolean cascade) {
     if( _key != null ) {
       Log.debug("lock-then-delete "+_key+" by job "+job_key);
       new PriorWriteLock(job_key).invoke(_key);
     }
-    return remove(fs);
+    return remove(fs, cascade);
   }
 
   // Obtain the write-lock on _key, which may already exist, using the current 'this'.

--- a/h2o-core/src/main/java/water/Lockable.java
+++ b/h2o-core/src/main/java/water/Lockable.java
@@ -70,7 +70,7 @@ public abstract class Lockable<T extends Lockable<T>> extends Keyed<T> {
     Lockable old =  write_lock(job_key);
     if( old != null ) {
       Log.debug("lock-then-clear "+_key+" by job "+job_key);
-      old.remove_impl(new Futures(), true).blockForPending();
+      old.remove_impl(new Futures(), false).blockForPending();  // internal delete, don't remove dependencies as they're often still needed.
     }
     return (T)this;
   }

--- a/h2o-core/src/main/java/water/Scope.java
+++ b/h2o-core/src/main/java/water/Scope.java
@@ -43,7 +43,7 @@ public class Scope {
       Futures fs = new Futures();
       for (Key key : keys.pop()) {
         int found = Arrays.binarySearch(arrkeep, key);
-        if ((arrkeep.length == 0 || found < 0) && key != null) Keyed.remove(key, fs);
+        if (arrkeep.length == 0 || found < 0) Keyed.remove(key, fs, true);
       }
       fs.blockForPending();
     }

--- a/h2o-core/src/main/java/water/api/FramesHandler.java
+++ b/h2o-core/src/main/java/water/api/FramesHandler.java
@@ -7,7 +7,6 @@ import water.exceptions.*;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.Log;
-import water.util.PrettyPrint;
 
 import java.util.*;
 
@@ -290,7 +289,7 @@ public class FramesHandler<I extends FramesHandler.Frames, S extends SchemaV3<I,
     Futures fs = new Futures();
     for (Key key : keys) {
       try {
-        getFromDKV("(none)", key).delete(null, fs);
+        getFromDKV("(none)", key).delete(null, fs, true);
       } catch (IllegalArgumentException iae) {
         missing.add(key.toString());
       }

--- a/h2o-core/src/main/java/water/api/ModelsHandler.java
+++ b/h2o-core/src/main/java/water/api/ModelsHandler.java
@@ -192,7 +192,7 @@ public class ModelsHandler<I extends ModelsHandler.Models, S extends SchemaV3<I,
     Futures fs = new Futures();
     for (Key key : keys) {
       try {
-        getFromDKV("(none)", key).delete(null, fs);
+        getFromDKV("(none)", key).delete(null, fs, true);
       } catch (IllegalArgumentException iae) {
         missing.add(key.toString());
       }

--- a/h2o-core/src/main/java/water/api/RemoveHandler.java
+++ b/h2o-core/src/main/java/water/api/RemoveHandler.java
@@ -8,8 +8,8 @@ public class RemoveHandler extends Handler {
   public RemoveV3 remove(int version, RemoveV3 u) {
     Keyed val = DKV.getGet(u.key.key());
     if (val != null) {
-      if (val instanceof Lockable) ((Lockable) val).delete(); // Fails if object already locked
-      else val.remove(); // Unconditional delete
+      if (val instanceof Lockable) ((Lockable) val).delete(u.cascade); // Fails if object already locked
+      else val.remove(u.cascade); // Unconditional delete
     }
     H2O.updateNotIdle();
     return u;

--- a/h2o-core/src/main/java/water/api/schemas3/RemoveV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/RemoveV3.java
@@ -8,7 +8,7 @@ public class RemoveV3 extends RequestSchemaV3<Iced, RemoveV3> {
   @API(help="Object to be removed.")
   public KeyV3 key;
 
-  @API(help="If true, deletion will cascade down the object tree.", direction = API.Direction.INPUT)
+  @API(help="If true, removal operation will cascade down the object tree.", direction = API.Direction.INPUT)
   public boolean cascade;
 
 }

--- a/h2o-core/src/main/java/water/api/schemas3/RemoveV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/RemoveV3.java
@@ -8,4 +8,7 @@ public class RemoveV3 extends RequestSchemaV3<Iced, RemoveV3> {
   @API(help="Object to be removed.")
   public KeyV3 key;
 
+  @API(help="If true, deletion will cascade down the object tree.", direction = API.Direction.INPUT)
+  public boolean cascade;
+
 }

--- a/h2o-core/src/main/java/water/fvec/FileVec.java
+++ b/h2o-core/src/main/java/water/fvec/FileVec.java
@@ -62,7 +62,7 @@ public abstract class FileVec extends ByteVec {
     // sections (_chunkSize < DFLT_CHUNK_SIZE) or skip data
     // (_chunkSize > DFLT_CHUNK_SIZE). This reverses this side-effect.
     Futures fs = new Futures();
-    Keyed.remove(_key, fs);
+    Keyed.remove(_key, fs, true);
     fs.blockForPending();
     if (chunkSize <= 0) throw new IllegalArgumentException("Chunk sizes must be > 0.");
     if (chunkSize > (1<<30) ) throw new IllegalArgumentException("Chunk sizes must be < 1G.");

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -77,7 +77,7 @@ public class Frame extends Lockable<Frame> {
     Key[] keys = tempFrame.keys();
     for( int i=0; i<keys.length; i++ )
       if( baseFrame.find(keys[i]) == -1 ) //only delete vecs that aren't shared
-        keys[i].remove();
+        Keyed.remove(keys[i]);
     DKV.remove(tempFrame._key); //delete the frame header
   }
 
@@ -776,7 +776,7 @@ public class Frame extends Lockable<Frame> {
 
   /** Actually remove/delete all Vecs from memory, not just from the Frame.
    *  @return the original Futures, for flow-coding */
-  @Override protected Futures remove_impl(Futures fs) {
+  @Override protected Futures remove_impl(Futures fs, boolean cascade) {
     final Key[] keys = _keys;
     if( keys.length==0 ) return fs;
 

--- a/h2o-core/src/main/java/water/fvec/RebalanceDataSet.java
+++ b/h2o-core/src/main/java/water/fvec/RebalanceDataSet.java
@@ -93,7 +93,7 @@ public class RebalanceDataSet extends H2O.H2OCountedCompleter {
   }
   @Override public boolean onExceptionalCompletion(Throwable t, CountedCompleter caller) {
     t.printStackTrace();
-    if( _out != null ) _out.delete(_jobKey,new Futures()).blockForPending();
+    if( _out != null ) _out.delete(_jobKey,new Futures(), true).blockForPending();
     return true;
   }
 

--- a/h2o-core/src/main/java/water/fvec/SubsetVec.java
+++ b/h2o-core/src/main/java/water/fvec/SubsetVec.java
@@ -23,9 +23,9 @@ public class SubsetVec extends WrappedVec {
     return new SubsetChunk(crows,this,masterVec());
   }
 
-  @Override public Futures remove_impl(Futures fs) {
-    Keyed.remove(_subsetRowsKey,fs);
-    return fs;
+  @Override public Futures remove_impl(Futures fs, boolean cascade) {
+    Keyed.remove(_subsetRowsKey, fs, true);
+    return super.remove_impl(fs, cascade);
   }
 
   /** Write out K/V pairs */

--- a/h2o-core/src/main/java/water/fvec/Vec.java
+++ b/h2o-core/src/main/java/water/fvec/Vec.java
@@ -940,7 +940,7 @@ public class Vec extends Keyed<Vec> {
 
   /**
    * Marks the Vec as mutating. Vec needs to be marked as mutating whenever
-   * it is modified ({@link #preWriting()}) or removed ({@link #remove_impl(Futures)}).
+   * it is modified ({@link #preWriting()}) or removed ({@link Keyed#remove_impl(Futures, boolean)}).
    */
   private static void setMutating(Key rskey) {
     Value val = DKV.get(rskey);
@@ -1328,7 +1328,7 @@ public class Vec extends Keyed<Vec> {
   /** Remove associated Keys when this guy removes.  For Vecs, remove all
    *  associated Chunks.
    *  @return Passed in Futures for flow-coding  */
-  @Override public Futures remove_impl( Futures fs ) {
+  @Override public Futures remove_impl(Futures fs, boolean cascade) {
     bulk_remove(new Key[]{_key}, nChunks());
     return fs;
   }
@@ -1586,7 +1586,7 @@ public class Vec extends Keyed<Vec> {
     @Override protected long checksum_impl() { throw H2O.fail(); }
     // Fail to remove a VectorGroup unless you also remove all related Vecs,
     // Chunks, Rollups (and any Frame that uses them), etc.
-    @Override protected Futures remove_impl( Futures fs ) { throw H2O.fail(); }
+    @Override protected Futures remove_impl(Futures fs, boolean cascade) { throw H2O.fail(); }
     /** Write out K/V pairs */
     @Override protected AutoBuffer writeAll_impl(AutoBuffer ab) { throw H2O.fail(); }
     @Override protected Keyed readAll_impl(AutoBuffer ab, Futures fs) { throw H2O.unimpl(); }

--- a/h2o-core/src/main/java/water/parser/ParseDataset.java
+++ b/h2o-core/src/main/java/water/parser/ParseDataset.java
@@ -229,8 +229,8 @@ public final class ParseDataset {
       if (mfpt != null) mfpt.onExceptionCleanup(fs);
       // Assume the input is corrupt - or already partially deleted after
       // parsing.  Nuke it all - no partial Vecs lying around.
-      for (Key k : _keys) Keyed.remove(k, fs);
-      Keyed.remove(_pds._job._result,fs);
+      for (Key k : _keys) Keyed.remove(k, fs, true);
+      Keyed.remove(_pds._job._result, fs, true);
       fs.blockForPending();
     }
   }
@@ -748,7 +748,7 @@ public final class ParseDataset {
         if(_deleteOnDone) vec.remove();
       } else {
         Frame fr = (Frame)ice;
-        if(_deleteOnDone) fr.delete(_jobKey,new Futures()).blockForPending();
+        if(_deleteOnDone) fr.delete(_jobKey,new Futures(), true).blockForPending();
         else if( fr._key != null ) fr.unlock(_jobKey);
       }
     }
@@ -1036,7 +1036,7 @@ public final class ParseDataset {
           if( _outerMFPT._deleteOnDone) ((ByteVec)ice).remove();
         } else {
           Frame fr = (Frame)ice;
-          if( _outerMFPT._deleteOnDone) fr.delete(_outerMFPT._jobKey,new Futures()).blockForPending();
+          if( _outerMFPT._deleteOnDone) fr.delete(_outerMFPT._jobKey,new Futures(), true).blockForPending();
           else if( fr._key != null ) fr.unlock(_outerMFPT._jobKey);
         }
       }
@@ -1048,7 +1048,7 @@ public final class ParseDataset {
       int ncols = _parseSetup._number_columns;
       for( int i = 0; i < ncols; ++i ) {
         Key vkey = _vg.vecKey(_vecIdStart + i);
-        Keyed.remove(vkey,fs);
+        Keyed.remove(vkey, fs, true);
         for( int c = 0; c < nchunks; ++c )
           DKV.remove(Vec.chunkKey(vkey,c),fs);
       }

--- a/h2o-core/src/main/java/water/rapids/Session.java
+++ b/h2o-core/src/main/java/water/rapids/Session.java
@@ -1,9 +1,6 @@
 package water.rapids;
 
-import water.DKV;
-import water.Futures;
-import water.Key;
-import water.MRTask;
+import water.*;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.nbhm.*;
@@ -136,7 +133,7 @@ public class Session {
           if (i > 0) REFCNTS.put(vec, i);
           else {
             REFCNTS.remove(vec);
-            vec.remove(fs);
+            Keyed.remove(vec, fs, true);
           }
         }
         DKV.remove(fr._key, fs);   // Shallow remove, internal Vecs removed 1-by-1
@@ -230,7 +227,7 @@ public class Session {
       for (Key<Vec> vec : fr.keys()) {
         GLOBALS.remove(vec);         // Not a global anymore
         if (REFCNTS.get(vec) == null) // If not shared with temps
-          vec.remove(fs);            // Remove unshared dead global
+          Keyed.remove(vec, fs, true);            // Remove unshared dead global
       }
     } else {                    // Else a temp and not a global
       fs = downRefCnt(fr, fs);   // Standard down-ref counting of all Vecs
@@ -248,7 +245,7 @@ public class Session {
     for (Key<Vec> vec : fr.keys())    // Refcnt -1 all Vecs
       if (addRefCnt(vec, -1) == 0) {
         if (fs == null) fs = new Futures();
-        vec.remove(fs);
+        Keyed.remove(vec, fs, true);
       }
     return fs;
   }
@@ -267,7 +264,7 @@ public class Session {
     if (fr != null) {          // Prior frame exists
       for (Key<Vec> vec : fr.keys()) {
         if (GLOBALS.remove(vec) && _getRefCnt(vec) == 0)
-          vec.remove(fs);       // Remove unused global vec
+          Keyed.remove(vec, fs, true);       // Remove unused global vec
       }
     }
     // Copy (defensive) the base vecs array.  Then copy any vecs which are

--- a/h2o-core/src/main/java/water/util/FrameUtils.java
+++ b/h2o-core/src/main/java/water/util/FrameUtils.java
@@ -927,7 +927,7 @@ public class FrameUtils {
   static public void cleanUp(IcedHashMap<Key, String> toDelete) {
     Futures fs = new Futures();
     for (Key k : toDelete.keySet()) {
-      k.remove(fs);
+      Keyed.remove(k, fs, true);
     }
     fs.blockForPending();
     toDelete.clear();

--- a/h2o-core/src/test/java/hex/ModelBuilderTest.java
+++ b/h2o-core/src/test/java/hex/ModelBuilderTest.java
@@ -232,8 +232,8 @@ public class ModelBuilderTest extends TestUtil {
     @Override
     protected double[] score0(double[] data, double[] preds) { return preds; }
     @Override
-    protected Futures remove_impl(Futures fs) {
-      super.remove_impl(fs);
+    protected Futures remove_impl(Futures fs, boolean cascade) {
+      super.remove_impl(fs, cascade);
       DKV.remove(_parms._trgt);
       return fs;
     }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -720,12 +720,12 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
   }
 
   @Override
-  protected Futures remove_impl(Futures fs) {
+  protected Futures remove_impl(Futures fs, boolean cascade) {
     DataInfo di = model_info().dataInfo();
     if (di != null) {
       di.remove(fs);
     }
-    return super.remove_impl(fs);
+    return super.remove_impl(fs, cascade);
   }
 
   @Override

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -910,6 +910,7 @@ def remove(x, cascade=True):
 
     :param x: H2OFrame, H2OEstimator, or string, or a list of those things: the object(s) or unique id(s)
         pointing to the object(s) to be removed.
+    :param cascade: boolean, if set to TRUE (default), the object dependencies (e.g. submodels) are also removed.
     """
     item_type = U(str, Keyed)
     assert_is_type(x, item_type, [item_type])

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -904,7 +904,7 @@ def log_and_echo(message=""):
     api("POST /3/LogAndEcho", data={"message": str(message)})
 
 
-def remove(x):
+def remove(x, cascade=True):
     """
     Remove object(s) from H2O.
 
@@ -920,14 +920,14 @@ def remove(x):
             rapids("(rm {})".format(xi.key))
             xi.detach()
         elif isinstance(xi, Keyed):
-            api("DELETE /3/DKV/%s" % xi.key)
+            api("DELETE /3/DKV/%s" % xi.key, data=dict(cascade=cascade))
             xi.detach()
         else:
             # string may be a Frame key name part of a rapids session... need to call rm thru rapids here
             try:
                 rapids("(rm {})".format(xi))
             except:
-                api("DELETE /3/DKV/%s" % xi)
+                api("DELETE /3/DKV/%s" % xi, data=dict(cascade=cascade))
 
 
 def remove_all(retained=None):

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -99,7 +99,7 @@ h2o.removeAll <- function(timeout_secs=0, retained_elements = c()) {
 #' @param ids The object or hex key associated with the object to be removed or a vector/list of those things.
 #' @seealso \code{\link{h2o.assign}}, \code{\link{h2o.ls}}
 #' @export
-h2o.rm <- function(ids) {
+h2o.rm <- function(ids, cascade=TRUE) {
   gc()
   if( !is.vector(ids) ) x_list = c(ids) else x_list = ids
   for (xi in x_list) {
@@ -109,9 +109,9 @@ h2o.rm <- function(ids) {
       if( is.null(key) ) return() # Lazy frame, never evaluated, nothing in cluster
       .h2o.__remoteSend(.h2o.__RAPIDS, h2oRestApiVersion = 99, ast=paste0("(rm ",key,")"), session_id=h2o.getConnection()@mutable$session_id, method = "POST")
     } else if( is(xi, "Keyed") ) {
-      .h2o.__remoteSend(paste0(.h2o.__DKV, "/",h2o.keyof(xi)), method = "DELETE")
+      .h2o.__remoteSend(paste0(.h2o.__DKV, "/",h2o.keyof(xi)), method = "DELETE", .params=list(cascade=cascade))
     } else if( is.character(xi) ) {
-      .h2o.__remoteSend(paste0(.h2o.__DKV, "/",xi), method = "DELETE")
+      .h2o.__remoteSend(paste0(.h2o.__DKV, "/",xi), method = "DELETE", .params=list(cascade=cascade))
     } else {
       stop("input to h2o.rm must be a Keyed instance (e.g. H2OFrame, H2OModel) or character")
     }

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -97,6 +97,7 @@ h2o.removeAll <- function(timeout_secs=0, retained_elements = c()) {
 #' Remove the h2o Big Data object(s) having the key name(s) from ids.
 #'
 #' @param ids The object or hex key associated with the object to be removed or a vector/list of those things.
+#' @param cascade Boolean, if set to TRUE (default), the object dependencies (e.g. submodels) are also removed.
 #' @seealso \code{\link{h2o.assign}}, \code{\link{h2o.ls}}
 #' @export
 h2o.rm <- function(ids, cascade=TRUE) {


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6639

An attempt at making `remove`/`delete` methods "cascadable".
Note that by contract, those methods were originally supposed to remove the object and all its subparts by default. Unfortunately, the contract was not fully respected by `Model` and `AutoML`.

Implemented the changes on backend and Py+R client.

FOR REVIEWER, main changes in:
- `Keyed`: https://github.com/h2oai/h2o-3/pull/3647/files#diff-eeadbba19e068aa9e00ffa0fa349f2b2
- `Lockable`: https://github.com/h2oai/h2o-3/pull/3647/files#diff-f748e31caa232a27f978e76704546969
- `RemoveHandler`: https://github.com/h2oai/h2o-3/pull/3647/files#diff-4491ddbd9d3bde94766d5e6058ca45fb
and for usage examples:
- `Model`: https://github.com/h2oai/h2o-3/pull/3647/files#diff-f7c84f8bfd6b9c51e43bccf2a55c6687
- `Leaderboard`:  https://github.com/h2oai/h2o-3/pull/3647/files#diff-c0a39c9d409ec866d644b215ae7580ad