### PR TITLE
PUBDEV-6593: Get rid of dependency on response column from TargetEncoder apply method.

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoding/TargetEncoder.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoding/TargetEncoder.java
@@ -305,7 +305,7 @@ public class TargetEncoder {
         return numeratorVec.mean() / denominatorVec.mean();
     }
 
-    Frame calculateAndAppendBlendedTEEncoding(Frame fr, Frame encodingMap, String targetColumnName, String appendedColumnName) {
+    Frame calculateAndAppendBlendedTEEncoding(Frame fr, Frame encodingMap, String appendedColumnName) {
       int numeratorIndex = fr.find("numerator");
       int denominatorIndex = fr.find("denominator");
 
@@ -357,7 +357,7 @@ public class TargetEncoder {
       }
     }
 
-    Frame calculateAndAppendTEEncoding(Frame fr, Frame encodingMap, String targetColumnName, String appendedColumnName) {
+    Frame calculateAndAppendTEEncoding(Frame fr, Frame encodingMap, String appendedColumnName) {
       int numeratorIndex = fr.find("numerator");
       int denominatorIndex = fr.find("denominator");
 
@@ -511,7 +511,12 @@ public class TargetEncoder {
           dataWithAllEncodings = data.deepCopy(Key.make().toString());
           DKV.put(dataWithAllEncodings);
 
-          ensureTargetColumnIsBinaryCategorical(dataWithAllEncodings, targetColumnName);
+          // Note: for KFold strategy we don't need targetColumnName so that we can exclude values from 
+          // current fold - as everything is already precomputed and stored in encoding map.
+          // This is not the case with LeaveOneOut when we need to subtract current row's value and for that 
+          // we need to make sure that response column is provided and is a binary categorical column.
+          if(dataLeakageHandlingStrategy == DataLeakageHandlingStrategy.LeaveOneOut)
+            ensureTargetColumnIsBinaryCategorical(dataWithAllEncodings, targetColumnName);
 
           for (String teColumnName : _columnNamesToEncode) {
 
@@ -569,7 +574,7 @@ public class TargetEncoder {
 
                   dataWithMergedAggregationsK = mergeByTEAndFoldColumns(dataWithAllEncodings, holdoutEncodeMap, teColumnIndex, foldColumnIndex, teColumnIndexInEncodingMap);
 
-                  Frame withEncodingsFrameK = calculateEncoding(dataWithMergedAggregationsK, encodingMapForCurrentTEColumn, targetColumnName, newEncodedColumnName, withBlendedAvg);
+                  Frame withEncodingsFrameK = calculateEncoding(dataWithMergedAggregationsK, encodingMapForCurrentTEColumn, newEncodedColumnName, withBlendedAvg);
 
                   Frame withAddedNoiseEncodingsFrameK = applyNoise(withEncodingsFrameK, newEncodedColumnName, noiseLevel, seed);
 
@@ -605,7 +610,7 @@ public class TargetEncoder {
 
                   Frame subtractedFrameL = subtractTargetValueForLOO(dataWithMergedAggregationsL, targetColumnName);
 
-                  Frame withEncodingsFrameL = calculateEncoding(subtractedFrameL, groupedTargetEncodingMap, targetColumnName, newEncodedColumnName, withBlendedAvg); // do we really need to pass groupedTargetEncodingMap again?
+                  Frame withEncodingsFrameL = calculateEncoding(subtractedFrameL, groupedTargetEncodingMap, newEncodedColumnName, withBlendedAvg); // do we really need to pass groupedTargetEncodingMap again?
 
                   Frame withAddedNoiseEncodingsFrameL = applyNoise(withEncodingsFrameL, newEncodedColumnName, noiseLevel, seed);
 
@@ -635,7 +640,7 @@ public class TargetEncoder {
                   int teColumnIndexInGroupedEncodingMapNone = groupedTargetEncodingMapForNone.find(teColumnName);
                   dataWithMergedAggregationsN = mergeByTEColumn(dataWithAllEncodings, groupedTargetEncodingMapForNone, teColumnIndex, teColumnIndexInGroupedEncodingMapNone);
 
-                  Frame withEncodingsFrameN = calculateEncoding(dataWithMergedAggregationsN, groupedTargetEncodingMapForNone, targetColumnName, newEncodedColumnName, withBlendedAvg);
+                  Frame withEncodingsFrameN = calculateEncoding(dataWithMergedAggregationsN, groupedTargetEncodingMapForNone, newEncodedColumnName, withBlendedAvg);
 
                   Frame withAddedNoiseEncodingsFrameN = applyNoise(withEncodingsFrameN, newEncodedColumnName, noiseLevel, seed);
                   // In cases when encoding has not seen some levels we will impute NAs with mean computed from training set. Mean is a dataleakage btw.
@@ -665,11 +670,11 @@ public class TargetEncoder {
         }
     }
 
-    Frame calculateEncoding(Frame preparedFrame, Frame encodingMap, String targetColumnName, String newEncodedColumnName, boolean withBlendedAvg) {
+    Frame calculateEncoding(Frame preparedFrame, Frame encodingMap, String newEncodedColumnName, boolean withBlendedAvg) {
         if (withBlendedAvg) {
-            return calculateAndAppendBlendedTEEncoding(preparedFrame, encodingMap, targetColumnName, newEncodedColumnName);
+            return calculateAndAppendBlendedTEEncoding(preparedFrame, encodingMap, newEncodedColumnName);
         } else {
-            return calculateAndAppendTEEncoding(preparedFrame, encodingMap, targetColumnName, newEncodedColumnName);
+            return calculateAndAppendTEEncoding(preparedFrame, encodingMap, newEncodedColumnName);
         }
     }
 
@@ -716,8 +721,12 @@ public class TargetEncoder {
                                      long seed) {
         double defaultNoiseLevel = 0.01;
         int targetIndex = data.find(targetColumnName);
-        Vec targetVec = data.vec(targetIndex);
-        double   noiseLevel = targetVec.isNumeric()  ?   defaultNoiseLevel * (targetVec.max() - targetVec.min()) : defaultNoiseLevel;
+        double   noiseLevel = 0.0;
+        // When noise is not provided and there is no response column in the `data` frame -> no noise will be added to transformations
+        if(targetIndex != -1) {
+          Vec targetVec = data.vec(targetIndex);
+          noiseLevel = targetVec.isNumeric() ? defaultNoiseLevel * (targetVec.max() - targetVec.min()) : defaultNoiseLevel;
+        }
         return applyTargetEncoding(data, targetColumnName, targetEncodingMap, dataLeakageHandlingStrategy, foldColumn, withBlendedAvg, noiseLevel, true, seed);
     }
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoding/TargetEncodingLeaveOneOutStrategyTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoding/TargetEncodingLeaveOneOutStrategyTest.java
@@ -65,7 +65,7 @@ public class TargetEncodingLeaveOneOutStrategyTest extends TestUtil {
       TargetEncoder tec = new TargetEncoder(teColumns);
       targetEncodingMap = tec.prepareEncodingMap(reimportedFrame, targetColumnName, null);
 
-      result = tec.calculateAndAppendBlendedTEEncoding(reimportedFrame, targetEncodingMap.get(teColumnName), targetColumnName, "targetEncoded");
+      result = tec.calculateAndAppendBlendedTEEncoding(reimportedFrame, targetEncodingMap.get(teColumnName), targetColumnName);
 
       double globalMean = 2.0 / 3;
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoding/TargetEncodingTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoding/TargetEncodingTest.java
@@ -2,6 +2,7 @@ package ai.h2o.automl.targetencoding;
 
 import org.junit.After;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import water.*;
 import water.fvec.*;
@@ -520,7 +521,7 @@ public class TargetEncodingTest extends TestUtil {
 
         merged = tec.mergeByTEColumn(reimportedFrame, targetEncodingMap.get("ColA"), 0, 0);
 
-        resultWithEncoding = tec.calculateAndAppendBlendedTEEncoding(merged, targetEncodingMap.get("ColA"), "ColB", "targetEncoded");
+        resultWithEncoding = tec.calculateAndAppendBlendedTEEncoding(merged, targetEncodingMap.get("ColA"), "ColB_te");
 
 //      String[] dom = resultWithEncoding.vec(1).domain();
         // k <- 20
@@ -539,12 +540,9 @@ public class TargetEncodingTest extends TestUtil {
         double lambda3 = 1.0 / (1.0 + (Math.exp((20.0 - 2) / 10)));
         double te3 = (1.0 - lambda3) * globalMean + (lambda3 * 2 / 2);
 
-//        printOutFrameAsTable(resultWithEncoding, true, resultWithEncoding.numRows());
-
         assertEquals(te1, resultWithEncoding.vec(4).at(0), 1e-5);
         assertEquals(te3, resultWithEncoding.vec(4).at(1), 1e-5);
         assertEquals(te2, resultWithEncoding.vec(4).at(2), 1e-5);
-
 
       } finally {
         new File(tmpName).delete();
@@ -903,6 +901,40 @@ public class TargetEncodingTest extends TestUtil {
     newReferenceFrame.delete(); // And we should not delete fr2 explicitly since it will be deleted by reference.
     assertEquals(1, fr.vec(0).at(0), 1e-5);
     fr.delete();
+  }
+
+  @Test
+  public void transformFrameWithoutResponseColumn() {
+    Scope.enter();
+    try {
+      String teColumnName = "ColA";
+      fr = new TestFrameBuilder()
+              .withName("testFrame")
+              .withColNames(teColumnName, "y")
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "b", "b"))
+              .withDataForCol(1, ar("2", "6", "6", "2"))
+              .build();
+
+      Frame frameWithoutResponse = new TestFrameBuilder()
+              .withName("testFrame2")
+              .withColNames(teColumnName)
+              .withVecTypes(Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "b", "b"))
+              .build();
+
+      String[] teColumns = {teColumnName};
+      TargetEncoder tec = new TargetEncoder(teColumns);
+
+      Map<String, Frame> encodingMap = tec.prepareEncodingMap(fr, "y", null);
+      Scope.track(encodingMap.get(teColumnName));
+
+      Frame encoded = tec.applyTargetEncoding(frameWithoutResponse, "y", encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, false, true, 1234);
+      Scope.track(encoded);
+    } finally {
+      Scope.exit();
+    }
+
   }
 
   @After


### PR DESCRIPTION
This will allow to make a predictions with TargetEncoder on data without response column. Other option is to use Mojo model.