### PR TITLE
Add DRF to list of supported algorithms for predict_contributions

### DIFF
--- a/h2o-docs/src/product/performance-and-prediction.rst
+++ b/h2o-docs/src/product/performance-and-prediction.rst
@@ -496,7 +496,7 @@ Predict Contributions
 
 In H2O-3, each returned H2OFrame has a specific shape (#rows, #features + 1). This includes a feature contribution column for each input feature, with the last column being the model bias (same value for each row). The sum of the feature contributions and the bias term is equal to the raw prediction of the model. Raw prediction of tree-based model is the sum of the predictions of the individual trees before the inverse link function is applied to get the actual prediction. For Gaussian distribution, the sum of the contributions is equal to the model prediction. 
 
-H2O-3 supports TreeSHAP for GBM and XGBoost. For these problems, the ``predict_contributions`` returns a new H2OFrame with the predicted feature contributions - SHAP (SHapley Additive exPlanation) values on an H2O model.
+H2O-3 supports TreeSHAP for DRF, GBM, and XGBoost. For these problems, the ``predict_contributions`` returns a new H2OFrame with the predicted feature contributions - SHAP (SHapley Additive exPlanation) values on an H2O model.
         
 **Note**: Multinomial classification models are currently not supported.
 


### PR DESCRIPTION
DRF added to list of algorithms that can be used to run predict_contributions.

https://0xdata.atlassian.net/browse/PUBDEV-6644