### PR TITLE
[PUBDEV-6658] Cloud hash should consist of timestamp as well

### DIFF
--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -352,9 +352,25 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     return sb.toString();
   }
 
-  @Override public int hashCode() { return _key.hashCode(); }
-  @Override public boolean equals(Object o) { return _key.equals   (((H2ONode)o)._key); }
-  @Override public int compareTo( Object o) { return _key.compareTo(((H2ONode)o)._key); }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    H2ONode h2ONode = (H2ONode) o;
+
+    if (_timestamp != h2ONode._timestamp) return false;
+    return _key.equals(h2ONode._key);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) _timestamp;
+    result = 31 * result + _key.hashCode();
+    return result;
+  }
+
+  @Override public int compareTo(Object o) { return _key.compareTo(((H2ONode)o)._key); }
 
   // index of this node in the current cloud... can change at the next cloud.
   public int index() { return H2O.CLOUD.nidx(this); }


### PR DESCRIPTION
The main purpose of this change is to be able to discover from client that the client is talking to old or new cluster simply by checking one field of the first node which is talking to client.

In the client code we can just check the of the cloud_hash and if it is not equal to previous name of the cloud hash the client was connected to, client should drop the previous state and connect to the new cluster.

Also this should not break any of the current behavior. `cloud_hash` is formed only from regular worker nodes (not clients) and regular worker nodes can't connect & disconnect from cluster, they are static. Therefore the worker nodes will have the same timestamp the whole time they are part of the cluster & therefore the `cloud_hash` will remain unchanged.