### PR TITLE
PUBDEV-6015: Deprecate support for Java 7

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1983,8 +1983,8 @@ final public class H2O {
     // Notes: 
     // - make sure that the following whitelist is logically consistent with whitelist in R code - see function .h2o.check_java_version in connection.R
     // - upgrade of the javassist library should be considered when adding support for a new java version
-    if (JAVA_VERSION.isKnown() && !isUserEnabledJavaVersion() && (JAVA_VERSION.getMajor()<7 || JAVA_VERSION.getMajor()>12)) {
-      System.err.println("Only Java 7, 8, 9, 10, 11 and 12 are supported, system version is " + System.getProperty("java.version"));
+    if (JAVA_VERSION.isKnown() && !isUserEnabledJavaVersion() && (JAVA_VERSION.getMajor()<8 || JAVA_VERSION.getMajor()>12)) {
+      System.err.println("Only Java 8, 9, 10, 11 and 12 are supported, system version is " + System.getProperty("java.version"));
       return true;
     }
     String vmName = System.getProperty("java.vm.name");

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -527,7 +527,7 @@ h2o.clusterStatus <- function() {
     return("Sorry, GNU Java is not supported for H2O.")
   }
   # NOTE for developers: keep the following blacklist in logically consistent with whitelist in java code - see water.H2O.checkUnsupportedJava, near line 1849
-  if (any(grepl("^java version \"1\\.[1-6]\\.", jver))) {
+  if (any(grepl("^java version \"1\\.[1-7]\\.", jver))) {
     return(paste0("Your java is not supported: ", jver[1]))
   }
   return(NULL)

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -181,11 +181,13 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
         warnNthreads <- TRUE
         nthreads <- 2
       }
+      # Note: Logging to stdout and stderr in Windows only works for R version 3.0.2 or later!
       stdout <- .h2o.getTmpFile("stdout")
+      stderr <- .h2o.getTmpFile("stderr")
       .h2o.startJar(ip = ip, port = port, name = name, nthreads = nthreads,
                     max_memory = max_mem_size, min_memory = min_mem_size,
                     enable_assertions = enable_assertions, forceDL = forceDL, license = license,
-                    extra_classpath = extra_classpath, ice_root = ice_root, stdout = stdout,
+                    extra_classpath = extra_classpath, ice_root = ice_root, stdout = stdout, stderr = stderr,
                     log_dir = log_dir, log_level = log_level, context_path = context_path,
                     jvm_custom_args = jvm_custom_args, bind_to_localhost = bind_to_localhost)
 
@@ -198,13 +200,17 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
       }
 
       if (!h2o.clusterIsUp(conn = tmpConn)) {
-        cat(paste(readLines(stdout), collapse="\n"), "\n")
-        print(tmpConn@ip)
-        print(tmpConn@port)
         rv <- .h2o.doRawGET(conn = tmpConn, urlSuffix = "")
-        print(rv$curlError)
-        print(rv$httpStatusCode)
-        print(rv$curlErrorMessage)
+        if (rv$curlError) {
+          cat("Diagnostic HTTP Request:\n   ")
+            cat(sprintf("HTTP Status Code: %s\n", rv$httpStatusCode))
+            cat(sprintf("HTTP Error Message: %s\n", rv$curlErrorMessage))
+        }
+        cat(paste(readLines(stdout), collapse="\n"), "\n")
+        if (file.info(stderr)$size > 0) {
+          cat("Error Output:\n   ")
+          cat(paste(readLines(stderr), collapse="\n   "), "\n")
+        }
 
         stop("H2O failed to start, stopping execution.")
       }
@@ -530,7 +536,7 @@ h2o.clusterStatus <- function() {
 .h2o.startJar <- function(ip = "localhost", port = 54321, name = NULL, nthreads = -1,
                           max_memory = NULL, min_memory = NULL,
                           enable_assertions = TRUE, forceDL = FALSE, license = NULL, extra_classpath = NULL,
-                          ice_root, stdout, log_dir, log_level, context_path, jvm_custom_args = NULL, 
+                          ice_root, stdout, stderr, log_dir, log_level, context_path, jvm_custom_args = NULL, 
                           bind_to_localhost) {
   command <- .h2o.checkJava()
 
@@ -544,8 +550,6 @@ h2o.clusterStatus <- function() {
     stop("`ice_root` must be specified for .h2o.startJar")
   }
 
-  # Note: Logging to stdout and stderr in Windows only works for R version 3.0.2 or later!
-  stderr <- .h2o.getTmpFile("stderr")
   write(Sys.getpid(), .h2o.getTmpFile("pid"), append = FALSE)   # Write PID to file to track if R started H2O
 
   jar_file <- .h2o.downloadJar(overwrite = forceDL)
@@ -629,14 +633,7 @@ h2o.clusterStatus <- function() {
   cat("\n")
 
   # Run the real h2o java command
-  rc = system2(command,
-               args=args,
-               stdout=stdout,
-               stderr=stderr,
-               wait=FALSE)
-  if (rc != 0L) {
-    stop(sprintf("Failed to exec %s with return code=%s", jar_file, as.character(rc)))
-  }
+  system2(command, args=args, stdout=stdout, stderr=stderr, wait=FALSE)
 }
 
 .h2o.getTmpFile <- function(type) {

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -313,7 +313,7 @@ test-junit-10-smoke-jenkins:
 	@$(MAKE) -f $(THIS_FILE) test-junit-10-smoke
 
 test-junit-7-smoke:
-	DOONLY=$$(head -n 1 tests/doOnlyJunitSmokeTestList) ./gradlew h2o-core:test h2o-algos:test h2o-scala_2.10:test h2o-scala_2.11:test -x h2o-algos:testMultiNode $$ADDITIONAL_GRADLE_OPTS
+	ADDITIONAL_TEST_JVM_OPTS="-Dsys.ai.h2o.debug.allowJavaVersions=7" DOONLY=$$(head -n 1 tests/doOnlyJunitSmokeTestList) ./gradlew h2o-core:test h2o-algos:test h2o-scala_2.10:test h2o-scala_2.11:test -x h2o-algos:testMultiNode $$ADDITIONAL_GRADLE_OPTS
 
 test-junit-7-smoke-jenkins:
 	$(call sed_test_scripts)


### PR DESCRIPTION
Java 7 support will be deprecated but the code and builds will still be Java 7 compatible and tested for Java 7 compatibility.

Users will be able to override the compatibility check if there is a good reason for it.

We will remove official java 7 support in H2O 3.26, in fix releases of 3.26 we will continue unofficially support Java 7. In H2O 3.28 neither code or builds will be Java 7 compatible.