### PR TITLE
PUBDEV-6673: Bring back old method Frame.toCSV

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1512,6 +1512,17 @@ public class Frame extends Lockable<Frame> {
     return job.start(t, fr.anyVec().nChunks());
   }
 
+  /**
+   * @deprecated As of release 3.24.0.5, replaced by {@link #toCSV(CSVStreamParams)}}
+   */
+  @Deprecated
+  public InputStream toCSV(boolean headers, boolean hex_string) {
+    CSVStreamParams params = new CSVStreamParams()
+            .setHeaders(headers)
+            .setHexString(hex_string);
+    return toCSV(params);
+  }
+
   /** Convert this Frame to a CSV (in an {@link InputStream}), that optionally
    *  is compatible with R 3.1's recent change to read.csv()'s behavior.
    *

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -5,6 +5,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import water.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -311,4 +313,30 @@ public class FrameTest extends TestUtil {
       Scope.exit();
     }
   }
+
+  @Test
+  public void testPubDev6673() {
+    checkToCSV(false, false);
+    checkToCSV(true, false);
+    checkToCSV(false, true);
+    checkToCSV(true, true);
+  }
+
+  private static void checkToCSV(final boolean headers, final boolean hex_string) {
+    final InputStream invoked = new ByteArrayInputStream(new byte[0]);
+
+    Frame f = new Frame() {
+      @Override
+      public InputStream toCSV(CSVStreamParams parms) {
+        assertEquals(headers, parms._headers);
+        assertEquals(hex_string, parms._hex_string);
+        return invoked;
+      }
+    };
+
+    InputStream wasInvoked = f.toCSV(headers, hex_string);
+
+    assertSame(invoked, wasInvoked); // just make sure the asserts were actually called
+  }
+
 }


### PR DESCRIPTION
marked as deprecated - users should migrate to the new one