### PR TITLE
Jenkins: increase the timeout for test-junit-automl

### DIFF
--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -188,7 +188,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Java 8 AutoML JUnit', target: 'test-junit-automl-jenkins', pythonVersion: '2.7', javaVersion: 8,
-      timeoutValue: 20, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      timeoutValue: 40, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ],
     [
       stageName: 'Java 8 XGBoost Multinode JUnit', target: 'test-junit-xgb-multi-jenkins', pythonVersion: '2.7', javaVersion: 8,


### PR DESCRIPTION
 increase the timeout for test-junit-automl: we now have more tests, and step gets interrupted for no good reason.