### PR TITLE
Fix runit pubdev 4628 deeplearning mojo large r

### DIFF
--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -775,32 +775,43 @@ random_dataset <-
       response_num = round(runif(1, 3, 10))
     }
 
-    # generate all the fractions
-    fractions <-
-      c(runif(1, 0, 1),
-        runif(1, 0, 1),
-        runif(1, 0, 1),
-        runif(1, 0, 1),
-        runif(1, 0, 1))
-    fractions <- fractions / sum(fractions)
-    random_frame <-
-      h2o.createFrame(
-        rows = num_rows,
-        cols = num_cols,
-        randomize = TRUE,
-        has_response = TRUE,
-        categorical_fraction = fractions[1],
-        integer_fraction = fractions[2],
-        binary_fraction = fractions[3],
-        time_fraction = fractions[4],
-        string_fraction = 0,
-        response_factors = response_num,
-        missing_fraction = runif(1, 0, 0.05)
-      )
-
-    return(random_frame)
+    return(random_dataseta_fixed_size(response_type, num_rows, num_cols, response_num, testrow)
   }
 
+
+#----------------------------------------------------------------------
+# This function will generate a random dataset for regression/binomial
+# and multinomial.  Copied from Pasha.
+#
+# Parameters:  response_type should be "regression", "binomial" or "multinomial"
+#----------------------------------------------------------------------
+random_dataset_fixed_size <-
+function(response_type, num_rows=1000, num_cols=10, response_num=3, testrow = 1000) {
+    # generate all the fractions
+    fractions <-
+    c(runif(1, 0, 1),
+    runif(1, 0, 1),
+    runif(1, 0, 1),
+    runif(1, 0, 1),
+    runif(1, 0, 1))
+    fractions <- fractions / sum(fractions)
+    random_frame <-
+    h2o.createFrame(
+    rows = num_rows,
+    cols = num_cols,
+    randomize = TRUE,
+    has_response = TRUE,
+    categorical_fraction = fractions[1],
+    integer_fraction = fractions[2],
+    binary_fraction = fractions[3],
+    time_fraction = fractions[4],
+    string_fraction = 0,
+    response_factors = response_num,
+    missing_fraction = runif(1, 0, 0.05)
+    )
+
+    return(random_frame)
+}
 #----------------------------------------------------------------------
 # This function will generate a random dataset containing enum columns only.
 # Copied from Pasha.
@@ -871,12 +882,11 @@ random_NN <- function(actFunc, max_layers, max_node_number) {
 
     if (grepl('Dropout', actFunc, fixed = TRUE)) {
       hiddenDropouts <- c(hiddenDropouts, runif(1, 0, 0.1))
-
     }
   }
   return(list("hidden" = hidden, "hiddenDropouts" = hiddenDropouts))
 }
-
+    
 #----------------------------------------------------------------------
 # This function will compare two frames and make sure they are equal.
 # However, the frames must contain columns that can be converted to

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -775,7 +775,7 @@ random_dataset <-
       response_num = round(runif(1, 3, 10))
     }
 
-    return(random_dataseta_fixed_size(response_type, num_rows, num_cols, response_num, testrow)
+    random_dataseta_fixed_size(response_type, num_rows, num_cols, response_num, testrow)
   }
 
 

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -786,7 +786,7 @@ random_dataset <-
 # Parameters:  response_type should be "regression", "binomial" or "multinomial"
 #----------------------------------------------------------------------
 random_dataset_fixed_size <-
-function(response_type, num_rows=1000, num_cols=10, response_num=3, testrow = 1000) {
+function(response_type, num_rows=1000, num_cols=10, response_num=3, testrow = 1000, seed=12345) {
     # generate all the fractions
     fractions <-
     c(runif(1, 0, 1),
@@ -807,7 +807,8 @@ function(response_type, num_rows=1000, num_cols=10, response_num=3, testrow = 10
     time_fraction = fractions[4],
     string_fraction = 0,
     response_factors = response_num,
-    missing_fraction = runif(1, 0, 0.05)
+    missing_fraction = 0.01,
+        seed = seed
     )
 
     return(random_frame)

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_autoencoder_mojo_large.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_autoencoder_mojo_large.R
@@ -16,14 +16,8 @@ test.deeplearning.mojo <-
     #----------------------------------------------------------------------
     # Run the test
     #----------------------------------------------------------------------
+    e <- tryCatch({
       numTest = 200 # set test dataset to contain 1000 rows
-      allAct <- c("Tanh", "TanhWithDropout", "Rectifier", "RectifierWithDropout")
-      problemType <- c("binomial", "multinomial", "regression")
-      missingValues <- c('Skip', 'MeanImputation')
-      allFactors <- c(TRUE, FALSE)
-      categoricalEncodings <- c("AUTO", "OneHotInternal", "Binary", "Eigen")
-      enableAutoEncoder <- allFactors[sample(1:length(allFactors), replace = F)[1]]
-      
       params_prob_data <- setParmsData(numTest) # generate model parameters, random dataset
       
       modelAndDir<-buildModelSaveMojo(params_prob_data$params) # build the model and save mojo
@@ -34,6 +28,12 @@ test.deeplearning.mojo <-
       twoFrames<-mojoH2Opredict(modelAndDir$model, modelAndDir$dirName, filename) # perform H2O and mojo prediction and return frames
       
       compareFrames(twoFrames$h2oPredict,twoFrames$mojoPredict, prob=0.1, tolerance = 1e-4)
+    }, error = function(x) x)
+    if (!is.null(e))
+      print("Oh, caught some error")
+      print(typeof(e))
+    if (!is.null(e) && (!all(sapply("DistributedException", grepl, e[[1]]))))
+      FAIL(e)   # throw error unless it is unstable model error.
   }
 
 mojoH2Opredict<-function(model, tmpdir_name, filename) {
@@ -83,41 +83,35 @@ buildModelSaveMojo <- function(params) {
   return(list("model"=model, "dirName"=tmpdir_name))
 }
 
-# setParmsData <- function(numTest=1000) {
-#   #----------------------------------------------------------------------
-#   # Parameters for the test.
-#   #----------------------------------------------------------------------
-#   allAct <- c("Tanh", "TanhWithDropout", "Rectifier", "RectifierWithDropout", "Maxout", "MaxoutWithDropout")
-#   problemType <- c("binomial", "multinomial", "regression")
-#   missingValues <- c('Skip', 'MeanImputation')
-#   allFactors <- c(TRUE, FALSE)
-#   categoricalEncodings <- c("AUTO", "OneHotInternal", "Binary", "Eigen")
-#   enableAutoEncoder <- FALSE
-# 
-#   problem <- problemType[sample(1:length(problemType), replace = F)[1]]
-#   actFunc <- allAct[sample(1:length(allAct), replace = F)[1]]
-#   missing_values <- missingValues[sample(1:length(missingValues), replace = F)[1]]
-#   cateEn <-categoricalEncodings[sample(1:length(categoricalEncodings), replace = F)[1]]
-#   toStandardize <- allFactors[sample(1:length(allFactors), replace = F)[1]]
-#   useAllFactors <- allFactors[sample(1:length(allFactors), replace = F)[1]]
-#   
-#   training_file <- random_dataset_fixed_size(response_type, num_rows=8000, num_cols=5, response_num=3, testrow = 200)
-#   ratios <- (h2o.nrow(training_file)-numTest)/h2o.nrow(training_file)
-#   allFrames <- h2o.splitFrame(training_file, ratios)
-#   training_frame <- allFrames[[1]]
-#   test_frame <- allFrames[[2]]
-#   allNames = h2o.names(training_frame)
-#   
-#   hiddens = c(2,5)  # fixed NN size
-#   if (grepl('Dropout', actFunc, fixed = TRUE)) {
-#     hiddenDropouts <- c(0.5,0.5)
-#   } else {
-#     hiddenDropouts <= c()
-#   }
+setParmsData <- function(numTest=1000) {
+  #----------------------------------------------------------------------
+  # Parameters for the test.
+  #----------------------------------------------------------------------
+  allAct <- c("Tanh", "TanhWithDropout", "Rectifier", "RectifierWithDropout")
+  problemType <- c("binomial", "multinomial", "regression")
+  missingValues <- c('Skip', 'MeanImputation')
+  allFactors <- c(TRUE, FALSE)
+  categoricalEncodings <- c("AUTO", "OneHotInternal", "Binary", "Eigen")
+  enableAutoEncoder <- allFactors[sample(1:length(allFactors), replace = F)[1]]
+
+  if (!enableAutoEncoder) # autoEncoder cannot use maxout
+    allAct <- c(allAct, "Maxout", "MaxoutWithDropout")
   
-setParmsData <- function(useAllFactors, actFunc, toStandardize, missing_values, cateEn, training_frame, response_type, response_num) {  
-  training_file <- random_dataset_fixed_size(response_type, num_rows=8000, num_cols=5, response_num=3, testrow = 200)
-  nn_structure <- list("hidden" = hidden, "hiddenDropouts" = hiddenDropouts)
+  problem <- problemType[sample(1:length(problemType), replace = F)[1]]
+  actFunc <- allAct[sample(1:length(allAct), replace = F)[1]]
+  missing_values <- missingValues[sample(1:length(missingValues), replace = F)[1]]
+  cateEn <-categoricalEncodings[sample(1:length(categoricalEncodings), replace = F)[1]]
+  toStandardize <- allFactors[sample(1:length(allFactors), replace = F)[1]]
+  useAllFactors <- allFactors[sample(1:length(allFactors), replace = F)[1]]
+  
+  training_file <- random_dataset(problem, testrow = numTest)
+  ratios <- (h2o.nrow(training_file)-numTest)/h2o.nrow(training_file)
+  allFrames <- h2o.splitFrame(training_file, ratios)
+  training_frame <- allFrames[[1]]
+  test_frame <- allFrames[[2]]
+  allNames = h2o.names(training_frame)
+  
+  nn_structure <- random_NN(actFunc, 6, 10)
   params                  <- list()
   params$use_all_factor_levels <- useAllFactors
   params$activation <- actFunc
@@ -127,12 +121,12 @@ setParmsData <- function(useAllFactors, actFunc, toStandardize, missing_values, 
   params$hidden <- nn_structure$hidden
   params$training_frame <- training_frame
   params$x <- allNames[-which(allNames=="response")]
-  params$autoencoder <- FALSE
+  params$autoencoder <- enableAutoEncoder
   if (!params$autoencoder)
     params$y <- "response"
   
   if (length(nn_structure$hiddenDropouts) > 0) {
-    params$input_dropout_ratio <- 0.5
+    params$input_dropout_ratio <- runif(1, 0, 0.1)
     params$hidden_dropout_ratios <- nn_structure$hiddenDropouts
   }
   return(list("params" = params, "tDataset" = test_frame))

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_autoencoder_mojo_large.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_autoencoder_mojo_large.R
@@ -11,7 +11,7 @@ source("../../scripts/h2o-r-test-setup.R")
 # randomly.  We hope to test all different network settings here.
 #----------------------------------------------------------------------
 
-test.deeplearning.mojo <-
+test.deeplearning.autoencoder.mojo <-
   function() {
     numTest = 200 # set test dataset to contain 1000 rows
     allAct <-
@@ -183,4 +183,4 @@ setParmsData <- function(useAllFactors, actFunc, toStandardize, missing_values, 
 }
 
 
-doTest("Deeplearning mojo test", test.deeplearning.mojo)
+doTest("Deeplearning autoencoder mojo test", test.deeplearning.autoencoder.mojo)

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_autoencoder_mojo_large.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_autoencoder_mojo_large.R
@@ -13,27 +13,85 @@ source("../../scripts/h2o-r-test-setup.R")
 
 test.deeplearning.mojo <-
   function() {
-    #----------------------------------------------------------------------
-    # Run the test
-    #----------------------------------------------------------------------
-    e <- tryCatch({
-      numTest = 200 # set test dataset to contain 1000 rows
-      params_prob_data <- setParmsData(numTest) # generate model parameters, random dataset
-      
-      modelAndDir<-buildModelSaveMojo(params_prob_data$params) # build the model and save mojo
-      
-      filename = sprintf("%s/in.csv", modelAndDir$dirName) # save the test dataset into a in.csv file.
-      h2o.downloadCSV(params_prob_data$tDataset[,params_prob_data$params$x], filename)
-      
-      twoFrames<-mojoH2Opredict(modelAndDir$model, modelAndDir$dirName, filename) # perform H2O and mojo prediction and return frames
-      
-      compareFrames(twoFrames$h2oPredict,twoFrames$mojoPredict, prob=0.1, tolerance = 1e-4)
-    }, error = function(x) x)
-    if (!is.null(e))
-      print("Oh, caught some error")
-      print(typeof(e))
-    if (!is.null(e) && (!all(sapply("DistributedException", grepl, e[[1]]))))
-      FAIL(e)   # throw error unless it is unstable model error.
+    numTest = 200 # set test dataset to contain 1000 rows
+    allAct <-
+      c(
+        "Tanh",
+        "TanhWithDropout",
+        "Rectifier",
+        "RectifierWithDropout"
+      )
+    problemType <- c("binomial", "multinomial", "regression")
+    missingValues <- c('MeanImputation', 'Skip')
+    categoricalEncodings <-
+      c("Eigen", "AUTO", "OneHotInternal", "Binary")
+    model_count = 1
+    useAllFactors <- TRUE
+    toStandardize <- FALSE
+    
+    for (missing_values in missingValues) {
+      for (cateEn in categoricalEncodings) {
+        for (actFunc in allAct) {
+          for (response_type in problemType) {
+            if (grepl('regression', response_type, fixed = TRUE)) {
+              response_num = 1
+            } else if (grepl('binomial', response_type, fixed = TRUE)) {
+              response_num = 2
+            } else {
+              response_num = 3
+            }
+            browser()
+            print(paste("*******   Model number", model_count, sep =
+                          ":"))
+            model_count = model_count + 1
+            print(paste("useAllFactor", useAllFactors, sep = ":"))
+            print(paste("activation function", actFunc, sep = ":"))
+            print(paste("toStandardsize", toStandardize, sep = ":"))
+            print(paste("missing values handling", missing_values, sep =
+                          ":"))
+            print(paste("categorical encodings", cateEn, sep = ":"))
+            print(paste("response type", response_type, sep = ":"))
+            print("Generating model parameters and dataset....")
+            params_prob_data <- setParmsData(
+              useAllFactors,
+              actFunc,
+              toStandardize,
+              missing_values,
+              cateEn,
+              response_type,
+              response_num
+            )
+            e <- tryCatch({           
+            print("Building model and saving mojo....")
+            modelAndDir <-
+              buildModelSaveMojo(params_prob_data$params) # build the model and save mojo
+            filename = sprintf("%s/in.csv", modelAndDir$dirName) # save the test dataset into a in.csv file.
+            h2o.downloadCSV(params_prob_data$tDataset[, params_prob_data$params$x], filename)
+            print("Generating model predict and mojo predict .....")
+            twoFrames <-
+              mojoH2Opredict(modelAndDir$model,
+                             modelAndDir$dirName,
+                             filename) # perform H2O and mojo prediction and return frames
+            print("Comparing model predict and mojo predict .....")
+            compareFrames(
+              twoFrames$h2oPredict,
+              twoFrames$mojoPredict,
+              prob = 0.1,
+              tolerance = 1e-4
+            )
+            }, error = function(x) x)
+            if (!is.null(e)) {
+              print("Oh, caught some error")
+              print(typeof(e))
+              if (!is.null(e) && (!all(sapply("DistributedException", grepl, e[[1]]))))
+                FAIL(e)   # throw error unless it is unstable model error. 
+            }
+
+            print("Test SUCCESS....")
+          }
+        }
+      }
+    }
   }
 
 mojoH2Opredict<-function(model, tmpdir_name, filename) {
@@ -83,53 +141,46 @@ buildModelSaveMojo <- function(params) {
   return(list("model"=model, "dirName"=tmpdir_name))
 }
 
-setParmsData <- function(numTest=1000) {
-  #----------------------------------------------------------------------
-  # Parameters for the test.
-  #----------------------------------------------------------------------
-  allAct <- c("Tanh", "TanhWithDropout", "Rectifier", "RectifierWithDropout")
-  problemType <- c("binomial", "multinomial", "regression")
-  missingValues <- c('Skip', 'MeanImputation')
-  allFactors <- c(TRUE, FALSE)
-  categoricalEncodings <- c("AUTO", "OneHotInternal", "Binary", "Eigen")
-  enableAutoEncoder <- allFactors[sample(1:length(allFactors), replace = F)[1]]
+setParmsData <- function(useAllFactors, actFunc, toStandardize, missing_values, cateEn, training_frame, response_type, response_num) {
+    if (grepl('regression', response_type, fixed = TRUE))  {
+        response_num <- 1
+    } else if (grepl('binomial', response_type, fixed = TRUE))  {
+        response_num <- 2
+    } else {
+        response_num <- 3
+    }
+    training_file <- random_dataset_fixed_size(response_type, 8000, 5, response_num, testrow = 200)
+    ratios <- (h2o.nrow(training_file)-200)/h2o.nrow(training_file)
+    allFrames <- h2o.splitFrame(training_file, ratios)
+    training_frame <- allFrames[[1]]
+    test_frame <- allFrames[[2]]
+    allNames = h2o.names(training_frame)
 
-  if (!enableAutoEncoder) # autoEncoder cannot use maxout
-    allAct <- c(allAct, "Maxout", "MaxoutWithDropout")
-  
-  problem <- problemType[sample(1:length(problemType), replace = F)[1]]
-  actFunc <- allAct[sample(1:length(allAct), replace = F)[1]]
-  missing_values <- missingValues[sample(1:length(missingValues), replace = F)[1]]
-  cateEn <-categoricalEncodings[sample(1:length(categoricalEncodings), replace = F)[1]]
-  toStandardize <- allFactors[sample(1:length(allFactors), replace = F)[1]]
-  useAllFactors <- allFactors[sample(1:length(allFactors), replace = F)[1]]
-  
-  training_file <- random_dataset(problem, testrow = numTest)
-  ratios <- (h2o.nrow(training_file)-numTest)/h2o.nrow(training_file)
-  allFrames <- h2o.splitFrame(training_file, ratios)
-  training_frame <- allFrames[[1]]
-  test_frame <- allFrames[[2]]
-  allNames = h2o.names(training_frame)
-  
-  nn_structure <- random_NN(actFunc, 6, 10)
-  params                  <- list()
-  params$use_all_factor_levels <- useAllFactors
-  params$activation <- actFunc
-  params$standardize <- toStandardize
-  params$missing_values_handling <- missing_values
-  params$categorical_encoding <- cateEn
-  params$hidden <- nn_structure$hidden
-  params$training_frame <- training_frame
-  params$x <- allNames[-which(allNames=="response")]
-  params$autoencoder <- enableAutoEncoder
-  if (!params$autoencoder)
-    params$y <- "response"
-  
-  if (length(nn_structure$hiddenDropouts) > 0) {
-    params$input_dropout_ratio <- runif(1, 0, 0.1)
-    params$hidden_dropout_ratios <- nn_structure$hiddenDropouts
-  }
-  return(list("params" = params, "tDataset" = test_frame))
+    params                  <- list()
+    params$use_all_factor_levels <- useAllFactors
+    params$activation <- actFunc
+    params$standardize <- toStandardize
+    params$missing_values_handling <- missing_values
+    params$categorical_encoding <- cateEn
+    hidden <- c(2,3)
+    if (grepl('Dropout', actFunc, fixed = TRUE)) {
+        hiddenDropouts <- c(0.5, 0.5)
+    } else {
+        hiddenDropouts <- c()
+    }
+    nn_structure <- list("hidden" = hidden, "hiddenDropouts" = hiddenDropouts)
+    params$hidden <- nn_structure$hidden
+    params$training_frame <- training_frame
+    params$x <- allNames[-which(allNames=="response")]
+    params$autoencoder <- TRUE
+    if (!params$autoencoder)
+        params$y <- "response"
+    if (length(nn_structure$hiddenDropouts) > 0) {
+        params$input_dropout_ratio <- 0.5
+        params$hidden_dropout_ratios <- nn_structure$hiddenDropouts
+    }
+    return(list("params" = params, "tDataset" = test_frame))
 }
+
 
 doTest("Deeplearning mojo test", test.deeplearning.mojo)

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_mojo_large.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_4628_deeplearning_mojo_large.R
@@ -38,6 +38,14 @@ test.deeplearning.mojo <-
       for (cateEn in categoricalEncodings) {
         for (actFunc in allAct) {
           for (response_type in problemType) {
+            browser()
+
+            # actFunc <- "MaxoutWithDropout"
+            # missing_values <- 'Skip'
+            # cateEn <- "Binary"
+            # response_type <- "regression"
+
+            
             if (grepl('regression', response_type, fixed = TRUE)) {
               response_num = 1
             } else if (grepl('binomial', response_type, fixed = TRUE)) {
@@ -170,6 +178,7 @@ setParmsData <- function(useAllFactors, actFunc, toStandardize, missing_values, 
   params$training_frame <- training_frame
   params$x <- allNames[-which(allNames=="response")]
   params$autoencoder <- FALSE
+  params$seed <- 12345
   if (!params$autoencoder)
     params$y <- "response"
   if (length(nn_structure$hiddenDropouts) > 0) {


### PR DESCRIPTION
Veronica has caught test failure for runit_PUBDEV_4628_deeplearning_mojo.R and I caught it here: https://0xdata.atlassian.net/browse/PUBDEV-6680?filter=-2

I have done the following:
1. Broken deeplearning tests into autoencoders and non-autoencoders.
2. For each type, run through all combinations in terms of activation function, missing value handline, categorical encoding and others.

Next:
fix the bug.