### PR TITLE
[PUBDEV-6681] Refactor out method for obtaining logs in Java

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -2291,6 +2291,10 @@ final public class H2O {
     return downloadLogs(destinationDir.toString(), logContainer);
   }
 
+  public static URI downloadLogs(URI destinationDir, String logContainer) {
+    return downloadLogs(destinationDir, LogArchiveContainer.valueOf(logContainer));
+  }
+
   public static URI downloadLogs(String destinationDir, LogArchiveContainer logContainer) {
     String outputFileStem = LogsHandler.getOutputLogStem();
     String outputFileName = outputFileStem + "." + logContainer.getFileExtension();
@@ -2304,4 +2308,9 @@ final public class H2O {
     }
     return destination.toURI();
   }
+  
+  public static URI downloadLogs(String destinationDir, String logContainer) {
+    return downloadLogs(destinationDir, LogArchiveContainer.valueOf(logContainer));
+  }
+  
 }

--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -7,14 +7,11 @@ import jsr166y.ForkJoinWorkerThread;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PropertyConfigurator;
 import water.UDPRebooted.ShutdownTsk;
+import water.api.LogsHandler;
 import water.api.RequestServer;
 import water.exceptions.H2OFailException;
 import water.exceptions.H2OIllegalArgumentException;
-import water.init.AbstractBuildVersion;
-import water.init.AbstractEmbeddedH2OConfig;
-import water.init.JarHash;
-import water.init.NetworkInit;
-import water.init.NodePersistentStorage;
+import water.init.*;
 import water.nbhm.NonBlockingHashMap;
 import water.parser.DecryptionTool;
 import water.parser.ParserService;
@@ -23,20 +20,11 @@ import water.server.ServletUtils;
 import water.util.*;
 import water.webserver.iface.WebServer;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Field;
-import java.net.Inet4Address;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.MulticastSocket;
-import java.net.NetworkInterface;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -2297,5 +2285,23 @@ final public class H2O {
 
   public static Key<DecryptionTool> defaultDecryptionTool() {
     return H2O.ARGS.decrypt_tool != null ? Key.<DecryptionTool>make(H2O.ARGS.decrypt_tool) : null;
+  }
+
+  public static URI downloadLogs(URI destinationDir, LogArchiveContainer logContainer) {
+    return downloadLogs(destinationDir.toString(), logContainer);
+  }
+
+  public static URI downloadLogs(String destinationDir, LogArchiveContainer logContainer) {
+    String outputFileStem = LogsHandler.getOutputLogStem();
+    String outputFileName = outputFileStem + "." + logContainer.getFileExtension();
+    byte[] logBytes = LogsHandler.downloadLogs(logContainer, outputFileStem);
+    File destination = new File(destinationDir, outputFileName);
+
+    try (FileOutputStream fileOutputStream = new FileOutputStream(destination)) {
+      fileOutputStream.write(logBytes);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return destination.toURI();
   }
 }

--- a/h2o-core/src/main/java/water/api/LogsHandler.java
+++ b/h2o-core/src/main/java/water/api/LogsHandler.java
@@ -248,15 +248,13 @@ public class LogsHandler extends Handler {
     assert H2O.CLOUD._memary.length == results.length : "Unexpected change in the cloud!";
     for (byte[] result : results) l += result.length;
     ByteArrayOutputStream baos = new ByteArrayOutputStream(l);
-
-    // Add top-level directory.
-    LogArchiveWriter archive = container.createLogArchiveWriter(baos);
-    {
+    
+    try (LogArchiveWriter archive = container.createLogArchiveWriter(baos)) {
+      
+      // Add top-level directory.
       LogArchiveWriter.ArchiveEntry entry = new LogArchiveWriter.ArchiveEntry(topDir + File.separator, now);
       archive.putNextEntry(entry);
-    }
-
-    try {
+      
       // Archive directory from each cloud member.
       for (int i = 0; i < results.length; i++) {
         String filename =
@@ -283,9 +281,6 @@ public class LogsHandler extends Handler {
 
       // Close the top-level directory.
       archive.closeEntry();
-    } finally {
-      // Close the archive file.
-      archive.close();
     }
 
     return baos.toByteArray();

--- a/h2o-core/src/main/java/water/api/LogsHandler.java
+++ b/h2o-core/src/main/java/water/api/LogsHandler.java
@@ -189,6 +189,27 @@ public class LogsHandler extends Handler {
     return s;
   }
 
+  public static byte[] downloadLogs(LogArchiveContainer logContainer, String outputFileStem) {
+    Log.info("\nCollecting logs.");
+
+    byte[][] workersLogs = getWorkersLogs(logContainer);
+    byte[] clientLogs = getClientLogs(logContainer);
+
+    try {
+      return archiveLogs(logContainer, new Date(), workersLogs, clientLogs, outputFileStem);
+    } catch (Exception e) {
+      return StringUtils.toBytes(e);
+    }
+  }
+
+
+  public static String getOutputLogStem() {
+    String pattern = "yyyyMMdd_hhmmss";
+    SimpleDateFormat formatter = new SimpleDateFormat(pattern);
+    String now = formatter.format(new Date());
+    return "h2ologs_" + now;
+  }
+  
   private static byte[][] getWorkersLogs(LogArchiveContainer logContainer) {
     H2ONode[] members = H2O.CLOUD.members();
     byte[][] perNodeArchiveByteArray = new byte[members.length][];
@@ -221,27 +242,6 @@ public class LogsHandler extends Handler {
       }
     }
     return null;
-  }
-
-  public static byte[] downloadLogs(LogArchiveContainer logContainer, String outputFileStem) {
-    Log.info("\nCollecting logs.");
-
-    byte[][] workersLogs = getWorkersLogs(logContainer);
-    byte[] clientLogs = getClientLogs(logContainer);
-
-    try {
-      return archiveLogs(logContainer, new Date(), workersLogs, clientLogs, outputFileStem);
-    } catch (Exception e) {
-      return StringUtils.toBytes(e);
-    }
-  }
-
-
-  public static String getOutputLogStem() {
-    String pattern = "yyyyMMdd_hhmmss";
-    SimpleDateFormat formatter = new SimpleDateFormat(pattern);
-    String now = formatter.format(new Date());
-    return "h2ologs_" + now;
   }
 
   private static byte[] archiveLogs(LogArchiveContainer container, Date now,

--- a/h2o-core/src/main/java/water/api/LogsHandler.java
+++ b/h2o-core/src/main/java/water/api/LogsHandler.java
@@ -117,8 +117,7 @@ public class LogsHandler extends Handler {
       tryComplete();
     }
   }
-
-
+  
   private static H2ONode getH2ONode(String nodeIdx) {
     try {
       int numNodeIdx = Integer.parseInt(nodeIdx);
@@ -201,18 +200,17 @@ public class LogsHandler extends Handler {
       return StringUtils.toBytes(e);
     }
   }
-
-
+  
   public static String getOutputLogStem() {
     String pattern = "yyyyMMdd_hhmmss";
     SimpleDateFormat formatter = new SimpleDateFormat(pattern);
     String now = formatter.format(new Date());
     return "h2ologs_" + now;
   }
-  
+
   private static byte[][] getWorkersLogs(LogArchiveContainer logContainer) {
     H2ONode[] members = H2O.CLOUD.members();
-    byte[][] perNodeArchiveByteArray = new byte[members.length][];
+    byte[][] perNodeArchive = new byte[members.length][];
 
     for (int i = 0; i < members.length; i++) {
       try {
@@ -220,15 +218,15 @@ public class LogsHandler extends Handler {
         if (members[i].isHealthy()) {
           GetLogsFromNode g = new GetLogsFromNode(i, logContainer);
           g.doIt();
-          perNodeArchiveByteArray[i] = g.bytes;
+          perNodeArchive[i] = g.bytes;
         } else {
-          perNodeArchiveByteArray[i] = StringUtils.bytesOf("Node not healthy");
+          perNodeArchive[i] = StringUtils.bytesOf("Node not healthy");
         }
       } catch (Exception e) {
-        perNodeArchiveByteArray[i] = StringUtils.toBytes(e);
+        perNodeArchive[i] = StringUtils.toBytes(e);
       }
     }
-    return perNodeArchiveByteArray;
+    return perNodeArchive;
   }
 
   private static byte[] getClientLogs(LogArchiveContainer logContainer) {


### PR DESCRIPTION
The main reason for this change is that in Sparkling Water, we are duplicating logic for downloading logs. With this change, we can remove the duplicated code.