### PR TITLE
Replace s3 path for datasets 

### DIFF
--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5858_mojo_predict.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5858_mojo_predict.py
@@ -9,8 +9,8 @@ def glrm_mojo():
     h2o.remove_all()
     train = h2o.import_file(pyunit_utils.locate("smalldata/glrm_test/pubdev_5858_glrm_mojo_train.csv"))
     test = h2o.import_file(pyunit_utils.locate("smalldata/glrm_test/pubdev_5858_glrm_mojo_test.csv"))
-    predict_10iter = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glrm_test/pubdev_5858_glrm_predict_10iter.csv")
-    predict_1iter = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/glrm_test/pubdev_5858_glrm_predict_1iter.csv")
+    predict_10iter = h2o.import_file(pyunit_utils.locate("smalldata/glrm_test/pubdev_5858_glrm_predict_10iter.csv"))
+    predict_1iter = h2o.import_file(pyunit_utils.locate("smalldata/glrm_test/pubdev_5858_glrm_predict_1iter.csv"))
 
     x = train.names
     transformN = "STANDARDIZE"


### PR DESCRIPTION
For test pyunit_pubdev_5858_mojo_predict.py, I replaced the s3 path with local path per Anmol fix.