### PR TITLE
[XGBOOST] fix smoke tests on GPU

### DIFF
--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -18,7 +18,8 @@ import water.util.Log;
 import water.util.Timer;
 import water.util.TwoDimTable;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -670,11 +671,15 @@ public class TestUtil extends Iced {
   public static <T> T[] aro(T ...a) { return a ;}
 
   // ==== Comparing Results ====
-  
+
   public static void assertFrameEquals(Frame expected, Frame actual, double delta) {
+    assertFrameEquals(expected, actual, delta, false);
+  }
+
+  public static void assertFrameEquals(Frame expected, Frame actual, double delta, boolean relativeDelta) {
     assertEquals("Frames have different number of vecs. ", expected.vecs().length, actual.vecs().length);
     for (int i = 0; i < expected.vecs().length; i++) {
-      assertVecEquals(i + "/" + expected._names[i] + " ", expected.vec(i), actual.vec(i), delta);
+      assertVecEquals(i + "/" + expected._names[i] + " ", expected.vec(i), actual.vec(i), delta, relativeDelta);
     }
   }
 
@@ -683,10 +688,25 @@ public class TestUtil extends Iced {
   }
 
   public static void assertVecEquals(String messagePrefix, Vec expecteds, Vec actuals, double delta) {
+    assertVecEquals(messagePrefix, expecteds, actuals, delta, false);
+  }
+
+  public static void assertVecEquals(String messagePrefix, Vec expecteds, Vec actuals, double delta, boolean relativeDelta) {
     assertEquals(expecteds.length(), actuals.length());
     for(int i = 0; i < expecteds.length(); i++) {
       final String message = messagePrefix + i + ": " + expecteds.at(i) + " != " + actuals.at(i) + ", chunkIds = " + expecteds.elem2ChunkIdx(i) + ", " + actuals.elem2ChunkIdx(i) + ", row in chunks = " + (i - expecteds.chunkForRow(i).start()) + ", " + (i - actuals.chunkForRow(i).start());
-      assertEquals(message, expecteds.at(i), actuals.at(i), delta);
+      double expectedVal = expecteds.at(i);
+      double actualVal = actuals.at(i);
+      double assertionDelta = delta;
+      if (relativeDelta) {
+        double deltaBase = Math.abs(expectedVal);
+        if (deltaBase == 0) {
+          assertionDelta = delta;
+        } else {
+          assertionDelta = deltaBase * delta;
+        }
+      }
+      assertEquals(message, expectedVal, actualVal, assertionDelta);
     }
   }
 

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostPredictImplComparisonTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostPredictImplComparisonTest.java
@@ -6,13 +6,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import water.DKV;
-import water.Key;
-import water.Scope;
-import water.TestUtil;
+import water.*;
 import water.fvec.Frame;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -23,7 +19,7 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
     public static void setup() {
         stall_till_cloudsize(1);
     }
-    
+
     @Parameterized.Parameters(name = "XGBoost(booster={0},distribution={1},response={2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
@@ -35,7 +31,7 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
             {"gbtree", "poisson", "AGE"},
             {"gbtree", "tweedie", "AGE"},
             {"gbtree", "gamma", "AGE"},
-            {"dart", "AUTO", "AGE"}, 
+            {"dart", "AUTO", "AGE"},
             {"dart", "bernoulli", "CAPSULE"},
             {"dart", "multinomial", "CAPSULE"},
             {"dart", "gaussian", "AGE"},
@@ -64,7 +60,7 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
     public String response;
 
     @Test
-    public void testPredictionsAreSame() throws IOException {
+    public void testPredictionsAreSame() {
         Scope.enter();
         try {
             Frame tfr = Scope.track(parse_test_file("./smalldata/prostate/prostate.csv"));
@@ -74,7 +70,7 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
             DKV.put(tfr);
 
             // split into train/test
-            SplitFrame sf = new SplitFrame(tfr, new double[] { 0.7, 0.3 }, null);
+            SplitFrame sf = new SplitFrame(tfr, new double[]{0.7, 0.3}, null);
             sf.exec().get();
             Key[] splits = sf._destination_frames;
             Frame trainFrame = Scope.track((Frame) splits[0].get());
@@ -91,20 +87,23 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
 
             XGBoostModel model = new hex.tree.xgboost.XGBoost(parms).trainModel().get();
             Scope.track_generic(model);
-            
+
             System.setProperty("sys.ai.h2o.xgboost.predict.native.enable", "true");
             Frame predsNative = Scope.track(model.score(testFrame));
             System.setProperty("sys.ai.h2o.xgboost.predict.native.enable", "false");
             Frame predsJava = Scope.track(model.score(testFrame));
 
-            assertFrameEquals(predsNative, predsJava, getDelta());
+            assertFrameEquals(predsNative, predsJava, getDelta(parms), true);
         } finally {
             Scope.exit();
         }
     }
-    
-    private double getDelta() {
-        if ("gbtree".equals(booster)) {
+
+    private double getDelta(XGBoostModel.XGBoostParameters parms) {
+        if (usesGpu(parms)) {
+            // train/predict on gpu is non-deterministic
+            return 1e-3;
+        } else if ("gbtree".equals(booster)) {
             return 1e-10;
         } else if ("dart".equals(booster)) {
             return 1e-10;
@@ -115,5 +114,11 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
             return 1e-3;
         }
     }
-    
+
+    private boolean usesGpu(XGBoostModel.XGBoostParameters parms) {
+        return parms._backend == XGBoostModel.XGBoostParameters.Backend.gpu ||
+            (parms._backend == XGBoostModel.XGBoostParameters.Backend.auto &&
+                XGBoost.hasGPU(H2O.CLOUD.members()[0], 0));
+    }
+
 }

--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostPredictImplComparisonTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/XGBoostPredictImplComparisonTest.java
@@ -93,17 +93,14 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
             System.setProperty("sys.ai.h2o.xgboost.predict.native.enable", "false");
             Frame predsJava = Scope.track(model.score(testFrame));
 
-            assertFrameEquals(predsNative, predsJava, getDelta(parms), true);
+            assertFrameEquals(predsNative, predsJava, getAbsDelta(), getRelDelta(parms));
         } finally {
             Scope.exit();
         }
     }
 
-    private double getDelta(XGBoostModel.XGBoostParameters parms) {
-        if (usesGpu(parms)) {
-            // train/predict on gpu is non-deterministic
-            return 1e-3;
-        } else if ("gbtree".equals(booster)) {
+    private double getAbsDelta() {
+        if ("gbtree".equals(booster)) {
             return 1e-10;
         } else if ("dart".equals(booster)) {
             return 1e-10;
@@ -112,6 +109,15 @@ public class XGBoostPredictImplComparisonTest extends TestUtil {
             // digit which when converted from float to double leads to difference
             // on 6th least significant decimal digit
             return 1e-3;
+        }
+    }
+    
+    private Double getRelDelta(XGBoostModel.XGBoostParameters parms) {
+        if (usesGpu(parms)) {
+            // train/predict on gpu is non-deterministic
+            return 1e-3;
+        } else {
+            return null;
         }
     }
 


### PR DESCRIPTION
I have verified that even xgboost native predict gives different results for gpu and cpu predictor. The worst diff encountered was on 3rd significant digit. Because of this I was forced to add frame comparison that would assert with relative precision - check n-th significant digit.