### PR TITLE
PUBDEV-6639: FIX, adding backward compatible support for external classes implementing `remove_impl`

### DIFF
--- a/h2o-core/src/main/java/water/Keyed.java
+++ b/h2o-core/src/main/java/water/Keyed.java
@@ -28,10 +28,16 @@ public abstract class Keyed<T extends Keyed> extends Iced<T> {
     return remove_impl(fs, cascade);
   }
 
-  /** Override to remove subparts, but not self, of composite Keyed objects.  
+  /**
+   * @deprecated Better override {@link #remove_impl(Futures, boolean)} instead
+   */
+  @Deprecated
+  protected Futures remove_impl(Futures fs) { return fs; }
+
+  /** Override to remove subparts, but not self, of composite Keyed objects.
    *  Examples include {@link Vec} (removing associated {@link Chunk} keys)
    *  and {@link Frame} (removing associated {@link Vec} keys.) */
-  protected Futures remove_impl(Futures fs, boolean cascade) { return fs; }
+  protected Futures remove_impl(Futures fs, boolean cascade) { return remove_impl(fs); }
 
   /** Removes the Keyed object associated to the key, and all subparts; blocking. */
   public static void remove( Key k ) {


### PR DESCRIPTION
From @navdeep-G :

hey, i just tried to update the h2o version in mli and have a few errors
Error:(215, 3) java: method does not override or implement a method from a supertype
For this in KLimeModel.java:
``` 
@Override
  protected Futures remove_impl(Futures fs) {
    if (_output._clustering != null)
      _output._clustering.remove(fs);
    if (_output._globalRegressionModel != null)
      _output._globalRegressionModel.remove(fs);
    if (_output._regressionModels != null)
      for (Model m : _output._regressionModels)
        if (m != null)
          m.remove(fs);
    return super.remove_impl(fs);
  }
```