### PR TITLE
Docs: Instructions to add cloud-boothook to force execution of user-data

### DIFF
--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -220,7 +220,8 @@ Transfer the MOJO file into the /tmp folder of this instance before launching. I
 Run following bash script as "userdata" to transfer your MOJO into the instance before you launch the instance. Be sure you change the ``mojofile`` path below.
 
 .. code::
-
+   
+   #cloud-boothook
    #!/bin/bash
    export mojofile="s3://yourbucket/yourmojo.zip"
    aws s3 cp $mojo /tmp/pipeline.mojo

--- a/h2o-docs/src/product/productionizing.rst
+++ b/h2o-docs/src/product/productionizing.rst
@@ -224,7 +224,7 @@ Run following bash script as "userdata" to transfer your MOJO into the instance 
    #cloud-boothook
    #!/bin/bash
    export mojofile="s3://yourbucket/yourmojo.zip"
-   aws s3 cp $mojo /tmp/pipeline.mojo
+   aws s3 cp $mojofile /tmp/pipeline.mojo
 
 After this instance has launched, you can make real time inference using the following command. Remember to change the IP address. Input data is provided through the ``row`` parameter in the URL.
 


### PR DESCRIPTION
User-data will not be run on custom AMIs automatically but can be forced with "#cloud-boothook".