### PR TITLE
PUBDEV-6319: Workaround for GroupBy race condition for TE

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoding/TargetEncoder.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoding/TargetEncoder.java
@@ -32,6 +32,9 @@ import java.util.*;
  */
 public class TargetEncoder {
 
+    // workaround for PUBDEV-6319: this makes sure TE does get consistent and correct aggregates
+    private static final AstGroup GROUP_BY = new AstGroup(false); 
+
     private BlendingParams _blendingParams;
     private String[] _columnNamesToEncode;
 
@@ -140,7 +143,7 @@ public class TargetEncoder {
       aggs[0] = new AstGroup.AGG(AstGroup.FCN.sum, targetIndex, na, -1);
       aggs[1] = new AstGroup.AGG(AstGroup.FCN.nrow, targetIndex, na, -1);
 
-      Frame result = new AstGroup().performGroupingWithAggregations(fr, groupByColumns, aggs).getFrame();
+      Frame result = GROUP_BY.performGroupingWithAggregations(fr, groupByColumns, aggs).getFrame();
       return register(result);
     }
 
@@ -221,7 +224,7 @@ public class TargetEncoder {
         return true;
     }
 
-    public static Frame groupByTEColumnAndAggregate(Frame data, int teColumnIndex) {
+    static Frame groupByTEColumnAndAggregate(Frame data, int teColumnIndex) {
       int numeratorColumnIndex = data.find("numerator");
       int denominatorColumnIndex = data.find("denominator");
       AstGroup.AGG[] aggs = new AstGroup.AGG[2];
@@ -230,7 +233,7 @@ public class TargetEncoder {
       aggs[0] = new AstGroup.AGG(AstGroup.FCN.sum, numeratorColumnIndex, na, -1);
       aggs[1] = new AstGroup.AGG(AstGroup.FCN.sum, denominatorColumnIndex, na, -1);
 
-      Frame result = new AstGroup().performGroupingWithAggregations(data, new int[]{teColumnIndex}, aggs).getFrame();
+      Frame result = GROUP_BY.performGroupingWithAggregations(data, new int[]{teColumnIndex}, aggs).getFrame();
       return register(result);
     }
 

--- a/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstGroupTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/mungers/AstGroupTest.java
@@ -1,58 +1,69 @@
 package water.rapids.ast.prims.mungers;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import water.*;
 import water.fvec.Frame;
 import water.fvec.TestFrameBuilder;
 import water.fvec.Vec;
-import water.rapids.Env;
 import water.rapids.Rapids;
-import water.rapids.Session;
 import water.rapids.Val;
-import water.rapids.vals.ValFrame;
-import water.rapids.vals.ValRow;
-import water.util.ArrayUtils;
-import water.util.TwoDimTable;
 
-import static org.junit.Assert.*;
-
+@RunWith(Parameterized.class)
 public class AstGroupTest extends TestUtil {
 
+  @Parameterized.Parameters
+  public static Object[] data() {
+    return new Object[]{
+            "GB",
+            "GBSafe" // available in tests only - testing workaround for TE
+    };
+  }
+
+  @Parameterized.Parameter
+  public String groupByOp;
+  
   @BeforeClass
   static public void setup() { stall_till_cloudsize(1); }
 
-  private Frame fr = null;
-
   @Test
-  public void TestGroup() {
+  public void testGroupBy() {
+    Scope.enter();
+    try {
+      Frame fr = new TestFrameBuilder()
+              .withName("testFrame")
+              .withColNames("ColA", "ColB", "ColC")
+              .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM)
+              .withDataForCol(0, ard(1, 1, 1, 2, 2, 2))
+              .withDataForCol(1, ard(1, 1, 2, 1, 2, 2))
+              .withDataForCol(2, ar(4, 5, 6, 7, 2, 6))
+              .withChunkLayout(2, 2, 2)
+              .build();
 
-    fr = new TestFrameBuilder()
-            .withName("testFrame")
-            .withColNames("ColA", "ColB", "ColC")
-            .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM)
-            .withDataForCol(0, ard(1, 1, 1, 2, 2, 2))
-            .withDataForCol(1, ard(1, 1, 2, 1, 2, 2))
-            .withDataForCol(2, ar(4, 5, 6, 7, 2, 6))
-            .withChunkLayout(2, 2, 2)
-            .build();
-    String tree = "(GB testFrame [0, 1] sum 2 \"all\" nrow 1 \"all\")";
-    Val val = Rapids.exec(tree);
-    Frame res = val.getFrame();
+      String rapidEx = "("+ groupByOp + " " + fr._key + " [0, 1] sum 2 \"all\" nrow 1 \"all\")";
+      Val val = Rapids.exec(rapidEx);
+      Frame res = val.getFrame();
+      Scope.track(res);
 
-    Vec resVec = res.vec(2);
-    Vec expected = vec(9, 6, 7, 8);
-    assertVecEquals(expected, resVec, 1e-5);
-
-    resVec.remove();
-    expected.remove();
-    res.delete();
+      Vec resVec = res.vec(2);
+      Vec expected = Scope.track(vec(9, 6, 7, 8));
+      assertVecEquals(expected, resVec, 1e-5);
+    } finally {
+      Scope.exit();
+    }
   }
 
-  @After
-  public void afterEach() {
-    fr.delete();
+  public static class AstGroupSafe extends AstGroup {
+    public AstGroupSafe() {
+      super(false);
+    }
+
+    @Override
+    public String str() {
+      return "GBSafe";
+    }
   }
+
 }

--- a/h2o-core/src/test/resources/META-INF/services/water.rapids.ast.AstPrimitive
+++ b/h2o-core/src/test/resources/META-INF/services/water.rapids.ast.AstPrimitive
@@ -1,0 +1,1 @@
+water.rapids.ast.prims.mungers.AstGroupTest$AstGroupSafe


### PR DESCRIPTION
This workarounds problem PUBDEV-6319 just for TE - we still need to come up with a proper fix that doesn't have negative memory usage implications.