### PR TITLE
PUBDEV-6694: add AUCPR as early stopping metric

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -962,6 +962,8 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
         return (float) classification_error();
       case AUC:
         return (float)(1-auc());
+      case AUCPR:
+        return (float)(1-AUCPR());
 /*      case r2:
         return (float)(1-r2());*/
       case mean_per_class_error:
@@ -1048,6 +1050,16 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     if (mm == null) return Double.NaN;
 
     return ((ModelMetricsBinomial)mm)._auc._auc;
+  }
+
+  public double AUCPR() {
+    if (scoringInfo != null)
+      return last_scored().cross_validation ? last_scored().scored_xval._pr_auc : last_scored().validation ? last_scored().scored_valid._pr_auc : last_scored().scored_train._pr_auc;
+
+    ModelMetrics mm = _output._cross_validation_metrics != null ? _output._cross_validation_metrics : _output._validation_metrics != null ? _output._validation_metrics : _output._training_metrics;
+    if (mm == null) return Double.NaN;
+
+    return ((ModelMetricsBinomial)mm)._auc._pr_auc;
   }
 
   public double deviance() {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1354,13 +1354,16 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
         if (_parms._stopping_metric == ScoreKeeper.StoppingMetric.deviance && !getClass().getSimpleName().contains("GLM")) {
           error("_stopping_metric", "Stopping metric cannot be deviance for classification.");
         }
-        if (nclasses()!=2 && _parms._stopping_metric == ScoreKeeper.StoppingMetric.AUC) {
-          error("_stopping_metric", "Stopping metric cannot be AUC for multinomial classification.");
+        if (nclasses()!=2 && (_parms._stopping_metric == ScoreKeeper.StoppingMetric.AUC || _parms._stopping_metric
+                == ScoreKeeper.StoppingMetric.AUCPR)) {
+          error("_stopping_metric", "Stopping metric cannot be AUC or AUCPR for multinomial " +
+                  "classification.");
         }
       } else {
         if (_parms._stopping_metric == ScoreKeeper.StoppingMetric.misclassification ||
                 _parms._stopping_metric == ScoreKeeper.StoppingMetric.AUC ||
-                _parms._stopping_metric == ScoreKeeper.StoppingMetric.logloss)
+                _parms._stopping_metric == ScoreKeeper.StoppingMetric.logloss || _parms._stopping_metric
+                == ScoreKeeper.StoppingMetric.AUCPR)
         {
           error("_stopping_metric", "Stopping metric cannot be " + _parms._stopping_metric.toString() + " for regression.");
         }

--- a/h2o-core/src/main/java/hex/ScoreKeeper.java
+++ b/h2o-core/src/main/java/hex/ScoreKeeper.java
@@ -126,9 +126,10 @@ public class ScoreKeeper extends Iced {
     RMSE(ConvergenceStrategy.LESS_IS_BETTER, true),
     MAE(ConvergenceStrategy.LESS_IS_BETTER, true),
     RMSLE(ConvergenceStrategy.LESS_IS_BETTER, true),
-    AUC(ConvergenceStrategy.MORE_IS_BETTER, false),
+    AUC(ConvergenceStrategy.MORE_IS_BETTER, true),
     lift_top_group(ConvergenceStrategy.MORE_IS_BETTER, false),
     misclassification(ConvergenceStrategy.LESS_IS_BETTER, true),
+    AUCPR(ConvergenceStrategy.MORE_IS_BETTER, true),
     mean_per_class_error(ConvergenceStrategy.LESS_IS_BETTER, true),
     custom(ConvergenceStrategy.LESS_IS_BETTER, false),
     custom_increasing(ConvergenceStrategy.MORE_IS_BETTER, false),
@@ -181,6 +182,9 @@ public class ScoreKeeper extends Iced {
           break;
         case misclassification:
           val = skj._classError;
+          break;
+        case AUCPR:
+          val = skj._pr_auc;
           break;
         case mean_per_class_error:
           val = skj._mean_per_class_error;

--- a/h2o-core/src/main/java/hex/ScoringInfo.java
+++ b/h2o-core/src/main/java/hex/ScoringInfo.java
@@ -75,6 +75,7 @@ public class ScoringInfo extends Iced<ScoringInfo> {
       case deviance:          { return cross_validation ? scored_xval._mean_residual_deviance : validation ? scored_valid._mean_residual_deviance : scored_train._mean_residual_deviance; }
       case logloss:           { return cross_validation ? scored_xval._logloss : validation ? scored_valid._logloss : scored_train._logloss; }
       case misclassification: { return cross_validation ? scored_xval._classError : validation ? scored_valid._classError : scored_train._classError; }
+      case AUCPR: { return cross_validation ? scored_xval._pr_auc : validation ? scored_valid._pr_auc : scored_train._pr_auc; }
       case lift_top_group:    { return cross_validation ? scored_xval._lift : validation ? scored_valid._lift : scored_train._lift; }
       case mean_per_class_error: { return cross_validation ? scored_xval._mean_per_class_error : validation ? scored_valid._mean_per_class_error : scored_train._mean_per_class_error; }
 //      case r2: { return cross_validation ? scored_xval._r2 : validation ? scored_valid._r2 : scored_train._r2; }

--- a/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
@@ -161,7 +161,11 @@ public class ModelParametersSchemaV3<P extends Model.Parameters, S extends Model
   /**
    * Metric to use for convergence checking, only for _stopping_rounds > 0
    */
-  @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python client.", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "anomaly_score", "custom", "custom_increasing"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
+  @API(help = "Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and " +
+          "anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and " +
+          "DRF with the Python client.", values = {"AUTO", "deviance", "logloss", "MSE", "RMSE","MAE","RMSLE", "AUC", 
+          "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "anomaly_score", "custom", 
+          "custom_increasing"}, level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
   public ScoreKeeper.StoppingMetric stopping_metric;
 
   @API(help = "Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)", level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -6,7 +6,6 @@ import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
-import org.junit.runner.Computer;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import water.fvec.*;

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -1003,14 +1003,14 @@ class H2ODeepLearningEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"aucpr"``, ``"mean_per_class_error"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "aucpr", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -640,14 +640,14 @@ class H2ODeepWaterEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"aucpr"``, ``"mean_per_class_error"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "aucpr", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -490,14 +490,14 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"aucpr"``, ``"mean_per_class_error"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "aucpr", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -484,14 +484,14 @@ class H2ORandomForestEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"aucpr"``, ``"mean_per_class_error"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "aucpr", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -285,14 +285,14 @@ class H2OXGBoostEstimator(H2OEstimator):
         client.
 
         One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
-        ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``, ``"custom_increasing"``
-        (default: ``"auto"``).
+        ``"lift_top_group"``, ``"misclassification"``, ``"aucpr"``, ``"mean_per_class_error"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
         """
         return self._parms.get("stopping_metric")
 
     @stopping_metric.setter
     def stopping_metric(self, stopping_metric):
-        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "lift_top_group", "misclassification", "aucpr", "mean_per_class_error", "custom", "custom_increasing"))
         self._parms["stopping_metric"] = stopping_metric
 
 

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6684_AUCPR_early_stop.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6684_AUCPR_early_stop.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+def test_AUCPR_early_stop():
+    '''
+    This pyunit test is written to ensure that the AUCPR can restrict the model training time for all
+    h2o algos.  See PUBDEV-6684.
+    '''
+    seed = 12345
+
+    # GBM run
+    cars = h2o.upload_file(pyunit_utils.locate("smalldata/junit/cars_20mpg.csv"))
+    cars = cars[cars["economy_20mpg"].isna() == 0]
+    cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
+
+    gbm = H2OGradientBoostingEstimator(seed=seed)
+    gbm.train(x=list(range(2,8)),y="economy_20mpg", training_frame=cars)
+    gbmEarlyStop = H2OGradientBoostingEstimator(seed=seed, stopping_metric="AUCPR", stopping_tolerance=0.01, 
+                                                stopping_rounds=5)
+    gbmEarlyStop.train(x=list(range(2,8)),y="economy_20mpg", training_frame=cars)
+    
+    numTrees = pyunit_utils.extract_from_twoDimTable(gbm._model_json["output"]["model_summary"],
+                                                     "number_of_trees", takeFirst=True)
+    numTreesEarlyStop = pyunit_utils.extract_from_twoDimTable(gbmEarlyStop._model_json["output"]["model_summary"],
+                                                              "number_of_trees", takeFirst=True)
+    print("Number of tress built with early stopping: {0}.  Number of trees built without early stopping: "
+          "{1}".format(numTreesEarlyStop[0], numTrees[0]))
+    assert numTreesEarlyStop[0] <= numTrees[0], "Early stopping criteria AUCPR is not working."
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_AUCPR_early_stop)
+else:
+    test_AUCPR_early_stop()

--- a/h2o-r/h2o-package/R/deeplearning.R
+++ b/h2o-r/h2o-package/R/deeplearning.R
@@ -99,8 +99,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
-#'        AUTO.
+#'        "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -209,7 +209,7 @@ h2o.deeplearning <- function(x, y, training_frame,
                              classification_stop = 0,
                              regression_stop = 1e-06,
                              stopping_rounds = 5,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing"),
                              stopping_tolerance = 0,
                              max_runtime_secs = 0,
                              score_validation_sampling = c("Uniform", "Stratified"),

--- a/h2o-r/h2o-package/R/deepwater.R
+++ b/h2o-r/h2o-package/R/deepwater.R
@@ -69,8 +69,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
-#'        AUTO.
+#'        "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -142,7 +142,7 @@ h2o.deepwater <- function(x, y, training_frame,
                           classification_stop = 0,
                           regression_stop = 0,
                           stopping_rounds = 5,
-                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                          stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing"),
                           stopping_tolerance = 0,
                           max_runtime_secs = 0,
                           ignore_const_cols = TRUE,

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -59,8 +59,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
-#'        AUTO.
+#'        "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -143,7 +143,7 @@ h2o.gbm <- function(x, y, training_frame,
                     nbins_cats = 1024,
                     r2_stopping = 1.797693135e+308,
                     stopping_rounds = 0,
-                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing"),
                     stopping_tolerance = 0.001,
                     max_runtime_secs = 0,
                     seed = -1,

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -56,8 +56,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
-#'        AUTO.
+#'        "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -118,7 +118,7 @@ h2o.randomForest <- function(x, y, training_frame,
                              nbins_cats = 1024,
                              r2_stopping = 1.797693135e+308,
                              stopping_rounds = 0,
-                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                             stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing"),
                              stopping_tolerance = 0.001,
                              max_runtime_secs = 0,
                              seed = -1,

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -35,8 +35,8 @@
 #' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
 #'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
 #'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
-#'        "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing". Defaults to
-#'        AUTO.
+#'        "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing".
+#'        Defaults to AUTO.
 #' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
 #'        much) Defaults to 0.001.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
@@ -107,7 +107,7 @@ h2o.xgboost <- function(x, y, training_frame,
                         offset_column = NULL,
                         weights_column = NULL,
                         stopping_rounds = 0,
-                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                        stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "lift_top_group", "misclassification", "AUCPR", "mean_per_class_error", "custom", "custom_increasing"),
                         stopping_tolerance = 0.001,
                         max_runtime_secs = 0,
                         seed = -1,

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6684_AUCPR_early_stop.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6684_AUCPR_early_stop.R
@@ -1,0 +1,27 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+######################################################################################
+#    This pyunit test is written to ensure that the AUCPR metric can restrict the model training time.
+#   See PUBDEV-6684.
+######################################################################################
+pubdev_6684_test <-
+function() {
+# random forest
+  training1_data <- h2o.importFile(locate("smalldata/junit/cars_20mpg.csv"))
+  y_index <- "economy_20mpg"
+  x_indices <- c(3:8)
+  training1_data["economy_20mpg"] <- as.factor(training1_data["economy_20mpg"])
+  print("*************  starting max_runtime_test for Random Forest")
+  model <- h2o.randomForest(y=y_index, x=x_indices, training_frame=training1_data, 
+                            seed=12345, stopping_rounds=5, stopping_metric="AUCPR", stopping_tolerance=0.1)
+  numTreesEarlyStop <- model@model$model_summary$number_of_trees
+  print("number of trees built with AUCPR early-stopping is")
+  print(numTreesEarlyStop)
+  model2 <- h2o.randomForest(y=y_index, x=x_indices, training_frame=training1_data, seed=12345)
+  numTrees <- model2@model$model_summary$number_of_trees
+  print("number of trees built without AUCPR early-stopping is")
+  print(numTrees)
+  expect_true(numTrees >= numTreesEarlyStop)
+}
+
+doTest("Perform the test for pubdev 6684: use AUCPR as an early stopping metric", pubdev_6684_test)


### PR DESCRIPTION
This PR completes the work for JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-6684?filter=myopenissues&orderby=priority%20DESC

Work done:
1. Added java backend support to allow AUCPR as an early-stopping parameter.
2. Added Runit and Pyunit test to ensure correct operation.

@ledell @NidhiMehta 
Please let me know if AUCPR is an okay name for the parameter.  I can change it to anything you guys want.  Just let me know please.