### PR TITLE
PUBDEV-6696 fix hex.deeplearning.DeepLearningCheckpointReporting.run

### DIFF
--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
@@ -14,6 +14,7 @@ import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.parser.ParseDataset;
 import water.util.TwoDimTable;
+import water.H2O;
 
 public class DeepLearningCheckpointReporting extends TestUtil {
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
@@ -98,7 +99,8 @@ public class DeepLearningCheckpointReporting extends TestUtil {
           durationAfter = durationAfter.substring(0, durationAfter.length()-4);
           double diff = Double.parseDouble(durationAfter) - Double.parseDouble(durationBefore);
           
-          // Assert.assertTrue("Duration must be smooth; actual " + diff + ", expected at most " + sleepTime + " (before=" + durationBefore + ", after=" + durationAfter + ")", diff < sleepTime+1);
+          if (H2O.getCloudSize() == 1) // only do this assertion for single node tests
+            Assert.assertTrue("Duration must be smooth; actual " + diff + ", expected at most " + sleepTime + " (before=" + durationBefore + ", after=" + durationAfter + ")", diff < sleepTime+1);
 
           // Check that time stamp does see the sleep
           String timeStampBefore = (String)table.get((int)(p._epochs),0);

--- a/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
+++ b/h2o-algos/src/test/java/hex/deeplearning/DeepLearningCheckpointReporting.java
@@ -13,10 +13,7 @@ import water.TestUtil;
 import water.fvec.Frame;
 import water.fvec.NFSFileVec;
 import water.parser.ParseDataset;
-import water.util.FileUtils;
 import water.util.TwoDimTable;
-
-import java.io.File;
 
 public class DeepLearningCheckpointReporting extends TestUtil {
   @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
@@ -101,7 +98,7 @@ public class DeepLearningCheckpointReporting extends TestUtil {
           durationAfter = durationAfter.substring(0, durationAfter.length()-4);
           double diff = Double.parseDouble(durationAfter) - Double.parseDouble(durationBefore);
           
-          Assert.assertTrue("Duration must be smooth; actual " + diff + ", expected at most " + sleepTime + " (before=" + durationBefore + ", after=" + durationAfter + ")", diff < sleepTime+1);
+          // Assert.assertTrue("Duration must be smooth; actual " + diff + ", expected at most " + sleepTime + " (before=" + durationBefore + ", after=" + durationAfter + ")", diff < sleepTime+1);
 
           // Check that time stamp does see the sleep
           String timeStampBefore = (String)table.get((int)(p._epochs),0);


### PR DESCRIPTION
This PR completes the work in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6696

Work done:  I removed the following assertation:

Assert.assertTrue("Duration must be smooth; actual " + diff + ", expected at most " + sleepTime + " (before=" + durationBefore + ", after=" + durationAfter + ")", diff < sleepTime+1);

This one seems to assert the time difference between model was first trained and then train again with checkpoint.  However, it does nothing to verify checkpointing itself.  Our jenkins system seems to be heavily loaded these days and execution time is not guaranteed for multi-node, multi-thread system.  
