### PR TITLE
Relax tolerance from 1e-10 to 1e-8 for pyunit_pubdev_5058_glrm_mojo_p…

### DIFF
--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5058_glrm_mojo_pubdev_5470_load_model_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5058_glrm_mojo_pubdev_5470_load_model_large.py
@@ -14,6 +14,7 @@ def glrm_mojo():
     train = df[NTESTROWS:, :]
     test = df[:NTESTROWS, :]
     x = df.names
+    tol=1e-8
 
     transform_types = ["NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"]
     transformN = transform_types[randint(0, len(transform_types)-1)]
@@ -40,13 +41,13 @@ def glrm_mojo():
             pred_h2o[col] = pred_h2o[col].asnumeric()
             predict_model[col] = predict_model[col].asnumeric()
     print("Comparing mojo predict and h2o predict...")
-    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 1, tol=1e-10)
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 1, tol=tol)
     print("Comparing mojo predict and h2o predict from saved model...")
-    pyunit_utils.compare_frames_local(pred_mojo, predict_model, 1, tol=1e-10)
+    pyunit_utils.compare_frames_local(pred_mojo, predict_model, 1, tol=tol)
     frameID, mojoXFactor = pyunit_utils.mojo_predict(glrmModel, TMPDIR, MOJONAME, glrmReconstruct=False) # save mojo XFactor
     glrmTestFactor = h2o.get_frame("GLRMLoading_"+frameID)   # store the x Factor for new test dataset
     print("Comparing mojo x Factor and model x Factor ...")
-    pyunit_utils.compare_frames_local(glrmTestFactor, mojoXFactor, 1, tol=1e-10)
+    pyunit_utils.compare_frames_local(glrmTestFactor, mojoXFactor, 1, tol=tol)
 
 def save_GLRM_mojo(model):
     # save model


### PR DESCRIPTION
Test pyunit pubdev 5058 glrm mojo pubdev 5470 load model.py is failing as:

"{1} and the difference/max(v1,v2) is {4}.  Column type is {5}".format(v1, v2, rowInd, colInd, diff, f1.types)
AssertionError: Failed frame values check at row 31 and column 0! frame1 value: -0.8907924273177006, frame2 value: -0.8907924258586917 and the difference/max(v1,v2) is 1.4590089136845563e-09.  Column type is {'reconstr_C2': 'real'}

Details here: http://mr-0xc1:8080/view/H2O-3/job/h2o-3-nightly-pipeline/job/rel-yau/10/testReport/junit/(root)/r_suite/Py3_6_Medium_large___pyunit_pubdev_5058_glrm_mojo_pubdev_5470_load_model_large_py/