### PR TITLE
[PUBDEV-6700] Set defaultValue to missingValuesHandling on XGBoostParameters

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -73,7 +73,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
 
     // H2O GBM options
     public boolean _quiet_mode = true;
-    public MissingValuesHandling _missing_values_handling;
+    public MissingValuesHandling _missing_values_handling = MissingValuesHandling.MeanImputation;
 
     public int _ntrees=50; // Number of trees in the final model. Grid Search, comma sep values:50,100,150,200
     public int _n_estimators;  // This doesn't seem to be used anywhere... (not in clients)


### PR DESCRIPTION
Discovered that `missingValuesHandling` has default value as `null`. I believe, if we use `Enum` We should not use `null` as valid value, instead create new enum field.

Based on the current code, it seems that `null` has the same meaning as `MeanImputation`.

This change will also help on Sparkling Water side as I wanted to eliminate possibility of setting nulls on our pipeline wrappers when possible.

Please let me know if this makes sense & or if I'm wrong somewhere.