### PR TITLE
PUBDEV-6678: Add a "Defining a MOJO import" section to the MOJO import chapter

### DIFF
--- a/h2o-docs/src/product/data-science/mojo_import.rst
+++ b/h2o-docs/src/product/data-science/mojo_import.rst
@@ -64,16 +64,19 @@ Advanced Generic Model Initialization
 
 It is also possible to import a MOJO from already uploaded MOJO bytes using Generic model. Generic model is the underlying mechanism behind MOJO import. In this case, there is no need to re-upload the MOJO every time a new MOJO imported model is created. The upload may occur only once.
 
-Defining a MOJO Import
-''''''''''''''''''''''
+Defining a Generic Model
+''''''''''''''''''''''''
 
 The following options can be specified when using a Generic model:
 
-- model_id: Specify a custom name for the model to use as a reference.
+- `model_id <algo-params/model_id.html>`__: Specify a custom name for the model to use as a reference.
 
-- model_key: Specify a key for the self-contained model archive.
+- **model_key**: Specify a key for the self-contained model archive.
 
-- path: Specify a path to the file with the self-contained model archive.
+- **path**: Specify a path to the file with the self-contained model archive.
+
+Examples
+''''''''
 
 .. example-code::
    .. code-block:: r

--- a/h2o-docs/src/product/data-science/mojo_import.rst
+++ b/h2o-docs/src/product/data-science/mojo_import.rst
@@ -62,8 +62,18 @@ To import a MOJO model in Flow:
 Advanced Generic Model Initialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is also possible to import a MOJO from already uploaded MOJO bytes using Generic model. Generic model is the underlying mechanism behind MOJO import. In this case, there is no need to re-upload the MOJO every 
-time a new MOJO imported model is created. The upload may occur only once.
+It is also possible to import a MOJO from already uploaded MOJO bytes using Generic model. Generic model is the underlying mechanism behind MOJO import. In this case, there is no need to re-upload the MOJO every time a new MOJO imported model is created. The upload may occur only once.
+
+Defining a MOJO Import
+''''''''''''''''''''''
+
+The following options can be specified when using a Generic model:
+
+- model_id: Specify a custom name for the model to use as a reference.
+
+- model_key: Specify a key for the self-contained model archive.
+
+- path: Specify a path to the file with the self-contained model archive.
 
 .. example-code::
    .. code-block:: r


### PR DESCRIPTION
Added information about three different options that can be specific when using a Generic model.

See: https://0xdata.atlassian.net/browse/PUBDEV-6678