### PR TITLE
Fix pyunit_utils.frame_compare 

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3615,7 +3615,7 @@ def compare_frames_local_onecolumn_NA_enum(f1, f2, prob=0.5, tol=1e-6, returnRes
                             return False
                     else:
                         assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                      "{1}".format(temp1[rowInd][colInd], temp1[rowInd][colInd], rowInd, colInd)
+                                      "{1}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd)
 
     if returnResult:
         return True
@@ -3642,7 +3642,7 @@ def compare_frames_local_onecolumn_NA_string(f1, f2, prob=0.5, returnResult=Fals
                             return False
                     else:
                         assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                                                         "{1}".format(temp1[rowInd][colInd], temp1[rowInd][colInd], rowInd, colInd)
+                                                                         "{1}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd)
 
     if returnResult:
         return True

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_5706_usersplits_pdp.py
@@ -36,6 +36,8 @@ def partial_plot_test_with_user_splits():
     pdpOrig = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True, save_to_file=filename)
     assert os.path.getsize(filename) > 0
     os.unlink(filename)
+    if os.path.isfile(filename):
+        os.remove(filename)
 
     pdpUserSplit = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'],server=True, plot=True,
                                           user_splits=user_splits)

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_6438_2D_pdp.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_6438_2D_pdp.py
@@ -33,14 +33,15 @@ def partial_plot_test_with_user_splits():
                           75.21052631578948, 77.10526315789474]
     user_splits['RACE'] = ["Black", "White"]
     pdpUserSplit2D = gbm_model.partial_plot(data=data,server=True, plot=True, user_splits=user_splits, 
-                                            col_pairs_2dpdp=[['AGE', 'PSA'], ['AGE', 'RACE']], save_to_file=filename)
+                                            col_pairs_2dpdp=[['AGE', 'PSA'], ['AGE', 'RACE']], save_to_file=filename)  
     pdpUserSplit1D2D = gbm_model.partial_plot(data=data, cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=True, 
                                               user_splits=user_splits, 
                                               col_pairs_2dpdp=[['AGE', 'PSA'], ['AGE', 'RACE']], save_to_file=filename)
     pdpUserSplit1D = gbm_model.partial_plot(data=data,cols=['AGE', 'RACE', 'DCAPS'], server=True, plot=True, 
                                             user_splits=user_splits, save_to_file=filename)
-
-    # compare results 1D pdp
+    if os.path.isfile(filename):
+        os.remove(filename)
+        # compare results 1D pdp
     for i in range(3):
         pyunit_utils.assert_H2OTwoDimTable_equal_upto(pdpUserSplit1D[i], pdpUserSplit1D2D[i], 
                                                       pdpUserSplit1D[i].col_header, tolerance=1e-10)

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_6672_2D_pdp_fix.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_6672_2D_pdp_fix.py
@@ -3,6 +3,7 @@ sys.path.insert(1,"../../")
 import h2o
 from tests import pyunit_utils
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import os
 
 '''
 Copied example from Honza to fix bug in 2D pdp.  Basically, when no figure is plotted, this bug will thrown an error.
@@ -12,8 +13,11 @@ def partial_plot_test_with_user_splits():
     train = h2o.import_file(pyunit_utils.locate('smalldata/flow_examples/abalone.csv.gz'))
     model = H2OGeneralizedLinearEstimator(training_frame=train)
     model.train(y="C9")
-    model.partial_plot(train, col_pairs_2dpdp=[["C1", "C2"]], save_to_file="pdp.png")
+    fn = "pdp.png"
+    model.partial_plot(train, col_pairs_2dpdp=[["C1", "C2"]], save_to_file=fn)
 
+    if os.path.isfile(fn):
+        os.remove(fn)
         
 if __name__ == "__main__":
     pyunit_utils.standalone_test(partial_plot_test_with_user_splits)

--- a/h2o-r/tests/testdir_misc/runit_PUBDEV_6438_2D_pdp.R
+++ b/h2o-r/tests/testdir_misc/runit_PUBDEV_6438_2D_pdp.R
@@ -20,6 +20,9 @@ test <- function() {
   h2o_pp_1d_2d = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("RACE", "AGE"), 
                                  col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")), plot = T, 
                                  user_splits=user_splits_list, save_to=temp_filename_no_extension)
+  if (file.exists(temp_filename_no_extension)) 
+    file.remove(temp_filename_no_extension)
+  
   h2o_pp_2d_only = h2o.partialPlot(object = prostate_drf, data = prostate_hex, col_pairs_2dpdp=list(c("RACE", "AGE"), c("AGE", "PSA")), plot = F,
                                    user_splits=user_splits_list)
   h2o_pp_1d_only = h2o.partialPlot(object = prostate_drf, data = prostate_hex, cols = c("RACE", "AGE"), plot = F, user_splits=user_splits_list)


### PR DESCRIPTION
Fix assert printout in utilsPY.py function compare_frames_local_.  I was printing out the same values in the error message.

In R/Pyunit partialplots tests, some will save the png file in tmp directories like: /var/folders/92/yj9_2cjj5sdcf7l38j323z7h0000gp/T.

Files in those directories are not cleaned out and will accumulate on the test machines.  Honza was talking to me about it but I was too think to get it.  Now I got it and fixed it.  Thanks, Wendy