### PR TITLE
PUBDEV-6716: Make sure TargetEncoderMojoModel and TargetEncoderModel return same values for unseen categorical levels

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoding/TargetEncoder.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoding/TargetEncoder.java
@@ -313,6 +313,31 @@ public class TargetEncoder {
       }
       return fr;
     }
+    
+    Frame imputeWithPosteriorForNALevelOrWithPrior(String teColumnName, Frame fr, int columnIndex, Frame encodingMapForCurrentTEColumn, double priorMean) {
+      int numberOfRowsInEncodingMap = (int) encodingMapForCurrentTEColumn.numRows();
+      String lastDomain = encodingMapForCurrentTEColumn.domains()[0][numberOfRowsInEncodingMap - 1];
+      boolean missingValuesWerePresent = lastDomain.equals(teColumnName + "_NA");
+      Frame encodingsForNALevel = null;
+      try {
+        encodingsForNALevel = encodingMapForCurrentTEColumn.deepSlice(new long[]{numberOfRowsInEncodingMap - 1}, null);
+
+        double numeratorForNALevel = encodingsForNALevel.vec(NUMERATOR_COL_NAME).at(0);
+        double denominatorForNALevel = encodingsForNALevel.vec(DENOMINATOR_COL_NAME).at(0);
+        double posteriorForNALevel = numeratorForNALevel / denominatorForNALevel;
+        double valueForImputation = missingValuesWerePresent ? posteriorForNALevel : priorMean;
+        Vec vecWithEncodings = fr.vec(columnIndex);
+        assert vecWithEncodings.get_type() == Vec.T_NUM : "Imputation of mean value is supported only for numerical vectors.";
+        long numberOfNAs = vecWithEncodings.naCnt();
+        if (numberOfNAs > 0) {
+          new FillNAWithDoubleValueTask(columnIndex, valueForImputation).doAll(fr);
+          Log.info(String.format("Frame with id = %s was imputed with posterior mean from NA level = %f ( %d rows were affected)", fr._key, valueForImputation, numberOfNAs));
+        }
+      } finally {
+        if (encodingsForNALevel != null) encodingsForNALevel.delete();
+      }
+      return fr;
+    }
 
     double calculatePriorMean(Frame fr) {
         Vec numeratorVec = fr.vec(NUMERATOR_COL_NAME);
@@ -659,7 +684,8 @@ public class TargetEncoder {
                   // Note: In case of creating encoding map based on the holdout set we'd better use stratified sampling.
                   // Maybe even choose size of holdout taking into account size of the minimal set that represents all levels.
                   // Otherwise there are higher chances to get NA's for unseen categories.
-                  Frame imputedEncodingsFrameN = imputeWithMean(withAddedNoiseEncodingsFrameN, withAddedNoiseEncodingsFrameN.find(newEncodedColumnName), priorMeanFromTrainingDataset);
+                  Frame imputedEncodingsFrameN = imputeWithPosteriorForNALevelOrWithPrior(teColumnName, withAddedNoiseEncodingsFrameN, 
+                          withAddedNoiseEncodingsFrameN.find(newEncodedColumnName), groupedTargetEncodingMapForNone, priorMeanFromTrainingDataset);
 
                   removeNumeratorAndDenominatorColumns(imputedEncodingsFrameN);
 


### PR DESCRIPTION
This PR makes sure that both TargetEncoderMojoModel and TargetEncoderModel return posterior probability from NA level for unexpected values. If no missing values were encountered during training then prior probability from training data is being used.