### PR TITLE
Fix pyunit_higgs_random_seeds_large_singleNode.py failure

### DIFF
--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_random_seeds_large_singleNode.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_higgs_random_seeds_large_singleNode.py
@@ -106,7 +106,7 @@ def random_seeds_test():
             assert abs(nativePreds1_2[ind]-nativePreds1[ind])<1e-7, "Native XGBoost Model 1 should have same predictions" \
                                                                     " as previous with same seed but do not."
         for ind in range(4):
-            assert abs(nativePred1[ind]-nativePred2[ind])>=1e-6, \
+            assert abs(nativePred1[ind]-nativePred2[ind])>=1e-10, \
                 "Native XGBoost model 1 prediction prob: {0} and native XGBoost model 3 prediction prob: {1}.  " \
                 "They are too similar.".format(nativePred1[ind], nativePred2[ind])
     else:


### PR DESCRIPTION
When we ran two native xgboost with different seeds, we compare the difference in prediction and they should be different.  Previously, we were able to say abs(pred1-pred2)>1e-6.  However, this one failed here: http://mr-0xc1:8080/view/H2O-3/job/h2o-3-pipeline/job/rel-yau/44/testReport/junit/(root)/r_suite/Py3_5_Single_Node___pyunit_higgs_random_seeds_large_singleNode_py/.

However, this is not H2O function and we have no control over how different they should be.  Hence, I decrease the tolerance from 1e-6 to 1e-8:
                             abs(pred1-pred2)>1e-8.