### PR TITLE
PUBDEV-6603 - H2OFrame.split_frame() leaks a _splitter object

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -108,6 +108,9 @@ class H2OFrame(Keyed):
             self._upload_python_object(python_obj, destination_frame, header, separator,
                                        column_names, column_types, na_strings, skipped_columns)
 
+    def __del__(self):
+        h2o.remove(self)
+
     @staticmethod
     def _expr(expr, cache=None):
         # TODO: merge this method with `__init__`
@@ -1831,6 +1834,7 @@ class H2OFrame(Keyed):
                 # lower_boundary is 0.0
                 upper_boundary = boundaries[i]
                 tmp_slice = self[(tmp_runif <= upper_boundary), :]
+                print(tmp_slice.key)
             elif i == num_slices - 1:
                 lower_boundary = boundaries[i - 1]
                 # upper_boundary is 1.0
@@ -1848,7 +1852,6 @@ class H2OFrame(Keyed):
                 splits.append(tmp_slice)
 
             i += 1
-
         del tmp_runif
         return splits
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -108,9 +108,6 @@ class H2OFrame(Keyed):
             self._upload_python_object(python_obj, destination_frame, header, separator,
                                        column_names, column_types, na_strings, skipped_columns)
 
-    def __del__(self):
-        h2o.remove(self)
-
     @staticmethod
     def _expr(expr, cache=None):
         # TODO: merge this method with `__init__`
@@ -1851,6 +1848,7 @@ class H2OFrame(Keyed):
                 splits.append(tmp_slice)
 
             i += 1
+        h2o.remove(tmp_runif)
         del tmp_runif
         return splits
 

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1834,7 +1834,6 @@ class H2OFrame(Keyed):
                 # lower_boundary is 0.0
                 upper_boundary = boundaries[i]
                 tmp_slice = self[(tmp_runif <= upper_boundary), :]
-                print(tmp_slice.key)
             elif i == num_slices - 1:
                 lower_boundary = boundaries[i - 1]
                 # upper_boundary is 1.0

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -1848,6 +1848,8 @@ class H2OFrame(Keyed):
                 splits.append(tmp_slice)
 
             i += 1
+        for split in splits:
+            split.refresh() # Force the split now (otherwise done lazily) to immediately delete tmp_runif
         h2o.remove(tmp_runif)
         del tmp_runif
         return splits

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5352.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5352.py
@@ -1,3 +1,5 @@
+import sys
+sys.path.insert(1,"../../")
 import h2o
 from h2o.estimators.random_forest import H2ORandomForestEstimator
 from tests import pyunit_utils

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6603.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6603.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*- 
+import sys
+sys.path.insert(1,"../../")
+from tests import pyunit_utils
+import h2o
+import pandas as pd
+ 
+
+def pubdev_6603():
+    hf = h2o.H2OFrame(pd.DataFrame([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]))
+    s1, s2 = hf.split_frame(ratios=[0.5], seed=1)
+    h2o.remove([hf, s1, s2])
+    assert len(h2o.ls()) == 0
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_6603)
+else:
+    pubdev_6603()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6603

## The problem

Method `split_frame` in `H2OFrame` python class attemps to delete the variable `tmp_runif` by issuing `        del tmp_runif` command on line `1885`.

Nothing is deleted, as `H2OFrame` does not override `__del__` properly.

## The solution

Implement `__del__` method for `H2OFrame` correctly.

## Discussion

1. Why doesn't python use `FrameSplitter` backend services ? In order not to break any contracts, this PR will focus solely on fixing the bug and won' attempt to fix what is possibly not broken (calling backend instead).

1. Other option would be to call `h2o.remove()` directly from `split_frame` method.
