### PR TITLE
PUBDEV-6719: Fix h2o.scale - no more in-place updates by default

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -245,6 +245,7 @@ public class Env extends Iced {
     init(new AstRename());
     init(new AstRowSlice());
     init(new AstScale());
+    init(new AstScale.AstScaleInPlace());
     init(new AstSetDomain());
     init(new AstSetLevel());
     init(new AstPivot());

--- a/h2o-core/src/main/java/water/rapids/Val.java
+++ b/h2o-core/src/main/java/water/rapids/Val.java
@@ -39,6 +39,7 @@ abstract public class Val extends Iced {
 
   // One of these methods is overridden in each subclass
   public double   getNum()   { throw badValue("number"); }
+  public boolean  getBool()  { return getNum() == 1; }
   public double[] getNums()  { throw badValue("number array"); }
   public String   getStr()   { throw badValue("String"); }
   public String[] getStrs()  { throw badValue("String array"); }

--- a/h2o-core/src/main/resources/META-INF/services/water.rapids.ast.AstRoot
+++ b/h2o-core/src/main/resources/META-INF/services/water.rapids.ast.AstRoot
@@ -16,6 +16,7 @@ water.rapids.ast.prims.time.AstHour
 water.rapids.ast.prims.reducers.AstMinNa
 water.rapids.ast.prims.assign.AstTmpAssign
 water.rapids.ast.prims.mungers.AstScale
+water.rapids.ast.prims.mungers.AstScale.AstScaleInPlace
 water.rapids.ast.prims.mungers.AstMerge
 water.rapids.ast.prims.mungers.AstSetLevel
 water.rapids.ast.prims.math.AstAcos

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2638,6 +2638,8 @@ round <- function(x, digits=0) {
 #' @param x An H2OFrame object.
 #' @param center either a \code{logical} value or numeric vector of length equal to the number of columns of x.
 #' @param scale either a \code{logical} value or numeric vector of length equal to the number of columns of x.
+#' @param inplace a \code{logical} values indicating whether directly overwrite original data (disabled by default).
+#'        Exposed for backwards compatibility (prior versions of this functions were always doing an inplace update). 
 #' @examples
 #' \dontrun{
 #' library(h2o)
@@ -2646,14 +2648,41 @@ round <- function(x, digits=0) {
 #' summary(iris_hf)
 #'
 #' # Scale and center all the numeric columns in iris data set
-#' scale(iris_hf[, 1:4])
+#' iris_scaled <- h2o.scale(iris_hf[, 1:4])
 #' }
 #' @export
-h2o.scale <- function(x, center = TRUE, scale = TRUE) .newExpr("scale", chk.H2OFrame(x), center, scale)
+h2o.scale <- function(x, center = TRUE, scale = TRUE, inplace = FALSE) {
+  scale_fun <- if (inplace) "scale_inplace" else "scale"
+  result <- .newExpr(scale_fun, chk.H2OFrame(x), center, scale)
+  if (inplace) {
+    result <- .eval.frame(result)
+  }
+  return(result)
+}
 
-#' @rdname h2o.scale
+#'
+#' Scaling and Centering of an H2OFrame
+#'
+#' Centers and/or scales the columns of an H2O dataset.
+#'
+#' @name scale
+#' @param x An H2OFrame object.
+#' @param center either a \code{logical} value or numeric vector of length equal to the number of columns of x.
+#' @param scale either a \code{logical} value or numeric vector of length equal to the number of columns of x.
+#' @examples
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#' iris_hf <- as.h2o(iris)
+#' summary(iris_hf)
+#'
+#' # Scale and center all the numeric columns in iris data set
+#' iris_scaled <- scale(iris_hf[, 1:4])
+#' }
 #' @export
-scale.H2OFrame <- h2o.scale
+scale.H2OFrame <- function(x, center = TRUE, scale = TRUE) {
+  h2o.scale(x, center = center, scale = scale, inplace = FALSE)
+}
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Below takes H2O primitives that do not start with "h2o.*" and appends "h2o.*" to ensure all H2O primitives exist

--- a/h2o-r/tests/testdir_munging/runit_scale_inplace.R
+++ b/h2o-r/tests/testdir_munging/runit_scale_inplace.R
@@ -1,0 +1,31 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+# This test shows h2o.scale will only scale the numeric values (and not corrupt the categoricals)
+test.scale.inplace <- function() {
+    prostate <- h2o.importFile(locate('smalldata/extdata/prostate.csv'))
+    prostate$ID <- NULL
+
+    # Save a local copy that H2O cannot touch
+    prostate_local <- as.data.frame(prostate)
+
+    expected <- as.data.frame(scale(prostate_local))
+
+    prostate_scaled <- h2o.scale(prostate)
+    
+    # Check the input dataset was not modified
+    expect_equal(prostate_local, as.data.frame(prostate))
+
+    print(head(expected))
+    print(head(as.data.frame(prostate_scaled)))
+
+    # Check the output is properly scaled
+    expect_equal(expected, as.data.frame(prostate_scaled))
+
+    # Scaling in-place
+    h2o.scale(prostate, inplace=TRUE)
+    expect_equal(expected, as.data.frame(prostate))
+}
+
+doTest("Test h2o.scale - in-place scaling", test.scale.inplace)


### PR DESCRIPTION
@seb-h2o I modified the default behavior of h2o.scale to not do an in-place update by default. This is dangerous (&unpredictable) in many scenarios and makes sense only in few.

The R client does have an option to switch to the old behavior - R client is much older and there might be people out there relying on this function. I don't think we need to do the same for the Python client, this behavior is completely unexpected.