### PR TITLE
Add H2ONode, H2OLeafNode, and H2OSplitNode to docs

### DIFF
--- a/h2o-py/docs/tree.rst
+++ b/h2o-py/docs/tree.rst
@@ -7,3 +7,24 @@ Tree Class in H2O
   :members:
   :undoc-members:
   :show-inheritance:
+
+:mod:`H2O Node Class`
+-------------------------------
+.. autoclass:: h2o.tree.H2ONode
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:mod:`H2O Leaf Node Class`
+-------------------------------
+.. autoclass:: h2o.tree.H2OLeafNode
+  :members:
+  :undoc-members:
+  :show-inheritance:
+
+:mod:`H2O Split Node Class`
+-------------------------------
+.. autoclass:: h2o.tree.H2OSplitNode
+  :members:
+  :undoc-members:
+  :show-inheritance:

--- a/h2o-py/h2o/tree/__init__.py
+++ b/h2o-py/h2o/tree/__init__.py
@@ -1,4 +1,6 @@
 from .tree import H2OTree
 from .tree import H2ONode
+from .tree import H2OSplitNode
+from .tree import H2OLeafNode
 
-__all__ = ["H2OTree", "H2ONode"]
+__all__ = ["H2OTree", "H2ONode", "H2OSplitNode", "H2OLeafNode"]


### PR DESCRIPTION
@michalkurka, 
I'm getting errors with LeafNode and SplitNode when I try to build the docs:

"'h2o.tree' has no attribute 'H2OSplitNode'"
"'h2o.tree' has no attribute 'H2OLeafNode'"

I also couldn't find an example to test.