### PR TITLE
PUBDEV 6732 - Cannot export model using java-rest-bindings

### DIFF
--- a/h2o-bindings/bin/gen_java.py
+++ b/h2o-bindings/bin/gen_java.py
@@ -252,7 +252,13 @@ def generate_proxy(classname, endpoints):
         required_param_strs = []
         for field in e["input_params"]:
             fname = field["name"]
-            ftype = "Path" if field["is_path_param"] else "Field"
+            if field["is_path_param"]:
+                ftype = "Path"
+            else:
+                if e["http_method"] == "GET":
+                    ftype = "Query"
+                else:
+                    ftype = "Field"
             ptype = translate_type(field["type"], field["schema_name"])
             if ptype.endswith("KeyV3") or ptype == "ColSpecifierV3": ptype = "String"
             if ptype.endswith("KeyV3[]"): ptype = "String[]"

--- a/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
+++ b/h2o-bindings/src/main/java/water/bindings/examples/retrofit/GBM_Example.java
@@ -3,6 +3,7 @@ package water.bindings.examples.retrofit;
 import water.bindings.H2oApi;
 import water.bindings.pojos.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -89,6 +90,13 @@ public class GBM_Example {
         assert model.output.getClass() == GBMModelOutputV3.class;
         assert model.parameters.getClass() == GBMParametersV3.class;
 
+        // STEP 9 (optional): export model as binary
+        ModelExportV3 modelExport = new ModelExportV3();
+        modelExport.modelId = model_key;
+
+        File binaryModelFile = File.createTempFile("model", ".h2o");
+        modelExport.dir = File.createTempFile("model", ".h2o").getPath();
+        binaryModelFile.deleteOnExit();
 
         // STEP 8: predict!
         ModelMetricsListSchemaV3 predict_params = new ModelMetricsListSchemaV3();


### PR DESCRIPTION
[PUBDEV-6732](https://0xdata.atlassian.net/browse/PUBDEV-6732)

Based on work of Herr [Christian Dietz](https://github.com/dietzc): https://github.com/h2oai/h2o-3/pull/1130, only small changes have been done - the original logic put `Field` in case of POST and `Query` in all other cases (except for explicitely marked `Path` params). In this PR, the logic is vice-versa to respect original layout more. Only `GET` officialy receive `@Query` annotation, others receive `@Field`, as they did before.

This pull request has been created to be easily able to push changes to the branch.