### PR TITLE
PUBDEV-6753: Fix mismatch between sorted grid metric and corresponding metric from the model

### DIFF
--- a/h2o-core/src/main/java/hex/AUC2.java
+++ b/h2o-core/src/main/java/hex/AUC2.java
@@ -279,6 +279,12 @@ public class AUC2 extends Iced {
 
   /** @return the default CM, or null for an empty AUC */
   public double[/*actual*/][/*predicted*/] defaultCM( ) { return _max_idx == -1 ? null : buildCM(_max_idx); }
+  
+  /** @return the CM that corresponds to a bin's index which brings max value for a given {@code criterion} */
+  public double[/*actual*/][/*predicted*/] cmByCriterion( ThresholdCriterion criterion) {
+    int maxIdx = criterion.max_criterion_idx(this);
+    return buildCM(maxIdx); 
+  }
   /** @return the default threshold; threshold that maximizes the default criterion */
   public double defaultThreshold( ) { return _max_idx == -1 ? 0.5 : _ths[_max_idx]; }
   /** @return the error of the default CM */

--- a/h2o-core/src/main/java/hex/AUC2.java
+++ b/h2o-core/src/main/java/hex/AUC2.java
@@ -111,6 +111,15 @@ public class AUC2 extends Iced {
       return mx;
     }
     public static final ThresholdCriterion[] VALUES = values();
+
+    public static AUC2.ThresholdCriterion fromString(String strRepr) {
+      for (ThresholdCriterion tc : ThresholdCriterion.values()) {
+        if (tc.toString().equalsIgnoreCase(strRepr)) {
+          return tc;
+        }
+      }
+      return null;
+    }
   } // public enum ThresholdCriterion
 
   public double threshold( int idx ) { return _ths[idx]; }

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -112,7 +112,6 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   public double mse() { return _MSE; }
   public double rmse() { return Math.sqrt(_MSE);}
   public ConfusionMatrix cm() { return null; }
-  public ConfusionMatrix cm(AUC2.ThresholdCriterion criterion) { return null; }
   public float[] hr() { return null; }
   public AUC2 auc_obj() { return null; }
 
@@ -139,10 +138,15 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     
     // Constructing confusion matrix based on criterion
     ConfusionMatrix cm;
-
-    AUC2.ThresholdCriterion criterionAsEnum = AUC2.ThresholdCriterion.fromString(criterion);
-    if(criterionAsEnum != null)
-      cm = mm.cm(criterionAsEnum);
+    if(mm instanceof ModelMetricsBinomial) {
+      AUC2.ThresholdCriterion criterionAsEnum = AUC2.ThresholdCriterion.fromString(criterion);
+      if(criterionAsEnum != null) {
+        ModelMetricsBinomial mmb = (ModelMetricsBinomial) mm;
+        cm = mmb.cm(criterionAsEnum);
+      }
+      else
+        cm = mm.cm();
+    }
     else
       cm = mm.cm();
     

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -139,11 +139,8 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     
     // Constructing confusion matrix based on criterion
     ConfusionMatrix cm;
-    AUC2.ThresholdCriterion criterionAsEnum = null;
-    try {
-      criterionAsEnum = AUC2.ThresholdCriterion.valueOf(criterion);
-    } catch (Exception ex) {
-    }
+
+    AUC2.ThresholdCriterion criterionAsEnum = AUC2.ThresholdCriterion.fromString(criterion);
     if(criterionAsEnum != null)
       cm = mm.cm(criterionAsEnum);
     else

--- a/h2o-core/src/main/java/hex/ModelMetrics.java
+++ b/h2o-core/src/main/java/hex/ModelMetrics.java
@@ -112,6 +112,7 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
   public double mse() { return _MSE; }
   public double rmse() { return Math.sqrt(_MSE);}
   public ConfusionMatrix cm() { return null; }
+  public ConfusionMatrix cm(AUC2.ThresholdCriterion criterion) { return null; }
   public float[] hr() { return null; }
   public AUC2 auc_obj() { return null; }
 
@@ -135,7 +136,20 @@ public class ModelMetrics extends Keyed<ModelMetrics> {
     Method method = null;
     Object obj = null;
     criterion = criterion.toLowerCase();
-    ConfusionMatrix cm = mm.cm();
+    
+    // Constructing confusion matrix based on criterion
+    ConfusionMatrix cm;
+    AUC2.ThresholdCriterion criterionAsEnum = null;
+    try {
+      criterionAsEnum = AUC2.ThresholdCriterion.valueOf(criterion);
+    } catch (Exception ex) {
+    }
+    if(criterionAsEnum != null)
+      cm = mm.cm(criterionAsEnum);
+    else
+      cm = mm.cm();
+    
+    // Getting (by reflection) method that corresponds to a given criterion
     try {
       method = mm.getClass().getMethod(criterion);
       obj = mm;

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -63,6 +63,13 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
     double[][] cm = _auc.defaultCM();
     return cm == null ? null : new ConfusionMatrix(cm, _domain);
   }
+  
+  @Override public ConfusionMatrix cm(AUC2.ThresholdCriterion criterion) {
+    if( _auc == null ) return null;
+    double[][] cm = _auc.cmByCriterion(criterion);
+    return cm == null ? null : new ConfusionMatrix(cm, _domain);
+  }
+  
   public GainsLift gainsLift() { return _gainsLift; }
 
   // expose simple metrics criteria for sorting

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -64,7 +64,7 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
     return cm == null ? null : new ConfusionMatrix(cm, _domain);
   }
   
-  @Override public ConfusionMatrix cm(AUC2.ThresholdCriterion criterion) {
+  public ConfusionMatrix cm(AUC2.ThresholdCriterion criterion) {
     if( _auc == null ) return null;
     double[][] cm = _auc.cmByCriterion(criterion);
     return cm == null ? null : new ConfusionMatrix(cm, _domain);

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_grid_f2_f0point5_metrics_PUBDEV-6753.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_grid_f2_f0point5_metrics_PUBDEV-6753.py
@@ -1,0 +1,110 @@
+from __future__ import print_function
+
+import sys
+
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+def grid_f0point5_metrics():
+
+    gbm_grid1 = train_grid()
+    
+    gbm_gridper_f0point5 = gbm_grid1.get_grid(sort_by='f0point5', decreasing=True)
+    print(gbm_gridper_f0point5)
+    sorted_metric_table_f0point5 = gbm_gridper_f0point5.sorted_metric_table()
+
+    # Lets compare values grid was sorted with and metrics from each model in the grid 
+    print("Model 0:")
+    best_gbm_f0point5 = gbm_gridper_f0point5.models[0]
+    model0_f0point5_valid = best_gbm_f0point5.F0point5(valid=True)
+    print(model0_f0point5_valid)
+    errorMsg = "Expected that metric value from sorted_metric_table is equal to corresponding metric for the model"
+    assert str(model0_f0point5_valid[0][1]) == sorted_metric_table_f0point5['f0point5'][0], errorMsg
+
+    print("Model 1:")
+    best_gbm_f0point5_1 = gbm_gridper_f0point5.models[1]
+    model1_f0point5_valid = best_gbm_f0point5_1.F0point5(valid=True)
+    print(model1_f0point5_valid)
+    assert str(model1_f0point5_valid[0][1]) == sorted_metric_table_f0point5['f0point5'][1], errorMsg
+
+
+    print("Model 2:")
+    best_gbm_f0point5_2 = gbm_gridper_f0point5.models[2]
+    model2_f0point5_valid = best_gbm_f0point5_2.F0point5(valid=True)
+    print(model2_f0point5_valid)
+    assert str(model2_f0point5_valid[0][1]) == sorted_metric_table_f0point5['f0point5'][2], errorMsg
+
+
+def grid_f2_metrics():
+
+    gbm_grid1 = train_grid()
+
+    gbm_gridper_f2 = gbm_grid1.get_grid(sort_by='f2', decreasing=True)
+    print(gbm_gridper_f2)
+    sorted_metric_table_f2 = gbm_gridper_f2.sorted_metric_table()
+
+    # Lets compare values grid was sorted with and metrics from each model in the grid 
+    print("Model 0:")
+    best_gbm_f2 = gbm_gridper_f2.models[0]
+    model0_f2_valid = best_gbm_f2.F2(valid=True)
+    print(model0_f2_valid)
+    
+    errorMsg = "Expected that metric value from sorted_metric_table is equal to corresponding metric for the model"
+    assert str(model0_f2_valid[0][1]) == sorted_metric_table_f2['f2'][0], errorMsg
+
+    print("Model 1:")
+    best_gbm_f2_1 = gbm_gridper_f2.models[1]
+    model1_f2_valid = best_gbm_f2_1.F2(valid=True)
+    print(model1_f2_valid)
+    assert str(model1_f2_valid[0][1]) == sorted_metric_table_f2['f2'][1], errorMsg
+
+
+    print("Model 2:")
+    best_gbm_f2_2 = gbm_gridper_f2.models[2]
+    model2_f2_valid = best_gbm_f2_2.F2(valid=True)
+    print(model2_f2_valid)
+    assert str(model2_f2_valid[0][1]) == sorted_metric_table_f2['f2'][2], errorMsg
+    
+
+def train_grid():
+    # Import a sample binary outcome dataset into H2O
+    data = h2o.import_file(pyunit_utils.locate("smalldata/testng/higgs_train_5k.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/testng/higgs_test_5k.csv"))
+    
+    # Identify predictors and response
+    x = data.columns
+    y = "response"
+    x.remove(y)
+    # For binary classification, response should be a factor
+    data[y] = data[y].asfactor()
+    test[y] = test[y].asfactor()
+    # Split data into train & validation
+    ss = data.split_frame(seed=1)
+    train = ss[0]
+    valid = ss[1]
+    # GBM hyperparameters
+    gbm_params1 = {'learn_rate': [0.01],
+                   'max_depth': [3],
+                   'sample_rate': [0.8],
+                   'col_sample_rate': [0.2, 0.5, 1.0]}
+    # Train and validate a cartesian grid of GBMs
+    gbm_grid1 = H2OGridSearch(model=H2OGradientBoostingEstimator,
+                              grid_id='gbm_grid1',
+                              hyper_params=gbm_params1)
+    gbm_grid1.train(x=x, y=y,
+                    training_frame=train,
+                    validation_frame=valid,
+                    ntrees=100,
+                    seed=1)
+    return gbm_grid1
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(grid_f0point5_metrics)
+    pyunit_utils.standalone_test(grid_f2_metrics)
+else:
+    grid_f0point5_metrics()
+    grid_f2_metrics()


### PR DESCRIPTION
Before the fix threshold(actually index that maximise metric's value) for computing any metrics was the one that maximise F1 metric. This is the only reason why f1 scores were fine whereas f0point5 and f2 were not.
