### PR TITLE
PUBDEV-6817: support PCA default

### DIFF
--- a/h2o-algos/src/test/java/hex/pca/PCATest.java
+++ b/h2o-algos/src/test/java/hex/pca/PCATest.java
@@ -79,6 +79,36 @@ public class PCATest extends TestUtil {
     }
   }
 
+  @Test public void testPCAwithNoK() throws InterruptedException, ExecutionException {
+    // Results with original training frame
+    Scope.enter();
+    PCAModel modelNok = null;
+    PCAModel modelK = null;
+    Frame train = null, score = null, scoreK = null;
+    try {
+      train = parse_test_file(Key.make("arrests.hex"), "smalldata/pca_test/USArrests.csv");
+      Scope.track(train);
+      pcaParameters._train = train._key;
+      pcaParameters._transform = DataInfo.TransformType.NONE;
+      pcaParameters._pca_method = PCAParameters.Method.GramSVD;
+      pcaParameters._seed = 12345;
+      modelNok = new PCA(pcaParameters).trainModel().get();
+      Scope.track_generic(modelNok);
+      score = modelNok.score(train);
+      Scope.track(score);
+      
+      pcaParameters._k=1;
+      modelK = new PCA(pcaParameters).trainModel().get();
+      Scope.track_generic(modelK);
+      scoreK = modelK.score(train);
+      Scope.track(scoreK);
+      isBitIdentical(score, scoreK);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+
   @Test public void testIrisSplitScoring() throws InterruptedException, ExecutionException {
     PCAModel model = null;
     Frame fr = null, fr2= null;

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -139,6 +139,8 @@ class H2OEstimator(ModelBase):
         if verbose and algo not in ["drf", "gbm", "deeplearning", "xgboost"]:
             raise H2OValueError("Verbose should only be set to True for drf, gbm, deeplearning, and xgboost models")
         parms = self._parms.copy()
+        if algo=="pca" and "k" not in parms.keys():
+            parms["k"] = 1
         if "__class__" in parms:  # FIXME: hackt for PY3
             del parms["__class__"]
         is_auto_encoder = bool(parms.get("autoencoder"))

--- a/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_6817_check_empty_k.py
+++ b/h2o-py/tests/testdir_algos/pca/pyunit_pubdev_6817_check_empty_k.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.pca import H2OPrincipalComponentAnalysisEstimator as H2OPCA
+
+
+
+def pca_prostate():
+  print("Importing prostate.csv data...\n")
+  prostate = h2o.upload_file(pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+
+  print("Converting CAPSULE, RACE, DPROS and DCAPS columns to factors")
+  prostate["CAPSULE"] = prostate["CAPSULE"].asfactor()
+  prostate["RACE"] = prostate["RACE"].asfactor()
+  prostate["DPROS"] = prostate["DPROS"].asfactor()
+  prostate["DCAPS"] = prostate["DCAPS"].asfactor()
+  prostate.describe()
+
+  fitPCA = H2OPCA(k=1, transform="NONE", pca_method="Power", seed=1234)
+  fitPCA.train(x=list(range(2,9)), training_frame=prostate)
+  fitPCA_noK = H2OPCA(transform="NONE", pca_method="Power", seed=1234)
+  fitPCA_noK.train(x=list(range(2,9)), training_frame=prostate)
+  pred = fitPCA.predict(prostate)
+  predNoK = fitPCA_noK.predict(prostate)
+  pyunit_utils.compare_frames_local(pred, predNoK, prob=1, tol=1e-10)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(pca_prostate)
+else:
+  pca_prostate()

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -114,6 +114,8 @@ NULL
     if (params$stopping_metric=="r2")
       stop("r2 cannot be used as an early stopping_metric yet.  Check this JIRA https://0xdata.atlassian.net/browse/PUBDEV-5381 for progress.")
   }
+  if (algo=="pca" && is.null(params$k)) # make sure to set k=1 for default for pca
+    params$k=1
   job <- .h2o.startModelJob(algo, params, h2oRestApiVersion)
   h2o.getFutureModel(job, verbose = verbose)
 }

--- a/h2o-r/tests/testdir_algos/pca/runit_pubdev_6817_noK_PCA.R
+++ b/h2o-r/tests/testdir_algos/pca/runit_pubdev_6817_noK_PCA.R
@@ -1,0 +1,17 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# Test PCA on USArrests.csv
+test.pca.arrests <- function() {
+  Log.info("Importing USArrests.csv data...\n")
+  arrests.hex <- h2o.uploadFile(locate("smalldata/pca_test/USArrests.csv"))
+  arrests.pca.h2o <- h2o.prcomp(training_frame = arrests.hex, k = 1, seed=12345)
+  browser()
+  pca_noK <- h2o.prcomp(training_frame = arrests.hex, seed=12345)
+  
+  pred1 <- h2o.predict(arrests.pca.h2o, arrests.hex)
+  pred2 <- h2o.predict(pca_noK, arrests.hex)
+  compareFrames(pred1, pred2)
+}
+
+doTest("PUBDEV-6817: PCA Test: check model when k is not specified", test.pca.arrests)


### PR DESCRIPTION
This PR fixes the problem in JIRA https://0xdata.atlassian.net/browse/PUBDEV-6817

When R/Python clients call PCA with no k specification, an error will be thrown.  However, in the docs, k=1 by default.  

1.  I implemented this support in R/Python.
2.  added R/Python/Java unit test to make sure models build when k is not specified.
