### PR TITLE
Fix for TargetEncodingTargetColumnTest

### DIFF
--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoding/TargetEncodingTargetColumnTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoding/TargetEncodingTargetColumnTest.java
@@ -1,145 +1,111 @@
 package ai.h2o.automl.targetencoding;
 
-import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import water.*;
 import water.fvec.*;
-import water.rapids.Rapids;
-import water.rapids.Val;
-import water.util.FrameUtils;
-import water.util.TwoDimTable;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Random;
-import java.util.UUID;
 
 import static org.junit.Assert.*;
 
 public class TargetEncodingTargetColumnTest extends TestUtil {
-
+  
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @BeforeClass
   public static void setup() {
     stall_till_cloudsize(1);
   }
 
-  private Frame fr = null;
-
-
-  //groupByTEColumnAndAggregateTest
-
   @Test
-  public void binaryCategoricalTargetColumnWorksTest() {
-    String tmpName = null;
-    String tmpName2 = null;
-    Frame fr2 = null;
-    Frame parsedFrame = null;
-    Frame parsedFrame2 = null;
+  public void binaryCategoricalTargetColumnWorksTest() throws Exception {
+    final File fr1ExportFile = temporaryFolder.newFile();
+    final File fr2ExportFile = temporaryFolder.newFile();
     try {
-      fr = new TestFrameBuilder()
-              .withName("testFrame")
+      Scope.enter();
+      final Frame fr = new TestFrameBuilder()
               .withColNames("ColA", "ColB")
               .withVecTypes(Vec.T_CAT, Vec.T_NUM)
               .withDataForCol(0, ar("NO", "YES", "NO"))
               .withDataForCol(1, ar(1, 2, 3))   // we need extra column because parsing from file will fail for csv with one column. For timeseries do we need more then one column?
               .build();
+      Scope.track(fr);
 
-      fr2 = new TestFrameBuilder()
-              .withName("testFrame2")
+      final Frame fr2 = new TestFrameBuilder()
               .withColNames("ColA2", "ColB2")
               .withVecTypes(Vec.T_CAT, Vec.T_NUM)
               .withDataForCol(0, ar("YES", "NO", "NO"))
               .withDataForCol(1, ar(1, 2, 3))
               .build();
+      Scope.track(fr2);
 
-      tmpName = UUID.randomUUID().toString();
-      Frame.export(fr, tmpName, fr._key.toString(), true, 1);
-      tmpName2 = UUID.randomUUID().toString();
-      Frame.export(fr2, tmpName2, fr2._key.toString(), true, 1);
-
-      try {
-        Thread.sleep(1000); // TODO why we need to wait? otherwise `parsedFrame` is empty.
-      } catch(InterruptedException ex) {
-
-      }
-
-      parsedFrame = parse_test_file(Key.make("parsed"), tmpName);
-      parsedFrame2 = parse_test_file(Key.make("parsed2"), tmpName2);
+      Frame.export(fr, fr1ExportFile.getAbsolutePath(), fr._key.toString(), true, 1)
+              .get();
+      Frame.export(fr2, fr2ExportFile.getAbsolutePath(), fr2._key.toString(), true, 1)
+              .get();
+      
+      final Frame parsedFrame = parse_test_file(Key.make(), fr1ExportFile.getAbsolutePath());
+      Scope.track(parsedFrame);
+      final Frame parsedFrame2 = parse_test_file(Key.make(), fr2ExportFile.getAbsolutePath());
+      Scope.track(parsedFrame2);
 
       String[] domains = parsedFrame.vec(0).domain();
       String[] domains2 = parsedFrame2.vec(0).domain();
       assertArrayEquals(domains, domains2);
     } finally {
-      new File(tmpName).delete();
-      new File(tmpName2).delete();
-      fr.delete();
-      fr2.delete();
-      parsedFrame.delete();
-      parsedFrame2.delete();
+      Scope.exit();
     }
   }
 
   @Test // BecauseRepresentationForCategoricalsIsNumericalInside frame
-  public void weCanSumTargetColumnTest() {
-    String tmpName = null;
-    Frame parsedFrame = null;
+  public void weCanSumTargetColumnTest() throws Exception {
+    final File frExportFile = temporaryFolder.newFile();
     try {
-      fr = new TestFrameBuilder()
-              .withName("testFrame")
+      Scope.enter();
+      final Frame fr = new TestFrameBuilder()
               .withColNames("ColA", "ColB")
               .withVecTypes(Vec.T_CAT, Vec.T_NUM)
               .withDataForCol(0, ar("NO", "YES", "NO"))
               .withDataForCol(1, ar(1, 2, 3))
               .build();
+      Scope.track(fr);
+      
+      Frame.export(fr, frExportFile.getAbsolutePath(), fr._key.toString() , true, 1)
+              .get();
 
-
-      tmpName = UUID.randomUUID().toString();
-      Frame.export(fr, tmpName, fr._key.toString(), true, 1);
-
-      try {
-        Thread.sleep(1000); // TODO why we need to wait? otherwise `parsedFrame` is empty.
-      } catch(InterruptedException ex) {
-
-      }
-      parsedFrame = parse_test_file(Key.make("parsed"), tmpName);
+      final Frame parsedFrame = parse_test_file(Key.make(), frExportFile.getAbsolutePath());
+      Scope.track(parsedFrame);
 
       assertEquals( 0,parsedFrame.vec(0).at8(0));
       assertEquals( 1,parsedFrame.vec(0).at8(1));
 
     } finally {
-      new File(tmpName).delete();
-      fr.delete();
-      parsedFrame.delete();
+      Scope.exit();
     }
   }
 
   //Test that we can do sum and count on binary categorical column due to numerical representation under the hood.
-  @Test // TODO move to Target encoding test
-  public void groupThenAggregateWithoutFoldsForBinaryTargetTest() {
-    String tmpName = null;
-    Frame parsedFrame = null;
+  @Test
+  public void groupThenAggregateWithoutFoldsForBinaryTargetTest() throws Exception {
+    final File frExportFile = temporaryFolder.newFile();
     try {
-      fr = new TestFrameBuilder()
-              .withName("testFrame")
+      Scope.enter();
+      final Frame fr = new TestFrameBuilder()
               .withColNames("ColA", "ColB")
               .withVecTypes(Vec.T_CAT, Vec.T_CAT)
               .withDataForCol(0, ar("a", "a", "b"))
               .withDataForCol(1, ar("NO", "YES", "NO"))
               .build();
 
-      tmpName = UUID.randomUUID().toString();
-      Frame.export(fr, tmpName, fr._key.toString(), true, 1);
+      Frame.export(fr, frExportFile.getAbsolutePath(), fr._key.toString(), true, 1)
+              .get();
 
-      try {
-        Thread.sleep(1000); // TODO why we need to wait? otherwise `parsedFrame` is empty.
-      } catch(InterruptedException ex) {
-
-      }
-      parsedFrame = parse_test_file(Key.make("parsed"), tmpName, true);
+      final Frame parsedFrame = parse_test_file(Key.make(), frExportFile.getAbsolutePath(), true);
+      Scope.track(parsedFrame);
 
       String[] teColumns = {"ColA"};
       TargetEncoder tec = new TargetEncoder(teColumns);
@@ -157,37 +123,25 @@ public class TargetEncodingTargetColumnTest extends TestUtil {
       res.delete();
 
     } finally {
-      new File(tmpName).delete();
-      fr.delete();
-      parsedFrame.delete();
+      Scope.exit();
     }
   }
 
   @Test
   public void categoricalTargetHasCardinalityOfTwoTest() {
     String targetColumnName = "ColC";
-    fr = new TestFrameBuilder()
-            .withName("testFrame")
-            .withColNames( targetColumnName)
-            .withVecTypes(Vec.T_CAT)
-            .withDataForCol(0, ar("2", "6", "6", "6", "6", "2"))
-            .build();
+    try {
+      Scope.enter();
+      final Frame fr = new TestFrameBuilder()
+              .withColNames(targetColumnName)
+              .withVecTypes(Vec.T_CAT)
+              .withDataForCol(0, ar("2", "6", "6", "6", "6", "2"))
+              .build();
+      Scope.track(fr);
 
-    assertEquals(2, fr.vec(0).cardinality());
-    fr.delete();
-  }
-
-  @After
-  public void afterEach() {
-    if (fr != null) fr.delete();
-  }
-
-  private void printOutColumnsMeta(Frame fr) {
-    for (String header : fr.toTwoDimTable().getColHeaders()) {
-      String type = fr.vec(header).get_type_str();
-      int cardinality = fr.vec(header).cardinality();
-      System.out.println(header + " - " + type + String.format("; Cardinality = %d", cardinality));
-
+      assertEquals(2, fr.vec(0).cardinality());
+    } finally {
+      Scope.exit();      
     }
   }
 }


### PR DESCRIPTION
Test failure reproduced locally on a cluster of `5`.

## Core issues:
- Not waiting for the `export` MRTask to finish properly. Waiting was done via `Thread.sleep()`.
- One frame re-used, causing possible key leaks and exceptions if one test fails (the @After part might actually find an old `Frame` or `null`).
- Temporary file names re-used.

## Other tweaks
- New test frames now have random keys.
- Scopes are now used.
- Removed unused imports.
- Temporary files are now managed by JUnit and properly placed on the filesystem & deleted without introducing tons of our additional code and taking care of the lifecycle. The tmp file deletion did not count with many exceptional states, e.g. failure to create the temporary file. JUnit handles this for us via `TemporaryFolder` class.