### PR TITLE
[PUBDEV-6831] DRF uses same value for sample_rate as defined in shared tree model params

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/drf/DRFModel.java
+++ b/h2o-algos/src/main/java/hex/tree/drf/DRFModel.java
@@ -19,8 +19,6 @@ public class DRFModel extends SharedTreeModelWithContributions<DRFModel, DRFMode
     public DRFParameters() {
       super();
       // Set DRF-specific defaults (can differ from SharedTreeModel's defaults)
-      _mtries = -1;
-      _sample_rate = 0.632f;
       _max_depth = 20;
       _min_rows = 1;
     }


### PR DESCRIPTION
When exposing DRF in sparkling water, I have discovered that we could do this tiny cleanup, please correct me if we should not do it.

_sample_rate was defined in DRF but with the same default as it's in https://github.com/h2oai/h2o-3/blob/325c6f37bca1be8fb8e4c7943b1d5fccb101421a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java#L77

We can keep the code a bit cleaner if we remove this unnecessary definition. WDYT?