### PR TITLE
PUBDEV-6778 - h2o.mojo_predict_df corrupts/removes the tmp directory in R

### DIFF
--- a/h2o-r/h2o-package/R/predict.R
+++ b/h2o-r/h2o-package/R/predict.R
@@ -180,15 +180,15 @@ h2o.mojo_predict_csv <- function(input_csv_path, mojo_zip_path, output_csv_path=
 #' @return Returns a data.frame containing computed predictions
 #' @export
 h2o.mojo_predict_df <- function(frame, mojo_zip_path, genmodel_jar_path=NULL, classpath=NULL, java_options=NULL, verbose=F, setInvNumNA=F) {
-	input_csv_path <- file.path(tempdir(), 'input.csv')
-	prediction_csv_path <- file.path(tempdir(), 'prediction.csv')
+	input_csv_path <- file.path(tempdir(), paste0('h2o_input_', stringi::stri_rand_strings(1,20), '.csv'))
+	prediction_csv_path <- file.path(tempdir(), paste0('h2o_prediction_', stringi::stri_rand_strings(1,20), '.csv'))
 	tryCatch(
 		{
 			write.csv(frame, file=input_csv_path, row.names=F)
-			return(h2o.mojo_predict_csv(input_csv_path=input_csv_path, mojo_zip_path=mojo_zip_path, output_csv_path=prediction_csv_path, genmodel_jar_path=genmodel_jar_path, classpath=classpath, java_options=java_options, verbose=verbose, setInvNumNA=setInvNumNA))
+			return(h2o.mojo_predict_csv(input_csv_path = input_csv_path, mojo_zip_path=mojo_zip_path, output_csv_path=prediction_csv_path, genmodel_jar_path=genmodel_jar_path, classpath=classpath, java_options=java_options, verbose=verbose, setInvNumNA=setInvNumNA))
 		},
-		finally={
-			unlink(input_csv_path)
+		finally = {
+		  unlink(input_csv_path)
 		  unlink(prediction_csv_path)
 		}
 	)

--- a/h2o-r/h2o-package/R/predict.R
+++ b/h2o-r/h2o-package/R/predict.R
@@ -180,8 +180,8 @@ h2o.mojo_predict_csv <- function(input_csv_path, mojo_zip_path, output_csv_path=
 #' @return Returns a data.frame containing computed predictions
 #' @export
 h2o.mojo_predict_df <- function(frame, mojo_zip_path, genmodel_jar_path=NULL, classpath=NULL, java_options=NULL, verbose=F, setInvNumNA=F) {
-	input_csv_path <- file.path(tempdir(), paste0('h2o_input_', stringi::stri_rand_strings(1,20), '.csv'))
-	prediction_csv_path <- file.path(tempdir(), paste0('h2o_prediction_', stringi::stri_rand_strings(1,20), '.csv'))
+	input_csv_path <- file.path(tempdir(), paste0('h2o_input_', runif(1,0,99999999999), '.csv'))
+	prediction_csv_path <- file.path(tempdir(), paste0('h2o_prediction_', runif(1,0,99999999999), '.csv'))
 	tryCatch(
 		{
 			write.csv(frame, file=input_csv_path, row.names=F)

--- a/h2o-r/h2o-package/R/predict.R
+++ b/h2o-r/h2o-package/R/predict.R
@@ -180,17 +180,16 @@ h2o.mojo_predict_csv <- function(input_csv_path, mojo_zip_path, output_csv_path=
 #' @return Returns a data.frame containing computed predictions
 #' @export
 h2o.mojo_predict_df <- function(frame, mojo_zip_path, genmodel_jar_path=NULL, classpath=NULL, java_options=NULL, verbose=F, setInvNumNA=F) {
-	tmp_dir <- tempdir()
-	dir.create(tmp_dir)
+	input_csv_path <- file.path(tempdir(), 'input.csv')
+	prediction_csv_path <- file.path(tempdir(), 'prediction.csv')
 	tryCatch(
 		{
-			input_csv_path <- file.path(tmp_dir, 'input.csv')
-			prediction_csv_path <- file.path(tmp_dir, 'prediction.csv')
 			write.csv(frame, file=input_csv_path, row.names=F)
 			return(h2o.mojo_predict_csv(input_csv_path=input_csv_path, mojo_zip_path=mojo_zip_path, output_csv_path=prediction_csv_path, genmodel_jar_path=genmodel_jar_path, classpath=classpath, java_options=java_options, verbose=verbose, setInvNumNA=setInvNumNA))
 		},
 		finally={
-			unlink(tmp_dir, recursive=T)
+			unlink(input_csv_path)
+		  unlink(prediction_csv_path)
 		}
 	)
 }

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6778.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6778.R
@@ -1,0 +1,28 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.tempdir <- function() {
+  
+  data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
+  cols <- c("Origin", "Distance")
+  model <- h2o.gbm(x=cols, y = "IsDepDelayed", training_frame = data, validation_frame = data, nfolds = 3, ntrees = 1)
+  mojo_name = h2o.download_mojo(model = model,path = tempdir(), get_genmodel_jar = TRUE
+                                , genmodel_name = "genmodel.jar", genmodel_path = tempdir())
+  frame = as.data.frame(data)
+  pred <- h2o.mojo_predict_df(frame = frame, mojo_zip_path = paste0(tempdir(),"/", mojo_name), genmodel_jar_path = paste0(tempdir(), "/", "genmodel.jar"))
+  
+  expect_true(file.exists(tempdir()))
+  expect_true(file.exists(paste0(tempdir(),"/","genmodel.jar")))
+  expect_true(file.exists(paste0(tempdir(), "/", mojo_name)))
+  
+  unlink(paste0(tempdir(),"/","genmodel.jar"))
+  unlink(paste0(tempdir(), "/", mojo_name))
+  
+  
+  
+
+}
+
+doTest("Tempdir remains undeleted/unaffected after mojo_predict_df is called", test.tempdir)

--- a/h2o-r/tests/testdir_jira/runit_pubdev_6778.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_6778.R
@@ -8,20 +8,20 @@ test.tempdir <- function() {
   data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
   cols <- c("Origin", "Distance")
   model <- h2o.gbm(x=cols, y = "IsDepDelayed", training_frame = data, validation_frame = data, nfolds = 3, ntrees = 1)
-  mojo_name = h2o.download_mojo(model = model,path = tempdir(), get_genmodel_jar = TRUE
-                                , genmodel_name = "genmodel.jar", genmodel_path = tempdir())
+  
+  tmpfolder <- paste0(tempdir(),'/', stringi::stri_rand_strings(1,20), '/')
+  dir.create(tmpfolder)
+  mojo_name = h2o.download_mojo(model = model,path = tmpfolder, get_genmodel_jar = TRUE
+                                , genmodel_name = "genmodel.jar", genmodel_path = tmpfolder)
+  
   frame = as.data.frame(data)
-  pred <- h2o.mojo_predict_df(frame = frame, mojo_zip_path = paste0(tempdir(),"/", mojo_name), genmodel_jar_path = paste0(tempdir(), "/", "genmodel.jar"))
+  pred <- h2o.mojo_predict_df(frame = frame, mojo_zip_path = paste0(tmpfolder, mojo_name), genmodel_jar_path = paste0(tmpfolder, "genmodel.jar"))
   
-  expect_true(file.exists(tempdir()))
-  expect_true(file.exists(paste0(tempdir(),"/","genmodel.jar")))
-  expect_true(file.exists(paste0(tempdir(), "/", mojo_name)))
+  expect_true(file.exists(tmpfolder))
+  expect_true(file.exists(paste0(tmpfolder,"genmodel.jar")))
+  expect_true(file.exists(paste0(tmpfolder, mojo_name)))
   
-  unlink(paste0(tempdir(),"/","genmodel.jar"))
-  unlink(paste0(tempdir(), "/", mojo_name))
-  
-  
-  
+  unlink(x = tmpfolder, recursive = TRUE)
 
 }
 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6778

After `h2o.mojo_predict_df` was called, the temp folder was deleted ! This was solved inside by re-creating it once it's called again, but destroying everything inside temp R temp folder.

Now, the files are unlinked as they're created after the `h2o.mojo_predict_df` is finishing, not touching the `tempdir`. Any attempts to create or delete the tempdir were removed from the code. The method now only relies on `tempdir()`, as it should.