### PR TITLE
PUBDEV-6839 - Unify TE arguments with standard H2O models

### DIFF
--- a/h2o-bindings/bin/custom/R/gen_targetencoder.py
+++ b/h2o-bindings/bin/custom/R/gen_targetencoder.py
@@ -1,12 +1,10 @@
 extensions = dict(
-    required_params=['training_frame', "target_column", "encoded_columns"],  # empty to override defaults in gen_defaults,
-    validate_required_params="""
-    if(missing(training_frame)) stop("Training frame must be specified.")
-    if(missing(target_column)) stop("Target column must be specified.")
-    if(missing(encoded_columns)) stop("Encoded columns must be specified.")
-    """,
+    required_params=['training_frame', "x", "y"],
     set_required_params="""
-parms$response_column <- target_column
+args <- .verify_dataxy(training_frame, x, y)
+if( !missing(fold_column) && !is.null(fold_column)) args$x_ignore <- args$x_ignore[!( fold_column == args$x_ignore )]
+parms$ignored_columns <- args$x_ignore
+parms$response_column <- args$y
 parms$training_frame <- training_frame
     """
 )

--- a/h2o-bindings/bin/custom/R/gen_targetencoder.py
+++ b/h2o-bindings/bin/custom/R/gen_targetencoder.py
@@ -1,5 +1,4 @@
 extensions = dict(
-    required_params=['training_frame', "x", "y"],
     set_required_params="""
 args <- .verify_dataxy(training_frame, x, y)
 if( !missing(fold_column) && !is.null(fold_column)) args$x_ignore <- args$x_ignore[!( fold_column == args$x_ignore )]

--- a/h2o-bindings/bin/custom/python/gen_targetencoder.py
+++ b/h2o-bindings/bin/custom/python/gen_targetencoder.py
@@ -24,24 +24,6 @@ def class_extensions():
                                                                 'seed': seed})
         return h2o.get_frame(output["name"])
 
-    def train(self, x = None, y = None,fold_column = None, training_frame = None, encoded_columns = None,
-                  target_column = None):
-
-        if (y is None):
-            y = target_column
-        if(x is None):
-            x = encoded_columns
-
-        def extend_parms(parms):
-            if target_column is not None:
-                parms["target_column"] = target_column
-            if encoded_columns is not None:
-                parms["encoded_columns"] = encoded_columns
-            parms["encoded_columns"] = parms["encoded_columns"] if "encoded_columns" in parms else x
-
-        super(self.__class__, self)._train(x = x, y = y, training_frame = training_frame, fold_column = fold_column,
-                                           extend_parms_fn=extend_parms)
-
 
 extensions = dict(
     __imports__="""import h2o""",

--- a/h2o-core/src/main/java/water/exceptions/H2OModelBuilderIllegalArgumentException.java
+++ b/h2o-core/src/main/java/water/exceptions/H2OModelBuilderIllegalArgumentException.java
@@ -3,7 +3,6 @@ package water.exceptions;
 import hex.Model;
 import hex.ModelBuilder;
 import water.H2OModelBuilderError;
-import water.util.IcedHashMap;
 import water.util.IcedHashMapGeneric;
 
 public class H2OModelBuilderIllegalArgumentException extends H2OIllegalArgumentException {

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -1131,6 +1131,25 @@ public class TestUtil extends Iced {
     return true;
   }
 
+  public static final String[] ignoredColumns(final Frame frame, final String... usedColumns) {
+    final Set<String> usedColumnsSet = new HashSet<>(usedColumns.length);
+    for (String usedColumn : usedColumns) {
+      usedColumnsSet.add(usedColumn);
+    }
+    
+    final String[] names = frame.names();
+    final String[] ignoredcolumns = new String[names.length - usedColumns.length];
+
+    int ignoredColumnsPointer = 0;
+    for (String name : names) {
+      if (!usedColumnsSet.contains(name)) {
+        ignoredcolumns[ignoredColumnsPointer++] = name;
+      }
+    }
+
+    return ignoredcolumns;
+  }
+
   public static boolean compareFrames(final Frame f1, final Frame f2) throws IllegalStateException {
     return compareFrames(f1, f2, 0);
   }

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -1132,22 +1132,9 @@ public class TestUtil extends Iced {
   }
 
   public static final String[] ignoredColumns(final Frame frame, final String... usedColumns) {
-    final Set<String> usedColumnsSet = new HashSet<>(usedColumns.length);
-    for (String usedColumn : usedColumns) {
-      usedColumnsSet.add(usedColumn);
-    }
-    
-    final String[] names = frame.names();
-    final String[] ignoredcolumns = new String[names.length - usedColumns.length];
-
-    int ignoredColumnsPointer = 0;
-    for (String name : names) {
-      if (!usedColumnsSet.contains(name)) {
-        ignoredcolumns[ignoredColumnsPointer++] = name;
-      }
-    }
-
-    return ignoredcolumns;
+    Set<String> ignored = new HashSet(Arrays.asList(frame.names()));
+    ignored.removeAll(Arrays.asList(usedColumns));
+    return ignored.toArray(new String[ignored.size()]);
   }
 
   public static boolean compareFrames(final Frame f1, final Frame f2) throws IllegalStateException {

--- a/h2o-docs/src/product/data-munging/target-encoding.rst
+++ b/h2o-docs/src/product/data-munging/target-encoding.rst
@@ -1,7 +1,7 @@
 Target Encoding
 ---------------
 
-Target encoding is the process of replacing a categorical value with the mean of the target variable. In this example, we will be trying to predict ``bad_loan`` using our cleaned lending club data: https://raw.githubusercontent.com/h2oai/app-consumer-loan/master/data/loan.csv.
+Target encoding is the process of replacing a categorical value with the mean of the target variable. Any non-categorical columns are automatically dropped by the target encoder model. In this example, we will be trying to predict ``bad_loan`` using our cleaned lending club data: https://raw.githubusercontent.com/h2oai/app-consumer-loan/master/data/loan.csv.
 
 One of the predictors is ``addr_state``, a categorical column with 50 unique values. To perform target encoding on ``addr_state``, we will calculate the average of ``bad_loan`` per state (since ``bad_loan`` is binomial, this will translate to the proportion of records with ``bad_loan = 1``).
 

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderBuilder.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderBuilder.java
@@ -8,10 +8,7 @@ import water.util.ArrayUtils;
 import water.util.IcedHashMapGeneric;
 import water.util.Log;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class TargetEncoderBuilder extends ModelBuilder<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters, TargetEncoderModel.TargetEncoderOutput> {
 
@@ -39,7 +36,7 @@ public class TargetEncoderBuilder extends ModelBuilder<TargetEncoderModel, Targe
   private class TargetEncoderDriver extends Driver {
     @Override
     public void computeImpl() {
-      final String[] encodedColumns = encodedColumnsFromIgnored(_parms.train()._names, _parms._ignored_columns,
+      final String[] encodedColumns = encodedColumnsFromIgnored(_parms.train(), _parms._ignored_columns,
               _parms._response_column, _parms._fold_column);
       TargetEncoder tec = new TargetEncoder(encodedColumns);
 
@@ -64,8 +61,16 @@ public class TargetEncoderBuilder extends ModelBuilder<TargetEncoderModel, Targe
     }
 
 
-    private String[] encodedColumnsFromIgnored(final String[] minued, final String[] subtrahend, final String responseName,
-                                                      final String foldColumnName) {
+    private String[] encodedColumnsFromIgnored(final Frame trainingFrame, final String[] subtrahend, final String responseName,
+                                               final String foldColumnName) {
+      // Ignore non-categorical columns by default
+      final ArrayList<String> minued = new ArrayList();
+      for (int i = 0; i < trainingFrame.numCols(); i++) {
+        if (trainingFrame.vec(i).isCategorical() && !trainingFrame.name(i).equals(responseName)) {
+          minued.add(trainingFrame.name(i));
+        }
+      }
+
       final Set<String> subtrahendSet = new HashSet(subtrahend.length + 1);
       for (String name : subtrahend) {
         subtrahendSet.add(name);

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -9,7 +9,6 @@ import water.Job;
 import water.Key;
 import water.fvec.Frame;
 import water.udf.CFuncRef;
-import water.util.ArrayUtils;
 import water.util.IcedHashMapGeneric;
 import water.util.TwoDimTable;
 
@@ -62,7 +61,6 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
     
     public IcedHashMapGeneric<String, Frame> _target_encoding_map;
     public TargetEncoderParameters _parms;
-    public IcedHashMapGeneric<String, Integer> column_name_to_idx;
     public IcedHashMapGeneric<String, Integer> _column_name_to_missing_val_presence;
     public double _prior_mean;
     
@@ -72,7 +70,6 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
       _parms = b._parms;
       _model_summary = constructSummary();
 
-      column_name_to_idx = createColumnNameToIndexMap(_parms);
       _column_name_to_missing_val_presence = createMissingValuesPresenceMap();
       _prior_mean = priorMean;
     }
@@ -102,15 +99,6 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
       }
 
       return summary;
-    }
-
-    private IcedHashMapGeneric<String, Integer> createColumnNameToIndexMap(TargetEncoderParameters teParams) {
-      IcedHashMapGeneric<String, Integer> teColumnNameToIdx = new IcedHashMapGeneric<>();
-      String[] features = ArrayUtils.remove(teParams.train().names().clone(), teParams._response_column);
-      for(String teColumn : _target_encoding_map.keySet()) {
-        teColumnNameToIdx.put(teColumn, ArrayUtils.find(features, teColumn));
-      }
-      return teColumnNameToIdx;
     }
 
     @Override public ModelCategory getModelCategory() {
@@ -180,7 +168,6 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
   @Override
   protected Futures remove_impl(Futures fs, boolean cascade) {
     TargetEncoderFrameHelper.encodingMapCleanUp(_output._target_encoding_map);
-    _output.column_name_to_idx.clear();
     return super.remove_impl(fs, cascade);
   }
 }

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -34,9 +34,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
   public static class TargetEncoderParameters extends Model.Parameters {
     public boolean _blending = false;
     public BlendingParams _blending_parameters = TargetEncoder.DEFAULT_BLENDING_PARAMS;
-    public Frame.VecSpecifier[] _encoded_columns;
     public TargetEncoder.DataLeakageHandlingStrategy _data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
-    public Frame.VecSpecifier _target_column;
     
     @Override
     public String algoName() {
@@ -105,13 +103,12 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
 
       return summary;
     }
-    
+
     private IcedHashMapGeneric<String, Integer> createColumnNameToIndexMap(TargetEncoderParameters teParams) {
       IcedHashMapGeneric<String, Integer> teColumnNameToIdx = new IcedHashMapGeneric<>();
-      String[] names = teParams.train().names().clone();
-      String[] features = ArrayUtils.remove(names, teParams._response_column);
-      for(Frame.VecSpecifier teColumn : teParams._encoded_columns) {
-        teColumnNameToIdx.put(teColumn._column_name, ArrayUtils.find(features, teColumn._column_name)); 
+      String[] features = ArrayUtils.remove(teParams.train().names().clone(), teParams._response_column);
+      for(String teColumn : _target_encoding_map.keySet()) {
+        teColumnNameToIdx.put(teColumn, ArrayUtils.find(features, teColumn));
       }
       return teColumnNameToIdx;
     }

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderMojoWriter.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderMojoWriter.java
@@ -47,15 +47,7 @@ public class TargetEncoderMojoWriter extends ModelMojoWriter {
       writekv("smoothing", teParams._blending_parameters.getF());
     }
     writekv("priorMean", output._prior_mean);
-
-    // Maybe we can use index of the column instead of its name in all the encoding maps. Check whether we need name somewhere.
-    Map<String, Integer> teColumnNameToIdx = output.column_name_to_idx;
-    startWritingTextFile("feature_engineering/target_encoding/te_column_name_to_idx_map.ini");
-    for(Map.Entry<String, Integer> entry: teColumnNameToIdx.entrySet()) {
-      writelnkv(entry.getKey(), entry.getValue().toString()); 
-    }
-    finishWritingTextFile();
-
+    
     Map<String, Integer> _teColumnNameToMissingValuesPresence = output._column_name_to_missing_val_presence;
     startWritingTextFile("feature_engineering/target_encoding/te_column_name_to_missing_values_presence.ini");
     for(Map.Entry<String, Integer> entry: _teColumnNameToMissingValuesPresence.entrySet()) {

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -3,7 +3,6 @@ import ai.h2o.targetencoding.TargetEncoder;
 import ai.h2o.targetencoding.TargetEncoderBuilder;
 import ai.h2o.targetencoding.TargetEncoderModel;
 import water.api.API;
-import water.api.schemas3.FrameV3;
 import water.api.schemas3.ModelParametersSchemaV3;
 
 import java.util.List;
@@ -11,12 +10,6 @@ import java.util.List;
 public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, TargetEncoderV3, TargetEncoderV3.TargetEncoderParametersV3> {
   public static class TargetEncoderParametersV3 extends ModelParametersSchemaV3<TargetEncoderModel.TargetEncoderParameters, TargetEncoderParametersV3> {
     
-    @API(help = "Columnds to encode.")
-    public FrameV3.ColSpecifierV3[] encoded_columns;
-    
-    @API(help = "Target column for the encoding")
-    public FrameV3.ColSpecifierV3 target_column;
-
     @API(help = "Blending enabled/disabled")
     public boolean blending;
 
@@ -33,19 +26,11 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, Ta
     public String[] fields() {
       final List<String> params = extractDeclaredApiParameters(getClass());
       params.add("model_id");
+      params.add("ignored_columns");
       params.add("training_frame");
       params.add("fold_column");
   
       return params.toArray(new String[0]);
-    }
-
-    @Override
-    public TargetEncoderModel.TargetEncoderParameters fillImpl(TargetEncoderModel.TargetEncoderParameters impl) {
-      super.fillImpl(impl);
-      if(response_column == null && target_column != null) {
-        impl._response_column = target_column.column_name;
-      }
-      return impl;
     }
 
     @Override

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TEMojoIntegrationTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TEMojoIntegrationTest.java
@@ -52,19 +52,14 @@ public class TEMojoIntegrationTest extends TestUtil {
       Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
 
       String responseColumnName = "survived";
-
       asFactor(fr, responseColumnName);
-
       Scope.track(fr);
 
-      Frame.VecSpecifier[] teColumns = {new Frame.VecSpecifier(fr._key, "home.dest"),
-              new Frame.VecSpecifier(fr._key, "embarked")};
-
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
       targetEncoderParameters._ignore_const_cols = false; // Why ignore_const_column ignores `name` column? bad naming
       targetEncoderParameters.setTrain(fr._key);
-      targetEncoderParameters._response_column = responseColumnName;
 
       TargetEncoderBuilder targetEncoderBuilder = new TargetEncoderBuilder(targetEncoderParameters);
 
@@ -78,11 +73,9 @@ public class TEMojoIntegrationTest extends TestUtil {
       }
 
       // Let's load model that we just have written and use it for prediction.
-      EasyPredictModelWrapper teModelWrapper = null;
 
       TargetEncoderMojoModel loadedMojoModel = (TargetEncoderMojoModel) MojoModel.load(mojoFile.getPath());
-
-      teModelWrapper = new EasyPredictModelWrapper(loadedMojoModel);
+      EasyPredictModelWrapper teModelWrapper = new EasyPredictModelWrapper(loadedMojoModel);
 
       // RowData that is not encoded yet
       RowData rowToPredictFor = new RowData();
@@ -159,7 +152,7 @@ public class TEMojoIntegrationTest extends TestUtil {
                 new Frame.VecSpecifier(fr._key, "embarked")};
 
         TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
-        targetEncoderParameters._encoded_columns = teColumns;
+        targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
         targetEncoderParameters._ignore_const_cols = false; // Why ignore_const_column ignores `name` column? bad naming
         targetEncoderParameters.setTrain(fr._key);
         targetEncoderParameters._response_column = responseColumnName;
@@ -252,11 +245,12 @@ public class TEMojoIntegrationTest extends TestUtil {
               new Frame.VecSpecifier(fr._key, "embarked")};
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
-      targetEncoderParameters._encoded_columns = teColumns;
-      targetEncoderParameters.setTrain(fr._key);
-      targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters._fold_column = foldColumnName;
       targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._fold_column,
+              targetEncoderParameters._response_column);
+      targetEncoderParameters.setTrain(fr._key);
+      targetEncoderParameters._ignore_const_cols = false;
 
       TargetEncoderBuilder job = new TargetEncoderBuilder(targetEncoderParameters);
 
@@ -334,7 +328,7 @@ public class TEMojoIntegrationTest extends TestUtil {
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = true;
       targetEncoderParameters._blending_parameters = TargetEncoder.DEFAULT_BLENDING_PARAMS;
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
@@ -429,7 +423,7 @@ public class TEMojoIntegrationTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
 
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest");
 
       // Enable blending
       targetEncoderParameters._blending = true;
@@ -514,7 +508,7 @@ public class TEMojoIntegrationTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
 
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
       targetEncoderParameters._blending = true;
       targetEncoderParameters._blending_parameters = new BlendingParams(5, 1);
 
@@ -561,7 +555,7 @@ public class TEMojoIntegrationTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
       targetEncoderParameters._ignore_const_cols = false; // Why ignore_const_column ignores `name` column? bad naming
       targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TEMojoIntegrationTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TEMojoIntegrationTest.java
@@ -152,10 +152,10 @@ public class TEMojoIntegrationTest extends TestUtil {
                 new Frame.VecSpecifier(fr._key, "embarked")};
 
         TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
-        targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
+        targetEncoderParameters._response_column = responseColumnName;
+        targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
         targetEncoderParameters._ignore_const_cols = false; // Why ignore_const_column ignores `name` column? bad naming
         targetEncoderParameters.setTrain(fr._key);
-        targetEncoderParameters._response_column = responseColumnName;
 
         TargetEncoderBuilder targetEncoderBuilder = new TargetEncoderBuilder(targetEncoderParameters);
 
@@ -328,10 +328,10 @@ public class TEMojoIntegrationTest extends TestUtil {
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = true;
       targetEncoderParameters._blending_parameters = TargetEncoder.DEFAULT_BLENDING_PARAMS;
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
+      targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);
-      targetEncoderParameters._response_column = responseColumnName;
 
       TargetEncoderBuilder job = new TargetEncoderBuilder(targetEncoderParameters);
 
@@ -419,19 +419,14 @@ public class TEMojoIntegrationTest extends TestUtil {
       asFactor(fr, responseColumnName);
       Scope.track(fr);
 
-      Frame.VecSpecifier[] teColumns = {new Frame.VecSpecifier(fr._key, "home.dest")};
-
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
-
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest");
-
+      targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", targetEncoderParameters._response_column);
       // Enable blending
       targetEncoderParameters._blending = true;
       targetEncoderParameters._blending_parameters = new BlendingParams(5, 1);
-
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);
-      targetEncoderParameters._response_column = responseColumnName;
 
       TargetEncoderBuilder job = new TargetEncoderBuilder(targetEncoderParameters);
 
@@ -503,18 +498,15 @@ public class TEMojoIntegrationTest extends TestUtil {
       asFactor(fr, responseColumnName);
       Scope.track(fr);
 
-      Frame.VecSpecifier[] teColumns = {new Frame.VecSpecifier(fr._key, "home.dest"),
-              new Frame.VecSpecifier(fr._key, "embarked")};
-
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
 
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
+      targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
       targetEncoderParameters._blending = true;
       targetEncoderParameters._blending_parameters = new BlendingParams(5, 1);
 
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);
-      targetEncoderParameters._response_column = responseColumnName;
 
       TargetEncoderBuilder targetEncoderBuilder = new TargetEncoderBuilder(targetEncoderParameters);
 
@@ -526,7 +518,6 @@ public class TEMojoIntegrationTest extends TestUtil {
 
       assertEquals(0, targetEncoderModel._output._target_encoding_map.get("embarked").byteSize());
       assertEquals(0, targetEncoderModel._output._target_encoding_map.get("home.dest").byteSize());
-      assertEquals(0, targetEncoderModel._output.column_name_to_idx.size());
     } finally {
       Scope.exit();
     }
@@ -555,10 +546,10 @@ public class TEMojoIntegrationTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
+      targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", responseColumnName);
       targetEncoderParameters._ignore_const_cols = false; // Why ignore_const_column ignores `name` column? bad naming
       targetEncoderParameters.setTrain(fr._key);
-      targetEncoderParameters._response_column = responseColumnName;
 
       TargetEncoderBuilder targetEncoderBuilder = new TargetEncoderBuilder(targetEncoderParameters);
 

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderBuilderTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderBuilderTest.java
@@ -41,7 +41,7 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
       targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
 
@@ -93,7 +93,7 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
       targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
       targetEncoderParameters._ignore_const_cols = false;
@@ -138,7 +138,7 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
       targetEncoderParameters._fold_column = foldColumnName;
       targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
@@ -194,7 +194,7 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._encoded_columns = teColumns;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
       targetEncoderParameters._fold_column = foldColumnName;
       targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderBuilderTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderBuilderTest.java
@@ -1,7 +1,6 @@
 package ai.h2o.targetencoding;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import water.Scope;
 import water.TestUtil;
@@ -41,14 +40,12 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
-      targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
+      targetEncoderParameters.setTrain(fr._key);
 
       TargetEncoderBuilder builder = new TargetEncoderBuilder(targetEncoderParameters);
-
-      builder.trainModel().get(); // Waiting for training to be finished
-      targetEncoderModel = builder.getTargetEncoderModel(); // TODO change the way of how we getting model after PUBDEV-6670. We should be able to get it from DKV with .trainModel().get()
+      targetEncoderModel = builder.trainModel().get();
        
       // Let's create encoding map by TargetEncoder directly
       TargetEncoder tec = new TargetEncoder(Frame.VecSpecifier.vecNames(teColumns));
@@ -58,9 +55,7 @@ public class TargetEncoderBuilderTest extends TestUtil {
       Scope.track(fr2);
 
       encodingMapFromTargetEncoder = tec.prepareEncodingMap(fr2, responseColumnName, null);
-
       targetEncodingMapFromBuilder = targetEncoderModel._output._target_encoding_map;
-
       areEncodingMapsIdentical(encodingMapFromTargetEncoder, targetEncodingMapFromBuilder);
 
     } finally {
@@ -93,15 +88,13 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
-      targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
+      targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._ignore_const_cols = false;
 
       TargetEncoderBuilder builder = new TargetEncoderBuilder(targetEncoderParameters);
-
-      builder.trainModel().get(); // Waiting for training to be finished
-      targetEncoderModel = builder.getTargetEncoderModel(); // TODO change the way of how we getting model after PUBDEV-6670. We should be able to get it from DKV with .trainModel().get()
+      targetEncoderModel = builder.trainModel().get();
 
       Map<String, Integer> teColumnNameToMissingValuesPresence = targetEncoderModel._output._column_name_to_missing_val_presence;
       assertTrue(teColumnNameToMissingValuesPresence.get("home.dest") == 0);
@@ -138,15 +131,14 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
-      targetEncoderParameters._fold_column = foldColumnName;
-      targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._fold_column = foldColumnName;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column,
+              targetEncoderParameters._fold_column);
+      targetEncoderParameters.setTrain(fr._key);
 
       TargetEncoderBuilder builder = new TargetEncoderBuilder(targetEncoderParameters);
-
-      builder.trainModel().get(); // Waiting for training to be finished
-      targetEncoderModel = builder.getTargetEncoderModel(); // TODO change the way of how we getting model after PUBDEV-6670. We should be able to get it from DKV with .trainModel().get()
+      targetEncoderModel = builder.trainModel().get();
 
       //Stage 2: 
       // Let's create encoding map by TargetEncoder directly
@@ -188,44 +180,36 @@ public class TargetEncoderBuilderTest extends TestUtil {
 
       asFactor(fr, responseColumnName);
 
-      BlendingParams params = new BlendingParams(3, 1);
-      Frame.VecSpecifier[] teColumns = {new Frame.VecSpecifier(fr._key, "home.dest"),
-              new Frame.VecSpecifier(fr._key, "embarked")};
-
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = false;
-      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked");
-      targetEncoderParameters._fold_column = foldColumnName;
-      targetEncoderParameters.setTrain(fr._key);
       targetEncoderParameters._response_column = responseColumnName;
+      targetEncoderParameters._fold_column = foldColumnName;
+      targetEncoderParameters._seed = 1234;
+      targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column,
+              targetEncoderParameters._fold_column);
+      targetEncoderParameters._train = fr._key;
 
       TargetEncoderBuilder builder = new TargetEncoderBuilder(targetEncoderParameters);
+      targetEncoderModel = builder.trainModel().get();
 
-      builder.trainModel().get(); // Waiting for training to be finished
-      targetEncoderModel = builder.getTargetEncoderModel(); // TODO change the way of how we getting model after PUBDEV-6670. We should be able to get it from DKV with .trainModel().get()
-      
-      long seed = 1234;
       TargetEncoder.DataLeakageHandlingStrategy strategy = TargetEncoder.DataLeakageHandlingStrategy.KFold;
-      Frame transformedTrainWithModelFromBuilder = targetEncoderModel.transform(fr,  TargetEncoder.DataLeakageHandlingStrategy.KFold.getVal(),false, params, seed);
+      Frame transformedTrainWithModelFromBuilder = targetEncoderModel.transform(fr, TargetEncoder.DataLeakageHandlingStrategy.KFold.getVal(),
+              false, null, targetEncoderParameters._seed);
       Scope.track(transformedTrainWithModelFromBuilder);
       targetEncodingMapFromBuilder = targetEncoderModel._output._target_encoding_map;
       
       //Stage 2: 
       // Let's create encoding map by TargetEncoder directly and transform with it
-      TargetEncoder tec = new TargetEncoder(Frame.VecSpecifier.vecNames(teColumns));
+      TargetEncoder tec = new TargetEncoder(new String[]{ "embarked", "home.dest"});
 
-      Frame fr2 = parse_test_file("./smalldata/gbm_test/titanic.csv");
-      addKFoldColumn(fr2, foldColumnName, 5, 1234L);
-      asFactor(fr2, responseColumnName);
-      Scope.track(fr2);
-
-      encodingMapFromTargetEncoder = tec.prepareEncodingMap(fr2, responseColumnName, foldColumnName);
-
-      Frame transformedTrainWithTargetEncoder = tec.applyTargetEncoding(fr2, responseColumnName, encodingMapFromTargetEncoder, strategy, foldColumnName, targetEncoderParameters._blending, false,params, seed);
+      encodingMapFromTargetEncoder = tec.prepareEncodingMap(fr, responseColumnName, foldColumnName, false);
+      Frame transformedTrainWithTargetEncoder = tec.applyTargetEncoding(fr, responseColumnName, encodingMapFromTargetEncoder,
+              strategy, foldColumnName, targetEncoderParameters._blending, false, TargetEncoder.DEFAULT_BLENDING_PARAMS, targetEncoderParameters._seed);
 
       Scope.track(transformedTrainWithTargetEncoder);
-      
-      assertTrue("Transformed by `TargetEncoderModel` and `TargetEncoder` train frames should be identical", isBitIdentical(transformedTrainWithModelFromBuilder, transformedTrainWithTargetEncoder));
+
+      assertTrue("Transformed by `TargetEncoderModel` and `TargetEncoder` train frames should be identical",
+              isBitIdentical(transformedTrainWithModelFromBuilder, transformedTrainWithTargetEncoder));
 
     } finally {
       removeEncodingMaps(encodingMapFromTargetEncoder, targetEncodingMapFromBuilder);

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
@@ -29,8 +29,8 @@ public class TargetEncoderModelTest extends TestUtil{
       parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
       parameters._blending_parameters = new BlendingParams(0.3,0.7);
       parameters._blending = true;
-      parameters._encoded_columns = new Frame.VecSpecifier[]{new Frame.VecSpecifier(trainingFrame._key, "Origin")};
       parameters._response_column = "IsDepDelayed";
+      parameters._ignored_columns = ignoredColumns(trainingFrame, "Origin", parameters._response_column);
       parameters._train = trainingFrame._key;
       parameters._seed = 0XFEED;
       
@@ -43,8 +43,8 @@ public class TargetEncoderModelTest extends TestUtil{
       Scope.track(transformedFrame);
       
       assertNotNull(transformedFrame);
-      assertEquals(trainingFrame.numCols() + parameters._encoded_columns.length, transformedFrame.numCols());
-      final int encodedColumnIndex = ArrayUtils.indexOf(transformedFrame.names(), parameters._encoded_columns[0]._column_name + "_te");
+      assertEquals(trainingFrame.numCols() + 1, transformedFrame.numCols());
+      final int encodedColumnIndex = ArrayUtils.indexOf(transformedFrame.names(), "Origin_te");
       assertNotEquals(-1, encodedColumnIndex);
       assertTrue(transformedFrame.vec(encodedColumnIndex).isNumeric());
     } finally {
@@ -65,8 +65,8 @@ public class TargetEncoderModelTest extends TestUtil{
       parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
       parameters._blending_parameters = null; // Explicitly set to null, default parameters should be used
       parameters._blending = true;
-      parameters._encoded_columns = new Frame.VecSpecifier[]{new Frame.VecSpecifier(trainingFrame._key, "Origin")};
       parameters._response_column = "IsDepDelayed";
+      parameters._ignored_columns = ignoredColumns(trainingFrame, "Origin", parameters._response_column);
       parameters._train = trainingFrame._key;
       parameters._seed = 0XFEED;
 
@@ -79,8 +79,8 @@ public class TargetEncoderModelTest extends TestUtil{
       Scope.track(transformedFrame);
 
       assertNotNull(transformedFrame);
-      assertEquals(trainingFrame.numCols() + parameters._encoded_columns.length, transformedFrame.numCols());
-      final int encodedColumnIndex = ArrayUtils.indexOf(transformedFrame.names(), parameters._encoded_columns[0]._column_name + "_te");
+      assertEquals(trainingFrame.numCols() + (trainingFrame.numCols() - parameters._ignored_columns.length - 1), transformedFrame.numCols());
+      final int encodedColumnIndex = ArrayUtils.indexOf(transformedFrame.names(), "Origin_te");
       assertNotEquals(-1, encodedColumnIndex);
       assertTrue(transformedFrame.vec(encodedColumnIndex).isNumeric());
     } finally {

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderMojoWriterTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderMojoWriterTest.java
@@ -24,24 +24,22 @@ public class TargetEncoderMojoWriterTest extends TestUtil {
 
   @Test
   public void writeModelToZipFile() throws Exception{
-    Frame trainFrame = parse_test_file("./smalldata/gbm_test/titanic.csv");
 
     TargetEncoderModel targetEncoderModel = null;
     String fileNameForMojo = "test_mojo_te.zip";
-    Scope.enter();
     try {
+      Scope.enter();
+      Frame trainFrame = parse_test_file("./smalldata/gbm_test/titanic.csv");
       Scope.track(trainFrame);
       TargetEncoderModel.TargetEncoderParameters p = new TargetEncoderModel.TargetEncoderParameters();
-      Frame.VecSpecifier[] teColumns = {new Frame.VecSpecifier(trainFrame._key, "home.dest"),
-              new Frame.VecSpecifier(trainFrame._key, "embarked")};
       String responseColumnName = "survived";
 
       asFactor(trainFrame, responseColumnName);
 
       p._blending = false;
-      p._encoded_columns = teColumns;
-      p.setTrain(trainFrame._key);
       p._response_column = responseColumnName;
+      p._ignored_columns = ignoredColumns(trainFrame, "home.dest", "embarked", p._response_column);
+      p.setTrain(trainFrame._key);
 
       TargetEncoderBuilder builder = new TargetEncoderBuilder(p);
 

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderTestSuite.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderTestSuite.java
@@ -22,7 +22,7 @@ import org.junit.runners.Suite;
         TargetEncoderMojoWriterTest.class
 })
 
-public class AllTETestsSuite {
+public class TargetEncoderTestSuite {
     // the class remains empty,
     // used only as a holder for the above annotations
 }

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderTestSuite.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderTestSuite.java
@@ -19,6 +19,7 @@ import org.junit.runners.Suite;
         TargetEncodingFrameHelperTest.class,
         TargetEncodingImmutabilityTest.class,
         TEMojoIntegrationTest.class,
+        TargetEncoderBuilderTest.class,
         TargetEncoderMojoWriterTest.class
 })
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModel.java
@@ -8,6 +8,12 @@ public class TargetEncoderMojoModel extends MojoModel {
 
   public TargetEncoderMojoModel(String[] columns, String[][] domains, String responseName) {
     super(columns, domains, responseName);
+    assert columns[columns.length - 1].equals(responseName);
+
+    _teColumnNameToIdx = new HashMap<>(columns.length - 1);
+    for (int i = 0; i < columns.length - 1; i++) {
+      _teColumnNameToIdx.put(columns[i], i);
+    }
   }
 
   public EncodingMaps _targetEncodingMap;

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoReader.java
@@ -13,8 +13,6 @@ public class TargetEncoderMojoReader extends ModelMojoReader<TargetEncoderMojoMo
   
   private static final String ENCODING_MAP_PATH = "feature_engineering/target_encoding/encoding_map.ini";
   
-  private static final String COLUMN_MAP_PATH = "feature_engineering/target_encoding/te_column_name_to_idx_map.ini";
-  
   private static final String MISSING_VALUES_PRESENCE_MAP_PATH = "feature_engineering/target_encoding/te_column_name_to_missing_values_presence.ini";
 
   @Override
@@ -30,7 +28,6 @@ public class TargetEncoderMojoReader extends ModelMojoReader<TargetEncoderMojoMo
       _model._smoothing = readkv("smoothing");
     }
     _model._targetEncodingMap = parseEncodingMap();
-    _model._teColumnNameToIdx = parseTEColumnNameToIndexMap();
     _model._teColumnNameToMissingValuesPresence = parseTEColumnNameToMissingValuesPresenceMap();
     _model._priorMean = readkv("priorMean");
   }
@@ -38,18 +35,6 @@ public class TargetEncoderMojoReader extends ModelMojoReader<TargetEncoderMojoMo
   @Override
   protected TargetEncoderMojoModel makeModel(String[] columns, String[][] domains, String responseColumn) {
     return new TargetEncoderMojoModel(columns, domains, responseColumn);
-  }
-  
-  private Map<String, Integer> parseTEColumnNameToIndexMap() throws IOException {
-    Map<String, Integer> teColumnNameToIndexMap = new HashMap<>();
-    if(exists(COLUMN_MAP_PATH)) {
-      Iterable<String> parsedFile = readtext(COLUMN_MAP_PATH);
-      for(String line : parsedFile) {
-        String[] nameAndIndex = line.split("\\s*=\\s*", 2);
-        teColumnNameToIndexMap.put(nameAndIndex[0], Integer.parseInt(nameAndIndex[1]));
-      }
-    }
-    return teColumnNameToIndexMap;
   }
   
   private Map<String, Integer> parseTEColumnNameToMissingValuesPresenceMap() throws IOException {

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/TargetEncoderPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/TargetEncoderPrediction.java
@@ -1,6 +1,5 @@
 package hex.genmodel.easy.prediction;
 
-import java.util.HashMap;
 
 public class TargetEncoderPrediction extends AbstractPrediction {
 

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -20,17 +20,17 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     """
 
     algo = "targetencoder"
+    param_names = {"blending", "k", "f", "data_leakage_handling", "model_id", "ignored_columns", "training_frame",
+                   "fold_column"}
 
     def __init__(self, **kwargs):
         super(H2OTargetEncoderEstimator, self).__init__()
         self._parms = {}
-        names_list = {"blending", "k", "f", "data_leakage_handling", "model_id", "ignored_columns", "training_frame",
-                      "fold_column"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -20,51 +20,21 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     """
 
     algo = "targetencoder"
-    param_names = {"encoded_columns", "target_column", "blending", "k", "f", "data_leakage_handling", "model_id",
-                   "training_frame", "fold_column"}
 
     def __init__(self, **kwargs):
         super(H2OTargetEncoderEstimator, self).__init__()
         self._parms = {}
+        names_list = {"blending", "k", "f", "data_leakage_handling", "model_id", "ignored_columns", "training_frame",
+                      "fold_column"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in self.param_names:
+            elif pname in names_list:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:
                 raise H2OValueError("Unknown parameter %s = %r" % (pname, pvalue))
-
-    @property
-    def encoded_columns(self):
-        """
-        Columnds to encode.
-
-        Type: ``List[str]``.
-        """
-        return self._parms.get("encoded_columns")
-
-    @encoded_columns.setter
-    def encoded_columns(self, encoded_columns):
-        assert_is_type(encoded_columns, None, [str])
-        self._parms["encoded_columns"] = encoded_columns
-
-
-    @property
-    def target_column(self):
-        """
-        Target column for the encoding
-
-        Type: ``str``.
-        """
-        return self._parms.get("target_column")
-
-    @target_column.setter
-    def target_column(self, target_column):
-        assert_is_type(target_column, None, str)
-        self._parms["target_column"] = target_column
-
 
     @property
     def blending(self):
@@ -128,6 +98,21 @@ class H2OTargetEncoderEstimator(H2OEstimator):
 
 
     @property
+    def ignored_columns(self):
+        """
+        Names of columns to ignore for training.
+
+        Type: ``List[str]``.
+        """
+        return self._parms.get("ignored_columns")
+
+    @ignored_columns.setter
+    def ignored_columns(self, ignored_columns):
+        assert_is_type(ignored_columns, None, [str])
+        self._parms["ignored_columns"] = ignored_columns
+
+
+    @property
     def training_frame(self):
         """
         Id of the training data frame.
@@ -180,21 +165,3 @@ class H2OTargetEncoderEstimator(H2OEstimator):
                                                                 'noise': noise,
                                                                 'seed': seed})
         return h2o.get_frame(output["name"])
-
-    def train(self, x = None, y = None,fold_column = None, training_frame = None, encoded_columns = None,
-                  target_column = None):
-
-        if (y is None):
-            y = target_column
-        if(x is None):
-            x = encoded_columns
-
-        def extend_parms(parms):
-            if target_column is not None:
-                parms["target_column"] = target_column
-            if encoded_columns is not None:
-                parms["encoded_columns"] = encoded_columns
-            parms["encoded_columns"] = parms["encoded_columns"] if "encoded_columns" in parms else x
-
-        super(self.__class__, self)._train(x = x, y = y, training_frame = training_frame, fold_column = fold_column,
-                                           extend_parms_fn=extend_parms)

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_target_encoding_model.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_target_encoding_model.py
@@ -22,8 +22,8 @@ def test_target_encoding_fit_method():
     trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
     trainingFrame[foldColumnName] = trainingFrame.kfold_column(n_folds=5, seed=1234)
     
-    te = H2OTargetEncoderEstimator(k = 0.7, f = 0.3, data_leakage_handling = "none")
-    te.train(training_frame = trainingFrame, encoded_columns = teColumns, target_column = targetColumnName)
+    te = H2OTargetEncoderEstimator(k = 0.7, f = 0.3, data_leakage_handling = "None")
+    te.train(training_frame=trainingFrame, x=teColumns, y=targetColumnName)
     print(te)
     transformed = te.transform(frame = trainingFrame)
     
@@ -37,12 +37,10 @@ def test_target_encoding_fit_method():
     
     # Test fold_column proper handling + kfold data leakage strategy defined
     te = H2OTargetEncoderEstimator(k=0.7, f=0.3)
-    te.train(training_frame=trainingFrame, fold_column="pclass", target_column=targetColumnName,
-             encoded_columns=teColumns)
+    te.train(training_frame=trainingFrame, fold_column="pclass", x=teColumns, y=targetColumnName)
     transformed = te.transform(trainingFrame, data_leakage_handling="kfold", seed = 1234)
 
-    te.train(training_frame=trainingFrame, fold_column="pclass", target_column=targetColumnName,
-             encoded_columns=teColumns)
+    te.train(training_frame=trainingFrame, fold_column="pclass", x=teColumns, y=targetColumnName)
     
     assert transformed is not None
     assert transformed.nrows == 1309

--- a/h2o-r/h2o-package/R/targetencoder.R
+++ b/h2o-r/h2o-package/R/targetencoder.R
@@ -5,12 +5,12 @@
 #'
 #' Transformation of a categorical variable with a mean value of the target variable
 #'
-#' @param training_frame Id of the training data frame.
 #' @param x (Optional) A vector containing the names or indices of the predictor variables to use in building the model.
 #'        If x is missing, then all columns except y are used.
 #' @param y The name or column index of the response variable in the data. 
 #'        The response must be either a numeric or a categorical/factor variable. 
 #'        If the response is numeric, then a regression model will be trained, otherwise it will train a classification model.
+#' @param training_frame Id of the training data frame.
 #' @param blending \code{Logical}. Blending enabled/disabled Defaults to FALSE.
 #' @param k Inflection point. Used for blending (if enabled). Blending is to be enabled separately using the 'blending'
 #'        parameter. Defaults to 20.
@@ -33,9 +33,9 @@
 #' # encoded_data <- h2o.transform(target_encoder, data)
 #' }
 #' @export
-h2o.targetencoder <- function(training_frame,
-                              x,
+h2o.targetencoder <- function(x,
                               y,
+                              training_frame,
                               blending = FALSE,
                               k = 20,
                               f = 10,

--- a/h2o-r/tests/testdir_algos/targetencoder/runit_targetencoder_model.R
+++ b/h2o-r/tests/testdir_algos/targetencoder/runit_targetencoder_model.R
@@ -4,7 +4,7 @@ source("../../../scripts/h2o-r-test-setup.R")
 test.model.targetencoder <- function() {
     data <- h2o.importFile(path = locate('smalldata/gbm_test/titanic.csv'), col.types=list(by.col.name=c("survived"),types=c("factor")))
     encoded_columns <- c('home.dest', 'cabin', 'embarked')
-    target_encoder <- h2o.targetencoder(training_frame = data, x= encoded_columns, y = "survived")
+    target_encoder <- h2o.targetencoder(training_frame = data, x = encoded_columns, y = "survived")
     encoded_data <- h2o.transform(target_encoder, data) # For now, there is only the predict method
     expect_false(is.null(encoded_data))
     expect_equal(h2o.ncol(data) + length(encoded_columns), h2o.ncol(encoded_data))

--- a/h2o-r/tests/testdir_algos/targetencoder/runit_targetencoder_model.R
+++ b/h2o-r/tests/testdir_algos/targetencoder/runit_targetencoder_model.R
@@ -4,14 +4,14 @@ source("../../../scripts/h2o-r-test-setup.R")
 test.model.targetencoder <- function() {
     data <- h2o.importFile(path = locate('smalldata/gbm_test/titanic.csv'), col.types=list(by.col.name=c("survived"),types=c("factor")))
     encoded_columns <- c('home.dest', 'cabin', 'embarked')
-    target_encoder <- h2o.targetencoder(training_frame = data, encoded_columns= encoded_columns, target_column = "survived")
+    target_encoder <- h2o.targetencoder(training_frame = data, x= encoded_columns, y = "survived")
     encoded_data <- h2o.transform(target_encoder, data) # For now, there is only the predict method
     expect_false(is.null(encoded_data))
     expect_equal(h2o.ncol(data) + length(encoded_columns), h2o.ncol(encoded_data))
     expect_true(h2o.nrow(data) == 1309)
     
     # Test fold_column proper handling + kfold data leakage strategy defined
-    target_encoder <- h2o.targetencoder(training_frame = data, encoded_columns= encoded_columns, target_column = "survived",
+    target_encoder <- h2o.targetencoder(training_frame = data, x= encoded_columns, y = "survived",
     fold_column = "pclass", data_leakage_handling = "KFold")
     encoded_data <- h2o.transform(target_encoder, data) # For now, there is only the predict method
     expect_false(is.null(encoded_data))


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6839

From the perspective of the JIRA and it's goals, as proposed by @seb-h2o , this part can be reviewed and addressed in comments right not. But there is a bug that got revealed by this change - the very way scoring is done. There is a map serialized into MOJO which basically points to a very specific index for the given feature in the dataset. Not only this implies the production dataset given to the MOJO must have the features ordered exactly as in the training dataset, it also implies all the features must be there, including fold column and others. 

This unfortunately righteously breaks MOJO tests, as currently, the number of features in TargetEncoderOutput started to work as in other models, showing only the number of features actually used, and not the whole dataset.

I'm currently working on a way to dig it out in a way that is compatible with what has already been released. In case you'd like to investigate the current behavior, see `TargetEncoderMojoModel` class, method `  public double[] score0(double[] row, double[] preds)`, row 51 `double categoricalLevelIndex = row[indexOfColumnInRow]; ` and its surroundings. It's obvious when the behavior of `rel-yau` and this branch is compared.
