### PR TITLE
Py code generator backport to `rel-yau`

### DIFF
--- a/h2o-bindings/bin/gen_python.py
+++ b/h2o-bindings/bin/gen_python.py
@@ -211,13 +211,13 @@ def gen_module(schema, algo):
     yield '    """'
     yield ""
     yield '    algo = "%s"' % algo
+    yield "    param_names = {%s}" % bi.wrap(", ".join('"%s"' % p for p in param_names),
+                                             indent=(" " * 19), indent_first=False)
     yield ""
     yield "    def __init__(self, **kwargs):"
     # TODO: generate __init__ docstring with all params (also generate exact signature to support auto-completion)
     yield "        super(%s, self).__init__()" % classname
     yield "        self._parms = {}"
-    yield "        names_list = {%s}" % bi.wrap(", ".join('"%s"' % p for p in param_names),
-                                                indent=(" " * 22), indent_first=False)
     if class_init_validation:
         yield reformat_block(class_init_validation, 8)
     yield "        for pname, pvalue in kwargs.items():"
@@ -226,7 +226,7 @@ def gen_module(schema, algo):
     yield '                self._parms["model_id"] = pvalue'
     if class_init_setparams:
         yield reformat_block(class_init_setparams, 12)
-    yield "            elif pname in names_list:"
+    yield "            elif pname in self.param_names:"
     yield "                # Using setattr(...) will invoke type-checking of the arguments"
     yield "                setattr(self, pname, pvalue)"
     yield "            else:"
@@ -331,9 +331,8 @@ def gen_init(modules):
     yield "#"
     module_strs = []
     for module, clz, category in sorted(modules):
-        if clz == "H2OGridSearch": continue
-        module_strs.append('"%s"' % clz)
-        if clz == "H2OAutoML": continue
+        if clz in ["H2OGridSearch", "H2OAutoML"]:
+            continue
         module_strs.append('"%s"' % clz)
         yield "from .%s import %s" % (module, clz)
     yield ""

--- a/h2o-py/h2o/estimators/__init__.py
+++ b/h2o-py/h2o/estimators/__init__.py
@@ -27,17 +27,11 @@ from .word2vec import H2OWord2vecEstimator
 from .xgboost import H2OXGBoostEstimator
 
 __all__ = (
-    "H2OAggregatorEstimator", "H2OAggregatorEstimator", "H2OAutoML", "H2OCoxProportionalHazardsEstimator",
-    "H2OCoxProportionalHazardsEstimator", "H2OAutoEncoderEstimator", "H2OAutoEncoderEstimator",
-    "H2ODeepLearningEstimator", "H2ODeepLearningEstimator", "H2ODeepWaterEstimator", "H2ODeepWaterEstimator",
-    "H2OEstimator", "H2OEstimator", "H2OGradientBoostingEstimator", "H2OGradientBoostingEstimator",
-    "H2OGenericEstimator", "H2OGenericEstimator", "H2OGeneralizedLinearEstimator", "H2OGeneralizedLinearEstimator",
-    "H2OGeneralizedLowRankEstimator", "H2OGeneralizedLowRankEstimator", "H2OIsolationForestEstimator",
-    "H2OIsolationForestEstimator", "H2OKMeansEstimator", "H2OKMeansEstimator", "H2ONaiveBayesEstimator",
-    "H2ONaiveBayesEstimator", "H2OPrincipalComponentAnalysisEstimator", "H2OPrincipalComponentAnalysisEstimator",
-    "H2OSupportVectorMachineEstimator", "H2OSupportVectorMachineEstimator", "H2ORandomForestEstimator",
-    "H2ORandomForestEstimator", "H2OStackedEnsembleEstimator", "H2OStackedEnsembleEstimator",
-    "H2OSingularValueDecompositionEstimator", "H2OSingularValueDecompositionEstimator", "H2OTargetEncoderEstimator",
-    "H2OTargetEncoderEstimator", "H2OWord2vecEstimator", "H2OWord2vecEstimator", "H2OXGBoostEstimator",
-    "H2OXGBoostEstimator"
+    "H2OAggregatorEstimator", "H2OCoxProportionalHazardsEstimator", "H2OAutoEncoderEstimator",
+    "H2ODeepLearningEstimator", "H2ODeepWaterEstimator", "H2OEstimator", "H2OGradientBoostingEstimator",
+    "H2OGenericEstimator", "H2OGeneralizedLinearEstimator", "H2OGeneralizedLowRankEstimator",
+    "H2OIsolationForestEstimator", "H2OKMeansEstimator", "H2ONaiveBayesEstimator",
+    "H2OPrincipalComponentAnalysisEstimator", "H2OSupportVectorMachineEstimator", "H2ORandomForestEstimator",
+    "H2OStackedEnsembleEstimator", "H2OSingularValueDecompositionEstimator", "H2OTargetEncoderEstimator",
+    "H2OWord2vecEstimator", "H2OXGBoostEstimator"
 )

--- a/h2o-py/h2o/estimators/aggregator.py
+++ b/h2o-py/h2o/estimators/aggregator.py
@@ -19,18 +19,18 @@ class H2OAggregatorEstimator(H2OEstimator):
     """
 
     algo = "aggregator"
+    param_names = {"model_id", "training_frame", "response_column", "ignored_columns", "ignore_const_cols",
+                   "target_num_exemplars", "rel_tol_num_exemplars", "transform", "categorical_encoding",
+                   "save_mapping_frame", "num_iteration_without_new_exemplar", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OAggregatorEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "response_column", "ignored_columns", "ignore_const_cols",
-                      "target_num_exemplars", "rel_tol_num_exemplars", "transform", "categorical_encoding",
-                      "save_mapping_frame", "num_iteration_without_new_exemplar", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/coxph.py
+++ b/h2o-py/h2o/estimators/coxph.py
@@ -20,19 +20,19 @@ class H2OCoxProportionalHazardsEstimator(H2OEstimator):
     """
 
     algo = "coxph"
+    param_names = {"model_id", "training_frame", "start_column", "stop_column", "response_column", "ignored_columns",
+                   "weights_column", "offset_column", "stratify_by", "ties", "init", "lre_min", "max_iterations",
+                   "interactions", "interaction_pairs", "interactions_only", "use_all_factor_levels",
+                   "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OCoxProportionalHazardsEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "start_column", "stop_column", "response_column", "ignored_columns",
-                      "weights_column", "offset_column", "stratify_by", "ties", "init", "lre_min", "max_iterations",
-                      "interactions", "interaction_pairs", "interactions_only", "use_all_factor_levels",
-                      "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/deeplearning.py
+++ b/h2o-py/h2o/estimators/deeplearning.py
@@ -32,35 +32,34 @@ class H2ODeepLearningEstimator(H2OEstimator):
     """
 
     algo = "deeplearning"
+    param_names = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
+                   "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "fold_assignment",
+                   "fold_column", "response_column", "ignored_columns", "ignore_const_cols", "score_each_iteration",
+                   "weights_column", "offset_column", "balance_classes", "class_sampling_factors",
+                   "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k", "checkpoint",
+                   "pretrained_autoencoder", "overwrite_with_best_model", "use_all_factor_levels", "standardize",
+                   "activation", "hidden", "epochs", "train_samples_per_iteration", "target_ratio_comm_to_comp", "seed",
+                   "adaptive_rate", "rho", "epsilon", "rate", "rate_annealing", "rate_decay", "momentum_start",
+                   "momentum_ramp", "momentum_stable", "nesterov_accelerated_gradient", "input_dropout_ratio",
+                   "hidden_dropout_ratios", "l1", "l2", "max_w2", "initial_weight_distribution", "initial_weight_scale",
+                   "initial_weights", "initial_biases", "loss", "distribution", "quantile_alpha", "tweedie_power",
+                   "huber_alpha", "score_interval", "score_training_samples", "score_validation_samples",
+                   "score_duty_cycle", "classification_stop", "regression_stop", "stopping_rounds", "stopping_metric",
+                   "stopping_tolerance", "max_runtime_secs", "score_validation_sampling", "diagnostics", "fast_mode",
+                   "force_load_balance", "variable_importances", "replicate_training_data", "single_node_mode",
+                   "shuffle_training_data", "missing_values_handling", "quiet_mode", "autoencoder", "sparse",
+                   "col_major", "average_activation", "sparsity_beta", "max_categorical_features", "reproducible",
+                   "export_weights_and_biases", "mini_batch_size", "categorical_encoding", "elastic_averaging",
+                   "elastic_averaging_moving_rate", "elastic_averaging_regularization", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2ODeepLearningEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
-                      "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "fold_assignment",
-                      "fold_column", "response_column", "ignored_columns", "ignore_const_cols", "score_each_iteration",
-                      "weights_column", "offset_column", "balance_classes", "class_sampling_factors",
-                      "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k", "checkpoint",
-                      "pretrained_autoencoder", "overwrite_with_best_model", "use_all_factor_levels", "standardize",
-                      "activation", "hidden", "epochs", "train_samples_per_iteration", "target_ratio_comm_to_comp",
-                      "seed", "adaptive_rate", "rho", "epsilon", "rate", "rate_annealing", "rate_decay",
-                      "momentum_start", "momentum_ramp", "momentum_stable", "nesterov_accelerated_gradient",
-                      "input_dropout_ratio", "hidden_dropout_ratios", "l1", "l2", "max_w2",
-                      "initial_weight_distribution", "initial_weight_scale", "initial_weights", "initial_biases",
-                      "loss", "distribution", "quantile_alpha", "tweedie_power", "huber_alpha", "score_interval",
-                      "score_training_samples", "score_validation_samples", "score_duty_cycle", "classification_stop",
-                      "regression_stop", "stopping_rounds", "stopping_metric", "stopping_tolerance", "max_runtime_secs",
-                      "score_validation_sampling", "diagnostics", "fast_mode", "force_load_balance",
-                      "variable_importances", "replicate_training_data", "single_node_mode", "shuffle_training_data",
-                      "missing_values_handling", "quiet_mode", "autoencoder", "sparse", "col_major",
-                      "average_activation", "sparsity_beta", "max_categorical_features", "reproducible",
-                      "export_weights_and_biases", "mini_batch_size", "categorical_encoding", "elastic_averaging",
-                      "elastic_averaging_moving_rate", "elastic_averaging_regularization", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/deepwater.py
+++ b/h2o-py/h2o/estimators/deepwater.py
@@ -22,30 +22,29 @@ class H2ODeepWaterEstimator(H2OEstimator):
     """
 
     algo = "deepwater"
+    param_names = {"model_id", "checkpoint", "autoencoder", "training_frame", "validation_frame", "nfolds",
+                   "balance_classes", "max_after_balance_size", "class_sampling_factors",
+                   "keep_cross_validation_models", "keep_cross_validation_predictions",
+                   "keep_cross_validation_fold_assignment", "fold_assignment", "fold_column", "response_column",
+                   "offset_column", "weights_column", "ignored_columns", "score_each_iteration", "categorical_encoding",
+                   "overwrite_with_best_model", "epochs", "train_samples_per_iteration", "target_ratio_comm_to_comp",
+                   "seed", "standardize", "learning_rate", "learning_rate_annealing", "momentum_start", "momentum_ramp",
+                   "momentum_stable", "distribution", "score_interval", "score_training_samples",
+                   "score_validation_samples", "score_duty_cycle", "classification_stop", "regression_stop",
+                   "stopping_rounds", "stopping_metric", "stopping_tolerance", "max_runtime_secs", "ignore_const_cols",
+                   "shuffle_training_data", "mini_batch_size", "clip_gradient", "network", "backend", "image_shape",
+                   "channels", "sparse", "gpu", "device_id", "cache_data", "network_definition_file",
+                   "network_parameters_file", "mean_image_file", "export_native_parameters_prefix", "activation",
+                   "hidden", "input_dropout_ratio", "hidden_dropout_ratios", "problem_type", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2ODeepWaterEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "checkpoint", "autoencoder", "training_frame", "validation_frame", "nfolds",
-                      "balance_classes", "max_after_balance_size", "class_sampling_factors",
-                      "keep_cross_validation_models", "keep_cross_validation_predictions",
-                      "keep_cross_validation_fold_assignment", "fold_assignment", "fold_column", "response_column",
-                      "offset_column", "weights_column", "ignored_columns", "score_each_iteration",
-                      "categorical_encoding", "overwrite_with_best_model", "epochs", "train_samples_per_iteration",
-                      "target_ratio_comm_to_comp", "seed", "standardize", "learning_rate", "learning_rate_annealing",
-                      "momentum_start", "momentum_ramp", "momentum_stable", "distribution", "score_interval",
-                      "score_training_samples", "score_validation_samples", "score_duty_cycle", "classification_stop",
-                      "regression_stop", "stopping_rounds", "stopping_metric", "stopping_tolerance", "max_runtime_secs",
-                      "ignore_const_cols", "shuffle_training_data", "mini_batch_size", "clip_gradient", "network",
-                      "backend", "image_shape", "channels", "sparse", "gpu", "device_id", "cache_data",
-                      "network_definition_file", "network_parameters_file", "mean_image_file",
-                      "export_native_parameters_prefix", "activation", "hidden", "input_dropout_ratio",
-                      "hidden_dropout_ratios", "problem_type", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -23,29 +23,28 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     """
 
     algo = "gbm"
+    param_names = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
+                   "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "score_each_iteration",
+                   "score_tree_interval", "fold_assignment", "fold_column", "response_column", "ignored_columns",
+                   "ignore_const_cols", "offset_column", "weights_column", "balance_classes", "class_sampling_factors",
+                   "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k", "ntrees", "max_depth",
+                   "min_rows", "nbins", "nbins_top_level", "nbins_cats", "r2_stopping", "stopping_rounds",
+                   "stopping_metric", "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node",
+                   "learn_rate", "learn_rate_annealing", "distribution", "quantile_alpha", "tweedie_power",
+                   "huber_alpha", "checkpoint", "sample_rate", "sample_rate_per_class", "col_sample_rate",
+                   "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
+                   "histogram_type", "max_abs_leafnode_pred", "pred_noise_bandwidth", "categorical_encoding",
+                   "calibrate_model", "calibration_frame", "custom_metric_func", "custom_distribution_func",
+                   "export_checkpoints_dir", "monotone_constraints", "check_constant_response"}
 
     def __init__(self, **kwargs):
         super(H2OGradientBoostingEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
-                      "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment",
-                      "score_each_iteration", "score_tree_interval", "fold_assignment", "fold_column",
-                      "response_column", "ignored_columns", "ignore_const_cols", "offset_column", "weights_column",
-                      "balance_classes", "class_sampling_factors", "max_after_balance_size",
-                      "max_confusion_matrix_size", "max_hit_ratio_k", "ntrees", "max_depth", "min_rows", "nbins",
-                      "nbins_top_level", "nbins_cats", "r2_stopping", "stopping_rounds", "stopping_metric",
-                      "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node", "learn_rate",
-                      "learn_rate_annealing", "distribution", "quantile_alpha", "tweedie_power", "huber_alpha",
-                      "checkpoint", "sample_rate", "sample_rate_per_class", "col_sample_rate",
-                      "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
-                      "histogram_type", "max_abs_leafnode_pred", "pred_noise_bandwidth", "categorical_encoding",
-                      "calibrate_model", "calibration_frame", "custom_metric_func", "custom_distribution_func",
-                      "export_checkpoints_dir", "monotone_constraints", "check_constant_response"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/generic.py
+++ b/h2o-py/h2o/estimators/generic.py
@@ -19,18 +19,18 @@ class H2OGenericEstimator(H2OEstimator):
     """
 
     algo = "generic"
+    param_names = {"model_id", "model_key", "path"}
 
     def __init__(self, **kwargs):
         super(H2OGenericEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "model_key", "path"}
         if all(kwargs.get(name, None) is None for name in ["model_key", "path"]):
             raise H2OValueError('At least one of ["model_key", "path"] is required.')
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -29,28 +29,27 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     """
 
     algo = "glm"
+    param_names = {"model_id", "training_frame", "validation_frame", "nfolds", "seed", "keep_cross_validation_models",
+                   "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "fold_assignment",
+                   "fold_column", "response_column", "ignored_columns", "ignore_const_cols", "score_each_iteration",
+                   "offset_column", "weights_column", "family", "tweedie_variance_power", "tweedie_link_power", "theta",
+                   "solver", "alpha", "lambda_", "lambda_search", "early_stopping", "nlambdas", "standardize",
+                   "missing_values_handling", "plug_values", "compute_p_values", "remove_collinear_columns",
+                   "intercept", "non_negative", "max_iterations", "objective_epsilon", "beta_epsilon",
+                   "gradient_epsilon", "link", "prior", "lambda_min_ratio", "beta_constraints", "max_active_predictors",
+                   "interactions", "interaction_pairs", "obj_reg", "export_checkpoints_dir", "balance_classes",
+                   "class_sampling_factors", "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k",
+                   "max_runtime_secs", "custom_metric_func"}
 
     def __init__(self, **kwargs):
         super(H2OGeneralizedLinearEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "nfolds", "seed",
-                      "keep_cross_validation_models", "keep_cross_validation_predictions",
-                      "keep_cross_validation_fold_assignment", "fold_assignment", "fold_column", "response_column",
-                      "ignored_columns", "ignore_const_cols", "score_each_iteration", "offset_column", "weights_column",
-                      "family", "tweedie_variance_power", "tweedie_link_power", "theta", "solver", "alpha", "lambda_",
-                      "lambda_search", "early_stopping", "nlambdas", "standardize", "missing_values_handling",
-                      "plug_values", "compute_p_values", "remove_collinear_columns", "intercept", "non_negative",
-                      "max_iterations", "objective_epsilon", "beta_epsilon", "gradient_epsilon", "link", "prior",
-                      "lambda_min_ratio", "beta_constraints", "max_active_predictors", "interactions",
-                      "interaction_pairs", "obj_reg", "export_checkpoints_dir", "balance_classes",
-                      "class_sampling_factors", "max_after_balance_size", "max_confusion_matrix_size",
-                      "max_hit_ratio_k", "max_runtime_secs", "custom_metric_func"}
         if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/glrm.py
+++ b/h2o-py/h2o/estimators/glrm.py
@@ -20,21 +20,21 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
     """
 
     algo = "glrm"
+    param_names = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
+                   "score_each_iteration", "loading_name", "transform", "k", "loss", "loss_by_col", "loss_by_col_idx",
+                   "multi_loss", "period", "regularization_x", "regularization_y", "gamma_x", "gamma_y",
+                   "max_iterations", "max_updates", "init_step_size", "min_step_size", "seed", "init", "svd_method",
+                   "user_y", "user_x", "expand_user_y", "impute_original", "recover_svd", "max_runtime_secs",
+                   "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OGeneralizedLowRankEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
-                      "score_each_iteration", "loading_name", "transform", "k", "loss", "loss_by_col",
-                      "loss_by_col_idx", "multi_loss", "period", "regularization_x", "regularization_y", "gamma_x",
-                      "gamma_y", "max_iterations", "max_updates", "init_step_size", "min_step_size", "seed", "init",
-                      "svd_method", "user_y", "user_x", "expand_user_y", "impute_original", "recover_svd",
-                      "max_runtime_secs", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/isolation_forest.py
+++ b/h2o-py/h2o/estimators/isolation_forest.py
@@ -24,20 +24,20 @@ class H2OIsolationForestEstimator(H2OEstimator):
     """
 
     algo = "isolationforest"
+    param_names = {"model_id", "training_frame", "score_each_iteration", "score_tree_interval", "ignored_columns",
+                   "ignore_const_cols", "ntrees", "max_depth", "min_rows", "max_runtime_secs", "seed",
+                   "build_tree_one_node", "mtries", "sample_size", "sample_rate", "col_sample_rate_change_per_level",
+                   "col_sample_rate_per_tree", "categorical_encoding", "stopping_rounds", "stopping_metric",
+                   "stopping_tolerance", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OIsolationForestEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "score_each_iteration", "score_tree_interval", "ignored_columns",
-                      "ignore_const_cols", "ntrees", "max_depth", "min_rows", "max_runtime_secs", "seed",
-                      "build_tree_one_node", "mtries", "sample_size", "sample_rate", "col_sample_rate_change_per_level",
-                      "col_sample_rate_per_tree", "categorical_encoding", "stopping_rounds", "stopping_metric",
-                      "stopping_tolerance", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/kmeans.py
+++ b/h2o-py/h2o/estimators/kmeans.py
@@ -20,20 +20,20 @@ class H2OKMeansEstimator(H2OEstimator):
     """
 
     algo = "kmeans"
+    param_names = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
+                   "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "fold_assignment",
+                   "fold_column", "ignored_columns", "ignore_const_cols", "score_each_iteration", "k", "estimate_k",
+                   "user_points", "max_iterations", "standardize", "seed", "init", "max_runtime_secs",
+                   "categorical_encoding", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OKMeansEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
-                      "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "fold_assignment",
-                      "fold_column", "ignored_columns", "ignore_const_cols", "score_each_iteration", "k", "estimate_k",
-                      "user_points", "max_iterations", "standardize", "seed", "init", "max_runtime_secs",
-                      "categorical_encoding", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/naive_bayes.py
+++ b/h2o-py/h2o/estimators/naive_bayes.py
@@ -25,21 +25,21 @@ class H2ONaiveBayesEstimator(H2OEstimator):
     """
 
     algo = "naivebayes"
+    param_names = {"model_id", "nfolds", "seed", "fold_assignment", "fold_column", "keep_cross_validation_models",
+                   "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "training_frame",
+                   "validation_frame", "response_column", "ignored_columns", "ignore_const_cols",
+                   "score_each_iteration", "balance_classes", "class_sampling_factors", "max_after_balance_size",
+                   "max_confusion_matrix_size", "max_hit_ratio_k", "laplace", "min_sdev", "eps_sdev", "min_prob",
+                   "eps_prob", "compute_metrics", "max_runtime_secs", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2ONaiveBayesEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "nfolds", "seed", "fold_assignment", "fold_column", "keep_cross_validation_models",
-                      "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "training_frame",
-                      "validation_frame", "response_column", "ignored_columns", "ignore_const_cols",
-                      "score_each_iteration", "balance_classes", "class_sampling_factors", "max_after_balance_size",
-                      "max_confusion_matrix_size", "max_hit_ratio_k", "laplace", "min_sdev", "eps_sdev", "min_prob",
-                      "eps_prob", "compute_metrics", "max_runtime_secs", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/pca.py
+++ b/h2o-py/h2o/estimators/pca.py
@@ -19,19 +19,19 @@ class H2OPrincipalComponentAnalysisEstimator(H2OEstimator):
     """
 
     algo = "pca"
+    param_names = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
+                   "score_each_iteration", "transform", "pca_method", "pca_impl", "k", "max_iterations",
+                   "use_all_factor_levels", "compute_metrics", "impute_missing", "seed", "max_runtime_secs",
+                   "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OPrincipalComponentAnalysisEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
-                      "score_each_iteration", "transform", "pca_method", "pca_impl", "k", "max_iterations",
-                      "use_all_factor_levels", "compute_metrics", "impute_missing", "seed", "max_runtime_secs",
-                      "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/psvm.py
+++ b/h2o-py/h2o/estimators/psvm.py
@@ -19,19 +19,19 @@ class H2OSupportVectorMachineEstimator(H2OEstimator):
     """
 
     algo = "psvm"
+    param_names = {"model_id", "training_frame", "validation_frame", "response_column", "ignored_columns",
+                   "ignore_const_cols", "hyper_param", "kernel_type", "gamma", "rank_ratio", "positive_weight",
+                   "negative_weight", "disable_training_metrics", "sv_threshold", "fact_threshold",
+                   "feasible_threshold", "surrogate_gap_threshold", "mu_factor", "max_iterations", "seed"}
 
     def __init__(self, **kwargs):
         super(H2OSupportVectorMachineEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "response_column", "ignored_columns",
-                      "ignore_const_cols", "hyper_param", "kernel_type", "gamma", "rank_ratio", "positive_weight",
-                      "negative_weight", "disable_training_metrics", "sv_threshold", "fact_threshold",
-                      "feasible_threshold", "surrogate_gap_threshold", "mu_factor", "max_iterations", "seed"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -19,27 +19,26 @@ class H2ORandomForestEstimator(H2OEstimator):
     """
 
     algo = "drf"
+    param_names = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
+                   "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "score_each_iteration",
+                   "score_tree_interval", "fold_assignment", "fold_column", "response_column", "ignored_columns",
+                   "ignore_const_cols", "offset_column", "weights_column", "balance_classes", "class_sampling_factors",
+                   "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k", "ntrees", "max_depth",
+                   "min_rows", "nbins", "nbins_top_level", "nbins_cats", "r2_stopping", "stopping_rounds",
+                   "stopping_metric", "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node", "mtries",
+                   "sample_rate", "sample_rate_per_class", "binomial_double_trees", "checkpoint",
+                   "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
+                   "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame", "distribution",
+                   "custom_metric_func", "export_checkpoints_dir", "check_constant_response"}
 
     def __init__(self, **kwargs):
         super(H2ORandomForestEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
-                      "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment",
-                      "score_each_iteration", "score_tree_interval", "fold_assignment", "fold_column",
-                      "response_column", "ignored_columns", "ignore_const_cols", "offset_column", "weights_column",
-                      "balance_classes", "class_sampling_factors", "max_after_balance_size",
-                      "max_confusion_matrix_size", "max_hit_ratio_k", "ntrees", "max_depth", "min_rows", "nbins",
-                      "nbins_top_level", "nbins_cats", "r2_stopping", "stopping_rounds", "stopping_metric",
-                      "stopping_tolerance", "max_runtime_secs", "seed", "build_tree_one_node", "mtries", "sample_rate",
-                      "sample_rate_per_class", "binomial_double_trees", "checkpoint",
-                      "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
-                      "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame", "distribution",
-                      "custom_metric_func", "export_checkpoints_dir", "check_constant_response"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -48,19 +48,19 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     """
 
     algo = "stackedensemble"
+    param_names = {"model_id", "training_frame", "response_column", "validation_frame", "blending_frame", "base_models",
+                   "metalearner_algorithm", "metalearner_nfolds", "metalearner_fold_assignment",
+                   "metalearner_fold_column", "metalearner_params", "seed", "keep_levelone_frame",
+                   "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OStackedEnsembleEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "response_column", "validation_frame", "blending_frame",
-                      "base_models", "metalearner_algorithm", "metalearner_nfolds", "metalearner_fold_assignment",
-                      "metalearner_fold_column", "metalearner_params", "seed", "keep_levelone_frame",
-                      "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/svd.py
+++ b/h2o-py/h2o/estimators/svd.py
@@ -19,18 +19,18 @@ class H2OSingularValueDecompositionEstimator(H2OEstimator):
     """
 
     algo = "svd"
+    param_names = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
+                   "score_each_iteration", "transform", "svd_method", "nv", "max_iterations", "seed", "keep_u",
+                   "u_name", "use_all_factor_levels", "max_runtime_secs", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OSingularValueDecompositionEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
-                      "score_each_iteration", "transform", "svd_method", "nv", "max_iterations", "seed", "keep_u",
-                      "u_name", "use_all_factor_levels", "max_runtime_secs", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -20,17 +20,17 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     """
 
     algo = "targetencoder"
+    param_names = {"encoded_columns", "target_column", "blending", "k", "f", "data_leakage_handling", "model_id",
+                   "training_frame", "fold_column"}
 
     def __init__(self, **kwargs):
         super(H2OTargetEncoderEstimator, self).__init__()
         self._parms = {}
-        names_list = {"encoded_columns", "target_column", "blending", "k", "f", "data_leakage_handling", "model_id",
-                      "training_frame", "fold_column"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/word2vec.py
+++ b/h2o-py/h2o/estimators/word2vec.py
@@ -19,13 +19,13 @@ class H2OWord2vecEstimator(H2OEstimator):
     """
 
     algo = "word2vec"
+    param_names = {"model_id", "training_frame", "min_word_freq", "word_model", "norm_model", "vec_size", "window_size",
+                   "sent_sample_rate", "init_learning_rate", "epochs", "pre_trained", "max_runtime_secs",
+                   "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OWord2vecEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "min_word_freq", "word_model", "norm_model", "vec_size",
-                      "window_size", "sent_sample_rate", "init_learning_rate", "epochs", "pre_trained",
-                      "max_runtime_secs", "export_checkpoints_dir"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
@@ -34,7 +34,7 @@ class H2OWord2vecEstimator(H2OEstimator):
                 setattr(self, pname, pvalue)
                 self._determine_vec_size();
                 setattr(self, 'vec_size', self.vec_size)
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -21,27 +21,27 @@ class H2OXGBoostEstimator(H2OEstimator):
     """
 
     algo = "xgboost"
+    param_names = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
+                   "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "score_each_iteration",
+                   "fold_assignment", "fold_column", "response_column", "ignored_columns", "ignore_const_cols",
+                   "offset_column", "weights_column", "stopping_rounds", "stopping_metric", "stopping_tolerance",
+                   "max_runtime_secs", "seed", "distribution", "tweedie_power", "categorical_encoding", "quiet_mode",
+                   "export_checkpoints_dir", "ntrees", "max_depth", "min_rows", "min_child_weight", "learn_rate", "eta",
+                   "sample_rate", "subsample", "col_sample_rate", "colsample_bylevel", "col_sample_rate_per_tree",
+                   "colsample_bytree", "max_abs_leafnode_pred", "max_delta_step", "monotone_constraints",
+                   "score_tree_interval", "min_split_improvement", "gamma", "nthread", "max_bins", "max_leaves",
+                   "min_sum_hessian_in_leaf", "min_data_in_leaf", "sample_type", "normalize_type", "rate_drop",
+                   "one_drop", "skip_drop", "tree_method", "grow_policy", "booster", "reg_lambda", "reg_alpha",
+                   "dmatrix_type", "backend", "gpu_id"}
 
     def __init__(self, **kwargs):
         super(H2OXGBoostEstimator, self).__init__()
         self._parms = {}
-        names_list = {"model_id", "training_frame", "validation_frame", "nfolds", "keep_cross_validation_models",
-                      "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment",
-                      "score_each_iteration", "fold_assignment", "fold_column", "response_column", "ignored_columns",
-                      "ignore_const_cols", "offset_column", "weights_column", "stopping_rounds", "stopping_metric",
-                      "stopping_tolerance", "max_runtime_secs", "seed", "distribution", "tweedie_power",
-                      "categorical_encoding", "quiet_mode", "export_checkpoints_dir", "ntrees", "max_depth", "min_rows",
-                      "min_child_weight", "learn_rate", "eta", "sample_rate", "subsample", "col_sample_rate",
-                      "colsample_bylevel", "col_sample_rate_per_tree", "colsample_bytree", "max_abs_leafnode_pred",
-                      "max_delta_step", "monotone_constraints", "score_tree_interval", "min_split_improvement", "gamma",
-                      "nthread", "max_bins", "max_leaves", "min_sum_hessian_in_leaf", "min_data_in_leaf", "sample_type",
-                      "normalize_type", "rate_drop", "one_drop", "skip_drop", "tree_method", "grow_policy", "booster",
-                      "reg_lambda", "reg_alpha", "dmatrix_type", "backend", "gpu_id"}
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue
                 self._parms["model_id"] = pvalue
-            elif pname in names_list:
+            elif pname in self.param_names:
                 # Using setattr(...) will invoke type-checking of the arguments
                 setattr(self, pname, pvalue)
             else:


### PR DESCRIPTION
Backporting changes in code generator that were required for sklearn API: this should solve daily merge conflicts from `rel-yau` to `master`.
This is only the `gen_py.py` part in https://github.com/h2oai/h2o-3/pull/3744: no business logic changes, just the list of the algo param names exposed as a class attribute (for introspection by sklearn wrapping logic, not used in `rel-yau`).