### PR TITLE
Fix PCA Mojo in order to play nicely with MOJO pipeline builder

### DIFF
--- a/h2o-algos/src/main/java/hex/generic/Generic.java
+++ b/h2o-algos/src/main/java/hex/generic/Generic.java
@@ -7,6 +7,7 @@ import water.H2O;
 import water.Key;
 import water.fvec.ByteVec;
 import water.fvec.Frame;
+import water.util.Log;
 
 import java.io.IOException;
 import java.util.*;
@@ -81,17 +82,20 @@ public class Generic extends ModelBuilder<GenericModel, GenericModelParameters, 
                 final MojoReaderBackend readerBackend = MojoReaderBackendFactory.createReaderBackend(mojoBytes.openStream(_job._key), MojoReaderBackendFactory.CachingStrategy.MEMORY);
                 mojoModel = ModelMojoReader.readFrom(readerBackend, true);
                 
-                if(!ALLOWED_MOJO_ALGOS.contains(mojoModel._modelDescriptor.algoName().toLowerCase())){
-                    throw new IllegalArgumentException(String.format("Unsupported MOJO model '%s'. ", mojoModel._modelDescriptor.algoName()));
+                if(! ALLOWED_MOJO_ALGOS.contains(mojoModel._modelDescriptor.algoName().toLowerCase())) {
+                    if (_parms._disable_algo_check)
+                        Log.warn(String.format("MOJO model '%s' is not supported but user disabled white-list check. Trying to load anyway.", mojoModel._modelDescriptor.algoName()));
+                    else
+                        throw new IllegalArgumentException(String.format("Unsupported MOJO model '%s'. ", mojoModel._modelDescriptor.algoName()));
                 }
 
                 final GenericModelOutput genericModelOutput = new GenericModelOutput(mojoModel._modelDescriptor, mojoModel._modelAttributes);
-                final GenericModel genericModel = new GenericModel(_result, _parms, genericModelOutput, mojoModel, mojoBytes);
+                final GenericModel genericModel = new GenericModel(_result, _parms, genericModelOutput, mojoModel, dataKey);
 
                 genericModel.write_lock(_job);
                 genericModel.unlock(_job);
             } catch (IOException e) {
-                throw new IllegalStateException("Unreachable MOJO file: " + mojoBytes._key, e);
+                throw new IllegalStateException("Unreachable MOJO file: " + dataKey, e);
             }
         }
     }
@@ -116,7 +120,7 @@ public class Generic extends ModelBuilder<GenericModel, GenericModelParameters, 
      * @return An instance of {@link ByteVec} containing the bytes of an uploaded MOJO, if present. Or exception. Never returns null.
      * @throws IllegalArgumentException In case the supplied key is invalid (MOJO missing, empty key etc.)
      */
-    private final ByteVec getUploadedMojo(final Key<Frame> key) throws IllegalArgumentException {
+    private ByteVec getUploadedMojo(final Key<Frame> key) throws IllegalArgumentException {
         Objects.requireNonNull(key); // Nicer null pointer exception in case null key is accidentally provided
 
         Frame mojoFrame = key.get();
@@ -134,4 +138,19 @@ public class Generic extends ModelBuilder<GenericModel, GenericModelParameters, 
     public BuilderVisibility builderVisibility() {
         return BuilderVisibility.Stable;
     }
+
+    /**
+     * Convenience method for importing MOJO into H2O.
+     * 
+     * @param location absolute path to MOJO file
+     * @param disableAlgoCheck if true skip the check of white-listed MOJO models, use at your own risk - some features might not work.
+     * @return instance of H2O Model wrapping a MOJO 
+     */
+    public static GenericModel importMojoModel(String location, boolean disableAlgoCheck) {
+        GenericModelParameters p = new GenericModelParameters();
+        p._path = location;
+        p._disable_algo_check = disableAlgoCheck;
+        return new Generic(p).trainModel().get();
+    }
+
 }

--- a/h2o-algos/src/main/java/hex/generic/GenericModel.java
+++ b/h2o-algos/src/main/java/hex/generic/GenericModel.java
@@ -7,26 +7,28 @@ import hex.genmodel.MojoReaderBackend;
 import hex.genmodel.MojoReaderBackendFactory;
 import hex.genmodel.algos.kmeans.KMeansMojoModel;
 import hex.tree.isofor.ModelMetricsAnomaly;
+import water.Futures;
 import water.H2O;
+import water.Iced;
 import water.Key;
 import water.fvec.ByteVec;
+import water.fvec.Frame;
+import water.util.Log;
 
 import java.io.IOException;
 
 public class GenericModel extends Model<GenericModel, GenericModelParameters, GenericModelOutput> {
 
-    private transient MojoModel _mojoModel;
-    private ByteVec _mojoBytes;
-    
+    private MojoModelSource _mojoModelSource;
+
     /**
      * Full constructor
      *
      */
-    public GenericModel(Key<GenericModel> selfKey, GenericModelParameters parms, GenericModelOutput output, MojoModel mojoModel, ByteVec mojoBytes) {
+    public GenericModel(Key<GenericModel> selfKey, GenericModelParameters parms, GenericModelOutput output, MojoModel mojoModel, Key<Frame> mojoSource) {
         super(selfKey, parms, output);
-        _mojoBytes = mojoBytes;
-        _mojoModel = mojoModel;
-        _output = new GenericModelOutput(_mojoModel._modelDescriptor, _mojoModel._modelAttributes);
+        _mojoModelSource = new MojoModelSource(mojoSource, mojoModel);
+        _output = new GenericModelOutput(mojoModel._modelDescriptor, mojoModel._modelAttributes);
 
     }
 
@@ -52,34 +54,104 @@ public class GenericModel extends Model<GenericModel, GenericModelParameters, Ge
                 return new ModelMetricsOrdinal.MetricBuilderOrdinal(_output.nclasses(), domain);
             case Regression:  return new ModelMetricsRegression.MetricBuilderRegression();
             case Clustering:
-                assert _mojoModel instanceof KMeansMojoModel;
-                KMeansMojoModel kMeansMojoModel = (KMeansMojoModel) _mojoModel;
-                return new ModelMetricsClustering.MetricBuilderClustering(_output.nfeatures(), kMeansMojoModel.getNumClusters());
+                if (mojoModel() instanceof KMeansMojoModel) {
+                    KMeansMojoModel kMeansMojoModel = (KMeansMojoModel) mojoModel();
+                    return new ModelMetricsClustering.MetricBuilderClustering(_output.nfeatures(), kMeansMojoModel.getNumClusters());
+                } else {
+                    return unsupportedMetricsBuilder();
+                }
             case AutoEncoder:
                 return new ModelMetricsAutoEncoder.MetricBuilderAutoEncoder(_output.nfeatures());
             case DimReduction:
-                throw new UnsupportedOperationException("DimReduction is not supported.");
+                return unsupportedMetricsBuilder();
             case WordEmbedding:
-                throw new UnsupportedOperationException("WordEmbedding is not supported.");
+                return unsupportedMetricsBuilder();
             case CoxPH:
-                throw new UnsupportedOperationException("CoxPH is not supported.");
-            case AnomalyDetection: return new ModelMetricsAnomaly.MetricBuilderAnomaly("");
-
-            default: throw H2O.unimpl();
+                return unsupportedMetricsBuilder();
+            case AnomalyDetection:
+                return new ModelMetricsAnomaly.MetricBuilderAnomaly();
+            default:
+                throw H2O.unimpl();
+        }
+    }
+    
+    private ModelMetrics.MetricBuilder unsupportedMetricsBuilder() {
+        if (_parms._disable_algo_check) {
+            Log.warn("Model category `" + _output._modelCategory + "` currently doesn't support calculating model metrics. " +
+                    "Model metrics will not be available.");
+            return new MetricBuilderGeneric(mojoModel().getPredsSize(_output._modelCategory));
+        } else {
+            throw new UnsupportedOperationException(_output._modelCategory + " is not supported.");
         }
     }
     
     @Override
     protected double[] score0(double[] data, double[] preds) {
-        if (_mojoModel == null) {
-            assert _mojoBytes != null;
-            _mojoModel = reconstructMojo(_mojoBytes);
-        }
-        return _mojoModel.score0(data,preds);
+        return mojoModel().score0(data,preds);
     }
 
     @Override
     public GenericModelMojoWriter getMojo() {
-        return new GenericModelMojoWriter(_mojoBytes);
+        return new GenericModelMojoWriter(_mojoModelSource.mojoByteVec());
     }
+
+    private MojoModel mojoModel() {
+        return _mojoModelSource.get();
+    }
+
+    private static class MetricBuilderGeneric extends ModelMetrics.MetricBuilder<MetricBuilderGeneric> {
+        private MetricBuilderGeneric(int predsSize) {
+            _work = new double[predsSize];
+        }
+
+        @Override
+        public double[] perRow(double[] ds, float[] yact, Model m) {
+            return ds;
+        }
+
+        @Override
+        public ModelMetrics makeModelMetrics(Model m, Frame f, Frame adaptedFrame, Frame preds) {
+            return null;
+        }
+    }
+
+    @Override
+    protected Futures remove_impl(Futures fs, boolean cascade) {
+        if (_parms._path != null) {
+            // user loaded the model by providing a path (not a Frame holding MOJO data) => we need to do the clean-up
+            Frame mojoFrame = _mojoModelSource._mojoSource.get();
+            if (mojoFrame != null) {
+                mojoFrame.remove(fs, cascade);
+            }
+        }
+        return super.remove_impl(fs, cascade);
+    }
+
+    private static class MojoModelSource extends Iced<MojoModelSource> {
+        private Key<Frame> _mojoSource;
+
+        private transient MojoModel _mojoModel;
+
+        MojoModelSource(Key<Frame> mojoSource, MojoModel mojoModel) {
+            _mojoSource = mojoSource;
+            _mojoModel = mojoModel;
+        }
+
+        private ByteVec mojoByteVec() {
+            return (ByteVec) _mojoSource.get().anyVec();
+        }
+
+        MojoModel get() {
+            if (_mojoModel == null) {
+                synchronized (this) {
+                    if (_mojoModel == null) {
+                        _mojoModel = reconstructMojo(mojoByteVec());
+                    }
+                }
+            }
+            assert _mojoModel != null;
+            return _mojoModel;
+        }
+    }
+
 }

--- a/h2o-algos/src/main/java/hex/generic/GenericModelOutput.java
+++ b/h2o-algos/src/main/java/hex/generic/GenericModelOutput.java
@@ -31,16 +31,18 @@ public class GenericModelOutput extends Model.Output {
         _names = modelDescriptor.columnNames();
         _modelCategory = modelDescriptor.getModelCategory();
         _nfeatures = modelDescriptor.nfeatures();
-        _model_summary = convertTable(modelAttributes.getModelSummary());
-        _cross_validation_metrics_summary = convertTable(modelAttributes.getCrossValidationMetricsSummary());
-        
-        if (modelAttributes != null && modelAttributes instanceof SharedTreeModelAttributes) {
-            fillSharedTreeModelAttributes((SharedTreeModelAttributes) modelAttributes, modelDescriptor);
-        } else {
-            _variable_importances = null;
+        if (modelAttributes != null) {
+            _model_summary = convertTable(modelAttributes.getModelSummary());
+            _cross_validation_metrics_summary = convertTable(modelAttributes.getCrossValidationMetricsSummary());
+
+            if (modelAttributes instanceof SharedTreeModelAttributes) {
+                fillSharedTreeModelAttributes((SharedTreeModelAttributes) modelAttributes, modelDescriptor);
+            } else {
+                _variable_importances = null;
+            }
+            convertMetrics(modelAttributes, modelDescriptor);
+            _scoring_history = convertTable(modelAttributes.getScoringHistory());
         }
-        convertMetrics(modelAttributes, modelDescriptor);
-        _scoring_history = convertTable(modelAttributes.getScoringHistory());
 
     }
 

--- a/h2o-algos/src/main/java/hex/generic/GenericModelParameters.java
+++ b/h2o-algos/src/main/java/hex/generic/GenericModelParameters.java
@@ -15,7 +15,13 @@ public class GenericModelParameters extends Model.Parameters {
      * Key to the file with embedded model
      */
     public Key<Frame> _model_key;
-    
+
+    /**
+     * Skip the check for white-listed algorithms, this allows load any MOJO.
+     * Use at your own risk - unsupported.
+     */
+    public boolean _disable_algo_check;
+
     @Override
     public String algoName() {
         return "Generic";

--- a/h2o-algos/src/main/java/hex/tree/isofor/ModelMetricsAnomaly.java
+++ b/h2o-algos/src/main/java/hex/tree/isofor/ModelMetricsAnomaly.java
@@ -36,6 +36,10 @@ public class ModelMetricsAnomaly extends ModelMetricsUnsupervised implements Sco
     private double _total_norm_score = 0;
     private long _nobs = 0;
 
+    public MetricBuilderAnomaly() {
+      this("");
+    }
+    
     public MetricBuilderAnomaly(String description) {
       _work = new double[2];
       _description = description;

--- a/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
+++ b/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
@@ -1,11 +1,7 @@
 package hex.generic;
 
 import hex.ModelCategory;
-import hex.ModelMetrics;
 import hex.ModelMetricsBinomial;
-import hex.deeplearning.DeepLearning;
-import hex.deeplearning.DeepLearningModel;
-import hex.genmodel.algos.deeplearning.DeeplearningMojoModel;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
 import hex.tree.drf.DRF;

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/pca/PCAMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/pca/PCAMojoModel.java
@@ -5,7 +5,6 @@ import hex.genmodel.MojoModel;
 public class PCAMojoModel extends MojoModel {
 
   double[][] _eigenvectors_raw;
-  public int[] _numLevels;
   public int [] _catOffsets;
   public int[] _permutation;
   public int _ncats;
@@ -48,4 +47,13 @@ public class PCAMojoModel extends MojoModel {
     }   
     return tpred;
   }
+
+  @Override public int getPredsSize() {
+    return _k;
+  }
+
+  @Override public int nclasses() {
+    return _k;
+  }
+
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -6,7 +6,6 @@ import hex.genmodel.IClusteringModel;
 import hex.genmodel.PredictContributions;
 import hex.genmodel.PredictContributionsFactory;
 import hex.genmodel.algos.deeplearning.DeeplearningMojoModel;
-import hex.genmodel.algos.pca.PCAMojoModel;
 import hex.genmodel.algos.glrm.GlrmMojoModel;
 import hex.genmodel.algos.targetencoder.TargetEncoderMojoModel;
 import hex.genmodel.algos.tree.SharedTreeMojoModel;
@@ -823,8 +822,8 @@ public class EasyPredictModelWrapper implements Serializable {
   }
   protected double[] preamble(ModelCategory c, RowData data, double offset) throws PredictException {
     validateModelCategory(c);
-    int predSize = (m instanceof PCAMojoModel)? ((PCAMojoModel) m)._k : m.getPredsSize(c);
-    return predict(data, offset, new double[predSize]);
+    final int predsSize = m.getPredsSize(c);
+    return predict(data, offset, new double[predsSize]);
   }
 
   private static double[] nanArray(int len) {


### PR DESCRIPTION
Implement a test that shows PCA can be used in MOJO Pipelines

Improvements & fixes in MOJO Import
    
    - added convenience method for loading of MOJO models
    - added an option to skip the check of white-listed algos
    - fixed an issue when the Frame MOJO is leaked (when user loads from path)
    - unsupported MOJOs don't get proper metric, they only get dummy metric object
    - fixed an issue of loading MOJOs that don't have model metadata

Fix PCA Mojo in order to play nicely with MOJO pipeline builder