### PR TITLE
PUBDEV-6848 - Target Encoder should ignore non-categorical encoded columns

### DIFF
--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderBuilder.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderBuilder.java
@@ -4,6 +4,7 @@ import hex.ModelBuilder;
 import hex.ModelCategory;
 import water.Scope;
 import water.fvec.Frame;
+import water.fvec.Vec;
 import water.util.IcedHashMapGeneric;
 import water.util.Log;
 
@@ -63,6 +64,16 @@ public class TargetEncoderBuilder extends ModelBuilder<TargetEncoderModel, Targe
       _parms._ignore_const_cols = false;
       Log.info("We don't want to ignore any columns during target encoding transformation therefore `_ignore_const_cols` parameter was set to `false`");
     }
+  }
+
+  @Override
+  protected void ignoreInvalidColumns(int npredictors, boolean expensive) {
+    new FilterCols(npredictors){
+      @Override
+      protected boolean filter(Vec v) {
+        return !v.isCategorical();
+      }
+    }.doIt(train(), "Removing non-categorical columns found in the list of encoded columns.", expensive);
   }
 
   /**

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
@@ -87,4 +87,30 @@ public class TargetEncoderModelTest extends TestUtil{
       Scope.exit();
     }
   }
+
+  @Test
+  public void testTargetEncoderModel_dropNonCategoricalCols() {
+    try {
+      Scope.enter();
+      Frame trainingFrame = parse_test_file("./smalldata/testng/airlines_train.csv");
+      Scope.track(trainingFrame);
+
+      TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+      parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
+      parameters._response_column = "IsDepDelayed";
+      parameters._ignored_columns = null;
+      parameters._train = trainingFrame._key;
+      parameters._seed = 0XFEED;
+
+
+      TargetEncoderBuilder job = new TargetEncoderBuilder(parameters);
+      final TargetEncoderModel targetEncoderModel = job.trainModel().get();
+      Scope.track_generic(targetEncoderModel);
+      // Check categorical colums for not being removed
+      assertArrayEquals(new String[]{"fYear", "fMonth", "fDayofMonth", "fDayOfWeek", "UniqueCarrier",
+              "Origin", "Dest", "IsDepDelayed"}, targetEncoderModel._output._names);
+    } finally {
+      Scope.exit();
+    }
+  }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModel.java
@@ -8,9 +8,8 @@ public class TargetEncoderMojoModel extends MojoModel {
 
   public TargetEncoderMojoModel(String[] columns, String[][] domains, String responseName) {
     super(columns, domains, responseName);
-    assert columns[columns.length - 1].equals(responseName);
 
-    _teColumnNameToIdx = new HashMap<>(columns.length - 1);
+    _teColumnNameToIdx = new HashMap<>(columns.length);
     for (int i = 0; i < columns.length - 1; i++) {
       _teColumnNameToIdx.put(columns[i], i);
     }

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModelTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModelTest.java
@@ -334,7 +334,7 @@ public class TargetEncoderMojoModelTest {
   // We test that order of transformation/predictions is determined by index of teColumn in the input data.
   @Test
   public void sortEncodingMapByIndex() {
-    TargetEncoderMojoModel targetEncoderMojoModel = new TargetEncoderMojoModel(null, null, null);
+    TargetEncoderMojoModel targetEncoderMojoModel = new TargetEncoderMojoModel(new String[0], new String[0][0], null);
     EncodingMaps encodingMaps = new EncodingMaps();
     EncodingMap encodingMapForCat1 = new EncodingMap();
     int factorValueForA = 0;

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoReaderTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoReaderTest.java
@@ -4,7 +4,6 @@ import hex.genmodel.MojoReaderBackend;
 import org.junit.Test;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_target_encoding_model.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_target_encoding_model.py
@@ -52,7 +52,15 @@ def test_target_encoding_fit_method():
 
     # Argument check
     te.train(training_frame=trainingFrame, fold_column="pclass", y=targetColumnName, x=teColumns)
-    
+
+    # Drop all non-categorical columns
+    te.train(x=None, y=targetColumnName, training_frame=trainingFrame, fold_column="pclass")
+    transformed = te.transform(trainingFrame, data_leakage_handling="kfold", seed=1234)
+    assert transformed.col_names == ['home.dest', 'pclass', 'embarked', 'cabin', 'sex', 'survived', 'name', 'age',
+                                     'sibsp', 'parch', 'ticket', 'fare', 'boat', 'body', 'kfold_column',
+                                     'sex_te', 'cabin_te', 'embarked_te', 'home.dest_te'] # 4 encoded columns
+
+
 testList = [
     test_target_encoding_fit_method
 ]

--- a/h2o-r/tests/testdir_algos/targetencoder/runit_targetencoder_model.R
+++ b/h2o-r/tests/testdir_algos/targetencoder/runit_targetencoder_model.R
@@ -21,6 +21,19 @@ test.model.targetencoder <- function() {
     mojo_name <- h2o.download_mojo(model = target_encoder, path = tempdir())
     mojo_path <- paste0(tempdir(),"/",mojo_name)
     expect_true(file.exists(mojo_path))
+    
+    # No encoded columns (x) given
+    target_encoder <- h2o.targetencoder(training_frame = data, y = "survived")
+    encoded_data <- h2o.transform(target_encoder, data) # For now, there is only the predict method
+    
+    expected_columns <-
+        c(
+        "home.dest","embarked","cabin","sex","pclass","survived","name","age","sibsp","parch",
+        "ticket","fare","boat","body","sex_te", "cabin_te","embarked_te","home.dest_te" # 4 new encoded columns
+        )
+        print(h2o.colnames(encoded_data))
+        expect_true(all(h2o.colnames(encoded_data) == expected_columns))
+    
 }
 
 doTest("Target Encoder Model test", test.model.targetencoder )


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6848

Target encoder won't ignore numeric columns. This PR ignores them if they're specified and supplies a standard warning message for the client to display it (tested manually, works).

The simplest use case for this is not to specify x in the client at all - nothing gets ignored then, as the default behavior is to use all the columns.
