### PR TITLE
PUBDEV-6879: Docs - CD 5.15 and 5.16 added to list of supported Hadoop platforms

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -428,6 +428,8 @@ Supported Versions
 -  CDH 5.10
 -  CDH 5.13
 -  CDH 5.14
+-  CDH 5.15
+-  CDH 5.16
 -  CDH 6.0
 -  CDH 6.1
 -  CDH 6.2


### PR DESCRIPTION
CD 5.15 and 5.16 have been added to list of supported Hadoop platforms.

See: https://0xdata.atlassian.net/browse/PUBDEV-6879