### PR TITLE
[PUBDEV-6821] Expose leader node idx via rest api

### DIFF
--- a/h2o-core/src/main/java/water/api/CloudHandler.java
+++ b/h2o-core/src/main/java/water/api/CloudHandler.java
@@ -41,6 +41,9 @@ class CloudHandler extends Handler {
     H2ONode[] members = H2O.CLOUD.members();
     cloud.bad_nodes = 0;
     cloud.cloud_healthy = true;
+    
+    H2ONode leader = H2O.CLOUD.leader();
+    cloud.leader_idx = leader == null ? -1 : leader.index();
     if (null != members) {
       cloud.nodes = new CloudV3.NodeV3[members.length];
       for (int i = 0; i < members.length; i++) {

--- a/h2o-core/src/main/java/water/api/schemas3/CloudV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/CloudV3.java
@@ -95,6 +95,9 @@ public class CloudV3 extends RequestSchemaV3<Iced, CloudV3> {
   @API(help="internal_security_enabled", direction=API.Direction.OUTPUT)
   public boolean internal_security_enabled;
 
+  @API(help="leader_idx", direction=API.Direction.OUTPUT)
+  public int leader_idx = -1;
+  
   // Output fields one-per-JVM
   public static class NodeV3 extends SchemaV3<Iced, NodeV3> {
     public NodeV3() {}

--- a/h2o-core/src/test/java/water/api/CloudHandlerTest.java
+++ b/h2o-core/src/test/java/water/api/CloudHandlerTest.java
@@ -1,0 +1,25 @@
+package water.api;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.TestUtil;
+import water.api.schemas3.CloudV3;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class CloudHandlerTest extends TestUtil {
+
+  @BeforeClass
+  public static void beforeClass() {
+    TestUtil.stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void status() {
+    final CloudHandler cloudHandler = new CloudHandler();
+    final CloudV3 status = cloudHandler.status(3, new CloudV3());
+    assertNotNull(status);
+    assertNotEquals(status.leader_idx, -1);
+  }
+}

--- a/h2o-py/h2o/backend/cluster.py
+++ b/h2o-py/h2o/backend/cluster.py
@@ -344,4 +344,4 @@ class H2OCluster(object):
 
 _cloud_v3_valid_keys = {"is_client", "build_number", "cloud_name", "locked", "node_idx", "consensus", "branch_name",
                         "version", "cloud_uptime_millis", "cloud_internal_timezone", "datafile_parser_timezone", "cloud_healthy", "bad_nodes", "cloud_size", "skip_ticks",
-                        "nodes", "build_age", "build_too_old", "internal_security_enabled"}
+                        "nodes", "build_age", "build_too_old", "internal_security_enabled", "leader_idx"}


### PR DESCRIPTION
Reincarnation of https://github.com/h2oai/h2o-3/pull/3834 as it was reverted due to failure mentioned here https://github.com/h2oai/h2o-3/pull/3839.

Let's wait for infra to verify this will do the trick :)

CC: @mn-mikke in the rest api based external backend, we should always use the leader node for the Flow UI and rest API