### PR TITLE
PUBDEV-6894: Add support for MapR 6.1

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -7,7 +7,7 @@ H2O's core code is written in Java. Inside H2O, a Distributed Key/Value store is
 
 H2O’s REST API allows access to all the capabilities of H2O from an external program or script via JSON over HTTP. The Rest API is used by H2O’s web interface (Flow UI), R binding (H2O-R), and Python binding (H2O-Python).
 
-The speed, quality, ease-of-use, and model-deployment for the various cutting edge Supervised and Unsupervised algorithms like Deep Learning, Tree Ensembles, and GLRM make H2O a highly sought after API for big data data science.
+The speed, quality, ease-of-use, and model-deployment for the various cutting edge Supervised and Unsupervised algorithms like Deep Learning, Tree Ensembles, and GLRM make H2O a highly sought after API for big data data science. 
 
 Requirements
 ------------

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -444,6 +444,7 @@ Supported Versions
 -  MapR 5.0
 -  MapR 5.1
 -  MapR 5.2
+-  MapR 6.1
 -  IOP 4.2
 
 **Important Points to Remember**:

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -444,6 +444,7 @@ Supported Versions
 -  MapR 5.0
 -  MapR 5.1
 -  MapR 5.2
+-  MapR 6.0
 -  MapR 6.1
 -  IOP 4.2
 


### PR DESCRIPTION
Support for MapR 6.0 and MapR 6.1 have been added to the H2O-3 documentation.

See: https://0xdata.atlassian.net/browse/PUBDEV-6894
https://github.com/h2oai/h2o-3/pull/3895