### PR TITLE
PUBDEV-5975: Proposal for a consistent behaviour of AutoML reruns

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -162,7 +162,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   }
 
   public AutoML(Key<AutoML> key, Date startTime, AutoMLBuildSpec buildSpec) {
-    super(key);
+    super(key == null ? Key.make(buildSpec.project()) : key);
     _startTime = startTime;
     _buildSpec = buildSpec;
     _runCountdown = Countdown.fromSeconds(buildSpec.build_control.stopping_criteria.max_runtime_secs());

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -74,12 +74,6 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       lastStartTime = startTime;
     }
 
-    // TODO: problems:
-    //   if same project_name but change validation_frame or leaderboard_frame, then the existing models from previous run are scored with a different metric.
-    //   - for change of leaderboard_frame, this is currently handled in Leaderboard.getOrMake
-    //   - where to handle change of validation_frame
-    //   - unfortunately, this can't be handled on client side
-
     // if user offers a different response column,
     //   the new models will be added to a new Leaderboard, without removing the previous one.
     // otherwise, the new models will be added to the existing leaderboard.

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -33,6 +33,7 @@ import static ai.h2o.automl.AutoMLBuildSpec.AutoMLStoppingCriteria.AUTO_STOPPING
 public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
   public static final Comparator<AutoML> byStartTime = Comparator.comparing(a -> a.startTime);
+  public static final String keySeparator = "@@";
 
   private final static boolean verifyImmutability = true; // check that trainingFrame hasn't been messed with
   private final static SimpleDateFormat timestampFormatForKeys = new SimpleDateFormat("yyyyMMdd_HHmmss");
@@ -76,7 +77,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
     // if user offers a different training frame or response column,
     //   the new models will be added to a new Leaderboard, without removing the previous one.
     // otherwise, the new models will be added to the existing leaderboard.
-    Key<AutoML> key = Key.make(buildSpec.project()+"@"+buildSpec.input_spec.training_frame+'.'+buildSpec.input_spec.response_column);
+    Key<AutoML> key = Key.make(buildSpec.project()+keySeparator+buildSpec.input_spec.training_frame+'.'+buildSpec.input_spec.response_column);
     AutoML aml = new AutoML(key, startTime, buildSpec);
     startAutoML(aml);
     return aml;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -71,7 +71,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       lastStartTime = startTime;
     }
 
-    AutoML aml = makeAutoML(Key.make(buildSpec.project()), startTime, buildSpec);
+    String keyString = buildSpec.project();
+    AutoML aml = AutoML.makeAutoML(Key.<AutoML>make(keyString), startTime, buildSpec);
+
+    DKV.put(aml);
     startAutoML(aml);
     return aml;
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -74,10 +74,10 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       lastStartTime = startTime;
     }
 
-    // if user offers a different training frame or response column,
+    // if user offers a different response column,
     //   the new models will be added to a new Leaderboard, without removing the previous one.
     // otherwise, the new models will be added to the existing leaderboard.
-    Key<AutoML> key = Key.make(buildSpec.project()+keySeparator+buildSpec.input_spec.training_frame+'.'+buildSpec.input_spec.response_column);
+    Key<AutoML> key = Key.make(buildSpec.project()+keySeparator+buildSpec.input_spec.response_column);
     AutoML aml = new AutoML(key, startTime, buildSpec);
     startAutoML(aml);
     return aml;

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -74,6 +74,12 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       lastStartTime = startTime;
     }
 
+    // TODO: problems:
+    //   if same project_name but change validation_frame or leaderboard_frame, then the existing models from previous run are scored with a different metric.
+    //   - for change of leaderboard_frame, this is currently handled in Leaderboard.getOrMake
+    //   - where to handle change of validation_frame
+    //   - unfortunately, this can't be handled on client side
+
     // if user offers a different response column,
     //   the new models will be added to a new Leaderboard, without removing the previous one.
     // otherwise, the new models will be added to the existing leaderboard.

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -4,6 +4,7 @@ import hex.ScoreKeeper;
 import hex.grid.HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria;
 import water.Iced;
 import water.Key;
+import water.api.schemas3.JobV3;
 import water.fvec.Frame;
 
 /**
@@ -173,17 +174,11 @@ public class AutoMLBuildSpec extends Iced {
   public AutoMLInput input_spec;
   public AutoMLBuildSpec.AutoMLBuildModels build_models;
 
-  private transient String project_cached = null;
-  public String project() {
-    if (null != project_cached)
-      return project_cached;
+  // output
+  public JobV3 job;
 
-    // allow the user to override:
-    if (null != build_control.project_name) {
-      project_cached = build_control.project_name;
-      return project_cached;
-    }
-    project_cached = "automl_"+input_spec.training_frame+"_"+input_spec.response_column;
-    return project_cached;
+  public String project() {
+    return build_control.project_name != null ? build_control.project_name
+            : "automl_"+input_spec.training_frame+"_"+input_spec.response_column;
   }
 }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -7,10 +7,16 @@ import water.Key;
 import water.api.schemas3.JobV3;
 import water.fvec.Frame;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 /**
  * Parameters which specify the build (or extension) of an AutoML build job.
  */
 public class AutoMLBuildSpec extends Iced {
+
+  private static final DateFormat projectTimeStampFormat = new SimpleDateFormat("yyyyMMdd_HmmssSSS");
 
   /**
    * Default constructor provides the default behavior.
@@ -179,7 +185,7 @@ public class AutoMLBuildSpec extends Iced {
 
   public String project() {
     if (build_control.project_name == null) {
-      build_control.project_name = "automl_"+input_spec.training_frame+"_"+input_spec.response_column;
+      build_control.project_name = "AutoML_"+ projectTimeStampFormat.format(new Date());
     }
     return build_control.project_name;
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -178,7 +178,9 @@ public class AutoMLBuildSpec extends Iced {
   public JobV3 job;
 
   public String project() {
-    return build_control.project_name != null ? build_control.project_name
-            : "automl_"+input_spec.training_frame+"_"+input_spec.response_column;
+    if (build_control.project_name == null) {
+      build_control.project_name = "automl_"+input_spec.training_frame+"_"+input_spec.response_column;
+    }
+    return build_control.project_name;
   }
 }

--- a/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
  */
 public class EventLog extends Keyed<EventLog> {
 
-  public Key<AutoML> _automlKey;
+  public final Key<AutoML> _automlKey;
   public EventLogEntry[] _events;
 
   public EventLog(Key<AutoML> automlKey) {
@@ -32,12 +32,6 @@ public class EventLog extends Keyed<EventLog> {
     if (null == eventLog) {
       eventLog = new EventLog(runKey);
     }
-    DKV.put(eventLog);
-    return eventLog;
-  }
-
-  static EventLog make(Key<AutoML> runKey) {
-    EventLog eventLog = new EventLog(runKey);
     DKV.put(eventLog);
     return eventLog;
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/EventLog.java
@@ -18,11 +18,11 @@ import java.io.Serializable;
  */
 public class EventLog extends Keyed<EventLog> {
 
-  public final Key<AutoML> _automlKey;
+  public final Key<AutoML> _automl_id;
   public EventLogEntry[] _events;
 
   public EventLog(Key<AutoML> automlKey) {
-    _automlKey = automlKey;
+    _automl_id = automlKey;
     _key = Key.make(idForRun(automlKey));
     _events = new EventLogEntry[0];
   }
@@ -62,7 +62,7 @@ public class EventLog extends Keyed<EventLog> {
 
   /** Add a EventLogEntry, but don't log. */
   public <V extends Serializable> EventLogEntry<V> addEvent(Level level, Stage stage, String message) {
-    EventLogEntry<V> entry = new EventLogEntry<>(_automlKey, level, stage, message);
+    EventLogEntry<V> entry = new EventLogEntry<>(_automl_id, level, stage, message);
     addEvent(entry);
     return entry;
   }
@@ -85,7 +85,7 @@ public class EventLog extends Keyed<EventLog> {
   }
 
   public TwoDimTable toTwoDimTable() {
-    String name = _automlKey == null ? "(new)" : _automlKey.toString();
+    String name = _automl_id == null ? "(new)" : _automl_id.toString();
     return toTwoDimTable("Event Log for AutoML:" + name);
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -43,7 +43,7 @@ public class Leaderboard extends Lockable<Leaderboard> {
    * <p>
    * Updated inside addModels().
    */
-  private final transient IcedHashMap<Key<ModelMetrics>, ModelMetrics> _leaderboard_model_metrics_cache = new IcedHashMap<>();
+  private final IcedHashMap<Key<ModelMetrics>, ModelMetrics> _leaderboard_model_metrics_cache = new IcedHashMap<>();
 
   /**
    * Map providing for a given metric name, the list of metric values in the same order as the models

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -24,8 +24,8 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
 
     private transient AutoML _aml;
 
-    protected Algo _algo;
-    protected String _id;
+    protected final Algo _algo;
+    protected final String _id;
     protected int _weight;
     protected boolean _ignoreConstraints;  // whether or not to ignore the max_models/max_runtime constraints
     protected String _description;
@@ -162,7 +162,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
     private String getSortMetric() {
         //ensures that the sort metric is always updated according to the defaults set by leaderboard
         Leaderboard leaderboard = aml().leaderboard();
-        return leaderboard == null ? null : leaderboard.sort_metric;
+        return leaderboard == null ? null : leaderboard._sort_metric;
     }
 
     private static ScoreKeeper.StoppingMetric metricValueOf(String name) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -162,7 +162,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
     private String getSortMetric() {
         //ensures that the sort metric is always updated according to the defaults set by leaderboard
         Leaderboard leaderboard = aml().leaderboard();
-        return leaderboard == null ? null : leaderboard._sort_metric;
+        return leaderboard == null ? null : leaderboard.getSortMetric();
     }
 
     private static ScoreKeeper.StoppingMetric metricValueOf(String name) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -81,7 +81,7 @@ public class StackedEnsembleStepsProvider implements ModelingStepsProvider<Stack
 
         private ModelingStep[] defaults = new StackedEnsembleModelStep[] {
                 new StackedEnsembleModelStep("best", DEFAULT_MODEL_TRAINING_WEIGHT, aml()) {
-                    { _description = _description+" (build using top model from each algorithm type)"; }
+                    { _description = _description+" (built using top model from each algorithm type)"; }
                     @Override
                     protected Job<StackedEnsembleModel> startJob() {
                         // Set aside List<Model> for best models per model type. Meaning best GLM, GBM, DRF, XRT, and DL (5 models).
@@ -104,7 +104,7 @@ public class StackedEnsembleStepsProvider implements ModelingStepsProvider<Stack
                     }
                 },
                 new StackedEnsembleModelStep("all", DEFAULT_MODEL_TRAINING_WEIGHT, aml()) {
-                    { _description = _description+" (build using all AutoML models)"; }
+                    { _description = _description+" (built using all AutoML models)"; }
                     @Override
                     protected Job<StackedEnsembleModel> startJob() {
                         int nonEnsembleCount = 0;

--- a/h2o-automl/src/main/java/water/automl/api/AutoMLBuilderHandler.java
+++ b/h2o-automl/src/main/java/water/automl/api/AutoMLBuilderHandler.java
@@ -14,6 +14,7 @@ public class AutoMLBuilderHandler extends Handler {
     AutoMLBuildSpec buildSpec = buildSpecSchema.createAndFillImpl();
     AutoML aml = AutoML.startAutoML(buildSpec);
     buildSpecSchema.job = new JobV3().fillFromImpl(aml.job());
+    buildSpecSchema.build_control.project_name = aml.projectName();
     return buildSpecSchema;
   }
 }

--- a/h2o-automl/src/main/java/water/automl/api/AutoMLHandler.java
+++ b/h2o-automl/src/main/java/water/automl/api/AutoMLHandler.java
@@ -50,7 +50,7 @@ public class AutoMLHandler extends Handler {
     final Key[] automlKeys = KeySnapshot.globalSnapshot().filter(new KeySnapshot.KVFilter() {
       @Override
       public boolean filter(KeySnapshot.KeyInfo k) {
-        return Value.isSubclassOf(k._type, AutoML.class) && k._key.toString().startsWith(project_name+"@");
+        return Value.isSubclassOf(k._type, AutoML.class) && k._key.toString().startsWith(project_name+AutoML.keySeparator);
       }
     }).keys();
     AutoML[] amls = new AutoML[automlKeys.length];

--- a/h2o-automl/src/main/java/water/automl/api/AutoMLHandler.java
+++ b/h2o-automl/src/main/java/water/automl/api/AutoMLHandler.java
@@ -8,12 +8,20 @@ import water.exceptions.H2OIllegalArgumentException;
 import water.exceptions.H2OKeyNotFoundArgumentException;
 import water.exceptions.H2OKeyWrongTypeArgumentException;
 
+import java.util.stream.Stream;
+
 public class AutoMLHandler extends Handler {
 
   @SuppressWarnings("unused") // called through reflection by RequestServer
   /** Return an AutoML object by ID. */
   public AutoMLV99 fetch(int version, AutoMLV99 autoMLV99) {
     AutoML autoML = DKV.getGet(autoMLV99.automl_id.name);
+    if (autoML == null) {
+      AutoML[] amls = fetchAllForProject(autoMLV99.automl_id.name);
+      if (amls.length > 0) {
+        autoML = Stream.of(amls).max(AutoML.byStartTime).get();
+      }
+    }
     return autoMLV99.fillFromImpl(autoML);
   }
 
@@ -36,5 +44,20 @@ public class AutoMLHandler extends Handler {
       throw new H2OKeyWrongTypeArgumentException(param_name, key.toString(), AutoML.class, ice.getClass());
 
     return (AutoML) ice;
+  }
+
+  public static AutoML[] fetchAllForProject(final String project_name) {
+    final Key[] automlKeys = KeySnapshot.globalSnapshot().filter(new KeySnapshot.KVFilter() {
+      @Override
+      public boolean filter(KeySnapshot.KeyInfo k) {
+        return Value.isSubclassOf(k._type, AutoML.class) && k._key.toString().startsWith(project_name+"@");
+      }
+    }).keys();
+    AutoML[] amls = new AutoML[automlKeys.length];
+    for (int i = 0; i < automlKeys.length; i++) {
+      AutoML aml = getFromDKV("(none)", automlKeys[i]);
+      amls[i] = aml;
+    }
+    return amls;
   }
 }

--- a/h2o-automl/src/main/java/water/automl/api/LeaderboardsHandler.java
+++ b/h2o-automl/src/main/java/water/automl/api/LeaderboardsHandler.java
@@ -46,7 +46,7 @@ public class LeaderboardsHandler extends Handler {
     if (null == s.project_name)
       throw new H2OKeyNotFoundArgumentException("Client must specify a project_name.");
 
-      return new LeaderboardV99().fillFromImpl(getFromDKV("project_name", Leaderboard.idForProject(s.project_name)));
+    return new LeaderboardV99().fillFromImpl(getFromDKV("project_name", Leaderboard.idForProject(s.project_name)));
   }
 
   // TODO: almost identical to ModelsHandler; refactor

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -31,7 +31,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
    */
   public static final class AutoMLBuildControlV99 extends Schema<AutoMLBuildSpec.AutoMLBuildControl, AutoMLBuildControlV99> {
 
-    @API(help="Optional project name used to group models from multiple AutoML runs into a single Leaderboard; derived from the training data name if not specified.")
+    @API(help="Optional project name used to group models from multiple AutoML runs into a single Leaderboard; derived from the training data name if not specified.", direction=API.Direction.INOUT)
     public String project_name;
 
     @API(help="Model performance based stopping criteria for the AutoML run.", direction=API.Direction.INPUT)

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLV99.java
@@ -90,19 +90,19 @@ public class AutoMLV99 extends SchemaV3<AutoML,AutoMLV99> {
     }
 
     // NOTE: don't return nulls; return an empty leaderboard/eventLog, to ease life for the client
-    Leaderboard leaderboard = autoML.leaderboard();
-    if (null == leaderboard) {
-      leaderboard = new Leaderboard(autoML.projectName(), autoML.eventLog(), autoML.getLeaderboardFrame(), this.sort_metric);
-    }
-    this.leaderboard = new LeaderboardV99().fillFromImpl(leaderboard);
-    this.leaderboard_table = new TwoDimTableV3().fillFromImpl(leaderboard.toTwoDimTable());
-
     EventLog eventLog = autoML.eventLog();
     if (null == eventLog) {
       eventLog = new EventLog(autoML._key);
     }
     this.event_log = new EventLogV99().fillFromImpl(eventLog);
     this.event_log_table = new TwoDimTableV3().fillFromImpl(eventLog.toTwoDimTable());
+
+    Leaderboard leaderboard = autoML.leaderboard();
+    if (null == leaderboard) {
+      leaderboard = new Leaderboard(project_name, eventLog, autoML.getLeaderboardFrame(), sort_metric);
+    }
+    this.leaderboard = new LeaderboardV99().fillFromImpl(leaderboard);
+    this.leaderboard_table = new TwoDimTableV3().fillFromImpl(leaderboard.toTwoDimTable());
 
     if (autoML.getActualModelingSteps() != null) {
       modeling_steps = new StepDefinitionV99[autoML.getActualModelingSteps().length];

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/EventLogV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/EventLogV99.java
@@ -12,11 +12,7 @@ public class EventLogV99 extends Schema<EventLog, EventLogV99> {
   public EventLogEntryV99[] events;
 
   @Override public EventLogV99 fillFromImpl(EventLog eventLog) {
-    super.fillFromImpl(eventLog, new String[] { "automl_id", "events" });
-
-    if (null != eventLog._automlKey) {
-      this.automl_id = new AutoMLV99.AutoMLKeyV3(eventLog._automlKey);
-    }
+    super.fillFromImpl(eventLog, new String[] { "events" });
 
     if (null != eventLog._events) {
       this.events = new EventLogEntryV99[eventLog._events.length];

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardV99.java
@@ -5,6 +5,8 @@ import water.api.API;
 import water.api.Schema;
 import water.api.schemas3.KeyV3;
 
+import java.util.stream.Stream;
+
 public class LeaderboardV99 extends Schema<Leaderboard, LeaderboardV99> {
   /**
    * Identifier for models that should be grouped together in the leaderboard
@@ -24,7 +26,7 @@ public class LeaderboardV99 extends Schema<Leaderboard, LeaderboardV99> {
    * Frame for which the metrics have been computed for this leaderboard.
    */
   @API(help="Frame for this leaderboard", direction=API.Direction.OUTPUT)
-  public KeyV3.FrameKeyV3[] leaderboard_frame;
+  public KeyV3.FrameKeyV3 leaderboard_frame;
 
   /**
    * Checksum for the Frame for which the metrics have been computed for this leaderboard.
@@ -49,5 +51,18 @@ public class LeaderboardV99 extends Schema<Leaderboard, LeaderboardV99> {
    */
   @API(help="Metric direction used in the sort", direction=API.Direction.INOUT)
   public boolean sort_decreasing;
+
+  @Override
+  public LeaderboardV99 fillFromImpl(Leaderboard leaderboard) {
+    super.fillFromImpl(leaderboard, new String[] { "models", "leaderboard_frame" });
+    models = Stream.of(leaderboard.getModelKeys())
+            .map(KeyV3.ModelKeyV3::new)
+            .toArray(KeyV3.ModelKeyV3[]::new);
+
+    if (leaderboard.leaderboardFrame() != null)
+      leaderboard_frame = new KeyV3.FrameKeyV3(leaderboard.leaderboardFrame()._key);
+
+    return this;
+  }
 }
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/LeaderboardV99.java
@@ -54,7 +54,7 @@ public class LeaderboardV99 extends Schema<Leaderboard, LeaderboardV99> {
 
   @Override
   public LeaderboardV99 fillFromImpl(Leaderboard leaderboard) {
-    super.fillFromImpl(leaderboard, new String[] { "models", "leaderboard_frame" });
+    super.fillFromImpl(leaderboard, new String[] { "models", "leaderboard_frame", "sort_metrics", "sort_decreasing" });
     models = Stream.of(leaderboard.getModelKeys())
             .map(KeyV3.ModelKeyV3::new)
             .toArray(KeyV3.ModelKeyV3[]::new);
@@ -62,7 +62,11 @@ public class LeaderboardV99 extends Schema<Leaderboard, LeaderboardV99> {
     if (leaderboard.leaderboardFrame() != null)
       leaderboard_frame = new KeyV3.FrameKeyV3(leaderboard.leaderboardFrame()._key);
 
+    sort_metrics = leaderboard.getSortMetricValues();
+    sort_decreasing = !Leaderboard.isLossFunction(sort_metric);
+
     return this;
   }
+
 }
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
@@ -7,6 +7,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import water.Key;
 import water.fvec.Frame;
+import water.util.Log;
 import water.util.TwoDimTable;
 
 public class LeaderboardTest extends water.TestUtil {
@@ -71,7 +72,8 @@ public class LeaderboardTest extends water.TestUtil {
       
       lb = Leaderboard.getOrMake("dummy_rank_tsv", eventLog, null, "mae");
       lb.addModel(model);
-      Assert.assertEquals("Error\n[0.19959320678410908, 0.44675855535636816, 0.19959320678410908, 0.3448260574357465, 0.31468498072970547]\n", lb.rankTsv()); 
+      Log.info(lb.rankTsv());
+      Assert.assertEquals("Error\n[0.3448260574357465, 0.19959320678410908, 0.44675855535636816, 0.19959320678410908, 0.31468498072970547]\n", lb.rankTsv());
     } finally {
       if (lb != null){
         lb.remove();

--- a/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/LeaderboardTest.java
@@ -23,7 +23,7 @@ public class LeaderboardTest extends water.TestUtil {
   @Test
   public void test_toTwoDimTable_with_empty_models_and_without_sort_metric() {
     Leaderboard lb = null;
-    EventLog eventLog = EventLog.make(dummy);
+    EventLog eventLog = EventLog.getOrMake(dummy);
     try {
       lb = Leaderboard.getOrMake("dummy_lb_no_sort_metric", eventLog, new Frame(), null);
 
@@ -39,7 +39,7 @@ public class LeaderboardTest extends water.TestUtil {
   @Test
   public void test_toTwoDimTable_with_empty_models_and_with_sort_metric() {
     Leaderboard lb = null;
-    EventLog eventLog = EventLog.make(dummy);
+    EventLog eventLog = EventLog.getOrMake(dummy);
     try {
       lb = Leaderboard.getOrMake("dummy_lb_logloss_sort_metric", eventLog, new Frame(), "logloss");
 
@@ -56,7 +56,7 @@ public class LeaderboardTest extends water.TestUtil {
   @Test
   public void test_rank_tsv() {
     Leaderboard lb = null;
-    EventLog eventLog = EventLog.make(dummy);
+    EventLog eventLog = EventLog.getOrMake(dummy);
     GBMModel model = null;
     Frame fr  = null;
     try {

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -297,7 +297,7 @@ class H2OAutoML(Keyed):
     #---------------------------------------------------------------------------
     @property
     def key(self):
-        return self.project_name
+        return self._job.dest_key if self._job else self.project_name
 
     @property
     def leader(self):
@@ -571,8 +571,7 @@ class H2OAutoML(Keyed):
     # Private
     #-------------------------------------------------------------------------------------------------------------------
     def _fetch(self):
-        key = self.project_name if not self._job else self._job.dest_key
-        state = H2OAutoML._fetch_state(key)
+        state = H2OAutoML._fetch_state(self.key)
         self._leader_id = state['leader_id']
         self._leaderboard = state['leaderboard']
         self._event_log = el = state['event_log']

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -571,7 +571,8 @@ class H2OAutoML(Keyed):
     # Private
     #-------------------------------------------------------------------------------------------------------------------
     def _fetch(self):
-        state = H2OAutoML._fetch_state(self.project_name)
+        key = self.project_name if not self._job else self._job.dest_key
+        state = H2OAutoML._fetch_state(key)
         self._leader_id = state['leader_id']
         self._leaderboard = state['leaderboard']
         self._event_log = el = state['event_log']
@@ -594,7 +595,7 @@ class H2OAutoML(Keyed):
         try:
             if job.progress > state.get('last_job_progress', 0):
                 # print("\nbar_progress={}, job_progress={}".format(bar_progress, job.progress))
-                events = H2OAutoML._fetch_state(self.project_name, properties=['event_log'])['event_log']
+                events = H2OAutoML._fetch_state(job.dest_key, properties=['event_log'])['event_log']
                 events = events[events['level'].isin(levels), :]
                 last_nrows = state.get('last_events_nrows', 0)
                 if events.nrows > last_nrows:

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -406,11 +406,6 @@ class H2OAutoML(Keyed):
         ncols = training_frame.ncols
         names = training_frame.names
 
-        #Set project name if None
-        if self.project_name is None:
-            self.project_name = "automl_" + training_frame.frame_id
-            self.build_control["project_name"] = self.project_name
-
         # Minimal required arguments are training_frame and y (response)
         if y is None:
             raise H2OValueError('The response column (y) is not set; please set it to the name of the column that you are trying to predict in your data.')
@@ -493,6 +488,9 @@ class H2OAutoML(Keyed):
             print("Exception from the back end: ")
             print(resp)
             return
+
+        if not self.project_name:
+            self.build_control['project_name'] = self.project_name = resp['build_control']['project_name']
 
         self._job = H2OJob(resp['job'], "AutoML")
         poll_updates = ft.partial(self._poll_training_updates, verbosity=self._verbosity, state={})

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -150,7 +150,7 @@ def test_leaderboard_with_no_algos():
 
     lb = aml.leaderboard
     assert lb.nrows == 0
-    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "mean_per_class_error", "rmse", "mse"], None)
+    check_leaderboard(aml, exclude_algos, ["unknown"], None)
 
 
 def test_leaderboard_for_binomial_with_custom_sorting():
@@ -164,7 +164,7 @@ def test_leaderboard_for_binomial_with_custom_sorting():
                     sort_metric="logloss")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "mean_per_class_error", "rmse", "mse"], "logloss")
+    check_leaderboard(aml, exclude_algos, ["logloss", "auc", "mean_per_class_error", "rmse", "mse"], "logloss")
 
 
 def test_leaderboard_for_multinomial_with_custom_sorting():
@@ -178,7 +178,7 @@ def test_leaderboard_for_multinomial_with_custom_sorting():
                     sort_metric="logloss")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["mean_per_class_error", "logloss", "rmse", "mse"], "logloss")
+    check_leaderboard(aml, exclude_algos, ["logloss", "mean_per_class_error", "rmse", "mse"], "logloss")
 
 
 def test_leaderboard_for_regression_with_custom_sorting():
@@ -192,7 +192,7 @@ def test_leaderboard_for_regression_with_custom_sorting():
                     sort_metric="RMSE")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
 
 
 def test_AUTO_stopping_metric_with_no_sorting_metric_binomial():
@@ -258,7 +258,7 @@ def test_AUTO_stopping_metric_with_custom_sorting_metric():
                     sort_metric="rmse")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     check_model_property(non_se, 'stopping_metric', True, "RMSE")
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_memory_cleanup.py
@@ -318,8 +318,9 @@ def test_suite_remove_automl():
 
         keys = list_keys_in_memory()
         # print(keys['all'].values)
-        assert contains_leaderboard(project_name, keys)
-        assert contains_event_log(project_name, keys)
+        assert aml.key.startswith(project_name)
+        assert contains_leaderboard(aml.key, keys)
+        assert contains_event_log(aml.key, keys)
         expectations = dict(
             models_base=max_models + 2,  # 2 SEs
             cv_models=0,
@@ -335,8 +336,8 @@ def test_suite_remove_automl():
         h2o.remove(aml)
         clean = list_keys_in_memory()
         print(clean['all'].values)
-        assert not contains_leaderboard(project_name, clean)
-        assert not contains_event_log(project_name, clean)
+        assert not contains_leaderboard(aml.key, clean)
+        assert not contains_event_log(aml.key, clean)
         assert len(clean['models_base']) == 0
         assert len(clean['cv_models']) == 0
         assert len(clean['models_all']) == 0
@@ -363,8 +364,9 @@ def test_suite_remove_automl():
 
         keys = list_keys_in_memory()
         # print(keys['all'].values)
-        assert contains_leaderboard(project_name, keys)
-        assert contains_event_log(project_name, keys)
+        assert aml.key.startswith(project_name)
+        assert contains_leaderboard(aml.key, keys)
+        assert contains_event_log(aml.key, keys)
         expectations = dict(
             models_base=max_models + 2,  # 2 SEs
             cv_models=(max_models+2) * nfolds,  # 1 cv model per fold for all models, incl. SEs
@@ -382,8 +384,8 @@ def test_suite_remove_automl():
         h2o.remove(aml)
         clean = list_keys_in_memory()
         print(clean['all'].values)
-        assert not contains_leaderboard(project_name, clean)
-        assert not contains_event_log(project_name, clean)
+        assert not contains_leaderboard(aml.key, clean)
+        assert not contains_event_log(aml.key, clean)
         assert len(clean['models_base']) == 0
         assert len(clean['cv_models']) == 0
         assert len(clean['models_all']) == 0
@@ -406,8 +408,9 @@ def test_suite_remove_automl():
 
         keys = list_keys_in_memory()
         # print(keys['all'].values)
-        assert contains_leaderboard(project_name, keys)
-        assert contains_event_log(project_name, keys)
+        assert aml.key.startswith(project_name)
+        assert contains_leaderboard(aml.key, keys)
+        assert contains_event_log(aml.key, keys)
         expectations = dict(
             models_base=max_models + 2,  # 2 SEs
             cv_models=0,
@@ -423,8 +426,8 @@ def test_suite_remove_automl():
         h2o.remove(aml)
         clean = list_keys_in_memory()
         print(clean['all'].values)
-        assert not contains_leaderboard(project_name, clean)
-        assert not contains_event_log(project_name, clean)
+        assert not contains_leaderboard(aml.key, clean)
+        assert not contains_event_log(aml.key, clean)
         assert len(clean['models_base']) == 0
         assert len(clean['cv_models']) == 0
         assert len(clean['models_all']) == 0
@@ -456,8 +459,9 @@ def test_suite_remove_automl():
         h2o.remove(aml)
         clean = list_keys_in_memory()
         print(clean['all'].values)
-        assert not contains_leaderboard(project_name, clean)
-        assert not contains_event_log(project_name, clean)
+        assert aml.key.startswith(project_name)
+        assert not contains_leaderboard(aml.key, clean)
+        assert not contains_event_log(aml.key, clean)
         assert len(clean['models_base']) == 0
         assert len(clean['cv_models']) == 0
         assert len(clean['models_all']) == 0

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_reruns.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_reruns.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
-import sys, os, time
-
-from h2o.exceptions import H2OTypeError
+import os
+import sys
 
 sys.path.insert(1, os.path.join("..","..",".."))
 import h2o
@@ -12,8 +11,38 @@ from h2o.automl import H2OAutoML
 def import_dataset():
     df = h2o.import_file(path=pu.locate("smalldata/prostate/prostate.csv"))
     target = "CAPSULE"
+    target_alt = "RACE"
     df[target] = df[target].asfactor()
-    return pu.ns(train=df, target=target)
+    df[target_alt] = df[target_alt].asfactor()
+    return pu.ns(train=df, target=target, target_alt=target_alt)
+
+
+def model_names(lb):
+    return lb[:, 0].as_data_frame().values.flatten()
+
+
+def assert_same_leaderboard(lb1, lb2, size=0):
+    print(lb1)
+    assert len(lb1) == size
+    print(lb2)
+    assert len(lb2) == size
+    assert all(m in lb2 for m in lb1)
+
+
+def assert_distinct_leaderboard(lb1, lb2, size=4):
+    print(lb1)
+    assert len(lb1) == size
+    print(lb2)
+    assert len(lb2) == size
+    assert not any(m in lb2 for m in lb1)
+
+
+def assert_extended_leaderboard(lb1, lb2, size=4):
+    print(lb1)
+    assert len(lb1) == size
+    print(lb2)
+    assert len(lb2) == size*2
+    assert all(m in lb2 for m in lb1)
 
 
 def suite_reruns_with_same_instance_without_project_name():
@@ -22,41 +51,41 @@ def suite_reruns_with_same_instance_without_project_name():
         ds = import_dataset()
         aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
         aml.train(y=ds.target, training_frame=ds.train)
-        project_name = aml.project_name
-        print(aml.leaderboard)
-        assert aml.leaderboard.nrows == 4
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
         aml.train(y=ds.target, training_frame=ds.train)
-        print(aml.leaderboard)
-        assert aml.leaderboard.nrows == 8
+        lb2 = model_names(aml.leaderboard)
         assert project_name == aml.project_name
-
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_predictors_adds_models_to_leaderboard():
         ds = import_dataset()
         aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
         aml.train(y=ds.target, training_frame=ds.train)
-        project_name = aml.project_name
-        print(aml.leaderboard)
-        assert aml.leaderboard.nrows == 4
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
         aml.train(x=ds.train.columns[1:], y=ds.target, training_frame=ds.train)
-        print(aml.leaderboard)
-        assert aml.leaderboard.nrows == 8
+        lb2 = model_names(aml.leaderboard)
         assert project_name == aml.project_name
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_training_frame_resets_leaderboard():
         ds = import_dataset()
         aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
         aml.train(y=ds.target, training_frame=ds.train)
-        project_name = aml.project_name
-        print(aml.leaderboard)
-        assert aml.leaderboard.nrows == 4
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
         aml.train(y=ds.target, training_frame=ds.train[1:])
-        print(aml.leaderboard)
-        assert aml.leaderboard.nrows == 4
+        lb2 = model_names(aml.leaderboard)
         assert project_name == aml.project_name
+        assert_distinct_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_target_resets_leaderboard():
-        pass
+        ds = import_dataset()
+        aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
+        aml.train(y=ds.target_alt, training_frame=ds.train)
+        lb2 = model_names(aml.leaderboard)
+        assert project_name == aml.project_name
+        assert_distinct_leaderboard(lb1, lb2, size=4)
 
     return [
         test_rerun_with_same_data_adds_models_to_leaderboard,
@@ -69,16 +98,44 @@ def suite_reruns_with_same_instance_without_project_name():
 def suite_reruns_with_same_instance_with_project_name():
 
     def test_rerun_with_same_data_adds_models_to_leaderboard():
-        pass
+        ds = import_dataset()
+        aml = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
+        aml.train(y=ds.target, training_frame=ds.train)
+        lb2 = model_names(aml.leaderboard)
+        assert project_name == aml.project_name
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_predictors_adds_models_to_leaderboard():
-        pass
+        ds = import_dataset()
+        aml = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
+        aml.train(x=ds.train.columns[1:], y=ds.target, training_frame=ds.train)
+        lb2 = model_names(aml.leaderboard)
+        assert project_name == aml.project_name
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_training_frame_resets_leaderboard():
-        pass
+        ds = import_dataset()
+        aml = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
+        aml.train(y=ds.target, training_frame=ds.train[1:])
+        lb2 = model_names(aml.leaderboard)
+        assert project_name == aml.project_name
+        assert_distinct_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_target_resets_leaderboard():
-        pass
+        ds = import_dataset()
+        aml = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name, lb1 = aml.project_name, model_names(aml.leaderboard)
+        aml.train(y=ds.target_alt, training_frame=ds.train)
+        lb2 = model_names(aml.leaderboard)
+        assert project_name == aml.project_name
+        assert_distinct_leaderboard(lb1, lb2, size=4)
 
     return [
         test_rerun_with_same_data_adds_models_to_leaderboard,
@@ -91,7 +148,15 @@ def suite_reruns_with_same_instance_with_project_name():
 def suite_reruns_with_different_instance_without_project_name():
 
     def test_rerun_with_same_data_generates_distinct_leaderboard():
-        pass
+        ds = import_dataset()
+        aml1 = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml1.train(y=ds.target, training_frame=ds.train)
+        lb1 = model_names(aml1.leaderboard)
+        aml2 = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml2.train(y=ds.target, training_frame=ds.train)
+        lb2 = model_names(aml2.leaderboard)
+        assert aml2.project_name != aml1.project_name
+        assert_distinct_leaderboard(lb1, lb2, size=4)
 
     return [
         test_rerun_with_same_data_generates_distinct_leaderboard,
@@ -101,16 +166,48 @@ def suite_reruns_with_different_instance_without_project_name():
 def suite_reruns_with_different_instances_same_project_name():
 
     def test_rerun_with_same_data_adds_models_to_leaderboard():
-        pass
+        ds = import_dataset()
+        aml1 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml1.train(y=ds.target, training_frame=ds.train)
+        lb1 = model_names(aml1.leaderboard)
+        aml2 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml2.train(y=ds.target, training_frame=ds.train)
+        lb2 = model_names(aml2.leaderboard)
+        assert aml1.project_name == aml2.project_name
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_predictors_adds_models_to_leaderboard():
-        pass
+        ds = import_dataset()
+        aml1 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml1.train(y=ds.target, training_frame=ds.train)
+        lb1 = model_names(aml1.leaderboard)
+        aml2 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml2.train(x=ds.train.columns[1:], y=ds.target, training_frame=ds.train)
+        lb2 = model_names(aml2.leaderboard)
+        assert aml1.project_name == aml2.project_name
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_training_frame_resets_leaderboard():
-        pass
+        ds = import_dataset()
+        aml1 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml1.train(y=ds.target, training_frame=ds.train)
+        lb1 = model_names(aml1.leaderboard)
+        aml2 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml2.train(y=ds.target, training_frame=ds.train[1:])
+        lb2 = model_names(aml2.leaderboard)
+        assert aml1.project_name == aml2.project_name
+        assert_distinct_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_target_resets_leaderboard():
-        pass
+        ds = import_dataset()
+        aml1 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml1.train(y=ds.target, training_frame=ds.train)
+        lb1 = model_names(aml1.leaderboard)
+        aml2 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml2.train(y=ds.target_alt, training_frame=ds.train)
+        lb2 = model_names(aml2.leaderboard)
+        assert aml1.project_name == aml2.project_name
+        assert_distinct_leaderboard(lb1, lb2, size=4)
 
     return [
         test_rerun_with_same_data_adds_models_to_leaderboard,

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_reruns.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_reruns.py
@@ -1,0 +1,128 @@
+from __future__ import print_function
+import sys, os, time
+
+from h2o.exceptions import H2OTypeError
+
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils as pu
+from h2o.automl import H2OAutoML
+
+
+def import_dataset():
+    df = h2o.import_file(path=pu.locate("smalldata/prostate/prostate.csv"))
+    target = "CAPSULE"
+    df[target] = df[target].asfactor()
+    return pu.ns(train=df, target=target)
+
+
+def suite_reruns_with_same_instance_without_project_name():
+
+    def test_rerun_with_same_data_adds_models_to_leaderboard():
+        ds = import_dataset()
+        aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name = aml.project_name
+        print(aml.leaderboard)
+        assert aml.leaderboard.nrows == 4
+        aml.train(y=ds.target, training_frame=ds.train)
+        print(aml.leaderboard)
+        assert aml.leaderboard.nrows == 8
+        assert project_name == aml.project_name
+
+
+    def test_rerun_with_different_predictors_adds_models_to_leaderboard():
+        ds = import_dataset()
+        aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name = aml.project_name
+        print(aml.leaderboard)
+        assert aml.leaderboard.nrows == 4
+        aml.train(x=ds.train.columns[1:], y=ds.target, training_frame=ds.train)
+        print(aml.leaderboard)
+        assert aml.leaderboard.nrows == 8
+        assert project_name == aml.project_name
+
+    def test_rerun_with_different_training_frame_resets_leaderboard():
+        ds = import_dataset()
+        aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
+        aml.train(y=ds.target, training_frame=ds.train)
+        project_name = aml.project_name
+        print(aml.leaderboard)
+        assert aml.leaderboard.nrows == 4
+        aml.train(y=ds.target, training_frame=ds.train[1:])
+        print(aml.leaderboard)
+        assert aml.leaderboard.nrows == 4
+        assert project_name == aml.project_name
+
+    def test_rerun_with_different_target_resets_leaderboard():
+        pass
+
+    return [
+        test_rerun_with_same_data_adds_models_to_leaderboard,
+        test_rerun_with_different_predictors_adds_models_to_leaderboard,
+        test_rerun_with_different_training_frame_resets_leaderboard,
+        test_rerun_with_different_target_resets_leaderboard,
+    ]
+
+
+def suite_reruns_with_same_instance_with_project_name():
+
+    def test_rerun_with_same_data_adds_models_to_leaderboard():
+        pass
+
+    def test_rerun_with_different_predictors_adds_models_to_leaderboard():
+        pass
+
+    def test_rerun_with_different_training_frame_resets_leaderboard():
+        pass
+
+    def test_rerun_with_different_target_resets_leaderboard():
+        pass
+
+    return [
+        test_rerun_with_same_data_adds_models_to_leaderboard,
+        test_rerun_with_different_predictors_adds_models_to_leaderboard,
+        test_rerun_with_different_training_frame_resets_leaderboard,
+        test_rerun_with_different_target_resets_leaderboard,
+    ]
+
+
+def suite_reruns_with_different_instance_without_project_name():
+
+    def test_rerun_with_same_data_generates_distinct_leaderboard():
+        pass
+
+    return [
+        test_rerun_with_same_data_generates_distinct_leaderboard,
+    ]
+
+
+def suite_reruns_with_different_instances_same_project_name():
+
+    def test_rerun_with_same_data_adds_models_to_leaderboard():
+        pass
+
+    def test_rerun_with_different_predictors_adds_models_to_leaderboard():
+        pass
+
+    def test_rerun_with_different_training_frame_resets_leaderboard():
+        pass
+
+    def test_rerun_with_different_target_resets_leaderboard():
+        pass
+
+    return [
+        test_rerun_with_same_data_adds_models_to_leaderboard,
+        test_rerun_with_different_predictors_adds_models_to_leaderboard,
+        test_rerun_with_different_training_frame_resets_leaderboard,
+        test_rerun_with_different_target_resets_leaderboard,
+    ]
+
+
+pu.run_tests([
+    suite_reruns_with_same_instance_without_project_name(),
+    suite_reruns_with_same_instance_with_project_name(),
+    suite_reruns_with_different_instance_without_project_name(),
+    suite_reruns_with_different_instances_same_project_name(),
+])

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_reruns.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_reruns.py
@@ -67,7 +67,7 @@ def suite_reruns_with_same_instance_without_project_name():
         assert project_name == aml.project_name
         assert_extended_leaderboard(lb1, lb2, size=4)
 
-    def test_rerun_with_different_training_frame_resets_leaderboard():
+    def test_rerun_with_different_training_frame_adds_models_to_leaderboard():
         ds = import_dataset()
         aml = H2OAutoML(max_models=2, seed=1, keep_cross_validation_predictions=True)
         aml.train(y=ds.target, training_frame=ds.train)
@@ -75,7 +75,7 @@ def suite_reruns_with_same_instance_without_project_name():
         aml.train(y=ds.target, training_frame=ds.train[1:])
         lb2 = model_names(aml.leaderboard)
         assert project_name == aml.project_name
-        assert_distinct_leaderboard(lb1, lb2, size=4)
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_target_resets_leaderboard():
         ds = import_dataset()
@@ -90,7 +90,7 @@ def suite_reruns_with_same_instance_without_project_name():
     return [
         test_rerun_with_same_data_adds_models_to_leaderboard,
         test_rerun_with_different_predictors_adds_models_to_leaderboard,
-        test_rerun_with_different_training_frame_resets_leaderboard,
+        test_rerun_with_different_training_frame_adds_models_to_leaderboard,
         test_rerun_with_different_target_resets_leaderboard,
     ]
 
@@ -117,7 +117,7 @@ def suite_reruns_with_same_instance_with_project_name():
         assert project_name == aml.project_name
         assert_extended_leaderboard(lb1, lb2, size=4)
 
-    def test_rerun_with_different_training_frame_resets_leaderboard():
+    def test_rerun_with_different_training_frame_adds_models_to_leaderboard():
         ds = import_dataset()
         aml = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
         aml.train(y=ds.target, training_frame=ds.train)
@@ -125,7 +125,7 @@ def suite_reruns_with_same_instance_with_project_name():
         aml.train(y=ds.target, training_frame=ds.train[1:])
         lb2 = model_names(aml.leaderboard)
         assert project_name == aml.project_name
-        assert_distinct_leaderboard(lb1, lb2, size=4)
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_target_resets_leaderboard():
         ds = import_dataset()
@@ -140,7 +140,7 @@ def suite_reruns_with_same_instance_with_project_name():
     return [
         test_rerun_with_same_data_adds_models_to_leaderboard,
         test_rerun_with_different_predictors_adds_models_to_leaderboard,
-        test_rerun_with_different_training_frame_resets_leaderboard,
+        test_rerun_with_different_training_frame_adds_models_to_leaderboard,
         test_rerun_with_different_target_resets_leaderboard,
     ]
 
@@ -187,7 +187,7 @@ def suite_reruns_with_different_instances_same_project_name():
         assert aml1.project_name == aml2.project_name
         assert_extended_leaderboard(lb1, lb2, size=4)
 
-    def test_rerun_with_different_training_frame_resets_leaderboard():
+    def test_rerun_with_different_training_frame_adds_models_to_leaderboard():
         ds = import_dataset()
         aml1 = H2OAutoML(project_name="test_automl_rerun", max_models=2, seed=1, keep_cross_validation_predictions=True)
         aml1.train(y=ds.target, training_frame=ds.train)
@@ -196,7 +196,7 @@ def suite_reruns_with_different_instances_same_project_name():
         aml2.train(y=ds.target, training_frame=ds.train[1:])
         lb2 = model_names(aml2.leaderboard)
         assert aml1.project_name == aml2.project_name
-        assert_distinct_leaderboard(lb1, lb2, size=4)
+        assert_extended_leaderboard(lb1, lb2, size=4)
 
     def test_rerun_with_different_target_resets_leaderboard():
         ds = import_dataset()
@@ -212,7 +212,7 @@ def suite_reruns_with_different_instances_same_project_name():
     return [
         test_rerun_with_same_data_adds_models_to_leaderboard,
         test_rerun_with_different_predictors_adds_models_to_leaderboard,
-        test_rerun_with_different_training_frame_resets_leaderboard,
+        test_rerun_with_different_training_frame_adds_models_to_leaderboard,
         test_rerun_with_different_target_resets_leaderboard,
     ]
 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -40,7 +40,7 @@
 #'        does not improve for k (stopping_rounds) scoring events. Defaults to 3 and must be an non-zero integer.  Use 0 to disable early stopping.
 #' @param seed Integer. Set a seed for reproducibility. AutoML can only guarantee reproducibility if max_models or early stopping is used
 #'        because max_runtime_secs is resource limited, meaning that if the resources are not the same between runs, AutoML may be able to train more models on one run vs another.
-#' @param project_name Character string to identify an AutoML project.  Defaults to NULL, which means a project name will be auto-generated based on the training frame ID.
+#' @param project_name Character string to identify an AutoML project.  Defaults to NULL, which means a project name will be auto-generated.
 #' @param exclude_algos Vector of character strings naming the algorithms to skip during the model-building phase.  An example use is exclude_algos = c("GLM", "DeepLearning", "DRF"),
 #'        and the full list of options is: "DRF" (Random Forest and Extremely-Randomized Trees), "GLM", "XGBoost", "GBM", "DeepLearning" and "StackedEnsemble".
 #         Defaults to NULL, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
@@ -176,10 +176,7 @@ h2o.automl <- function(x, y, training_frame,
     build_control$stopping_criteria$seed <- seed
   }
 
-  # If project_name is NULL, auto-gen based on training_frame ID
-  if (is.null(project_name)) {
-    build_control$project_name <- paste0("automl_", training_frame_id)
-  } else {
+  if (!is.null(project_name)) {
     build_control$project_name <- project_name
   }
 
@@ -368,10 +365,10 @@ h2o.predict.H2OAutoML <- function(object, newdata, ...) {
   return(frame)
 }
 
-.automl.fetch_state <- function(project_name, properties=NULL) {
+.automl.fetch_state <- function(run_id, properties=NULL) {
   # GET AutoML job and leaderboard for project
-  automl_job <- .h2o.__remoteSend(h2oRestApiVersion = 99, method = "GET", page = paste0("AutoML/", project_name))
-  #project <- automl_job$project  # This is not functional right now, we can get project_name from user input instead
+  automl_job <- .h2o.__remoteSend(h2oRestApiVersion = 99, method = "GET", page = paste0("AutoML/", run_id))
+  project_name = automl_job$project_name
 
   leaderboard <- as.data.frame(automl_job$leaderboard_table)
   row.names(leaderboard) <- seq(nrow(leaderboard))

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -285,6 +285,7 @@ h2o.automl <- function(x, y, training_frame,
 
   # GET AutoML object
   aml <- h2o.getAutoML(project_name = res$job$dest$name)
+  attr(aml, "id") <- res$job$dest$name
   return(aml)
 }
 

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -871,4 +871,4 @@ setClass("H2OAutoML", slots = c(project_name = "character",
                                 training_info = "list"),
                       contains = "Keyed")
 #' @rdname h2o.keyof
-setMethod("h2o.keyof", signature("H2OAutoML"), function(object) object@project_name)
+setMethod("h2o.keyof", signature("H2OAutoML"), function(object) attr(object, "id"))

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_memory_cleanup.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_memory_cleanup.R
@@ -24,11 +24,11 @@ automl.cleanup.suite <- function() {
   test_remove_automl_instance <- function() {
     ds <- import_dataset()
     aml <- h2o.automl(project_name="test_remove_R_automl_instance",
-    x=ds$x, y=ds$y,
-    training_frame=ds$train,
-    validation_frame=ds$valid,
-    leaderboard_frame=ds$test,
-    max_models=max_models)
+                      x=ds$x, y=ds$y,
+                      training_frame=ds$train,
+                      validation_frame=ds$valid,
+                      leaderboard_frame=ds$test,
+                      max_models=max_models)
 
     keys <- h2o.ls()$key
     expect_gt(length(grep("_AutoML_", keys)), nrow(aml@leaderboard))

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
@@ -42,7 +42,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      project_name = "r_lbsm_test_aml2",
                      sort_metric = "RMSE")
   aml2@leaderboard
-  expect_equal(names(aml2@leaderboard), c("model_id", "mean_residual_deviance", "rmse", "mse", "mae", "rmsle"))
+  expect_equal(names(aml2@leaderboard), c("model_id", "rmse", "mean_residual_deviance", "mse", "mae", "rmsle"))
   # check that rmse col is sorted already
   rmse_col <- as.vector(aml2@leaderboard[,"rmse"])
   expect_equal(identical(rmse_col, sort(rmse_col, decreasing = FALSE)), TRUE)
@@ -62,7 +62,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      project_name = "r_lbsm_test_aml3",
                      sort_metric = "MSE")
   aml3@leaderboard
-  expect_equal(names(aml3@leaderboard),c("model_id", "mean_per_class_error", "logloss", "rmse", "mse"))
+  expect_equal(names(aml3@leaderboard),c("model_id", "mse", "mean_per_class_error", "logloss", "rmse"))
   # check that mse col is sorted already
   mse_col <- as.vector(aml3@leaderboard[,"mse"])
   expect_equal(identical(mse_col, sort(mse_col, decreasing = FALSE)), TRUE)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-5975

Due to the inherent issues with the current Python API for AutoML, user can obtain surprising results when looking at the leaderboard when doing reruns in AutoML, especially in the following cases:
- when running multiple `aml.train` on a single `aml` (AutoML) instance.
- when creating multiple `AutoML` instances without any `project_name`.

On backend side, it seems that it was also designed with a feature in mind that was never completed: the notion of `project` distinct from the `automl_id`. But it's very difficult to guess what designers had in mind as there is not true support for the concept of a project that would include multiple `AutoML` instances for example.

The contract for this proposal is detailed in the `pyunit_automl_reruns.py` test suite, so I encourage to look at it first.
To sum it up, the idea is:
- to always create a new unique `project` (and therefore leaderboard), each time the user creates and `AutoML` instance without specifying the `project_name`.
- to allow cumulative reruns (keep adding new models to the leaderboard), if user is calling `train` multiple times on the same project name, with compatible data (same training_frame, same response column).
- to allow reruns but with a new leaderboard, if user is changing the response column ~~or the training_frame~~ (previous leaderboard is still accessible by id). 

## More issues
https://0xdata.atlassian.net/browse/PUBDEV-6708

This issue is due to **reruns** as well.
Current behaviour allows changing the `leaderboard_frame` and the new models will still be appended to the existing leaderboard (ignoring the new frame), this is just plain wrong!

The leaderboard should be identified uniquely by `project_name` + `leaderboard_frame`, making this rerun logic still more complicated.

# Rerun behaviour contract
see https://github.com/h2oai/h2o-3/pull/3907/files#diff-1281d5db9141adc08c3047885255f970