### PR TITLE
PUBDEV-6870 - Error in PredictCSV unused column detection

### DIFF
--- a/h2o-algos/src/test/java/hex/mojo/PredictCsvTest.java
+++ b/h2o-algos/src/test/java/hex/mojo/PredictCsvTest.java
@@ -100,6 +100,48 @@ public class PredictCsvTest {
     }
   }
 
+  @Test
+  public void testScoreNoMissingColumns() throws IOException {
+    final PrintStream originaOutputStream = System.out;
+    String predictCsvOutput = null;
+    try {
+      Scope.enter();
+      // The following iris dataset has columns named: {C1,C2,C3,C4,C5}, while the test dataset used below has descriptive names. 
+      Frame train = Scope.track(TestUtil.parse_test_file("smalldata/junit/iris.csv"));
+
+      GBMModel.GBMParameters p = new GBMModel.GBMParameters();
+      p._train = train._key;
+      p._seed = 0xC0DE;
+      p._response_column = "class";
+      p._ntrees = 1;
+
+      GBMModel model = new GBM(p).trainModel().get();
+      final File modelFile = folder.newFile();
+      model.exportMojo(modelFile.getAbsolutePath(), true);
+
+      final File outputFile = folder.newFile();
+
+      ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+      PrintStream printStream = new PrintStream(outputBytes);
+      System.setOut(printStream);
+      try {
+        PredictCsv.main(new String[]{"--mojo", modelFile.getAbsolutePath(),
+                "--input", FileUtils.getFile("smalldata/junit/iris.csv").getAbsolutePath(),
+                "--output", outputFile.getAbsolutePath()});
+        fail("Expected PredictCSV to exit");
+      } catch (PreventedExitException e) {
+        assertEquals(0, e.status); // PredictCsv is expected to finish without errors
+      }
+
+      predictCsvOutput = new String(outputBytes.toByteArray());
+      assertTrue(predictCsvOutput.isEmpty());
+    } finally {
+      System.setOut(originaOutputStream);
+      System.out.print(predictCsvOutput);
+      Scope.exit();
+    }
+  }
+
 
   protected static class PreventedExitException extends SecurityException {
     public final int status;

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
@@ -418,7 +418,7 @@ public class PredictCsv {
       if (!parsedColumnNames.contains(columnName) && !columnName.equals(model.m._responseColumn)) {
         missingColumns.add(columnName);
       } else {
-        parsedColumnNames.remove(missingColumns);
+        parsedColumnNames.remove(columnName);
       }
     }
     

--- a/h2o-py/tests/testdir_misc/pyunit_mojo_predict.py
+++ b/h2o-py/tests/testdir_misc/pyunit_mojo_predict.py
@@ -181,7 +181,7 @@ def mojo_predict_csv_test(target_dir):
 
     download_mojo(multi_gbm, mojo_zip_path)
 
-    print("\nPerforming Binomial Prediction using MOJO @... " + target_dir)
+    print("\nPerforming Multinomial Prediction using MOJO @... " + target_dir)
     prediction_result = h2o.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=mojo_zip_path,
                                                    output_csv_path=output_csv)
 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6870

This fixed the original issue as described in the JIRA. However, this solution as implemented here still has some limitations:

1. If the dataset predictions are made on has no header, it is going to report the first line as unused - which is wrong.
2. If the dataset predictions are made on has different header, it is going to report those haders as unused columns. 

Both points of course have no impact on prediction. This is hard to fix, the code has no way to know whether there is header or no, despite some heuristics can be done (detection of numbers in headers etc. - but still, there are valid datasets with features numbered as plain integers)

Also, weak spot in our CSV writer is found again in the output:

```
Downloading MOJO @... /tmp/tmp2666f_ch
    => /tmp/tmp2666f_ch/model.zip  (81897 bytes)
    Time taken = 0.051s
    => /tmp/tmp2666f_ch/model.zip  (81897 bytes)
    => /tmp/tmp2666f_ch/h2o-genmodel.jar  (12872947 bytes)
Detected 1 unused columns in the input data set: {}
```

Reason ? Here:
```
Model column names: [AGE, RACE, DPROS, DCAPS, PSA, VOL, GLEASON, CAPSULE]
Parsed column names: [, AGE, RACE, DPROS, DCAPS, PSA, VOL, GLEASON]
Parsed response names: CAPSULE
```