### PR TITLE
PUBDEV-6905: Docs - Target Encoding reference

### DIFF
--- a/h2o-docs/src/product/data-munging/target-encoding.rst
+++ b/h2o-docs/src/product/data-munging/target-encoding.rst
@@ -463,3 +463,4 @@ References
 -  `Target Encoding in H2O-3 Demo <https://github.com/h2oai/h2o-3/blob/master/h2o-r/demos/rdemo.target_encode.R>`__
 -  `Automatic Feature Engineering Webinar <https://www.youtube.com/watch?v=VMTKcT1iHww>`__
 -   Daniele Micci-Barreca. 2001. A preprocessing scheme for high-cardinality categorical attributes in classification and prediction problems. SIGKDD Explor. Newsl. 3, 1 (July 2001), 27-32.
+- Zumel, Nina B. and John Mount. “vtreat: a data.frame Processor for Predictive Modeling.” (2016).

--- a/h2o-docs/src/product/data-munging/target-encoding.rst
+++ b/h2o-docs/src/product/data-munging/target-encoding.rst
@@ -463,4 +463,4 @@ References
 -  `Target Encoding in H2O-3 Demo <https://github.com/h2oai/h2o-3/blob/master/h2o-r/demos/rdemo.target_encode.R>`__
 -  `Automatic Feature Engineering Webinar <https://www.youtube.com/watch?v=VMTKcT1iHww>`__
 -   Daniele Micci-Barreca. 2001. A preprocessing scheme for high-cardinality categorical attributes in classification and prediction problems. SIGKDD Explor. Newsl. 3, 1 (July 2001), 27-32.
-- Zumel, Nina B. and John Mount. “vtreat: a data.frame Processor for Predictive Modeling.” (2016).
+-  `Zumel, Nina B. and John Mount. "vtreat: a data.frame Processor for Predictive Modeling." (2016). <https://arxiv.org/abs/1611.09477>`__


### PR DESCRIPTION
A new reference for "Impact Encoding" has been added to the list on the Target Encoding page.

See: https://0xdata.atlassian.net/browse/PUBDEV-6905