### PR TITLE
[PUBDEV-6922] Send data to and from external backend not by each item, but after specified block size

### DIFF
--- a/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
+++ b/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java
@@ -42,45 +42,45 @@ final class ExternalFrameReaderBackend {
         for (int rowIdx = 0; rowIdx < chunks[0]._len; rowIdx++) {
             for(int i = 0; i < selectedColumnIndices.length; i++){
                 if (chunks[selectedColumnIndices[i]].isNA(rowIdx)) {
-                    ExternalFrameUtils.sendNA(ab, channel, expectedTypes[i]);
+                    ExternalFrameUtils.sendNA(ab, expectedTypes[i]);
                 } else {
                     final Chunk chnk = chunks[selectedColumnIndices[i]];
                     switch (expectedTypes[i]) {
                         case EXPECTED_BOOL:
-                            ExternalFrameUtils.sendBoolean(ab, channel, (byte)chnk.at8(rowIdx));
+                            ExternalFrameUtils.sendBoolean(ab, (byte)chnk.at8(rowIdx));
                             break;
                         case EXPECTED_BYTE:
-                            ExternalFrameUtils.sendByte(ab, channel, (byte)chnk.at8(rowIdx));
+                            ExternalFrameUtils.sendByte(ab, (byte)chnk.at8(rowIdx));
                             break;
                         case EXPECTED_CHAR:
-                            ExternalFrameUtils.sendChar(ab, channel, (char)chnk.at8(rowIdx));
+                            ExternalFrameUtils.sendChar(ab, (char)chnk.at8(rowIdx));
                             break;
                         case EXPECTED_SHORT:
-                            ExternalFrameUtils.sendShort(ab, channel, (short)chnk.at8(rowIdx));
+                            ExternalFrameUtils.sendShort(ab, (short)chnk.at8(rowIdx));
                             break;
                         case EXPECTED_INT:
-                            ExternalFrameUtils.sendInt(ab, channel, (int)chnk.at8(rowIdx));
+                            ExternalFrameUtils.sendInt(ab, (int)chnk.at8(rowIdx));
                             break;
                         case EXPECTED_FLOAT:
-                            ExternalFrameUtils.sendFloat(ab, channel, (float)chnk.atd(rowIdx));
+                            ExternalFrameUtils.sendFloat(ab, (float)chnk.atd(rowIdx));
                             break;
                         case EXPECTED_LONG:
-                            ExternalFrameUtils.sendLong(ab, channel, chnk.at8(rowIdx));
+                            ExternalFrameUtils.sendLong(ab, chnk.at8(rowIdx));
                             break;
                         case EXPECTED_DOUBLE:
-                            ExternalFrameUtils.sendDouble(ab, channel, chnk.atd(rowIdx));
+                            ExternalFrameUtils.sendDouble(ab, chnk.atd(rowIdx));
                             break;
                         case EXPECTED_TIMESTAMP:
-                            ExternalFrameUtils.sendTimestamp(ab, channel, chnk.at8(rowIdx));
+                            ExternalFrameUtils.sendTimestamp(ab, chnk.at8(rowIdx));
                             break;
                         case EXPECTED_STRING:
                             if (chnk.vec().isCategorical()) {
-                                ExternalFrameUtils.sendString(ab, channel, chnk.vec().domain()[(int) chnk.at8(rowIdx)]);
+                                ExternalFrameUtils.sendString(ab, chnk.vec().domain()[(int) chnk.at8(rowIdx)]);
                             } else if (chnk.vec().isString()) {
-                                ExternalFrameUtils.sendString(ab, channel, chnk.atStr(valStr, rowIdx).toString());
+                                ExternalFrameUtils.sendString(ab, chnk.atStr(valStr, rowIdx).toString());
                             } else if (chnk.vec().isUUID()) {
                                 UUID uuid = new UUID(chnk.at16h(rowIdx), chnk.at16l(rowIdx));
-                                ExternalFrameUtils.sendString(ab, channel, uuid.toString());
+                                ExternalFrameUtils.sendString(ab, uuid.toString());
                             } else {
                                 assert false : "Can never be here";
                             }
@@ -89,5 +89,6 @@ final class ExternalFrameReaderBackend {
                 }
             }
         }
+        ExternalFrameUtils.writeToChannel(ab, channel);
     }
 }

--- a/h2o-core/src/main/java/water/ExternalFrameUtils.java
+++ b/h2o-core/src/main/java/water/ExternalFrameUtils.java
@@ -128,117 +128,104 @@ public class ExternalFrameUtils {
         return vecTypes;
     }
 
-    static void sendIntArray(AutoBuffer ab, ByteChannel channel, int[] data) throws IOException{
+    static void sendIntArray(AutoBuffer ab, int[] data) {
         ab.putA4(data);
-        writeToChannel(ab, channel);
     }
 
-    static void sendDoubleArray(AutoBuffer ab, ByteChannel channel, double[] data) throws IOException{
+    static void sendDoubleArray(AutoBuffer ab, double[] data) {
         ab.putA8d(data);
-        writeToChannel(ab, channel);
     }
 
-    static void sendBoolean(AutoBuffer ab, ByteChannel channel, boolean data) throws IOException{
-        sendBoolean(ab, channel, data ? (byte)1 : (byte)0);
+    static void sendBoolean(AutoBuffer ab, boolean data) {
+        sendBoolean(ab, data ? (byte)1 : (byte)0);
     }
 
-    static void sendBoolean(AutoBuffer ab, ByteChannel channel, byte boolData) throws IOException{
+    static void sendBoolean(AutoBuffer ab, byte boolData) {
         ab.put1(boolData);
-        putMarkerAndSend(ab, channel, boolData);
+        putMarker(ab, boolData);
     }
 
-    static void sendByte(AutoBuffer ab, ByteChannel channel, byte data) throws IOException{
+    static void sendByte(AutoBuffer ab, byte data) {
         ab.put1(data);
-        putMarkerAndSend(ab, channel, data);
+        putMarker(ab, data);
     }
 
-    static void sendChar(AutoBuffer ab, ByteChannel channel, char data) throws IOException{
+    static void sendChar(AutoBuffer ab, char data) {
         ab.put2(data);
-        putMarkerAndSend(ab, channel, data);
+        putMarker(ab, data);
     }
 
-    static void sendShort(AutoBuffer ab, ByteChannel channel, short data) throws IOException{
+    static void sendShort(AutoBuffer ab, short data) {
         ab.put2s(data);
-        putMarkerAndSend(ab, channel, data);
+        putMarker(ab, data);
     }
 
-    static void sendInt(AutoBuffer ab, ByteChannel channel, int data) throws IOException{
+    static void sendInt(AutoBuffer ab, int data) {
         ab.putInt(data);
-        putMarkerAndSend(ab, channel, data);
+        putMarker(ab, data);
     }
 
-    static void sendLong(AutoBuffer ab, ByteChannel channel, long data) throws IOException{
+    static void sendLong(AutoBuffer ab, long data) {
         ab.put8(data);
-        putMarkerAndSend(ab, channel, data);
+        putMarker(ab, data);
     }
 
-    static void sendFloat(AutoBuffer ab, ByteChannel channel, float data) throws IOException{
+    static void sendFloat(AutoBuffer ab, float data) {
         ab.put4f(data);
-        writeToChannel(ab, channel);
     }
 
-    static void sendDouble(AutoBuffer ab, ByteChannel channel, double data) throws IOException{
+    static void sendDouble(AutoBuffer ab, double data) {
         ab.put8d(data);
-        writeToChannel(ab, channel);
     }
 
-    static void sendString(AutoBuffer ab, ByteChannel channel, String data) throws IOException{
+    static void sendString(AutoBuffer ab, String data) {
         ab.putStr(data);
         if(data != null && data.equals(STR_MARKER_NEXT_BYTE_FOLLOWS)){
             ab.put1(MARKER_ORIGINAL_VALUE);
         }
-        writeToChannel(ab, channel);
     }
 
-    static void sendTimestamp(AutoBuffer ab, ByteChannel channel, long time) throws IOException{
-        sendLong(ab, channel, time);
+    static void sendTimestamp(AutoBuffer ab, long time) {
+        sendLong(ab, time);
     }
 
-    static void sendTimestamp(AutoBuffer ab, ByteChannel channel, Timestamp data) throws IOException{
-        sendLong(ab, channel, data.getTime());
+    static void sendTimestamp(AutoBuffer ab, Timestamp data) {
+        sendLong(ab, data.getTime());
     }
 
-    static void sendNA(AutoBuffer ab, ByteChannel channel, byte expectedType) throws IOException{
+    static void sendNA(AutoBuffer ab, byte expectedType) {
         switch (expectedType){
             case EXPECTED_BOOL: // // fall through to byte since BOOL is internally stored in frame as number (byte)
             case EXPECTED_BYTE:
                 ab.put1(NUM_MARKER_NEXT_BYTE_FOLLOWS);
                 ab.put1(MARKER_NA);
-                writeToChannel(ab, channel);
                 break;
             case EXPECTED_CHAR:
                 ab.put2(NUM_MARKER_NEXT_BYTE_FOLLOWS);
                 ab.put1(MARKER_NA);
-                writeToChannel(ab, channel);
                 break;
             case EXPECTED_SHORT:
                 ab.put2s(NUM_MARKER_NEXT_BYTE_FOLLOWS);
                 ab.put1(MARKER_NA);
-                writeToChannel(ab, channel);
                 break;
             case EXPECTED_INT:
                 ab.putInt(NUM_MARKER_NEXT_BYTE_FOLLOWS);
                 ab.put1(MARKER_NA);
-                writeToChannel(ab, channel);
                 break;
             case EXPECTED_TIMESTAMP: // fall through to long since TIMESTAMP is internally stored in frame as long
             case EXPECTED_LONG:
                 ab.put8(NUM_MARKER_NEXT_BYTE_FOLLOWS);
                 ab.put1(MARKER_NA);
-                writeToChannel(ab, channel);
                 break;
             case EXPECTED_FLOAT:
                 ab.put4f(Float.NaN);
-                writeToChannel(ab, channel);
                 break;
             case EXPECTED_DOUBLE:
                 ab.put8d(Double.NaN);
-                writeToChannel(ab, channel);
                 break;
             case EXPECTED_STRING:
                 ab.putStr(STR_MARKER_NEXT_BYTE_FOLLOWS);
                 ab.put1(MARKER_NA);
-                writeToChannel(ab, channel);
                 break;
             default:
                 throw new IllegalArgumentException("Unknown expected type " + expectedType);
@@ -300,12 +287,12 @@ public class ExternalFrameUtils {
     /**
      * Sends another byte as a marker if it's needed and send the data
      */
-    private static void putMarkerAndSend(AutoBuffer ab, ByteChannel channel, long data) throws IOException{
+    private static void putMarker(AutoBuffer ab, long data) {
         if(data == NUM_MARKER_NEXT_BYTE_FOLLOWS){
             // we need to send another byte because zero is represented as 00 ( 2 bytes )
             ab.put1(MARKER_ORIGINAL_VALUE);
         }
-        writeToChannel(ab, channel);
+
     }
 
     public static void writeToChannel(AutoBuffer ab, ByteChannel channel) throws IOException {

--- a/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
@@ -51,15 +51,15 @@ import static water.ExternalFrameUtils.writeToChannel;
  * </p>
  */
 final public class ExternalFrameWriterClient {
-  private AutoBuffer ab;
-  private ByteChannel channel;
+  private final AutoBuffer ab;
+  private final ByteChannel channel;
   private byte[] expectedTypes;
   private int currentColIdx = 0;
   private int currentRowIdx = 0;
-  private int timeout;
+  private final int timeout;
   private int numRows;
   private int numCols;
-  private long blockSize;
+  private final long blockSize;
 
   /**
    * Initialize the External frame writer
@@ -126,10 +126,13 @@ final public class ExternalFrameWriterClient {
   }
 
   public void close() throws IOException, ExternalFrameConfirmationException {
-    // write remaining data
-    writeToChannel(ab, channel);
-    waitForRequestToFinish(timeout, ExternalBackendRequestType.WRITE_TO_CHUNK.getByte());
-    channel.close();
+    try {
+      // write remaining data
+      writeToChannel(ab, channel);
+      waitForRequestToFinish(timeout, ExternalBackendRequestType.WRITE_TO_CHUNK.getByte());
+    } finally {
+      channel.close();
+    }
   }
 
   public void sendBoolean(boolean data) throws IOException {

--- a/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
@@ -59,7 +59,7 @@ final public class ExternalFrameWriterClient {
   private int timeout;
   private int numRows;
   private int numCols;
-  private int batchSize = 1000000; // 1 MegaByte
+  private int blockSize;
 
   /**
    * Initialize the External frame writer
@@ -68,15 +68,16 @@ final public class ExternalFrameWriterClient {
    *
    * @param channel communication channel to h2o node
    */
-  public ExternalFrameWriterClient(ByteChannel channel, int timeout) {
+  public ExternalFrameWriterClient(ByteChannel channel, int timeout, int blockSize) {
     this.ab = new AutoBuffer();
     this.channel = channel;
     this.timeout = timeout;
+    this.blockSize = blockSize;
   }
 
-  public static ExternalFrameWriterClient create(String ip, int port, short timestamp, int timeout) throws IOException {
+  public static ExternalFrameWriterClient create(String ip, int port, short timestamp, int timeout, int blockSize) throws IOException {
     ByteChannel channel = ExternalFrameUtils.getConnection(ip, port, timestamp);
-    return new ExternalFrameWriterClient(channel, timeout);
+    return new ExternalFrameWriterClient(channel, timeout, blockSize);
   }
 
   public void initFrame(String keyName, String[] names) throws IOException, ExternalFrameConfirmationException {
@@ -224,7 +225,7 @@ final public class ExternalFrameWriterClient {
       currentColIdx = 0;
     }
 
-    if (ab.position() > batchSize) {
+    if (ab.position() > blockSize) {
       writeToChannel(ab, channel);
     }
   }

--- a/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
@@ -125,6 +125,8 @@ final public class ExternalFrameWriterClient {
   }
 
   public void close() throws IOException, ExternalFrameConfirmationException {
+    // write remaining data
+    writeToChannel(ab, channel);
     waitForRequestToFinish(timeout, ExternalBackendRequestType.WRITE_TO_CHUNK.getByte());
     channel.close();
   }

--- a/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
+++ b/h2o-core/src/main/java/water/ExternalFrameWriterClient.java
@@ -59,7 +59,7 @@ final public class ExternalFrameWriterClient {
   private int timeout;
   private int numRows;
   private int numCols;
-  private int blockSize;
+  private long blockSize;
 
   /**
    * Initialize the External frame writer
@@ -68,14 +68,14 @@ final public class ExternalFrameWriterClient {
    *
    * @param channel communication channel to h2o node
    */
-  public ExternalFrameWriterClient(ByteChannel channel, int timeout, int blockSize) {
+  public ExternalFrameWriterClient(ByteChannel channel, int timeout, long blockSize) {
     this.ab = new AutoBuffer();
     this.channel = channel;
     this.timeout = timeout;
     this.blockSize = blockSize;
   }
 
-  public static ExternalFrameWriterClient create(String ip, int port, short timestamp, int timeout, int blockSize) throws IOException {
+  public static ExternalFrameWriterClient create(String ip, int port, short timestamp, int timeout, long blockSize) throws IOException {
     ByteChannel channel = ExternalFrameUtils.getConnection(ip, port, timestamp);
     return new ExternalFrameWriterClient(channel, timeout, blockSize);
   }

--- a/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
+++ b/h2o-core/src/test/java/water/ExternalFrameWriterClientTest.java
@@ -303,8 +303,9 @@ public class ExternalFrameWriterClientTest extends TestUtil {
     static Frame createFrame(final WriteOperation op,
                              final String[] writeEndpoints) throws IOException, ExternalFrameConfirmationException {
         
+        final int blockSize = 1000 * 1000;
         ByteChannel sock = ExternalFrameUtils.getConnection(writeEndpoints[0], H2O.SELF.getTimestamp());
-        ExternalFrameWriterClient mainClient = new ExternalFrameWriterClient(sock, 10);
+        ExternalFrameWriterClient mainClient = new ExternalFrameWriterClient(sock, 10, blockSize);
         mainClient.initFrame(op.frameName(), op.colNames());
         
         final long[] rowsPerChunk = new long[writeEndpoints.length]; // number of chunks will be number of h2o nodes
@@ -317,7 +318,7 @@ public class ExternalFrameWriterClientTest extends TestUtil {
                 public void run() {
                     try {
                         ByteChannel sock = ExternalFrameUtils.getConnection(writeEndpoints[0], H2O.SELF.getTimestamp());
-                        ExternalFrameWriterClient writer = new ExternalFrameWriterClient(sock, 10);
+                        ExternalFrameWriterClient writer = new ExternalFrameWriterClient(sock, 10, blockSize);
                         try {
                             writer.createChunk(op.frameName(), op.colTypes(),  currentIndex, op.nrows(), op.maxVecSizes());
         


### PR DESCRIPTION
The goal of this change is to send the data to and from external backend after some pre-defined ( currently hard-coded) batch size to improve the overall performance