### PR TITLE
PUBDEV-6897: Add GBM POJO support for OneHotExplicit encoding

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
+++ b/h2o-algos/src/main/java/hex/tree/SharedTreeModel.java
@@ -5,6 +5,7 @@ import hex.*;
 import static hex.ModelCategory.Binomial;
 import static hex.genmodel.GenModel.createAuxKey;
 
+import hex.genmodel.CategoricalEncoding;
 import hex.genmodel.algos.tree.SharedTreeMojoModel;
 import hex.genmodel.algos.tree.SharedTreeNode;
 import hex.genmodel.algos.tree.SharedTreeSubgraph;
@@ -658,15 +659,31 @@ public abstract class SharedTreeModel<
 
   protected boolean binomialOpt() { return true; }
 
+  @Override protected CategoricalEncoding getGenModelEncoding() {
+    switch (_parms._categorical_encoding) {
+      case AUTO:
+      case Enum:
+        return CategoricalEncoding.AUTO;
+      case OneHotExplicit:
+        return CategoricalEncoding.OneHotExplicit;
+      default:
+        return null;
+    }
+  }
+  
   @Override protected SBPrintStream toJavaInit(SBPrintStream sb, CodeGeneratorPipeline fileCtx) {
-    if (_parms._categorical_encoding != Parameters.CategoricalEncodingScheme.AUTO &&
-        _parms._categorical_encoding != Parameters.CategoricalEncodingScheme.Enum) {
-      throw new IllegalArgumentException("Only default categorical_encoding scheme is supported for POJO/MOJO");
+    CategoricalEncoding encoding = getGenModelEncoding();
+    if (encoding == null) {
+      throw new IllegalArgumentException("Only default and 1-hot explicit scheme is supported for POJO/MOJO");
     }
     sb.nl();
     sb.ip("public boolean isSupervised() { return true; }").nl();
     sb.ip("public int nfeatures() { return " + _output.nfeatures() + "; }").nl();
     sb.ip("public int nclasses() { return " + _output.nclasses() + "; }").nl();
+    if (encoding != CategoricalEncoding.AUTO) {
+      sb.ip("public hex.genmodel.CategoricalEncoding getCategoricalEncoding() { return hex.genmodel.CategoricalEncoding." + 
+              encoding.name() + "; }").nl();
+    }
     return sb;
   }
 

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -115,6 +115,39 @@ public class GBMTest extends TestUtil {
     }
   }
 
+  @Test public void testOneHotExplicitWithPOJO() {
+    try {
+      Scope.enter();
+      final String response = "CAPSULE";
+      Frame fr = parse_test_file("./smalldata/logreg/prostate.csv")
+              .toCategoricalCol("RACE")
+              .toCategoricalCol(response);
+      fr.remove("ID").remove();
+      Scope.track(fr);
+      DKV.put(fr);
+
+      GBMModel.GBMParameters parms = makeGBMParameters();
+      parms._train = fr._key;
+      parms._response_column = response;
+      parms._ntrees = 5;
+      parms._categorical_encoding = Model.Parameters.CategoricalEncodingScheme.OneHotExplicit;
+
+      GBM job = new GBM(parms);
+      GBMModel gbm = job.trainModel().get();
+      Scope.track_generic(gbm);
+
+      // Done building model; produce a score column with predictions
+      Frame scored = Scope.track(gbm.score(fr));
+
+      // Build a POJO & MOJO, validate same results
+      Assert.assertTrue(gbm.testJavaScoring(fr, scored,1e-15));
+
+    } finally {
+      Scope.exit();
+    }
+
+  }
+  
   @Test public void testBasicGBM() {
     // Regression tests
     basicGBM("./smalldata/junit/cars.csv",

--- a/h2o-genmodel/src/main/java/hex/genmodel/CategoricalEncoding.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/CategoricalEncoding.java
@@ -1,0 +1,6 @@
+package hex.genmodel;
+
+public enum CategoricalEncoding {
+  AUTO,
+  OneHotExplicit
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
@@ -93,6 +93,11 @@ public abstract class GenModel implements IGenModel, IGeneratedModel, Serializab
     return _names;
   }
 
+  /** The original names of all columns used, including response and offset columns. */
+  @Override public String[] getOrigNames() {
+    return null;
+  }
+  
   /** The name of the response column. */
   @Override public String getResponseName() {
     // Note: _responseColumn is not set when deprecated constructor GenModel(String[] names, String[][] domains) is used
@@ -121,6 +126,11 @@ public abstract class GenModel implements IGenModel, IGeneratedModel, Serializab
     return nclasses();
   }
 
+  /** Return type of encoding expected by the model implementation. */
+  @Override public CategoricalEncoding getCategoricalEncoding() {
+    return CategoricalEncoding.AUTO; // by default model handles the encoding
+  }
+
   /** Returns true if this model represents a classifier, else it is used for regression. */
   @Override public boolean isClassifier() {
     ModelCategory cat = getModelCategory();
@@ -146,6 +156,11 @@ public abstract class GenModel implements IGenModel, IGeneratedModel, Serializab
   /** Returns domain values for all columns, including the response column. */
   @Override public String[][] getDomainValues() {
     return _domains;
+  }
+
+  @Override
+  public String[][] getOrigDomainValues() {
+    return null;
   }
 
   /** Returns index of a column with given name, or -1 if the column is not found. */

--- a/h2o-genmodel/src/main/java/water/genmodel/IGeneratedModel.java
+++ b/h2o-genmodel/src/main/java/water/genmodel/IGeneratedModel.java
@@ -1,5 +1,7 @@
 package water.genmodel;
 
+import hex.genmodel.CategoricalEncoding;
+
 /**
  * A generic interface to access generated models.
  */
@@ -12,6 +14,9 @@ public interface IGeneratedModel {
 
     /** The names of columns used in the model. It contains names of input columns and a name of response column. */
     public String[] getNames();
+
+    /** The original names of columns used in the model. It contains names of input columns and a name of response column. */
+    public String[] getOrigNames();
 
     /** The name of the response column. */
     @Deprecated
@@ -31,6 +36,8 @@ public interface IGeneratedModel {
      * @throws java.lang.UnsupportedOperationException if called on a non-classifier model.
      */
     public int getNumResponseClasses();
+
+    public CategoricalEncoding getCategoricalEncoding();
 
     /** @return true if this model represents a classifier, else it is used for regression. */
     public boolean isClassifier();
@@ -53,6 +60,9 @@ public interface IGeneratedModel {
 
     /** Returns domain values for all columns including response column. */
     public String[][] getDomainValues();
+
+    /** Returns original domain values for all columns including response column. */
+    public String[][] getOrigDomainValues();
 
     /** Returns index of column with give name or -1 if column is not found. */
     public int getColIdx(String name);


### PR DESCRIPTION
This enables users to export a POJO for a model that was trained
with 1-hot-explicit encoding.

There is currently no support in EasyPredictModelWrapper - users will
need to apply the encoding externally and let the Wrapper know by
flipping a `useExternalEncoding` to true.