### PR TITLE
PUBDEV-6934 Don't build xgboost extension as a fat-jar

### DIFF
--- a/h2o-genmodel-extensions/xgboost/build.gradle
+++ b/h2o-genmodel-extensions/xgboost/build.gradle
@@ -31,19 +31,3 @@ dependencies {
     testCompile 'com.esotericsoftware.kryo:kryo:2.21'
     testCompile "junit:junit:${junitVersion}"
 }
-
-// Disable default jar
-jar {
-    enabled = false
-}
-
-shadowJar {
-    archiveName = jar.archiveName
-}
-
-artifacts {
-    archives shadowJar
-}
-jar.dependsOn shadowJar
-build.dependsOn shadowJar
-


### PR DESCRIPTION
This doesn't play nice with dependency management