### PR TITLE
PUBDEV-6893 - Saving files in Python not properly creating directories

### DIFF
--- a/h2o-py/h2o/backend/connection.py
+++ b/h2o-py/h2o/backend/connection.py
@@ -736,11 +736,13 @@ class H2OConnection(backwards_compatible()):
         status_code = response.status_code
         if status_code == 200 and save_to:
             if save_to.startswith("~"): save_to = os.path.expanduser(save_to)
+            save_to = os.path.join(str(save_to), '')
             if os.path.isdir(save_to) or save_to.endswith(os.path.sep):
-                dirname = os.path.abspath(save_to)
+                dirname = os.path.join(os.path.abspath(save_to), '')
                 filename = H2OConnection._find_file_name(response)
             else:
                 dirname, filename = os.path.split(os.path.abspath(save_to))
+                dirname = os.path.join(dirname, '')
             fullname = os.path.join(dirname, filename)
             try:
                 if not os.path.exists(dirname):

--- a/h2o-py/h2o/backend/connection.py
+++ b/h2o-py/h2o/backend/connection.py
@@ -736,13 +736,11 @@ class H2OConnection(backwards_compatible()):
         status_code = response.status_code
         if status_code == 200 and save_to:
             if save_to.startswith("~"): save_to = os.path.expanduser(save_to)
-            save_to = os.path.join(str(save_to), '')
             if os.path.isdir(save_to) or save_to.endswith(os.path.sep):
                 dirname = os.path.join(os.path.abspath(save_to), '')
                 filename = H2OConnection._find_file_name(response)
             else:
                 dirname, filename = os.path.split(os.path.abspath(save_to))
-                dirname = os.path.join(dirname, '')
             fullname = os.path.join(dirname, filename)
             try:
                 if not os.path.exists(dirname):

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -1003,6 +1003,7 @@ def download_pojo(model, path="", get_jar=True, jar_name=""):
     if not model.have_pojo:
         raise H2OValueError("Export to POJO not supported")
 
+    path = str(os.path.join(path, ''))
     if path == "":
         java_code = api("GET /3/Models.java/%s" % model.model_id)
         print(java_code)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_pojo.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_pojo.py
@@ -5,6 +5,7 @@ sys.path.insert(1, os.path.join("..","..",".."))
 import h2o
 import time
 import tempfile
+import shutil
 from tests import pyunit_utils
 from h2o.automl import H2OAutoML
 
@@ -18,15 +19,17 @@ def automl_pojo():
     aml.train(y="CAPSULE", training_frame=fr1)
 
     # download pojo
-    model_zip_path = os.path.join(tempfile.mkdtemp(), 'model.zip')
+    model_zip_path = tempfile.mkdtemp()
+    model_zip_file_path = os.path.join(model_zip_path, aml._leader_id + ".java")
     time0 = time.time()
-    print("\nDownloading POJO @... " + model_zip_path)
+    print("\nDownloading POJO @... " + model_zip_file_path)
     pojo_file  = aml.download_pojo(model_zip_path)
     print("    => %s  (%d bytes)" % (pojo_file, os.stat(pojo_file).st_size))
     assert os.path.exists(pojo_file)
     print("    Time taken = %.3fs" % (time.time() - time0))
-    assert os.path.isfile(model_zip_path)
-    os.remove(model_zip_path)
+    assert os.path.isfile(model_zip_file_path)
+    shutil.rmtree(model_zip_path)
+    
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(automl_pojo)

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6893_download_pojo_creatable_location.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6893_download_pojo_creatable_location.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+import sys
+
+sys.path.insert(1, "../../")
+import h2o
+import os
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+
+
+def download_pojo():
+    iris = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    
+    
+    # Compensate slash at the end
+    model = H2OGradientBoostingEstimator(ntrees=1)
+    model.train(x=list(range(4)), y=4, training_frame=iris)
+
+    export_dir = pyunit_utils.locate("results") + "/downloadable_pojo"
+    h2o.download_pojo(model=model, path=export_dir)
+    assert os.path.isdir(export_dir)
+    assert os.path.exists(os.path.join(export_dir, model.model_id + '.java'))
+    
+    # Slash present at the end
+    model = H2OGradientBoostingEstimator(ntrees=1)
+    model.train(x=list(range(4)), y=4, training_frame=iris)
+    export_dir = pyunit_utils.locate("results") + "/downloadable_pojo/"
+    h2o.download_pojo(model=model, path=export_dir)
+    assert os.path.isdir(export_dir)
+    assert os.path.exists(os.path.join(export_dir, model.model_id + '.java'))
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(download_pojo)
+else:
+    download_pojo()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6893

This is a problem with paths - with splits being done in the code, there are scenarios where the path given might be considered as ending with a filename, rather than a directory. This happens when users forgets to put slash at the end of the string (like the issue reporter did : `h2o.download_pojo(model=m, path='test_ae_pojo', get_jar=True)`). Therefore the "NotADirectory" error reported.

Solution is to simply use `os.path.join` to consider the user-given path to end with a diretory all the time. `os.path.join` manages to do it in an os-independent way (so the documentation says).

H2O documentation of the `download_pojo` method says: `    :param path: an absolute path to the directory where POJO should be saved.`.