### PR TITLE
PUBDEV-6950 checking deepSlice negative indices

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1126,7 +1126,7 @@ public class Frame extends Lockable<Frame> {
    *  <li><em>an unordered list of positive</em> - just these, allowing dups
    *  </ul>
    *
-   *  <p>The numbering is 1-based; zero's are not allowed in the lists, nor are out-of-range values.
+   *  <p> Out-of-range values are not allowed in the lists.
    *  @return the sliced Frame
    */
   public Frame deepSlice( Object orows, Object ocols ) {

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstRowSlice.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstRowSlice.java
@@ -98,7 +98,9 @@ public class AstRowSlice extends AstPrimitive {
         }
       }.doAll(fr.types(), fr).outputFrame(fr.names(), fr.domains());
     } else if ((asts[2] instanceof AstNum)) {
-      long[] rows = new long[]{(long) (((AstNum) asts[2]).getNum())};
+      double num = ((AstNum) asts[2]).getNum();
+      if(num < 0) throw new IllegalStateException("Checking whether deepSlice with negative indices is being used "); 
+      long[] rows = new long[]{(long) num};
       returningFrame = fr.deepSlice(rows, null);
     } else if ((asts[2] instanceof AstExec) || (asts[2] instanceof AstId)) {
       Frame predVec = stk.track(asts[2].exec(env)).getFrame();

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -112,8 +112,7 @@ public class FrameTest extends TestUtil {
   }
 
   /**
-   * This test is testing deepSlice functionality and shows that we can use zero-based indexes for slicing
-   * // TODO if confirmed go and correct comments for Frame.deepSlice() method
+   * This test is testing deepSlice functionality and also shows that we can use zero-based indexes for slicing
    */
   @Test
   public void testRowDeepSlice() {

--- a/h2o-core/src/test/java/water/fvec/FrameTest.java
+++ b/h2o-core/src/test/java/water/fvec/FrameTest.java
@@ -140,6 +140,18 @@ public class FrameTest extends TestUtil {
       assertEquals(2, slicedRange.numRows());
       assertStringVecEquals(svec("a", "d"), slicedRange.vec(0));
       assertVecEquals(vec(1,4), slicedRange.vec(1), 1e-5);
+
+      //checking negative indices for "All but this" use case
+      try {
+        Frame slicedRangeExcept = input.deepSlice(new long[]{-1}, null); // <--- failing here already
+      } catch (AssertionError ex) { // Catching internal assertion error from deepSlice method 
+        fail("Unsupported negative index in deepSlice");
+      }
+      
+      // Uncomment once ^^^ is fixed
+      // assertEquals(3, slicedRangeExcept.numRows());
+      // assertStringVecEquals(svec("a", "c", "d"), slicedRangeExcept.vec(0));
+      // assertVecEquals(vec(1, 3, 4), slicedRangeExcept.vec(1), 1e-5);
     } finally {
       Scope.exit();
     }


### PR DESCRIPTION
This PR has two purposes:
1) Confirm that zero-based slicing is actually supported. Correction of the Javadoc is needed then.
2)Test deepSlice with negative indices ( "all but these" slicing). FrameTest.testRowDeepSlice() test fails due to the usage of the negative value for slicing