### PR TITLE
PUBDEV-6749 - Fix grid search parameter checksum comparison

### DIFF
--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -271,7 +271,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     }
   }
   
-  protected static final Set<String> IGNORED_FIELDS_PARAM_HASH = Collections.singleton("_export_checkpoints_dir");
+  private static final Set<String> IGNORED_FIELDS_PARAM_HASH = Collections.singleton("_export_checkpoints_dir");
   /**
    * Build a model based on specified parameters and save it to resulting Grid object.
    *

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -271,7 +271,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     }
   }
   
-  private static final Set<String> IGNORED_FIELDS_PARAM_HASH = Collections.singleton("_export_checkpoints_dir");
+  protected static final Set<String> IGNORED_FIELDS_PARAM_HASH = Collections.singleton("_export_checkpoints_dir");
   /**
    * Build a model based on specified parameters and save it to resulting Grid object.
    *
@@ -320,7 +320,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
         if ((m == null) || (m._parms == null))
           return false;
         try {
-          return m._parms.checksum() == checksum;
+          return m._parms.checksum(IGNORED_FIELDS_PARAM_HASH) == checksum;
         } catch (H2OConcurrentModificationException e) {
           // We are inspecting model parameters that doesn't belong to us - they might be modified (or deleted) while
           // checksum is being calculated: we skip them (see PUBDEV-5286)


### PR DESCRIPTION
I introduced a checksum with ignored fields for Grid Search in https://0xdata.atlassian.net/browse/PUBDEV-6739 . 

The idea was not to train new models when Grid search is resumed (once loaded from disk) and the user sets `_export_checkpoints_dir` to null. If `_export_checkpoints_dir` is not ignored in checksum for GridSearch, it leads to training the same models once again, as the checksum seems to be different, but the parameters are really the same.

**Short summary**
There was one more place comparing the checksums. And one of those checksums was with `_export_checkpoints_dir` ignored, and one of them was not, as I forgot to modify the line. This is now resolved.