### PR TITLE
EasyPredictModelWrapper Refactoring: first step towards 1-hot encoding for POJO/MOJO

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
@@ -58,6 +58,16 @@ public abstract class GenModel implements IGenModel, IGeneratedModel, Serializab
     return _names.length;
   }
 
+  public int nCatFeatures() {
+    int nCat = 0;
+    String[][] domainValues = getDomainValues();
+    for (int i = 0; i < nfeatures(); i++) {
+      if (domainValues[i] != null)
+        nCat++;
+    }
+    return nCat;
+  }
+
   /** Returns names of input features. */
   @Override public String[] features() {
     return Arrays.copyOf(_names, nfeatures());

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/CategoricalEncoder.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/CategoricalEncoder.java
@@ -1,0 +1,21 @@
+package hex.genmodel.easy;
+
+import java.io.Serializable;
+
+public interface CategoricalEncoder extends Serializable {
+
+  /**
+   * Encodes a given categorical level into a raw array onto the right position.
+   * @param level categorical level
+   * @param rawData raw input to score0
+   * @return true if provided categorical level was valid and was properly encoded, false if nothing was written to raw data
+   */
+  boolean encodeCatValue(String level, double[] rawData);
+
+  /**
+   * Encode NA (missing level) into raw data.
+   * @param rawData target raw data array
+   */
+  void encodeNA(double[] rawData);
+  
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/DWImageConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/DWImageConverter.java
@@ -11,20 +11,20 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.HashMap;
+import java.util.Map;
 
 public class DWImageConverter extends RowToRawDataConverter {
 
   private final DeepwaterMojoModel _dwm;
   
-  DWImageConverter(DeepwaterMojoModel m, HashMap<String, Integer> modelColumnNameToIndexMap, HashMap<Integer, HashMap<String, Integer>> domainMap,
-                          EasyPredictModelWrapper.ErrorConsumer errorConsumer, EasyPredictModelWrapper.Config config) {
+  DWImageConverter(DeepwaterMojoModel m, Map<String, Integer> modelColumnNameToIndexMap, Map<Integer, CategoricalEncoder> domainMap,
+                   EasyPredictModelWrapper.ErrorConsumer errorConsumer, EasyPredictModelWrapper.Config config) {
     super(m, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
     _dwm = m;
   }
 
   @Override
-  protected boolean convertValue(String columnName, Object o, String[] domainValues, int targetIndex, double[] rawData) throws PredictException {
+  protected boolean convertValue(String columnName, Object o, CategoricalEncoder catEncoder, int targetIndex, double[] rawData) throws PredictException {
     BufferedImage img = null;
 
     if (o instanceof String) {
@@ -62,7 +62,7 @@ public class DWImageConverter extends RowToRawDataConverter {
         rawData[i] = _destData[i];
       return true;
     } else
-      return super.convertValue(columnName, o, domainValues, targetIndex, rawData);
+      return super.convertValue(columnName, o, catEncoder, targetIndex, rawData);
   }
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/DWImageConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/DWImageConverter.java
@@ -1,0 +1,68 @@
+package hex.genmodel.easy;
+
+import hex.genmodel.GenModel;
+import hex.genmodel.algos.deepwater.DeepwaterMojoModel;
+import hex.genmodel.easy.exception.PredictException;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.HashMap;
+
+public class DWImageConverter extends RowToRawDataConverter {
+
+  private final DeepwaterMojoModel _dwm;
+  
+  DWImageConverter(DeepwaterMojoModel m, HashMap<String, Integer> modelColumnNameToIndexMap, HashMap<Integer, HashMap<String, Integer>> domainMap,
+                          EasyPredictModelWrapper.ErrorConsumer errorConsumer, EasyPredictModelWrapper.Config config) {
+    super(m, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
+    _dwm = m;
+  }
+
+  @Override
+  protected boolean convertValue(String columnName, Object o, String[] domainValues, int targetIndex, double[] rawData) throws PredictException {
+    BufferedImage img = null;
+
+    if (o instanceof String) {
+      String s = ((String) o).trim();
+      // Url to an image given
+      boolean isURL = s.matches("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
+      try {
+        img = isURL ? ImageIO.read(new URL(s)) : ImageIO.read(new File(s));
+      } catch (IOException e) {
+        throw new PredictException("Couldn't read image from " + s);
+      }
+    } else if (o instanceof byte[]) {
+      // Read the image from raw bytes
+      InputStream is = new ByteArrayInputStream((byte[]) o);
+      try {
+        img = ImageIO.read(is);
+      } catch (IOException e) {
+        throw new PredictException("Couldn't interpret raw bytes as an image.");
+      }
+    }
+
+    if (img != null) {
+      int W = _dwm._width;
+      int H = _dwm._height;
+      int C = _dwm._channels;
+      float[] _destData = new float[W * H * C];
+      try {
+        GenModel.img2pixels(img, W, H, C, _destData, 0, _dwm._meanImageData);
+      } catch (IOException e) {
+        e.printStackTrace();
+        throw new PredictException("Couldn't vectorize image.");
+      }
+      rawData = new double[_destData.length];
+      for (int i = 0; i < rawData.length; ++i)
+        rawData[i] = _destData[i];
+      return true;
+    } else
+      return super.convertValue(columnName, o, domainValues, targetIndex, rawData);
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/DWTextConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/DWTextConverter.java
@@ -3,21 +3,21 @@ package hex.genmodel.easy;
 import hex.genmodel.GenModel;
 import hex.genmodel.easy.exception.PredictException;
 
-import java.util.HashMap;
+import java.util.Map;
 
 public class DWTextConverter extends RowToRawDataConverter {
 
-  DWTextConverter(GenModel m, HashMap<String, Integer> modelColumnNameToIndexMap, HashMap<Integer, HashMap<String, Integer>> domainMap,
-                         EasyPredictModelWrapper.ErrorConsumer errorConsumer, EasyPredictModelWrapper.Config config) {
+  DWTextConverter(GenModel m, Map<String, Integer> modelColumnNameToIndexMap, Map<Integer, CategoricalEncoder> domainMap,
+                  EasyPredictModelWrapper.ErrorConsumer errorConsumer, EasyPredictModelWrapper.Config config) {
     super(m, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
   }
 
   @Override
-  protected boolean convertValue(String columnName, Object o, String[] domainValues, int targetIndex, double[] rawData) throws PredictException {
+  protected boolean convertValue(String columnName, Object o, CategoricalEncoder catEncoder, int targetIndex, double[] rawData) throws PredictException {
     if (o instanceof String) {
       throw new PredictException("MOJO scoring for text classification is not yet implemented.");
     }
-    return super.convertValue(columnName, o, domainValues, targetIndex, rawData);
+    return super.convertValue(columnName, o, catEncoder, targetIndex, rawData);
   }
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/DWTextConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/DWTextConverter.java
@@ -1,0 +1,23 @@
+package hex.genmodel.easy;
+
+import hex.genmodel.GenModel;
+import hex.genmodel.easy.exception.PredictException;
+
+import java.util.HashMap;
+
+public class DWTextConverter extends RowToRawDataConverter {
+
+  DWTextConverter(GenModel m, HashMap<String, Integer> modelColumnNameToIndexMap, HashMap<Integer, HashMap<String, Integer>> domainMap,
+                         EasyPredictModelWrapper.ErrorConsumer errorConsumer, EasyPredictModelWrapper.Config config) {
+    super(m, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
+  }
+
+  @Override
+  protected boolean convertValue(String columnName, Object o, String[] domainValues, int targetIndex, double[] rawData) throws PredictException {
+    if (o instanceof String) {
+      throw new PredictException("MOJO scoring for text classification is not yet implemented.");
+    }
+    return super.convertValue(columnName, o, domainValues, targetIndex, rawData);
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/DomainMapConstructor.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/DomainMapConstructor.java
@@ -3,6 +3,7 @@ package hex.genmodel.easy;
 import hex.genmodel.GenModel;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  *  Create map from input variable domain information.
@@ -15,21 +16,16 @@ public class DomainMapConstructor {
     _m = m;
   }
 
-  public HashMap<Integer, HashMap<String, Integer>> create() {
-   
-    // This contains the categorical string to numeric mapping.
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new HashMap<>();
+  public Map<Integer, CategoricalEncoder> create() {
+    Map<Integer, CategoricalEncoder> domainMap = new HashMap<>();
+    String[] columnNames = _m.getNames();
     for (int i = 0; i < _m.getNumCols(); i++) {
       String[] domainValues = _m.getDomainValues(i);
       if (domainValues != null) {
-        HashMap<String, Integer> m = new HashMap<>();
-        for (int j = 0; j < domainValues.length; j++) {
-          m.put(domainValues[j], j);
-        }
-
-        domainMap.put(i, m);
+        domainMap.put(i, new EnumEncoder(columnNames[i], i, domainValues));
       }
     }
     return domainMap;
   }
+
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/DomainMapConstructor.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/DomainMapConstructor.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
  */
 public class DomainMapConstructor {
 
-  public final GenModel _m;
+  private final GenModel _m;
   
   public DomainMapConstructor(GenModel m) {
     _m = m;

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -307,10 +307,10 @@ public class EasyPredictModelWrapper implements Serializable {
               " and apply the encoding manually before calling the predict function. For more information please refer to https://0xdata.atlassian.net/browse/PUBDEV-6929.");
     }
 
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(m).create();
+    Map<Integer, CategoricalEncoder> domainMap = new DomainMapConstructor(m).create();
     // Create map of column names to index number.
-    HashMap<String, Integer> modelColumnNameToIndexMap = new HashMap<>();
     String[] modelColumnNames = m.getNames();
+    Map<String, Integer> modelColumnNameToIndexMap = new HashMap<>(modelColumnNames.length);
     for (int i = 0; i < modelColumnNames.length; i++) {
       modelColumnNameToIndexMap.put(modelColumnNames[i], i);
     }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -53,7 +53,6 @@ import java.util.*;
 public class EasyPredictModelWrapper implements Serializable {
   // These private members are read-only after the constructor.
   public final GenModel m;
-  public final HashMap<Integer, HashMap<String, Integer>> domainMap;
   private final RowToRawDataConverter rowDataConverter;
 
   private final boolean useExtendedOutput;
@@ -308,7 +307,7 @@ public class EasyPredictModelWrapper implements Serializable {
               " and apply the encoding manually before calling the predict function. For more information please refer to https://0xdata.atlassian.net/browse/PUBDEV-6929.");
     }
 
-    domainMap = new DomainMapConstructor(m).create();
+    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(m).create();
     // Create map of column names to index number.
     HashMap<String, Integer> modelColumnNameToIndexMap = new HashMap<>();
     String[] modelColumnNames = m.getNames();
@@ -381,6 +380,8 @@ public class EasyPredictModelWrapper implements Serializable {
   ErrorConsumer getErrorConsumer() {
     return rowDataConverter.getErrorConsumer();
   }
+
+  
   
   /**
    * Make a prediction on a new data point using an AutoEncoder model.

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EnumEncoder.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EnumEncoder.java
@@ -1,0 +1,39 @@
+package hex.genmodel.easy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnumEncoder implements CategoricalEncoder {
+
+  private final String columnName;
+  private final int targetIndex;
+  private final Map<String, Integer> domainMap;
+
+  public EnumEncoder(String columnName, int targetIndex, String[] domainValues) {
+    this.columnName = columnName;
+    this.targetIndex = targetIndex;
+    domainMap = new HashMap<>();
+    for (int j = 0; j < domainValues.length; j++) {
+      domainMap.put(domainValues[j], j);
+    }
+    
+  }
+
+  @Override
+  public boolean encodeCatValue(String levelName, double[] rawData) {
+    Integer levelIndex = domainMap.get(levelName);
+    if (levelIndex == null) {
+      levelIndex = domainMap.get(columnName + "." + levelName);
+    }
+    if (levelIndex == null)
+      return false;
+    rawData[targetIndex] = levelIndex; 
+    return true;
+  }
+
+  @Override
+  public void encodeNA(double[] rawData) {
+    rawData[targetIndex] = Double.NaN;
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/RowDataConverterFactory.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/RowDataConverterFactory.java
@@ -3,13 +3,13 @@ package hex.genmodel.easy;
 import hex.genmodel.GenModel;
 import hex.genmodel.algos.deepwater.DeepwaterMojoModel;
 
-import java.util.HashMap;
+import java.util.Map;
 
 class RowDataConverterFactory {
 
   static RowToRawDataConverter makeConverter(GenModel m,
-                                             HashMap<String, Integer> modelColumnNameToIndexMap,
-                                             HashMap<Integer, HashMap<String, Integer>> domainMap,
+                                             Map<String, Integer> modelColumnNameToIndexMap,
+                                             Map<Integer, CategoricalEncoder> domainMap,
                                              EasyPredictModelWrapper.ErrorConsumer errorConsumer,
                                              EasyPredictModelWrapper.Config config) {
     if (m instanceof DeepwaterMojoModel) {

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/RowDataConverterFactory.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/RowDataConverterFactory.java
@@ -1,0 +1,28 @@
+package hex.genmodel.easy;
+
+import hex.genmodel.GenModel;
+import hex.genmodel.algos.deepwater.DeepwaterMojoModel;
+
+import java.util.HashMap;
+
+class RowDataConverterFactory {
+
+  static RowToRawDataConverter makeConverter(GenModel m,
+                                             HashMap<String, Integer> modelColumnNameToIndexMap,
+                                             HashMap<Integer, HashMap<String, Integer>> domainMap,
+                                             EasyPredictModelWrapper.ErrorConsumer errorConsumer,
+                                             EasyPredictModelWrapper.Config config) {
+    if (m instanceof DeepwaterMojoModel) {
+      DeepwaterMojoModel dwm = (DeepwaterMojoModel) m;
+      if (dwm._problem_type.equals("image"))
+        return new DWImageConverter(dwm, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
+      else if (dwm._problem_type.equals("text")) {
+        return new DWTextConverter(dwm, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
+      }
+    }
+    
+    return new RowToRawDataConverter(m, modelColumnNameToIndexMap, domainMap,
+            errorConsumer, config);
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/RowToRawDataConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/RowToRawDataConverter.java
@@ -1,52 +1,38 @@
 package hex.genmodel.easy;
 
 import hex.genmodel.GenModel;
-import hex.genmodel.algos.deepwater.DeepwaterMojoModel;
 import hex.genmodel.easy.exception.PredictException;
 import hex.genmodel.easy.exception.PredictNumberFormatException;
 import hex.genmodel.easy.exception.PredictUnknownCategoricalLevelException;
 import hex.genmodel.easy.exception.PredictUnknownTypeException;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
+import java.io.Serializable;
 import java.util.HashMap;
 
 /**
  * This class is intended to transform a RowData instance - for which we want to get prediction to - into a raw array
  */
-public class RowToRawDataConverter {
+public class RowToRawDataConverter implements Serializable {
 
-  public final GenModel _m;
+  private final String[][] _domainValues;
   private final HashMap<String, Integer> _modelColumnNameToIndexMap;
   private final HashMap<Integer, HashMap<String, Integer>> _domainMap;
   private final EasyPredictModelWrapper.ErrorConsumer _errorConsumer;
 
   private final boolean _convertUnknownCategoricalLevelsToNa;
   private final boolean _convertInvalidNumbersToNa;
-
-  private final boolean _isImage;
-  private final boolean _isText;
   
   public RowToRawDataConverter(GenModel m,
                                HashMap<String, Integer> modelColumnNameToIndexMap,
                                HashMap<Integer, HashMap<String, Integer>> domainMap,
                                EasyPredictModelWrapper.ErrorConsumer errorConsumer,
-                               boolean convertUnknownCategoricalLevelsToNa,
-                               boolean convertInvalidNumbersToNa) {
-    _m = m;
+                               EasyPredictModelWrapper.Config config) {
+    _domainValues = m.getDomainValues();
     _modelColumnNameToIndexMap = modelColumnNameToIndexMap;
     _domainMap = domainMap;
     _errorConsumer = errorConsumer;
-    _convertUnknownCategoricalLevelsToNa = convertUnknownCategoricalLevelsToNa;
-    _convertInvalidNumbersToNa = convertInvalidNumbersToNa;
-
-    _isImage = _m instanceof DeepwaterMojoModel && ((DeepwaterMojoModel) _m)._problem_type.equals("image");
-    _isText  = _m instanceof DeepwaterMojoModel && ((DeepwaterMojoModel) _m)._problem_type.equals("text");
+    _convertUnknownCategoricalLevelsToNa = config.getConvertUnknownCategoricalLevelsToNa();
+    _convertInvalidNumbersToNa = config.getConvertInvalidNumbersToNa();
   }
 
   /**
@@ -67,10 +53,8 @@ public class RowToRawDataConverter {
         continue;
       }
 
-      String[] domainValues = _m.getDomainValues(index);
       Object o = data.get(dataColumnName);
-
-      if (convertValue(dataColumnName, o, domainValues, index, rawData)) {
+      if (convertValue(dataColumnName, o, _domainValues[index], index, rawData)) {
         return rawData;
       }
     }
@@ -81,63 +65,22 @@ public class RowToRawDataConverter {
                                  int targetIndex, double[] rawData) throws PredictException {
     if (domainValues == null) {
       // Column is either numeric or a string (for images or text)
-      BufferedImage img = null;
       double value = Double.NaN;
       if (o instanceof String) {
         String s = ((String) o).trim();
-        // Url to an image given
-        if (_isImage) {
-          boolean isURL = s.matches("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
-          try {
-            img = isURL ? ImageIO.read(new URL(s)) : ImageIO.read(new File(s));
-          } catch (IOException e) {
-            throw new PredictException("Couldn't read image from " + s);
-          }
-        } else if (_isText) {
-          // TODO: use model-specific vectorization of text
-          throw new PredictException("MOJO scoring for text classification is not yet implemented.");
-        } else {
-          // numeric
-          try {
-            value = Double.parseDouble(s);
-          } catch (NumberFormatException nfe) {
-            if (!_convertInvalidNumbersToNa)
-              throw new PredictNumberFormatException("Unable to parse value: " + s + ", from column: " + columnName + ", as Double; " + nfe.getMessage());
-          }
+        // numeric
+        try {
+          value = Double.parseDouble(s);
+        } catch (NumberFormatException nfe) {
+          if (!_convertInvalidNumbersToNa)
+            throw new PredictNumberFormatException("Unable to parse value: " + s + ", from column: " + columnName + ", as Double; " + nfe.getMessage());
         }
       } else if (o instanceof Double) {
         value = (Double) o;
-      } else if (o instanceof byte[] && _isImage) {
-        // Read the image from raw bytes
-        InputStream is = new ByteArrayInputStream((byte[]) o);
-        try {
-          img = ImageIO.read(is);
-        } catch (IOException e) {
-          throw new PredictException("Couldn't interpret raw bytes as an image.");
-        }
       } else {
         throw new PredictUnknownTypeException(
                 "Unexpected object type " + o.getClass().getName() + " for numeric column " + columnName);
       }
-
-      if (_isImage && img != null) {
-        DeepwaterMojoModel dwm = (DeepwaterMojoModel) _m;
-        int W = dwm._width;
-        int H = dwm._height;
-        int C = dwm._channels;
-        float[] _destData = new float[W * H * C];
-        try {
-          GenModel.img2pixels(img, W, H, C, _destData, 0, dwm._meanImageData);
-        } catch (IOException e) {
-          e.printStackTrace();
-          throw new PredictException("Couldn't vectorize image.");
-        }
-        rawData = new double[_destData.length];
-        for (int i = 0; i < rawData.length; ++i)
-          rawData[i] = _destData[i];
-        return true;
-      }
-
       if (Double.isNaN(value)) {
         // If this point is reached, the original value remains NaN.
         _errorConsumer.dataTransformError(columnName, o, "Given non-categorical value is unparseable, treating as NaN.");
@@ -176,6 +119,10 @@ public class RowToRawDataConverter {
     }
 
     return false;
+  }
+
+  EasyPredictModelWrapper.ErrorConsumer getErrorConsumer() {
+    return _errorConsumer;
   }
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/RowToRawDataConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/RowToRawDataConverter.java
@@ -28,6 +28,9 @@ public class RowToRawDataConverter {
 
   private final boolean _convertUnknownCategoricalLevelsToNa;
   private final boolean _convertInvalidNumbersToNa;
+
+  private final boolean _isImage;
+  private final boolean _isText;
   
   public RowToRawDataConverter(GenModel m,
                                HashMap<String, Integer> modelColumnNameToIndexMap,
@@ -41,6 +44,9 @@ public class RowToRawDataConverter {
     _errorConsumer = errorConsumer;
     _convertUnknownCategoricalLevelsToNa = convertUnknownCategoricalLevelsToNa;
     _convertInvalidNumbersToNa = convertInvalidNumbersToNa;
+
+    _isImage = _m instanceof DeepwaterMojoModel && ((DeepwaterMojoModel) _m)._problem_type.equals("image");
+    _isText  = _m instanceof DeepwaterMojoModel && ((DeepwaterMojoModel) _m)._problem_type.equals("text");
   }
 
   /**
@@ -52,11 +58,6 @@ public class RowToRawDataConverter {
    * but this conversion is only needed to make it possible to produce predictions so it makes sense
    */
   public double[] convert(RowData data, double[] rawData) throws PredictException {  
-
-    // TODO: refactor
-    boolean isImage = _m instanceof DeepwaterMojoModel && ((DeepwaterMojoModel) _m)._problem_type.equals("image");
-    boolean isText  = _m instanceof DeepwaterMojoModel && ((DeepwaterMojoModel) _m)._problem_type.equals("text");
-
     for (String dataColumnName : data.keySet()) {
       Integer index = _modelColumnNameToIndexMap.get(dataColumnName);
 
@@ -66,110 +67,115 @@ public class RowToRawDataConverter {
         continue;
       }
 
-      BufferedImage img = null;
       String[] domainValues = _m.getDomainValues(index);
+      Object o = data.get(dataColumnName);
 
-      if (domainValues == null) {
-        // Column is either numeric or a string (for images or text)
-        double value = Double.NaN;
-        Object o = data.get(dataColumnName);
-        if (o instanceof String) {
-          String s = ((String) o).trim();
-          // Url to an image given
-          if (isImage) {
-            boolean isURL = s.matches("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
-            try {
-              img = isURL? ImageIO.read(new URL(s)) : ImageIO.read(new File(s));
-            }
-            catch (IOException e) {
-              throw new PredictException("Couldn't read image from " + s);
-            }
-          } else if (isText) {
-            // TODO: use model-specific vectorization of text
-            throw new PredictException("MOJO scoring for text classification is not yet implemented.");
-          }
-          else {
-            // numeric
-            try {
-              value = Double.parseDouble(s);
-            } catch(NumberFormatException nfe) {
-              if (!_convertInvalidNumbersToNa)
-                throw new PredictNumberFormatException("Unable to parse value: " + s + ", from column: "+ dataColumnName + ", as Double; " + nfe.getMessage());
-            }
-          }
-        } else if (o instanceof Double) {
-          value = (Double) o;
-        } else if (o instanceof byte[] && isImage) {
-          // Read the image from raw bytes
-          InputStream is = new ByteArrayInputStream((byte[]) o);
-          try {
-            img = ImageIO.read(is);
-          } catch (IOException e) {
-            throw new PredictException("Couldn't interpret raw bytes as an image.");
-          }
-        } else {
-          throw new PredictUnknownTypeException(
-                  "Unexpected object type " + o.getClass().getName() + " for numeric column " + dataColumnName);
-        }
-
-        if (isImage && img != null) {
-          DeepwaterMojoModel dwm = (DeepwaterMojoModel) _m;
-          int W = dwm._width;
-          int H = dwm._height;
-          int C = dwm._channels;
-          float[] _destData = new float[W * H * C];
-          try {
-            GenModel.img2pixels(img, W, H, C, _destData, 0, dwm._meanImageData);
-          } catch (IOException e) {
-            e.printStackTrace();
-            throw new PredictException("Couldn't vectorize image.");
-          }
-          rawData = new double[_destData.length];
-          for (int i = 0; i < rawData.length; ++i)
-            rawData[i] = _destData[i];
-          return rawData;
-        }
-
-        if (Double.isNaN(value)) {
-          // If this point is reached, the original value remains NaN.
-          _errorConsumer.dataTransformError(dataColumnName, o, "Given non-categorical value is unparseable, treating as NaN.");
-        }
-        rawData[index] = value;
-      }
-      else {
-        // Column has categorical value.
-        Object o = data.get(dataColumnName);
-        double value;
-        if (o instanceof String) {
-          String levelName = (String) o;
-          HashMap<String, Integer> columnDomainMap = _domainMap.get(index);
-          Integer levelIndex = columnDomainMap.get(levelName);
-          if (levelIndex == null) {
-            levelIndex = columnDomainMap.get(dataColumnName + "." + levelName);
-          }
-          if (levelIndex == null) {
-            if (_convertUnknownCategoricalLevelsToNa) {
-              value = Double.NaN;
-              _errorConsumer.unseenCategorical(dataColumnName, o, "Previously unseen categorical level detected, marking as NaN.");
-            } else {
-              _errorConsumer.dataTransformError(dataColumnName, o, "Unknown categorical level detected.");
-              throw new PredictUnknownCategoricalLevelException("Unknown categorical level (" + dataColumnName + "," + levelName + ")", dataColumnName, levelName);
-            }
-          }
-          else {
-            value = levelIndex;
-          }
-        } else if (o instanceof Double && Double.isNaN((double)o)) {
-          _errorConsumer.dataTransformError(dataColumnName, o, "Missing factor value detected, setting to NaN");
-          value = (double)o; //Missing factor is the only Double value allowed
-        } else {
-          _errorConsumer.dataTransformError(dataColumnName, o, "Unknown categorical variable type.");
-          throw new PredictUnknownTypeException(
-                  "Unexpected object type " + o.getClass().getName() + " for categorical column " + dataColumnName);
-        }
-        rawData[index] = value;
+      if (convertValue(dataColumnName, o, domainValues, index, rawData)) {
+        return rawData;
       }
     }
     return rawData;
   }
+
+  protected boolean convertValue(String columnName, Object o, String[] domainValues,
+                                 int targetIndex, double[] rawData) throws PredictException {
+    if (domainValues == null) {
+      // Column is either numeric or a string (for images or text)
+      BufferedImage img = null;
+      double value = Double.NaN;
+      if (o instanceof String) {
+        String s = ((String) o).trim();
+        // Url to an image given
+        if (_isImage) {
+          boolean isURL = s.matches("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
+          try {
+            img = isURL ? ImageIO.read(new URL(s)) : ImageIO.read(new File(s));
+          } catch (IOException e) {
+            throw new PredictException("Couldn't read image from " + s);
+          }
+        } else if (_isText) {
+          // TODO: use model-specific vectorization of text
+          throw new PredictException("MOJO scoring for text classification is not yet implemented.");
+        } else {
+          // numeric
+          try {
+            value = Double.parseDouble(s);
+          } catch (NumberFormatException nfe) {
+            if (!_convertInvalidNumbersToNa)
+              throw new PredictNumberFormatException("Unable to parse value: " + s + ", from column: " + columnName + ", as Double; " + nfe.getMessage());
+          }
+        }
+      } else if (o instanceof Double) {
+        value = (Double) o;
+      } else if (o instanceof byte[] && _isImage) {
+        // Read the image from raw bytes
+        InputStream is = new ByteArrayInputStream((byte[]) o);
+        try {
+          img = ImageIO.read(is);
+        } catch (IOException e) {
+          throw new PredictException("Couldn't interpret raw bytes as an image.");
+        }
+      } else {
+        throw new PredictUnknownTypeException(
+                "Unexpected object type " + o.getClass().getName() + " for numeric column " + columnName);
+      }
+
+      if (_isImage && img != null) {
+        DeepwaterMojoModel dwm = (DeepwaterMojoModel) _m;
+        int W = dwm._width;
+        int H = dwm._height;
+        int C = dwm._channels;
+        float[] _destData = new float[W * H * C];
+        try {
+          GenModel.img2pixels(img, W, H, C, _destData, 0, dwm._meanImageData);
+        } catch (IOException e) {
+          e.printStackTrace();
+          throw new PredictException("Couldn't vectorize image.");
+        }
+        rawData = new double[_destData.length];
+        for (int i = 0; i < rawData.length; ++i)
+          rawData[i] = _destData[i];
+        return true;
+      }
+
+      if (Double.isNaN(value)) {
+        // If this point is reached, the original value remains NaN.
+        _errorConsumer.dataTransformError(columnName, o, "Given non-categorical value is unparseable, treating as NaN.");
+      }
+      rawData[targetIndex] = value;
+    } else {
+      // Column has categorical value.
+      double value;
+      if (o instanceof String) {
+        String levelName = (String) o;
+        HashMap<String, Integer> columnDomainMap = _domainMap.get(targetIndex);
+        Integer levelIndex = columnDomainMap.get(levelName);
+        if (levelIndex == null) {
+          levelIndex = columnDomainMap.get(columnName + "." + levelName);
+        }
+        if (levelIndex == null) {
+          if (_convertUnknownCategoricalLevelsToNa) {
+            value = Double.NaN;
+            _errorConsumer.unseenCategorical(columnName, o, "Previously unseen categorical level detected, marking as NaN.");
+          } else {
+            _errorConsumer.dataTransformError(columnName, o, "Unknown categorical level detected.");
+            throw new PredictUnknownCategoricalLevelException("Unknown categorical level (" + columnName + "," + levelName + ")", columnName, levelName);
+          }
+        } else {
+          value = levelIndex;
+        }
+      } else if (o instanceof Double && Double.isNaN((double) o)) {
+        _errorConsumer.dataTransformError(columnName, o, "Missing factor value detected, setting to NaN");
+        value = (double) o; //Missing factor is the only Double value allowed
+      } else {
+        _errorConsumer.dataTransformError(columnName, o, "Unknown categorical variable type.");
+        throw new PredictUnknownTypeException(
+                "Unexpected object type " + o.getClass().getName() + " for categorical column " + columnName);
+      }
+      rawData[targetIndex] = value;
+    }
+
+    return false;
+  }
+
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
@@ -105,7 +105,7 @@ public class PredictCsv {
     switch (category) {
       case AutoEncoder:
         String[] cnames =  this.model.m.getNames();
-        int numCats = this.model.domainMap.size();
+        int numCats = this.model.m.nCatFeatures();
         int numNums = this.model.m.nfeatures()-numCats;
         String[][] domainValues = this.model.m.getDomainValues();
         int lastCatIdx = numCats-1;

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModelTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModelTest.java
@@ -1,9 +1,6 @@
 package hex.genmodel.algos.targetencoder;
 
-import hex.genmodel.easy.DomainMapConstructor;
-import hex.genmodel.easy.EasyPredictModelWrapper;
-import hex.genmodel.easy.RowData;
-import hex.genmodel.easy.RowToRawDataConverter;
+import hex.genmodel.easy.*;
 import hex.genmodel.easy.error.VoidErrorConsumer;
 import hex.genmodel.easy.exception.PredictException;
 import org.junit.Test;
@@ -94,7 +91,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col1, 0);
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
+    Map<Integer, CategoricalEncoder> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
     RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
 
 
@@ -167,7 +164,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col1, 0);
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
+    Map<Integer, CategoricalEncoder> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
     RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, new EasyPredictModelWrapper.Config());
 
     RowData rowToPredictFor = new RowData();
@@ -228,7 +225,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col1, 0);
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
+    Map<Integer, CategoricalEncoder> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
     RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
 
     //Case 1:  Unexpected value `C`
@@ -303,7 +300,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col1, 0);
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
+    Map<Integer, CategoricalEncoder> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
     RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
 
     //Case 1:  Unexpected value `C`

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModelTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/targetencoder/TargetEncoderMojoModelTest.java
@@ -1,6 +1,7 @@
 package hex.genmodel.algos.targetencoder;
 
 import hex.genmodel.easy.DomainMapConstructor;
+import hex.genmodel.easy.EasyPredictModelWrapper;
 import hex.genmodel.easy.RowData;
 import hex.genmodel.easy.RowToRawDataConverter;
 import hex.genmodel.easy.error.VoidErrorConsumer;
@@ -12,6 +13,10 @@ import java.util.*;
 import static org.junit.Assert.*;
 
 public class TargetEncoderMojoModelTest {
+  
+  private final EasyPredictModelWrapper.Config config = new EasyPredictModelWrapper.Config()
+          .setConvertInvalidNumbersToNa(true)
+          .setConvertUnknownCategoricalLevelsToNa(true);
   
   @Test
   public void computeLambda(){
@@ -90,7 +95,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
     HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
-    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, true, true);
+    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
 
 
     // Case when number of training examples equal to inflection point. Encoding should be between prior and posterior
@@ -163,7 +168,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
     HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
-    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, true, true);
+    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, new EasyPredictModelWrapper.Config());
 
     RowData rowToPredictFor = new RowData();
     rowToPredictFor.put(numerical_col1, 42.0);
@@ -224,7 +229,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
     HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
-    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, true, true);
+    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
 
     //Case 1:  Unexpected value `C`
     RowData rowToPredictFor = new RowData();
@@ -299,7 +304,7 @@ public class TargetEncoderMojoModelTest {
     modelColumnNameToIndexMap.put(numerical_col2, 2);
 
     HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(targetEncoderMojoModel).create();
-    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, true, true);
+    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(targetEncoderMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
 
     //Case 1:  Unexpected value `C`
     RowData rowToPredictFor = new RowData();

--- a/h2o-genmodel/src/test/java/hex/genmodel/easy/DomainMapConstructorTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/easy/DomainMapConstructorTest.java
@@ -3,7 +3,9 @@ package hex.genmodel.easy;
 import hex.genmodel.easy.stub.TestMojoModel;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -14,13 +16,26 @@ public class DomainMapConstructorTest {
 
     TestMojoModel testMojoModel = new TestMojoModel();
 
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(testMojoModel).create();
-    
-    assertEquals(0, (int)domainMap.get(0).get("S"));
-    assertEquals(1, (int)domainMap.get(0).get("Q"));
-    assertEquals(0, (int)domainMap.get(2).get("male"));
-    assertEquals(1, (int)domainMap.get(2).get("female"));
+    Map<Integer, CategoricalEncoder> domainMap = new DomainMapConstructor(testMojoModel).create();
+
+    checkEncode(domainMap, 0, 0, "S");
+    checkEncode(domainMap, 1, 0, "Q");
+    checkEncode(domainMap, 0, 2, "male");
+    checkEncode(domainMap, 1, 2, "female");
     
     assertFalse(domainMap.containsKey(1));
   }
+  
+  private static void checkEncode(Map<Integer, CategoricalEncoder> domainMap, int expectedLabel, int colIndex, String levelName) {
+    double[] actual = new double[3];
+    Arrays.fill(actual, Double.NaN);
+    double[] expected = new double[3];
+    Arrays.fill(expected, Double.NaN);
+    expected[colIndex] = expectedLabel;
+
+    domainMap.get(colIndex).encodeCatValue(levelName, actual);
+    
+    assertArrayEquals(expected, actual, 0);
+  }
+
 }

--- a/h2o-genmodel/src/test/java/hex/genmodel/easy/EasyPredictModelWrapperTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/easy/EasyPredictModelWrapperTest.java
@@ -506,9 +506,7 @@ public class EasyPredictModelWrapperTest {
     MyAutoEncoderModel model = new MyAutoEncoderModel();
     EasyPredictModelWrapper m = new EasyPredictModelWrapper(model);
 
-    Field errorConsumerField = m.getClass().getDeclaredField("errorConsumer");
-    errorConsumerField.setAccessible(true);
-    Object errorConsumer = errorConsumerField.get(m);
+    EasyPredictModelWrapper.ErrorConsumer errorConsumer = m.getErrorConsumer();
     Assert.assertNotNull(errorConsumer);
     Assert.assertEquals(VoidErrorConsumer.class, errorConsumer.getClass());
   }
@@ -520,9 +518,7 @@ public class EasyPredictModelWrapperTest {
     EasyPredictModelWrapper modelWrapper = new EasyPredictModelWrapper(new EasyPredictModelWrapper.Config()
         .setModel(model));
 
-    Field errorConsumerField = modelWrapper.getClass().getDeclaredField("errorConsumer");
-    errorConsumerField.setAccessible(true);
-    Object errorConsumer = errorConsumerField.get(modelWrapper);
+    EasyPredictModelWrapper.ErrorConsumer errorConsumer = modelWrapper.getErrorConsumer();
     Assert.assertNotNull(errorConsumer);
     Assert.assertEquals(VoidErrorConsumer.class, errorConsumer.getClass());
   }

--- a/h2o-genmodel/src/test/java/hex/genmodel/easy/RowToRawDataConverterTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/easy/RowToRawDataConverterTest.java
@@ -34,7 +34,7 @@ public class RowToRawDataConverterTest {
 
     // Indices for this map are based on `m.getDomainValues()` method
     HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(testMojoModel).create();
-    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(testMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, true, true);
+    RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(testMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, new EasyPredictModelWrapper.Config());
 
     double[] rawData = new double[rowToPredictFor.size()];
     rowToRawDataConverter.convert(rowToPredictFor, rawData);

--- a/h2o-genmodel/src/test/java/hex/genmodel/easy/RowToRawDataConverterTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/easy/RowToRawDataConverterTest.java
@@ -6,6 +6,7 @@ import hex.genmodel.easy.stub.TestMojoModel;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -33,7 +34,7 @@ public class RowToRawDataConverterTest {
     TestMojoModel testMojoModel = new TestMojoModel();
 
     // Indices for this map are based on `m.getDomainValues()` method
-    HashMap<Integer, HashMap<String, Integer>> domainMap = new DomainMapConstructor(testMojoModel).create();
+    Map<Integer, CategoricalEncoder> domainMap = new DomainMapConstructor(testMojoModel).create();
     RowToRawDataConverter rowToRawDataConverter = new RowToRawDataConverter(testMojoModel, modelColumnNameToIndexMap, domainMap, errorConsumer, new EasyPredictModelWrapper.Config());
 
     double[] rawData = new double[rowToPredictFor.size()];


### PR DESCRIPTION
This PR refactors EasyPredictModelWrapper in order to be able to add support for 1-hot encoding to POJO/MOJO.

- DeepWater-specific code is refactored out of the common class
- new interface CategoricalEncoder is introduced in order to enable other encoding (not just enum/label) encoding