### PR TITLE
PUBDEV-6967 - TE broken in flow - response_column parameter not exposed.

### DIFF
--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -228,7 +228,7 @@ public class RequestServer extends HttpServlet {
   @Override protected void doHead(HttpServletRequest rq, HttpServletResponse rs)   { doGeneric("HEAD", rq, rs); }
   @Override protected void doDelete(HttpServletRequest rq, HttpServletResponse rs) { doGeneric("DELETE", rq, rs); }
   @Override protected void doOptions(HttpServletRequest rq, HttpServletResponse rs) {
-    if (true) {
+    if (System.getProperty(H2O.OptArgs.SYSTEM_DEBUG_CORS) != null) {
       rs.setHeader("Access-Control-Allow-Origin", "*");
       rs.setHeader("Access-Control-Allow-Headers", "Content-Type");
       rs.setStatus(HttpServletResponse.SC_OK);

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -228,7 +228,7 @@ public class RequestServer extends HttpServlet {
   @Override protected void doHead(HttpServletRequest rq, HttpServletResponse rs)   { doGeneric("HEAD", rq, rs); }
   @Override protected void doDelete(HttpServletRequest rq, HttpServletResponse rs) { doGeneric("DELETE", rq, rs); }
   @Override protected void doOptions(HttpServletRequest rq, HttpServletResponse rs) {
-    if (System.getProperty(H2O.OptArgs.SYSTEM_DEBUG_CORS) != null) {
+    if (true) {
       rs.setHeader("Access-Control-Allow-Origin", "*");
       rs.setHeader("Access-Control-Allow-Headers", "Content-Type");
       rs.setStatus(HttpServletResponse.SC_OK);

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -16,7 +16,7 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, Ta
     @API(help = "Inflection point. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.")
     public double k;
 
-    @API(help = "Smooothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.")
+    @API(help = "Smoothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.")
     public double f;
 
     @API(help = "Data leakage handling strategy. Default to None.", values = {"None", "KFold", "LeaveOneOut"})

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -29,6 +29,7 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, Ta
       params.add("ignored_columns");
       params.add("training_frame");
       params.add("fold_column");
+      params.add("response_column");
   
       return params.toArray(new String[0]);
     }

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -21,7 +21,7 @@ class H2OTargetEncoderEstimator(H2OEstimator):
 
     algo = "targetencoder"
     param_names = {"blending", "k", "f", "data_leakage_handling", "model_id", "ignored_columns", "training_frame",
-                   "fold_column"}
+                   "fold_column", "response_column"}
 
     def __init__(self, **kwargs):
         super(H2OTargetEncoderEstimator, self).__init__()
@@ -139,6 +139,21 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     def fold_column(self, fold_column):
         assert_is_type(fold_column, None, str)
         self._parms["fold_column"] = fold_column
+
+
+    @property
+    def response_column(self):
+        """
+        Response variable column.
+
+        Type: ``str``.
+        """
+        return self._parms.get("response_column")
+
+    @response_column.setter
+    def response_column(self, response_column):
+        assert_is_type(response_column, None, str)
+        self._parms["response_column"] = response_column
 
 
     def transform(self, frame, data_leakage_handling="None", noise=-1, seed=-1):

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -70,7 +70,7 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     @property
     def f(self):
         """
-        Smooothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.
+        Smoothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.
 
         Type: ``float``  (default: ``10``).
         """

--- a/h2o-r/h2o-package/R/targetencoder.R
+++ b/h2o-r/h2o-package/R/targetencoder.R
@@ -14,7 +14,7 @@
 #' @param blending \code{Logical}. Blending enabled/disabled Defaults to FALSE.
 #' @param k Inflection point. Used for blending (if enabled). Blending is to be enabled separately using the 'blending'
 #'        parameter. Defaults to 20.
-#' @param f Smooothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending'
+#' @param f Smoothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending'
 #'        parameter. Defaults to 10.
 #' @param data_leakage_handling Data leakage handling strategy. Default to None. Must be one of: "None", "KFold", "LeaveOneOut". Defaults to
 #'        None.

--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.10.7"
+    "h2o-flow": "0.10.8"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6967

Ẃe're accidentally not exposing `response_column` parameter, which results in Flow not showing it as an option. All other APIs were working fine. Also fixes a typo on "Smoothing" parameter help ( cc @angela0xdata ).

YouTube video demonstration:

[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/LXNk92e3tRI/0.jpg)](https://www.youtube.com/watch?v=LXNk92e3tRI)


Flow PR: https://github.com/h2oai/h2o-flow/pull/148
