### PR TITLE
replace nonexistent 'continue' keyword in R with 'next'

### DIFF
--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -957,7 +957,7 @@ assertCorrectSkipColumns <-
           # only tests half of the columns to save time
           print(paste0("testing column ", ind))
           if (allFrameTypes[ind] == "uuid")
-            continue
+            next
           for (rind in c(1:rowNum)) {
             if (is.na(f1R[rind, ind]))
               expect_true(
@@ -1319,7 +1319,7 @@ assertCorrectSkipColumnsNamesTypes <- function(originalFile, parsePath, skippedC
     for (ind in c(1:length(cfullnames))) {
         if (cfullnames[ind] == cskipnames[skipcount]) {
             if (allFrameTypes[ind] == "uuid")
-            continue
+              next
             for (rind in c(1:rowNum)) {
                 if (is.na(originalR[rind, ind])) {
                     expect_true(


### PR DESCRIPTION
was causing test errors in some conditions, for example in `PUBDEV_5705_drop_columns_parser_arff_large.R`:
```
>
[2019-10-16 15:09:31] [ERROR] : Error: Test failed: 'Test ARFF Parse with skipped columns'
* object 'continue' not found
1: withWarnings(test())
2: withCallingHandlers(expr, warning = wHandler)
3: test()
4: assertCorrectSkipColumns(fileName, fullFrameR, skip99Per, TRUE, h2o.getTypes(f1))
```