### PR TITLE
PUBDEV-6992: Deprecated Frame.find(Vec) and Frame.find(Key)

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -384,7 +384,8 @@ public class Frame extends Lockable<Frame> {
 
   /**   Finds the matching column index, or -1 if missing
    *  @return the matching column index, or -1 if missing 
-   *  @deprecated as many columns in a Frame could be backed by the same Vec, we can't return single column index that corresponds to a given {@code vec}
+   *  @deprecated as many columns in a Frame could be backed by the same Vec, we can't return single column index that corresponds to a given {@code vec}.
+   *  Please use {@link #find(String)} instead.
    */
   @Deprecated()
   public int find( Vec vec ) {
@@ -398,7 +399,8 @@ public class Frame extends Lockable<Frame> {
 
   /**   Finds the matching column index, or -1 if missing
    *  @return the matching column index, or -1 if missing 
-   *  @deprecated as many columns in a Frame could be backed by the same Vec (and its key), we can't return single column index that corresponds to a given {@code key}
+   *  @deprecated as many columns in a Frame could be backed by the same Vec (and its key), we can't return single column index that corresponds to a given {@code key}.
+   *  Please use {@link #find(String)} instead.
    */
   @Deprecated
   public int find( Key key ) {

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -383,7 +383,10 @@ public class Frame extends Lockable<Frame> {
   }
 
   /**   Finds the matching column index, or -1 if missing
-   *  @return the matching column index, or -1 if missing */
+   *  @return the matching column index, or -1 if missing 
+   *  @deprecated as many columns in a Frame could be backed by the same Vec, we can't return single column index that corresponds to a given {@code vec}
+   */
+  @Deprecated()
   public int find( Vec vec ) {
     Vec[] vecs = vecs(); //warning: side-effect
     if (vec == null) return -1;
@@ -394,7 +397,10 @@ public class Frame extends Lockable<Frame> {
   }
 
   /**   Finds the matching column index, or -1 if missing
-   *  @return the matching column index, or -1 if missing */
+   *  @return the matching column index, or -1 if missing 
+   *  @deprecated as many columns in a Frame could be backed by the same Vec (and its key), we can't return single column index that corresponds to a given {@code key}
+   */
+  @Deprecated
   public int find( Key key ) {
     for( int i=0; i<_keys.length; i++ )
       if( key.equals(_keys[i]) )


### PR DESCRIPTION
This PR is an implementation of the suggestion from discussion https://github.com/h2oai/h2o-3/pull/3975#discussion_r335547805 