### PR TITLE
XGBoost - xgboost consumes a lot of memory in distributed mode

### DIFF
--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
@@ -124,6 +124,7 @@ public class XGBoostUpdater extends Thread {
         // Do one iteration
         assert _booster != null;
         _booster.update(_trainMat, _tid);
+        _booster.saveRabitCheckpoint();
       }
       return _booster;
     }


### PR DESCRIPTION
- after comparison with XGBoost code I discovered a missing call to Rabit.checkpoint()