### PR TITLE
PUBDEV-6996: Python Docs: Remove examples for `ignored_columns` and `response_column`

### DIFF
--- a/h2o-bindings/bin/custom/python/gen_drf.py
+++ b/h2o-bindings/bin/custom/python/gen_drf.py
@@ -150,39 +150,6 @@ examples = dict(
 ...                fold_column="fold_numbers")
 >>> cars_drf.auc(xval=True)
 """,
-    response_column="""
->>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
->>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
->>> predictors = ["displacement","power","weight","acceleration","year"]
->>> response_column = "economy_20mpg"
->>> train, valid = cars.split_frame(ratios = [.8],
-...                                 seed = 1234)
->>> cars_drf = H2ORandomForestEstimator(seed = 1234)
->>> cars_drf.train(x = predictors,
-...                y = response_column,
-...                training_frame = train,
-...                validation_frame = valid)
->>> cars_drf.auc(valid=True)
-""",
-    ignored_columns="""
->>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
->>> airlines["Year"]= airlines["Year"].asfactor()
->>> airlines["Month"]= airlines["Month"].asfactor()
->>> airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
->>> airlines["Cancelled"] = airlines["Cancelled"].asfactor()
->>> airlines['FlightNum'] = airlines['FlightNum'].asfactor()
->>> predictors = airlines.columns[:9]
->>> response = "IsDepDelayed"
->>> train, valid= airlines.split_frame(ratios = [.8],
-...                                   seed = 1234)
->>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
->>> airlines_drf = H2ORandomForestEstimator(ignored_columns = col_list,
-...                                         seed =1234)
->>> airlines_drf.train(y=response,
-...                    training_frame = train,
-...                    validation_frame = valid)
->>> airlines_drf.auc(valid=True)
-""",
     ignore_const_cols="""
 >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
 >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()

--- a/h2o-bindings/bin/custom/python/gen_gbm.py
+++ b/h2o-bindings/bin/custom/python/gen_gbm.py
@@ -160,37 +160,6 @@ examples = dict(
 ...                fold_column="fold_numbers")
 >>> cars_gbm.auc(xval=True)
 """,
-    response_column="""
->>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
->>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
->>> predictors = ["displacement","power","weight","acceleration","year"]
->>> response_column = "economy_20mpg"
->>> train, valid = cars.split_frame(ratios = [.8], seed = 1234)
->>> cars_gbm = H2OGradientBoostingEstimator(seed = 1234)
->>> cars_gbm.train(x = predictors,
-...                y = response_column,
-...                training_frame = train,
-...                validation_frame = valid)
->>> cars_gbm.auc(valid=True)
-""",
-    ignored_columns="""
->>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
->>> airlines["Year"]= airlines["Year"].asfactor()
->>> airlines["Month"]= airlines["Month"].asfactor()
->>> airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
->>> airlines["Cancelled"] = airlines["Cancelled"].asfactor()
->>> airlines['FlightNum'] = airlines['FlightNum'].asfactor()
->>> predictors = airlines.columns[:9]
->>> response = "IsDepDelayed"
->>> train, valid= airlines.split_frame(ratios = [.8], seed = 1234)
->>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
->>> airlines_gbm = H2OGradientBoostingEstimator(ignored_columns = col_list,
-...                                             seed = 1234)
->>> airlines_gbm.train(y=response,
-...                    training_frame=train,
-...                    validation_frame=valid)
-airlines_gbm.auc(valid=True)
-""",
     ignore_const_cols="""
 >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
 >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()

--- a/h2o-bindings/bin/custom/python/gen_glm.py
+++ b/h2o-bindings/bin/custom/python/gen_glm.py
@@ -270,35 +270,6 @@ examples = dict(
 ...                fold_column="fold_numbers")
 >>> cars_glm.auc(xval=True)
 """,
-    response_column="""
->>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
->>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
->>> predictors = ["displacement","power","weight","acceleration","year"]
->>> response_column = "economy_20mpg"
->>> train, valid = cars.split_frame(ratios = [.8], seed = 1234)
->>> cars_glm = H2OGeneralizedLinearEstimator(seed = 1234,
-...                                          family = 'binomial')
->>> cars_glm.train(x = predictors,
-...                y = response_column,
-...                training_frame = train,
-...                validation_frame = valid)
->>> cars_glm.auc(valid=True)
-""",
-    ignored_columns="""
->>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
->>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
->>> predictors = ["displacement","power","weight","acceleration","year"]
->>> response = "economy_20mpg"
->>> train, valid = cars.split_frame(ratios = [.8], seed = 1234)
->>> ignored_col = ["cylinders","power"]
->>> cars_glm = H2OGeneralizedLinearEstimator(seed = 1234,
-...                                          family='binomial',
-...                                          ignored_columns=ignored_col)
->>> cars_glm.train(y=response,
-...                training_frame=train,
-...                validation_frame=valid)
->>> cars_glm.auc()
-""",
     ignore_const_cols="""
 >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
 >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()

--- a/h2o-bindings/bin/custom/python/gen_isolationforest.py
+++ b/h2o-bindings/bin/custom/python/gen_isolationforest.py
@@ -82,16 +82,6 @@ examples = dict(
 ...               training_frame = cars)
 >>> cars_if.model_performance()
 """,
-    ignored_columns="""
->>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
->>> predictors = airlines.columns[:9]
->>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
->>> airlines_if = H2OIsolationForestEstimator(ignored_columns = col_list,
-...                                           seed = 1234)
->>> airlines_if.train(x = predictors,
-...                   training_frame = airlines)
->>> airlines_if.model_performance()
-""",
     max_depth="""
 >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
 >>> predictors = ["displacement","power","weight","acceleration","year"]

--- a/h2o-bindings/bin/custom/python/gen_kmeans.py
+++ b/h2o-bindings/bin/custom/python/gen_kmeans.py
@@ -78,16 +78,6 @@ examples = dict(
 ...               validation_frame = valid)
 >>> cars_km.scoring_history()
 """,
-    ignored_columns="""
->>> ozone = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/glm_test/ozone.csv")
->>> train, valid = ozone.split_frame(ratios = [.8], seed = 1234)
->>> ignore_col = ["wind"]
->>> ozone_km = H2OKMeansEstimator(ignored_columns = ignore_col,
-...                               seed = 1234)
->>> ozone_km.train(training_frame = train,
-...                validation_frame = valid)
->>> ozone_km.scoring_history()
-""",
     init="""
 >>> seeds = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/flow_examples/seeds_dataset.txt")
 >>> predictors = seeds.columns[0:7]

--- a/h2o-bindings/bin/custom/python/gen_naivebayes.py
+++ b/h2o-bindings/bin/custom/python/gen_naivebayes.py
@@ -130,24 +130,6 @@ examples = dict(
 ...               validation_frame = valid)
 >>> cars_nb.auc()
 """,
-    ignored_columns="""
->>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
->>> airlines["Year"]= airlines["Year"].asfactor()
->>> airlines["Month"]= airlines["Month"].asfactor()
->>> airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
->>> airlines["Cancelled"] = airlines["Cancelled"].asfactor()
->>> airlines['FlightNum'] = airlines['FlightNum'].asfactor()
->>> predictors = airlines.columns[:9]
->>> response = "IsDepDelayed"
->>> train, valid= airlines.split_frame(ratios = [.8], seed = 1234)
->>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
->>> airlines_nb = H2ONaiveBayesEstimator(ignored_columns = col_list,
-...                                      seed = 1234)
->>> airlines_nb.train(y = response,
-...                   training_frame = train,
-...                   validation_frame = valid)
->>> airlines_nb.auc()
-""",
     keep_cross_validation_fold_assignment="""
 >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
 >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
@@ -290,17 +272,6 @@ examples = dict(
 ...                                  seed = 1234)
 >>> cars_nb.train(x = predictors,
 ...               y = response,
-...               training_frame = cars)
->>> cars_nb.auc()
-""",
-    response_column="""
->>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
->>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
->>> predictors = ["displacement","power","weight","acceleration","year"]
->>> response_column = "economy_20mpg"
->>> cars_nb = H2ONaiveBayesEstimator(seed = 1234)
->>> cars_nb.train(x = predictors,
-...               y = response_column,
 ...               training_frame = cars)
 >>> cars_nb.auc()
 """,

--- a/h2o-bindings/bin/custom/python/gen_xgboost.py
+++ b/h2o-bindings/bin/custom/python/gen_xgboost.py
@@ -175,33 +175,6 @@ examples = dict(
 ...                   fold_column="fold_numbers")
 >>> titanic_xgb.auc(xval=True)
 """,
-    response_column="""
->>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
->>> titanic['survived'] = titanic['survived'].asfactor()
->>> predictors = titanic.columns
->>> del predictors[1:3]
->>> response = 'survived'
->>> train, valid = titanic.split_frame(ratios = [.8],
-...                                    seed = 1234)
->>> titanic_xgb = H2OXGBoostEstimator(seed = 1234)
->>> titanic_xgb.train(x=predictors,
-...                   y=response,
-...                   training_frame=train,
-...                   validation_frame=valid)
->>> titanic_xgb.auc(valid=True)
-""",
-    ignored_columns="""
->>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
->>> titanic['survived'] = titanic['survived'].asfactor()
->>> response = 'survived'
->>> train, valid = titanic.split_frame(ratios = [.8], seed = 1234)
->>> titanic_xgb = H2OXGBoostEstimator(seed = 1234,
-...                                   ignored_columns=["fare","parch"])
->>> titanic_xgb.train(y=response,
-...                   training_frame=train,
-...                   validation_frame=valid)
->>> titanic_xgb.auc(valid=True)
-""",
     ignore_const_cols="""
 >>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
 >>> titanic['survived'] = titanic['survived'].asfactor()

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -360,20 +360,6 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         Response variable column.
 
         Type: ``str``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
-        >>> predictors = ["displacement","power","weight","acceleration","year"]
-        >>> response_column = "economy_20mpg"
-        >>> train, valid = cars.split_frame(ratios = [.8], seed = 1234)
-        >>> cars_gbm = H2OGradientBoostingEstimator(seed = 1234)
-        >>> cars_gbm.train(x = predictors,
-        ...                y = response_column,
-        ...                training_frame = train,
-        ...                validation_frame = valid)
-        >>> cars_gbm.auc(valid=True)
         """
         return self._parms.get("response_column")
 
@@ -389,25 +375,6 @@ class H2OGradientBoostingEstimator(H2OEstimator):
         Names of columns to ignore for training.
 
         Type: ``List[str]``.
-
-        :examples:
-
-        >>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
-        >>> airlines["Year"]= airlines["Year"].asfactor()
-        >>> airlines["Month"]= airlines["Month"].asfactor()
-        >>> airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
-        >>> airlines["Cancelled"] = airlines["Cancelled"].asfactor()
-        >>> airlines['FlightNum'] = airlines['FlightNum'].asfactor()
-        >>> predictors = airlines.columns[:9]
-        >>> response = "IsDepDelayed"
-        >>> train, valid= airlines.split_frame(ratios = [.8], seed = 1234)
-        >>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
-        >>> airlines_gbm = H2OGradientBoostingEstimator(ignored_columns = col_list,
-        ...                                             seed = 1234)
-        >>> airlines_gbm.train(y=response,
-        ...                    training_frame=train,
-        ...                    validation_frame=valid)
-        airlines_gbm.auc(valid=True)
         """
         return self._parms.get("ignored_columns")
 

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -344,21 +344,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         Response variable column.
 
         Type: ``str``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
-        >>> predictors = ["displacement","power","weight","acceleration","year"]
-        >>> response_column = "economy_20mpg"
-        >>> train, valid = cars.split_frame(ratios = [.8], seed = 1234)
-        >>> cars_glm = H2OGeneralizedLinearEstimator(seed = 1234,
-        ...                                          family = 'binomial')
-        >>> cars_glm.train(x = predictors,
-        ...                y = response_column,
-        ...                training_frame = train,
-        ...                validation_frame = valid)
-        >>> cars_glm.auc(valid=True)
         """
         return self._parms.get("response_column")
 
@@ -374,22 +359,6 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         Names of columns to ignore for training.
 
         Type: ``List[str]``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
-        >>> predictors = ["displacement","power","weight","acceleration","year"]
-        >>> response = "economy_20mpg"
-        >>> train, valid = cars.split_frame(ratios = [.8], seed = 1234)
-        >>> ignored_col = ["cylinders","power"]
-        >>> cars_glm = H2OGeneralizedLinearEstimator(seed = 1234,
-        ...                                          family='binomial',
-        ...                                          ignored_columns=ignored_col)
-        >>> cars_glm.train(y=response,
-        ...                training_frame=train,
-        ...                validation_frame=valid)
-        >>> cars_glm.auc()
         """
         return self._parms.get("ignored_columns")
 

--- a/h2o-py/h2o/estimators/isolation_forest.py
+++ b/h2o-py/h2o/estimators/isolation_forest.py
@@ -123,17 +123,6 @@ class H2OIsolationForestEstimator(H2OEstimator):
         Names of columns to ignore for training.
 
         Type: ``List[str]``.
-
-        :examples:
-
-        >>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
-        >>> predictors = airlines.columns[:9]
-        >>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
-        >>> airlines_if = H2OIsolationForestEstimator(ignored_columns = col_list,
-        ...                                           seed = 1234)
-        >>> airlines_if.train(x = predictors,
-        ...                   training_frame = airlines)
-        >>> airlines_if.model_performance()
         """
         return self._parms.get("ignored_columns")
 

--- a/h2o-py/h2o/estimators/kmeans.py
+++ b/h2o-py/h2o/estimators/kmeans.py
@@ -266,17 +266,6 @@ class H2OKMeansEstimator(H2OEstimator):
         Names of columns to ignore for training.
 
         Type: ``List[str]``.
-
-        :examples:
-
-        >>> ozone = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/glm_test/ozone.csv")
-        >>> train, valid = ozone.split_frame(ratios = [.8], seed = 1234)
-        >>> ignore_col = ["wind"]
-        >>> ozone_km = H2OKMeansEstimator(ignored_columns = ignore_col,
-        ...                               seed = 1234)
-        >>> ozone_km.train(training_frame = train,
-        ...                validation_frame = valid)
-        >>> ozone_km.scoring_history()
         """
         return self._parms.get("ignored_columns")
 

--- a/h2o-py/h2o/estimators/naive_bayes.py
+++ b/h2o-py/h2o/estimators/naive_bayes.py
@@ -325,18 +325,6 @@ class H2ONaiveBayesEstimator(H2OEstimator):
         Response variable column.
 
         Type: ``str``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
-        >>> predictors = ["displacement","power","weight","acceleration","year"]
-        >>> response_column = "economy_20mpg"
-        >>> cars_nb = H2ONaiveBayesEstimator(seed = 1234)
-        >>> cars_nb.train(x = predictors,
-        ...               y = response_column,
-        ...               training_frame = cars)
-        >>> cars_nb.auc()
         """
         return self._parms.get("response_column")
 
@@ -352,25 +340,6 @@ class H2ONaiveBayesEstimator(H2OEstimator):
         Names of columns to ignore for training.
 
         Type: ``List[str]``.
-
-        :examples:
-
-        >>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
-        >>> airlines["Year"]= airlines["Year"].asfactor()
-        >>> airlines["Month"]= airlines["Month"].asfactor()
-        >>> airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
-        >>> airlines["Cancelled"] = airlines["Cancelled"].asfactor()
-        >>> airlines['FlightNum'] = airlines['FlightNum'].asfactor()
-        >>> predictors = airlines.columns[:9]
-        >>> response = "IsDepDelayed"
-        >>> train, valid= airlines.split_frame(ratios = [.8], seed = 1234)
-        >>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
-        >>> airlines_nb = H2ONaiveBayesEstimator(ignored_columns = col_list,
-        ...                                      seed = 1234)
-        >>> airlines_nb.train(y = response,
-        ...                   training_frame = train,
-        ...                   validation_frame = valid)
-        >>> airlines_nb.auc()
         """
         return self._parms.get("ignored_columns")
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -353,21 +353,6 @@ class H2ORandomForestEstimator(H2OEstimator):
         Response variable column.
 
         Type: ``str``.
-
-        :examples:
-
-        >>> cars = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/junit/cars_20mpg.csv")
-        >>> cars["economy_20mpg"] = cars["economy_20mpg"].asfactor()
-        >>> predictors = ["displacement","power","weight","acceleration","year"]
-        >>> response_column = "economy_20mpg"
-        >>> train, valid = cars.split_frame(ratios = [.8],
-        ...                                 seed = 1234)
-        >>> cars_drf = H2ORandomForestEstimator(seed = 1234)
-        >>> cars_drf.train(x = predictors,
-        ...                y = response_column,
-        ...                training_frame = train,
-        ...                validation_frame = valid)
-        >>> cars_drf.auc(valid=True)
         """
         return self._parms.get("response_column")
 
@@ -383,26 +368,6 @@ class H2ORandomForestEstimator(H2OEstimator):
         Names of columns to ignore for training.
 
         Type: ``List[str]``.
-
-        :examples:
-
-        >>> airlines= h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
-        >>> airlines["Year"]= airlines["Year"].asfactor()
-        >>> airlines["Month"]= airlines["Month"].asfactor()
-        >>> airlines["DayOfWeek"] = airlines["DayOfWeek"].asfactor()
-        >>> airlines["Cancelled"] = airlines["Cancelled"].asfactor()
-        >>> airlines['FlightNum'] = airlines['FlightNum'].asfactor()
-        >>> predictors = airlines.columns[:9]
-        >>> response = "IsDepDelayed"
-        >>> train, valid= airlines.split_frame(ratios = [.8],
-        ...                                   seed = 1234)
-        >>> col_list = ['DepTime','CRSDepTime','ArrTime','CRSArrTime']
-        >>> airlines_drf = H2ORandomForestEstimator(ignored_columns = col_list,
-        ...                                         seed =1234)
-        >>> airlines_drf.train(y=response,
-        ...                    training_frame = train,
-        ...                    validation_frame = valid)
-        >>> airlines_drf.auc(valid=True)
         """
         return self._parms.get("ignored_columns")
 

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -337,22 +337,6 @@ class H2OXGBoostEstimator(H2OEstimator):
         Response variable column.
 
         Type: ``str``.
-
-        :examples:
-
-        >>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
-        >>> titanic['survived'] = titanic['survived'].asfactor()
-        >>> predictors = titanic.columns
-        >>> del predictors[1:3]
-        >>> response = 'survived'
-        >>> train, valid = titanic.split_frame(ratios = [.8],
-        ...                                    seed = 1234)
-        >>> titanic_xgb = H2OXGBoostEstimator(seed = 1234)
-        >>> titanic_xgb.train(x=predictors,
-        ...                   y=response,
-        ...                   training_frame=train,
-        ...                   validation_frame=valid)
-        >>> titanic_xgb.auc(valid=True)
         """
         return self._parms.get("response_column")
 
@@ -368,19 +352,6 @@ class H2OXGBoostEstimator(H2OEstimator):
         Names of columns to ignore for training.
 
         Type: ``List[str]``.
-
-        :examples:
-
-        >>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
-        >>> titanic['survived'] = titanic['survived'].asfactor()
-        >>> response = 'survived'
-        >>> train, valid = titanic.split_frame(ratios = [.8], seed = 1234)
-        >>> titanic_xgb = H2OXGBoostEstimator(seed = 1234,
-        ...                                   ignored_columns=["fare","parch"])
-        >>> titanic_xgb.train(y=response,
-        ...                   training_frame=train,
-        ...                   validation_frame=valid)
-        >>> titanic_xgb.auc(valid=True)
         """
         return self._parms.get("ignored_columns")
 


### PR DESCRIPTION
I changed Aggregator, DeepLearning, TargetEncoder, and StackedEnsemble as well; they haven't been merged yet.