### PR TITLE
Fix pyunit_trace.py on kerberized env as well

### DIFF
--- a/h2o-hadoop-common/tests/python/pyunit_trace.py
+++ b/h2o-hadoop-common/tests/python/pyunit_trace.py
@@ -10,19 +10,19 @@ from tests import pyunit_utils
 def trace_request():
     err = None
     try:
-        h2o.api("TRACE /")
+        h2o.api("TRACE /3/Cloud")
     except H2OServerError as e:
         err = e
 
-    msg = str(err.message)
+    msg = str(err.args[0])
 
     assert err is not None
     print("<Error message>")
     print(msg)
     print("</Error Message>")
 
-    # exact message depends on Jetty Version
-    assert (msg.startswith("HTTP 500") and "TRACE method is not supported" in msg) or \
+    # exact message depends on Jetty Version and security settings
+    assert (msg.startswith("HTTP 500") or \
            msg.startswith("HTTP 405 Method Not Allowed")
 
 


### PR DESCRIPTION
is it just py3 but I keep locally getting the error that err has no attribute message
on kerberos, we get just error 500 the actual TRACE error is only visible in h2o logs
