### PR TITLE
Add ability to specify algo parameters (e.g. monotonicity constraints) in H2O AutoML

### DIFF
--- a/h2o-automl/build.gradle
+++ b/h2o-automl/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
   // Test dependencies only
   testCompile "junit:junit:${junitVersion}"
+  testCompile "com.github.stefanbirkner:system-rules:1.18.0"
   testCompile project(path: ":h2o-core", configuration: "testArchives")
   testRuntimeOnly project(":${defaultWebserverModule}")
 }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -2,13 +2,13 @@ package ai.h2o.automl;
 
 import hex.Model;
 import hex.ScoreKeeper;
-import hex.deeplearning.DeepLearningModel;
-import hex.ensemble.StackedEnsembleModel;
-import hex.glm.GLMModel;
+import hex.deeplearning.DeepLearningModel.DeepLearningParameters;
+import hex.ensemble.StackedEnsembleModel.StackedEnsembleParameters;
+import hex.glm.GLMModel.GLMParameters;
 import hex.grid.HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria;
-import hex.tree.drf.DRFModel;
-import hex.tree.gbm.GBMModel;
-import hex.tree.xgboost.XGBoostModel;
+import hex.tree.drf.DRFModel.DRFParameters;
+import hex.tree.gbm.GBMModel.GBMParameters;
+import hex.tree.xgboost.XGBoostModel.XGBoostParameters;
 import water.H2O;
 import water.Iced;
 import water.Key;
@@ -277,12 +277,12 @@ public class AutoMLBuildSpec extends Iced {
 
     private Model.Parameters defaultParameters(Algo algo) {
       switch (algo) {
-        case DeepLearning: return new DeepLearningModel.DeepLearningParameters();
-        case DRF: return new DRFModel.DRFParameters();
-        case GBM: return new GBMModel.GBMParameters();
-        case GLM: return new GLMModel.GLMParameters();
-        case StackedEnsemble: return new StackedEnsembleModel.StackedEnsembleParameters();
-        case XGBoost: return new XGBoostModel.XGBoostParameters();
+        case DeepLearning: return new DeepLearningParameters();
+        case DRF: return new DRFParameters();
+        case GBM: return new GBMParameters();
+        case GLM: return new GLMParameters();
+        case StackedEnsemble: return new StackedEnsembleParameters();
+        case XGBoost: return new XGBoostParameters();
         default: throw new H2OIllegalArgumentException("Custom parameters are not supported for "+algo.name()+".");
       }
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -12,7 +12,6 @@ import hex.tree.xgboost.XGBoostModel;
 import water.H2O;
 import water.Iced;
 import water.Key;
-import water.api.schemas3.JobV3;
 import water.exceptions.H2OIllegalArgumentException;
 import water.exceptions.H2OIllegalValueException;
 import water.fvec.Frame;
@@ -348,9 +347,6 @@ public class AutoMLBuildSpec extends Iced {
   public final AutoMLBuildControl build_control = new AutoMLBuildControl();
   public final AutoMLInput input_spec = new AutoMLInput();
   public final AutoMLBuildModels build_models = new AutoMLBuildModels();
-
-  // output
-  public JobV3 job;
 
   public String project() {
     if (build_control.project_name == null) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -1,5 +1,6 @@
 package ai.h2o.automl;
 
+import ai.h2o.automl.AutoMLBuildSpec.AutoMLCustomParameters;
 import ai.h2o.automl.EventLogEntry.Stage;
 import ai.h2o.automl.WorkAllocations.JobType;
 import ai.h2o.automl.WorkAllocations.Work;
@@ -18,6 +19,7 @@ import water.Job;
 import water.Key;
 import water.exceptions.H2OIllegalArgumentException;
 import water.util.Log;
+import water.util.PojoUtils;
 
 import java.util.Map;
 
@@ -119,6 +121,13 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         params._keep_cross_validation_fold_assignment = buildSpec.build_control.nfolds != 0 && buildSpec.build_control.keep_cross_validation_fold_assignment;
         params._export_checkpoints_dir = buildSpec.build_control.export_checkpoints_dir;
     }
+
+    void setCustomParams(Model.Parameters params) {
+        AutoMLCustomParameters customParams = aml().getBuildSpec().build_models.algo_parameters;
+        if (customParams == null) return;
+        customParams.setCustomParameters(_algo, params);
+    }
+
 
     /**
      * Configures early-stopping for the model or set of models to be built.
@@ -235,6 +244,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
 
             setCommonModelBuilderParams(builder._parms);
             setStoppingCriteria(builder._parms, defaults, true);
+            setCustomParams(builder._parms);
 
             // override model's max_runtime_secs to ensure that the total max_runtime doesn't exceed expectations
             if (_ignoreConstraints)
@@ -307,6 +317,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
 
             setCommonModelBuilderParams(baseParms);
             setStoppingCriteria(baseParms, defaults, false);
+            setCustomParams(baseParms);
 
             AutoMLBuildSpec buildSpec = aml().getBuildSpec();
             RandomDiscreteValueSearchCriteria searchCriteria =

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -19,7 +19,6 @@ import water.Job;
 import water.Key;
 import water.exceptions.H2OIllegalArgumentException;
 import water.util.Log;
-import water.util.PojoUtils;
 
 import java.util.Map;
 
@@ -125,7 +124,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
     void setCustomParams(Model.Parameters params) {
         AutoMLCustomParameters customParams = aml().getBuildSpec().build_models.algo_parameters;
         if (customParams == null) return;
-        customParams.setCustomParameters(_algo, params);
+        customParams.applyCustomParameters(_algo, params);
     }
 
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
@@ -46,7 +46,9 @@ public class GBMStepsProvider implements ModelingStepsProvider<GBMStepsProvider.
             }
 
             GBMParameters prepareModelParameters() {
-                return GBMSteps.prepareModelParameters();
+                GBMParameters gbmParameters = GBMSteps.prepareModelParameters();
+                gbmParameters._ntrees = 10000;
+                return gbmParameters;
             }
         }
 
@@ -111,7 +113,6 @@ public class GBMStepsProvider implements ModelingStepsProvider<GBMStepsProvider.
                         GBMParameters gbmParameters = prepareModelParameters();
 
                         Map<String, Object[]> searchParams = new HashMap<>();
-                        searchParams.put("_ntrees", new Integer[]{10000});
                         searchParams.put("_max_depth", new Integer[]{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17});
                         searchParams.put("_min_rows", new Integer[]{1, 5, 10, 15, 30, 100});
                         searchParams.put("_learn_rate", new Double[]{0.001, 0.005, 0.008, 0.01, 0.05, 0.08, 0.1, 0.5, 0.8});

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -193,20 +193,6 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
         default:
           return (V)value.value();
       }
-//      Class oriClazz = val.getClass();
-//      if (Schema.class.isAssignableFrom(oriClazz)) {
-//        Schema sch = (Schema)val;
-//        return (V)sch.createAndFillImpl();
-//      } else if (oriClazz.isArray() && Schema.class.isAssignableFrom(oriClazz.getComponentType())) {
-//        Schema[] sch =(Schema[])val;
-//        Class<? extends Iced> destClass = sch[0].getImplClass();
-//        Iced[] vals = (Iced[])Array.newInstance(destClass, sch.length);
-//        for (int i=0; i<sch.length; i++) {
-//          vals[i] = sch[i].createAndFillImpl();
-//        }
-//        return (V)vals;
-//      }
-//      return (V)val;
     }
   }
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -163,6 +163,11 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     }
   }
 
+  public static final class AutoMLCustomParametersV99 extends Schema<AutoMLBuildSpec.AutoMLCustomParameters, AutoMLCustomParametersV99> {
+
+
+  }
+
   public static final class AutoMLBuildModelsV99 extends Schema<AutoMLBuildSpec.AutoMLBuildModels, AutoMLBuildModelsV99> {
 
     @API(help="A list of algorithms to skip during the model-building phase.", valuesProvider=AlgoProvider.class, direction=API.Direction.INPUT)
@@ -174,6 +179,8 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help="The list of modeling steps to be used by the AutoML engine (they may not all get executed, depending on other constraints).", direction=API.Direction.INPUT)
     public StepDefinitionV99[] modeling_plan;
 
+    @API(help="Custom algorithm parameters.", direction=API.Direction.INPUT)
+    public AutoMLCustomParametersV99 algo_parameters;
   } // class AutoMLBuildModels
 
   ////////////////

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -175,13 +175,13 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
   }
 
   public static final class AutoMLCustomParameterV99<V> extends Schema<Iced, AutoMLCustomParameterV99<V>> {
-    @API(help="", valuesProvider=ScopeProvider.class, direction=API.Direction.INPUT)
+    @API(help="Scope of application of the parameter (specific algo, or any algo).", valuesProvider=ScopeProvider.class, direction=API.Direction.INPUT)
     public String scope;
 
-    @API(help="", direction=API.Direction.INPUT)
+    @API(help="Name of the model parameter.", direction=API.Direction.INPUT)
     public String name;
 
-    @API(help="", direction=API.Direction.INPUT)
+    @API(help="Value of the model parameter.", direction=API.Direction.INPUT)
     public JSONValue value;
 
     @SuppressWarnings("unchecked")
@@ -213,16 +213,17 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     public AutoMLBuildSpec.AutoMLBuildModels fillImpl(AutoMLBuildSpec.AutoMLBuildModels impl) {
       super.fillImpl(impl, new String[]{"algo_parameters"});
       if (algo_parameters != null) {
+         AutoMLBuildSpec.AutoMLCustomParameters.Builder builder = AutoMLBuildSpec.AutoMLCustomParameters.create();
         for (AutoMLCustomParameterV99 param : algo_parameters) {
           if (ScopeProvider.ANY_ALGO.equals(param.scope)) {
-            impl.algo_parameters.add(param.name, param.getFormattedValue());
+            builder.add(param.name, param.getFormattedValue());
           } else {
             Algo algo = EnumUtils.valueOf(Algo.class, param.scope);
-            impl.algo_parameters.add(algo, param.name, param.getFormattedValue());
+            builder.add(algo, param.name, param.getFormattedValue());
           }
         }
+        impl.algo_parameters = builder.build();
       }
-      impl.algo_parameters.end();
       return impl;
     }
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -164,8 +164,11 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
   }
 
   public static final class AutoMLCustomParametersV99 extends Schema<AutoMLBuildSpec.AutoMLCustomParameters, AutoMLCustomParametersV99> {
-
-
+    @Override
+    public AutoMLBuildSpec.AutoMLCustomParameters fillImpl(AutoMLBuildSpec.AutoMLCustomParameters impl) {
+      // conversion logic goes here
+        return impl;
+    }
   }
 
   public static final class AutoMLBuildModelsV99 extends Schema<AutoMLBuildSpec.AutoMLBuildModels, AutoMLBuildModelsV99> {

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -15,6 +15,7 @@ import water.api.schemas3.*;
 import water.api.schemas3.ModelParamsValuesProviders.StoppingMetricValuesProvider;
 import water.util.*;
 
+import java.lang.reflect.Array;
 import java.util.Map;
 
 import static ai.h2o.automl.AutoMLBuildSpec.AutoMLStoppingCriteria.AUTO_STOPPING_TOLERANCE;
@@ -188,11 +189,24 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     V getFormattedValue() {
       switch (name) {
         case "monotone_constraints":
-          final Map<String, Double> kvs = (Map)value.value();
-          return (V)kvs.entrySet().stream().map(e -> new KeyValue(e.getKey(), e.getValue())).toArray(KeyValue[]::new);
+          return (V)value.valueAsArray(KeyValue[].class, KeyValueV3[].class);
         default:
           return (V)value.value();
       }
+//      Class oriClazz = val.getClass();
+//      if (Schema.class.isAssignableFrom(oriClazz)) {
+//        Schema sch = (Schema)val;
+//        return (V)sch.createAndFillImpl();
+//      } else if (oriClazz.isArray() && Schema.class.isAssignableFrom(oriClazz.getComponentType())) {
+//        Schema[] sch =(Schema[])val;
+//        Class<? extends Iced> destClass = sch[0].getImplClass();
+//        Iced[] vals = (Iced[])Array.newInstance(destClass, sch.length);
+//        for (int i=0; i<sch.length; i++) {
+//          vals[i] = sch[i].createAndFillImpl();
+//        }
+//        return (V)vals;
+//      }
+//      return (V)val;
     }
   }
 

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -15,7 +15,6 @@ import water.api.schemas3.*;
 import water.api.schemas3.ModelParamsValuesProviders.StoppingMetricValuesProvider;
 import water.util.*;
 
-import java.lang.reflect.Array;
 import java.util.Map;
 
 import static ai.h2o.automl.AutoMLBuildSpec.AutoMLStoppingCriteria.AUTO_STOPPING_TOLERANCE;

--- a/h2o-automl/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-automl/src/main/resources/META-INF/services/water.api.Schema
@@ -1,6 +1,7 @@
 water.automl.api.schemas3.AutoMLBuildSpecV99
 water.automl.api.schemas3.AutoMLBuildSpecV99$AutoMLBuildControlV99
 water.automl.api.schemas3.AutoMLBuildSpecV99$AutoMLBuildModelsV99
+water.automl.api.schemas3.AutoMLBuildSpecV99$AutoMLCustomParameterV99
 water.automl.api.schemas3.AutoMLBuildSpecV99$AutoMLInputV99
 water.automl.api.schemas3.AutoMLBuildSpecV99$AutoMLStoppingCriteriaV99
 water.automl.api.schemas3.AutoMLV99

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLBuildSpecTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLBuildSpecTest.java
@@ -1,0 +1,150 @@
+package ai.h2o.automl;
+
+import ai.h2o.automl.AutoMLBuildSpec.AutoMLCustomParameters;
+import hex.KeyValue;
+import hex.tree.drf.DRFModel;
+import hex.tree.gbm.GBMModel;
+import hex.tree.xgboost.XGBoostModel;
+import org.junit.Test;
+import water.exceptions.H2OIllegalValueException;
+
+import java.util.Arrays;
+
+public class AutoMLBuildSpecTest {
+
+    @Test
+    public void expect_custom_param_is_set_to_all_algos_supporting_it_by_default() {
+        AutoMLBuildSpec buildSpec = new AutoMLBuildSpec();
+        AutoMLCustomParameters algoParameters = buildSpec.build_models.algo_parameters;
+        assert algoParameters != null;
+        for (Algo algo : Algo.values()) assert !algoParameters.hasCustomParams(algo);
+
+        final String paramName = "monotone_constraints";
+        final KeyValue[] paramValue = new KeyValue[] {new KeyValue("AGE", 1)};
+        algoParameters.add(paramName, paramValue);
+
+        for (Algo algo : Algo.values()) {
+            boolean supportsParam = Arrays.asList(Algo.XGBoost, Algo.GBM).contains(algo);
+            assert algoParameters.hasCustomParams(algo) ^ !supportsParam;
+            assert algoParameters.hasCustomParam(algo, paramName) ^ !supportsParam;
+            assert algoParameters.getCustomParameters(algo) != null;
+            switch (algo) {
+                case XGBoost:
+                    assert paramValue == ((XGBoostModel.XGBoostParameters)algoParameters.getCustomParameters(algo))._monotone_constraints;
+                    break;
+                case GBM:
+                    assert paramValue == ((GBMModel.GBMParameters)algoParameters.getCustomParameters(algo))._monotone_constraints;
+                    break;
+            }
+        }
+    }
+
+
+    @Test
+    public void expect_custom_param_can_be_set_to_a_specific_algo_only() {
+        AutoMLBuildSpec buildSpec = new AutoMLBuildSpec();
+        AutoMLCustomParameters algoParameters = buildSpec.build_models.algo_parameters;
+        assert algoParameters != null;
+        for (Algo algo : Algo.values()) assert !algoParameters.hasCustomParams(algo);
+
+        final String paramName = "monotone_constraints";
+        final KeyValue[] paramValue = new KeyValue[] {new KeyValue("AGE", 1)};
+        algoParameters.add(Algo.GBM, paramName, paramValue);
+
+        for (Algo algo : Algo.values()) {
+            boolean assignedAlgo = Algo.GBM == algo;
+            assert algoParameters.hasCustomParams(algo) ^ !assignedAlgo;
+            assert algoParameters.hasCustomParam(algo, paramName) ^ !assignedAlgo;
+            assert algoParameters.getCustomParameters(algo) != null;
+            switch (algo) {
+                case XGBoost:
+                    assert null == ((XGBoostModel.XGBoostParameters)algoParameters.getCustomParameters(algo))._monotone_constraints;
+                    break;
+                case GBM:
+                    assert paramValue == ((GBMModel.GBMParameters)algoParameters.getCustomParameters(algo))._monotone_constraints;
+                    break;
+            }
+        }
+    }
+
+    @Test
+    public void expect_multiple_params_can_be_chained() {
+        AutoMLBuildSpec buildSpec = new AutoMLBuildSpec();
+        AutoMLCustomParameters algoParameters = buildSpec.build_models.algo_parameters;
+
+        KeyValue[] monotone_constraints = new KeyValue[] {new KeyValue("AGE", 1)};
+        int ntrees = 100;
+        algoParameters.add("monotone_constraints", monotone_constraints)
+                      .add("ntrees", ntrees);
+
+        for (Algo algo : Algo.values()) {
+            boolean supportsNtrees = Arrays.asList(Algo.DRF, Algo.GBM, Algo.XGBoost).contains(algo);
+            assert algoParameters.hasCustomParam(algo, "ntrees") ^ !supportsNtrees;
+            switch (algo) {
+                case DRF:
+                    assert Arrays.equals(algoParameters.getCustomParameterNames(algo), new String[]{"ntrees"});
+                    assert ntrees == ((DRFModel.DRFParameters)algoParameters.getCustomParameters(algo))._ntrees;
+                    break;
+                case GBM:
+                    assert Arrays.equals(algoParameters.getCustomParameterNames(algo), new String[]{"monotone_constraints", "ntrees"});
+                    assert ntrees == ((GBMModel.GBMParameters)algoParameters.getCustomParameters(algo))._ntrees;
+                    assert monotone_constraints == ((GBMModel.GBMParameters)algoParameters.getCustomParameters(algo))._monotone_constraints;
+                    break;
+                case XGBoost:
+                    assert Arrays.equals(algoParameters.getCustomParameterNames(algo), new String[]{"monotone_constraints", "ntrees"});
+                    assert ntrees == ((XGBoostModel.XGBoostParameters)algoParameters.getCustomParameters(algo))._ntrees;
+                    assert monotone_constraints == ((XGBoostModel.XGBoostParameters)algoParameters.getCustomParameters(algo))._monotone_constraints;
+                    break;
+                default:
+                    assert algoParameters.getCustomParameterNames(algo) == null;
+            }
+        }
+    }
+
+    @Test(expected = H2OIllegalValueException.class)
+    public void expect_exception_when_setting_a_wrong_value_to_a_custom_param() {
+        AutoMLBuildSpec buildSpec = new AutoMLBuildSpec();
+        AutoMLCustomParameters algoParameters = buildSpec.build_models.algo_parameters;
+
+        final String paramName = "monotone_constraints";
+        final String paramValue = "wrong";
+        algoParameters.add(Algo.GBM, paramName, paramValue);
+    }
+
+
+    @Test(expected = H2OIllegalValueException.class)
+    public void expect_exception_when_setting_a_custom_param_that_is_not_allowed() {
+        AutoMLBuildSpec buildSpec = new AutoMLBuildSpec();
+        AutoMLCustomParameters algoParameters = buildSpec.build_models.algo_parameters;
+
+        final String paramName = "auto_rebalance";
+        final boolean paramValue = false;
+        algoParameters.add(paramName, paramValue);
+    }
+
+    @Test
+    public void expect_applyCustomParameters_overrides_dest_parameters_with_only_custom_ones() {
+        AutoMLBuildSpec buildSpec = new AutoMLBuildSpec();
+        AutoMLCustomParameters algoParameters = buildSpec.build_models.algo_parameters;
+
+        KeyValue[] monotone_constraints = new KeyValue[] {new KeyValue("AGE", 1)};
+        int ntrees = 100;
+        algoParameters.add("monotone_constraints", monotone_constraints)
+                .add("ntrees", ntrees);
+
+        GBMModel.GBMParameters customParameters = (GBMModel.GBMParameters) algoParameters.getCustomParameters(Algo.GBM);
+        assert customParameters._monotone_constraints == monotone_constraints;
+        assert customParameters._ntrees == ntrees;
+        assert customParameters._seed == -1; //default
+
+        GBMModel.GBMParameters destParameters = new GBMModel.GBMParameters();
+        destParameters._monotone_constraints = new KeyValue[0];
+        destParameters._ntrees = 6666;
+        destParameters._seed = 12345;
+
+        algoParameters.applyCustomParameters(Algo.GBM, destParameters);
+        assert destParameters._monotone_constraints == monotone_constraints;
+        assert destParameters._ntrees == ntrees;
+        assert destParameters._seed == 12345;
+    }
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLBuildSpecTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLBuildSpecTest.java
@@ -21,7 +21,7 @@ public class AutoMLBuildSpecTest {
 
         final String paramName = "monotone_constraints";
         final KeyValue[] paramValue = new KeyValue[] {new KeyValue("AGE", 1)};
-        algoParameters.add(paramName, paramValue);
+        algoParameters.add(paramName, paramValue).end();
 
         for (Algo algo : Algo.values()) {
             boolean supportsParam = Arrays.asList(Algo.XGBoost, Algo.GBM).contains(algo);
@@ -49,7 +49,7 @@ public class AutoMLBuildSpecTest {
 
         final String paramName = "monotone_constraints";
         final KeyValue[] paramValue = new KeyValue[] {new KeyValue("AGE", 1)};
-        algoParameters.add(Algo.GBM, paramName, paramValue);
+        algoParameters.add(Algo.GBM, paramName, paramValue).end();
 
         for (Algo algo : Algo.values()) {
             boolean assignedAlgo = Algo.GBM == algo;
@@ -75,7 +75,8 @@ public class AutoMLBuildSpecTest {
         KeyValue[] monotone_constraints = new KeyValue[] {new KeyValue("AGE", 1)};
         int ntrees = 100;
         algoParameters.add("monotone_constraints", monotone_constraints)
-                      .add("ntrees", ntrees);
+                      .add("ntrees", ntrees)
+                      .end();
 
         for (Algo algo : Algo.values()) {
             boolean supportsNtrees = Arrays.asList(Algo.DRF, Algo.GBM, Algo.XGBoost).contains(algo);
@@ -108,7 +109,7 @@ public class AutoMLBuildSpecTest {
 
         final String paramName = "monotone_constraints";
         final String paramValue = "wrong";
-        algoParameters.add(Algo.GBM, paramName, paramValue);
+        algoParameters.add(Algo.GBM, paramName, paramValue).end();
     }
 
 
@@ -119,7 +120,7 @@ public class AutoMLBuildSpecTest {
 
         final String paramName = "auto_rebalance";
         final boolean paramValue = false;
-        algoParameters.add(paramName, paramValue);
+        algoParameters.add(paramName, paramValue).end();
     }
 
     @Test
@@ -130,7 +131,8 @@ public class AutoMLBuildSpecTest {
         KeyValue[] monotone_constraints = new KeyValue[] {new KeyValue("AGE", 1)};
         int ntrees = 100;
         algoParameters.add("monotone_constraints", monotone_constraints)
-                .add("ntrees", ntrees);
+                      .add("ntrees", ntrees)
+                      .end();
 
         GBMModel.GBMParameters customParameters = (GBMModel.GBMParameters) algoParameters.getCustomParameters(Algo.GBM);
         assert customParameters._monotone_constraints == monotone_constraints;

--- a/h2o-core/src/main/java/water/api/SchemaMetadata.java
+++ b/h2o-core/src/main/java/water/api/SchemaMetadata.java
@@ -423,6 +423,9 @@ public final class SchemaMetadata extends Iced {
     StringBuffer sb = new StringBuffer(type.getCanonicalName());
     sb.delete(0, sb.indexOf(".")+1);
     sb.setCharAt(0, Character.toUpperCase(sb.charAt(0)));
-    return sb.toString().replace(".", "").replace("$", "");
+    return sb.toString()
+            .replaceAll("V\\d+\\.", "") // remove the version number in the middle (for internal classes)
+            .replace(".", "")
+            .replace("$", "");
   }
 }

--- a/h2o-core/src/main/java/water/util/JSONUtils.java
+++ b/h2o-core/src/main/java/water/util/JSONUtils.java
@@ -13,4 +13,7 @@ public class JSONUtils {
   public static Properties parseToProperties(String json) {
     return new Gson().fromJson(json, Properties.class);
   }
+  public static String toJSON(Object o) {
+    return new Gson().toJson(o);
+  }
 }

--- a/h2o-core/src/main/java/water/util/JSONUtils.java
+++ b/h2o-core/src/main/java/water/util/JSONUtils.java
@@ -3,6 +3,7 @@ package water.util;
 import com.google.gson.Gson;
 import water.nbhm.NonBlockingHashMap;
 
+import java.lang.reflect.Type;
 import java.util.Properties;
 
 public class JSONUtils {
@@ -10,9 +11,15 @@ public class JSONUtils {
   public static NonBlockingHashMap<String, Object> parse(String json) {
     return new Gson().fromJson(json, NonBlockingHashMap.class);
   }
+
   public static Properties parseToProperties(String json) {
     return new Gson().fromJson(json, Properties.class);
   }
+
+  public static <T> T parse(String json, Class<T> type) {
+    return new Gson().fromJson(json, type);
+  }
+
   public static String toJSON(Object o) {
     return new Gson().toJson(o);
   }

--- a/h2o-core/src/main/java/water/util/JSONUtils.java
+++ b/h2o-core/src/main/java/water/util/JSONUtils.java
@@ -3,7 +3,6 @@ package water.util;
 import com.google.gson.Gson;
 import water.nbhm.NonBlockingHashMap;
 
-import java.lang.reflect.Type;
 import java.util.Properties;
 
 public class JSONUtils {

--- a/h2o-core/src/main/java/water/util/JSONValue.java
+++ b/h2o-core/src/main/java/water/util/JSONValue.java
@@ -4,6 +4,7 @@ import water.Iced;
 import water.api.Schema;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 
 public class JSONValue<V> extends Iced {
 
@@ -50,4 +51,16 @@ public class JSONValue<V> extends Iced {
         return ts;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JSONValue<?> jsonValue = (JSONValue<?>) o;
+        return Objects.equals(_json, jsonValue._json) && Objects.equals(_clazz, jsonValue._clazz);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_json, _clazz);
+    }
 }

--- a/h2o-core/src/main/java/water/util/JSONValue.java
+++ b/h2o-core/src/main/java/water/util/JSONValue.java
@@ -1,0 +1,21 @@
+package water.util;
+
+import water.Iced;
+
+public class JSONValue<V> extends Iced {
+
+    public static <V> JSONValue<V> fromValue(V v) {
+        return new JSONValue<>(JSONUtils.toJSON(v));
+    }
+
+    protected String _json;
+
+    public JSONValue(String json) {
+        _json = json;
+    }
+
+    @SuppressWarnings("unchecked")
+    public V value() {
+        return (V) JSONUtils.parse(_json);
+    }
+}

--- a/h2o-core/src/main/java/water/util/JSONValue.java
+++ b/h2o-core/src/main/java/water/util/JSONValue.java
@@ -1,21 +1,53 @@
 package water.util;
 
 import water.Iced;
+import water.api.Schema;
+
+import java.lang.reflect.Array;
 
 public class JSONValue<V> extends Iced {
 
+    @SuppressWarnings("unchecked")
     public static <V> JSONValue<V> fromValue(V v) {
-        return new JSONValue<>(JSONUtils.toJSON(v));
+        return new JSONValue(JSONUtils.toJSON(v), v.getClass());
     }
 
     protected String _json;
+    protected Class<V> _clazz;
 
     public JSONValue(String json) {
-        _json = json;
+        this(json, null);
+    }
+
+    public JSONValue(String _json, Class<V> _clazz) {
+        this._json = _json;
+        this._clazz = _clazz;
+    }
+
+    public V value() {
+        return valueAs(_clazz);
     }
 
     @SuppressWarnings("unchecked")
-    public V value() {
-        return (V) JSONUtils.parse(_json);
+    public <T> T valueAs(Class<T> clazz) {
+        if (clazz == null) return (T)JSONUtils.parse(_json);
+        return JSONUtils.parse(_json, clazz);
     }
+
+    public <T extends Iced, S extends Schema<T, S>> T valueAs(Class<T> clazz, Class<S> schema) {
+        S s = valueAs(schema);
+        return s.createAndFillImpl();
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T extends Iced, S extends Schema<T, S>> T[] valueAsArray(Class<T[]> clazz, Class<S[]> schema) {
+        S[] ss = valueAs(schema);
+        Class<T> tClazz = (Class<T>)clazz.getComponentType();
+        T[] ts = (T[])Array.newInstance(tClazz, ss.length);
+        for (int i = 0; i < ss.length; i++) {
+            ts[i] = ss[i].createAndFillImpl();
+        }
+        return ts;
+    }
+
 }

--- a/h2o-core/src/main/java/water/util/JSONValue.java
+++ b/h2o-core/src/main/java/water/util/JSONValue.java
@@ -9,7 +9,10 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
+ * CLass providing encapsulation for json values, especially for parts of json objects with polymorphic values.
  *
+ * Idea is to store json (or part of json object) as json string + class for serialization.
+ * It can then later be parsed dynamically using the provided `value` and `valueAs` methods.
  * @param <V>
  */
 public class JSONValue<V> extends Iced {

--- a/h2o-core/src/main/java/water/util/PojoUtils.java
+++ b/h2o-core/src/main/java/water/util/PojoUtils.java
@@ -635,21 +635,28 @@ public class PojoUtils {
       }
       Object value = setFields.get(key);
       if (value instanceof Map) {
-        // handle nested objects
-        try {
-          // In some cases, the target object has children already (e.g., defaults), while in other cases it doesn't.
-          if (null == f.get(o))
-            f.set(o, f.getType().newInstance());
-          fillFromMap(f.get(o), (Map<String, Object>) value);
-        } catch (IllegalAccessException e) {
-          throw new IllegalArgumentException("Cannot get value of the field: '" + key + "' on object " + o);
-        } catch (InstantiationException e) {
+        if (f.getType().isInstance(value)) {
+          setField(o, key, value);
+        } else {
+          // handle nested objects
           try {
-            throw new IllegalArgumentException("Cannot create new child object of type: " +
-                    PojoUtils.getFieldEvenInherited(o, key).getClass().getCanonicalName() + " for field: '" + key + "' on object " + o);
-          } catch (NoSuchFieldException ee) {
-            // Can't happen: we've already checked for this.
-            throw new IllegalArgumentException("Cannot create new child object of type for field: '" + key + "' on object " + o);
+            // In some cases, the target object has children already (e.g., defaults), while in other cases it doesn't.
+            if (null == f.get(o))
+              f.set(o, f.getType().newInstance());
+            fillFromMap(f.get(o), (Map<String, Object>) value);
+          }
+          catch (IllegalAccessException e) {
+            throw new IllegalArgumentException("Cannot get value of the field: '" + key + "' on object " + o);
+          }
+          catch (InstantiationException e) {
+            try {
+              throw new IllegalArgumentException("Cannot create new child object of type: " +
+                      PojoUtils.getFieldEvenInherited(o, key).getClass().getCanonicalName() + " for field: '" + key + "' on object " + o);
+            }
+            catch (NoSuchFieldException ee) {
+              // Can't happen: we've already checked for this.
+              throw new IllegalArgumentException("Cannot create new child object of type for field: '" + key + "' on object " + o);
+            }
           }
         }
       } else if (value instanceof List) {

--- a/h2o-core/src/main/java/water/util/PojoUtils.java
+++ b/h2o-core/src/main/java/water/util/PojoUtils.java
@@ -646,16 +646,13 @@ public class PojoUtils {
           if (null == f.get(o))
             f.set(o, f.getType().newInstance());
           fillFromMap(f.get(o), (Map<String, Object>) value);
-        }
-        catch (IllegalAccessException e) {
+        } catch (IllegalAccessException e) {
           throw new IllegalArgumentException("Cannot get value of the field: '" + key + "' on object " + o);
-        }
-        catch (InstantiationException e) {
+        } catch (InstantiationException e) {
           try {
             throw new IllegalArgumentException("Cannot create new child object of type: " +
                     PojoUtils.getFieldEvenInherited(o, key).getClass().getCanonicalName() + " for field: '" + key + "' on object " + o);
-          }
-          catch (NoSuchFieldException ee) {
+          } catch (NoSuchFieldException ee) {
             // Can't happen: we've already checked for this.
             throw new IllegalArgumentException("Cannot create new child object of type for field: '" + key + "' on object " + o);
           }

--- a/h2o-core/src/main/java/water/util/PojoUtils.java
+++ b/h2o-core/src/main/java/water/util/PojoUtils.java
@@ -1,7 +1,6 @@
 package water.util;
 
 import water.*;
-import water.api.API;
 import water.api.Schema;
 import water.api.SchemaServer;
 import water.api.schemas3.FrameV3;
@@ -9,12 +8,9 @@ import water.api.schemas3.KeyV3;
 import water.exceptions.H2OIllegalArgumentException;
 import water.exceptions.H2ONotFoundArgumentException;
 
-import javax.management.modelmbean.InvalidTargetObjectTypeException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;

--- a/h2o-core/src/test/java/water/util/JSONValueTest.java
+++ b/h2o-core/src/test/java/water/util/JSONValueTest.java
@@ -1,8 +1,12 @@
 package water.util;
 
 import hex.KeyValue;
+import hex.Model;
 import org.junit.Test;
+import water.Key;
+import water.api.schemas3.KeyV3;
 import water.api.schemas3.KeyValueV3;
+import water.fvec.Frame;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -65,6 +69,41 @@ public class JSONValueTest {
         assertEquals(expected[0].getValue(), vKVs[0].getValue(), 1e-10);
         assertEquals(expected[1].getKey(), vKVs[1].getKey());
         assertEquals(expected[1].getValue(), vKVs[1].getValue(), 1e-10);
+    }
+
+    @Test public void test_iced() {
+        Map<String, Object> mKV = new HashMap<>();
+        mKV.put("name", "foo");
+        mKV.put("type", "Frame");
+        JSONValue<Map> jKV = JSONValue.fromValue(mKV);
+
+        KeyV3.FrameKeyV3 keyV3 = jKV.valueAsSchema(KeyV3.FrameKeyV3.class);
+        assertEquals("foo", keyV3.name);
+        assertEquals("Frame", keyV3.type);
+
+        Key<Frame> expected = Key.make("foo");
+        Key<Frame> key = jKV.valueAs(Key.class, KeyV3.class);
+        assertEquals(expected, key);
+    }
+
+    @Test public void test_iced_array() {
+        Map<String, Object> mKVs[] = new HashMap[]{new HashMap(), new HashMap()};
+        mKVs[0].put("name", "foo");
+        mKVs[0].put("type", "Model");
+        mKVs[1].put("name", "bar");
+        mKVs[1].put("type", "Model");
+        JSONValue<Map[]> jKVs = JSONValue.fromValue(mKVs);
+
+        KeyV3.ModelKeyV3[] keysV3 = jKVs.valueAsSchemas(KeyV3.ModelKeyV3[].class);
+        assertEquals("foo", keysV3[0].name);
+        assertEquals("bar", keysV3[1].name);
+        assertEquals("Model", keysV3[0].type);
+        assertEquals("Model", keysV3[1].type);
+
+        Key<Model>[] expected = new Key[] { Key.make("foo"), Key.make("bar") };
+        Key<Model>[] keys = jKVs.valueAsArray(Key[].class, KeyV3[].class);
+        assertEquals(expected[0], keys[0]);
+        assertEquals(expected[1], keys[1]);
     }
 
 }

--- a/h2o-core/src/test/java/water/util/JSONValueTest.java
+++ b/h2o-core/src/test/java/water/util/JSONValueTest.java
@@ -1,0 +1,70 @@
+package water.util;
+
+import hex.KeyValue;
+import org.junit.Test;
+import water.api.schemas3.KeyValueV3;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class JSONValueTest {
+
+    @Test public void test_primitive_type() {
+        JSONValue jInt = JSONValue.fromValue(123);
+        assertEquals("123", jInt._json);
+        assertEquals(123, jInt.value());
+        assertEquals(jInt, new JSONValue<>("123", Integer.class));
+    }
+
+    @Test public void test_primitive_array() {
+        JSONValue jInts = JSONValue.fromValue(new int[] {1, 2, 3});
+        assertEquals("[1,2,3]", jInts._json);
+        assertArrayEquals(new int[] {1, 2, 3}, (int[])jInts.value());
+        assertEquals(jInts, new JSONValue<>("[1,2,3]", int[].class));
+    }
+
+    @Test public void test_string() {
+        JSONValue jStr = JSONValue.fromValue("123");
+        assertEquals("\"123\"", jStr._json);
+        assertEquals("123", jStr.value());
+        assertEquals(jStr, new JSONValue<>("\"123\"", String.class));
+    }
+
+    @Test public void test_string_array() {
+        JSONValue jStrs = JSONValue.fromValue(new String[] {"1", "2", "3"});
+        assertEquals("[\"1\",\"2\",\"3\"]", jStrs._json);
+        assertArrayEquals(new String[] {"1", "2", "3"}, (String[])jStrs.value());
+        assertEquals(jStrs, new JSONValue<>("[\"1\",\"2\",\"3\"]", String[].class));
+    }
+
+    @Test public void test_autoparseable() {
+        Map<String, Object> mKV = new HashMap<>();
+        mKV.put("key", "foo");
+        mKV.put("value", 123.);
+        JSONValue<Map> jKV = JSONValue.fromValue(mKV);
+        assertTrue("{\"key\":\"foo\",\"value\":123.0}".equals(jKV._json)
+                || "{\"value\":123.0,\"key\":\"foo\"}".equals(jKV._json));
+        KeyValue expected = new KeyValue("foo", 123.);
+        KeyValue vKV = jKV.valueAs(KeyValue.class, KeyValueV3.class);
+        assertEquals(expected.getKey(), vKV.getKey());
+        assertEquals(expected.getValue(), vKV.getValue(), 1e-10);
+    }
+
+    @Test public void test_autoparseable_array() {
+        Map<String, Object> mKVs[] = new HashMap[]{new HashMap(), new HashMap()};
+        mKVs[0].put("key", "foo");
+        mKVs[0].put("value", 123.);
+        mKVs[1].put("key", "bar");
+        mKVs[1].put("value", 456.);
+        JSONValue<Map[]> jKVs = JSONValue.fromValue(mKVs);
+        KeyValue[] expected = new KeyValue[] { new KeyValue("foo", 123.), new KeyValue("bar", 456.) };
+        KeyValue[] vKVs = jKVs.valueAsArray(KeyValue[].class, KeyValueV3[].class);
+        assertEquals(expected[0].getKey(), vKVs[0].getKey());
+        assertEquals(expected[0].getValue(), vKVs[0].getValue(), 1e-10);
+        assertEquals(expected[1].getKey(), vKVs[1].getKey());
+        assertEquals(expected[1].getValue(), vKVs[1].getValue(), 1e-10);
+    }
+
+}

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -268,8 +268,16 @@ class H2OAutoML(Keyed):
                             plan.append(dict(name=name, steps=[dict(id=i) for i in ids]))
             self.build_models['modeling_plan'] = plan
 
-        assert_is_type(algo_parameters, None, dict)
-        self.build_models['algo_parameters_json'] = algo_parameters
+        if algo_parameters is not None:
+            assert_is_type(algo_parameters, dict)
+            algo_parameters_json = []
+            for k, v in algo_parameters.items():
+                scope, __, name = k.partition('__')
+                if len(name) == 0:
+                    name, scope = scope, 'any'
+                algo_parameters_json.append(dict(scope=scope, name=name, value=v))
+
+            self.build_models['algo_parameters'] = algo_parameters_json
 
         assert_is_type(keep_cross_validation_predictions, bool)
         self.build_control["keep_cross_validation_predictions"] = keep_cross_validation_predictions

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -111,6 +111,11 @@ class H2OAutoML(Keyed):
         :param include_algos: List of character strings naming the algorithms to restrict to during the model-building phase.
           This can't be used in combination with `exclude_algos` param.
           Defaults to ``None``, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
+        :param modeling_plan: List of modeling steps to be used by the AutoML engine (they may not all get executed, depending on other constraints).
+          Defaults to None (Expert usage only).
+        :param algo_parameters: Dict of ``param_name=param_value`` to be passed to internal models. Defaults to none (Expert usage only).
+          By default, params are set only to algorithms accepting them, and ignored by others.
+          Only following parameters are currently allowed: ``"monotone_constraints"``, ``"ntrees"``.
         :param keep_cross_validation_predictions: Whether to keep the predictions of the cross-validation predictions.
           This needs to be set to ``True`` if running the same AutoML object for repeated runs because CV predictions are required to build 
           additional Stacked Ensemble models in AutoML. This option defaults to ``False``.

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -115,7 +115,7 @@ class H2OAutoML(Keyed):
           Defaults to None (Expert usage only).
         :param algo_parameters: Dict of ``param_name=param_value`` to be passed to internal models. Defaults to none (Expert usage only).
           By default, params are set only to algorithms accepting them, and ignored by others.
-          Only following parameters are currently allowed: ``"monotone_constraints"``, ``"ntrees"``.
+          Only following parameters are currently allowed: ``"monotone_constraints"``.
         :param keep_cross_validation_predictions: Whether to keep the predictions of the cross-validation predictions.
           This needs to be set to ``True`` if running the same AutoML object for repeated runs because CV predictions are required to build 
           additional Stacked Ensemble models in AutoML. This option defaults to ``False``.

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -275,7 +275,8 @@ class H2OAutoML(Keyed):
                 scope, __, name = k.partition('__')
                 if len(name) == 0:
                     name, scope = scope, 'any'
-                algo_parameters_json.append(dict(scope=scope, name=name, value=v))
+                value = [dict(key=k, value=v) for k, v in v.items()] if isinstance(v, dict) else v   # we can't use stringify_dict here as this will be converted into a JSON string
+                algo_parameters_json.append(dict(scope=scope, name=name, value=value))
 
             self.build_models['algo_parameters'] = algo_parameters_json
 

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -65,6 +65,7 @@ class H2OAutoML(Keyed):
                  exclude_algos=None,
                  include_algos=None,
                  modeling_plan=None,
+                 algo_parameters=None,
                  keep_cross_validation_predictions=False,
                  keep_cross_validation_models=False,
                  keep_cross_validation_fold_assignment=False,
@@ -267,6 +268,8 @@ class H2OAutoML(Keyed):
                             plan.append(dict(name=name, steps=[dict(id=i) for i in ids]))
             self.build_models['modeling_plan'] = plan
 
+        assert_is_type(algo_parameters, None, dict)
+        self.build_models['algo_parameters_json'] = algo_parameters
 
         assert_is_type(keep_cross_validation_predictions, bool)
         self.build_control["keep_cross_validation_predictions"] = keep_cross_validation_predictions

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_model_selection.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_model_selection.py
@@ -255,15 +255,15 @@ def test_algo_parameters():
 
 
 pu.run_tests([
-    test_exclude_algos,
-    test_include_algos,
-    test_include_exclude_algos,
-    test_bad_modeling_plan_using_full_syntax,
-    test_bad_modeling_plan_using_simplified_syntax,
-    test_modeling_plan_using_full_syntax,
-    test_modeling_plan_using_simplified_syntax,
-    test_modeling_plan_using_minimal_syntax,
-    test_modeling_steps,
-    test_exclude_algos_is_applied_on_top_of_modeling_plan,
+    # test_exclude_algos,
+    # test_include_algos,
+    # test_include_exclude_algos,
+    # test_bad_modeling_plan_using_full_syntax,
+    # test_bad_modeling_plan_using_simplified_syntax,
+    # test_modeling_plan_using_full_syntax,
+    # test_modeling_plan_using_simplified_syntax,
+    # test_modeling_plan_using_minimal_syntax,
+    # test_modeling_steps,
+    # test_exclude_algos_is_applied_on_top_of_modeling_plan,
     test_algo_parameters,
 ])

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_model_selection.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_model_selection.py
@@ -245,6 +245,15 @@ def test_exclude_algos_is_applied_on_top_of_modeling_plan():
     assert len(se) == 0
 
 
+def test_algo_parameters():
+    ds = import_dataset()
+    aml = H2OAutoML(project_name="py_monotone_constraints",
+                    algo_parameters=dict(monotone_constraints=dict(AGE=1)),
+                    max_models=2,
+                    seed=1)
+    aml.train(y=ds.target, training_frame=ds.train)
+
+
 pu.run_tests([
     test_exclude_algos,
     test_include_algos,
@@ -255,5 +264,6 @@ pu.run_tests([
     test_modeling_plan_using_simplified_syntax,
     test_modeling_plan_using_minimal_syntax,
     test_modeling_steps,
-    test_exclude_algos_is_applied_on_top_of_modeling_plan
+    test_exclude_algos_is_applied_on_top_of_modeling_plan,
+    test_algo_parameters,
 ])

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_model_selection.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_model_selection.py
@@ -251,7 +251,7 @@ def test_monotone_constraints_can_be_passed_as_algo_parameter():
     aml = H2OAutoML(project_name="py_monotone_constraints",
                     algo_parameters=dict(
                         monotone_constraints=dict(AGE=1, VOL=-1),  # constraints just for the sake of testing
-                        ntrees=10,
+                        # ntrees=10,
                     ),
                     max_models=6,
                     seed=1)
@@ -262,9 +262,8 @@ def test_monotone_constraints_can_be_passed_as_algo_parameter():
         "models not supporting the constraint should not have been skipped"
     for m in models_supporting_monotone_constraints:
         model = h2o.get_model(m)
-        param = next(p for p in model._model_json['parameters'] if p['name'] == 'monotone_constraints')
+        value = next(v['actual'] for n, v in model.params.items() if n == 'monotone_constraints')
         # print(param)
-        value = param['actual_value']
         assert isinstance(value, list)
         assert len(value) == 2
         age = next((v for v in value if v['key'] == 'AGE'), None)
@@ -274,18 +273,17 @@ def test_monotone_constraints_can_be_passed_as_algo_parameter():
         assert vol is not None
         assert vol['value'] == -1.0
 
-    models_supporting_ntrees = [n for n in model_names if re.match(r"DRF|GBM|XGBoost|XRT", n)]
-    assert len(models_supporting_ntrees) > 0
-    for m in models_supporting_ntrees:
-        model = h2o.get_model(m)
-        param = next(p for p in model._model_json['parameters'] if p['name'] == 'ntrees')
-        value = param['actual_value']
-        assert value == 10
+    # models_supporting_ntrees = [n for n in model_names if re.match(r"DRF|GBM|XGBoost|XRT", n)]
+    # assert len(models_supporting_ntrees) > 0
+    # for m in models_supporting_ntrees:
+    #     model = h2o.get_model(m)
+    #     value = next(v['actual'] for n, v in model.params.items() if n == 'ntrees')
+    #     assert value == 10
 
 
 def test_algo_parameter_can_be_applied_only_to_a_specific_algo():
     ds = import_dataset()
-    aml = H2OAutoML(project_name="py_monotone_constraints",
+    aml = H2OAutoML(project_name="py_specific_algo_param",
                     algo_parameters=dict(
                         GBM__monotone_constraints=dict(AGE=1)
                     ),
@@ -297,9 +295,7 @@ def test_algo_parameter_can_be_applied_only_to_a_specific_algo():
     assert next((m for m in models_supporting_monotone_constraints if m.startswith('GBM')), None), "There should be at least one GBM model"
     for m in models_supporting_monotone_constraints:
         model = h2o.get_model(m)
-        mc_param = next(p for p in model._model_json['parameters'] if p['name'] == 'monotone_constraints')
-        # print(mc_param)
-        mc_value = mc_param['actual_value']
+        mc_value = next(v['actual'] for n, v in model.params.items() if n == 'monotone_constraints')
         if m.startswith('GBM'):
             assert isinstance(mc_value, list)
             age = next((v for v in mc_value if v['key'] == 'AGE'), None)
@@ -311,7 +307,7 @@ def test_algo_parameter_can_be_applied_only_to_a_specific_algo():
 
 def test_cannot_set_unauthorized_algo_parameter():
     ds = import_dataset()
-    aml = H2OAutoML(project_name="py_monotone_constraints",
+    aml = H2OAutoML(project_name="py_unauthorized_algo_param",
                     algo_parameters=dict(
                         score_tree_interval=7
                     ),

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -49,7 +49,7 @@
 #' @param modeling_plan List. The list of modeling steps to be used by the AutoML engine (they may not all get executed, depending on other constraints). Optional (Expert usage only).
 #' @param algo_parameters List. A list of param_name=param_value to be passed to internal models. Defaults to none (Expert usage only).
 #'        By default, params are set only to algorithms accepting them, and ignored by others.
-#'        Only following parameters are currently allowed: "monotone_constraints", "ntrees".
+#'        Only following parameters are currently allowed: "monotone_constraints".
 #' @param keep_cross_validation_predictions \code{Logical}. Whether to keep the predictions of the cross-validation predictions. This needs to be set to TRUE if running the same AutoML object for repeated runs because CV predictions are required to build additional Stacked Ensemble models in AutoML. This option defaults to FALSE.
 #' @param keep_cross_validation_models \code{Logical}. Whether to keep the cross-validated models. Keeping cross-validation models may consume significantly more memory in the H2O cluster. This option defaults to FALSE.
 #' @param keep_cross_validation_fold_assignment \code{Logical}. Whether to keep fold assignments in the models. Deleting them will save memory in the H2O cluster. Defaults to FALSE.

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -47,7 +47,6 @@
 #' @param include_algos Vector of character strings naming the algorithms to restrict to during the model-building phase. This can't be used in combination with exclude_algos param.
 #         Defaults to NULL, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
 #' @param modeling_plan List. The list of modeling steps to be used by the AutoML engine (they may not all get executed, depending on other constraints). Optional (Expert usage only).
-#' @param algo_parameters List.
 #' @param algo_parameters List. A list of param_name=param_value to be passed to internal models. Defaults to none (Expert usage only).
 #'        By default, params are set only to algorithms accepting them, and ignored by others.
 #'        Only following parameters are currently allowed: "monotone_constraints", "ntrees".

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -251,7 +251,7 @@ h2o.automl <- function(x, y, training_frame,
         name <- k
       } else {
         scope <- tokens[1]
-        name <- paste0(tokens[2:len(tokens)], collapse="__")
+        name <- paste0(tokens[2:length(tokens)], collapse="__")
       }
       value <- algo_parameters[[k]]
       if (is.list(value) && !is.null(names(value))) {

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_model_selection.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_model_selection.R
@@ -203,6 +203,39 @@ automl.model_selection.suite <- function() {
     expect_equal(length(models$non_se), 3)
   }
 
+  test_monotone_constraints_can_be_passed_as_algo_parameter <- function() {
+    ds <- import_dataset()
+    aml <- h2o.automl(x = ds$x, y = ds$y.idx,
+      training_frame = ds$train,
+      algo_parameters = list(
+        monotone_constraints = list(AGE=1, VOL=-1),
+        ntrees = 10
+      ),
+      project_name="r_monotone_constraints",
+      max_models = 6,
+      seed = 1
+    )
+    models <- get_partitioned_models(aml)$all
+    models_supporting_monotone_constraints <- models[grepl("^(GBM|XGBoost)", models)]
+    expect_lt(length(models_supporting_monotone_constraints), length(models))
+    for (m in models_supporting_monotone_constraints) {
+      model <- h2o.getModel(m)
+      mc <- model@parameters$monotone_constraints
+      expect_equal(mc[[1]]$key, "AGE")
+      expect_equal(mc[[1]]$value, 1)
+      expect_equal(mc[[2]]$key, "VOL")
+      expect_equal(mc[[2]]$value, -1)
+    }
+
+    models_supporting_ntrees <- models[grepl("^(DRF|GBM|XGBoost|XRT)", models)]
+    expect_gt(length(models_supporting_ntrees), 0)
+    for (m in models_supporting_ntrees) {
+      model <- h2o.getModel(m)
+      expect_equal(model@parameters$ntrees, 10)
+    }
+  }
+
+
   makeSuite(
     test_exclude_algos,
     test_include_algos,
@@ -211,7 +244,8 @@ automl.model_selection.suite <- function() {
     test_modeling_plan_full_syntax,
     test_modeling_plan_minimal_syntax,
     test_modeling_steps,
-    test_exclude_algos_is_applied_on_top_of_modeling_plan
+    test_exclude_algos_is_applied_on_top_of_modeling_plan,
+    test_monotone_constraints_can_be_passed_as_algo_parameter,
   )
 }
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_model_selection.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_model_selection.R
@@ -208,8 +208,8 @@ automl.model_selection.suite <- function() {
     aml <- h2o.automl(x = ds$x, y = ds$y.idx,
       training_frame = ds$train,
       algo_parameters = list(
-        monotone_constraints = list(AGE=1, VOL=-1),
-        ntrees = 10
+        monotone_constraints = list(AGE=1, VOL=-1)
+        # ntrees = 10
       ),
       project_name="r_monotone_constraints",
       max_models = 6,
@@ -227,11 +227,35 @@ automl.model_selection.suite <- function() {
       expect_equal(mc[[2]]$value, -1)
     }
 
-    models_supporting_ntrees <- models[grepl("^(DRF|GBM|XGBoost|XRT)", models)]
-    expect_gt(length(models_supporting_ntrees), 0)
-    for (m in models_supporting_ntrees) {
+    # models_supporting_ntrees <- models[grepl("^(DRF|GBM|XGBoost|XRT)", models)]
+    # expect_gt(length(models_supporting_ntrees), 0)
+    # for (m in models_supporting_ntrees) {
+    #   model <- h2o.getModel(m)
+    #   expect_equal(model@parameters$ntrees, 10)
+    # }
+  }
+
+  test_algo_parameter_can_be_applied_only_to_a_specific_algo <- function() {
+    ds <- import_dataset()
+    aml <- h2o.automl(x = ds$x, y = ds$y.idx,
+      training_frame = ds$train,
+      algo_parameters = list(GBM__monotone_constraints = list(AGE=1)),
+      project_name="r_specific_algo_param",
+      max_models = 6,
+      seed = 1
+    )
+    models <- get_partitioned_models(aml)$all
+    models_supporting_monotone_constraints <- models[grepl("^(GBM|XGBoost)", models)]
+    expect_lt(length(models_supporting_monotone_constraints), length(models))
+    for (m in models_supporting_monotone_constraints) {
       model <- h2o.getModel(m)
-      expect_equal(model@parameters$ntrees, 10)
+      mc <- model@parameters$monotone_constraints
+      if (grepl("^GBM", m)) {
+        expect_equal(mc[[1]]$key, "AGE")
+        expect_equal(mc[[1]]$value, 1)
+      } else {
+        expect_null(mc[[1]])
+      }
     }
   }
 
@@ -246,6 +270,7 @@ automl.model_selection.suite <- function() {
     test_modeling_steps,
     test_exclude_algos_is_applied_on_top_of_modeling_plan,
     test_monotone_constraints_can_be_passed_as_algo_parameter,
+    test_algo_parameter_can_be_applied_only_to_a_specific_algo,
   )
 }
 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6737

Current implementation restricts the parameters that can be assigned by the user to:
- `monotone_constraints` as required by initial customer request.

Added a System property to allow overriding of `any` parameter: the plan is to use this for development/benchmarking.
Tuning algorithms, and running benchmarks against versions with different parameters is currently a hassle (recompile, rename built jar, upload it, keep reference...).
Having those parameters configurable from client will allow us to try more combinations faster (may also support hyperparameters override in the future for benchmarking as well).
