### PR TITLE
PUBDEV-7002: Fix creating multiple instances of H2O server using R on Windows

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -668,12 +668,14 @@ h2o.clusterStatus <- function() {
     usr <- gsub("[^A-Za-z0-9]", "_", Sys.getenv("USER", unset="UnknownUser"))
   }
 
+  temp_dir_path <- tempfile()
+  dir.create(temp_dir_path)
   if(type == "stdout")
-    file.path(tempdir(), paste("h2o", usr, "started_from_r.out", sep="_"))
+    file.path(temp_dir_path, paste("h2o", usr, "started_from_r.out", sep="_"))
   else if(type == "stderr")
-    file.path(tempdir(), paste("h2o", usr, "started_from_r.err", sep="_"))
+    file.path(temp_dir_path, paste("h2o", usr, "started_from_r.err", sep="_"))
   else
-    file.path(tempdir(), paste("h2o", usr, "started_from_r.pid", sep="_"))
+    file.path(temp_dir_path, paste("h2o", usr, "started_from_r.pid", sep="_"))
 }
 
 .h2o.startedH2O <- function() {


### PR DESCRIPTION
Performing multiple h2o.init is allowed as long as different ports are supplied. However because of how R handles tempdir() (only a single dir per R session) and how Windows handles access to files creating multiple instances of h2o server currently fails. After the first server is created any consecutive server creation will fail because it'll try to access previous files which Windows will deny.

This PR fixes it by using tempfile (which is guaranteed to be unique for every call) as a template for a temporary directory.