### PR TITLE
PUBDEV-6975: Attempt to reuse existing tools for grid search over TE hyper parameters

### DIFF
--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -35,7 +35,8 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
     public double _k = TargetEncoder.DEFAULT_BLENDING_PARAMS.getK();
     public double _f = TargetEncoder.DEFAULT_BLENDING_PARAMS.getF();
     public TargetEncoder.DataLeakageHandlingStrategy _data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
-    public double _noise_level = 0;
+    public double _noise_level = 0.01;
+    
     @Override
     public String algoName() {
       return ALGO_NAME;
@@ -160,7 +161,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
             _parms._data_leakage_handling != null ? _parms._data_leakage_handling : TargetEncoder.DataLeakageHandlingStrategy.None;
     
     return _targetEncoder.applyTargetEncoding(fr, _parms._response_column, this._output._target_encoding_map, leakageHandlingStrategy,
-            _parms._fold_column, _parms._blending, _parms._seed,false, Key.<Frame>make(destination_key), blendingParams);
+            _parms._fold_column, _parms._blending, _parms._noise_level, _parms._seed, Key.<Frame>make(destination_key), blendingParams );
   }
   
 

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -150,7 +150,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
   
   @Override
   protected double[] score0(double data[], double preds[]){
-    throw new UnsupportedOperationException("TargetEncoderModel doesn't support scoring. Use `transform()` instead.");
+    throw new UnsupportedOperationException("TargetEncoderModel doesn't support scoring on raw data. Use transform() or score() instead.");
   }
 
   @Override

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -34,7 +34,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
     public boolean _blending = false;
     public BlendingParams _blending_parameters = TargetEncoder.DEFAULT_BLENDING_PARAMS;
     public TargetEncoder.DataLeakageHandlingStrategy _data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
-    
+    public double _noise_level = 0;
     @Override
     public String algoName() {
       return ALGO_NAME;

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -32,7 +32,8 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
 
   public static class TargetEncoderParameters extends Model.Parameters {
     public boolean _blending = false;
-    public BlendingParams _blending_parameters = TargetEncoder.DEFAULT_BLENDING_PARAMS;
+    public double _k = TargetEncoder.DEFAULT_BLENDING_PARAMS.getK();
+    public double _f = TargetEncoder.DEFAULT_BLENDING_PARAMS.getF();
     public TargetEncoder.DataLeakageHandlingStrategy _data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
     public double _noise_level = 0;
     @Override
@@ -54,7 +55,10 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
     public long progressUnits() {
       return 0;
     }
-    
+
+    public BlendingParams getBlendingParameters() {
+      return _k!=0 && _f!=0 ? new BlendingParams(_k, _f) : TargetEncoder.DEFAULT_BLENDING_PARAMS;
+    }
   }
 
   public static class TargetEncoderOutput extends Model.Output {
@@ -119,7 +123,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
    */
   public Frame transform(Frame data, byte strategy, double noiseLevel, final boolean useBlending, BlendingParams blendingParams,
                          long seed) {
-    if(blendingParams == null) blendingParams = _parms._blending_parameters != null ? _parms._blending_parameters : TargetEncoder.DEFAULT_BLENDING_PARAMS;
+    if(blendingParams == null) blendingParams = _parms.getBlendingParameters();
     
     final TargetEncoder.DataLeakageHandlingStrategy leakageHandlingStrategy = TargetEncoder.DataLeakageHandlingStrategy.fromVal(strategy);
     return _targetEncoder.applyTargetEncoding(data, _parms._response_column, this._output._target_encoding_map, leakageHandlingStrategy,
@@ -137,7 +141,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
    * @return An instance of {@link Frame} with transformed data, registered in DKV.
    */
   public Frame transform(Frame data, byte strategy, final boolean useBlending, BlendingParams blendingParams, long seed) {
-    if(blendingParams == null) blendingParams = _parms._blending_parameters != null ? _parms._blending_parameters : TargetEncoder.DEFAULT_BLENDING_PARAMS;
+    if(blendingParams == null) blendingParams = _parms.getBlendingParameters();
     
     final TargetEncoder.DataLeakageHandlingStrategy leakageHandlingStrategy = TargetEncoder.DataLeakageHandlingStrategy.fromVal(strategy);
     return _targetEncoder.applyTargetEncoding(data, _parms._response_column, this._output._target_encoding_map, leakageHandlingStrategy,
@@ -151,7 +155,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
 
   @Override
   public Frame score(Frame fr, String destination_key, Job j, boolean computeMetrics, CFuncRef customMetricFunc) throws IllegalArgumentException {
-    final BlendingParams blendingParams = _parms._blending_parameters != null ? _parms._blending_parameters : TargetEncoder.DEFAULT_BLENDING_PARAMS;
+    final BlendingParams blendingParams = _parms.getBlendingParameters();
     final TargetEncoder.DataLeakageHandlingStrategy leakageHandlingStrategy = 
             _parms._data_leakage_handling != null ? _parms._data_leakage_handling : TargetEncoder.DataLeakageHandlingStrategy.None;
     

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderMojoWriter.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderMojoWriter.java
@@ -43,8 +43,8 @@ public class TargetEncoderMojoWriter extends ModelMojoWriter {
     TargetEncoderModel.TargetEncoderParameters teParams = output._parms;
     writekv("with_blending", teParams._blending);
     if(teParams._blending) {
-      writekv("inflection_point", teParams._blending_parameters.getK());
-      writekv("smoothing", teParams._blending_parameters.getF());
+      writekv("inflection_point", teParams._k);
+      writekv("smoothing", teParams._f);
     }
     writekv("priorMean", output._prior_mean);
     

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -45,10 +45,8 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, Ta
     @Override
     protected TargetEncoderParametersV3 fillFromImpl(TargetEncoderModel.TargetEncoderParameters impl, String[] fieldsToSkip) {
       final TargetEncoderParametersV3 teParamsV3 = super.fillFromImpl(impl, fieldsToSkip);
-      if (impl._blending_parameters != null) {
-        teParamsV3.f = impl._blending_parameters.getF();
-        teParamsV3.k = impl._blending_parameters.getK();
-      }
+      teParamsV3.k = impl._k;
+      teParamsV3.f = impl._f;
       return teParamsV3;
     }
   }

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -21,6 +21,9 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, Ta
 
     @API(help = "Data leakage handling strategy. Default to None.", values = {"None", "KFold", "LeaveOneOut"})
     public TargetEncoder.DataLeakageHandlingStrategy data_leakage_handling;
+
+    @API(help = "Noise level", required = false, direction = API.Direction.INPUT, gridable = true)
+    public double noise_level;
   
     @Override
     public String[] fields() {

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -24,6 +24,9 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, Ta
 
     @API(help = "Noise level", required = false, direction = API.Direction.INPUT, gridable = true)
     public double noise_level;
+    
+    @API(help = "Seed for the specified noise level", required = false, direction = API.Direction.INPUT)
+    public long seed;
   
     @Override
     public String[] fields() {

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TEMojoIntegrationTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TEMojoIntegrationTest.java
@@ -332,7 +332,6 @@ public class TEMojoIntegrationTest extends TestUtil {
 
       TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = new TargetEncoderModel.TargetEncoderParameters();
       targetEncoderParameters._blending = true;
-      targetEncoderParameters._blending_parameters = TargetEncoder.DEFAULT_BLENDING_PARAMS;
       targetEncoderParameters._response_column = responseColumnName;
       targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
       targetEncoderParameters._ignore_const_cols = false;
@@ -395,7 +394,7 @@ public class TEMojoIntegrationTest extends TestUtil {
       int homeDestIndex = ArrayUtils.find(fr.vec(teColumn).domain(), homeDestFactorValue);
       int[] encodingComponentsForHomeDest = homeDestEncodingMap.get(homeDestIndex);
       double posteriorMean = (double) encodingComponentsForHomeDest[0] / encodingComponentsForHomeDest[1];
-      double expectedLambda = TargetEncoderMojoModel.computeLambda(encodingComponentsForHomeDest[1], targetEncoderParameters._blending_parameters.getK(), targetEncoderParameters._blending_parameters.getF());
+      double expectedLambda = TargetEncoderMojoModel.computeLambda(encodingComponentsForHomeDest[1], targetEncoderParameters._k, targetEncoderParameters._f);
 
       double expectedBlendedEncodingForHomeDest = TargetEncoderMojoModel.computeBlendedEncoding(expectedLambda, posteriorMean, expectedPriorMean);
 
@@ -431,7 +430,8 @@ public class TEMojoIntegrationTest extends TestUtil {
       
       // We want to test case when inflection point is higher than number of missing values in the training frame, i.e. blending would favor prior probability
       int inflectionPoint = 600;
-      targetEncoderParameters._blending_parameters = new BlendingParams(inflectionPoint, 1);
+      targetEncoderParameters._k = inflectionPoint;
+      targetEncoderParameters._f = 1;
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);
 
@@ -470,7 +470,8 @@ public class TEMojoIntegrationTest extends TestUtil {
 
 
       // Encoding should be coming from posterior probability of NAs in the training frame
-      Frame encodingsFromTargetEncoderModel = targetEncoderModel.transform(withNullFrame, noneHoldoutStrategy, 0.0, true,targetEncoderParameters._blending_parameters, 1234);
+      BlendingParams blendingParams = new BlendingParams(targetEncoderParameters._k, targetEncoderParameters._f);
+      Frame encodingsFromTargetEncoderModel = targetEncoderModel.transform(withNullFrame, noneHoldoutStrategy, 0.0, true, blendingParams, 1234);
       Scope.track(encodingsFromTargetEncoderModel);
 
       assertEquals(encodingsFromMojoModel[0], encodingsFromTargetEncoderModel.vec("home.dest_te").at(0), 1e-5);
@@ -484,7 +485,7 @@ public class TEMojoIntegrationTest extends TestUtil {
               .build();
 
       // In case we predict for unseen level, encodings should be coming from prior probability of the response
-      Frame encodingsFromTEModelForUnseenLevel = targetEncoderModel.transform(withUnseenLevelFrame, noneHoldoutStrategy, 0.0,true, targetEncoderParameters._blending_parameters, 1234);
+      Frame encodingsFromTEModelForUnseenLevel = targetEncoderModel.transform(withUnseenLevelFrame, noneHoldoutStrategy, 0.0,true, blendingParams, 1234);
       Scope.track(encodingsFromTEModelForUnseenLevel);
 
       // This prediction will essentially be a prior as inflection point is 600 vs only one value in the `withUnseenLevelFrame` frame
@@ -519,7 +520,8 @@ public class TEMojoIntegrationTest extends TestUtil {
 
       // We want to test case when inflection point is lower than number of missing values in the training frame, i.e. blending would favor posterior probability
       int inflectionPoint = 5;
-      targetEncoderParameters._blending_parameters = new BlendingParams(inflectionPoint, 1);
+      targetEncoderParameters._k = inflectionPoint;
+      targetEncoderParameters._f = 1;
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);
 
@@ -558,7 +560,8 @@ public class TEMojoIntegrationTest extends TestUtil {
 
 
       // Encoding should be coming from posterior probability of NAs in the training frame
-      Frame encodingsFromTargetEncoderModel = targetEncoderModel.transform(withNullFrame, noneHoldoutStrategy, 0.0, true,targetEncoderParameters._blending_parameters, 1234);
+      BlendingParams blendingParams = new BlendingParams(targetEncoderParameters._k, targetEncoderParameters._f);
+      Frame encodingsFromTargetEncoderModel = targetEncoderModel.transform(withNullFrame, noneHoldoutStrategy, 0.0, true, blendingParams, 1234);
       Scope.track(encodingsFromTargetEncoderModel);
 
       assertEquals(encodingsFromMojoModel[0], encodingsFromTargetEncoderModel.vec("home.dest_te").at(0), 1e-5);
@@ -571,7 +574,7 @@ public class TEMojoIntegrationTest extends TestUtil {
               .withDataForCol(0, ar("xxx"))
               .build();
 
-      Frame encodingsFromTEModelForUnseenLevel = targetEncoderModel.transform(withUnseenLevelFrame, noneHoldoutStrategy, 0.0,true, targetEncoderParameters._blending_parameters, 1234);
+      Frame encodingsFromTEModelForUnseenLevel = targetEncoderModel.transform(withUnseenLevelFrame, noneHoldoutStrategy, 0.0,true, blendingParams, 1234);
       Scope.track(encodingsFromTEModelForUnseenLevel);
 
       assertEquals(encodingsFromMojoModel[0], encodingsFromTEModelForUnseenLevel.vec("home.dest_te").at(0), 1e-5);
@@ -605,7 +608,8 @@ public class TEMojoIntegrationTest extends TestUtil {
       targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", targetEncoderParameters._response_column);
       // Enable blending
       targetEncoderParameters._blending = true;
-      targetEncoderParameters._blending_parameters = new BlendingParams(randomInflectionPoint, 1);
+      targetEncoderParameters._k = randomInflectionPoint;
+      targetEncoderParameters._f = 1;
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);
 
@@ -643,7 +647,8 @@ public class TEMojoIntegrationTest extends TestUtil {
               .build();
 
 
-      Frame encodingsFromTargetEncoderModel = targetEncoderModel.transform(withNullFrame, noneHoldoutStrategy, 0.0, true,targetEncoderParameters._blending_parameters, 1234);
+      BlendingParams blendingParams = new BlendingParams(targetEncoderParameters._k, targetEncoderParameters._f);
+      Frame encodingsFromTargetEncoderModel = targetEncoderModel.transform(withNullFrame, noneHoldoutStrategy, 0.0, true, blendingParams, 1234);
       Scope.track(encodingsFromTargetEncoderModel);
 
       double predictionFromTEModel = encodingsFromTargetEncoderModel.vec("home.dest_te").at(0);
@@ -673,7 +678,8 @@ public class TEMojoIntegrationTest extends TestUtil {
       targetEncoderParameters._response_column = responseColumnName;
       targetEncoderParameters._ignored_columns = ignoredColumns(fr, "home.dest", "embarked", targetEncoderParameters._response_column);
       targetEncoderParameters._blending = true;
-      targetEncoderParameters._blending_parameters = new BlendingParams(5, 1);
+      targetEncoderParameters._k = 5;
+      targetEncoderParameters._f = 1;
 
       targetEncoderParameters._ignore_const_cols = false;
       targetEncoderParameters.setTrain(fr._key);

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
@@ -27,7 +27,8 @@ public class TargetEncoderModelTest extends TestUtil{
 
       TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
       parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
-      parameters._blending_parameters = new BlendingParams(0.3,0.7);
+      parameters._k = 0.3;
+      parameters._f = 0.7;
       parameters._blending = true;
       parameters._response_column = "IsDepDelayed";
       parameters._ignored_columns = ignoredColumns(trainingFrame, "Origin", parameters._response_column);
@@ -63,7 +64,6 @@ public class TargetEncoderModelTest extends TestUtil{
 
       TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
       parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
-      parameters._blending_parameters = null; // Explicitly set to null, default parameters should be used
       parameters._blending = true;
       parameters._response_column = "IsDepDelayed";
       parameters._ignored_columns = ignoredColumns(trainingFrame, "Origin", parameters._response_column);

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
@@ -11,7 +11,6 @@ import water.TestUtil;
 import water.api.GridSearchHandler;
 
 import java.util.HashMap;
-import java.util.function.Function;
 
 import static org.junit.Assert.*;
 
@@ -30,7 +29,6 @@ public class TargetEncoderRGSTest extends TestUtil {
       HashMap<String, Object[]> hpGrid = new HashMap<>();
       hpGrid.put("blending", new Boolean[]{true, false});
       hpGrid.put("noise_level", new Double[]{0.0, 0.01,  0.1});
-      // TODO figure out how to work with hierarchical parameters BlendingParams(inflection_point, smoothing) or BlendingParams(k, f)
       hpGrid.put("k", new Double[]{1.0, 2.0, 3.0});
       hpGrid.put("f", new Double[]{5.0, 10.0, 20.0});
       

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
@@ -1,0 +1,52 @@
+package ai.h2o.targetencoding.strategy;
+
+import ai.h2o.targetencoding.TargetEncoderModel;
+import hex.grid.HyperSpaceSearchCriteria;
+import hex.grid.HyperSpaceWalker;
+import hex.schemas.TargetEncoderV3;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.Scope;
+import water.TestUtil;
+import water.api.GridSearchHandler;
+
+import java.util.HashMap;
+
+public class TargetEncoderRGSTest extends TestUtil {
+
+  @BeforeClass
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void getTargetEncodingMapByTrainingTEBuilder() {
+
+    Scope.enter();
+    try {
+      HashMap<String, Object[]> hpGrid = new HashMap<>();
+      hpGrid.put("blending", new Boolean[]{true, false});
+      hpGrid.put("noise_level", new Double[]{0.0, 0.01,  0.1});
+      // TODO figure out how to work with hierarchical parameters BlendingParams(inflection_point, smoothing) or BlendingParams(k, f)
+//      hpGrid.put("_inflection_point", new Double[]{1.0, 2.0, 3.0, 5.0, 10.0, 50.0, 100.0});
+//      hpGrid.put("_smoothing", new Double[]{5.0, 10.0, 20.0});
+      
+      TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+
+      GridSearchHandler.DefaultModelParametersBuilderFactory<TargetEncoderModel.TargetEncoderParameters, TargetEncoderV3.TargetEncoderParametersV3> modelParametersBuilderFactory = new GridSearchHandler.DefaultModelParametersBuilderFactory<>();
+
+      HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+      HyperSpaceWalker.RandomDiscreteValueWalker<TargetEncoderModel.TargetEncoderParameters> walker = new HyperSpaceWalker.RandomDiscreteValueWalker<>(parameters, hpGrid, modelParametersBuilderFactory, hyperSpaceSearchCriteria);
+
+      HyperSpaceWalker.HyperSpaceIterator<TargetEncoderModel.TargetEncoderParameters> iterator = walker.iterator();
+      
+      while (iterator.hasNext(null)) {
+        TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = iterator.nextModelParameters(null);
+        System.out.println( targetEncoderParameters._blending + ":" +  targetEncoderParameters._noise_level);
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
+}

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
@@ -11,6 +11,9 @@ import water.TestUtil;
 import water.api.GridSearchHandler;
 
 import java.util.HashMap;
+import java.util.function.Function;
+
+import static org.junit.Assert.*;
 
 public class TargetEncoderRGSTest extends TestUtil {
 
@@ -28,8 +31,8 @@ public class TargetEncoderRGSTest extends TestUtil {
       hpGrid.put("blending", new Boolean[]{true, false});
       hpGrid.put("noise_level", new Double[]{0.0, 0.01,  0.1});
       // TODO figure out how to work with hierarchical parameters BlendingParams(inflection_point, smoothing) or BlendingParams(k, f)
-//      hpGrid.put("_inflection_point", new Double[]{1.0, 2.0, 3.0, 5.0, 10.0, 50.0, 100.0});
-//      hpGrid.put("_smoothing", new Double[]{5.0, 10.0, 20.0});
+      hpGrid.put("k", new Double[]{1.0, 2.0, 3.0});
+      hpGrid.put("f", new Double[]{5.0, 10.0, 20.0});
       
       TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
 
@@ -39,11 +42,13 @@ public class TargetEncoderRGSTest extends TestUtil {
       HyperSpaceWalker.RandomDiscreteValueWalker<TargetEncoderModel.TargetEncoderParameters> walker = new HyperSpaceWalker.RandomDiscreteValueWalker<>(parameters, hpGrid, modelParametersBuilderFactory, hyperSpaceSearchCriteria);
 
       HyperSpaceWalker.HyperSpaceIterator<TargetEncoderModel.TargetEncoderParameters> iterator = walker.iterator();
-      
+      int count = 0;
       while (iterator.hasNext(null)) {
         TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = iterator.nextModelParameters(null);
-        System.out.println( targetEncoderParameters._blending + ":" +  targetEncoderParameters._noise_level);
+        System.out.println( targetEncoderParameters._blending + ":" +  targetEncoderParameters._noise_level + ":" +  targetEncoderParameters._k + ":" +  targetEncoderParameters._f);
+        count++;
       }
+      assertEquals("Unexpected number of grid items", 54, count);
     } finally {
       Scope.exit();
     }


### PR DESCRIPTION
This PR is related to https://github.com/h2oai/h2o-3/pull/3183 task and essentially an attempt to reuse existing grid walkers for TargetEncoder.

In original PR https://github.com/h2oai/h2o-3/pull/3183 I had independently implemented RGS as before we did not treat TE  as a model( and HyperSpaceWalker is highly coupled with the model concept). But now we do threat TE as a regular model hence the effort of this PR.


As stated in jira https://0xdata.atlassian.net/browse/PUBDEV-7006 we are missing `noise` parameter.  If we will follow this jira proposal https://0xdata.atlassian.net/browse/PUBDEV-7007 then we will remove `data_leakage_handling` and `noise` parameters from the `TargetEncoderParameters` and therefore we won't be able to grid-search over them. 

The problem is that parameters we want to grid search over are not necessarily a Model parameters. Some parameters might be needed during application of the Model. 

Pipeline is as follows:
1) Train TE model
2) apply TE model with different params to different frames
3) train predictive Model (GBM, DRF etc) on training frame and predict on test frame
4) evaluate quality of predictions

So we would ideally want to operate with Pipeline parametes ( or collection of the Model parameters) when we do grid search with `HyperSpaceWalker` in order to be able to correctly reuse existing tools for RGS.

Update:
There is also a difficulty with BlendingParams field in `TargetEncoderParameters` as it is a class and not a primitive. Need to investigate how difficult it will be to adapt the code of random walker.
Update Update:
As a result this PR do the following things:
1) introduce `_noice_level` parameter to TargetEncoderParameters class. (Flow will reflect this)
2) exposed `seed` to a Flow UI so that `noise_level` could be reproducible
3) got rid of field of `BlendingParameters`  type and replaced it with just `k` and `f` blending parameters.
4) added test that shows that we can use `HyperSpaceWalker` to iterate over `TargetEncoderParameters`