### PR TITLE
Refactoring: get rid of obsolete references to UDP

### DIFF
--- a/h2o-core/src/main/java/water/FJPacket.java
+++ b/h2o-core/src/main/java/water/FJPacket.java
@@ -19,7 +19,7 @@ class FJPacket extends H2OCountedCompleter {
     super(UDP.udp.UDPS[ctrl]._prior);
     _ab = ab; _ctrl = ctrl;
     assert 0 < _ctrl && _ctrl < udp.UDPS.length;
-    assert udp.UDPS[_ctrl]._udp != null:"missing udp " + _ctrl;
+    assert udp.UDPS[_ctrl]._udp != null:"missing message handler " + _ctrl;
   }
 
   @Override

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -74,8 +74,8 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     _sendThread = null;
   }
 
-  private UDP_TCP_SendThread startSendThread() {
-    UDP_TCP_SendThread newSendThread = new UDP_TCP_SendThread(); // Launch the UDP send thread  
+  private SmallMessagesSendThread startSendThread() {
+    SmallMessagesSendThread newSendThread = new SmallMessagesSendThread(); // Launch the send thread for small messages  
     _sendThread = newSendThread;
     newSendThread.start();
     return newSendThread;
@@ -105,16 +105,24 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
         _ipLow = ArrayUtils.encodeAsLong(b, 0, 8);
       }
     }
-    public int htm_port() { return getPort()-H2O.ARGS.port_offset; }
-    public int udp_port() { return getPort()  ; }
-    @Override public String toString() { return getAddress()+":"+htm_port(); }
+    /**
+     * Retrieves the public communication port on which the REST API is exposed
+     * @return port number
+     */
+    int getApiPort() { return getPort()-H2O.ARGS.port_offset; }
+    /**
+     * Retrieves the internal node-to-node communication port
+     * @return port number
+     */
+    int getInternalPort() { return getPort()  ; }
+    @Override public String toString() { return getAddress()+":"+ getApiPort(); }
     public String getIpPortString() {
-      return getAddress().getHostAddress() + ":" + htm_port();
+      return getAddress().getHostAddress() + ":" + getApiPort();
     }
     AutoBuffer write( AutoBuffer ab ) {
       return (!H2O.IS_IPV6
               ? ab.put4((int) _ipLow)
-              : ab.put8(_ipLow).put8(_ipHigh)).put2((char) udp_port());
+              : ab.put8(_ipLow).put8(_ipHigh)).put2((char) getInternalPort());
     }
     static H2Okey read( AutoBuffer ab ) {
       try {
@@ -130,7 +138,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
       H2Okey key = (H2Okey)x;
       // Must be unsigned long-arithmetic, or overflow will make a broken sort
       int res = MathUtils.compareUnsigned(_ipHigh, _ipLow, key._ipHigh, key._ipLow);
-      return res != 0 ? res : udp_port() - key.udp_port();
+      return res != 0 ? res : getInternalPort() - key.getInternalPort();
     }
 
     static int SIZE_OF_IP = H2O.IS_IPV6 ? 16 : 4;
@@ -202,7 +210,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
       Log.info("Client reconnected with a new timestamp=" + newTimestamp + ", old client: " + toDebugString());
       if (_sendThread != null) {
         // We generally assume a lost client will eventually re-connect and we will want to deliver all the messages - 
-        // see the isActive() method in the UDP_TCP_SendThread. However, when we detect a client was re-spawned 
+        // see the isActive() method in the SmallMessagesSendThread. However, when we detect a client was re-spawned 
         // (and thus lost its previous state) we don't need to keep sending the old messages. That is why we kill the old 
         // thread right away by injecting a new fresh instance. The old thread will detect it is not active and will 
         // give the new one chance to start delivering messages.
@@ -412,15 +420,15 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   }
 
   // ---------------
-  // Send UDP via batched TCP.  Note: has to happen out-of-band with the
+  // Send a message via batched TCP.  Note: has to happen out-of-band with the
   // standard AutoBuffer writing, which can hit the case of needing a TypeId
   // mapping mid-serialization.  Thus this path uses another TCP channel that
   // is specifically not any of the above channels.  This channel is limited to
   // messages which are presented in their entirety (not streamed) thus never
   // need another (nested) TCP channel.
-  private transient UDP_TCP_SendThread _sendThread = null; // null if Node was removed from cloud or we didn't need to communicate with it yet
+  private transient SmallMessagesSendThread _sendThread = null; // null if Node was removed from cloud or we didn't need to communicate with it yet
   public final void sendMessage(ByteBuffer bb, byte msg_priority) {
-    UDP_TCP_SendThread sendThread = _sendThread;
+    SmallMessagesSendThread sendThread = _sendThread;
     if (sendThread == null) {
       // Sending threads are created lazily.
       // This is because we will intern all client nodes including the ones that have nothing to do with the cluster.
@@ -491,14 +499,14 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
   
   // Private thread serving (actually ships the bytes over) small msg Q.
   // Buffers the small messages together and sends the bytes over via TCP channel.
-  private static String SEND_THREAD_NAME_PREFIX = "UDP-TCP-SEND-";
-  class UDP_TCP_SendThread extends Thread {
+  private static String SEND_THREAD_NAME_PREFIX = "TCP-SMALL-SEND-";
+  class SmallMessagesSendThread extends Thread {
 
     private ByteChannel _chan;  // Lazily made on demand; closed & reopened on error
 
     private final ByteBuffer _bb; // Reusable output large buffer
 
-    UDP_TCP_SendThread(){
+    SmallMessagesSendThread(){
       super(SEND_THREAD_NAME_PREFIX + H2ONode.this);
       _bb = AutoBuffer.BBP_BIG.make();
     }
@@ -583,7 +591,7 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
           // booted.  Basically the ERRR log will show endless repeat attempts to
           // connect to the missing node
           if( keepSending() && !H2O.getShutdownRequested() && (Paxos._cloudLocked || retries++ > 300) ) {
-            Log.err("Got IO error when sending batch UDP bytes: ",ioe);
+            Log.err("Got IO error when sending a batch of bytes: ",ioe);
             retries = 150;      // Throttle the pace of error msgs
           }
           if( _chan != null )

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -130,7 +130,7 @@ public abstract class Paxos {
     Paxos.print("Announcing new Cloud Membership: ", H2O.CLOUD._memary);
     Log.info("Cloud of size ", H2O.CLOUD.size(), " formed ", H2O.CLOUD.toString());
     H2Okey leader = H2O.CLOUD.leader()._key;
-    H2O.notifyAboutCloudSize(H2O.SELF_ADDRESS, H2O.API_PORT, leader.getAddress(), leader.htm_port(), H2O.CLOUD.size());
+    H2O.notifyAboutCloudSize(H2O.SELF_ADDRESS, H2O.API_PORT, leader.getAddress(), leader.getApiPort(), H2O.CLOUD.size());
     return 0;
   }
 

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -105,7 +105,7 @@ public class TCPReceiverThread extends Thread {
         // Pass off the TCP connection to a separate reader thread
         switch( chanType ) {
         case TCP_SMALL:
-          new UDP_TCP_ReaderThread(H2ONode.intern(inetAddress, port, timestamp), wrappedSocket).start();
+          new SmallMessagesReaderThread(H2ONode.intern(inetAddress, port, timestamp), wrappedSocket).start();
           break;
         case TCP_BIG:
           new TCPReaderThread(wrappedSocket, new AutoBuffer(wrappedSocket, inetAddress, timestamp), inetAddress, timestamp).start();
@@ -192,13 +192,13 @@ public class TCPReceiverThread extends Thread {
    *  reads the raw bytes of a message from the channel, copies them into a
    *  byte array which is than passed on to FJQ.  Each message is expected to
    *  be MSG_SZ(2B) MSG BODY(MSG_SZ*B) EOM MARKER (1B - 0xef). */
-  static class UDP_TCP_ReaderThread extends Thread {
+  static class SmallMessagesReaderThread extends Thread {
     private final ByteChannel _chan;
     private final ByteBuffer _bb;
     private final H2ONode _h2o;
 
-    public UDP_TCP_ReaderThread(H2ONode h2o, ByteChannel chan) {
-      super("UDP-TCP-READ-" + h2o);
+    public SmallMessagesReaderThread(H2ONode h2o, ByteChannel chan) {
+      super("TCP-SMALL-READ-" + h2o);
       _h2o = h2o;
       _chan = chan;
       _bb = ByteBuffer.allocateDirect(AutoBuffer.BBP_BIG._size).order(ByteOrder.nativeOrder());
@@ -312,7 +312,7 @@ public class TCPReceiverThread extends Thread {
         // prior client was shutdown, it might see leftover trash UDP packets
         // from the servers intended for the prior client.
         if( !(H2O.ARGS.client && now-H2O.START_TIME_MILLIS.get() < HeartBeatThread.CLIENT_TIMEOUT) )
-          Log.warn("UDP packets from outside the cloud: "+_unknown_packets_per_sec+"/sec, last one from "+ab._h2o+ " @ "+new Date());
+          Log.warn("Received packets from outside the cloud: "+_unknown_packets_per_sec+"/sec, last one from "+ab._h2o+ " @ "+new Date());
         _unknown_packets_per_sec = 0;
         _unknown_packet_time = ab._h2o._last_heard_from;
       }

--- a/h2o-core/src/main/java/water/TimeLine.java
+++ b/h2o-core/src/main/java/water/TimeLine.java
@@ -87,7 +87,7 @@ public class TimeLine extends UDP {
     // not record who he sent to!  With this hack the Timeline record always
     // contains the info about "the other guy": inet+port for the receiver in
     // the sender's Timeline, and vice-versa for the receiver's Timeline.
-    if( sr==0 ) b0 = (b0 & ~0xFFFF00) | (h2o._key.udp_port()<<8);
+    if( sr==0 ) b0 = (b0 & ~0xFFFF00) | (h2o._key.getInternalPort()<<8);
     tl[idx*WORDS_PER_EVENT+2+1] = b0;
     tl[idx*WORDS_PER_EVENT+3+1] = b8;
   }
@@ -119,7 +119,7 @@ public class TimeLine extends UDP {
 //    H2ONode h2o = b._h2o==null ? H2O.SELF : b._h2o;
 //    // First long word going out has sender-port and a 'bad' control packet
 //    long b0 = UDP.udp.i_o.ordinal(); // Special flag to indicate io-record and not a rpc-record
-//    b0 |= H2O.SELF._key.udp_port()<<8;
+//    b0 |= H2O.SELF._key.getInternalPort()<<8;
 //    b0 |= flavor<<24;           // I/O flavor; one of the Value.persist backends
 //    long iotime = b._time_start_ms > 0 ? (b._time_close_ms - b._time_start_ms) : 0;
 //    b0 |= iotime<<32;           // msec from start-to-finish, including non-i/o overheads
@@ -142,7 +142,7 @@ public class TimeLine extends UDP {
 //    long io_ms = System.currentTimeMillis() - start_io_ms;
 //    // First long word going out has sender-port and a 'bad' control packet
 //    long b0 = UDP.udp.i_o.ordinal(); // Special flag to indicate io-record and not a rpc-record
-//    b0 |= H2O.SELF._key.udp_port()<<8;
+//    b0 |= H2O.SELF._key.getInternalPort()<<8;
 //    b0 |= flavor<<24;           // I/O flavor; one of the Value.persist backends
 //    b0 |= io_ms<<32;            // msec from start-to-finish, including non-i/o overheads
 //    record2(H2O.SELF,block_ns,true,r_w,0,b0,size);

--- a/h2o-core/src/main/java/water/init/TimelineSnapshot.java
+++ b/h2o-core/src/main/java/water/init/TimelineSnapshot.java
@@ -209,7 +209,7 @@ public final class TimelineSnapshot implements
         case i_o:                 // Shows up as I/O-completing recorded packets
           return false;
         default:
-          throw new RuntimeException("unexpected udp packet type " + e.toString());
+          throw new RuntimeException("unexpected packet type " + e.toString());
       }
 
       // Check that port numbers are compatible.  Really check that the


### PR DESCRIPTION
People are sometimes confused by error messages that mention "UDP" packets.

UDP was originally used to exchange small messages between H2O nodes, I removed the references from places that only use TCP.

I left all UDP classes - the meaning of UDP over the time changed to "small messages", we can kill the rest of the UDP references eventually as well but IMHO this change should be good enough to clear the confusion.