### PR TITLE
Normalize paths before importing

### DIFF
--- a/h2o-r/h2o-package/R/import.R
+++ b/h2o-r/h2o-package/R/import.R
@@ -102,6 +102,9 @@ h2o.importFolder <- function(path, pattern = "", destination_frame = "", parse =
       skipped_columns[a] = skipped_columns[a]-1   # change index to be from 0 to ncol-1
     }
   }
+  
+  path <- sapply(path, normalizePath, mustWork = FALSE)
+  
   if(length(path) > 1L) {
     destFrames <- c()
     fails <- c()


### PR DESCRIPTION
If importing files with not absolute paths then it gets an error, this can be fixed by normalizing paths before importing.

## Before fix

To reproduce:

Download example csv file:

``` bash
mkdir -p ~/mytmp/data
cd ~/mytmp/data
wget https://raw.githubusercontent.com/ledell/LatinR-2019-h2o-tutorial/master/data/loan.csv
```

``` r
library("h2o") 
h2o.init()
```

    ##  Connection successful!
    ## 
    ## R is connected to the H2O cluster: 
    ##     H2O cluster uptime:         6 minutes 20 seconds 
    ##     H2O cluster timezone:       Asia/Vientiane 
    ##     H2O data parsing timezone:  UTC 
    ##     H2O cluster version:        3.27.0.99999 
    ##     H2O cluster version age:    23 minutes  
    ##     H2O cluster name:           H2O_started_from_R_jcrodriguez_udr558 
    ##     H2O cluster total nodes:    1 
    ##     H2O cluster total memory:   3.18 GB 
    ##     H2O cluster total cores:    8 
    ##     H2O cluster allowed cores:  8 
    ##     H2O cluster healthy:        TRUE 
    ##     H2O Connection ip:          localhost 
    ##     H2O Connection port:        54321 
    ##     H2O Connection proxy:       NA 
    ##     H2O Internal Security:      FALSE 
    ##     H2O API Extensions:         Amazon S3, XGBoost, Algos, AutoML, Core V3, TargetEncoder, Core V4 
    ##     R Version:                  R version 3.6.1 (2019-07-05)

``` r
## error loading with relative path
setwd("~")
data_file <- "./mytmp/data/loan.csv"

file.exists(data_file)
```

    ## [1] TRUE

``` r
data <- h2o.importFile(data_file)
```

    ## 
    ## ERROR: Unexpected HTTP Status code: 404 Not Found (url = http://localhost:54321/3/ImportFiles?path=.%2Fmytmp%2Fdata%2Floan.csv&pattern=)
    ## 
    ## water.exceptions.H2ONotFoundArgumentException
    ##  [1] "water.exceptions.H2ONotFoundArgumentException: File ./mytmp/data/loan.csv does not exist"                           
    ##  [2] "    water.persist.PersistNFS.importFiles(PersistNFS.java:136)"                                                      
    ##  [3] "    water.persist.PersistManager.importFiles(PersistManager.java:374)"                                              
    ##  [4] "    water.api.ImportFilesHandler.importFiles(ImportFilesHandler.java:25)"                                           
    ##  [5] "    sun.reflect.GeneratedMethodAccessor5.invoke(Unknown Source)"                                                    
    ##  [6] "    sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)"                          
    ##  [7] "    java.lang.reflect.Method.invoke(Method.java:498)"                                                               
    ##  [8] "    water.api.Handler.handle(Handler.java:60)"                                                                      
    ##  [9] "    water.api.RequestServer.serve(RequestServer.java:468)"                                                          
    ## [10] "    water.api.RequestServer.doGeneric(RequestServer.java:301)"                                                      
    ## [11] "    water.api.RequestServer.doGet(RequestServer.java:225)"                                                          
    ## [12] "    javax.servlet.http.HttpServlet.service(HttpServlet.java:735)"                                                   
    ## [13] "    javax.servlet.http.HttpServlet.service(HttpServlet.java:848)"                                                   
    ## [14] "    org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:684)"                                         
    ## [15] "    org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:501)"                                     
    ## [16] "    org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086)"                             
    ## [17] "    org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:427)"                                      
    ## [18] "    org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020)"                              
    ## [19] "    org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135)"                                  
    ## [20] "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:154)"                          
    ## [21] "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)"                                
    ## [22] "    water.webserver.jetty8.Jetty8ServerAdapter$LoginHandler.handle(Jetty8ServerAdapter.java:119)"                   
    ## [23] "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:154)"                          
    ## [24] "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)"                                
    ## [25] "    org.eclipse.jetty.server.Server.handle(Server.java:370)"                                                        
    ## [26] "    org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:494)"                 
    ## [27] "    org.eclipse.jetty.server.BlockingHttpConnection.handleRequest(BlockingHttpConnection.java:53)"                  
    ## [28] "    org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:973)"                
    ## [29] "    org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1035)"
    ## [30] "    org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:641)"                                               
    ## [31] "    org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:231)"                                          
    ## [32] "    org.eclipse.jetty.server.BlockingHttpConnection.handle(BlockingHttpConnection.java:72)"                         
    ## [33] "    org.eclipse.jetty.server.bio.SocketConnector$ConnectorEndPoint.run(SocketConnector.java:264)"                   
    ## [34] "    org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)"                               
    ## [35] "    org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)"                                
    ## [36] "    java.lang.Thread.run(Thread.java:748)"

    ## Error in .h2o.doSafeREST(h2oRestApiVersion = h2oRestApiVersion, urlSuffix = page, : 
    ## 
    ## ERROR MESSAGE:
    ## 
    ## File ./mytmp/data/loan.csv does not exist

``` r
data <- h2o.importFile(normalizePath(data_file))
```

    ## 
      |                                                                       
      |                                                                 |   0%
      |                                                                       
      |=================================================================| 100%

``` r
## error loading with alias path
data_file <- "~/mytmp/data/loan.csv"

file.exists(data_file)
```

    ## [1] TRUE

``` r
data <- h2o.importFile(data_file)
```

    ## 
    ## ERROR: Unexpected HTTP Status code: 404 Not Found (url = http://localhost:54321/3/ImportFiles?path=~%2Fmytmp%2Fdata%2Floan.csv&pattern=)
    ## 
    ## water.exceptions.H2ONotFoundArgumentException
    ##  [1] "water.exceptions.H2ONotFoundArgumentException: File ~/mytmp/data/loan.csv does not exist"                           
    ##  [2] "    water.persist.PersistNFS.importFiles(PersistNFS.java:136)"                                                      
    ##  [3] "    water.persist.PersistManager.importFiles(PersistManager.java:374)"                                              
    ##  [4] "    water.api.ImportFilesHandler.importFiles(ImportFilesHandler.java:25)"                                           
    ##  [5] "    sun.reflect.GeneratedMethodAccessor5.invoke(Unknown Source)"                                                    
    ##  [6] "    sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)"                          
    ##  [7] "    java.lang.reflect.Method.invoke(Method.java:498)"                                                               
    ##  [8] "    water.api.Handler.handle(Handler.java:60)"                                                                      
    ##  [9] "    water.api.RequestServer.serve(RequestServer.java:468)"                                                          
    ## [10] "    water.api.RequestServer.doGeneric(RequestServer.java:301)"                                                      
    ## [11] "    water.api.RequestServer.doGet(RequestServer.java:225)"                                                          
    ## [12] "    javax.servlet.http.HttpServlet.service(HttpServlet.java:735)"                                                   
    ## [13] "    javax.servlet.http.HttpServlet.service(HttpServlet.java:848)"                                                   
    ## [14] "    org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:684)"                                         
    ## [15] "    org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:501)"                                     
    ## [16] "    org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1086)"                             
    ## [17] "    org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:427)"                                      
    ## [18] "    org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1020)"                              
    ## [19] "    org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:135)"                                  
    ## [20] "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:154)"                          
    ## [21] "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)"                                
    ## [22] "    water.webserver.jetty8.Jetty8ServerAdapter$LoginHandler.handle(Jetty8ServerAdapter.java:119)"                   
    ## [23] "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:154)"                          
    ## [24] "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:116)"                                
    ## [25] "    org.eclipse.jetty.server.Server.handle(Server.java:370)"                                                        
    ## [26] "    org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:494)"                 
    ## [27] "    org.eclipse.jetty.server.BlockingHttpConnection.handleRequest(BlockingHttpConnection.java:53)"                  
    ## [28] "    org.eclipse.jetty.server.AbstractHttpConnection.headerComplete(AbstractHttpConnection.java:973)"                
    ## [29] "    org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.headerComplete(AbstractHttpConnection.java:1035)"
    ## [30] "    org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:641)"                                               
    ## [31] "    org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:231)"                                          
    ## [32] "    org.eclipse.jetty.server.BlockingHttpConnection.handle(BlockingHttpConnection.java:72)"                         
    ## [33] "    org.eclipse.jetty.server.bio.SocketConnector$ConnectorEndPoint.run(SocketConnector.java:264)"                   
    ## [34] "    org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:608)"                               
    ## [35] "    org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:543)"                                
    ## [36] "    java.lang.Thread.run(Thread.java:748)"

    ## Error in .h2o.doSafeREST(h2oRestApiVersion = h2oRestApiVersion, urlSuffix = page, : 
    ## 
    ## ERROR MESSAGE:
    ## 
    ## File ~/mytmp/data/loan.csv does not exist

``` r
data <- h2o.importFile(normalizePath(data_file))
```

    ## 
      |                                                                       
      |                                                                 |   0%
      |                                                                       
      |==                                                               |   3%
      |                                                                       
      |=================================================================| 100%

## After fix

Now it works for single files, multiple files, for importFolder, and also for URLs

``` r
library("h2o") 
h2o.init()
setwd("~")
data_file <- "./mytmp/data/loan.csv"
data <- h2o.importFile(data_file)
```

    ## 
      |                                                                       
      |                                                                 |   0%
      |                                                                       
      |======================                                           |  34%
      |                                                                       
      |=================================================================| 100%

``` r
dim(data)
```

    ## [1] 163987     15

``` r
data_file <- "~/mytmp/data/loan.csv"
data <- h2o.importFile(data_file)
```

    ## 
      |                                                                       
      |                                                                 |   0%
      |                                                                       
      |=================================================================| 100%

``` r
dim(data)
```

    ## [1] 163987     15

``` r
file.copy("./mytmp/data/loan.csv", "./mytmp/data/loan_copy.csv", overwrite = TRUE)
```

    ## [1] TRUE

``` r
data <- h2o.importFile(c("./mytmp/data/loan.csv", "~/mytmp/data/loan_copy.csv"))
```

    ## 
      |                                                                       
      |                                                                 |   0%
      |                                                                       
      |=================================================================| 100%

``` r
dim(data)
```

    ## [1] 327974     15

``` r
data <- h2o.importFolder("~/mytmp/data")
```

    ## 
      |                                                                       
      |                                                                 |   0%
      |                                                                       
      |=================================================================| 100%

``` r
dim(data)
```

    ## [1] 327974     15

``` r
data_file <- "https://raw.githubusercontent.com/ledell/LatinR-2019-h2o-tutorial/master/data/loan.csv"
data <- h2o.importFile(data_file)
```

    ## 
      |                                                                       
      |                                                                 |   0%
      |                                                                       
      |============                                                     |  19%
      |                                                                       
      |==========================                                       |  41%
      |                                                                       
      |=================================================                |  75%
      |                                                                       
      |=================================================================| 100%

``` r
dim(data)
```

    ## [1] 163987     15
