### PR TITLE
PUBDEV-6998: ensure project_name is validated before AutoML is being trained

### DIFF
--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -7,6 +7,7 @@ from h2o.exceptions import H2OValueError
 from h2o.frame import H2OFrame
 from h2o.job import H2OJob
 from h2o.model.model_base import ModelBase
+from h2o.utils.shared_utils import check_id
 from h2o.utils.typechecks import assert_is_type, is_type
 
 
@@ -206,6 +207,7 @@ class H2OAutoML(Keyed):
         # Set project name if provided. If None, then we set in .train() to "automl_" + training_frame.frame_id
         if project_name is not None:
             assert_is_type(project_name, str)
+            check_id(project_name, "H2OAutoML")
             self.build_control["project_name"] = project_name
             self.project_name = project_name
         else:

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -44,19 +44,22 @@ def _py_tmp_key(append):
 
 
 def check_frame_id(frame_id):
-    """Check that the provided frame id is valid in Rapids language."""
-    if frame_id is None:
+    check_id(frame_id, "H2OFrame")
+
+
+def check_id(id, type):
+    """Check that the provided id is valid in Rapids language."""
+    if id is None:
         return
-    if frame_id.strip() == "":
-        raise H2OValueError("Frame id cannot be an empty string: %r" % frame_id)
-    for i, ch in enumerate(frame_id):
+    if id.strip() == "":
+        raise H2OValueError("%s id cannot be an empty string: %r" % (type, id))
+    for i, ch in enumerate(id):
         # '$' character has special meaning at the beginning of the string; and prohibited anywhere else
         if ch == "$" and i == 0: continue
         if ch not in _id_allowed_characters:
-            raise H2OValueError("Character '%s' is illegal in frame id: %s" % (ch, frame_id))
-    if re.match(r"-?[0-9]", frame_id):
-        raise H2OValueError("Frame id cannot start with a number: %s" % frame_id)
-
+            raise H2OValueError("Character '%s' is illegal in %s id: %s" % (ch, type, id))
+    if re.match(r"-?[0-9]", id):
+        raise H2OValueError("%s id cannot start with a number: %s" % (type, id))
 
 
 def temp_ctr():

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -40,6 +40,15 @@ def get_partitioned_model_names(leaderboard):
     return model_names, non_se_model_names, se_model_names
 
 
+def test_invalid_project_name():
+    print("Check constructor raises error if project name is invalid")
+    try:
+        H2OAutoML(project_name="1nvalid")
+    except Exception as e:
+        assert "H2OAutoML" in str(e)
+        assert "1nvalid" in str(e)
+
+
 def test_early_stopping_args():
     print("Check arguments to H2OAutoML class")
     ds = import_dataset()
@@ -293,6 +302,7 @@ def test_frames_cannot_be_passed_as_key():
     # Add a test that checks fold_column like in runit
 
 pyunit_utils.run_tests([
+    test_invalid_project_name,
     test_early_stopping_args,
     test_no_x_train_set_only,
     test_no_x_train_and_validation_sets,

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -177,6 +177,7 @@ h2o.automl <- function(x, y, training_frame,
   }
 
   if (!is.null(project_name)) {
+    .key.validate(project_name)
     build_control$project_name <- project_name
   }
 
@@ -411,10 +412,8 @@ h2o.predict.H2OAutoML <- function(object, newdata, ...) {
     modeling_steps <- NULL
   }
 
-  project <- automl_job$project
-
   return(list(
-    project_name=project,
+    project_name=project_name,
     leaderboard=leaderboard,
     leader=leader,
     event_log=event_log,

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -46,6 +46,16 @@ automl.args.test <- function() {
 
     print("Check arguments to H2OAutoML class")
 
+    test_invalid_project_name <- function() {
+      print("Try a project name starting with a number")
+      ds <- import_dataset()
+      expect_error(h2o.automl(y = ds$y,
+                              training_frame = ds$train,
+                              max_models = max_models,
+                              project_name = "1nvalid_name"),
+                   "1nvalid_name")
+    }
+
     test_without_y <- function() {
         print("Try without a y")
         ds <- import_dataset()
@@ -416,6 +426,7 @@ automl.args.test <- function() {
 
 
     makeSuite(
+        test_invalid_project_name,
         test_without_y,
         test_without_x,
         test_y_as_index_x_as_name,


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6998

Minor fix: needs to restrict project_name to the same constraints as for h2o frames, because we're dynamically generating leaderboard and event_log frames from this project name