### PR TITLE
PUBDEV-6195: AutoML, add warning message on empty leaderboard 

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -284,6 +284,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     if (0 < leaderboard().getModelKeys().length) {
       Log.info(leaderboard().toTwoDimTable("Leaderboard for project " + projectName(), true).toString());
+    } else {
+      long max_runtime_secs = (long)_buildSpec.build_control.stopping_criteria.max_runtime_secs();
+      eventLog().warn(Stage.Workflow, "Empty leaderboard.\n"
+              +"AutoML was not able to build any model within a max runtime constraint of "+max_runtime_secs+" seconds, "
+              +"you may want to increase this value before retrying.");
     }
 
     possiblyVerifyImmutability();

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -69,7 +69,7 @@ class H2OAutoML(Keyed):
                  keep_cross_validation_fold_assignment=False,
                  sort_metric="AUTO",
                  export_checkpoints_dir=None,
-                 verbosity=None):
+                 verbosity="warn"):
         """
         Create a new H2OAutoML instance.
         
@@ -122,7 +122,7 @@ class H2OAutoML(Keyed):
           ``"mse"``, ``"mae"``, ``"rmlse"``. For multinomial classification choose between ``"mean_per_class_error"``, ``"logloss"``, ``"rmse"``, ``"mse"``.
         :param export_checkpoints_dir: Path to a directory where every model will be stored in binary form.
         :param verbosity: Verbosity of the backend messages printed during training.
-            Available options are 'debug', 'info' or 'warn'. Defaults to None (disable live log).
+            Available options are None (live log disabled), 'debug', 'info' or 'warn'. Defaults to 'warn'.
         """
         # Check if H2O jar contains AutoML
         try:

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -56,7 +56,7 @@
 #'        "mean_per_class_error" for multinomial classification, and "mean_residual_deviance" for regression.
 #' @param export_checkpoints_dir (Optional) Path to a directory where every model will be stored in binary form.
 #' @param verbosity Verbosity of the backend messages printed during training; Optional.
-#'        Must be one of "debug", "info", "warn". Defaults to NULL (disable live log).
+#'        Must be one of NULL (live log disabled), "debug", "info", "warn". Defaults to "warn".
 #' @details AutoML finds the best model, given a training frame and response, and returns an H2OAutoML object,
 #'          which contains a leaderboard of all the models that were trained in the process, ranked by a default model performance metric.
 #' @return An \linkS4class{H2OAutoML} object.
@@ -95,7 +95,7 @@ h2o.automl <- function(x, y, training_frame,
                        keep_cross_validation_fold_assignment = FALSE,
                        sort_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "mean_per_class_error"),
                        export_checkpoints_dir = NULL,
-                       verbosity = NULL)
+                       verbosity = "warn")
 {
 
   tryCatch({
@@ -282,6 +282,7 @@ h2o.automl <- function(x, y, training_frame,
     poll_state <<- do.call(.automl.poll_updates, list(job, verbosity=verbosity, state=poll_state))
   }
   .h2o.__waitOnJob(res$job$key$name, pollUpdates=poll_updates)
+  .automl.poll_updates(h2o.get_job(res$job$key$name), verbosity, poll_state) # ensure the last update is retrieved
 
   # GET AutoML object
   aml <- h2o.getAutoML(project_name = res$job$dest$name)

--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -790,6 +790,19 @@ h2o.list_jobs <- function() {
   df
 }
 
+h2o.get_job <- function(job_key) {
+  myJobUrlSuffix <- paste0(.h2o.__JOBS, "/", job_key)
+  rawResponse <- .h2o.doSafeGET(urlSuffix = myJobUrlSuffix)
+  jsonObject <- .h2o.fromJSON(jsonlite::fromJSON(rawResponse, simplifyDataFrame=FALSE))
+  jobs <- jsonObject$jobs
+  if (length(jobs) > 1) {
+    stop("Job list has more than 1 entry")
+  } else if (length(jobs) == 0) {
+    stop("Job list is empty")
+  }
+  jobs[[1]]
+}
+
 #' Check H2O Server Health
 #'
 #' Warn if there are sick nodes.
@@ -866,18 +879,8 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
   keepRunning <- TRUE
   tryCatch({
     while (keepRunning) {
-      myJobUrlSuffix <- paste0(.h2o.__JOBS, "/", job_key)
-      rawResponse <- .h2o.doSafeGET(urlSuffix = myJobUrlSuffix)
-      jsonObject <- .h2o.fromJSON(jsonlite::fromJSON(rawResponse, simplifyDataFrame=FALSE))
-      jobs <- jsonObject$jobs
-      if (length(jobs) > 1) {
-        stop("Job list has more than 1 entry")
-      } else if (length(jobs) == 0) {
-        stop("Job list is empty")
-      }
-
-      job = jobs[[1]]
-      status = job$status
+      job <- h2o.get_job(job_key)
+      status <- job$status
       stopifnot(is.character(status))
 
       # check failed up front...

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -1,7 +1,7 @@
 setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
-automl.leaderboard.test <- function() {
+automl.leaderboard.suite <- function() {
 
     # Test each ML task to make sure the leaderboard is working as expected:
     # Leaderboard columns are correct for each ML task
@@ -10,84 +10,105 @@ automl.leaderboard.test <- function() {
 
     all_algos <- c("GLM", "DeepLearning", "GBM", "DRF", "XGBoost", "StackedEnsemble")
 
-    # Binomial:
-    fr1 <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
-    fr1["CAPSULE"] <- as.factor(fr1["CAPSULE"])
-    exclude_algos <- c("GLM", "DeepLearning", "DRF")  #Expect GBM + StackedEnsemble
-    aml1 <- h2o.automl(y = 2, training_frame = fr1, max_models = 10,
-                       project_name = "r_lb_test_aml1",
-                       exclude_algos = exclude_algos)
-    aml1@leaderboard
-    # check that correct leaderboard columns exist
-    expect_equal(names(aml1@leaderboard), c("model_id", "auc", "logloss", "mean_per_class_error", "rmse", "mse"))
-    model_ids <- as.vector(aml1@leaderboard$model_id)
-    # check that no excluded algos are present in leaderboard
-    exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
-    expect_equal(exclude_algo_count, 0)
-    include_algos <- setdiff(all_algos, exclude_algos)
-    # check that expected algos are included in leaderboard
-    for (a in include_algos) {
-      expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+    test.binomial <- function() {
+        # Binomial:
+        fr <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))
+        fr["CAPSULE"] <- as.factor(fr["CAPSULE"])
+        exclude_algos <- c("GLM", "DeepLearning", "DRF")  #Expect GBM + StackedEnsemble
+        aml <- h2o.automl(y = 2, training_frame = fr, max_models = 10,
+                           project_name = "r_aml_lb_binomial_test",
+                           exclude_algos = exclude_algos)
+        aml@leaderboard
+        # check that correct leaderboard columns exist
+        expect_equal(names(aml@leaderboard), c("model_id", "auc", "logloss", "mean_per_class_error", "rmse", "mse"))
+        model_ids <- as.vector(aml@leaderboard$model_id)
+        # check that no excluded algos are present in leaderboard
+        exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
+        expect_equal(exclude_algo_count, 0)
+        include_algos <- setdiff(all_algos, exclude_algos)
+        # check that expected algos are included in leaderboard
+        for (a in include_algos) {
+          expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+        }
     }
 
 
-    # Regression:
-    fr2 <- h2o.uploadFile(locate("smalldata/extdata/australia.csv"))
-    exclude_algos <- c("GBM", "DeepLearning")  #Expect GLM, DRF (and XRT), XGBoost, StackedEnsemble
-    aml2 <- h2o.automl(y = "runoffnew", training_frame = fr2, max_models = 10,
-                       project_name = "r_lb_test_aml2",
-                       exclude_algos = exclude_algos)
-    aml2@leaderboard
-    expect_equal(names(aml2@leaderboard), c("model_id", "mean_residual_deviance", "rmse", "mse", "mae", "rmsle"))
-    model_ids <- as.vector(aml2@leaderboard$model_id)
-    # check that no excluded algos are present in leaderboard
-    exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
-    expect_equal(exclude_algo_count, 0)
-    include_algos <- c(setdiff(all_algos, exclude_algos), "XRT")
-    # check that expected algos are included in leaderboard
-    for (a in include_algos) {
-      expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+    test.regression <- function() {
+        # Regression:
+        fr <- h2o.uploadFile(locate("smalldata/extdata/australia.csv"))
+        exclude_algos <- c("GBM", "DeepLearning")  #Expect GLM, DRF (and XRT), XGBoost, StackedEnsemble
+        aml <- h2o.automl(y = "runoffnew", training_frame = fr, max_models = 10,
+                           project_name = "r_aml_lb_regression_test",
+                           exclude_algos = exclude_algos)
+        aml@leaderboard
+        expect_equal(names(aml@leaderboard), c("model_id", "mean_residual_deviance", "rmse", "mse", "mae", "rmsle"))
+        model_ids <- as.vector(aml@leaderboard$model_id)
+        # check that no excluded algos are present in leaderboard
+        exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
+        expect_equal(exclude_algo_count, 0)
+        include_algos <- c(setdiff(all_algos, exclude_algos), "XRT")
+        # check that expected algos are included in leaderboard
+        for (a in include_algos) {
+          expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+        }
     }
 
-    # Multinomial:
-    fr3 <- as.h2o(iris)
-    exclude_algos <- c("XGBoost")
-    aml3 <- h2o.automl(y = 5, training_frame = fr3, max_models = 10,
-                       project_name = "r_lb_test_aml3",
-                       exclude_algos = exclude_algos)
-    aml3@leaderboard
-    expect_equal(names(aml3@leaderboard),c("model_id", "mean_per_class_error", "logloss", "rmse", "mse"))
-    model_ids <- as.vector(aml3@leaderboard$model_id)
-    # check that no excluded algos are present in leaderboard
-    exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
-    expect_equal(exclude_algo_count, 0)
-    # check that expected algos are included in leaderboard
-    include_algos <- c(setdiff(all_algos, exclude_algos), "XRT")
-    for (a in include_algos) {
-      expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+    test.multinomial <- function() {
+        # Multinomial:
+        fr <- as.h2o(iris)
+        exclude_algos <- c("XGBoost")
+        aml <- h2o.automl(y = 5, training_frame = fr, max_models = 10,
+                           project_name = "r_aml_lb_multinomial_test",
+                           exclude_algos = exclude_algos)
+        aml@leaderboard
+        expect_equal(names(aml@leaderboard),c("model_id", "mean_per_class_error", "logloss", "rmse", "mse"))
+        model_ids <- as.vector(aml@leaderboard$model_id)
+        # check that no excluded algos are present in leaderboard
+        exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
+        expect_equal(exclude_algo_count, 0)
+        # check that expected algos are included in leaderboard
+        include_algos <- c(setdiff(all_algos, exclude_algos), "XRT")
+        for (a in include_algos) {
+          expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+        }
     }
 
+    test.empty_leaderboard <- function() {
+        # Exclude all the algorithms, check for empty leaderboard
+        fr <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))  #need to reload data (getting error otherwise)
+        fr["CAPSULE"] <- as.factor(fr["CAPSULE"])
+        exclude_algos <- c("GLM", "DRF", "GBM", "DeepLearning", "XGBoost", "StackedEnsemble")
+        aml <- h2o.automl(y = 2, training_frame = fr, max_runtime_secs = 5,
+                           project_name = "r_aml_lb_empty_test",
+                           exclude_algos = exclude_algos)
+        aml@leaderboard
+        expect_equal(nrow(aml@leaderboard), 0)
 
-    # Exclude all the algorithms, check for empty leaderboard
-    fr1 <- h2o.uploadFile(locate("smalldata/logreg/prostate.csv"))  #need to reload data (getting error otherwise)
-    fr1["CAPSULE"] <- as.factor(fr1["CAPSULE"])
-    exclude_algos <- c("GLM", "DRF", "GBM", "DeepLearning", "XGBoost", "StackedEnsemble")
-    aml4 <- h2o.automl(y = 2, training_frame = fr1, max_runtime_secs = 5,
-                       project_name = "r_lb_test_aml4",
-                       exclude_algos = exclude_algos)
-    aml4@leaderboard
-    expect_equal(nrow(aml4@leaderboard), 0)
-
-    # Include all algorithms (all should be there, given large enough max_models)
-    fr3 <- as.h2o(iris)
-    aml5 <- h2o.automl(y = 5, training_frame = fr3, max_models = 12,
-                       project_name = "r_lb_test_aml5")
-    model_ids <- as.vector(aml5@leaderboard$model_id)
-    include_algos <- c(all_algos, "XRT")
-    for (a in include_algos) {
-      expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+        warnings = aml@event_log[aml@event_log['level'] == 'Warn','message']
+        last_warning = warnings[nrow(warnings), 1]
+        expect_true(grepl("Empty leaderboard", last_warning))
     }
 
+    test.all_algos <- function() {
+        # Include all algorithms (all should be there, given large enough max_models)
+        fr <- as.h2o(iris)
+        aml <- h2o.automl(y = 5, training_frame = fr, max_models = 12,
+                           project_name = "r_aml_lb__all_algoes_test")
+        model_ids <- as.vector(aml@leaderboard$model_id)
+        include_algos <- c(all_algos, "XRT")
+        for (a in include_algos) {
+          expect_equal(sum(grepl(a, model_ids)) > 0, TRUE)
+        }
+    }
+
+    makeSuite(
+      test.binomial,
+      test.regression,
+      test.multinomial,
+      test.empty_leaderboard,
+      test.all_algos
+    )
 }
 
-doTest("AutoML Leaderboard Test", automl.leaderboard.test)
+doSuite("AutoML Leaderboard Test", automl.leaderboard.suite())
+


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6195

Raise warning event from backend on empty leaderboard.
Also set verbosity to 'warn' by default from Py+R clients, otherwise those warnings are pointless.