### PR TITLE
PUBDEV-7011: fixed swallowed error on model.actual_params property

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -88,7 +88,7 @@ class ModelBase(backwards_compatible(Keyed)):
         params = {}
         for p in self.parms:
             if p in params_to_select.keys():
-                params[p] = self.parms[p]["actual_value"].get(params_to_select[p], None)
+                params[p] = (self.parms[p].get("actual_value") or {}).get(params_to_select[p], None)
             else:
                 params[p] = self.parms[p]["actual_value"]
         return params


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7011

`@property` decorator is swallowing errors raised by the property function, hence the confusing result when trying to obtain `actual_value` from `None` validation frame. 