### PR TITLE
PUBDEV-6987: Fix bug for merge involving empty frames

### DIFF
--- a/h2o-core/src/main/java/water/rapids/BinaryMerge.java
+++ b/h2o-core/src/main/java/water/rapids/BinaryMerge.java
@@ -14,6 +14,7 @@ import water.util.Log;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import static java.math.BigInteger.ONE;
 
 import static water.rapids.SingleThreadRadixOrder.getSortedOXHeaderKey;
 
@@ -74,10 +75,10 @@ class BinaryMerge extends DTask<BinaryMerge> {
     }
     
     long min() {
-      return BigInteger.valueOf(((long)_msb) << _shift).add(_base[0].subtract(BigInteger.ONE)).longValue();
+      return BigInteger.valueOf(((long)_msb) << _shift).add(_base[0].subtract(ONE)).longValue();
     }
     long max() {
-      return BigInteger.valueOf(((long)_msb+1) << _shift).add(_base[0].subtract(BigInteger.ONE).subtract(BigInteger.ONE)).longValue();
+      return BigInteger.valueOf(((long)_msb+1) << _shift).add(_base[0].subtract(ONE).subtract(ONE)).longValue();
     }
   }
 
@@ -325,7 +326,7 @@ class BinaryMerge extends DTask<BinaryMerge> {
 
   private long updateVal(Long oldVal, BigInteger baseD) {
     // we know oldVal is not zero
-    BigInteger xInc = baseD.add(BigInteger.valueOf(oldVal).subtract(BigInteger.ONE));
+    BigInteger xInc = baseD.add(BigInteger.valueOf(oldVal).subtract(ONE));
     if (xInc.bitLength() > 64) {
       Log.warn("Overflow in BinaryMerge.java");
       return oldVal;  // should have died sooner or later

--- a/h2o-core/src/main/java/water/rapids/Merge.java
+++ b/h2o-core/src/main/java/water/rapids/Merge.java
@@ -8,7 +8,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import static java.math.BigInteger.ZERO;
+import static java.math.BigInteger.ONE;
 import static water.rapids.SingleThreadRadixOrder.getSortedOXHeaderKey;
 
 public class Merge {
@@ -52,7 +53,6 @@ public class Merge {
   public static Frame merge(final Frame leftFrame, final Frame riteFrame, final int leftCols[], final int riteCols[],
                             boolean allLeft, int[][] id_maps) {
     int[] ascendingL, ascendingR;
-
     if (leftCols != null && leftCols.length>0) {
       ascendingL = new int[leftCols.length];
       Arrays.fill(ascendingL, 1);
@@ -109,6 +109,7 @@ public class Merge {
 
     // Running 3 consecutive times on an idle cluster showed that running left
     // and right in parallel was a little slower (97s) than one by one (89s).
+    // empty frame will come back with base = Long.MIN_VALUE (-9223372036854775808).  
     // TODO: retest in future
     RadixOrder leftIndex = createIndex(true ,leftFrame,leftCols,id_maps, ascendingL);
     RadixOrder riteIndex = createIndex(false,rightFrame,riteCols,id_maps, ascendingR);
@@ -125,7 +126,16 @@ public class Merge {
     final BigInteger riteBase = hasRite ? riteIndex._base [0] : leftBase;
 
     // initialize for double columns, may not be used....
-    long leftMSBfrom = riteBase.subtract(leftBase).shiftRight(leftShift).longValue();
+    boolean leftFrameEmpty = (leftFrame.numRows()==0);
+    boolean riteFrameEmpty = (riteFrame.numRows()==0);
+    long leftMSBfrom = riteBase.subtract(leftBase).shiftRight(leftShift).longValue();  // value when all frames nonempty
+    if (riteFrameEmpty) { // if riteFrame is empty, need to modify it because riteBase is Long.MIN_VALUE
+      if (leftFrameEmpty) { // if both left and rite frames are empty.
+        leftMSBfrom = 0;
+      } else {  // only riteFrame is empty
+        leftMSBfrom = ZERO.subtract(leftBase).shiftRight(leftShift).longValue();
+      }
+    }
     boolean riteBaseExceedsleftBase=riteBase.compareTo(leftBase)>0;
     // deal with the left range below the right minimum, if any
     if (riteBaseExceedsleftBase) {  // right branch has higher minimum column value
@@ -153,9 +163,14 @@ public class Merge {
     }
 
     BigInteger rightS = BigInteger.valueOf(256L<<riteShift);
-    long leftMSBto = riteBase.add(rightS).subtract(BigInteger.ONE).subtract(leftBase).shiftRight(leftShift).longValue();
-    // -1 because the 256L<<riteShift is one after the max extent.  
-    // No need -for +1 for NA here because, as for leftMSBfrom above, the NA spot is on -both sides
+    long leftMSBto = riteBase.add(rightS).subtract(ONE).subtract(leftBase).shiftRight(leftShift).longValue();
+    if (riteFrameEmpty) { // rite frame is empty
+      if (leftFrameEmpty) { // both left and rite frames are empty
+        leftMSBto = ZERO.add(rightS).subtract(ONE).shiftRight(leftShift).longValue();
+      } else {  // only riteFrame is empty
+        leftMSBto = ZERO.add(rightS).subtract(ONE).subtract(leftBase).shiftRight(leftShift).longValue();
+      }
+    }
 
     // deal with the left range above the right maximum, if any.  For doubles, -1 from shift to avoid negative outcome
     boolean leftRangeAboveRightMax = leftIndex._isCategorical[0]?
@@ -181,23 +196,25 @@ public class Merge {
       }
     } else {
       // completely ignore right MSBs after the right peak
-      assert leftMSBto >= 255;
-      leftMSBto = 255;
+      if (!leftFrameEmpty) {
+        assert leftMSBto >= 255;
+        leftMSBto = 255;
+      }
     }
 
     // the overlapped region; i.e. between [ max(leftMin,rightMin), min(leftMax, rightMax) ]
-    for (int leftMSB=(int)leftMSBfrom; leftMSB<=leftMSBto; leftMSB++) {
-
-      assert leftMSB >= 0;
-      assert leftMSB <= 255;
-
+    // when right frame is empty, the leftMSBto will be 9223372036854775808 and hence the code will
+    // stall here.  I have changed the way leftMSBto in order to avoid this problem.
+    assert leftMSBfrom >= 0;
+    assert leftMSBto <= 255;
+    for (int leftMSB = (int) leftMSBfrom; leftMSB <= leftMSBto; leftMSB++) {
       // calculate the key values at the bin extents:  [leftFrom,leftTo] in terms of keys
-      long leftFrom= (((long)leftMSB  ) << leftShift) -1 + leftBase.longValue();  // -1 for leading NA spot
-      long leftTo  = (((long)leftMSB+1) << leftShift) -1 + leftBase.longValue()-1;  // -1 for leading NA spot and another -1 to get last of previous bin
+      long leftFrom = leftFrameEmpty ? 0 : ((((long) leftMSB) << leftShift) - 1 + leftBase.longValue());  // -1 for leading NA spot
+      long leftTo = leftFrameEmpty ? 0 : (((((long) leftMSB + 1) << leftShift) - 1 + leftBase.longValue()) - 1);  // -1 for leading NA spot and another -1 to get last of previous bin
 
       // which right bins do these left extents occur in (could span multiple, and fall in the middle)
-      int rightMSBfrom = (int)((leftFrom - riteBase.longValue() + 1) >> riteShift);   // +1 again for the leading NA spot
-      int rightMSBto   = (int)((leftTo   - riteBase.longValue() + 1) >> riteShift);
+      int rightMSBfrom = (int) ((leftFrom - (riteFrameEmpty ? 0 : riteBase.longValue()) + 1) >> riteShift);   // +1 again for the leading NA spot
+      int rightMSBto = (int) ((leftTo - (riteFrameEmpty ? 0 : riteBase.longValue()) + 1) >> riteShift);
 
       // the non-matching part of this region will have been dealt with above when allLeft==true
       if (rightMSBfrom < 0) rightMSBfrom = 0;
@@ -205,10 +222,10 @@ public class Merge {
       if (rightMSBto > 255) rightMSBto = 255;
       assert rightMSBto >= rightMSBfrom;
 
-      for (int rightMSB=rightMSBfrom; rightMSB<=rightMSBto; rightMSB++) {
-        BinaryMerge bm = new BinaryMerge(new BinaryMerge.FFSB(leftFrame, leftMSB,leftShift,leftIndex._bytesUsed,leftIndex._base),
-                                         new BinaryMerge.FFSB(rightFrame,rightMSB,riteShift,riteIndex._bytesUsed,riteIndex._base),
-                                         allLeft);
+      for (int rightMSB = rightMSBfrom; rightMSB <= rightMSBto; rightMSB++) {
+        BinaryMerge bm = new BinaryMerge(new BinaryMerge.FFSB(leftFrame, leftMSB, leftShift, leftIndex._bytesUsed, leftIndex._base),
+                new BinaryMerge.FFSB(rightFrame, rightMSB, riteShift, riteIndex._bytesUsed, riteIndex._base),
+                allLeft);
         bmList.add(bm);
         // TODO: choose the bigger side to execute on (where that side of index
         // already is) to minimize transfer.  within BinaryMerge it will

--- a/h2o-core/src/main/java/water/rapids/RadixCount.java
+++ b/h2o-core/src/main/java/water/rapids/RadixCount.java
@@ -5,6 +5,8 @@ import water.fvec.Chunk;
 import water.util.MathUtils;
 
 import java.math.BigInteger;
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
 
 class RadixCount extends MRTask<RadixCount> {
   static class Long2DArray extends Iced {
@@ -53,8 +55,8 @@ class RadixCount extends MRTask<RadixCount> {
         // common case as should never really have NA in join columns.
         for (int r = 0; r < chk._len; r++) {    // note that 0th bucket here is for rows to exclude from merge result
           long ctrVal = isIntVal ?
-                  BigInteger.valueOf(chk.at8(r)*_ascending).subtract(_base).add(BigInteger.ONE).shiftRight(_shift).longValue():
-                  MathUtils.convertDouble2BigInteger(_ascending*chk.atd(r)).subtract(_base).add(BigInteger.ONE).shiftRight(_shift).longValue();
+                  BigInteger.valueOf(chk.at8(r)*_ascending).subtract(_base).add(ONE).shiftRight(_shift).longValue():
+                  MathUtils.convertDouble2BigInteger(_ascending*chk.atd(r)).subtract(_base).add(ONE).shiftRight(_shift).longValue();
           tmp[(int) ctrVal]++;
         }
       } else {    // contains NAs in column
@@ -64,8 +66,8 @@ class RadixCount extends MRTask<RadixCount> {
           if (chk.isNA(r)) tmp[0]++;
           else {
             long ctrVal = isIntVal ?
-                    BigInteger.valueOf(_ascending*chk.at8(r)).subtract(_base).add(BigInteger.ONE).shiftRight(_shift).longValue():
-                    MathUtils.convertDouble2BigInteger(_ascending*chk.atd(r)).subtract(_base).add(BigInteger.ONE).shiftRight(_shift).longValue();
+                    BigInteger.valueOf(_ascending*chk.at8(r)).subtract(_base).add(ONE).shiftRight(_shift).longValue():
+                    MathUtils.convertDouble2BigInteger(_ascending*chk.atd(r)).subtract(_base).add(ONE).shiftRight(_shift).longValue();
             tmp[(int) ctrVal]++;
           }
 
@@ -79,7 +81,7 @@ class RadixCount extends MRTask<RadixCount> {
       // first column (for MSB split) in an Enum
       // map left categorical to right levels using _id_maps
       assert _id_maps[0].length > 0;
-      assert _base.compareTo(BigInteger.ZERO)==0;
+      assert _base.compareTo(ZERO)==0;
       if (chk.vec().naCnt() == 0) {
         for (int r=0; r<chk._len; r++) {
           tmp[BigInteger.valueOf(_id_maps[0][(int)chk.at8(r)]+1).shiftRight(_shift).intValue()]++;

--- a/h2o-core/src/main/java/water/rapids/RadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/RadixOrder.java
@@ -12,6 +12,8 @@ import water.util.Log;
 import water.util.MathUtils;
 
 import java.math.BigInteger;
+import static java.math.BigInteger.ZERO;
+import static java.math.BigInteger.ONE;
 
 
 // counted completer so that left and right index can run at the same time
@@ -117,7 +119,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     for (int i=0; i<_whichCols.length; i++) {
       Vec col = _DF.vec(_whichCols[i]);
       // TODO: strings that aren't already categoricals and fixed precision double.
-      BigInteger max=BigInteger.ZERO;
+      BigInteger max=ZERO;
 
       _isInt[i] = col.isCategorical() || col.isInt();
       _isCategorical[i] = col.isCategorical();
@@ -125,7 +127,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
         // simpler and more robust for now for all categorical bases to be 0,
         // even though some subsets may be far above 0; i.e. forgo uncommon
         // efficiency savings for now
-        _base[i] = BigInteger.ZERO;
+        _base[i] = ZERO;
         if (_isLeft) {
           // the left's levels have been matched to the right's levels and we
           // store the mapped values so it's that mapped range we need here (or
@@ -207,7 +209,7 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
   private long computeShift( final BigInteger max, final int i )  {
     int biggestBit = 0;
 
-    int rangeD = max.subtract(_base[i]).add(BigInteger.ONE).add(BigInteger.ONE).bitLength();
+    int rangeD = max.subtract(_base[i]).add(ONE).add(ONE).bitLength();
     biggestBit = _isInt[i] ? rangeD : (rangeD == 64 ? 64 : rangeD + 1);
 
     // TODO: feed back to R warnings()
@@ -217,12 +219,12 @@ class RadixOrder extends H2O.H2OCountedCompleter<RadixOrder> {
     long MSBwidth = 1L << _shift[i];
 
     BigInteger msbWidth = BigInteger.valueOf(MSBwidth);
-    if (_base[i].mod(msbWidth).compareTo(BigInteger.ZERO) != 0) {
-      _base[i] =  _isInt[i]? msbWidth.multiply(_base[i].divide(msbWidth).add(_base[i].signum()<0?BigInteger.valueOf(-1L):BigInteger.ZERO))
+    if (_base[i].mod(msbWidth).compareTo(ZERO) != 0) {
+      _base[i] =  _isInt[i]? msbWidth.multiply(_base[i].divide(msbWidth).add(_base[i].signum()<0?BigInteger.valueOf(-1L):ZERO))
               :msbWidth.multiply (_base[i].divide(msbWidth));; // dealing with unsigned integer here
-      assert _base[i].mod(msbWidth).compareTo(BigInteger.ZERO) == 0;
+      assert _base[i].mod(msbWidth).compareTo(ZERO) == 0;
     }
-    return max.subtract(_base[i]).add(BigInteger.ONE).shiftRight(_shift[i]).intValue();
+    return max.subtract(_base[i]).add(ONE).shiftRight(_shift[i]).intValue();
   }
 
   private static class SendSplitMSB extends MRTask<SendSplitMSB> {

--- a/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
+++ b/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
@@ -10,6 +10,8 @@ import water.util.PrettyPrint;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Hashtable;
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
 
 class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
   private final boolean _isLeft;
@@ -134,7 +136,7 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
     for (int r=0; r<chk[0]._len; r++) {    // tight, branch free and cache efficient (surprisingly)
       int MSBvalue = 0;  // default for NA
      //long thisx = 0;
-      BigInteger thisx = BigInteger.ZERO;
+      BigInteger thisx = ZERO;
       if (!chk[0].isNA(r)) {
         // TODO: restore branch-free again, go by column and retain original
         // compression with no .at8()
@@ -145,8 +147,8 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
           // able to use as raw, but when we can maybe can do in bulk
         } else {    // dealing with numeric columns (int or double) or enum
           thisx = isIntCols[0] ?
-                  BigInteger.valueOf(_ascending[0]*chk[0].at8(r)).subtract(_base[0]).add(BigInteger.ONE):
-                  MathUtils.convertDouble2BigInteger(_ascending[0]*chk[0].atd(r)).subtract(_base[0]).add(BigInteger.ONE);
+                  BigInteger.valueOf(_ascending[0]*chk[0].at8(r)).subtract(_base[0]).add(ONE):
+                  MathUtils.convertDouble2BigInteger(_ascending[0]*chk[0].atd(r)).subtract(_base[0]).add(ONE);
           MSBvalue = thisx.shiftRight(_shift).intValue();
         }
       }
@@ -174,8 +176,8 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
         if (_isLeft && _id_maps[c] != null) thisx = BigInteger.valueOf(_id_maps[c][(int)chk[c].at8(r)] + 1);
         else {
           thisx =  isIntCols[c]?
-                  BigInteger.valueOf(_ascending[c]*chk[c].at8(r)).subtract(_base[c]).add(BigInteger.ONE):
-                  MathUtils.convertDouble2BigInteger(_ascending[c]*chk[c].atd(r)).subtract(_base[c]).add(BigInteger.ONE);
+                  BigInteger.valueOf(_ascending[c]*chk[c].at8(r)).subtract(_base[c]).add(ONE):
+                  MathUtils.convertDouble2BigInteger(_ascending[c]*chk[c].atd(r)).subtract(_base[c]).add(ONE);
         }
         keyArray = thisx.toByteArray();  // switched already here.
         offIndex = keyArray.length > 8 ? -1 : _bytesUsed[c] - keyArray.length;

--- a/h2o-py/tests/testdir_munging/pyunit_6987_merge_one_empty.py
+++ b/h2o-py/tests/testdir_munging/pyunit_6987_merge_one_empty.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+def mergeOneEmptyFrame():
+    # PUBDEV-6987: merge with one empty frame and one normal frame.
+    file1 = h2o.H2OFrame({"A1":[1], "A2":[0]})
+    file2 = h2o.H2OFrame({"A1":[], "A2":[]})
+    # all_x = all_y = False, only merge rows that appear both it the right and left frames
+    f1Mergef2 = file1.merge(file2) # right frame is empty, stall here
+    f2Mergef1 = file2.merge(file1)  # left frame is empty, should return empty frame
+    f2Mergef2 = file2.merge(file2)  # merging of empty frame with just headers
+
+    # all three frames should have zero number of rows
+    assert f1Mergef2.nrows == 0, "Expected empty rows but actual number of row is {0}!".format(f1Mergef2.nrows)
+    assert f2Mergef1.nrows == 0, "Expected empty rows but actual number of row is {0}!".format(f2Mergef1.nrows)
+    assert f2Mergef2.nrows == 0, "Expected empty rows but actual number of row is {0}!".format(f2Mergef2.nrows)   
+    
+    f1Mergef2 = file1.merge(file2, all_x=True) # should contain content of file1, merge everything in f1
+    f2Mergef1 = file2.merge(file1, all_y=True) # should contain content of file1, merge everything in f2
+
+    assert f1Mergef2.nrow == 1, "Expected one row  but actual number of row is {0}!".format(f1Mergef2.nrows)
+    assert f2Mergef1.nrow == 1, "Expected one row  but actual number of row is {0}!".format(f2Mergef1.nrows)
+    pyunit_utils.compare_frames_local(f1Mergef2, file1, prob=1)
+    pyunit_utils.compare_frames_local(f2Mergef1, file1, prob=1)    
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(mergeOneEmptyFrame)
+else:
+    mergeOneEmptyFrame()
+


### PR DESCRIPTION
This PR resolve the issue in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-6987?filter=-1

A user reported that merge will get stuck if one of the frames is empty.

I did the following:
1. Check if we have an empty frame before merging.  If one frame is empty, return the other frame right away.  If both frames are empty, throw an error.
2. Added pyunit test to make sure my fix works.