### PR TITLE
PUBDEV-6737: expose monotone_constraints as a top level parameter in AutoML

### DIFF
--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -209,9 +209,24 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help="Custom algorithm parameters.", direction=API.Direction.INPUT)
     public AutoMLCustomParameterV99[] algo_parameters;
 
+    public KeyValueV3[] monotone_constraints;
+
     @Override
     public AutoMLBuildSpec.AutoMLBuildModels fillImpl(AutoMLBuildSpec.AutoMLBuildModels impl) {
       super.fillImpl(impl, new String[]{"algo_parameters"});
+
+      if (monotone_constraints != null) {
+        AutoMLCustomParameterV99 mc = new AutoMLCustomParameterV99();
+        mc.scope = ScopeProvider.ANY_ALGO;
+        mc.name = "monotone_constraints";
+        mc.value = JSONValue.fromValue(monotone_constraints);
+        if (algo_parameters == null) {
+          algo_parameters = new AutoMLCustomParameterV99[] {mc};
+        } else {
+          algo_parameters = ArrayUtils.append(algo_parameters, mc);
+        }
+      }
+
       if (algo_parameters != null) {
          AutoMLBuildSpec.AutoMLCustomParameters.Builder builder = AutoMLBuildSpec.AutoMLCustomParameters.create();
         for (AutoMLCustomParameterV99 param : algo_parameters) {

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -209,6 +209,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @API(help="Custom algorithm parameters.", direction=API.Direction.INPUT)
     public AutoMLCustomParameterV99[] algo_parameters;
 
+    @API(help="A mapping representing monotonic constraints. Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint.", direction= API.Direction.INPUT)
     public KeyValueV3[] monotone_constraints;
 
     @Override

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -65,6 +65,7 @@ class H2OAutoML(Keyed):
                  exclude_algos=None,
                  include_algos=None,
                  modeling_plan=None,
+                 monotone_constraints=None,
                  algo_parameters=None,
                  keep_cross_validation_predictions=False,
                  keep_cross_validation_models=False,
@@ -113,6 +114,8 @@ class H2OAutoML(Keyed):
           Defaults to ``None``, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
         :param modeling_plan: List of modeling steps to be used by the AutoML engine (they may not all get executed, depending on other constraints).
           Defaults to None (Expert usage only).
+        :param monotone_constraints: Dict representing monotonic constraints.
+          Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint.
         :param algo_parameters: Dict of ``param_name=param_value`` to be passed to internal models. Defaults to none (Expert usage only).
           By default, params are set only to algorithms accepting them, and ignored by others.
           Only following parameters are currently allowed: ``"monotone_constraints"``.
@@ -272,6 +275,11 @@ class H2OAutoML(Keyed):
                         else:
                             plan.append(dict(name=name, steps=[dict(id=i) for i in ids]))
             self.build_models['modeling_plan'] = plan
+
+        if monotone_constraints is not None:
+            if algo_parameters is None:
+                algo_parameters = {}
+            algo_parameters['monotone_constraints'] = monotone_constraints
 
         if algo_parameters is not None:
             assert_is_type(algo_parameters, dict)

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -47,6 +47,8 @@
 #' @param include_algos Vector of character strings naming the algorithms to restrict to during the model-building phase. This can't be used in combination with exclude_algos param.
 #         Defaults to NULL, which means that all appropriate H2O algorithms will be used, if the search stopping criteria allow. Optional.
 #' @param modeling_plan List. The list of modeling steps to be used by the AutoML engine (they may not all get executed, depending on other constraints). Optional (Expert usage only).
+#' @param monotone_constraints List. A mapping representing monotonic constraints.
+#         Use +1 to enforce an increasing constraint and -1 to specify a decreasing constraint.
 #' @param algo_parameters List. A list of param_name=param_value to be passed to internal models. Defaults to none (Expert usage only).
 #'        By default, params are set only to algorithms accepting them, and ignored by others.
 #'        Only following parameters are currently allowed: "monotone_constraints".
@@ -93,6 +95,7 @@ h2o.automl <- function(x, y, training_frame,
                        exclude_algos = NULL,
                        include_algos = NULL,
                        modeling_plan = NULL,
+                       monotone_constraints = NULL,
                        algo_parameters = NULL,
                        keep_cross_validation_predictions = FALSE,
                        keep_cross_validation_models = FALSE,
@@ -241,6 +244,11 @@ h2o.automl <- function(x, y, training_frame,
       }
     })
     build_models$modeling_plan <- modeling_plan
+  }
+
+  if (!is.null(monotone_constraints)) {
+    if(is.null(algo_parameters)) algo_parameters <- list()
+    algo_parameters$monotone_constraints <- monotone_constraints
   }
   if (!is.null(algo_parameters)) {
     keys <- names(algo_parameters)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6737

This PR applies on top of https://github.com/h2oai/h2o-3/pull/4005
if we decide to expose `monotone_constraints` as a top level param in clients.