### PR TITLE
PUBDEV-7016 - .h2o.__waitOnJob R function tries to split lines in a stracktrace a non-existing object

### DIFF
--- a/h2o-r/h2o-package/R/communication.R
+++ b/h2o-r/h2o-package/R/communication.R
@@ -892,7 +892,7 @@ h2o.show_progress <- function() assign("PROGRESS_BAR", TRUE, .pkg.env)
         if (!is.null(job$stacktrace)) {cat(job$stacktrace)}
         cat("\n")
 
-        m <- strsplit(jobs[[1]]$exception, "\n")[[1]][1]
+        m <- strsplit(job$stacktrace, "\n")[[1]][1]
         m <- gsub(".*msg ","",m)
         stop(m, call.=FALSE)
       }


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7016

On line 894 (roughly) in communication.R file, there was a refactoring done, but this line was left intact:

```R
m <- strsplit(jobs[[1]]$exception, "\n")[[1]][1]
```

The  problem is simple, the object "jobs" no longer exists - this leads to a failure when an H2O job finishes with an error. Tests were failing as well, e.g. runit_import_sql_no_log. This was never released, as the changes were introduced in commit #65fc46b3 and are part of 3.28.0.1 release. 