### PR TITLE
PUBDEV-7017: shorten pyunit_PUBDEV_5705_drop_columns_parser_csv_large_py

### DIFF
--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
@@ -26,8 +26,6 @@ def test_csv_parser_column_skip():
 
     # load in whole dataset
     skip_all = list(range(f1.ncol))
-    skip_even = list(range(0, f1.ncol, 2))
-    skip_odd = list(range(1, f1.ncol, 2))
     skip_start_end = [0, f1.ncol - 1]
     skip_except_last = list(range(0, f1.ncol - 2))
     skip_except_first = list(range(1, f1.ncol))
@@ -39,22 +37,10 @@ def test_csv_parser_column_skip():
     skip_random.sort()
 
     try:
-        loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns=skip_all)
-        sys.exit(1)  # should have failed here
-    except:
-        pass
-
-    try:
         importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
         sys.exit(1)  # should have failed here
     except:
         pass
-
-    # skip even columns
-    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_even)
-
-    # skip odd columns
-    pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_odd)
 
     # skip the very beginning and the very end.
     pyunit_utils.checkCorrectSkips(f1, savefilenamewithpath, skip_start_end)


### PR DESCRIPTION
This PR completes the work in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7017?filter=-1

I have skipped the following tests:
1. remove test for h2o.upload_file;
2. remove skipping odd/even column numbers.