### PR TITLE
[PUBDEV-7053] Make Name of LdapLoginModule Independent on Jetty Version

### DIFF
--- a/h2o-jetty-8/src/main/java/ai/h2o/org/eclipse/jetty/jaas/api/LdapLoginModule.java
+++ b/h2o-jetty-8/src/main/java/ai/h2o/org/eclipse/jetty/jaas/api/LdapLoginModule.java
@@ -1,4 +1,4 @@
-package ai.h2o.org.eclipse.jetty.plus.jaas.spi;
+package ai.h2o.org.eclipse.jetty.jaas.api;
 
 /**
  * LdapLoginModule is relocated in Sparkling Water to the package ai.h2o.org.eclipse.jetty.jaas.spi

--- a/h2o-jetty-9/src/main/java/ai/h2o/org/eclipse/jetty/jaas/spi/LdapLoginModule.java
+++ b/h2o-jetty-9/src/main/java/ai/h2o/org/eclipse/jetty/jaas/spi/LdapLoginModule.java
@@ -1,8 +1,8 @@
 package ai.h2o.org.eclipse.jetty.jaas.spi;
 
 /**
- * LdapLoginModule is relocated in Sparkling Water to package ai.h2o.org.eclipse.jetty.plus.jaas.spi
- * This class lets user define login module that will work both for H2O and SW
+ * LdapLoginModule is relocated in Sparkling Water to the package ai.h2o.org.eclipse.jetty.jaas.spi
+ * of Jetty 9. This class lets user define login module that will work both for H2O and SW
  * (user needs to put "org.eclipse.jetty.jaas.spi.LdapLoginModule required" in the login conf)
  */
 public class LdapLoginModule extends org.eclipse.jetty.jaas.spi.LdapLoginModule { /* empty */ }

--- a/h2o-jetty-9/src/main/java/ai/h2o/org/eclipse/jetty/plus/jaas/spi/LdapLoginModule.java
+++ b/h2o-jetty-9/src/main/java/ai/h2o/org/eclipse/jetty/plus/jaas/spi/LdapLoginModule.java
@@ -5,4 +5,4 @@ package ai.h2o.org.eclipse.jetty.plus.jaas.spi;
  * of Jetty 9. External backend workers on Hadoop 2 utilize Jetty 8 and thus the module 
  * org.eclipse.jetty.plus.jaas.spi. This class enables to use only one package name for both cases.
  */
-public class LdapLoginModule extends org.eclipse.jetty.plus.jaas.spi.LdapLoginModule { /* empty */ }
+public class LdapLoginModule extends org.eclipse.jetty.jaas.spi.LdapLoginModule { /* empty */ }


### PR DESCRIPTION
Sparkling Water utilize Jetty 9 and expects `ai.h2o.org.eclipse.jetty.jaas.spi.LdapLoginModule` in the login conf. When SW runs in external backend, it starts H2O workers via H2O extended jar which contains Jetty 8 for hadoop 2 distributions. Thus H2O workers expect `ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModule` in the login conf.

