### PR TITLE
Disable client mode unless explicitly enabled

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -344,6 +344,9 @@ final public class H2O {
     /** -client, -client=true; Client-only; no work; no homing of Keys (but can cache) */
     public boolean client;
 
+    /** -allow_clients, -allow_clients=true; Enable clients to connect to this H2O node - disabled by default */
+    public boolean allow_clients = false;
+
     /** specifies a file to write when the node is up */
     public String notify_local;
 
@@ -522,6 +525,9 @@ final public class H2O {
       }
       else if (s.matches("client")) {
         trgt.client = true;
+      }
+      else if (s.matches("allow_clients")) {
+        trgt.allow_clients = true;
       }
       else if (s.matches("notify_local")) {
         i = s.incrementAndCheck(i, args);

--- a/h2o-core/src/main/java/water/Paxos.java
+++ b/h2o-core/src/main/java/water/Paxos.java
@@ -59,8 +59,15 @@ public abstract class Paxos {
       }
     }
 
+    if(!H2O.ARGS.allow_clients && h2o.isClient()) {
+      // ignore requests from clients if cloud is not started with client connections enabled
+      ListenerService.getInstance().report("clients_disabled", h2o);
+      return 0;
+    }
+    
     if(h2o._heartbeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash){
       // ignore requests from this node as they are coming from different cluster
+      ListenerService.getInstance().report("different_cloud", h2o);
       return 0;
     }
 

--- a/h2o-core/src/main/java/water/UDPClientEvent.java
+++ b/h2o-core/src/main/java/water/UDPClientEvent.java
@@ -16,6 +16,10 @@ public class UDPClientEvent extends UDP {
   AutoBuffer call(AutoBuffer ab) {
 
     ClientEvent ce = new ClientEvent().read(ab);
+    // Ignore client events when H2O is started without client connections enabled
+    if (!H2O.ARGS.allow_clients) {
+      return ab;
+    }
     // Ignore messages from different cloud
     if (ce.senderHeartBeat._cloud_name_hash != H2O.SELF._heartbeat._cloud_name_hash) {
       return ab;

--- a/h2o-core/src/test/java/water/PaxosTest.java
+++ b/h2o-core/src/test/java/water/PaxosTest.java
@@ -1,0 +1,38 @@
+package water;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+public class PaxosTest extends TestUtil {
+
+  @Before
+  public void setUp() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void doClientHeartbeatWhenClientsDisabled() {
+    Collection<H2OListenerExtension> listenerExtensions = ExtensionManager.getInstance().getListenerExtensions();
+    NodeLocalEventCollectingListener ext = (NodeLocalEventCollectingListener)listenerExtensions.iterator().next();
+    ext.clear();
+
+    H2ONode clientNode = H2ONode.intern(InetAddress.getLoopbackAddress(), 33333, (short) -1);
+    HeartBeat clientHeartBeat = new HeartBeat();
+    clientHeartBeat._cloud_name_hash = H2O.CLOUD._hash;
+    clientHeartBeat._jar_md5 = H2O.SELF._heartbeat._jar_md5;
+    clientHeartBeat._client = true;
+    clientNode.setHeartBeat(clientHeartBeat);
+
+    Paxos.doHeartbeat(clientNode);
+
+    ArrayList<Object[]> events = ext.getData("clients_disabled");
+    assertEquals(1, events.size());
+    assertArrayEquals(new Object[]{clientNode}, events.get(0));
+  }
+}

--- a/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -157,6 +157,7 @@ public class h2odriver extends Configured implements Tool {
   static String hivePrincipal = null;
   static boolean refreshTokens = false;
   static boolean disableFlow = false;
+  static boolean swExtBackend = false;
 
   String proxyUrl = null;
   // Runtime state that might be touched by different threads.
@@ -1079,7 +1080,9 @@ public class h2odriver extends Configured implements Tool {
       else if (s.equals("-disable_flow")) {
         disableFlow = true;
       }
-      else if (s.equals("-session_timeout")) {
+      else if (s.equals("-sw_ext_backend")) {
+        swExtBackend = true;
+      } else if (s.equals("-session_timeout")) {
         i++; if (i >= args.length) { usage(); }
         sessionTimeout = args[i];
       }
@@ -1659,6 +1662,9 @@ public class h2odriver extends Configured implements Tool {
     if (disableFlow) {
       addMapperArg(conf, "-disable_flow");
     }
+    if (swExtBackend) {
+      addMapperArg(conf, "-allow_clients");
+    }
     addMapperArg(conf, "-user_name", userName);
 
     for (String s : extraArguments) {
@@ -1668,6 +1674,7 @@ public class h2odriver extends Configured implements Tool {
     if (client) {
       addMapperArg(conf, "-md5skip");
       addMapperArg(conf, "-disable_web");
+      addMapperArg(conf, "-allow_clients");
     }
 
     // Proxy

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -261,12 +261,14 @@ class H2OCloudNode(object):
     terminated: Only from a signal.  Not normal shutdown.
     """
 
-    def __init__(self, is_client, cloud_num, nodes_per_cloud, node_num, cloud_name, h2o_jar, ip, base_port,
+    def __init__(self, is_client, allow_clients,
+                 cloud_num, nodes_per_cloud, node_num, cloud_name, h2o_jar, ip, base_port,
                  xmx, cp, output_dir, test_ssl, ldap_config_path, jvm_opts, flatfile):
         """
         Create a node in a cloud.
 
         :param is_client: Whether this node is an H2O client node (vs a worker node) or not.
+        :param allow_clients: Whether to enable client connections.
         :param cloud_num: Dense 0-based cluster index number.
         :param nodes_per_cloud: How many H2O java instances are in a cluster. Clustes are symmetric.
         :param node_num: This node's dense 0-based node index number.
@@ -282,6 +284,7 @@ class H2OCloudNode(object):
         :return The node object.
         """
         self.is_client = is_client
+        self.allow_clients = allow_clients
         self.cloud_num = cloud_num
         self.nodes_per_cloud = nodes_per_cloud
         self.node_num = node_num
@@ -350,6 +353,9 @@ class H2OCloudNode(object):
                "-ip", self.ip]
         if self.flatfile is not None:
             cmd += ["-flatfile", self.flatfile]
+
+        if self.allow_clients:
+            cmd += ["-allow_clients"]
 
         if self.ldap_config_path is not None:
             cmd.append('-login_conf')
@@ -575,7 +581,7 @@ class H2OCloud(object):
                 with open(self.flatfile, "a") as ff:
                     for node in self.nodes:
                         ff.write("%s:%s\n" % (node.ip, node.port))
-            node = H2OCloudNode(is_client,
+            node = H2OCloudNode(is_client, use_client,
                                 self.cloud_num, actual_nodes_per_cloud, node_num,
                                 self.cloud_name,
                                 self.h2o_jar,


### PR DESCRIPTION
H2O instances will need to be started with option `-allow_clients` to enable client connections.

For H2O on Hadoop, the `h2odriver` will need to be started with a flag `-sw_ext_backend`. This will automatically add `-allow_clients`. In the future, this option can enforce validation of security parameters (eg. make sure when security is enabled, internal_secure_connections is enabled as well).