### PR TITLE
Scoring info not allowed to be ran simultaneously for paralle grid builder.

### DIFF
--- a/h2o-core/src/main/java/hex/ParallelModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ParallelModelBuilder.java
@@ -55,17 +55,22 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
 
     @Override
     public void onModelSuccess(Model model) {
-      _modelInProgressCounter.decrementAndGet();
-      _callback.onBuildSucces(model, ParallelModelBuilder.this);
+      try {
+        _callback.onBuildSucces(model, ParallelModelBuilder.this);
+      } finally {
+        _modelInProgressCounter.decrementAndGet();
+      }
       attemptComplete();
     }
 
     @Override
     public void onModelFailure(Throwable cause, Model.Parameters parameters) {
-      _modelInProgressCounter.decrementAndGet();
-
-      final ModelBuildFailure modelBuildFailure = new ModelBuildFailure(cause, parameters);
-      _callback.onBuildFailure(modelBuildFailure, ParallelModelBuilder.this);
+      try {
+        final ModelBuildFailure modelBuildFailure = new ModelBuildFailure(cause, parameters);
+        _callback.onBuildFailure(modelBuildFailure, ParallelModelBuilder.this);
+      } finally {
+        _modelInProgressCounter.decrementAndGet();
+      }
       attemptComplete();
     }
     

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -182,8 +182,8 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     @Override
     public void onBuildSucces(final Model finishedModel, final ParallelModelBuilder parallelModelBuilder) {
       try {
-        constructScoringInfo(finishedModel);
         parallelSearchGridLock.lock();
+        constructScoringInfo(finishedModel);
         grid.putModel(finishedModel._parms.checksum(IGNORED_FIELDS_PARAM_HASH), finishedModel._key);
 
         _job.update(1);

--- a/h2o-r/tests/testdir_algos/grid/runit_grid_parallel.R
+++ b/h2o-r/tests/testdir_algos/grid/runit_grid_parallel.R
@@ -17,4 +17,4 @@ test.grid.resume <- function() {
 
 }
 
-doTest("Resume grid search after cluster restart", test.grid.resume)
+doTest("Parallel Grid Search test", test.grid.resume)


### PR DESCRIPTION
Constructing scoring info in parallel is potentially dangerous - the logic sorts scoring infos held inside an array internally. Uses built `_models` for that as well. 