### PR TITLE
PUBDEV-6911 - Allow H2OGenericEstimator to be instantiated with no params.

### DIFF
--- a/h2o-bindings/bin/custom/python/gen_generic.py
+++ b/h2o-bindings/bin/custom/python/gen_generic.py
@@ -21,9 +21,5 @@ def class_extensions():
 
 
 extensions = dict(
-    __init__validation="""
-if all(kwargs.get(name, None) is None for name in ["model_key", "path"]):
-    raise H2OValueError('At least one of ["model_key", "path"] is required.')
-""",
     __class__=class_extensions,
 )

--- a/h2o-py/h2o/estimators/generic.py
+++ b/h2o-py/h2o/estimators/generic.py
@@ -24,8 +24,6 @@ class H2OGenericEstimator(H2OEstimator):
     def __init__(self, **kwargs):
         super(H2OGenericEstimator, self).__init__()
         self._parms = {}
-        if all(kwargs.get(name, None) is None for name in ["model_key", "path"]):
-            raise H2OValueError('At least one of ["model_key", "path"] is required.')
         for pname, pvalue in kwargs.items():
             if pname == 'model_id':
                 self._id = pvalue

--- a/h2o-py/tests/testdir_generic_model/pyunit_generic_model.py
+++ b/h2o-py/tests/testdir_generic_model/pyunit_generic_model.py
@@ -1,0 +1,34 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+import tempfile
+from h2o.estimators import H2OGradientBoostingEstimator, H2OGenericEstimator
+from tests import pyunit_utils
+
+# Test of MOJO convenience methods
+def generic_blank_constructor():
+    
+    # Train a model
+    airlines = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
+    model = H2OGradientBoostingEstimator(ntrees = 1)
+    model.train(x = ["Origin", "Dest"], y = "IsDepDelayed", training_frame=airlines)
+    
+    #Save the previously created model into a temporary file
+    original_model_filename = tempfile.mkdtemp()
+    original_model_filename = model.download_mojo(original_model_filename)
+    
+    # Load the model from the temporary using an empty constructor
+    mojo_model = H2OGenericEstimator()
+    mojo_model.path = original_model_filename
+    mojo_model.train()
+    assert isinstance(mojo_model, H2OGenericEstimator)
+    
+    # Test scoring is available on the model
+    predictions = mojo_model.predict(airlines)
+    assert predictions is not None
+    assert predictions.nrows == 24421
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(generic_blank_constructor)
+else:
+    generic_blank_constructor()


### PR DESCRIPTION
## Description

### Situation
In Python, when a `H2OModel` is fetched from the server and not cached locally, it is first instantiated and then populated with values. This is best seen in the `get_model()` method in `h2o.py`:

```python
def get_model(model_id):
    """
    Load a model from the server.

    :param model_id: The model identification in H2O

    :returns: Model object, a subclass of H2OEstimator
    """
    assert_is_type(model_id, str)
    model_json = api("GET /3/Models/%s" % model_id)["models"][0]
    algo = model_json["algo"]
    if algo == "svd":            m = H2OSVD()
    elif algo == "pca":          m = H2OPrincipalComponentAnalysisEstimator()
    elif algo == "drf":          m = H2ORandomForestEstimator()
    elif algo == "naivebayes":   m = H2ONaiveBayesEstimator()
    elif algo == "kmeans":       m = H2OKMeansEstimator()
    elif algo == "glrm":         m = H2OGeneralizedLowRankEstimator()
    elif algo == "glm":          m = H2OGeneralizedLinearEstimator()
    elif algo == "gbm":          m = H2OGradientBoostingEstimator()
    elif algo == "deepwater":    m = H2ODeepWaterEstimator()
    elif algo == "xgboost":      m = H2OXGBoostEstimator()
    elif algo == "word2vec":     m = H2OWord2vecEstimator()
    elif algo == "generic": m = H2OGenericEstimator()
    elif algo == "deeplearning":
        if model_json["output"]["model_category"] == "AutoEncoder":
            m = H2OAutoEncoderEstimator()
        else:
            m = H2ODeepLearningEstimator()
    elif algo == "stackedensemble": m = H2OStackedEnsembleEstimator()
    elif algo == "isolationforest": m = H2OIsolationForestEstimator()
    else:
        raise ValueError("Unknown algo type: " + algo)
    m._resolve_model(model_id, model_json)
    return m
```

Among others, there is the `H2OGenericEstimator` instantiated around line 818. The line looks like this: `elif algo == "generic": m = H2OGenericEstimator()`

### The problem
However, the constructor of `H2OGenericEstimator` did not allow initialization with no parameters and usage of setters afterwards. It required either `path` or `key` to be present. 

### The solution

Just remove the check. The following piece of code is perfectly "legal" in H2O API:

```python
    mojo_model = H2OGenericEstimator()
    mojo_model.path = original_model_filename
    mojo_model.train()
```

## Links
[PUBDEV-6911](https://0xdata.atlassian.net/browse/PUBDEV-6911)