### PR TITLE
Adds custom assembly for h2odriver for CDP 7.0

### DIFF
--- a/h2o-dist/buildinfo.json
+++ b/h2o-dist/buildinfo.json
@@ -94,6 +94,11 @@
             "zip_file_path" : "h2o-SUBST_PROJECT_VERSION-cdh6.3.zip"
         },
         {
+            "distribution" : "cdp7.0",
+            "zip_file_name" : "h2o-SUBST_PROJECT_VERSION-cdp7.0.zip",
+            "zip_file_path" : "h2o-SUBST_PROJECT_VERSION-cdp7.0.zip"
+        },
+        {
             "distribution" : "hdp2.2",
             "zip_file_name" : "h2o-SUBST_PROJECT_VERSION-hdp2.2.zip",
             "zip_file_path" : "h2o-SUBST_PROJECT_VERSION-hdp2.2.zip"

--- a/h2o-hadoop-3/h2o-cdp7.0-assembly/build.gradle
+++ b/h2o-hadoop-3/h2o-cdp7.0-assembly/build.gradle
@@ -1,0 +1,130 @@
+ext {
+    hadoopVersion = 'cdh6.3.0'
+    hadoopMavenArtifactVersion = '3.0.0-cdh6.3.0'
+    orcSupported = true
+    orcHiveExecVersion = "2.1.1-cdh6.3.0"
+}
+
+apply plugin: 'java'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+description = 'H2O HDFS client shadowjar for Hadoop ' + hadoopVersion
+
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+configurations {
+    compile.exclude group: 'org.apache.hadoop'
+    compile.exclude group: 'org.apache.hive'
+}
+
+dependencies {
+    compile (project(":h2o-jetty-9")) {
+        exclude module: "servlet-api"
+        exclude group: "javax.servlet", module: "javax.servlet-api"
+    }
+    compile(project(":h2o-mapreduce-generic")) {
+        transitive = false
+    }
+    compile project(":h2o-security")
+    compileOnly "org.apache.hadoop:hadoop-client:$hadoopMavenArtifactVersion"
+    compileOnly "org.apache.hadoop:hadoop-mapreduce-client-app:$hadoopMavenArtifactVersion"
+    // Libraries need for Google Cloud Storage strongly require this Guava version
+    compile('com.google.guava:guava:20.0') {force = true}
+    compile(project(':h2o-app')) {
+        exclude module: "${defaultWebserverModule}"
+        exclude module: "h2o-ext-krbstandalone"
+    }
+    compile project(":h2o-web")
+    compile project(":h2o-avro-parser")
+    // Include GCS persist layer
+    compile(project(":h2o-persist-gcs"))
+    // Include S3 persist layer
+    compile(project(":h2o-persist-s3"))
+    // Include HDFS persist layer
+    compile (project(':h2o-persist-hdfs')) {
+        transitive = false
+    }
+    compile (project(':h2o-hive')) {
+        transitive = false
+    }
+
+    // For standalone mode to work with MapR, this extra library needs to be
+    // included, and it's not pulled in by the dependency stuff;  this must
+    // be a bug in MapR's packaging process.
+    if (project.hasProperty("maprExtraDependency")) {
+        compile(project.property("maprExtraDependency"))
+    }
+    if (orcSupported) {
+        compile(project(":h2o-orc-parser")) {
+            // We do not get any dependencies but directly rely on provided environment
+            transitive = false
+        }
+
+        // Here we depends on hive-exec, but it is Hadoop version specific
+        compile("org.apache.hive:hive-exec:$orcHiveExecVersion") {
+            transitive = false
+        }
+    }
+    compile(project(":h2o-parquet-parser"))
+}
+
+//
+// Bundle optional modules
+// The process is defined by convention. There are two flags:
+//  - -Pwith${componentName}=true - enables component "componentName" and includes it in assembly
+//  - -P${componentName}Version=3.14 - overrides default component version
+//
+for (comp in optionalComponents) {
+    def compName = comp['name']
+    def compVersion = comp['version']
+    def compEnabled = comp['enabled']
+    def compPropName = "with${compName.capitalize()}"
+    def compPropVersionName = "${compName}Version"
+
+    if (!project.hasProperty(compPropVersionName)) {
+        project.ext.set(compPropVersionName, compVersion)
+    }
+    if (compEnabled || project.hasProperty(compPropName) && project.property(compPropName)) {
+        logger.lifecycle("== ${project.path}: Using optional component: ${compName}, version ${project.findProperty(compPropVersionName)}")
+        apply from: "$rootDir/gradle/components/${compName}.gradle"
+    }
+
+}
+
+def hadoopShadowJarExcludes = ['META-INF/*.DSA',
+                               'META-INF/*.SF',
+                               'synchronize.properties',
+                               'uploader.properties',
+                               'test.properties',
+                               'cockpitlite.properties',
+                               'devpay_products.properties',
+                               // the license files are excluded for OS X compatibility (this is mainly for development)
+                               // OS X is unable to unpack these files from the jar on filesystem that is not case sensitive
+                               'LICENSE', 'license', 'LICENSE/*', 'license/*', 'META-INF/license', 'META-INF/LICENSE'
+]
+
+shadowJar {
+    mergeServiceFiles()
+    // Keep JODATIME shadowed even for CDH 6+
+    relocate 'org.joda.time', 'ai.h2o.org.joda.time'
+    exclude hadoopShadowJarExcludes
+    relocate 'com.google.common', 'ai.h2o.com.google.common'
+    baseName = 'h2odriver'
+    classifier = ''
+    manifest {
+        attributes 'Main-Class': 'water.hadoop.h2odriver'
+    }
+    zip64 true
+}
+
+artifacts {
+    archives shadowJar
+}
+
+// We just need Shadow Jar
+jar {
+    enabled = false
+}
+
+build.dependsOn shadowJar

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -10,7 +10,7 @@ set -x
 
 # Set common variables.
 TOPDIR=$(cd `dirname $0` && pwd)
-HADOOP_VERSIONS="cdh5.4 cdh5.5 cdh5.6 cdh5.7 cdh5.8 cdh5.9 cdh5.10 cdh5.13 cdh5.14 cdh5.15 cdh5.16 cdh6.0 cdh6.1 cdh6.2 cdh6.3 hdp2.2 hdp2.3 hdp2.4 hdp2.5 hdp2.6 hdp3.0 hdp3.1 mapr4.0 mapr5.0 mapr5.1 mapr5.2 mapr6.0 mapr6.1 iop4.2"
+HADOOP_VERSIONS="cdh5.4 cdh5.5 cdh5.6 cdh5.7 cdh5.8 cdh5.9 cdh5.10 cdh5.13 cdh5.14 cdh5.15 cdh5.16 cdh6.0 cdh6.1 cdh6.2 cdh6.3 cdp7.0 hdp2.2 hdp2.3 hdp2.4 hdp2.5 hdp2.6 hdp3.0 hdp3.1 mapr4.0 mapr5.0 mapr5.1 mapr5.2 mapr6.0 mapr6.1 iop4.2"
 
 function make_zip_common {
   PROJECT_BASE=$1

--- a/settings.gradle
+++ b/settings.gradle
@@ -84,7 +84,7 @@ if (System.getProperty("user.name").equals("jenkins")
   // Default hadoop build targets
   def allTargets = [
          "cdh5.4", "cdh5.5", "cdh5.6", "cdh5.7", "cdh5.8", "cdh5.9", "cdh5.10", "cdh5.13", "cdh5.14", "cdh5.15", "cdh5.16", 
-         "cdh6.0", "cdh6.1", "cdh6.2", "cdh6.3",
+         "cdh6.0", "cdh6.1", "cdh6.2", "cdh6.3", "cdp7.0",
          "hdp2.2", "hdp2.3", "hdp2.4", "hdp2.5", "hdp2.6","hdp3.0","hdp3.1",
          "mapr4.0", "mapr5.0", "mapr5.1", "mapr5.2", "mapr6.0", "mapr6.1", "iop4.2"
   ]


### PR DESCRIPTION
CDH 7.0 is unreleased, this built is based on dependencies for CDH 6.3
used in compile-time. All Hadoop depenedencies are then excluded -
this makes this driver build compatible with generally any Hadoop 3.x
distribution. However, further dependency changes will be made to made
this CDP 7.0 specific.