### PR TITLE
PUBDEV-7072: add AUCPR column to AutoML leaderboard for binomial classification

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -196,6 +196,9 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   private void initLeaderboard(AutoMLBuildSpec buildSpec) {
     String sort_metric = buildSpec.input_spec.sort_metric;
     sort_metric = sort_metric == null || StoppingMetric.AUTO.name().equalsIgnoreCase(sort_metric) ? null : sort_metric.toLowerCase();
+    if ("deviance".equalsIgnoreCase(sort_metric)) {
+        sort_metric = "mean_residual_deviance"; //compatibility with names used in leaderboard
+    }
     _leaderboard = Leaderboard.getOrMake(_key.toString(), _eventLog, _leaderboardFrame, sort_metric);
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -58,8 +58,8 @@ public class Leaderboard extends Lockable<Leaderboard> {
 
   /**
    * Metrics reported in leaderboard
-   * Regression metrics: mean_residual_deviance, rmse, mse, mae, rmsle
-   * Binomial metrics: auc, logloss, mean_per_class_error, rmse, mse
+   * Regression metrics: deviance, rmse, mse, mae, rmsle
+   * Binomial metrics: auc, logloss, aucpr, mean_per_class_error, rmse, mse
    * Multinomial metrics: logloss, mean_per_class_error, rmse, mse
    */
   private String[] _metrics;
@@ -159,7 +159,7 @@ public class Leaderboard extends Lockable<Leaderboard> {
    * <li>
    *     <ul>binomial classification: auc</ul>
    *     <ul>multinomial classification: logloss</ul>
-   *     <ul>regression: mean_residual_deviance</ul>
+   *     <ul>regression: deviance</ul>
    * </li>
    * @return the metric used to sort the models in the leaderboard.
    */
@@ -431,11 +431,11 @@ public class Leaderboard extends Lockable<Leaderboard> {
 
   private static String[] defaultMetricsForModel(Model m) {
     if (m._output.isBinomialClassifier()) { //binomial
-      return new String[] {"auc", "logloss", "mean_per_class_error", "rmse", "mse"};
+      return new String[] {"auc", "logloss", "aucpr", "mean_per_class_error", "rmse", "mse"};
     } else if (m._output.isMultinomialClassifier()) { // multinomial
       return new String[] {"mean_per_class_error", "logloss", "rmse", "mse"};
     } else if (m._output.isSupervised()) { // regression
-      return new String[] {"mean_residual_deviance", "rmse", "mse", "mae", "rmsle"};
+      return new String[] {"deviance", "rmse", "mse", "mae", "rmsle"};
     }
     return new String[0];
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Leaderboard.java
@@ -58,7 +58,7 @@ public class Leaderboard extends Lockable<Leaderboard> {
 
   /**
    * Metrics reported in leaderboard
-   * Regression metrics: deviance, rmse, mse, mae, rmsle
+   * Regression metrics: mean_residual_deviance, rmse, mse, mae, rmsle
    * Binomial metrics: auc, logloss, aucpr, mean_per_class_error, rmse, mse
    * Multinomial metrics: logloss, mean_per_class_error, rmse, mse
    */
@@ -159,7 +159,7 @@ public class Leaderboard extends Lockable<Leaderboard> {
    * <li>
    *     <ul>binomial classification: auc</ul>
    *     <ul>multinomial classification: logloss</ul>
-   *     <ul>regression: deviance</ul>
+   *     <ul>regression: mean_residual_deviance</ul>
    * </li>
    * @return the metric used to sort the models in the leaderboard.
    */
@@ -435,7 +435,7 @@ public class Leaderboard extends Lockable<Leaderboard> {
     } else if (m._output.isMultinomialClassifier()) { // multinomial
       return new String[] {"mean_per_class_error", "logloss", "rmse", "mse"};
     } else if (m._output.isSupervised()) { // regression
-      return new String[] {"deviance", "rmse", "mse", "mae", "rmsle"};
+      return new String[] {"mean_residual_deviance", "rmse", "mse", "mae", "rmsle"};
     }
     return new String[0];
   }

--- a/h2o-core/src/main/java/hex/ModelMetricsRegression.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsRegression.java
@@ -12,10 +12,21 @@ import water.util.ArrayUtils;
 import water.util.MathUtils;
 
 public class ModelMetricsRegression extends ModelMetricsSupervised {
-  /** For all algos except GLM this is mean residual deviance.  For GLM it's total residual deviance. */
-  public double residual_deviance() { return _mean_residual_deviance; }
-  public double mean_residual_deviance() { return _mean_residual_deviance; }
   public final double _mean_residual_deviance;
+  /**
+   * Alias for {@link #mean_residual_deviance()}.
+   *
+   * Required for consistency when retrieving metrics using reflection, as it is exposed for input as {@link ScoreKeeper.StoppingMetric#deviance}.
+   * @return {@link #mean_residual_deviance()}
+   */
+  @SuppressWarnings("unused")
+  public double deviance() { return _mean_residual_deviance; }
+  /**
+   * @return {@link #mean_residual_deviance()} for all algos except GLM, for which it means "total residual deviance".
+   **/
+  public double residual_deviance() { return _mean_residual_deviance; }
+  @SuppressWarnings("unused")
+  public double mean_residual_deviance() { return _mean_residual_deviance; }
   public final double _mean_absolute_error;
   public double mae() { return _mean_absolute_error; }
   public final double _root_mean_squared_log_error;

--- a/h2o-core/src/main/java/hex/ModelMetricsRegression.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsRegression.java
@@ -14,14 +14,6 @@ import water.util.MathUtils;
 public class ModelMetricsRegression extends ModelMetricsSupervised {
   public final double _mean_residual_deviance;
   /**
-   * Alias for {@link #mean_residual_deviance()}.
-   *
-   * Required for consistency when retrieving metrics using reflection, as it is exposed for input as {@link ScoreKeeper.StoppingMetric#deviance}.
-   * @return {@link #mean_residual_deviance()}
-   */
-  @SuppressWarnings("unused")
-  public double deviance() { return _mean_residual_deviance; }
-  /**
    * @return {@link #mean_residual_deviance()} for all algos except GLM, for which it means "total residual deviance".
    **/
   public double residual_deviance() { return _mean_residual_deviance; }

--- a/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
+++ b/h2o-py/tests/testdir_algos/automl/binomial/pyunit_automl_prostate.py
@@ -31,7 +31,7 @@ def prostate_automl():
     aml.train(y="CAPSULE", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     print(aml.leader)
     print(aml.leaderboard)
-    assert set(aml.leaderboard.columns) == set(["model_id", "auc", "logloss", "mean_per_class_error", "rmse", "mse"])
+    assert set(aml.leaderboard.columns) == set(["model_id", "auc", "logloss", "aucpr", "mean_per_class_error", "rmse", "mse"])
 
 # Should we allow models to accumulate in the leaderboard across runs?
 removeall_before_running = True

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -114,7 +114,7 @@ def test_leaderboard_for_binomial():
                     exclude_algos=exclude_algos)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "mean_per_class_error", "rmse", "mse"], "auc", True)
+    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "aucpr", "mean_per_class_error", "rmse", "mse"], "auc", True)
 
 
 def test_leaderboard_for_multinomial():
@@ -140,7 +140,7 @@ def test_leaderboard_for_regression():
                     seed=automl_seed)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "mean_residual_deviance")
+    check_leaderboard(aml, exclude_algos, ["deviance", "rmse", "mse", "mae", "rmsle"], "deviance")
 
 
 def test_leaderboard_with_all_algos():
@@ -180,7 +180,7 @@ def test_leaderboard_for_binomial_with_custom_sorting():
                     sort_metric="logloss")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["logloss", "auc", "mean_per_class_error", "rmse", "mse"], "logloss")
+    check_leaderboard(aml, exclude_algos, ["logloss", "auc", "aucpr", "mean_per_class_error", "rmse", "mse"], "logloss")
 
 
 def test_leaderboard_for_multinomial_with_custom_sorting():
@@ -208,7 +208,7 @@ def test_leaderboard_for_regression_with_custom_sorting():
                     sort_metric="RMSE")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "deviance", "mse", "mae", "rmsle"], "rmse")
 
 
 def test_AUTO_stopping_metric_with_no_sorting_metric_binomial():
@@ -221,7 +221,7 @@ def test_AUTO_stopping_metric_with_no_sorting_metric_binomial():
                     exclude_algos=exclude_algos)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "mean_per_class_error", "rmse", "mse"], "auc", True)
+    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "aucpr", "mean_per_class_error", "rmse", "mse"], "auc", True)
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     first = [m for m in non_se if 'XGBoost_1' in m]
     others = [m for m in non_se if m not in first]
@@ -239,7 +239,7 @@ def test_AUTO_stopping_metric_with_no_sorting_metric_regression():
                     seed=automl_seed)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "mean_residual_deviance")
+    check_leaderboard(aml, exclude_algos, ["deviance", "rmse", "mse", "mae", "rmsle"], "deviance")
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     first = [m for m in non_se if 'XGBoost_1' in m]
     others = [m for m in non_se if m not in first]
@@ -258,7 +258,7 @@ def test_AUTO_stopping_metric_with_auc_sorting_metric():
                     sort_metric='auc')
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "mean_per_class_error", "rmse", "mse"], "auc", True)
+    check_leaderboard(aml, exclude_algos, ["auc", "logloss", "aucpr", "mean_per_class_error", "rmse", "mse"], "auc", True)
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     check_model_property(non_se, 'stopping_metric', True, "logloss")
 
@@ -274,7 +274,7 @@ def test_AUTO_stopping_metric_with_custom_sorting_metric():
                     sort_metric="rmse")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "deviance", "mse", "mae", "rmsle"], "rmse")
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     check_model_property(non_se, 'stopping_metric', True, "RMSE")
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_leaderboard.py
@@ -140,7 +140,7 @@ def test_leaderboard_for_regression():
                     seed=automl_seed)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["deviance", "rmse", "mse", "mae", "rmsle"], "deviance")
+    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "mean_residual_deviance")
 
 
 def test_leaderboard_with_all_algos():
@@ -208,7 +208,21 @@ def test_leaderboard_for_regression_with_custom_sorting():
                     sort_metric="RMSE")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["rmse", "deviance", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
+
+
+def test_leaderboard_for_regression_with_custom_sorting_deviance():
+    print("Check leaderboard for Regression sort by deviance")
+    ds = prepare_data('regression')
+    exclude_algos = ["GBM", "DeepLearning"]
+    aml = H2OAutoML(project_name="py_aml_lb_test_custom_regr_deviance",
+                    exclude_algos=exclude_algos,
+                    max_models=10,
+                    seed=automl_seed,
+                    sort_metric="deviance")
+    aml.train(y=ds.target, training_frame=ds.train)
+
+    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "rmse")
 
 
 def test_AUTO_stopping_metric_with_no_sorting_metric_binomial():
@@ -239,7 +253,7 @@ def test_AUTO_stopping_metric_with_no_sorting_metric_regression():
                     seed=automl_seed)
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["deviance", "rmse", "mse", "mae", "rmsle"], "deviance")
+    check_leaderboard(aml, exclude_algos, ["mean_residual_deviance", "rmse", "mse", "mae", "rmsle"], "mean_residual_deviance")
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     first = [m for m in non_se if 'XGBoost_1' in m]
     others = [m for m in non_se if m not in first]
@@ -274,7 +288,7 @@ def test_AUTO_stopping_metric_with_custom_sorting_metric():
                     sort_metric="rmse")
     aml.train(y=ds.target, training_frame=ds.train)
 
-    check_leaderboard(aml, exclude_algos, ["rmse", "deviance", "mse", "mae", "rmsle"], "rmse")
+    check_leaderboard(aml, exclude_algos, ["rmse", "mean_residual_deviance", "mse", "mae", "rmsle"], "rmse")
     non_se = get_partitioned_model_names(aml.leaderboard).non_se
     check_model_property(non_se, 'stopping_metric', True, "RMSE")
 

--- a/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
+++ b/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
@@ -23,7 +23,7 @@ def australia_automl():
     aml.train(y="runoffnew", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     print(aml.leader)
     print(aml.leaderboard)
-    assert set(aml.leaderboard.columns) == set(["model_id", "mean_residual_deviance","rmse", "mse", "mae", "rmsle"])
+    assert set(aml.leaderboard.columns) == set(["model_id", "deviance","rmse", "mse", "mae", "rmsle"])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(australia_automl)

--- a/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
+++ b/h2o-py/tests/testdir_algos/automl/regression/pyunit_automl_australia.py
@@ -23,7 +23,7 @@ def australia_automl():
     aml.train(y="runoffnew", training_frame=train,validation_frame=valid, leaderboard_frame=test)
     print(aml.leader)
     print(aml.leaderboard)
-    assert set(aml.leaderboard.columns) == set(["model_id", "deviance","rmse", "mse", "mae", "rmsle"])
+    assert set(aml.leaderboard.columns) == set(["model_id", "mean_residual_deviance","rmse", "mse", "mae", "rmsle"])
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(australia_automl)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -20,7 +20,7 @@ automl.leaderboard.suite <- function() {
                            exclude_algos = exclude_algos)
         aml@leaderboard
         # check that correct leaderboard columns exist
-        expect_equal(names(aml@leaderboard), c("model_id", "auc", "logloss", "mean_per_class_error", "rmse", "mse"))
+        expect_equal(names(aml@leaderboard), c("model_id", "auc", "logloss", "aucpr", "mean_per_class_error", "rmse", "mse"))
         model_ids <- as.vector(aml@leaderboard$model_id)
         # check that no excluded algos are present in leaderboard
         exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))
@@ -41,7 +41,7 @@ automl.leaderboard.suite <- function() {
                            project_name = "r_aml_lb_regression_test",
                            exclude_algos = exclude_algos)
         aml@leaderboard
-        expect_equal(names(aml@leaderboard), c("model_id", "mean_residual_deviance", "rmse", "mse", "mae", "rmsle"))
+        expect_equal(names(aml@leaderboard), c("model_id", "deviance", "rmse", "mse", "mae", "rmsle"))
         model_ids <- as.vector(aml@leaderboard$model_id)
         # check that no excluded algos are present in leaderboard
         exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_leaderboard.R
@@ -41,7 +41,7 @@ automl.leaderboard.suite <- function() {
                            project_name = "r_aml_lb_regression_test",
                            exclude_algos = exclude_algos)
         aml@leaderboard
-        expect_equal(names(aml@leaderboard), c("model_id", "deviance", "rmse", "mse", "mae", "rmsle"))
+        expect_equal(names(aml@leaderboard), c("model_id", "mean_residual_deviance", "rmse", "mse", "mae", "rmsle"))
         model_ids <- as.vector(aml@leaderboard$model_id)
         # check that no excluded algos are present in leaderboard
         exclude_algo_count <- sum(sapply(exclude_algos, function(i) sum(grepl(i, model_ids))))

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
@@ -13,7 +13,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      sort_metric = "AUC")  #currently returns unsorted lb for "AUC"
   aml1@leaderboard
   # check that correct leaderboard columns exist
-  expect_equal(names(aml1@leaderboard), c("model_id", "auc", "logloss", "mean_per_class_error", "rmse", "mse"))
+  expect_equal(names(aml1@leaderboard), c("model_id", "auc", "logloss", "aucpr", "mean_per_class_error", "rmse", "mse"))
   # check that auc col is sorted already
   auc_col <- as.vector(aml1@leaderboard[,"auc"])
   expect_equal(identical(auc_col, sort(auc_col, decreasing = TRUE)), TRUE)
@@ -42,7 +42,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      project_name = "r_lbsm_test_aml2",
                      sort_metric = "RMSE")
   aml2@leaderboard
-  expect_equal(names(aml2@leaderboard), c("model_id", "rmse", "mean_residual_deviance", "mse", "mae", "rmsle"))
+  expect_equal(names(aml2@leaderboard), c("model_id", "rmse", "deviance", "mse", "mae", "rmsle"))
   # check that rmse col is sorted already
   rmse_col <- as.vector(aml2@leaderboard[,"rmse"])
   expect_equal(identical(rmse_col, sort(rmse_col, decreasing = FALSE)), TRUE)
@@ -52,7 +52,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      project_name = "r_lbsm_test_aml2_auto")
   aml2@leaderboard
   # check that leaderboard is sorted by mean_residual_deviance
-  mrd_col <- as.vector(aml2@leaderboard[,"mean_residual_deviance"])
+  mrd_col <- as.vector(aml2@leaderboard[,"deviance"])
   expect_equal(identical(mrd_col, sort(mrd_col, decreasing = FALSE)), TRUE)
   
   

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_sort_metric.R
@@ -42,7 +42,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      project_name = "r_lbsm_test_aml2",
                      sort_metric = "RMSE")
   aml2@leaderboard
-  expect_equal(names(aml2@leaderboard), c("model_id", "rmse", "deviance", "mse", "mae", "rmsle"))
+  expect_equal(names(aml2@leaderboard), c("model_id", "rmse", "mean_residual_deviance", "mse", "mae", "rmsle"))
   # check that rmse col is sorted already
   rmse_col <- as.vector(aml2@leaderboard[,"rmse"])
   expect_equal(identical(rmse_col, sort(rmse_col, decreasing = FALSE)), TRUE)
@@ -52,7 +52,7 @@ automl.leaderboard_sort_metric.test <- function() {
                      project_name = "r_lbsm_test_aml2_auto")
   aml2@leaderboard
   # check that leaderboard is sorted by mean_residual_deviance
-  mrd_col <- as.vector(aml2@leaderboard[,"deviance"])
+  mrd_col <- as.vector(aml2@leaderboard[,"mean_residual_deviance"])
   expect_equal(identical(mrd_col, sort(mrd_col, decreasing = FALSE)), TRUE)
   
   


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7072

Leaderboard now looks like this:
```
> aml@leaderboard
                                        model_id       auc    logloss     aucpr
1                   GBM_1_AutoML_20191126_062347 0.9950717 0.11876769 0.9850958
2 XGBoost_grid__1_AutoML_20191126_062347_model_5 0.9949223 0.10305487 0.9480312
3                   GLM_1_AutoML_20191126_062347 0.9947730 0.10012978 0.9848061
4 XGBoost_grid__1_AutoML_20191126_062347_model_2 0.9947357 0.09782578 0.9849690
5 XGBoost_grid__1_AutoML_20191126_062347_model_1 0.9936529 0.10097153 0.9838275
6                   GBM_4_AutoML_20191126_062347 0.9935783 0.10115086 0.9840811
  mean_per_class_error      rmse        mse
1           0.03345281 0.1800188 0.03240677
2           0.02882318 0.1604014 0.02572860
3           0.03345281 0.1710249 0.02924950
4           0.03345281 0.1655949 0.02742167
5           0.02882318 0.1654495 0.02737353
6           0.02942055 0.1645574 0.02707914
```

Also, renamed renamed leaderboard column `mean_residual_deviance` to `deviance` for consistency.