### PR TITLE
[PUBDEV-7096] Add option which can stop cluster if nothing has touched the rest api for the specified timeout

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -753,7 +753,7 @@ final public class H2O {
     }
     
     if (ARGS.rest_api_ping_timeout < 0) {
-      parseFailed("rest_api_ping_timeout needs to be 0 or higher, was (" + ARGS.rest_api_ping_timeout + ")");
+      parseFailed(String.format("rest_api_ping_timeout needs to be 0 or higher, was (%d)", ARGS.rest_api_ping_timeout));
     }
 
     // Validate extension arguments
@@ -1667,8 +1667,8 @@ final public class H2O {
     }
 
     if (H2O.ARGS.rest_api_ping_timeout > 0) {
-      Log.info("Registering REST API Check Thread. If 3/Ping endpoint is not accessed during " + H2O.ARGS.rest_api_ping_timeout + "" +
-          " ms, the cluster will be terminated.");
+      Log.info(String.format("Registering REST API Check Thread. If 3/Ping endpoint is not" +
+          " accessed during %d ms, the cluster will be terminated.", H2O.ARGS.rest_api_ping_timeout));
       new RestApiPingCheckThread().start();
     }
     // Create the starter Cloud with 1 member

--- a/h2o-core/src/main/java/water/RestApiPingCheckThread.java
+++ b/h2o-core/src/main/java/water/RestApiPingCheckThread.java
@@ -6,6 +6,7 @@ import water.util.Log;
 public class RestApiPingCheckThread extends Thread {
   
   public RestApiPingCheckThread() {
+    super("RestApiPingCheckThread");
     this.setDaemon(true);
   }
 

--- a/h2o-core/src/main/java/water/RestApiPingCheckThread.java
+++ b/h2o-core/src/main/java/water/RestApiPingCheckThread.java
@@ -1,0 +1,33 @@
+package water;
+
+import water.api.PingHandler;
+import water.util.Log;
+
+public class RestApiPingCheckThread extends Thread {
+  
+  public RestApiPingCheckThread() {
+    this.setDaemon(true);
+  }
+
+  @Override
+  public void run() {
+    while (!Thread.currentThread().isInterrupted()) {
+      if (H2O.CLOUD._memary.length != 0 && H2O.SELF == H2O.CLOUD.leader()) {
+        if (isTimeoutExceeded(PingHandler.lastAccessed, H2O.ARGS.rest_api_ping_timeout)) {
+          Log.fatal("Stopping H2O cluster since we haven't received any REST api request on 3/Ping!");
+          H2O.shutdown(-1);
+        }
+      }
+      try {
+        Thread.sleep(H2O.ARGS.rest_api_ping_timeout);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+  
+  private static boolean isTimeoutExceeded(long lastHeardFrom, long timeout) {
+    return (System.currentTimeMillis() - lastHeardFrom) >= timeout;
+  }
+}
+    

--- a/h2o-core/src/main/java/water/RestApiPingCheckThread.java
+++ b/h2o-core/src/main/java/water/RestApiPingCheckThread.java
@@ -21,6 +21,7 @@ public class RestApiPingCheckThread extends Thread {
       } else if (H2O.CLOUD._memary.length != 0 && Paxos._cloudLocked) {
         // Cloud is locked, but we are not leader, we can stop the thread
         Thread.currentThread().interrupt();
+        continue;
       }
       try {
         Thread.sleep(H2O.ARGS.rest_api_ping_timeout);

--- a/h2o-core/src/main/java/water/RestApiPingCheckThread.java
+++ b/h2o-core/src/main/java/water/RestApiPingCheckThread.java
@@ -17,6 +17,9 @@ public class RestApiPingCheckThread extends Thread {
           Log.fatal("Stopping H2O cluster since we haven't received any REST api request on 3/Ping!");
           H2O.shutdown(-1);
         }
+      } else if (H2O.CLOUD._memary.length != 0 && Paxos._cloudLocked) {
+        // Cloud is locked, but we are not leader, we can stop the thread
+        Thread.currentThread().interrupt();
       }
       try {
         Thread.sleep(H2O.ARGS.rest_api_ping_timeout);

--- a/h2o-core/src/main/java/water/api/PingHandler.java
+++ b/h2o-core/src/main/java/water/api/PingHandler.java
@@ -1,0 +1,29 @@
+package water.api;
+
+import water.H2O;
+import water.H2ONode;
+import water.api.schemas3.PingV3;
+
+public class PingHandler extends Handler {
+  
+  // Time in msec since somebody accessed the '3/Ping' endpoint on this node
+  public static long lastAccessed; 
+
+  @SuppressWarnings("unused") // called through reflection by RequestServer
+  public PingV3 ping(int version, PingV3 ping) {
+
+    ping.cloud_uptime_millis = System.currentTimeMillis() - H2O.START_TIME_MILLIS.get();
+    ping.cloud_healthy = true;
+    H2ONode[] members = H2O.CLOUD.members();
+
+    if (null != members) {
+      ping.nodes = new PingV3.NodeMemoryInfoV3[members.length];
+      for (int i = 0; i < members.length; i++) {
+        H2ONode n = members[i];
+        ping.nodes[i] = new PingV3.NodeMemoryInfoV3(n.getIpPortString(), n._heartbeat.get_free_mem());
+      }
+    }
+    lastAccessed = System.currentTimeMillis();
+    return ping;
+  }
+}

--- a/h2o-core/src/main/java/water/api/RegisterV3Api.java
+++ b/h2o-core/src/main/java/water/api/RegisterV3Api.java
@@ -71,7 +71,7 @@ public class RegisterV3Api extends AbstractRegister {
             "Parse a raw byte-oriented Frame into a useful columnar data Frame."); // NOTE: prefer POST due to higher content limits
 
     context.registerEndpoint("ping",
-        "GET /3/Ping", PingHandler.class, "status",
+        "GET /3/Ping", PingHandler.class, "ping",
         "The endpoint used to let H2O know from external services that it should keep running.");
 
     // Admin

--- a/h2o-core/src/main/java/water/api/RegisterV3Api.java
+++ b/h2o-core/src/main/java/water/api/RegisterV3Api.java
@@ -70,6 +70,10 @@ public class RegisterV3Api extends AbstractRegister {
             "POST /3/ParseSVMLight", ParseHandler.class, "parseSVMLight",
             "Parse a raw byte-oriented Frame into a useful columnar data Frame."); // NOTE: prefer POST due to higher content limits
 
+    context.registerEndpoint("ping",
+        "GET /3/Ping", PingHandler.class, "status",
+        "The endpoint used to let H2O know from external services that it should keep running.");
+
     // Admin
     context.registerEndpoint("cloudStatus",
             "GET /3/Cloud", CloudHandler.class, "status",

--- a/h2o-core/src/main/java/water/api/RequestServer.java
+++ b/h2o-core/src/main/java/water/api/RequestServer.java
@@ -590,7 +590,8 @@ public class RequestServer extends HttpServlet {
             path[2].equals("Log") ||
             path[2].equals("Progress") ||
             path[2].equals("Typeahead") ||
-            path[2].equals("WaterMeterCpuTicks")
+            path[2].equals("WaterMeterCpuTicks") ||
+            path[2].equals("Ping")
         ) {
           return LogFilterLevel.DO_NOT_LOG;
         }

--- a/h2o-core/src/main/java/water/api/schemas3/PingV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/PingV3.java
@@ -1,0 +1,35 @@
+package water.api.schemas3;
+
+import water.Iced;
+import water.api.API;
+
+public class PingV3 extends RequestSchemaV3<Iced, PingV3> {
+  public PingV3() {
+  }
+
+  @API(help = "cloud_uptime_millis", direction = API.Direction.OUTPUT)
+  public long cloud_uptime_millis;
+
+  @API(help = "cloud_healthy", direction = API.Direction.OUTPUT)
+  public boolean cloud_healthy;
+
+  @API(help="nodes", direction=API.Direction.OUTPUT)
+  public NodeMemoryInfoV3[] nodes;
+  
+  public static class NodeMemoryInfoV3 extends SchemaV3<Iced, NodeMemoryInfoV3> {
+    public NodeMemoryInfoV3() {
+    }
+
+    public NodeMemoryInfoV3(String ipPort, long freeMemory) {
+      ip_port = ipPort;
+      free_mem = freeMemory;
+    }
+
+
+    @API(help="IP address and port in the form a.b.c.d:e", direction=API.Direction.OUTPUT)
+    public String ip_port;
+
+    @API(help = "Free heap", direction = API.Direction.OUTPUT)
+    public long free_mem;
+  }
+}

--- a/h2o-core/src/main/java/water/api/schemas3/PingV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/PingV3.java
@@ -24,8 +24,7 @@ public class PingV3 extends RequestSchemaV3<Iced, PingV3> {
       ip_port = ipPort;
       free_mem = freeMemory;
     }
-
-
+    
     @API(help="IP address and port in the form a.b.c.d:e", direction=API.Direction.OUTPUT)
     public String ip_port;
 

--- a/h2o-core/src/main/resources/META-INF/services/water.api.Schema
+++ b/h2o-core/src/main/resources/META-INF/services/water.api.Schema
@@ -154,3 +154,5 @@ water.api.schemas3.StringPairV3
 water.api.schemas3.KeyValueV3
 water.api.schemas3.GridExportV3
 water.api.schemas3.GridImportV3
+water.api.schemas3.PingV3
+water.api.schemas3.PingV3$NodeMemoryInfoV3

--- a/h2o-core/src/test/java/water/api/PingHandlerTest.java
+++ b/h2o-core/src/test/java/water/api/PingHandlerTest.java
@@ -1,0 +1,23 @@
+package water.api;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.TestUtil;
+import water.api.schemas3.PingV3;
+
+import static org.junit.Assert.assertNotNull;
+
+public class PingHandlerTest extends TestUtil {
+
+  @BeforeClass
+  public static void beforeClass() {
+    TestUtil.stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void status() {
+    final PingHandler handler = new PingHandler();
+    final PingV3 heartbeat = handler.ping(3, new PingV3());
+    assertNotNull(heartbeat);
+  }
+}


### PR DESCRIPTION
Initial implementation. I have tried to to find a single place which is called for all successful rest API calls, but couldn't find it, that is why I made this check only for 3/Cloud.

If you have better ideas, please let me know. I hope that at some point with complete switch to REST api on SW side, we can remove the watchdog client etc(maybe client as well), but that will take several major iterations still, so these 2 need to coexist now