### PR TITLE
PUBDEV-6796 - Spearman's correlation coeffiecient (Pearson part)

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Env.java
+++ b/h2o-core/src/main/java/water/rapids/Env.java
@@ -15,6 +15,7 @@ import water.rapids.ast.prims.operators.*;
 import water.rapids.ast.prims.reducers.*;
 import water.rapids.ast.prims.repeaters.*;
 import water.rapids.ast.prims.search.*;
+import water.rapids.ast.prims.statistics.AstPearson;
 import water.rapids.ast.prims.string.*;
 import water.rapids.ast.prims.time.*;
 import water.rapids.ast.prims.timeseries.*;
@@ -297,6 +298,9 @@ public class Env extends Iced {
     init(new AstRepLen());
     init(new AstSeq());
     init(new AstSeqLen());
+    
+    // Statistics
+    init(new AstPearson());
 
     // Custom (eg. algo-specific)
     for (AstPrimitive prim : PrimsService.INSTANCE.getAllPrims())

--- a/h2o-core/src/main/java/water/rapids/ast/prims/statistics/AstPearson.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/statistics/AstPearson.java
@@ -1,0 +1,163 @@
+package water.rapids.ast.prims.statistics;
+
+import water.DKV;
+import water.MRTask;
+import water.Value;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import water.rapids.Env;
+import water.rapids.Val;
+import water.rapids.ast.AstPrimitive;
+import water.rapids.ast.AstRoot;
+import water.rapids.vals.ValNum;
+import water.util.VecUtils;
+
+import java.util.Objects;
+
+/**
+ * Pearson's correlation coefficient (PCC) calculation
+ *
+ * Note: If one of the observation's columns used to calculate Pearson's corr. coef. contains a NaN value,
+ * the whole line is skipped.
+ */
+public class AstPearson extends AstPrimitive {
+  @Override
+  public int nargs() {
+    return 1 + 3; // Frame ID and ID of two numerical vectors to calculate PCC on.
+  }
+
+  @Override
+  public String[] args() {
+    return new String[0];
+  }
+
+  @Override
+  public Val apply(Env env, Env.StackHelp stk, AstRoot[] asts) {
+    final Value value = DKV.get(asts[1].str());
+    if (!value.isFrame()) {
+      throw new IllegalArgumentException(String.format("The given key '%s' is not a frame.", asts[1]));
+    }
+
+    final Frame frame = value.get(Frame.class);
+    final Vec x = getVectorFromFrame(frame, asts[2].str());
+    final Vec y = getVectorFromFrame(frame, asts[3].str());
+    // Can't use means from rollup stats - lines with NAs in the columns evaluated are skipped completely. 
+    final double[] means = VecUtils.calculateMeansIgnoringNas(x, y);
+
+    final PearsonCorrelationCoefficientTask pearsonTask = new PearsonCorrelationCoefficientTask(means[0], means[1])
+            .doAll(x, y);
+    return new ValNum(pearsonTask.get_pearsonCorrelationCoefficient());
+  }
+
+  /**
+   * Retrieves a vector from a {@link Frame} or throws {@link IllegalArgumentException} if not found.
+   *
+   * @param frame            Frame to obtain vector from
+   * @param userGivenColName Column name to calculate PCC from, obtained from user's input
+   * @return An instance of {@link Vec} from the {@link Frame} given, if exists. Otherwise an exception is thrown.
+   * @throws IllegalArgumentException Thrown if the given column name is not to be found in the {@link Frame}.
+   */
+  private Vec getVectorFromFrame(final Frame frame, final String userGivenColName) throws IllegalArgumentException {
+    Objects.requireNonNull(frame, "Frame must not be null.");
+    Objects.requireNonNull(userGivenColName, "Column name to calculate Pearson's cor. coef. from must not be null.");
+
+    final Vec vec = frame.vec(userGivenColName);
+    if (vec == null) {
+      throw new IllegalArgumentException(String.format("No column found for given name '%s'. Unable to calculate Pearson's corr. coef.",
+              userGivenColName));
+    }
+
+    return vec;
+  }
+  @Override
+  public String str() {
+    return "pearson";
+  }
+
+  /**
+   * A task to do calculate Pearson's correlation coefficient.
+   * The intermediate calculations required for standard deviant of both columns could be calculated by existing code,
+   * however the point is to perform the calculations by going through the data only once.
+   * <p>
+   * Note: If one of the observation's columns used to calculate Pearson's corr. coef. contains a NaN value,
+   * the whole line is skipped.
+   *
+   * @see {@link water.rapids.ast.prims.advmath.AstVariance}
+   */
+  private static class PearsonCorrelationCoefficientTask extends MRTask<PearsonCorrelationCoefficientTask> {
+
+    // Arguments obtained externally
+    private final double _xMean;
+    private final double _yMean;
+
+    private double _pearsonCorrelationCoefficient;
+
+    // Required to later finish calculation of standard deviation
+    private double _xDiffSquared = 0;
+    private double _yDiffSquared = 0;
+    private double _xyAvgDiffMul = 0;
+    // If at least one of the vectors contains NaN, such line is skipped
+    private long _linesVisited;
+
+    /**
+     * @param xMean Mean value of the first 'x' vector, with NaNs skipped
+     * @param yMean Mean value of the second 'y' vector, with NaNs skipped
+     */
+    private PearsonCorrelationCoefficientTask(final double xMean, final double yMean) {
+      this._xMean = xMean;
+      this._yMean = yMean;
+    }
+
+    @Override
+    public void map(Chunk[] chunks) {
+      assert chunks.length == 2; // Amount of linear correlation only calculated between two vectors at once
+      final Chunk xChunk = chunks[0];
+      final Chunk yChunk = chunks[1];
+          
+
+      for (int row = 0; row < chunks[0].len(); row++) {
+        final double x = xChunk.atd(row);
+        final double y = yChunk.atd(row);
+        if (Double.isNaN(x) || Double.isNaN(y)) {
+          continue; // Skip NaN values
+        }
+        _linesVisited++;
+
+        final double xDiffFromMean = x - _xMean;
+        final double yDiffFromMean = y - _yMean;
+        _xyAvgDiffMul += xDiffFromMean * yDiffFromMean;
+
+        _xDiffSquared += Math.pow(xDiffFromMean, 2);
+        _yDiffSquared += Math.pow(yDiffFromMean, 2);
+      }
+    }
+
+
+    @Override
+    public void reduce(final PearsonCorrelationCoefficientTask mrt) {
+      // The intermediate results are addable. The final calculations are done afterwards.
+      this._xDiffSquared += mrt._xDiffSquared;
+      this._yDiffSquared += mrt._yDiffSquared;
+      this._xyAvgDiffMul += mrt._xyAvgDiffMul;
+      this._linesVisited += mrt._linesVisited;
+    }
+
+    @Override
+    protected void postGlobal() {
+      // X Standard deviation
+      final double xStdDev = Math.sqrt(1D / (_linesVisited - 1) * _xDiffSquared);
+
+      // Y Standard deviation
+      final double yStdDev = Math.sqrt(1D / (_linesVisited - 1) * _yDiffSquared);
+
+      _pearsonCorrelationCoefficient = (_xyAvgDiffMul)
+              / ((_linesVisited - 1) * xStdDev * yStdDev);
+    }
+
+    public double get_pearsonCorrelationCoefficient() {
+      return _pearsonCorrelationCoefficient;
+    }
+  }
+
+}

--- a/h2o-core/src/main/java/water/rapids/ast/prims/statistics/AstPearson.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/statistics/AstPearson.java
@@ -42,8 +42,14 @@ public class AstPearson extends AstPrimitive {
     final Frame frame = value.get(Frame.class);
     final Vec x = getVectorFromFrame(frame, asts[2].str());
     final Vec y = getVectorFromFrame(frame, asts[3].str());
-    // Can't use means from rollup stats - lines with NAs in the columns evaluated are skipped completely. 
-    final double[] means = VecUtils.calculateMeansIgnoringNas(x, y);
+    
+    final double[] means;
+    if (x.naCnt() == 0 && y.naCnt() == 0) {
+      means = new double[]{x.mean(), y.mean()};
+    } else {
+      // Can't use means from rollup stats - lines with NAs in the columns evaluated are skipped completely. 
+      means = VecUtils.calculateMeansIgnoringNas(x, y);
+    }
 
     final PearsonCorrelationCoefficientTask pearsonTask = new PearsonCorrelationCoefficientTask(means[0], means[1])
             .doAll(x, y);

--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -11,6 +11,8 @@ import water.nbhm.NonBlockingHashMapLong;
 import water.parser.BufferedString;
 import water.parser.Categorical;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.*;
 
 public class VecUtils {
@@ -824,6 +826,82 @@ public class VecUtils {
       for (int i = 0; i < c.len(); i++) {
         nc.addCategorical(_domainIndicesMap[(int) c.at8(i)]);
       }
+    }
+  }
+
+  /**
+   * Calculates means of given numerical Vectors. Provided there is a NaN on a row in any of the give vectors,
+   * the row is skipped and involved in the mean calculation.
+   *
+   * @param vecs An array of {@link Vec}, must not be empty, nor null. All vectors must be of same length.
+   * @return An array of doubles with means for given vectors in the order they were given as arguments.
+   * @throws IllegalArgumentException Zero vectors provided,
+   */
+  public static double[] calculateMeansIgnoringNas(final Vec... vecs) throws IllegalArgumentException {
+    if (vecs.length < 1) {
+      throw new IllegalArgumentException("There are no vectors to calculate means from.");
+    }
+
+    final long referenceVectorLength = vecs[0].length();
+
+    for (int i = 0; i < vecs.length; i++) {
+      if (Vec.T_NUM != vecs[i].get_type()) {
+        throw new IllegalArgumentException(String.format("Given vector '%s' is not numerical.",
+                vecs[i]._key.toString()));
+      }
+      if (referenceVectorLength != vecs[i].length()) {
+        throw new IllegalArgumentException("Vectors to calculate means from do not have the same length." +
+                String.format(" Vector '%s' is of length '%d'", vecs[i]._key.toString(), vecs[i].length()));
+      }
+    }
+
+    return new NaIgnoringMeanTask()
+            .doAll(vecs)._means;
+  }
+
+  /**
+   * Calculates means of given numerical Vectors. Provided there is a NaN on a row in any of the give vectors,
+   * the row is skipped and involved in the mean calculation.
+   */
+  private static class NaIgnoringMeanTask extends MRTask<NaIgnoringMeanTask> {
+
+    private double[] _means;
+    private long _linesVisited = 0;
+
+    @Override
+    public void map(Chunk[] cs) {
+      // Sums might get big, BigDecimal ensures local accuracy and no overflow
+      final BigDecimal[] averages = new BigDecimal[cs.length];
+      for (int i = 0; i < averages.length; i++) {
+        averages[i] = new BigDecimal(0, MathContext.UNLIMITED);
+      }
+
+      row:
+      for (int row = 0; row < cs[0].len(); row++) {
+        final double[] values = new double[cs.length];
+        for (int col = 0; col < cs.length; col++) {
+          values[col] = cs[col].atd(row);
+          if (Double.isNaN(values[col])) break row; // If a NaN is detected in any of the columns, just skip the row
+        }
+        _linesVisited++;
+        for (int i = 0; i < values.length; i++) {
+          averages[i] = averages[i].add(new BigDecimal(values[i], MathContext.UNLIMITED), MathContext.UNLIMITED);
+        }
+      }
+
+      this._means = new double[cs.length];
+      for (int i = 0; i < averages.length; i++) {
+        this._means[i] = averages[i].divide(new BigDecimal(_linesVisited), MathContext.DECIMAL64).doubleValue();
+      }
+    }
+
+    @Override
+    public void reduce(NaIgnoringMeanTask mrt) {
+      final int numChunks = _means.length;
+      for (int i = 0; i < numChunks; i++) {
+        _means[i] = (_means[i] * _linesVisited + mrt._means[i] * mrt._linesVisited) / (_linesVisited + mrt._linesVisited);
+      }
+      _linesVisited += mrt._linesVisited;
     }
   }
 


### PR DESCRIPTION
# PUBDEV-6796 ( Pearson correlation part)
- [JIRA PUBDEV-6796](https://0xdata.atlassian.net/browse/PUBDEV-6796)
- [H2O Support Portal Ticket 95038](https://support.h2o.ai/a/tickets/95038)

## Description

Goal of the original JIRA is to calculate a **Spearman's** correlation coefficient (SCC) of two numerical `Vec`s. I've decided to warm myself up and provide the less complex **Pearson's** correlation coefficient (PCC).

**Pearson's correlation coefficient** is calculated as follows:

![pearson](https://user-images.githubusercontent.com/8769110/69530519-72818280-0f72-11ea-8259-b268bfc34952.png)

where s<sub>x</sub> & s<sub>y</sub> are standard deviations of column `x` or `y` respectively.

### Role of mean values
Both SCC and PCC require mean values of the two colums/vecs `x` and `y`. However, the dataset might contain `NaN`s. The computation alone `drops` lines with `NaN`s. If there is a line with a `NaN` in at least one of the two columns PCC value is calculated for, that line is not included in the calculation.

This makes the `Vec.mean()` value (Mean pre-calculated from rollup stats) unusable, as such mean is calculated per each column/vector independetly and it might contain lines avoided by the PCC calculation algorithm. Therefore, `VecUtils.calculateMeansIgnoringNas` method has been introduced. Such method calculates means for `n > 0` numerical vecs, skipping over lines where any of the Vec has `NaN` in it. For PCC and SCC, `n = 2`, always. That's self understood, but the method was written in a more general way.

## PCC Implementation

The actual algorithm is exposed as rapids expression `AstPearson`. Example of a Rapids expression:

```
(pearson iris_pearson 'sepal_len' 'petal_len')
```

It is **tested** in `RapidsTest` class. The `testPearson` test has been manually calculated and verified using [Wolfram Alpha](https://www.wolframalpha.com/widgets/view.jsp?id=3038cb5ccf72f21a13801d9c78f70937). The other test, testing calculation of linear correlation on the **Iris** dataset named `testPearsonIris` is also verified using [Wolfram Alpha](https://www.wolframalpha.com/widgets/view.jsp?id=3038cb5ccf72f21a13801d9c78f70937) and using another [third party tool](https://www.socscistatistics.com/tests/pearson/default2.aspx).

## Questions

1. Provided we want to stick to using `double`, should we use [Iterative mean](http://www.heikohoffmann.de/htmlthesis/node134.html) to calculate the mean values in `VecUtils.calculateMeansIgnoringNas`, more specifically in `VecUtils.NaIgnoringMeanTask` ? I'm afraid about double overflow with current plain additive method used.
2. Do we want to expose PCC (and later SCC) using a dedicated function in Python and R, e.g. like `h2o.pearson()` ? Do we want to group those somehow, as the number of descriptive statistics might increase.

### Fun fact
Did you know `sepal length` and `petal length` have strong positive correlation according to Pearson's ?