### PR TITLE
PUBDEV-7110: Early stopping logic should not be located within HyperSpaceIterator's hasNext method

### DIFF
--- a/h2o-algos/src/test/java/hex/glrm/GLRMGridTest.java
+++ b/h2o-algos/src/test/java/hex/glrm/GLRMGridTest.java
@@ -2,6 +2,7 @@ package hex.glrm;
 
 import hex.genmodel.algos.glrm.GlrmInitialization;
 import hex.genmodel.algos.glrm.GlrmLoss;
+import hex.grid.HyperSpaceSearchCriteria;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -127,8 +128,13 @@ public class GLRMGridTest extends TestUtil {
       //
       Key<Grid> gridKey = Key.make("GLRM_grid_iris" + Key.rand());
 
+      GridSearch.SimpleParametersBuilderFactory<GLRMModel.GLRMParameters> simpleParametersBuilderFactory =
+              new GridSearch.SimpleParametersBuilderFactory<>();
+      HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria =
+              new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+
       // 1st iteration
-      final Job<Grid> gs1 = GridSearch.startGridSearch(gridKey, params, hyperParms);
+      final Job<Grid> gs1 = GridSearch.startGridSearch(gridKey, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 1);
       grid = (Grid<GLRMModel.GLRMParameters>) gs1.get();
       // Make sure number of produced models match size of specified hyper space
       Grid.SearchFailure failures = grid.getFailures();
@@ -146,7 +152,7 @@ public class GLRMGridTest extends TestUtil {
       Arrays.sort(hyperParamNames2);
       final int hyperSpaceSize2 = ArrayUtils.crossProductSize(hyperParms);
       Assert.assertArrayEquals("Names of hyperspaces should be same!", hyperParamNames1, hyperParamNames2);
-      final Job<Grid> gs2 = GridSearch.startGridSearch(gridKey, params, hyperParms);
+      final Job<Grid> gs2 = GridSearch.startGridSearch(gridKey, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 1);
       grid = (Grid<GLRMModel.GLRMParameters>) gs2.get();
       // Make sure number of produced models match size of specified hyper space
       failures = grid.getFailures();

--- a/h2o-algos/src/test/java/hex/grid/GridTest.java
+++ b/h2o-algos/src/test/java/hex/grid/GridTest.java
@@ -4,7 +4,6 @@ import hex.Model;
 import hex.genmodel.utils.DistributionFamily;
 import hex.tree.gbm.GBMModel;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -16,6 +15,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashMap;
 
 import static org.junit.Assert.*;
@@ -27,7 +27,7 @@ public class GridTest extends TestUtil {
 
   @BeforeClass
   public static void setUp() {
-    stall_till_cloudsize(1);
+    stall_till_cloudsize(2);
   }
 
   @Test
@@ -137,10 +137,84 @@ public class GridTest extends TestUtil {
       gs = GridSearch.startGridSearch(null, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 1);
 
       final Grid grid2 = gs.get();
-      Scope.track_generic(grid2
-      );
+      Scope.track_generic(grid2);
       // We expect not to get more than number of valid combinations
       assertEquals(numberOfValidCombinations, gs.get().getModelCount());
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void test_parallel_grid_search_MaxModelIsSatisfiedWhenSomeModelsHaveFailed() {
+    try {
+      Scope.enter();
+      final Frame trainingFrame = parse_test_file("smalldata/iris/iris_train.csv");
+      Scope.track(trainingFrame);
+
+      final Integer min_rows_value_that_cause_error = 5000000;
+
+      HashMap<String, Object[]> hyperParms = new HashMap<String, Object[]>() {{
+        put("_distribution", new DistributionFamily[]{DistributionFamily.multinomial});
+        put("_max_depth", new Integer[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        put("_min_rows", new Integer[]{10, min_rows_value_that_cause_error});
+      }};
+
+      // From total of 20 combinations only 10 are expected to be valid.
+      int numberOfValidCombinations = 10;
+
+      GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+      params._train = trainingFrame._key;
+      params._response_column = "species";
+
+      GridSearch.SimpleParametersBuilderFactory simpleParametersBuilderFactory = new GridSearch.SimpleParametersBuilderFactory();
+      HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+      hyperSpaceSearchCriteria.set_max_models(numberOfValidCombinations);
+      hyperSpaceSearchCriteria.set_stopping_rounds(10000);
+
+      Job<Grid> gs = GridSearch.startGridSearch(null, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 4);
+      Scope.track_generic(gs);
+      final Grid grid = gs.get();
+      Scope.track_generic(grid);
+
+
+      Arrays.asList(grid.getModels()).forEach(m -> {
+        GBMModel.GBMParameters parms = (GBMModel.GBMParameters) m._parms;
+        System.out.println(parms._max_depth + " : " + parms._min_rows);
+      });
+
+      Arrays.asList(grid.getFailures().getFailedParameters()).forEach(m -> {
+        GBMModel.GBMParameters parms = (GBMModel.GBMParameters) m;
+        System.out.println("Failed: " + parms._max_depth + " : " + parms._min_rows);
+      });
+
+      // There is a chance to get expected number of models without hitting failing combination with `min_rows` = `min_rows_value_that_cause_error`
+      // but it is quite a small one and false positive tests would not hurt
+      assertEquals(numberOfValidCombinations, grid.getModelCount());
+
+      // Test case 2.
+      // Let's test that we actually failing with `min_rows` = `min_rows_value_that_cause_error`
+      int max_models_one_more_than_number_of_valid_ones = numberOfValidCombinations + 1;
+      hyperSpaceSearchCriteria.set_max_models(max_models_one_more_than_number_of_valid_ones);
+
+      gs = GridSearch.startGridSearch(null, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 6);
+
+      final Grid grid2 = gs.get();
+      Scope.track_generic(grid2);
+
+      Arrays.asList(grid2.getModels()).forEach(m -> {
+        GBMModel.GBMParameters parms = (GBMModel.GBMParameters) m._parms;
+        System.out.println(parms._max_depth + " : " + parms._min_rows);
+      });
+
+      Arrays.asList(grid2.getFailures().getFailedParameters()).forEach(m -> {
+        GBMModel.GBMParameters parms = (GBMModel.GBMParameters) m;
+        System.out.println("Failed: " + parms._max_depth + " : " + parms._min_rows);
+      });
+      // We expect not to get more than number of valid combinations
+      assertEquals(10, grid2.getModelCount());
+      assertEquals(20, grid2.getModelCount() + grid2.getFailures().getFailureCount());
 
     } finally {
       Scope.exit();
@@ -669,8 +743,10 @@ public class GridTest extends TestUtil {
     }
   }
 
+
+  // Multirun tests
   @Test
-  public void testParallelRandomSearchWithDefaultMaxModels_MultiRun() {
+  public void testParallelRandomSearchWithDefaultMaxModels_multirun() {
     try {
       Scope.enter();
       final Frame trainingFrame = parse_test_file("smalldata/iris/iris_train.csv");
@@ -706,10 +782,8 @@ public class GridTest extends TestUtil {
       final Grid grid = gs.get();
       Scope.track_generic(grid);
 
-
       int expectedNumberOfModelsFromTwoGrids = 10;
       assertEquals(expectedNumberOfModelsFromTwoGrids, grid.getModelCount());
-
     } finally {
       Scope.exit();
     }
@@ -717,7 +791,7 @@ public class GridTest extends TestUtil {
 
 
   @Test
-  public void test_parallel_random_search_with_custom_max_models_multirun() {
+  public void test_parallel_random_search_with_max_models_greater_than_parallelism_multirun() {
     try {
       Scope.enter();
       final Frame trainingFrame = parse_test_file("smalldata/iris/iris_train.csv");
@@ -751,6 +825,53 @@ public class GridTest extends TestUtil {
       // Train a grid with new hyper parameters
       hyperParms.put("_learn_rate", new Double[]{0.5});
       gs = GridSearch.startGridSearch(grid1._key, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 2);
+      Scope.track_generic(gs);
+      final Grid grid = gs.get();
+      Scope.track_generic(grid);
+
+      int expectedNumberOfModelsFromTwoGrids = 2 * custom_max_model;
+      assertEquals(expectedNumberOfModelsFromTwoGrids, grid.getModelCount());
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void test_parallel_random_search_with_max_models_less_than_parallelism_multirun() {
+    try {
+      Scope.enter();
+      final Frame trainingFrame = parse_test_file("smalldata/iris/iris_train.csv");
+      Scope.track(trainingFrame);
+
+      // Setup random hyperparameter search space
+      HashMap<String, Object[]> hyperParms = new HashMap<String, Object[]>() {{
+        put("_distribution", new DistributionFamily[]{DistributionFamily.multinomial});
+        put("_ntrees", new Integer[]{5});
+        put("_max_depth", new Integer[]{2});
+        put("_min_rows", new Integer[]{10,11,12,13,14});
+        put("_learn_rate", new Double[]{.7});
+      }};
+
+      GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+      params._train = trainingFrame._key;
+      params._response_column = "species";
+
+      GridSearch.SimpleParametersBuilderFactory simpleParametersBuilderFactory = new GridSearch.SimpleParametersBuilderFactory();
+      HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+      int custom_max_model = 3;
+      hyperSpaceSearchCriteria.set_max_models(custom_max_model);
+
+      Job<Grid> gs = GridSearch.startGridSearch(null, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 4);
+      Scope.track_generic(gs);
+      final Grid grid1 = gs.get();
+      Scope.track_generic(grid1);
+
+      assertEquals(custom_max_model, grid1.getModelCount());
+
+      // Train a grid with new hyper parameters
+      hyperParms.put("_learn_rate", new Double[]{0.5});
+      gs = GridSearch.startGridSearch(grid1._key, params, hyperParms, simpleParametersBuilderFactory, hyperSpaceSearchCriteria, 4);
       Scope.track_generic(gs);
       final Grid grid = gs.get();
       Scope.track_generic(grid);

--- a/h2o-algos/src/test/java/hex/grid/GridTest.java
+++ b/h2o-algos/src/test/java/hex/grid/GridTest.java
@@ -27,7 +27,7 @@ public class GridTest extends TestUtil {
 
   @BeforeClass
   public static void setUp() {
-    stall_till_cloudsize(2);
+    stall_till_cloudsize(1);
   }
 
   @Test

--- a/h2o-core/src/main/java/hex/ParallelModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ParallelModelBuilder.java
@@ -30,19 +30,17 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
 
   private final transient ParallelModelBuilderCallback _callback;
 
-  public AtomicInteger getModelInProgressCounterNative() {
-    return _modelInProgressCounterNative;
+  public AtomicInteger getModelInProgressCounter() {
+    return _modelInProgressCounter;
   }
 
-  //  private final transient IcedAtomicInt _modelInProgressCounter = new IcedAtomicInt(); // TODO remove after tests. Should be fine not to use Iced version as ParallelModelBuilder itself is not going to be distributed
-  private final  AtomicInteger _modelInProgressCounterNative = new AtomicInteger(); // TODO rename Native
+  private final  AtomicInteger _modelInProgressCounter = new AtomicInteger();
 
-  public AtomicInteger getModelCompletedCounterNative() {
-    return _modelCompletedCounterNative;
+  public AtomicInteger getModelCompletedCounter() {
+    return _modelCompletedCounter;
   }
 
-  //  private final transient IcedAtomicInt _modelCompletedCounter = new IcedAtomicInt();
-  private final  AtomicInteger _modelCompletedCounterNative = new AtomicInteger();
+  private final  AtomicInteger _modelCompletedCounter = new AtomicInteger();
 
   private final transient AtomicBoolean _completed = new AtomicBoolean(false);
   private final transient ParallelModelBuiltListener _parallelModelBuiltListener;
@@ -61,7 +59,7 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
    */
   public void run(final Collection<ModelBuilder> modelBuilders) {
       for (final ModelBuilder modelBuilder : modelBuilders) {
-        _modelInProgressCounterNative.incrementAndGet();
+        _modelInProgressCounter.incrementAndGet();
 
         // Set the callbacks
         modelBuilder.setModelBuilderListener(_parallelModelBuiltListener);
@@ -77,8 +75,8 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
       try {
         _callback.onBuildSuccess(model, ParallelModelBuilder.this);
       } finally {
-        _modelCompletedCounterNative.incrementAndGet();
-        _modelInProgressCounterNative.decrementAndGet();
+        _modelCompletedCounter.incrementAndGet();
+        _modelInProgressCounter.decrementAndGet();
 
         _callback.postBuildSuccess(model, ParallelModelBuilder.this);
       }
@@ -91,7 +89,7 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
       try {
         _callback.onBuildFailure(modelBuildFailure, ParallelModelBuilder.this);
       } finally {
-        _modelInProgressCounterNative.decrementAndGet();
+        _modelInProgressCounter.decrementAndGet();
       }
       _callback.postBuildFailure(modelBuildFailure, ParallelModelBuilder.this);
       attemptComplete();
@@ -127,7 +125,7 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
   }
   
   private void attemptComplete(){
-    if(!_completed.get() || _modelInProgressCounterNative.get() != 0) return;
+    if(!_completed.get() || _modelInProgressCounter.get() != 0) return;
     complete(this);
   }
 

--- a/h2o-core/src/main/java/hex/ParallelModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ParallelModelBuilder.java
@@ -21,11 +21,9 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
 
     public abstract void onBuildSuccess(final Model model, final ParallelModelBuilder parallelModelBuilder);
 
-    public void postBuildSuccess(final Model model, final ParallelModelBuilder parallelModelBuilder) {};
-
     public abstract void onBuildFailure(final ModelBuildFailure modelBuildFailure, final ParallelModelBuilder parallelModelBuilder);
 
-    public void postBuildFailure(final ModelBuildFailure modelBuildFailure, final ParallelModelBuilder parallelModelBuilder) {};
+    public abstract void afterBuildProcessing(final ParallelModelBuilder parallelModelBuilder, final Model model);
   }
 
   private final transient ParallelModelBuilderCallback _callback;
@@ -78,7 +76,7 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
         _modelCompletedCounter.incrementAndGet();
         _modelInProgressCounter.decrementAndGet();
 
-        _callback.postBuildSuccess(model, ParallelModelBuilder.this);
+        _callback.afterBuildProcessing(ParallelModelBuilder.this, model);
       }
       attemptComplete();
     }
@@ -91,7 +89,7 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
       } finally {
         _modelInProgressCounter.decrementAndGet();
       }
-      _callback.postBuildFailure(modelBuildFailure, ParallelModelBuilder.this);
+      _callback.afterBuildProcessing(ParallelModelBuilder.this, null);
       attemptComplete();
     }
   }

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -223,8 +223,8 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     private void attemptBuildNextModel(final ParallelModelBuilder parallelModelBuilder, final Model previousModel) {
 
       synchronized (hyperspaceIterator) {
-        int numberOfExpectedToCompleteModels = parallelModelBuilder.getModelInProgressCounterNative().get();
-        int numberOfCompletedModels = parallelModelBuilder.getModelCompletedCounterNative().get();
+        int numberOfExpectedToCompleteModels = parallelModelBuilder.getModelInProgressCounter().get();
+        int numberOfCompletedModels = parallelModelBuilder.getModelCompletedCounter().get();
 
         if (hyperspaceIterator.hasNext(previousModel)
                 && isThereEnoughTime()

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -223,14 +223,11 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     private void attemptBuildNextModel(final ParallelModelBuilder parallelModelBuilder, final Model previousModel) {
 
       synchronized (hyperspaceIterator) {
-        int numberOfExpectedToCompleteModels = parallelModelBuilder.getModelInProgressCounter().get();
-        int numberOfCompletedModels = parallelModelBuilder.getModelCompletedCounter().get();
-
         if (hyperspaceIterator.hasNext(previousModel)
                 && isThereEnoughTime()
-                && (hyperspaceIterator.max_models() == 0 || numberOfCompletedModels + numberOfExpectedToCompleteModels < hyperspaceIterator.max_models())
+                && !hasReachedMaxModels(parallelModelBuilder)
                 && !_job.stop_requested()
-                && (previousModel == null || !_hyperSpaceWalker.stopEarly(previousModel, grid.getScoringInfos()))) {
+                && !_hyperSpaceWalker.stopEarly(previousModel, grid.getScoringInfos())) {
 
           final MP nextModelParams = getNextModelParams(hyperspaceIterator, previousModel, grid);
 
@@ -242,6 +239,12 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
           parallelModelBuilder.noMoreModels();
         }
       }
+    }
+
+    private boolean hasReachedMaxModels(ParallelModelBuilder parallelModelBuilder) {
+      int numberOfInProgressModels = parallelModelBuilder.getModelInProgressCounter().get();
+      int numberOfCompletedModels = parallelModelBuilder.getModelCompletedCounter().get();
+      return !(hyperspaceIterator.max_models() == 0 || numberOfCompletedModels + numberOfInProgressModels < hyperspaceIterator.max_models());
     }
 
     private void constructScoringInfo(final Model model) {

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -211,13 +211,8 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     }
 
     @Override
-    public void postBuildSuccess(Model finishedModel, ParallelModelBuilder parallelModelBuilder) {
+    public void afterBuildProcessing(ParallelModelBuilder parallelModelBuilder, Model finishedModel) {
       attemptBuildNextModel(parallelModelBuilder, finishedModel);
-    }
-
-    @Override
-    public void postBuildFailure(ParallelModelBuilder.ModelBuildFailure modelBuildFailure, ParallelModelBuilder parallelModelBuilder) {
-      attemptBuildNextModel(parallelModelBuilder, null);
     }
 
     private void attemptBuildNextModel(final ParallelModelBuilder parallelModelBuilder, final Model previousModel) {

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -453,7 +453,7 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
     /** Based on the last model, the given array of ScoringInfo, and our stopping criteria should we stop early? */
     @Override
     public boolean stopEarly(Model model, ScoringInfo[] sk) {
-      return ScoreKeeper.stopEarly(ScoringInfo.scoreKeepers(sk),
+      return model !=null && ScoreKeeper.stopEarly(ScoringInfo.scoreKeepers(sk),
               search_criteria().stopping_rounds(),
               ScoreKeeper.ProblemType.forSupervised(model._output.isClassifier()),
               search_criteria().stopping_metric(),

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -143,7 +143,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Java 8 AutoML JUnit', target: 'test-junit-automl-jenkins', pythonVersion: '2.7', javaVersion: 8,
-      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      timeoutValue: 360, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ],
     [
       stageName: 'Java 8 XGBoost Multinode JUnit', target: 'test-junit-xgb-multi-jenkins', pythonVersion: '2.7', javaVersion: 8,

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -143,7 +143,7 @@ def call(final pipelineContext) {
     ],
     [
       stageName: 'Java 8 AutoML JUnit', target: 'test-junit-automl-jenkins', pythonVersion: '2.7', javaVersion: 8,
-      timeoutValue: 360, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
+      timeoutValue: 120, component: pipelineContext.getBuildConfig().COMPONENT_JAVA, additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ],
     [
       stageName: 'Java 8 XGBoost Multinode JUnit', target: 'test-junit-xgb-multi-jenkins', pythonVersion: '2.7', javaVersion: 8,


### PR DESCRIPTION
Need for this changes has arisen from within https://github.com/h2oai/h2o-3/pull/4040

These changes separate iteration logic from logic for early stopping. This also will enable us to support ability to nest multiple `FilteredWalker`s by properly implementing `hasNext` method.