### PR TITLE
prevent possibility for random gbm search to select max_depth=0

### DIFF
--- a/h2o-docs/src/booklets/v2_2015/source/GBM_Vignette_code_examples/gbm_gridsearch_random.py
+++ b/h2o-docs/src/booklets/v2_2015/source/GBM_Vignette_code_examples/gbm_gridsearch_random.py
@@ -1,6 +1,6 @@
 #Define parameters for gridsearch
 ntrees_opt = range(0,100,1)
-max_depth_opt = range(0,20,1)
+max_depth_opt = range(1,20,1)
 learn_rate_opt = [s/float(1000) for s in range(1,101)]
 hyper_parameters = {"ntrees": ntrees_opt, 
     "max_depth":max_depth_opt, "learn_rate":learn_rate_opt}


### PR DESCRIPTION
fixing this:
[pybooklet.gbm.vignette.py.out.txt](https://github.com/h2oai/h2o-3/files/3911587/pybooklet.gbm.vignette.py.out.txt)

```
Errors/Warnings building gridsearch model

Hyper-parameter: learn_rate, 0.065
Hyper-parameter: max_depth, 0
Hyper-parameter: ntrees, 46
failure_details: Illegal argument(s) for GBM model: Grid_GBM_py_4_sid_81c0_model_python_1574887042748_367_model_5.  Details: ERRR on field: _max_depth: _max_depth must be > 0.

failure_stack_traces: water.exceptions.H2OModelBuilderIllegalArgumentException: Illegal argument(s) for GBM model: Grid_GBM_py_4_sid_81c0_model_python_1574887042748_367_model_5.  Details: ERRR on field: _max_depth: _max_depth must be > 0.

	at water.exceptions.H2OModelBuilderIllegalArgumentException.makeFromBuilder(H2OModelBuilderIllegalArgumentException.java:19)
	at hex.tree.gbm.GBM.init(GBM.java:83)
	at hex.tree.SharedTree$Driver.computeImpl(SharedTree.java:190)
	at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:239)
	at hex.ModelBuilder.trainModelNested(ModelBuilder.java:381)
	at hex.ModelBuilder$TrainModelNestedRunnable.run(ModelBuilder.java:416)
	at water.H2O.runOnH2ONode(H2O.java:1335)
	at water.H2O.runOnH2ONode(H2O.java:1324)
	at hex.ModelBuilder.trainModelNested(ModelBuilder.java:397)
```
