### PR TITLE
Avoid ArrayIndexOutOfBoundsException when we receive a garbage message

### DIFF
--- a/h2o-core/src/main/java/water/UDPRebooted.java
+++ b/h2o-core/src/main/java/water/UDPRebooted.java
@@ -55,7 +55,7 @@ public class UDPRebooted extends UDP {
       }
     }else{
       ListenerService.getInstance().report("shutdown_ignored");
-      Log.warn("Receive "+ T.values()[shutdownPacketType].toString()+ " request from H2O with older version than 3.14.0.4. This request" +
+      Log.warn("Receive shutdownPacketType=" + shutdownPacketType + " request from H2O with older version than 3.14.0.4. This request" +
               " will be ignored");
     }
     // if we receive request from H2O with a wrong version, just ignore the request


### PR DESCRIPTION
(that looks like UDPRebooted)