### PR TITLE
Grid: Make sure getModelKeys returns keys in a stable order

### DIFF
--- a/h2o-algos/src/test/java/hex/grid/GridTest.java
+++ b/h2o-algos/src/test/java/hex/grid/GridTest.java
@@ -1,8 +1,6 @@
 package hex.grid;
 
 import hex.Model;
-import hex.ModelBuilder;
-import hex.ParallelModelBuilder;
 import hex.genmodel.utils.DistributionFamily;
 import hex.tree.gbm.GBMModel;
 import org.junit.Before;
@@ -16,11 +14,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.BiConsumer;
 
-import static hex.genmodel.utils.DistributionFamily.AUTO;
 import static org.junit.Assert.*;
 
 public class GridTest extends TestUtil {
@@ -399,4 +393,16 @@ public class GridTest extends TestUtil {
     }
   }
 
+  @Test
+  public void testGetModelKeys() {
+    Grid<?> grid = new Grid<>(null, null, null, null);
+    grid.putModel(3, Key.make("2"));
+    grid.putModel(2, Key.make("1"));
+    grid.putModel(1, Key.make("3"));
+
+    assertArrayEquals(
+            new Key[]{Key.make("1"), Key.make("2"), Key.make("3")},
+            grid.getModelKeys()
+    );
+  }
 }

--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -317,7 +317,9 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> {
    * @return list of model keys
    */
   public Key<Model>[] getModelKeys() {
-    return _models.values().toArray(new Key[_models.size()]);
+    Key<Model>[] keys = _models.values().toArray(new Key[_models.size()]);
+    Arrays.sort(keys);
+    return keys;
   }
 
   /**

--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -314,7 +314,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> {
   /**
    * Returns keys of all models included in this object.
    *
-   * @return list of model keys
+   * @return list of model keys sorted lexically
    */
   public Key<Model>[] getModelKeys() {
     Key<Model>[] keys = _models.values().toArray(new Key[_models.size()]);


### PR DESCRIPTION
getModelKeys is backed by IcedHashMap - which itself doesn't guarantee
stable ordering