### PR TITLE
PUBDEV-7127: Don't perform internal self-check when converting trees in H2O

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/CompressedTreeTest.java
+++ b/h2o-algos/src/test/java/hex/tree/CompressedTreeTest.java
@@ -32,7 +32,7 @@ public class CompressedTreeTest extends TestUtil  {
       GBMModel model = trainGbm(ntrees);
       GbmMojoModel mojo = (GbmMojoModel) model.toMojo();
 
-      SharedTreeGraph expectedGraph = mojo._computeGraph(-1);
+      SharedTreeGraph expectedGraph = mojo.computeGraph(-1);
       assertEquals(5, expectedGraph.subgraphArray.size()); // sanity check the MOJO created graph
 
       for (int i = 0; i < ntrees; i++) {
@@ -56,7 +56,7 @@ public class CompressedTreeTest extends TestUtil  {
       GBMModel model = trainGbm(ntrees);
       GbmMojoModel mojo = (GbmMojoModel) model.toMojo();
 
-      SharedTreeGraph expectedGraph = mojo._computeGraph(-1);
+      SharedTreeGraph expectedGraph = mojo.computeGraph(-1);
       assertEquals(5, expectedGraph.subgraphArray.size()); // sanity check the MOJO created graph
 
       double[][] data = frameToMatrix(getAdaptedTrainFrame(model));

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2293,7 +2293,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
           final int ntrees = treemodel.getNTreeGroups();
           trees = new SharedTreeGraph[ntrees];
           for (int t = 0; t < ntrees; t++)
-            trees[t] = treemodel._computeGraph(t);
+            trees[t] = treemodel.computeGraph(t);
         }
 
         EasyPredictModelWrapper epmw;

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -6,20 +6,14 @@ import biz.k11i.xgboost.gbm.GradBooster;
 import biz.k11i.xgboost.tree.RegTree;
 import biz.k11i.xgboost.tree.RegTreeNode;
 import hex.*;
-import hex.genmodel.algos.tree.SharedTreeGraph;
-import hex.genmodel.algos.tree.SharedTreeGraphConverter;
-import hex.genmodel.algos.tree.SharedTreeNode;
-import hex.genmodel.algos.tree.SharedTreeSubgraph;
+import hex.genmodel.algos.tree.*;
 import hex.genmodel.algos.xgboost.XGBoostNativeMojoModel;
 import hex.genmodel.utils.DistributionFamily;
-import hex.glm.GLMModel;
 import hex.tree.PlattScalingHelper;
 import hex.tree.xgboost.predict.*;
 import hex.tree.xgboost.util.PredictConfiguration;
 import ml.dmlc.xgboost4j.java.*;
 import water.*;
-import water.api.API;
-import water.api.schemas3.KeyV3;
 import water.codegen.CodeGeneratorPipeline;
 import water.fvec.Frame;
 import water.fvec.Vec;
@@ -651,6 +645,10 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
     }
   }
 
+  @Override
+  public SharedTreeGraph convert(int treeNumber, String treeClass, ConvertTreeOptions options) {
+    return convert(treeNumber, treeClass); // options are currently not applicable to in-H2O conversion
+  }
 
   private int getXGBoostClassIndex(final String treeClass) {
     final ModelCategory modelCategory = _output.getModelCategory();

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostJavaMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostJavaMojoModel.java
@@ -109,7 +109,12 @@ public final class XGBoostJavaMojoModel extends XGBoostMojoModel implements Pred
   @Override
   public SharedTreeGraph convert(final int treeNumber, final String treeClass) {
     GradBooster booster = _predictor.getBooster();
-    return _computeGraph(booster, treeNumber);
+    return computeGraph(booster, treeNumber);
+  }
+
+  @Override
+  public SharedTreeGraph convert(final int treeNumber, final String treeClass, final ConvertTreeOptions options) {
+    return convert(treeNumber, treeClass); // Options currently do not apply to XGBoost trees conversion
   }
 
   private class OneHotEncoderFactory {

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostMojoModel.java
@@ -9,6 +9,7 @@ import hex.genmodel.MojoModel;
 import hex.genmodel.algos.tree.*;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 
 
@@ -173,7 +174,7 @@ public abstract class XGBoostMojoModel extends MojoModel implements SharedTreeGr
     return categorical;
   }
 
-  protected SharedTreeGraph _computeGraph(final GradBooster booster, final int treeNumber) {
+  SharedTreeGraph computeGraph(final GradBooster booster, final int treeNumber) {
 
     if (!(booster instanceof GBTree)) {
       throw new IllegalArgumentException(String.format("Given XGBoost model is not backed by a tree-based booster. Booster class is %d",
@@ -203,6 +204,11 @@ public abstract class XGBoostMojoModel extends MojoModel implements SharedTreeGr
                 true, features); // Root node is at index 0
     }
     return sharedTreeGraph;
+  }
+
+  @Override
+  public SharedTreeGraph convert(int treeNumber, String treeClass, ConvertTreeOptions options) {
+    return convert(treeNumber, treeClass); // no use for options as of now
   }
 
 }

--- a/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostNativeMojoModel.java
+++ b/h2o-genmodel-extensions/xgboost/src/main/java/hex/genmodel/algos/xgboost/XGBoostNativeMojoModel.java
@@ -154,6 +154,6 @@ public final class XGBoostNativeMojoModel extends XGBoostMojoModel {
       e.printStackTrace();
     }
 
-    return _computeGraph(booster, treeNumber);
+    return computeGraph(booster, treeNumber);
   }
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ConvertTreeOptions.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/ConvertTreeOptions.java
@@ -1,0 +1,30 @@
+package hex.genmodel.algos.tree;
+
+public class ConvertTreeOptions {
+  static final ConvertTreeOptions DEFAULT = new ConvertTreeOptions();
+
+  final boolean _checkTreeConsistency;
+
+  public ConvertTreeOptions() {
+    this(false);
+  }
+  
+  private ConvertTreeOptions(boolean checkTreeConsistency) {
+    _checkTreeConsistency = checkTreeConsistency;
+  }
+
+  /**
+   * Performs a self-check on each converted tree. Inconsistencies are reported in the log.
+   * @return a new instance of the options object with consistency-check flag enabled 
+   */
+  public ConvertTreeOptions withTreeConsistencyCheckEnabled() {
+    return new ConvertTreeOptions(true);
+  }
+
+  @Override
+  public String toString() {
+    return "ConvertTreeOptions{" +
+            "_checkTreeConsistency=" + _checkTreeConsistency +
+            '}';
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeGraphConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeGraphConverter.java
@@ -10,7 +10,11 @@ public interface SharedTreeGraphConverter {
      *
      * @param treeNumber Number of the tree in the model to convert
      * @param treeClass  Tree's class. If not specified, all the classes form a forest in the resulting {@link SharedTreeGraph}
+     * @param options    Allows to fine-tune the conversion process (eg. disable some internal consistency self-checks)
      * @return An instance of {@link SharedTreeGraph} containing a single tree or a forest of multiple trees.
      */
+    SharedTreeGraph convert(final int treeNumber, final String treeClass, final ConvertTreeOptions options);
+
     SharedTreeGraph convert(final int treeNumber, final String treeClass);
+
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoModelWithContributions.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/tree/SharedTreeMojoModelWithContributions.java
@@ -15,7 +15,7 @@ public abstract class SharedTreeMojoModelWithContributions extends SharedTreeMoj
         if (_nclasses > 2) {
             throw new UnsupportedOperationException("Predicting contributions for multinomial classification problems is not yet supported.");
         }
-        SharedTreeGraph graph = _computeGraph(-1);
+        SharedTreeGraph graph = computeGraph(-1);
         final SharedTreeNode[] empty = new SharedTreeNode[0];
         List<TreeSHAPPredictor<double[]>> treeSHAPs = new ArrayList<>(graph.subgraphArray.size());
         for (SharedTreeSubgraph tree : graph.subgraphArray) {

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -2,6 +2,7 @@ package hex.genmodel.tools;
 
 import hex.genmodel.GenModel;
 import hex.genmodel.MojoModel;
+import hex.genmodel.algos.tree.ConvertTreeOptions;
 import hex.genmodel.algos.tree.SharedTreeGraph;
 import hex.genmodel.algos.tree.SharedTreeGraphConverter;
 
@@ -9,8 +10,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Print dot (graphviz) representation of one or more trees in a DRF or GBM model.
@@ -199,7 +198,8 @@ public class PrintMojo {
 
     if(genModel instanceof SharedTreeGraphConverter){
       SharedTreeGraphConverter treeBackedModel = (SharedTreeGraphConverter) genModel;
-      final SharedTreeGraph g = treeBackedModel.convert(treeToPrint, null);
+      ConvertTreeOptions options = new ConvertTreeOptions().withTreeConsistencyCheckEnabled();
+      final SharedTreeGraph g = treeBackedModel.convert(treeToPrint, null, options);
       if (printRaw) {
         g.print();
       }

--- a/h2o-genmodel/src/test/java/hex/genmodel/algos/tree/ConvertTreeOptionsTest.java
+++ b/h2o-genmodel/src/test/java/hex/genmodel/algos/tree/ConvertTreeOptionsTest.java
@@ -1,0 +1,16 @@
+package hex.genmodel.algos.tree;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ConvertTreeOptionsTest {
+
+  @Test
+  public void enableCheckTreeConsistency() {
+    ConvertTreeOptions opts = new ConvertTreeOptions();
+    assertFalse(opts._checkTreeConsistency);
+
+    assertTrue(opts.withTreeConsistencyCheckEnabled()._checkTreeConsistency);
+  }
+}


### PR DESCRIPTION
Only keep in PrintMojo - which was the original intention of the check