### PR TITLE
disabling XGBoost in multinode

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
@@ -22,7 +22,8 @@ public enum Algo {
     boolean enabled() {
       // on single node, XGBoost is enabled by default if the extension is enabled.
       // on multinode, the same condition applies, but only on Linux by default: needs to be activated explicitly for other platforms.
-      boolean enabledOnMultinode = Boolean.parseBoolean(System.getProperty(DISTRIBUTED_XGBOOST_ENABLED, isLinux() ? "true" : "false"));
+      // 2019-12-12: temporarily disabled on Linux multinode until XGBoost issue is fixed.
+      boolean enabledOnMultinode = Boolean.parseBoolean(System.getProperty(DISTRIBUTED_XGBOOST_ENABLED, isLinux() ? "false" : "false"));
       return ExtensionManager.getInstance().isCoreExtensionEnabled(this.name()) && (H2O.CLOUD.size() == 1 || enabledOnMultinode);
     }
   },

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -323,7 +323,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
         boolean isMultinode = H2O.CLOUD.size() > 1;
         _eventLog.warn(Stage.ModelTraining,
                 isMultinode ? "AutoML: "+algo.name()+" is not available in multi-node cluster; skipping it."
-                        + " See http://docs.h2o.ai/h2o/latest-stable/h2o-docs/automl.html#experimental-features for more details."
+                        + " See http://docs.h2o.ai/h2o/latest-stable/h2o-docs/automl.html#experimental-features for details."
                         : "AutoML: "+algo.name()+" is not available; skipping it."
         );
         skippedAlgos.add(algo);

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -320,7 +320,11 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
 
     for (Algo algo : Algo.values()) {
       if (!skippedAlgos.contains(algo) && !algo.enabled()) {
-        _eventLog.warn(Stage.ModelTraining, "AutoML: "+algo.name()+" is not available; skipping it.");
+        boolean isMultinode = H2O.CLOUD.size() > 1;
+        _eventLog.warn(Stage.ModelTraining,
+                isMultinode ? "AutoML: "+algo.name()+" is not available in multi-node cluster; skipping it." :
+                        "AutoML: "+algo.name()+" is not available; skipping it."
+        );
         skippedAlgos.add(algo);
       }
     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -322,8 +322,9 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
       if (!skippedAlgos.contains(algo) && !algo.enabled()) {
         boolean isMultinode = H2O.CLOUD.size() > 1;
         _eventLog.warn(Stage.ModelTraining,
-                isMultinode ? "AutoML: "+algo.name()+" is not available in multi-node cluster; skipping it." :
-                        "AutoML: "+algo.name()+" is not available; skipping it."
+                isMultinode ? "AutoML: "+algo.name()+" is not available in multi-node cluster; skipping it."
+                        + " See http://docs.h2o.ai/h2o/latest-stable/h2o-docs/automl.html#experimental-features for more details."
+                        : "AutoML: "+algo.name()+" is not available; skipping it."
         );
         skippedAlgos.add(algo);
       }


### PR DESCRIPTION
disabling XGBoost in multinode and improved warning message when user is trying to use it in cluster environment.