### PR TITLE
PUBDEV-7142: Docs - MOJOs available for PCA

### DIFF
--- a/h2o-docs/src/product/mojo-quickstart.rst
+++ b/h2o-docs/src/product/mojo-quickstart.rst
@@ -12,7 +12,7 @@ A MOJO (Model Object, Optimized) is an alternative to H2O's POJO. As with POJOs,
 
 **Notes**: 
 
-- MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, Stacked Ensembles, SVM, Word2vec, and XGBoost models.
+- MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, PCA, Stacked Ensembles, SVM, Word2vec, and XGBoost models.
 - MOJOs are only supported for encodings that are either default or ``enum``. 
 - MOJO predict cannot parse columns enclosed in double quotes (for example, ""2"").  
 

--- a/h2o-genmodel/src/main/java/overview.html
+++ b/h2o-genmodel/src/main/java/overview.html
@@ -313,7 +313,7 @@ for scoring in real time.
 <p></p>
 <b>Notes</b>: 
 <ul>
-<li>MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, Stacked Ensembles, SVM, Word2vec, and XGBoost algorithms.</li>
+<li>MOJOs are supported for AutoML, Deep Learning, DRF, GBM, GLM, GLRM, K-Means, PCA, Stacked Ensembles, SVM, Word2vec, and XGBoost algorithms.</li>
 <li>MOJOs are only supported for encodings that are either default or Enum.</li>
 </ul>
 


### PR DESCRIPTION
MOJOs are now available for PCA. The docs have been updated to reflect this.

See: https://0xdata.atlassian.net/browse/PUBDEV-7142