### PR TITLE
PUBDEV-7143: Docs - MOJO import support for XGBoost

### DIFF
--- a/h2o-docs/src/product/save-and-load-model.rst
+++ b/h2o-docs/src/product/save-and-load-model.rst
@@ -93,6 +93,7 @@ Only a subset of H2O MOJO models is supported in this version.
 -  DRF (Distributed Random Forest)
 -  IRF (Isolation Random Forest)
 -  GLM (Generalized Linear Model)
+-  XGBoost
 
 Importing a MOJO
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Support for MOJO import has been added to XGBoost. The docs have been updated to reflect this.

See: https://0xdata.atlassian.net/browse/PUBDEV-7143