### PR TITLE
PUBDEV-7145: Docs - calibration_frame and calibrate_model options for XGBoost

### DIFF
--- a/h2o-docs/src/product/data-science/algo-params/calibrate_model.rst
+++ b/h2o-docs/src/product/data-science/algo-params/calibrate_model.rst
@@ -1,7 +1,7 @@
 ``calibrate_model``
 -------------------
 
-- Available in: GBM, DRF
+- Available in: GBM, DRF, XGBoost
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/algo-params/calibration_frame.rst
+++ b/h2o-docs/src/product/data-science/algo-params/calibration_frame.rst
@@ -1,7 +1,7 @@
 ``calibration_frame``
 ---------------------
 
-- Available in: GBM, DRF
+- Available in: GBM, DRF, XGBoost
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/xgboost.rst
+++ b/h2o-docs/src/product/data-science/xgboost.rst
@@ -194,6 +194,10 @@ Defining an XGBoost Model
 
 -  `export_checkpoints_dir <algo-params/export_checkpoints_dir.html>`__: Specify a directory to which generated models will automatically be exported.
 
+-  `calibrate_model <algo-params/calibrate_model.html>`__: Use Platt scaling to calculate calibrated class probabilities. Defaults to False.
+
+-  `calibration_frame <algo-params/calibration_frame.html>`__: Specifies the frame to be used for Platt scaling.
+
 "LightGBM" Emulation Mode Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The calibration_frame and calibrate_model options can now be specified in XGBoost. The docs have been updated to reflect this change.

See: https://0xdata.atlassian.net/browse/PUBDEV-7145