### PR TITLE
PUBDEV-7149 - Endless loop when CsvParser parser $ sign enclosed in quotes

### DIFF
--- a/h2o-core/src/main/java/water/parser/CsvParser.java
+++ b/h2o-core/src/main/java/water/parser/CsvParser.java
@@ -210,7 +210,7 @@ MAIN_LOOP:
             str.addChar();
             if (c == quotes) {
               state = COND_QUOTE;
-              break;
+              continue MAIN_LOOP;
             }
             if ((quotes != 0) || ((!isEOL(c) && (c != CHAR_SEPARATOR)))) {
               state = STRING;


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7149

Standalone `$` was considered to be a possible currency. However, when quotes were reached in the state of `POSSIBLE_CURRENCY`, the main loop should continue, instead of being broken.

Also tested with

```R
tmp <- data.frame(text = "$", stringsAsFactors = FALSE)
data <- as.h2o(tmp)
```

and it works in the original case. The JUNIT presented in this PR contains exactly the same data as sent by the R client.

Note, we don't have access to the original dataset on Stack Overflow and it the user might be hitting our "chunking issue", which is solved in a separate JIRA - more complex task.