### PR TITLE
PUBDEV-7177: Make sure h2odriver gets correct version of Hadoop dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,8 @@ publicNexusLocation="http://nexus.h2o.ai:8081/repository"
 defaultParquetVersion=1.8.1
 
 # Default Hadoop client version
-defaultHadoopClientVersion=2.8.4
+defaultHadoopVersion=2.8.4
+defaultHdfsDependency=hadoop-hdfs-client
 
 # Default Hive version
 defaultHiveExecVersion=1.1.0

--- a/h2o-app/build.gradle
+++ b/h2o-app/build.gradle
@@ -8,7 +8,6 @@ dependencies {
   compile project(":h2o-core")
   compile project(":h2o-algos")
   compile project(":h2o-automl")
-  compile project(":h2o-ext-krbstandalone")
   compile project(":h2o-ext-target-encoder")
   runtime project(":${defaultWebserverModule}")
   if (project.hasProperty("doIncludeMojoPipeline") && project.doIncludeMojoPipeline == "true") {

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile project(":h2o-persist-s3")
     compile project(":h2o-persist-http")
     compile project(":h2o-persist-hdfs")
+    compile project(":h2o-ext-krbstandalone")
     if (project.hasProperty("doIncludeOrc") && project.doIncludeOrc == "true") {
         compile project(":h2o-orc-parser")
     }

--- a/h2o-extensions/krbstandalone/build.gradle
+++ b/h2o-extensions/krbstandalone/build.gradle
@@ -3,7 +3,7 @@ description = "H2O Kerberos Standalone support"
 dependencies {
     compile project(":h2o-core")
     compile project(":h2o-persist-hdfs")
-    compile("org.apache.hadoop:hadoop-auth:$defaultHadoopClientVersion") {
+    compile("org.apache.hadoop:hadoop-auth:$defaultHadoopVersion") {
         // Pull all dependencies to allow run directly from IDE or command line
         transitive = true
     }

--- a/h2o-hadoop-2/assemblyjar.gradle
+++ b/h2o-hadoop-2/assemblyjar.gradle
@@ -6,12 +6,30 @@ description = 'H2O HDFS client shadowjar for Hadoop ' + hadoopVersion
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+def hasCustomHdfsDep = ext.has("hdfsDependency") && (ext.get("hdfsDependency") != defaultHdfsDependency)
+
+if (hasCustomHdfsDep) {
+  configurations {
+    compile.exclude group: "org.apache.hadoop", module: "${defaultHdfsDependency}"
+  }
+}
+
 dependencies {
+  compile ("org.apache.hadoop:hadoop-client:$hadoopMavenArtifactVersion") {
+    force = true
+  }
+  compile ("org.apache.hadoop:hadoop-common:$hadoopMavenArtifactVersion") {
+    force = true
+  }
+  if (hasCustomHdfsDep) {
+    compile ("org.apache.hadoop:${hdfsDependency}:$hadoopMavenArtifactVersion") {
+      force = true
+    }
+  }
   compile(project(":h2o-mapreduce-generic")) {
     transitive = false
   }
   compile project(":h2o-security")
-  compile "org.apache.hadoop:hadoop-client:$hadoopMavenArtifactVersion"
   // Libraries need for Google Cloud Storage strongly require this Guava version
   compile('com.google.guava:guava:20.0') {force = true}
   compile(project(':h2o-app')) {

--- a/h2o-hadoop-2/assemblyjar.gradle
+++ b/h2o-hadoop-2/assemblyjar.gradle
@@ -10,7 +10,7 @@ def hasCustomHdfsDep = ext.has("hdfsDependency") && (ext.get("hdfsDependency") !
 
 if (hasCustomHdfsDep) {
   configurations {
-    compile.exclude group: "org.apache.hadoop", module: "${defaultHdfsDependency}"
+    compile.exclude group: "org.apache.hadoop", module: "$defaultHdfsDependency"
   }
 }
 

--- a/h2o-hadoop-2/h2o-hdp2.6-assembly/build.gradle
+++ b/h2o-hadoop-2/h2o-hdp2.6-assembly/build.gradle
@@ -1,6 +1,7 @@
 ext {
   hadoopVersion = 'hdp2.6'
-  hadoopMavenArtifactVersion = '2.7.3.2.6.1.0-129'
+  hadoopMavenArtifactVersion = '2.7.3.2.6.5.196-1'
+  hdfsDependency = "hadoop-hdfs"
   orcSupported = true
   orcHiveExecVersion = "1.2.1000.2.6.1.0-129"
 }

--- a/h2o-hadoop-2/h2o-hdp2.6-assembly/build.gradle
+++ b/h2o-hadoop-2/h2o-hdp2.6-assembly/build.gradle
@@ -1,7 +1,7 @@
 ext {
   hadoopVersion = 'hdp2.6'
   hadoopMavenArtifactVersion = '2.7.3.2.6.5.196-1'
-  hdfsDependency = "hadoop-hdfs"
+  hdfsDependency = "hadoop-hdfs" // override the default hdfs dependency (Hadoops < 2.8 don't have hadoop-hdfs-client)
   orcSupported = true
   orcHiveExecVersion = "1.2.1000.2.6.1.0-129"
 }

--- a/h2o-hadoop-common/tests/python/pyunit_gcs_import.py
+++ b/h2o-hadoop-common/tests/python/pyunit_gcs_import.py
@@ -6,10 +6,11 @@ sys.path.insert(1, os.path.join("../../../h2o-py"))
 from tests import pyunit_utils
 import h2o
 
+
 def gcs_import():
     # Just test the import works - no class clashes, no exception
     fr = h2o.import_file("gs://gcp-public-data-nexrad-l2/2018/01/01/KABR/NWS_NEXRAD_NXL2DPBL_KABR_20180101050000_20180101055959.tar", parse=False)
-    assert fr.nrow > 0
+    assert len(fr) == 1
 
 
 if __name__ == "__main__":

--- a/h2o-parsers/h2o-orc-parser/build.gradle
+++ b/h2o-parsers/h2o-orc-parser/build.gradle
@@ -12,7 +12,7 @@ configurations{
 }
 
 dependencies {
-  hadoopCommonExclude("org.apache.hadoop:hadoop-common:${defaultHadoopClientVersion}")
+  hadoopCommonExclude("org.apache.hadoop:hadoop-common:${defaultHadoopVersion}")
   hiveExecExclude("org.apache.hive:hive-exec:$defaultHiveExecVersion"){
       // this dependency need to be excluded manually as Gradle can't find it in maven central
       exclude group: 'org.pentaho', module: 'pentaho-aggdesigner-algorithm'
@@ -28,7 +28,7 @@ dependencies {
   }
 
   // Note: What is connection between hive-exec version and hadoop-version and orc version?
-  // Note: In this case we are using hive version which is compatible with $defaultHadoopClientVersion
+  // Note: In this case we are using hive version which is compatible with $defaultHadoopVersion
   // Note: for newest version it should be replaces by hive-orc
   compile("org.apache.hive:hive-exec:$defaultHiveExecVersion") {
       // we can't use transitive=false so we need to exclude the dependencies manually
@@ -40,7 +40,7 @@ dependencies {
       exclude group: 'org.pentaho', module: 'pentaho-aggdesigner-algorithm'
   }
   // For compilation we need common
-  compile("org.apache.hadoop:hadoop-common:$defaultHadoopClientVersion") {
+  compile("org.apache.hadoop:hadoop-common:$defaultHadoopVersion") {
       // we can't use transitive=false so we need to exclude the dependencies manually
       configurations.hadoopCommonExclude.getResolvedConfiguration().getResolvedArtifacts().each {
           if (it.moduleVersion.id.group != "org.apache.hadoop" && it.moduleVersion.id.module.name != "hadoop-common") {
@@ -53,7 +53,7 @@ dependencies {
   testCompile project(path: ":h2o-core", configuration: "testArchives")
   testRuntimeOnly project(":${defaultWebserverModule}")
   // We need correct version of MapRe Hadoop to run JUnits
-  testRuntime("org.apache.hadoop:hadoop-client:$defaultHadoopClientVersion") {
+  testRuntime("org.apache.hadoop:hadoop-client:$defaultHadoopVersion") {
       exclude module: "jasper-runtime"
       exclude module: "jasper-compiler"
       exclude module: "curator-client"

--- a/h2o-parsers/h2o-parquet-compat/h2o-parquet-v17-compat/build.gradle
+++ b/h2o-parsers/h2o-parquet-compat/h2o-parquet-v17-compat/build.gradle
@@ -4,7 +4,7 @@
 description = "H2O Parquet Compatibility Test - Parquet 1.7.x)"
 
 def parquetHadoopVersion = binding.variables.get("hadoopVersion") ?
-  binding.variables.get("hadoopVersion") : defaultHadoopClientVersion
+  binding.variables.get("hadoopVersion") : defaultHadoopVersion
 
 dependencies {
   compile project(":h2o-core")

--- a/h2o-parsers/h2o-parquet-parser/build.gradle
+++ b/h2o-parsers/h2o-parquet-parser/build.gradle
@@ -4,7 +4,7 @@
 description = "H2O Parquet Parser"
 
 def parquetHadoopVersion = binding.variables.get("hadoopVersion") ?
-  binding.variables.get("hadoopVersion") : defaultHadoopClientVersion
+  binding.variables.get("hadoopVersion") : defaultHadoopVersion
 
 configurations{
     // Configuration used to get all transitive dependencies for org.apache.hadoop:hadoop-common

--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -9,11 +9,11 @@ configurations {
 dependencies {
     compile project(":h2o-core")
     compile('net.java.dev.jets3t:jets3t:0.9.0')
-    compile("org.apache.hadoop:hadoop-hdfs-client:$defaultHadoopClientVersion") {
+    compile("org.apache.hadoop:$defaultHdfsDependency:$defaultHadoopVersion") {
         // Pull all dependencies to allow run directly from IDE or command line
         transitive = true
     }
-    compile("org.apache.hadoop:hadoop-aws:$defaultHadoopClientVersion")
+    compile("org.apache.hadoop:hadoop-aws:$defaultHadoopVersion")
     testCompile "junit:junit:${junitVersion}"
     testCompile "org.hamcrest:hamcrest-junit:2.0.0.0"
     testCompile project(path: ":h2o-core", configuration: "testArchives")


### PR DESCRIPTION
The issue is that declaring hadoop-hdfs-client dependency causes to use default Hadoop libraries, not the specific Hadoop libraries for the given distribution

For now fixed for HDP 2.6