### PR TITLE
PUBDEV-7172: Replace "View Page Source" link with "Edit on GitHub"

### DIFF
--- a/h2o-docs/src/product/conf.py
+++ b/h2o-docs/src/product/conf.py
@@ -209,7 +209,20 @@ html_last_updated_fmt = '%b %d, %Y'
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
+
+# Add 'Edit on Github' link instead of 'View page source'
+# reference:https://docs.readthedocs.io/en/latest/vcs.html
+html_context = {
+    # Enable the "Edit in GitHub link within the header of each page.
+    'display_github': True,
+    # Set the following variables to generate the resulting github URL for each page. 
+    # Format Template: https://{{ github_host|default("github.com") }}
+    #/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}
+    #https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/index.rst
+    'github_repo': 'h2oai/h2o-3',
+    'github_version': 'master/h2o-docs/src/product/',
+}
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/h2o-docs/src/product/data-science/glm.rst
+++ b/h2o-docs/src/product/data-science/glm.rst
@@ -618,7 +618,7 @@ The two variance components are estimated iteratively by applying a gamma GLM to
  H_a=T_a (T_a^T W^{-1} T_a )^{-1} T_a^T W^{-1}
 
 Estimation of Fixed Effect Dispersion Parameter/Variance
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 A gamma GLM is used to fit the dispersion part of the model with response
 :math:`y_{d,i}=(e_i^2)⁄(1-h_i )` where :math:`E(y_d )=u_d` and :math:`u_d≡\phi` (i.e., :math:`\delta_e^2` for a Gaussian response). The GLM model for the dispersion parameter is then specified by the link function :math:`g_d (.)` and the linear predictor :math:`X_d \beta_d` with prior weights for :math:`(1-h_i )⁄2` for :math:`g_d (u_d )=X_d \beta_d`. Because we are not using a dispersion model, :math:`X_d \beta_d` will only contain the intercept term.


### PR DESCRIPTION
driveby fix: Fixed heading underlining in GLM