### PR TITLE
Fixed typos for related parameters in exclude_algos and include_algos

### DIFF
--- a/h2o-docs/src/product/conf.py
+++ b/h2o-docs/src/product/conf.py
@@ -209,7 +209,20 @@ html_last_updated_fmt = '%b %d, %Y'
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
+
+# Add 'Edit on Github' link instead of 'View page source'
+# reference:https://docs.readthedocs.io/en/latest/vcs.html
+html_context = {
+    # Enable the "Edit in GitHub link within the header of each page.
+    'display_github': True,
+    # Set the following variables to generate the resulting github URL for each page. 
+    # Format Template: https://{{ github_host|default("github.com") }}
+    #/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}
+    #https://github.com/h2oai/h2o-3/blob/master/h2o-docs/src/product/index.rst
+    'github_repo': 'h2oai/h2o-3',
+    'github_version': 'master/h2o-docs/src/product/',
+}
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/h2o-docs/src/product/data-science/algo-params/exclude_algos.rst
+++ b/h2o-docs/src/product/data-science/algo-params/exclude_algos.rst
@@ -21,7 +21,7 @@ The algorithms that can be specified include:
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
-- `include-algos <include_algos.html>`__
+- `include_algos <include_algos.html>`__
 
 Example
 ~~~~~~~

--- a/h2o-docs/src/product/data-science/algo-params/include_algos.rst
+++ b/h2o-docs/src/product/data-science/algo-params/include_algos.rst
@@ -21,7 +21,7 @@ The algorithms that can be specified include:
 Related Parameters
 ~~~~~~~~~~~~~~~~~~
 
-- `exclude-algos <exclude_algos.html>`__
+- `exclude_algos <exclude_algos.html>`__
 
 Example
 ~~~~~~~

--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -52,7 +52,7 @@ class H2OGridSearch(h2o_meta()):
             >>> criteria = {"strategy": "RandomDiscrete", "stopping_rounds": 5,
             ...             "stopping_metric": "misclassification",
             ...             "stopping_tolerance": 0.00001}
-    :param parallelism Level of parallelism during grid model building. 1 = sequential building (default). 
+    :param parallelism: Level of parallelism during grid model building. 1 = sequential building (default). 
          Use the value of 0 for adaptive parallelism - decided by H2O. Any number > 1 sets the exact number of models
          built in parallel.
     :returns: a new H2OGridSearch instance


### PR DESCRIPTION
driveby fix: Replace "show source" link with "edit on github" link in the docs.