### PR TITLE
Fix H2O_Load.R - missing comma in list of files.

### DIFF
--- a/h2o-r/H2O_Load.R
+++ b/h2o-r/H2O_Load.R
@@ -13,7 +13,7 @@ src <-
 function() {
   warning("MAY NOT WORK ON YOUR SYSTEM -- **TRY TO CHANGE `ROOT.PATH`!**")
   to_src <- c("astfun.R", "classes.R", "config.R", "connection.R", "constants.R", "logging.R", "communication.R",
-              "import.R", "frame.R", "kvstore.R", "grid.R", "generic.R"
+              "import.R", "frame.R", "kvstore.R", "grid.R", "generic.R",
               "parse.R", "export.R", "models.R", "edicts.R", "coxph.R", "coxphutils.R", "glm.R", "glrm.R", "pca.R", "kmeans.R",
               "gbm.R", "deeplearning.R", "deepwater.R", "naivebayes.R", "randomforest.R", "svd.R", "locate.R", "predict.R",
               "isolationforest.R", "psvm.R")


### PR DESCRIPTION
Fixing my own mistake in H2O_Load_R file - after generic R file, there should be a separator.