### PR TITLE
Doc: Adding back in specific API-related changes in H2O-3 after deleting Migration chapter

### DIFF
--- a/h2o-docs/src/product/api-changes.rst
+++ b/h2o-docs/src/product/api-changes.rst
@@ -1,0 +1,22 @@
+API-Related Changes
+-------------------
+
+H2O-3 does its best to keep backwards compatibility between major versions, but sometimes breaking changes are needed in order to improve code quality and to address issues. This section provides a list of current breaking changes between specific releases.
+
+From 3.22 or Below to 3.24
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Java API
+''''''''
+
+The following classes were moved and/or renamed:
+
+=================================================   ======================================
+  Until 3.22                                          From 3.24
+=================================================   ======================================
+``hex.StackedEnsembleModel``                        ``hex.ensemble.StackedEnsembleModel``
+``hex.StackedEnsembleModel.MetalearnerAlgorithm``   ``hex.ensemble.Metalearner.Algorithm``
+``ai.h2o.automl.AutoML.algo``                       ``ai.h2o.automl.Algo``
+=================================================   ======================================
+
+Some internal methods of ``StackedEnsemble`` and ``StackedEnsembleModel`` are no longer public, but this should not impact users.

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -25,6 +25,11 @@ Additional Resources:
 .. toctree::
    :maxdepth: 2
 
+   api-changes
+
+.. toctree::
+   :maxdepth: 2
+
    quick-start-videos
    
 .. toctree::

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -215,6 +215,8 @@ If you've used previous versions of H2O, the following links will help guide you
 
 -  `Recent Changes <https://github.com/h2oai/h2o-3/blob/master/Changes.md>`_: This document describes the most recent changes in the latest build of H2O. It lists new features, enhancements (including changed parameter default values), and bug fixes for each release, organized by sub-categories such as Python, R, and Web UI.
 
+-  `API Related Changes <api-changes.html>`__: This section describes changes made in H2O-3 that can affect backwards compatibility. 
+
 -  `Contributing code <https://github.com/h2oai/h2o-3/blob/master/CONTRIBUTING.md>`_: If you're interested in contributing code to H2O, we appreciate your assistance! This document describes how to access our list of Jiras that are suggested tasks for contributors and how to contact us.
 
 Flow Users


### PR DESCRIPTION
- API-related changes is it's own chapter and appears after the Welcome chapter.
- Added a link to this new chapter in the "Experienced Users" topic.

![Screen Shot 2020-01-09 at 10 10 59 AM](https://user-images.githubusercontent.com/18428990/72092972-5a6a8600-32c8-11ea-9be4-f444243194f3.png)
