### PR TITLE
Fix merge empty errors

### DIFF
--- a/h2o-py/tests/testdir_munging/pyunit_6987_merge_one_empty.py
+++ b/h2o-py/tests/testdir_munging/pyunit_6987_merge_one_empty.py
@@ -23,8 +23,15 @@ def mergeOneEmptyFrame():
 
     assert f1Mergef2.nrow == 1, "Expected one row  but actual number of row is {0}!".format(f1Mergef2.nrows)
     assert f2Mergef1.nrow == 1, "Expected one row  but actual number of row is {0}!".format(f2Mergef1.nrows)
-    pyunit_utils.compare_frames_local(f1Mergef2, file1, prob=1)
-    pyunit_utils.compare_frames_local(f2Mergef1, file1, prob=1)    
+    
+    assert f1Mergef2.ncols==2,  "Expected two columns but actual number of row is {0}!".format(f1Mergef2.ncols)
+    assert f2Mergef1.ncols==2,  "Expected two columns but actual number of row is {0}!".format(f2Mergef1.ncols)
+    
+    assert f1Mergef2[0,0]==file1[0,0], "f1Mergef2: Expected content {0} at row 0, col 0 but actual content is {1}".format(file1[0,0], f1Mergef2[0,0])
+    assert f2Mergef1[0,0]==file1[0,0], "f2Mergef1: Expected content {0} at row 0, col 0 but actual content is {1}".format(file1[0,0], f2Mergef1[0,0])
+
+    assert f1Mergef2[0,1]==file1[0,1], "f1Mergef2: Expected content {0} at row 0, col 1 but actual content is {1}".format(file1[0,1], f1Mergef2[0,1])
+    assert f2Mergef1[0,1]==file1[0,1], "f2Mergef1: Expected content {0} at row 0, col 1 but actual content is {1}".format(file1[0,1], f2Mergef1[0,1]) 
     
 if __name__ == "__main__":
     pyunit_utils.standalone_test(mergeOneEmptyFrame)


### PR DESCRIPTION
This PR is generated to investigate the failure of pyunit_6987_merge_one_empty.py runs caught by Pavel.

I made changes to the test file to directly compare the contents of the file and do not use the compare_file from pyunit_utils.  