### PR TITLE
PUBDEV-7197 - Parallel GS threads should call Hyperspace iterator one…

### DIFF
--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -211,8 +211,6 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     private void attemptBuildNextModel(final ParallelModelBuilder parallelModelBuilder, final Model previousModel) {
       // Attempt to train next model
       try {
-        // I hereby claim that the locking system below has been researched by Andrey Spiridonov
-        // and the credit should go to him. Thank you.
         parallelSearchGridLock.lock();
         final MP nextModelParams = getNextModelParams(hyperspaceIterator, previousModel, grid);
         if (nextModelParams != null

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -211,6 +211,8 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     private void attemptBuildNextModel(final ParallelModelBuilder parallelModelBuilder, final Model previousModel) {
       // Attempt to train next model
       try {
+        // I hereby claim that the locking system below has been researched by Andrey Spiridonov
+        // and the credit should go to him. Thank you.
         parallelSearchGridLock.lock();
         final MP nextModelParams = getNextModelParams(hyperspaceIterator, previousModel, grid);
         if (nextModelParams != null


### PR DESCRIPTION
… at a time

https://0xdata.atlassian.net/browse/PUBDEV-7197

In the GridSearch class, there is 

```java
private MP getNextModelParams(final HyperSpaceWalker.HyperSpaceIterator<MP> hyperSpaceWalker, final Model model, final Grid grid){
      MP params = null;

      while (params == null) {
        if (hyperSpaceWalker.hasNext(model)) {
          params = hyperSpaceWalker.nextModelParameters(model);
          final Key modelKey = grid.getModelKey(params.checksum(IGNORED_FIELDS_PARAM_HASH));
          if(modelKey != null){
            params = null;
          }
        } else {
          break;
        }
      }

      return params;
    }
  }
```

method which calls hyperspace iterator and asks for next model params. It is perfectly possible (but highly improbable) for two threads accessing the nextModelParams method to obtain the same parameters - hyperspace iterators are not thread safe.

Solution is to use mutually exclusive access. 

Currently, the **worst thing** that can happen is that one model parameters are used twice and thus the same model is built twice. It has no impact on the grid, as all the models are stored in the grid as key -> value, where key is has of the parameters. Therefore, the model will still occur only once in the Grid.