### PR TITLE
PUBDEV-7204: GridSearch over TE parameters is not working

### DIFF
--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -93,6 +93,8 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   private static String[] SCHEMAS = new String[0];
   private static ModelBuilder[] BUILDERS = new ModelBuilder[0];
 
+  protected boolean _startUpOnceModelBuilder = false;
+
   /** One-time start-up only ModelBuilder, endlessly cloned by the GUI for the
    *  default settings. */
   protected ModelBuilder(P parms, boolean startup_once) { this(parms,startup_once,"hex.schemas."); }
@@ -100,6 +102,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     String base = getName();
     if (!startup_once)
       throw H2O.fail("Algorithm " + base + " registration issue. It can only be called at startup.");
+    _startUpOnceModelBuilder = true;
     _job = null;
     _result = null;
     _parms = parms;

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderBuilder.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderBuilder.java
@@ -29,38 +29,43 @@ public class TargetEncoderBuilder extends ModelBuilder<TargetEncoderModel, Targe
     super(new TargetEncoderModel.TargetEncoderParameters(), startupOnce);
   }
 
-  @Override
-  public void init(boolean expensive) {
-    super.init(expensive);
-  }
-
   private class TargetEncoderDriver extends Driver {
     @Override
     public void computeImpl() {
-      // In case ModelBuilder is registered with default model parameters ( i.e. without training frame etc.) we want to init it at this stage as well
-      if(_startUpOnceModelBuilder) init(false);
+      _targetEncoderModel = null;
+      try {
+        init(true);
 
-      final int numColsRemoved = hasFoldCol() ? 2 : 1; // Response is always at the last index, fold column is on the index before.
+        final int numColsRemoved = hasFoldCol() ? 2 : 1; // Response is always at the last index, fold column is on the index before.
+        final String[] encodedColumns = Arrays.copyOf(train().names(), train().names().length - numColsRemoved);
+        TargetEncoder tec = new TargetEncoder(encodedColumns);
 
-      final String[] encodedColumns = Arrays.copyOf(train().names(), train().names().length - numColsRemoved);
-      TargetEncoder tec = new TargetEncoder(encodedColumns);
+        TargetEncoderModel.TargetEncoderOutput emptyOutput =
+                new TargetEncoderModel.TargetEncoderOutput(TargetEncoderBuilder.this, new IcedHashMapGeneric<>(), Double.NaN);
+        TargetEncoderModel model = new TargetEncoderModel(dest(), _parms, emptyOutput, tec);
+        _targetEncoderModel = model.delete_and_lock(_job); // and clear & write-lock it (smashing any prior)
 
-      Scope.untrack(train().keys());
+        Scope.untrack(train().keys());
 
-      IcedHashMapGeneric<String, Frame> _targetEncodingMap = tec.prepareEncodingMap(train(), _parms._response_column, _parms._fold_column);
+        IcedHashMapGeneric<String, Frame> _targetEncodingMap = tec.prepareEncodingMap(train(), _parms._response_column, _parms._fold_column);
 
-      // Mean could be computed from any encoding map as response column is shared
-      double priorMean = tec.calculatePriorMean(_targetEncodingMap.entrySet().iterator().next().getValue());
+        // Mean could be computed from any encoding map as response column is shared
+        double priorMean = tec.calculatePriorMean(_targetEncodingMap.entrySet().iterator().next().getValue());
 
-      for(Map.Entry<String, Frame> entry: _targetEncodingMap.entrySet()) {
-        Frame frameWithEncodingMap = entry.getValue();
-        Scope.untrack(frameWithEncodingMap.keys());
+        for(Map.Entry<String, Frame> entry: _targetEncodingMap.entrySet()) {
+          Frame frameWithEncodingMap = entry.getValue();
+          Scope.untrack(frameWithEncodingMap.keys());
+        }
+
+        disableIgnoreConstColsFeature();
+        _targetEncoderModel._output = new TargetEncoderModel.TargetEncoderOutput(TargetEncoderBuilder.this, _targetEncodingMap, priorMean);
+        _job.update(1);
+        _targetEncoderModel.update(_job);
+      } finally {
+        if (_targetEncoderModel != null) {
+          _targetEncoderModel.unlock(_job);
+        }
       }
-
-      disableIgnoreConstColsFeature();
-      TargetEncoderModel.TargetEncoderOutput output = new TargetEncoderModel.TargetEncoderOutput(TargetEncoderBuilder.this, _targetEncodingMap, priorMean);
-      _targetEncoderModel = new TargetEncoderModel(_result, _parms, output, tec);
-      DKV.put(_targetEncoderModel);
     }
 
     private void disableIgnoreConstColsFeature() {

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -54,7 +54,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
 
     @Override
     public long progressUnits() {
-      return 0;
+      return 1;
     }
 
     public BlendingParams getBlendingParameters() {

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
@@ -1,55 +1,125 @@
 package ai.h2o.targetencoding.strategy;
 
 import ai.h2o.targetencoding.TargetEncoderModel;
+import hex.grid.Grid;
+import hex.grid.GridSearch;
 import hex.grid.HyperSpaceSearchCriteria;
 import hex.grid.HyperSpaceWalker;
 import hex.schemas.TargetEncoderV3;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import water.Job;
+import water.Key;
 import water.Scope;
 import water.TestUtil;
 import water.api.GridSearchHandler;
+import water.fvec.Frame;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Objects;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-public class TargetEncoderRGSTest extends TestUtil {
+@RunWith(Enclosed.class)
+public class TargetEncoderRGSTest{
 
-  @BeforeClass
-  public static void setup() {
-    stall_till_cloudsize(1);
-  }
+  public static class TargetEncoderRGSNonParametrizedTest extends TestUtil {
 
-  @Test
-  public void getTargetEncodingMapByTrainingTEBuilder() {
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
 
-    Scope.enter();
-    try {
-      HashMap<String, Object[]> hpGrid = new HashMap<>();
-      hpGrid.put("blending", new Boolean[]{true, false});
-      hpGrid.put("noise_level", new Double[]{0.0, 0.01,  0.1});
-      hpGrid.put("k", new Double[]{1.0, 2.0, 3.0});
-      hpGrid.put("f", new Double[]{5.0, 10.0, 20.0});
-      
-      TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+    @Test
+    public void getTargetEncodingMapByTrainingTEBuilder() {
 
-      GridSearchHandler.DefaultModelParametersBuilderFactory<TargetEncoderModel.TargetEncoderParameters, TargetEncoderV3.TargetEncoderParametersV3> modelParametersBuilderFactory = new GridSearchHandler.DefaultModelParametersBuilderFactory<>();
+      Scope.enter();
+      try {
+        HashMap<String, Object[]> hpGrid = new HashMap<>();
+        hpGrid.put("blending", new Boolean[]{true, false});
+        hpGrid.put("noise_level", new Double[]{0.0, 0.01, 0.1});
+        hpGrid.put("k", new Double[]{1.0, 2.0, 3.0});
+        hpGrid.put("f", new Double[]{5.0, 10.0, 20.0});
 
-      HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
-      HyperSpaceWalker.RandomDiscreteValueWalker<TargetEncoderModel.TargetEncoderParameters> walker = new HyperSpaceWalker.RandomDiscreteValueWalker<>(parameters, hpGrid, modelParametersBuilderFactory, hyperSpaceSearchCriteria);
+        TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
 
-      HyperSpaceWalker.HyperSpaceIterator<TargetEncoderModel.TargetEncoderParameters> iterator = walker.iterator();
-      int count = 0;
-      while (iterator.hasNext(null)) {
-        TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = iterator.nextModelParameters(null);
-        System.out.println( targetEncoderParameters._blending + ":" +  targetEncoderParameters._noise_level + ":" +  targetEncoderParameters._k + ":" +  targetEncoderParameters._f);
-        count++;
+        GridSearchHandler.DefaultModelParametersBuilderFactory<TargetEncoderModel.TargetEncoderParameters, TargetEncoderV3.TargetEncoderParametersV3> modelParametersBuilderFactory = new GridSearchHandler.DefaultModelParametersBuilderFactory<>();
+
+        HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+        HyperSpaceWalker.RandomDiscreteValueWalker<TargetEncoderModel.TargetEncoderParameters> walker = new HyperSpaceWalker.RandomDiscreteValueWalker<>(parameters, hpGrid, modelParametersBuilderFactory, hyperSpaceSearchCriteria);
+
+        HyperSpaceWalker.HyperSpaceIterator<TargetEncoderModel.TargetEncoderParameters> iterator = walker.iterator();
+        int count = 0;
+        while (iterator.hasNext(null)) {
+          TargetEncoderModel.TargetEncoderParameters targetEncoderParameters = iterator.nextModelParameters(null);
+          System.out.println(targetEncoderParameters._blending + ":" + targetEncoderParameters._noise_level + ":" + targetEncoderParameters._k + ":" + targetEncoderParameters._f);
+          count++;
+        }
+        assertEquals("Unexpected number of grid items", 54, count);
+      } finally {
+        Scope.exit();
       }
-      assertEquals("Unexpected number of grid items", 54, count);
-    } finally {
-      Scope.exit();
     }
   }
 
+  @RunWith(Parameterized.class)
+  public static class TargetEncoderRGSParametrizedTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Parameterized.Parameters(name = "RGS over TE parameters: parallelism = {0}")
+    public static Object[] parallelism() {
+      return new Integer[]{1, 2, 4};
+    }
+
+    @Parameterized.Parameter
+    public int parallelism;
+
+    @Test
+    public void regularGSOverTEParameters_parallel() {
+
+      Scope.enter();
+      try {
+        Frame trainingFrame = parse_test_file("./smalldata/gbm_test/titanic.csv");
+        Scope.track(trainingFrame);
+        String responseColumn = "survived";
+        asFactor(trainingFrame, responseColumn);
+
+        HashMap<String, Object[]> hpGrid = new HashMap<>();
+        hpGrid.put("blending", new Boolean[]{true, false});
+        hpGrid.put("noise_level", new Double[]{0.0, 0.01,  0.1});
+        hpGrid.put("k", new Double[]{1.0, 2.0, 3.0});
+        hpGrid.put("f", new Double[]{5.0, 10.0, 20.0});
+
+        TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+        parameters._train = trainingFrame._key;
+        parameters._response_column = responseColumn;
+        parameters._ignored_columns = ignoredColumns(trainingFrame, "home.dest", "embarked", parameters._response_column);
+
+        GridSearchHandler.DefaultModelParametersBuilderFactory<TargetEncoderModel.TargetEncoderParameters, TargetEncoderV3.TargetEncoderParametersV3> modelParametersBuilderFactory = new GridSearchHandler.DefaultModelParametersBuilderFactory<>();
+
+        HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+        HyperSpaceWalker.RandomDiscreteValueWalker<TargetEncoderModel.TargetEncoderParameters> walker = new HyperSpaceWalker.RandomDiscreteValueWalker<>(parameters, hpGrid, modelParametersBuilderFactory, hyperSpaceSearchCriteria);
+
+        Job<Grid> gs = GridSearch.startGridSearch(Key.make(), walker, parallelism);
+
+        Scope.track_generic(gs);
+        final Grid grid = gs.get();
+        Scope.track_generic(grid);
+
+        assertEquals(54, grid.getModelCount());
+        assertTrue(Arrays.stream(grid.getModels()).allMatch(Objects::nonNull));
+      } finally {
+        Scope.exit();
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes two issues:
1) Implementation of TargetEncoderBuilder does not take into account the way how GridSearch is working. Instead of using TargetEncoderBuilder's constructor which sets passed model parameters, GridSearch is using startupOnce constructor with default parameters so that it can later reassign them with values from the grid. Even though initialisation is being called, training frame is not available  in default model parameters

2) Wrong key was passed to TargetEncoderModel
```new TargetEncoderModel(_result, ...   ```. Instead of `_result` from ModelBuilder the one from Job was used. See for more details my comment https://github.com/h2oai/h2o-3/pull/4216#discussion_r368741184
