### PR TITLE
[PUBDEV-7203] Expose Individual Chunks via REST API

### DIFF
--- a/h2o-core/src/main/java/water/ChunkAutoBufferReader.java
+++ b/h2o-core/src/main/java/water/ChunkAutoBufferReader.java
@@ -20,61 +20,61 @@ public final class ChunkAutoBufferReader implements Closeable  {
     }
 
     public boolean readBoolean() {
-        boolean data = buffer.getZ();
+        final boolean data = buffer.getZ();
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }
 
     public byte readByte() {
-        byte data = buffer.get1();
+        final byte data = buffer.get1();
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }
 
     public char readChar() {
-        char data = buffer.get2();
+        final char data = buffer.get2();
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }
 
     public short readShort() {
-        short data = buffer.get2s();
+        final short data = buffer.get2s();
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }
 
     public int readInt() {
-        int data = buffer.getInt();
+        final int data = buffer.getInt();
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }
 
     public long readLong() {
-        long data = buffer.get8();
+        final long data = buffer.get8();
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }
 
     public float readFloat() {
-        float data = buffer.get4f();
+        final float data = buffer.get4f();
         isLastNA = ExternalFrameUtils.isNA(data);
         return data;
     }
 
     public double readDouble() {
-        double data = buffer.get8d();
+        final double data = buffer.get8d();
         isLastNA = ExternalFrameUtils.isNA(data);
         return data;
     }
 
     public String readString() {
-        String data = buffer.getStr();
+        final String data = buffer.getStr();
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }
 
     public Timestamp readTimestamp() {
-        Timestamp data = new Timestamp(buffer.get8());
+        final Timestamp data = new Timestamp(buffer.get8());
         isLastNA = ExternalFrameUtils.isNA(buffer, data);
         return data;
     }

--- a/h2o-core/src/main/java/water/ChunkAutoBufferReader.java
+++ b/h2o-core/src/main/java/water/ChunkAutoBufferReader.java
@@ -1,7 +1,6 @@
 package water;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Timestamp;
 
@@ -88,7 +87,7 @@ public final class ChunkAutoBufferReader implements Closeable  {
     }
     
     @Override
-    public void close() throws IOException {
+    public void close() {
         buffer.close();
     }
 }

--- a/h2o-core/src/main/java/water/ChunkAutoBufferReader.java
+++ b/h2o-core/src/main/java/water/ChunkAutoBufferReader.java
@@ -1,0 +1,94 @@
+package water;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Timestamp;
+
+public final class ChunkAutoBufferReader implements Closeable  {
+    
+    private final AutoBuffer buffer;
+    private final int numRows;
+    private boolean isLastNA = false;
+    
+    public ChunkAutoBufferReader(InputStream inputStream) {
+        this.buffer = new AutoBuffer(inputStream);
+        this.numRows = readInt();
+    }
+
+    public int getNumRows() {
+        return numRows;
+    }
+
+    public boolean readBoolean() {
+        boolean data = buffer.getZ();
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    public byte readByte() {
+        byte data = buffer.get1();
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    public char readChar() {
+        char data = buffer.get2();
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    public short readShort() {
+        short data = buffer.get2s();
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    public int readInt() {
+        int data = buffer.getInt();
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    public long readLong() {
+        long data = buffer.get8();
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    public float readFloat() {
+        float data = buffer.get4f();
+        isLastNA = ExternalFrameUtils.isNA(data);
+        return data;
+    }
+
+    public double readDouble() {
+        double data = buffer.get8d();
+        isLastNA = ExternalFrameUtils.isNA(data);
+        return data;
+    }
+
+    public String readString() {
+        String data = buffer.getStr();
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    public Timestamp readTimestamp() {
+        Timestamp data = new Timestamp(buffer.get8());
+        isLastNA = ExternalFrameUtils.isNA(buffer, data);
+        return data;
+    }
+
+    /**
+     * This method is used to check if the last received value was marked as NA by H2O backend
+     */
+    public boolean isLastNA() {
+        return isLastNA;
+    }
+    
+    @Override
+    public void close() throws IOException {
+        buffer.close();
+    }
+}

--- a/h2o-core/src/main/java/water/ChunkAutoBufferWriter.java
+++ b/h2o-core/src/main/java/water/ChunkAutoBufferWriter.java
@@ -6,7 +6,6 @@ import water.fvec.Frame;
 import water.parser.BufferedString;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.UUID;
 
@@ -22,13 +21,13 @@ public final class ChunkAutoBufferWriter implements Closeable  {
     }
 
     public void writeChunk(String frameName, int chunkId, byte[] expectedTypes, int[] selectedColumnIndices) {
-        Frame frame = DKV.getGet(frameName);
-        Chunk[] chunks = ChunkUtils.getChunks(frame, chunkId);
-        int numberOfRows = chunks[0]._len;
+        final Frame frame = DKV.getGet(frameName);
+        final Chunk[] chunks = ChunkUtils.getChunks(frame, chunkId);
+        final int numberOfRows = chunks[0]._len;
         ExternalFrameUtils.sendInt(buffer, numberOfRows);
 
         // buffered string to be reused for strings to avoid multiple allocation in the loop
-        BufferedString valStr = new BufferedString();
+        final BufferedString valStr = new BufferedString();
         for (int rowIdx = 0; rowIdx < numberOfRows; rowIdx++) {
             for(int i = 0; i < selectedColumnIndices.length; i++){
                 if (chunks[selectedColumnIndices[i]].isNA(rowIdx)) {

--- a/h2o-core/src/main/java/water/ChunkAutoBufferWriter.java
+++ b/h2o-core/src/main/java/water/ChunkAutoBufferWriter.java
@@ -1,0 +1,89 @@
+package water;
+
+import water.fvec.Chunk;
+import water.fvec.ChunkUtils;
+import water.fvec.Frame;
+import water.parser.BufferedString;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.UUID;
+
+import static water.ExternalFrameUtils.*;
+import static water.ExternalFrameUtils.EXPECTED_STRING;
+
+public final class ChunkAutoBufferWriter implements Closeable  {
+    
+    private final AutoBuffer buffer;
+    
+    public ChunkAutoBufferWriter(OutputStream outputStream) {
+        this.buffer = new AutoBuffer(outputStream, false);
+    }
+
+    public void writeChunk(String frameName, int chunkId, byte[] expectedTypes, int[] selectedColumnIndices) {
+        Frame frame = DKV.getGet(frameName);
+        Chunk[] chunks = ChunkUtils.getChunks(frame, chunkId);
+        int numberOfRows = chunks[0]._len;
+        ExternalFrameUtils.sendInt(buffer, numberOfRows);
+
+        // buffered string to be reused for strings to avoid multiple allocation in the loop
+        BufferedString valStr = new BufferedString();
+        for (int rowIdx = 0; rowIdx < numberOfRows; rowIdx++) {
+            for(int i = 0; i < selectedColumnIndices.length; i++){
+                if (chunks[selectedColumnIndices[i]].isNA(rowIdx)) {
+                    ExternalFrameUtils.sendNA(buffer, expectedTypes[i]);
+                } else {
+                    final Chunk chnk = chunks[selectedColumnIndices[i]];
+                    switch (expectedTypes[i]) {
+                        case EXPECTED_BOOL:
+                            ExternalFrameUtils.sendBoolean(buffer, (byte)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_BYTE:
+                            ExternalFrameUtils.sendByte(buffer, (byte)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_CHAR:
+                            ExternalFrameUtils.sendChar(buffer, (char)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_SHORT:
+                            ExternalFrameUtils.sendShort(buffer, (short)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_INT:
+                            ExternalFrameUtils.sendInt(buffer, (int)chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_FLOAT:
+                            ExternalFrameUtils.sendFloat(buffer, (float)chnk.atd(rowIdx));
+                            break;
+                        case EXPECTED_LONG:
+                            ExternalFrameUtils.sendLong(buffer, chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_DOUBLE:
+                            ExternalFrameUtils.sendDouble(buffer, chnk.atd(rowIdx));
+                            break;
+                        case EXPECTED_TIMESTAMP:
+                            ExternalFrameUtils.sendTimestamp(buffer, chnk.at8(rowIdx));
+                            break;
+                        case EXPECTED_STRING:
+                            String string = null;
+                            if (chnk.vec().isCategorical()) {
+                                string = chnk.vec().domain()[(int) chnk.at8(rowIdx)];
+                            } else if (chnk.vec().isString()) {
+                                string = chnk.atStr(valStr, rowIdx).toString();
+                            } else if (chnk.vec().isUUID()) {
+                                string = new UUID(chnk.at16h(rowIdx), chnk.at16l(rowIdx)).toString();
+                            } else {
+                                assert false : "Can never be here";
+                            }
+                            ExternalFrameUtils.sendString(buffer, string);
+                            break;
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        buffer.close();
+    }
+}

--- a/h2o-core/src/main/java/water/ChunkAutoBufferWriter.java
+++ b/h2o-core/src/main/java/water/ChunkAutoBufferWriter.java
@@ -83,7 +83,7 @@ public final class ChunkAutoBufferWriter implements Closeable  {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         buffer.close();
     }
 }

--- a/h2o-core/src/main/java/water/ExternalFrameUtils.java
+++ b/h2o-core/src/main/java/water/ExternalFrameUtils.java
@@ -128,72 +128,72 @@ public class ExternalFrameUtils {
         return vecTypes;
     }
 
-    static void sendIntArray(AutoBuffer ab, int[] data) {
+    public static void sendIntArray(AutoBuffer ab, int[] data) {
         ab.putA4(data);
     }
 
-    static void sendDoubleArray(AutoBuffer ab, double[] data) {
+    public static void sendDoubleArray(AutoBuffer ab, double[] data) {
         ab.putA8d(data);
     }
 
-    static void sendBoolean(AutoBuffer ab, boolean data) {
+    public static void sendBoolean(AutoBuffer ab, boolean data) {
         sendBoolean(ab, data ? (byte)1 : (byte)0);
     }
 
-    static void sendBoolean(AutoBuffer ab, byte boolData) {
+    public static void sendBoolean(AutoBuffer ab, byte boolData) {
         ab.put1(boolData);
         putMarker(ab, boolData);
     }
 
-    static void sendByte(AutoBuffer ab, byte data) {
+    public static void sendByte(AutoBuffer ab, byte data) {
         ab.put1(data);
         putMarker(ab, data);
     }
 
-    static void sendChar(AutoBuffer ab, char data) {
+    public static void sendChar(AutoBuffer ab, char data) {
         ab.put2(data);
         putMarker(ab, data);
     }
 
-    static void sendShort(AutoBuffer ab, short data) {
+    public static void sendShort(AutoBuffer ab, short data) {
         ab.put2s(data);
         putMarker(ab, data);
     }
 
-    static void sendInt(AutoBuffer ab, int data) {
+    public static void sendInt(AutoBuffer ab, int data) {
         ab.putInt(data);
         putMarker(ab, data);
     }
 
-    static void sendLong(AutoBuffer ab, long data) {
+    public static void sendLong(AutoBuffer ab, long data) {
         ab.put8(data);
         putMarker(ab, data);
     }
 
-    static void sendFloat(AutoBuffer ab, float data) {
+    public static void sendFloat(AutoBuffer ab, float data) {
         ab.put4f(data);
     }
 
-    static void sendDouble(AutoBuffer ab, double data) {
+    public static void sendDouble(AutoBuffer ab, double data) {
         ab.put8d(data);
     }
 
-    static void sendString(AutoBuffer ab, String data) {
+    public static void sendString(AutoBuffer ab, String data) {
         ab.putStr(data);
         if(data != null && data.equals(STR_MARKER_NEXT_BYTE_FOLLOWS)){
             ab.put1(MARKER_ORIGINAL_VALUE);
         }
     }
 
-    static void sendTimestamp(AutoBuffer ab, long time) {
+    public static void sendTimestamp(AutoBuffer ab, long time) {
         sendLong(ab, time);
     }
 
-    static void sendTimestamp(AutoBuffer ab, Timestamp data) {
+    public static void sendTimestamp(AutoBuffer ab, Timestamp data) {
         sendLong(ab, data.getTime());
     }
 
-    static void sendNA(AutoBuffer ab, byte expectedType) {
+    public static void sendNA(AutoBuffer ab, byte expectedType) {
         switch (expectedType){
             case EXPECTED_BOOL: // // fall through to byte since BOOL is internally stored in frame as number (byte)
             case EXPECTED_BYTE:
@@ -252,7 +252,7 @@ public class ExternalFrameUtils {
         return data != null && data.equals(STR_MARKER_NEXT_BYTE_FOLLOWS) && ab.get1() == MARKER_NA;
     }
 
-    static int[] getStartPositions(int[] elemSizes){
+    public static int[] getStartPositions(int[] elemSizes){
         int[] startPos = new int[elemSizes.length];
         for(int i = 1; i<elemSizes.length; i++){
             startPos[i] = startPos[ i - 1] + elemSizes[i - 1];
@@ -260,7 +260,7 @@ public class ExternalFrameUtils {
         return startPos;
     }
 
-    static int[] getElemSizes(byte[] expectedTypes, int[] vecElemSizes){
+    public static int[] getElemSizes(byte[] expectedTypes, int[] vecElemSizes){
         assert vecElemSizes != null : "vecElemSizes should be not null!";
         int vecCount = 0;
         int[] elemSizes = new int[expectedTypes.length];

--- a/h2o-core/src/main/java/water/api/ChunkServlet.java
+++ b/h2o-core/src/main/java/water/api/ChunkServlet.java
@@ -1,0 +1,160 @@
+package water.api;
+
+import water.AutoBuffer;
+import water.DKV;
+import water.ExternalFrameUtils;
+import water.fvec.Chunk;
+import water.fvec.ChunkUtils;
+import water.fvec.Frame;
+import water.parser.BufferedString;
+import water.server.ServletUtils;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+import java.util.UUID;
+
+import static water.ExternalFrameUtils.*;
+import static water.ExternalFrameUtils.EXPECTED_STRING;
+
+/**
+ * This servlet class handles GET requests for the path /3/Chunk
+ * It requires 4 get parameters
+ * - frame_name - a unique string identifier of H2O Frame
+ * - chunk_id - a unique identifier of the chunk within the H2O Frame
+ * - expected_type - byte array encoded in Base64 encoding. The types corresponds to the `selected_columns` parameter
+ * - selected_columns - selected columns indices encoded int Base64 encoding.
+ * The result is represented as a stream of binary data. Data are encoded to AutoBuffer row by row. 
+ * The data stream starts with the integer representing the number of rows.
+ */
+public class ChunkServlet extends HttpServlet {
+
+  private static class RequestParameters {
+    final String frameName;
+    final int chunkId;
+    final byte[] expectedTypes;
+    final int[] selectedColumnIndices;
+    
+    public RequestParameters(String frameName, int chunkId, byte[] expectedTypes, int[] selectedColumnIndices) {
+      this.frameName = frameName;
+      this.chunkId = chunkId;
+      this.expectedTypes = expectedTypes;
+      this.selectedColumnIndices = selectedColumnIndices;
+    }
+  }
+  
+  private String getParameterAsString(HttpServletRequest request, String parameterName) {
+    String result = request.getParameter(parameterName);
+    if (result == null) {
+      throw new RuntimeException(String.format("Cannot find value for parameter \'%s\'", parameterName));
+    }
+    return result;
+  }
+  
+  private RequestParameters extractRequestParameters(HttpServletRequest request) {
+    String frameName = getParameterAsString(request, "frame_name");
+    
+    String chunkIdString = getParameterAsString(request, "chunk_id");
+    int chunkId = Integer.parseInt(chunkIdString);
+    
+    String expectedTypesString = getParameterAsString(request, "expected_types");
+    byte[] expectedTypes = Base64.getDecoder().decode(expectedTypesString);
+
+    String selectedColumnsString = getParameterAsString(request, "selected_columns");
+    byte[] selectedColumnsBytes = Base64.getDecoder().decode(selectedColumnsString);
+    ByteBuffer buffer = ByteBuffer.wrap(selectedColumnsBytes).order(ByteOrder.BIG_ENDIAN);
+    int[] selectedColumnIndices = new int[selectedColumnsBytes.length / 4];
+    buffer.asIntBuffer().put(selectedColumnIndices);
+            
+    return new RequestParameters(frameName, chunkId, expectedTypes, selectedColumnIndices); 
+  }
+  
+  private void writeData(RequestParameters parameters, AutoBuffer buffer) {
+    Frame frame = DKV.getGet(parameters.frameName);
+    Chunk[] chunks = ChunkUtils.getChunks(frame, parameters.chunkId);
+    int numberOfRows = chunks[0]._len;
+    int[] selectedColumnIndices = parameters.selectedColumnIndices;
+    byte[] expectedTypes = parameters.expectedTypes;
+    ExternalFrameUtils.sendInt(buffer, numberOfRows);
+
+    // buffered string to be reused for strings to avoid multiple allocation in the loop
+    BufferedString valStr = new BufferedString();
+    for (int rowIdx = 0; rowIdx < numberOfRows; rowIdx++) {
+      for(int i = 0; i < selectedColumnIndices.length; i++){
+        if (chunks[selectedColumnIndices[i]].isNA(rowIdx)) {
+          ExternalFrameUtils.sendNA(buffer, expectedTypes[i]);
+        } else {
+          final Chunk chnk = chunks[selectedColumnIndices[i]];
+          switch (expectedTypes[i]) {
+            case EXPECTED_BOOL:
+              ExternalFrameUtils.sendBoolean(buffer, (byte)chnk.at8(rowIdx));
+              break;
+            case EXPECTED_BYTE:
+              ExternalFrameUtils.sendByte(buffer, (byte)chnk.at8(rowIdx));
+              break;
+            case EXPECTED_CHAR:
+              ExternalFrameUtils.sendChar(buffer, (char)chnk.at8(rowIdx));
+              break;
+            case EXPECTED_SHORT:
+              ExternalFrameUtils.sendShort(buffer, (short)chnk.at8(rowIdx));
+              break;
+            case EXPECTED_INT:
+              ExternalFrameUtils.sendInt(buffer, (int)chnk.at8(rowIdx));
+              break;
+            case EXPECTED_FLOAT:
+              ExternalFrameUtils.sendFloat(buffer, (float)chnk.atd(rowIdx));
+              break;
+            case EXPECTED_LONG:
+              ExternalFrameUtils.sendLong(buffer, chnk.at8(rowIdx));
+              break;
+            case EXPECTED_DOUBLE:
+              ExternalFrameUtils.sendDouble(buffer, chnk.atd(rowIdx));
+              break;
+            case EXPECTED_TIMESTAMP:
+              ExternalFrameUtils.sendTimestamp(buffer, chnk.at8(rowIdx));
+              break;
+            case EXPECTED_STRING:
+              String string = null;
+              if (chnk.vec().isCategorical()) {
+                string = chnk.vec().domain()[(int) chnk.at8(rowIdx)];
+              } else if (chnk.vec().isString()) {
+                string = chnk.atStr(valStr, rowIdx).toString();
+              } else if (chnk.vec().isUUID()) {
+                string = new UUID(chnk.at16h(rowIdx), chnk.at16l(rowIdx)).toString();
+              } else {
+                assert false : "Can never be here";
+              }
+              ExternalFrameUtils.sendString(buffer, string);
+              break;
+          }
+        }
+      }
+    }
+  }
+  
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+    String uri = ServletUtils.getDecodedUri(request);
+    try {
+      RequestParameters parameters = extractRequestParameters(request);
+      response.setContentType("application/octet-stream");
+      ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
+      OutputStream outputStream = response.getOutputStream();
+      AutoBuffer buffer = new AutoBuffer(outputStream, false);
+      try {
+        writeData(parameters, buffer);
+      } finally {
+        buffer.close();
+      }
+      buffer.close();
+    } catch (Exception e) {
+      ServletUtils.sendErrorResponse(response, e, uri);
+    } finally {
+      ServletUtils.logRequest("GET", request, response);
+    }
+  }
+}

--- a/h2o-core/src/main/java/water/api/ChunkServlet.java
+++ b/h2o-core/src/main/java/water/api/ChunkServlet.java
@@ -1,6 +1,9 @@
 package water.api;
 
 import water.ChunkAutoBufferWriter;
+import water.DKV;
+import water.ExternalFrameUtils;
+import water.fvec.Frame;
 import water.server.ServletUtils;
 
 import javax.servlet.http.HttpServlet;
@@ -46,29 +49,112 @@ public final class ChunkServlet extends HttpServlet {
     return result;
   }
   
-  private RequestParameters extractRequestParameters(final HttpServletRequest request) {
+  private RequestParameters parseRequestParameters(final HttpServletRequest request) {
     final String frameName = getParameterAsString(request, "frame_name");
     
     final String chunkIdString = getParameterAsString(request, "chunk_id");
-    int chunkId = Integer.parseInt(chunkIdString);
+    final int chunkId = Integer.parseInt(chunkIdString);
     
     final String expectedTypesString = getParameterAsString(request, "expected_types");
-    byte[] expectedTypes = Base64.getDecoder().decode(expectedTypesString);
+    final byte[] expectedTypes = Base64.getDecoder().decode(expectedTypesString);
 
     final String selectedColumnsString = getParameterAsString(request, "selected_columns");
-    byte[] selectedColumnsBytes = Base64.getDecoder().decode(selectedColumnsString);
+    final byte[] selectedColumnsBytes = Base64.getDecoder().decode(selectedColumnsString);
     final IntBuffer buffer = ByteBuffer.wrap(selectedColumnsBytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer();
-    int[] selectedColumnIndices = new int[buffer.remaining()];
+    final int[] selectedColumnIndices = new int[buffer.remaining()];
     buffer.get(selectedColumnIndices);
             
     return new RequestParameters(frameName, chunkId, expectedTypes, selectedColumnIndices); 
+  }
+  
+  private void validateRequestParameters(final RequestParameters parameters) {
+    final Frame frame = DKV.getGet(parameters.frameName);
+    if (frame == null) {
+      throw new RuntimeException(String.format("A frame with name '%s' doesn't exist.", parameters.frameName));
+    }
+
+    validateChunkId(parameters, frame);
+    validateSelectedColumns(parameters, frame);
+    validateExpectedTypes(parameters, frame);
+  }
+  
+  private void validateChunkId(final RequestParameters parameters, final Frame frame) {
+    if (parameters.chunkId < 0) {
+      throw new RuntimeException(String.format("chunk_id can't be negative. Current value: %d", parameters.chunkId));
+    }
+    
+    final int numberOfChunks = frame.anyVec().nChunks();
+    if (parameters.chunkId >= numberOfChunks) {
+      final String message = String.format(
+        "chunk_id '%d' is out of range. The frame '%s' has %d chunks.",
+        parameters.chunkId,
+        parameters.frameName,
+        numberOfChunks);
+      throw new RuntimeException(message);
+    }
+  }
+
+  private void validateSelectedColumns(final RequestParameters parameters, final Frame frame) {
+    for (int i = 0; i < parameters.selectedColumnIndices.length; i++) {
+      if (parameters.selectedColumnIndices[i] < 0) {
+        final String message = String.format(
+          "Selected column index ('selected_columns') at position %d with the value '%d' is negative.",
+          i,
+          parameters.selectedColumnIndices[i]);
+        throw new RuntimeException(message);
+      }
+      if (parameters.selectedColumnIndices[i] >= frame.numCols()) {
+        final String message = String.format(
+          "Selected column index ('selected_columns') at position %d with the value '%d' is out of range. Frame '%s' has %d columns.",
+          i,
+          parameters.selectedColumnIndices[i],
+          parameters.frameName,
+          frame.numCols());
+        throw new RuntimeException(message);
+      }
+    }    
+  }
+
+  private void validateExpectedTypes(final RequestParameters parameters, final Frame frame) {
+    for (int i = 0; i < parameters.expectedTypes.length; i++) {
+      if (parameters.expectedTypes[i] < ExternalFrameUtils.EXPECTED_BOOL ||
+          parameters.expectedTypes[i] > ExternalFrameUtils.EXPECTED_VECTOR) {
+        final String message = String.format(
+          "Expected Type ('expected_types') at position %d with the value '%d' is invalid.",
+          i,
+          parameters.expectedTypes[i]);
+        throw new RuntimeException(message);
+      }
+    }
+    
+    if (parameters.selectedColumnIndices.length != parameters.expectedTypes.length) {
+      final String message = String.format(
+        "The number of expected_types '%d' is not the same as the number of selected_columns '%d'",
+        parameters.expectedTypes.length,
+        parameters.selectedColumnIndices.length);
+      throw new RuntimeException(message);
+    }
+    
+    final byte[] expectedVecTypes = new byte[parameters.expectedTypes.length];
+    final byte[] frameTypes = frame.types();
+    for (int i = 0; i < parameters.expectedTypes.length; i++) {
+      final int frameTypePosition = parameters.selectedColumnIndices[i];  
+      if (expectedVecTypes[i] != frameTypes[frameTypePosition]) {
+        final String message = String.format(
+          "Expected Type ('expected_types') at position %d doesn't correspond to the frame column type at position %d.",
+          i,
+          frameTypePosition);
+        throw new RuntimeException(message);
+      }
+    }
   }
   
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     final String uri = ServletUtils.getDecodedUri(request);
     try {
-      final RequestParameters parameters = extractRequestParameters(request);
+      final RequestParameters parameters = parseRequestParameters(request);
+      validateRequestParameters(parameters);
       response.setContentType("application/octet-stream");
       ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
       try (OutputStream outputStream = response.getOutputStream();

--- a/h2o-core/src/main/java/water/api/ChunkServlet.java
+++ b/h2o-core/src/main/java/water/api/ChunkServlet.java
@@ -1,12 +1,6 @@
 package water.api;
 
-import water.AutoBuffer;
-import water.DKV;
-import water.ExternalFrameUtils;
-import water.fvec.Chunk;
-import water.fvec.ChunkUtils;
-import water.fvec.Frame;
-import water.parser.BufferedString;
+import water.ChunkAutoBufferWriter;
 import water.server.ServletUtils;
 
 import javax.servlet.http.HttpServlet;
@@ -16,10 +10,6 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Base64;
-import java.util.UUID;
-
-import static water.ExternalFrameUtils.*;
-import static water.ExternalFrameUtils.EXPECTED_STRING;
 
 /**
  * This servlet class handles GET requests for the path /3/Chunk
@@ -73,69 +63,6 @@ public class ChunkServlet extends HttpServlet {
     return new RequestParameters(frameName, chunkId, expectedTypes, selectedColumnIndices); 
   }
   
-  private void writeData(RequestParameters parameters, AutoBuffer buffer) {
-    Frame frame = DKV.getGet(parameters.frameName);
-    Chunk[] chunks = ChunkUtils.getChunks(frame, parameters.chunkId);
-    int numberOfRows = chunks[0]._len;
-    int[] selectedColumnIndices = parameters.selectedColumnIndices;
-    byte[] expectedTypes = parameters.expectedTypes;
-    ExternalFrameUtils.sendInt(buffer, numberOfRows);
-
-    // buffered string to be reused for strings to avoid multiple allocation in the loop
-    BufferedString valStr = new BufferedString();
-    for (int rowIdx = 0; rowIdx < numberOfRows; rowIdx++) {
-      for(int i = 0; i < selectedColumnIndices.length; i++){
-        if (chunks[selectedColumnIndices[i]].isNA(rowIdx)) {
-          ExternalFrameUtils.sendNA(buffer, expectedTypes[i]);
-        } else {
-          final Chunk chnk = chunks[selectedColumnIndices[i]];
-          switch (expectedTypes[i]) {
-            case EXPECTED_BOOL:
-              ExternalFrameUtils.sendBoolean(buffer, (byte)chnk.at8(rowIdx));
-              break;
-            case EXPECTED_BYTE:
-              ExternalFrameUtils.sendByte(buffer, (byte)chnk.at8(rowIdx));
-              break;
-            case EXPECTED_CHAR:
-              ExternalFrameUtils.sendChar(buffer, (char)chnk.at8(rowIdx));
-              break;
-            case EXPECTED_SHORT:
-              ExternalFrameUtils.sendShort(buffer, (short)chnk.at8(rowIdx));
-              break;
-            case EXPECTED_INT:
-              ExternalFrameUtils.sendInt(buffer, (int)chnk.at8(rowIdx));
-              break;
-            case EXPECTED_FLOAT:
-              ExternalFrameUtils.sendFloat(buffer, (float)chnk.atd(rowIdx));
-              break;
-            case EXPECTED_LONG:
-              ExternalFrameUtils.sendLong(buffer, chnk.at8(rowIdx));
-              break;
-            case EXPECTED_DOUBLE:
-              ExternalFrameUtils.sendDouble(buffer, chnk.atd(rowIdx));
-              break;
-            case EXPECTED_TIMESTAMP:
-              ExternalFrameUtils.sendTimestamp(buffer, chnk.at8(rowIdx));
-              break;
-            case EXPECTED_STRING:
-              String string = null;
-              if (chnk.vec().isCategorical()) {
-                string = chnk.vec().domain()[(int) chnk.at8(rowIdx)];
-              } else if (chnk.vec().isString()) {
-                string = chnk.atStr(valStr, rowIdx).toString();
-              } else if (chnk.vec().isUUID()) {
-                string = new UUID(chnk.at16h(rowIdx), chnk.at16l(rowIdx)).toString();
-              } else {
-                assert false : "Can never be here";
-              }
-              ExternalFrameUtils.sendString(buffer, string);
-              break;
-          }
-        }
-      }
-    }
-  }
-  
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     String uri = ServletUtils.getDecodedUri(request);
@@ -144,13 +71,16 @@ public class ChunkServlet extends HttpServlet {
       response.setContentType("application/octet-stream");
       ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
       OutputStream outputStream = response.getOutputStream();
-      AutoBuffer buffer = new AutoBuffer(outputStream, false);
+      ChunkAutoBufferWriter writer = new ChunkAutoBufferWriter(outputStream);
       try {
-        writeData(parameters, buffer);
+        writer.writeChunk(
+            parameters.frameName, 
+            parameters.chunkId, 
+            parameters.expectedTypes,
+            parameters.selectedColumnIndices);
       } finally {
-        buffer.close();
+        writer.close();
       }
-      buffer.close();
     } catch (Exception e) {
       ServletUtils.sendErrorResponse(response, e, uri);
     } finally {

--- a/h2o-core/src/main/java/water/api/ChunkServlet.java
+++ b/h2o-core/src/main/java/water/api/ChunkServlet.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.IntBuffer;
 import java.util.Base64;
 
 /**
@@ -56,9 +57,9 @@ public class ChunkServlet extends HttpServlet {
 
     String selectedColumnsString = getParameterAsString(request, "selected_columns");
     byte[] selectedColumnsBytes = Base64.getDecoder().decode(selectedColumnsString);
-    ByteBuffer buffer = ByteBuffer.wrap(selectedColumnsBytes).order(ByteOrder.BIG_ENDIAN);
-    int[] selectedColumnIndices = new int[selectedColumnsBytes.length / 4];
-    buffer.asIntBuffer().put(selectedColumnIndices);
+    IntBuffer buffer = ByteBuffer.wrap(selectedColumnsBytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer();
+    int[] selectedColumnIndices = new int[buffer.remaining()];
+    buffer.get(selectedColumnIndices);
             
     return new RequestParameters(frameName, chunkId, expectedTypes, selectedColumnIndices); 
   }

--- a/h2o-core/src/main/java/water/api/ChunkServlet.java
+++ b/h2o-core/src/main/java/water/api/ChunkServlet.java
@@ -22,7 +22,7 @@ import java.util.Base64;
  * The result is represented as a stream of binary data. Data are encoded to AutoBuffer row by row. 
  * The data stream starts with the integer representing the number of rows.
  */
-public class ChunkServlet extends HttpServlet {
+public final class ChunkServlet extends HttpServlet {
 
   private static class RequestParameters {
     final String frameName;
@@ -38,26 +38,26 @@ public class ChunkServlet extends HttpServlet {
     }
   }
   
-  private String getParameterAsString(HttpServletRequest request, String parameterName) {
-    String result = request.getParameter(parameterName);
+  private String getParameterAsString(final HttpServletRequest request, final String parameterName) {
+    final String result = request.getParameter(parameterName);
     if (result == null) {
       throw new RuntimeException(String.format("Cannot find value for parameter \'%s\'", parameterName));
     }
     return result;
   }
   
-  private RequestParameters extractRequestParameters(HttpServletRequest request) {
-    String frameName = getParameterAsString(request, "frame_name");
+  private RequestParameters extractRequestParameters(final HttpServletRequest request) {
+    final String frameName = getParameterAsString(request, "frame_name");
     
-    String chunkIdString = getParameterAsString(request, "chunk_id");
+    final String chunkIdString = getParameterAsString(request, "chunk_id");
     int chunkId = Integer.parseInt(chunkIdString);
     
-    String expectedTypesString = getParameterAsString(request, "expected_types");
+    final String expectedTypesString = getParameterAsString(request, "expected_types");
     byte[] expectedTypes = Base64.getDecoder().decode(expectedTypesString);
 
-    String selectedColumnsString = getParameterAsString(request, "selected_columns");
+    final String selectedColumnsString = getParameterAsString(request, "selected_columns");
     byte[] selectedColumnsBytes = Base64.getDecoder().decode(selectedColumnsString);
-    IntBuffer buffer = ByteBuffer.wrap(selectedColumnsBytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer();
+    final IntBuffer buffer = ByteBuffer.wrap(selectedColumnsBytes).order(ByteOrder.BIG_ENDIAN).asIntBuffer();
     int[] selectedColumnIndices = new int[buffer.remaining()];
     buffer.get(selectedColumnIndices);
             
@@ -66,9 +66,9 @@ public class ChunkServlet extends HttpServlet {
   
   @Override
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
-    String uri = ServletUtils.getDecodedUri(request);
+    final String uri = ServletUtils.getDecodedUri(request);
     try {
-      RequestParameters parameters = extractRequestParameters(request);
+      final RequestParameters parameters = extractRequestParameters(request);
       response.setContentType("application/octet-stream");
       ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
       OutputStream outputStream = response.getOutputStream();
@@ -85,7 +85,7 @@ public class ChunkServlet extends HttpServlet {
     } catch (Exception e) {
       ServletUtils.sendErrorResponse(response, e, uri);
     } finally {
-      ServletUtils.logRequest("GET", request, response);
+      ServletUtils.logRequest(request.getMethod(), request, response);
     }
   }
 }

--- a/h2o-core/src/main/java/water/api/ChunkServlet.java
+++ b/h2o-core/src/main/java/water/api/ChunkServlet.java
@@ -71,16 +71,13 @@ public final class ChunkServlet extends HttpServlet {
       final RequestParameters parameters = extractRequestParameters(request);
       response.setContentType("application/octet-stream");
       ServletUtils.setResponseStatus(response, HttpServletResponse.SC_OK);
-      OutputStream outputStream = response.getOutputStream();
-      ChunkAutoBufferWriter writer = new ChunkAutoBufferWriter(outputStream);
-      try {
+      try (OutputStream outputStream = response.getOutputStream();
+           ChunkAutoBufferWriter writer = new ChunkAutoBufferWriter(outputStream)) {
         writer.writeChunk(
-            parameters.frameName, 
-            parameters.chunkId, 
-            parameters.expectedTypes,
-            parameters.selectedColumnIndices);
-      } finally {
-        writer.close();
+          parameters.frameName,
+          parameters.chunkId,
+          parameters.expectedTypes,
+          parameters.selectedColumnIndices);
       }
     } catch (Exception e) {
       ServletUtils.sendErrorResponse(response, e, uri);

--- a/h2o-core/src/main/java/water/webserver/H2OHttpViewImpl.java
+++ b/h2o-core/src/main/java/water/webserver/H2OHttpViewImpl.java
@@ -2,11 +2,7 @@ package water.webserver;
 
 import org.apache.commons.io.IOUtils;
 import water.ExtensionManager;
-import water.api.DatasetServlet;
-import water.api.NpsBinServlet;
-import water.api.PostFileServlet;
-import water.api.PutKeyServlet;
-import water.api.RequestServer;
+import water.api.*;
 import water.server.ServletUtils;
 import water.util.Log;
 import water.webserver.iface.H2OHttpConfig;
@@ -39,6 +35,8 @@ public class H2OHttpViewImpl implements H2OHttpView {
     SERVLETS.put("/3/DownloadDataset.bin", DatasetServlet.class);
     SERVLETS.put("/3/PutKey.bin", PutKeyServlet.class);
     SERVLETS.put("/3/PutKey", PutKeyServlet.class);
+    SERVLETS.put("/3/Chunk.bin", ChunkServlet.class);
+    SERVLETS.put("/3/Chunk", ChunkServlet.class);
     SERVLETS.put("/", RequestServer.class);
   }
 


### PR DESCRIPTION
Lots of the code is extracted from [`ExternalFrameReaderBackend`](https://github.com/h2oai/h2o-3/blob/8b9882de0701538be731a0b4110dbec8fb67bf09/h2o-core/src/main/java/water/ExternalFrameReaderBackend.java) and [`ExternalFrameReaderClient`](https://github.com/h2oai/h2o-3/blob/914448614409b50b096893affa1b4a45905e0c12/h2o-core/src/main/java/water/ExternalFrameReaderClient.java) to minimalize changes. Once the whole initiative of REST transportation logic is done, all `ExternalFrame*`classes can be removed.