### PR TITLE
PUBDEV-7205: fixed bug in reading user_splits in Java.

### DIFF
--- a/h2o-core/src/main/java/hex/PartialDependence.java
+++ b/h2o-core/src/main/java/hex/PartialDependence.java
@@ -116,7 +116,9 @@ public class PartialDependence extends Lockable<PartialDependence> {
       // convert one dimension info into two dimensionl
       _user_split_per_col = new double[numUserSplits][];
       int[] user_splits_start = new int[numUserSplits];
-      System.arraycopy(_num_user_splits, 0, user_splits_start, 1, numUserSplits-1);
+      for (int cindex = 1; cindex < numUserSplits; cindex++) {  // fixed bug in user_splits_start
+        user_splits_start[cindex] = _num_user_splits[cindex-1]+user_splits_start[cindex-1];
+      }
       for (int cindex=0; cindex < numUserSplits; cindex++) {
         int splitNum = _num_user_splits[cindex];
         _user_split_per_col[cindex] = new double[splitNum];

--- a/h2o-r/tests/testdir_misc/runit_pubdev_7205_user_pdp.R
+++ b/h2o-r/tests/testdir_misc/runit_pubdev_7205_user_pdp.R
@@ -1,0 +1,30 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+##
+# PUBDEV-7205: fixed pdp bug caught by Megan Kurka.  Thanks.
+##
+
+testpdpUserSplits <- function() {
+  iris.hex <- h2o.importFile(locate("smalldata/iris/iris.csv"), "iris.hex", col.names=c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "response"))
+  temp <- as.data.frame(iris.hex[,4:5])
+  for (ind in c(1:h2o.nrow(iris.hex))) {
+    if (temp[ind, 2]=="Iris-virginica") {
+      temp[ind,1] = 0
+    } else {
+      temp[ind,1] = 1
+    }
+  }
+  iris.hex <- h2o.cbind(iris.hex, as.h2o(temp[,1]))
+  iris.gbm <- h2o.gbm(model_id = "gbm_iris",
+                      x = 1:4,
+                      y = 6,
+                      training_frame = iris.hex)
+  pdps <- h2o.partialPlot(object=iris.gbm, data=iris.hex, cols=c("Sepal.Width", "Petal.Length", "Petal.Width"), 
+  user_splits=list(c("Sepal.Width","0","1"), c("Petal.Length","1","2"),c("Petal.Width", "3","4","5")))
+  petalW <- pdps[[3]]$Petal.Width
+  expect_true(checkEqualsNumeric(petalW, c(3,4,5)))
+  }
+
+doTest("Test Partial Dependence Plots in H2O with User defined split points: ", testpdpUserSplits)
+


### PR DESCRIPTION
This PR fixes the bug found by Megan Kurka: https://0xdata.atlassian.net/browse/PUBDEV-7205

The problem is in reading off the user defined splits that are passed to java backend as one array.  I fixed the problem in 119 of PartialDependency.java where the start of each column was set to the wrong value in user_splits_start.

Added the R example from Megan to check and make sure the splits are correct.