### PR TITLE
PUBDEV-7201: sklearn wrappers should expose wrapped estimator as a public property

### DIFF
--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -545,8 +545,8 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
     @property
     def estimator(self):
         """
-        The wrapped estimator is created only when the current object is `fit`, so this property
-        :return: the wrapped estimator or None if `fit` hasn't been called yet
+        The wrapped estimator is created only when the current object is `fit`, so this property returns None until then.
+        :return: the wrapped estimator or None if `fit` hasn't been called on the current object yet.
         """
         return self._estimator
 

--- a/h2o-py/h2o/sklearn/wrapper.py
+++ b/h2o-py/h2o/sklearn/wrapper.py
@@ -528,7 +528,7 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
         # we only keep a ref to parameters names
         # all those params are also exposed as a regular attribute and can be modified directly
         #  on the estimator instance
-        self._estimator_param_names = estimator_params.keys()
+        self._estimator_param_names = list(estimator_params.keys())
         self.set_params(**estimator_params)
 
         self._frame_params = None
@@ -541,6 +541,14 @@ class BaseSklearnEstimator(BaseEstimator, BaseEstimatorMixin, H2OConnectionMonit
         :return: `param`, or, if the param name may conflict with another method or property on the instance,`param_`
         """
         return param+'_' if param in dir(cls) else param
+
+    @property
+    def estimator(self):
+        """
+        The wrapped estimator is created only when the current object is `fit`, so this property
+        :return: the wrapped estimator or None if `fit` hasn't been called yet
+        """
+        return self._estimator
 
     def set_params(self, **params):
         """Set the parameters of this estimator.

--- a/h2o-py/tests/testdir_sklearn/pyunit_sklearn_automl_pipeline.py
+++ b/h2o-py/tests/testdir_sklearn/pyunit_sklearn_automl_pipeline.py
@@ -56,7 +56,7 @@ def test_binomial_classification_with_h2o_frames():
     data = _get_data(format='h2o', n_classes=2)
     assert isinstance(data.X_train, h2o.H2OFrame)
     pipeline.fit(data.X_train, data.y_train)
-    assert len(pipeline.named_steps.h2oautomlclassifier._estimator.leaderboard) == max_models+2
+    assert len(pipeline.named_steps.h2oautomlclassifier.estimator.leaderboard) == max_models+2
 
     preds = pipeline.predict(data.X_test)
     assert isinstance(preds, h2o.H2OFrame)
@@ -81,7 +81,7 @@ def test_multinomial_classification_with_numpy_frames():
     data = _get_data(format='numpy', n_classes=3)
     assert isinstance(data.X_train, np.ndarray)
     pipeline.fit(data.X_train, data.y_train)
-    assert len(pipeline.named_steps.h2oautomlclassifier._estimator.leaderboard) == max_models+2
+    assert len(pipeline.named_steps.h2oautomlclassifier.estimator.leaderboard) == max_models+2
 
     preds = pipeline.predict(data.X_test)
     assert isinstance(preds, np.ndarray)
@@ -107,7 +107,7 @@ def test_regression_with_numpy_frames():
     data = _get_data(format='numpy', n_classes=0)
     assert isinstance(data.X_train, np.ndarray)
     pipeline.fit(data.X_train, data.y_train)
-    assert len(pipeline.named_steps.h2oautomlregressor._estimator.leaderboard) == max_models+2
+    assert len(pipeline.named_steps.h2oautomlregressor.estimator.leaderboard) == max_models+2
 
     preds = pipeline.predict(data.X_test)
     assert isinstance(preds, np.ndarray)
@@ -132,7 +132,7 @@ def test_generic_estimator_for_classification():
     assert isinstance(data.X_train, np.ndarray)
 
     pipeline.fit(data.X_train, data.y_train)
-    assert len(pipeline.named_steps.h2oautomlestimator._estimator.leaderboard) == max_models+2
+    assert len(pipeline.named_steps.h2oautomlestimator.estimator.leaderboard) == max_models+2
 
     preds = pipeline.predict(data.X_test)
     assert isinstance(preds, np.ndarray)
@@ -160,7 +160,7 @@ def test_generic_estimator_for_regression():
     data = _get_data(format='numpy', n_classes=0)
     assert isinstance(data.X_train, np.ndarray)
     pipeline.fit(data.X_train, data.y_train)
-    assert len(pipeline.named_steps.h2oautomlestimator._estimator.leaderboard) == max_models+2
+    assert len(pipeline.named_steps.h2oautomlestimator.estimator.leaderboard) == max_models+2
 
     preds = pipeline.predict(data.X_test)
     assert isinstance(preds, np.ndarray)

--- a/h2o-py/tests/testdir_sklearn/pyunit_sklearn_params.py
+++ b/h2o-py/tests/testdir_sklearn/pyunit_sklearn_params.py
@@ -137,10 +137,10 @@ def test_params_are_correctly_passed_to_underlying_transformer():
     pca = H2OPCA(seed=seed)
     pca.set_params(transform='DEMEAN', k=3)
     pca.model_id = "dummy"
-    assert pca._estimator is None
+    assert pca.estimator is None
     pca._make_estimator()  # normally done when calling `fit`
-    assert pca._estimator
-    parms = pca._estimator._parms
+    assert pca.estimator
+    parms = pca.estimator._parms
     assert parms['seed'] == seed
     assert parms['transform'] == 'DEMEAN'
     assert parms['k'] == 3
@@ -152,9 +152,9 @@ def test_params_are_correctly_passed_to_underlying_estimator():
     estimator = H2OGradientBoostingEstimator(seed=seed)
     estimator.set_params(max_depth=10, learn_rate=0.5)
     estimator.model_id = "dummy"
-    assert estimator._estimator is None
+    assert estimator.estimator is None
     estimator._make_estimator()  # normally done when calling `fit`
-    real_estimator = estimator._estimator
+    real_estimator = estimator.estimator
     assert real_estimator
     parms = real_estimator._parms
     assert real_estimator.seed == parms['seed'] == seed
@@ -169,9 +169,9 @@ def test_params_are_correctly_passed_to_underlying_automl():
     estimator = H2OAutoMLEstimator(seed=seed)
     estimator.set_params(max_models=5, nfolds=0)
     estimator.project_name = "dummy"
-    assert estimator._estimator is None
+    assert estimator.estimator is None
     estimator._make_estimator()  # normally done when calling `fit`
-    aml = estimator._estimator
+    aml = estimator.estimator
     assert aml
     assert aml.build_control["stopping_criteria"]["seed"] == seed
     assert aml.build_control["stopping_criteria"]["max_models"] == 5


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7201

the property used to be "python-hidden". As some editors like Jupyter notebook use this convention to remove those hidden properties from auto-completion hints, exposing it here as a proper property.

Also, minor fix on some internal property that couldn't be pickled correctly.