### PR TITLE
PUBDEV-7212 - Rank vectors of Spearman correlation might have differe…

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/SpearmanCorrelation.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/SpearmanCorrelation.java
@@ -218,8 +218,8 @@ public class SpearmanCorrelation {
     orderYWriter.close();
 
     // Ensure chunk layout is the same by adding the vectors into a new Frame.
-    final Frame sameChunkLayoutFrame = new Frame();
-    sameChunkLayoutFrame.add(new String[]{"X", "Y"}, new Vec[]{orderX, orderY});
+    final Frame sameChunkLayoutFrame = new Frame(new String[]{"X"}, new Vec[]{orderX});
+    sameChunkLayoutFrame.add("Y", orderY);
 
     // Return the vectors with ranks - the ones with same chunk layout from inside the frame
     return new SpearmanRankedVectors(sameChunkLayoutFrame.vec("X"), sameChunkLayoutFrame.vec("Y"));

--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/SpearmanCorrelation.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/SpearmanCorrelation.java
@@ -217,7 +217,12 @@ public class SpearmanCorrelation {
     orderXWriter.close();
     orderYWriter.close();
 
-    return new SpearmanRankedVectors(orderX, orderY);
+    // Ensure chunk layout is the same by adding the vectors into a new Frame.
+    final Frame sameChunkLayoutFrame = new Frame();
+    sameChunkLayoutFrame.add(new String[]{"X", "Y"}, new Vec[]{orderX, orderY});
+
+    // Return the vectors with ranks - the ones with same chunk layout from inside the frame
+    return new SpearmanRankedVectors(sameChunkLayoutFrame.vec("X"), sameChunkLayoutFrame.vec("Y"));
   }
 
   /**

--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/SpearmanCorrelation.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/SpearmanCorrelation.java
@@ -8,7 +8,6 @@ import water.fvec.Frame;
 import water.fvec.Vec;
 import water.rapids.Merge;
 import water.util.FrameUtils;
-import water.util.VecUtils;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -327,8 +326,8 @@ public class SpearmanCorrelation {
       throw new IllegalArgumentException("There are no vectors to calculate means from.");
     }
 
-    // Validate vectors types and length
     final long referenceVectorLength = vecs[0].length();
+
     for (int i = 0; i < vecs.length; i++) {
       if (!vecs[i].isCategorical() && !vecs[i].isNumeric()) {
         throw new IllegalArgumentException(String.format("Given vector '%s' is not numerical or categorical.",
@@ -340,22 +339,8 @@ public class SpearmanCorrelation {
       }
     }
 
-    if (VecUtils.areVectorsMutuallyCompatible(vecs)) {
-      return new MeanTask()
-              .doAll(vecs)._means;
-    } else {
-      // Vectors are not mutually compatible, calculate means one vector at a time
-      // Observations with NaNs were removed before calculation of means - there is no shortcoming but small performance penalty
-      // in calculating the means separately
-      final double[] means = new double[vecs.length];
-      for (int vecIndex = 0; vecIndex < vecs.length; vecIndex++) {
-        final double mean = new MeanTask()
-                .doAll(vecs[vecIndex])._means[0];
-        means[vecIndex] = mean;
-      }
-
-      return means;
-    }
+    return new MeanTask()
+            .doAll(vecs)._means;
   }
 
   /**

--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -827,4 +827,23 @@ public class VecUtils {
     }
   }
 
+  /**
+   * Checks whether all the gives vectors are mutually compatible.
+   *
+   * @param vectors An array of {@link Vec} to test
+   * @return False if at least one of the vectors is not compatible with any of the other vectors. Otherwise true.
+   */
+  public static boolean areVectorsMutuallyCompatible(Vec... vectors) {
+
+    for (int i = 0; i < vectors.length; i++) {
+      // Start at i + 1, as previous combinations were already compared and vec always is compatible with itself.
+      for (int j = i + 1; j < vectors.length; j++) {
+        boolean areVectorsCompatible = vectors[i].isCompatibleWith(vectors[j]);
+        if (!areVectorsCompatible) return false;
+      }
+    }
+
+    return true;
+  }
+
 }

--- a/h2o-core/src/main/java/water/util/VecUtils.java
+++ b/h2o-core/src/main/java/water/util/VecUtils.java
@@ -827,23 +827,4 @@ public class VecUtils {
     }
   }
 
-  /**
-   * Checks whether all the gives vectors are mutually compatible.
-   *
-   * @param vectors An array of {@link Vec} to test
-   * @return False if at least one of the vectors is not compatible with any of the other vectors. Otherwise true.
-   */
-  public static boolean areVectorsMutuallyCompatible(Vec... vectors) {
-
-    for (int i = 0; i < vectors.length; i++) {
-      // Start at i + 1, as previous combinations were already compared and vec always is compatible with itself.
-      for (int j = i + 1; j < vectors.length; j++) {
-        boolean areVectorsCompatible = vectors[i].isCompatibleWith(vectors[j]);
-        if (!areVectorsCompatible) return false;
-      }
-    }
-
-    return true;
-  }
-
 }


### PR DESCRIPTION
…nt chunk layout

https://0xdata.atlassian.net/browse/PUBDEV-7212

The crucial stacktrace is 

```
java.lang.IllegalArgumentException
 [1] "java.lang.IllegalArgumentException: Vec C2 is not compatible with the rest of the frame"                     
 [2] "    water.fvec.Frame.checkCompatibility(Frame.java:273)"                                                     
 [3] "    water.fvec.Frame.<init>(Frame.java:180)"                                                                 
 [4] "    water.fvec.Frame.<init>(Frame.java:138)"                                                                 
 [5] "    water.fvec.Frame.<init>(Frame.java:133)"                                                                 
 [6] "    water.MRTask.doAll(MRTask.java:378)"                                                                     
 [7] "    water.MRTask.doAll(MRTask.java:377)"                                                                     
 [8] "    water.rapids.ast.prims.advmath.SpearmanCorrelation.calculateMeans(SpearmanCorrelation.java:343)"         
 [9] "    water.rapids.ast.prims.advmath.SpearmanCorrelation.calculate(SpearmanCorrelation.java:45)"               
[10] "    water.rapids.ast.prims.advmath.AstCorrelation.spearman(AstCorrelation.java:85)"                          
[11] "    water.rapids.ast.prims.advmath.AstCorrelation.apply(AstCorrelation.java:71)"                             
```

## Cause

When two different frames (different vecs with different keys) are parsed and then sent to `AstCor` for Spearman's Rho calculation, the vectors might have different chunk layout. This is not an issue until the columns with ranks are created. Those effectively copy the chunk layout of their predecessors - which is wanted (might be e.g. categorical - no need to caulcuate ranks for categoricals). However, such vectors are incompatible when `Frame.isCompatible` method is invoked before the beginning of `MeanTask`, which is an MRTask originally invoked in the following way:

```
      return new MeanTask()
              .doAll(vecs)._means;
```
The vectors passed as an argument to `doAll(vecs)` method are checked for compatibility. Otherwise, it would be hard to iterate over them in `map` phase.

## Solution

One solution is to make the vectors compatible. Which, in the worst case, might end up by effectively duplicating the data.

A better solution is to check vector compatibility. If vectors are compatible, then the means are calculated in one MRTask named `MeanTask`. If not, then the `MeanTask` is executed exactly twice instead of once, as there are always two columns with ranks compared.

To introduce a general vector compatibility check with decent O(n), I've created `public static boolean areVectorsMutuallyCompatible(Vec... vectors) ` in `VecUtils`. This check is then used in `SpearmanCorrelation.calculateMeans` method.
 