### PR TITLE
PUBDEV-6745 - H2O Frame does not escape double quotes for CSV format

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1646,16 +1646,12 @@ public class Frame extends Lockable<Frame> {
         if (!_curChks[i].isNA(_chkRow)) {
           if (v.isCategorical()) {
             final String escapedString = escapeQuotesForCsv(v.factor(_curChks[i].at8(_chkRow)));
-            sb.append('"')
-                    .append(escapedString)
-                    .append('"');
+            sb.append('"').append(escapedString).append('"');
           } else if (v.isUUID()) sb.append(PrettyPrint.UUID(_curChks[i].at16l(_chkRow), _curChks[i].at16h(_chkRow)));
           else if (v.isInt()) sb.append(_curChks[i].at8(_chkRow));
           else if (v.isString()) {
             final String escapedString = escapeQuotesForCsv(_curChks[i].atStr(tmpStr, _chkRow).toString());
-            sb.append('"')
-                    .append(escapedString)
-                    .append('"');
+            sb.append('"').append(escapedString).append('"');
           } else {
             double d = _curChks[i].atd(_chkRow);
             // R 3.1 unfortunately changed the behavior of read.csv().
@@ -1676,7 +1672,7 @@ public class Frame extends Lockable<Frame> {
       return StringUtils.bytesOf(sb);
     }
 
-    static final Pattern doubleQuotePattern = Pattern.compile("\"{1}");
+    static final Pattern doubleQuotePattern = Pattern.compile("\"");
     /**
      * Escapes  double-quotes (ASCII 34) in a String.
      *

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1659,6 +1659,9 @@ public class Frame extends Lockable<Frame> {
 
         if (escapingRequired) {
           localEscapedCategoricalVecDomains[i] = escapedDomain;
+        } else {
+          // If the domain does not need escaping, simply link to the original domain and drop the escaped array
+          localEscapedCategoricalVecDomains[i] = originalDomain;
         }
       }
 
@@ -1680,7 +1683,7 @@ public class Frame extends Lockable<Frame> {
         if (i > 0) sb.append(_parms._separator);
         if (!_curChks[i].isNA(_chkRow)) {
           if (v.isCategorical()) {
-            final String escapedString = getEscapedCategoricalLevel(i, (int) _curChks[i].at8(_chkRow), v);
+            final String escapedString = _escapedCategoricalVecDomains[i][(int) _curChks[i].at8(_chkRow)];
             sb.append('"').append(escapedString).append('"');
           } else if (v.isUUID()) sb.append(PrettyPrint.UUID(_curChks[i].at16l(_chkRow), _curChks[i].at16h(_chkRow)));
           else if (v.isInt()) sb.append(_curChks[i].at8(_chkRow));
@@ -1705,25 +1708,6 @@ public class Frame extends Lockable<Frame> {
       }
       sb.append('\n');
       return StringUtils.bytesOf(sb);
-    }
-
-    /**
-     * Returns a factor escaped for CSV format, if required.
-     *
-     * @param vectorId              Id of the categorical vector
-     * @param categoricalLevelIndex Index of the categorical level in the original domain
-     * @param vec                   Vector with it's domain
-     * @return A {@link String} representation of the categorical level, with double-quotes escaped for CSV.
-     */
-    private String getEscapedCategoricalLevel(final int vectorId, final int categoricalLevelIndex, final Vec vec) {
-      final String[] escapedDomain = _escapedCategoricalVecDomains[vectorId];
-
-      if (escapedDomain == null) {
-        return vec.factor(categoricalLevelIndex);
-      } else {
-        return escapedDomain[categoricalLevelIndex];
-      }
-
     }
 
     private static final Pattern DOUBLE_QUOTE_PATTERN = Pattern.compile("\"");

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1597,7 +1597,7 @@ public class Frame extends Lockable<Frame> {
     Chunk[] _curChks;
     int _lastChkIdx;
     public volatile int _curChkIdx; // used only for progress reporting
-    private transient final String[][] escapedCategoricalVecDomains;
+    private transient final String[][] _escapedCategoricalVecDomains;
 
     public CSVStream(Frame fr, CSVStreamParams parms) {
       this(firstChunks(fr), parms._headers ? fr.names() : null, fr.anyVec().nChunks(), parms);
@@ -1629,7 +1629,7 @@ public class Frame extends Lockable<Frame> {
       _line = StringUtils.bytesOf(sb);
       _chkRow = -1; // first process the header line
       _curChks = chks;
-      escapedCategoricalVecDomains = escapeCategoricalVecDomains(_curChks);
+      _escapedCategoricalVecDomains = escapeCategoricalVecDomains(_curChks);
     }
 
     /**
@@ -1718,7 +1718,7 @@ public class Frame extends Lockable<Frame> {
      * @return A {@link String} representation of the categorical level, with double-quotes escaped for CSV.
      */
     private String getEscapedCategoricalLevel(final int vectorId, final int categoricalLevelIndex, final Vec vec) {
-      final String[] escapedDomain = escapedCategoricalVecDomains[vectorId];
+      final String[] escapedDomain = _escapedCategoricalVecDomains[vectorId];
 
       if (escapedDomain == null) {
         return vec.factor(categoricalLevelIndex);

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1642,6 +1642,7 @@ public class Frame extends Lockable<Frame> {
      * @return A 2D array of String[][]. Elements can be null of give domain does not need escaping.
      */
     private String[][] escapeCategoricalVecDomains(final Chunk[] chunks) {
+      if(chunks == null) return null;
       final String[][] localEscapedCategoricalVecDomains = new String[chunks.length][];
 
       for (int i = 0; i < chunks.length; i++) {

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1659,8 +1659,6 @@ public class Frame extends Lockable<Frame> {
 
         if (escapingRequired) {
           localEscapedCategoricalVecDomains[i] = escapedDomain;
-        } else {
-          localEscapedCategoricalVecDomains[i] = null;
         }
       }
 

--- a/h2o-r/tests/testdir_misc/runit_as.frame.R
+++ b/h2o-r/tests/testdir_misc/runit_as.frame.R
@@ -23,6 +23,30 @@ test <- function() {
     print(sprintf("nrow(Nhex): %d", nrow(Nhex)))
     print(sprintf("nrow(x): %d", nrow(x)))
 	expect_that(nrow(Nhex), equals(nrow(x)))
+	
+	# Quote writing
+	original <- data.frame(
+	  ngram = c(
+	    "SIRET:417 653 698",
+	    "SIRET:417 653 698 00031",
+	    "Sans",
+	    "Sans esc.",
+	    "Sans esc. jusqu\"\"au", # Two quotes in line
+	    "Sans esc. jusqu\"au 15.11.2018"
+	  )
+	)
+	print("Original data")
+	print(original)
+	
+	h2o_fr <- as.h2o(original)
+	print("H2O Frame")
+	print(h2o_fr)
+	
+	as_df <- as.data.frame(h2o_fr)
+	print("As data frame:")
+	print(as_df)
+	
+	expect_true(all(as_df == original))
       
     
 }


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-6745
## Problem
H2O Frame, when serialized into CSV, does not escape double quotes. We only use double quotes to enclose the characters, therefore single quotes do not need to be escaped.

In CSV - all quotes not enclosing a token should be escaped by putting another quote in front of it.

## Solution

Make `Frame.CSVStream` class escape double quotes. :smile:

Introduced `static final Pattern doubleQuotePattern = Pattern.compile("\"{1}");` to compile the pattern only once. Then, all potential Strings are sent to `escapeQuotesForCsv` method that will escape the double quotes using a `Matcher` obtained from the `Pattern`.