### PR TITLE
[PUBDEV-6502] fix XGBoost multinode issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ doUploadUBenchResults=false
 #
 # Internal Nexus location
 #
-localNexusLocation=http://nexus:8081/nexus/repository
+localNexusLocation=http://nexus.0xdata.loc:8081/nexus/repository
 
 #
 # Public Nexus location

--- a/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
@@ -22,8 +22,7 @@ public enum Algo {
     boolean enabled() {
       // on single node, XGBoost is enabled by default if the extension is enabled.
       // on multinode, the same condition applies, but only on Linux by default: needs to be activated explicitly for other platforms.
-      // 2019-12-12: temporarily disabled on Linux multinode until XGBoost issue is fixed.
-      boolean enabledOnMultinode = Boolean.parseBoolean(System.getProperty(DISTRIBUTED_XGBOOST_ENABLED, isLinux() ? "false" : "false"));
+      boolean enabledOnMultinode = Boolean.parseBoolean(System.getProperty(DISTRIBUTED_XGBOOST_ENABLED, isLinux() ? "true" : "false"));
       return ExtensionManager.getInstance().isCoreExtensionEnabled(this.name()) && (H2O.CLOUD.size() == 1 || enabledOnMultinode);
     }
   },

--- a/h2o-core/src/main/java/water/H2ONode.java
+++ b/h2o-core/src/main/java/water/H2ONode.java
@@ -164,6 +164,10 @@ public final class H2ONode extends Iced<H2ONode> implements Comparable {
     static int SIZE = SIZE_OF_IP /* ip */ + 2 /* port */;
   }
 
+  public String getIp() {
+    return _key.getHostString();
+  }
+
   public String getIpPortString() {
     return _key.getIpPortString();
   }

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -23,9 +23,8 @@ import water.util.Log;
 import water.util.SBPrintStream;
 
 import java.io.*;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Stream;
 
 import static hex.genmodel.algos.xgboost.XGBoostMojoModel.ObjectiveType;
 import static hex.tree.xgboost.XGBoost.makeDataInfo;
@@ -33,6 +32,9 @@ import static water.H2O.OptArgs.SYSTEM_PROP_PREFIX;
 
 public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParameters, XGBoostOutput> 
         implements SharedTreeGraphConverter, Model.LeafNodeAssignment, Model.Contributions {
+
+  private static final String PROP_VERBOSITY = H2O.OptArgs.SYSTEM_PROP_PREFIX + ".xgboost.verbosity";
+  private static final String PROP_NTHREAD = SYSTEM_PROP_PREFIX + "xgboost.nthread";
 
   private XGBoostModelInfo model_info;
 
@@ -279,7 +281,11 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
       params.put("eta", p._learn_rate);
     }
     params.put("max_depth", p._max_depth);
-    params.put("silent", p._quiet_mode);
+    if (System.getProperty(PROP_VERBOSITY) != null) {
+      params.put("verbosity", System.getProperty(PROP_VERBOSITY));
+    } else {
+      params.put("silent", p._quiet_mode);
+    }
     if (p._subsample!=1.0) {
       Log.info("Using user-provided parameter subsample instead of sample_rate.");
       params.put("subsample", p._subsample);
@@ -394,7 +400,7 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
     final int nthread = p._nthread != -1 ? Math.min(p._nthread, nthreadMax) : nthreadMax;
     if (nthread < p._nthread) {
       Log.warn("Requested nthread=" + p._nthread + " but the cluster has only " + nthreadMax + " available." +
-              "Training will use nthread=" + nthreadMax + " instead of the user specified value.");
+              "Training will use nthread=" + nthread + " instead of the user specified value.");
     }
     params.put("nthread", nthread);
 
@@ -440,7 +446,23 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
   }
   
   private static int getMaxNThread() {
-    return Integer.getInteger(SYSTEM_PROP_PREFIX + "xgboost.nthread", H2O.ARGS.nthreads);
+    if (System.getProperty(PROP_NTHREAD) != null) {
+      return Integer.getInteger(System.getProperty(PROP_NTHREAD));
+    } else {
+      int maxNodesPerHost = 1;
+      Set<String> checkedNodes = new HashSet<>();
+      for (H2ONode node : H2O.CLOUD.members()) {
+        String nodeHost = node.getIp();
+        if (!checkedNodes.contains(nodeHost)) {
+          checkedNodes.add(nodeHost);
+          long cnt = Stream.of(H2O.CLOUD.members()).filter(h -> h.getIp().equals(nodeHost)).count();
+          if (cnt > maxNodesPerHost) {
+            maxNodesPerHost = (int) cnt;
+          }
+        }
+      }
+      return Math.max(1, H2O.ARGS.nthreads / maxNodesPerHost);
+    }
   }
 
   @Override protected AutoBuffer writeAll_impl(AutoBuffer ab) {

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/RabitTrackerH2O.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/rabit/RabitTrackerH2O.java
@@ -213,6 +213,7 @@ public class RabitTrackerH2O implements IRabitTracker {
                 this.trackerThread.join(timeout);
             } catch (InterruptedException e) {
                 Log.debug("Rabit tracker thread got suddenly interrupted.", e);
+                Thread.currentThread().interrupt();
             }
         }
         return 0;
@@ -220,6 +221,8 @@ public class RabitTrackerH2O implements IRabitTracker {
 
     @Override
     public void uncaughtException(Thread t, Throwable e) {
+        Log.err("Uncaught exception occurred on Rabit tracker thread " + t.getName(), e);
+        Log.err(e);
         stop();
     }
 }

--- a/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
+++ b/h2o-extensions/xgboost/src/main/java/ml/dmlc/xgboost4j/java/XGBoostUpdater.java
@@ -63,6 +63,7 @@ public class XGBoostUpdater extends Thread {
       } else {
         Log.debug("Updater thread interrupted.", e);
       }
+      Thread.currentThread().interrupt();
     } catch (XGBoostError e) {
       Log.err("XGBoost training iteration failed");
       Log.err(e);
@@ -162,10 +163,6 @@ public class XGBoostUpdater extends Thread {
     public String toString() {
       return "SerializeBooster";
     }
-  }
-
-  Booster getBooster() {
-    return _booster;
   }
 
   byte[] getBoosterBytes() {


### PR DESCRIPTION
- auto-limit the number of CPU used when running multiple H2O nodes on one machine
- fix cleanup issues when XGBoost training job is canceled
- enable multi-node xgboost back for AutoML
- some minor code improvements