### PR TITLE
PUBDEV-7223: Add an option to specify JDBC URL to get Delegation Token

### DIFF
--- a/h2o-mapreduce-generic/src/main/java/water/hadoop/HiveTokenGenerator.java
+++ b/h2o-mapreduce-generic/src/main/java/water/hadoop/HiveTokenGenerator.java
@@ -1,7 +1,6 @@
 package water.hadoop;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.security.token.delegation.DelegationTokenIdentifier;
@@ -24,60 +23,75 @@ public class HiveTokenGenerator {
 
   public static class HiveOptions {
     
-    final String _host;
+    final String _jdbcUrl;
     final String _principal;
 
-    public HiveOptions(String hiveHost, String hivePrincipal) {
-      _host = hiveHost;
+    public HiveOptions(String hiveJdbcUrl, String hivePrincipal) {
+      _jdbcUrl = hiveJdbcUrl;
       _principal = hivePrincipal;
     }
 
-    private static boolean isPresent(String value) {
-      return value != null && !value.isEmpty();
-    }
-    
-    public static HiveOptions make(String hiveHost, String hivePrincipal) {
-      if (isPresent(hiveHost) && isPresent(hivePrincipal)) {
-        return new HiveOptions(hiveHost, hivePrincipal);
+    public static HiveOptions make(String hiveJdbcUrl, String hivePrincipal) {
+      if (isPresent(hiveJdbcUrl) && isPresent(hivePrincipal)) {
+        return new HiveOptions(hiveJdbcUrl, hivePrincipal);
       } else {
         return null;
       }
     }
     
     public static HiveOptions make(Configuration conf) {
-      String hiveHost = conf.get(H2O_HIVE_HOST);
+      String hiveJdbcUrl = conf.get(H2O_HIVE_JDBC_URL);
       String hivePrincipal = conf.get(H2O_HIVE_PRINCIPAL);
-      return make(hiveHost, hivePrincipal);
+      return make(hiveJdbcUrl, hivePrincipal);
     }
     
   }
+
+  private static boolean isPresent(String value) {
+    return value != null && !value.isEmpty();
+  }
+
+  static String makeHiveJdbcUrl(String hiveJdbcUrlPattern, String hiveHost, String hivePrincipal) {
+    if (hiveJdbcUrlPattern != null) {
+      String result = hiveJdbcUrlPattern;
+      if (hiveHost != null)
+        result = result.replace("{{host}}", hiveHost);
+      if (hivePrincipal != null)
+        result = result.replace("{{principal}}", hivePrincipal);
+      return result;
+    } else if (isPresent(hiveHost) && isPresent(hivePrincipal)) {
+      return "jdbc:hive2://" + hiveHost + "/" + ";principal=" + hivePrincipal;
+    } else
+      return null;
+  }
   
   public static void addHiveDelegationTokenIfHivePresent(
-      Job job, String hiveHost, String hivePrincipal
+      Job job, String hiveJdbcUrlPattern, String hiveHost, String hivePrincipal
   ) throws IOException, InterruptedException {
+    final String hiveJdbcUrl = makeHiveJdbcUrl(hiveJdbcUrlPattern, hiveHost, hivePrincipal); 
     if (isHiveDriverPresent()) {
-      new HiveTokenGenerator().addHiveDelegationToken(job, hiveHost, hivePrincipal);
+      new HiveTokenGenerator().addHiveDelegationToken(job, hiveJdbcUrl, hivePrincipal);
     } else {
       log("Hive driver not present, not generating token.", null);
       Configuration conf = job.getConfiguration();
       // pass configured values if any to mapper
-      if (hiveHost != null) conf.set(H2O_HIVE_HOST, hiveHost);
+      if (hiveJdbcUrl != null) conf.set(H2O_HIVE_JDBC_URL, hiveJdbcUrl);
       if (hivePrincipal != null) conf.set(H2O_HIVE_PRINCIPAL, hivePrincipal);
     }
   }
 
   public void addHiveDelegationToken(
       Job job,
-      String hiveHost,
+      String hiveJdbcUrl,
       String hivePrincipal
   ) throws IOException, InterruptedException {
-    HiveOptions options = HiveOptions.make(hiveHost, hivePrincipal);
+    HiveOptions options = HiveOptions.make(hiveJdbcUrl, hivePrincipal);
     if (options == null) {
-      log("Hive host or principal not set, no token generated.", null);
+      log("Hive JDBC URL or principal not set, no token generated.", null);
       return;
     }
     Configuration conf = job.getConfiguration();
-    conf.set(H2O_HIVE_HOST, options._host);
+    conf.set(H2O_HIVE_JDBC_URL, options._jdbcUrl);
     conf.set(H2O_HIVE_PRINCIPAL, options._principal);
     UserGroupInformation realUser = UserGroupInformation.getCurrentUser();
     if (realUser.getRealUser() != null) {
@@ -110,7 +124,7 @@ public class HiveTokenGenerator {
   }
 
   private String getDelegationTokenFromConnection(String url, String principal, String userName) {
-    try (Connection connection = DriverManager.getConnection(url + ";principal=" + principal)) {
+    try (Connection connection = DriverManager.getConnection(url)) {
       return ((HiveConnection) connection).getDelegationToken(userName, principal);
     } catch (SQLException e) {
       log("Failed to get connection.", e);
@@ -124,10 +138,9 @@ public class HiveTokenGenerator {
     }
 
     String currentUser = UserGroupInformation.getCurrentUser().getShortUserName();
-    String hiveJdbcUrl = "jdbc:hive2://" + options._host + "/";
-    log("Getting delegation token from " + hiveJdbcUrl + " with " + options._principal + ", " + currentUser, null);
+    log("Getting delegation token from " + options._jdbcUrl + ", " + currentUser, null);
 
-    String tokenStr = getDelegationTokenFromConnection(hiveJdbcUrl, options._principal, currentUser);
+    String tokenStr = getDelegationTokenFromConnection(options._jdbcUrl, options._principal, currentUser);
     if (tokenStr != null) {
       Token<DelegationTokenIdentifier> hive2Token = new Token<>();
       hive2Token.decodeFromUrlString(tokenStr);

--- a/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -149,6 +149,7 @@ public class h2odriver extends Configured implements Tool {
   static String keytabPath = null;
   static boolean reportHostname = false;
   static boolean driverDebug = false;
+  static String hiveJdbcUrlPattern = null; 
   static String hiveHost = null;
   static String hivePrincipal = null;
   static boolean refreshTokens = false;
@@ -1324,6 +1325,9 @@ public class h2odriver extends Configured implements Tool {
         reportHostname = true;
       } else if (s.equals("-driver_debug")) {
         driverDebug = true;
+      } else if (s.equals("-hiveJdbcUrlPattern")) {
+        i++; if (i >= args.length) { usage (); }
+        hiveJdbcUrlPattern = args[i];
       } else if (s.equals("-hiveHost")) {
         i++; if (i >= args.length) { usage (); }
         hiveHost = args[i];
@@ -2129,7 +2133,7 @@ public class h2odriver extends Configured implements Tool {
     j.setOutputKeyClass(Text.class);
     j.setOutputValueClass(Text.class);
 
-    HiveTokenGenerator.addHiveDelegationTokenIfHivePresent(j, hiveHost, hivePrincipal);
+    HiveTokenGenerator.addHiveDelegationTokenIfHivePresent(j, hiveJdbcUrlPattern, hiveHost, hivePrincipal);
     if (refreshTokens && principal != null && keytabPath != null) {
       j.getConfiguration().set(H2O_AUTH_PRINCIPAL, principal);
       byte[] payloadData = readBinaryFile(keytabPath);

--- a/h2o-mapreduce-generic/src/main/java/water/hadoop/h2omapper.java
+++ b/h2o-mapreduce-generic/src/main/java/water/hadoop/h2omapper.java
@@ -35,7 +35,7 @@ public class h2omapper extends Mapper<Text, Text, Text, Text> {
 
   public static final String H2O_AUTH_PRINCIPAL = "h2o.auth.principal";
   public static final String H2O_AUTH_KEYTAB = "h2o.auth.keytab";
-  public static final String H2O_HIVE_HOST = "h2o.hive.host";
+  public static final String H2O_HIVE_JDBC_URL = "h2o.hive.jdbc.url";
   public static final String H2O_HIVE_PRINCIPAL = "h2o.hive.principal";
   
   public static final String H2O_IP_ENVVAR = "h2o.ip.envvar";

--- a/h2o-mapreduce-generic/src/test/java/water/hadoop/HiveTokenGeneratorTest.java
+++ b/h2o-mapreduce-generic/src/test/java/water/hadoop/HiveTokenGeneratorTest.java
@@ -1,0 +1,24 @@
+package water.hadoop;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HiveTokenGeneratorTest {
+
+  @Test
+  public void makeHiveJdbcUrl() {
+    assertNull(HiveTokenGenerator.makeHiveJdbcUrl(null, null, null));
+    assertEquals(
+            "jdbc:hive2://host:42/;principal=principal",
+            HiveTokenGenerator.makeHiveJdbcUrl(null, "host:42", "principal"));
+    assertEquals(
+            "jdbc:hive2://hostname:10000/core;ssl=true;sslTrustStore=/path/to/file.jks;principal=hive/HOST@DOMAIN",
+            HiveTokenGenerator.makeHiveJdbcUrl("jdbc:hive2://{{host}}/core;ssl=true;sslTrustStore=/path/to/file.jks;principal={{principal}}", "hostname:10000", "hive/HOST@DOMAIN"));
+    assertEquals(
+            "jdbc:hive2://hostname:10000/core;ssl=true;sslTrustStore=/path/to/file.jks;principal=hive/HOST@DOMAIN",
+            HiveTokenGenerator.makeHiveJdbcUrl("jdbc:hive2://hostname:10000/core;ssl=true;sslTrustStore=/path/to/file.jks;principal={{principal}}", null, "hive/HOST@DOMAIN"));
+    assertEquals("anything", HiveTokenGenerator.makeHiveJdbcUrl("anything", null, null));
+  }
+
+}


### PR DESCRIPTION
User can now specify custom JDBC URL to retrieve Hive Delegation token, eg.:

    h2odriver ... -hiveJdbcUrlPattern "jdbc:hive2://hostname:10000/core;ssl=true;sslTrustStore=/path/to/file.jks;principal={{principal}}" -hivePrincipal "hive/HOST@DOMAIN"

`hiveJdbcUrlPattern` is a pattern where parts {{host}} and {{principal}} can be substituted with values given in parameter `-hiveHost` and `-hivePrincipal`

This substitution is optional, a full URL can be given as well:

    h2odriver ... -hiveJdbcUrlPattern "jdbc:hive2://hostname:10000/core;ssl=true;sslTrustStore=/path/to/file.jks;principal=hive/HOST@DOMAIN" -hivePrincipal "hive/HOST@DOMAIN"

`hivePrincipal` needs to be present on the command line (it is used not just to generate the URL).