### PR TITLE
PUBDEV-7186: fix rbind bug to allow it on all numerical types

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2633,8 +2633,16 @@ class H2OFrame(Keyed):
             if frame.ncol != self.ncol:
                 raise H2OValueError("Cannot row-bind a dataframe with %d columns to a data frame with %d columns: "
                                     "the columns must match" % (frame.ncol, self.ncol))
-            if frame.columns != self.columns or frame.types != self.types:
-                raise H2OValueError("Column names and types must match for rbind() to work")
+            if frame.columns != self.columns:
+                raise H2OValueError("Column names must match for rbind() to work")
+            if frame.types != self.types: # compare the whole list here
+                validTypes = [u'float', u'real', u'double', u'int', u'long', u'numeric']
+                for eachKey in frame.types.keys(): 
+                    sametypes = frame.types[eachKey]==self.types[eachKey]
+                    bothNumericTypes = (frame.types[eachKey] in validTypes) and (self.types[eachKey] in validTypes)
+                    if not(sametypes) and not(bothNumericTypes):
+                        raise H2OValueError("Column types must match for rbind() to work.  First column type {0}.  "
+                                            "Second column type {1})".format(self.types[eachKey], frame.types[eachKey]))
         fr = H2OFrame._expr(expr=ExprNode("rbind", self, *frames), cache=self._ex._cache)
         fr._ex._cache.nrows = self.nrow + sum(frame.nrow for frame in frames)
         return fr

--- a/h2o-py/tests/testdir_munging/pyunit_pubdev_7186_rbind_summary.py
+++ b/h2o-py/tests/testdir_munging/pyunit_pubdev_7186_rbind_summary.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# -*- encoding: utf-8 -*-
+import h2o
+import math
+from h2o.exceptions import H2OTypeError, H2OValueError
+from tests import pyunit_utils
+
+
+def test_rbind_summary():
+    h2o.remove_all()
+    df = h2o.H2OFrame([1, 2, 5.5], destination_frame="df") # original frame
+    dfr = h2o.H2OFrame([5.5, 1, 2], destination_frame="dfr") # reversed row content
+    df1 = df[2, :]
+    df2 = df[:2, :]
+    summary = df1.summary(return_data=True)
+    df3 = df1.rbind(df2) # fixed
+    df3r = df2.rbind(df1)
+
+    compareFramesLocal(dfr, df3) # should contain 5.5, 1, 2
+    compareFramesLocal(df, df3r) # should contain 1,2,5.5
+    
+    df1 = df[3,:] # this will result in an NA since we do not have 4 rows in df.
+    dfr[0,0] = float('nan')
+    df4 = df1.rbind(df2)
+    compareFramesLocal(df4, dfr) # should contain NA, 1, 2
+
+# performing the same test with an additionl categorical column per Michalk request.
+    h2o.remove_all()
+    df = h2o.H2OFrame([[1,"a"],[2,"b"],[5.5,"c"]],destination_frame="dfc") # original frame
+    df[1]=df[1].asfactor()
+    dfr = h2o.H2OFrame([[5.5,"c"], [1,"a"], [2,"b"]],destination_frame="dfrc") # reversed row content
+    dfr[1] = df[1].asfactor() # this somehow switch the row content of the factor column to be alphabetical
+    dfr[0,1]='c'
+    dfr[1,1]='a'
+    dfr[2,1]='b'
+    df1 = df[2, :]
+    df2 = df[:2, :]
+    summary = df1.summary(return_data=True)
+    df3 = df1.rbind(df2) # fixed
+    df3r = df2.rbind(df1)
+    compareFramesLocal(dfr, df3) # should contain 5.5, 1, 2
+    compareFramesLocal(df, df3r) # should contain 1,2,5.5
+    
+    # copying test from Michalk
+    df1 = h2o.H2OFrame([[1,"a"],[2,"b"]])
+    df1[1]=df1[1].asfactor()
+
+    df2 = h2o.H2OFrame([[2.2,"b"],[1.1,"a"]])
+    df2[1]=df2[1].asfactor()
+
+    print(df1.summary())
+    print(df2.summary())
+
+    df3 = df1.rbind(df2)
+    assert df3.nrow==(df1.nrow+df2.nrow), "Expected rbind rows: {0}, actual rows: " \
+                                          "{1}".format(df1.nrow+df2.nrow, df3.nrow)   
+ 
+# I am having problems with as_data_frame.  Hence using my own function here
+def compareFramesLocal(f1, f2):
+    ncol = f1.ncol
+    nrow = f1.nrow
+    
+    for cind in range(ncol):
+        f1[cind] = f1[cind].asnumeric()
+        f2[cind] = f2[cind].asnumeric()       
+        for rind in range(nrow):
+            temp1 = f1[rind, cind]
+            temp2 = f2[rind, cind]
+            if not(math.isnan(temp1) and math.isnan(temp2)):
+                assert temp1 == temp2, "Frame contents are row {0}, col {1} are different.  Frame 1: {2}.  Frame 2:" \
+                                       " {3}".format(rind, cind, f1[rind, cind], f2[rind, cind])
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_rbind_summary)
+else:
+    test_rbind_summary()

--- a/h2o-py/tests/testdir_munging/pyunit_rbind.py
+++ b/h2o-py/tests/testdir_munging/pyunit_rbind.py
@@ -30,12 +30,10 @@ def rbind_check():
     except H2OValueError:
         pass
 
-    try:
-        frame6 = h2o.H2OFrame({"a": [1.1, 1.2, 1.3]})
-        frame4.rbind(frame6)
-        assert False, "Expected the rbind of vecs of different types to fail"
-    except H2OValueError:
-        pass
+    frame6 = h2o.H2OFrame({"a": [1.1, 1.2, 1.3]})
+    frameNew = frame4.rbind(frame6)
+    assert frameNew.nrow==(frame6.nrow+frame4.nrow), "Expected number of row: {0}, Actual number of row: " \
+                                      "{1}".format((frame6.nrow+frame4.nrow), frameNew.nrow)
 
     try:
         frame7 = h2o.H2OFrame({"b": [1, 2, 3, 4, 5]})


### PR DESCRIPTION
This PR fixes the bug in https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7186?filter=myopenissues&orderby=priority%20DESC.

The user has made incorrect call to rbind.  Remember rbind will generate a new frame.  If you do not call it with a frame = frame1.rbind(frame2), you will lose the reference to frame.  I added this comment to the JIRA.

I made the following changes:
1. allow rbind for columns that are numerical, they don't have to match int to int.  Allow rbind of a int and real columns.
2. Added pyunit test to ensure my fix works.