### PR TITLE
Updates for newer version of Sphinx and new extension

### DIFF
--- a/h2o-py/test-requirements.txt
+++ b/h2o-py/test-requirements.txt
@@ -22,11 +22,11 @@ scikit-learn==0.19.1
 six==1.11.0
 seaborn==0.8.1
 matplotlib==2.1.1
-sphinx==1.6.6
+sphinx==2.3.1
 numpydoc==0.7.0
 mysqlclient==1.3.12
 recommonmark==0.4.0
 sphinx_rtd_theme==0.2.4
-git+https://github.com/svx/sphinxcontrib-osexample@1cc4afcc6089083256aa642d9faa12352ef45d68#egg=sphinxcontrib-osexample
+sphinx_tabs==1.1.12
 shap==0.28.3
 boto3>=1.7.50


### PR DESCRIPTION
- Upgraded the version of sphinx to 2.3.1
- Removed deprecated osexample extension
- Added sphinx_tab extension version 1.1.12 (more info here: https://github.com/djungelorm/sphinx-tabs)