### PR TITLE
PUBDEV-6917 Introduce HDP 3.2 H2O driver to support Azure Data Lake S…

### DIFF
--- a/docker/hadoop/hdp/scripts/sbin/add_hdp_repo.sh
+++ b/docker/hadoop/hdp/scripts/sbin/add_hdp_repo.sh
@@ -15,6 +15,11 @@ function print_green {
 }
 
 case "${1}" in
+  3.2)
+    major_version="3"
+    hdp_version="3.2.0.0"
+    ubuntu_repo_version="14"
+    ;;
   3.1)
     major_version="3"
     hdp_version="3.1.0.0"

--- a/h2o-dist/buildinfo.json
+++ b/h2o-dist/buildinfo.json
@@ -134,6 +134,11 @@
             "zip_file_path" : "h2o-SUBST_PROJECT_VERSION-hdp3.1.zip"
         },
         {
+            "distribution" : "hdp3.2",
+            "zip_file_name" : "h2o-SUBST_PROJECT_VERSION-hdp3.2.zip",
+            "zip_file_path" : "h2o-SUBST_PROJECT_VERSION-hdp3.2.zip"
+        },
+        {
             "distribution" : "mapr4.0",
             "zip_file_name" : "h2o-SUBST_PROJECT_VERSION-mapr4.0.zip",
             "zip_file_path" : "h2o-SUBST_PROJECT_VERSION-mapr4.0.zip"

--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -441,6 +441,7 @@ Supported Versions
 -  HDP 2.6
 -  HDP 3.0
 -  HDP 3.1
+-  HDP 3.2
 -  MapR 4.0
 -  MapR 5.0
 -  MapR 5.1

--- a/h2o-hadoop-3/h2o-hdp3.2-assembly/build.gradle
+++ b/h2o-hadoop-3/h2o-hdp3.2-assembly/build.gradle
@@ -1,0 +1,15 @@
+ext {
+  hadoopVersion = 'hdp3.2'
+  hadoopMavenArtifactVersion = '3.2.1'
+  orcSupported = true
+  orcHiveExecVersion = "3.1.2"
+}
+
+apply from: '../assemblyjar.gradle'
+
+dependencies {
+  compile (project(":h2o-jetty-9")) {
+    exclude module: "servlet-api"
+    exclude group: "javax.servlet", module: "javax.servlet-api"
+  }
+}

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -10,7 +10,7 @@ set -x
 
 # Set common variables.
 TOPDIR=$(cd `dirname $0` && pwd)
-HADOOP_VERSIONS="cdh5.4 cdh5.5 cdh5.6 cdh5.7 cdh5.8 cdh5.9 cdh5.10 cdh5.13 cdh5.14 cdh5.15 cdh5.16 cdh6.0 cdh6.1 cdh6.2 cdh6.3 cdp7.0 hdp2.2 hdp2.3 hdp2.4 hdp2.5 hdp2.6 hdp3.0 hdp3.1 mapr4.0 mapr5.0 mapr5.1 mapr5.2 mapr6.0 mapr6.1 iop4.2"
+HADOOP_VERSIONS="cdh5.4 cdh5.5 cdh5.6 cdh5.7 cdh5.8 cdh5.9 cdh5.10 cdh5.13 cdh5.14 cdh5.15 cdh5.16 cdh6.0 cdh6.1 cdh6.2 cdh6.3 cdp7.0 hdp2.2 hdp2.3 hdp2.4 hdp2.5 hdp2.6 hdp3.0 hdp3.1 hdp3.2 mapr4.0 mapr5.0 mapr5.1 mapr5.2 mapr6.0 mapr6.1 iop4.2"
 
 function make_zip_common {
   PROJECT_BASE=$1

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -19,7 +19,7 @@ class BuildConfig {
   public static final String S3CMD_IMAGE = DOCKER_REGISTRY + '/opsh2oai/s3cmd'
 
   private static final String HADOOP_IMAGE_NAME_PREFIX = 'h2o-3-hadoop'
-  private static final String HADOOP_IMAGE_VERSION_TAG = '75'
+  private static final String HADOOP_IMAGE_VERSION_TAG = '76'
 
   public static final String XGB_TARGET_MINIMAL = 'minimal'
   public static final String XGB_TARGET_OMP = 'omp'

--- a/settings.gradle
+++ b/settings.gradle
@@ -87,7 +87,7 @@ if (System.getProperty("user.name").equals("jenkins")
   def allTargets = [
          "cdh5.4", "cdh5.5", "cdh5.6", "cdh5.7", "cdh5.8", "cdh5.9", "cdh5.10", "cdh5.13", "cdh5.14", "cdh5.15", "cdh5.16", 
          "cdh6.0", "cdh6.1", "cdh6.2", "cdh6.3", "cdp7.0",
-         "hdp2.2", "hdp2.3", "hdp2.4", "hdp2.5", "hdp2.6","hdp3.0","hdp3.1",
+         "hdp2.2", "hdp2.3", "hdp2.4", "hdp2.5", "hdp2.6","hdp3.0","hdp3.1", "hdp3.2",
          "mapr4.0", "mapr5.0", "mapr5.1", "mapr5.2", "mapr6.0", "mapr6.1", "iop4.2"
   ]
   // Compute targets


### PR DESCRIPTION
…torage Gen 2 (abfs:// protocol)

No code changes required in H2O itself.

https://0xdata.atlassian.net/browse/PUBDEV-6917

Works with H2O just by supplying the proper driver. Since `hadoop-azure` version `3.2.0`, there is `org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem` present. Which provides out of the box support for Azure `abfs[s]://` protocol. Previous versions support `wasb` only. However, this requires hadoop `3.2` ideally. Doesn't work with versions 2.x, as there are classes missing on the classpath.

Hint: there is a newer version `3.2.1` and this one should probably be used: https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-azure

Below is the configuration used, make sure to replace the `<storage_account_name_here>` with real storage account names. Plus fill the secret shared key. The configuration comes from: https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html

```xml
<?xml version="1.0"?>
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
<configuration>
<property>
  <name>fs.azure.account.auth.type.<storage_account_name_here>.dfs.core.windows.net</name>
  <value>SharedKey</value>
  <description>
  </description>
</property>
<property>
  <name>fs.azure.account.key.<storage_account_name_here>.dfs.core.windows.net</name>
<value>INSERT_YOUR_KEY_HERE</value>
  <description>
  The secret password. Never share these.
  </description>
</property>
<property>
    <name>fs.abfs.impl</name>
    <value>org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem</value>
</property>
<property>
    <name>fs.abfss.impl</name>
    <value>org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem</value>
</property>
</configuration>
```

As this requires `hadoop 3.2`, this PR aims to provide H2O driver support for this new Hadoop.  Maybe the driver will work with previous Hadoop versions as well, but that is not guaranteed. You might give it a try @JHerna17 

![Screenshot from 2020-01-25 10-58-52](https://user-images.githubusercontent.com/8769110/73124779-be1ad180-3f9f-11ea-96d2-46a70c45d549.png)

## Hadoop smoke pipeline
http://mr-0xc1:8080/view/H2O-3/job/h2o-3-hadoop-smoke-pipeline/job/pavel%252Fpubdev-6917/
