### PR TITLE
Fix failing S3 tests by reverting upgrade of GCS client lib to 1.19.0

### DIFF
--- a/h2o-persist-gcs/build.gradle
+++ b/h2o-persist-gcs/build.gradle
@@ -4,7 +4,7 @@ description = "H2O Persist GCS"
 
 dependencies {
     compile project(":h2o-core")
-    compile 'com.google.cloud:google-cloud-storage:1.103.0'
+    compile 'com.google.cloud:google-cloud-storage:1.19.0'
     testCompile "junit:junit:${junitVersion}"
     testCompile project(path: ":h2o-core", configuration: "testArchives")
     testRuntimeOnly project(":${defaultWebserverModule}")


### PR DESCRIPTION
http://mr-0xc1:8080/job/h2o-3-pipeline/job/PR-4242/5/testReport/junit/(root)/r_suite/Py3_5_Small___pyunit_persistence_py/

This stacktrace
```
java.lang.IllegalStateException: Socket not created by this factory
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.util.Asserts.check(Asserts.java:34)
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.conn.ssl.SSLSocketFactory.isSecure(SSLSocketFactory.java:436)
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:186)
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.impl.conn.ManagedClientConnectionImpl.open(ManagedClientConnectionImpl.java:326)
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.impl.client.DefaultRequestDirector.tryConnect(DefaultRequestDirector.java:605)
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:440)
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:835)
01-25 07:52:34.118 127.0.0.1:40004       218    #66483-26 ERRR: 	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
```

is caused by me upgrading the GCS client library to version `1.103.0`. Looks like some classpath issues. There is no problem in keeping the original version `1.19.0` - there are no issues with it. Let's just revert.