### PR TITLE
PUBDEV-7227: unsupported Python bytecode instructions when calling `apply` on H2OFrame

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -7,13 +7,13 @@ Rapids expressions. These are helper classes for H2OFrame.
 """
 from __future__ import division, print_function, absolute_import, unicode_literals
 
-import collections
+from collections import Iterable, OrderedDict
 import copy
 import gc
 import inspect
 import math
-import sys
 import time
+import traceback
 import numbers
 
 import tabulate
@@ -73,10 +73,6 @@ class ExprNode(object):
         There are more details available under the H2OCache class declaration.
     """
 
-    # Magical count-of-5:   (get 2 more when looking at it in debug mode)
-    #  2 for _get_ast_str frame, 2 for _get_ast_str local dictionary list, 1 for parent
-    MAGIC_REF_COUNT = 5 if sys.gettrace() is None else 7  # M = debug ? 7 : 5
-
     # Flag to control application of local expression tree optimizations
     __ENABLE_EXPR_OPTIMIZATIONS__ = True
 
@@ -135,12 +131,11 @@ class ExprNode(object):
             else:
                 break
 
-    # Recursively build a rapids execution string.  Any object with more than
-    # MAGIC_REF_COUNT referrers will be cached as a temp until the next client GC
-    # cycle - consuming memory.  Do Not Call This except when you need to do some
-    # other cluster operation on the evaluated object.  Examples might be: lazy
-    # dataset time parse vs changing the global timezone.  Global timezone change
-    # is eager, so the time parse as to occur in the correct order relative to
+    # Recursively build a rapids execution string.
+    # Any object with more than 1 referrer node will be cached as a temp until the next client GC cycle - consuming memory.
+    # Do Not Call This except when you need to do some other cluster operation on the evaluated object.
+    # Examples might be: lazy dataset time parse vs changing the global timezone.
+    # Global timezone change is eager, so the time parse as to occur in the correct order relative to
     # the timezone change, so cannot be lazy.
     #
     def _get_ast_str(self, top):
@@ -150,13 +145,19 @@ class ExprNode(object):
             return self._cache._id  # Data already computed under ID, but not cached
         assert isinstance(self._children,tuple)
         exec_str = "({} {})".format(self._op, " ".join([ExprNode._arg_to_expr(ast) for ast in self._children]))
-        # explicit call to gc.collect as recommended before calling gc.get_referrers to obtain only live referrers;
-        # otherwise, this creates subtle bugs for Py < 3.7 as we have logic below based on the ref count.
-        # Also filtering out the frames for the referrers (they appear until 3.6) and change the behaviour depending on the execution path.
-        gc.collect()
+
+        def is_ast_expr(ref):
+            return isinstance(ref, list) and any(map(lambda r: isinstance(r, ASTId), ref))
+
         referrers = gc.get_referrers(self)
-        gc_ref_cnt = len([r for r in referrers if not inspect.isframe(r)])
-        if top or gc_ref_cnt >= ExprNode.MAGIC_REF_COUNT:
+        # removing frames from the referrers to get a consistent behaviour accross Py versions
+        #  as stack frames don't appear in the referrers from Py 3.7.
+        # also removing the AST expressions built in astfun.py
+        #  as they keep a reference to self if the lambda itself is using a free variable.
+        proper_ref = [r for r in referrers if not (inspect.isframe(r) or is_ast_expr(r))]
+        ref_cnt = len(proper_ref)
+        # if this self node is referenced by at least one other node (nested expr), then create a tmp frame
+        if top or ref_cnt > 1:
             self._cache._id = _py_tmp_key(append=h2o.connection().session_id)
             exec_str = "(tmp= {} {})".format(self._cache._id, exec_str)
         return exec_str
@@ -365,7 +366,7 @@ class H2OCache(object):
         self._fill_data(res)
 
     def _fill_data(self, json):
-        self._data = collections.OrderedDict()
+        self._data = OrderedDict()
         for c in json["columns"]:
             c.pop('__meta')  # Redundant description ColV3
             c.pop('domain_cardinality')  # Same as len(c['domain'])
@@ -389,7 +390,7 @@ class H2OCache(object):
         """Pretty tabulated string of all the cached data, and column names"""
         if not self.is_valid(): self.fill(rows=rows)
         # Pretty print cached data
-        d = collections.OrderedDict()
+        d = OrderedDict()
         # If also printing the rollup stats, build a full row-header
         if rollups:
             col = next(iter(viewvalues(self._data)))  # Get a sample column

--- a/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_apply.py
+++ b/h2o-py/tests/testdir_apis/Data_Manipulation/pyunit_h2oH2OFrame_apply.py
@@ -21,6 +21,6 @@ def h2o_H2OFrame_apply():
            (colMean[0,3]==h2oframe[0,3]), "h2o.H2OFrame.apply() command is not working."
 
 if __name__ == "__main__":
-    pyunit_utils.standalone_test(h2o_H2OFrame_apply())
+    pyunit_utils.standalone_test(h2o_H2OFrame_apply)
 else:
     h2o_H2OFrame_apply()

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -130,19 +130,22 @@ def pyunit_apply_with_args():
         scale_with_arg=lambda x: x.scale(False, False),
         scale_with_kwarg=lambda x: x.scale(center=False, scale=False),
         scale_with_argkwarg=lambda x: x.scale(False, scale=False),
-        scale_with_global_arg=(lambda x: x.scale(false, scale=false)) if not PY2 else None,
-        scale_with_args=(lambda x: x.scale(*args)) if not PY2 else None,
-        scale_with_kwargs=(lambda x: x.scale(**kwargs)) if not PY2 else None,
-        scale_with_partial_args=(lambda x: x.scale(False, *partial_args)) if not PY2 else None,
-        scale_with_partial_kwargs=(lambda x: x.scale(False, **partial_kwargs)) if not PY2 else None,
-        scale_with_args_and_kwargs=(lambda x: x.scale(*partial_args, **partial_kwargs)) if not PY2 else None,
-        scale_with_all_kind_args=(lambda x: x.scale(False, *partial_args, **partial_kwargs)) if not PY2 else None,  # strangely this works because our signature verification is not that strict, but it's fine... at least behaves as expected.
+        scale_with_global_arg=(lambda x: x.scale(false, scale=false)),
+        scale_with_args=(lambda x: x.scale(*args)),
+        scale_with_kwargs=(lambda x: x.scale(**kwargs)),
+        scale_with_partial_args=(lambda x: x.scale(False, *partial_args)),
+        scale_with_partial_kwargs=(lambda x: x.scale(False, **partial_kwargs)),
+        scale_with_partial_kwargs2=(lambda x: x.scale(center=False, **partial_kwargs)),
+        scale_with_args_and_kwargs=(lambda x: x.scale(*partial_args, **partial_kwargs)),
+        scale_with_all_kind_args=(lambda x: x.scale(False, *partial_args, scale=False, **partial_kwargs)) if not PY2 else None,  # surprisingly this works because our signature verification is not that strict, but it's fine... at least behaves as expected.
     )
     for test, lbd in to_test.items():
         if lbd:
             print(test)
-            res = fr.apply(lbd).as_data_frame()
-            assert_frame_equal(res, ref)
+            res = fr.apply(lbd)
+            res_df = res.as_data_frame()
+            assert_frame_equal(res_df, ref)
+            h2o.remove(res)
 
 
 
@@ -175,7 +178,8 @@ def assert_column_equal(h2o_result, pd_result):
 
 __AXIS_ASSERTS__ = { 0: assert_column_equal, 1: assert_row_equal}
 
-__TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
+# __TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
+__TESTS__ = [pyunit_apply_with_args]
 
 if __name__ == "__main__":
     for func in __TESTS__:

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 from __future__ import division, print_function
+from future.utils import PY2
 import sys
 
 sys.path.insert(1, "../../")
@@ -129,18 +130,19 @@ def pyunit_apply_with_args():
         scale_with_arg=lambda x: x.scale(False, False),
         scale_with_kwarg=lambda x: x.scale(center=False, scale=False),
         scale_with_argkwarg=lambda x: x.scale(False, scale=False),
-        scale_with_global_arg=lambda x: x.scale(false, scale=false),
-        scale_with_args=lambda x: x.scale(*args),
-        scale_with_kwargs=lambda x: x.scale(**kwargs),
-        scale_with_partial_args=lambda x: x.scale(False, *partial_args),
-        scale_with_partial_kwargs=lambda x: x.scale(False, **partial_kwargs),
-        scale_with_args_and_kwargs=lambda x: x.scale(*partial_args, **partial_kwargs),
-        scale_with_all_kind_args=lambda x: x.scale(False, *partial_args, **partial_kwargs),  # strangely this works because our signature verification is not that strict, but it's fine... at least behaves as expected.
+        scale_with_global_arg=(lambda x: x.scale(false, scale=false)) if not PY2 else None,
+        scale_with_args=(lambda x: x.scale(*args)) if not PY2 else None,
+        scale_with_kwargs=(lambda x: x.scale(**kwargs)) if not PY2 else None,
+        scale_with_partial_args=(lambda x: x.scale(False, *partial_args)) if not PY2 else None,
+        scale_with_partial_kwargs=(lambda x: x.scale(False, **partial_kwargs)) if not PY2 else None,
+        scale_with_args_and_kwargs=(lambda x: x.scale(*partial_args, **partial_kwargs)) if not PY2 else None,
+        scale_with_all_kind_args=(lambda x: x.scale(False, *partial_args, **partial_kwargs)) if not PY2 else None,  # strangely this works because our signature verification is not that strict, but it's fine... at least behaves as expected.
     )
     for test, lbd in to_test.items():
-        print(test)
-        res = fr.apply(lbd).as_data_frame()
-        assert_frame_equal(res, ref)
+        if lbd:
+            print(test)
+            res = fr.apply(lbd).as_data_frame()
+            assert_frame_equal(res, ref)
 
 
 
@@ -173,7 +175,8 @@ def assert_column_equal(h2o_result, pd_result):
 
 __AXIS_ASSERTS__ = { 0: assert_column_equal, 1: assert_row_equal}
 
-__TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
+# __TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
+__TESTS__ = [pyunit_apply_with_args]
 
 if __name__ == "__main__":
     for func in __TESTS__:

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -42,6 +42,8 @@ def pd_to_int(h2o, pd):
 #
 OPS_VEC_TO_SCALAR = {
     "mean": [lambda x: x.mean(), [0,1], None, None],
+    "mean_with_arg": [lambda x: x.mean(False), [0,1], lambda x: x.mean(skipna=False), None],
+    "mean_with_kwarg": [lambda x: x.mean(skipna=False), [0,1], None, None],
     "median": [lambda x: x.median(), [0], None, h2o_to_float],
     "max": [lambda x: x.max(), [0,1], None, h2o_to_float],
     "min": [lambda x: x.min(), [0,1], None, h2o_to_float],
@@ -88,7 +90,7 @@ def test_ops(fr, pf, ops_map):
             fce, supported_axes, pandas_fce, assert_transf = op
             assert_fce = get_assert_fce_for_axis(axis, assert_transf)
             op_desc = "Op '{}' (axis={}) ".format(name, axis)
-            sys.stdout.write(op_desc)
+            print(op_desc, end='')
             if axis not in supported_axes:
                 print("UNSUPPORTED")
             else:

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -175,8 +175,7 @@ def assert_column_equal(h2o_result, pd_result):
 
 __AXIS_ASSERTS__ = { 0: assert_column_equal, 1: assert_row_equal}
 
-# __TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
-__TESTS__ = [pyunit_apply_with_args]
+__TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
 
 if __name__ == "__main__":
     for func in __TESTS__:

--- a/h2o-py/tests/testdir_misc/pyunit_apply.py
+++ b/h2o-py/tests/testdir_misc/pyunit_apply.py
@@ -178,8 +178,7 @@ def assert_column_equal(h2o_result, pd_result):
 
 __AXIS_ASSERTS__ = { 0: assert_column_equal, 1: assert_row_equal}
 
-# __TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
-__TESTS__ = [pyunit_apply_with_args]
+__TESTS__ = [pyunit_apply_n_to_n_ops, pyunit_apply_n_to_1_ops, pyunit_apply_with_args]
 
 if __name__ == "__main__":
     for func in __TESTS__:


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7227

`lambda_to_expr` implementation doesn't support some bytecode instructions introduced in Python 3.7.

Also added support for some instructions introduced with 3.6, especially `CALL_FUNCTION_EX`, even if they don't seem that useful in the context of `H2OFrame.apply`, but the greater support, the better.

Note that our jenkins pipeline is still not running tests using Python 3.7, so this will be officially supported only once https://github.com/h2oai/h2o-3/pull/3560 is fixed.