### PR TITLE
PUBDEV-7218: Use max_models = 0 to signify unbounded search for Cartesian iterator

### DIFF
--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -119,7 +119,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     long gridWork=0;
     if (gridSize > 0) {//if total grid space is known, walk it all and count up models to be built (not subject to time-based or converge-based early stopping)
       int count=0;
-      while (it.hasNext(model) && (it.max_models() > 0 && count++ < it.max_models())) { //only walk the first max_models models, if specified
+      while (it.hasNext(model) && (it.max_models() == 0 || count++ < it.max_models())) { //only walk the first max_models models, if specified
         try {
           Model.Parameters parms = it.nextModelParameters(model);
           gridWork += (parms._nfolds > 0 ? (parms._nfolds+1/*main model*/) : 1) *parms.progressUnits();

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -397,7 +397,7 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
         @Override
         public double max_runtime_secs() { return Double.MAX_VALUE; }
 
-        public int max_models() { return _maxHyperSpaceSize > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int)_maxHyperSpaceSize; }
+        public int max_models() { return 0; }
 
         @Override
         public void modelFailed(Model failedModel) {


### PR DESCRIPTION
RGS is already using setting max_models = 0 when all models should be trained. It is better for all grid iterator types to be consistent with each other in this aspect