### PR TITLE
GLM COEFFICIENTS FIX

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -118,6 +118,8 @@ public class DataInfo extends Keyed<DataInfo> {
   public int [] _permutation; // permutation matrix mapping input col indices to adaptedFrame
   public double [] _normMul;  // scale the predictor column by this value
   public double [] _normSub;  // subtract from the predictor this value
+  public double [] _normMulStandardizationOff;
+  public double [] _normSubStandardizationOff;
   public double [] _normRespMul;  // scale the response column by this value
   public double [] _normRespSub;  // subtract from the response column this value
   public double [] _numMeans;
@@ -377,6 +379,28 @@ public class DataInfo extends Keyed<DataInfo> {
     }
     return beta;
   }
+  
+  public double[] denormalizeBeta(double [] beta, boolean standardize){
+    int N = fullN()+1;
+    assert (beta.length % N) == 0:"beta len = " + beta.length + " expected multiple of" + N;
+    int nclasses = beta.length/N;
+    beta = MemoryManager.arrayCopyOf(beta,beta.length);
+    if (standardize == false && _predictor_transform == DataInfo.TransformType.NONE) {
+      for(int c = 0; c < nclasses; ++c) {
+        int off = N*c;
+        double norm = 0.0;        // Reverse any normalization on the intercept
+        // denormalize only the numeric coefs (categoricals are not normalized)
+        final int numoff = numStart();
+        for (int i = numoff; i < N-1; i++) {
+          double b = beta[off + i] * _normMulStandardizationOff[i - numoff];
+          norm += b * _normSubStandardizationOff[i - numoff]; // Also accumulate the intercept adjustment
+          beta[off + i] = b;
+        }
+        beta[off + N - 1] -= norm;
+      }
+    }
+    return beta;
+  } 
 
   private int [] _fullCatOffsets;
   private int [][] _catMap;
@@ -603,6 +627,7 @@ public class DataInfo extends Keyed<DataInfo> {
       boolean isIWV = v instanceof InteractionWrappedVec;
       switch (t) {
         case STANDARDIZE:
+        case NONE:
           if( isIWV ) {
             InteractionWrappedVec iwv = (InteractionWrappedVec)v;
             for(int offset=0;offset<iwv.expandedLength();++offset) {
@@ -649,6 +674,9 @@ public class DataInfo extends Keyed<DataInfo> {
     if(t == TransformType.NONE) {
       _normMul = null;
       _normSub = null;
+      _normMulStandardizationOff = MemoryManager.malloc8d(numNums());
+      _normSubStandardizationOff = MemoryManager.malloc8d(numNums());
+      setTransform(t, _normMulStandardizationOff, _normSubStandardizationOff, _cats, _nums);
     } else {
       _normMul = MemoryManager.malloc8d(numNums());
       _normSub = MemoryManager.malloc8d(numNums());

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1246,10 +1246,16 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       return best;
     }
 
-    public double[] getNormBeta() {return _submodels[_selected_lambda_idx].getBeta(MemoryManager.malloc8d(_dinfo.fullN()+1));}
+    public double[] getNormBeta() {
+      if(this.isStandardized()) {
+        return _submodels[_selected_lambda_idx].getBeta(MemoryManager.malloc8d(_dinfo.fullN()+1));
+      } else {
+        return _dinfo.denormalizeBeta(_submodels[_selected_lambda_idx].getBeta(MemoryManager.malloc8d(_dinfo.fullN()+1)), this.isStandardized());
+      }
+    }
 
     public double[][] getNormBetaMultinomial() {
-      return getNormBetaMultinomial(_selected_lambda_idx);
+      return getNormBetaMultinomial(_selected_lambda_idx, this.isStandardized());
     }
 
     public double[][] getNormBetaMultinomial(int idx) {
@@ -1263,6 +1269,24 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         beta = ArrayUtils.expandAndScatter(beta,nclasses()*(_dinfo.fullN()+1),sm.idxs);
       for(int i = 0; i < res.length; ++i)
         res[i] = Arrays.copyOfRange(beta,i*N,(i+1)*N);
+      return res;
+    }
+
+    public double[][] getNormBetaMultinomial(int idx, boolean standardized) {
+      if(_submodels == null || _submodels.length == 0) // no model yet
+        return null;
+      double [][] res = new double[nclasses()][];
+      Submodel sm = _submodels[idx];
+      int N = _dinfo.fullN()+1;
+      double [] beta = sm.beta;
+      if(sm.idxs != null)
+        beta = ArrayUtils.expandAndScatter(beta,nclasses()*(_dinfo.fullN()+1),sm.idxs);
+      for(int i = 0; i < res.length; ++i)
+        if(standardized) {
+          res[i] = Arrays.copyOfRange(beta, i * N, (i + 1) * N);
+        } else {
+          res[i] = _dinfo.denormalizeBeta(Arrays.copyOfRange(beta, i * N, (i + 1) * N), standardized);
+        }
       return res;
     }
 
@@ -1329,9 +1353,27 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         res.put(_output._coefficient_names[i], b[i]);
     return res;
   }
-
-
-
+  
+  public HashMap<String,Double> standardizedCoefficients(){
+    HashMap<String, Double> res = new HashMap<>();
+    final double [] b = dinfo().denormalizeBeta(beta(), _parms._standardize);
+    if(b == null) return res;
+    if(_parms._family == Family.multinomial || _parms._family == Family.ordinal){
+      String [] responseDomain = _output._domains[_output._domains.length-1];
+      int len = b.length/_output.nclasses();
+      assert b.length == len*_output.nclasses();
+      for(int c = 0; c < _output.nclasses(); ++c) {
+        String prefix =  responseDomain[c] + "_";
+        for (int i = 0; i < len; ++i)
+          res.put(prefix + _output._coefficient_names[i], b[c*len+i]);
+      }
+    } else for (int i = 0; i < b.length; ++i)
+      res.put(_output._coefficient_names[i], b[i]);
+    return res;
+  }
+  
+  
+  
   // TODO: Shouldn't this be in schema? have it here for now to be consistent with others...
   /**
    * Re-do the TwoDim table generation with updated model.

--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -50,8 +50,7 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       coefficients_table = new TwoDimTableV3();
       if (impl.nclasses() > 2) // only change coefficient names for multinomials
         coefficients_table_multinomials_with_class_names = new TwoDimTableV3();
-
-      if(impl.isStandardized()){
+      
         int n = impl.nclasses();
         String[] cols = new String[n*2];
         String[] cols2=null;
@@ -121,40 +120,6 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
           standardized_coefficient_magnitudes = new TwoDimTableV3();
           standardized_coefficient_magnitudes.fillFromImpl(tdt);
         }
-      } else {
-        int n = impl.nclasses();
-        String [] cols = new String[n];
-        String [] cols2 = null;
-        if (n>2) {
-          String[] classNames = impl._domains[impl.responseIdx()];
-          cols2 = new String[n];
-          for (int i = 0; i < n; ++i) {
-            cols2[i] = "coefs_class_" + classNames[i];
-          }
-        }
-          for (int i = 0; i < n; ++i) {
-            cols[i] = "coefs_class_" +i;
-          }
-
-        String [] colTypes = new String[cols.length];
-        Arrays.fill(colTypes, "double");
-        String [] colFormats = new String[cols.length];
-        Arrays.fill(colFormats,"%5f");
-
-        TwoDimTable tdt = new TwoDimTable("Coefficients","glm multinomial coefficients", ns, cols, colTypes, colFormats, "names");
-
-        for(int c = 0; c < n; ++c) {
-          double [] beta = impl.get_global_beta_multinomial()[c];
-          tdt.set(0,c,beta[beta.length-1]);
-          for(int i = 0; i < beta.length-1; ++i)
-            tdt.set(i + 1, c, beta[i]);
-        }
-        coefficients_table.fillFromImpl(tdt);
-        if (n>2) {  // restore column names from pythonized ones
-          coefficients_table_multinomials_with_class_names.fillFromImpl(tdt);
-          revertCoeffNames(cols2, n, coefficients_table_multinomials_with_class_names);
-        }
-      }
 
       return this;
     }
@@ -213,18 +178,16 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
         colnames = new String[]{"Coefficients","Std. Error","z value","p value"};
       }
       int stdOff = colnames.length;
-      if(impl.isStandardized()) {
-        colTypes = ArrayUtils.append(colTypes,"double");
-        colFormats = ArrayUtils.append(colFormats,"%5f");
-        colnames = ArrayUtils.append(colnames,"Standardized Coefficients");
-      }
+      colTypes = ArrayUtils.append(colTypes,"double");
+      colFormats = ArrayUtils.append(colFormats,"%5f");
+      colnames = ArrayUtils.append(colnames,"Standardized Coefficients");
       TwoDimTable tdt = new TwoDimTable("Coefficients","glm coefficients", ns, colnames, colTypes, colFormats, "names");
       tdt.set(0, 0, beta[beta.length - 1]);
       for (int i = 0; i < beta.length - 1; ++i) {
         tdt.set(i + 1, 0, beta[i]);
       }
       double[] norm_beta = null;
-      if(impl.isStandardized() &&impl.beta() != null) {
+      if(impl.beta() != null) {
         norm_beta = impl.getNormBeta();
         tdt.set(0, stdOff, norm_beta[norm_beta.length - 1]);
         for (int i = 0; i < norm_beta.length - 1; ++i)
@@ -244,7 +207,7 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
         }
       }
       coefficients_table.fillFromImpl(tdt);
-      if(impl.isStandardized() && impl.beta() != null) {
+      if(impl.beta() != null) {
         magnitudes = norm_beta.clone();
         for (int i = 0; i < magnitudes.length; ++i)
           if (magnitudes[i] < 0) magnitudes[i] *= -1;

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
@@ -5,7 +5,6 @@ import hex.DataInfo;
 import hex.FrameSplitter;
 import hex.ModelMetricsBinomialGLM.ModelMetricsMultinomialGLM;
 import hex.SplitFrame;
-import hex.deeplearning.DeepLearningModel;
 import hex.glm.GLMModel.GLMParameters;
 import hex.glm.GLMModel.GLMParameters.Family;
 import hex.glm.GLMModel.GLMParameters.Solver;
@@ -102,7 +101,7 @@ public class GLMBasicTestMultinomial extends TestUtil {
       Scope.exit();
     }
   }
-
+  
   @Test
   public void testCovtypeNoIntercept(){
     GLMParameters params = new GLMParameters(Family.multinomial);

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -109,6 +109,79 @@ public class GLMTest  extends TestUtil {
       }
     }
   }
+
+  @Test
+  public void testStandardizedCoeff() {
+    // test for multinomial
+    testCoeffs(Family.multinomial, "smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv", "C11");
+    // test for binomial
+    testCoeffs(Family.binomial, "smalldata/glm_test/binomial_20_cols_10KRows.csv", "C21");
+    // test for Gaussian
+    testCoeffs(Family.gaussian, "smalldata/glm_test/gaussian_20cols_10000Rows.csv", "C21");
+  }
+  
+  public void testCoeffs(Family family, String fileName, String responseColumn) {
+    try {
+      Scope.enter();
+      Frame train = parse_test_file(fileName);
+      // set cat columns
+      int numCols = train.numCols();
+      int enumCols = (numCols-1)/2;
+      for (int cindex=0; cindex<enumCols; cindex++) {
+        train.replace(cindex, train.vec(cindex).toCategoricalVec()).remove();
+      }
+      int response_index = numCols-1;
+      if (family.equals(Family.binomial) || (family.equals(Family.multinomial))) {
+        train.replace((response_index), train.vec(response_index).toCategoricalVec()).remove();
+      }
+      DKV.put(train);
+      Scope.track(train);
+      
+      GLMParameters params = new GLMParameters(family);
+      params._standardize=true;
+      params._response_column = responseColumn;
+      params._train = train._key;
+      GLMModel glm = new GLM(params).trainModel().get();
+      Scope.track_generic(glm);
+      
+      // standardize numerical columns of train
+      int numStart = enumCols;  // start of numerical columns
+      int[] numCols2Transform = new int[enumCols];
+      double[] colMeans = new double[enumCols];
+      double[] oneOSigma = new double[enumCols];
+      int countIndex = 0;
+      for (int cindex = numStart; cindex < response_index; cindex++) {
+        numCols2Transform[countIndex]=cindex;
+        colMeans[countIndex] = train.vec(cindex).mean();
+        oneOSigma[countIndex] = 1.0/train.vec(cindex).sigma();
+        countIndex++;
+      }
+      new TestUtil.StandardizeColumns(numCols2Transform, colMeans, oneOSigma, train).doAll(train);
+      DKV.put(train);
+      Scope.track(train);
+      
+      params._standardize=false;
+      params._train = train._key;
+      GLMModel glmS = new GLM(params).trainModel().get();
+      Scope.track_generic(glmS);
+      
+      if (family.equals(Family.multinomial)) {
+        double[][] coeff1 = glm._output.getNormBetaMultinomial();
+        double[][] coeff2 = glmS._output.getNormBetaMultinomial();
+        for (int classind = 0; classind < coeff1.length; classind++) {
+          assert TestUtil.equalTwoArrays(coeff1[classind], coeff2[classind], 1e-6);
+        }
+      } else {
+        assert TestUtil.equalTwoArrays(glm._output.getNormBeta(), glmS._output.getNormBeta(), 1e-6);
+      }
+      // Zuzana:  this is for you.  Right now it does not work.
+ /*     HashMap<String, Double> coeff1 = glm.standardized_coefficients();
+       HashMap<String, Double> coeff2 = glmS.standardized_coefficients();
+       assert TestUtil.equalTwoHashMaps(coeff1, coeff2, 1e-6); */
+    } finally {
+      Scope.exit();
+    }
+  }
   //------------------- simple tests on synthetic data------------------------------------
   @Test
   public void testGaussianRegression() throws InterruptedException, ExecutionException {

--- a/h2o-core/src/main/java/water/fvec/InteractionWrappedVec.java
+++ b/h2o-core/src/main/java/water/fvec/InteractionWrappedVec.java
@@ -96,6 +96,10 @@ public class InteractionWrappedVec extends WrappedVec {
     return sigma == 0? 1.0 : 1.0/sigma;
   }
 
+  public double getSigma(int i) {
+    return (t == null)? sigma() : t._sigma[i];
+  }
+
   private static class GetMeanTask extends MRTask<GetMeanTask> {
     private double[] _d;     // means, NA skipped
     private double[] _sigma; // sds, NA skipped

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -841,6 +841,56 @@ public class TestUtil extends Iced {
     return flipped;
   }
 
+  public static boolean equalTwoArrays(double[] array1, double[] array2, double tol) {
+    assert array1.length==array2.length:"Arrays have different lengths";
+    for (int index=0; index < array1.length; index++) {
+      if (Math.abs(array1[index]-array2[index])>tol)
+        return false;
+    }
+    return true;
+  }
+
+  public static class StandardizeColumns extends MRTask<StandardizeColumns> {
+    int[] _columns2Transform;
+    double[] _colMeans;
+    double[] _oneOStd;
+
+    public StandardizeColumns(int[] cols, double[] colMeans, double[] oneOSigma,
+                              Frame transF) {
+      assert cols.length==colMeans.length;
+      assert colMeans.length==oneOSigma.length;
+      _columns2Transform = cols;
+      _colMeans = colMeans;
+      _oneOStd = oneOSigma;
+
+      int numCols = transF.numCols();
+      for (int cindex:cols) { // check to make sure columns are numerical
+        assert transF.vec(cindex).isNumeric();
+      }
+    }
+
+    @Override public void map(Chunk[] chks) {
+      int chunkLen = chks[0].len();
+      int colCount = 0;
+      for (int cindex:_columns2Transform) {
+        for (int rindex=0; rindex < chunkLen; rindex++) {
+          double temp = (chks[cindex].atd(rindex)-_colMeans[colCount])*_oneOStd[colCount];
+          chks[cindex].set(rindex, temp);
+        }
+        colCount += 1;
+      }
+    }
+  }
+  
+  public static boolean equalTwoHashMaps(HashMap<String, Double> coeff1, HashMap<String, Double> coeff2, double tol) {
+    assert coeff1.size()==coeff2.size():"HashMap sizes are differenbt";
+    for (String key:coeff1.keySet()) {
+      if (Math.abs(coeff1.get(key)-coeff2.get(key)) > tol)
+        return false;
+    }
+    return true;
+  }
+  
   public static boolean equalTwoDimTables(TwoDimTable tab1, TwoDimTable tab2, double tol) {
     boolean same = true;
     //compare colHeaders

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -629,9 +629,9 @@ class ModelBase(h2o_meta(Keyed)):
         coeffNames = tbl["names"]
         all_col_header = tbl.col_header
         startIndex = 1
-        endIndex = len(all_col_header)
+        endIndex = int((len(all_col_header)-1)/2+1)
         if standardize:
-            startIndex = (len(all_col_header)-1)/2+1 # start index for standardized coefficients
+            startIndex = int((len(all_col_header)-1)/2+1) # start index for standardized coefficients
             endIndex = len(all_col_header)
         for nameIndex in list(range(startIndex, endIndex)):
             coeffList = tbl[all_col_header[nameIndex]]

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -599,11 +599,13 @@ class ModelBase(h2o_meta(Keyed)):
 
         Note: standardize = True by default, if set to False then coef() return the coefficients which are fit directly.
         """
-        tbl = self._model_json["output"]["coefficients_table"]
-        if tbl is None:
-            return None
-        return {name: coef for name, coef in zip(tbl["names"], tbl["coefficients"])}
-
+        if self._model_json["output"]['model_category']=="Multinomial":
+            return self._fillMultinomialDict(False)
+        else:
+            tbl = self._model_json["output"]["coefficients_table"]
+            if tbl is None:
+                return None
+            return {name: coef for name, coef in zip(tbl["names"], tbl["coefficients"])}
 
     def coef_norm(self):
         """
@@ -612,16 +614,30 @@ class ModelBase(h2o_meta(Keyed)):
         These coefficients can be used to evaluate variable importance.
         """
         if self._model_json["output"]["model_category"]=="Multinomial":
-            tbl = self._model_json["output"]["standardized_coefficient_magnitudes"]
-            if tbl is None:
-                return None
-            return {name: coef for name, coef in zip(tbl["names"], tbl["coefficients"])}
+            return self._fillMultinomialDict(True)
         else:
             tbl = self._model_json["output"]["coefficients_table"]
             if tbl is None:
                 return None
             return {name: coef for name, coef in zip(tbl["names"], tbl["standardized_coefficients"])}
 
+    def _fillMultinomialDict(self, standardize=False):
+        tbl = self._model_json["output"]["coefficients_table_multinomials_with_class_names"]
+        if tbl is None:
+            return None
+        coeff_dict = {} # contains coefficient names
+        coeffNames = tbl["names"]
+        all_col_header = tbl.col_header
+        startIndex = 1
+        endIndex = len(all_col_header)
+        if standardize:
+            startIndex = (len(all_col_header)-1)/2+1 # start index for standardized coefficients
+            endIndex = len(all_col_header)
+        for nameIndex in list(range(startIndex, endIndex)):
+            coeffList = tbl[all_col_header[nameIndex]]
+            t1Dict = {name: coef for name, coef in zip(coeffNames, coeffList)}
+            coeff_dict[all_col_header[nameIndex]]=t1Dict
+        return coeff_dict
 
     def r2(self, train=False, valid=False, xval=False):
         """

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -1726,7 +1726,17 @@ def generate_sign_vec(table1, table2):
                 break       # found what we need.  Goto next column
 
     return sign_vec
-
+def equal_two_dicts(dict1, dict2, tolerance=1e-6, throwError=True):
+    size1 = len(dict1)
+    if (size1 == len(dict2)):   # only proceed if lengths are the same
+        for key1 in dict1.keys():
+            diff = abs(dict1[key1]-dict2[key1])
+            if (diff > tolerance):
+                if throwError:
+                    assert False, "Dict 1 value {0} and Dict 2 value {1} do not agree.".format(dict1[key1], dict2[key1])
+                else:
+                    return False
+                
 def equal_two_arrays(array1, array2, eps, tolerance, throwError=True):
     """
     This function will compare the values of two python tuples.  First, if the values are below

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_7238_standardized_coeff_check.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_7238_standardized_coeff_check.py
@@ -1,0 +1,61 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import math
+
+# check varimp for Binomial, Multinomial, Regression when standardize is set to False.
+# I did the following:
+# 1. train GLM with a dataset with standardize = True
+# 2. train GLM with a dataset with standardized numerical columns and with standardize = False
+#
+# The standardized coefficients from model 1 and the coefficients from model 2 should be the same in this case.
+def test_standardized_coeffs():
+    print("Checking standardized coefficients for multinomials....")
+    buildModelCheckStdCoeffs("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv", "multinomial")
+
+    print("Checking standardized coefficients for binomials....")
+    buildModelCheckStdCoeffs("smalldata/glm_test/binomial_20_cols_10KRows.csv", "binomial")
+
+    print("Checking standardized coefficients for regression....")
+    buildModelCheckStdCoeffs("smalldata/glm_test/gaussian_20cols_10000Rows.csv", "gaussian")
+ 
+def buildModelCheckStdCoeffs(training_fileName, family):
+    training_data = h2o.import_file(pyunit_utils.locate(training_fileName))
+    ncols = training_data.ncols
+    Y = ncols-1
+    x = list(range(0,Y))
+    enumCols = Y/2
+    if family == 'binomial' or family == 'multinomial':
+        training_data[Y] = training_data[Y].asfactor()  #
+    for ind in range(enumCols): # first half of the columns are enums
+        training_data[ind] = training_data[ind].asfactor()
+    model1 = H2OGeneralizedLinearEstimator(family=family, standardize=True)
+    model1.train(training_frame=training_data, x=x, y=Y)
+    stdCoeff1 = model1.coef_norm()
+    
+    # standardize numerical columns here
+    for ind in range(enumCols, Y): # change the numerical columns to have mean 0 and std 1
+        aver = training_data[ind].mean()
+        sigma = 1.0/math.sqrt(training_data[ind].var())
+        training_data[ind] = (training_data[ind]-aver)*sigma
+
+    model2 = H2OGeneralizedLinearEstimator(family=family, standardize=False)
+    model2.train(training_frame=training_data, x=x, y=Y)
+    #coeff2 = model2.coef_norm() # this will crash before Zuzana fix, please use this one after your fix.
+    coeff2 = model2.coef()  # Zuzana: remove this one and use the above after you are done with your fix.
+
+    if family == 'multinomial': # special treatment, it contains a dict of dict
+        assert len(stdCoeff1) == len(coeff2), "Coefficient dictionary lengths are different.  One has length {0} while" \
+                                              " the other one has length {1}.".format(len(stdCoeff1), len(coeff2))
+        for name in stdCoeff1.keys():
+            pyunit_utils.equal_two_dicts(stdCoeff1[name], coeff2[name[4:]])
+    else:
+        pyunit_utils.equal_two_dicts(stdCoeff1, stdCoeff1)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_standardized_coeffs)
+else:
+    test_standardized_coeffs()

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -1472,9 +1472,8 @@ h2o.coef_norm <- function(object) {
 grabCoeff <- function(tempTable, nameStart, standardize=FALSE) {
     coeffNamesPerClass <- tempTable$names # contains coeff names per class
     totTableLength <- length(tempTable)
-    numClass <- totTableLength
     startIndex <- 2
-    endIndex <- numClass
+    endIndex <- (totTableLength-1)/2+1
     if (standardize) {
         startIndex <- (totTableLength-1)/2+2   # starting index for standardized coefficients
         endIndex <- totTableLength

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_pubdev_7238_standardized_coeff_check.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_pubdev_7238_standardized_coeff_check.R
@@ -1,0 +1,57 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+glmStandardizeCoeffsCheck <- function() {
+  browser()
+  # check multinomial
+  print("Checking standardized coefficients for multinomials....")
+  checkCoeffs("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv", "multinomial")
+  
+  # check gaussian
+  print("Checking standardized coefficients for regression....")
+  checkCoeffs("smalldata/glm_test/gaussian_20cols_10000Rows.csv", "gaussian")
+  
+  # check binomial
+  print("Checking standardized coefficients for binomials....")
+  checkCoeffs("smalldata/glm_test/binomial_20_cols_10KRows.csv", "binomial")
+}
+
+checkCoeffs <- function(filename, family) {
+  training_frame <- h2o.uploadFile(locate(filename))
+  numCols <- ncol(training_frame)
+  colNames <- names(training_frame)
+  Y <- numCols
+  totPredCols <- Y-1
+  x <- c(1:totPredCols)
+  if ((family=="multinomial") || (family=="binomial")) {
+    training_frame[colNames[Y]] <- h2o.asfactor(training_frame[colNames[Y]])
+  }
+  lastEnumCol <- totPredCols/2
+  for (index in c(1:lastEnumCol)) {
+    training_frame[colNames[index]] <- h2o.asfactor(training_frame[colNames[index]])
+  }
+  m1 <- h2o.glm(y = Y, x = x, training_frame = training_frame, family = family, standardize=TRUE) 
+  coeff1 <- h2o.coef_norm(m1)
+  # standardize numerical columns
+  startIndex <- totPredCols/2+1
+  for (index in c(startIndex:totPredCols)) {
+    aver <- h2o.mean(training_frame[colNames[index]])
+    sig <- 1.0/sqrt(h2o.var(training_frame[colNames[index]]))
+    training_frame[colNames[index]] <- (training_frame[colNames[index]]-aver)*sig
+  }
+  m2 <- h2o.glm(y = Y, x = x, training_frame = training_frame, family = family, standardize=FALSE)
+  # coeff2 <- h2o.coef_norm(m2) # this will fail before zuzana's fix
+  coeff2 <- h2o.coef(m2) # Zuzana:  please use the above once you fix the JIRA
+  if ((family=="multinomial") || (family=="binomial")) {
+   numCompares = length(coeff1)
+   for (index in c(2:numCompares)) { # skip the coefficient names
+     numCoeff = length(coeff1[[index]])
+     for (index2 in c(2:numCoeff)) # skip the class name which is different
+      expect_equal(coeff1[[index]][index2], coeff2[[index]][index2])
+   }
+  } else {
+  expect_equal(coeff1, coeff2)
+  }
+}
+
+doTest("GLM: Check standardized coefficients when standardize = FALSE.", glmStandardizeCoeffsCheck)

--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_pubdev_7238_standardized_coeff_check.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_pubdev_7238_standardized_coeff_check.R
@@ -40,8 +40,7 @@ checkCoeffs <- function(filename, family) {
     training_frame[colNames[index]] <- (training_frame[colNames[index]]-aver)*sig
   }
   m2 <- h2o.glm(y = Y, x = x, training_frame = training_frame, family = family, standardize=FALSE)
-  # coeff2 <- h2o.coef_norm(m2) # this will fail before zuzana's fix
-  coeff2 <- h2o.coef(m2) # Zuzana:  please use the above once you fix the JIRA
+  coeff2 <- h2o.coef_norm(m2)
   if ((family=="multinomial") || (family=="binomial")) {
    numCompares = length(coeff1)
    for (index in c(2:numCompares)) { # skip the coefficient names


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7118
With this change, glm model with standardize=False will calculate also the standardizedCoefficients (as in standardize=True case).
Note to be checked: it stands in documentation (model_base.py), that if standardize=False then coef() return the coefficients which are fit directly - does this mean that varimp should be calculated from these and not from newly calculated standardized ones?
