### PR TITLE
PUBDEV-7238: fixed multinomial standardized coefficients in R/Python API

### DIFF
--- a/h2o-r/tests/testdir_algos/glm/runit_GLM_pubdev_7238_standardized_coeff_check.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_GLM_pubdev_7238_standardized_coeff_check.R
@@ -2,7 +2,10 @@ setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
 source("../../../scripts/h2o-r-test-setup.R")
 
 glmStandardizeCoeffsCheck <- function() {
-  browser()
+  # check binomial
+  print("Checking standardized coefficients for binomials....")
+  checkCoeffs("smalldata/glm_test/binomial_20_cols_10KRows.csv", "binomial")
+  
   # check multinomial
   print("Checking standardized coefficients for multinomials....")
   checkCoeffs("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv", "multinomial")
@@ -10,10 +13,6 @@ glmStandardizeCoeffsCheck <- function() {
   # check gaussian
   print("Checking standardized coefficients for regression....")
   checkCoeffs("smalldata/glm_test/gaussian_20cols_10000Rows.csv", "gaussian")
-  
-  # check binomial
-  print("Checking standardized coefficients for binomials....")
-  checkCoeffs("smalldata/glm_test/binomial_20_cols_10KRows.csv", "binomial")
 }
 
 checkCoeffs <- function(filename, family) {
@@ -41,15 +40,21 @@ checkCoeffs <- function(filename, family) {
   }
   m2 <- h2o.glm(y = Y, x = x, training_frame = training_frame, family = family, standardize=FALSE)
   coeff2 <- h2o.coef_norm(m2)
-  if ((family=="multinomial") || (family=="binomial")) {
+  coeff2Coef <- h2o.coef(m2)
+ if (family == "multinomial") {
    numCompares = length(coeff1)
-   for (index in c(2:numCompares)) { # skip the coefficient names
+   for (index in c(2:numCompares)) {
+     # skip the coefficient names
      numCoeff = length(coeff1[[index]])
-     for (index2 in c(2:numCoeff)) # skip the class name which is different
-      expect_equal(coeff1[[index]][index2], coeff2[[index]][index2])
+     for (index2 in c(2:numCoeff)) {
+       # skip the class name which is different
+       expect_equal(coeff1[[index]][index2], coeff2[[index]][index2])
+       expect_equal(coeff2[[index]][[index2]], coeff2Coef[[index]][[index2]]) # test R API coef() and coef_norm(), should equal here
+     }
    }
-  } else {
-  expect_equal(coeff1, coeff2)
+ } else {
+    expect_equal(coeff1, coeff2)
+    expect_equal(coeff2, coeff2Coef) # test R API coef() and coef_norm().  They should be equal in this case
   }
 }
 


### PR DESCRIPTION
This PR fixed the problems in JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7238?filter=myopenissues&orderby=priority%20DESC

In this PR, I fixed the following:
1. R API, coeff_norm() is not implemented correctly for multinomial.  I fixed it and added a Runit test.
2. For Python API, coeff_norm() is not implemented correctly for multinomial.  I fixed it and added a Pyunit test.