### PR TITLE
PUBDEV-6818: Fix Unsupported Exception

### DIFF
--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -421,7 +421,7 @@ public final class AutoBuffer {
           // For small-packet write, send via UDP.  Since nothing is sent until
           // now, this close() call trivially orders - since the reader will not
           // even start (much less close()) until this packet is sent.
-          if( _bb.limit() < MTU) return udpSend();
+          if( _bb.position() < MTU) return udpSend();
           // oops - Big Write, switch to TCP and finish out there
         }
       }
@@ -1359,7 +1359,7 @@ public final class AutoBuffer {
 
     put1(8);                    // Ship as full longs
     int sofar = x;
-    if ((y-sofar)*8 > _bb.remaining()) expandByteBuffer(ary.length*8);
+    if ((y-sofar)*8 > _bb.remaining()) expandByteBuffer(nzlen*8);
     while( sofar < y ) {
       LongBuffer lb = _bb.asLongBuffer();
       int len = Math.min(y - sofar, lb.remaining());

--- a/h2o-core/src/main/java/water/AutoBuffer.java
+++ b/h2o-core/src/main/java/water/AutoBuffer.java
@@ -421,7 +421,7 @@ public final class AutoBuffer {
           // For small-packet write, send via UDP.  Since nothing is sent until
           // now, this close() call trivially orders - since the reader will not
           // even start (much less close()) until this packet is sent.
-          if( _bb.position() < MTU) return udpSend();
+          if( _bb.limit() < MTU) return udpSend();
           // oops - Big Write, switch to TCP and finish out there
         }
       }

--- a/h2o-core/src/main/java/water/TimeLine.java
+++ b/h2o-core/src/main/java/water/TimeLine.java
@@ -184,7 +184,7 @@ public class TimeLine extends UDP {
   // possible to the same point in time.
   static long[][] SNAPSHOT;
   static long TIME_LAST_SNAPSHOT = 1;
-  static private H2O CLOUD;      // Cloud instance being snapshotted
+  static private H2O CLOUD = H2O.CLOUD;      // Cloud instance being snapshotted
   public static H2O getCLOUD(){return CLOUD;}
   static public long[][] system_snapshot() {
     // Now spin-wait until we see all snapshots check in.

--- a/h2o-core/src/main/java/water/TimeLine.java
+++ b/h2o-core/src/main/java/water/TimeLine.java
@@ -184,7 +184,7 @@ public class TimeLine extends UDP {
   // possible to the same point in time.
   static long[][] SNAPSHOT;
   static long TIME_LAST_SNAPSHOT = 1;
-  static private H2O CLOUD = H2O.CLOUD;      // Cloud instance being snapshotted
+  static private H2O CLOUD;      // Cloud instance being snapshotted
   public static H2O getCLOUD(){return CLOUD;}
   static public long[][] system_snapshot() {
     // Now spin-wait until we see all snapshots check in.
@@ -221,6 +221,9 @@ public class TimeLine extends UDP {
 
   // Send our most recent timeline to the remote via TCP
   @Override AutoBuffer call( AutoBuffer ab ) {
+    if (CLOUD == null) {
+      return null;
+    }
     long[] a = snapshot();
     if( ab._h2o == H2O.SELF ) {
       synchronized(TimeLine.class) {
@@ -236,6 +239,9 @@ public class TimeLine extends UDP {
 
   // Receive a remote timeline
   static void tcp_call( final AutoBuffer ab ) {
+    if (CLOUD == null) {
+      return;
+    }
     ab.getPort();
     long[] snap = ab.getA8();
     int idx = CLOUD.nidx(ab._h2o);

--- a/h2o-core/src/test/java/water/AutoBufferTest.java
+++ b/h2o-core/src/test/java/water/AutoBufferTest.java
@@ -6,6 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
@@ -13,6 +14,38 @@ public class AutoBufferTest extends TestUtil {
 
   @BeforeClass()
   public static void setup() { stall_till_cloudsize(1); }
+
+  @Test
+  public void testPutA8ArrayWithJustZeros() {
+    long[] arr = new long[AutoBuffer.BBP_SML._size * 2];
+    AutoBuffer ab = new AutoBuffer(H2O.SELF, (byte) 1);
+    ab.putA8(arr);
+    assertTrue(ab._bb.hasArray());
+    assertFalse(ab._bb.isDirect());
+    assertEquals(ab._bb.array().length, 16);
+
+  }
+
+  @Test
+  public void testPutA8SmallBufferAfterTrimmed() {
+    long[] arr = new long[AutoBuffer.BBP_SML._size * 2];
+    arr[1000] = 42;
+    AutoBuffer ab = new AutoBuffer(H2O.SELF, (byte) 1);
+    ab.putA8(arr);
+    assertTrue(ab._bb.hasArray());
+    assertFalse(ab._bb.isDirect());
+    assertEquals(ab._bb.array().length, 16);
+  }
+
+  @Test
+  public void testPutA8BigBufferAfterTrimmed() {
+    long[] arr = new long[AutoBuffer.BBP_SML._size * 2];
+    Arrays.fill(arr, Long.MAX_VALUE);
+    AutoBuffer ab = new AutoBuffer(H2O.SELF, (byte) 1);
+    ab.putA8(arr);
+    assertFalse(ab._bb.hasArray());
+    assertTrue(ab._bb.isDirect());
+  }
 
   @Test
   public void testOutputStreamBigDataBigChunks() {


### PR DESCRIPTION
Fixes 

```
Exception in thread "TCP-SMALL-SEND-/192.168.3.113:54323" java.lang.UnsupportedOperationException
	at java.nio.ByteBuffer.array(ByteBuffer.java:994)
	at water.H2ONode$SmallMessagesSendThread.run(H2ONode.java:590)
```
From java documentation:
 > UnsupportedOperationException - If this buffer is not backed by an accessible array

Still trying to find the cause