### PR TITLE
Prevent processing garbage data

### DIFF
--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -309,6 +309,11 @@ public class TCPReceiverThread extends Thread {
     boolean is_member = cloud.contains(ab._h2o);
     boolean is_client = ab._h2o.isClient();
 
+
+    if(ctrl > UDP.udp.UDPS.length) {
+      return;
+    }
+
     // Some non-Paxos packet from a non-member.  Probably should record & complain.
     // Filter unknown-packet-reports.  In bad situations of poisoned Paxos
     // voting we can get a LOT of these packets/sec, flooding the logs.

--- a/h2o-core/src/main/java/water/TCPReceiverThread.java
+++ b/h2o-core/src/main/java/water/TCPReceiverThread.java
@@ -310,7 +310,8 @@ public class TCPReceiverThread extends Thread {
     boolean is_client = ab._h2o.isClient();
 
 
-    if(ctrl > UDP.udp.UDPS.length) {
+    // Skip garbage traffic
+    if(ctrl >= UDP.udp.UDPS.length) {
       return;
     }
 


### PR DESCRIPTION
Avoids:
```
ava.lang.ArrayIndexOutOfBoundsException: 13
	at water.TCPReceiverThread.basic_packet_handling(TCPReceiverThread.java:315)
	at water.TCPReceiverThread$SmallMessagesReaderThread.run(TCPReceiverThread.java:257)
java.lang.ArrayIndexOutOfBoundsException: 14
	at water.TCPReceiverThread.basic_packet_handling(TCPReceiverThread.java:315)
	at water.TCPReceiverThread$SmallMessagesReaderThread.run(TCPReceiverThread.java:257)
java.lang.ArrayIndexOutOfBoundsException: 11
	at water.TCPReceiverThread.basic_packet_handling(TCPReceiverThread.java:315)
	at water.TCPReceiverThread$SmallMessagesReaderThread.run(TCPReceiverThread.java:257)
java.lang.ArrayIndexOutOfBoundsException: 16
	at water.TCPReceiverThread.basic_packet_handling(TCPReceiverThread.java:315)
	at water.TCPReceiverThread$SmallMessagesReaderThread.run(TCPReceiverThread.java:257)
```

Which is observable when running Sparking Water on EMR, CC: @mn-mikke 