### PR TITLE
AutoML: simplifying logic for default stopping tolerance

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -140,9 +140,9 @@ public class AutoMLBuildSpec extends Iced {
 
     public AutoMLStoppingCriteria() {
       // reasonable defaults:
-      set_max_models(0);
-      set_max_runtime_secs(3600);
-      set_max_runtime_secs_per_model(0);
+      set_max_models(0); // no limit
+      set_max_runtime_secs(0); // no limit
+      set_max_runtime_secs_per_model(0); // no limit
 
       set_stopping_rounds(3);
       set_stopping_tolerance(AUTO_STOPPING_TOLERANCE);

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -60,15 +60,6 @@ public class AutoMLBuildSpec extends Iced {
 
     public AutoMLBuildControl() {
       stopping_criteria = new AutoMLStoppingCriteria();
-
-      // reasonable defaults:
-      stopping_criteria.set_max_models(0); //no limit
-      stopping_criteria.set_max_runtime_secs(0); //no limit
-      stopping_criteria.set_max_runtime_secs_per_model(0); //no limit
-
-      stopping_criteria.set_stopping_rounds(3);
-      stopping_criteria.set_stopping_tolerance(0.001);
-      stopping_criteria.set_stopping_metric(StoppingMetric.AUTO);
     }
   }
 
@@ -154,7 +145,7 @@ public class AutoMLBuildSpec extends Iced {
       set_max_runtime_secs_per_model(0);
 
       set_stopping_rounds(3);
-      set_stopping_tolerance(0.001);
+      set_stopping_tolerance(AUTO_STOPPING_TOLERANCE);
       set_stopping_metric(StoppingMetric.AUTO);
     }
   }

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -319,23 +319,4 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
   public AutoMLBuildSpec fillImpl(AutoMLBuildSpec impl) {
     return super.fillImpl(impl, new String[] {"job"});
   }
-
-  @Override
-  public AutoMLBuildSpecV99 fillFromBody(String body) {
-    AutoMLBuildSpecV99 schema = super.fillFromBody(body); //default JSON filling
-
-    // TODO: need to understand why we set stopping tolerance to AUTO iff stopping_criteria is provided without stopping_tolerance
-    Map<String, Object> json_body = JSONUtils.parse(body);
-    if (json_body.containsKey("build_control")) {
-      Map<String, Object> build_control = (Map)json_body.get("build_control");
-      if (build_control.containsKey("stopping_criteria")) {
-        Map<String, Object> stopping_criteria = (Map)build_control.get("stopping_criteria");
-
-        if (!stopping_criteria.containsKey("stopping_tolerance")) {
-          schema.build_control.stopping_criteria.stopping_tolerance = AUTO_STOPPING_TOLERANCE;
-        }
-      }
-    }
-    return schema;
-  }
 }

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -317,7 +317,7 @@ h2o.automl <- function(x, y, training_frame,
   # GET AutoML object
   aml <- h2o.get_automl(project_name = res$job$dest$name)
   attr(aml, "id") <- res$job$dest$name
-  attr(aml, '_build_json') <- res # hidden attribute for debugging/testing
+  attr(aml, '_build_resp') <- res # hidden attribute for debugging/testing
   return(aml)
 }
 

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -317,6 +317,7 @@ h2o.automl <- function(x, y, training_frame,
   # GET AutoML object
   aml <- h2o.get_automl(project_name = res$job$dest$name)
   attr(aml, "id") <- res$job$dest$name
+  attr(aml, '_build_json') <- res # hidden attribute for debugging/testing
   return(aml)
 }
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -127,20 +127,49 @@ automl.args.test <- function() {
         )
     }
 
+    test_early_stopping_defaults <- function () {
+        print("Early stopping defaults")
+        ds <- import_dataset()
+        aml <- h2o.automl(x = ds$x, y = ds$y,
+                   training_frame = ds$train,
+                   max_models = max_models,
+                   project_name = "aml_early_stopping_defaults",
+        )
+        json <- attr(aml, "_build_json")
+        stopping_criteria <- json$build_control$stopping_criteria
+        auto_stopping_tolerance <- (function(fr) min(0.05, max(0.001, 1/sqrt((1 - sum(h2o.nacnt(fr)) / (ncol(fr) * nrow(fr))) * nrow(fr)))))(ds$train)
+        expect_equal(stopping_criteria$stopping_rounds, 3)
+        expect_equal(stopping_criteria$stopping_tolerance, auto_stopping_tolerance)
+        expect_equal(stopping_criteria$stopping_metric, 'AUTO')
+        expect_equal(stopping_criteria$max_models, max_models)
+        expect_equal(stopping_criteria$max_runtime_secs, 0)
+        expect_equal(stopping_criteria$max_runtime_secs_per_model, 0)
+    }
+
     test_early_stopping <- function() {
         print("Early stopping args")
         ds <- import_dataset()
-        h2o.automl(x = ds$x, y = ds$y,
+        aml <- h2o.automl(x = ds$x, y = ds$y,
             training_frame = ds$train,
             validation_frame = ds$valid,
             leaderboard_frame = ds$test,
             max_models = max_models,
+            max_runtime_secs = 1200,
+            max_runtime_secs_per_model = 60,
             stopping_metric = "AUC",
             stopping_tolerance = 0.001,
-            stopping_rounds = 3,
+            stopping_rounds = 2,
             sort_metric = "RMSE",
             project_name = "aml7",
         )
+        json <- attr(aml, "_build_json")
+        stopping_criteria <- json$build_control$stopping_criteria
+        expect_equal(stopping_criteria$stopping_rounds, 2)
+        expect_equal(stopping_criteria$stopping_tolerance,0.001)
+        expect_equal(stopping_criteria$stopping_metric, 'AUC')
+        expect_equal(stopping_criteria$max_models, max_models)
+        expect_equal(stopping_criteria$max_runtime_secs, 1200)
+        expect_equal(stopping_criteria$max_runtime_secs_per_model, 60)
     }
 
     test_metrics_case_insensitive <- function() {
@@ -449,6 +478,7 @@ automl.args.test <- function() {
         test_training_with_validation_frame,
         test_training_with_leaderboard_frame,
         test_training_with_validation_and_leaderboard_frame,
+        test_early_stopping_defaults,
         test_early_stopping,
         test_metrics_case_insensitive,
         test_leaderboard_growth,

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_args.R
@@ -135,7 +135,7 @@ automl.args.test <- function() {
                    max_models = max_models,
                    project_name = "aml_early_stopping_defaults",
         )
-        json <- attr(aml, "_build_json")
+        json <- attr(aml, "_build_resp")
         stopping_criteria <- json$build_control$stopping_criteria
         auto_stopping_tolerance <- (function(fr) min(0.05, max(0.001, 1/sqrt((1 - sum(h2o.nacnt(fr)) / (ncol(fr) * nrow(fr))) * nrow(fr)))))(ds$train)
         expect_equal(stopping_criteria$stopping_rounds, 3)
@@ -162,7 +162,7 @@ automl.args.test <- function() {
             sort_metric = "RMSE",
             project_name = "aml7",
         )
-        json <- attr(aml, "_build_json")
+        json <- attr(aml, "_build_resp")
         stopping_criteria <- json$build_control$stopping_criteria
         expect_equal(stopping_criteria$stopping_rounds, 2)
         expect_equal(stopping_criteria$stopping_tolerance,0.001)


### PR DESCRIPTION
Existing logic was confusing, splitting the logic in 2 different places, and giving the impression that default `stopping_tolerance` was `0.001`, when it is actually is an adaptative value, computed from some properties of the training frame.