### PR TITLE
PUBDEV-7189: ensure that AutoML works even if XGBoost extension is missing on the classpath

### DIFF
--- a/h2o-automl/build.gradle
+++ b/h2o-automl/build.gradle
@@ -4,12 +4,13 @@ dependencies {
   compile project(":h2o-genmodel")
   compile project(":h2o-core")
   compile project(":h2o-algos")
-  compile project(":h2o-ext-xgboost")
+  compileOnly project(":h2o-ext-xgboost")
 
   // Test dependencies only
   testCompile "junit:junit:${junitVersion}"
   testCompile "com.github.stefanbirkner:system-rules:1.18.0"
   testCompile project(path: ":h2o-core", configuration: "testArchives")
+  testCompile project(":h2o-ext-xgboost")
   testRuntimeOnly project(":${defaultWebserverModule}")
 }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/Algo.java
@@ -19,7 +19,7 @@ public enum Algo {
     private static final String DISTRIBUTED_XGBOOST_ENABLED = H2O.OptArgs.SYSTEM_PROP_PREFIX + "automl.xgboost.multinode.enabled";
 
     @Override
-    boolean enabled() {
+    public boolean enabled() {
       // on single node, XGBoost is enabled by default if the extension is enabled.
       // on multinode, the same condition applies, but only on Linux by default: needs to be activated explicitly for other platforms.
       boolean enabledOnMultinode = Boolean.parseBoolean(System.getProperty(DISTRIBUTED_XGBOOST_ENABLED, isLinux() ? "true" : "false"));
@@ -32,7 +32,7 @@ public enum Algo {
     return this.name().toLowerCase();
   }
 
-  boolean enabled() {
+  public boolean enabled() {
     return true;
   }
 }

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelParametersProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelParametersProvider.java
@@ -1,0 +1,9 @@
+package ai.h2o.automl;
+
+import hex.Model.Parameters;
+
+public interface ModelParametersProvider<P extends Parameters> {
+
+    P newDefaultParameters();
+
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsProvider.java
@@ -10,6 +10,8 @@ public interface ModelingStepsProvider<T extends ModelingSteps> {
     String getName();
 
     /**
+     * Creates an instance of {@link ModelingSteps} associated to this provider's name,
+     * or returns null to fully skip this provider..
      *
      * @param aml the {@link AutoML} instance needed to build the {@link ModelingSteps}
      * @return an instance of {@link ModelingSteps} listing all the various AutoML steps executable with this provider name.

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsRegistry.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStepsRegistry.java
@@ -3,6 +3,7 @@ package ai.h2o.automl;
 import ai.h2o.automl.events.EventLogEntry.Stage;
 import ai.h2o.automl.StepDefinition.Alias;
 import ai.h2o.automl.StepDefinition.Step;
+import hex.Model;
 import water.Iced;
 import water.nbhm.NonBlockingHashMap;
 import water.util.ArrayUtils;
@@ -21,12 +22,23 @@ import java.util.stream.Stream;
 public class ModelingStepsRegistry extends Iced<ModelingStepsRegistry> {
 
     static final NonBlockingHashMap<String, ModelingStepsProvider> stepsByName = new NonBlockingHashMap<>();
+    static final NonBlockingHashMap<String, ModelParametersProvider> parametersByName = new NonBlockingHashMap<>();
 
     static {
         ServiceLoader<ModelingStepsProvider> trainingStepsProviders = ServiceLoader.load(ModelingStepsProvider.class);
         for (ModelingStepsProvider provider : trainingStepsProviders) {
             stepsByName.put(provider.getName(), provider);
+            if (provider instanceof ModelParametersProvider) {  // mainly for hardcoded providers in this module, that's why we can reuse the ModelingStepsProvider
+                parametersByName.put(provider.getName(), (ModelParametersProvider)provider);
+            }
         }
+    }
+
+    public static Model.Parameters defaultParameters(String provider) {
+        if (parametersByName.containsKey(provider)) {
+            return parametersByName.get(provider).newDefaultParameters();
+        }
+        return null;
     }
 
     /**
@@ -42,6 +54,8 @@ public class ModelingStepsRegistry extends Iced<ModelingStepsRegistry> {
                 throw new IllegalArgumentException("Missing provider for training steps '"+def._name+"'");
             }
             ModelingSteps steps = provider.newInstance(aml);
+            if (steps == null) continue;
+
             ModelingStep[] toAdd;
             if (def._alias != null) {
                 toAdd = steps.getSteps(def._alias);

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/DRFStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/DRFStepsProvider.java
@@ -9,7 +9,9 @@ import water.Key;
 
 import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
 
-public class DRFStepsProvider implements ModelingStepsProvider<DRFStepsProvider.DRFSteps> {
+public class DRFStepsProvider
+        implements ModelingStepsProvider<DRFStepsProvider.DRFSteps>
+                 , ModelParametersProvider<DRFParameters> {
 
     public static class DRFSteps extends ModelingSteps {
 
@@ -74,6 +76,11 @@ public class DRFStepsProvider implements ModelingStepsProvider<DRFStepsProvider.
     @Override
     public DRFSteps newInstance(AutoML aml) {
         return new DRFSteps(aml);
+    }
+
+    @Override
+    public DRFParameters newDefaultParameters() {
+        return new DRFParameters();
     }
 }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/DeepLearningStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/DeepLearningStepsProvider.java
@@ -12,7 +12,9 @@ import java.util.Map;
 import static ai.h2o.automl.ModelingStep.GridStep.DEFAULT_GRID_TRAINING_WEIGHT;
 import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
 
-public class DeepLearningStepsProvider implements ModelingStepsProvider<DeepLearningStepsProvider.DeepLearningSteps> {
+public class DeepLearningStepsProvider
+        implements ModelingStepsProvider<DeepLearningStepsProvider.DeepLearningSteps>
+                 , ModelParametersProvider<DeepLearningParameters> {
 
     public static class DeepLearningSteps extends ModelingSteps {
 
@@ -156,6 +158,11 @@ public class DeepLearningStepsProvider implements ModelingStepsProvider<DeepLear
     @Override
     public DeepLearningSteps newInstance(AutoML aml) {
         return new DeepLearningSteps(aml);
+    }
+
+    @Override
+    public DeepLearningParameters newDefaultParameters() {
+        return new DeepLearningParameters();
     }
 }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
@@ -13,7 +13,9 @@ import java.util.Map;
 import static ai.h2o.automl.ModelingStep.GridStep.DEFAULT_GRID_TRAINING_WEIGHT;
 import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
 
-public class GBMStepsProvider implements ModelingStepsProvider<GBMStepsProvider.GBMSteps> {
+public class GBMStepsProvider
+        implements ModelingStepsProvider<GBMStepsProvider.GBMSteps>
+                 , ModelParametersProvider<GBMParameters> {
 
     public static class GBMSteps extends ModelingSteps {
 
@@ -149,6 +151,11 @@ public class GBMStepsProvider implements ModelingStepsProvider<GBMStepsProvider.
     @Override
     public GBMSteps newInstance(AutoML aml) {
         return new GBMSteps(aml);
+    }
+
+    @Override
+    public GBMParameters newDefaultParameters() {
+        return new GBMParameters();
     }
 }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
@@ -8,7 +8,9 @@ import water.Job;
 import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
 
 
-public class GLMStepsProvider implements ModelingStepsProvider<GLMStepsProvider.GLMSteps> {
+public class GLMStepsProvider
+        implements ModelingStepsProvider<GLMStepsProvider.GLMSteps>
+                 , ModelParametersProvider<GLMParameters> {
 
     public static class GLMSteps extends ModelingSteps {
 
@@ -87,6 +89,11 @@ public class GLMStepsProvider implements ModelingStepsProvider<GLMStepsProvider.
     @Override
     public GLMSteps newInstance(AutoML aml) {
         return new GLMSteps(aml);
+    }
+
+    @Override
+    public GLMParameters newDefaultParameters() {
+        return new GLMParameters();
     }
 }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -17,7 +17,9 @@ import java.util.stream.Stream;
 
 import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
 
-public class StackedEnsembleStepsProvider implements ModelingStepsProvider<StackedEnsembleStepsProvider.StackedEnsembleSteps> {
+public class StackedEnsembleStepsProvider
+        implements ModelingStepsProvider<StackedEnsembleStepsProvider.StackedEnsembleSteps>
+                 , ModelParametersProvider<StackedEnsembleParameters> {
 
     public static class StackedEnsembleSteps extends ModelingSteps {
 
@@ -155,6 +157,11 @@ public class StackedEnsembleStepsProvider implements ModelingStepsProvider<Stack
     @Override
     public StackedEnsembleSteps newInstance(AutoML aml) {
         return new StackedEnsembleSteps(aml);
+    }
+
+    @Override
+    public StackedEnsembleParameters newDefaultParameters() {
+        return new StackedEnsembleParameters();
     }
 }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
@@ -1,0 +1,188 @@
+package ai.h2o.automl.modeling;
+
+import ai.h2o.automl.Algo;
+import ai.h2o.automl.AutoML;
+import ai.h2o.automl.ModelingStep;
+import ai.h2o.automl.ModelingSteps;
+import hex.genmodel.utils.DistributionFamily;
+import hex.grid.Grid;
+import hex.tree.xgboost.XGBoostModel;
+import hex.tree.xgboost.XGBoostModel.XGBoostParameters;
+import water.Job;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static ai.h2o.automl.ModelingStep.GridStep.DEFAULT_GRID_TRAINING_WEIGHT;
+import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
+
+public class XGBoostSteps extends ModelingSteps {
+
+    static XGBoostParameters prepareModelParameters(AutoML aml, boolean emulateLightGBM) {
+        XGBoostParameters xgBoostParameters = new XGBoostParameters();
+
+        if (emulateLightGBM) {
+            xgBoostParameters._tree_method = XGBoostParameters.TreeMethod.hist;
+            xgBoostParameters._grow_policy = XGBoostParameters.GrowPolicy.lossguide;
+        }
+
+        // setDistribution: no way to identify gaussian, poisson, laplace? using descriptive statistics?
+        xgBoostParameters._distribution = aml.getResponseColumn().isBinary() && !(aml.getResponseColumn().isNumeric()) ? DistributionFamily.bernoulli
+                : aml.getResponseColumn().isCategorical() ? DistributionFamily.multinomial
+                : DistributionFamily.AUTO;
+
+        xgBoostParameters._score_tree_interval = 5;
+        xgBoostParameters._stopping_rounds = 5;
+
+        xgBoostParameters._ntrees = 10000;
+        xgBoostParameters._learn_rate = 0.05;
+//            xgBoostParameters._min_split_improvement = 0.01f;
+
+        return xgBoostParameters;
+    }
+
+    static abstract class XGBoostModelStep extends ModelingStep.ModelStep<XGBoostModel> {
+
+        boolean _emulateLightGBM;
+
+        XGBoostModelStep(String id, int weight, AutoML autoML, boolean emulateLightGBM) {
+            super(Algo.XGBoost, id, weight, autoML);
+            _emulateLightGBM = emulateLightGBM;
+        }
+
+        XGBoostParameters prepareModelParameters() {
+            return XGBoostSteps.prepareModelParameters(aml(), _emulateLightGBM);
+        }
+    }
+
+    static abstract class XGBoostGridStep extends ModelingStep.GridStep<XGBoostModel> {
+        boolean _emulateLightGBM;
+
+        public XGBoostGridStep(String id, int weight, AutoML autoML, boolean emulateLightGBM) {
+            super(Algo.XGBoost, id, weight, autoML);
+            _emulateLightGBM = emulateLightGBM;
+        }
+
+        XGBoostParameters prepareModelParameters() {
+            return XGBoostSteps.prepareModelParameters(aml(), _emulateLightGBM);
+        }
+    }
+
+
+    private ModelingStep[] defaults = new XGBoostModelStep[] {
+            new XGBoostModelStep("def_1", DEFAULT_MODEL_TRAINING_WEIGHT, aml(),false) {
+                @Override
+                protected Job<XGBoostModel> startJob() {
+                    //XGB 1 (medium depth)
+                    XGBoostParameters xgBoostParameters = prepareModelParameters();
+                    xgBoostParameters._max_depth = 10;
+                    xgBoostParameters._min_rows = 5;
+                    xgBoostParameters._sample_rate = 0.6;
+                    xgBoostParameters._col_sample_rate = 0.8;
+                    xgBoostParameters._col_sample_rate_per_tree = 0.8;
+
+                    if (_emulateLightGBM) {
+                        xgBoostParameters._max_leaves = 1 << xgBoostParameters._max_depth;
+                        xgBoostParameters._max_depth = xgBoostParameters._max_depth * 2;
+//                        xgBoostParameters._min_data_in_leaf = (float) xgBoostParameters._min_rows;
+                        xgBoostParameters._min_sum_hessian_in_leaf = (float) xgBoostParameters._min_rows;
+                    }
+
+                    return trainModel(xgBoostParameters);
+                }
+            },
+            new XGBoostModelStep("def_2", DEFAULT_MODEL_TRAINING_WEIGHT, aml(), false) {
+                @Override
+                protected Job<XGBoostModel> startJob() {
+                    //XGB 2 (deep)
+                    XGBoostParameters xgBoostParameters = prepareModelParameters();
+                    xgBoostParameters._max_depth = 20;
+                    xgBoostParameters._min_rows = 10;
+                    xgBoostParameters._sample_rate = 0.6;
+                    xgBoostParameters._col_sample_rate = 0.8;
+                    xgBoostParameters._col_sample_rate_per_tree = 0.8;
+
+                    if (_emulateLightGBM) {
+                        xgBoostParameters._max_leaves = 1 << xgBoostParameters._max_depth;
+                        xgBoostParameters._max_depth = xgBoostParameters._max_depth * 2;
+//                        xgBoostParameters._min_data_in_leaf = (float) xgBoostParameters._min_rows;
+                        xgBoostParameters._min_sum_hessian_in_leaf = (float) xgBoostParameters._min_rows;
+                    }
+
+                    return trainModel(xgBoostParameters);
+                }
+            },
+            new XGBoostModelStep("def_3", DEFAULT_MODEL_TRAINING_WEIGHT, aml(), false) {
+                @Override
+                protected Job<XGBoostModel> startJob() {
+                    //XGB 3 (shallow)
+                    XGBoostParameters xgBoostParameters = prepareModelParameters();
+                    xgBoostParameters._max_depth = 5;
+                    xgBoostParameters._min_rows = 3;
+                    xgBoostParameters._sample_rate = 0.8;
+                    xgBoostParameters._col_sample_rate = 0.8;
+                    xgBoostParameters._col_sample_rate_per_tree = 0.8;
+
+                    if (_emulateLightGBM) {
+                        xgBoostParameters._max_leaves = 1 << xgBoostParameters._max_depth;
+                        xgBoostParameters._max_depth = xgBoostParameters._max_depth * 2;
+//                        xgBoostParameters._min_data_in_leaf = (float) xgBoostParameters._min_rows;
+                        xgBoostParameters._min_sum_hessian_in_leaf = (float) xgBoostParameters._min_rows;
+                    }
+
+                    return trainModel(xgBoostParameters);
+                }
+            },
+    };
+
+    private ModelingStep[] grids = new XGBoostGridStep[] {
+            new XGBoostGridStep("grid_1", 5* DEFAULT_GRID_TRAINING_WEIGHT, aml(), false) {
+                @Override
+                protected Job<Grid> startJob() {
+                    XGBoostParameters xgBoostParameters = prepareModelParameters();
+                    Map<String, Object[]> searchParams = new HashMap<>();
+//                    searchParams.put("_ntrees", new Integer[]{100, 1000, 10000}); // = _n_estimators
+
+                    if (_emulateLightGBM) {
+                        searchParams.put("_max_leaves", new Integer[]{1<<5, 1<<10, 1<<15, 1<<20});
+                        searchParams.put("_max_depth", new Integer[]{10, 20, 50});
+                        searchParams.put("_min_sum_hessian_in_leaf", new Double[]{0.01, 0.1, 1.0, 3.0, 5.0, 10.0, 15.0, 20.0});
+                    } else {
+                        searchParams.put("_max_depth", new Integer[]{5, 10, 15, 20});
+                        searchParams.put("_min_rows", new Double[]{0.01, 0.1, 1.0, 3.0, 5.0, 10.0, 15.0, 20.0});  // = _min_child_weight
+                    }
+
+                    searchParams.put("_sample_rate", new Double[]{0.6, 0.8, 1.0}); // = _subsample
+                    searchParams.put("_col_sample_rate" , new Double[]{ 0.6, 0.8, 1.0}); // = _colsample_bylevel"
+                    searchParams.put("_col_sample_rate_per_tree", new Double[]{ 0.7, 0.8, 0.9, 1.0}); // = _colsample_bytree: start higher to always use at least about 40% of columns
+//                    searchParams.put("_learn_rate", new Double[]{0.01, 0.05, 0.08, 0.1, 0.15, 0.2, 0.3, 0.5, 0.8, 1.0}); // = _eta
+//                    searchParams.put("_min_split_improvement", new Float[]{0.01f, 0.05f, 0.1f, 0.5f, 1f, 5f, 10f, 50f}); // = _gamma
+//                    searchParams.put("_tree_method", new XGBoostParameters.TreeMethod[]{XGBoostParameters.TreeMethod.auto});
+                    searchParams.put("_booster", new XGBoostParameters.Booster[]{ //gblinear crashes currently
+                            XGBoostParameters.Booster.gbtree, //default, let's use it more often
+                            XGBoostParameters.Booster.gbtree,
+                            XGBoostParameters.Booster.dart
+                    });
+
+                    searchParams.put("_reg_lambda", new Float[]{0.001f, 0.01f, 0.1f, 1f, 10f, 100f});
+                    searchParams.put("_reg_alpha", new Float[]{0.001f, 0.01f, 0.1f, 0.5f, 1f});
+
+                    return hyperparameterSearch(xgBoostParameters, searchParams);
+                }
+            },
+    };
+
+    public XGBoostSteps(AutoML autoML) {
+        super(autoML);
+    }
+
+    @Override
+    protected ModelingStep[] getDefaultModels() {
+        return defaults;
+    }
+
+    @Override
+    protected ModelingStep[] getGrids() {
+        return grids;
+    }
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
@@ -158,8 +158,8 @@ public class XGBoostSteps extends ModelingSteps {
 //                    searchParams.put("_learn_rate", new Double[]{0.01, 0.05, 0.08, 0.1, 0.15, 0.2, 0.3, 0.5, 0.8, 1.0}); // = _eta
 //                    searchParams.put("_min_split_improvement", new Float[]{0.01f, 0.05f, 0.1f, 0.5f, 1f, 5f, 10f, 50f}); // = _gamma
 //                    searchParams.put("_tree_method", new XGBoostParameters.TreeMethod[]{XGBoostParameters.TreeMethod.auto});
-                    searchParams.put("_booster", new XGBoostParameters.Booster[]{ //gblinear crashes currently
-                            XGBoostParameters.Booster.gbtree, //default, let's use it more often
+                    searchParams.put("_booster", new XGBoostParameters.Booster[]{ // include gblinear? cf. https://0xdata.atlassian.net/browse/PUBDEV-7254
+                            XGBoostParameters.Booster.gbtree, //default, let's use it more often: note that some combinations may be trained multiple time by the RGS then.
                             XGBoostParameters.Booster.gbtree,
                             XGBoostParameters.Booster.dart
                     });

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostStepsProvider.java
@@ -2,6 +2,7 @@ package ai.h2o.automl.modeling;
 
 import ai.h2o.automl.*;
 import hex.Model;
+import hex.ModelBuilder;
 import water.util.Log;
 
 
@@ -23,14 +24,7 @@ public class XGBoostStepsProvider implements ModelingStepsProvider<XGBoostSteps>
 
     @Override
     public Model.Parameters newDefaultParameters() {
-        if (Algo.XGBoost.enabled()) {
-            try {
-                return (Model.Parameters)Class.forName("hex.tree.xgboost.XGBoostModel.XGBoostParameters").getConstructor().newInstance();
-            } catch (ReflectiveOperationException e) {
-                throw Log.throwErr(e);
-            }
-        }
-        return null;
+        return Algo.XGBoost.enabled() ? ModelBuilder.make(getName(), null, null)._parms : null;
     }
 }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostStepsProvider.java
@@ -1,190 +1,15 @@
 package ai.h2o.automl.modeling;
 
 import ai.h2o.automl.*;
-import hex.genmodel.utils.DistributionFamily;
-import hex.grid.Grid;
-import hex.tree.xgboost.XGBoostModel;
-import hex.tree.xgboost.XGBoostModel.XGBoostParameters;
-import water.Job;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static ai.h2o.automl.ModelingStep.GridStep.DEFAULT_GRID_TRAINING_WEIGHT;
-import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
-
-public class XGBoostStepsProvider implements ModelingStepsProvider<XGBoostStepsProvider.XGBoostSteps> {
-
-    public static class XGBoostSteps extends ModelingSteps {
-
-        static XGBoostParameters prepareModelParameters(AutoML aml, boolean emulateLightGBM) {
-            XGBoostParameters xgBoostParameters = new XGBoostParameters();
-
-            if (emulateLightGBM) {
-                xgBoostParameters._tree_method = XGBoostParameters.TreeMethod.hist;
-                xgBoostParameters._grow_policy = XGBoostParameters.GrowPolicy.lossguide;
-            }
-
-            // setDistribution: no way to identify gaussian, poisson, laplace? using descriptive statistics?
-            xgBoostParameters._distribution = aml.getResponseColumn().isBinary() && !(aml.getResponseColumn().isNumeric()) ? DistributionFamily.bernoulli
-                    : aml.getResponseColumn().isCategorical() ? DistributionFamily.multinomial
-                    : DistributionFamily.AUTO;
-
-            xgBoostParameters._score_tree_interval = 5;
-            xgBoostParameters._stopping_rounds = 5;
-
-            xgBoostParameters._ntrees = 10000;
-            xgBoostParameters._learn_rate = 0.05;
-//            xgBoostParameters._min_split_improvement = 0.01f;
-
-            return xgBoostParameters;
-        }
-
-        static abstract class XGBoostModelStep extends ModelingStep.ModelStep<XGBoostModel> {
-
-            boolean _emulateLightGBM;
-
-            XGBoostModelStep(String id, int weight, AutoML autoML, boolean emulateLightGBM) {
-                super(Algo.XGBoost, id, weight, autoML);
-                _emulateLightGBM = emulateLightGBM;
-            }
-
-            XGBoostParameters prepareModelParameters() {
-                return XGBoostSteps.prepareModelParameters(aml(), _emulateLightGBM);
-            }
-        }
-
-        static abstract class XGBoostGridStep extends ModelingStep.GridStep<XGBoostModel> {
-            boolean _emulateLightGBM;
-
-            public XGBoostGridStep(String id, int weight, AutoML autoML, boolean emulateLightGBM) {
-                super(Algo.XGBoost, id, weight, autoML);
-                _emulateLightGBM = emulateLightGBM;
-            }
-
-            XGBoostParameters prepareModelParameters() {
-                return XGBoostSteps.prepareModelParameters(aml(), _emulateLightGBM);
-            }
-        }
+import hex.Model;
+import water.util.Log;
 
 
-        private ModelingStep[] defaults = new XGBoostModelStep[] {
-                new XGBoostModelStep("def_1", DEFAULT_MODEL_TRAINING_WEIGHT, aml(),false) {
-                    @Override
-                    protected Job<XGBoostModel> startJob() {
-                        //XGB 1 (medium depth)
-                        XGBoostParameters xgBoostParameters = prepareModelParameters();
-                        xgBoostParameters._max_depth = 10;
-                        xgBoostParameters._min_rows = 5;
-                        xgBoostParameters._sample_rate = 0.6;
-                        xgBoostParameters._col_sample_rate = 0.8;
-                        xgBoostParameters._col_sample_rate_per_tree = 0.8;
-
-                        if (_emulateLightGBM) {
-                            xgBoostParameters._max_leaves = 1 << xgBoostParameters._max_depth;
-                            xgBoostParameters._max_depth = xgBoostParameters._max_depth * 2;
-//                        xgBoostParameters._min_data_in_leaf = (float) xgBoostParameters._min_rows;
-                            xgBoostParameters._min_sum_hessian_in_leaf = (float) xgBoostParameters._min_rows;
-                        }
-
-                        return trainModel(xgBoostParameters);
-                    }
-                },
-                new XGBoostModelStep("def_2", DEFAULT_MODEL_TRAINING_WEIGHT, aml(), false) {
-                    @Override
-                    protected Job<XGBoostModel> startJob() {
-                        //XGB 2 (deep)
-                        XGBoostParameters xgBoostParameters = prepareModelParameters();
-                        xgBoostParameters._max_depth = 20;
-                        xgBoostParameters._min_rows = 10;
-                        xgBoostParameters._sample_rate = 0.6;
-                        xgBoostParameters._col_sample_rate = 0.8;
-                        xgBoostParameters._col_sample_rate_per_tree = 0.8;
-
-                        if (_emulateLightGBM) {
-                            xgBoostParameters._max_leaves = 1 << xgBoostParameters._max_depth;
-                            xgBoostParameters._max_depth = xgBoostParameters._max_depth * 2;
-//                        xgBoostParameters._min_data_in_leaf = (float) xgBoostParameters._min_rows;
-                            xgBoostParameters._min_sum_hessian_in_leaf = (float) xgBoostParameters._min_rows;
-                        }
-
-                        return trainModel(xgBoostParameters);
-                    }
-                },
-                new XGBoostModelStep("def_3", DEFAULT_MODEL_TRAINING_WEIGHT, aml(), false) {
-                    @Override
-                    protected Job<XGBoostModel> startJob() {
-                        //XGB 3 (shallow)
-                        XGBoostParameters xgBoostParameters = prepareModelParameters();
-                        xgBoostParameters._max_depth = 5;
-                        xgBoostParameters._min_rows = 3;
-                        xgBoostParameters._sample_rate = 0.8;
-                        xgBoostParameters._col_sample_rate = 0.8;
-                        xgBoostParameters._col_sample_rate_per_tree = 0.8;
-
-                        if (_emulateLightGBM) {
-                            xgBoostParameters._max_leaves = 1 << xgBoostParameters._max_depth;
-                            xgBoostParameters._max_depth = xgBoostParameters._max_depth * 2;
-//                        xgBoostParameters._min_data_in_leaf = (float) xgBoostParameters._min_rows;
-                            xgBoostParameters._min_sum_hessian_in_leaf = (float) xgBoostParameters._min_rows;
-                        }
-
-                        return trainModel(xgBoostParameters);
-                    }
-                },
-        };
-
-        private ModelingStep[] grids = new XGBoostGridStep[] {
-                new XGBoostGridStep("grid_1", 5* DEFAULT_GRID_TRAINING_WEIGHT, aml(), false) {
-                    @Override
-                    protected Job<Grid> startJob() {
-                        XGBoostParameters xgBoostParameters = prepareModelParameters();
-                        Map<String, Object[]> searchParams = new HashMap<>();
-//                    searchParams.put("_ntrees", new Integer[]{100, 1000, 10000}); // = _n_estimators
-
-                        if (_emulateLightGBM) {
-                            searchParams.put("_max_leaves", new Integer[]{1<<5, 1<<10, 1<<15, 1<<20});
-                            searchParams.put("_max_depth", new Integer[]{10, 20, 50});
-                            searchParams.put("_min_sum_hessian_in_leaf", new Double[]{0.01, 0.1, 1.0, 3.0, 5.0, 10.0, 15.0, 20.0});
-                        } else {
-                            searchParams.put("_max_depth", new Integer[]{5, 10, 15, 20});
-                            searchParams.put("_min_rows", new Double[]{0.01, 0.1, 1.0, 3.0, 5.0, 10.0, 15.0, 20.0});  // = _min_child_weight
-                        }
-
-                        searchParams.put("_sample_rate", new Double[]{0.6, 0.8, 1.0}); // = _subsample
-                        searchParams.put("_col_sample_rate" , new Double[]{ 0.6, 0.8, 1.0}); // = _colsample_bylevel"
-                        searchParams.put("_col_sample_rate_per_tree", new Double[]{ 0.7, 0.8, 0.9, 1.0}); // = _colsample_bytree: start higher to always use at least about 40% of columns
-//                    searchParams.put("_learn_rate", new Double[]{0.01, 0.05, 0.08, 0.1, 0.15, 0.2, 0.3, 0.5, 0.8, 1.0}); // = _eta
-//                    searchParams.put("_min_split_improvement", new Float[]{0.01f, 0.05f, 0.1f, 0.5f, 1f, 5f, 10f, 50f}); // = _gamma
-//                    searchParams.put("_tree_method", new XGBoostParameters.TreeMethod[]{XGBoostParameters.TreeMethod.auto});
-                        searchParams.put("_booster", new XGBoostParameters.Booster[]{ //gblinear crashes currently
-                                XGBoostParameters.Booster.gbtree, //default, let's use it more often
-                                XGBoostParameters.Booster.gbtree,
-                                XGBoostParameters.Booster.dart
-                        });
-
-                        searchParams.put("_reg_lambda", new Float[]{0.001f, 0.01f, 0.1f, 1f, 10f, 100f});
-                        searchParams.put("_reg_alpha", new Float[]{0.001f, 0.01f, 0.1f, 0.5f, 1f});
-
-                        return hyperparameterSearch(xgBoostParameters, searchParams);
-                    }
-                },
-        };
-
-        public XGBoostSteps(AutoML autoML) {
-            super(autoML);
-        }
-
-        @Override
-        protected ModelingStep[] getDefaultModels() {
-            return defaults;
-        }
-
-        @Override
-        protected ModelingStep[] getGrids() {
-            return grids;
-        }
-    }
+/**
+ * This class is decoupled from the XGBoostSteps implementation to avoid having to load XGBoost classes
+ * when the extension is not available.
+ */
+public class XGBoostStepsProvider implements ModelingStepsProvider<XGBoostSteps>, ModelParametersProvider<Model.Parameters> {
 
     @Override
     public String getName() {
@@ -193,7 +18,19 @@ public class XGBoostStepsProvider implements ModelingStepsProvider<XGBoostStepsP
 
     @Override
     public XGBoostSteps newInstance(AutoML aml) {
-        return new XGBoostSteps(aml);
+        return Algo.XGBoost.enabled() ? new XGBoostSteps(aml) : null;
+    }
+
+    @Override
+    public Model.Parameters newDefaultParameters() {
+        if (Algo.XGBoost.enabled()) {
+            try {
+                return (Model.Parameters)Class.forName("hex.tree.xgboost.XGBoostModel.XGBoostParameters").getConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+                throw Log.throwErr(e);
+            }
+        }
+        return null;
     }
 }
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLBuildSpecTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLBuildSpecTest.java
@@ -5,6 +5,7 @@ import hex.KeyValue;
 import hex.tree.drf.DRFModel;
 import hex.tree.gbm.GBMModel;
 import hex.tree.xgboost.XGBoostModel;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -14,13 +15,16 @@ import water.exceptions.H2OIllegalValueException;
 
 import java.util.Arrays;
 
-public class AutoMLBuildSpecTest {
+public class AutoMLBuildSpecTest extends water.TestUtil {
 
     @Rule
     public ExpectedException thrown= ExpectedException.none();
 
     @Rule
     public final TestRule restoreSystemProperties = new RestoreSystemProperties();
+
+    @BeforeClass
+    public static void setup() { stall_till_cloudsize(1); }
 
     private void enableAnyCustomParam() {
         System.setProperty(AutoMLCustomParameters.ALGO_PARAMS_ALL_ENABLED, "true");


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7189

fully decoupled algorithms implementation logic from AutoML classes, especially for XGBoost so that AutoML will work even if XGB extension is not in the classpath.

Tested locally: no proper way to test this using UTs. Ideally, would need a separate `xgboost-automl` module to ensure this: not sure it's worth the additional complexity for a single class though...