### PR TITLE
PUBDEV-7230 - Force connections to FlowUI on port 54321 to TLS1.2

### DIFF
--- a/h2o-jetty-8/build.gradle
+++ b/h2o-jetty-8/build.gradle
@@ -2,6 +2,7 @@ description = "Brings Jetty 8 as the HTTP implementation used in H2O server-side
 
 dependencies {
     compile project(":h2o-webserver-iface")
+    compile project(":h2o-security")
     compile 'org.eclipse.jetty:jetty-server:8.1.21.v20160908'
     compile "org.eclipse.jetty:jetty-servlets:8.1.21.v20160908"
     compile "org.eclipse.jetty:jetty-plus:8.1.21.v20160908"

--- a/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
+++ b/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
@@ -62,6 +62,7 @@ class Jetty8Helper {
     if (config.jks != null) {
       proto = "https";
       final SslContextFactory sslContextFactory = new SslContextFactory(config.jks);
+      sslContextFactory.setIncludeCipherSuites("TLSv1.2"); // TLS 1.2 is prioritized
       sslContextFactory.setKeyStorePassword(config.jks_pass);
       if (config.jks_alias != null) {
         sslContextFactory.setCertAlias(config.jks_alias);

--- a/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
+++ b/h2o-jetty-8/src/main/java/water/webserver/jetty8/Jetty8Helper.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import water.network.SecurityUtils;
 import water.webserver.iface.H2OHttpConfig;
 import water.webserver.iface.H2OHttpView;
 import water.webserver.iface.LoginType;
@@ -62,7 +63,7 @@ class Jetty8Helper {
     if (config.jks != null) {
       proto = "https";
       final SslContextFactory sslContextFactory = new SslContextFactory(config.jks);
-      sslContextFactory.setIncludeCipherSuites("TLSv1.2"); // TLS 1.2 is prioritized
+      sslContextFactory.setIncludeCipherSuites(SecurityUtils.defaultTLSVersion()); // Prioritize the default TLS version
       sslContextFactory.setKeyStorePassword(config.jks_pass);
       if (config.jks_alias != null) {
         sslContextFactory.setCertAlias(config.jks_alias);

--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     compile project(":h2o-webserver-iface")
-    compile 'org.eclipse.jetty:jetty-server:9.4.26.v20200117'
-    compile "org.eclipse.jetty:jetty-servlets:9.4.26.v20200117"
-    compile 'org.eclipse.jetty:jetty-jaas:9.4.26.v20200117'
-    compile 'org.eclipse.jetty:jetty-proxy:9.4.26.v20200117'
-    compile 'org.eclipse.jetty:jetty-servlet:9.4.26.v20200117'
+    compile 'org.eclipse.jetty:jetty-server:9.3.20.v20170531'
+    compile "org.eclipse.jetty:jetty-servlets:9.3.20.v20170531"
+    compile 'org.eclipse.jetty:jetty-jaas:9.3.20.v20170531'
+    compile 'org.eclipse.jetty:jetty-proxy:9.3.20.v20170531'
+    compile 'org.eclipse.jetty:jetty-servlet:9.3.20.v20170531'
     testCompile group: "junit", name: "junit", version: "4.12"
     testCompile "org.mockito:mockito-core:2.23.0"
 }

--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile project(":h2o-webserver-iface")
+    compile project(":h2o-security")
     compile 'org.eclipse.jetty:jetty-server:9.3.20.v20170531'
     compile "org.eclipse.jetty:jetty-servlets:9.3.20.v20170531"
     compile 'org.eclipse.jetty:jetty-jaas:9.3.20.v20170531'

--- a/h2o-jetty-9/build.gradle
+++ b/h2o-jetty-9/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     compile project(":h2o-webserver-iface")
-    compile 'org.eclipse.jetty:jetty-server:9.3.20.v20170531'
-    compile "org.eclipse.jetty:jetty-servlets:9.3.20.v20170531"
-    compile 'org.eclipse.jetty:jetty-jaas:9.3.20.v20170531'
-    compile 'org.eclipse.jetty:jetty-proxy:9.3.20.v20170531'
-    compile 'org.eclipse.jetty:jetty-servlet:9.3.20.v20170531'
+    compile 'org.eclipse.jetty:jetty-server:9.4.26.v20200117'
+    compile "org.eclipse.jetty:jetty-servlets:9.4.26.v20200117"
+    compile 'org.eclipse.jetty:jetty-jaas:9.4.26.v20200117'
+    compile 'org.eclipse.jetty:jetty-proxy:9.4.26.v20200117'
+    compile 'org.eclipse.jetty:jetty-servlet:9.4.26.v20200117'
     testCompile group: "junit", name: "junit", version: "4.12"
     testCompile "org.mockito:mockito-core:2.23.0"
 }

--- a/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
+++ b/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
@@ -15,6 +15,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.eclipse.jetty.util.thread.Scheduler;
+import water.network.SecurityUtils;
 import water.webserver.iface.H2OHttpConfig;
 import water.webserver.iface.H2OHttpView;
 import water.webserver.iface.LoginType;
@@ -54,7 +55,7 @@ class Jetty9Helper {
         final ServerConnector connector;
         if (isSecured) {
             final SslContextFactory sslContextFactory = new SslContextFactory(config.jks);
-            sslContextFactory.setIncludeCipherSuites("TLSv1.2"); // TLS 1.2 is prioritized
+            sslContextFactory.setIncludeCipherSuites(SecurityUtils.defaultTLSVersion()); // Prioritize the default TLS version
             sslContextFactory.setKeyStorePassword(config.jks_pass);
             if (config.jks_alias != null) {
                 sslContextFactory.setCertAlias(config.jks_alias);

--- a/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
+++ b/h2o-jetty-9/src/main/java/water/webserver/jetty9/Jetty9Helper.java
@@ -60,7 +60,8 @@ class Jetty9Helper {
 
         final ServerConnector connector;
         if (isSecured) {
-            final SslContextFactory sslContextFactory = new SslContextFactory(config.jks);
+            final SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+            sslContextFactory.addExcludeProtocols("TLSv1.1", "TLSv1");
             sslContextFactory.setKeyStorePassword(config.jks_pass);
             if (config.jks_alias != null) {
                 sslContextFactory.setCertAlias(config.jks_alias);
@@ -154,10 +155,10 @@ class Jetty9Helper {
 
         final SessionHandler sessionHandler = new SessionHandler();
         if (config.session_timeout > 0) {
-            sessionHandler.getSessionManager().setMaxInactiveInterval(config.session_timeout * 60);
+            sessionHandler.setMaxInactiveInterval(config.session_timeout * 60);
         }
         sessionHandler.setHandler(security);
-        jettyServer.setSessionIdManager(sessionHandler.getSessionManager().getSessionIdManager());
+        jettyServer.setSessionIdManager(sessionHandler.getSessionIdManager());
 
         // Pass-through to H2O if authenticated.
         jettyServer.setHandler(sessionHandler);


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7230

This is probably the way we should go:
- Keep Jetty updated as much as possible (security)
- Disable old TLS once and for all. Disable 1.2 once 1.3 support comes out as well ?