### PR TITLE
PUBDEV-7271 - Sequential DKV manager

### DIFF
--- a/h2o-algos/src/test/java/hex/DKVManagerTest.java
+++ b/h2o-algos/src/test/java/hex/DKVManagerTest.java
@@ -4,37 +4,45 @@ import hex.naivebayes.NaiveBayes;
 import hex.naivebayes.NaiveBayesModel;
 import hex.tree.gbm.GBM;
 import hex.tree.gbm.GBMModel;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import water.*;
-import water.fvec.*;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static hex.genmodel.utils.DistributionFamily.AUTO;
 import static org.junit.Assert.*;
-import static water.fvec.VecHelper.*;
+import static water.TestUtil.ar;
+import static water.fvec.VecHelper.vecChunkIdx;
 
+@RunWith(H2ORunner.class)
+@CloudSize(5)
+public class DKVManagerTest {
 
-public class DKVManagerTest extends TestUtil {
-
-    @BeforeClass()
-    public static void setup() {
-        stall_till_cloudsize(1);
-    }
-    
     @Rule
-    public ExpectedException expectedException = ExpectedException.none(); 
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static void testRetainModel(Model model, Frame trainingFrame){
+        assertNotNull(DKV.get(model._key));
+        DKVManager.retain(new Key[]{model._key, trainingFrame._key});
+        assertNotNull(DKV.get(model._key));
+        
+    }
 
     @Test
     public void testNaiveBayesModel() {
         NaiveBayesModel model = null;
         Frame trainingFrame = null, preds = null;
         try {
-            trainingFrame = parse_test_file("./smalldata/iris/iris_wheader.csv");
+            trainingFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv");
             List<Key> retainedKeys = new ArrayList<>();
             retainedKeys.add(trainingFrame._key);
             // Test the training frame has not been deleted
@@ -64,13 +72,12 @@ public class DKVManagerTest extends TestUtil {
         }
     }
 
-
     @Test
     public void testGBM() {
         GBMModel model = null;
         Frame trainingFrame = null, preds = null;
         try {
-            trainingFrame = parse_test_file("./smalldata/gbm_test/Mfgdata_gaussian_GBM_testing.csv");
+            trainingFrame = TestUtil.parse_test_file("./smalldata/gbm_test/Mfgdata_gaussian_GBM_testing.csv");
 
             // Test the training frame has not been deleted
             testRetainFrame(trainingFrame);
@@ -152,6 +159,53 @@ public class DKVManagerTest extends TestUtil {
       }
     }
 
+    @Test
+    public void testGBM_TwoModels() {
+        try {
+            Scope.enter();
+            final Frame trainingFrame = TestUtil.parse_test_file("./smalldata/gbm_test/Mfgdata_gaussian_GBM_testing.csv");
+            Scope.track(trainingFrame);
+
+            // Test the training frame has not been deleted
+            testRetainFrame(trainingFrame);
+
+            // A little integration test
+            GBMModel.GBMParameters parms = new GBMModel.GBMParameters();
+            parms._train = trainingFrame._key;
+            parms._distribution = AUTO;
+            parms._response_column = trainingFrame._names[1];
+            parms._ntrees = 1;
+            parms._max_depth = 1;
+            parms._min_rows = 1;
+            parms._nbins = 20;
+            parms._learn_rate = 1.0f;
+            parms._score_each_iteration = true;
+            parms._nfolds = 5;
+
+            GBM job = new GBM(parms);
+            Model model = job.trainModel().get();
+            Scope.track_generic(model);
+            assertNotNull(model);
+
+            final Frame preds = model.score(trainingFrame);
+            assertNotNull(preds);
+
+            DKVManager.retain(new Key[]{trainingFrame._key});
+            model.deleteCrossValidationFoldAssignment();
+
+            Value value = DKV.get(model._key);
+            assertNull(value);
+
+            // Second model is trained after the original has been deleted, with same parameters
+            job = new GBM(parms);
+            model = job.trainModel().get();
+            assertNotNull(model);
+            Scope.track_generic(model);
+        } finally {
+            Scope.exit();
+        }
+    }
+
     /**
      * Train a model by using a single input data frame. Retain the model. The frame should be retained (remain in DKV),
      * as the model links to it as a training frame.
@@ -160,7 +214,7 @@ public class DKVManagerTest extends TestUtil {
     public void testRetainModels_sharedFrames() {
         try {
             Scope.enter();
-            Frame trainingFrame = parse_test_file("./smalldata/iris/iris_wheader.csv");
+            Frame trainingFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv");
             Scope.track(trainingFrame);
 
             // A little integration test
@@ -190,7 +244,6 @@ public class DKVManagerTest extends TestUtil {
         
     }
 
-
   /**
    * If a model has been trained using a Frame with shared vecs and the model is retained, the training frame should stay
    * intact.
@@ -199,7 +252,7 @@ public class DKVManagerTest extends TestUtil {
   public void testRetainModels_sharedVecs() {
     try {
       Scope.enter();
-      Frame trainingFrame = parse_test_file("./smalldata/iris/iris_wheader.csv");
+      final Frame trainingFrame = TestUtil.parse_test_file("/home/pavel/Work/h2o-3/smalldata/iris/iris_wheader.csv");
       Scope.track(trainingFrame);
 
       Frame sharedFrame = new Frame(Key.<Frame>make("sharedFrame"));
@@ -234,50 +287,11 @@ public class DKVManagerTest extends TestUtil {
       for (Key k : trainingFrame.keys()) {
         assertNotNull(DKV.get(k));
       }
-
-
     } finally {
       Scope.exit();
     }
 
   }
-
-    /**
-     * Train a model from a frame. Retain the frame only and let the model be deleted. The frame should remain in DKV.
-     */
-    @Test
-    public void testdeleteModel_retainFrame() {
-        try {
-            Scope.enter();
-            Frame trainingFrame = parse_test_file("./smalldata/iris/iris_wheader.csv");
-            Scope.track(trainingFrame);
-
-          NaiveBayesModel.NaiveBayesParameters parms = new NaiveBayesModel.NaiveBayesParameters();
-            parms._train = trainingFrame._key;
-            parms._laplace = 0;
-            parms._response_column = trainingFrame._names[4];
-            parms._compute_metrics = false;
-
-            final Model model = new NaiveBayes(parms).trainModel().get();
-            Scope.track_generic(model);
-
-          DKVManager.retain(new Key[]{trainingFrame._key});
-
-          // Training frame of the model should be retained as well
-            final Value value = DKV.get(trainingFrame._key);
-            assertNotNull(value);
-            assertTrue(value.isFrame());
-            assertFalse(value.isDeleted());
-
-            assertNotNull(value.get()); // The training frame should be there
-            
-            assertNull(DKV.get(model._key)); // The model should be deleted
-
-        } finally {
-            Scope.exit();
-        }
-
-    }
 
   // Retaining models & integration test with models is in h2o-algos subproject.
   @Test
@@ -329,11 +343,41 @@ public class DKVManagerTest extends TestUtil {
         }
     }
     
-    private static void testRetainModel(Model model, Frame trainingFrame){
-      assertNotNull(DKV.get(model._key));
-      DKVManager.retain(new Key[]{model._key});
-      assertNotNull(DKV.get(model._key));
-        
+    /**
+     * Train a model from a frame. Retain the frame only and let the model be deleted. The frame should remain in DKV.
+     */
+    @Test
+    public void testdeleteModel_retainFrame() {
+        try {
+            Scope.enter();
+            Frame trainingFrame = TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv");
+            Scope.track(trainingFrame);
+
+          NaiveBayesModel.NaiveBayesParameters parms = new NaiveBayesModel.NaiveBayesParameters();
+            parms._train = trainingFrame._key;
+            parms._laplace = 0;
+            parms._response_column = trainingFrame._names[4];
+            parms._compute_metrics = false;
+
+            final Model model = new NaiveBayes(parms).trainModel().get();
+            Scope.track_generic(model);
+
+          DKVManager.retain(new Key[]{trainingFrame._key});
+
+          // Training frame of the model should be retained as well
+            final Value value = DKV.get(trainingFrame._key);
+            assertNotNull(value);
+            assertTrue(value.isFrame());
+            assertFalse(value.isDeleted());
+
+            assertNotNull(value.get()); // The training frame should be there
+            
+            assertNull(DKV.get(model._key)); // The model should be deleted
+
+        } finally {
+            Scope.exit();
+        }
+
     }
     
     private static void testModelDeletion(final Model model){

--- a/h2o-core/src/main/java/water/DKVManager.java
+++ b/h2o-core/src/main/java/water/DKVManager.java
@@ -22,26 +22,10 @@ public class DKVManager {
     retainedKeysSet.addAll(Arrays.asList(retainedKeys));
     // Frames and models have multiple nested keys. Those must be extracted and kept from deletion as well.
     extractNestedKeys(retainedKeysSet);
-    Set<Value> removedKeys = collectUniqueKeys();
-    removeValues(removedKeys, retainedKeysSet);
-  }
-
-  /**
-   * Collects a {@link Set} of keys available cluster-wide
-   *
-   * @return
-   */
-  private static final Set<Value> collectUniqueKeys() {
-    final Value[] collectedValues = new CollectValuesTask()
+    final Value[] removedKeys = new CollectValuesTask()
             .doAllNodes()
             ._collectedValues;
-    final Set<Value> clusterValues = new HashSet<>(collectedValues.length);
-
-    for (final Value value : collectedValues) {
-      clusterValues.add(value);
-    }
-
-    return clusterValues;
+    removeValues(removedKeys, retainedKeysSet);
   }
 
   /**
@@ -50,7 +34,7 @@ public class DKVManager {
    * @param removedValues Values to be removed
    * @param retainedKeys  A {@link Set} of keys to be retained
    */
-  private static void removeValues(final Set<Value> removedValues, final Set<Key> retainedKeys) {
+  private static void removeValues(final Value[] removedValues, final Set<Key> retainedKeys) {
 
     for (final Value value : removedValues) {
       if (retainedKeys.contains(value._key)) {


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7271'

H2O is not completely safe for parallel usage. The internal DKV store does not handle parallel removal of a single value well.

The current removal mechanism is prone to errors due to possible removal of several cross-validation models multiple times.