### PR TITLE
PUBDEV-7136: Specify number of columns in R head/tail function

### DIFF
--- a/h2o-r/tests/testdir_jira/runit_pub_7136_head_tail_display_specific_number_of_columns.R
+++ b/h2o-r/tests/testdir_jira/runit_pub_7136_head_tail_display_specific_number_of_columns.R
@@ -1,0 +1,25 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.head_tail_colnum_frame <- function() {
+    
+  iris <- h2o.importFile(locate("smalldata/iris/iris_train.csv"))
+  head(iris,2,3)
+  head(iris,2)
+  head(iris,2)
+  head(iris,,3)
+  head(iris,2,0)
+  head(iris,0,0)
+
+  tail(iris,2,3)
+  tail(iris,2)
+  tail(iris,,3)
+  tail(iris,0,3)
+  tail(iris,2,0)
+  tail(iris,0,0)
+    
+}
+
+doTest("Test frame add.", test.head_tail_colnum_frame)


### PR DESCRIPTION
adding option to specify number of columns in head/tail of R client is required here: https://0xdata.atlassian.net/browse/PUBDEV-7136, so that R client is consistent with Python client.