### PR TITLE
Avoid array copying in Model.clearModelMetrics

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -840,26 +840,24 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     public boolean isAutoencoder() { return false; } // Override in DeepLearning and so on.
 
     public synchronized Key<ModelMetrics>[] clearModelMetrics(boolean keepModelTrainingMetrics) {
-      final List<Key<ModelMetrics>> removed;
+      Key<ModelMetrics>[] removed;
       if (keepModelTrainingMetrics) {
-        final Set<Key> kept = new HashSet(0);
-        if (_training_metrics != null) kept.add(_training_metrics._key);
-        if (_validation_metrics != null) kept.add(_validation_metrics._key);
-        if (_cross_validation_metrics != null) kept.add(_cross_validation_metrics._key);
+        Key<ModelMetrics>[] kept = new Key[0];
+        if (_training_metrics != null) kept = ArrayUtils.append(kept, _training_metrics._key);
+        if (_validation_metrics != null) kept = ArrayUtils.append(kept, _validation_metrics._key);
+        if (_cross_validation_metrics != null) kept = ArrayUtils.append(kept, _cross_validation_metrics._key);
 
-        removed = new ArrayList<>(_model_metrics.length - kept.size());
+        removed = new Key[0];
         for (Key<ModelMetrics> k : _model_metrics) {
-          if (!kept.contains(k)) {
-            removed.add(k);
-          }
+          if (!ArrayUtils.contains(kept, k))
+            removed = ArrayUtils.append(removed, k);
         }
-        _model_metrics = kept.toArray(new Key[kept.size()]);
-        return removed.toArray(new Key[removed.size()]);
+        _model_metrics = kept;
       } else {
-        final Key[] removedArr = Arrays.copyOf(_model_metrics, _model_metrics.length);
+        removed = Arrays.copyOf(_model_metrics, _model_metrics.length);
         _model_metrics = new Key[0];
-        return removedArr;
       }
+      return removed;
     }
 
     public synchronized Key<ModelMetrics>[] getModelMetrics() { return Arrays.copyOf(_model_metrics, _model_metrics.length); }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -840,24 +840,26 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     public boolean isAutoencoder() { return false; } // Override in DeepLearning and so on.
 
     public synchronized Key<ModelMetrics>[] clearModelMetrics(boolean keepModelTrainingMetrics) {
-      Key<ModelMetrics>[] removed;
+      final List<Key<ModelMetrics>> removed;
       if (keepModelTrainingMetrics) {
-        Key<ModelMetrics>[] kept = new Key[0];
-        if (_training_metrics != null) kept = ArrayUtils.append(kept, _training_metrics._key);
-        if (_validation_metrics != null) kept = ArrayUtils.append(kept, _validation_metrics._key);
-        if (_cross_validation_metrics != null) kept = ArrayUtils.append(kept, _cross_validation_metrics._key);
+        final Set<Key> kept = new HashSet(0);
+        if (_training_metrics != null) kept.add(_training_metrics._key);
+        if (_validation_metrics != null) kept.add(_validation_metrics._key);
+        if (_cross_validation_metrics != null) kept.add(_cross_validation_metrics._key);
 
-        removed = new Key[0];
+        removed = new ArrayList<>(_model_metrics.length - kept.size());
         for (Key<ModelMetrics> k : _model_metrics) {
-          if (!ArrayUtils.contains(kept, k))
-            removed = ArrayUtils.append(removed, k);
+          if (!kept.contains(k)) {
+            removed.add(k);
+          }
         }
-        _model_metrics = kept;
+        _model_metrics = kept.toArray(new Key[kept.size()]);
+        return removed.toArray(new Key[removed.size()]);
       } else {
-        removed = Arrays.copyOf(_model_metrics, _model_metrics.length);
+        final Key[] removedArr = Arrays.copyOf(_model_metrics, _model_metrics.length);
         _model_metrics = new Key[0];
+        return removedArr;
       }
-      return removed;
     }
 
     public synchronized Key<ModelMetrics>[] getModelMetrics() { return Arrays.copyOf(_model_metrics, _model_metrics.length); }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -847,10 +847,11 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
         if (_validation_metrics != null) kept = ArrayUtils.append(kept, _validation_metrics._key);
         if (_cross_validation_metrics != null) kept = ArrayUtils.append(kept, _cross_validation_metrics._key);
 
-        removed = new Key[0];
+        removed = new Key[_model_metrics.length - kept.length];
+        int removedIndex = 0;
         for (Key<ModelMetrics> k : _model_metrics) {
           if (!ArrayUtils.contains(kept, k))
-            removed = ArrayUtils.append(removed, k);
+            removed[removedIndex++] = k;
         }
         _model_metrics = kept;
       } else {

--- a/h2o-core/src/test/java/hex/ModelBuilderTest.java
+++ b/h2o-core/src/test/java/hex/ModelBuilderTest.java
@@ -265,12 +265,25 @@ public class ModelBuilderTest extends TestUtil {
     }
   }
 
+  public static class DummyModelMetrics extends ModelMetrics {
+
+    public DummyModelMetrics(final Frame trainingFrame) {
+      super(null, trainingFrame, 0, 0, "Dummy model Metrics", null);
+    }
+  }
+
   public static class DummyModelOutput extends Model.Output {
     public final String _msg;
-    public DummyModelOutput(ModelBuilder b, Frame train, String msg) {
+
+    public DummyModelOutput(DummyModelBuilder b, Frame train, String msg) {
       super(b, train);
+      if (b._parms._makeModelMetrics) {
+        _training_metrics = new DummyModelMetrics(b.train());
+        _model_metrics= new Key[]{_training_metrics._key};
+      }
       _msg = msg;
     }
+
     @Override
     public ModelCategory getModelCategory() {
       return ModelCategory.Binomial;
@@ -294,6 +307,7 @@ public class ModelBuilderTest extends TestUtil {
   public static class DummyModelParameters extends Model.Parameters {
     public DummyAction _action;
     public boolean _makeModel;
+    public boolean _makeModelMetrics;
     public boolean _cancel_job;
     public DummyModelParameters() {}
     public DummyModelParameters(String msg, Key trgt) {

--- a/h2o-core/src/test/java/hex/ModelTest.java
+++ b/h2o-core/src/test/java/hex/ModelTest.java
@@ -1,0 +1,60 @@
+package hex;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.Key;
+import water.Scope;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class ModelTest {
+
+    @Test
+    public void testClearModelMetrics() {
+        try {
+            Scope.enter();
+            final int nRows = 1000;
+            final double[] feature = new double[nRows];
+            final String[] response = new String[nRows];
+            for (int i = 0; i < feature.length; i++) {
+                feature[i] = i % 7;
+                response[i] = i % 3 == 0 ? "A" : "B";
+            }
+            final Frame train = new TestFrameBuilder()
+                    .withName("testFrame")
+                    .withColNames("ColA", "Response")
+                    .withVecTypes(Vec.T_NUM, Vec.T_CAT)
+                    .withDataForCol(0, feature)
+                    .withDataForCol(1, response)
+                    .build();
+            assertEquals(feature.length, train.numRows());
+
+            ModelBuilderTest.DummyModelParameters parameters = new ModelBuilderTest.DummyModelParameters();
+            parameters._train = train._key;
+            parameters._makeModel = true;
+            parameters._makeModelMetrics = true;
+            parameters._response_column = "Response";
+            ModelBuilderTest.DummyModelBuilder modelBuilder = new ModelBuilderTest.DummyModelBuilder(parameters);
+            final ModelBuilderTest.DummyModel model = modelBuilder.trainModel().get();
+            Scope.track_generic(model);
+            assertNotNull(model);
+            assertNotNull(model._output._training_metrics);
+
+            final Key<ModelMetrics>[] noneRemoved = model._output.clearModelMetrics(true);
+            assertEquals(0, noneRemoved.length);
+
+            final Key<ModelMetrics>[] trainingRemoved = model._output.clearModelMetrics(false);
+            assertEquals(1, trainingRemoved.length);
+        } finally {
+            Scope.exit();
+        }
+    }
+
+}


### PR DESCRIPTION
Found this piece of code during implementation of a different task. It's a tiny small refactor I'd like to propose.

1. The array is enlarged every time a new metric is removed. We know beforehand how many models will be removed.
2. It is searched in the Array of **not removed** keys sequentially, we might use Set to be speed it up a little bit :) 