### PR TITLE
Proposal: Attempt at simplifying contract and logic of Hyperspace iterator

### DIFF
--- a/h2o-algos/src/test/java/hex/grid/GridTest.java
+++ b/h2o-algos/src/test/java/hex/grid/GridTest.java
@@ -55,12 +55,12 @@ public class GridTest extends TestUtil {
       params._seed = 42;
 
       HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria searchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+      searchCriteria.set_max_runtime_secs(1d);
+
       Job<Grid> gridSearch = GridSearch.startGridSearch(null, params,
               hyperParms,
               new GridSearch.SimpleParametersBuilderFactory(),
               searchCriteria, 2);
-
-      searchCriteria.set_max_runtime_secs(1d);
 
       Scope.track_generic(gridSearch);
       final Grid grid = gridSearch.get();

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -60,8 +60,23 @@ public class AutoMLBuildSpec extends Iced {
 
     public static final int AUTO_STOPPING_TOLERANCE = -1;
 
+    public static double default_stopping_tolerance_for_frame(Frame frame) {
+      return HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria.default_stopping_tolerance_for_frame(frame);
+    }
+
     private final HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria _searchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
     private double _max_runtime_secs_per_model = 0;
+
+    public AutoMLStoppingCriteria() {
+      // reasonable defaults:
+      set_max_models(0); // no limit
+      set_max_runtime_secs(0); // no limit
+      set_max_runtime_secs_per_model(0); // no limit
+
+      set_stopping_rounds(3);
+      set_stopping_tolerance(AUTO_STOPPING_TOLERANCE);
+      set_stopping_metric(StoppingMetric.AUTO);
+    }
 
     public double max_runtime_secs_per_model() {
       return _max_runtime_secs_per_model;
@@ -123,23 +138,8 @@ public class AutoMLBuildSpec extends Iced {
       _searchCriteria.set_default_stopping_tolerance_for_frame(frame);
     }
 
-    public static double default_stopping_tolerance_for_frame(Frame frame) {
-      return HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria.default_stopping_tolerance_for_frame(frame);
-    }
-
     public HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria getSearchCriteria() {
       return _searchCriteria;
-    }
-
-    public AutoMLStoppingCriteria() {
-      // reasonable defaults:
-      set_max_models(0); // no limit
-      set_max_runtime_secs(0); // no limit
-      set_max_runtime_secs_per_model(0); // no limit
-
-      set_stopping_rounds(3);
-      set_stopping_tolerance(AUTO_STOPPING_TOLERANCE);
-      set_stopping_metric(StoppingMetric.AUTO);
     }
   }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -322,9 +322,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             setCustomParams(baseParms);
 
             AutoMLBuildSpec buildSpec = aml().getBuildSpec();
-            RandomDiscreteValueSearchCriteria searchCriteria =
-                    (RandomDiscreteValueSearchCriteria) buildSpec.build_control.stopping_criteria.getSearchCriteria().clone();
-            searchCriteria.set_stopping_criteria((StoppingCriteria) searchCriteria.stopping_criteria().clone());
+            RandomDiscreteValueSearchCriteria searchCriteria = buildSpec.build_control.stopping_criteria.getSearchCriteria().deepClone();
 
             Work work = getAllocatedWork();
             double maxAssignedTimeSecs = aml().timeRemainingMs() * getWorkAllocations().remainingWorkRatio(work) / 1e3;

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -322,7 +322,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             setCustomParams(baseParms);
 
             AutoMLBuildSpec buildSpec = aml().getBuildSpec();
-            RandomDiscreteValueSearchCriteria searchCriteria = buildSpec.build_control.stopping_criteria.getSearchCriteria().deepClone();
+            RandomDiscreteValueSearchCriteria searchCriteria = (RandomDiscreteValueSearchCriteria)buildSpec.build_control.stopping_criteria.getSearchCriteria().clone();
 
             Work work = getAllocatedWork();
             double maxAssignedTimeSecs = aml().timeRemainingMs() * getWorkAllocations().remainingWorkRatio(work) / 1e3;

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -12,7 +12,9 @@ import hex.ScoreKeeper.StoppingMetric;
 import hex.ensemble.StackedEnsembleModel;
 import hex.grid.Grid;
 import hex.grid.GridSearch;
+import hex.grid.HyperSpaceSearchCriteria;
 import hex.grid.HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria;
+import hex.grid.HyperSpaceSearchCriteria.StoppingCriteria;
 import water.Iced;
 import water.Job;
 import water.Key;
@@ -322,6 +324,8 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             AutoMLBuildSpec buildSpec = aml().getBuildSpec();
             RandomDiscreteValueSearchCriteria searchCriteria =
                     (RandomDiscreteValueSearchCriteria) buildSpec.build_control.stopping_criteria.getSearchCriteria().clone();
+            searchCriteria.set_stopping_criteria((StoppingCriteria) searchCriteria.stopping_criteria().clone());
+
             Work work = getAllocatedWork();
             double maxAssignedTimeSecs = aml().timeRemainingMs() * getWorkAllocations().remainingWorkRatio(work) / 1e3;
             // predicate can be removed if/when we decide to include SEs in the max_models limit

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -167,6 +167,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     public AutoMLStoppingCriteria fillImpl(AutoMLStoppingCriteria impl) {
       AutoMLStoppingCriteria filled = super.fillImpl(impl, new String[] {"_searchCriteria"});
       PojoUtils.copyProperties(filled.getSearchCriteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
+      PojoUtils.copyProperties(filled.getSearchCriteria().stopping_criteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
       return filled;
     }
 
@@ -174,6 +175,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     public AutoMLStoppingCriteriaV99 fillFromImpl(AutoMLStoppingCriteria impl) {
       AutoMLStoppingCriteriaV99 schema = super.fillFromImpl(impl, new String[]{"_searchCriteria"});
       PojoUtils.copyProperties(schema, impl.getSearchCriteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
+      PojoUtils.copyProperties(schema, impl.getSearchCriteria().stopping_criteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
       return schema;
     }
   }

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -15,9 +15,6 @@ import water.api.schemas3.*;
 import water.util.*;
 
 import java.util.Arrays;
-import java.util.Map;
-
-import static ai.h2o.automl.AutoMLBuildSpec.AutoMLStoppingCriteria.AUTO_STOPPING_TOLERANCE;
 
 // TODO: this is about to change from SchemaV3 to RequestSchemaV3:
 public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpecV99> {
@@ -167,7 +164,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     public AutoMLStoppingCriteria fillImpl(AutoMLStoppingCriteria impl) {
       AutoMLStoppingCriteria filled = super.fillImpl(impl, new String[] {"_searchCriteria"});
       PojoUtils.copyProperties(filled.getSearchCriteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
-      PojoUtils.copyProperties(filled.getSearchCriteria().stopping_criteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
+      PojoUtils.copyProperties(filled.getSearchCriteria().stoppingCriteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
       return filled;
     }
 
@@ -175,7 +172,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     public AutoMLStoppingCriteriaV99 fillFromImpl(AutoMLStoppingCriteria impl) {
       AutoMLStoppingCriteriaV99 schema = super.fillFromImpl(impl, new String[]{"_searchCriteria"});
       PojoUtils.copyProperties(schema, impl.getSearchCriteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
-      PojoUtils.copyProperties(schema, impl.getSearchCriteria().stopping_criteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
+      PojoUtils.copyProperties(schema, impl.getSearchCriteria().stoppingCriteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
       return schema;
     }
   }

--- a/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
+++ b/h2o-automl/src/main/java/water/automl/api/schemas3/AutoMLBuildSpecV99.java
@@ -163,7 +163,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @Override
     public AutoMLStoppingCriteria fillImpl(AutoMLStoppingCriteria impl) {
       AutoMLStoppingCriteria filled = super.fillImpl(impl, new String[] {"_searchCriteria"});
-      PojoUtils.copyProperties(filled.getSearchCriteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
+      PojoUtils.copyProperties(filled.getSearchCriteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"_stoppingCriteria"});
       PojoUtils.copyProperties(filled.getSearchCriteria().stoppingCriteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
       return filled;
     }
@@ -171,7 +171,7 @@ public class AutoMLBuildSpecV99 extends SchemaV3<AutoMLBuildSpec, AutoMLBuildSpe
     @Override
     public AutoMLStoppingCriteriaV99 fillFromImpl(AutoMLStoppingCriteria impl) {
       AutoMLStoppingCriteriaV99 schema = super.fillFromImpl(impl, new String[]{"_searchCriteria"});
-      PojoUtils.copyProperties(schema, impl.getSearchCriteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
+      PojoUtils.copyProperties(schema, impl.getSearchCriteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"_stoppingCriteria"});
       PojoUtils.copyProperties(schema, impl.getSearchCriteria().stoppingCriteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES, new String[] {"max_runtime_secs_per_model"});
       return schema;
     }

--- a/h2o-core/src/main/java/hex/ParallelModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ParallelModelBuilder.java
@@ -18,7 +18,7 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
 
   public static abstract class ParallelModelBuilderCallback<D extends ParallelModelBuilderCallback> extends Iced<D> {
 
-    public abstract void onBuildSucces(final Model model, final ParallelModelBuilder parallelModelBuilder);
+    public abstract void onBuildSuccess(final Model model, final ParallelModelBuilder parallelModelBuilder);
 
     public abstract void onBuildFailure(final ModelBuildFailure modelBuildFailure, final ParallelModelBuilder parallelModelBuilder);
   }
@@ -56,7 +56,7 @@ public class ParallelModelBuilder extends ForkJoinTask<ParallelModelBuilder> {
     @Override
     public void onModelSuccess(Model model) {
       try {
-        _callback.onBuildSucces(model, ParallelModelBuilder.this);
+        _callback.onBuildSuccess(model, ParallelModelBuilder.this);
       } finally {
         _modelInProgressCounter.decrementAndGet();
       }

--- a/h2o-core/src/main/java/hex/grid/Grid.java
+++ b/h2o-core/src/main/java/hex/grid/Grid.java
@@ -105,7 +105,7 @@ public class Grid<MP extends Model.Parameters> extends Lockable<Grid<MP>> {
       String[] nm = Arrays.copyOf(m, m.length + 1);
       nm[m.length] = failureDetails;
       _failure_details = nm;
-      // Append raw parames
+      // Append raw params
       String[][] rp = _failed_raw_params;
       String[][] nrp = Arrays.copyOf(rp, rp.length + 1);
       nrp[rp.length] = rawParams;

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -383,7 +383,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
           Log.warn("Grid search: construction of model parameters failed! Exception: ", e);
           // Model parameters cannot be constructed for some reason
           final Model failedModel = model;
-          it.onModelFailure(failedModel, history -> grid.appendFailedModelParameters(failedModel != null ? failedModel._key : null, history, e));
+          it.onModelFailure(failedModel, failedHyperParams -> grid.appendFailedModelParameters(failedModel != null ? failedModel._key : null, failedHyperParams, e));
         } finally {
           // Update progress by 1 increment
           _job.update(1);

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -116,7 +116,9 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
     Model model = null;
     HyperSpaceWalker.HyperSpaceIterator<MP> it = _hyperSpaceWalker.iterator();
     long gridWork=0;
-    if (gridSize > 0) {//if total grid space is known, walk it all and count up models to be built (not subject to time-based or converge-based early stopping)
+    // if total grid space is known, walk it all and count up models to be built (not subject to time-based or converge-based early stopping)
+    // skip it if no model limit it specified as the entire hyperspace can be extremely large.
+    if (gridSize > 0 && maxModels() > 0) {
       while (it.hasNext(model)) {
         try {
           Model.Parameters parms = it.nextModelParameters(model);
@@ -163,6 +165,10 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
    */
   public long getModelCount() {
     return _hyperSpaceWalker.getMaxHyperSpaceSize();
+  }
+
+  private long maxModels() {
+    return _hyperSpaceWalker.search_criteria().stopping_criteria() == null ? 0 : _hyperSpaceWalker.search_criteria().stopping_criteria()._max_models;
   }
 
   private double maxRuntimeSecs() {

--- a/h2o-core/src/main/java/hex/grid/GridSearch.java
+++ b/h2o-core/src/main/java/hex/grid/GridSearch.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * By default, the grid search invokes cartesian grid search, but it can be
  * modified by passing explicit hyper space walk strategy via the
- * {@link #startGridSearch(Key, HyperSpaceWalker)} method.
+ * {@link #startGridSearch(Key, HyperSpaceWalker, int)} method.
  *
  * If any of forked jobs fails then the failure is ignored, and grid search
  * normally continue in traversing the hyper space.
@@ -64,7 +64,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * }</pre>
  *
  * @see HyperSpaceWalker
- * @see #startGridSearch(Key, HyperSpaceWalker)
+ * @see #startGridSearch(Key, HyperSpaceWalker, int)
  */
 public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSearch> {
   public final Key<Grid> _result;
@@ -168,11 +168,11 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
   }
 
   private long maxModels() {
-    return _hyperSpaceWalker.search_criteria().stopping_criteria() == null ? 0 : _hyperSpaceWalker.search_criteria().stopping_criteria()._max_models;
+    return _hyperSpaceWalker.search_criteria().stoppingCriteria() == null ? 0 : _hyperSpaceWalker.search_criteria().stoppingCriteria().getMaxModels();
   }
 
   private double maxRuntimeSecs() {
-    return  _hyperSpaceWalker.search_criteria().stopping_criteria() == null ? 0 : _hyperSpaceWalker.search_criteria().stopping_criteria()._max_runtime_secs;
+    return  _hyperSpaceWalker.search_criteria().stoppingCriteria() == null ? 0 : _hyperSpaceWalker.search_criteria().stoppingCriteria().getMaxRuntimeSecs();
   }
 
   private double remainingTimeSecs() {
@@ -182,9 +182,9 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
   }
 
   private ScoreKeeper.StoppingMetric sortingMetric() {
-    return _hyperSpaceWalker.search_criteria().stopping_criteria() == null
+    return _hyperSpaceWalker.search_criteria().stoppingCriteria() == null
             ? ScoreKeeper.StoppingMetric.AUTO
-            : _hyperSpaceWalker.search_criteria().stopping_criteria()._stopping_metric;
+            : _hyperSpaceWalker.search_criteria().stoppingCriteria().getStoppingMetric();
   }
 
   private class ModelFeeder<MP extends Model.Parameters, D extends ModelFeeder> extends ParallelModelBuilder.ParallelModelBuilderCallback<D>{
@@ -604,7 +604,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
    * @return GridSearch Job, with models run with these parameters, built as needed - expected to be
    * an expensive operation.  If the models in question are "in progress", a 2nd build will NOT be
    * kicked off.  This is a non-blocking call.
-   * @see #startGridSearch(Key, Model.Parameters, Map, ModelParametersBuilderFactory, HyperSpaceSearchCriteria)
+   * @see #startGridSearch(Key, Model.Parameters, Map, ModelParametersBuilderFactory, HyperSpaceSearchCriteria, int)
    */
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
           final Key<Grid> destKey,
@@ -636,7 +636,7 @@ public final class GridSearch<MP extends Model.Parameters> extends Keyed<GridSea
    * an expensive operation.  If the models in question are "in progress", a 2nd build will NOT be
    * kicked off.  This is a non-blocking call.
    *
-   * @see #startGridSearch(Key, Model.Parameters, Map, ModelParametersBuilderFactory, HyperSpaceSearchCriteria)
+   * @see #startGridSearch(Key, Model.Parameters, Map, ModelParametersBuilderFactory, HyperSpaceSearchCriteria, int)
    */
   public static <MP extends Model.Parameters> Job<Grid> startGridSearch(
           final Key<Grid> destKey,

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
@@ -11,10 +11,18 @@ import water.fvec.Frame;
 public class HyperSpaceSearchCriteria extends Iced {
   public enum Strategy { Unknown, Cartesian, RandomDiscrete } // search strategy
 
+  public static class StoppingCriteria extends Iced {
+    public int _max_models = 0;  // no limit
+    public double _max_runtime_secs = 0;  // no time limit
+    public int _stopping_rounds = 0;
+    public ScoreKeeper.StoppingMetric _stopping_metric = ScoreKeeper.StoppingMetric.AUTO;
+    public double _stopping_tolerance = 1e-3;  // = Model.Parameters.defaultStoppingTolerance()
+  }
+
   public final Strategy _strategy;
   public final Strategy strategy() { return _strategy; }
 
-  public ScoreKeeper.StoppingMetric stopping_metric() { return ScoreKeeper.StoppingMetric.AUTO; }
+  public StoppingCriteria stopping_criteria() { return null; }
 
 
 // TODO: add a factory which accepts a Strategy and calls the right constructor
@@ -40,21 +48,23 @@ public class HyperSpaceSearchCriteria extends Iced {
    */
   public static final class RandomDiscreteValueSearchCriteria extends HyperSpaceSearchCriteria {
     private long _seed = -1; // -1 means true random
+    private StoppingCriteria _stopping_criteria;
 
-    /////////////////////
-    // stopping criteria:
-    private int _max_models = 0;
-    private double _max_runtime_secs = 0;
-    private int _stopping_rounds = 0;
-    private ScoreKeeper.StoppingMetric _stopping_metric = ScoreKeeper.StoppingMetric.AUTO;
-    private double _stopping_tolerance = 1e-3;  // = Model.Parameters.defaultStoppingTolerance()
+    public RandomDiscreteValueSearchCriteria() {
+      super(Strategy.RandomDiscrete);
+      _stopping_criteria = new StoppingCriteria();
+    }
 
+    @Override
+    public StoppingCriteria stopping_criteria() {
+      return _stopping_criteria;
+    }
 
     /** Seed for the random choices of hyperparameter values.  Set to a value other than -1 to get a repeatable pseudorandom sequence. */
     public long seed() { return _seed; }
 
     /** Max number of models to build. */
-    public int max_models() { return _max_models; }
+    public int max_models() { return _stopping_criteria._max_models; }
 
     /**
      * Max runtime for the entire grid, in seconds. Set to 0 to disable. Can be combined with <i>max_runtime_secs</i> in the model parameters. If
@@ -62,7 +72,7 @@ public class HyperSpaceSearchCriteria extends Iced {
      * the remainder of the grid time.  If <i>max_runtime_secs</i> <b>is</b> set in the mode parameters each build is launched
      * with a limit equal to the minimum of the model time limit and the remaining time for the grid.
      */
-    public double max_runtime_secs() { return _max_runtime_secs; }
+    public double max_runtime_secs() { return _stopping_criteria._max_runtime_secs; }
 
     /**
      * Early stopping based on convergence of stopping_metric.
@@ -70,13 +80,13 @@ public class HyperSpaceSearchCriteria extends Iced {
      * k scoring events.
      * Can only trigger after at least 2k scoring events. Use 0 to disable.
      */
-    public int stopping_rounds() { return _stopping_rounds; }
+    public int stopping_rounds() { return _stopping_criteria._stopping_rounds; }
 
     /** Metric to use for convergence checking; only for _stopping_rounds > 0 */
-    public ScoreKeeper.StoppingMetric stopping_metric() { return _stopping_metric; }
+    public ScoreKeeper.StoppingMetric stopping_metric() { return _stopping_criteria._stopping_metric; }
 
     /** Relative tolerance for metric-based stopping criterion: stop if relative improvement is not at least this much. */
-    public double stopping_tolerance() { return _stopping_tolerance; }
+    public double stopping_tolerance() { return _stopping_criteria._stopping_tolerance; }
 
     /** Calculate a reasonable stopping tolerance for the Frame.
      * Currently uses only the NA percentage and nrows, but later
@@ -89,12 +99,7 @@ public class HyperSpaceSearchCriteria extends Iced {
     }
 
     public void set_default_stopping_tolerance_for_frame(Frame frame) {
-      _stopping_tolerance = default_stopping_tolerance_for_frame(frame);
-    }
-
-
-    public RandomDiscreteValueSearchCriteria() {
-      super(Strategy.RandomDiscrete);
+      _stopping_criteria._stopping_tolerance = default_stopping_tolerance_for_frame(frame);
     }
 
     public void set_seed(long seed) {
@@ -102,23 +107,23 @@ public class HyperSpaceSearchCriteria extends Iced {
     }
 
     public void set_max_models(int max_models) {
-      _max_models = max_models;
+      _stopping_criteria._max_models = max_models;
     }
 
     public void set_max_runtime_secs(double max_runtime_secs) {
-      _max_runtime_secs = max_runtime_secs;
+      _stopping_criteria._max_runtime_secs = max_runtime_secs;
     }
 
     public void set_stopping_rounds(int stopping_rounds) {
-      _stopping_rounds = stopping_rounds;
+      _stopping_criteria._stopping_rounds = stopping_rounds;
     }
 
     public void set_stopping_metric(ScoreKeeper.StoppingMetric stopping_metric) {
-      _stopping_metric = stopping_metric;
+      _stopping_criteria._stopping_metric = stopping_metric;
     }
 
     public void set_stopping_tolerance(double stopping_tolerance) {
-      this._stopping_tolerance = stopping_tolerance;
+      _stopping_criteria._stopping_tolerance = stopping_tolerance;
     }
   }
 }

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
@@ -98,6 +98,14 @@ public class HyperSpaceSearchCriteria extends Iced {
       return Math.min(0.05, Math.max(0.001, 1/Math.sqrt((1 - frame.naFraction()) * frame.numRows())));
     }
 
+    /**
+     * Allows to set all the stopping criteria at once
+     * @param stopping_criteria
+     */
+    public void set_stopping_criteria(StoppingCriteria stopping_criteria) {
+      _stopping_criteria = stopping_criteria;
+    }
+
     public void set_default_stopping_tolerance_for_frame(Frame frame) {
       _stopping_criteria._stopping_tolerance = default_stopping_tolerance_for_frame(frame);
     }

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceSearchCriteria.java
@@ -1,6 +1,7 @@
 package hex.grid;
 
 import hex.ScoreKeeper;
+import javafx.scene.paint.Stop;
 import water.Iced;
 import water.fvec.Frame;
 
@@ -29,6 +30,10 @@ public class HyperSpaceSearchCriteria extends Iced {
 
   public HyperSpaceSearchCriteria(Strategy strategy) {
     this._strategy = strategy;
+  }
+
+  public HyperSpaceSearchCriteria deepClone() {
+    return (HyperSpaceSearchCriteria) this.clone();
   }
 
   /**
@@ -98,14 +103,6 @@ public class HyperSpaceSearchCriteria extends Iced {
       return Math.min(0.05, Math.max(0.001, 1/Math.sqrt((1 - frame.naFraction()) * frame.numRows())));
     }
 
-    /**
-     * Allows to set all the stopping criteria at once
-     * @param stopping_criteria
-     */
-    public void set_stopping_criteria(StoppingCriteria stopping_criteria) {
-      _stopping_criteria = stopping_criteria;
-    }
-
     public void set_default_stopping_tolerance_for_frame(Frame frame) {
       _stopping_criteria._stopping_tolerance = default_stopping_tolerance_for_frame(frame);
     }
@@ -132,6 +129,13 @@ public class HyperSpaceSearchCriteria extends Iced {
 
     public void set_stopping_tolerance(double stopping_tolerance) {
       _stopping_criteria._stopping_tolerance = stopping_tolerance;
+    }
+
+    @Override
+    public RandomDiscreteValueSearchCriteria deepClone() {
+      RandomDiscreteValueSearchCriteria clone = (RandomDiscreteValueSearchCriteria) super.deepClone();
+      clone._stopping_criteria = (StoppingCriteria) clone._stopping_criteria.clone();
+      return clone;
     }
   }
 }

--- a/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
+++ b/h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java
@@ -43,7 +43,7 @@ public interface HyperSpaceWalker<MP extends Model.Parameters, C extends HyperSp
 
     /**
      * Inform the Iterator that a model build failed in case it needs to adjust its internal state.
-     * Implementations are expected to consume the {@code withHistory} callback with the iterator permutations history.
+     * Implementations are expected to consume the {@code withFailedModelHyperParams} callback with the hyperParams used to create the failed model.
      * @param failedModel: the model whose training failed.
      * @param withFailedModelHyperParams: consumes the "raw" hyperparameters values used for the failed model.
      */

--- a/h2o-core/src/main/java/hex/schemas/HyperSpaceSearchCriteriaV99.java
+++ b/h2o-core/src/main/java/hex/schemas/HyperSpaceSearchCriteriaV99.java
@@ -9,8 +9,6 @@ import water.api.schemas3.SchemaV3;
 import water.exceptions.H2OIllegalArgumentException;
 import water.util.PojoUtils;
 
-import java.util.Properties;
-
 /**
  * Search criteria for a hyperparameter search including directives for how to search and
  * when to stop the search.
@@ -73,14 +71,14 @@ public class HyperSpaceSearchCriteriaV99<I extends HyperSpaceSearchCriteria, S e
     @Override
     public RandomDiscreteValueSearchCriteria fillImpl(RandomDiscreteValueSearchCriteria impl) {
       RandomDiscreteValueSearchCriteria filledImpl = super.fillImpl(impl);
-      PojoUtils.copyProperties(filledImpl.stopping_criteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES);
+      PojoUtils.copyProperties(filledImpl.stoppingCriteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES);
       return filledImpl;
     }
 
     @Override
     public RandomDiscreteValueSearchCriteriaV99 fillFromImpl(RandomDiscreteValueSearchCriteria impl) {
       RandomDiscreteValueSearchCriteriaV99 schema = super.fillFromImpl(impl);
-      PojoUtils.copyProperties(this, impl.stopping_criteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES);
+      PojoUtils.copyProperties(this, impl.stoppingCriteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES);
       return schema;
     }
   }

--- a/h2o-core/src/main/java/hex/schemas/HyperSpaceSearchCriteriaV99.java
+++ b/h2o-core/src/main/java/hex/schemas/HyperSpaceSearchCriteriaV99.java
@@ -2,10 +2,14 @@ package hex.schemas;
 
 import hex.ScoreKeeper.StoppingMetric;
 import hex.grid.HyperSpaceSearchCriteria;
+import hex.grid.HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria;
 import water.api.API;
 import water.api.EnumValuesProvider;
 import water.api.schemas3.SchemaV3;
 import water.exceptions.H2OIllegalArgumentException;
+import water.util.PojoUtils;
+
+import java.util.Properties;
 
 /**
  * Search criteria for a hyperparameter search including directives for how to search and
@@ -32,7 +36,7 @@ public class HyperSpaceSearchCriteriaV99<I extends HyperSpaceSearchCriteria, S e
    * Search criteria for random hyperparameter search using hyperparameter values given by
    * lists. Includes directives for how to search and when to stop the search.
    */
-  public static class RandomDiscreteValueSearchCriteriaV99 extends HyperSpaceSearchCriteriaV99<HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria, RandomDiscreteValueSearchCriteriaV99> {
+  public static class RandomDiscreteValueSearchCriteriaV99 extends HyperSpaceSearchCriteriaV99<RandomDiscreteValueSearchCriteria, RandomDiscreteValueSearchCriteriaV99> {
     public RandomDiscreteValueSearchCriteriaV99() {
       strategy = HyperSpaceSearchCriteria.Strategy.RandomDiscrete;
     }
@@ -65,6 +69,20 @@ public class HyperSpaceSearchCriteriaV99<I extends HyperSpaceSearchCriteria, S e
     @API(help = "Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)",
             level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
     public double stopping_tolerance;
+
+    @Override
+    public RandomDiscreteValueSearchCriteria fillImpl(RandomDiscreteValueSearchCriteria impl) {
+      RandomDiscreteValueSearchCriteria filledImpl = super.fillImpl(impl);
+      PojoUtils.copyProperties(filledImpl.stopping_criteria(), this, PojoUtils.FieldNaming.DEST_HAS_UNDERSCORES);
+      return filledImpl;
+    }
+
+    @Override
+    public RandomDiscreteValueSearchCriteriaV99 fillFromImpl(RandomDiscreteValueSearchCriteria impl) {
+      RandomDiscreteValueSearchCriteriaV99 schema = super.fillFromImpl(impl);
+      PojoUtils.copyProperties(this, impl.stopping_criteria(), PojoUtils.FieldNaming.ORIGIN_HAS_UNDERSCORES);
+      return schema;
+    }
   }
 
   public static class RandomSearchStoppingMetricValuesProvider extends EnumValuesProvider<StoppingMetric> {
@@ -91,7 +109,7 @@ public class HyperSpaceSearchCriteriaV99<I extends HyperSpaceSearchCriteria, S e
     if (HyperSpaceSearchCriteria.Strategy.Cartesian == strategy) {
       defaults = new HyperSpaceSearchCriteria.CartesianSearchCriteria();
     } else if (HyperSpaceSearchCriteria.Strategy.RandomDiscrete == strategy) {
-      defaults = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+      defaults = new RandomDiscreteValueSearchCriteria();
     } else {
       throw new H2OIllegalArgumentException("search_criteria.strategy", strategy.toString());
     }

--- a/h2o-docs/src/product/api-changes.rst
+++ b/h2o-docs/src/product/api-changes.rst
@@ -38,3 +38,12 @@ The following classes were moved:
 ``ai.h2o.automl.Leaderboard``                       ``ai.h2o.automl.leaderboard.Leaderboard``
 =================================================   =========================================
 
+
+From 3.28 or Below to 3.30
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Java API
+''''''''
+
+`hex.grid.HyperSpaceWalker` and `hex.grid.HyperspaceWalker.HyperSpaceIterator` interfaces have been simplified.
+Users implementing those interfaces directly, for example to create a custom grid search exploration algorithm, may want to look at the default implementations in ` h2o-core/src/main/java/hex/grid/HyperSpaceWalker.java` if they are facing any issue when compiling against the new interfaces.

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_args.py
@@ -306,7 +306,7 @@ def test_keep_cross_validation_fold_assignment_enabled_with_nfolds_eq_0():
 
 def test_stacked_ensembles_are_trained_after_timeout():
     print("Check that Stacked Ensembles are still trained after timeout")
-    max_runtime_secs = 20
+    max_runtime_secs = 10
     ds = import_dataset()
     aml = H2OAutoML(project_name="py_aml_SE_after_timeout", seed=1, max_runtime_secs=max_runtime_secs, exclude_algos=['XGBoost', 'DeepLearning'])
     start = time.time()

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
@@ -33,7 +33,6 @@ def airline_gbm_random_grid():
     air_grid = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_parameters, search_criteria=search_crit)
     air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, nfolds=5, fold_assignment='Modulo', keep_cross_validation_predictions=True, distribution="bernoulli", seed=5678)
 
-    air_grid.show()
     assert(len(air_grid.get_grid())==5)
     print(air_grid.get_grid("logloss"))
 

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_random_grid.py
@@ -33,6 +33,7 @@ def airline_gbm_random_grid():
     air_grid = H2OGridSearch(H2OGradientBoostingEstimator, hyper_params=hyper_parameters, search_criteria=search_crit)
     air_grid.train(x=myX, y="IsDepDelayed", training_frame=air_hex, nfolds=5, fold_assignment='Modulo', keep_cross_validation_predictions=True, distribution="bernoulli", seed=5678)
 
+    air_grid.show()
     assert(len(air_grid.get_grid())==5)
     print(air_grid.get_grid("logloss"))
 


### PR DESCRIPTION
This is a simplification proposal due to the following observations after planning to add more iterator for AutoML:
1. Lack of clear separation of concerns between `HyperspaceWalker` and `HyperspaceIterator`, leading to more issues (see following).
2. `HyperspaceIterator` complexity is way too high: it should focus on iteration, i.e. providing new model parameters.
3. Our implementations of `HyperspaceIterator` modify the state of their parent walker, making it unsafe to create multiple iterators (somehow an heresy to the concept of iterators), hence the legacy introduction of (still heretic) `reset` method on iterator, when a consumer should just be able to create a new one safely.
4. Confusion between `GridSearch` and `Iterator` about who is responsible to handle termination logic (esp. based on number of models or on runtime): instead, leveraging job timing properties for that.

Additional suggestions
- break up this file: 
   1. walker+iterator interfaces in one file.
   2. base/abstract classes in one file.
   3. implementations in their dedicated file.
   4. walker factory in dedicated file.
 this generates backwards incompatibility only for consumers not using the `GridSearch.startGridSearch` static methods, and for those implementing their own walker: probably very few of them, we can help them using the migration guide.
- `hasNext` and `nextModelParameters` should take either NO argument, or the entire `Grid`: currently the `model` param is ignored in all our implementations, and if we want to add some decision logic based on training history, the next params should be picked based on the entire history, not on the last model built, especially when the grid is trained in parallel.