### PR TITLE
PUBDEV-7305: missing model timing properties in client mode

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -64,6 +64,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
 
   void compute() {
     try {
+      _model.write_lock(_job);
       B builder = createBuilder();
 
       if (_hasMetalearnerParams) {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -276,6 +276,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     if (res != null && res._output != null) {
       res._output._job = _job;
       res._output.stopClock();
+//      res.unlock(_job == null ? null : _job._key, false); // last resort: dirty way to force unlock to be able to reacquire lock
       res.write_lock(_job);
       res.update(_job);
       res.unlock(_job);

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -275,15 +275,9 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     if (res != null && res._output != null) {
       res._output._job = _job;
       res._output.stopClock();
-      try {
-        res.write_lock(_job);
-        res.update(_job);
-        res.unlock(_job);
-      } catch (Exception e) {
-        Log.info("current job: ", _job);
-        Log.info("lockers: ", res._lockers);
-        throw e;
-      }
+      res.write_lock(_job);
+      res.update(_job);
+      res.unlock(_job);
     }
     Log.info("Completing model "+ reskey);
   }

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -259,6 +259,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
 
     @Override
     public boolean onExceptionalCompletion(Throwable ex, CountedCompleter caller) {
+      setFinalState();
       if (_modelBuilderListener != null) {
         _modelBuilderListener.onModelFailure(ex, _parms);
       }

--- a/h2o-r/tests/testdir_misc/runit_model_output_timing.R
+++ b/h2o-r/tests/testdir_misc/runit_model_output_timing.R
@@ -1,0 +1,18 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.model_timing_attributes <- function() {
+  fr <- h2o.importFile(locate("smalldata/logreg/prostate_train.csv"))
+  target <- "CAPSULE"
+  fr[target] <- as.factor(fr[target])
+
+  gbm <- h2o.gbm(model_id = "R_test_model_output_timing",
+                 y = target,
+                 training_frame = fr)
+
+  expect_gt(gbm@model$start_time, 0)
+  expect_gt(gbm@model$end_time, 0)
+  expect_gt(gbm@model$run_time, 0)
+}
+
+doTest("Test model exposes timing properties", test.model_timing_attributes)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7305

Ensuring that model is updated to DKV after setting those properties.
GLM being the usual bad boy, had to change the lock/update logic to make it work consistently like other models, ie. not leaving the CV models locked until the main model is being built, but by acquiring the lock only when needed.


Added a R test for this as only R tests are run in Client Mode...
There is already a Py test checking this: h2o-py/tests/testdir_jira/pyunit_pubdev_5829_pubdev_6091_get_model_timestamp.py