### PR TITLE
HEXDEV-744: Provide a Python wheel that can't be used to start a local H2O

### DIFF
--- a/h2o-py/build.gradle
+++ b/h2o-py/build.gradle
@@ -22,12 +22,14 @@ ext {
 //
 task createVersionFiles() {
     doLast {
-        file("${buildDir}/h2o").mkdirs()
-        File version_file = new File("${buildDir}/h2o", "version.txt")
-        version_file.write(PROJECT_VERSION)
+        ["main", "client"].each {
+            file("${buildDir}/$it/h2o/").mkdirs()
+            File version_file = new File("${buildDir}/$it/h2o", "version.txt")
+            version_file.write(PROJECT_VERSION)
 
-        File build_file = new File("${buildDir}/h2o", "buildinfo.txt")
-        build_file.write(buildVersion.toString())
+            File build_file = new File("${buildDir}/$it/h2o", "buildinfo.txt")
+            build_file.write(buildVersion.toString())
+        }
     }
 }
 
@@ -49,7 +51,14 @@ task verifyTestDependencies(type: Exec) {
 
 task copyH2OJar(type: Copy, dependsOn: [configurations.compile]) {
     from "${rootDir}/build/h2o.jar"
-    into "${buildDir}/h2o/backend/bin/"
+    into "${buildDir}/main/h2o/backend/bin/"
+}
+
+task copyH2OClientJar(type: Copy, dependsOn: [jar]) {
+    from("${buildDir}/libs/h2o-py.jar") {
+        rename("h2o-py.jar", "h2o.jar")
+    }
+    into "${buildDir}/client/h2o/backend/bin/"
 }
 
 task copySrcFiles(type: Copy, dependsOn: [copyH2OJar]) {
@@ -62,16 +71,45 @@ task copySrcFiles(type: Copy, dependsOn: [copyH2OJar]) {
         include "README.md"
         include "requirements.txt"
     }
-    into "${buildDir}"
+    into "${buildDir}/main"
+}
+
+task copyClientSrcFiles(type: Copy, dependsOn: [copyH2OClientJar]) {
+    from ("${projectDir}") {
+        include "setup.py"
+        include "setup.cfg"
+        include "h2o/**"
+        include "DESCRIPTION.rst"
+        include "MANIFEST.in"
+        include "README.md"
+        include "requirements.txt"
+    }
+    into "${buildDir}/client"
 }
 
 task buildDist(type: Exec, dependsOn: [verifyDependencies, createVersionFiles, copySrcFiles]) {
-    workingDir buildDir
+    workingDir new File(buildDir, "main")
     doFirst {
-        file("${buildDir}/tmp").mkdirs()
-        standardOutput = new FileOutputStream(file("${buildDir}/tmp/h2o-py_buildDist.out"))
+        file("${buildDir}/main/tmp").mkdirs()
+        standardOutput = new FileOutputStream(file("${buildDir}/main/tmp/h2o-py_buildDist.out"))
     }
     commandLine getOsSpecificCommandLine([pythonexe, "setup.py", "bdist_wheel"])
+}
+
+task copyMainDist(type: Copy, dependsOn: [buildDist]) {
+    from ("${buildDir}/main/") {
+        include "dist/**"
+    }
+    into "${buildDir}"
+}
+
+task buildClientDist(type: Exec, dependsOn: [verifyDependencies, createVersionFiles, copyClientSrcFiles]) {
+    workingDir new File(buildDir, "client")
+    doFirst {
+        file("${buildDir}/client/tmp").mkdirs()
+        standardOutput = new FileOutputStream(file("${buildDir}/client/tmp/h2o-py_buildDist.out"))
+    }
+    commandLine getOsSpecificCommandLine([pythonexe, "setup.py", "bdist_wheel", "--client"])
 }
 
 task smokeTest(type: Exec, dependsOn: [verifyTestDependencies]) {
@@ -112,4 +150,5 @@ task cleanBuild(type: Delete) {
 // Define the dependencies
 //
 clean.dependsOn cleanBuild, cleanUpSmokeTest, cleanCoverageData
-build.dependsOn buildDist
+buildDist.dependsOn buildClientDist // to have a predictable order of these 2 
+build.dependsOn copyMainDist

--- a/h2o-py/setup.py
+++ b/h2o-py/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 from codecs import open
 import os
+import sys
 import shutil
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -15,12 +16,15 @@ version = "0.0.local"
 with open(os.path.join(here, 'h2o/version.txt'), encoding='utf-8') as f:
     version = f.read()
 
+client = "--client" in sys.argv
+if client:
+    sys.argv.remove("--client")
 
 packages = find_packages(exclude=["tests*"])
 print("Found packages: %r" % packages)
 
 setup(
-    name='h2o',
+    name='h2o_client' if client else 'h2o',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see

--- a/h2o-py/src/main/java/water/H2OApp.java
+++ b/h2o-py/src/main/java/water/H2OApp.java
@@ -1,0 +1,9 @@
+package water;
+
+public class H2OApp {
+
+  public static void main(String[] args) {
+    throw new IllegalStateException("Client version of the library cannot be used to start a local H2O instance. Use h2o.connect() instead.");
+  }
+
+}

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -22,6 +22,7 @@ function make_zip_common {
   mkdir $IMAGEDIR/python
 
   cp h2o-py/build/dist/*whl $IMAGEDIR/python
+  cp h2o-py/build/client/dist/*whl $IMAGEDIR/python
 
   mkdir -p $IMAGEDIR/bindings/java
   cp h2o-bindings/build/distributions/h2o-bindings-*.zip $IMAGEDIR/bindings/java
@@ -115,6 +116,7 @@ do
 done
 
 cp h2o-py/build/dist/*whl target/Python
+cp h2o-py/build/client/dist/*whl target/Python
 
 cd h2o-py && sphinx-build -b html docs/ docs/docs/
 cd ..


### PR DESCRIPTION
The build will now produce a Python wheel `h2o_client` that cannot be used to start a local H2O instance. The bundled jar mimics the regular `h2o.jar` but produces an error when actually executed. This is a failsafe mechanism in cluster deployments when users sometimes accidentally start a local instance instead of connecting to the cluster.