### PR TITLE
PUBDEV-7267 - Terminal nodes recognized by lack of children. Also, split column not filled for terminal nodes in case of XGBoost.

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -182,7 +182,7 @@ public class TreeHandler extends Handler {
         int[] nodeLevels = node.getParent().isBitset() ? extractNodeLevels(node) : null;
         nodeDescriptionBuilder.append("Node has id ");
         nodeDescriptionBuilder.append(node.getNodeNumber());
-        if (node.getColName() != null && node.getRightChild() == null && node.getLeftChild() == null) {
+        if (node.getColName() != null && node.isLeaf()) {
             nodeDescriptionBuilder.append(" and splits on column '");
             nodeDescriptionBuilder.append(node.getColName());
             nodeDescriptionBuilder.append("'. ");

--- a/h2o-algos/src/main/java/hex/tree/TreeHandler.java
+++ b/h2o-algos/src/main/java/hex/tree/TreeHandler.java
@@ -182,7 +182,7 @@ public class TreeHandler extends Handler {
         int[] nodeLevels = node.getParent().isBitset() ? extractNodeLevels(node) : null;
         nodeDescriptionBuilder.append("Node has id ");
         nodeDescriptionBuilder.append(node.getNodeNumber());
-        if (node.getColName() != null) {
+        if (node.getColName() != null && node.getRightChild() == null && node.getLeftChild() == null) {
             nodeDescriptionBuilder.append(" and splits on column '");
             nodeDescriptionBuilder.append(node.getColName());
             nodeDescriptionBuilder.append("'. ");
@@ -195,6 +195,8 @@ public class TreeHandler extends Handler {
         if (!Float.isNaN(node.getParent().getSplitValue())) {
             nodeDescriptionBuilder.append(" Parent node split threshold is ");
             nodeDescriptionBuilder.append(node.getParent().getSplitValue());
+            nodeDescriptionBuilder.append(". Prediction: ");
+            nodeDescriptionBuilder.append(node.getPredValue());
             nodeDescriptionBuilder.append(".");
         } else if (node.getParent().isBitset()) {
             nodeLevels = extractNodeLevels(node);

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoostModel.java
@@ -665,13 +665,12 @@ public class XGBoostModel extends Model<XGBoostModel, XGBoostModel.XGBoostParame
       sharedTreeNode.setSplitValue(xgBoostNode.getSplitCondition());
     }
     sharedTreeNode.setPredValue(xgBoostNode.getLeafValue());
-    sharedTreeNode.setCol(xgBoostNode.getSplitIndex(), featureProperties._names[xgBoostNode.getSplitIndex()]);
     sharedTreeNode.setInclusiveNa(inclusiveNA);
     sharedTreeNode.setNodeNumber(nodeIndex);
-
     if (!xgBoostNode.isLeaf()) {
+      sharedTreeNode.setCol(xgBoostNode.getSplitIndex(), featureProperties._names[xgBoostNode.getSplitIndex()]);
       constructSubgraph(xgBoostNodes, sharedTreeSubgraph.makeLeftChildNode(sharedTreeNode),
-          xgBoostNode.getLeftChildIndex(), sharedTreeSubgraph, featureProperties, xgBoostNode.default_left());
+              xgBoostNode.getLeftChildIndex(), sharedTreeSubgraph, featureProperties, xgBoostNode.default_left());
       constructSubgraph(xgBoostNodes, sharedTreeSubgraph.makeRightChildNode(sharedTreeNode),
           xgBoostNode.getRightChildIndex(), sharedTreeSubgraph, featureProperties, !xgBoostNode.default_left());
     }

--- a/h2o-py/tests/testdir_tree/pyunit_tree_pubdev_7267.py
+++ b/h2o-py/tests/testdir_tree/pyunit_tree_pubdev_7267.py
@@ -1,0 +1,30 @@
+import h2o
+import os, sys
+
+sys.path.insert(1, os.path.join("..", ".."))
+
+from h2o.tree import H2OTree
+from h2o.estimators import H2OXGBoostEstimator
+from tests import pyunit_utils
+
+# PUBDDEV-7267
+def test_terminal_xgboost_nodes():
+    df = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/demos/bank-additional-full.csv")
+
+    xgboost = H2OXGBoostEstimator(max_depth=1, ntrees=1)
+    model = xgboost.train(y="y", training_frame=df)
+    tree = H2OTree(xgboost, 0)
+    assert len(tree.node_ids) == 3
+
+    # Depth is 1 - last two nodes should be described as terminal
+    assert "terminal node" in tree.descriptions[1]
+    assert "terminal node" in tree.descriptions[2]
+
+    # Prediction is part of the description for terminal nodes
+    assert "Prediction: " in tree.descriptions[1]
+    assert "Prediction: " in tree.descriptions[2]
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_terminal_xgboost_nodes)
+else:
+    test_terminal_xgboost_nodes()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7262

Please note, marked for `3.28.0.5`, which is not today's release. Feel free to move it to current release of course (@michalkurka).

- XGBoost uses 0 as split column index on terminal nodes, which means nothing. We should not add split column if the nodes is terminal for XGBoost models (fixed).
- Adjusted leaf-detection mechanism inside H2OTreeHandler as well - if the node does not have any children and has empty split column, it is considered to be a leaf node. Until now, only the presence of split column name was tested - this step is not needed for the fix.

- Leaf nodes did not have prediction values in description for some reason. I added them. This has nothing to do with the original issue, but it is convenient to add it as well.