### PR TITLE
PSVM shouldn't be used a SE Metalearner

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -24,7 +24,6 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
     gbm,
     glm,
     naivebayes,
-    psvm,
     xgboost,
   }
 

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -3,15 +3,10 @@ package hex.ensemble;
 import hex.Model;
 import hex.ModelBuilder;
 import hex.ModelCategory;
-import hex.deeplearning.DeepLearningModel.DeepLearningParameters;
 import hex.ensemble.Metalearner.Algorithm;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters;
-import hex.naivebayes.NaiveBayesModel.NaiveBayesParameters;
-import hex.psvm.PSVMModel.PSVMParameters;
-import hex.tree.drf.DRFModel.DRFParameters;
-import hex.tree.gbm.GBMModel.GBMParameters;
 import water.exceptions.H2OIllegalArgumentException;
 import water.nbhm.NonBlockingHashMap;
 
@@ -35,7 +30,6 @@ public class Metalearners {
                 new LocalProvider<>(Algorithm.gbm, GBMMetalearner::new),
                 new LocalProvider<>(Algorithm.glm, GLMMetalearner::new),
                 new LocalProvider<>(Algorithm.naivebayes, NaiveBayesMetalearner::new),
-                new LocalProvider<>(Algorithm.psvm, PSVMMetalearner::new),
         };
         for (MetalearnerProvider provider : localProviders) {
             providersByName.put(provider.getName(), provider);
@@ -149,12 +143,6 @@ public class Metalearners {
     static class NaiveBayesMetalearner extends SimpleMetalearner {
         public NaiveBayesMetalearner() {
             super(Algorithm.naivebayes.name());
-        }
-    }
-
-    static class PSVMMetalearner extends SimpleMetalearner {
-        public PSVMMetalearner() {
-            super(Algorithm.psvm.name());
         }
     }
 

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -71,7 +71,6 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
                     + "'gbm' (GBM with default parameters), "
                     + "'glm' (GLM with default parameters), "
                     + "'naivebayes' (NaiveBayes with default parameters), "
-                    + "'psvm' (PSVM with default parameters), "
                     + "or 'xgboost' (if available, XGBoost with default parameters)."
     )
     public Algorithm metalearner_algorithm;

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -281,11 +281,11 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         Type of algorithm to use as the metalearner. Options include 'AUTO' (GLM with non negative weights; if
         validation_frame is present, a lambda search is performed), 'deeplearning' (Deep Learning with default
         parameters), 'drf' (Random Forest with default parameters), 'gbm' (GBM with default parameters), 'glm' (GLM with
-        default parameters), 'naivebayes' (NaiveBayes with default parameters), 'psvm' (PSVM with default parameters),
-        or 'xgboost' (if available, XGBoost with default parameters).
+        default parameters), 'naivebayes' (NaiveBayes with default parameters), or 'xgboost' (if available, XGBoost with
+        default parameters).
 
-        One of: ``"auto"``, ``"deeplearning"``, ``"drf"``, ``"gbm"``, ``"glm"``, ``"naivebayes"``, ``"psvm"``,
-        ``"xgboost"``  (default: ``"auto"``).
+        One of: ``"auto"``, ``"deeplearning"``, ``"drf"``, ``"gbm"``, ``"glm"``, ``"naivebayes"``, ``"xgboost"``
+        (default: ``"auto"``).
 
         :examples:
 
@@ -323,7 +323,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
 
     @metalearner_algorithm.setter
     def metalearner_algorithm(self, metalearner_algorithm):
-        assert_is_type(metalearner_algorithm, None, Enum("auto", "deeplearning", "drf", "gbm", "glm", "naivebayes", "psvm", "xgboost"))
+        assert_is_type(metalearner_algorithm, None, Enum("auto", "deeplearning", "drf", "gbm", "glm", "naivebayes", "xgboost"))
         self._parms["metalearner_algorithm"] = metalearner_algorithm
 
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_metalearner.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_metalearner.py
@@ -58,7 +58,7 @@ def stackedensemble_metalearner_test():
     def train_ensemble_using_metalearner(algo, expected_algo):
         print("Training ensemble using {} metalearner.".format(algo))
 
-        meta_params = dict(metalearner_nfolds=3) if algo is not 'psvm' else {}
+        meta_params = dict(metalearner_nfolds=3)
 
         se = H2OStackedEnsembleEstimator(base_models=[my_gbm, my_rf], metalearner_algorithm=algo, **meta_params)
         se.train(x=x, y=y, training_frame=train)
@@ -71,8 +71,7 @@ def stackedensemble_metalearner_test():
         if meta_params:
             assert(meta.params['nfolds']['actual'] == 3)
 
-
-    metalearner_algos = ['AUTO', 'deeplearning', 'drf', 'gbm', 'glm', 'naivebayes', 'psvm', 'xgboost']
+    metalearner_algos = ['AUTO', 'deeplearning', 'drf', 'gbm', 'glm', 'naivebayes', 'xgboost']
     for algo in metalearner_algos:
         expected_algo = 'glm' if algo == 'AUTO' else algo
         train_ensemble_using_metalearner(algo, expected_algo)

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -23,9 +23,9 @@
 #' @param metalearner_algorithm Type of algorithm to use as the metalearner. Options include 'AUTO' (GLM with non negative weights; if
 #'        validation_frame is present, a lambda search is performed), 'deeplearning' (Deep Learning with default
 #'        parameters), 'drf' (Random Forest with default parameters), 'gbm' (GBM with default parameters), 'glm' (GLM
-#'        with default parameters), 'naivebayes' (NaiveBayes with default parameters), 'psvm' (PSVM with default
-#'        parameters), or 'xgboost' (if available, XGBoost with default parameters). Must be one of: "AUTO",
-#'        "deeplearning", "drf", "gbm", "glm", "naivebayes", "psvm", "xgboost". Defaults to AUTO.
+#'        with default parameters), 'naivebayes' (NaiveBayes with default parameters), or 'xgboost' (if available,
+#'        XGBoost with default parameters). Must be one of: "AUTO", "deeplearning", "drf", "gbm", "glm", "naivebayes",
+#'        "xgboost". Defaults to AUTO.
 #' @param metalearner_nfolds Number of folds for K-fold cross-validation of the metalearner algorithm (0 to disable or >= 2). Defaults to
 #'        0.
 #' @param metalearner_fold_assignment Cross-validation fold assignment scheme for metalearner cross-validation.  Defaults to AUTO (which is
@@ -49,7 +49,7 @@ h2o.stackedEnsemble <- function(x,
                                 validation_frame = NULL,
                                 blending_frame = NULL,
                                 base_models = list(),
-                                metalearner_algorithm = c("AUTO", "deeplearning", "drf", "gbm", "glm", "naivebayes", "psvm", "xgboost"),
+                                metalearner_algorithm = c("AUTO", "deeplearning", "drf", "gbm", "glm", "naivebayes", "xgboost"),
                                 metalearner_nfolds = 0,
                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
                                 metalearner_fold_column = NULL,


### PR DESCRIPTION
Since PSVM has a bug with metrics (NaNs for some), let's remove it as a metalearner in SE: https://0xdata.atlassian.net/browse/PUBDEV-7314