### PR TITLE
fix PUBDEV-6063 failing test (since changes in PUBDEV-7227)

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -156,6 +156,7 @@ class ExprNode(object):
         #  as they keep a reference to self if the lambda itself is using a free variable.
         proper_ref = [r for r in referrers if not (inspect.isframe(r) or is_ast_expr(r))]
         ref_cnt = len(proper_ref)
+        del referrers, proper_ref
         # if this self node is referenced by at least one other node (nested expr), then create a tmp frame
         if top or ref_cnt > 1:
             self._cache._id = _py_tmp_key(append=h2o.connection().session_id)

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2706,7 +2706,6 @@ class H2OFrame(Keyed):
 
         splits = []
         tmp_runif = self.runif(seed)
-        tmp_runif.frame_id = "%s_splitter" % _py_tmp_key(h2o.connection().session_id)
 
         i = 0
         while i < num_slices:


### PR DESCRIPTION
removed the not-really-useful temporary `splitter` frame renaming in `split_frame` method as it causes the original key to remain until next Python GC collection (Python <=3.6 only), and causing `pyunit_pubdev_6603.py` to fail.