### PR TITLE
PUBDEV-7317 - AWS temporary credentials using HDFS documentation

### DIFF
--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -62,24 +62,29 @@ H2O supports both AWS Credentials (pair consisting of AWS SECRET KEY and AWS SEC
         h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
         
--  Just like regular AWS credentials, temporary credentials using AWS SESSION TOKEN can be passed in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. For an example ``core-site.xml`` file, refer to `Core-site.xml`_. The only difference lies in specifying a triplet of (AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN)
+-  Just like regular AWS credentials, temporary credentials using AWS SESSION TOKEN can be passed in standalone mode by creating a ``core-site.xml`` file and passing it in with the flag ``-hdfs_config``. For an example ``core-site.xml`` file, refer to `Core-site.xml`_. The only difference lies in specifying a triplet of (AWS SECRET KEY, AWS SECRET ACCESS KEY and AWS SESSION TOKEN) and defining a credentials provider capable of resolving temporary credentials.
 
    1. Edit the properties in the core-site.xml file to include your Access Key ID, Access Key, and Session Token as shown in the following example:
 
      ::
 
        <property>
-         <name>fs.s3.awsAccessKeyId</name>
+         <name>fs.s3a.aws.credentials.provider</name>
+         <value>org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider</value>
+       </property>
+
+       <property>
+         <name>fs.s3a.access.key</name>
          <value>[AWS SECRET KEY]</value>
        </property>
 
        <property>
-         <name>fs.s3.awsSecretAccessKey</name>
+         <name>fs.s3a.secret.key</name>
          <value>[AWS SECRET ACCESS KEY]</value>
        </property>
 
        <property>
-         <name>fs.s3.awsSessionToken</name>
+         <name>fs.s3a.session.token</name>
          <value>[AWS SESSION TOKEN]<value>
        <property>
 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7317 
Target is `3.28.0.4`

This PR is a continuation of https://github.com/h2oai/h2o-3/pull/4348 - as the configuration for temporary credentials was wrong.

## Working configuration example:

Source documentation: https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html

```
<?xml version="1.0"?>
<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>

<!-- Put site-specific property overrides in this file. -->

<configuration>

<property>
  <name>fs.s3a.aws.credentials.provider</name>
  <value>org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider</value>
</property>

 <property>
  <name>fs.s3a.access.key</name>
  <value>ASIAXUHFDIL6MAW3JXBB</value>
</property>

<property>
  <name>fs.s3a.secret.key</name>
  <value>wAA7vwzr2dd+U7ACoZsyRV6AVhr3+5uMpqHoke/F</value>
</property>

<property>
  <name>fs.s3a.session.token</name>
  <value>FwoGZXIvYXdzEIf//////////wEaDLaXA5DXpp335dzffCKCAYKHWimCUcSKE8UgYbjYri5Qfki23L7hlvo6WwRjhJtd0NL9jFiVEmcO3JaGqGsI2GhpVLRYXvTKKmFdTyS5miT9MCeNeP1v7Yv6VIfiavgbehnTU8+dwCKP9St8L/jJ/GFGulKrtAIC6pmllDxOlDBe8fjl0UN7Ae5zFY1Qf3nBuecosP7</value>
</property>

</configuration>
```

Yes, we do ship `org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider` with H2O.

Also tested manually.
![Screenshot from 2020-02-22 07-09-36](https://user-images.githubusercontent.com/8769110/75087794-f5e84b00-5544-11ea-946e-76f31d0b49cd.png)



