### PR TITLE
Fix for Python test runner

### DIFF
--- a/h2o-py/tests/pybooklet_utils/utilsPY.py
+++ b/h2o-py/tests/pybooklet_utils/utilsPY.py
@@ -50,5 +50,4 @@ def pybooklet_exec(test_name):
     pyunit = "import h2o\nfrom tests import pybooklet_utils\n"
     with open(test_name, "r") as t: pyunit = pyunit + t.read()
     pyunit_c = compile(pyunit, '<string>', 'exec')
-    p = {}
-    exec(pyunit_c, p)
+    exec(pyunit_c, dict(__name__='main'))

--- a/h2o-py/tests/pydemo_utils/utilsPY.py
+++ b/h2o-py/tests/pydemo_utils/utilsPY.py
@@ -12,8 +12,7 @@ def ipy_notebook_exec(path, save_and_norun=None):
     if save_and_norun is not None:
         with open(save_and_norun, "w") as f: f.write(program)
     else:
-        d = {}
-        exec(program, d)  # safe, but horrible (exec is horrible)
+        exec(program, dict(__name__='main'))
 
 def ipy_blocks(notebook):
     if 'worksheets' in list(notebook.keys()):
@@ -58,5 +57,4 @@ def pydemo_exec(test_name):
         if "h2o.init" not in line:
             program += line if '\n' in line else line + '\n'
     demo_c = compile(program, '<string>', 'exec')
-    p = {}
-    exec(demo_c, p)
+    exec(demo_c, dict(__name__='main'))

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -539,7 +539,7 @@ def hadoop_namenode():
 def pyunit_exec(test_name):
     with open(test_name, "r") as t: pyunit = t.read()
     pyunit_c = compile(pyunit, os.path.abspath(test_name), 'exec')
-    exec(pyunit_c, {})
+    exec(pyunit_c, dict(__name__='main'))  # forcing module name to ensure that the test behaves the same way as when executed using `python my_test.py`
 
 def standalone_test(test):
     if not h2o.connection() or not h2o.connection().connected:


### PR DESCRIPTION
fixing the Python test runner to ensure that tests are executed in same context as when executed directly as scripts (using `python my_test.py` or from IDE).