### PR TITLE
Improved H2ORunner key grouping and logging

### DIFF
--- a/h2o-core/src/test/java/water/runner/H2ORunner.java
+++ b/h2o-core/src/test/java/water/runner/H2ORunner.java
@@ -129,6 +129,11 @@ public class H2ORunner extends BlockJUnit4ClassRunner {
                         Log.err(String.format("       Chunk id %d, key '%s'", i, chunkKey));
                         leakedKeysSet.remove(chunkKey);
                     }
+                    
+                    if (leakedKeysSet.contains(vec.rollupStatsKey())) {
+                        Log.err(String.format("       Rollup stats '%s'", vec.rollupStatsKey().toString()));
+                        leakedKeysSet.remove(vec.rollupStatsKey());
+                    }
 
                     leakedKeysSet.remove(vecKey);
                 }
@@ -137,11 +142,11 @@ public class H2ORunner extends BlockJUnit4ClassRunner {
         }
 
         if (!leakedKeysSet.isEmpty()) {
-            Log.err(String.format("%nThere are also %d more leaked keys:", leakedKeysSet.size()));
+            Log.err(String.format("%nThere are %d uncategorized leaked keys detected:", leakedKeysSet.size()));
         }
 
         for (Key key : leakedKeysSet) {
-            Log.err(String.format("Key '%s'", key.toString()));
+            Log.err(String.format("Key '%s' of type %s.", key.toString(), key.valueClass()));
         }
     }
 


### PR DESCRIPTION
Sample output: 
![Screenshot from 2020-02-25 20-24-27](https://user-images.githubusercontent.com/8769110/75280147-324dcc80-580d-11ea-92ac-92751bb3b7d1.png)

```
02-25 20:23:50.028 192.168.0.102:54321   11466  main      ERRR: Leaked frame with key '123STARTSWITHDIGITS'. This frame contains the following vectors:
02-25 20:23:50.029 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff01000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.029 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0100000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.029 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff01000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.029 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff02000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.029 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0200000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.029 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff02000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.030 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff03000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.030 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0300000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.030 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff03000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.030 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff04000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.030 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0400000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.030 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff04000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.030 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff05000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0500000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff05000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff06000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0600000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff06000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff07000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0700000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.031 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff07000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.032 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff08000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.032 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0800000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.032 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff08000000feffffff$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.032 192.168.0.102:54321   11466  main      ERRR:    Vector '$04ff09000000ffffffff$nfs:/../smalldata/logreg/prostate.csv'. This vector contains the following chunks:
02-25 20:23:50.032 192.168.0.102:54321   11466  main      ERRR:        Chunk id 0, key '$05ff0900000000000000$nfs:/../smalldata/logreg/prostate.csv'
02-25 20:23:50.032 192.168.0.102:54321   11466  main      ERRR:        Rollup stats '$05ff09000000feffffff$nfs:/../smalldata/logreg/prostate.csv'

java.lang.IllegalStateException: Test method 'water.rapids.RapidsTest.test_frameKeyStartsWithNumber' leaked 28 keys.

	at water.runner.H2ORunner.checkLeakedKeys(H2ORunner.java:103)
	at water.runner.H2ORunner.leaf(H2ORunner.java:88)
	at water.runner.H2ORunner.runChild(H2ORunner.java:69)
	at water.runner.H2ORunner.runChild(H2ORunner.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at water.runner.H2ORunnerAfters.evaluate(H2ORunnerAfters.java:32)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:230)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:58)

Disconnected from the target VM, address: '127.0.0.1:53045', transport: 'socket'

Process finished with exit code 255
```
