### PR TITLE
Collect a set of local keys on each node before each test to compare against after the test ran. This isolates the test leaks & only one test fails.

### DIFF
--- a/h2o-core/src/test/java/water/runner/CheckKeysTask.java
+++ b/h2o-core/src/test/java/water/runner/CheckKeysTask.java
@@ -33,7 +33,7 @@ public class CheckKeysTask extends MRTask<CheckKeysTask> {
     @Override
     protected void setupLocal() {
 
-        final Set<Key> initKeys = LocalTestRuntime.initKeys;
+        final Set<Key> initKeys = LocalTestRuntime.beforeTestKeys;
         final Set<Key> keysAfterTest = H2O.localKeySet();
 
         final int numLeakedKeys = keysAfterTest.size() - initKeys.size();

--- a/h2o-core/src/test/java/water/runner/CleanAllKeysTask.java
+++ b/h2o-core/src/test/java/water/runner/CleanAllKeysTask.java
@@ -9,7 +9,7 @@ public class CleanAllKeysTask extends MRTask<CleanAllKeysTask> {
 
     @Override
     protected void setupLocal() {
-        LocalTestRuntime.initKeys.clear();
+        LocalTestRuntime.beforeTestKeys.clear();
         H2O.raw_clear();
         water.fvec.Vec.ESPC.clear();
     }

--- a/h2o-core/src/test/java/water/runner/CollectBeforeTestKeysTask.java
+++ b/h2o-core/src/test/java/water/runner/CollectBeforeTestKeysTask.java
@@ -5,10 +5,10 @@ import water.H2O;
 import water.MRTask;
 
 @Ignore
-public class CollectInitKeysTask extends MRTask<CollectInitKeysTask>  {
+public class CollectBeforeTestKeysTask extends MRTask<CollectBeforeTestKeysTask>  {
 
     @Override
     protected void setupLocal() {
-        LocalTestRuntime.initKeys.addAll(H2O.localKeySet());
+        LocalTestRuntime.beforeTestKeys.addAll(H2O.localKeySet());
     }
 }

--- a/h2o-core/src/test/java/water/runner/H2ORunner.java
+++ b/h2o-core/src/test/java/water/runner/H2ORunner.java
@@ -1,6 +1,7 @@
 package water.runner;
 
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.internal.AssumptionViolatedException;
@@ -41,16 +42,11 @@ public class H2ORunner extends BlockJUnit4ClassRunner {
     }
 
 
-    /**
-     * Returns a {@link Statement}: run all non-overridden {@code @BeforeClass} methods on this class
-     * and superclasses before executing {@code statement}; if any throws an
-     * Exception, stop execution and pass the exception on.
-     */
-    protected Statement withBeforeClasses(Statement statement) {
-        List<FrameworkMethod> befores = getTestClass()
-                .getAnnotatedMethods(BeforeClass.class);
-        return befores.isEmpty() ? statement :
-                new H2ORunnerBefores(statement, befores, null);
+    @Override
+    protected Statement withBefores(FrameworkMethod method, Object target, Statement statement) {
+        List<FrameworkMethod> befores = getTestClass().getAnnotatedMethods(
+                Before.class);
+        return new H2ORunnerBefores(statement, befores, null);
     }
 
     @Override

--- a/h2o-core/src/test/java/water/runner/H2ORunnerBefores.java
+++ b/h2o-core/src/test/java/water/runner/H2ORunnerBefores.java
@@ -26,7 +26,7 @@ public class H2ORunnerBefores extends RunBefores {
         for (FrameworkMethod before : befores) {
             before.invokeExplosively(target);
         }
-        new CollectInitKeysTask().doAllNodes();
+        new CollectBeforeTestKeysTask().doAllNodes();
         next.evaluate();
     }
 }

--- a/h2o-core/src/test/java/water/runner/LocalTestRuntime.java
+++ b/h2o-core/src/test/java/water/runner/LocalTestRuntime.java
@@ -8,5 +8,5 @@ import java.util.Set;
 
 @Ignore
 class LocalTestRuntime {
-    static Set<Key> initKeys = new HashSet<>();
+    static Set<Key> beforeTestKeys = new HashSet<>();
 }


### PR DESCRIPTION
This isolates the test failures by collecting a set of local keys before each test is actually ran on each node. The comparison afterwards is done against such keys. 

After each test class, the DKV is still completely cleared.

![Screenshot from 2020-02-25 20-42-49](https://user-images.githubusercontent.com/8769110/75281630-e81a1a80-580f-11ea-81c2-364e36af798b.png)
