### PR TITLE
TargetEncoderModel's summary prints fold column as column that is going to be encoded by this model

### DIFF
--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -9,6 +9,7 @@ import water.Job;
 import water.Key;
 import water.fvec.Frame;
 import water.udf.CFuncRef;
+import water.util.ArrayUtils;
 import water.util.IcedHashMapGeneric;
 import water.util.TwoDimTable;
 
@@ -92,13 +93,14 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
     }
     
     private TwoDimTable constructSummary(){
-      TwoDimTable summary = new TwoDimTable("Target Encoder model summary.", "Summary for target encoder model", new String[_names.length],
+
+      String[] columnsForSummary = ArrayUtils.difference(_names, new String[]{responseName(), foldName()});
+      TwoDimTable summary = new TwoDimTable("Target Encoder model summary.", "Summary for target encoder model", new String[columnsForSummary.length],
               new String[]{"Original name", "Encoded column name"}, new String[]{"string", "string"}, null, null);
 
-      for (int i = 0; i < _names.length; i++) {
-        final String originalColName = _names[i];
-        if(originalColName.equals(responseName())) continue;
-        
+      for (int i = 0; i < columnsForSummary.length; i++) {
+        final String originalColName = columnsForSummary[i];
+
         summary.set(i, 0, originalColName);
         summary.set(i, 1, originalColName + TargetEncoder.ENCODED_COLUMN_POSTFIX);
       }

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_add_te_model_to_a_regular_model.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_add_te_model_to_a_regular_model.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+
+import os
+import sys
+
+sys.path.insert(1, os.path.join("..","..","..",".."))
+import h2o
+from tests import pyunit_utils
+from h2o.estimators import H2OTargetEncoderEstimator
+
+
+def test_target_encoder_model_summary_does_not_contain_fold_column():
+    print("Check that attached TargetEncoderModel is being used during training and scoring")
+    targetColumnName = "survived"
+    foldColumnName = "kfold_column"
+
+    teColumns = ["cabin", "embarked"]
+    trainingFrame = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/titanic.csv"), header=1)
+
+    trainingFrame[targetColumnName] = trainingFrame[targetColumnName].asfactor()
+    trainingFrame[foldColumnName] = trainingFrame.kfold_column(n_folds=5, seed=1234)
+
+    te = H2OTargetEncoderEstimator(k = 0.7, f = 0.3, data_leakage_handling = "KFold", fold_column=foldColumnName)
+    te.train(training_frame=trainingFrame, x=teColumns, y=targetColumnName)
+    print(te)
+    print(trainingFrame)
+
+    model_summary = te._model_json['output']['model_summary'].as_data_frame()
+    print(model_summary)
+    encoded_column_names = model_summary['encoded_column_name']
+
+    # Checking that we don't have empty entries in TwoDim table
+    assert len(model_summary) == 2
+
+    encoded_columns_with_te_suffix = model_summary[encoded_column_names.str.contains('_te', regex=True)]
+    assert len(encoded_columns_with_te_suffix) == 2
+
+    transformed = te.transform(trainingFrame, data_leakage_handling = "KFold")
+
+    # Checking that fold column is not being encoded.
+    assert foldColumnName+"_te" not in transformed.col_names
+
+
+testList = [
+    test_target_encoder_model_summary_does_not_contain_fold_column
+]
+
+pyunit_utils.run_tests(testList)


### PR DESCRIPTION
This PR addresses 2 issues in TargetEncoder's summary:

1) fold_column is being printed as if TE model was trained to encode it
<img width="619" alt="Screenshot 2020-03-06 at 18 11 59" src="https://user-images.githubusercontent.com/1162131/76108719-64181d80-5fdb-11ea-8039-0be4b0dd7aa6.png">

2) on backend skipping with `continue` does not decrease size of TwoDimensional table as a result we get extra empty lines in the summary's printout
