### PR TITLE
PUBDEV-7358: changed order of parameter for TargetEncoder's Flow UI

### DIFF
--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -5,6 +5,7 @@ import ai.h2o.targetencoding.TargetEncoderModel;
 import water.api.API;
 import water.api.schemas3.ModelParametersSchemaV3;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, TargetEncoderV3, TargetEncoderV3.TargetEncoderParametersV3> {
@@ -30,13 +31,14 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, Ta
   
     @Override
     public String[] fields() {
-      final List<String> params = extractDeclaredApiParameters(getClass());
+      final List<String> params = new ArrayList<>();
       params.add("model_id");
-      params.add("ignored_columns");
       params.add("training_frame");
       params.add("fold_column");
       params.add("response_column");
-  
+      params.add("ignored_columns");
+      params.addAll(extractDeclaredApiParameters(getClass()));
+
       return params.toArray(new String[0]);
     }
 

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -11,19 +11,19 @@ import java.util.List;
 public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoderBuilder, TargetEncoderV3, TargetEncoderV3.TargetEncoderParametersV3> {
   public static class TargetEncoderParametersV3 extends ModelParametersSchemaV3<TargetEncoderModel.TargetEncoderParameters, TargetEncoderParametersV3> {
     
-    @API(help = "Blending enabled/disabled")
+    @API(help = "Blending enabled/disabled", level = API.Level.secondary)
     public boolean blending;
 
-    @API(help = "Inflection point. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.")
+    @API(help = "Inflection point. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.", level = API.Level.secondary)
     public double k;
 
-    @API(help = "Smoothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.")
+    @API(help = "Smoothing. Used for blending (if enabled). Blending is to be enabled separately using the 'blending' parameter.", level = API.Level.secondary)
     public double f;
 
-    @API(help = "Data leakage handling strategy.", values = {"None", "KFold", "LeaveOneOut"})
+    @API(help = "Data leakage handling strategy.", values = {"None", "KFold", "LeaveOneOut"}, level = API.Level.secondary)
     public TargetEncoder.DataLeakageHandlingStrategy data_leakage_handling;
 
-    @API(help = "Noise level", required = false, direction = API.Direction.INPUT, gridable = true)
+    @API(help = "Noise level", required = false, direction = API.Direction.INPUT, gridable = true, level = API.Level.expert)
     public double noise_level;
     
     @API(help = "Seed for the specified noise level", required = false, direction = API.Direction.INPUT)

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -20,8 +20,8 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     """
 
     algo = "targetencoder"
-    param_names = {"blending", "k", "f", "data_leakage_handling", "noise_level", "seed", "model_id", "ignored_columns",
-                   "training_frame", "fold_column", "response_column"}
+    param_names = {"model_id", "training_frame", "fold_column", "response_column", "ignored_columns", "blending", "k",
+                   "f", "data_leakage_handling", "noise_level", "seed"}
 
     def __init__(self, **kwargs):
         super(H2OTargetEncoderEstimator, self).__init__()
@@ -35,6 +35,97 @@ class H2OTargetEncoderEstimator(H2OEstimator):
                 setattr(self, pname, pvalue)
             else:
                 raise H2OValueError("Unknown parameter %s = %r" % (pname, pvalue))
+
+    @property
+    def training_frame(self):
+        """
+        Id of the training data frame.
+
+        Type: ``H2OFrame``.
+
+        :examples:
+
+        >>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
+        >>> predictors = ["home.dest", "cabin", "embarked"]
+        >>> response = "survived"
+        >>> titanic["survived"] = titanic["survived"].asfactor()
+        >>> fold_col = "kfold_column"
+        >>> titanic[fold_col] = titanic.kfold_column(n_folds=5, seed=1234)
+        >>> titanic_te = H2OTargetEncoderEstimator(k=35,
+        ...                                        f=25,
+        ...                                        blending=True)
+        >>> titanic_te.train(x=predictors,
+        ...                  y=response,
+        ...                  training_frame=titanic)
+        >>> titanic_te
+        """
+        return self._parms.get("training_frame")
+
+    @training_frame.setter
+    def training_frame(self, training_frame):
+        self._parms["training_frame"] = H2OFrame._validate(training_frame, 'training_frame')
+
+
+    @property
+    def fold_column(self):
+        """
+        Column with cross-validation fold index assignment per observation.
+
+        Type: ``str``.
+
+        :examples:
+
+        >>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
+        >>> predictors = ["home.dest", "cabin", "embarked"]
+        >>> response = "survived"
+        >>> titanic["survived"] = titanic["survived"].asfactor()
+        >>> fold_col = "kfold_column"
+        >>> titanic[fold_col] = titanic.kfold_column(n_folds=5, seed=1234)
+        >>> titanic_te = H2OTargetEncoderEstimator(k=35,
+        ...                                        f=25,
+        ...                                        blending=True)
+        >>> titanic_te.train(x=predictors,
+        ...                  y=response,
+        ...                  training_frame=titanic)
+        >>> titanic_te
+        """
+        return self._parms.get("fold_column")
+
+    @fold_column.setter
+    def fold_column(self, fold_column):
+        assert_is_type(fold_column, None, str)
+        self._parms["fold_column"] = fold_column
+
+
+    @property
+    def response_column(self):
+        """
+        Response variable column.
+
+        Type: ``str``.
+        """
+        return self._parms.get("response_column")
+
+    @response_column.setter
+    def response_column(self, response_column):
+        assert_is_type(response_column, None, str)
+        self._parms["response_column"] = response_column
+
+
+    @property
+    def ignored_columns(self):
+        """
+        Names of columns to ignore for training.
+
+        Type: ``List[str]``.
+        """
+        return self._parms.get("ignored_columns")
+
+    @ignored_columns.setter
+    def ignored_columns(self, ignored_columns):
+        assert_is_type(ignored_columns, None, [str])
+        self._parms["ignored_columns"] = ignored_columns
+
 
     @property
     def blending(self):
@@ -190,97 +281,6 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     def seed(self, seed):
         assert_is_type(seed, None, int)
         self._parms["seed"] = seed
-
-
-    @property
-    def ignored_columns(self):
-        """
-        Names of columns to ignore for training.
-
-        Type: ``List[str]``.
-        """
-        return self._parms.get("ignored_columns")
-
-    @ignored_columns.setter
-    def ignored_columns(self, ignored_columns):
-        assert_is_type(ignored_columns, None, [str])
-        self._parms["ignored_columns"] = ignored_columns
-
-
-    @property
-    def training_frame(self):
-        """
-        Id of the training data frame.
-
-        Type: ``H2OFrame``.
-
-        :examples:
-
-        >>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
-        >>> predictors = ["home.dest", "cabin", "embarked"]
-        >>> response = "survived"
-        >>> titanic["survived"] = titanic["survived"].asfactor()
-        >>> fold_col = "kfold_column"
-        >>> titanic[fold_col] = titanic.kfold_column(n_folds=5, seed=1234)
-        >>> titanic_te = H2OTargetEncoderEstimator(k=35,
-        ...                                        f=25,
-        ...                                        blending=True)
-        >>> titanic_te.train(x=predictors,
-        ...                  y=response,
-        ...                  training_frame=titanic)
-        >>> titanic_te
-        """
-        return self._parms.get("training_frame")
-
-    @training_frame.setter
-    def training_frame(self, training_frame):
-        self._parms["training_frame"] = H2OFrame._validate(training_frame, 'training_frame')
-
-
-    @property
-    def fold_column(self):
-        """
-        Column with cross-validation fold index assignment per observation.
-
-        Type: ``str``.
-
-        :examples:
-
-        >>> titanic = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv")
-        >>> predictors = ["home.dest", "cabin", "embarked"]
-        >>> response = "survived"
-        >>> titanic["survived"] = titanic["survived"].asfactor()
-        >>> fold_col = "kfold_column"
-        >>> titanic[fold_col] = titanic.kfold_column(n_folds=5, seed=1234)
-        >>> titanic_te = H2OTargetEncoderEstimator(k=35,
-        ...                                        f=25,
-        ...                                        blending=True)
-        >>> titanic_te.train(x=predictors,
-        ...                  y=response,
-        ...                  training_frame=titanic)
-        >>> titanic_te
-        """
-        return self._parms.get("fold_column")
-
-    @fold_column.setter
-    def fold_column(self, fold_column):
-        assert_is_type(fold_column, None, str)
-        self._parms["fold_column"] = fold_column
-
-
-    @property
-    def response_column(self):
-        """
-        Response variable column.
-
-        Type: ``str``.
-        """
-        return self._parms.get("response_column")
-
-    @response_column.setter
-    def response_column(self, response_column):
-        assert_is_type(response_column, None, str)
-        self._parms["response_column"] = response_column
 
 
     def transform(self, frame, data_leakage_handling="None", noise=-1, seed=-1):

--- a/h2o-r/h2o-package/R/targetencoder.R
+++ b/h2o-r/h2o-package/R/targetencoder.R
@@ -11,6 +11,8 @@
 #'        The response must be either a numeric or a categorical/factor variable. 
 #'        If the response is numeric, then a regression model will be trained, otherwise it will train a classification model.
 #' @param training_frame Id of the training data frame.
+#' @param model_id Destination id for this model; auto-generated if not specified.
+#' @param fold_column Column with cross-validation fold index assignment per observation.
 #' @param blending \code{Logical}. Blending enabled/disabled Defaults to FALSE.
 #' @param k Inflection point. Used for blending (if enabled). Blending is to be enabled separately using the 'blending'
 #'        parameter. Defaults to 10.
@@ -20,8 +22,6 @@
 #' @param noise_level Noise level Defaults to 0.01.
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default).
 #'        Defaults to -1 (time-based random number).
-#' @param model_id Destination id for this model; auto-generated if not specified.
-#' @param fold_column Column with cross-validation fold index assignment per observation.
 #' @examples
 #' \dontrun{
 #' # library(h2o)
@@ -38,14 +38,14 @@
 h2o.targetencoder <- function(x,
                               y,
                               training_frame,
+                              model_id = NULL,
+                              fold_column = NULL,
                               blending = FALSE,
                               k = 10,
                               f = 20,
                               data_leakage_handling = c("None", "KFold", "LeaveOneOut"),
                               noise_level = 0.01,
-                              seed = -1,
-                              model_id = NULL,
-                              fold_column = NULL)
+                              seed = -1)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -68,6 +68,10 @@ h2o.targetencoder <- function(x,
   parms$response_column <- args$y
   parms$training_frame <- training_frame
 
+  if (!missing(model_id))
+    parms$model_id <- model_id
+  if (!missing(fold_column))
+    parms$fold_column <- fold_column
   if (!missing(blending))
     parms$blending <- blending
   if (!missing(k))
@@ -80,10 +84,6 @@ h2o.targetencoder <- function(x,
     parms$noise_level <- noise_level
   if (!missing(seed))
     parms$seed <- seed
-  if (!missing(model_id))
-    parms$model_id <- model_id
-  if (!missing(fold_column))
-    parms$fold_column <- fold_column
 
   # Error check and build model
   model <- .h2o.modelJob('targetencoder', parms, h2oRestApiVersion=3, verbose=FALSE)


### PR DESCRIPTION
Originally user was being asked to select ignored_columns ( from empty set) and only then comes training_frame parameter

<img width="1566" alt="Screenshot 2020-03-06 at 20 53 09" src="https://user-images.githubusercontent.com/1162131/76120128-20c8a980-5ff1-11ea-88d7-e252c5133dfc.png">
