### PR TITLE
PUBDEV-6787: Populate base_models attribute in Stacked Ensemble in Python and R

### DIFF
--- a/h2o-bindings/bin/custom/R/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/R/gen_stackedensemble.py
@@ -56,6 +56,7 @@ if (!missing(metalearner_params))
 if (!missing(metalearner_params)) {
     model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]] #Need the `[[ ]]` to avoid a nested list
 }
+model@model <- .h2o.fill_stackedensemble(model@model, model@parameters, model@allparams)
 model@model$model_summary <- capture.output({
 
   print_ln <- function(...) cat(..., sep = "\\n")
@@ -86,6 +87,13 @@ model@model$model_summary <- capture.output({
 
 })
 class(model@model$model_summary) <- "h2o.stackedEnsemble.summary"
+""",
+    module="""
+.h2o.fill_stackedensemble <- function(model, parameters, allparams) {
+  # Store base models for the Stacked Ensemble in user-readable form
+  model$base_models <- unlist(lapply(parameters$base_models, function (base_model) base_model$name))
+  return(model)
+}
 """
 )
 

--- a/h2o-bindings/bin/custom/python/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/python/gen_stackedensemble.py
@@ -134,6 +134,13 @@ if is_type(base_models, {ptype}):
 else:
     assert_is_type({pname}, None, [str])
     self._parms["{sname}"] = {pname}
+""",
+        getter="""
+base_models = self.actual_params.get("base_models", [])
+base_models = [base_model["name"] for base_model in base_models]
+if len(base_models) == 0:
+    base_models = self._parms.get("base_models")
+return base_models
 """
     ),
 

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -263,7 +263,11 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         >>> stack.train(x=x, y=y, training_frame=train, validation_frame=test)
         >>> stack.model_performance()
         """
-        return self._parms.get("base_models")
+        base_models = self.actual_params.get("base_models", [])
+        base_models = [base_model["name"] for base_model in base_models]
+        if len(base_models) == 0:
+            base_models = self._parms.get("base_models")
+        return base_models
 
     @base_models.setter
     def base_models(self, base_models):

--- a/h2o-r/h2o-package/R/kvstore.R
+++ b/h2o-r/h2o-package/R/kvstore.R
@@ -210,6 +210,11 @@ h2o.getModel <- function(model_id) {
     }
   })
 
+  # Run model specific hooks
+  model_fill_func <- paste0(".h2o.fill_", json$algo)
+  if (exists(model_fill_func, mode="function")) {
+    model <- do.call(model_fill_func, list(model, parameters, allparams))
+  }
 
   # Convert ignored_columns/response_column to valid R x/y
 

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -134,6 +134,7 @@ h2o.stackedEnsemble <- function(x,
   if (!missing(metalearner_params)) {
       model@parameters$metalearner_params <- list(fromJSON(model@parameters$metalearner_params))[[1]] #Need the `[[ ]]` to avoid a nested list
   }
+  model@model <- .h2o.fill_stackedensemble(model@model, model@parameters, model@allparams)
   model@model$model_summary <- capture.output({
 
     print_ln <- function(...) cat(..., sep = "\n")
@@ -166,3 +167,11 @@ h2o.stackedEnsemble <- function(x,
   class(model@model$model_summary) <- "h2o.stackedEnsemble.summary"
   return(model)
 }
+
+
+.h2o.fill_stackedensemble <- function(model, parameters, allparams) {
+  # Store base models for the Stacked Ensemble in user-readable form
+  model$base_models <- unlist(lapply(parameters$base_models, function (base_model) base_model$name))
+  return(model)
+}
+

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_base_models_user_readable.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_base_models_user_readable.R
@@ -1,0 +1,56 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# PUBDEV-6787
+stackedensemble.base_models.are.easily.accessible.test <- function() {
+    # This test checks the following (for binomial classification):
+    #
+    # 1) That passing in a list of models for base_models works.
+    # 2) That passing in a list of models and model_ids results in the
+    #    same stacked ensemble.
+
+    train <- h2o.uploadFile(locate("smalldata/testng/higgs_train_5k.csv"),
+                            destination_frame = "higgs_train_5k")
+    y <- "response"
+    x <- setdiff(names(train), y)
+    train[,y] <- as.factor(train[,y])
+    nfolds <- 5
+
+    # Train & Cross-validate a GBM
+    my_gbm <- h2o.gbm(x = x,
+                      y = y,
+                      training_frame = train,
+                      distribution = "bernoulli",
+                      ntrees = 10,
+                      nfolds = nfolds,
+                      fold_assignment = "Modulo",
+                      keep_cross_validation_predictions = TRUE,
+                      seed = 1)
+
+    # Train & Cross-validate a RF
+    my_rf <- h2o.randomForest(x = x,
+                              y = y,
+                              training_frame = train,
+                              ntrees = 10,
+                              nfolds = nfolds,
+                              fold_assignment = "Modulo",
+                              keep_cross_validation_predictions = TRUE,
+                              seed = 1)
+
+    # Train a stacked ensemble using the GBM and RF above
+    stack <- h2o.stackedEnsemble(x = x,
+                                 y = y,
+                                 training_frame = train,
+                                 model_id = "my_ensemble_binomial",
+                                 base_models = list(my_gbm@model_id, my_rf@model_id))
+
+    retriveved_stack <- h2o.getModel(stack@model_id)
+
+    expect_equal(stack@model$base_models, unlist(lapply(stack@parameters$base_models,
+                                                        function (base_model) base_model$name)))
+    expect_equal(stack@model$base_models, retriveved_stack@model$base_models)
+    # Ensure that we have only model ids here not some nested list
+    expect_true(is.character(stack@model$base_models) && length(stack@model$base_models) == 2)
+}
+
+doTest("Stacked Ensemble base_models are in model$base_models Test", stackedensemble.base_models.are.easily.accessible.test)


### PR DESCRIPTION
In python, if it doesn't have any `base_models` in `_parms`, it uses `actual_params` to retrieve `base_models` and it contains the names of the models.

In R, it populates `ensemble@model$base_models` with a vector of base model names.