### PR TITLE
PUBDEV-4534: Add the possibility to use Grids as base model for StackedEnsemble

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -57,8 +57,9 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
     // Base models
     @API(level = API.Level.critical, direction = API.Direction.INOUT,
-            help = "List of models (or model ids) to ensemble/stack together. If not using blending frame, then models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
-    public KeyV3.ModelKeyV3 base_models[];
+            help = "List of models or grids (or their ids) to ensemble/stack together. Grids are expanded to individual models. "
+                    + "If not using blending frame, then models must have been cross-validated using nfolds > 1, and folds must be identical across models.", required = true)
+    public KeyV3 base_models[];
 
     
     // Metalearner algorithm

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -31,6 +31,7 @@ import water.util.Log;
 
 import java.util.*;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -1098,5 +1099,64 @@ public class StackedEnsembleTest extends TestUtil {
     }
   }
 
+  @Test
+  public void testBaseModelsWorkWithGrid() {
+    GBMModel gbmModel = null;
+    try {
+      Scope.enter();
 
+      final Frame trainingFrame = TestUtil.parse_test_file("./smalldata/junit/weather.csv");
+      Scope.track(trainingFrame);
+      trainingFrame.toCategoricalCol("RainTomorrow");
+
+      GBMModel.GBMParameters parameters = new GBMModel.GBMParameters();
+      parameters._train = trainingFrame._key;
+      parameters._seed = 0xFEED;
+      parameters._response_column = "RainTomorrow";
+      parameters._ntrees = 1;
+      parameters._keep_cross_validation_predictions = true;
+
+      GBM gbm = new GBM(parameters);
+      gbmModel = gbm.trainModel().get();
+      assertNotNull(gbmModel);
+
+      final Integer[] maxDepthArr = new Integer[]{2, 3, 4};
+      HashMap<String, Object[]> hyperParms = new HashMap<String, Object[]>() {{
+        put("_distribution", new DistributionFamily[]{DistributionFamily.bernoulli});
+        put("_max_depth", maxDepthArr);
+      }};
+
+      GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+      params._train = trainingFrame._key;
+      params._response_column = "RainTomorrow";
+      params._seed = 42;
+
+      Job<Grid> gs = GridSearch.startGridSearch(null, params, hyperParms);
+      Scope.track_generic(gs);
+      final Grid grid = gs.get();
+      Scope.track_generic(grid);
+
+      final StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = trainingFrame._key;
+      seParams._response_column = "RainTomorrow";
+      seParams._metalearner_algorithm = Algorithm.AUTO;
+      seParams._base_models = new Key[]{gbmModel._key, grid._key};
+      seParams._seed = 0xFEED;
+
+      final StackedEnsemble stackedEnsemble = new StackedEnsemble(seParams);
+      List<Key> expectedBaseModels = new ArrayList<Key>();
+      expectedBaseModels.add(gbmModel._key);
+      Collections.addAll(expectedBaseModels, grid.getModelKeys());
+
+      assertArrayEquals(expectedBaseModels.toArray(new Key[0]), stackedEnsemble._parms._base_models);
+    } finally {
+      Scope.exit();
+
+      if(gbmModel != null){
+        gbmModel.deleteCrossValidationModels();
+        gbmModel.deleteCrossValidationPreds();
+        gbmModel.remove();
+      }
+    }
+  }
 }

--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -4,6 +4,7 @@ from __future__ import division, print_function, absolute_import, unicode_litera
 import itertools
 
 import h2o
+from h2o.base import Keyed
 from h2o.job import H2OJob
 from h2o.frame import H2OFrame
 from h2o.exceptions import H2OValueError
@@ -22,7 +23,7 @@ from h2o.utils.typechecks import assert_is_type, is_type
         giniCoef=lambda self, *args, **kwargs: self.gini(*args, **kwargs)
     )
 )
-class H2OGridSearch(h2o_meta()):
+class H2OGridSearch(h2o_meta(Keyed)):
     """
     Grid Search of a Hyper-Parameter Space for a Model
 
@@ -89,6 +90,9 @@ class H2OGridSearch(h2o_meta()):
         self._future = False  # used by __repr__/show to query job state#
         self._job = None  # used when _future is True#
 
+    @property
+    def key(self):
+        return self._id
 
     @property
     def grid_id(self):
@@ -130,6 +134,10 @@ class H2OGridSearch(h2o_meta()):
     @property
     def failed_raw_params(self):
         return self._grid_json.get("failed_raw_params", None)
+
+
+    def detach(self):
+        self._id = None
 
 
     def start(self, x, y=None, training_frame=None, offset_column=None, fold_column=None, weights_column=None,

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_base_models.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_base_models.py
@@ -7,9 +7,11 @@ import h2o
 import sys
 sys.path.insert(1,"../../../")  # allow us to run this standalone
 
+from h2o.grid import H2OGridSearch
 from h2o.estimators.random_forest import H2ORandomForestEstimator
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from h2o.exceptions import H2OResponseError
 from h2o import get_model
 from tests import pyunit_utils as pu
 
@@ -18,8 +20,8 @@ seed = 1
 
 
 def prepare_data(blending=False):
-    fr = h2o.import_file(path=pu.locate("smalldata/testng/higgs_train_5k.csv"))
-    target = "response"
+    fr = h2o.import_file(path=pu.locate("smalldata/junit/weather.csv"))
+    target = "RainTomorrow"
     fr[target] = fr[target].asfactor()
     ds = pu.ns(x=fr.columns, y=target, train=fr)
 
@@ -109,8 +111,93 @@ def test_base_models_are_populated():
     assert pu.is_type(retrieved_se.base_models, [str])
 
 
+# PUBDEV-4534
+def test_stacked_ensemble_accepts_mixed_definition_of_base_models():
+    """This test asserts that base models can be one of these:
+    * list of models
+    * GridSearch
+    * list of GridSearches
+    * list of Gridsearches and models
+    """
+    def _prepare_test_env():
+        hyper_parameters = dict()
+        hyper_parameters["ntrees"] = [1, 3, 5]
+        params = dict(
+            fold_assignment="modulo",
+            nfolds=3,
+            keep_cross_validation_predictions=True
+        )
+
+        data = prepare_data()
+
+        drf = H2ORandomForestEstimator(**params)
+        drf.train(data.x, data.y, data.train, validation_frame=data.train)
+
+        gs1 = H2OGridSearch(H2OGradientBoostingEstimator(**params), hyper_params=hyper_parameters)
+        gs1.train(data.x, data.y, data.train, validation_frame=data.train)
+
+        gs2 = H2OGridSearch(H2ORandomForestEstimator(**params), hyper_params=hyper_parameters)
+        gs2.train(data.x, data.y, data.train, validation_frame=data.train)
+
+        return dict(data=data, drf=drf, gs1=gs1, gs2=gs2)
+
+    def test_base_models_work_properly_with_list_of_models():
+        env = _prepare_test_env()
+        se = H2OStackedEnsembleEstimator(base_models=[env["drf"]])
+        se.train(env["data"].x, env["data"].y, env["data"].train)
+        assert se.base_models == [env["drf"].model_id], "StackedEnsembles don't work properly with single model in base models"
+
+    def test_validation_on_backend_works():
+        data = prepare_data()
+        se = H2OStackedEnsembleEstimator(base_models=[data.train.frame_id])
+        try:
+            se.train(data.x, data.y, data.train)
+        except H2OResponseError as e:
+            print(e)
+            assert "Unsupported type \"class water.fvec.Frame\" as a base model." in str(e), \
+                "StackedEnsembles' base models validation exception probably changed."
+        else:
+            assert False, "StackEnsembles' base models validation doesn't work properly."
+
+    def _check_base_models(name, base_models_1, base_models_2, error_message):
+        def test():
+            env = _prepare_test_env()
+            se1 = H2OStackedEnsembleEstimator(base_models=base_models_1(env), seed=seed)
+            se1.train(env["data"].x, env["data"].y, env["data"].train)
+            se2 = H2OStackedEnsembleEstimator(base_models=base_models_2(env), seed=seed)
+            se2.train(env["data"].x, env["data"].y, env["data"].train)
+            assert sorted(se1.base_models) == sorted(se2.base_models), error_message
+        test.__name__ = "test_stackedensembles_base_models_{}".format(name)
+        return test
+
+    test_cases = [
+        {"name": "expand_single_grid",
+         "base_models_1": lambda env: env["gs1"].models,
+         "base_models_2": lambda env: env["gs1"],
+         "error_message": "StackedEnsembles don't expand properly single grid."},
+        {"name": "expand_multiple_grids_in_list",
+         "base_models_1": lambda env: env["gs1"].models + env["gs2"].models,
+         "base_models_2": lambda env: [env["gs1"], env["gs2"]],
+         "error_message": "StackedEnsembles don't expand properly multiple grids in a list."},
+        {"name": "expand_mixture_of_grids_and_models",
+         "base_models_1": lambda env: env["gs1"].models + [env["drf"]] + env["gs2"].models,
+         "base_models_2": lambda env: [env["gs1"], env["drf"], env["gs2"]],
+         "error_message": "StackedEnsembles don't expand properly with mixture of grids and models."},
+        {"name": "expand_mixture_of_grid_ids_and_model_ids",
+         "base_models_1": lambda env: env["gs1"].models + [env["drf"]] + env["gs2"].models,
+         "base_models_2": lambda env: [m.model_id for m in env["gs1"].models + [env["drf"]] + env["gs2"].models],
+         "error_message": "StackedEnsembles don't work properly with mixture of grids id and model ids."},
+    ]
+
+    return [test_base_models_work_properly_with_list_of_models,
+            test_validation_on_backend_works] + [
+        _check_base_models(**kwargs) for kwargs in test_cases
+    ]
+
+
 pu.run_tests([
     test_suite_stackedensemble_base_models(),
     test_suite_stackedensemble_base_models(blending=True),
-    test_base_models_are_populated
+    test_base_models_are_populated,
+    test_stacked_ensemble_accepts_mixed_definition_of_base_models(),
 ])

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -805,6 +805,9 @@ setClass("H2OGrid", representation(grid_id = "character",
                                    failed_raw_params = "matrix",
                                    summary_table = "ANY"))
 
+#' @rdname h2o.keyof
+setMethod("h2o.keyof", signature("H2OGrid"), function(object) object@grid_id)
+
 #' Format grid object in user-friendly way
 #'
 #' @rdname H2OGrid-class

--- a/h2o-r/h2o-package/R/constants.R
+++ b/h2o-r/h2o-package/R/constants.R
@@ -53,7 +53,8 @@ assign("LOG_FILE_NAME", NULL,  .pkg.env)
                    data.frame(type = "character", scalar = TRUE,  row.names = "VecSpecifier", stringsAsFactors = FALSE),
                    data.frame(type = "character", scalar = FALSE,  row.names = "VecSpecifier[]", stringsAsFactors = FALSE),
                    data.frame(type = "list",      scalar = FALSE, row.names = "KeyValue[]",   stringsAsFactors = FALSE),
-                   data.frame(type = "list",      scalar = FALSE, row.names = "StringPair[]", stringsAsFactors = FALSE))
+                   data.frame(type = "list",      scalar = FALSE, row.names = "StringPair[]", stringsAsFactors = FALSE),
+                   data.frame(type = "list",        scalar = FALSE, row.names = "Key<Keyed>[]", stringsAsFactors = FALSE))
 
 #' Capabilities endpoints
 .h2o.__ALL_CAPABILITIES  <- "Capabilities"

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_base_models_using_grid.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_base_models_using_grid.R
@@ -1,0 +1,157 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+prepare_test_env <- function() {
+  train <- h2o.uploadFile(locate("smalldata/junit/weather.csv"),
+                          destination_frame = "weather_train")
+
+  y <- "RainTomorrow"
+  x <- setdiff(names(train), y)
+  train[,y] <- as.factor(train[,y])
+  nfolds <- 5
+  env <- list()
+  env$train <- train
+  env$x <- x
+  env$y <- y
+  env$my_gbm <- h2o.gbm(x = x,
+                        y = y,
+                        training_frame = train,
+                        distribution = "bernoulli",
+                        ntrees = 10,
+                        nfolds = nfolds,
+                        fold_assignment = "Modulo",
+                        keep_cross_validation_predictions = TRUE,
+                        seed = 1)
+
+  hyper_params <- list(ntrees = c(3, 5))
+
+  env$grid1 <- h2o.grid("gbm", x = x, y = y,
+                        training_frame = train,
+                        validation_frame = train,
+                        seed = 1,
+                        nfolds = nfolds,
+                        fold_assignment = "Modulo",
+                        keep_cross_validation_predictions = TRUE,
+                        hyper_params = hyper_params)
+
+  env$grid2 <- h2o.grid("drf", x = x, y = y,
+                        training_frame = train,
+                        validation_frame = train,
+                        seed = 1,
+                        nfolds = nfolds,
+                        fold_assignment = "Modulo",
+                        keep_cross_validation_predictions = TRUE,
+                        hyper_params = hyper_params)
+  return(env)
+}
+
+get_base_models <- function(ensemble) {
+  unlist(lapply(ensemble@parameters$base_models, function (base_model) base_model$name))
+}
+
+expect_equal_unordered <- function (lhs, rhs) {
+  expect_equal(sort(lhs), sort(rhs))
+}
+
+# PUBDEV-4534
+stackedensemble_base_models_accept_list_of_models_test <- function() {
+  attach(prepare_test_env())
+  stack0 <- h2o.stackedEnsemble(x = x,
+                                y = y,
+                                training_frame = train,
+                                base_models = list(my_gbm))
+  expect_equal_unordered(get_base_models(stack0), my_gbm@model_id)
+}
+
+stackedensemble_base_models_accept_grid_test <- function() {
+  # Single Grid
+  attach(prepare_test_env())
+  stack1 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = grid1
+  )
+
+  stack2 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = grid1@model_ids
+  )
+
+  expect_equal_unordered(get_base_models(stack1), get_base_models(stack2))
+}
+
+stackedensemble_base_models_accept_list_of_grids_test <- function() {
+  # List of Grids
+  attach(prepare_test_env())
+  stack3 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = list(grid1, grid2)
+  )
+
+  stack4 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = as.list(c(grid1@model_ids, grid2@model_ids))
+  )
+
+  expect_equal_unordered(get_base_models(stack3), get_base_models(stack4))
+}
+
+stackedensemble_base_models_accept_mixture_of_grids_and_models_test <- function() {
+  # List of grids and models
+  attach(prepare_test_env())
+  stack5 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = list(grid1, my_gbm, grid2)
+  )
+
+  stack6 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = as.list(c(grid1@model_ids, my_gbm@model_id, grid2@model_ids))
+  )
+
+  expect_equal_unordered(get_base_models(stack5), get_base_models(stack6))
+}
+
+stackedensemble_base_models_accept_mixture_of_grids_and_models_and_their_ids_test <- function() {
+  # List of grids and models using model_id
+  attach(prepare_test_env())
+  stack7 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = list(grid1, my_gbm@model_id, grid2)
+  )
+
+  stack8 <- h2o.stackedEnsemble(x=x,
+                                y=y,
+                                training_frame = train,
+                                base_models = as.list(c(grid1@model_ids, my_gbm@model_id, grid2@model_ids))
+  )
+
+  expect_equal_unordered(get_base_models(stack7), get_base_models(stack8))
+}
+
+stackedensemble_base_models_validate_test <- function() {
+  # Check that we validate base models
+  # For some reason the error is printed so to make cleaner test logs I capture the output here as
+  # it could be confusing seeing exception in passing test
+  attach(prepare_test_env())
+  expect_error(capture.output(h2o.stackedEnsemble(x=x,
+                                                  y=y,
+                                                  training_frame = train,
+                                                  base_models = as.list(c(grid1@model_ids, h2o.keyof(train))))),
+               "Unsupported type \"class water.fvec.Frame\" as a base model.")
+}
+
+doSuite("Stacked Ensemble accept both models and grid as base models", makeSuite(
+  stackedensemble_base_models_accept_list_of_models_test,
+  stackedensemble_base_models_accept_grid_test,
+  stackedensemble_base_models_accept_list_of_grids_test,
+  stackedensemble_base_models_accept_mixture_of_grids_and_models_and_their_ids_test,
+  stackedensemble_base_models_accept_mixture_of_grids_and_models_test,
+  stackedensemble_base_models_validate_test
+))


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-4534
```
Currently, the `base_models` argument only accepts a list of model ids.
Let's expand this (on the client side) to support the following:
* a single grid
* list of grids
* a mix of grids and models

The backend should turn each type of input into a list of model ids.
```