### PR TITLE
PUBDEV-7364: Make sure no logs are lost when h2omapper fails

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -842,11 +842,12 @@ final public class H2O {
    *  @param status H2O's requested process exit value.
    */
   public static void exit(int status) {
+    // Log subsystem might be still caching message, let it know to flush the cache and start logging even if we don't have SELF yet
+    Log.notifyAboutProcessExiting();
+
     // Embedded H2O path (e.g. inside Hadoop mapper task).
     if( embeddedH2OConfig != null )
       embeddedH2OConfig.exit(status);
-    // Flush all cached messages
-    Log.flushStdout();
 
     // Standalone H2O path,p or if the embedded config does not exit
     System.exit(status);

--- a/h2o-core/src/main/java/water/util/Log.java
+++ b/h2o-core/src/main/java/water/util/Log.java
@@ -64,6 +64,16 @@ abstract public class Log {
     assert H2O.SELF_ADDRESS != null && H2O.H2O_PORT != 0;
   }
   
+  public static void notifyAboutProcessExiting() {
+    // make sure we write out whatever we have right now 
+    Log.flushStdout();
+
+    // if there are any other log messages after this call, we want to preserve them as well
+    _preHeader = "(exiting) ";
+    setQuiet(false);
+    INIT_MSGS = null;
+  }
+  
   public static void setLogLevel(String sLvl, boolean quiet) {
     init(sLvl, quiet);
   }


### PR DESCRIPTION
When h2omapper fails before discovering SELF (ip & port) it loses all log messages.

```
LogType:stdout
LogLastModifiedTime:Tue Mar 03 13:38:49 -0500 2020
LogLength:1786
LogContents:
POST 0: Entered run
TOKEN REFRESH: Delegation token refresh not active.
POST 11: After setEmbeddedH2OConfig
NetworkBasedClouding: exit called (-1)
NetworkBasedClouding: after bwt.start()
NetworkBasedClouding: after write to mapperCallbackPort
```

This happens because EmbeddedConfig#exit never returns and prevents calling Log.flushAllMessages() before exiting.