### PR TITLE
fix PUBDEV_5924_merge_bug_large error

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3675,8 +3675,8 @@ def compare_frames_local_onecolumn_NA(f1, f2, prob=0.5, tol=1e-6, returnResult=F
                         if (diff > tol):
                             return False
                     else:
-                        assert diff<=tol, "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                      "{1} and the difference/max(v1,v2) is {4}.  Column type is {5}".format(v1, v2, rowInd, colInd, diff, f1.types)
+                        assert diff<=tol, "Failed frame values check at row {2} and column {3}! frame1 value: {0}, column name: {4}. frame2 value: " \
+                                          "{1}, column name:{5}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd, f1.names[0], f2.names[0])
     if returnResult:
         return True
 
@@ -3701,8 +3701,8 @@ def compare_frames_local_onecolumn_NA_enum(f1, f2, prob=0.5, tol=1e-6, returnRes
                         if not(temp1[rowInd][colInd]==temp2[rowInd][colInd]):
                             return False
                     else:
-                        assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                      "{1}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd)
+                        assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, column name: {4}. frame2 value: " \
+                                      "{1}, column name:{5}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd, f1.names[0], f2.names[0])
 
     if returnResult:
         return True
@@ -3728,8 +3728,8 @@ def compare_frames_local_onecolumn_NA_string(f1, f2, prob=0.5, returnResult=Fals
                         if not(temp1[rowInd][colInd]==temp2[rowInd][colInd]):
                             return False
                     else:
-                        assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, frame2 value: " \
-                                                                         "{1}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd)
+                        assert temp1[rowInd][colInd]==temp2[rowInd][colInd], "Failed frame values check at row {2} and column {3}! frame1 value: {0}, column name: {4}. frame2 value: " \
+                                                                             "{1}, column name:{5}".format(temp1[rowInd][colInd], temp2[rowInd][colInd], rowInd, colInd, f1.names[0], f2.names[0])
 
     if returnResult:
         return True

--- a/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5924_merge_bug_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5924_merge_bug_large.py
@@ -56,8 +56,11 @@ def perform_merges_assert_correct_merge(frame1, frame2):
 def assert_equal_frames(f1, f2, sortColName):
     f1sorted = f1.sort(sortColName)
     f2sorted = f2.sort(sortColName)
-
-    pyunit_utils.compare_frames_equal_names(f1sorted, f2sorted)
+    colNames = f1sorted.col_names
+    colNames2 = f2sorted.col_names
+    for index in range(0, len(colNames)):
+        if colNames[index] in colNames2:
+            pyunit_utils.compare_frames_equal_names(f1sorted[colNames[index]], f2sorted[colNames[index]])
 
 def total_na_cnts(fr):
     na_list = fr.nacnt()


### PR DESCRIPTION
When comparing frames, the column orders can change (though rarely) during merge.  When this happens, I have no information as to why the comparison failed.

Here, I did two things
1. compare only one column at a time;
2. print out the column names of the two frames being compared so that we know which columns are in error.