### PR TITLE
PUBDEV-3452 Fix KMeans fold assignment stratified

### DIFF
--- a/h2o-algos/src/main/java/hex/kmeans/KMeans.java
+++ b/h2o-algos/src/main/java/hex/kmeans/KMeans.java
@@ -103,6 +103,9 @@ public class KMeans extends ClusteringModelBuilder<KMeansModel,KMeansModel.KMean
         error("_cluster_size_constraints", "\"The number of cluster size constraints is not equal to k = \" + _parms._k");
       }
     }
+    if(_parms._fold_assignment == Model.Parameters.FoldAssignmentScheme.Stratified){
+      error("fold_assignment", "K-means is an unsupervised algorithm; the stratified fold assignment cannot be used because of the missing response column.");
+    }
     if (expensive && error_count() == 0) checkMemoryFootPrint();
   }
 

--- a/h2o-docs/src/product/data-science/k-means.rst
+++ b/h2o-docs/src/product/data-science/k-means.rst
@@ -31,7 +31,7 @@ Defining a K-Means Model
 
 -  `keep_cross_validation_fold_assignment <algo-params/keep_cross_validation_fold_assignment.html>`__: Enable this option to preserve the cross-validation fold assignment.
 
--  `fold_assignment <algo-params/fold_assignment.html>`__: (Applicable only if a value for **nfolds** is specified and **fold_column** is not specified) Specify the cross-validation fold assignment scheme. The available options are AUTO (which is Random), Random, `Modulo <https://en.wikipedia.org/wiki/Modulo_operation>`__, or Stratified (which will stratify the folds based on the response variable for classification problems).
+-  `fold_assignment <algo-params/fold_assignment.html>`__: (Applicable only if a value for **nfolds** is specified and **fold_column** is not specified) Specify the cross-validation fold assignment scheme. The available options are AUTO (which is Random), Random, `Modulo <https://en.wikipedia.org/wiki/Modulo_operation>`__.
 
 -  `fold_column <algo-params/fold_column.html>`__: Specify the column that contains the cross-validation fold index assignment per observation.
 

--- a/h2o-py/tests/testdir_algos/kmeans/pyunit_init_err_casesKmeans.py
+++ b/h2o-py/tests/testdir_algos/kmeans/pyunit_init_err_casesKmeans.py
@@ -2,7 +2,7 @@
 # -*- encoding: utf-8 -*-
 import h2o
 from h2o.estimators.kmeans import H2OKMeansEstimator
-from h2o.exceptions import H2OTypeError
+from h2o.exceptions import H2OTypeError, H2OResponseError
 from tests import pyunit_utils
 
 import random
@@ -84,6 +84,12 @@ def init_err_casesKmeans():
     for s in start: s[2] = s[0]
     H2OKMeansEstimator(k=3, user_points=h2o.H2OFrame(list(zip(*start)))).\
         train(x=list(range(numcol)), training_frame=benign_h2o)
+
+    try:
+        H2OKMeansEstimator(k=5, nfolds=3, fold_assignment="Stratified").train(x=list(range(numcol)), training_frame=benign_h2o)
+        assert False
+    except H2OResponseError:
+        pass
 
 
 


### PR DESCRIPTION
Add check to Kmeans model the` fold_assignment `parameter cannot be `Stratified`.

Enhance pyunit test to check it throws a correct exception.

Edit documentation the ` fold_assignment ` parameter cannot be `Stratified`.

JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-3452