### PR TITLE
PUBDEV-7352 - Enable import of Stacked Ensemble MOJO models

### DIFF
--- a/h2o-algos/src/main/java/hex/generic/Generic.java
+++ b/h2o-algos/src/main/java/hex/generic/Generic.java
@@ -33,6 +33,7 @@ public class Generic extends ModelBuilder<GenericModel, GenericModelParameters, 
         allowedAlgos.add("isolationforest");
         allowedAlgos.add("drf");
         allowedAlgos.add("deeplearning");
+        allowedAlgos.add("stackedensemble");
         
         ALLOWED_MOJO_ALGOS = Collections.unmodifiableSet(allowedAlgos);
     }

--- a/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
+++ b/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
@@ -24,6 +24,7 @@ import water.*;
 import water.fvec.Frame;
 import water.runner.CloudSize;
 import water.runner.H2ORunner;
+import water.util.FrameUtilsTest;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -903,6 +904,11 @@ public class GenericModelTest extends TestUtil {
             Scope.track(predictions);
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
+
+            final Frame originalModelPredictions = stackedEnsembleModel.score(testFrame);
+            Scope.track(originalModelPredictions);
+            assertTrue(FrameUtilsTest.compareFrames(predictions, originalModelPredictions));
+            
             assertTrue(equallyScored);
         } finally {
             Scope.exit();

--- a/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
+++ b/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
@@ -4,6 +4,9 @@ import hex.ModelCategory;
 import hex.ModelMetricsBinomial;
 import hex.deeplearning.DeepLearning;
 import hex.deeplearning.DeepLearningModel;
+import hex.ensemble.Metalearner;
+import hex.ensemble.StackedEnsemble;
+import hex.ensemble.StackedEnsembleModel;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
 import hex.tree.drf.DRF;
@@ -22,10 +25,7 @@ import water.fvec.Frame;
 import water.runner.CloudSize;
 import water.runner.H2ORunner;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 
 import static hex.genmodel.utils.DistributionFamily.AUTO;
@@ -782,19 +782,19 @@ public class GenericModelTest extends TestUtil {
 
             final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
             assertTrue(equallyScored);
-            
+
         } finally {
             Scope.exit();
         }
     }
-    
-        @Test
+
+    @Test
     public void downloadable_mojo_deeplearning() throws IOException {
         try {
             Scope.enter();
             final Frame trainingFrame = parse_test_file("./smalldata/testng/airlines_train.csv");
             Scope.track(trainingFrame);
-            
+
             DeepLearningModel.DeepLearningParameters parms = new DeepLearningModel.DeepLearningParameters();
             parms._train = trainingFrame._key;
             parms._distribution = AUTO;
@@ -826,6 +826,89 @@ public class GenericModelTest extends TestUtil {
             Scope.exit();
         }
     }
+
+
+    @Test
+    public void stackedEnsembleMojoTest() throws IOException {
+        try {
+            Scope.enter();
+
+            final Frame trainingFrame = parse_test_file("./smalldata/testng/airlines_train.csv");
+            Scope.track(trainingFrame);
+
+            // Create DeepLearning Model
+            final DeepLearningModel.DeepLearningParameters deepLearningParameters = new DeepLearningModel.DeepLearningParameters();
+            deepLearningParameters._train = trainingFrame._key;
+            deepLearningParameters._distribution = AUTO;
+            deepLearningParameters._epochs = 1;
+            deepLearningParameters._response_column = "IsDepDelayed";
+            deepLearningParameters._nfolds = 2;
+            deepLearningParameters._keep_cross_validation_predictions = true;
+            deepLearningParameters._seed = 0XFEED;
+
+            final DeepLearning deepLearning = new DeepLearning(deepLearningParameters);
+            final DeepLearningModel deepLearningModel = deepLearning.trainModel().get();
+            Scope.track_generic(deepLearningModel);
+
+
+            // Create GBM model
+            final GBMModel.GBMParameters gbmParameters = new GBMModel.GBMParameters();
+            gbmParameters._train = trainingFrame._key;
+            gbmParameters._distribution = AUTO;
+            gbmParameters._response_column = "IsDepDelayed";
+            gbmParameters._ntrees = 1;
+            gbmParameters._nfolds = 2;
+            gbmParameters._keep_cross_validation_predictions = true;
+
+            gbmParameters._seed = 0XFEED;
+
+            final GBM gbm = new GBM(gbmParameters);
+            final GBMModel gbmModel = gbm.trainModel().get();
+            Scope.track_generic(gbmModel);
+
+            final StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleModel.StackedEnsembleParameters();
+            stackedEnsembleParameters._train = trainingFrame._key;
+            stackedEnsembleParameters._response_column = "IsDepDelayed";
+            stackedEnsembleParameters._metalearner_algorithm = Metalearner.Algorithm.AUTO;
+            stackedEnsembleParameters._base_models = new Key[]{deepLearningModel._key, gbmModel._key};
+            stackedEnsembleParameters._seed = 0xFEED;
+
+            final StackedEnsemble stackedEnsemble = new StackedEnsemble(stackedEnsembleParameters);
+            final StackedEnsembleModel stackedEnsembleModel = stackedEnsemble.trainModel().get();
+            Scope.track_generic(stackedEnsembleModel);
+            assertNotNull(stackedEnsembleModel);
+
+            final File originalModelMojoFile = File.createTempFile("mojo", "zip");
+            stackedEnsembleModel.getMojo().writeTo(new FileOutputStream(originalModelMojoFile));
+
+            final Key<Frame> mojo = importMojo(originalModelMojoFile.getAbsolutePath());
+
+            // Create Generic model from given imported MOJO
+            final GenericModelParameters genericModelParameters = new GenericModelParameters();
+            genericModelParameters._model_key = mojo;
+            final Generic generic = new Generic(genericModelParameters);
+            final GenericModel genericModel = trainAndCheck(generic);
+            Scope.track_generic(genericModel);
+
+            // Compare the two MOJOs byte-wise
+            final File genericModelMojoFile = temporaryFolder.newFile();
+            genericModelMojoFile.deleteOnExit();
+            genericModel.getMojo().writeTo(new FileOutputStream(genericModelMojoFile));
+            assertArrayEquals(FileUtils.readFileToByteArray(originalModelMojoFile), FileUtils.readFileToByteArray(genericModelMojoFile));
+
+            // Test scoring
+            final Frame testFrame = parse_test_file("./smalldata/testng/airlines_test.csv");
+            Scope.track(testFrame);
+            final Frame predictions = genericModel.score(testFrame);
+            Scope.track(predictions);
+
+            final boolean equallyScored = genericModel.testJavaScoring(testFrame, predictions, 0);
+            assertTrue(equallyScored);
+        } finally {
+            Scope.exit();
+        }
+    }
+
 
     private GenericModel trainAndCheck(Generic builder) {
         GenericModel model = builder.trainModel().get();

--- a/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_stackedensemble.py
+++ b/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_stackedensemble.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import tempfile
+
+sys.path.insert(1, "../../")
+
+import h2o
+from h2o.estimators import H2OGenericEstimator, H2OGradientBoostingEstimator, \
+    H2ORandomForestEstimator, H2OStackedEnsembleEstimator
+from tests import pyunit_utils
+from tests.testdir_generic_model import Capturing, compare_output, compare_params
+
+
+def stackedensemble_mojo_model_test():
+    train = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_test.csv"))
+    x = train.columns
+    y = "species"
+
+    nfolds = 2
+    gbm = H2OGradientBoostingEstimator(nfolds=nfolds,
+                                       fold_assignment="Modulo",
+                                       keep_cross_validation_predictions=True)
+    gbm.train(x=x, y=y, training_frame=train)
+    rf = H2ORandomForestEstimator(nfolds=nfolds,
+                                  fold_assignment="Modulo",
+                                  keep_cross_validation_predictions=True)
+    rf.train(x=x, y=y, training_frame=train)
+    se = H2OStackedEnsembleEstimator(training_frame=train,
+                                     validation_frame=test,
+                                     base_models=[gbm.model_id, rf.model_id])
+    se.train(x=x, y=y, training_frame=train)
+    print(se)
+    with Capturing() as original_output:
+        se.show()
+
+    original_model_filename = tempfile.mkdtemp()
+    original_model_filename = se.download_mojo(original_model_filename)
+
+    key = h2o.lazy_import(original_model_filename)
+    fr = h2o.get_frame(key[0])
+    generic_mojo_model = H2OGenericEstimator(model_key=fr)
+    generic_mojo_model.train()
+    compare_params(se, generic_mojo_model)
+
+    predictions = generic_mojo_model.predict(test)
+    assert predictions is not None
+
+    # Test constructor generating the model from existing MOJO file
+    generic_mojo_model_from_file = H2OGenericEstimator.from_file(original_model_filename)
+    assert generic_mojo_model_from_file is not None
+    predictions = generic_mojo_model_from_file.predict(test)
+    assert predictions is not None
+
+    generic_mojo_filename = tempfile.mkdtemp("zip", "genericMojo")
+    generic_mojo_filename = generic_mojo_model_from_file.download_mojo(path=generic_mojo_filename)
+    assert os.path.getsize(generic_mojo_filename) == os.path.getsize(original_model_filename)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(stackedensemble_mojo_model_test)
+
+else:
+    stackedensemble_mojo_model_test()

--- a/h2o-r/tests/testdir_algos/generic/runit_generic_model_mojo_stackedensemble.R
+++ b/h2o-r/tests/testdir_algos/generic/runit_generic_model_mojo_stackedensemble.R
@@ -1,0 +1,55 @@
+source("generic_model_test_common.R")
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.model.generic.stackedensemble <- function() {
+    train <- h2o.uploadFile(locate("smalldata/testng/higgs_train_5k.csv"))
+    y <- "response"
+    x <- setdiff(names(train), y)
+    train[, y] <- as.factor(train[, y])
+    nfolds <- 5
+    
+    gbm <- h2o.gbm(
+        x = x,
+        y = y,
+        training_frame = train,
+        distribution = "bernoulli",
+        ntrees = 10,
+        nfolds = nfolds,
+        fold_assignment = "Modulo",
+        keep_cross_validation_predictions = TRUE,
+        seed = 1
+    )
+    
+    randomforest <- h2o.randomForest(
+        x = x,
+        y = y,
+        training_frame = train,
+        ntrees = 5,
+        nfolds = nfolds,
+        fold_assignment = "Modulo",
+        keep_cross_validation_predictions = TRUE,
+        seed = 1
+    )
+    stackedensemble <- h2o.stackedEnsemble(
+        x = x,
+        y = y,
+        training_frame = train,
+        base_models = list(gbm@model_id, randomforest@model_id)
+    )
+    print(stackedensemble)
+    mojo_original_name <- h2o.download_mojo(model = stackedensemble, path = tempdir())
+    mojo_original_path <- paste0(tempdir(),"/",mojo_original_name)
+    
+    generic_model <- h2o.genericModel(mojo_original_path)
+    print(generic_model)
+    
+    generic_model_preds  <- h2o.predict(generic_model, train)
+    expect_equal(length(generic_model_preds), 3)
+    expect_equal(h2o.nrow(generic_model_preds), 5000)
+    generic_model_path <- h2o.download_mojo(model = generic_model, path = tempdir())
+    expect_equal(file.size(paste0(tempdir(),"/",generic_model_path)), file.size(mojo_original_path))
+    
+}
+
+doTest("Generic model from StackedEnsemble MOJO", test.model.generic.stackedensemble )


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7352

Scoring only. No emphasis put on model info and output. Yet the output seems to ok.

- Java test verifies MOJO importability/MOJO download + scoring correctness + byte-wise mojo comparison.
- Python & R tests verify mojo import/download + scoring functionality. No comparison of output is done to the original model. Aim of this PR is only to provide scoring.

<details><summary>Original model output</summary>

```
Model Details:
==============

H2OBinomialModel: stackedensemble
Model ID:  StackedEnsemble_model_R_1584442967663_1407 
Number of Base Models: 2

Base Models (count by algorithm type):

drf gbm 
  1   1 

Metalearner:

Metalearner algorithm: glm


H2OBinomialMetrics: stackedensemble
** Reported on training data. **

MSE:  0.1420669
RMSE:  0.3769177
LogLoss:  0.4517939
Mean Per-Class Error:  0.1910265
AUC:  0.8993468
AUCPR:  0.8864197
Gini:  0.7986936

Confusion Matrix (vertical: actual; across: predicted) for F1-optimal threshold:
          0    1    Error       Rate
0      1651  679 0.291416  =679/2330
1       242 2428 0.090637  =242/2670
Totals 1893 3107 0.184200  =921/5000

Maximum Metrics: Maximum metrics at their respective thresholds
                        metric threshold       value idx
1                       max f1  0.441837    0.840575 229
2                       max f2  0.336658    0.903414 280
3                 max f0point5  0.625085    0.837175 136
4                 max accuracy  0.468397    0.819600 216
5                max precision  0.895850    1.000000   0
6                   max recall  0.145604    1.000000 372
7              max specificity  0.895850    1.000000   0
8             max absolute_mcc  0.466264    0.639403 217
9   max min_per_class_accuracy  0.526935    0.812017 186
10 max mean_per_class_accuracy  0.502027    0.815816 198
11                     max tns  0.895850 2330.000000   0
12                     max fns  0.895850 2615.000000   0
13                     max fps  0.069763 2330.000000 399
14                     max tps  0.145604 2670.000000 372
15                     max tnr  0.895850    1.000000   0
16                     max fnr  0.895850    0.979401   0
17                     max fpr  0.069763    1.000000 399
18                     max tpr  0.145604    1.000000 372

Gains/Lift Table: Extract with `h2o.gainsLift(<model>, <data>)` or `h2o.gainsLift(<model>, valid=<T/F>, xval=<T/F>)`
```

</details>

<details><summary>Generic output</summary>

```
Model Details:
==============

H2OBinomialModel: generic
Model ID:  Generic_model_R_1584442967663_1410 
NULL


H2OBinomialMetrics: generic
** Reported on training data. **

MSE:  0.1420669
RMSE:  0.3769177
LogLoss:  0.4517939
Mean Per-Class Error:  0.1910265
AUC:  0.8993468
AUCPR:  0.8864197
Gini:  0.7986936
R^2:  0.4290924

Confusion Matrix (vertical: actual; across: predicted) for F1-optimal threshold:
          0    1    Error       Rate
0      1651  679 0.291416  =679/2330
1       242 2428 0.090637  =242/2670
Totals 1893 3107 0.184200  =921/5000

Maximum Metrics: Maximum metrics at their respective thresholds
                        metric threshold       value idx
1                       max f1  0.441837    0.840575 229
2                       max f2  0.336658    0.903414 280
3                 max f0point5  0.625085    0.837175 136
4                 max accuracy  0.468397    0.819600 216
5                max precision  0.895850    1.000000   0
6                   max recall  0.145604    1.000000 372
7              max specificity  0.895850    1.000000   0
8             max absolute_mcc  0.466264    0.639403 217
9   max min_per_class_accuracy  0.526935    0.812017 186
10 max mean_per_class_accuracy  0.502027    0.815816 198
11                     max tns  0.895850 2330.000000   0
12                     max fns  0.895850 2615.000000   0
13                     max fps  0.069763 2330.000000 399
14                     max tps  0.145604 2670.000000 372
15                     max tnr  0.895850    1.000000   0
16                     max fnr  0.895850    0.979401   0
17                     max fpr  0.069763    1.000000 399
18                     max tpr  0.145604    1.000000 372

Gains/Lift Table: Extract with `h2o.gainsLift(<model>, <data>)` or `h2o.gainsLift(<model>, valid=<T/F>, xval=<T/F>)`
```

</details>