### PR TITLE
[BUILD] Install conda for jenkins user.

### DIFF
--- a/docker/jenkins-images/Dockerfile-release
+++ b/docker/jenkins-images/Dockerfile-release
@@ -14,14 +14,16 @@ RUN \
     cd s3cmd-${S3_CMD_VERSION} && \
     python setup.py install
 
-# Install conda
+# Install conda for jenkins
+ENV PATH /home/jenkins/miniconda3/bin/:$PATH
+USER jenkins
 RUN \
     curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh && \
-    bash /tmp/miniconda.sh -bfp /usr/local && \
+    bash /tmp/miniconda.sh -b && \
     rm /tmp/miniconda.sh && \
     conda install -y anaconda-client conda-build && \
     conda update conda && \
     conda clean --all --yes
+USER root
 
-ENV PATH /opt/conda/bin:$PATH
 ENV GRADLE_USER_HOME=/home/jenkins/.gradle

--- a/h2o-py/conda/h2o/meta.yaml
+++ b/h2o-py/conda/h2o/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ data.get("version") }}
 
 source:
-  path: ../..
+  path: ../../main
 
 requirements:
   build:

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -14,7 +14,7 @@ class BuildConfig {
   private static final String DEFAULT_HADOOP_IMAGE_NAME_PREFIX = 'dev-build-hadoop-gradle'
   private static final String DEFAULT_RELEASE_IMAGE_NAME_PREFIX = 'dev-release-gradle'
 
-  public static final int DEFAULT_IMAGE_VERSION_TAG = 25
+  public static final int DEFAULT_IMAGE_VERSION_TAG = 26
   public static final String AWSCLI_IMAGE = DOCKER_REGISTRY + '/opsh2oai/awscli'
   public static final String S3CMD_IMAGE = DOCKER_REGISTRY + '/opsh2oai/s3cmd'
 


### PR DESCRIPTION
Fixes the conda issues by installing miniconda for `jenkins` instead of `root`. Also fixes the path in `h2o-py/conda/h2o/meta.yaml`.