### PR TITLE
Fix typo on cross-validation.srt

### DIFF
--- a/h2o-docs/src/product/cross-validation.rst
+++ b/h2o-docs/src/product/cross-validation.rst
@@ -15,7 +15,7 @@ For example, for ``nfolds=5``, 6 models are built. The first 5 models (cross-val
 This main model contains training metrics and cross-validation metrics (and optionally, validation metrics if a validation frame was provided). The main model also contains pointers to the 5 cross-validation models
 for further inspection.
 
-All 5 cross-validation models contain training metrics (from the 80% training data) and validation metrics (from their 20% holdout/validation data). To compute their individual validation metrics, each of the 5 cross-validation models had to make predictions on their 20% of of rows of the original training frame, and score against the true labels of the 20% holdout.
+All 5 cross-validation models contain training metrics (from the 80% training data) and validation metrics (from their 20% holdout/validation data). To compute their individual validation metrics, each of the 5 cross-validation models had to make predictions on their 20% of rows of the original training frame, and score against the true labels of the 20% holdout.
 
 For the main model, this is how the cross-validation metrics are computed: The 5 holdout predictions are combined into one prediction for the full training dataset (i.e., predictions for every row of the training data, but the model making the prediction for a particular row has not seen that row during training). This “holdout prediction" is then scored against the true labels, and the overall cross-validation metrics are computed.
 


### PR DESCRIPTION
Fixes typo on documentation page `h2o-docs/src/product/cross-validation.rst`