### PR TITLE
PUBDEV-5808: Add max_runtime_secs to Stacked Ensemble

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -37,7 +37,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
   protected P _metalearner_parameters;
   protected boolean _hasMetalearnerParams;
   protected long _metalearnerSeed;
-  protected long _remainingTime;
+  protected long _maxRuntimeSecs;
 
   void init(Frame levelOneTrainingFrame,
             Frame levelOneValidationFrame,
@@ -49,7 +49,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
             StackedEnsembleParameters parms,
             boolean hasMetalearnerParams,
             long metalearnerSeed,
-            long remainingTime) {
+            long maxRuntimeSecs) {
 
     _levelOneTrainingFrame = levelOneTrainingFrame;
     _levelOneValidationFrame = levelOneValidationFrame;
@@ -61,7 +61,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
     _parms = parms;
     _hasMetalearnerParams = hasMetalearnerParams;
     _metalearnerSeed = metalearnerSeed;
-    _remainingTime = remainingTime;
+    _maxRuntimeSecs = maxRuntimeSecs;
   }
 
   void compute() {
@@ -113,7 +113,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
     parms._train = _levelOneTrainingFrame._key;
     parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
     parms._response_column = _model.responseColumn;
-    parms._max_runtime_secs = _remainingTime;
+    parms._max_runtime_secs = _maxRuntimeSecs;
   }
 
   protected void setCrossValidationParams(P parms) {

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -111,6 +111,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
     parms._train = _levelOneTrainingFrame._key;
     parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
     parms._response_column = _model.responseColumn;
+    parms._max_runtime_secs = _parms._max_runtime_secs;
   }
 
   protected void setCrossValidationParams(P parms) {

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -37,6 +37,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
   protected P _metalearner_parameters;
   protected boolean _hasMetalearnerParams;
   protected long _metalearnerSeed;
+  protected long _remainingTime;
 
   void init(Frame levelOneTrainingFrame,
             Frame levelOneValidationFrame,
@@ -47,7 +48,8 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
             Job metalearnerJob,
             StackedEnsembleParameters parms,
             boolean hasMetalearnerParams,
-            long metalearnerSeed) {
+            long metalearnerSeed,
+            long remainingTime) {
 
     _levelOneTrainingFrame = levelOneTrainingFrame;
     _levelOneValidationFrame = levelOneValidationFrame;
@@ -59,7 +61,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
     _parms = parms;
     _hasMetalearnerParams = hasMetalearnerParams;
     _metalearnerSeed = metalearnerSeed;
-
+    _remainingTime = remainingTime;
   }
 
   void compute() {
@@ -111,7 +113,7 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
     parms._train = _levelOneTrainingFrame._key;
     parms._valid = (_levelOneValidationFrame == null ? null : _levelOneValidationFrame._key);
     parms._response_column = _model.responseColumn;
-    parms._max_runtime_secs = _parms._max_runtime_secs;
+    parms._max_runtime_secs = _remainingTime;
   }
 
   protected void setCrossValidationParams(P parms) {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -219,7 +219,9 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
       List<Frame> baseModelPredictions = new ArrayList<>();
 
       for (Key<Model> k : baseModelKeys) {
-        if (shouldStop()) break;
+        if (stop_requested())
+          throw new Job.JobCancelledException();
+
         if (_model._output._metalearner == null || _model.isUsefulBaseModel(k)) {
           Model aModel = DKV.getGet(k);
           if (null == aModel)
@@ -240,18 +242,6 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
         Scope.untrack(levelOneFrame.keysList());
       }
       return levelOneFrame;
-    }
-
-    private boolean shouldStop() {
-      if (stop_requested()) {
-        if (timeout()) {
-          Log.info("Stopping StackedEnsemble training because of timeout");
-          return true;
-        } else {
-          throw new Job.JobCancelledException();
-        }
-      }
-      return false;
     }
 
     protected Frame buildPredictionsForBaseModel(Model model, Frame frame) {

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -43,6 +43,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "metalearner_fold_assignment",
       "metalearner_fold_column",
       "metalearner_params",
+      "max_runtime_secs",
       "seed",
       "score_training_samples",
       "keep_levelone_frame",

--- a/h2o-bindings/bin/custom/R/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/R/gen_stackedensemble.py
@@ -115,6 +115,9 @@ If x is missing, then all columns except y are used.  Training frame is used onl
 """,
         seed="""
 Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
+""",
+        max_runtime_secs="""
+Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit. Defaults to 0.
 """
     ),
     examples="""

--- a/h2o-bindings/bin/custom/R/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/R/gen_stackedensemble.py
@@ -95,7 +95,12 @@ class(model@model$model_summary) <- "h2o.stackedEnsemble.summary"
 .h2o.fill_stackedensemble <- function(model, parameters, allparams) {
   # Store base models for the Stacked Ensemble in user-readable form
   model$base_models <- unlist(lapply(parameters$base_models, function (base_model) base_model$name))
-  model$metalearner_model <- h2o.getModel(model$metalearner$name)
+  if (!is.null(model$metalearner)) {
+    model$metalearner_model <- h2o.getModel(model$metalearner$name)
+  } else {
+    stop(paste("Meta learner didn't get to be trained in time.",
+               "Try increasing max_runtime_secs or setting it to 0 (unlimited)."))
+  }
   return(model)
 }
 """

--- a/h2o-bindings/bin/custom/R/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/R/gen_stackedensemble.py
@@ -115,9 +115,6 @@ If x is missing, then all columns except y are used.  Training frame is used onl
 """,
         seed="""
 Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
-""",
-        max_runtime_secs="""
-Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit. Defaults to 0.
 """
     ),
     examples="""

--- a/h2o-bindings/bin/custom/python/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/python/gen_stackedensemble.py
@@ -6,6 +6,9 @@ def update_param(name, param):
         param['type'] = 'KeyValue'
         param['default_value'] = None
         return param
+    elif name == 'max_runtime_secs':
+        param['help'] = """Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit."""
+        return param
     return None  # param untouched
 
 

--- a/h2o-bindings/bin/custom/python/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/python/gen_stackedensemble.py
@@ -6,9 +6,6 @@ def update_param(name, param):
         param['type'] = 'KeyValue'
         param['default_value'] = None
         return param
-    elif name == 'max_runtime_secs':
-        param['help'] = """Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit."""
-        return param
     return None  # param untouched
 
 

--- a/h2o-bindings/bin/custom/python/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/python/gen_stackedensemble.py
@@ -127,6 +127,9 @@ def class_extensions():
         parms = sup._make_parms(x, y, training_frame, extend_parms_fn=extend_parms, **kwargs)
 
         sup._train(parms, verbose=verbose)
+        if self.metalearner() is None:
+            raise EnvironmentError("Meta learner didn't get to be trained in time. "
+                                   "Try increasing max_runtime_secs or setting it to 0 (unlimited).")
 
 
 extensions = dict(

--- a/h2o-bindings/bin/custom/python/gen_stackedensemble.py
+++ b/h2o-bindings/bin/custom/python/gen_stackedensemble.py
@@ -128,7 +128,7 @@ def class_extensions():
 
         sup._train(parms, verbose=verbose)
         if self.metalearner() is None:
-            raise EnvironmentError("Meta learner didn't get to be trained in time. "
+            raise H2OResponseError("Meta learner didn't get to be trained in time. "
                                    "Try increasing max_runtime_secs or setting it to 0 (unlimited).")
 
 
@@ -140,6 +140,7 @@ import warnings
 
 import h2o
 from h2o.base import Keyed
+from h2o.exceptions import H2OResponseError
 from h2o.grid import H2OGridSearch
 from h2o.utils.shared_utils import quoted
 from h2o.utils.typechecks import is_type

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -63,10 +63,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   }
 
   protected long remainingTimeSecs() {
-    long remainingTimeMillis = _build_model_countdown.remainingTime();
-    if (remainingTimeMillis == Long.MAX_VALUE)
-      return 0;
-    return (long) Math.ceil(remainingTimeMillis / 1000.0);
+    return (long) Math.ceil(_build_model_countdown.remainingTime() / 1000.0);
   }
 
   /** Default model-builder key */

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -62,6 +62,13 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     return _job.stop_requested() || timeout();
   }
 
+  protected long remainingTimeSecs() {
+    long remainingTimeMillis = _build_model_countdown.remainingTime();
+    if (remainingTimeMillis == Long.MAX_VALUE)
+      return 0;
+    return (long) Math.ceil(remainingTimeMillis / 1000.0);
+  }
+
   /** Default model-builder key */
   public static <S extends Model> Key<S> defaultKey(String algoName) {
     return Key.make(H2O.calcNextUniqueModelId(algoName));

--- a/h2o-docs/src/product/data-science/algo-params/max_runtime_secs.rst
+++ b/h2o-docs/src/product/data-science/algo-params/max_runtime_secs.rst
@@ -3,7 +3,7 @@
 ``max_runtime_secs``
 -----------------------
 
-- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, AutoML, XGBoost, Word2vec, Isolation Forest
+- Available in: GBM, DRF, Deep Learning, GLM, PCA, GLRM, Naïve-Bayes, K-Means, AutoML, XGBoost, Word2vec, Isolation Forest, Stacked Ensembles
 - Hyperparameter: yes
 
 Description

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -97,6 +97,9 @@ Defining a Stacked Ensemble Model
 
 -  **keep_levelone_frame**: (Optional) Keep the level one data frame that's constructed for the metalearning step. Defaults to False.
 
+-  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: (Optional) Maximum allowed runtime in seconds for the metalearner model
+   training. Use 0 to disable.
+
 -  `seed <algo-params/seed.html>`__: (Optional) Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 
 -  `export_checkpoints_dir <algo-params/export_checkpoints_dir.html>`__: Specify a directory to which generated models will automatically be exported.

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -97,8 +97,7 @@ Defining a Stacked Ensemble Model
 
 -  **keep_levelone_frame**: (Optional) Keep the level one data frame that's constructed for the metalearning step. Defaults to False.
 
--  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: (Optional) Maximum allowed runtime in seconds for the metalearner model
-   training. Use 0 to disable the time limit. Defaults to 0.
+-  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: (Optional) Maximum allowed runtime in seconds for the metalearner model training. Use 0 to disable the time limit. Defaults to 0.
 
 -  `seed <algo-params/seed.html>`__: (Optional) Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 
@@ -490,5 +489,4 @@ Statistical Applications in Genetics and Molecular Biology. Volume 6, Issue 1. (
 .. _4:
 
 [4] `LeDell, E. "Scalable Ensemble Learning and Computationally Efficient Variance Estimation" (Doctoral Dissertation). University of California, Berkeley, USA. (2015) <http://www.stat.berkeley.edu/~ledell/papers/ledell-phd-thesis.pdf>`__
-
 

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -98,7 +98,7 @@ Defining a Stacked Ensemble Model
 -  **keep_levelone_frame**: (Optional) Keep the level one data frame that's constructed for the metalearning step. Defaults to False.
 
 -  `max_runtime_secs <algo-params/max_runtime_secs.html>`__: (Optional) Maximum allowed runtime in seconds for the metalearner model
-   training. Use 0 to disable.
+   training. Use 0 to disable the time limit. Defaults to 0.
 
 -  `seed <algo-params/seed.html>`__: (Optional) Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 
@@ -490,6 +490,5 @@ Statistical Applications in Genetics and Molecular Biology. Volume 6, Issue 1. (
 .. _4:
 
 [4] `LeDell, E. "Scalable Ensemble Learning and Computationally Efficient Variance Estimation" (Doctoral Dissertation). University of California, Berkeley, USA. (2015) <http://www.stat.berkeley.edu/~ledell/papers/ledell-phd-thesis.pdf>`__
-
 
 

--- a/h2o-docs/src/product/flow/packs/test-small/stackedensemble_weather.flow
+++ b/h2o-docs/src/product/flow/packs/test-small/stackedensemble_weather.flow
@@ -31,7 +31,7 @@
     },
     {
       "type": "cs",
-      "input": "buildModel 'stackedensemble', {\"model_id\":\"stackedensemble-6d61bf50-c3c0-4c82-b76f-4845723264e3\",\"training_frame\":\"weather.hex\",\"response_column\":\"RainTomorrow\",\"validation_frame\":\"weather.hex\",\"base_models\":[\"gbm-204e1edf-8521-4658-b531-71c1fea360f6\",\"drf-ed824362-1f8e-4b03-b0bd-7702c0886406\"],\"metalearner_algorithm\":\"AUTO\",\"metalearner_nfolds\":0,\"seed\":-1,\"keep_levelone_frame\":false}"
+      "input": "buildModel 'stackedensemble', {\"model_id\":\"stackedensemble-6d61bf50-c3c0-4c82-b76f-4845723264e3\",\"training_frame\":\"weather.hex\",\"response_column\":\"RainTomorrow\",\"validation_frame\":\"weather.hex\",\"base_models\":[\"gbm-204e1edf-8521-4658-b531-71c1fea360f6\",\"drf-ed824362-1f8e-4b03-b0bd-7702c0886406\"],\"metalearner_algorithm\":\"AUTO\",\"metalearner_nfolds\":0,\"seed\":-1,\"keep_levelone_frame\":false,\"max_runtime_secs\":4}"
     },
     {
       "type": "cs",

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -553,7 +553,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def max_runtime_secs(self):
         """
-        Maximum allowed runtime in seconds for model training. Use 0 to disable.
+        Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit. Defaults to 0.
 
         Type: ``float``  (default: ``0``).
         """

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -553,7 +553,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def max_runtime_secs(self):
         """
-        Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit. Defaults to 0.
+        Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit.
 
         Type: ``float``  (default: ``0``).
         """

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -63,8 +63,8 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     algo = "stackedensemble"
     param_names = {"model_id", "training_frame", "response_column", "validation_frame", "blending_frame", "base_models",
                    "metalearner_algorithm", "metalearner_nfolds", "metalearner_fold_assignment",
-                   "metalearner_fold_column", "metalearner_params", "seed", "score_training_samples",
-                   "keep_levelone_frame", "export_checkpoints_dir"}
+                   "metalearner_fold_column", "metalearner_params", "max_runtime_secs", "seed",
+                   "score_training_samples", "keep_levelone_frame", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OStackedEnsembleEstimator, self).__init__()
@@ -548,6 +548,21 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
             self._parms["metalearner_params"] = str(json.dumps(metalearner_params))
         else:
             self._parms["metalearner_params"] = None
+
+
+    @property
+    def max_runtime_secs(self):
+        """
+        Maximum allowed runtime in seconds for model training. Use 0 to disable.
+
+        Type: ``float``  (default: ``0``).
+        """
+        return self._parms.get("max_runtime_secs")
+
+    @max_runtime_secs.setter
+    def max_runtime_secs(self, max_runtime_secs):
+        assert_is_type(max_runtime_secs, None, numeric)
+        self._parms["max_runtime_secs"] = max_runtime_secs
 
 
     @property

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -842,3 +842,6 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
         parms = sup._make_parms(x, y, training_frame, extend_parms_fn=extend_parms, **kwargs)
 
         sup._train(parms, verbose=verbose)
+        if self.metalearner() is None:
+            raise EnvironmentError("Meta learner didn't get to be trained in time."
+                                   "Try increasing max_runtime_secs or setting it to 0 (unlimited).")

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -553,7 +553,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     @property
     def max_runtime_secs(self):
         """
-        Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit.
+        Maximum allowed runtime in seconds for model training. Use 0 to disable.
 
         Type: ``float``  (default: ``0``).
         """

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -12,6 +12,7 @@ import warnings
 
 import h2o
 from h2o.base import Keyed
+from h2o.exceptions import H2OResponseError
 from h2o.grid import H2OGridSearch
 from h2o.utils.shared_utils import quoted
 from h2o.utils.typechecks import is_type
@@ -843,5 +844,5 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
 
         sup._train(parms, verbose=verbose)
         if self.metalearner() is None:
-            raise EnvironmentError("Meta learner didn't get to be trained in time."
+            raise H2OResponseError("Meta learner didn't get to be trained in time. "
                                    "Try increasing max_runtime_secs or setting it to 0 (unlimited).")

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_max_runtime_secs.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_max_runtime_secs.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+
+
+import h2o
+import sys
+
+sys.path.insert(1, "../../../")  # allow us to run this standalone
+
+from h2o.grid import H2OGridSearch
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from tests import pyunit_utils as pu
+
+seed = 1
+
+
+def prepare_data():
+    fr = h2o.import_file(path=pu.locate("smalldata/junit/weather.csv"))
+    target = "RainTomorrow"
+    fr[target] = fr[target].asfactor()
+    ds = pu.ns(x=fr.columns, y=target, train=fr)
+
+    return ds
+
+
+def test_stackedensemble_propagates_the_max_runtime_secs():
+    max_runtime_secs = 4
+    hyper_parameters = dict()
+    hyper_parameters["ntrees"] = [1, 3, 5]
+    params = dict(
+        fold_assignment="modulo",
+        nfolds=3,
+        keep_cross_validation_predictions=True
+    )
+
+    data = prepare_data()
+
+    gs1 = H2OGridSearch(H2OGradientBoostingEstimator(**params), hyper_params=hyper_parameters)
+    gs1.train(data.x, data.y, data.train, validation_frame=data.train)
+
+    se = H2OStackedEnsembleEstimator(base_models=[gs1], max_runtime_secs=max_runtime_secs)
+    se.train(data.x, data.y, data.train)
+    metalearner = h2o.get_model(se.metalearner()["name"])
+
+    # metalearner has the set max_runtine_secs
+    assert metalearner.actual_params['max_runtime_secs'] == max_runtime_secs
+
+    # stack ensemble has the set max_runtime_secs
+    assert se.max_runtime_secs == max_runtime_secs
+
+pu.run_tests([
+    test_stackedensemble_propagates_the_max_runtime_secs
+])

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_max_runtime_secs.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_max_runtime_secs.py
@@ -74,12 +74,11 @@ def test_stackedensemble_respects_the_max_runtime_secs():
         base_models=gs1.model_ids,
         max_runtime_secs=max_runtime_secs,
         blending_frame=big_blending_frame)
-    se.train(data.x, data.y, data.train)
-
-    assert se.metalearner() is not None
-
-    # We should have SE with just one base model due to time constrains; intercept + base_model ==> 2
-    assert len(se.metalearner().coef()) == 2
+    try:
+        se.train(data.x, data.y, data.train)
+        assert False, "This should have failed due to time out."
+    except EnvironmentError:
+        pass
 
 
 pu.run_tests([

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_max_runtime_secs.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_max_runtime_secs.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 import h2o
 import sys
 
+from h2o.exceptions import H2OResponseError
+
 sys.path.insert(1, "../../../")  # allow us to run this standalone
 
 from h2o.grid import H2OGridSearch
@@ -77,7 +79,7 @@ def test_stackedensemble_respects_the_max_runtime_secs():
     try:
         se.train(data.x, data.y, data.train)
         assert False, "This should have failed due to time out."
-    except EnvironmentError:
+    except H2OResponseError:
         pass
 
 

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -34,6 +34,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param metalearner_params Parameters for metalearner algorithm
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param seed Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 #' @param score_training_samples Specify the number of training set samples for scoring. The value must be >= 0. To use all training samples,
 #'        enter 0. Defaults to 10000.
@@ -103,6 +104,7 @@ h2o.stackedEnsemble <- function(x,
                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
                                 metalearner_fold_column = NULL,
                                 metalearner_params = NULL,
+                                max_runtime_secs = 0,
                                 seed = -1,
                                 score_training_samples = 10000,
                                 keep_levelone_frame = FALSE,
@@ -162,6 +164,8 @@ h2o.stackedEnsemble <- function(x,
     parms$metalearner_fold_assignment <- metalearner_fold_assignment
   if (!missing(metalearner_fold_column))
     parms$metalearner_fold_column <- metalearner_fold_column
+  if (!missing(max_runtime_secs))
+    parms$max_runtime_secs <- max_runtime_secs
   if (!missing(seed))
     parms$seed <- seed
   if (!missing(score_training_samples))
@@ -233,6 +237,7 @@ h2o.stackedEnsemble <- function(x,
                                                 metalearner_fold_assignment = c("AUTO", "Random", "Modulo", "Stratified"),
                                                 metalearner_fold_column = NULL,
                                                 metalearner_params = NULL,
+                                                max_runtime_secs = 0,
                                                 seed = -1,
                                                 score_training_samples = 10000,
                                                 keep_levelone_frame = FALSE,
@@ -297,6 +302,8 @@ h2o.stackedEnsemble <- function(x,
     parms$metalearner_fold_assignment <- metalearner_fold_assignment
   if (!missing(metalearner_fold_column))
     parms$metalearner_fold_column <- metalearner_fold_column
+  if (!missing(max_runtime_secs))
+    parms$max_runtime_secs <- max_runtime_secs
   if (!missing(seed))
     parms$seed <- seed
   if (!missing(score_training_samples))

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -336,3 +336,4 @@ h2o.stackedEnsemble <- function(x,
   model$metalearner_model <- h2o.getModel(model$metalearner$name)
   return(model)
 }
+

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -34,7 +34,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param metalearner_params Parameters for metalearner algorithm
-#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit. Defaults to 0.
 #' @param seed Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 #' @param score_training_samples Specify the number of training set samples for scoring. The value must be >= 0. To use all training samples,
 #'        enter 0. Defaults to 10000.
@@ -336,4 +336,3 @@ h2o.stackedEnsemble <- function(x,
   model$metalearner_model <- h2o.getModel(model$metalearner$name)
   return(model)
 }
-

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -34,7 +34,7 @@
 #'        classification problems. Must be one of: "AUTO", "Random", "Modulo", "Stratified".
 #' @param metalearner_fold_column Column with cross-validation fold index assignment per observation for cross-validation of the metalearner.
 #' @param metalearner_params Parameters for metalearner algorithm
-#' @param max_runtime_secs Maximum allowed runtime in seconds for metalearner model training. Use 0 to disable the time limit. Defaults to 0.
+#' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param seed Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 #' @param score_training_samples Specify the number of training set samples for scoring. The value must be >= 0. To use all training samples,
 #'        enter 0. Defaults to 10000.

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -333,7 +333,12 @@ h2o.stackedEnsemble <- function(x,
 .h2o.fill_stackedensemble <- function(model, parameters, allparams) {
   # Store base models for the Stacked Ensemble in user-readable form
   model$base_models <- unlist(lapply(parameters$base_models, function (base_model) base_model$name))
-  model$metalearner_model <- h2o.getModel(model$metalearner$name)
+  if (!is.null(model$metalearner)) {
+    model$metalearner_model <- h2o.getModel(model$metalearner$name)
+  } else {
+    stop(paste("Meta learner didn't get to be trained in time.",
+               "Try increasing max_runtime_secs or setting it to 0 (unlimited)."))
+  }
   return(model)
 }
 

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_max_runtime_secs.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_max_runtime_secs.R
@@ -1,0 +1,52 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+stackedensemble.max_runtime_secs.test <- function() {
+    max_runtime_secs <- 4
+    train <- h2o.uploadFile(locate("smalldata/iris/iris_train.csv"))
+    y <- "species"
+    x <- setdiff(names(train), y)
+    train[,y] <- as.factor(train[,y])
+    nfolds <- 5
+
+    # Train & Cross-validate a GBM
+    my_gbm <- h2o.gbm(x = x,
+                      y = y,
+                      training_frame = train,
+                      distribution = "multinomial",
+                      ntrees = 10,
+                      max_depth = 3,
+                      min_rows = 2,
+                      learn_rate = 0.2,
+                      nfolds = nfolds,
+                      fold_assignment = "Modulo",
+                      keep_cross_validation_predictions = TRUE,
+                      seed = 1)
+
+
+    # Train & Cross-validate a RF
+    my_rf <- h2o.randomForest(x = x,
+                              y = y,
+                              training_frame = train,
+                              ntrees = 50,
+                              nfolds = nfolds,
+                              fold_assignment = "Modulo",
+                              keep_cross_validation_predictions = TRUE,
+                              seed = 1)
+
+    # Train a stacked ensemble using the GBM and RF above
+    stack <- h2o.stackedEnsemble(x = x,
+                                 y = y,
+                                 training_frame = train,
+                                 model_id = "my_ensemble_l1",
+                                 base_models = list(my_gbm@model_id, my_rf@model_id),
+                                 max_runtime_secs = max_runtime_secs)
+
+    # metalearner has the set max_runtine_secs
+    expect_equal(stack@model$metalearner_model@parameters$max_runtime_secs, max_runtime_secs)
+
+    # stack ensemble has the set max_runtime_secs
+    expect_equal(stack@parameters$max_runtime_secs, max_runtime_secs)
+}
+
+doTest("Stacked Ensemble max_runtime_secs Test", stackedensemble.max_runtime_secs.test)

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_max_runtime_secs.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_max_runtime_secs.R
@@ -86,17 +86,16 @@ stackedensemble.max_runtime_secs_is_obeyed.test <- function() {
         blending_frame <- h2o.rbind(blending_frame, blending_frame)
     }
     # Train a stacked ensemble using the GBM and RF above
-    stack <- h2o.stackedEnsemble(x = x,
+    error <- tryCatch(h2o.stackedEnsemble(x = x,
                                  y = y,
                                  training_frame = train,
                                  model_id = "my_ensemble_l1",
                                  base_models = list(my_gbm@model_id, my_rf@model_id),
                                  max_runtime_secs = max_runtime_secs,
                                  blending_frame = blending_frame
-                                )
-
-    # should use just one model (3 classes) + intercept => 4
-    expect_equal(length(stack@model$metalearner_model@model$coefficients), 4)
+                                ),
+             error = function(e) e)
+    expect_equal(error$message, "Error when retrieving meta learner possibly due to time out. Try increasing max_runtime_secs or setting it to 0 (unlimited).")
 }
 
 doSuite("Stacked Ensemble max_runtime_secs Test", makeSuite(

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_max_runtime_secs.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_max_runtime_secs.R
@@ -43,10 +43,63 @@ stackedensemble.max_runtime_secs.test <- function() {
                                  max_runtime_secs = max_runtime_secs)
 
     # metalearner has the set max_runtine_secs
-    expect_equal(stack@model$metalearner_model@parameters$max_runtime_secs, max_runtime_secs)
+    expect_lte(stack@model$metalearner_model@parameters$max_runtime_secs, max_runtime_secs)
 
     # stack ensemble has the set max_runtime_secs
     expect_equal(stack@parameters$max_runtime_secs, max_runtime_secs)
 }
 
-doTest("Stacked Ensemble max_runtime_secs Test", stackedensemble.max_runtime_secs.test)
+
+stackedensemble.max_runtime_secs_is_obeyed.test <- function() {
+    max_runtime_secs <- 1
+    train <- h2o.uploadFile(locate("smalldata/iris/iris_train.csv"))
+    y <- "species"
+    x <- setdiff(names(train), y)
+    train[,y] <- as.factor(train[,y])
+    nfolds <- 5
+
+    # Train & Cross-validate a GBM
+    my_gbm <- h2o.gbm(x = x,
+                      y = y,
+                      training_frame = train,
+                      distribution = "multinomial",
+                      ntrees = 10,
+                      max_depth = 3,
+                      min_rows = 2,
+                      learn_rate = 0.2,
+                      nfolds = nfolds,
+                      fold_assignment = "Modulo",
+                      seed = 1)
+
+
+    # Train & Cross-validate a RF
+    my_rf <- h2o.randomForest(x = x,
+                              y = y,
+                              training_frame = train,
+                              ntrees = 50,
+                              nfolds = nfolds,
+                              fold_assignment = "Modulo",
+                              seed = 1)
+
+    blending_frame <- train
+    for (i in seq_len(15)){
+        blending_frame <- h2o.rbind(blending_frame, blending_frame)
+    }
+    # Train a stacked ensemble using the GBM and RF above
+    stack <- h2o.stackedEnsemble(x = x,
+                                 y = y,
+                                 training_frame = train,
+                                 model_id = "my_ensemble_l1",
+                                 base_models = list(my_gbm@model_id, my_rf@model_id),
+                                 max_runtime_secs = max_runtime_secs,
+                                 blending_frame = blending_frame
+                                )
+
+    # should use just one model (3 classes) + intercept => 4
+    expect_equal(length(stack@model$metalearner_model@model$coefficients), 4)
+}
+
+doSuite("Stacked Ensemble max_runtime_secs Test", makeSuite(
+  stackedensemble.max_runtime_secs.test,
+  stackedensemble.max_runtime_secs_is_obeyed.test,
+))


### PR DESCRIPTION
This PR consists of:

- `max_runtime_secs` is exposed in R,  Python, and Flow.

- updated the `max_runtime_secs` page and the Stacked Ensemble page in the User Guide.


Link to Jira: https://0xdata.atlassian.net/browse/PUBDEV-5808