### PR TITLE
PUBDEV-7126: Make Date formatters ThreadLocal

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -27,7 +27,7 @@ import java.util.Date;
  */
 public class AutoMLBuildSpec extends Iced {
 
-  private static final DateFormat projectTimeStampFormat = new SimpleDateFormat("yyyyMMdd_HmmssSSS");
+  private static final ThreadLocal<DateFormat> projectTimeStampFormat = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyyMMdd_HmmssSSS"));
 
   /**
    * The specification of overall build parameters for the AutoML process.
@@ -345,7 +345,7 @@ public class AutoMLBuildSpec extends Iced {
 
   public String project() {
     if (build_control.project_name == null) {
-      build_control.project_name = "AutoML_"+ projectTimeStampFormat.format(new Date());
+      build_control.project_name = "AutoML_"+ projectTimeStampFormat.get().format(new Date());
     }
     return build_control.project_name;
   }

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -57,7 +57,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             final HyperSpaceSearchCriteria searchCriteria)
     {
         aml().eventLog().info(Stage.ModelTraining, "AutoML: starting "+resultKey+" hyperparameter search")
-                .setNamedValue("start_"+_algo+"_"+_id, new Date(), EventLogEntry.epochFormat);
+                .setNamedValue("start_"+_algo+"_"+_id, new Date(), EventLogEntry.epochFormat.get());
         return GridSearch.startGridSearch(
                 resultKey,
                 baseParams,
@@ -76,7 +76,7 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
         ModelBuilder builder = ModelBuilder.make(_algo.urlName(), job, (Key<Model>) resultKey);
         builder._parms = params;
         aml().eventLog().info(Stage.ModelTraining, "AutoML: starting "+resultKey+" model training")
-                .setNamedValue("start_"+_algo+"_"+_id, new Date(), EventLogEntry.epochFormat);
+                .setNamedValue("start_"+_algo+"_"+_id, new Date(), EventLogEntry.epochFormat.get());
         builder.init(false);          // validate parameters
         try {
             return builder.trainModelOnH2ONode();

--- a/h2o-automl/src/main/java/ai/h2o/automl/events/EventLogEntry.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/events/EventLogEntry.java
@@ -45,7 +45,7 @@ public class EventLogEntry<V extends Serializable> extends Iced {
   }
 
   static String nowStr() {
-    return dateTimeFormat.format(new Date());
+    return dateTimeFormat.get().format(new Date());
   }
 
   static abstract class SimpleFormat<T> extends Format {
@@ -65,17 +65,20 @@ public class EventLogEntry<V extends Serializable> extends Iced {
     }
   }
 
-  public static final Format epochFormat = new SimpleFormat<Date>() {
+  public static final ThreadLocal<Format> epochFormat = ThreadLocal.withInitial(() -> new SimpleFormat<Date>() {
     @Override
     public StringBuffer format(Date date, StringBuffer toAppendTo) {
         long epoch = Math.round(date.getTime() / 1e3);
         toAppendTo.append(epoch);
         return toAppendTo;
     }
-  };
-  public static final SimpleDateFormat dateTimeISOFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"); // uses local timezone
-  public static final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.S"); // uses local timezone
-  public static final SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss.S");  // uses local timezone
+  });
+  // uses local timezone
+  public static final ThreadLocal<SimpleDateFormat> dateTimeISOFormat = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"));
+  // uses local timezone
+  public static final ThreadLocal<SimpleDateFormat> dateTimeFormat = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.S"));
+  // uses local timezone
+  public static final ThreadLocal<SimpleDateFormat> timeFormat = ThreadLocal.withInitial(() ->new SimpleDateFormat("HH:mm:ss.S"));
 
   private static final String[] colHeaders = {
           "timestamp",
@@ -173,7 +176,7 @@ public class EventLogEntry<V extends Serializable> extends Iced {
 
   void addTwoDimTableRow(TwoDimTable table, int row) {
     int col = 0;
-    table.set(row, col++, timeFormat.format(new Date(_timestamp)));
+    table.set(row, col++, timeFormat.get().format(new Date(_timestamp)));
     table.set(row, col++, _level);
     table.set(row, col++, _stage);
     table.set(row, col++, _message);
@@ -184,7 +187,7 @@ public class EventLogEntry<V extends Serializable> extends Iced {
   @Override
   public String toString() {
     return String.format("%-12s %-"+longestLevel+"s %-"+longestStage+"s %s %s %s",
-            timeFormat.format(new Date(_timestamp)),
+            timeFormat.get().format(new Date(_timestamp)),
             _level,
             _stage,
             Objects.toString(_message, ""),

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
@@ -284,7 +284,7 @@ public class XGBoostSteps extends ModelingSteps {
 */
 
                     aml().eventLog().info(EventLogEntry.Stage.ModelTraining, "AutoML: starting "+resultKey+" model training")
-                            .setNamedValue("start_"+_algo+"_"+_id, new Date(), EventLogEntry.epochFormat);
+                            .setNamedValue("start_"+_algo+"_"+_id, new Date(), EventLogEntry.epochFormat.get());
                     return asModelsJob(GridSearch.startGridSearch(
                             Key.make(result+"_grid"),
                             new SequentialWalker<>(

--- a/h2o-automl/src/test/java/ai/h2o/automl/events/EventLogTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/events/EventLogTest.java
@@ -39,7 +39,7 @@ public class EventLogTest extends water.TestUtil {
                                     events.getColHeaders());
 
             DateTime now = DateTime.now();
-            DateTime entry_time = new DateTime(EventLogEntry.timeFormat.parse((String)events.get(0, 0)).getTime());
+            DateTime entry_time = new DateTime(EventLogEntry.timeFormat.get().parse((String)events.get(0, 0)).getTime());
             Assert.assertEquals(now.getHourOfDay(), entry_time.getHourOfDay());
             Assert.assertEquals(now.getMinuteOfHour(), entry_time.getMinuteOfHour());
             Assert.assertEquals(now.getSecondOfMinute(), entry_time.getSecondOfMinute(), 1.0);


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7126

I was also considering to use [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html), which was introduced in Java 8 and is thread-safe, however, it would require quite a lot of changes (e.g., changing some variables from `java.util.Date` to `java.time.LocalDateTime`) or a lot of in-place conversions. The change would make sense to me if we would want to deal with time zones, which I don't think we want/need to do in this case but I might be wrong...