### PR TITLE
Fix a race condition in SegmentModelsBuilder

### DIFF
--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -184,6 +184,10 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
    */
   public static <B extends ModelBuilder, MP extends Model.Parameters> B make(MP parms) {
     Key<Model> mKey = ModelBuilder.defaultKey(parms.algoName());
+    return make(parms, mKey);
+  }
+
+  public static <B extends ModelBuilder, MP extends Model.Parameters> B make(MP parms, Key<Model> mKey) {
     Job<Model> mJob = new Job<>(mKey, parms.javaName(), parms.algoName());
     B newMB = ModelBuilder.make(parms.algoName(), mJob, mKey);
     newMB._parms = parms.clone();

--- a/h2o-core/src/main/java/hex/segments/LocalSequentialSegmentModelsBuilder.java
+++ b/h2o-core/src/main/java/hex/segments/LocalSequentialSegmentModelsBuilder.java
@@ -66,7 +66,8 @@ class LocalSequentialSegmentModelsBuilder extends Iced<LocalSequentialSegmentMod
   }
 
   private ModelBuilder makeBuilder(long segmentIdx, double[] segmentVals) {
-    ModelBuilder builder = ModelBuilder.make(_blueprint_parms);
+    Key<Model> mKey = SegmentModelsUtils.makeUniqueModelKey(_job._result, segmentIdx);
+    ModelBuilder builder = ModelBuilder.make(_blueprint_parms, mKey);
     builder._parms._train = makeSegmentFrame(_full_train, segmentIdx, segmentVals);
     builder._parms._valid = makeSegmentFrame(_full_valid, segmentIdx, segmentVals);
     return builder;

--- a/h2o-core/src/main/java/hex/segments/SegmentModelsUtils.java
+++ b/h2o-core/src/main/java/hex/segments/SegmentModelsUtils.java
@@ -1,0 +1,12 @@
+package hex.segments;
+
+import hex.Model;
+import water.Key;
+
+public class SegmentModelsUtils {
+
+  static Key<Model> makeUniqueModelKey(Key<SegmentModels> smKey, long segmentIdx) {
+    return Key.make(smKey.toString() + "_" + segmentIdx);
+  }
+
+}

--- a/h2o-core/src/test/java/hex/ModelBuilderTest.java
+++ b/h2o-core/src/test/java/hex/ModelBuilderTest.java
@@ -135,17 +135,29 @@ public class ModelBuilderTest extends TestUtil {
   }
   
   @Test
-  public void testMakeByModelParameters() {
+  public void testMakeFromModelParams() {
     DummyModelParameters params = new DummyModelParameters();
 
     ModelBuilder modelBuilder = ModelBuilder.make(params);
 
     assertNotNull(modelBuilder._job); 
     assertNotNull(modelBuilder._result); 
-    assertEquals(params, params); 
-    assertNotEquals(modelBuilder._parms, params); 
+    assertNotSame(modelBuilder._parms, params); 
   }
 
+  @Test
+  public void testMakeFromParamsAndKey() {
+    DummyModelParameters params = new DummyModelParameters();
+    Key<Model> mKey = Key.make();
+
+    ModelBuilder modelBuilder = ModelBuilder.make(params, mKey);
+
+    assertNotNull(modelBuilder._job);
+    assertEquals(modelBuilder._job._result, mKey);
+    assertEquals(mKey, modelBuilder._result);
+    assertNotSame(modelBuilder._parms, params);
+  }
+  
   @Test
   public void testScoreReorderedDomain() {
     Frame train = null, test = null, scored = null;

--- a/h2o-core/src/test/java/hex/segments/SegmentModelsUtilsTest.java
+++ b/h2o-core/src/test/java/hex/segments/SegmentModelsUtilsTest.java
@@ -1,0 +1,16 @@
+package hex.segments;
+
+import hex.Model;
+import org.junit.Test;
+import water.Key;
+
+import static org.junit.Assert.*;
+
+public class SegmentModelsUtilsTest {
+
+  @Test
+  public void makeUniqueModelKey() {
+    Key<Model> mKey = SegmentModelsUtils.makeUniqueModelKey(Key.make("prefix_1"), 42);
+    assertEquals("prefix_1_42", mKey.toString());
+  }
+}


### PR DESCRIPTION
In SegmentModelBuilder each H2O node is generating a unique model ID based on
state of the local node (not a global state), this leads to collisions
because the model ids might not necessarily be globally unique.

The attached screenshot is showing an example of such model-key collisions.