### PR TITLE
PUBDEV-7409 - Provide original algorithm name for MOJO import

### DIFF
--- a/h2o-algos/src/main/java/hex/generic/GenericModelOutput.java
+++ b/h2o-algos/src/main/java/hex/generic/GenericModelOutput.java
@@ -13,7 +13,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class GenericModelOutput extends Model.Output {
-
+    final String _original_model_identifier;
+    final String _original_model_full_name;
     final ModelCategory _modelCategory;
     final int _nfeatures;
     final double _defaultThreshold;
@@ -33,6 +34,8 @@ public class GenericModelOutput extends Model.Output {
         _modelCategory = modelDescriptor.getModelCategory();
         _nfeatures = modelDescriptor.nfeatures();
         _defaultThreshold = modelDescriptor.defaultThreshold();
+        _original_model_identifier = modelDescriptor.algoName();
+        _original_model_full_name = modelDescriptor.algoFullName();
 
         if (modelAttributes != null) {
             _model_summary = convertTable(modelAttributes.getModelSummary());

--- a/h2o-algos/src/main/java/hex/schemas/GenericModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GenericModelV3.java
@@ -23,5 +23,13 @@ public class GenericModelV3 extends ModelSchemaV3<GenericModel, GenericModelV3, 
     public static final class GenericModelOutputV3 extends ModelOutputSchemaV3<GenericModelOutput, GenericModelOutputV3>{
         @API(help="Variable Importances", direction=API.Direction.OUTPUT, level = API.Level.secondary)
         TwoDimTableV3 variable_importances;
+        
+        @API(help = "Short identifier of the original algorithm name", direction = API.Direction.OUTPUT,
+                level = API.Level.secondary)
+        String original_model_identifier;
+        
+        @API(help = "Full, potentially long name of the original agorithm", direction = API.Direction.OUTPUT,
+                level = API.Level.secondary)
+        String original_model_full_name;
     }
 }

--- a/h2o-py/tests/testdir_generic_model/pyunit_generic_model.py
+++ b/h2o-py/tests/testdir_generic_model/pyunit_generic_model.py
@@ -22,12 +22,15 @@ def generic_blank_constructor():
     mojo_model.path = original_model_filename
     mojo_model.train()
     assert isinstance(mojo_model, H2OGenericEstimator)
-    
+
+    assert mojo_model._model_json["output"]["original_model_identifier"] == "gbm"
+    assert mojo_model._model_json["output"]["original_model_full_name"] == "Gradient Boosting Machine"
+
     # Test scoring is available on the model
     predictions = mojo_model.predict(airlines)
     assert predictions is not None
     assert predictions.nrows == 24421
-    
+
 if __name__ == "__main__":
     pyunit_utils.standalone_test(generic_blank_constructor)
 else:


### PR DESCRIPTION
[PUBDEV-7409](https://0xdata.atlassian.net/browse/PUBDEV-7409)

Provide original algorithm name for MOJO imported models. When unknown (wrapped models from outside of the H2O world), just leave it to null.

    For all imported MOJOs

    Show both the short and the long name from model.ini