### PR TITLE
Local smalldata path prefix

### DIFF
--- a/h2o-core/src/main/java/water/util/FileUtils.java
+++ b/h2o-core/src/main/java/water/util/FileUtils.java
@@ -132,12 +132,12 @@ public class FileUtils {
   private static Optional<File> findFileInPredefinedPath(final String fileName) {
     Objects.requireNonNull(fileName);
 
-    final String smallDataPathPrefix = System.getenv("H2O_FILES_SEARCH_PATH");
-    if (smallDataPathPrefix == null) return Optional.empty();
+    final String searchPath = System.getenv("H2O_FILES_SEARCH_PATH");
+    if (searchPath == null) return Optional.empty();
 
-    final StringBuilder localizedFileNameBuilder = new StringBuilder(smallDataPathPrefix);
+    final StringBuilder localizedFileNameBuilder = new StringBuilder(searchPath);
 
-    if (!smallDataPathPrefix.endsWith("/")) {
+    if (!searchPath.endsWith("/")) {
       localizedFileNameBuilder.append('/');
     }
     

--- a/h2o-core/src/main/java/water/util/FileUtils.java
+++ b/h2o-core/src/main/java/water/util/FileUtils.java
@@ -101,13 +101,12 @@ public class FileUtils {
    *  @param fname filename
    *  @return      Found file or null */
   public static File locateFile(String fname) {
-
+    // Search in pre-defined path, when active, overrides all other, including direct file lookup
     final Optional<File> fileInPredefinedPath = findFileInPredefinedPath(fname);
     if (fileInPredefinedPath.isPresent()) return fileInPredefinedPath.get();
     
     File file = new File(fname);
     if (file.exists()) return file;
-    
     
     file = new File("target/" + fname);
     if (!file.exists())
@@ -144,11 +143,13 @@ public class FileUtils {
     
     // If the file starts with {"./", ".\", "../", "..\"} (or multiple instances of these), strip it.
     // Does not match relative paths from top of the filesystem tree (starting with "/").
-    final Pattern pattern = Pattern.compile("\\.+[\\/]{1}(.*)");
+    final Pattern pattern = Pattern.compile("(\\.+[\\/]{1})+(.*)");
     final Matcher matcher = pattern.matcher(fileName);
-    
-    if(matcher.matches()){
-      localizedFileNameBuilder.append(matcher.group(1));
+
+    if (matcher.matches()) {
+      localizedFileNameBuilder.append(matcher.group(2));
+    } else if (fileName.startsWith("/")) {
+      return Optional.empty(); // The "/" at the beginning indicates absolute path, except for Windows. Do not attempt.
     } else {
       localizedFileNameBuilder.append(fileName);
     }

--- a/h2o-core/src/main/java/water/util/FileUtils.java
+++ b/h2o-core/src/main/java/water/util/FileUtils.java
@@ -102,11 +102,12 @@ public class FileUtils {
    *  @return      Found file or null */
   public static File locateFile(String fname) {
 
+    final Optional<File> fileInPredefinedPath = findFileInPredefinedPath(fname);
+    if (fileInPredefinedPath.isPresent()) return fileInPredefinedPath.get();
+    
     File file = new File(fname);
     if (file.exists()) return file;
     
-    final Optional<File> fileInPredefinedPath = findFileInPredefinedPath(fname);
-    if (fileInPredefinedPath.isPresent()) return fileInPredefinedPath.get();
     
     file = new File("target/" + fname);
     if (!file.exists())
@@ -141,7 +142,7 @@ public class FileUtils {
       localizedFileNameBuilder.append('/');
     }
     
-    // If the file starts with {"./", ".\"} (or multiple instances of these), strip it.
+    // If the file starts with {"./", ".\", "../", "..\"} (or multiple instances of these), strip it.
     // Does not match relative paths from top of the filesystem tree (starting with "/").
     final Pattern pattern = Pattern.compile("\\.+[\\/]{1}(.*)");
     final Matcher matcher = pattern.matcher(fileName);

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -452,8 +452,6 @@ public class TestUtil extends Iced {
     return ParseDataset.parse(outputKey, new Key[]{nfs._key}, true, guessedSetup);
   }
 
-  private static final String TEST_DATA_PATH_PREFIX_KEY = "H2O_TEST_DATA_PATH_PREFIX";
-
   /**
    * @param fileName File to prefix with local test file path
    * @return Original path prefixed with local small data path from environment variable, if the environment variable is
@@ -462,7 +460,7 @@ public class TestUtil extends Iced {
   private static String localTestDataPath(final String fileName) {
     Objects.requireNonNull(fileName);
 
-    final String smallDataPathPrefix = System.getenv(TEST_DATA_PATH_PREFIX_KEY);
+    final String smallDataPathPrefix = System.getenv("H2O_TEST_DATA_PATH_PREFIX");
     if (smallDataPathPrefix == null) return fileName;
 
     final StringBuilder localizedFileNameBuilder = new StringBuilder(smallDataPathPrefix);

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -437,7 +437,9 @@ public class TestUtil extends Iced {
     return parse_test_file(outputKey, fname, transformer, null);
   }
 
-  public static Frame parse_test_file( Key outputKey, String fname, ParseSetupTransformer transformer, int[] skippedColumns) {
+  public static Frame parse_test_file(final Key outputKey, String fname, final ParseSetupTransformer transformer,
+                                      final int[] skippedColumns) {
+    fname = localTestDataPath(fname);
     NFSFileVec nfs = makeNfsFileVec(fname);
     ParseSetup guessedSetup = ParseSetup.guessSetup(new Key[]{nfs._key}, false, ParseSetup.GUESS_HEADER);
     if (skippedColumns != null) {
@@ -450,7 +452,35 @@ public class TestUtil extends Iced {
     return ParseDataset.parse(outputKey, new Key[]{nfs._key}, true, guessedSetup);
   }
 
-  protected Frame parse_test_file( String fname, String na_string, int check_header, byte[] column_types) {
+  private static final String TEST_DATA_PATH_PREFIX_KEY = "H2O_TEST_DATA_PATH_PREFIX";
+
+  /**
+   * @param fileName File to prefix with local test file path
+   * @return Original path prefixed with local small data path from environment variable, if the environment variable is
+   * present. Otherwise the original path.
+   */
+  private static String localTestDataPath(final String fileName) {
+    Objects.requireNonNull(fileName);
+
+    final String smallDataPathPrefix = System.getenv(TEST_DATA_PATH_PREFIX_KEY);
+    if (smallDataPathPrefix == null) return fileName;
+
+    final StringBuilder localizedFileNameBuilder = new StringBuilder(smallDataPathPrefix);
+
+    if (!smallDataPathPrefix.endsWith("/")) {
+      localizedFileNameBuilder.append('/');
+    }
+
+    if (fileName.startsWith("./")) {
+      localizedFileNameBuilder.append(fileName, 2, fileName.length());
+    } else {
+      localizedFileNameBuilder.append(fileName);
+    }
+
+    return localizedFileNameBuilder.toString();
+  }
+
+  protected Frame parse_test_file(String fname, String na_string, int check_header, byte[] column_types) {
     return parse_test_file(fname, na_string, check_header, column_types, null, null);
   }
 

--- a/h2o-core/src/test/java/water/TestUtil.java
+++ b/h2o-core/src/test/java/water/TestUtil.java
@@ -437,9 +437,7 @@ public class TestUtil extends Iced {
     return parse_test_file(outputKey, fname, transformer, null);
   }
 
-  public static Frame parse_test_file(final Key outputKey, String fname, final ParseSetupTransformer transformer,
-                                      final int[] skippedColumns) {
-    fname = localTestDataPath(fname);
+  public static Frame parse_test_file( Key outputKey, String fname, ParseSetupTransformer transformer, int[] skippedColumns) {
     NFSFileVec nfs = makeNfsFileVec(fname);
     ParseSetup guessedSetup = ParseSetup.guessSetup(new Key[]{nfs._key}, false, ParseSetup.GUESS_HEADER);
     if (skippedColumns != null) {
@@ -452,33 +450,7 @@ public class TestUtil extends Iced {
     return ParseDataset.parse(outputKey, new Key[]{nfs._key}, true, guessedSetup);
   }
 
-  /**
-   * @param fileName File to prefix with local test file path
-   * @return Original path prefixed with local small data path from environment variable, if the environment variable is
-   * present. Otherwise the original path.
-   */
-  private static String localTestDataPath(final String fileName) {
-    Objects.requireNonNull(fileName);
-
-    final String smallDataPathPrefix = System.getenv("H2O_TEST_DATA_PATH_PREFIX");
-    if (smallDataPathPrefix == null) return fileName;
-
-    final StringBuilder localizedFileNameBuilder = new StringBuilder(smallDataPathPrefix);
-
-    if (!smallDataPathPrefix.endsWith("/")) {
-      localizedFileNameBuilder.append('/');
-    }
-
-    if (fileName.startsWith("./")) {
-      localizedFileNameBuilder.append(fileName, 2, fileName.length());
-    } else {
-      localizedFileNameBuilder.append(fileName);
-    }
-
-    return localizedFileNameBuilder.toString();
-  }
-
-  protected Frame parse_test_file(String fname, String na_string, int check_header, byte[] column_types) {
+  protected Frame parse_test_file( String fname, String na_string, int check_header, byte[] column_types) {
     return parse_test_file(fname, na_string, check_header, column_types, null, null);
   }
 

--- a/h2o-core/src/test/java/water/util/FileUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/FileUtilsTest.java
@@ -1,0 +1,68 @@
+package water.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.runner.RunWith;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class FileUtilsTest {
+
+    @Rule
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    @Test
+    public void testFindFileInPredefinedPath() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final Method findFileInPredefinedPath = FileUtils.class.getDeclaredMethod("findFileInPredefinedPath",
+                String.class);
+        assertTrue(Modifier.isStatic(findFileInPredefinedPath.getModifiers()));
+        assertTrue(Modifier.isPrivate(findFileInPredefinedPath.getModifiers()));
+        try {
+            final File h2oHomeDir = new File(System.getProperty("user.dir")).getParentFile();
+            environmentVariables.set("H2O_FILES_SEARCH_PATH", h2oHomeDir.getAbsolutePath());
+
+            findFileInPredefinedPath.setAccessible(true);
+            final Object returnedObject = findFileInPredefinedPath.invoke(null,
+                    "./smalldata/testng/airlines_train.csv");
+            assertEquals(Optional.class, returnedObject.getClass());
+            final Optional<File> returnedOptional = (Optional) returnedObject;
+            assertTrue(returnedOptional.isPresent());
+            assertTrue(returnedOptional.get().exists());
+            assertTrue(returnedOptional.get().isFile());
+        } finally {
+            findFileInPredefinedPath.setAccessible(false);
+        }
+
+    }
+
+    @Test
+    public void testFileImportWithPredefinedPath() {
+        try {
+            Scope.enter();
+            final File h2oHomeDir = new File(System.getProperty("user.dir")).getParentFile();
+            environmentVariables.set("H2O_FILES_SEARCH_PATH", h2oHomeDir.getAbsolutePath());
+
+            final Frame trainingFrame = Scope.track(TestUtil.parse_test_file("./smalldata/testng/airlines_train.csv"));
+            assertNotNull(trainingFrame);
+        } finally {
+            Scope.exit();
+        }
+    }
+}

--- a/h2o-core/src/test/java/water/util/FileUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/FileUtilsTest.java
@@ -51,6 +51,7 @@ public class FileUtilsTest {
             testFileFound("./smalldata/testng/airlines_train.csv", testedMethod);
             testFileFound("../smalldata/testng/airlines_train.csv", testedMethod);
             testFileFound("../../../smalldata/testng/airlines_train.csv", testedMethod);
+            testFileNotFound("/smalldata/testng/airlines_train.csv", testedMethod);
 
         } finally {
             testedMethod.setAccessible(false);

--- a/h2o-core/src/test/java/water/util/FileUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/FileUtilsTest.java
@@ -14,9 +14,6 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
@@ -30,26 +27,53 @@ public class FileUtilsTest {
 
     @Test
     public void testFindFileInPredefinedPath() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        final Method findFileInPredefinedPath = FileUtils.class.getDeclaredMethod("findFileInPredefinedPath",
+        final Method testedMethod = FileUtils.class.getDeclaredMethod("findFileInPredefinedPath",
                 String.class);
-        assertTrue(Modifier.isStatic(findFileInPredefinedPath.getModifiers()));
-        assertTrue(Modifier.isPrivate(findFileInPredefinedPath.getModifiers()));
+        assertTrue(Modifier.isStatic(testedMethod.getModifiers()));
+        assertTrue(Modifier.isPrivate(testedMethod.getModifiers()));
         try {
             final File h2oHomeDir = new File(System.getProperty("user.dir")).getParentFile();
             environmentVariables.set("H2O_FILES_SEARCH_PATH", h2oHomeDir.getAbsolutePath());
+            testedMethod.setAccessible(true);
+            testFileFound("smalldata/testng/airlines_train.csv", testedMethod);
+            testFileFound("./smalldata/testng/airlines_train.csv", testedMethod);
+            testFileFound("../smalldata/testng/airlines_train.csv", testedMethod);
+            testFileFound("../../../smalldata/testng/airlines_train.csv", testedMethod);
+            testFileNotFound("some/non/existing/path", testedMethod);
+            // Existing file, "/" at the beginning marks absolute path - should not find.
+            testFileNotFound("/smalldata/testng/airlines_train.csv", testedMethod);
 
-            findFileInPredefinedPath.setAccessible(true);
-            final Object returnedObject = findFileInPredefinedPath.invoke(null,
-                    "./smalldata/testng/airlines_train.csv");
-            assertEquals(Optional.class, returnedObject.getClass());
-            final Optional<File> returnedOptional = (Optional) returnedObject;
-            assertTrue(returnedOptional.isPresent());
-            assertTrue(returnedOptional.get().exists());
-            assertTrue(returnedOptional.get().isFile());
+            // Test with "/" at the end of the path to test the file path and the directory path are joined correctly
+            environmentVariables.set("H2O_FILES_SEARCH_PATH", h2oHomeDir.getAbsolutePath() + "/");
+            assertTrue(System.getenv("H2O_FILES_SEARCH_PATH").endsWith("/"));
+
+            testFileFound("smalldata/testng/airlines_train.csv", testedMethod);
+            testFileFound("./smalldata/testng/airlines_train.csv", testedMethod);
+            testFileFound("../smalldata/testng/airlines_train.csv", testedMethod);
+            testFileFound("../../../smalldata/testng/airlines_train.csv", testedMethod);
+
         } finally {
-            findFileInPredefinedPath.setAccessible(false);
+            testedMethod.setAccessible(false);
         }
 
+    }
+
+    private static void testFileFound(final String filePath, final Method findFileInPredefinedPath) throws InvocationTargetException,
+            IllegalAccessException {
+        final Object returnedObject = findFileInPredefinedPath.invoke(null, filePath);
+        assertEquals(Optional.class, returnedObject.getClass());
+        final Optional<File> returnedOptional = (Optional) returnedObject;
+        assertTrue(returnedOptional.isPresent());
+        assertTrue(returnedOptional.get().exists());
+        assertTrue(returnedOptional.get().isFile());
+    }
+
+    private static void testFileNotFound(final String filePath, final Method findFileInPredefinedPath) throws InvocationTargetException,
+            IllegalAccessException {
+        final Object returnedObject = findFileInPredefinedPath.invoke(null, filePath);
+        assertEquals(Optional.class, returnedObject.getClass());
+        final Optional<File> returnedOptional = (Optional) returnedObject;
+        assertFalse(returnedOptional.isPresent());
     }
 
     @Test


### PR DESCRIPTION
The original driver of this change was the inconvenience of JUnit tests in multinode. When H2O nodes are started via `H2OTestNodeStarter`, they're unable to find and parse the imported files, as the path is relative to H2O-3 working directory. One option was to enable downloading them from the S3 via `H2O_JUNIT_ALLOW_NO_SMALLDATA=TRUE` environment variable, but this might introduce unnecessary delays while downloading the data. Also, it is unnecessary to keep downloading the data over and over again. This variable is there for a different purpose.

A solution to define an environment variable with absolute path to the directory containing the test files (usually smalldata, but can also be bigdata and bigdata-laptop) arised. As it turned out (https://github.com/h2oai/h2o-3/pull/4463#issuecomment-606080773), such a solution can be generalized and whole H2O can be instructed via environment variable (do we want H2O arg as well ?) to search for the files in such a pre-defined location.

![Screenshot from 2020-03-31 09-37-43](https://user-images.githubusercontent.com/8769110/77999771-84fe3500-7333-11ea-9a91-6b6ff5f437f0.png)


Makes running our JUnit tests in multinode locally easier. Without the need to modify the code.

