### PR TITLE
PUBDEV-7423: Adding print method for H2OSegmentModels in R

### DIFF
--- a/h2o-r/h2o-package/R/segment.R
+++ b/h2o-r/h2o-package/R/segment.R
@@ -54,3 +54,16 @@ h2o.segment_train <- function(algorithm,
 
   return(do.call(segment_train_fun_name, args = params))
 }
+
+#' @rdname H2OSegmentModels-class
+#' @param object an \code{H2OModel} object.
+#' @export
+setMethod("show", "H2OSegmentModels", 
+          function(object) {
+            cat("Segment Models ID:", object@segment_models_id, "\n")
+            cat("Individual Segment Models:\n")
+            df <- as.data.frame(object)
+            print(df)
+            invisible(object)
+        })
+


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7423

Now it will print something like this in R when you type the object name (as below), or wrap it in `print()` or `show()`:

```
> models
Segment Models ID: GBM_segment_models_R_1585799836187_2 
Individual Segment Models:
     Species    Status                                  Model Errors Warnings
1     setosa SUCCEEDED GBM_segment_models_R_1585799836187_2_0   <NA>     <NA>
2 versicolor SUCCEEDED GBM_segment_models_R_1585799836187_2_1   <NA>     <NA>
3  virginica SUCCEEDED GBM_segment_models_R_1585799836187_2_2   <NA>     <NA>
```

It used to be this:
```
> models
An object of class "H2OSegmentModels"
Slot "segment_models_id":
[1] "GBM_segment_models_R_1585732049703_2"
```