### PR TITLE
H2ORunner for AutoMLTest to ensure per-method key leak detection

### DIFF
--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -14,11 +14,14 @@ import hex.tree.xgboost.XGBoostModel.XGBoostParameters;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import water.DKV;
 import water.Key;
 import water.Lockable;
 import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
 import water.util.ArrayUtils;
 import water.util.Log;
 
@@ -31,13 +34,10 @@ import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.*;
 
+@RunWith(H2ORunner.class)
+@CloudSize(1)
 public class AutoMLTest extends water.TestUtil {
-
-  @BeforeClass public static void setup() {
-    stall_till_cloudsize(1);
-//    stall_till_cloudsize(new String[] {"-log_level", "DEBUG"}, 1);
-  }
-
+  
   @Test public void test_basic_automl_behaviour_using_cv() {
     AutoML aml=null;
     Frame fr=null;


### PR DESCRIPTION
Use `H2ORunner` to improve key leak detection on a per-method basis. There were key leaks [detected](http://mr-0xc1:8080/view/H2O-3/job/h2o-3-nightly-pipeline/job/master/4188/testReport/junit/ai.h2o.automl/AutoMLTest/Java_8_AutoML_JUnit___testWorkPlanWithExploitation/) in `testWorkPlanWithExploitation` - which is the last test and the leak could have appeared anywhere before.

Happens occasionally.