### PR TITLE
Add DRF to `predict_contributions` doc string for Python and R

### DIFF
--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -178,7 +178,7 @@ class ModelBase(h2o_meta(Keyed)):
 
     def predict_contributions(self, test_data):
         """
-        Predict feature contributions - SHAP values on an H2O Model (only GBM and XGBoost models).
+        Predict feature contributions - SHAP values on an H2O Model (only DRF, GBM and XGBoost models).
         
         Returned H2OFrame has shape (#rows, #features + 1) - there is a feature contribution column for each input
         feature, the last column is the model bias (same value for each row). The sum of the feature contributions

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -794,7 +794,7 @@ staged_predict_proba.H2OModel <- function(object, newdata, ...) {
 #' @export
 h2o.staged_predict_proba <- staged_predict_proba.H2OModel
 
-#' Predict feature contributions - SHAP values on an H2O Model (only GBM and XGBoost models).
+#' Predict feature contributions - SHAP values on an H2O Model (only DRF, GBM and XGBoost models).
 #'
 #' Returned H2OFrame has shape (#rows, #features + 1) - there is a feature contribution column for each input
 #' feature, the last column is the model bias (same value for each row). The sum of the feature contributions


### PR DESCRIPTION
TreeSHAP seems to be supported even for DRF ([1], [2]) but Python and R doc strings mention only GBM and XGBoost.

@navdeep-G or is the omission of DRF intentional?

[1] https://github.com/h2oai/h2o-3/pull/3628
[2] https://h2o-release.s3.amazonaws.com/h2o/rel-yau/3/docs-website/h2o-docs/performance-and-prediction.html#predict-contributions