### PR TITLE
PUBDEV-7441 - Target encoder does not unlock output Frame

### DIFF
--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoder.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoder.java
@@ -234,12 +234,12 @@ public class TargetEncoder extends Iced<TargetEncoder>{
     }
     
     private void updateDomainGlobally(Frame fr, String teColumnName, String[] domain) {
-      Lockable lock = fr.write_lock();
+      fr.write_lock();
       Vec updatedVec = fr.vec(teColumnName);
       updatedVec.setDomain(domain);
       DKV.put(updatedVec);
       fr.update();
-      lock.unlock();
+      fr.unlock();
     }
 
     Frame getOutOfFoldData(Frame encodingMap, String foldColumnName, long currentFoldValue)  {


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7441
Discovered as a part of https://0xdata.atlassian.net/browse/PUBDEV-7020 and should be merged together, therefore this PR targets the `PUBDEV-7020_extended_demo` branch, as this branch provides tests to reproduce this and therefore no effort is duplicated.

## The problem

Please see the following piece of code (https://github.com/h2oai/h2o-3/blob/master/h2o-core/src/main/java/water/fvec/Frame.java#L1832) demonstrating proper usage of locks:

```java
  public Frame toCategoricalCol(int columIdx){
    write_lock();
    replace(columIdx, vec(columIdx).toCategoricalVec()).remove();
    // Update frame in DKV
    update();
    unlock();
    return this;
  }
```

Notice how the locks are used. The `write_lock()` and `unlock()` is applied to the very same Frame object (with same object reference).

The original code in the `TargetEncoder` class looked as follows:

```java
    private void updateDomainGlobally(Frame fr, String teColumnName, String[] domain) {
      Lockable lock = fr.write_lock();
      Vec updatedVec = fr.vec(teColumnName);
      updatedVec.setDomain(domain);
      DKV.put(updatedVec);
      fr.update();
      lock.unlock();
    }
```
Please notice the `lock.unlock();` operation is not done on the original Frame (variable `fr`), but rather the Lockable instance (which is a Frame in fact). Problem is, by calling `Lockable lock = fr.write_lock();`, the `lock` variable does not contain reference to the same object as `fr` does. The `Lockable` is a completely new `Frame` wrapper object ! See the screenshot below:

![Screenshot from 2020-04-07 09-16-51](https://user-images.githubusercontent.com/8769110/78641933-36f8ac80-78b2-11ea-946f-0b51de38d7af.png)

`fr` and `lockable` are different objects. The `unlock` operation called on lockable is only propagated if an `update` operation is called on the original `Frame` after the `unlock` operation has been issued on the lock.

## The solution

The simplest of solutions is to call the `unlock` operation on the original frame, just like in the example posted above. Therefore, instead of `lockable.unlock()`, `fr.unlock();` is called. And that's it. This approach saves the need for one more update afterwards.

