### PR TITLE
PUBDEV-7362: Fixed merge error

### DIFF
--- a/h2o-core/src/main/java/water/rapids/Merge.java
+++ b/h2o-core/src/main/java/water/rapids/Merge.java
@@ -90,12 +90,11 @@ public class Merge {
     Frame rightFrame = naPresent ? new RemoveNAsTask(riteCols)
             .doAll(riteFrame.types(), riteFrame).outputFrame(riteFrame.names(), riteFrame.domains())
             : riteFrame;
-
-
+    
     // map missing levels to -1 (rather than increasing slots after the end)
     // for now to save a deep branch later
-    for (int i=0; i<id_maps.length; i++) {
-      if (id_maps[i] == null) continue;
+    for (int i=0; i<id_maps.length; i++) { // id_maps is for leftFrame.  
+      if (id_maps[i] == null) continue;    // id_maps -1 represent leftFrame levels not found in riteFrame
       assert id_maps[i].length >= leftFrame.vec(leftCols[i]).max()+1
               :"Left frame cardinality is higher than right frame!  Switch frames and change merge directions to get " +
               "around this restriction.";
@@ -103,7 +102,7 @@ public class Merge {
       int right_max = (int)rightFrame.vec(riteCols[i]).max();
       for (int j=0; j<id_maps[i].length; j++) {
         assert id_maps[i][j] >= 0;
-        if (id_maps[i][j] > right_max) id_maps[i][j] = -1;
+        if (id_maps[i][j] > right_max) id_maps[i][j] = -1;  // map enum levels of left frame to -1 if not found in rite frame
       }
     }
 
@@ -127,10 +126,10 @@ public class Merge {
     final BigInteger riteBase = riteFrameEmpty?ZERO : riteIndex._base [0];
 
     // initialize for double columns, may not be used....
-    long leftMSBfrom = riteBase.subtract(leftBase).shiftRight(leftShift).longValue();  // value when all frames nonempty
-    boolean riteBaseExceedsleftBase=riteFrameEmpty?false:riteBase.compareTo(leftBase)>0;
+    long leftMSBfrom = riteBase.subtract(leftBase).shiftRight(leftShift).longValue();    // calculate the MSB or base differences between rite and left base 
+    boolean riteBaseExceedsleftBase=riteFrameEmpty?false:riteBase.compareTo(leftBase)>0; // true if rite base minimum value exceeds left base minimum value
     // deal with the left range below the right minimum, if any
-    if (riteBaseExceedsleftBase) {  // right branch has higher minimum column value
+    if (riteBaseExceedsleftBase) {  // left base starts at lower value than rite frame
       // deal with the range of the left below the start of the right, if any
       assert leftMSBfrom >= 0;
       if (leftMSBfrom>255) {
@@ -139,29 +138,30 @@ public class Merge {
       }
       // run the merge for the whole lefts that end before the first right.
       // The overlapping one with the right base is dealt with inside
-      // BinaryMerge (if _allLeft)
-      if (allLeft) for (int leftMSB=0; leftMSB<leftMSBfrom; leftMSB++) {
-        BinaryMerge bm = new BinaryMerge(new BinaryMerge.FFSB(leftFrame, leftMSB, leftShift,
-                leftIndex._bytesUsed, leftIndex._base), new BinaryMerge.FFSB(rightFrame,/*rightMSB*/-1, riteShift,
-                riteIndex._bytesUsed, riteIndex._base),
-                true);
+      if (allLeft) { // no need to iterate from 0 to 255, only need to go from leftbase MSB to min(max leftMSB, ritebaseMSB)
+        for (int leftMSB = 0; leftMSB < leftMSBfrom; leftMSB++) {  // grab only left frame and add to final merged frame
+          BinaryMerge bm = new BinaryMerge(new BinaryMerge.FFSB(leftFrame, leftMSB, leftShift,
+                  leftIndex._bytesUsed, leftIndex._base), new BinaryMerge.FFSB(rightFrame,/*rightMSB*/-1, riteShift,
+                  riteIndex._bytesUsed, riteIndex._base),
+                  true);
           bmList.add(bm);
           fs.add(new RPC<>(SplitByMSBLocal.ownerOfMSB(leftMSB), bm).call());
         }
+      }
     } else {
       // completely ignore right MSBs below the left base
-      assert leftMSBfrom <= 0;
+      assert leftMSBfrom <= 0;  // rite frame starts with lower or equal base than right
       leftMSBfrom = 0;
     }
 
-    BigInteger rightS = BigInteger.valueOf(256L<<riteShift);
+    BigInteger rightS = BigInteger.valueOf(256L<<riteShift);  // get max value of key values possible, power of 2 only
     long leftMSBto = leftFrameEmpty?0:riteBase.add(rightS).subtract(ONE).subtract(leftBase).shiftRight(leftShift).longValue();
     // deal with the left range above the right maximum, if any.  For doubles, -1 from shift to avoid negative outcome
     boolean leftRangeAboveRightMax = leftIndex._isCategorical[0]?
             leftBase.add(BigInteger.valueOf(256L<<leftShift)).compareTo(riteBase.add(rightS)) > 0:
             leftBase.add(BigInteger.valueOf(256L<<leftShift)).compareTo(riteBase.add(rightS)) >= 0;
 
-    if (leftRangeAboveRightMax) { //
+    if (leftRangeAboveRightMax) { // left and rite frames have no overlap and left frame base is higher than rite max
       assert leftMSBto <= 255;
       if (leftMSBto<0) {
         // The left range starts after the right range ends.  So every left row
@@ -169,19 +169,19 @@ public class Merge {
         leftMSBto = -1;  // all MSBs (0-255) need to fetch the left rows only
       }
       // run the merge for the whole lefts that start after the last right
-      if (allLeft) for (int leftMSB=(int)leftMSBto+1; leftMSB<=255; leftMSB++) {
-        BinaryMerge bm = new BinaryMerge(new BinaryMerge.FFSB(leftFrame,   leftMSB    ,leftShift,
-                leftIndex._bytesUsed,leftIndex._base),
-                new BinaryMerge.FFSB(rightFrame,/*rightMSB*/-1,riteShift,
-                        riteIndex._bytesUsed,riteIndex._base),
-                true);
+      if (allLeft) {  // not worthy restricting length here unless store column max.
+        for (int leftMSB = (int) leftMSBto + 1; leftMSB <= 255; leftMSB++) {
+          BinaryMerge bm = new BinaryMerge(new BinaryMerge.FFSB(leftFrame, leftMSB, leftShift, leftIndex._bytesUsed,
+                  leftIndex._base), new BinaryMerge.FFSB(rightFrame,/*rightMSB*/-1, riteShift, 
+                  riteIndex._bytesUsed, riteIndex._base), true);
           bmList.add(bm);
           fs.add(new RPC<>(SplitByMSBLocal.ownerOfMSB(leftMSB), bm).call());
+        }
       }
     } else if (!leftFrameEmpty){
       // completely ignore right MSBs after the right peak
-        assert leftMSBto >= 255;
-        leftMSBto = 255;
+      assert leftMSBto >= 255;
+      leftMSBto = 255;
     }
 
     // the overlapped region; i.e. between [ max(leftMin,rightMin), min(leftMax, rightMax) ]
@@ -195,8 +195,10 @@ public class Merge {
       long leftTo = leftFrameEmpty ? 0 : (((((long) leftMSB + 1) << leftShift) - 1 + leftBase.longValue()) - 1);  // -1 for leading NA spot and another -1 to get last of previous bin
 
       // which right bins do these left extents occur in (could span multiple, and fall in the middle)
-      int rightMSBfrom = (int) ((leftFrom - (riteFrameEmpty ? 0 : riteBase.longValue()) + 1) >> riteShift);   // +1 again for the leading NA spot
-      int rightMSBto = (int) ((leftTo - (riteFrameEmpty ? 0 : riteBase.longValue()) + 1) >> riteShift);
+      long temprightMSB = (leftFrom - (riteFrameEmpty ? 0 : riteBase.longValue()) + 1) >> riteShift; // direct casting to int can give wrong values
+      int rightMSBfrom =  temprightMSB < 0 ? 0 : (int) temprightMSB;   // +1 again for the leading NA spot
+      temprightMSB = (leftTo - (riteFrameEmpty ? 0 : riteBase.longValue()) + 1) >> riteShift;
+      int rightMSBto =  temprightMSB < 0 ? 0 : (int) temprightMSB;
 
       // the non-matching part of this region will have been dealt with above when allLeft==true
       if (rightMSBfrom < 0) rightMSBfrom = 0;
@@ -224,7 +226,6 @@ public class Merge {
     fs.blockForPending();
     
     Log.debug("took: " + (System.nanoTime() - t0) / 1e9+" seconds.");
-    
     Log.debug("Removing DKV keys of left and right index.  ... ");
     // TODO: In future we won't delete but rather persist them as index on the table
     // Explicitly deleting here (rather than Arno's cleanUp) to reveal if we're not removing keys early enough elsewhere
@@ -243,7 +244,6 @@ public class Merge {
       }
     }
     Log.debug("took: " + (System.nanoTime() - t0)/1e9+" seconds.");
-
     Log.info("Allocating and populating chunk info (e.g. size and batch number) ...");
     t0 = System.nanoTime();
     long ansN = 0;
@@ -314,8 +314,7 @@ public class Merge {
     ChunkStitcher ff = new ChunkStitcher(chunkSizes, chunkLeftMSB, chunkRightMSB, chunkBatch);
     ff.doAll(fr);
     Log.debug("took: " + (System.nanoTime() - t0) / 1e9+" seconds");
-
-    //Merge.cleanUp();
+    
     return fr;
   }
 

--- a/h2o-core/src/main/java/water/rapids/RadixCount.java
+++ b/h2o-core/src/main/java/water/rapids/RadixCount.java
@@ -48,8 +48,26 @@ class RadixCount extends MRTask<RadixCount> {
     long tmp[] = _counts._val[chk.cidx()] = new long[256];
     boolean isIntVal = chk.vec().isCategorical() || chk.vec().isInt();
     // TODO: assert chk instanceof integer or enum; -- but how since many
-    // integers (C1,C2 etc)?  Alternatively: chk.getClass().equals(C8Chunk.class)
-    if (!(_isLeft && chk.vec().isCategorical())) {  // for numeric columns or to deal with the rite frame during merge
+    if (chk.vec().isCategorical()) {
+      assert _id_maps[0].length > 0;
+      assert _base.compareTo(ZERO)==0;
+      if (chk.vec().naCnt() == 0) {
+        for (int r=0; r<chk._len; r++) {
+          int ctrVal = _isLeft?BigInteger.valueOf(_id_maps[0][(int)chk.at8(r)]+1).shiftRight(_shift).intValue()
+                  :BigInteger.valueOf((int)chk.at8(r)+1).shiftRight(_shift).intValue();
+          tmp[ctrVal]++;
+        }
+      } else {
+        for (int r=0; r<chk._len; r++) {
+          if (chk.isNA(r)) tmp[0]++;
+          else {
+            int ctrVal = _isLeft?BigInteger.valueOf(_id_maps[0][(int)chk.at8(r)]+1).shiftRight(_shift).intValue()
+                    :BigInteger.valueOf((int)chk.at8(r)+1).shiftRight(_shift).intValue();
+            tmp[ctrVal]++;
+          }
+        }
+      }
+    } else if (!(_isLeft && chk.vec().isCategorical())) {
       if (chk.vec().naCnt() == 0) { // no NAs in column
         // There are no NA in this join column; hence branch-free loop. Most
         // common case as should never really have NA in join columns.
@@ -57,7 +75,7 @@ class RadixCount extends MRTask<RadixCount> {
           long ctrVal = isIntVal ?
                   BigInteger.valueOf(chk.at8(r)*_ascending).subtract(_base).add(ONE).shiftRight(_shift).longValue():
                   MathUtils.convertDouble2BigInteger(_ascending*chk.atd(r)).subtract(_base).add(ONE).shiftRight(_shift).longValue();
-          tmp[(int) ctrVal]++;
+          tmp[(int) ctrVal]++;  // ctrVal is the MSB value of chk.at8(r)
         }
       } else {    // contains NAs in column
         // There are some NA in the column so have to branch.  TODO: warn user
@@ -75,23 +93,6 @@ class RadixCount extends MRTask<RadixCount> {
           // TODO: allow NA-to-NA join to be turned off.  Do that in bmerge as a simple low-cost switch.
           // Note that NA and the minimum may well both be in MSB 0 but most of
           // the time we will not have NA in join columns
-        }
-      }
-    } else {
-      // first column (for MSB split) in an Enum
-      // map left categorical to right levels using _id_maps
-      assert _id_maps[0].length > 0;
-      assert _base.compareTo(ZERO)==0;
-      if (chk.vec().naCnt() == 0) {
-        for (int r=0; r<chk._len; r++) {
-          tmp[BigInteger.valueOf(_id_maps[0][(int)chk.at8(r)]+1).shiftRight(_shift).intValue()]++;
-        //  tmp[(_id_maps[0][(int)chk.at8(r)]+1) >> _shift]++;
-        }
-      } else {
-        for (int r=0; r<chk._len; r++) {
-          if (chk.isNA(r)) tmp[0]++;
-          else tmp[BigInteger.valueOf(_id_maps[0][(int)chk.at8(r)]+1).shiftRight(_shift).intValue()]++;
-       //   else tmp[(_id_maps[0][(int)chk.at8(r)]+1) >> _shift]++;
         }
       }
     }

--- a/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
+++ b/h2o-core/src/main/java/water/rapids/SingleThreadRadixOrder.java
@@ -248,7 +248,7 @@ class SingleThreadRadixOrder extends DTask<SingleThreadRadixOrder> {
       _obatch = _o[batch0];
     }
     int offset = (int) (start % _batchSize);
-    for (int i=1; i<len; i++) {
+    for (int i=1; i<len; i++) { // like bubble sort
       int cmp = keycmp(_xbatch, offset+i, _xbatch, offset+i-1);  // TO DO: we don't need to compare the whole key here.  Set cmpLen < keySize
       if (cmp < 0) {
         System.arraycopy(_xbatch, (offset+i)*_keySize, keytmp, 0, _keySize);

--- a/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
+++ b/h2o-core/src/main/java/water/rapids/SplitByMSBLocal.java
@@ -135,17 +135,16 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
 
     for (int r=0; r<chk[0]._len; r++) {    // tight, branch free and cache efficient (surprisingly)
       int MSBvalue = 0;  // default for NA
-     //long thisx = 0;
       BigInteger thisx = ZERO;
       if (!chk[0].isNA(r)) {
         // TODO: restore branch-free again, go by column and retain original
         // compression with no .at8()
-        if (_isLeft && _id_maps[0]!=null) { // dealing with enum columns
-          thisx = BigInteger.valueOf(_id_maps[0][(int)chk[0].at8(r)] + 1);
+        if (_id_maps[0]!=null) { // dealing with enum column
+          thisx = BigInteger.valueOf(_isLeft?_id_maps[0][(int)chk[0].at8(r)] + 1:(int)chk[0].at8(r) + 1);
           MSBvalue = thisx.shiftRight(_shift).intValue();
           // may not be worth that as has to be global minimum so will rarely be
           // able to use as raw, but when we can maybe can do in bulk
-        } else {    // dealing with numeric columns (int or double) or enum
+        } else {    // dealing with numeric columns (int or double)
           thisx = isIntCols[0] ?
                   BigInteger.valueOf(_ascending[0]*chk[0].at8(r)).subtract(_base[0]).add(ONE):
                   MathUtils.convertDouble2BigInteger(_ascending[0]*chk[0].atd(r)).subtract(_base[0]).add(ONE);
@@ -173,8 +172,9 @@ class SplitByMSBLocal extends MRTask<SplitByMSBLocal> {
       for (int c=1; c<chk.length; c++) {  // TO DO: left align subsequent
         offset += _bytesUsed[c-1];     // advance offset by the previous field width
         if (chk[c].isNA(r)) continue;  // NA is a zero field so skip over as java initializes memory to 0 for us always
-        if (_isLeft && _id_maps[c] != null) thisx = BigInteger.valueOf(_id_maps[c][(int)chk[c].at8(r)] + 1);
-        else {
+        if (_id_maps[c] != null) {
+          thisx = BigInteger.valueOf(_isLeft?_id_maps[c][(int)chk[c].at8(r)] + 1:(int)chk[c].at8(r) + 1);
+        } else { // for numerical/integer columns
           thisx =  isIntCols[c]?
                   BigInteger.valueOf(_ascending[c]*chk[c].at8(r)).subtract(_base[c]).add(ONE):
                   MathUtils.convertDouble2BigInteger(_ascending[c]*chk[c].atd(r)).subtract(_base[c]).add(ONE);

--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstMerge.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstMerge.java
@@ -135,15 +135,15 @@ public class AstMerge extends AstPrimitive {
       if (allLeft && allRite)
         throw new IllegalArgumentException("all.x=TRUE and all.y=TRUE is not supported.  Choose one only.");
 
-      boolean onlyLeftAllOff = (allLeft && !allRite) || !allRite;
-      int[][] id_maps = new int[ncols][];
+      boolean onlyLeftAllOff = allLeft || (!allLeft && !allRite); // use left frame as reference unless allRite==true
+      int[][] id_maps = new int[ncols][]; // will contain enum levels of the not included frame mapped to combined enum levels of both left/rite frames
       for (int i = 0; i < ncols; i++) { // flip the frame orders for allRite
         Vec lv = onlyLeftAllOff ? l.vec(i) : r.vec(i);
         Vec rv = onlyLeftAllOff ? r.vec(i) : l.vec(i);
 
         if (onlyLeftAllOff ? lv.isCategorical() : rv.isCategorical()) {
           assert onlyLeftAllOff ? rv.isCategorical() : lv.isCategorical();  // if not, would have thrown above
-          id_maps[i] = onlyLeftAllOff ? CategoricalWrappedVec.computeMap(lv.domain(), rv.domain()) : CategoricalWrappedVec.computeMap(rv.domain(), lv.domain());
+          id_maps[i] = CategoricalWrappedVec.computeMap(lv.domain(), rv.domain());  // flipped already, no need to flip again
         }
       }
 

--- a/h2o-py/tests/testdir_munging/pyunit_pubdev_7362_big_merge_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_pubdev_7362_big_merge_large.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+
+def check_big_merge():
+    h2o.remove_all()
+    nrow = 1000000
+    ncol = 2
+    iRange = 100000
+    frame1 = h2o.create_frame(rows=nrow, cols=ncol, integer_fraction=1, seed = 12345, integer_range = iRange, missing_fraction=0.0)
+    frame2 = h2o.create_frame(rows = nrow, cols = ncol, integer_fraction=1, seed = 54321, integer_range = iRange, missing_fraction=0.0)
+
+    frame1.set_names(["C1","C2"])
+    frame2.set_names(["C1","C3"])
+
+    mergedExact = frame1.merge(frame2, by_x=["C1"],by_y=["C1"], all_x=False, all_y=False)    
+    mergedLeft = frame1.merge(frame2,by_x=["C1"],by_y=["C1"], all_x=True)
+
+    assert mergedExact.nrow < mergedLeft.nrow, "Expected row numbers are wrong"
+ 
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(check_big_merge)
+else:
+    check_big_merge()

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -933,15 +933,25 @@ random_NN <- function(actFunc, max_layers, max_node_number) {
 #----------------------------------------------------------------------
 compareFrames <- function(frame1, frame2, prob=0.5, tolerance=1e-6) {
   expect_true(nrow(frame1) == nrow(frame2) && ncol(frame1) == ncol(frame2), info="frame1 and frame2 are different in size.")
-  for (colInd in range(1, ncol(frame1))) {
-    temp1=as.numeric(frame1[,colInd])
-    temp2=as.numeric(frame2[,colInd])
-    for (rowInd in range(1,nrow(frame1))) {
-      if (runif(1,0,1) < prob)
+  for (colInd in c(1:ncol(frame1))) {
+
+    notNumericCols = !(h2o.isnumeric(frame1[,colInd]) && h2o.isnumeric(frame2[,colInd]))
+    if (notNumericCols) {
+      temp1 = frame1[,colInd]
+      temp2 = frame2[,colInd]
+    } else { 
+      temp1=as.numeric(frame1[,colInd])
+      temp2=as.numeric(frame2[,colInd])
+    }
+    for (rowInd in c(1:nrow(frame1))) {
+      if (runif(1,0,1) <= prob)
         if (is.na(temp1[rowInd, 1])) {
           expect_true(is.na(temp2[rowInd, 1]), info=paste0("Errow at row ", rowInd, ". Frame is value is na but Frame 2 value is ", temp2[rowInd,1]))
         } else {
-          expect_true((abs(temp1[rowInd,1]-temp2[rowInd,1])/max(1,abs(temp1[rowInd,1]), abs(temp2[rowInd,1])))< tolerance, info=paste0("Error at row ", rowInd, ". Frame 1 value ", temp1[rowInd,1], ". Frame 2 value ", temp2[rowInd,1]))
+          if (notNumericCols)
+            expect_true(temp1[rowInd,1]==temp2[rowInd,1],info=paste0("Error at row ", rowInd, ". Frame 1 value ", temp1[rowInd,1], ". Frame 2 value ", temp2[rowInd,1]))
+          else          
+            expect_true((abs(temp1[rowInd,1]-temp2[rowInd,1])/max(1,abs(temp1[rowInd,1]), abs(temp2[rowInd,1])))< tolerance, info=paste0("Error at row ", rowInd, ". Frame 1 value ", temp1[rowInd,1], ". Frame 2 value ", temp2[rowInd,1]))
         }
     }
   }

--- a/h2o-r/tests/testdir_jira/runit_PUBDEV_7362_merge_duplicate_others.R
+++ b/h2o-r/tests/testdir_jira/runit_PUBDEV_7362_merge_duplicate_others.R
@@ -1,0 +1,164 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+# problem with merge.
+test <- function() {
+    # code from Kuba
+    left <- as.h2o(data.frame(topic=c("A","B","C","D"), value=c(12,13,14,15))) # [A, 12][B, 13][C, 14][D, 15]
+    right <- as.h2o(data.frame(topic=c("Y","B","X","D"), bigValue=c(10000, 20000, 30000, 40000))) #[Y, 10000][B, 20000][X, 30000][D, 40000]
+
+    merged <- h2o.merge(right, left, all.x = TRUE, method="radix")
+    resultF <- as.h2o(data.frame(topic=c("B","D","X","Y"), bigvalue=c(20000, 40000, 30000, 10000), value = c(13, 15, NA, NA)))
+    assertMergeCorrect(h2o.arrange(merged,"topic"), h2o.arrange(resultF,"topic"))
+    
+    merged <- h2o.merge(left, right, all.y = TRUE, method="radix")
+    resultF <- as.h2o(data.frame(topic=c("B","D","X","Y"), value = c(13, 15, NA, NA), bigvalue=c(20000, 40000, 30000, 10000)))
+    assertMergeCorrect(h2o.arrange(merged,"topic"), h2o.arrange(resultF,"topic"))
+ 
+    merged <- h2o.merge(left, right, all.x = FALSE, all.y = FALSE, method="radix")
+    resultF <- as.h2o(data.frame(topic=c("B","D"), value = c(13, 15), bigvalue=c(20000, 40000)))
+    assertMergeCorrect(h2o.arrange(merged,"topic"), h2o.arrange(resultF,"topic"))
+    
+    merged <- h2o.merge(right, left, all.x = FALSE, all.y = FALSE, method="radix")
+    resultF <- as.h2o(data.frame(topic=c("B","D"), bigvalue=c(20000, 40000), value = c(13, 15)))
+    assertMergeCorrect(h2o.arrange(merged,"topic"), h2o.arrange(resultF,"topic"))
+    
+    # customer code
+    left_hf <- as.h2o(data.frame(fruit = c(-177000000, -4000000, 100000000000, 200000000000, 1000000000000),
+                                 color <- c('red', 'orange', 'yellow', 'red', 'blue')))
+    right_hf <- as.h2o(data.frame(fruit = c(-177000000), citrus <- c(FALSE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    resultF <- as.h2o(data.frame(fruit = c(100000000000,200000000000,1000000000000,-177000000,-4000000), 
+                                 color=c('yellow','red','blue','red','orange'), citrus=c(NA, NA, NA, FALSE, NA)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # left frame starts lower
+    left_hf <- as.h2o(data.frame(fruit = c(2,3,0,257,256), color <- c('red', 'orange', 'yellow', 'red', 'blue')))
+    right_hf <- as.h2o( data.frame(fruit = c(258,518,517,1030,1028,1028,1030,2049),
+                                   citrus <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE,TRUE)))
+    merged2 <- h2o.merge(left_hf, right_hf, all.y = TRUE) # H2O give wrong answer
+    print(merged2)
+    resultF <- as.h2o(data.frame(fruit=c(258,517,518,1028,1028,1030,1030,2049),
+                                 color=c(NA,NA,NA,NA,NA,NA,NA,NA),
+                                 citrus=c(TRUE,FALSE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE)))
+    assertMergeCorrect(h2o.arrange(merged2, "fruit"), h2o.arrange(resultF,"fruit"))
+    
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    print(merged)
+    resultF <- as.h2o(data.frame(fruit=c(0,2,3,256,257), color=c('yellow','red','orange','blue','red'), citrus=c(NA,NA,NA,NA,NA)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # both frame more or less overlapped
+    left_hf <- as.h2o(data.frame(fruit = c(2,3,3,3,0,4,7,9,257,256,518,518,1028), 
+                                 color = c('red', 'orange', 'yellow', 'red', 'blue', 'purple', 
+                                           'cyan','red', 'orange', 'yellow', 'red', 'blue','negra')))
+    right_hf <- as.h2o(data.frame(fruit = c(3,3,3,3,6,8,12,14,258,518,518,517,1030,1028,1028,1030,2049), 
+                                  citrus = c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE,TRUE, TRUE, FALSE, 
+                                             FALSE, TRUE, TRUE, FALSE, FALSE, TRUE, TRUE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    resultF <- as.h2o(data.frame(fruit=c(0,2,3,3,3,3,3,3,3,3,3,3,3,3,4,7,9,256,257,518,518,518,518,1028,1028), 
+                                 color=c('blue','red','orange','orange','orange','orange','yellow','yellow','yellow',
+                                         'yellow','red','red','red','red','purple','cyan','red','yellow','orange',
+                                         'red','red','blue','blue','negra','negra'),
+                                 citrus=c(NA,NA,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,
+                                          NA,NA,NA,NA,NA,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    merged <- h2o.merge(left_hf, right_hf, all.x=FALSE, all.y=FALSE)
+    resultF <- as.h2o(data.frame(fruit=c(3,3,3,3,3,3,3,3,3,3,3,3,518,518,518,518,1028,1028), 
+                                 color=c('orange','orange','orange','orange','yellow','yellow','yellow','yellow',
+                                         'red','red','red','red','red','red','blue','blue','negra','negra'),
+                                 citrus=c(TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,TRUE,TRUE,FALSE,FALSE,
+                                          FALSE,FALSE,FALSE,FALSE,FALSE,FALSE)))
+    assertMergeCorrect(h2o.arrange(merged, "fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # both frame with duplicate keys
+    # left frame starts higher and with overlap
+    left_hf <- as.h2o(data.frame(fruit = c(2,3,0,257,256,518,1028), color <- c('red', 'orange', 'yellow', 'red', 'blue', 'purple', 'cyan')))
+    right_hf <- as.h2o(data.frame(fruit = c(258,518,517,1030,1028,1030,1035), citrus <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = FALSE, all.y=FALSE)
+    resultF <- as.h2o(data.frame(fruit=c(518, 1028), color=c('purple', 'cyan'), citrus=c(TRUE, TRUE)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # left frame starts higher and no overlap
+    left_hf <- as.h2o(data.frame(fruit = c(2,3,0,14,15,16,17), 
+                                 color <- c('red', 'orange', 'yellow', 'red', 'blue', 'purple', 'cyan')))
+    right_hf <- as.h2o(data.frame(fruit = c(258,518,517,1030,1028,1030,1035), 
+                                  citrus <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = FALSE, all.y=FALSE)
+    print(merged)
+    expect_true((nrow(merged) == 0 && ncol(merged) == 3), info="Merged frame and expected result are different in size.")
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    resultF <-as.h2o(data.frame(fruit=c(0,2,3,14,15,16,17),
+                                color=c('yellow','red','orange','red', 'blue', 'purple', 'cyan'),
+                                citrus=c(NA,NA,NA,NA,NA,NA,NA)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # code from Kuba
+    left <- as.h2o(data.frame(topic=c("A","B","C","D"), value=c(12,13,14,15))) # [A, 12][B, 13][C, 14][D, 15]
+    right <- as.h2o(data.frame(topic=c("Y","B","X","D"), bigValue=c(10000, 20000, 30000, 40000))) #[Y, 10000][B, 20000][X, 30000][D, 40000]
+    merged <- h2o.merge(left, right, all.y = TRUE, method="radix")
+    resultF <- as.h2o(data.frame(topic=c("B","D","X","Y"), value = c(13, 15, NA, NA), bigvalue=c(20000, 40000, 30000, 10000)))
+    assertMergeCorrect(h2o.arrange(merged,"topic"), h2o.arrange(resultF,"topic"))
+
+   
+    # example from Neema
+    left_hf <- as.h2o(data.frame(fruit = c(-177000000, -4000000, 100000000000, 200000000000, 1000000000000),
+                                 color <- c('red', 'orange', 'yellow', 'red', 'blue')))
+    right_hf <- as.h2o(data.frame(fruit = c(-177000000, -177000000),
+                                  citrus <- c(FALSE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    resultF <- as.h2o(data.frame(fruit = c(100000000000,200000000000,1000000000000,-177000000,-177000000,-4000000), 
+                                 color=c('yellow','red','blue','red','red','orange'), citrus=c(NA, NA, NA, FALSE, FALSE, NA)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+
+    merged <- h2o.merge(left_hf, right_hf, all.y = TRUE)
+    resultF <- as.h2o(data.frame(fruit = c(-177000000,-177000000), 
+                                 color=c('red','red'), citrus=c(FALSE, FALSE)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # more or less overlapped
+    left_hf <- as.h2o(data.frame(fruit = c(2,3,0,257,256,518,1028), 
+                                 color <- c('red', 'orange', 'yellow', 'red', 'blue', 'purple', 'cyan')))
+    right_hf <- as.h2o(data.frame(fruit = c(2,1,3,258,518,517,1030,1028,1030,1035,0), 
+                                  citrus <- c(FALSE, TRUE, FALSE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE, TRUE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    resultF <- as.h2o(data.frame(fruit=c(0,2,3,256,257,518,1028),
+                                 color=c('yellow','red','orange','blue','red','purple','cyan'),
+                                 citrus=c(TRUE, FALSE, FALSE, NA, NA, TRUE, TRUE)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # left frame with duplicate keys
+    left_hf <- as.h2o(data.frame(fruit = c(2,3,3,3,3,0,257,256,518,1028, 1028, 1028), 
+                                 color <- c('red', 'orange', 'yellow', 'red', 'blue', 'purple', 'cyan',
+                                            'black','red','violet','magenta','cyan')))
+    right_hf <- as.h2o(data.frame(fruit = c(258,517,1030,1028,1030,2049), 
+                                  citrus <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    resultF <- as.h2o(data.frame(fruit=c(0,2,3,3,3,3,256,257,518,1028,1028,1028),
+                                 color=c('purple','red', 'orange', 'yellow', 'red', 'blue','black','cyan','red','violet','magenta','cyan'),
+                                 citrus=c(NA,NA,NA,NA,NA,NA,NA,NA,NA,FALSE,FALSE,FALSE)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+    
+    # rite frame with duplicate keys
+    left_hf <- as.h2o(data.frame(fruit = c(2,3,0,257,256,518,1028), 
+                                 color <- c('red', 'orange', 'yellow', 'red', 'blue', 'purple', 'cyan')))
+    right_hf <- as.h2o(data.frame(fruit = c(3,3,3,3,258,518,517,1030,1028,1028,1030,2049), 
+                                  citrus <- c(TRUE, TRUE, FALSE, FALSE, TRUE, FALSE, TRUE,TRUE, TRUE, FALSE, FALSE, TRUE)))
+    merged <- h2o.merge(left_hf, right_hf, all.x = TRUE)
+    resultF <- as.h2o(data.frame(fruit=c(0,2,3,3,3,3,256,257,518,1028,1028), 
+                                 color=c('yellow','red','orange','orange','orange','orange','blue','red','purple','cyan','cyan'),
+                                 citrus=c(NA, NA, TRUE, TRUE, FALSE, FALSE, NA, NA, FALSE, TRUE, FALSE)))
+    assertMergeCorrect(h2o.arrange(merged,"fruit"), h2o.arrange(resultF,"fruit"))
+}
+
+assertMergeCorrect <- function(mergedFrame, resultF) {
+    colnames(mergedFrame) <- colnames(resultF)
+    print("Merged Frame")
+    print(mergedFrame,n=nrow(mergedFrame))
+    print("Expected Frame")
+    print(resultF,n=nrow(resultF))
+    compareFrames(mergedFrame, resultF, prob=1)
+}
+
+doTest("PUBDEV-7362: check merge", test)

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -165,14 +165,6 @@ def call(final pipelineContext) {
 
   def BENCHMARK_STAGES = [
     [
-      stageName: 'MERGE Benchmark', executionScript: 'h2o-3/scripts/jenkins/groovy/benchmarkStage.groovy',
-      timeoutValue: 120, target: 'benchmark', component: pipelineContext.getBuildConfig().COMPONENT_ANY,
-      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
-      customData: [algorithm: 'merge'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
-      nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
-      healthCheckSuppressed: true
-    ],
-    [
       stageName: 'GBM Benchmark', executionScript: 'h2o-3/scripts/jenkins/groovy/benchmarkStage.groovy',
       timeoutValue: 120, target: 'benchmark', component: pipelineContext.getBuildConfig().COMPONENT_ANY,
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
@@ -227,6 +219,22 @@ def call(final pipelineContext) {
       timeoutValue: 120, target: 'benchmark-dmlc-r-xgboost', component: pipelineContext.getBuildConfig().COMPONENT_ANY,
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
       customData: [algorithm: 'xgb-dmlc'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
+      nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
+      healthCheckSuppressed: true
+    ],
+    [ 
+      stageName: 'MERGE Benchmark', executionScript: 'h2o-3/scripts/jenkins/groovy/benchmarkStage.groovy',
+      timeoutValue: 120, target: 'benchmark-xgb-vanilla', component: pipelineContext.getBuildConfig().COMPONENT_ANY,
+      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY],
+      customData: [algorithm: 'merge'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
+      nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
+      healthCheckSuppressed: true
+    ],
+    [
+      stageName: 'SORT Benchmark', executionScript: 'h2o-3/scripts/jenkins/groovy/benchmarkStage.groovy',
+      timeoutValue: 120, target: 'benchmark-dmlc-r-xgboost', component: pipelineContext.getBuildConfig().COMPONENT_ANY,
+      additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_R],
+      customData: [algorithm: 'sort'], makefilePath: pipelineContext.getBuildConfig().BENCHMARK_MAKEFILE_PATH,
       nodeLabel: pipelineContext.getBuildConfig().getBenchmarkNodeLabel(),
       healthCheckSuppressed: true
     ]


### PR DESCRIPTION
This PR fixes the bugs (I hope) in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7362?filter=-1

I have performed the following:
1. During the conversion of long/BigInteger to int, if the result is negative, the casting will generate strange results.  I checked the results in long/BigInteger before casting it to integer.
2. For categorical merge columns, the use of id_maps is incorrect.  It should be associated with the right frame but was somehow used for the left frame.
3.The major work was to replace the previous bmerge_r with my own. 
4. I added a R unit test that include failed merges from Neema/Kuba and a customer. 
5. Added comments to various part of the code so that the next time I need to fix something, I can understand what is going on much faster.