### PR TITLE
[xgboost] add precision to R contrib test

### DIFF
--- a/docker/scripts/install_R_version
+++ b/docker/scripts/install_R_version
@@ -74,7 +74,7 @@ echo "Installing dependencies for R ${R_VERSION}"
   ))" 2>&1 | tee R.install.1.log
 checkRInstallLog R.install.1.log
 # Latest XGBoost (from source)
-/usr/local/R/current/bin/R -e 'chooseCRANmirror(graphics=FALSE, ind=58);install.packages(c("xgboost", type="source"))' | tee R.install.2.log
+/usr/local/R/current/bin/R -e 'chooseCRANmirror(graphics=FALSE, ind=58);install.packages(c("xgboost"), type="source")' | tee R.install.2.log
 checkRInstallLog R.install.2.log
 # RCUrl 1.95-4.12 is the last to support R 3.3
 # survival 2.44-1.1 is the last to support R 3.3

--- a/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_predict_contribs.R
+++ b/h2o-r/tests/testdir_algos/xgboost/runit_XGBoost_predict_contribs.R
@@ -9,7 +9,8 @@ test.XGBoost.predict_contribs <- function() {
     housing_hex <- h2o.importFile(locate("smalldata/gbm_test/BostonHousing.csv"))
 
     # Train an H2O model
-    h2o_model <- h2o.xgboost(training_frame = housing_hex, y = "medv", seed = 42)
+    set.seed(42)
+    h2o_model <- h2o.xgboost(training_frame = housing_hex, y = "medv")
     h2o_predict <- h2o.predict(h2o_model, housing_hex)
     
     # Train a native XGBoost model
@@ -35,7 +36,7 @@ test.XGBoost.predict_contribs <- function() {
     # Rename BiasTerm to match XGBoost
     colnames(h2o_contribs) <- c(colnames(h2o_contribs)[1:(ncol(h2o_contribs)-1)], "BIAS")
     
-    expect_equal(h2o_contribs, xgb_contribs)
+    expect_equal(h2o_contribs, xgb_contribs, 1e-6)
 }
 
 doTest("GBM Test: Classification with 50 categorical level predictor", test.XGBoost.predict_contribs)


### PR DESCRIPTION
- use same precision when comparing direct and h2o xgboostt
- also fix a typo in dockerfile