### PR TITLE
Properly clear env vars in K8S Junit test.

### DIFF
--- a/h2o-k8s/src/test/java/water/k8s/KubernetesEmbeddedConfigProviderTest.java
+++ b/h2o-k8s/src/test/java/water/k8s/KubernetesEmbeddedConfigProviderTest.java
@@ -32,6 +32,7 @@ public class KubernetesEmbeddedConfigProviderTest {
     
     @Test
     public void testInactiveOnK8SEnvVariablesSet(){
+        environmentVariables.clear("H2O_KUBERNETES_SERVICE_DNS");
         kubernetesEmbeddedConfigProvider.init();
         assertFalse(kubernetesEmbeddedConfigProvider.isActive());
     }


### PR DESCRIPTION
Not sure how this happened, but the env variable is not cleared in one of the K8S Junit tests, causing it to fail. Fix is trivial.