### PR TITLE
PUBDEV-7400

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -7,14 +7,12 @@ Rapids expressions. These are helper classes for H2OFrame.
 """
 from __future__ import division, print_function, absolute_import, unicode_literals
 
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
 import copy
 import gc
 import inspect
 import math
-import sys
 import time
-import traceback
 import numbers
 
 import tabulate

--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -150,7 +150,7 @@ class ExprNode(object):
 
         def is_debug_ref(ref):
             # if ref is a dict, then it is a `locals` scope: most of those are added in debug mode.
-            # However, keeping it if this scope refers to an H2OFrame (has `_ex` attribute`
+            # However, keeping it if this scope refers to an H2OFrame (has `_ex` entry)
             return isinstance(ref, dict) and '_ex' not in ref
 
         referrers = gc.get_referrers(self)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7400

added heuristic to exclude debug referrers from counting to avoid creation of self-referential tmp frames.

Should work at least with IDEs whose Python debugging integration is based on pydevd debugger: https://pypi.org/project/pydevd/