### PR TITLE
PUBDEV-7343: Doc improvements for Hive Import

### DIFF
--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -191,18 +191,21 @@ core-site.xml must be configured for at least the following properties (class, p
         </property>
     </configuration>
 
+.. _direct_hive_import:
 
 Direct Hive Import
 ~~~~~~~~~~~~~~~~~~
 
-H2O supports direct ingestion of data managed by Hive in Hadoop. This feature is available only when H2O is running as a Hadoop job. Internally H2O uses metadata in Hive Metastore database to determine the location and format of given Hive table. H2O then imports data directly from HDFS so limitations of supported formats mentioned above apply. Data from hive can pulled into H2O using ``import_hive_table`` function. H2O can read Hive table metadata two ways - either via direct Metastore access (preferred) or via JDBC. 
+H2O supports direct ingestion of data managed by Hive in Hadoop. This feature is available only when H2O is running as a Hadoop job. Internally H2O uses metadata in Hive Metastore database to determine the location and format of given Hive table. H2O then imports data directly from HDFS so limitations of supported formats mentioned above apply. Data from hive can pulled into H2O using ``import_hive_table`` function. H2O can read Hive table metadata two ways - either via direct Metastore access or via JDBC. 
+
+**Note**: When ingesting data from Hive in Hadoop, direct Hive import is preferred over :ref:`hive2`.
 
 Requirements
 ''''''''''''
 
 - The user running H2O must have read access to Hive and the files it manages.
 
-- For Direct Metastore access, the Hive jars and configuration must be present on H2O job classpath - either by adding it to yarn.application.classpath (or similar property for your resource manger of choice) or by adding Hive jars and configuration to libjars. Note that Direct Metastore access is the perferred method.
+- For Direct Metastore access, the Hive jars and configuration must be present on H2O job classpath - either by adding it to yarn.application.classpath (or similar property for your resource manger of choice) or by adding Hive jars and configuration to libjars. 
 
 - For JDBC metadata access, the Hive JDBC Driver must be on H2O job classpath.
 
@@ -216,35 +219,23 @@ Limitations
 Importing Examples
 ''''''''''''''''''
 
-Example 1: Access Metadata via Metastore (preferred)
-####################################################
+Example 1: Access Metadata via Metastore
+########################################
 
 This example shows how to access metadata via the metastore. 
 
-1. Add the Hive JDBC driver to H2O's classpath.
-
- .. code-block:: bash
-
-      # Add the Hive JDBC driver to H2O's classpath
-      java -cp hive-jdbc.jar:<path_to_h2o_jar> water.H2OApp
-
-
-2. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
+1. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
 
  .. code-block:: bash
 
       # start the h2o.jar 
       hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
 
-3. Initialize H2O in either R or Python and import data.
+2. Import data in R or Python.
 
  .. tabs::
 
    .. code-tab:: r R
-
-        # initialize h2o in R
-        library(h2o)
-        h2o.init(extra_classpath=["hive-jdbc-standalone.jar"])
 
         # basic import
         basic_import <- h2o.import_hive_table("default", "table_name")
@@ -260,10 +251,6 @@ This example shows how to access metadata via the metastore.
                                                        [["2017", "02"]])
 
    .. code-tab:: python
-
-        # initialize h2o in Python
-        import h2o
-        h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
 
         # basic import
         basic_import = h2o.import_hive_table("default", "table_name")
@@ -284,30 +271,18 @@ Example 2: Access Metadata via JDBC
 
 This example shows how to access metadata via JDBC.  
 
-1. Add the Hive JDBC driver to H2O's classpath.
-
- .. code-block:: bash
-
-      # Add the Hive JDBC driver to H2O's classpath
-      java -cp hive-jdbc.jar:<path_to_h2o_jar> water.H2OApp
-
-
-2. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
+1. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
 
  .. code-block:: bash
 
       # start the h2o.jar 
       hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
 
-3. Initialize H2O in either R or Python and import data.
+2. Import data in R or Python.
 
  .. tabs::
 
    .. code-tab:: r R
-
-        # start the h2o.jar in R
-        library(h2o)
-        h2o.init(extra_classpath=["hive-jdbc-standalone.jar"])
 
         # basic import of metadata via JDBC
         basic_import <- h2o.import_hive_table("jdbc:hive2://hive-server:10000/default", "table_name")
@@ -315,17 +290,13 @@ This example shows how to access metadata via JDBC.
 
    .. code-tab:: python
 
-        # start the h2o.jar in Python
-        import h2o
-        h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
-
         # basic import of metadata via JDBC
         basic_import = h2o.import_hive_table("jdbc:hive2://hive-server:10000/default", "table_name")
 
 JDBC Databases
 ~~~~~~~~~~~~~~
 
-Relational databases that include a JDBC (Java database connectivity) driver can be used as the source of data for machine learning in H2O. Currently supported SQL databases are MySQL, PostgreSQL, MariaDB, Netezza, Amazon Redshift, Teradata, and Hive. (Refer to :ref:`hive2` for more information.) Data from these SQL databases can be pulled into H2O using the ``import_sql_table`` and ``import_sql_select`` functions.
+Relational databases that include a JDBC (Java database connectivity) driver can be used as the source of data for machine learning in H2O. Currently supported SQL databases are MySQL, PostgreSQL, MariaDB, Netezza, Amazon Redshift, Teradata, and Hive. (Refer to :ref:`hive2` for more information.) Data from these SQL databases can be pulled into H2O using the ``import_sql_table`` and ``import_sql_select`` functions. 
 
 Refer to the following articles for examples about using JDBC data sources with H2O.
 
@@ -423,7 +394,11 @@ Using the Hive 2 JDBC Driver
 
 H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O with the JDBC driver for your Hive version. A demo showing how to ingest data from Hive through the Hive v2 JDBC driver is available `here <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/hive_jdbc_driver/Hive.md>`__. The basic steps are described below. 
 
-**Note**: H2O can only load data from Hive version 2.2.0 or greater due to a limited implementation of the JDBC interface by Hive in earlier versions.
+**Notes**: 
+
+- :ref:`direct_hive_import` is preferred over using the Hive 2 JDBC driver.
+- H2O can only load data from Hive version 2.2.0 or greater due to a limited implementation of the JDBC interface by Hive in earlier versions.
+
 
 1. Set up a table with data. 
 
@@ -477,15 +452,7 @@ H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O w
         # Add the Hive JDBC driver to H2O's classpath
         java -cp hive-jdbc.jar:<path_to_h2o_jar> water.H2OApp
 
-
-4. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
-
- .. code-block:: bash
-
-        # start the h2o.jar 
-        hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
-
-5. Initialize H2O in either R or Python and import data.
+4. Initialize H2O in either R or Python and import data.
 
  .. tabs::
 
@@ -506,7 +473,7 @@ H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O w
         h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
 
 
-6. After the jar file with JDBC driver is added, then data from the Hive databases can be pulled into H2O using the aforementioned ``import_sql_table`` and ``import_sql_select`` functions. 
+5. After the jar file with JDBC driver is added, then data from the Hive databases can be pulled into H2O using the aforementioned ``import_sql_table`` and ``import_sql_select`` functions. 
 
  .. tabs::
 

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -3,6 +3,8 @@ Getting Data into Your H2O Cluster
 
 The first step toward building and scoring your models is getting your data into the H2O cluster/Java process that’s running on your local or remote machine. Whether you're importing data, uploading data, or retrieving data from HDFS or S3, be sure that your data is compatible with H2O.
 
+.. _supported_file_formats:
+
 Supported File Formats
 ----------------------
 
@@ -70,7 +72,7 @@ To access Alluxio data source, an Alluxio client library that is part of Alluxio
 
 **H2O Command Line**
 
-::
+.. code-block:: bash
 
      java -cp alluxio-core-client-1.3.0-jar-with-dependencies.jar:build/h2o.jar water.H2OApp
 
@@ -78,7 +80,7 @@ To access Alluxio data source, an Alluxio client library that is part of Alluxio
 
 An Alluxio data source is referenced using ``alluxio://`` schema and location of Alluxio master. For example,
 
-::
+.. code-block:: bash
 
     alluxio://localhost:19998/iris.csv
 
@@ -97,7 +99,7 @@ Note: The jar available at Maven central is not compatible with IBM Swift Object
 
 **H2O Command Line**
 
-::
+.. code-block:: bash
 
     java -cp hadoop-openstack.jar:h2o.jar water.H2OApp
 
@@ -105,7 +107,7 @@ Note: The jar available at Maven central is not compatible with IBM Swift Object
 
 Data source is available under the regular Swift URI structure: ``swift://<CONTAINER>.<SERVICE>/path/to/file`` For example,
 
-::
+.. code-block:: bash
 
     swift://smalldata.h2o/iris.csv
 
@@ -151,7 +153,7 @@ To access the Google Cloud Store Object Store, Google's cloud storage connector,
 
 **H2O Command Line**
 
-::
+.. code-block:: bash
 
     H2O on Hadoop:
     hadoop jar h2o-driver.jar -libjars /path/to/gcs-connector-latest-hadoop2.jar
@@ -164,7 +166,7 @@ To access the Google Cloud Store Object Store, Google's cloud storage connector,
 
 Data source is available under the regular Google Storage URI structure: ``gs://<BUCKETNAME>/path/to/file`` For example,
 
-::
+.. code-block:: bash
 
     gs://mybucket/iris.csv
 
@@ -190,52 +192,109 @@ core-site.xml must be configured for at least the following properties (class, p
     </configuration>
 
 
-Direct Hive import
+Direct Hive Import
 ~~~~~~~~~~~~~~~~~~
 
-H2O supports direct ingestion of data managed by Hive in Hadoop. This feature is available only when H2O is running as a Hadoop job. Internally H2O uses metadata in Hive Metastore database to determine the location and format of given Hive table. H2O then imports data directly from HDFS so limitations of supported formats mentioned above apply. Data from hive can pulled into H2O using ``import_hive_table`` function. H2O can read Hive table metadata two ways - either via direct Metastore access or via JDBC.
+H2O supports direct ingestion of data managed by Hive in Hadoop. This feature is available only when H2O is running as a Hadoop job. Internally H2O uses metadata in Hive Metastore database to determine the location and format of given Hive table. H2O then imports data directly from HDFS so limitations of supported formats mentioned above apply. Data from hive can pulled into H2O using ``import_hive_table`` function. H2O can read Hive table metadata two ways - either via direct Metastore access (preferred) or via JDBC. 
 
-Requirements:
+Requirements
+''''''''''''
 
-- Direct Metastore access - Hive jars and configuration must be present on H2O job classpath - either via adding it to yarn.application.classpath (or similar property for your resource manger of choice) or by adding Hive jars and configuration to libjars.
-- JDBC metadata access - Hive JDBC Driver must be on H2O job classpath. (See below for details about access Kerberized Hive via JDBC.)
 - The user running H2O must have read access to Hive and the files it manages.
 
-Limitations
+- For Direct Metastore access, the Hive jars and configuration must be present on H2O job classpath - either by adding it to yarn.application.classpath (or similar property for your resource manger of choice) or by adding Hive jars and configuration to libjars. Note that Direct Metastore access is the perferred method.
 
-- Imported table must be stored in a format supported by H2O. (See above.)
-- CSV - Hive table property ``skip.header.line.count`` is currently not supported, CSV files with header rows will be imported with header row as data
-- Partitioned tables with different storage formats. H2O supports importing partitioned tables that use different storage formats for different partitions; however in some cases (for example large number of small partitions), H2O may run out of memory while importing even though the final data would easily fit into the memory allocated to the H2O cluster.
+- For JDBC metadata access, the Hive JDBC Driver must be on H2O job classpath.
+
+Limitations
+'''''''''''
+
+- The imported table must be stored in a :ref:`format supported by H2O<supported_file_formats>`. 
+- CSV: The Hive table property ``skip.header.line.count`` is currently not supported. CSV files with header rows will be imported with the header row as data.
+- Partitioned tables with different storage formats. H2O supports importing partitioned tables that use different storage formats for different partitions; however in some cases (for example large number of small partitions), H2O may run out of memory while importing, even though the final data would easily fit into the memory allocated to the H2O cluster.
+
+Importing Examples
+''''''''''''''''''
+
+Example 1: Access Metadata via Metastore (preferred)
+####################################################
 
 .. tabs::
+
    .. code-tab:: r R
 
+        # Add the Hive JDBC driver to H2O's classpath
+        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
 
+        # start the h2o.jar in R
+        library(h2o)
+        h2o.init(extra_classpath=["hive-jdbc-standalone.jar"])
+
+        # basic import
         basic_import <- h2o.import_hive_table("default", "table_name")
-        multi_format_enabled <- h2o.import_hive_table("default", "table_name", allow_multi_format=True)
-        with_partition_filter <- h2o.import_hive_table("default", "table_name", [["2017", "02"]])
 
-        # access metadata via JDBC
+        # multi-format import
+        multi_format_enabled <- h2o.import_hive_table("default", 
+                                                      "table_name", 
+                                                      allow_multi_format=True)
+
+        # import with partitioned filter
+        with_partition_filter <- h2o.import_hive_table("default", 
+                                                       "table_name", 
+                                                       [["2017", "02"]])
+
+   .. code-tab:: python
+
+        # Add the Hive JDBC driver to H2O's classpath
+        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
+
+        # start the h2o.jar in Python
+        import h2o
+        h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
+
+        # basic import
+        basic_import = h2o.import_hive_table("default", "table_name")
+
+        # multi-format import
+        multi_format_enabled = h2o.import_hive_table("default", 
+                                                     "table_name", 
+                                                     allow_multi_format=True)
+
+        # import with partitioned filter
+        with_partition_filter = h2o.import_hive_table("default", 
+                                                      "table_name", 
+                                                      [["2017", "02"]])
+
+
+Example 2: Access Metadata via JDBC
+###################################
+
+.. tabs::
+
+   .. code-tab:: r R
+
+        # Add the Hive JDBC driver to H2O's classpath
+        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
+
+        # start the h2o.jar in R
+        library(h2o)
+        h2o.init(extra_classpath=["hive-jdbc-standalone.jar"])
+
+        # basic import of metadata via JDBC
         basic_import <- h2o.import_hive_table("jdbc:hive2://hive-server:10000/default", "table_name")
-        # access metadata via Metastore
-        multi_format_enabled <- h2o.import_hive_table("default", "table_name", allow_multi_format=True)
-        with_partition_filter <- h2o.import_hive_table("default", "table_name", [["2017", "02"]])
 
 
    .. code-tab:: python
 
+        # Add the Hive JDBC driver to H2O's classpath
+        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
 
-        basic_import = h2o.import_hive_table("default", "table_name")
-        multi_format_enabled = h2o.import_hive_table("default", "table_name", allow_multi_format=True)
-        with_partition_filter = h2o.import_hive_table("default", "table_name", [["2017", "02"]])
+        # start the h2o.jar in Python
+        import h2o
+        h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
 
-        # access metadata via JDBC
+        # basic import of metadata via JDBC
         basic_import = h2o.import_hive_table("jdbc:hive2://hive-server:10000/default", "table_name")
-        # access metadata via Metastore
-        multi_format_enabled = h2o.import_hive_table("default", "table_name", allow_multi_format=True)
-        with_partition_filter = h2o.import_hive_table("default", "table_name", [["2017", "02"]])
-
-
 
 JDBC Databases
 ~~~~~~~~~~~~~~
@@ -247,6 +306,9 @@ Refer to the following articles for examples about using JDBC data sources with 
 - `Setup postgresql database on OSX <https://aichamp.wordpress.com/2017/03/20/setup-postgresql-database-on-osx/>`__
 - `Restoring DVD rental database into postgresql <https://aichamp.wordpress.com/2017/03/20/restoring-dvd-rental-database-into-postgresql/>`__
 - `Building H2O GLM model using Postgresql database and JDBC driver <https://aichamp.wordpress.com/2017/03/20/building-h2o-glm-model-using-postgresql-database-and-jdbc-driver/>`__
+
+**Note**: The handling of categorical values is different between file ingest and JDBC ingests. Te JDBC treats categorical values as Strings. Strings are not compressed in any way in H2O memory, and using the JDBC interface might need more memory and additional data post-processing (converting to categoricals explicitly).
+
 
 ``import_sql_table``
 ''''''''''''''''''''
@@ -333,42 +395,118 @@ The ``import_sql_select`` function accepts the following parameters:
 Using the Hive 2 JDBC Driver
 ''''''''''''''''''''''''''''
 
-H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O with the JDBC driver for your Hive version. 
+H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O with the JDBC driver for your Hive version. A demo showing how to ingest data from Hive through the Hive v2 JDBC driver is available `here <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/hive_jdbc_driver/Hive.md>`__. The basic steps are described below. 
 
-**Notes**: 
+**Note**: H2O can only load data from Hive version 2.2.0 or greater due to a limited implementation of the JDBC interface by Hive in earlier versions.
 
-- H2O can only load data from Hive version 2.2.0 or greater due to a limited implementation of the JDBC interface by Hive in earlier versions.
+1. Set up a table with data. 
 
-- This feature is still experimental. In addition, Hive2 support in H2O is not yet suitable for large datasets.
+    a. Retrieve the AirlinesTest dataset from `S3 <https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/AirlinesTest.csv.zip>`__.
 
-A demo showing how to ingest data from Hive through the Hive v2 JDBC driver is available `here <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/hive_jdbc_driver/Hive.md>`__. The basic steps are described below. 
+    b. Run the CLI client for Hive: 
 
-**Retrieve the Hive JDBC Client Jar**
+     .. code-block:: bash
 
-- For Hortonworks, Hive JDBC client jars can be found on one of the edge nodes after you have installed HDP: ``/usr/hdp/current/hive-client/lib/hive-jdbc-<version>-standalone.jar``. More information is available here: `https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.6.4/bk_data-access/content/hive-jdbc-odbc-drivers.html <https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.6.4/bk_data-access/content/hive-jdbc-odbc-drivers.html>`__
-- For Cloudera, install the JDBC package for your operating system, and then add ``/usr/lib/hive/lib/hive-jdbc-<version>-standalone.jar`` to your classpath. More information is available here: `https://www.cloudera.com/documentation/enterprise/5-3-x/topics/cdh_ig_hive_jdbc_install.html <https://www.cloudera.com/documentation/enterprise/5-3-x/topics/cdh_ig_hive_jdbc_install.html>`__
-- You can also retrieve this from Maven for the desire version using ``mvn dependency:get -Dartifact=groupId:artifactId:version``.
+       beeline -u jdbc:hive2://hive-host:10000/db-name
 
-**Provide H2O with the JDBC Driver**
+    c. Create the DB table:
 
-Add the Hive JDBC driver to H2O's classpath:
+     .. code-block:: bash
 
-::
-  
-      java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
+       CREATE EXTERNAL TABLE IF IT DOES NOT EXIST AirlinesTest(
+         fYear STRING ,
+         fMonth STRING ,
+         fDayofMonth STRING ,
+         fDayOfWeek STRING ,
+         DepTime INT ,
+         ArrTime INT ,
+         UniqueCarrier STRING ,
+         Origin STRING ,
+         Dest STRING ,
+         Distance INT ,
+         IsDepDelayed STRING ,
+         IsDepDelayed_REC INT
+       )
+           COMMENT 'test table'
+           ROW FORMAT DELIMITED
+           FIELDS TERMINATED BY ','
+           LOCATION '/tmp';
 
-Start the h2o.jar in the terminal with your downloaded JDBC driver in the classpath: 
+    d. Import the data from the dataset: 
 
-.. tabs::
-   .. code-tab:: r R
+    .. code-block:: bash
 
-        h2o.init(extra_classpath = "hive-jdbc.jar")
+      LOAD DATA INPATH '/tmp/AirlinesTest.csv' OVERWRITE INTO TABLE AirlinesTest
 
-   .. code-tab:: python
+2. Retrieve the Hive JDBC client jar.
 
-        h2o.init(extra_classpath=["hive-jdbc.jar"])
+  - For Hortonworks, Hive JDBC client jars can be found on one of the edge nodes after you have installed HDP: ``/usr/hdp/current/hive-client/lib/hive-jdbc-<version>-standalone.jar``. More information is available `here <https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.6.4/bk_data-access/content/hive-jdbc-odbc-drivers.html>`__.
+  - For Cloudera, install the JDBC package for your operating system, and then add ``/usr/lib/hive/lib/hive-jdbc-<version>-standalone.jar`` to your classpath. More information is available `here: <https://www.cloudera.com/documentation/enterprise/5-3-x/topics/cdh_ig_hive_jdbc_install.html>`__.
+  - You can also retrieve this from Maven for the desire version using ``mvn dependency:get -Dartifact=groupId:artifactId:version``.
 
-After the jar file with JDBC driver is added, then data from the Hive databases can be pulled into H2O using the aforementioned ``import_sql_table`` and ``import_sql_select`` functions. 
+3. Add the Hive JDBC driver to H2O's classpath, then start the h2o.jar in the terminal with your downloaded JDBC driver in the classpath
+
+ .. tabs::
+
+   .. group-tab:: R
+
+     .. code-block:: r
+
+        # Add the Hive JDBC driver to H2O's classpath
+        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
+
+        # start the h2o.jar in R
+        library(h2o)
+        h2o.init(extra_classpath=["hive-jdbc-standalone.jar"])
+
+   .. group-tab:: Python
+
+     .. code-block:: python
+
+        # Add the Hive JDBC driver to H2O's classpath
+        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
+
+        # start the h2o.jar in Python
+        import h2o
+        h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
+
+   .. group-tab:: Terminal
+
+     .. code-block:: bash
+
+        # Add the Hive JDBC driver to H2O's classpath for running clustered 
+        # H2O on Hadoop from terminal 
+        hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
+
+
+4. After the jar file with JDBC driver is added, then data from the Hive databases can be pulled into H2O using the aforementioned ``import_sql_table`` and ``import_sql_select`` functions. 
+
+ .. tabs::
+
+  .. code-tab:: r R
+
+    connection_url <- "jdbc:hive2://localhost:10000/default"
+    select_query <- "SELECT * FROM AirlinesTest;"
+    username <- "username"
+    password <- "changeit"
+
+    airlines_dataset <- h2o.import_sql_select(connection_url, 
+                                              select_query, 
+                                              username, 
+                                              password)
+
+  .. code-tab :: python
+
+    connection_url = "jdbc:hive2://localhost:10000/default"
+    select_query = "SELECT * FROM AirlinesTest;"
+    username = "username"
+    password = "changeit"
+
+    airlines_dataset = h2o.import_sql_select(connection_url, 
+                                             select_query, 
+                                             username, 
+                                             password)
+
 
 Connecting to Hive in a Kerberized Hadoop Cluster
 #################################################
@@ -404,7 +542,7 @@ Requirements:
 
 Example command:
 
-::
+.. code-block:: bash
 
       export HADOOP_CLASSPATH=/path/to/hive-jdbc-standalone.jar
       hadoop jar h2odriver.jar \
@@ -427,7 +565,7 @@ Requirements:
 
 Example command:
 
-::
+.. code-block:: bash
 
       hadoop jar h2odriver.jar [-libjars /path/to/hive-jdbc-standalone.jar] \
           -nodes 1 -mapperXmx 4G \
@@ -435,9 +573,7 @@ Example command:
           -pricipal user/host@DOMAIN.COM -keytab path/to/user.keytab \
           -refreshTokens
 
-**Note on refreshTokens:**
-
-The provided keytab will be copied over to the machine running the H2O Cluster leader node. For this reason, it’s strongly recommended that both YARN and HDFS be secured with encryption.
+**Note on refreshTokens:** The provided keytab will be copied over to the machine running the H2O Cluster leader node. For this reason, we strongly recommended that both YARN and HDFS be secured with encryption.
 
 Generating the Token in the Driver with Refresh in the Mapper
 #############################################################
@@ -454,7 +590,7 @@ Requirements:
 
 Example command:
 
-::
+.. code-block:: bash
 
       export HADOOP_CLASSPATH=/path/to/hive-jdbc-standalone.jar
       hadoop jar h2odriver.jar [-libjars /path/to/hive-jdbc-standalone.jar] \

--- a/h2o-docs/src/product/getting-data-into-h2o.rst
+++ b/h2o-docs/src/product/getting-data-into-h2o.rst
@@ -219,14 +219,30 @@ Importing Examples
 Example 1: Access Metadata via Metastore (preferred)
 ####################################################
 
-.. tabs::
+This example shows how to access metadata via the metastore. 
+
+1. Add the Hive JDBC driver to H2O's classpath.
+
+ .. code-block:: bash
+
+      # Add the Hive JDBC driver to H2O's classpath
+      java -cp hive-jdbc.jar:<path_to_h2o_jar> water.H2OApp
+
+
+2. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
+
+ .. code-block:: bash
+
+      # start the h2o.jar 
+      hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
+
+3. Initialize H2O in either R or Python and import data.
+
+ .. tabs::
 
    .. code-tab:: r R
 
-        # Add the Hive JDBC driver to H2O's classpath
-        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
-
-        # start the h2o.jar in R
+        # initialize h2o in R
         library(h2o)
         h2o.init(extra_classpath=["hive-jdbc-standalone.jar"])
 
@@ -238,17 +254,14 @@ Example 1: Access Metadata via Metastore (preferred)
                                                       "table_name", 
                                                       allow_multi_format=True)
 
-        # import with partitioned filter
+        # import with partition filter
         with_partition_filter <- h2o.import_hive_table("default", 
                                                        "table_name", 
                                                        [["2017", "02"]])
 
    .. code-tab:: python
 
-        # Add the Hive JDBC driver to H2O's classpath
-        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
-
-        # start the h2o.jar in Python
+        # initialize h2o in Python
         import h2o
         h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
 
@@ -260,7 +273,7 @@ Example 1: Access Metadata via Metastore (preferred)
                                                      "table_name", 
                                                      allow_multi_format=True)
 
-        # import with partitioned filter
+        # import with partition filter
         with_partition_filter = h2o.import_hive_table("default", 
                                                       "table_name", 
                                                       [["2017", "02"]])
@@ -269,12 +282,28 @@ Example 1: Access Metadata via Metastore (preferred)
 Example 2: Access Metadata via JDBC
 ###################################
 
-.. tabs::
+This example shows how to access metadata via JDBC.  
+
+1. Add the Hive JDBC driver to H2O's classpath.
+
+ .. code-block:: bash
+
+      # Add the Hive JDBC driver to H2O's classpath
+      java -cp hive-jdbc.jar:<path_to_h2o_jar> water.H2OApp
+
+
+2. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
+
+ .. code-block:: bash
+
+      # start the h2o.jar 
+      hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
+
+3. Initialize H2O in either R or Python and import data.
+
+ .. tabs::
 
    .. code-tab:: r R
-
-        # Add the Hive JDBC driver to H2O's classpath
-        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
 
         # start the h2o.jar in R
         library(h2o)
@@ -285,9 +314,6 @@ Example 2: Access Metadata via JDBC
 
 
    .. code-tab:: python
-
-        # Add the Hive JDBC driver to H2O's classpath
-        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
 
         # start the h2o.jar in Python
         import h2o
@@ -401,42 +427,42 @@ H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O w
 
 1. Set up a table with data. 
 
-    a. Retrieve the AirlinesTest dataset from `S3 <https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/AirlinesTest.csv.zip>`__.
+  a. Retrieve the AirlinesTest dataset from `S3 <https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/AirlinesTest.csv.zip>`__.
 
-    b. Run the CLI client for Hive: 
+  b. Run the CLI client for Hive: 
 
-     .. code-block:: bash
+   .. code-block:: bash
 
-       beeline -u jdbc:hive2://hive-host:10000/db-name
+     beeline -u jdbc:hive2://hive-host:10000/db-name
 
-    c. Create the DB table:
+  c. Create the DB table:
 
-     .. code-block:: bash
+   .. code-block:: sql
 
-       CREATE EXTERNAL TABLE IF IT DOES NOT EXIST AirlinesTest(
-         fYear STRING ,
-         fMonth STRING ,
-         fDayofMonth STRING ,
-         fDayOfWeek STRING ,
-         DepTime INT ,
-         ArrTime INT ,
-         UniqueCarrier STRING ,
-         Origin STRING ,
-         Dest STRING ,
-         Distance INT ,
-         IsDepDelayed STRING ,
-         IsDepDelayed_REC INT
-       )
-           COMMENT 'test table'
-           ROW FORMAT DELIMITED
-           FIELDS TERMINATED BY ','
-           LOCATION '/tmp';
+     CREATE EXTERNAL TABLE IF IT DOES NOT EXIST AirlinesTest(
+       fYear STRING ,
+       fMonth STRING ,
+       fDayofMonth STRING ,
+       fDayOfWeek STRING ,
+       DepTime INT ,
+       ArrTime INT ,
+       UniqueCarrier STRING ,
+       Origin STRING ,
+       Dest STRING ,
+       Distance INT ,
+       IsDepDelayed STRING ,
+       IsDepDelayed_REC INT
+     )
+         COMMENT 'test table'
+         ROW FORMAT DELIMITED
+         FIELDS TERMINATED BY ','
+         LOCATION '/tmp';
 
-    d. Import the data from the dataset: 
+  d. Import the data from the dataset. Note that the file must be present on HDFS in /tmp.
 
-    .. code-block:: bash
+   .. code-block:: sql
 
-      LOAD DATA INPATH '/tmp/AirlinesTest.csv' OVERWRITE INTO TABLE AirlinesTest
+     LOAD DATA INPATH '/tmp/AirlinesTest.csv' OVERWRITE INTO TABLE AirlinesTest
 
 2. Retrieve the Hive JDBC client jar.
 
@@ -444,7 +470,22 @@ H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O w
   - For Cloudera, install the JDBC package for your operating system, and then add ``/usr/lib/hive/lib/hive-jdbc-<version>-standalone.jar`` to your classpath. More information is available `here: <https://www.cloudera.com/documentation/enterprise/5-3-x/topics/cdh_ig_hive_jdbc_install.html>`__.
   - You can also retrieve this from Maven for the desire version using ``mvn dependency:get -Dartifact=groupId:artifactId:version``.
 
-3. Add the Hive JDBC driver to H2O's classpath, then start the h2o.jar in the terminal with your downloaded JDBC driver in the classpath
+3. Add the Hive JDBC driver to H2O's classpath.
+
+ .. code-block:: bash
+
+        # Add the Hive JDBC driver to H2O's classpath
+        java -cp hive-jdbc.jar:<path_to_h2o_jar> water.H2OApp
+
+
+4. Start the H2O jar in the terminal with your downloaded Hive JDBC driver in the classpath
+
+ .. code-block:: bash
+
+        # start the h2o.jar 
+        hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
+
+5. Initialize H2O in either R or Python and import data.
 
  .. tabs::
 
@@ -452,10 +493,7 @@ H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O w
 
      .. code-block:: r
 
-        # Add the Hive JDBC driver to H2O's classpath
-        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
-
-        # start the h2o.jar in R
+        # initialize h2o in R
         library(h2o)
         h2o.init(extra_classpath=["hive-jdbc-standalone.jar"])
 
@@ -463,23 +501,12 @@ H2O can ingest data from Hive through the Hive v2 JDBC driver by providing H2O w
 
      .. code-block:: python
 
-        # Add the Hive JDBC driver to H2O's classpath
-        java -cp hive-jdbc.jar:<path_to_h2o_jar>: water.H2OApp
-
-        # start the h2o.jar in Python
+        # initialize h2o in Python
         import h2o
         h2o.init(extra_classpath = ["hive-jdbc-standalone.jar"])
 
-   .. group-tab:: Terminal
 
-     .. code-block:: bash
-
-        # Add the Hive JDBC driver to H2O's classpath for running clustered 
-        # H2O on Hadoop from terminal 
-        hadoop jar h2odriver.jar -libjars hive-jdbc-standalone.jar -nodes 3 -mapperXmx 6g
-
-
-4. After the jar file with JDBC driver is added, then data from the Hive databases can be pulled into H2O using the aforementioned ``import_sql_table`` and ``import_sql_select`` functions. 
+6. After the jar file with JDBC driver is added, then data from the Hive databases can be pulled into H2O using the aforementioned ``import_sql_table`` and ``import_sql_select`` functions. 
 
  .. tabs::
 


### PR DESCRIPTION
- Noted that Direct metatore access is the preferred method for import Hive tables over JDBC
- Updated examples
- prettified code using code-block:: bash instead of ::