### PR TITLE
PUBDEV-7089 Add info message instead of NPE in case of wrong usage of P…

### DIFF
--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -44,10 +44,14 @@ public class PrintMojo implements MojoPrinter {
           mojoPrinter = printer;
         }
       }
+      if (mojoPrinter == null) {
+        System.out.println("No supported MojoPrinter for format required found. Please make sure you are using h2o-genmodel.jar for executing this tool.");
+        System.exit(1);
+      }
     } else {
       mojoPrinter = new PrintMojo();
     }
-    
+
     // Parse command line arguments
     mojoPrinter.parseArgs(args);
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PrintMojo.java
@@ -45,7 +45,7 @@ public class PrintMojo implements MojoPrinter {
         }
       }
       if (mojoPrinter == null) {
-        System.out.println("No supported MojoPrinter for format required found. Please make sure you are using h2o-genmodel.jar for executing this tool.");
+        System.out.println("No supported MojoPrinter for the format required found. Please make sure you are using h2o-genmodel.jar for executing this tool.");
         System.exit(1);
       }
     } else {


### PR DESCRIPTION
In case you try to execute PrintMojo with --format png by using h2o.jar instead of h2o-genmodel.jar, ServiceLoader doesn't see JgraphtPrintMojo class and hence PrintMojo is not able to find mojoPrinter which supports required .png format. This produces NPE and it looks like the tool doesn't work. After this change, instead of printing NPE it will print informative message: "No supported MojoPrinter for the format required found. Please make sure you are using h2o-genmodel.jar for executing this tool."