### PR TITLE
[PUBDEV-7465] add option to run xgboost on secured cluster (#4532)

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -262,6 +262,9 @@ final public class H2O {
     /** -internal_security_enabled is a boolean that indicates if internal communication paths are secured*/
     public boolean internal_security_enabled = false;
 
+    /** -allow_insecure_xgboost is a boolean that allows xgboost to run in a secured cluster */
+    public boolean allow_insecure_xgboost;
+
     /** -decrypt_tool specifies the DKV key where a default decrypt tool will be installed*/
     public String decrypt_tool = null;
 
@@ -699,6 +702,9 @@ final public class H2O {
       }
       else if (s.matches("internal_security_conf_rel_paths")) {
         trgt.internal_security_conf_rel_paths = true;
+      }
+      else if (s.matches("allow_insecure_xgboost")) {
+        trgt.allow_insecure_xgboost = true;
       }
       else if (s.matches("decrypt_tool")) {
         i = s.incrementAndCheck(i, args);

--- a/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/tree/xgboost/XGBoost.java
@@ -100,8 +100,10 @@ public class XGBoost extends ModelBuilder<XGBoostModel,XGBoostModel.XGBoostParam
   @Override public void init(boolean expensive) {
     super.init(expensive);
     if (H2O.CLOUD.size() > 1) {
-      if(H2O.SELF.getSecurityManager().securityEnabled) {
+      if (H2O.SELF.getSecurityManager().securityEnabled && !H2O.ARGS.allow_insecure_xgboost) {
         throw new H2OIllegalArgumentException("Cannot run XGBoost on an SSL enabled cluster larger than 1 node. XGBoost does not support SSL encryption.");
+      } else {
+        Log.info("Executing XGBoost on an secured cluster might compromise security.");
       }
     }
     if (H2O.ARGS.client && _parms._build_tree_one_node)

--- a/h2o-hadoop-common/tests/python/pyunit_xgboost_smoke.py
+++ b/h2o-hadoop-common/tests/python/pyunit_xgboost_smoke.py
@@ -1,0 +1,24 @@
+#! /usr/env/python
+import sys
+import os
+sys.path.insert(1, os.path.join("../../../h2o-py"))
+from tests import pyunit_utils
+import h2o
+from h2o.estimators import H2OXGBoostEstimator
+
+def xgb_smoke():
+  df = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+  train = df.drop("ID")
+  vol = train['VOL']
+  vol[vol == 0] = None
+  gle = train['GLEASON']
+  gle[gle == 0] = None
+  train['CAPSULE'] = train['CAPSULE'].asfactor()
+  xgb = H2OXGBoostEstimator(ntrees=10, learn_rate=0.1)
+  xgb.train(x=list(range(1, train.ncol)), y="CAPSULE", training_frame=train)
+  xgb.predict(train)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(xgb_smoke)
+else:
+    xgb_smoke()

--- a/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
+++ b/h2o-mapreduce-generic/src/main/java/water/hadoop/h2odriver.java
@@ -110,6 +110,7 @@ public class h2odriver extends Configured implements Tool {
   static String jksAlias = null;
   static String securityConf = null;
   static boolean internal_secure_connections = false;
+  static boolean allow_insecure_xgboost = false;
   static boolean hashLogin = false;
   static boolean ldapLogin = false;
   static boolean kerberosLogin = false;
@@ -1190,6 +1191,9 @@ public class h2odriver extends Configured implements Tool {
         i++; if (i >= args.length) { usage(); }
         securityConf = args[i];
       }
+      else if (s.equals("-allow_insecure_xgboost")) {
+        allow_insecure_xgboost = true;
+      }
       else if (s.equals("-hash_login")) {
         hashLogin = true;
       }
@@ -1861,6 +1865,9 @@ public class h2odriver extends Configured implements Tool {
       securityConf = SecurityUtils.generateSSLConfig(credentials);
       addMapperConf(conf, "", credentials.jks.name, credentials.jks.getLocation());
       addMapperConf(conf, "-internal_security_conf", "default-security.config", securityConf);
+    }
+    if (allow_insecure_xgboost) {
+      addMapperArg(conf, "-allow_insecure_xgboost");
     }
 
     conf.set(h2omapper.H2O_MAPPER_CONF_LENGTH, Integer.toString(mapperConfLength));

--- a/scripts/jenkins/groovy/hadoopCommands.groovy
+++ b/scripts/jenkins/groovy/hadoopCommands.groovy
@@ -21,7 +21,7 @@ private GString getCommandHadoop(final stageConfig) {
             hadoop jar h2o-hadoop-*/h2o-${stageConfig.customData.distribution}${stageConfig.customData.version}-assembly/build/libs/h2odriver.jar \\
                 -disable_flow \\
                 -n 1 -mapperXmx 2g -baseport 54445 -timeout 300 \\
-                -internal_secure_connections \\
+                -internal_secure_connections -allow_insecure_xgboost \\
                 -jks mykeystore.jks \\
                 -notify h2o_one_node \\
                 -flatfile flatfile.lst \\


### PR DESCRIPTION
There was a key leak in `GroupByTest` class in nightlies. Probably due to a cluster shutdown in the middle of some other test. As `ZGroupByMedianTest`, I'm annotating this one with H2ORunner for better key leak detection as well. 

Goal is to have better error propagation and key leak detection with more precise output in the future, if that happens again.