### PR TITLE
PUBDEV-7446 - Throw error when https is true on h2o.init() while starting local cluster

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -294,6 +294,8 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
         if not start_h2o: raise
         if ip and not (ip == "localhost" or ip == "127.0.0.1"):
             raise H2OConnectionError('Can only start H2O launcher if IP address is localhost.')
+        if https:
+            raise H2OConnectionError('Unable to start local server with https enabled. Consider disabling https.')
         hs = H2OLocalServer.start(nthreads=nthreads, enable_assertions=enable_assertions, max_mem_size=mmax,
                                   min_mem_size=mmin, ice_root=ice_root, log_dir=log_dir, log_level=log_level,
                                   max_log_file_size=max_log_file_size, port=port, name=name,

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -295,8 +295,9 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
         if ip and not (ip == "localhost" or ip == "127.0.0.1"):
             raise H2OConnectionError('Can only start H2O launcher if IP address is localhost.')
         if https:
-            raise H2OConnectionError('Unable to start local server with https enabled. Consider disabling https or'
-                                     'start H2O manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start).')
+            raise H2OConnectionError('Starting local server is not available with https enabled. You may start local'
+                                     ' instance of H2O with https manually '
+                                     '(http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start).')
         hs = H2OLocalServer.start(nthreads=nthreads, enable_assertions=enable_assertions, max_mem_size=mmax,
                                   min_mem_size=mmin, ice_root=ice_root, log_dir=log_dir, log_level=log_level,
                                   max_log_file_size=max_log_file_size, port=port, name=name,

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -295,7 +295,8 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
         if ip and not (ip == "localhost" or ip == "127.0.0.1"):
             raise H2OConnectionError('Can only start H2O launcher if IP address is localhost.')
         if https:
-            raise H2OConnectionError('Unable to start local server with https enabled. Consider disabling https.')
+            raise H2OConnectionError('Unable to start local server with https enabled. Consider disabling https or'
+                                     'start H2O manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start).')
         hs = H2OLocalServer.start(nthreads=nthreads, enable_assertions=enable_assertions, max_mem_size=mmax,
                                   min_mem_size=mmin, ice_root=ice_root, log_dir=log_dir, log_level=log_level,
                                   max_log_file_size=max_log_file_size, port=port, name=name,

--- a/h2o-py/tests/testdir_misc/pyunit_init_https.py
+++ b/h2o-py/tests/testdir_misc/pyunit_init_https.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+from h2o.exceptions import H2OConnectionError
+
+def test_https_startup():
+    try:
+        h2o.init(ip = "127.0.0.1", port="12345", https=True)  # Port 12345 is used, as 54321 is expected to be occupied
+        assert False, "Expected to fail starting local H2O server with https=true"
+    except H2OConnectionError as err:
+        print(err)  # HTTPS is not allowed during localhost startup
+        assert "Unable to start local server with https enabled. Consider disabling https." == str(err)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_https_startup)
+else:
+    test_https_startup()

--- a/h2o-py/tests/testdir_misc/pyunit_init_https.py
+++ b/h2o-py/tests/testdir_misc/pyunit_init_https.py
@@ -12,7 +12,7 @@ def test_https_startup():
         assert False, "Expected to fail starting local H2O server with https=true"
     except H2OConnectionError as err:
         print(err)  # HTTPS is not allowed during localhost startup
-        assert "Unable to start local server with https enabled. Consider disabling https." == str(err)
+        assert "Unable to start local server with https enabled. Consider disabling https orstart H2O manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)." == str(err)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_https_startup)

--- a/h2o-py/tests/testdir_misc/pyunit_init_https.py
+++ b/h2o-py/tests/testdir_misc/pyunit_init_https.py
@@ -12,7 +12,7 @@ def test_https_startup():
         assert False, "Expected to fail starting local H2O server with https=true"
     except H2OConnectionError as err:
         print(err)  # HTTPS is not allowed during localhost startup
-        assert "Unable to start local server with https enabled. Consider disabling https orstart H2O manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)." == str(err)
+        assert "Starting local server is not available with https enabled. You may start local instance of H2O with https manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)." == str(err)
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_https_startup)

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -193,8 +193,8 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
       cat("\nH2O is not running yet, starting it now...\n")
       
       if(isTRUE(https)){
-        stop(paste0("Unable to start local server with https enabled. ",
-         "Consider disabling https or start H2O manually ",
+        stop(paste0("Starting local server is not available with https enabled. ",
+         "You may start local instance of H2O with https manually ",
          "(http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)."))
       }
 

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -193,7 +193,9 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
       cat("\nH2O is not running yet, starting it now...\n")
       
       if(isTRUE(https)){
-        stop("Unable to start local server with https enabled. Consider disabling https.")
+        stop(paste0("Unable to start local server with https enabled. ",
+         "Consider disabling https or start H2O manually ",
+         "(http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)."))
       }
 
       if (nthreads == -2) {

--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -191,6 +191,10 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
       stop("Cannot connect to H2O server. Please check that H2O is running at ", h2o.getBaseURL(tmpConn))
     else if (ip == "localhost" || ip == "127.0.0.1") {
       cat("\nH2O is not running yet, starting it now...\n")
+      
+      if(isTRUE(https)){
+        stop("Unable to start local server with https enabled. Consider disabling https.")
+      }
 
       if (nthreads == -2) {
         warnNthreads <- TRUE

--- a/h2o-r/tests/testdir_misc/runit_init_https.R
+++ b/h2o-r/tests/testdir_misc/runit_init_https.R
@@ -1,0 +1,25 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+h2o_init_test <- function() {
+
+  
+  e <- tryCatch({
+    h2o.init(
+      strict_version_check = FALSE,
+      ip = "127.0.0.1",
+      port = 12345,
+      https = TRUE
+    )
+  }, error = function(x) x)
+  
+  expect_false(is.null(e))
+  print(e)
+  err_message <- e[[1]]
+  expect_true("Unable to start local server with https enabled. Consider disabling https." == err_message)
+}
+
+doTest("Error thrown when HTTPS is enabled on h2o.init() (local cluster)",
+       h2o_init_test)

--- a/h2o-r/tests/testdir_misc/runit_init_https.R
+++ b/h2o-r/tests/testdir_misc/runit_init_https.R
@@ -18,7 +18,7 @@ h2o_init_test <- function() {
   expect_false(is.null(e))
   print(e)
   err_message <- e[[1]]
-  expect_true("Unable to start local server with https enabled. Consider disabling https." == err_message)
+  expect_true("Unable to start local server with https enabled. Consider disabling https or start H2O manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)." == err_message)
 }
 
 doTest("Error thrown when HTTPS is enabled on h2o.init() (local cluster)",

--- a/h2o-r/tests/testdir_misc/runit_init_https.R
+++ b/h2o-r/tests/testdir_misc/runit_init_https.R
@@ -18,7 +18,7 @@ h2o_init_test <- function() {
   expect_false(is.null(e))
   print(e)
   err_message <- e[[1]]
-  expect_true("Unable to start local server with https enabled. Consider disabling https or start H2O manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)." == err_message)
+  expect_true("Starting local server is not available with https enabled. You may start local instance of H2O with https manually (http://docs.h2o.ai/h2o/latest-stable/h2o-docs/welcome.html#new-user-quick-start)." == err_message)
 }
 
 doTest("Error thrown when HTTPS is enabled on h2o.init() (local cluster)",


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7446

Only when the cluster does not exist and an attempt is made to locally start the cluster, throw an error if HTTPS is set to true.