### PR TITLE
Py Rapids expr: explicitly prevent creation of tmp frames for scalars

### DIFF
--- a/h2o-py/h2o/expr.py
+++ b/h2o-py/h2o/expr.py
@@ -104,7 +104,13 @@ class ExprNode(object):
         self._eval_driver('scalar')
         return self._cache
 
-    def _eval_driver(self, top=None):
+    def _eval_driver(self, top):
+        """
+        :param top: if this is a top expression (providing a final result),
+            then specifies the expected result type (accepted values = ['frame', 'scalar']),
+            or None if no object creation is expected.
+        :return: self expr
+        """
         exec_str = self._get_ast_str(top)
         res = ExprNode.rapids(exec_str)
         if 'scalar' in res:

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -924,7 +924,7 @@ def assign(data, xid):
     assert_is_type(xid, str)
     assert_satisfies(xid, xid != data.frame_id)
     check_frame_id(xid)
-    data._ex = ExprNode("assign", xid, data)._eval_driver(False)
+    data._ex = ExprNode("assign", xid, data)._eval_driver()
     data._ex._cache._id = xid
     data._ex._children = None
     return data
@@ -950,7 +950,7 @@ def deep_copy(data, xid):
     assert_satisfies(xid, xid != data.frame_id)
     check_frame_id(xid)
     duplicate = data.apply(lambda x: x)
-    duplicate._ex = ExprNode("assign", xid, duplicate)._eval_driver(False)
+    duplicate._ex = ExprNode("assign", xid, duplicate)._eval_driver()
     duplicate._ex._cache._id = xid
     duplicate._ex._children = None
     return duplicate

--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -924,7 +924,7 @@ def assign(data, xid):
     assert_is_type(xid, str)
     assert_satisfies(xid, xid != data.frame_id)
     check_frame_id(xid)
-    data._ex = ExprNode("assign", xid, data)._eval_driver()
+    data._ex = ExprNode("assign", xid, data)._eval_driver(None)
     data._ex._cache._id = xid
     data._ex._children = None
     return data
@@ -950,7 +950,7 @@ def deep_copy(data, xid):
     assert_satisfies(xid, xid != data.frame_id)
     check_frame_id(xid)
     duplicate = data.apply(lambda x: x)
-    duplicate._ex = ExprNode("assign", xid, duplicate)._eval_driver()
+    duplicate._ex = ExprNode("assign", xid, duplicate)._eval_driver(None)
     duplicate._ex._cache._id = xid
     duplicate._ex._children = None
     return duplicate

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_5180.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_5180.py
@@ -7,7 +7,7 @@ from tests import pyunit_utils
 def pubdev_5180():
 
     frame = h2o.create_frame(binary_fraction=1, binary_ones_fraction=0.5, missing_fraction=0, rows=1, cols=1)
-    exp_str = ExprNode("assign", 123456789123456789123456789, frame)._get_ast_str(False)
+    exp_str = ExprNode("assign", 123456789123456789123456789, frame)._get_ast_str()
     assert exp_str.find('123456789123456789L') == -1
 
 if __name__ == "__main__":


### PR DESCRIPTION
in Py client, prevent rapids expression to return a tmp frame when asking for a scalar (issue in debug mode)