### PR TITLE
Do not enfoce one common output dir for H2O-3 subprojects.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,6 @@ allprojects {
 
     // Support different IDEs
     apply plugin: 'idea'
-    idea.module.inheritOutputDirs = true
     apply plugin: 'eclipse'
     apply from: "$rootDir/gradle/artifacts.gradle"
 


### PR DESCRIPTION
Having a single output folder as a common source of truth is causing classpath issues. I believe this idea.module.inheritOutputDirs = true is an old switch for better Gradle support in older IDEAs. Per-module specific output is perfectly fine with 2019 and 2020 IDEA and resolves all the classpath issues.

E.g. there is no need to do this (see classpath of H2OApp) - screenshot by @honzasterba :

<img width="1071" alt="Screenshot 2020-04-30 at 22 01 50" src="https://user-images.githubusercontent.com/8769110/80788548-b57efc00-8b89-11ea-9e2d-112a15daea93.png">


**Please give this branch a try locally.**