### PR TITLE
PUBDEV-7491: Enable using quantile and other distributions in SE

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -73,8 +73,8 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
       setCommonParams(builder._parms);
       setCrossValidationParams(builder._parms);
       setCustomParams(builder._parms);
-
       validateParams(builder._parms);
+      prepareModel(builder._parms);
 
       builder.init(false);
       Job<M> j = builder.trainModel();
@@ -129,6 +129,8 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
   protected void setCustomParams(P parms) { }
 
   protected void validateParams(P parms) { }
+
+  protected void prepareModel(P parms) {}
 
   protected void cleanup() {
     if (!_parms._keep_base_model_predictions) {

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearner.java
@@ -73,8 +73,8 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
       setCommonParams(builder._parms);
       setCrossValidationParams(builder._parms);
       setCustomParams(builder._parms);
+
       validateParams(builder._parms);
-      prepareModel(builder._parms);
 
       builder.init(false);
       Job<M> j = builder.trainModel();
@@ -88,6 +88,8 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
       Log.info("Finished training metalearner model(" + _model._parms._metalearner_algorithm + ").");
 
       _model._output._metalearner = builder.get();
+      _model._dist = _model._output._metalearner._dist;
+
       _model.doScoreOrCopyMetrics(_job);
 
       if (_parms._keep_levelone_frame) {
@@ -129,8 +131,6 @@ public abstract class Metalearner<B extends ModelBuilder<M, P, ?>, M extends Mod
   protected void setCustomParams(P parms) { }
 
   protected void validateParams(P parms) { }
-
-  protected void prepareModel(P parms) {}
 
   protected void cleanup() {
     if (!_parms._keep_base_model_predictions) {

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -135,10 +135,15 @@ public class Metalearners {
 
                 parms._distribution = distribution;
             }
-            _model._dist = DistributionFactory.getDistribution(parms);
+        }
+
+        @Override
+        protected void prepareModel(Model.Parameters parms) {
+            super.prepareModel(parms);
+            // Create _dist based on potentially coerced _distribution param from validateParams
+          //  _model._dist = DistributionFactory.getDistribution(parms);
         }
     }
-
 
     static class DLMetalearner extends MetalearnerWithDistribution {
         public DLMetalearner() {

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -141,7 +141,7 @@ public class Metalearners {
         protected void prepareModel(Model.Parameters parms) {
             super.prepareModel(parms);
             // Create _dist based on potentially coerced _distribution param from validateParams
-          //  _model._dist = DistributionFactory.getDistribution(parms);
+            _model._dist = DistributionFactory.getDistribution(parms);
         }
     }
 

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -100,11 +100,63 @@ public class Metalearners {
         ModelBuilder createBuilder() {
             return ModelBuilder.make(_algo, _metalearnerJob, _metalearnerKey);
         }
+
+        @Override
+        protected void setCustomParams(Model.Parameters parms) {
+            super.setCustomParams(parms);
+            switch (_parms._distribution) {
+                case bernoulli:
+                case quasibinomial:
+                case multinomial:
+                case poisson:
+                case laplace:
+                case gaussian:
+                case gamma:
+                    setOverridableParm(parms, "distribution", _parms._distribution);
+                    break;
+                case huber:
+                    setOverridableParm(parms, "distribution", _parms._distribution);
+                    setOverridableParm(parms, "huber_alpha", _parms._huber_alpha);
+                    break;
+                case tweedie:
+                    setOverridableParm(parms, "distribution", _parms._distribution);
+                    setOverridableParm(parms, "tweedie_power", _parms._tweedie_power);
+                    break;
+                case quantile:
+                    setOverridableParm(parms, "distribution", _parms._distribution);
+                    setOverridableParm(parms, "quantile_alpha", _parms._quantile_alpha);
+                    break;
+                case custom:
+                    setOverridableParm(parms, "distribution", _parms._distribution);
+                    setOverridableParm(parms, "custom_distribution_func", _parms._custom_distribution_func);
+                    break;
+                default:
+                    throw new H2OIllegalArgumentException("Metalearner doesn't support distribution \""
+                            .concat(_parms._distribution.name())
+                            .concat("\". Please specify desired distribution manually in metalearner_params."));
+            }
+        }
     }
 
     static class DLMetalearner extends SimpleMetalearner {
         public DLMetalearner() {
             super(Algorithm.deeplearning.name());
+        }
+
+        @Override
+        protected void setCustomParams(Model.Parameters parms) {
+            switch (_parms._distribution) {
+                case custom:
+                case quasibinomial:
+                case ordinal:
+                case modified_huber:
+                    throw new H2OIllegalArgumentException("Deep Learning metalearner doesn't support inferred distribution \""
+                            .concat(_parms._distribution.name())
+                            .concat("\". Please specify desired distribution manually in metalearner_params."));
+                case AUTO:
+                    return;
+            }
+            super.setCustomParams(parms);
         }
     }
 
@@ -112,11 +164,30 @@ public class Metalearners {
         public DRFMetalearner() {
             super(Algorithm.drf.name());
         }
+
+        @Override
+        protected void setCustomParams(Model.Parameters parms) {
+            return;
+        }
     }
 
     static class GBMMetalearner extends SimpleMetalearner {
         public GBMMetalearner() {
             super(Algorithm.gbm.name());
+        }
+
+        @Override
+        protected void setCustomParams(Model.Parameters parms) {
+            switch (_parms._distribution) {
+                case ordinal:
+                case modified_huber:
+                    throw new H2OIllegalArgumentException("GBM metalearner doesn't support inferred distribution \""
+                            .concat(_parms._distribution.name())
+                            .concat("\". Please specify desired distribution manually in metalearner_params."));
+                case AUTO:
+                    return;
+            }
+            super.setCustomParams(parms);
         }
     }
 
@@ -128,21 +199,51 @@ public class Metalearners {
 
         @Override
         protected void setCustomParams(GLMParameters parms) {
-            if (_model.modelCategory == ModelCategory.Regression) {
-                parms._family = GLMParameters.Family.gaussian;
-            } else if (_model.modelCategory == ModelCategory.Binomial) {
-                parms._family = GLMParameters.Family.binomial;
-            } else if (_model.modelCategory == ModelCategory.Multinomial) {
-                parms._family = GLMParameters.Family.multinomial;
-            } else {
-                throw new H2OIllegalArgumentException("Family " + _model.modelCategory + "  is not supported.");
+            switch (_parms._distribution) {
+                case gaussian:
+                    setOverridableParm(parms, "family", GLMParameters.Family.gaussian);
+                    break;
+                case bernoulli:
+                    setOverridableParm(parms, "family", GLMParameters.Family.binomial);
+                    break;
+                case ordinal:
+                    setOverridableParm(parms, "family", GLMParameters.Family.ordinal);
+                    break;
+                case quasibinomial:
+                    setOverridableParm(parms, "family", GLMParameters.Family.quasibinomial);
+                    break;
+                case multinomial:
+                    setOverridableParm(parms, "family", GLMParameters.Family.multinomial);
+                    break;
+                case poisson:
+                    setOverridableParm(parms, "family", GLMParameters.Family.poisson);
+                    break;
+                case gamma:
+                    setOverridableParm(parms, "family", GLMParameters.Family.gamma);
+                    break;
+                case tweedie:
+                    setOverridableParm(parms, "family", GLMParameters.Family.tweedie);
+                    setOverridableParm(parms, "tweedie_power", _parms._tweedie_power);
+                    break;
+                case AUTO:
+                    break;
+                default:
+                    throw new H2OIllegalArgumentException("GLM metalearner doesn't support inferred distribution \""
+                            .concat(_parms._distribution.name())
+                            .concat("\". Please specify desired family and link manually in metalearner_params."));
             }
+
         }
     }
 
     static class NaiveBayesMetalearner extends SimpleMetalearner {
         public NaiveBayesMetalearner() {
             super(Algorithm.naivebayes.name());
+        }
+
+        @Override
+        protected void setCustomParams(Model.Parameters parms) {
+            return;
         }
     }
 
@@ -154,19 +255,19 @@ public class Metalearners {
             super.setCustomParams(parms);
 
             //specific to AUTO mode
-            parms._non_negative = true;
+            setOverridableParm(parms, "non_negative", true);
             //parms._alpha = new double[] {0.0, 0.25, 0.5, 0.75, 1.0};
 
             // feature columns are already homogeneous (probabilities); when standardization is enabled,
             // there can be information loss if some columns have very low probabilities compared with others for example (bad model)
             // giving more weight than it should to those columns.
-            parms._standardize = false;
+            setOverridableParm(parms,"standardize",false);
 
             // Enable lambda search if a validation frame is passed in to get a better GLM fit.
             // Since we are also using non_negative to true, we should also set early_stopping = false.
             if (parms._valid != null) {
-                parms._lambda_search = true;
-                parms._early_stopping = false;
+                setOverridableParm(parms, "lambda_search", true);
+                setOverridableParm(parms, "early_stopping", false);
             }
         }
     }

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -136,13 +136,6 @@ public class Metalearners {
                 parms._distribution = distribution;
             }
         }
-
-        @Override
-        protected void prepareModel(Model.Parameters parms) {
-            super.prepareModel(parms);
-            // Create _dist based on potentially coerced _distribution param from validateParams
-            _model._dist = DistributionFactory.getDistribution(parms);
-        }
     }
 
     static class DLMetalearner extends MetalearnerWithDistribution {

--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -1,5 +1,6 @@
 package hex.ensemble;
 
+import hex.DistributionFactory;
 import hex.Model;
 import hex.ModelBuilder;
 import hex.ensemble.Metalearner.Algorithm;
@@ -134,6 +135,7 @@ public class Metalearners {
 
                 parms._distribution = distribution;
             }
+            _model._dist = DistributionFactory.getDistribution(parms);
         }
     }
 

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -316,7 +316,8 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
                 metalearnerJob,
                 _parms,
                 hasMetaLearnerParams,
-                metalearnerSeed
+                metalearnerSeed,
+                _parms._metalearner_parameters_user_override
         );
         metalearner.compute();
       } else {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -4,6 +4,7 @@ import hex.Model;
 import hex.ModelBuilder;
 import hex.ModelCategory;
 
+import hex.genmodel.utils.DistributionFamily;
 import hex.grid.Grid;
 import water.DKV;
 import water.Job;
@@ -72,6 +73,10 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
   @Override
   public void init(boolean expensive) {
     super.init(expensive);
+
+    if (_parms._distribution != DistributionFamily.AUTO) {
+      throw new H2OIllegalArgumentException("Setting \"distribution\" to StackedEnsemble is unsupported. Please set it in \"metalearner_parameters\".");
+    }
 
     checkFoldColumnPresent(_parms._metalearner_fold_column, train(), valid(), _parms.blending());
     validateAndExpandBaseModels();

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsemble.java
@@ -316,8 +316,7 @@ public class StackedEnsemble extends ModelBuilder<StackedEnsembleModel,StackedEn
                 metalearnerJob,
                 _parms,
                 hasMetaLearnerParams,
-                metalearnerSeed,
-                _parms._metalearner_parameters_user_override
+                metalearnerSeed
         );
         metalearner.compute();
       } else {

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -360,6 +360,8 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
           Log.warn("Stacked Ensemble is not able to inherit distribution from GLM's family " + ((GLMModel.GLMParameters) parms)._family + ".");
         }
       }
+    } else if (parms instanceof DRFModel.DRFParameters) {
+      inferBasicDistribution();
     } else {
       _parms._distribution = parms._distribution;
     }

--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -150,7 +150,6 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
         Frame.deleteTempFrameAndItsNonSharedVecs(baseModelPredictions[i], levelOneFrame);
       }
     }
-
     // Add response column to level one frame
     levelOneFrame.add(this.responseColumn, adaptFrm.vec(this.responseColumn));
     
@@ -426,10 +425,13 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
       parms._link = GLMModel.GLMParameters.Link.family_default;
       if (this._output.isBinomialClassifier()) {
          parms._family = GLMModel.GLMParameters.Family.binomial;
+         _parms._distribution = DistributionFamily.bernoulli;
       } else if (this._output.isClassifier()) {
         parms._family = GLMModel.GLMParameters.Family.multinomial;
+        _parms._distribution = DistributionFamily.multinomial;
       } else {
         parms._family = GLMModel.GLMParameters.Family.gaussian;
+        _parms._distribution = DistributionFamily.gaussian;
       }
     }
   }

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -23,11 +23,7 @@ import water.api.schemas3.FrameV3;
 import com.google.gson.Gson;
 import water.fvec.Frame;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-
+import java.util.*;
 
 
 public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,StackedEnsembleV99,StackedEnsembleV99.StackedEnsembleParametersV99> {
@@ -134,10 +130,12 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       
       if (metalearner_params != null && !metalearner_params.isEmpty()) {
         Properties p = new Properties();
-        
+
         HashMap<String, String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>() {
         }.getType());
+        impl._metalearner_parameters_user_override = new HashSet<>(map.size());
         for (Map.Entry<String, String[]> param : map.entrySet()) {
+          impl._metalearner_parameters_user_override.add(param.getKey());
           String[] paramVal = param.getValue();
           if (paramVal.length == 1) {
             p.setProperty(param.getKey(), paramVal[0]);

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -1,7 +1,6 @@
 package hex.schemas;
 
 import com.google.gson.reflect.TypeToken;
-import hex.ensemble.Metalearner;
 import hex.ensemble.Metalearner.Algorithm;
 import hex.ensemble.StackedEnsemble;
 import hex.ensemble.StackedEnsembleModel;
@@ -133,9 +132,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
 
         HashMap<String, String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>() {
         }.getType());
-        impl._metalearner_parameters_user_override = new HashSet<>(map.size());
         for (Map.Entry<String, String[]> param : map.entrySet()) {
-          impl._metalearner_parameters_user_override.add(param.getKey());
           String[] paramVal = param.getValue();
           if (paramVal.length == 1) {
             p.setProperty(param.getKey(), paramVal[0]);
@@ -151,6 +148,9 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
           case glm:
             paramsSchema = new GLMV3.GLMParametersV3();
             params = new GLMModel.GLMParameters();
+            // FIXME: This is here because there is no Family.AUTO. It enables us to know if the user specified family or not.
+            // FIXME: Family.AUTO will be implemented in https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7444
+            ((GLMModel.GLMParameters) params)._family = null;
             break;
           case gbm:
             paramsSchema = new GBMV3.GBMParametersV3();

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -22,7 +22,11 @@ import water.api.schemas3.FrameV3;
 import com.google.gson.Gson;
 import water.fvec.Frame;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 
 
 public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,StackedEnsembleV99,StackedEnsembleV99.StackedEnsembleParametersV99> {
@@ -129,7 +133,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       
       if (metalearner_params != null && !metalearner_params.isEmpty()) {
         Properties p = new Properties();
-
+        
         HashMap<String, String[]> map = new Gson().fromJson(metalearner_params, new TypeToken<HashMap<String, String[]>>() {
         }.getType());
         for (Map.Entry<String, String[]> param : map.entrySet()) {

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -1159,4 +1159,252 @@ public class StackedEnsembleTest extends TestUtil {
       }
     }
   }
+
+  @Test
+  public void testCanInferFromBaseModelsDistribution() {
+    List<Lockable> deletables = new ArrayList<>();
+    try {
+      final int seed = 1;
+      final Frame train = parse_test_file("./smalldata/testng/prostate_train.csv");
+      deletables.add(train);
+      final Frame test = parse_test_file("./smalldata/testng/prostate_test.csv");
+      deletables.add(test);
+      final String target = "CAPSULE";
+      int target_idx = train.find(target);
+      train.replace(target_idx, train.vec(target_idx).toCategoricalVec()).remove();
+      DKV.put(train);
+      test.remove(target_idx).remove();
+      DKV.put(test);
+
+      GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+      params._train = train._key;
+      params._response_column = target;
+      params._seed = seed;
+      params._keep_cross_validation_models = false;
+      params._keep_cross_validation_predictions = true;
+      params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+      params._nfolds = 3;
+      params._distribution = DistributionFamily.bernoulli;
+
+      Job<Grid> gridSearch = GridSearch.startGridSearch(null, params, new HashMap<String, Object[]>() {{
+        put("_ntrees", new Integer[]{3, 5});
+      }});
+      Grid grid = gridSearch.get();
+      deletables.add(grid);
+      Model[] gridModels = grid.getModels();
+      deletables.addAll(Arrays.asList(gridModels));
+      Assert.assertEquals(2, gridModels.length);
+
+      StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = train._key;
+      seParams._response_column = target;
+      seParams._base_models = ArrayUtils.append(grid.getModelKeys());
+      seParams._metalearner_algorithm = Algorithm.AUTO;
+      seParams._seed = seed;
+      StackedEnsembleModel se = new StackedEnsemble(seParams).trainModel().get();
+      deletables.add(se);
+
+      Assert.assertTrue(((GLMModel.GLMParameters) se._output._metalearner._parms)._family == GLMModel.GLMParameters.Family.binomial);
+
+      StackedEnsembleParameters seParams2 = new StackedEnsembleParameters();
+      seParams2._train = train._key;
+      seParams2._response_column = target;
+      seParams2._base_models = ArrayUtils.append(grid.getModelKeys());
+      seParams2._metalearner_algorithm = Algorithm.gbm;
+      seParams2._seed = seed;
+      StackedEnsembleModel se2 = new StackedEnsemble(seParams2).trainModel().get();
+      deletables.add(se2);
+
+      Assert.assertTrue(se2._output._metalearner._parms._distribution == DistributionFamily.bernoulli);
+    } finally {
+      for (Lockable l : deletables) {
+        if (l instanceof Model) ((Model) l).deleteCrossValidationPreds();
+        l.delete();
+      }
+    }
+  }
+
+  @Test
+  public void testCanInferFromBaseModelsFamily() {
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.gaussian, GLMModel.GLMParameters.Link.identity, DistributionFamily.gaussian, false);
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.gamma, GLMModel.GLMParameters.Link.log, DistributionFamily.gamma, false);
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.gamma, GLMModel.GLMParameters.Link.identity, DistributionFamily.gamma, false);
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.tweedie, GLMModel.GLMParameters.Link.tweedie, DistributionFamily.tweedie, false);
+  }
+
+  @Test
+  public void testCanInferFromBaseModelsMixedFamilyAndDistributions() {
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.gaussian, GLMModel.GLMParameters.Link.identity, DistributionFamily.gaussian, true);
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.gamma, GLMModel.GLMParameters.Link.log, DistributionFamily.gamma, true);
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.gamma, GLMModel.GLMParameters.Link.identity, DistributionFamily.gamma, true);
+    familyAndLinkInferenceTestHelper(GLMModel.GLMParameters.Family.tweedie, GLMModel.GLMParameters.Link.tweedie, DistributionFamily.tweedie, true);
+  }
+
+  @Test
+  public void testInferenceOfDistributionFallbacksToBasicDistribution() {
+    List<Lockable> deletables = new ArrayList<>();
+    try {
+      final int seed = 1;
+      final Frame train = parse_test_file("./smalldata/iris/iris_train.csv");
+      deletables.add(train);
+      final Frame test = parse_test_file("./smalldata/iris/iris_test.csv");
+      deletables.add(test);
+      final String target = "petal_wid";
+      int target_idx = train.find(target);
+      DKV.put(train);
+      test.remove(target_idx).remove();
+      DKV.put(test);
+
+      GBMModel.GBMParameters params = new GBMModel.GBMParameters();
+      params._train = train._key;
+      params._response_column = target;
+      params._seed = seed;
+      params._keep_cross_validation_models = false;
+      params._keep_cross_validation_predictions = true;
+      params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+      params._nfolds = 3;
+      params._distribution = DistributionFamily.tweedie;
+
+      Job<Grid> gridSearch = GridSearch.startGridSearch(null, params, new HashMap<String, Object[]>() {{
+        put("_ntrees", new Integer[]{3, 5});
+      }});
+      Grid grid = gridSearch.get();
+      deletables.add(grid);
+      Model[] gridModels = grid.getModels();
+      deletables.addAll(Arrays.asList(gridModels));
+      Assert.assertEquals(2, gridModels.length);
+
+      StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = train._key;
+      seParams._response_column = target;
+      seParams._base_models = ArrayUtils.append(grid.getModelKeys());
+      seParams._metalearner_algorithm = Algorithm.drf; // does NOT support tweedie
+      seParams._seed = seed;
+      StackedEnsembleModel se = new StackedEnsemble(seParams).trainModel().get();
+      deletables.add(se);
+
+      Assert.assertTrue(se._output._metalearner._parms._distribution == DistributionFamily.gaussian);
+    } finally {
+      for (Lockable l : deletables) {
+        if (l instanceof Model) ((Model) l).deleteCrossValidationPreds();
+        l.delete();
+      }
+    }
+  }
+
+
+  private void familyAndLinkInferenceTestHelper(
+          GLMModel.GLMParameters.Family family,
+          GLMModel.GLMParameters.Link link,
+          DistributionFamily distribution,
+          boolean mixed) {
+    List<Lockable> deletables = new ArrayList<>();
+    try {
+      final int seed = 1;
+      final Frame train = parse_test_file("./smalldata/iris/iris_train.csv");
+      deletables.add(train);
+      final Frame test = parse_test_file("./smalldata/iris/iris_test.csv");
+      deletables.add(test);
+      final String target = "petal_wid";
+      int target_idx = train.find(target);
+      DKV.put(train);
+      test.remove(target_idx).remove();
+      DKV.put(test);
+
+      GLMModel.GLMParameters params = new GLMModel.GLMParameters();
+      params._train = train._key;
+      params._response_column = target;
+      params._seed = seed;
+      params._keep_cross_validation_models = false;
+      params._keep_cross_validation_predictions = true;
+      params._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+      params._nfolds = 3;
+      params._family = family;
+      params._link = link;
+
+      Job<Grid> gridSearch = GridSearch.startGridSearch(null, params, new HashMap<String, Object[]>() {{
+        put("_non_negative", new Boolean[]{false, true});
+      }});
+      Grid grid = gridSearch.get();
+      deletables.add(grid);
+      Model[] gridModels = grid.getModels();
+      deletables.addAll(Arrays.asList(gridModels));
+      Assert.assertEquals(2, gridModels.length);
+
+      Grid gridGBM = null;
+      if (mixed) {
+        GBMModel.GBMParameters paramsGBM = new GBMModel.GBMParameters();
+        paramsGBM._train = train._key;
+        paramsGBM._response_column = target;
+        paramsGBM._seed = seed;
+        paramsGBM._keep_cross_validation_models = false;
+        paramsGBM._keep_cross_validation_predictions = true;
+        paramsGBM._fold_assignment = Model.Parameters.FoldAssignmentScheme.Modulo;
+        paramsGBM._nfolds = 3;
+        paramsGBM._distribution = distribution;
+        Job<Grid> gridSearchGBM = GridSearch.startGridSearch(null, paramsGBM, new HashMap<String, Object[]>() {{
+          put("_ntrees", new Integer[]{3, 5});
+        }});
+        gridGBM = gridSearchGBM.get();
+        deletables.add(gridGBM);
+        Model[] gridModelsGBM = gridGBM.getModels();
+        deletables.addAll(Arrays.asList(gridModelsGBM));
+        Assert.assertEquals(2, gridModelsGBM.length);
+      }
+
+      StackedEnsembleParameters seParams = new StackedEnsembleParameters();
+      seParams._train = train._key;
+      seParams._response_column = target;
+      if (mixed) {
+        // first glm and then gbm base models
+        seParams._base_models = ArrayUtils.append(grid.getModelKeys(), gridGBM.getModelKeys());
+      } else {
+        seParams._base_models = ArrayUtils.append(grid.getModelKeys());
+      }
+      seParams._metalearner_algorithm = Algorithm.AUTO;
+      seParams._seed = seed;
+      StackedEnsembleModel se = new StackedEnsemble(seParams).trainModel().get();
+      deletables.add(se);
+
+      Assert.assertTrue(((GLMModel.GLMParameters) se._output._metalearner._parms)._family == family);
+      Assert.assertTrue(((GLMModel.GLMParameters) se._output._metalearner._parms)._link == link);
+
+
+      StackedEnsembleParameters seParams2 = new StackedEnsembleParameters();
+      seParams2._train = train._key;
+      seParams2._response_column = target;
+      if (mixed) {
+        seParams2._base_models = ArrayUtils.append(grid.getModelKeys(), gridGBM.getModelKeys());
+      } else {
+        seParams2._base_models = ArrayUtils.append(grid.getModelKeys());
+      }
+      seParams2._metalearner_algorithm = Algorithm.gbm;
+      seParams2._seed = seed;
+      StackedEnsembleModel se2 = new StackedEnsemble(seParams2).trainModel().get();
+      deletables.add(se2);
+
+      Assert.assertTrue(se2._output._metalearner._parms._distribution == distribution);
+
+      if (mixed) {
+        // first gbm and then glm base models
+        StackedEnsembleParameters seParams3 = new StackedEnsembleParameters();
+        seParams3._train = train._key;
+        seParams3._response_column = target;
+        seParams3._base_models = ArrayUtils.append(gridGBM.getModelKeys(), grid.getModelKeys());
+        seParams3._metalearner_algorithm = Algorithm.AUTO;
+        seParams3._seed = seed;
+        StackedEnsembleModel se3 = new StackedEnsemble(seParams3).trainModel().get();
+        deletables.add(se3);
+
+        Assert.assertTrue(((GLMModel.GLMParameters) se3._output._metalearner._parms)._family == family);
+        Assert.assertTrue(((GLMModel.GLMParameters) se3._output._metalearner._parms)._link == link);
+      }
+
+    } finally {
+      for (Lockable l : deletables) {
+        if (l instanceof Model) ((Model) l).deleteCrossValidationPreds();
+        l.delete();
+      }
+    }
+  }
 }

--- a/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
+++ b/h2o-algos/src/test/java/hex/ensemble/StackedEnsembleTest.java
@@ -373,7 +373,6 @@ public class StackedEnsembleTest extends TestUtil {
         Assert.assertEquals(4, models.length);
 
         StackedEnsembleParameters seParams = new StackedEnsembleParameters();
-        seParams._distribution = DistributionFamily.bernoulli;
         seParams._train = train._key;
         seParams._blending = blend._key;
         seParams._response_column = target;

--- a/h2o-extensions/xgboost/src/main/java/hex/ensemble/XGBoostMetalearnerProvider.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/ensemble/XGBoostMetalearnerProvider.java
@@ -1,12 +1,22 @@
 package hex.ensemble;
 
-import hex.tree.xgboost.XGBoostModel.XGBoostParameters;
+import hex.genmodel.utils.DistributionFamily;
 
 public class XGBoostMetalearnerProvider implements MetalearnerProvider<XGBoostMetalearnerProvider.XGBoostMetalearner> {
 
-    static class XGBoostMetalearner extends Metalearners.SimpleMetalearner {
+    static class XGBoostMetalearner extends Metalearners.MetalearnerWithDistribution {
         public XGBoostMetalearner() {
             super(Algorithm.xgboost.name());
+            _supportedDistributionFamilies = new DistributionFamily[]{
+                    DistributionFamily.AUTO,
+                    DistributionFamily.bernoulli,
+                    DistributionFamily.quasibinomial,
+                    DistributionFamily.multinomial,
+                    DistributionFamily.gaussian,
+                    DistributionFamily.poisson,
+                    DistributionFamily.gamma,
+                    DistributionFamily.tweedie,
+            };
         }
     }
 

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
@@ -8,9 +8,11 @@ import warnings
 sys.path.insert(1, "../../../")  # allow us to run this standalone
 
 import h2o
+from h2o.estimators.random_forest import H2ORandomForestEstimator
 from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 from h2o.estimators.gbm import H2OGradientBoostingEstimator
 from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from h2o.estimators.naive_bayes import H2ONaiveBayesEstimator
 from tests import pyunit_utils
 
 
@@ -53,7 +55,6 @@ def infer_distribution_helper(dist, expected_dist, kwargs1={}, kwargs2={}):
     se.train(x, y, train)
     assert se.metalearner().actual_params.get("distribution") == expected_dist, \
         "Expected distribution {} but got {}".format(expected_dist, se.metalearner().actual_params.get("distribution"))
-
 
 def infer_distribution_test():
     from h2o.utils import CustomDistributionGeneric, CustomDistributionGaussian
@@ -200,7 +201,8 @@ def infer_family_test():
     infer_family_helper("gamma", "gaussian", "log", "identity", kwargs2=dict(family="tweedie", link="tweedie"))
 
 
-def infer_mixed_family_and_dist_helper(family, expected_family, first_glm, expected_link=None, kwargs_glm=None, kwargs_gbm=None, metalearner_params=None):
+def infer_mixed_family_and_dist_helper(family, expected_family, first_glm, expected_link=None, kwargs_glm=None,
+                                       kwargs_gbm=None, metalearner_params=None):
     kwargs_glm = dict() if kwargs_glm is None else kwargs_glm
     kwargs_gbm = dict() if kwargs_gbm is None else kwargs_gbm
     metalearner_params = dict() if metalearner_params is None else metalearner_params
@@ -257,7 +259,8 @@ def infer_mixed_family_and_dist_helper(family, expected_family, first_glm, expec
                                      validation_frame=test,
                                      base_models=[glm, gbm] if first_glm else [gbm, glm],
                                      metalearner_algorithm="glm",
-                                     metalearner_params={k:v for k, v in metalearner_params.items() if k != "distribution"})
+                                     metalearner_params={k: v for k, v in metalearner_params.items() if
+                                                         k != "distribution"})
     se.train(x, y, train)
     assert se.metalearner().actual_params.get("family") == expected_family, \
         "Expected family {} but got {}".format(expected_family, se.metalearner().actual_params.get("family"))
@@ -269,7 +272,8 @@ def infer_mixed_family_and_dist_helper(family, expected_family, first_glm, expec
                                           validation_frame=test,
                                           base_models=[glm, gbm] if first_glm else [gbm, glm],
                                           metalearner_algorithm="auto",
-                                          metalearner_params={k:v for k, v in metalearner_params.items() if k != "distribution"})
+                                          metalearner_params={k: v for k, v in metalearner_params.items() if
+                                                              k != "distribution"})
     se_auto.train(x, y, train)
     assert se_auto.metalearner().actual_params.get("family") == expected_family, \
         "Expected family {} but got {}".format(expected_family, se_auto.metalearner().actual_params.get("family"))
@@ -280,7 +284,8 @@ def infer_mixed_family_and_dist_helper(family, expected_family, first_glm, expec
                                          validation_frame=test,
                                          base_models=[glm, gbm] if first_glm else [gbm, glm],
                                          metalearner_algorithm="gbm",
-                                         metalearner_params={k:v for k, v in metalearner_params.items() if k != "family" and k != "link"})
+                                         metalearner_params={k: v for k, v in metalearner_params.items() if
+                                                             k != "family" and k != "link"})
     se_gbm.train(x, y, train)
     assert se_gbm.metalearner().actual_params.get("distribution") == expected_distribution, \
         "Expected distribution {} but got {}".format(expected_distribution,
@@ -329,25 +334,181 @@ def metalearner_obeys_metalearner_params_test():
         infer_mixed_family_and_dist_helper(family, "poisson", True, metalearner_params=metalearner_params)
 
     # without metalearner_params it would revert to default
-    infer_mixed_family_and_dist_helper("gamma", "poisson", False, kwargs_glm=dict(family="tweedie"), metalearner_params=metalearner_params)
-    infer_mixed_family_and_dist_helper("gamma", "poisson", True, kwargs_glm=dict(family="tweedie"), metalearner_params=metalearner_params)
-    infer_mixed_family_and_dist_helper("gamma", "poisson", False, kwargs_gbm=dict(distribution="tweedie"), metalearner_params=metalearner_params)
-    infer_mixed_family_and_dist_helper("gamma", "poisson", True, kwargs_gbm=dict(distribution="tweedie"), metalearner_params=metalearner_params)
+    infer_mixed_family_and_dist_helper("gamma", "poisson", False, kwargs_glm=dict(family="tweedie"),
+                                       metalearner_params=metalearner_params)
+    infer_mixed_family_and_dist_helper("gamma", "poisson", True, kwargs_glm=dict(family="tweedie"),
+                                       metalearner_params=metalearner_params)
+    infer_mixed_family_and_dist_helper("gamma", "poisson", False, kwargs_gbm=dict(distribution="tweedie"),
+                                       metalearner_params=metalearner_params)
+    infer_mixed_family_and_dist_helper("gamma", "poisson", True, kwargs_gbm=dict(distribution="tweedie"),
+                                       metalearner_params=metalearner_params)
 
     # without metalerarner_params could inherit the link if all GLMs share the same link
-    infer_mixed_family_and_dist_helper("gamma", "gamma", False, expected_link="identity", kwargs_glm=dict(link="log"), metalearner_params=dict(family="gamma", link="identity", distribution="gamma"))
-    infer_mixed_family_and_dist_helper("gamma", "gamma", True, expected_link="identity", kwargs_glm=dict(link="log"), metalearner_params=dict(family="gamma", link="identity", distribution="gamma"))
+    infer_mixed_family_and_dist_helper("gamma", "gamma", False, expected_link="identity", kwargs_glm=dict(link="log"),
+                                       metalearner_params=dict(family="gamma", link="identity", distribution="gamma"))
+    infer_mixed_family_and_dist_helper("gamma", "gamma", True, expected_link="identity", kwargs_glm=dict(link="log"),
+                                       metalearner_params=dict(family="gamma", link="identity", distribution="gamma"))
 
     # don't propagate link from different family
-    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, expected_link="identity", kwargs_glm=dict(link="log"),
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, expected_link="identity",
+                                       kwargs_glm=dict(link="log"),
                                        metalearner_params=dict(family="gaussian", distribution="gaussian"))
     infer_mixed_family_and_dist_helper("gamma", "gaussian", True, expected_link="identity", kwargs_glm=dict(link="log"),
                                        metalearner_params=dict(family="gaussian", distribution="gaussian"))
 
-    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, expected_link="identity", kwargs_glm=dict(link="log"),
-                                       metalearner_params=dict(family="gaussian", link="identity", distribution="gaussian"))
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, expected_link="identity",
+                                       kwargs_glm=dict(link="log"),
+                                       metalearner_params=dict(family="gaussian", link="identity",
+                                                               distribution="gaussian"))
     infer_mixed_family_and_dist_helper("gamma", "gaussian", True, expected_link="identity", kwargs_glm=dict(link="log"),
-                                       metalearner_params=dict(family="gaussian", link="identity", distribution="gaussian"))
+                                       metalearner_params=dict(family="gaussian", link="identity",
+                                                               distribution="gaussian"))
+
+
+def infer_uses_defaults_when_base_model_doesnt_support_distributions_test():
+    train = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_test.csv"))
+    x_reg = train.columns
+    y_reg = "petal_wid"
+    x_reg.remove(y_reg)
+
+    nfolds = 2
+    glm_reg = H2OGeneralizedLinearEstimator(nfolds=nfolds,
+                                            fold_assignment="Modulo",
+                                            keep_cross_validation_predictions=True,
+                                            family="tweedie"
+                                            )
+    glm_reg.train(x=x_reg, y=y_reg, training_frame=train)
+
+    gbm_reg = H2OGradientBoostingEstimator(nfolds=nfolds,
+                                           fold_assignment="Modulo",
+                                           keep_cross_validation_predictions=True,
+                                           distribution="tweedie"
+                                           )
+    gbm_reg.train(x=x_reg, y=y_reg, training_frame=train)
+
+    drf_reg = H2ORandomForestEstimator(nfolds=nfolds,
+                                       fold_assignment="Modulo",
+                                       keep_cross_validation_predictions=True
+                                       )
+    drf_reg.train(x=x_reg, y=y_reg, training_frame=train)
+
+    se_reg_0 = H2OStackedEnsembleEstimator(training_frame=train,
+                                           validation_frame=test,
+                                           base_models=[glm_reg, gbm_reg],
+                                           metalearner_algorithm="gbm")
+    se_reg_0.train(x_reg, y_reg, train)
+
+    assert se_reg_0.metalearner().actual_params.get("distribution") == "tweedie", \
+        "Expected distribution {} but got {}".format("tweedie",
+                                                     se_reg_0.metalearner().actual_params.get("distribution"))
+
+    se_reg_1 = H2OStackedEnsembleEstimator(training_frame=train,
+                                           validation_frame=test,
+                                           base_models=[glm_reg, gbm_reg, drf_reg],
+                                           metalearner_algorithm="gbm")
+    se_reg_1.train(x_reg, y_reg, train)
+
+    assert se_reg_1.metalearner().actual_params.get("distribution") == "gaussian", \
+        "Expected distribution {} but got {}".format("gaussian",
+                                                     se_reg_1.metalearner().actual_params.get("distribution"))
+
+    se_reg_2 = H2OStackedEnsembleEstimator(training_frame=train,
+                                           validation_frame=test,
+                                           base_models=[drf_reg, glm_reg, gbm_reg],
+                                           metalearner_algorithm="gbm")
+    se_reg_2.train(x_reg, y_reg, train)
+
+    assert se_reg_2.metalearner().actual_params.get("distribution") == "gaussian", \
+        "Expected distribution {} but got {}".format("gaussian",
+                                                     se_reg_2.metalearner().actual_params.get("distribution"))
+
+
+def basic_inference_works_for_DRF_and_NB_test():
+    train = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_test.csv"))
+
+    x_class = train.columns
+    y_class = "species"
+    x_class.remove(y_class)
+
+    nfolds = 2
+
+    nb_class = H2ONaiveBayesEstimator(nfolds=nfolds,
+                                      fold_assignment="Modulo",
+                                      keep_cross_validation_predictions=True,
+                                      )
+    nb_class.train(x=x_class, y=y_class, training_frame=train)
+
+    gbm_class = H2OGradientBoostingEstimator(nfolds=nfolds,
+                                             fold_assignment="Modulo",
+                                             keep_cross_validation_predictions=True,
+                                             )
+    gbm_class.train(x=x_class, y=y_class, training_frame=train)
+
+    drf_class = H2ORandomForestEstimator(nfolds=nfolds,
+                                         fold_assignment="Modulo",
+                                         keep_cross_validation_predictions=True
+                                         )
+    drf_class.train(x=x_class, y=y_class, training_frame=train)
+
+    se_class_0 = H2OStackedEnsembleEstimator(training_frame=train,
+                                             validation_frame=test,
+                                             base_models=[nb_class, gbm_class, drf_class],
+                                             metalearner_algorithm="gbm")
+    se_class_0.train(x_class, y_class, train)
+
+    assert se_class_0.metalearner().actual_params.get("distribution") == "multinomial", \
+        "Expected distribution {} but got {}".format("multinomial",
+                                                     se_class_0.metalearner().actual_params.get("distribution"))
+
+    se_class_1 = H2OStackedEnsembleEstimator(training_frame=train,
+                                             validation_frame=test,
+                                             base_models=[gbm_class, drf_class, nb_class],
+                                             metalearner_algorithm="gbm")
+    se_class_1.train(x_class, y_class, train)
+
+    assert se_class_1.metalearner().actual_params.get("distribution") == "multinomial", \
+        "Expected distribution {} but got {}".format("multinomial",
+                                                     se_class_1.metalearner().actual_params.get("distribution"))
+
+    se_class_2 = H2OStackedEnsembleEstimator(training_frame=train,
+                                             validation_frame=test,
+                                             base_models=[drf_class, nb_class, gbm_class],
+                                             metalearner_algorithm="gbm")
+    se_class_2.train(x_class, y_class, train)
+
+    assert se_class_2.metalearner().actual_params.get("distribution") == "multinomial", \
+        "Expected distribution {} but got {}".format("multinomial",
+                                                     se_class_2.metalearner().actual_params.get("distribution"))
+
+    se_class_3 = H2OStackedEnsembleEstimator(training_frame=train,
+                                             validation_frame=test,
+                                             base_models=[nb_class, gbm_class, drf_class])
+    se_class_3.train(x_class, y_class, train)
+
+    assert se_class_3.metalearner().actual_params.get("family") == "multinomial", \
+        "Expected family {} but got {}".format("multinomial",
+                                               se_class_3.metalearner().actual_params.get("family"))
+
+    se_class_4 = H2OStackedEnsembleEstimator(training_frame=train,
+                                             validation_frame=test,
+                                             base_models=[gbm_class, drf_class, nb_class])
+    se_class_4.train(x_class, y_class, train)
+
+    assert se_class_4.metalearner().actual_params.get("family") == "multinomial", \
+        "Expected family {} but got {}".format("multinomial",
+                                               se_class_4.metalearner().actual_params.get("family"))
+
+    se_class_5 = H2OStackedEnsembleEstimator(training_frame=train,
+                                             validation_frame=test,
+                                             base_models=[drf_class, nb_class, gbm_class])
+    se_class_5.train(x_class, y_class, train)
+
+    assert se_class_5.metalearner().actual_params.get("family") == "multinomial", \
+        "Expected family {} but got {}".format("multinomial",
+                                               se_class_5.metalearner().actual_params.get("family"))
+
 
 if __name__ == "__main__":
     pyunit_utils.run_tests([
@@ -355,4 +516,6 @@ if __name__ == "__main__":
         infer_family_test,
         infer_mixed_family_and_dist_test,
         metalearner_obeys_metalearner_params_test,
+        infer_uses_defaults_when_base_model_doesnt_support_distributions_test,
+        basic_inference_works_for_DRF_and_NB_test,
     ])

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+
+import sys
+import warnings
+
+sys.path.insert(1, "../../../")  # allow us to run this standalone
+
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from tests import pyunit_utils
+
+
+def infer_distribution_helper(dist, expected_dist, kwargs1={}, kwargs2={}):
+    train = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_test.csv"))
+    if dist == "multinomial":
+        y = "species"
+    elif dist == "bernoulli":
+        train["response"] = (train["species"] == "Iris-versicolor").asfactor()
+        test["response"] = (test["species"] == "Iris-versicolor").asfactor()
+        y = "response"
+    elif dist == "quasibinomial":
+        train["response"] = (train["species"] == "Iris-versicolor")
+        test["response"] = (test["species"] == "Iris-versicolor")
+        y = "response"
+    else:
+        y = "petal_wid"
+
+    x = train.columns
+    x.remove(y)
+
+    nfolds = 2
+    gbm = H2OGradientBoostingEstimator(nfolds=nfolds,
+                                       fold_assignment="Modulo",
+                                       keep_cross_validation_predictions=True,
+                                       distribution=dist, **kwargs1)
+    gbm.train(x=x, y=y, training_frame=train)
+
+    gbm2 = H2OGradientBoostingEstimator(nfolds=nfolds,
+                                        fold_assignment="Modulo",
+                                        keep_cross_validation_predictions=True,
+                                        distribution=dist, **kwargs2)
+    gbm2.train(x=x, y=y, training_frame=train)
+
+    se = H2OStackedEnsembleEstimator(training_frame=train,
+                                     validation_frame=test,
+                                     base_models=[gbm, gbm2],
+                                     metalearner_algorithm="gbm")
+    se.train(x, y, train)
+    assert se.metalearner().actual_params.get("distribution") == expected_dist, \
+        "Expected distribution {} but got {}".format(expected_dist, se.metalearner().actual_params.get("distribution"))
+
+
+def infer_distribution_test():
+    from h2o.utils import CustomDistributionGeneric, CustomDistributionGaussian
+
+    class CustomDistributionGaussian2(CustomDistributionGeneric):
+        def link(self):
+            return "identity"
+
+        def init(self, w, o, y):
+            return [w * (y - o), w]
+
+        def gradient(self, y, f):
+            return y - f
+
+        def gamma(self, w, y, z, f):
+            return [w * z, w]
+
+    custom_dist1 = h2o.upload_custom_distribution(CustomDistributionGaussian)
+    custom_dist2 = h2o.upload_custom_distribution(CustomDistributionGaussian2)
+
+    for dist in ["poisson", "laplace", "tweedie", "gaussian", "huber", "gamma",
+                 "quantile", "bernoulli", "quasibinomial", "multinomial"]:
+        infer_distribution_helper(dist, dist)
+
+    # custom distribution
+    infer_distribution_helper("custom", "custom",
+                              dict(custom_distribution_func=custom_dist1),
+                              dict(custom_distribution_func=custom_dist1))
+
+    # revert to default
+    infer_distribution_helper("tweedie", "gaussian", dict(tweedie_power=1.2))
+    infer_distribution_helper("huber", "gaussian", dict(huber_alpha=0.2))
+    infer_distribution_helper("quantile", "gaussian", dict(quantile_alpha=0.2))
+    infer_distribution_helper("custom", "gaussian",
+                              dict(custom_distribution_func=custom_dist1),
+                              dict(custom_distribution_func=custom_dist2))
+
+    # unaffected by param for different distribution
+    infer_distribution_helper("quantile", "quantile", dict(tweedie_power=1.2))
+    infer_distribution_helper("tweedie", "tweedie", dict(huber_alpha=0.2))
+    infer_distribution_helper("huber", "huber", dict(quantile_alpha=0.2))
+    infer_distribution_helper("custom", "custom",
+                              dict(custom_distribution_func=custom_dist1),
+                              dict(custom_distribution_func=custom_dist1,
+                                   tweedie_power=1.2))
+
+
+def infer_family_helper(family, expected_family, link, expected_link, kwargs1=None, kwargs2=None):
+    kwargs1 = dict() if kwargs1 is None else kwargs1
+    kwargs2 = dict() if kwargs2 is None else kwargs2
+    train = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_test.csv"))
+    if family == "multinomial":
+        y = "species"
+    elif family == "binomial":
+        train["response"] = (train["species"] == "Iris-versicolor").asfactor()
+        test["response"] = (test["species"] == "Iris-versicolor").asfactor()
+        y = "response"
+    elif family == "quasibinomial" or family == "fractionalbinomial":
+        train["response"] = (train["species"] == "Iris-versicolor")/2
+        test["response"] = (test["species"] == "Iris-versicolor")/2
+        y = "response"
+    elif family == "ordinal":
+        y = "response"
+        train[y] = (train["species"] == "Iris-versicolor")
+        test[y] = (test["species"] == "Iris-versicolor")
+        train[(train["species"] == "Iris-setosa"), y] = 2
+        test[(test["species"] == "Iris-setosa"), y] = 2
+        train[y] = train[y].asfactor()
+        test[y] = test[y].asfactor()
+    else:
+        y = "petal_wid"
+
+    x = train.columns
+    x.remove(y)
+
+    if "link" not in kwargs1 and link:
+        kwargs1["link"] = link
+
+    if "link" not in kwargs2 and link:
+        kwargs2["link"] = link
+
+    nfolds = 2
+    glm = H2OGeneralizedLinearEstimator(nfolds=nfolds,
+                                        fold_assignment="Modulo",
+                                        keep_cross_validation_predictions=True,
+                                        family=family,
+                                        **kwargs1)
+    glm.train(x=x, y=y, training_frame=train)
+
+    glm2 = H2OGeneralizedLinearEstimator(nfolds=nfolds,
+                                         fold_assignment="Modulo",
+                                         keep_cross_validation_predictions=True,
+                                         family=family,
+                                         **kwargs2)
+    glm2.train(x=x, y=y, training_frame=train)
+
+    se = H2OStackedEnsembleEstimator(training_frame=train,
+                                     validation_frame=test,
+                                     base_models=[glm, glm2],
+                                     metalearner_algorithm="glm")
+    se.train(x, y, train)
+    assert se.metalearner().actual_params.get("family") == expected_family, \
+        "Expected family {} but got {}".format(expected_family, se.metalearner().actual_params.get("family"))
+    if link:
+        assert se.metalearner().actual_params.get("link") == expected_link, \
+            "Expected link {} but got {}".format(expected_family, se.metalearner().actual_params.get("link"))
+
+    se_auto = H2OStackedEnsembleEstimator(training_frame=train,
+                                          validation_frame=test,
+                                          base_models=[glm, glm2],
+                                          metalearner_algorithm="auto")
+    se_auto.train(x, y, train)
+    assert se_auto.metalearner().actual_params.get("family") == expected_family, \
+        "Expected family {} but got {}".format(expected_family, se_auto.metalearner().actual_params.get("family"))
+    if link:
+        assert se_auto.metalearner().actual_params.get("link") == expected_link, \
+            "Expected link {} but got {}".format(expected_family, se_auto.metalearner().actual_params.get("link"))
+
+
+def infer_family_test():
+    families = dict(
+        # family = list of links
+        gaussian=["identity", "log", "inverse"],
+        binomial=["logit"],
+        # fractionalbinomial=["logit"], # FIXME: fractional binomial distribution does not exists
+        multinomial=[None],
+        # ordinal=["ologit"], # FIXME: ordinal distribution does not exists
+        quasibinomial=["logit"],
+        poisson=["identity", "log"],
+        # negativebinomial=["identity", "log"], # FIXME: negative binomial distribution is not implemented
+        gamma=["identity", "log", "inverse"],
+        tweedie=["tweedie"]
+    )
+
+    for family, links in families.items():
+        for link in links:
+            print(family, link)
+            infer_family_helper(family, family, link, link)
+
+if __name__ == "__main__":
+    pyunit_utils.run_tests([
+        infer_distribution_test,
+        infer_family_test
+    ])

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
@@ -113,8 +113,8 @@ def infer_family_helper(family, expected_family, link, expected_link, kwargs1=No
         test["response"] = (test["species"] == "Iris-versicolor").asfactor()
         y = "response"
     elif family == "quasibinomial" or family == "fractionalbinomial":
-        train["response"] = (train["species"] == "Iris-versicolor")/2
-        test["response"] = (test["species"] == "Iris-versicolor")/2
+        train["response"] = (train["species"] == "Iris-versicolor") / 2
+        test["response"] = (test["species"] == "Iris-versicolor") / 2
         y = "response"
     elif family == "ordinal":
         y = "response"
@@ -132,22 +132,24 @@ def infer_family_helper(family, expected_family, link, expected_link, kwargs1=No
 
     if "link" not in kwargs1 and link:
         kwargs1["link"] = link
+    if "family" not in kwargs1:
+        kwargs1["family"] = family
 
     if "link" not in kwargs2 and link:
         kwargs2["link"] = link
+    if "family" not in kwargs2:
+        kwargs2["family"] = family
 
     nfolds = 2
     glm = H2OGeneralizedLinearEstimator(nfolds=nfolds,
                                         fold_assignment="Modulo",
                                         keep_cross_validation_predictions=True,
-                                        family=family,
                                         **kwargs1)
     glm.train(x=x, y=y, training_frame=train)
 
     glm2 = H2OGeneralizedLinearEstimator(nfolds=nfolds,
                                          fold_assignment="Modulo",
                                          keep_cross_validation_predictions=True,
-                                         family=family,
                                          **kwargs2)
     glm2.train(x=x, y=y, training_frame=train)
 
@@ -160,7 +162,7 @@ def infer_family_helper(family, expected_family, link, expected_link, kwargs1=No
         "Expected family {} but got {}".format(expected_family, se.metalearner().actual_params.get("family"))
     if link:
         assert se.metalearner().actual_params.get("link") == expected_link, \
-            "Expected link {} but got {}".format(expected_family, se.metalearner().actual_params.get("link"))
+            "Expected link {} but got {}".format(expected_link, se.metalearner().actual_params.get("link"))
 
     se_auto = H2OStackedEnsembleEstimator(training_frame=train,
                                           validation_frame=test,
@@ -171,7 +173,7 @@ def infer_family_helper(family, expected_family, link, expected_link, kwargs1=No
         "Expected family {} but got {}".format(expected_family, se_auto.metalearner().actual_params.get("family"))
     if link:
         assert se_auto.metalearner().actual_params.get("link") == expected_link, \
-            "Expected link {} but got {}".format(expected_family, se_auto.metalearner().actual_params.get("link"))
+            "Expected link {} but got {}".format(expected_link, se_auto.metalearner().actual_params.get("link"))
 
 
 def infer_family_test():
@@ -191,11 +193,166 @@ def infer_family_test():
 
     for family, links in families.items():
         for link in links:
-            print(family, link)
             infer_family_helper(family, family, link, link)
+
+    # revert to default
+    infer_family_helper("gamma", "gaussian", "log", "identity", kwargs2=dict(link="inverse"))
+    infer_family_helper("gamma", "gaussian", "log", "identity", kwargs2=dict(family="tweedie", link="tweedie"))
+
+
+def infer_mixed_family_and_dist_helper(family, expected_family, first_glm, expected_link=None, kwargs_glm=None, kwargs_gbm=None, metalearner_params=None):
+    kwargs_glm = dict() if kwargs_glm is None else kwargs_glm
+    kwargs_gbm = dict() if kwargs_gbm is None else kwargs_gbm
+    metalearner_params = dict() if metalearner_params is None else metalearner_params
+
+    distribution = family if not family == "binomial" else "bernoulli"
+    expected_distribution = expected_family if not expected_family == "binomial" else "bernoulli"
+
+    train = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    test = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_test.csv"))
+    if family == "multinomial":
+        y = "species"
+    elif family == "binomial":
+        train["response"] = (train["species"] == "Iris-versicolor").asfactor()
+        test["response"] = (test["species"] == "Iris-versicolor").asfactor()
+        y = "response"
+    elif family == "quasibinomial" or family == "fractionalbinomial":
+        train["response"] = (train["species"] == "Iris-versicolor") / 2
+        test["response"] = (test["species"] == "Iris-versicolor") / 2
+        y = "response"
+    elif family == "ordinal":
+        y = "response"
+        train[y] = (train["species"] == "Iris-versicolor")
+        test[y] = (test["species"] == "Iris-versicolor")
+        train[(train["species"] == "Iris-setosa"), y] = 2
+        test[(test["species"] == "Iris-setosa"), y] = 2
+        train[y] = train[y].asfactor()
+        test[y] = test[y].asfactor()
+    else:
+        y = "petal_wid"
+
+    x = train.columns
+    x.remove(y)
+
+    if "family" not in kwargs_glm:
+        kwargs_glm["family"] = family
+
+    if "distribution" not in kwargs_gbm:
+        kwargs_gbm["distribution"] = distribution
+
+    nfolds = 2
+    glm = H2OGeneralizedLinearEstimator(nfolds=nfolds,
+                                        fold_assignment="Modulo",
+                                        keep_cross_validation_predictions=True,
+                                        **kwargs_glm)
+    glm.train(x=x, y=y, training_frame=train)
+
+    gbm = H2OGradientBoostingEstimator(nfolds=nfolds,
+                                       fold_assignment="Modulo",
+                                       keep_cross_validation_predictions=True,
+                                       **kwargs_gbm)
+    gbm.train(x=x, y=y, training_frame=train)
+
+    se = H2OStackedEnsembleEstimator(training_frame=train,
+                                     validation_frame=test,
+                                     base_models=[glm, gbm] if first_glm else [gbm, glm],
+                                     metalearner_algorithm="glm",
+                                     metalearner_params={k:v for k, v in metalearner_params.items() if k != "distribution"})
+    se.train(x, y, train)
+    assert se.metalearner().actual_params.get("family") == expected_family, \
+        "Expected family {} but got {}".format(expected_family, se.metalearner().actual_params.get("family"))
+    if expected_link:
+        assert se.metalearner().actual_params.get("link") == expected_link, \
+            "Expected link {} but got {}".format(expected_link, se.metalearner().actual_params.get("link"))
+
+    se_auto = H2OStackedEnsembleEstimator(training_frame=train,
+                                          validation_frame=test,
+                                          base_models=[glm, gbm] if first_glm else [gbm, glm],
+                                          metalearner_algorithm="auto",
+                                          metalearner_params={k:v for k, v in metalearner_params.items() if k != "distribution"})
+    se_auto.train(x, y, train)
+    assert se_auto.metalearner().actual_params.get("family") == expected_family, \
+        "Expected family {} but got {}".format(expected_family, se_auto.metalearner().actual_params.get("family"))
+    if expected_link:
+        assert se_auto.metalearner().actual_params.get("link") == expected_link, \
+            "Expected link {} but got {}".format(expected_link, se_auto.metalearner().actual_params.get("link"))
+    se_gbm = H2OStackedEnsembleEstimator(training_frame=train,
+                                         validation_frame=test,
+                                         base_models=[glm, gbm] if first_glm else [gbm, glm],
+                                         metalearner_algorithm="gbm",
+                                         metalearner_params={k:v for k, v in metalearner_params.items() if k != "family" and k != "link"})
+    se_gbm.train(x, y, train)
+    assert se_gbm.metalearner().actual_params.get("distribution") == expected_distribution, \
+        "Expected distribution {} but got {}".format(expected_distribution,
+                                                     se_gbm.metalearner().actual_params.get("distribution"))
+
+
+def infer_mixed_family_and_dist_test():
+    families = dict(
+        # family = list of links
+        gaussian=["identity", "log", "inverse"],
+        binomial=["logit"],
+        # fractionalbinomial=["logit"], # FIXME: fractional binomial distribution does not exists
+        multinomial=[None],
+        # ordinal=["ologit"], # FIXME: ordinal distribution does not exists
+        quasibinomial=["logit"],
+        poisson=["identity", "log"],
+        # negativebinomial=["identity", "log"], # FIXME: negative binomial distribution is not implemented
+        gamma=["identity", "log", "inverse"],
+        tweedie=["tweedie"]
+    )
+
+    for family in families.keys():
+        infer_mixed_family_and_dist_helper(family, family, False)
+        infer_mixed_family_and_dist_helper(family, family, True)
+
+    # revert to default
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, kwargs_glm=dict(family="tweedie"))
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", True, kwargs_glm=dict(family="tweedie"))
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, kwargs_gbm=dict(distribution="tweedie"))
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", True, kwargs_gbm=dict(distribution="tweedie"))
+
+    # should inherit the link if all GLMs share the same link
+    infer_mixed_family_and_dist_helper("gamma", "gamma", True, expected_link="log", kwargs_glm=dict(link="log"))
+    # TODO: is this behaviour OK? What to do differently? (we are looking on first GLM base model not just first base model for link inference)
+    infer_mixed_family_and_dist_helper("gamma", "gamma", False, expected_link="log", kwargs_glm=dict(link="log"))
+
+    # should not change when we specify the default link
+    infer_mixed_family_and_dist_helper("tweedie", "tweedie", False, kwargs_glm=dict(link="tweedie"))
+    infer_mixed_family_and_dist_helper("tweedie", "tweedie", True, kwargs_glm=dict(link="tweedie"))
+
+
+def metalearner_obeys_metalearner_params_test():
+    metalearner_params = dict(distribution="poisson", family="poisson")
+    for family in ["gaussian", "tweedie"]:
+        infer_mixed_family_and_dist_helper(family, "poisson", False, metalearner_params=metalearner_params)
+        infer_mixed_family_and_dist_helper(family, "poisson", True, metalearner_params=metalearner_params)
+
+    # without metalearner_params it would revert to default
+    infer_mixed_family_and_dist_helper("gamma", "poisson", False, kwargs_glm=dict(family="tweedie"), metalearner_params=metalearner_params)
+    infer_mixed_family_and_dist_helper("gamma", "poisson", True, kwargs_glm=dict(family="tweedie"), metalearner_params=metalearner_params)
+    infer_mixed_family_and_dist_helper("gamma", "poisson", False, kwargs_gbm=dict(distribution="tweedie"), metalearner_params=metalearner_params)
+    infer_mixed_family_and_dist_helper("gamma", "poisson", True, kwargs_gbm=dict(distribution="tweedie"), metalearner_params=metalearner_params)
+
+    # without metalerarner_params could inherit the link if all GLMs share the same link
+    infer_mixed_family_and_dist_helper("gamma", "gamma", False, expected_link="identity", kwargs_glm=dict(link="log"), metalearner_params=dict(family="gamma", link="identity", distribution="gamma"))
+    infer_mixed_family_and_dist_helper("gamma", "gamma", True, expected_link="identity", kwargs_glm=dict(link="log"), metalearner_params=dict(family="gamma", link="identity", distribution="gamma"))
+
+    # don't propagate link from different family
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, expected_link="identity", kwargs_glm=dict(link="log"),
+                                       metalearner_params=dict(family="gaussian", distribution="gaussian"))
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", True, expected_link="identity", kwargs_glm=dict(link="log"),
+                                       metalearner_params=dict(family="gaussian", distribution="gaussian"))
+
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", False, expected_link="identity", kwargs_glm=dict(link="log"),
+                                       metalearner_params=dict(family="gaussian", link="identity", distribution="gaussian"))
+    infer_mixed_family_and_dist_helper("gamma", "gaussian", True, expected_link="identity", kwargs_glm=dict(link="log"),
+                                       metalearner_params=dict(family="gaussian", link="identity", distribution="gaussian"))
 
 if __name__ == "__main__":
     pyunit_utils.run_tests([
         infer_distribution_test,
-        infer_family_test
+        infer_family_test,
+        infer_mixed_family_and_dist_test,
+        metalearner_obeys_metalearner_params_test,
     ])


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7491

### Proposal of solution / description
This PR should enable user to use different distributions/families in SE (metalearner).

As far as I can tell, the current solution infers task (Binomial/Multinomial Classification, Regression) from the first base model. It is possible to set "distribution" in `metalearner_params`, however, doing the same thing for "family" is not possible since GLM/Auto metalearner overrides it (without warning) based on the `ModelCategory`.

In this PR, I am trying to make SE behave the way I would expect it to behave as a user.
This means distribution/family resolution in the following order:

1. If user specifies "distribution" in `metalearner_params` use that (even if it means that metalearner fails with "Unsupported distribution"; user should know about it and change it manually).
1. If there is no "distribution" specification in `metalearner_params`, try to infer it from first base model (also check that all other base models have the same distribution + its params (see TODO))
1. If the "distribution" from the first base model isn't compatible with the metalearner, fallback to the current solution using default distribution per task (Binomial/Multinomial Classification, Regression).
