### PR TITLE
PUBDEV-6686: Show how concurrent DRF building can lead to a failure

### DIFF
--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -30,8 +30,8 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   public ToEigenVec getToEigenVec() { return null; }
   public boolean shouldReorder(Vec v) { return _parms._categorical_encoding.needsResponse() && isSupervised(); }
 
-  transient private IcedHashMap<Key,String> _toDelete = new IcedHashMap<>();
-  void cleanUp() { FrameUtils.cleanUp(_toDelete); }
+  // initialized to be non-null to provide nicer exceptions when used incorrectly (instead of NPE)
+  private transient Workspace _workspace = new Workspace(false);
 
   public Job<M> _job;     // Job controlling this build
   /** Block till completion, and return the built model from the DKV.  Note the
@@ -1168,6 +1168,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     }
     // NOTE: allow re-init:
     clearInitState();
+    initWorkspace(expensive);
     assert _parms != null;      // Parms must already be set in
 
     if( _parms._train == null ) {
@@ -1486,7 +1487,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     if (fr.numRows()==0) error(field, frDesc + " must have > 0 rows.");
     Frame adapted = new Frame(null /* not putting this into KV */, fr._names.clone(), fr.vecs().clone());
     try {
-      String[] msgs = Model.adaptTestForTrain(adapted, null, null, _train._names, _train.domains(), _parms, expensive, true, null, getToEigenVec(), _toDelete, false);
+      String[] msgs = Model.adaptTestForTrain(adapted, null, null, _train._names, _train.domains(), _parms, expensive, true, null, getToEigenVec(), _workspace.getToDelete(expensive), false);
       Vec response = adapted.vec(_parms._response_column);
       if (response == null && _parms._response_column != null)
         error(field, frDesc + " must have a response column '" + _parms._response_column + "'.");
@@ -1510,7 +1511,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       if (scopeTrack)
         Scope.track(encoded);
       else
-        _toDelete.put(encoded._key, Arrays.toString(Thread.currentThread().getStackTrace()));
+        _workspace.getToDelete(true).put(encoded._key, Arrays.toString(Thread.currentThread().getStackTrace()));
     }
     return encoded;
   }
@@ -1783,6 +1784,39 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
    */
   public String getName() {
     return getClass().getSimpleName().toLowerCase();
+  }
+
+  private void cleanUp() {
+    _workspace.cleanUp();
+  }
+
+  @SuppressWarnings("WeakerAccess") // optionally allow users create workspace directly (instead of relying on init) 
+  protected final void initWorkspace(boolean expensive) {
+    if (expensive)
+      _workspace = new Workspace(true);
+  }
+
+  private static class Workspace {
+    private final IcedHashMap<Key,String> _toDelete;
+
+    private Workspace(boolean expensive) {
+      _toDelete = expensive ? new IcedHashMap<>() : null;
+    }
+
+    private IcedHashMap<Key, String> getToDelete(boolean expensive) {
+      if (! expensive)
+        return null; // incorrect usages during "inexpensive" initialization will fail
+      if (_toDelete == null) {
+        throw new IllegalStateException("ModelBuilder was not correctly initialized. " +
+                "Expensive phase requires field `_toDelete` to be non-null. " +
+                "Does your implementation of init method call super.init(true) or alternatively initWorkspace(true)?");
+      }
+      return _toDelete;
+    }
+
+    private void cleanUp() {
+      FrameUtils.cleanUp(_toDelete);
+    }
   }
 
 }

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1796,14 +1796,14 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       _workspace = new Workspace(true);
   }
 
-  private static class Workspace {
+  static class Workspace {
     private final IcedHashMap<Key,String> _toDelete;
 
     private Workspace(boolean expensive) {
       _toDelete = expensive ? new IcedHashMap<>() : null;
     }
 
-    private IcedHashMap<Key, String> getToDelete(boolean expensive) {
+    IcedHashMap<Key, String> getToDelete(boolean expensive) {
       if (! expensive)
         return null; // incorrect usages during "inexpensive" initialization will fail
       if (_toDelete == null) {
@@ -1814,7 +1814,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
       return _toDelete;
     }
 
-    private void cleanUp() {
+    void cleanUp() {
       FrameUtils.cleanUp(_toDelete);
     }
   }

--- a/h2o-core/src/main/java/water/util/FrameUtils.java
+++ b/h2o-core/src/main/java/water/util/FrameUtils.java
@@ -918,6 +918,9 @@ public class FrameUtils {
   }
 
   static public void cleanUp(IcedHashMap<Key, String> toDelete) {
+    if (toDelete == null) {
+      return;
+    }
     Futures fs = new Futures();
     for (Key k : toDelete.keySet()) {
       Keyed.remove(k, fs, true);

--- a/h2o-core/src/test/java/hex/ModelBuilderTest.java
+++ b/h2o-core/src/test/java/hex/ModelBuilderTest.java
@@ -9,6 +9,7 @@ import water.fvec.Frame;
 import water.fvec.TestFrameBuilder;
 import water.fvec.Vec;
 import water.parser.BufferedString;
+import water.util.ReflectionUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -123,6 +124,35 @@ public class ModelBuilderTest extends TestUtil {
     }
   }
 
+  @Test
+  public void testWorkSpaceInit() {
+    DummyModelBuilder builder = new DummyModelBuilder(new DummyModelParameters());
+    // workspace is initialized upon builder instantiation
+    ModelBuilder.Workspace workspace = ReflectionUtils.getFieldValue(builder, "_workspace");
+    assertNotNull(workspace);
+    assertNull(workspace.getToDelete(false));
+    // cheap init keeps workspace unchanged
+    builder.init(false);
+    workspace = ReflectionUtils.getFieldValue(builder, "_workspace");
+    assertNotNull(workspace);
+    assertNull(workspace.getToDelete(false));
+    // it is not possible to get "to delete" structure in for expensive operations
+    try {
+      workspace.getToDelete(true);
+      fail("Exception expected");
+    } catch (IllegalStateException e) {
+      assertEquals(
+              "ModelBuilder was not correctly initialized. Expensive phase requires field `_toDelete` to be non-null. " +
+                      "Does your implementation of init method call super.init(true) or alternatively initWorkspace(true)?", 
+              e.getMessage()
+      );
+    }
+    // expensive init will switch the workspace and let us get "to delete" for expensive ops
+    builder.init(true);
+    workspace = ReflectionUtils.getFieldValue(builder, "_workspace");
+    assertNotNull(workspace.getToDelete(true));
+  }
+  
   @Test
   public void testMakeUnknownModel() {
     try {

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_6686_concurrent_drf.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_6686_concurrent_drf.py
@@ -1,0 +1,27 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+
+
+def test_pubdev_6686():
+    train = h2o.import_file(path="http://h2o-public-test-data.s3.amazonaws.com/smalldata/jira/pubdev_6686.csv")
+
+    # Start a "long" running model that needs at least one column to be adapted (categorical_encoding="enum_limited")
+    rf1 = H2ORandomForestEstimator(nfolds=3, ntrees=100, max_depth=10, categorical_encoding="enum_limited")
+    rf1.start(y="model_pred", x=train.names.remove("y"), training_frame=train)
+
+    # Start a model that finishes quickly and calls clean-up
+    rf2 = H2ORandomForestEstimator(ntrees=1, max_depth=2)
+    rf2.start(y="model_pred", x=train.names.remove("y"), training_frame=train)
+    
+    # Both models should finish without errors
+    rf2.join()
+    rf1.join()
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_pubdev_6686)
+else:
+    test_pubdev_6686()


### PR DESCRIPTION
We need to make sure "_toDelete" is not shared for different instances of model builders. Otherwise completion of one model might trigger deleting data of another model.