### PR TITLE
Enable parallel builds for Gradle by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,3 +62,5 @@ defaultHdfsDependency=hadoop-hdfs-client
 defaultHiveExecVersion=1.1.0
 
 defaultWebserverModule=h2o-jetty-8
+
+org.gradle.parallel=true


### PR DESCRIPTION
With Gradle 6.3, parallelized build proves to reduce build time significantly, for some it reduces the time below 50%, for some even below 25%. Not to mention building the hadoop drivers.

We've double checked locally the Hadoop drivers are built correctly and checked the corectness by deploying a random sample of them.