### PR TITLE
Create cross-validation frame locked in order to avoid overwriting

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -365,11 +365,19 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
 
     /** Read-Lock both training and validation User frames. */
     public void read_lock_frames(Job job) {
+      Key k = job._key;
       Frame tr = train();
       if (tr != null)
-        tr.read_lock(job._key);
+        read_lock_frame(tr, k);
       if (_valid != null && !_train.equals(_valid))
-        _valid.get().read_lock(job._key);
+        read_lock_frame(_valid.get(), k);
+    }
+
+    private void read_lock_frame(Frame fr, Key k) {
+      if (_is_cv_model)
+        fr.write_lock_to_read_lock(k);
+      else
+        fr.read_lock(k);
     }
 
     /** Read-UnLock both training and validation User frames.  This method is

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -613,11 +613,11 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     for( int i=0; i<N; i++ ) {
       String identifier = origDest + "_cv_" + (i+1);
       // Training/Validation share the same data, but will have exclusive weights
-      Frame cvTrain = new Frame(Key.make(identifier+"_train"),cv_fr.names(),cv_fr.vecs());
+      Frame cvTrain = new Frame(Key.make(identifier + "_train"), cv_fr.names(), cv_fr.vecs());
       cvTrain.write_lock(_job);
       cvTrain.add(weightName, weights[2*i]);
       cvTrain.update(_job);
-      Frame cvValid = new Frame(Key.make(identifier+"_valid"),cv_fr.names(),cv_fr.vecs());
+      Frame cvValid = new Frame(Key.make(identifier + "_valid"), cv_fr.names(), cv_fr.vecs());
       cvValid.write_lock(_job);
       cvValid.add(weightName, weights[2*i+1]);
       cvValid.update(_job);

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -597,7 +597,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   }
 
   // Step 3: Build N train & validation frames; build N ModelBuilders; error check them all
-  public ModelBuilder<M, P, O>[] cv_makeFramesAndBuilders( int N, Vec[] weights ) {
+  private ModelBuilder<M, P, O>[] cv_makeFramesAndBuilders( int N, Vec[] weights ) {
     final long old_cs = _parms.checksum();
     final String origDest = _result.toString();
 
@@ -613,13 +613,15 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     for( int i=0; i<N; i++ ) {
       String identifier = origDest + "_cv_" + (i+1);
       // Training/Validation share the same data, but will have exclusive weights
-      Frame cvTrain = new Frame(Key.<Frame>make(identifier+"_train"),cv_fr.names(),cv_fr.vecs());
+      Frame cvTrain = new Frame(Key.make(identifier+"_train"),cv_fr.names(),cv_fr.vecs());
+      cvTrain.write_lock(_job);
       cvTrain.add(weightName, weights[2*i]);
-      DKV.put(cvTrain);
-      Frame cvValid = new Frame(Key.<Frame>make(identifier+"_valid"),cv_fr.names(),cv_fr.vecs());
+      cvTrain.update(_job);
+      Frame cvValid = new Frame(Key.make(identifier+"_valid"),cv_fr.names(),cv_fr.vecs());
+      cvValid.write_lock(_job);
       cvValid.add(weightName, weights[2*i+1]);
-      DKV.put(cvValid);
-
+      cvValid.update(_job);
+      
       // Shallow clone - not everything is a private copy!!!
       ModelBuilder<M, P, O> cv_mb = (ModelBuilder)this.clone();
       cv_mb.setTrain(cvTrain);

--- a/h2o-core/src/test/java/hex/CreateFrameTest.java
+++ b/h2o-core/src/test/java/hex/CreateFrameTest.java
@@ -1,13 +1,15 @@
 package hex;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import water.TestUtil;
+import org.junit.runner.RunWith;
 import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
 
-public class CreateFrameTest extends TestUtil {
-  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class CreateFrameTest {
 
   @Test public void basicTest() {
     CreateFrame cf = new CreateFrame();
@@ -21,12 +23,16 @@ public class CreateFrameTest extends TestUtil {
     cf.positive_response = false;
     cf.has_response = true;
     cf.seed = 1234;
-    Frame frame = cf.execImpl().get();
-    Assert.assertTrue(frame.numCols() == 11);
-    Assert.assertTrue(frame.numRows() == 100);
-    // Tries to print a frame
-    frame.toString();
-    frame.delete();
+    Frame frame = null;
+    try {
+      frame = cf.execImpl().get();
+      Assert.assertTrue(frame.numCols() == 11);
+      Assert.assertTrue(frame.numRows() == 100);
+      // Tries to print a frame
+      frame.toString();
+    } finally {
+      if (frame != null) frame.delete();
+    }
   }
 
   @Test public void binaryTest() {
@@ -42,12 +48,16 @@ public class CreateFrameTest extends TestUtil {
     cf.positive_response = false;
     cf.has_response = true;
     cf.seed = 1234;
-    Frame frame = cf.execImpl().get();
-    Assert.assertTrue(frame.numCols() == 101);
-    Assert.assertTrue(frame.numRows() == 10);
-    // Print a fame
-    frame.toString();
-    frame.delete();
+    Frame frame = null;
+    try {
+      frame = cf.execImpl().get();
+      Assert.assertTrue(frame.numCols() == 101);
+      Assert.assertTrue(frame.numRows() == 10);
+      // Print a frame
+      frame.toString();
+    } finally {
+      if (frame != null) frame.delete();
+    }
   }
 
   @Test public void timeTest() {
@@ -64,12 +74,16 @@ public class CreateFrameTest extends TestUtil {
     cf.positive_response = false;
     cf.has_response = true;
     cf.seed = 1234;
-    Frame frame = cf.execImpl().get();
-    Assert.assertTrue(frame.numCols() == 101);
-    Assert.assertTrue(frame.numRows() == 10);
-    // Print a fame
-    frame.toString();
-    frame.delete();
+    Frame frame = null;
+    try {
+      frame = cf.execImpl().get();
+      Assert.assertTrue(frame.numCols() == 101);
+      Assert.assertTrue(frame.numRows() == 10);
+      // Print a frame
+      frame.toString();
+    } finally {
+      if (frame != null) frame.delete();
+    }
   }
 
   @Test public void stringTest() {
@@ -87,12 +101,16 @@ public class CreateFrameTest extends TestUtil {
     cf.positive_response = false;
     cf.has_response = true;
     cf.seed = 1234;
-    Frame frame = cf.execImpl().get();
-    Assert.assertTrue(frame.numCols() == 101);
-    Assert.assertTrue(frame.numRows() == 10);
-    // Print a fame
-    frame.toString();
-    frame.delete();
+    Frame frame = null;
+    try {
+      frame = cf.execImpl().get();
+      Assert.assertTrue(frame.numCols() == 101);
+      Assert.assertTrue(frame.numRows() == 10);
+      // Print a frame
+      frame.toString();
+    } finally {
+      if (frame != null) frame.delete();
+    }
   }
 
   @Test public void everything() {
@@ -110,12 +128,16 @@ public class CreateFrameTest extends TestUtil {
     cf.positive_response = false;
     cf.has_response = true;
     cf.seed = 1234;
-    Frame frame = cf.execImpl().get();
-    Assert.assertTrue(frame.numCols() == 101);
-    Assert.assertTrue(frame.numRows() == 100);
-    // Print a fame
-    frame.toString();
-    frame.delete();
+    Frame frame = null;
+    try {
+      frame = cf.execImpl().get();
+      Assert.assertTrue(frame.numCols() == 101);
+      Assert.assertTrue(frame.numRows() == 100);
+      // Print a frame
+      frame.toString();
+    } finally {
+      if (frame != null) frame.delete();
+    }
   }
 
   @Test public void trainTest() {

--- a/h2o-core/src/test/java/water/LockableTest.java
+++ b/h2o-core/src/test/java/water/LockableTest.java
@@ -1,0 +1,63 @@
+package water;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class LockableTest {
+
+  @Rule
+  public transient ExpectedException ee = ExpectedException.none();
+  
+  @Test
+  public void write_lock_to_read_lock() {
+    Key<Job> jobKey = Key.make();
+    Key<TstLockable> key = Key.make();
+    try {
+      TstLockable lockable = new TstLockable(key);
+
+      lockable.write_lock(jobKey);
+      lockable.update(jobKey);
+
+      assertNotNull(DKV.getGet(key));
+
+      lockable.write_lock_to_read_lock(jobKey);
+
+      // deleting will not work
+      ee.expectMessage("is already in use");
+      lockable.delete();
+    } finally {
+      DKV.remove(key);
+    }
+  }
+
+  @Test
+  public void write_lock_to_read_lock_fail() {
+    Key<Job> jobKey = Key.make();
+    Key<TstLockable> key = Key.make();
+    try {
+      TstLockable lockable = new TstLockable(key);
+      DKV.put(lockable);
+
+      // cannot convert to read lock if write lock doesn't exist
+      ee.expectMessage("not write-locked");
+      lockable.write_lock_to_read_lock(jobKey);
+    } finally {
+      DKV.remove(key);
+    }
+  }
+
+  private static class TstLockable extends Lockable<TstLockable> {
+    private TstLockable(Key<TstLockable> key) {
+      super(key);
+    }
+  }
+
+}

--- a/h2o-py/tests/testdir_jira/pyunit_model_id_conflict.py
+++ b/h2o-py/tests/testdir_jira/pyunit_model_id_conflict.py
@@ -1,0 +1,46 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+
+
+def start_model(train):
+    rf = H2ORandomForestEstimator(nfolds=3, ntrees=10, max_depth=10, categorical_encoding="enum_limited",
+                                  model_id="mateusz")
+    rf.start(y="model_pred",
+             x=train.names.remove("y"),
+             training_frame=train)
+    return rf
+
+
+def test_conflicting_model_id():
+    train = h2o.import_file(path="http://h2o-public-test-data.s3.amazonaws.com/smalldata/jira/pubdev_6686.csv")
+
+    # Start the first model
+    first_model = start_model(train)
+
+    # Start some models to run in parallel with the first one
+    rfs = []
+    for i in range(10):
+        print(i)
+        rfs.append(start_model(train))
+
+    # First model has to finish successfully
+    first_model.join()
+
+    # Parallel built models can fail, no guarantees
+    for m in rfs:
+        try:
+            m.join()
+        except:
+            pass
+
+    # A new model to overwrite the old one has to succeed
+    start_model(train).join()
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_conflicting_model_id)
+else:
+    test_conflicting_model_id()


### PR DESCRIPTION
When CV is used, we create a new Frame for each CV fold. This mechanism doesn't use any sort of locking as of now and it is thus possible to overwrite frames by running 2 models with the same id.

The idea of the PR is to create the frame with a write-lock and keep the frame locked for the whole time of its existence. In order to do that correctly, we are adding a mechanism to Lockable that allows to atomically convert a write-lock to a read-lock (the expectation on MB is that frames will be read-locked).