### PR TITLE
PUBDEV-7504: Make sure user gets a warning when trying to get varimp from Stacked Ensemble

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -1944,8 +1944,8 @@ h2o.varimp <- function(object) {
   o <- object
   if( is(o, "H2OModel") ) {
     vi <- o@model$variable_importances
-    if( is.null(vi) ) { # may be glm
-      tvi <- object@model$standardized_coefficient_magnitudes 
+    if( is.null(vi) && !is.null(object@model$standardized_coefficient_magnitudes)) { # may be glm
+      tvi <- object@model$standardized_coefficient_magnitudes
       maxCoeff <- max(tvi$coefficients)
       sumCoeff <- sum(tvi$coefficients)
       scaledCoeff <- tvi$coefficients/maxCoeff

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_variable_importance.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_variable_importance.R
@@ -13,21 +13,10 @@ stackedensemble.varimp.test <- function() {
   y <- "AGE"
   nfolds <- 5
 
-  my_gbm <- h2o.gbm(x = x,
-                    y = y,
-                    training_frame = train,
-                    distribution = "gaussian",
-                    max_depth = 3,
-                    learn_rate = 0.2,
-                    nfolds = nfolds,
-                    fold_assignment = "Modulo",
-                    keep_cross_validation_predictions = TRUE,
-                    seed = 1)
-
   my_rf <- h2o.randomForest(x = x,
                             y = y,
                             training_frame = train,
-                            ntrees = 30,
+                            ntrees = 10,
                             nfolds = nfolds,
                             fold_assignment = "Modulo",
                             keep_cross_validation_predictions = TRUE,
@@ -36,7 +25,7 @@ stackedensemble.varimp.test <- function() {
   my_xrf <- h2o.randomForest(x = x,
                              y = y,
                              training_frame = train,
-                             ntrees = 50,
+                             ntrees = 10,
                              histogram_type = "Random",
                              nfolds = nfolds,
                              fold_assignment = "Modulo",
@@ -48,7 +37,7 @@ stackedensemble.varimp.test <- function() {
                                training_frame = train,
                                validation_frame = test,  #also test that validation_frame is working
                                model_id = "my_ensemble_gaussian",
-                               base_models = list(my_gbm@model_id, my_rf@model_id, my_xrf@model_id))
+                               base_models = list(my_rf, my_xrf))
 
   w = tryCatch(h2o.varimp(stack), warning=function(w) return(w))
   expect_equal(w$message, "This model doesn't have variable importances")

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_variable_importance.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_variable_importance.R
@@ -1,0 +1,60 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+stackedensemble.varimp.test <- function() {
+  col_types <- c("Numeric","Numeric","Numeric","Enum","Enum","Numeric","Numeric","Numeric","Numeric")
+  dat <- h2o.uploadFile(locate("smalldata/extdata/prostate.csv"),
+                        destination_frame = "prostate.hex",
+                        col.types = col_types)
+  ss <- h2o.splitFrame(dat, ratios = 0.8, seed = 1)
+  train <- ss[[1]]
+  test <- ss[[2]]
+  x <- c("CAPSULE","GLEASON","RACE","DPROS","DCAPS","PSA","VOL")
+  y <- "AGE"
+  nfolds <- 5
+
+  my_gbm <- h2o.gbm(x = x,
+                    y = y,
+                    training_frame = train,
+                    distribution = "gaussian",
+                    max_depth = 3,
+                    learn_rate = 0.2,
+                    nfolds = nfolds,
+                    fold_assignment = "Modulo",
+                    keep_cross_validation_predictions = TRUE,
+                    seed = 1)
+
+  my_rf <- h2o.randomForest(x = x,
+                            y = y,
+                            training_frame = train,
+                            ntrees = 30,
+                            nfolds = nfolds,
+                            fold_assignment = "Modulo",
+                            keep_cross_validation_predictions = TRUE,
+                            seed = 1)
+
+  my_xrf <- h2o.randomForest(x = x,
+                             y = y,
+                             training_frame = train,
+                             ntrees = 50,
+                             histogram_type = "Random",
+                             nfolds = nfolds,
+                             fold_assignment = "Modulo",
+                             keep_cross_validation_predictions = TRUE,
+                             seed = 1)
+
+  stack <- h2o.stackedEnsemble(x = x,
+                               y = y,
+                               training_frame = train,
+                               validation_frame = test,  #also test that validation_frame is working
+                               model_id = "my_ensemble_gaussian",
+                               base_models = list(my_gbm@model_id, my_rf@model_id, my_xrf@model_id))
+
+  w = tryCatch(h2o.varimp(stack), warning=function(w) return(w))
+  expect_equal(w$message, "This model doesn't have variable importances")
+
+  w2 = tryCatch(h2o.varimp_plot(stack), warning=function(w) return(w))
+  expect_equal(w2$message, "This model doesn't have variable importances")
+}
+
+doTest("Stacked Ensemble warns about unimplemented variable importance", stackedensemble.varimp.test)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7504

Fixes R to warn that SE doesn't have var.imp.


In python, it works almost as expected - it **prints** the message but doesn't throw an exception.  I would rather throw an exception but then again h2o-py does quite a lot of things that aren't exactly pythonic so I assume printing the warning is wanted behaviour.  But the user gets a clear message of what's wrong so it's probably not that urgent to change the behaviour.

Not throwing an exception in `varimp`  leads to the following message in `varimp_plot` (the warning is printed and then execution continues and fails on something else).

```

Warning: This model doesn't have variable importances
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-12-0e6c61b8b46e> in <module>
----> 1 _se.varimp_plot()

~/sources/h2o-3/h2o-py/h2o/model/model_base.py in varimp_plot(self, num_of_features, server)
   1356         importances = self.varimp(use_pandas=False)
   1357         # features labels correspond to the first value of each tuple in the importances list
-> 1358         feature_labels = [tup[0] for tup in importances]
   1359         # relative importances correspond to the first value of each tuple in the importances list
   1360         scaled_importances = [tup[2] for tup in importances]

TypeError: 'NoneType' object is not iterable

```