### PR TITLE
PUBDEV-7519: Remove old docs "front" page from the h2o-3 build

### DIFF
--- a/h2o-docs/src/front/README.md
+++ b/h2o-docs/src/front/README.md
@@ -1,0 +1,5 @@
+# Docs Front Page
+
+Note that this page is no longer maintained. The docs.h2o.ai site is now maintained outside of the H2O-3 repo.
+
+

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -152,7 +152,6 @@ mkdir target/docs-website/h2o-algos
 mkdir target/docs-website/h2o-genmodel
 mkdir target/docs-website/h2o-scala_2.10
 mkdir target/docs-website/h2o-scala_2.11
-cp -rp h2o-docs/src/front/* target/docs-website
 cp -rp h2o-docs/src/product/_build/html/* target/docs-website/h2o-docs
 cp -rp h2o-docs/web/* target/docs-website/h2o-docs
 cp -p h2o-docs/src/booklets/v2_2015/source/*.pdf target/docs-website/h2o-docs/booklets


### PR DESCRIPTION
The docs front page is maintained in the docs.h2o.ai repo. This is because we have many products, and the site can be updated outside of h2o-3 releases.

We should remove this from the build where it still shows up. (For example: https://s3.console.aws.amazon.com/s3/buckets/h2o-release/h2o/rel-zahradnik/1/docs-website/?region=us-east-1&tab=overview#)

We've gotten a couple of requests lately to provide all h2o-3 docs in a tar file, and it would be best to not include that old build page. 

Added a README to the /front folder.