### PR TITLE
PUBDEV-6938 GroupBy - support for grouping by String columns

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/mungers/AstGroup.java
@@ -588,7 +588,7 @@ public class AstGroup extends AstPrimitive {
     GBTask(int[] gbCols, byte[] gbColsTypes, AGG[] aggs, boolean hasMedian) {
       _gbCols = gbCols;
       _gbColsTypes = gbColsTypes;
-      _stringGbColsCnt = ArrayUtils.occurenceCount(_gbColsTypes, Vec.T_STR);
+      _stringGbColsCnt = ArrayUtils.occurrenceCount(_gbColsTypes, Vec.T_STR);
       _numericGbColsCnt = gbColsTypes.length - _stringGbColsCnt;
       _aggs = aggs;
       _hasMedian = hasMedian;
@@ -895,7 +895,7 @@ public class AstGroup extends AstPrimitive {
     BuildGroup(int[] gbCols, byte[] gbColsTypes, AGG[] aggs, IcedHashSet<G> gss, G[] grps, int medianCols) {
       _gbCols = gbCols;
       _gbColsTypes = gbColsTypes;
-      _stringGbColsCnt = ArrayUtils.occurenceCount(_gbColsTypes, Vec.T_STR);
+      _stringGbColsCnt = ArrayUtils.occurrenceCount(_gbColsTypes, Vec.T_STR);
       _numericGbColsCnt = gbColsTypes.length - _stringGbColsCnt;
       _aggs = aggs;
       _gss = gss;

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -2019,14 +2019,14 @@ public class ArrayUtils {
   }
 
   /**
-   * Count number of occurences of element in given array.
+   * Count number of occurrences of element in given array.
    *
-   * @param array   array in which number of occurences should be counted.
-   * @param element element whose occurences should be counted.
+   * @param array   array in which number of occurrences should be counted.
+   * @param element element whose occurrences should be counted.
    *
-   * @return  number of occurences of element in given array.
+   * @return  number of occurrences of element in given array.
    */
-  public static int occurenceCount(byte[] array, byte element) {
+  public static int occurrenceCount(byte[] array, byte element) {
     int cnt = 0;
 
     for (byte b : array)

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -1401,10 +1401,18 @@ public class ArrayUtils {
       res[i] = ary[idxs[i]];
     return res;
   }
+
   public static int[] select(int[] ary, int[] idxs) {
     int [] res = MemoryManager.malloc4(idxs.length);
     for(int i = 0; i < res.length; ++i)
       res[i] = ary[idxs[i]];
+    return res;
+  }
+
+  public static byte[] select(byte[] array, int[] idxs) {
+    byte[] res = MemoryManager.malloc1(idxs.length);
+    for(int i = 0; i < res.length; ++i)
+      res[i] = array[idxs[i]];
     return res;
   }
 
@@ -2010,4 +2018,21 @@ public class ArrayUtils {
     return false;
   }
 
+  /**
+   * Count number of occurences of element in given array.
+   *
+   * @param array   array in which number of occurences should be counted.
+   * @param element element whose occurences should be counted.
+   *
+   * @return  number of occurences of element in given array.
+   */
+  public static int occurenceCount(byte[] array, byte element) {
+    int cnt = 0;
+
+    for (byte b : array)
+      if (b == element)
+        cnt++;
+
+    return cnt;
+  }
 }

--- a/h2o-core/src/test/java/water/rapids/GroupByTest.java
+++ b/h2o-core/src/test/java/water/rapids/GroupByTest.java
@@ -400,8 +400,10 @@ public class GroupByTest extends TestUtil {
       System.out.println("GroupBy result:");
       System.out.println(resFrame.toTwoDimTable().toString());
 
-      Assert.assertEquals(expectedResFrame.numCols(), resFrame.numCols());
-      Assert.assertEquals(expectedResFrame.numRows(), resFrame.numRows());
+      Assert.assertEquals("Number of columns in the output frame after groupby does not match the expected number.",
+                          expectedResFrame.numCols(), resFrame.numCols());
+      Assert.assertEquals("Number of rows in the output frame after groupby does not match the expected number.",
+                          expectedResFrame.numRows(), resFrame.numRows());
 
       for(int i = 0; i < expectedResFrame.numCols(); i++) {
         Vec expectedVec = expectedResFrame.vec(i);
@@ -409,7 +411,8 @@ public class GroupByTest extends TestUtil {
         if (expectedVec.get_type() == Vec.T_STR)
           assertStringVecEquals(expectedVec, resFrame.vec(i));
         else
-          assertVecEquals(expectedVec, resFrame.vec(i), 0);
+          assertVecEquals("Vector (at index " + i + ") in the output frame after groupby frame does not mismatch the expected one.",
+                          expectedVec, resFrame.vec(i), 0);
       }
 
       resFrame.remove();

--- a/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
@@ -2,17 +2,8 @@ package water.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static water.util.ArrayUtils.append;
-import static water.util.ArrayUtils.countNonzeros;
-import static water.util.ArrayUtils.decodeAsInt;
-import static water.util.ArrayUtils.encodeAsInt;
-import static water.util.ArrayUtils.remove;
-import static water.util.ArrayUtils.toDouble;
+import static org.junit.Assert.*;
+import static water.util.ArrayUtils.*;
 
 /**
  * Test FrameUtils interface.
@@ -242,4 +233,38 @@ public class ArrayUtilsTest {
     assertArrayEquals(new double[]{1.0, 42.0}, toDouble(new int[]{1, 42}), 0);
   }
 
+  @Test
+  public void testOccurrenceCount() {
+    byte[] arr = new byte[]{ 1, 2, 1, 1, 3, 4 };
+    assertEquals("Occurrence count mismatch.", 3, ArrayUtils.occurrenceCount(arr, (byte) 1));
+    assertEquals("Occurrence count mismatch.", 0, ArrayUtils.occurrenceCount(arr, (byte) 0));
+  }
+
+  @Test
+  public void testOccurrenceCountEmptyArray() {
+    byte[] arr = new byte[]{};
+    assertEquals("Occurrence count mismatch.", 0, ArrayUtils.occurrenceCount(arr, (byte) 1));
+  }
+  
+  @Test
+  public void testByteArraySelect() {
+    byte[] arr = new byte[]{ 1, 2, 3, 4, 5, 6 };
+    int[] idxs = new int[]{ 3, 1, 5 };
+
+    byte[] expectedSelectedElements = new byte[]{ 4, 2, 6 };
+
+    assertArrayEquals("Selected array elements mismatch.", 
+                      expectedSelectedElements, ArrayUtils.select(arr, idxs));
+  }
+  
+  @Test
+  public void testByteArrayEmptySelect() {
+    byte[] arr = new byte[]{ 1, 2, 3, 4, 5, 6 };
+    int[] idxs = new int[]{};
+
+    byte[] expectedSelectedElements = new byte[]{};
+
+    assertArrayEquals("Selected array elements mismatch.",
+                      expectedSelectedElements, ArrayUtils.select(arr, idxs));
+  }
 }


### PR DESCRIPTION
This PR adds GroupBy support for` String` values (not for `AstGroup.FCN` functions, but it allows grouping rows by a column which is of type `String`), in order to implement TF-IDF (#4380) by using GroupBy operation (`AstGroup`).

This functionality is not directly accessible from "Ast API", but it can be used via public methods and classes from `AstGroup` as shown in the unit test.