### PR TITLE
H2ORunner checks cloud size before each test leaf execution

### DIFF
--- a/h2o-core/src/test/java/water/runner/H2ORunner.java
+++ b/h2o-core/src/test/java/water/runner/H2ORunner.java
@@ -42,7 +42,6 @@ public class H2ORunner extends BlockJUnit4ClassRunner {
         doOnlyTestNames = new HashSet();
         ignoreTestsNames = new HashSet();
         createTestFilters();
-        TestUtil.stall_till_cloudsize(fetchCloudSize());
     }
 
 
@@ -75,6 +74,8 @@ public class H2ORunner extends BlockJUnit4ClassRunner {
      */
     private void leaf(Statement statement, Description description,
                       RunNotifier notifier) {
+        TestUtil.stall_till_cloudsize(fetchCloudSize());
+        
         final EachTestNotifier eachNotifier = new EachTestNotifier(notifier, description);
         eachNotifier.fireTestStarted();
         try {


### PR DESCRIPTION
When `TestUtil.stall_till_cloud_size` method is called, it checks against `private static boolean _stall_called_before = false;` whether it has already been called or not.

Making sure the cloud size is correct before each leaf is one option - giving us the per-test immediate feedback. Which I'm not sure is needed. But the call is extremely cheap. At this place, it is also made sure this part is not executed if the test is ignored - and we keep the order of method calls defined by original JUnit pipeline.