### PR TITLE
PDP Error message for non-regression/binomial.

### DIFF
--- a/h2o-core/src/main/java/hex/PartialDependence.java
+++ b/h2o-core/src/main/java/hex/PartialDependence.java
@@ -69,7 +69,7 @@ public class PartialDependence extends Lockable<PartialDependence> {
 
   private void checkSanityAndFillParams() {
     if (!((_model_id.get()._output.nclasses()==2) || (_model_id.get()._output.nclasses()==1)))
-      throw H2O.unimpl(); // only for regression and binary classification for now
+      throw H2O.unimpl("Partial Dependence Plot is only available for regression and binary classification.");
     
     _predictor_column = (_model_id.get()._output.nclasses()==1)?0:2;  // regression: column 0, binary classifier: 2
     if (_cols != null || _col_pairs_2dpdp != null) {


### PR DESCRIPTION
Problem: https://stackoverflow.com/questions/61722372/getting-water-exception-for-h2o-partial-plot

The user probably reached this block:
```JAVA
  private void checkSanityAndFillParams() {
    if (!((_model_id.get()._output.nclasses()==2) || (_model_id.get()._output.nclasses()==1)))
      throw H2O.unimpl(); // only for regression and binary classification for now
```
Which means the model was not  regress. or bin.
There is an example provided: https://github.com/prabhuSub/H2O-Water-Exception/blob/master/Sample_issue.ipynb
And the training dataset name is already suspicous digiq_wine_multiclass_training(1)_scrubbed.csv
Target variable is is_buyer - the name suggests it is cardinality 2, but it's multinomial really if you look at the dataset (attached).

[digiq_wine_multiclass_training(1)_scrubbed.zip](https://github.com/h2oai/h2o-3/files/4619851/digiq_wine_multiclass_training.1._scrubbed.zip)

### Do not merge ! We're about to release.