### PR TITLE
Replace townsfold gradle release plugin with researchgate release plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         classpath 'org.ow2.asm:asm:5.1'
         classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
-        classpath 'com.github.townsfolk:gradle-release:1.2'
+        classpath 'net.researchgate:gradle-release:2.6.0'
         classpath 'com.adaptc.gradle:nexus-workflow:0.6'
         classpath 'org.testng:testng:6.8'
         classpath 'be.insaneprogramming.gradle:animalsniffer-gradle-plugin:+'
@@ -338,6 +338,8 @@ task buildH2oDevDist(type: Exec) {
     environment['BRANCH_NAME'] = branchName
     environment['BUILD_NUMBER'] = buildNumber
     environment['LAST_COMMIT_HASH'] = lastCommitHash
+    // For both master and release branch, return the version in gradle.properties to original version
+    environment['CURRENT_VERSION'] = version
     
     commandLine './make-dist.sh'
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -73,7 +73,7 @@ publishing {
                   artifact(signature, new Action<MavenArtifact>() {
                       @Override
                       void execute(MavenArtifact t) {
-                          t.classifier = signature.toSignArtifact.classifier != "" ? signature.toSignArtifact.classifier : null
+                          t.classifier = signature.classifier != "" ? signature.classifier : null
                           t.extension = signature.type == "xml.asc" ? "pom.asc" : signature.type
                       }
                   })

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,10 +1,14 @@
-apply plugin: 'release'
+apply plugin: 'net.researchgate.release'
 apply plugin: 'nexus-workflow'
 
 release {
-  tagPrefix = "release"
-  // Safe point - do releases only from release branch - can be deleted in future
-  //requireBranch = "testing"
+    failOnCommitNeeded = true
+    tagTemplate = 'jenkins-$version'
+    tagCommitMessage = "[H2O Release] :"
+    newVersionCommitMessage = "[Reverting back to H2O version] :"
+    git {
+        requireBranch = "rel-[a-zA-Z]*|master"
+    }
 }
 
 // Helper task uploading all artifacts
@@ -18,7 +22,3 @@ publishAll.dependsOn {
 task stageAll
 stageAll.dependsOn publishAll, nexusStagingRelease
 nexusStagingRelease.mustRunAfter publishAll
-
-
-// Create release as final step
-createReleaseTag.dependsOn stageAll

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -68,8 +68,7 @@ if [ -n "$DO_RELEASE" ]; then
 fi
 
 # Run some required gradle tasks to produce final build output.
-./gradlew booklets
-./gradlew $DO_RELEASE publish
+./gradlew $DO_RELEASE -Prelease.branch=${BRANCH_NAME} -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${PROJECT_VERSION} -Prelease.newVersion=${CURRENT_VERSION} publish
 
 # Create target dir, which is uploaded to s3.
 mkdir target

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -154,7 +154,7 @@ try {
                             pipelineContext.getBuildSummary().setStageDetails(this, TAG_STAGE_NAME, env.NODE_NAME, env.WORKSPACE)
                             sh """
                                 cd ${env.BUILD_NUMBER_DIR}
-                                git tag -a jenkins-${env.BRANCH_NAME}-${currentBuild.number} -m "Jenkins build branch_name ${env.BRANCH_NAME} build_number ${env.PROJECT_VERSION}"
+                                git tag -a jenkins-${env.BRANCH_NAME}-${currentBuild.number} -m "Jenkins build branch_name ${env.BRANCH_NAME} build_number ${env.PROJECT_VERSION}" HEAD^
                             """
                             sshagent (credentials: ['h2oOpsGitPrivateKey']) {
                                 if ((env.NIGHTLY_BUILD == null || env.NIGHTLY_BUILD.toLowerCase() == 'false')) {
@@ -163,8 +163,7 @@ try {
                                         echo "Process release tags"
                                         git tag -d jenkins-rel-latest-stable
                                         git push origin :refs/tags/jenkins-rel-latest-stable
-                                        git tag -a jenkins-${env.PROJECT_VERSION} -m "Jenkins build branch_name ${env.BRANCH_NAME} build_number ${env.PROJECT_VERSION}"
-                                        git tag -a jenkins-rel-latest-stable -f -m "Jenkins build branch_name ${env.BRANCH_NAME} build_number ${env.PROJECT_VERSION}"
+                                        git tag -a jenkins-rel-latest-stable -f -m "Jenkins build branch_name ${env.BRANCH_NAME} build_number ${env.PROJECT_VERSION}" HEAD^
                                     """
                                 }
                                 sh """


### PR DESCRIPTION
This is how Sparkling Water invokes it:

`./gradlew -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${version} -Prelease.newVersion=${nextVersion} -PdoRelease release -x check`

https://github.com/h2oai/sparkling-water/blob/5ee475f0447386db83c7d00c69745630e35fa30b/ci/Jenkinsfile-release#L172

It's probably best to refer to the official documentation when it comes to CI usage: https://github.com/researchgate/gradle-release



Configuration:

https://github.com/h2oai/sparkling-water/blob/master/gradle/release.gradle 