### PR TITLE
PUBDEV-7481: GLM not running with alpha arrays properly

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -257,6 +257,7 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public String fullName() { return "Generalized Additive Model"; }
     public String javaName() { return GAMModel.class.getName(); }
     public double _prior = -1;
+    public boolean _cold_start = false; // start building GLM model from scratch if true
     public int _nlambdas = -1;
     public boolean _non_negative = false;
     public boolean _remove_collinear_columns = false;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -85,6 +85,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   public static class RegularizationPath extends Iced {
     public double []   _lambdas;
+    public double[] _alphas;
     public double []   _explained_deviance_train;
     public double []   _explained_deviance_valid;
     public double [][] _coefficients;
@@ -92,8 +93,8 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public String []   _coefficient_names;
   }
 
-
-  public RegularizationPath getRegularizationPath() {
+  // go through all submodels, copy lambda, alpha, coefficient values and deviance value\s
+  public RegularizationPath getRegularizationPath() { // will be invoked even without lambda_search=true
     RegularizationPath rp = new RegularizationPath();
     rp._coefficient_names = _output._coefficient_names;
     int N = _output._submodels.length;
@@ -109,6 +110,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       P*=_output.nclasses();
     }
     rp._lambdas = new double[N];
+    rp._alphas = new double[N];
     rp._coefficients = new double[N][];
     rp._explained_deviance_train = new double[N];
     if (_parms._valid != null)
@@ -118,6 +120,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     for (int i = 0; i < N; ++i) {
       Submodel sm = _output._submodels[i];
       rp._lambdas[i] = sm.lambda_value;
+      rp._alphas[i] = sm.alpha_value;
       rp._coefficients[i] = sm.getBeta(MemoryManager.malloc8d(P));
       if (_parms._standardize) {
         rp._coefficients_std[i] = rp._coefficients[i];
@@ -125,7 +128,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       }
       rp._explained_deviance_train[i] = 1 - (_output._training_metrics._nobs*sm.devianceTrain)/((GLMMetrics)_output._training_metrics).null_deviance();
       if (rp._explained_deviance_valid != null)
-        rp._explained_deviance_valid[i] = 1 - _output._validation_metrics._nobs*sm.devianceTest/((GLMMetrics)_output._validation_metrics).null_deviance();
+        rp._explained_deviance_valid[i] = 1 - _output._validation_metrics._nobs*sm.devianceValid /((GLMMetrics)_output._validation_metrics).null_deviance();
     }
     return rp;
   }
@@ -214,13 +217,15 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   public void update(double [] beta, double devianceTrain, double devianceTest,int iter){
     int id = _output._submodels.length-1;
-    _output._submodels[id] = new Submodel(_output._submodels[id].lambda_value,beta,iter,devianceTrain,devianceTest);
+    _output._submodels[id] = new Submodel(_output._submodels[id].lambda_value,_output._submodels[id].alpha_value,beta,
+            iter,devianceTrain,devianceTest);
     _output.setSubmodelIdx(id);
   }
 
   public void update(double [] beta, double[] ubeta, double devianceTrain, double devianceTest,int iter){
     int id = _output._submodels.length-1;
-    Submodel sm = new Submodel(_output._submodels[id].lambda_value,beta,iter,devianceTrain,devianceTest);
+    Submodel sm = new Submodel(_output._submodels[id].lambda_value,_output._submodels[id].alpha_value,beta,iter,
+            devianceTrain,devianceTest);
     sm.ubeta = Arrays.copyOf(ubeta, ubeta.length);
     _output._submodels[id] = sm;
     _output.setSubmodelIdx(id);
@@ -266,6 +271,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public double _prior = -1;
     public boolean _lambda_search = false;
     public boolean _HGLM = false; // true to enable HGLM
+    public boolean _cold_start = false; // start GLM model from scratch if true
     public int _nlambdas = -1;
     public boolean _non_negative = false;
     public double _lambda_min_ratio = -1; // special
@@ -837,7 +843,6 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     // function inverse of link function
     public final double linkInv(double x) {
       switch(_link) {
-//        case multinomial: // should not be used
         case ologlog:
           return 1.0-Math.exp(-1.0*Math.exp(x));
         case oprobit:
@@ -1047,9 +1052,10 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   public static class Submodel extends Iced {
     public final double lambda_value;
+    public final double alpha_value;
     public final int    iteration;
     public final double devianceTrain;
-    public final double devianceTest;
+    public final double devianceValid;
     public final int    [] idxs;
     public final double [] beta;
     public double[] ubeta;  // store HGLM random coefficients
@@ -1068,12 +1074,13 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public int rank(){
       return idxs != null?idxs.length:(ArrayUtils.countNonzeros(beta));
     }
-
-    public Submodel(double lambda , double [] beta, int iteration, double devTrain, double devTest) {
+    
+    public Submodel(double lambda , double alpha, double [] beta, int iteration, double devTrain, double devValid){
       this.lambda_value = lambda;
+      this.alpha_value = alpha;
       this.iteration = iteration;
       this.devianceTrain = devTrain;
-      this.devianceTest = devTest;
+      this.devianceValid = devValid;
       int r = 0;
       if(beta != null){
         // grab the indeces of non-zero coefficients
@@ -1127,13 +1134,22 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     String[] _random_coefficient_names; // for HGLM
     String[] _random_column_names;
     public long _training_time_ms;
-    public int _best_lambda_idx; // lambda which minimizes deviance on validation (if provided) or train (if not)
-    public int _lambda_1se = -1; // lambda_best + sd(lambda); only applicable if running lambda search with nfold
-    public int _selected_lambda_idx; // lambda which minimizes deviance on validation (if provided) or train (if not)
-    public double lambda_best(){return _submodels.length == 0 ? -1 : _submodels[_best_lambda_idx].lambda_value;}
+    int _lambda_array_size; // store number of lambdas to iterate over
+    public int _lambda_1se = -1; // lambda_best+sd(lambda) submodel index; applicable if running lambda search with cv 
+    public int _selected_lambda_idx; // lambda index with best deviance
+    public int _selected_alpha_idx;     // alpha index with best deviance
+    public int _selected_submodel_idx;  // submodel index with best deviance
+    public int _best_submodel_idx;      // submodel index with best deviance
+    public int _best_lambda_idx;        // the same as best_submodel_idx, kept to ensure backward compatibility
+    public double lambda_best(){return _submodels.length == 0 ? -1 : _submodels[_best_submodel_idx].lambda_value;}
     public double dispersion(){ return _dispersion;}
-    public double lambda_1se(){return _lambda_1se == -1 || _lambda_1se >= _submodels.length?-1:_submodels.length == 0 ? -1 : _submodels[_lambda_1se].lambda_value;}
-    public double lambda_selected(){return _submodels[_selected_lambda_idx].lambda_value;}
+    public double alpha_best() { return _submodels.length == 0 ? -1 : _submodels[_selected_submodel_idx].alpha_value;}
+    public double lambda_1se(){return (_lambda_1se==-1 || _submodels.length==0 || _lambda_1se>=_submodels.length) ?
+            -1 : _submodels[_lambda_1se].lambda_value;}
+    public int bestSubmodelIndex() { return _selected_submodel_idx; }
+    public double lambda_selected(){
+      return _submodels[_selected_submodel_idx].lambda_value;
+    }
     double[] _global_beta;
     double[] _ubeta;  // HGLM:  random coefficients
     private double[] _zvalues;
@@ -1169,7 +1185,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public boolean _multinomial;
     public boolean _ordinal;
 
-    public int rank() { return _submodels[_selected_lambda_idx].rank();}
+    public int rank() { return _submodels[_selected_submodel_idx].rank();}
 
     public boolean isStandardized() {
       return _dinfo._predictor_transform == TransformType.STANDARDIZE;
@@ -1234,7 +1250,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         _global_beta_multinomial=ArrayUtils.convertTo2DMatrix(beta, coefficient_names.length);
       else
         _global_beta=beta;
-      _submodels = new Submodel[]{new Submodel(0,beta,-1,Double.NaN,Double.NaN)};
+      _submodels = new Submodel[]{new Submodel(0, 0,beta,-1,Double.NaN,Double.NaN)};
     }
     
     public GLMOutput() {_isSupervised = true; _nclasses = -1;}
@@ -1312,26 +1328,26 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       Submodel best = _submodels[0];
       for(int i = 1; i < _submodels.length; ++i) {
         Submodel sm = _submodels[i];
-        if(!(sm.devianceTest > best.devianceTest) && sm.devianceTrain < best.devianceTrain){
+        if(!(sm.devianceValid > best.devianceValid) && sm.devianceTrain < best.devianceTrain){
           bestId = i;
           best = sm;
         }
       }
-      setSubmodelIdx(_best_lambda_idx = bestId);
+      setSubmodelIdx(_best_submodel_idx = bestId);
       return best;
     }
 
     public double[] getNormBeta() {
       if(this.isStandardized()) {
-        return _submodels[_selected_lambda_idx].getBeta(MemoryManager.malloc8d(_dinfo.fullN()+1));
+        return _submodels[_selected_submodel_idx].getBeta(MemoryManager.malloc8d(_dinfo.fullN()+1));
       } else {
-        return _dinfo.normalizeBeta(_submodels[_selected_lambda_idx].getBeta(MemoryManager.malloc8d(_dinfo.fullN()+1)), this.isStandardized());
+        return _dinfo.normalizeBeta(_submodels[_selected_submodel_idx].getBeta(MemoryManager.malloc8d(_dinfo.fullN()+1)), this.isStandardized());
 
       }
     }
 
     public double[][] getNormBetaMultinomial() {
-      return getNormBetaMultinomial(_selected_lambda_idx, this.isStandardized());
+      return getNormBetaMultinomial(_selected_submodel_idx, this.isStandardized());
     }
 
     public double[][] getNormBetaMultinomial(int idx) {
@@ -1361,17 +1377,19 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
         if(standardized) {
           res[i] = Arrays.copyOfRange(beta, i * N, (i + 1) * N);
         } else {
-          //res[i] = _dinfo.denormalizeBeta(Arrays.copyOfRange(beta, i * N, (i + 1) * N), standardized);
-          res[i] = _dinfo.normalizeBeta(Arrays.copyOfRange(beta, i * N, (i + 1) * N), standardized);
+           res[i] = _dinfo.normalizeBeta(Arrays.copyOfRange(beta, i * N, (i + 1) * N), standardized);
         }
       return res;
     }
 
     public double[][] get_global_beta_multinomial(){return _global_beta_multinomial;}
 
-
+    // set model coefficients to that of submodel index l
     public void setSubmodelIdx(int l){
-      _selected_lambda_idx = l;
+      _selected_submodel_idx = l;
+      _best_lambda_idx = l; // kept to ensure backward compatibility
+      _selected_alpha_idx = l / _lambda_array_size ;
+      _selected_lambda_idx = l % _lambda_array_size;
       if (_random_coefficient_names != null) 
         _ubeta = Arrays.copyOf(_submodels[l].ubeta, _submodels[l].ubeta.length);
       if(_multinomial || _ordinal) {
@@ -1388,17 +1406,11 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       }
     }
     public double [] beta() { return _global_beta;}
-    public Submodel bestSubmodel(){ return _submodels[_best_lambda_idx];}
-
-    public void setSubmodel(double lambdaCVEstimate) {
-      for(int i = 0; i < _submodels.length; ++i)
-        if(_submodels[i] != null && _submodels[i].lambda_value == lambdaCVEstimate) {
-          setSubmodelIdx(i);
-          return;
-        }
-      throw new NoSuchElementException("has no model for lambda = " + lambdaCVEstimate);
+    public Submodel bestSubmodel() {
+      return _submodels[_selected_submodel_idx];
     }
 
+    // given lambda value, return the corresponding submodel index
     public Submodel getSubmodel(double lambdaCVEstimate) {
       for(int i = 0; i < _submodels.length; ++i)
         if(_submodels[i] != null && _submodels[i].lambda_value == lambdaCVEstimate) {
@@ -1471,12 +1483,12 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       _output._model_summary.set(0, 1, _parms._link.toString());
       String regularization = "None";
       if (_parms._lambda != null && !(_parms._lambda.length == 1 && _parms._lambda[0] == 0)) { // have regularization
-        if (_parms._alpha[0] == 0)
+        if (_parms._alpha[_output._selected_alpha_idx] == 0)
           regularization = "Ridge ( lambda = ";
-        else if (_parms._alpha[0] == 1)
+        else if (_parms._alpha[_output._selected_alpha_idx] == 1)
           regularization = "Lasso (lambda = ";
         else
-          regularization = "Elastic Net (alpha = " + MathUtils.roundToNDigits(_parms._alpha[0], 4) + ", lambda = ";
+          regularization = "Elastic Net (alpha = " + MathUtils.roundToNDigits(_parms._alpha[_output._selected_alpha_idx], 4) + ", lambda = ";
         regularization = regularization + MathUtils.roundToNDigits(_parms._lambda[_output._selected_lambda_idx], 4) + " )";
       }
       _output._model_summary.set(0, 2, regularization);

--- a/h2o-algos/src/main/java/hex/glm/GLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMUtils.java
@@ -33,6 +33,12 @@ public class GLMUtils {
     }
     return gamColIndices;
   }
+  
+  public static GLM.GLMGradientInfo copyGInfo(GLM.GLMGradientInfo ginfo) {
+    double[] gradient = ginfo._gradient.clone();
+    GLM.GLMGradientInfo tempGinfo = new GLM.GLMGradientInfo(ginfo._likelihood, ginfo._objVal, gradient);
+    return tempGinfo;
+  }
 
   public static TwoDimTable combineScoringHistory(TwoDimTable glmSc1, TwoDimTable earlyStopSc2, 
                                                   List<Integer> scoreIterationList) {

--- a/h2o-algos/src/main/java/hex/schemas/GAMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMV3.java
@@ -53,6 +53,7 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
             "gradient_epsilon",
             "link",
             "prior",
+            "cold_start", // if true, will start GLM model from initial values and conditions
             "lambda_min_ratio",
             "beta_constraints",
             "max_active_predictors",
@@ -159,6 +160,11 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
 
     @API(help = "Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean of response does not reflect reality.", level = Level.expert)
     public double prior;
+
+    @API(help = "Only applicable to multiple alpha/lambda values when calling GLM from GAM.  If false, build the next" +
+            " model for next set of alpha/lambda values starting from the values provided by current model.  If true" +
+            " will start GLM model from scratch.", level = Level.critical)
+    public boolean cold_start;
 
     @API(help = "Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all coefficients to zero)." +
             " Default indicates: if the number of observations is greater than the number of variables, then lambda_min_ratio" +

--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -31,8 +31,15 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
     @API(help="Standardized Coefficient Magnitudes")
     TwoDimTableV3 standardized_coefficient_magnitudes;
 
-    @API(help="Lambda minimizing the objective value, only applicable with lambd search")
+    @API(help="Lambda minimizing the objective value, only applicable with lambda search or when arrays of alpha and " +
+            "lambdas are provided")
     double lambda_best;
+
+    @API(help="Alpha minimizing the objective value, only applicable when arrays of alphas are given ")
+    double alpha_best;
+
+    @API(help="submodel index minimizing the objective value, only applicable for arrays of alphas/lambda ")
+    int best_submodel_index; // denote the submodel index that yields the best result
 
     @API(help="Lambda best + 1 standard error. Only applicable with lambda search and cross-validation")
     double lambda_1se;
@@ -154,6 +161,8 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       super.fillFromImpl(impl);
       lambda_1se = impl.lambda_1se();
       lambda_best = impl.lambda_best();
+      alpha_best = impl.alpha_best();
+      best_submodel_index = impl.bestSubmodelIndex();
       dispersion = impl.dispersion();
       if(impl._multinomial || impl._ordinal)
         return fillMultinomial(impl);

--- a/h2o-algos/src/main/java/hex/schemas/GLMRegularizationPathV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMRegularizationPathV3.java
@@ -12,6 +12,8 @@ public class GLMRegularizationPathV3  extends SchemaV3<GLMModel.RegularizationPa
   public KeyV3.ModelKeyV3 model;
   @API(help="Computed lambda values")
   public double [] lambdas;
+  @API(help="alpha values used in building submodels")
+  public double [] alphas;
   @API(help="explained deviance on the training set")
   public double [] explained_deviance_train;
   @API(help="explained deviance on the validation set")

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -16,7 +16,7 @@ import water.api.schemas3.StringPairV3;
 public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
 
   public static final class GLMParametersV3 extends ModelParametersSchemaV3<GLMParameters, GLMParametersV3> {
-     public static final String[] fields = new String[] {
+    public static final String[] fields = new String[]{
             "model_id",
             "training_frame",
             "validation_frame",
@@ -31,7 +31,7 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "ignored_columns",
             "random_columns", // HGLM denote random columns, array
             "ignore_const_cols",
-            "score_each_iteration", 
+            "score_each_iteration",
             "score_iteration_interval",
             "offset_column",
             "weights_column",
@@ -57,12 +57,13 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "objective_epsilon",
             "beta_epsilon",
             "gradient_epsilon",
-            "link", 
+            "link",
             "rand_link", // link function for random components, array
             "startval",  // initial starting values for fixed and randomized coefficients, double array
             "calc_like", // HGLM, true will return likelhood function value
             "HGLM",  // boolean: true - enabled HGLM, false - normal GLM
             "prior",
+            "cold_start", // if true, will start GLM model from initial values and conditions
             "lambda_min_ratio",
             "beta_constraints",
             "max_active_predictors",
@@ -70,9 +71,9 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "interaction_pairs",
             "obj_reg",
             "export_checkpoints_dir",
-             "stopping_rounds",
-             "stopping_metric",
-             "stopping_tolerance",
+            "stopping_rounds",
+            "stopping_metric",
+            "stopping_tolerance",
             // dead unused args forced here by backwards compatibility, remove in V4
             "balance_classes",
             "class_sampling_factors",
@@ -133,6 +134,11 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help = "Standardize numeric columns to have zero mean and unit variance", level = Level.critical)
     public boolean standardize;
 
+    @API(help = "Only applicable to multiple alpha/lambda values.  If false, build the next model for next set of " +
+            "alpha/lambda values starting from the values provided by current model.  If true will start GLM model " +
+            "from scratch.", level = Level.critical)
+    public boolean cold_start;
+
     @API(help = "Handling of missing values. Either MeanImputation, Skip or PlugValues.", values = { "MeanImputation", "Skip", "PlugValues" }, level = API.Level.expert, direction=API.Direction.INOUT, gridable = true)
     public GLMParameters.MissingValuesHandling missing_values_handling;
 
@@ -170,7 +176,7 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     @API(help = "Link function array for random component in HGLM.", values = {"[identity]", "[family_default]"},level = Level.secondary, gridable=true)   
     public GLMParameters.Link[] rand_link; // link function for random components
 
-    @API(help = "double array to initialize fixed and random coefficients for HGLM.", gridable=true)
+    @API(help = "double array to initialize fixed and random coefficients for HGLM, coefficients for GLM.", gridable=true)
     public double[] startval;
     
     @API(help = "random columns indices for HGLM.")

--- a/h2o-bindings/bin/custom/python/gen_glm.py
+++ b/h2o-bindings/bin/custom/python/gen_glm.py
@@ -43,6 +43,7 @@ def class_extensions():
         ns = x.pop("coefficient_names")
         res = {
             "lambdas": x["lambdas"],
+            "alphas": x["alphas"],
             "explained_deviance_train": x["explained_deviance_train"],
             "explained_deviance_valid": x["explained_deviance_valid"],
             "coefficients": [dict(zip(ns, y)) for y in x["coefficients"]],

--- a/h2o-py/h2o/estimators/gam.py
+++ b/h2o-py/h2o/estimators/gam.py
@@ -36,11 +36,12 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
                    "solver", "alpha", "lambda_", "lambda_search", "early_stopping", "nlambdas", "standardize",
                    "missing_values_handling", "plug_values", "compute_p_values", "remove_collinear_columns",
                    "intercept", "non_negative", "max_iterations", "objective_epsilon", "beta_epsilon",
-                   "gradient_epsilon", "link", "prior", "lambda_min_ratio", "beta_constraints", "max_active_predictors",
-                   "interactions", "interaction_pairs", "obj_reg", "export_checkpoints_dir", "stopping_rounds",
-                   "stopping_metric", "stopping_tolerance", "balance_classes", "class_sampling_factors",
-                   "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k", "max_runtime_secs",
-                   "custom_metric_func", "num_knots", "knot_ids", "gam_columns", "bs", "scale", "keep_gam_cols"}
+                   "gradient_epsilon", "link", "prior", "cold_start", "lambda_min_ratio", "beta_constraints",
+                   "max_active_predictors", "interactions", "interaction_pairs", "obj_reg", "export_checkpoints_dir",
+                   "stopping_rounds", "stopping_metric", "stopping_tolerance", "balance_classes",
+                   "class_sampling_factors", "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k",
+                   "max_runtime_secs", "custom_metric_func", "num_knots", "knot_ids", "gam_columns", "bs", "scale",
+                   "keep_gam_cols"}
 
     def __init__(self, **kwargs):
         super(H2OGeneralizedAdditiveEstimator, self).__init__()
@@ -643,6 +644,23 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
     def prior(self, prior):
         assert_is_type(prior, None, numeric)
         self._parms["prior"] = prior
+
+
+    @property
+    def cold_start(self):
+        """
+        Only applicable to multiple alpha/lambda values when calling GLM from GAM.  If false, build the next model for
+        next set of alpha/lambda values starting from the values provided by current model.  If true will start GLM
+        model from scratch.
+
+        Type: ``bool``  (default: ``False``).
+        """
+        return self._parms.get("cold_start")
+
+    @cold_start.setter
+    def cold_start(self, cold_start):
+        assert_is_type(cold_start, None, bool)
+        self._parms["cold_start"] = cold_start
 
 
     @property

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -37,7 +37,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
                    "lambda_search", "early_stopping", "nlambdas", "standardize", "missing_values_handling",
                    "plug_values", "compute_p_values", "remove_collinear_columns", "intercept", "non_negative",
                    "max_iterations", "objective_epsilon", "beta_epsilon", "gradient_epsilon", "link", "rand_link",
-                   "startval", "calc_like", "HGLM", "prior", "lambda_min_ratio", "beta_constraints",
+                   "startval", "calc_like", "HGLM", "prior", "cold_start", "lambda_min_ratio", "beta_constraints",
                    "max_active_predictors", "interactions", "interaction_pairs", "obj_reg", "export_checkpoints_dir",
                    "stopping_rounds", "stopping_metric", "stopping_tolerance", "balance_classes",
                    "class_sampling_factors", "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k",
@@ -1255,7 +1255,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     @property
     def startval(self):
         """
-        double array to initialize fixed and random coefficients for HGLM.
+        double array to initialize fixed and random coefficients for HGLM, coefficients for GLM.
 
         Type: ``List[float]``.
         """
@@ -1325,6 +1325,22 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def prior(self, prior):
         assert_is_type(prior, None, numeric)
         self._parms["prior"] = prior
+
+
+    @property
+    def cold_start(self):
+        """
+        Only applicable to multiple alpha/lambda values.  If false, build the next model for next set of alpha/lambda
+        values starting from the values provided by current model.  If true will start GLM model from scratch.
+
+        Type: ``bool``  (default: ``False``).
+        """
+        return self._parms.get("cold_start")
+
+    @cold_start.setter
+    def cold_start(self, cold_start):
+        assert_is_type(cold_start, None, bool)
+        self._parms["cold_start"] = cold_start
 
 
     @property
@@ -1823,6 +1839,7 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         ns = x.pop("coefficient_names")
         res = {
             "lambdas": x["lambdas"],
+            "alphas": x["alphas"],
             "explained_deviance_train": x["explained_deviance_train"],
             "explained_deviance_valid": x["explained_deviance_valid"],
             "coefficients": [dict(zip(ns, y)) for y in x["coefficients"]],

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -4277,3 +4277,81 @@ def saveModelMojo(model):
     os.makedirs(tmpdir)
     model.download_mojo(path=tmpdir)    # save mojo
     return tmpdir
+
+# This file will contain functions used by GLM test only.
+def assertEqualRegPaths(keys, pathList, index, onePath, tol=1e-6):
+    for oneKey in keys:
+        if (pathList[oneKey] != None):
+            assert abs(pathList[oneKey][index]-onePath[oneKey][0]) < tol, \
+                "Expected value: {0}, Actual: {1}".format(pathList[oneKey][index], onePath[oneKey][0])
+
+
+
+def assertEqualCoeffDicts(coef1Dict, coef2Dict, tol = 1e-6):
+    assert len(coef1Dict) == len(coef2Dict), "Length of first coefficient dict: {0}, length of second coefficient " \
+                                             "dict: {1} and they are different.".format(len(coef1Dict, len(coef2Dict)))
+    for key in coef1Dict:
+        assert abs(coef1Dict[key]-coef2Dict[key]) < tol, "Coefficient for {0} from first dict: {1}, from second dict:" \
+                                                         " {2} and they are different.".format(key, coef1Dict[key],
+                                                                                               coef2Dict[key])
+def assertEqualModelMetrics(metrics1, metrics2, tol = 1e-6,
+                            keySet=["MSE", "AUC", "Gini", "null_deviance", "logloss", "RMSE",
+                                    "pr_auc", "r2"]):
+    # 1. Check model types
+    model1_type = metrics1.__class__.__name__
+    model2_type = metrics2.__class__.__name__
+    assert model1_type is model2_type, "The model types differ. The first model metric is of type {0} and the second " \
+                                       "model metric is of type {1}.".format(model1_type, model2_type)
+
+    metricDict1 = metrics1._metric_json
+    metricDict2 = metrics2._metric_json
+
+    for key in keySet:
+        if key in metricDict1.keys() and (isinstance(metricDict1[key], float)): # only compare floating point metrics
+            assert abs(metricDict1[key]-metricDict2[key])/max(1,max(metricDict1[key],metricDict2[key])) < tol, \
+                "ModelMetric {0} from model 1,  {1} from model 2 are different.".format(metricDict1[key],metricDict2[key])
+
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated from the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. training metrics from alpha array should equal to the individual model matching the alpha/lambda value;
+def compareSubmodelsNindividualModels(modelWithArray, trainingData, xarray, yindex):
+    best_submodel_index = modelWithArray._model_json["output"]["best_submodel_index"]
+    r = H2OGeneralizedLinearEstimator.getGLMRegularizationPath(modelWithArray)  # contains all lambda/alpha values of submodels trained.
+    submodel_num = len(r["lambdas"])
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    for submodIndx in range(submodel_num):  # manually build glm model and compare to those built before
+        modelGLM = H2OGeneralizedLinearEstimator(family='binomial', alpha=[r["alphas"][submodIndx]], Lambda=[r["lambdas"][submodIndx]])
+        modelGLM.train(training_frame=trainingData, x=xarray, y=yindex)
+        # check coefficients between submodels and model trained with same parameters
+        assertEqualCoeffDicts(r["coefficients"][submodIndx], modelGLM.coef())
+        modelGLMr = H2OGeneralizedLinearEstimator.getGLMRegularizationPath(modelGLM) # contains one item only
+        assertEqualRegPaths(regKeys, r, submodIndx, modelGLMr)
+        if (best_submodel_index == submodIndx):  # check training metrics of modelGLM should equal that of m since it is the best subModel
+            assertEqualModelMetrics(modelWithArray._model_json["output"]["training_metrics"],
+                                    modelGLM._model_json["output"]["training_metrics"])
+            assertEqualCoeffDicts(modelWithArray.coef(), modelGLM.coef()) # model coefficient should come from best submodel
+        else:  # check and make sure best_submodel_index has lowest deviance
+            assert modelGLM.residual_deviance() - modelWithArray.residual_deviance() >= 0, \
+                "Individual model has better residual_deviance than best submodel!"
+
+def extractNextCoeff(cs_norm, orderedCoeffNames, startVal):
+    for ind in range(0, len(startVal)):
+        startVal[ind] = cs_norm[orderedCoeffNames[ind]]
+    return startVal
+
+def assertCoefEqual(regCoeff, coeff, coeffClassSet, tol=1e-6):
+    for key in regCoeff:
+        temp = key.split('_')
+        classInd = int(temp[1])
+        val1 = regCoeff[key]
+        val2 = coeff[coeffClassSet[classInd]][temp[0]]
+        assert type(val1)==type(val2), "type of coeff1: {0}, type of coeff2: {1}".format(type(val1), type(val2))
+        diff = abs(val1-val2)
+        print("val1: {0}, val2: {1}, tol: {2}".format(val1, val2, tol))
+        assert diff < tol, "diff {0} exceeds tolerance {1}.".format(diff, tol)

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_glm_startvals.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_glm_startvals.py
@@ -1,0 +1,51 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+import math
+
+# test startval to set GLM coefficients
+def set_glm_startvals():
+    # read in the dataset and construct training set (and validation set)
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    mL = glm(family='binomial')
+    mL.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+    mLcoeff = mL.coef()
+    r = glm.getGLMRegularizationPath(mL)
+    rcoeff = r["coefficients"][0]
+    responseMean = d[1].mean()
+    initIntercept = math.log(responseMean/(1.0-responseMean))
+    startval1 = [0,0,0,0,0,0,0,initIntercept]
+    startval2 = [rcoeff["AGE"], rcoeff["RACE"], rcoeff["DPROS"], rcoeff["DCAPS"], rcoeff["PSA"], rcoeff["VOL"], 
+                rcoeff["GLEASON"], rcoeff["Intercept"]]
+    startvalBad = [0,0]
+    
+    ml1 = glm(family="binomial", startval = startval1) # same starting condition as GLM
+    ml1.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+    ml1Coeff = ml1.coef()
+    pyunit_utils.assertEqualCoeffDicts(mLcoeff, ml1Coeff , tol = 1e-6) # coeffs should be the same
+
+    ml2 = glm(family="binomial", startval = startval2) # different starting condition from GLM
+    ml2.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+    ml2Coeff = ml2.coef()   
+    
+    try:
+        pyunit_utils.assertEqualCoeffDicts(mLcoeff, ml2Coeff , tol = 1e-6)
+        assert False, "Should have thrown an error as coefficients are different!"        
+    except Exception as ex:
+        print(ex)
+    
+    try:
+        mlbad =  glm(family="binomial", startval = startvalBad)
+        mlbad.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+        assert False, "Should have thrown an error with bad GLM initial values!"
+    except Exception as ex:
+        print(ex)
+        print("Test completed!  Success!")
+            
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(set_glm_startvals)
+else:
+    set_glm_startvals()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array.py
@@ -1,0 +1,60 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of lambda and alpha, the glm should return the best submodel in its training metrics calculation.
+#
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated from the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. training metrics from alpha array should equal to the individual model matching the alpha/lambda value.
+def glm_alpha_lambda_arrays():
+    # read in the dataset and construct training set (and validation set)
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    mL = glm(family='binomial',Lambda=[0.9, 0.5, 0.1], alpha=[0.1,0.5,0.9],solver='COORDINATE_DESCENT')
+    mL.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+    r = glm.getGLMRegularizationPath(mL)
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    best_submodel_index = mL._model_json["output"]["best_submodel_index"]
+    m2 = glm.makeGLMModel(model=mL,coefs=r['coefficients'][best_submodel_index])
+    dev1 = r['explained_deviance_train'][best_submodel_index]
+    p2 = m2.model_performance(d)
+    dev2 = 1-p2.residual_deviance()/p2.null_deviance()
+    assert abs(dev1 - dev2) < 1e-6
+    for l in range(0,len(r['lambdas'])):
+        m = glm(family='binomial',alpha=[r['alphas'][l]],Lambda=[r['lambdas'][l]],solver='COORDINATE_DESCENT')
+        m.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+        mr = glm.getGLMRegularizationPath(m)
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        diff = 0
+        diff2 = 0
+        for n in cs.keys():
+            diff = max(diff,abs((cs[n] - m.coef()[n])))
+            diff2 = max(diff2,abs((cs_norm[n] - m.coef_norm()[n])))
+        assert diff < 1e-2
+        assert diff2 < 1e-2
+        p = m.model_performance(d)
+        devm = 1-p.residual_deviance()/p.null_deviance()
+        devn = r['explained_deviance_train'][l]
+        assert abs(devm - devn) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, r, l, mr, tol=1e-5)
+        if (l == best_submodel_index): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["training_metrics"],
+                                                 mL._model_json["output"]["training_metrics"], tol=1e-5)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert p.residual_deviance() >= p2.residual_deviance(), "Best submodel does not have lowerest " \
+                                                                    "residual_deviance()!"
+            
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_lambda_arrays)
+else:
+    glm_alpha_lambda_arrays()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_gaussian_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_gaussian_cv.py
@@ -1,0 +1,41 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of alpha and lambda, build two cross-validation models, one with validation dataset
+# and one without for Gaussian.  Since they use the metrics from cross-validation, they should come up with
+# the same models
+def glm_alpha_lambda_arrays_cv():
+    print("Testing glm cross-validation with alpha array, lambda array for binomial models.")
+    h2o_data = h2o.import_file(
+        path=pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname]
+    myY = "C21"
+    myX = h2o_data.names.remove(myY)
+    data_frames = h2o_data.split_frame(ratios=[0.8])
+    training_data = data_frames[0]
+    test_data = data_frames[1]
+    
+    # choices made in model_all and model_xval should be the same since they should be using xval metrics
+    model_all = glm(family="gaussian", Lambda=[0.1,0.5,0.9], alpha=[0.1,0.5,0.9], nfolds=3, cold_start=True)
+    model_all.train(x=myX, y=myY, training_frame = training_data, validation_frame = test_data)
+    model_all_rpath = glm.getGLMRegularizationPath(model_all)
+    model_xval =  glm(family="gaussian", Lambda=[0.1,0.5,0.9], alpha=[0.1,0.5,0.9], nfolds=3, cold_start=True)
+    model_xval.train(x=myX, y=myY, training_frame = training_data)
+    model_xval_rpath = glm.getGLMRegularizationPath(model_xval)
+
+    for l in range(0,len(model_all_rpath['lambdas'])):
+        print("comparing coefficients for submodel {0}".format(l))
+        pyunit_utils.assertEqualCoeffDicts(model_all_rpath['coefficients'][l], model_xval_rpath['coefficients'][l], tol=1e-6)
+        pyunit_utils.assertEqualCoeffDicts(model_all_rpath['coefficients_std'][l], model_xval_rpath['coefficients_std'][l], tol=1e-6)
+
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_lambda_arrays_cv)
+else:
+    glm_alpha_lambda_arrays_cv()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_multinomial_coldStart.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_multinomial_coldStart.py
@@ -1,0 +1,65 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+import math
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of alpha and no lambda, the lambdas will be estimated as the max of gradient divided by
+# the corresponding alpha value.  
+#
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated from the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. training metrics from alpha array should equal to the individual model matching the alpha/lambda value;
+def glm_alpha_array_lambda_null():
+    # first test: compare coefficients and deviance
+    keySets = ["MSE", "null_deviance", "logloss", "RMSE", "r2"]
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    mL = glm(family='multinomial',alpha=[0.1,0.5,0.9], Lambda=[0.1, 0.5, 0.9], cold_start=True)
+    d[54] = d[54].asfactor()
+    mL.train(training_frame=d,x=list(range(0,54)),y=54)
+    r = glm.getGLMRegularizationPath(mL)
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    best_submodel_index = mL._model_json["output"]["best_submodel_index"]
+    coefClassSet = ['coefs_class_0','coefs_class_1', 'coefs_class_2', 'coefs_class_3', 'coefs_class_4','coefs_class_5', 
+                    'coefs_class_6', 'coefs_class_7']
+    coefClassSetNorm = ['std_coefs_class_0','std_coefs_class_1', 'std_coefs_class_2', 'std_coefs_class_3', 
+                        'std_coefs_class_4', 'std_coefs_class_5', 'std_coefs_class_6', 'std_coefs_class_7']
+    groupedClass = d.group_by("C55")
+    groupedClass.count()
+    classFrame = groupedClass.get_frame()
+    classProb = classFrame[1]/d.nrow
+    coeffIndex = [52, 105, 158, 211, 264, 317, 370]
+    startVal = [0]*371
+    for ind in range(classProb.nrow):
+        startVal[coeffIndex[ind]] = math.log(classProb[ind,0])
+
+    for l in range(0,len(r['lambdas'])):
+        m = glm(family='multinomial',alpha=[r['alphas'][l]],Lambda=[r['lambdas'][l]], startval = startVal)
+        m.train(training_frame=d,x=list(range(0,54)),y=54)
+        mr = glm.getGLMRegularizationPath(m)
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        pyunit_utils.assertCoefEqual(cs, m.coef(),coefClassSet)
+        pyunit_utils.assertCoefEqual(cs_norm, m.coef_norm(), coefClassSetNorm)
+        devm = 1-m.residual_deviance()/m.null_deviance()
+        devn = r['explained_deviance_train'][l]
+        assert abs(devm - devn) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, r, l, mr)
+        if (l == best_submodel_index): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["training_metrics"],
+                                                 mL._model_json["output"]["training_metrics"],tol=1e-2, keySet=keySets)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert m.logloss() >= mL.logloss(), "Best submodel does not have lowerest " \
+                                                                    "logloss()!"
+        
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_array_lambda_null)
+else:
+    glm_alpha_array_lambda_null()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_validation.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_validation.py
@@ -1,0 +1,67 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of alpha and no lambda, the lambdas will be estimated as the max of gradient divided by
+# the corresponding alpha value.  
+#
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated for the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. validation metrics/training metrics from alpha array should equal to the individual model matching the alpha/lambda value;
+
+def glm_alpha_array_lambda_null():
+    # compare coefficients and deviance when only training dataset is available
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    for ind in range(10):
+        train[ind] = train[ind].asfactor()
+    train["C21"] = train["C21"].asfactor()
+    frames = train.split_frame(ratios=[0.8],seed=12345)
+    d = frames[0]
+    d_test = frames[1]
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    
+    # compare results when validation dataset is present
+    mLVal = glm(family='binomial',alpha=[0.1,0.5,0.9],Lambda=[0.9,0.5,0.1],solver='COORDINATE_DESCENT') # train with validations set
+    mLVal.train(training_frame=d,x=list(range(20)),y=20, validation_frame=d_test)
+    rVal = glm.getGLMRegularizationPath(mLVal)
+    best_submodel_indexVal = mLVal._model_json["output"]["best_submodel_index"]
+    m2Val = glm.makeGLMModel(model=mLVal,coefs=rVal['coefficients'][best_submodel_indexVal])
+    dev1Val = rVal['explained_deviance_valid'][best_submodel_indexVal]
+    p2Val = m2Val.model_performance(d_test)
+    dev2Val = 1-p2Val.residual_deviance()/p2Val.null_deviance()
+    print(dev1Val," =?= ",dev2Val)
+    assert abs(dev1Val - dev2Val) < 1e-6
+    
+    for l in range(0,len(rVal['lambdas'])):       
+        # test with validation dataset
+        mVal = glm(family='binomial',alpha=[rVal['alphas'][l]],Lambda=[rVal['lambdas'][l]],solver='COORDINATE_DESCENT')
+        mVal.train(training_frame=d,x=list(range(20)),y=20, validation_frame = d_test)
+        mrVal= glm.getGLMRegularizationPath(mVal)
+        csVal = rVal['coefficients'][l]
+        cs_normVal = rVal['coefficients_std'][l]
+        pyunit_utils.assertEqualCoeffDicts(csVal, mVal.coef(), tol=1e-3)
+        pyunit_utils.assertEqualCoeffDicts(cs_normVal, mVal.coef_norm(), 1e-3)
+        p = mVal.model_performance(d_test)
+        devmVal = 1-p.residual_deviance()/p.null_deviance()
+        devnVal = rVal['explained_deviance_valid'][l]
+        assert abs(devmVal - devnVal) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, rVal, l, mrVal, tol=1e-5)
+        if (l == best_submodel_indexVal): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(mVal._model_json["output"]["validation_metrics"],
+                                                 mLVal._model_json["output"]["validation_metrics"], tol=1e-2)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert p.residual_deviance() >= p2Val.residual_deviance(), "Best submodel does not have lowerest " \
+                                                                    "residual_deviance()!"
+            
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_array_lambda_null)
+else:
+    glm_alpha_array_lambda_null()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_warm_start.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_alpha_array_warm_start.py
@@ -1,0 +1,69 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+import math
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of lambda and alpha, the glm should return the best submodel in its training metrics calculation.
+#
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated from the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. training metrics from alpha array should equal to the individual model matching the alpha/lambda value.
+def glm_alpha_lambda_arrays():
+    # read in the dataset and construct training set (and validation set)
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    mL = glm(family='binomial',Lambda=[0.9, 0.5, 0.1], alpha=[0.1,0.5,0.9],solver='COORDINATE_DESCENT',cold_start=False)
+    mL.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+    r = glm.getGLMRegularizationPath(mL)
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    best_submodel_index = mL._model_json["output"]["best_submodel_index"]
+    m2 = glm.makeGLMModel(model=mL,coefs=r['coefficients'][best_submodel_index])
+    dev1 = r['explained_deviance_train'][best_submodel_index]
+    p2 = m2.model_performance(d)
+    dev2 = 1-p2.residual_deviance()/p2.null_deviance()
+    print(dev1," =?= ",dev2)
+    assert abs(dev1 - dev2) < 1e-6
+    responseMean = d[1].mean()
+    initIntercept = math.log(responseMean/(1.0-responseMean))
+    startValInit = [0, 0, 0, 0, 0, 0, 0, initIntercept]
+    startVal = [0, 0, 0, 0, 0, 0, 0, initIntercept]
+    orderedCoeffNames = ["AGE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON", "Intercept"]
+    for l in range(0,len(r['lambdas'])):
+        m = glm(family='binomial',alpha=[r['alphas'][l]],Lambda=[r['lambdas'][l]],solver='COORDINATE_DESCENT',
+                startval=startVal)
+        m.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+        mr = glm.getGLMRegularizationPath(m)
+
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        pyunit_utils.assertEqualCoeffDicts(cs, m.coef(), tol=1e-3)
+        pyunit_utils.assertEqualCoeffDicts(cs_norm, m.coef_norm(), 1e-3)
+        if (l+1)<len(r['lambdas']) and r['alphas'][l]!=r['alphas'][l+1]:
+            startVal = startValInit
+        else:
+            startVal = pyunit_utils.extractNextCoeff(cs_norm, orderedCoeffNames, startVal) # prepare startval for next round
+
+        p = m.model_performance(d)
+        devm = 1-p.residual_deviance()/p.null_deviance()
+        devn = r['explained_deviance_train'][l]
+        assert abs(devm - devn) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, r, l, mr, tol=1e-4)
+        if (l == best_submodel_index): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["training_metrics"],
+                                                 mL._model_json["output"]["training_metrics"], tol=1e-4)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert p.residual_deviance() >= p2.residual_deviance(), "Best submodel does not have lowerest " \
+                                                                    "residual_deviance()!"
+            
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_lambda_arrays)
+else:
+    glm_alpha_lambda_arrays()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_null_alpha_array.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_null_alpha_array.py
@@ -1,0 +1,56 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of alpha and no lambda, the lambdas will be estimated as the max of gradient divided by
+# the corresponding alpha value.  
+#
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated from the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. training metrics from alpha array should equal to the individual model matching the alpha/lambda value;
+def glm_alpha_array_lambda_null():
+    # first test: compare coefficients and deviance
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    mL = glm(family='binomial',alpha=[0.1,0.5,0.9],solver='COORDINATE_DESCENT')
+    mL.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+    r = glm.getGLMRegularizationPath(mL)
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    best_submodel_index = mL._model_json["output"]["best_submodel_index"]
+    m2 = glm.makeGLMModel(model=mL,coefs=r['coefficients'][best_submodel_index])
+    dev1 = r['explained_deviance_train'][best_submodel_index]
+    p2 = m2.model_performance(d)
+    dev2 = 1-p2.residual_deviance()/p2.null_deviance()
+    print(dev1," =?= ",dev2)
+    assert abs(dev1 - dev2) < 1e-6
+    for l in range(0,len(r['lambdas'])):
+        m = glm(family='binomial',alpha=[r['alphas'][l]],Lambda=[r['lambdas'][l]],solver='COORDINATE_DESCENT')
+        m.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+        mr = glm.getGLMRegularizationPath(m)
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        pyunit_utils.assertEqualCoeffDicts(cs, m.coef())
+        pyunit_utils.assertEqualCoeffDicts(cs_norm, m.coef_norm())
+        p = m.model_performance(d)
+        devm = 1-p.residual_deviance()/p.null_deviance()
+        devn = r['explained_deviance_train'][l]
+        assert abs(devm - devn) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, r, l, mr)
+        if (l == best_submodel_index): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["training_metrics"],
+                                                 mL._model_json["output"]["training_metrics"])
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert p.residual_deviance() >= p2.residual_deviance(), "Best submodel does not have lowerest " \
+                                                                    "residual_deviance()!"
+            
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_array_lambda_null)
+else:
+    glm_alpha_array_lambda_null()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_null_alpha_array_multinomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_null_alpha_array_multinomial.py
@@ -1,0 +1,54 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of alpha and no lambda, the lambdas will be estimated as the max of gradient divided by
+# the corresponding alpha value.  
+#
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated from the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. training metrics from alpha array should equal to the individual model matching the alpha/lambda value;
+def glm_alpha_array_lambda_null():
+    # first test: compare coefficients and deviance
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    mL = glm(family='multinomial',alpha=[0.1,0.5,0.9])
+    d[54] = d[54].asfactor()
+    mL.train(training_frame=d,x=list(range(0,54)),y=54)
+    r = glm.getGLMRegularizationPath(mL)
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    best_submodel_index = mL._model_json["output"]["best_submodel_index"]
+    coefClassSet = ['coefs_class_0', 'coefs_class_1', 'coefs_class_2', 'coefs_class_3', 'coefs_class_4','coefs_class_5', 
+                    'coefs_class_6', 'coefs_class_7']
+    coefClassSetNorm = ['std_coefs_class_0', 'std_coefs_class_1', 'std_coefs_class_2', 'std_coefs_class_3', 
+                        'std_coefs_class_4', 'std_coefs_class_5', 'std_coefs_class_6', 'std_coefs_class_7']
+    for l in range(0,len(r['lambdas'])):
+        m = glm(family='multinomial',alpha=[r['alphas'][l]],Lambda=[r['lambdas'][l]])
+        m.train(training_frame=d,x=list(range(0,54)),y=54)
+        mr = glm.getGLMRegularizationPath(m)
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        pyunit_utils.assertCoefEqual(cs, m.coef(),coefClassSet, tol=1e-5)
+        pyunit_utils.assertCoefEqual(cs_norm, m.coef_norm(), coefClassSetNorm, tol=1e-5)
+        devm = 1-m.residual_deviance()/m.null_deviance()
+        devn = r['explained_deviance_train'][l]
+        assert abs(devm - devn) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, r, l, mr)
+        if (l == best_submodel_index): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["training_metrics"],
+                                                 mL._model_json["output"]["training_metrics"],tol=1e-2)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert m.logloss() >= mL.logloss(), "Best submodel does not have lowerest " \
+                                                                    "logloss()!"
+        
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_array_lambda_null)
+else:
+    glm_alpha_array_lambda_null()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_null_alpha_array_validation.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_null_alpha_array_validation.py
@@ -1,0 +1,66 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given arrays of alpha and no lambda, the lambdas will be estimated as the max of gradient divided by
+# the corresponding alpha value.  
+#
+# When an array of alpha and/or lambdas are given, a list of submodels are also built.  For each submodel built, only
+# the coefficients, lambda/alpha/deviance values are returned.  The model metrics is calculated for the submodel
+# with the best deviance.  
+#
+# In this test, in addition, we build separate models using just one lambda and one alpha values as when building one
+# submodel.  In theory, the coefficients obtained from the separate models should equal to the submodels.  We check 
+# and compare the followings:
+# 1. coefficients from submodels and individual model should match when they are using the same alpha/lambda value;
+# 2. validation metrics/training metrics from alpha array should equal to the individual model matching the alpha/lambda value;
+
+def glm_alpha_array_lambda_null():
+    # compare coefficients and deviance when only training dataset is available
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    for ind in range(10):
+        train[ind] = train[ind].asfactor()
+    train["C21"] = train["C21"].asfactor()
+    frames = train.split_frame(ratios=[0.8],seed=12345)
+    d = frames[0]
+    d_test = frames[1]
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    
+    # compare results when validation dataset is present
+    mLVal = glm(family='binomial',alpha=[0.1,0.5,0.9],solver='COORDINATE_DESCENT') # train with validations set
+    mLVal.train(training_frame=d,x=list(range(20)),y=20, validation_frame=d_test)
+    rVal = glm.getGLMRegularizationPath(mLVal)
+    best_submodel_indexVal = mLVal._model_json["output"]["best_submodel_index"]
+    m2Val = glm.makeGLMModel(model=mLVal,coefs=rVal['coefficients'][best_submodel_indexVal])
+    dev1Val = rVal['explained_deviance_valid'][best_submodel_indexVal]
+    p2Val = m2Val.model_performance(d_test)
+    dev2Val = 1-p2Val.residual_deviance()/p2Val.null_deviance()
+    assert abs(dev1Val - dev2Val) < 1e-6
+    
+    for l in range(0,len(rVal['lambdas'])):       
+        # test with validation dataset
+        mVal = glm(family='binomial',alpha=[rVal['alphas'][l]],Lambda=[rVal['lambdas'][l]],solver='COORDINATE_DESCENT')
+        mVal.train(training_frame=d,x=list(range(20)),y=20, validation_frame = d_test)
+        mrVal= glm.getGLMRegularizationPath(mVal)
+        csVal = rVal['coefficients'][l]
+        cs_normVal = rVal['coefficients_std'][l]
+        pyunit_utils.assertEqualCoeffDicts(csVal, mVal.coef(), tol=1e-2)
+        pyunit_utils.assertEqualCoeffDicts(cs_normVal, mVal.coef_norm(), tol=1e-2)
+        p = mVal.model_performance(d_test)
+        devmVal = 1-p.residual_deviance()/p.null_deviance()
+        devnVal = rVal['explained_deviance_valid'][l]
+        assert abs(devmVal - devnVal) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, rVal, l, mrVal, tol=1e-4)
+        if (l == best_submodel_indexVal): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(mVal._model_json["output"]["validation_metrics"],
+                                                 mLVal._model_json["output"]["validation_metrics"], tol=1e-2)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert p.residual_deviance() >= p2Val.residual_deviance(), "Best submodel does not have lowerest " \
+                                                                    "residual_deviance()!"
+            
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_array_lambda_null)
+else:
+    glm_alpha_array_lambda_null()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_large.py
@@ -1,0 +1,46 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# with lambda_search enable and warm start, the model built with lambda search and with separate lambda/alpha values
+# and previous beta should be close
+def glm_alpha_lambda_arrays():
+    # read in the dataset and construct training set (and validation set)
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    mL = glm(family='binomial',lambda_search=True, alpha=[0.9,0.5,0.1],solver='COORDINATE_DESCENT')
+    mL.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+    r = glm.getGLMRegularizationPath(mL)
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    best_submodel_index = mL._model_json["output"]["best_submodel_index"]
+    m2 = glm.makeGLMModel(model=mL,coefs=r['coefficients'][best_submodel_index])
+    dev1 = r['explained_deviance_train'][best_submodel_index]
+    p2 = m2.model_performance(d)
+    dev2 = 1-p2.residual_deviance()/p2.null_deviance()
+    assert abs(dev1 - dev2) < 1e-6
+    for l in range(0,len(r['lambdas'])):
+        m = glm(family='binomial',alpha=[r['alphas'][l]],Lambda=r['lambdas'][l],solver='COORDINATE_DESCENT')
+        m.train(training_frame=d,x=[2,3,4,5,6,7,8],y=1)
+        mr = glm.getGLMRegularizationPath(m)
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        print("comparing coefficients for submodel {0}".format(l))
+        pyunit_utils.assertEqualCoeffDicts(cs, m.coef(), tol=1e-2)
+        pyunit_utils.assertEqualCoeffDicts(cs_norm, m.coef_norm(), tol=1e-2)
+        p = m.model_performance(d)
+        devm = 1-p.residual_deviance()/p.null_deviance()
+        devn = r['explained_deviance_train'][l]
+        assert abs(devm - devn) < 1e-4
+        pyunit_utils.assertEqualRegPaths(regKeys, r, l, mr, tol=1e-4) # check all values from regPaths
+        if (l == best_submodel_index): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["training_metrics"],
+                                    mL._model_json["output"]["training_metrics"])
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert p.residual_deviance() >= p2.residual_deviance(), "Best submodel does not have lowerest " \
+                                                                    "residual_deviance()!" 
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_lambda_arrays)
+else:
+    glm_alpha_lambda_arrays()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_multinomial_coldStart_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_multinomial_coldStart_large.py
@@ -1,0 +1,46 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given alpha array and lambda_search=True, test with cold_start=True for multinomials
+def glm_alpha_array_lambda_null():
+    # first test: compare coefficients and deviance
+    d = h2o.import_file(path=pyunit_utils.locate("smalldata/covtype/covtype.20k.data"))
+    mL = glm(family='multinomial',alpha=[0.1,0.5,0.9], lambda_search=True, solver='COORDINATE_DESCENT', cold_start=True,
+             nlambdas = 5)
+    d[54] = d[54].asfactor()
+    mL.train(training_frame=d,x=list(range(0,54)),y=54)
+    r = glm.getGLMRegularizationPath(mL)
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+    best_submodel_index = mL._model_json["output"]["best_submodel_index"]
+    coefClassSet = ['coefs_class_0', 'coefs_class_1', 'coefs_class_2', 'coefs_class_3', 'coefs_class_4','coefs_class_5', 
+                    'coefs_class_6', 'coefs_class_7']
+    coefClassSetNorm = ['std_coefs_class_0', 'std_coefs_class_1', 'std_coefs_class_2', 'std_coefs_class_3', 
+                        'std_coefs_class_4', 'std_coefs_class_5', 'std_coefs_class_6', 'std_coefs_class_7']
+    for l in range(0,len(r['lambdas'])):
+        print("compare models for index {0}, alpha {1}, lambda{2}".format(l, r['alphas'][l], r['lambdas'][l]))
+        m = glm(family='multinomial',alpha=[r['alphas'][l]],Lambda=[r['lambdas'][l]], solver='COORDINATE_DESCENT')
+        m.train(training_frame=d,x=list(range(0,54)),y=54)
+        mr = glm.getGLMRegularizationPath(m)
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        pyunit_utils.assertCoefEqual(cs, m.coef(),coefClassSet)
+        pyunit_utils.assertCoefEqual(cs_norm, m.coef_norm(), coefClassSetNorm)
+        devm = 1-m.residual_deviance()/m.null_deviance()
+        devn = r['explained_deviance_train'][l]
+        assert abs(devm - devn) < 1e-6
+        pyunit_utils.assertEqualRegPaths(regKeys, r, l, mr)
+        if (l == best_submodel_index): # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["training_metrics"],
+                                                 mL._model_json["output"]["training_metrics"],
+                                                 keySet=["MSE","null_deviance", "logloss", "RMSE", "r2"], tol=5e-1)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert devm <= r['explained_deviance_train'][best_submodel_index], "Best submodel does not best " \
+                                                                    "explained_deviance_train!"
+        
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_array_lambda_null)
+else:
+    glm_alpha_array_lambda_null()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_multinomial_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_multinomial_cv.py
@@ -1,0 +1,41 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given alpha array and lambda_search=True, build two cross-validation models, one with validation dataset
+# and one without for multinomial.  Since they use the metrics from cross-validation, they should come up with
+# the same models.
+def glm_alpha_array_with_lambda_search_cv():
+    # read in the dataset and construct training set (and validation set)
+    print("Testing glm cross-validation with alpha array, lambda_search for multiomial models.")
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname]
+    myY = "C11"
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    myX = h2o_data.names.remove(myY)
+    data_frames = h2o_data.split_frame(ratios=[0.8])
+    training_data = data_frames[0]
+    test_data = data_frames[1]
+    # build model with CV but no validation dataset
+    cv_model = glm(family='multinomial',alpha=[0.1,0.5,0.9], lambda_search=True, nfolds = 3)
+    cv_model.train(training_frame=training_data,x=myX,y=myY)
+    cv_r = glm.getGLMRegularizationPath(cv_model)
+    # build model with CV and with validation dataset
+    cv_model_valid = glm(family='multinomial',alpha=[0.1,0.5,0.9], lambda_search=True, nfolds = 3)
+    cv_model_valid.train(training_frame=training_data, validation_frame = test_data, x=myX,y=myY)
+    cv_r_valid = glm.getGLMRegularizationPath(cv_model_valid)
+
+    for l in range(0,len(cv_r['lambdas'])):
+        print("comparing coefficients for submodel {0}".format(l))
+        pyunit_utils.assertEqualCoeffDicts(cv_r['coefficients'][l], cv_r_valid['coefficients'][l], tol=1e-6)
+        pyunit_utils.assertEqualCoeffDicts(cv_r['coefficients_std'][l], cv_r_valid['coefficients_std'][l], tol=1e-6)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_array_with_lambda_search_cv)
+else:
+    glm_alpha_array_with_lambda_search_cv()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_validation_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7481_lambda_search_alpha_array_validation_large.py
@@ -1,0 +1,50 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# with lambda_search=True and an alpha array and warm start, we provide a validation dataset here.
+def glm_alpha_lambda_arrays():
+    # compare coefficients and deviance when only training dataset is available
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    for ind in range(10):
+        train[ind] = train[ind].asfactor()
+    train["C21"] = train["C21"].asfactor()
+    frames = train.split_frame(ratios=[0.8],seed=12345)
+    d = frames[0]
+    d_test = frames[1]
+    regKeys = ["alphas", "lambdas", "explained_deviance_valid", "explained_deviance_train"]
+
+    # compare results when validation dataset is present
+    mLVal = glm(family='binomial',alpha=[0.1,0.5], lambda_search=True, solver='COORDINATE_DESCENT', nlambdas=3) # train with validations set
+    mLVal.train(training_frame=d,x=list(range(20)),y=20, validation_frame=d_test)
+    rVal = glm.getGLMRegularizationPath(mLVal)
+    best_submodel_indexVal = mLVal._model_json["output"]["best_submodel_index"]
+    m2Val = glm.makeGLMModel(model=mLVal,coefs=rVal['coefficients'][best_submodel_indexVal])
+    dev1Val = rVal['explained_deviance_valid'][best_submodel_indexVal]
+    p2Val = m2Val.model_performance(d_test)
+    dev2Val = 1-p2Val.residual_deviance()/p2Val.null_deviance()
+    assert abs(dev1Val - dev2Val) < 1e-6
+    for l in range(0,len(rVal['lambdas'])):
+        m = glm(family='binomial',alpha=[rVal['alphas'][l]],Lambda=rVal['lambdas'][l],solver='COORDINATE_DESCENT')
+        m.train(training_frame=d,x=list(range(20)),y=20, validation_frame=d_test)
+        mr = glm.getGLMRegularizationPath(m)
+        p = m.model_performance(d_test);
+        cs = rVal['coefficients'][l]
+        cs_norm = rVal['coefficients_std'][l]
+        print("Comparing submodel index {0}".format(l))
+        pyunit_utils.assertEqualCoeffDicts(cs, m.coef(), tol=1e-1)
+        pyunit_utils.assertEqualCoeffDicts(cs_norm, m.coef_norm(), tol=1e-1)
+        pyunit_utils.assertEqualRegPaths(regKeys, rVal, l, mr, tol=1e-3)
+        dVal = 1-p.residual_deviance()/p.null_deviance()
+        if l == best_submodel_indexVal: # check training metrics, should equal for best submodel index
+            pyunit_utils.assertEqualModelMetrics(m._model_json["output"]["validation_metrics"],
+                                    mLVal._model_json["output"]["validation_metrics"],tol=1e-2)
+        else: # for other submodel, should have worse residual_deviance() than best submodel
+            assert dVal<=dev2Val, "Best submodel does not have highest explained deviance_valid for submodel: !".format(l) 
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_lambda_arrays)
+else:
+    glm_alpha_lambda_arrays()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7575_lambda_null_alpha_array_binomial_cv.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7575_lambda_null_alpha_array_binomial_cv.py
@@ -1,0 +1,40 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# Given alpha array and using default lambda, build two cross-validation models, one with validation dataset
+# and one without for binomial.  Since they use the metrics from cross-validation, they should come up with
+# the same models.
+def glm_alpha_arrays_null_lambda_cv():
+    print("Testing glm cross-validation with alpha array, default lambda values for binomial models.")
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    enum_columns = ["C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"]
+    for cname in enum_columns:
+        h2o_data[cname] = h2o_data[cname]
+    myY = "C21"
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    myX = h2o_data.names.remove(myY)
+    data_frames = h2o_data.split_frame(ratios=[0.8])
+    training_data = data_frames[0]
+    test_data = data_frames[1]
+    
+    # build model with CV but no validation dataset
+    cv_model = glm(family='binomial',alpha=[0.1,0.5,0.9], nfolds = 3)
+    cv_model.train(training_frame=training_data,x=myX,y=myY)
+    cv_r = glm.getGLMRegularizationPath(cv_model)
+    # build model with CV and with validation dataset
+    cv_model_valid = glm(family='binomial',alpha=[0.1,0.5,0.9], nfolds = 3)
+    cv_model_valid.train(training_frame=training_data, validation_frame = test_data, x=myX,y=myY)
+    cv_r_valid = glm.getGLMRegularizationPath(cv_model_valid)
+
+    for l in range(0,len(cv_r['lambdas'])):
+        print("comparing coefficients for submodel {0}".format(l))
+        pyunit_utils.assertEqualCoeffDicts(cv_r['coefficients'][l], cv_r_valid['coefficients'][l], tol=1e-6)
+        pyunit_utils.assertEqualCoeffDicts(cv_r['coefficients_std'][l], cv_r_valid['coefficients_std'][l], tol=1e-6)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glm_alpha_arrays_null_lambda_cv)
+else:
+    glm_alpha_arrays_null_lambda_cv()

--- a/h2o-r/h2o-package/R/gam.R
+++ b/h2o-r/h2o-package/R/gam.R
@@ -82,6 +82,9 @@
 #'        Defaults to family_default.
 #' @param prior Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
 #'        of response does not reflect reality. Defaults to -1.
+#' @param cold_start \code{Logical}. Only applicable to multiple alpha/lambda values when calling GLM from GAM.  If false, build
+#'        the next model for next set of alpha/lambda values starting from the values provided by current model.  If
+#'        true will start GLM model from scratch. Defaults to FALSE.
 #' @param lambda_min_ratio Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all
 #'        coefficients to zero). Default indicates: if the number of observations is greater than the number of
 #'        variables, then lambda_min_ratio is set to 0.0001; if the number of observations is less than the number of
@@ -171,6 +174,7 @@ h2o.gam <- function(x,
                     gradient_epsilon = -1,
                     link = c("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit"),
                     prior = -1,
+                    cold_start = FALSE,
                     lambda_min_ratio = -1,
                     beta_constraints = NULL,
                     max_active_predictors = -1,
@@ -304,6 +308,8 @@ h2o.gam <- function(x,
     parms$link <- link
   if (!missing(prior))
     parms$prior <- prior
+  if (!missing(cold_start))
+    parms$cold_start <- cold_start
   if (!missing(lambda_min_ratio))
     parms$lambda_min_ratio <- lambda_min_ratio
   if (!missing(max_active_predictors))
@@ -411,6 +417,7 @@ h2o.gam <- function(x,
                                     gradient_epsilon = -1,
                                     link = c("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit"),
                                     prior = -1,
+                                    cold_start = FALSE,
                                     lambda_min_ratio = -1,
                                     beta_constraints = NULL,
                                     max_active_predictors = -1,
@@ -549,6 +556,8 @@ h2o.gam <- function(x,
     parms$link <- link
   if (!missing(prior))
     parms$prior <- prior
+  if (!missing(cold_start))
+    parms$cold_start <- cold_start
   if (!missing(lambda_min_ratio))
     parms$lambda_min_ratio <- lambda_min_ratio
   if (!missing(max_active_predictors))

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -83,12 +83,15 @@
 #' @param link Link function. Must be one of: "family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit".
 #'        Defaults to family_default.
 #' @param rand_link Link function array for random component in HGLM. Must be one of: "[identity]", "[family_default]".
-#' @param startval double array to initialize fixed and random coefficients for HGLM.
+#' @param startval double array to initialize fixed and random coefficients for HGLM, coefficients for GLM.
 #' @param calc_like \code{Logical}. if true, will return likelihood function value for HGLM. Defaults to FALSE.
 #' @param HGLM \code{Logical}. If set to true, will return HGLM model.  Otherwise, normal GLM model will be returned Defaults
 #'        to FALSE.
 #' @param prior Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
 #'        of response does not reflect reality. Defaults to -1.
+#' @param cold_start \code{Logical}. Only applicable to multiple alpha/lambda values.  If false, build the next model for next set
+#'        of alpha/lambda values starting from the values provided by current model.  If true will start GLM model from
+#'        scratch. Defaults to FALSE.
 #' @param lambda_min_ratio Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all
 #'        coefficients to zero). Default indicates: if the number of observations is greater than the number of
 #'        variables, then lambda_min_ratio is set to 0.0001; if the number of observations is less than the number of
@@ -211,6 +214,7 @@ h2o.glm <- function(x,
                     calc_like = FALSE,
                     HGLM = FALSE,
                     prior = -1,
+                    cold_start = FALSE,
                     lambda_min_ratio = -1,
                     beta_constraints = NULL,
                     max_active_predictors = -1,
@@ -351,6 +355,8 @@ h2o.glm <- function(x,
     parms$HGLM <- HGLM
   if (!missing(prior))
     parms$prior <- prior
+  if (!missing(cold_start))
+    parms$cold_start <- cold_start
   if (!missing(lambda_min_ratio))
     parms$lambda_min_ratio <- lambda_min_ratio
   if (!missing(max_active_predictors))
@@ -452,6 +458,7 @@ h2o.glm <- function(x,
                                     calc_like = FALSE,
                                     HGLM = FALSE,
                                     prior = -1,
+                                    cold_start = FALSE,
                                     lambda_min_ratio = -1,
                                     beta_constraints = NULL,
                                     max_active_predictors = -1,
@@ -597,6 +604,8 @@ h2o.glm <- function(x,
     parms$HGLM <- HGLM
   if (!missing(prior))
     parms$prior <- prior
+  if (!missing(cold_start))
+    parms$cold_start <- cold_start
   if (!missing(lambda_min_ratio))
     parms$lambda_min_ratio <- lambda_min_ratio
   if (!missing(max_active_predictors))

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7481_glm_alpha_array_lambda_null_regPath.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7481_glm_alpha_array_lambda_null_regPath.R
@@ -1,0 +1,17 @@
+library(glmnet)
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# I am testing when we have an alpha array and no lambda, GLM should still build and report back submodel parameters
+# in RegularizationPath.  Simple test to make sure alphas are reported back in regularization path.
+test.glm_reg_path <- function() {
+    browser()
+    d <-  h2o.importFile(path = locate("smalldata/logreg/prostate.csv"))
+    alphaArray <- c(0.1,0.5,0.9)
+    m = h2o.glm(training_frame=d,x=3:9,y=2,family='binomial',alpha=alphaArray)
+    regpath = h2o.getGLMFullRegularizationPath(m)
+  
+    expect_true(length(alphaArray)==length(regpath$alphas))
+}
+
+doTest("GLM Regularization Path extraction with alpha array but no lambda specified", test.glm_reg_path)

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7481_startval_multinomials.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7481_startval_multinomials.R
@@ -1,0 +1,34 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+glmMultinomial <- function() {
+  tot <- 1e-5
+  D <- h2o.uploadFile(locate("smalldata/covtype/covtype.20k.data"), destination_frame="covtype.hex")  
+  D[,55] <- as.factor(D[,55])
+  Y <- 55
+  X   <- 1:54  
+  startval <- c(1:371)*0
+  startval[53] <- -1.9166426513747452
+  startval[106] <-  -1.200312843494449
+  startval[159] <-  -2.2256240518579173
+  startval[212] <- -2.2256240518579173
+  startval[265] <-  -2.121931593300788
+  startval[318] <- -2.2256240518579173
+  startval[371] <- -2.2256240518579173
+  Log.info("Build the model")
+  m1 <- h2o.glm(y = Y, x = X, training_frame = D, family = "multinomial", alpha = 0.99, solver='IRLSM')
+  m1coeff <- h2o.coef(m1)
+  m2 <- h2o.glm(y = Y, x = X, training_frame = D, family = "multinomial", alpha = 0.99, solver='IRLSM', startval=startval)
+  m2coeff <- h2o.coef(m2)
+  outerLen <- length(m1coeff)
+  innerLen <- length(m1coeff[[1]])
+  for (ind in c(2:outerLen)) {
+    for (ind2 in c(1:innerLen)) {
+      print(m1coeff[[ind]][ind2])
+      print(m2coeff[[ind]][ind2])
+      expect_true(abs(m1coeff[[ind]][ind2]-m2coeff[[ind]][ind2])<tot)
+    }
+  }
+}
+
+doTest("GLM: Multinomial startval", glmMultinomial)


### PR DESCRIPTION
This PR aims to fix the problem specified in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7481?filter=-1

It looks like GLM with lambda search enabled only runs with the first alpha value specified in the array.  In addition, each lambda value will start building GLM model with coefficients and other parameters set to the values of the previous GLM model building.

When a user provides an alpha/lambda array, the default setting is to have the system cold start from default initial values for every lambda/alpha value.  However, if a user wants warm start, she can set cold_start=False to force the system to build GLM model starting with the states of the previous GLM model build.

When lambda_search=True, the default is to do warm start unless the user set cold_start=False.

I have completed the following:

1. Added loop to set alpha value as well as lambda.  Added parametets to keep track of submodels' alpha, submodel index and others.
2. Fixed best model selection for alpha/lambda arrays.
3. Added alpha array to submodel reports.  Finished work for alpha array with empty lambda, alpha and lambda arrays.
4. Add parameter cold_start to allow user to choose starting from initial values if desired.  Here is the default setup: if lambda search is disabled, user can set cold_start=True and every lambda/alpha values will start from initial values.  If user set cold_start=False, next lambda/alpha GLM will start from previous GLM beta values.
5. User can use startval to set GLM initial coefficients if they desired to.
