### PR TITLE
PUBDEV-7531: Docs - Minio instance configuration

### DIFF
--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -205,37 +205,53 @@ Build a cluster of EC2 instances by running the following commands on the host t
 Minio Instance
 ''''''''''''''
 
-Minio Cloud Storage is an alternative to Amazon AWS S3. When using a Minio server, the following additional parameters are specified in the Java launch command:
+Minio Cloud Storage is an alternative to Amazon AWS S3. When connecting to a Minio server, the following additional parameters are specified in the Java launch command:
 
 - ``endpoint``: Specifies a Minio server instance (including address and port). This overrides the existing endpoint, which is currently hardcoded to be AWS S3.
 
 - ``enable.path.style``: Specifies to override the default S3 behavior to expose every bucket as a full DNS enabled path. Note that this is a Minio recommendation.
 
+To pass in AWS credentials, create a ``core-site.xml`` file that contains your Access Key ID and Secret Access Key and use the flag ``-hdfs_config`` flag when launching:
+
+::
+
+       <property>
+         <name>fs.s3.awsAccessKeyId</name>
+         <value>[AWS SECRET KEY]</value>
+       </property>
+
+       <property>
+         <name>fs.s3.awsSecretAccessKey</name>
+         <value>[AWS SECRET ACCESS KEY]</value>
+       </property>
+
 1. Launch H2O by entering the following in the command line:
 
   ::
 
-      java -Dsys.ai.h2o.persist.s3.endPoint=https://play.min.io:9000 -Dsys.ai.h2o.persist.s3.enable.path.style=true -jar h2o.jar
+      java -Dsys.ai.h2o.persist.s3.endPoint=https://play.min.io:9000 -Dsys.ai.h2o.persist.s3.enable.path.style=true -jar h2o.jar -hdfs_config core-site.xml
 
-2. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**. You can pass the AWS Access Key and Secret Access Key in an S3 URL in Flow, R, or Python (where ``MINIO_ACCESS_KEY`` represents your user name, and ``MINIO_SECRET_KEY`` represents your password).
+  **Note**: https://play.min.io:9000 is an example Minio server URL.
+
+2. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**.
 
  - To import the data from the Flow API:
 
   ::
 
-   importFiles [ "s3://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv" ]
+   importFiles [ "s3://bucket/path/to/file.csv" ]
 
  - To import the data from the R API:
 
   ::
 
-   h2o.importFile(path = "s3://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv")
+   h2o.importFile(path = "s3://bucket/path/to/file.csv")
 
  - To import the data from the Python API:
 
   ::
 
-   h2o.import_file(path = "s3://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv")
+   h2o.import_file(path = "s3://bucket/path/to/file.csv")
 
 Launching H2O
 '''''''''''''

--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -151,7 +151,7 @@ The following is an example core-site.xml file:
             <name>fs.s3.awsSessionToken</name>
             <value>insert session token here</value>
         </property>
-        </configuration>
+    </configuration>
 
 AWS Multi-Node Instance
 '''''''''''''''''''''''
@@ -211,7 +211,7 @@ Minio Cloud Storage is an alternative to Amazon AWS S3. When connecting to a Min
 
 - ``enable.path.style``: Specifies to override the default S3 behavior to expose every bucket as a full DNS enabled path. Note that this is a Minio recommendation.
 
-To pass in AWS credentials, create a ``core-site.xml`` file that contains your Access Key ID and Secret Access Key and use the flag ``-hdfs_config`` flag when launching:
+To pass in credentials, create a ``core-site.xml`` file that contains your Access Key ID and Secret Access Key and use the flag ``-hdfs_config`` flag when launching:
 
 ::
 

--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -168,39 +168,17 @@ Minio Instance
 
 Minio Cloud Storage is an alternative to Amazon AWS S3. When using a Minio server, the following additional parameters are specified in the Java launch command:
 
-- ``endpoint``: Specifies a minio server instance (including address and port). This overrides the existing endpoint, which is currently hardcoded to be AWS S3.
+- ``endpoint``: Specifies a Minio server instance (including address and port). This overrides the existing endpoint, which is currently hardcoded to be AWS S3.
 
 - ``enable.path.style``: Specifies to override the default S3 behavior to expose every bucket as a full DNS enabled path. Note that this is a Minio recommendation.
 
-1. Edit the properties in the ``core-site.xml`` file to include your these new parameters as well as the Access Key ID and Access Key. Refer to the following example:
+1. Launch H2O by entering the following in the command line:
 
   ::
 
-      <property>
-        <name>Dsys.ai.h2o.persist.s3.endPoint</name>
-        <value>example.minio.io:9000</value>
-      </property>
-      <property>
-        <name>Dsys.ai.h2o.persist.s3.enable.path.style</name>
-        <value>true</value>
-      </property>
-      <property>
-        <name>Daws.AccessKeyId</name>
-        <value>[MINIO SECRET KEY]</value>
-      </property>
+      java -Dsys.ai.h2o.persist.s3.endPoint=s3.amazonaws.com -jar h2o.jar
 
-      <property>
-        <name>Daws.SecretAccessKey</name>
-        <value>[MINIO SECRET ACCESS KEY]</value>
-      </property>
-
-2. Launch with the configuration file ``core-site.xml`` by entering the following in the command line:
-
-  ::
-
-      java -jar h2o.jar -hdfs_config core-site.xml
-
-3. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**. You can pass the AWS Access Key and Secret Access Key in an S3 URL in Flow, R, or Python (where ``MINIO_ACCESS_KEY`` represents your user name, and ``MINIO_SECRET_KEY`` represents your password).
+2. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**. You can pass the AWS Access Key and Secret Access Key in an S3 URL in Flow, R, or Python (where ``MINIO_ACCESS_KEY`` represents your user name, and ``MINIO_SECRET_KEY`` represents your password).
 
  - To import the data from the Flow API:
 
@@ -219,47 +197,6 @@ Minio Cloud Storage is an alternative to Amazon AWS S3. When using a Minio serve
   ::
 
    h2o.import_file(path = "s3://<MINIO_ACCESS_KEY>:<MINIO_SECRET_KEY>@bucket/path/to/file.csv")
-
-
-.. _Core-site.xml:
-
-Core-site.xml Example
-'''''''''''''''''''''
-
-The following is an example core-site.xml file:
-
-::
-
-    <?xml version="1.0"?>
-    <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
-
-    <!-- Put site-specific property overrides in this file. -->
-
-    <configuration>
-
-        <!--
-        <property>
-        <name>fs.default.name</name>
-        <value>s3://<your s3 bucket></value>
-        </property>
-        -->
-
-        <property>
-            <name>fs.s3.awsAccessKeyId</name>
-            <value>insert access key here</value>
-        </property>
-
-        <property>
-            <name>fs.s3.awsSecretAccessKey</name>
-            <value>insert secret key here</value>
-        </property>
-
-        <property>
-            <name>fs.s3.awsSessionToken</name>
-            <value>insert session token here</value>
-        </property>
-        </configuration>
-
 
 Launching H2O
 '''''''''''''

--- a/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
+++ b/h2o-docs/src/product/cloud-integration/ec2-and-s3.rst
@@ -114,6 +114,45 @@ H2O supports both AWS Credentials (pair consisting of AWS SECRET KEY and AWS SEC
 
 **Note**: Passing credentials in the URL, e.g. ``h2o.importFile(path = "s3://<AWS_ACCESS_KEY>:<AWS_SECRET_KEY>:<AWS_SESSION_TOKEN>@bucket/path/to/file.csv")``, is considered a security risk and is deprecated. 
 
+.. _Core-site.xml:
+
+Core-site.xml Example
+'''''''''''''''''''''
+
+The following is an example core-site.xml file:
+
+::
+
+    <?xml version="1.0"?>
+    <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+    <!-- Put site-specific property overrides in this file. -->
+
+    <configuration>
+
+        <!--
+        <property>
+        <name>fs.default.name</name>
+        <value>s3://<your s3 bucket></value>
+        </property>
+        -->
+
+        <property>
+            <name>fs.s3.awsAccessKeyId</name>
+            <value>insert access key here</value>
+        </property>
+
+        <property>
+            <name>fs.s3.awsSecretAccessKey</name>
+            <value>insert secret key here</value>
+        </property>
+
+        <property>
+            <name>fs.s3.awsSessionToken</name>
+            <value>insert session token here</value>
+        </property>
+        </configuration>
+
 AWS Multi-Node Instance
 '''''''''''''''''''''''
 
@@ -176,7 +215,7 @@ Minio Cloud Storage is an alternative to Amazon AWS S3. When using a Minio serve
 
   ::
 
-      java -Dsys.ai.h2o.persist.s3.endPoint=s3.amazonaws.com -jar h2o.jar
+      java -Dsys.ai.h2o.persist.s3.endPoint=https://play.min.io:9000 -Dsys.ai.h2o.persist.s3.enable.path.style=true -jar h2o.jar
 
 2. Import the data using ``importFile`` with the Minio S3 url path: **s3://bucket/path/to/file.csv**. You can pass the AWS Access Key and Secret Access Key in an S3 URL in Flow, R, or Python (where ``MINIO_ACCESS_KEY`` represents your user name, and ``MINIO_SECRET_KEY`` represents your password).
 


### PR DESCRIPTION
Minio instance configuration does not use core-site.xml. The documentation has been updated to reflect this.

See: https://0xdata.atlassian.net/browse/PUBDEV-7531