### PR TITLE
[build] Fix signing of published artifacts

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -29,14 +29,6 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
 }
 
-plugins.withType(org.gradle.api.publish.maven.plugins.MavenPublishPlugin) {
-    // Publish it only if "maven-publish" plugin is in the context
-    artifacts {
-        toPublish javadocJar
-        toPublish testJar
-    }
-}
-
 
 clean {
     doLast {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,34 +1,12 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
-apply plugin: "signing"
-
-// Default task to bundle sources code as jar
-task sourcesJar(type: Jar) {
-  classifier = 'sources'
-  from sourceSets.main.allSource
-}
+apply plugin: 'signing'
 
 // Container for generated POMs (by default added into archive configuration)
 configurations {
     pom {
         transitive = false
     }
-}
-
-configurations {
-    toPublish
-}
-
-artifacts {
-    toPublish sourcesJar
-}
-
-task signAll(type : Sign) {
-    sign configurations.archives
-    // Sign additional artifacts
-    sign configurations.toPublish
-    // Sign only in case of release
-    required = project.ext.isRelease || project.hasProperty("doSignAll")
 }
 
 //
@@ -62,23 +40,6 @@ publishing {
           from components.java
 
           // Publish additional artifacts as documentaiton or source code
-          configurations.toPublish.allArtifacts.each { art ->
-              logger.debug("Publishing artifact for: " + art)
-              artifact art
-          }
-
-          if (signAll.required) {
-              signAll.signatures.all { Signature signature ->
-                  logger.debug("Publishing signature for: " + signature.file + ", type=" + signature.type)
-                  artifact(signature, new Action<MavenArtifact>() {
-                      @Override
-                      void execute(MavenArtifact t) {
-                          t.classifier = signature.classifier != "" ? signature.classifier : null
-                          t.extension = signature.type == "xml.asc" ? "pom.asc" : signature.type
-                      }
-                  })
-              }
-          }
 
           pom.withXml { provider ->
                 def h2oPOM = {
@@ -130,6 +91,10 @@ publishing {
       }
   }
 
+  signing {
+    sign publishing.publications.mavenAll
+  }
+
   repositories {
       maven {
           name "BuildRepo"
@@ -153,9 +118,9 @@ publishing {
           maven {
               name "LocalNexusRepo"
               if (project.ext.isRelease) {
-                url "${localNexusLocation}/releases"
+                url "${localNexusLocation}/maven-releases"
               } else {
-                url "${localNexusLocation}/snapshots"
+                url "${localNexusLocation}/maven-snapshots"
               }
 
               credentials {


### PR DESCRIPTION
These artifacts were present in local Nexus after publish:
```
h2o-algos-3.31.0.99999-javadoc.jar | Thu May 14 13:25:27 UTC 2020 | 2244574 |  
-- | -- | -- | --
h2o-algos-3.31.0.99999-javadoc.jar.asc | Thu May 14 13:25:27 UTC 2020 | 650 |  
h2o-algos-3.31.0.99999-javadoc.jar.asc.md5 | Thu May 14 13:25:27 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999-javadoc.jar.asc.sha1 | Thu May 14 13:25:27 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999-javadoc.jar.asc.sha256 | Thu May 14 13:25:27 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999-javadoc.jar.asc.sha512 | Thu May 14 13:25:27 UTC 2020 | 128 |  
h2o-algos-3.31.0.99999-javadoc.jar.md5 | Thu May 14 13:25:27 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999-javadoc.jar.sha1 | Thu May 14 13:25:27 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999-javadoc.jar.sha256 | Thu May 14 13:25:27 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999-javadoc.jar.sha512 | Thu May 14 13:25:27 UTC 2020 | 128 |  
h2o-algos-3.31.0.99999.jar | Thu May 14 13:25:27 UTC 2020 | 1364628 |  
h2o-algos-3.31.0.99999.jar.asc | Thu May 14 13:25:27 UTC 2020 | 650 |  
h2o-algos-3.31.0.99999.jar.asc.md5 | Thu May 14 13:25:27 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999.jar.asc.sha1 | Thu May 14 13:25:27 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999.jar.asc.sha256 | Thu May 14 13:25:27 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999.jar.asc.sha512 | Thu May 14 13:25:27 UTC 2020 | 128 |  
h2o-algos-3.31.0.99999.jar.md5 | Thu May 14 13:25:27 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999.jar.sha1 | Thu May 14 13:25:27 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999.jar.sha256 | Thu May 14 13:25:27 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999.jar.sha512 | Thu May 14 13:25:27 UTC 2020 | 128 |  
h2o-algos-3.31.0.99999.module | Thu May 14 13:25:28 UTC 2020 | 14998 |  
h2o-algos-3.31.0.99999.module.asc | Thu May 14 13:25:28 UTC 2020 | 650 |  
h2o-algos-3.31.0.99999.module.asc.md5 | Thu May 14 13:25:28 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999.module.asc.sha1 | Thu May 14 13:25:28 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999.module.asc.sha256 | Thu May 14 13:25:28 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999.module.asc.sha512 | Thu May 14 13:25:28 UTC 2020 | 128 |  
h2o-algos-3.31.0.99999.module.md5 | Thu May 14 13:25:28 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999.module.sha1 | Thu May 14 13:25:28 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999.module.sha256 | Thu May 14 13:25:28 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999.module.sha512 | Thu May 14 13:25:28 UTC 2020 | 128 |  
h2o-algos-3.31.0.99999.pom | Thu May 14 13:25:27 UTC 2020 | 6632 |  
h2o-algos-3.31.0.99999.pom.asc | Thu May 14 13:25:28 UTC 2020 | 650 |  
h2o-algos-3.31.0.99999.pom.asc.md5 | Thu May 14 13:25:28 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999.pom.asc.sha1 | Thu May 14 13:25:28 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999.pom.asc.sha256 | Thu May 14 13:25:28 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999.pom.asc.sha512 | Thu May 14 13:25:28 UTC 2020 | 128 |  
h2o-algos-3.31.0.99999.pom.md5 | Thu May 14 13:25:27 UTC 2020 | 32 |  
h2o-algos-3.31.0.99999.pom.sha1 | Thu May 14 13:25:27 UTC 2020 | 40 |  
h2o-algos-3.31.0.99999.pom.sha256 | Thu May 14 13:25:27 UTC 2020 | 64 |  
h2o-algos-3.31.0.99999.pom.sha512 | Thu May 14 13:25:27 UTC 2020 | 128 |  
```