### PR TITLE
PUBDEV-7454: Make get_leaderboard work for re-attached H2OAutoML object

### DIFF
--- a/h2o-py/h2o/automl/_h2o_automl_output.py
+++ b/h2o-py/h2o/automl/_h2o_automl_output.py
@@ -10,6 +10,7 @@ class H2OAutoMLOutput(H2OAutoMLBaseMixin, Keyed):
 
     def __init__(self, state):
         self._project_name = state['project_name']
+        self._key = state['json']['automl_id']['name']
         self._leader = state['leader']
         self._leaderboard = state['leaderboard']
         self._event_log = el = state['event_log']
@@ -53,7 +54,7 @@ class H2OAutoMLOutput(H2OAutoMLBaseMixin, Keyed):
     #-------------------------------------------------------------------------------------------------------------------
     @property
     def key(self):
-        return self.project_name
+        return self._key
 
     def detach(self):
         self._project_name = None

--- a/h2o-py/h2o/automl/autoh2o.py
+++ b/h2o-py/h2o/automl/autoh2o.py
@@ -615,5 +615,5 @@ def get_leaderboard(aml, extra_columns=None):
     >>> lb_custom = h2o.automl.get_leaderboard(aml, ['predict_time_per_row_ms', 'training_time_ms'])
     >>> lb_custom_sorted = lb_custom.sort(by='predict_time_per_row_ms')
     """
-    assert_is_type(aml, H2OAutoML)
+    assert_is_type(aml, H2OAutoML, H2OAutoMLOutput)
     return H2OAutoML._fetch_leaderboard(aml.key, extra_columns)

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
@@ -3,7 +3,7 @@ import sys, os
 sys.path.insert(1, os.path.join("..","..",".."))
 import h2o
 from tests import pyunit_utils
-from h2o.automl import H2OAutoML
+from h2o.automl import H2OAutoML, get_leaderboard
 from h2o.automl.autoh2o import get_automl
 
 
@@ -37,5 +37,7 @@ def test_get_automl():
     predictions_from_output = get_aml.predict(train)
     assert (predictions == predictions_from_output).all()
 
+    # Test get_leaderboard PUBDEV-7454
+    assert (get_leaderboard(aml) == get_leaderboard(get_aml)).all()
 
 pyunit_utils.run_tests([test_get_automl])

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_get_automl.py
@@ -39,5 +39,6 @@ def test_get_automl():
 
     # Test get_leaderboard PUBDEV-7454
     assert (get_leaderboard(aml) == get_leaderboard(get_aml)).all()
+    assert (get_leaderboard(aml, 'ALL') == get_leaderboard(get_aml, 'ALL')).all()
 
 pyunit_utils.run_tests([test_get_automl])

--- a/h2o-r/h2o-package/R/automl.R
+++ b/h2o-r/h2o-package/R/automl.R
@@ -423,6 +423,7 @@ h2o.predict.H2OAutoML <- function(object, newdata, ...) {
   # GET AutoML job and leaderboard for project
   automl_job <- .h2o.__remoteSend(h2oRestApiVersion = 99, method = "GET", page = paste0("AutoML/", run_id))
   project_name <- automl_job$project_name
+  automl_id <- automl_job$automl_id$name
 
   leaderboard <- as.data.frame(automl_job$leaderboard_table)
   row.names(leaderboard) <- seq(nrow(leaderboard))
@@ -465,6 +466,7 @@ h2o.predict.H2OAutoML <- function(object, newdata, ...) {
   }
 
   return(list(
+    automl_id=automl_id,
     project_name=project_name,
     leaderboard=leaderboard,
     leader=leader,
@@ -503,14 +505,16 @@ h2o.get_automl <- function(project_name) {
   }
 
   # Make AutoML object
-  return(new("H2OAutoML",
+  automl <- new("H2OAutoML",
              project_name = state$project,
              leader = state$leader,
              leaderboard = state$leaderboard,
              event_log = state$event_log,
              modeling_steps = state$modeling_steps,
              training_info = training_info
-  ))
+  )
+  attr(automl, "id") <- state$automl_id
+  return(automl)
 }
 
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
@@ -30,7 +30,7 @@ automl.get.automl.test <- function() {
     expect_equal(aml1@leader@model_id, get_aml1@leader@model_id)
     expect_equal(aml1@leaderboard, get_aml1@leaderboard)
     expect_equal(h2o.dim(aml1@event_log), h2o.dim(get_aml1@event_log))
-
+    expect_equal(h2o.get_leaderboard(aml1), h2o.get_leaderboard(get_aml1))
 }
 
 doTest("AutoML h2o.get_automl Test", automl.get.automl.test)

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_get_automl.R
@@ -31,6 +31,7 @@ automl.get.automl.test <- function() {
     expect_equal(aml1@leaderboard, get_aml1@leaderboard)
     expect_equal(h2o.dim(aml1@event_log), h2o.dim(get_aml1@event_log))
     expect_equal(h2o.get_leaderboard(aml1), h2o.get_leaderboard(get_aml1))
+    expect_equal(h2o.get_leaderboard(aml1, "ALL"), h2o.get_leaderboard(get_aml1, "ALL"))
 }
 
 doTest("AutoML h2o.get_automl Test", automl.get.automl.test)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7454

In both, python and R, get_leaderboard was failing on reattached AutoML object:

In python, it used `key` property that had the same value as `project_name` in the reattached object instead of `project_name@@response_column`.

In R, it used `id` attribute that wasn't set, so I set it in `h2o.get_automl`. 

For both I use value retrieved from `automl_job$automl_id$name`.