### PR TITLE
Revert release repository locaton

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -119,9 +119,9 @@ publishing {
           maven {
               name "LocalNexusRepo"
               if (project.ext.isRelease) {
-                url "${localNexusLocation}/maven-releases"
+                url "${localNexusLocation}/releases"
               } else {
-                url "${localNexusLocation}/maven-snapshots"
+                url "${localNexusLocation}/snapshots"
               }
 
               credentials {


### PR DESCRIPTION
I forgot to revert maven repository url to original after local experimenting !
The same changes go (or don't go - depends on point of view) to rel-zahradnik as a part of https://github.com/h2oai/h2o-3/pull/4623