### PR TITLE
PUBDEV-7547: Create an additional StackedEnsemble only from monotonically constrained models

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -12,6 +12,7 @@ import hex.glm.GLMModel;
 import water.DKV;
 import water.Job;
 import water.Key;
+import water.util.PojoUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -144,11 +145,11 @@ public class StackedEnsembleStepsProvider
                     boolean hasMonotoneConstrains(Key<Model> modelKey) {
                         Model model = DKV.getGet(modelKey);
                         try {
-                            KeyValue[] mc = (KeyValue[]) model._parms.getClass()
-                                    .getField("_monotone_constraints")
-                                    .get(model._parms);
+                            KeyValue[] mc = (KeyValue[]) PojoUtils.getFieldValue(
+                                    model._parms, "_monotone_constraints",
+                                    PojoUtils.FieldNaming.CONSISTENT);
                             return mc != null && mc.length > 0;
-                        } catch (NoSuchFieldException | IllegalAccessException e) {
+                        } catch (IllegalArgumentException e) {
                             return false;
                         }
                     }
@@ -190,10 +191,8 @@ public class StackedEnsembleStepsProvider
                     protected StackedEnsembleParameters getStackedEnsembleParameters(Key<Model>[] baseModels, boolean isLast) {
                         StackedEnsembleParameters params = super.getStackedEnsembleParameters(baseModels, isLast);
                         GLMModel.GLMParameters metalearnerParams = new GLMModel.GLMParameters();
-                        // Ensure that we have non negative constraint to make it easier to reason about the whole ensemble
-                        // Hard wired in case Metalearner.Algorithm.AUTO changes its implementation
-                        metalearnerParams._non_negative = true;
-                        params._metalearner_algorithm = Metalearner.Algorithm.glm;
+                        // AUTO has non negative constraint to make it easier to reason about the whole ensemble
+                        params._metalearner_algorithm = Metalearner.Algorithm.AUTO;
                         params._metalearner_parameters = metalearnerParams;
                         return params;
                     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -188,16 +188,6 @@ public class StackedEnsembleStepsProvider
                     }
 
                     @Override
-                    protected StackedEnsembleParameters getStackedEnsembleParameters(Key<Model>[] baseModels, boolean isLast) {
-                        StackedEnsembleParameters params = super.getStackedEnsembleParameters(baseModels, isLast);
-                        GLMModel.GLMParameters metalearnerParams = new GLMModel.GLMParameters();
-                        // AUTO has non negative constraint to make it easier to reason about the whole ensemble
-                        params._metalearner_algorithm = Metalearner.Algorithm.AUTO;
-                        params._metalearner_parameters = metalearnerParams;
-                        return params;
-                    }
-
-                    @Override
                     protected Job<StackedEnsembleModel> startJob() {
                         return stack(_algo + "_MonotonicallyConstrainedModels", getBaseModels(), true);
                     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -3,9 +3,13 @@ package ai.h2o.automl.modeling;
 import ai.h2o.automl.*;
 import ai.h2o.automl.WorkAllocations.Work;
 import ai.h2o.automl.events.EventLogEntry;
+import hex.KeyValue;
 import hex.Model;
+import hex.ensemble.Metalearner;
 import hex.ensemble.StackedEnsembleModel;
 import hex.ensemble.StackedEnsembleModel.StackedEnsembleParameters;
+import hex.glm.GLMModel;
+import water.DKV;
 import water.Job;
 import water.Key;
 
@@ -66,9 +70,15 @@ public class StackedEnsembleStepsProvider
             }
 
             Job<StackedEnsembleModel> stack(String modelName, Key<Model>[] baseModels, boolean isLast) {
+                StackedEnsembleParameters stackedEnsembleParameters = getStackedEnsembleParameters(baseModels, isLast);
+                Key<StackedEnsembleModel> modelKey = makeKey(modelName, false);
+                return trainModel(modelKey, stackedEnsembleParameters);
+            }
+
+            protected StackedEnsembleParameters getStackedEnsembleParameters(Key<Model>[] baseModels, boolean isLast) {
                 AutoMLBuildSpec buildSpec = aml().getBuildSpec();
                 // Set up Stacked Ensemble
-                StackedEnsembleModel.StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleParameters();
+                StackedEnsembleParameters stackedEnsembleParameters = new StackedEnsembleParameters();
                 stackedEnsembleParameters._base_models = baseModels;
                 stackedEnsembleParameters._valid = (aml().getValidationFrame() == null ? null : aml().getValidationFrame()._key);
                 stackedEnsembleParameters._blending = (aml().getBlendingFrame() == null ? null : aml().getBlendingFrame()._key);
@@ -81,9 +91,7 @@ public class StackedEnsembleStepsProvider
                 stackedEnsembleParameters.initMetalearnerParams();
                 stackedEnsembleParameters._metalearner_parameters._keep_cross_validation_models = buildSpec.build_control.keep_cross_validation_models;
                 stackedEnsembleParameters._metalearner_parameters._keep_cross_validation_predictions = buildSpec.build_control.keep_cross_validation_predictions;
-
-                Key<StackedEnsembleModel> modelKey = makeKey(modelName, false);
-                return trainModel(modelKey, stackedEnsembleParameters);
+                return stackedEnsembleParameters;
             }
 
         }
@@ -128,6 +136,71 @@ public class StackedEnsembleStepsProvider
                     @Override
                     protected Job<StackedEnsembleModel> startJob() {
                         return stack(_algo+"_AllModels", getBaseModels(), true);
+                    }
+                },
+                new StackedEnsembleModelStep("monotone", DEFAULT_MODEL_TRAINING_WEIGHT, aml()) {
+                    { _description = _description+" (built using monotonically constrained AutoML models)"; }
+
+                    boolean hasMonotoneConstrains(Key<Model> modelKey) {
+                        Model model = DKV.getGet(modelKey);
+                        try {
+                            KeyValue[] mc = (KeyValue[]) model._parms.getClass()
+                                    .getField("_monotone_constraints")
+                                    .get(model._parms);
+                            return mc != null && mc.length > 0;
+                        } catch (NoSuchFieldException | IllegalAccessException e) {
+                            return false;
+                        }
+                    }
+
+                    @Override
+                    protected boolean canRun() {
+                        boolean canRun = super.canRun();
+                        if (!canRun) return false;
+                        int monotoneModels=0;
+                        for (Key<Model> modelKey: getTrainedModelsKeys()) {
+                            if (hasMonotoneConstrains(modelKey))
+                                monotoneModels++;
+                            if (monotoneModels >= 2)
+                                return true;
+                        }
+                        if (monotoneModels == 1) {
+                            aml().job().update(getAllocatedWork().consume(),
+                                    "Only one monotone base model; skipping this StackedEnsemble");
+                            aml().eventLog().info(EventLogEntry.Stage.ModelTraining,
+                                    String.format("Skipping StackedEnsemble '%s' since there is only one monotone model to stack", _id));
+                        } else {
+                            aml().job().update(getAllocatedWork().consume(),
+                                    "No monotone base model; skipping this StackedEnsemble");
+                            aml().eventLog().info(EventLogEntry.Stage.ModelTraining,
+                                    String.format("Skipping StackedEnsemble '%s' since there is no monotone model to stack", _id));
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    protected Key<Model>[] getBaseModels() {
+                        return Stream.of(getTrainedModelsKeys())
+                                .filter(k -> !isStackedEnsemble(k) && hasMonotoneConstrains(k))
+                                .toArray(Key[]::new);
+                    }
+
+                    @Override
+                    protected StackedEnsembleParameters getStackedEnsembleParameters(Key<Model>[] baseModels, boolean isLast) {
+                        StackedEnsembleParameters params = super.getStackedEnsembleParameters(baseModels, isLast);
+                        GLMModel.GLMParameters metalearnerParams = new GLMModel.GLMParameters();
+                        // Ensure that we have non negative constraint to make it easier to reason about the whole ensemble
+                        // Hard wired in case Metalearner.Algorithm.AUTO changes its implementation
+                        metalearnerParams._non_negative = true;
+                        params._metalearner_algorithm = Metalearner.Algorithm.glm;
+                        params._metalearner_parameters = metalearnerParams;
+                        return params;
+                    }
+
+                    @Override
+                    protected Job<StackedEnsembleModel> startJob() {
+                        return stack(_algo + "_MonotonicallyConstrainedModels", getBaseModels(), true);
                     }
                 },
         };

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -358,7 +358,7 @@ public class AutoMLTest extends water.TestUtil {
         put(Algo.GBM, 5*10+1*60); // models+grids
         put(Algo.GLM, 1*10);
         put(Algo.XGBoost, 3*10+1*100); // models+grids
-        put(Algo.StackedEnsemble, 2*10);
+        put(Algo.StackedEnsemble, 3*10);
       }};
       int maxTotalWork = 0;
       for (Map.Entry<Algo, Integer> entry : defaultAllocs.entrySet()) {
@@ -398,7 +398,7 @@ public class AutoMLTest extends water.TestUtil {
         put(Algo.GBM, 5*10+1*60); // models+grids
         put(Algo.GLM, 1*10);
         put(Algo.XGBoost, 3*10+1*100); // models+grids
-        put(Algo.StackedEnsemble, 2*10);
+        put(Algo.StackedEnsemble, 3*10);
       }};
       Map<Algo, Integer> exploitationAllocs = new HashMap<Algo, Integer>(){{
         put(Algo.GBM, 1*10);

--- a/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepRegistryTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/ModelingStepRegistryTest.java
@@ -65,7 +65,7 @@ public class ModelingStepRegistryTest extends TestUtil {
     @Test
     public void test_non_empty_definition() {
         ModelingStepsRegistry registry = new ModelingStepsRegistry();
-        assertEquals(2, registry.getOrderedSteps(new StepDefinition[]{
+        assertEquals(3, registry.getOrderedSteps(new StepDefinition[]{
                 new StepDefinition(Algo.StackedEnsemble.name(), StepDefinition.Alias.defaults)
         }, aml).length);
     }
@@ -77,7 +77,7 @@ public class ModelingStepRegistryTest extends TestUtil {
                 .map(name -> new StepDefinition(name, StepDefinition.Alias.all))
                 .collect(Collectors.toList());
         ModelingStep[] modelingSteps = registry.getOrderedSteps(allSteps.toArray(new StepDefinition[0]), aml);
-        assertEquals((1 + 3/*DL*/) + (2/*DRF*/) + (5 + 1 + 1/*GBM*/) + (1/*GLM*/) + (2/*SE*/) + (3 + 1 + 2/*XGB*/),
+        assertEquals((1 + 3/*DL*/) + (2/*DRF*/) + (5 + 1 + 1/*GBM*/) + (1/*GLM*/) + (3/*SE*/) + (3 + 1 + 2/*XGB*/),
                 modelingSteps.length);
         assertEquals(1, Stream.of(modelingSteps).filter(s -> s._algo == Algo.DeepLearning).filter(ModelingStep.ModelStep.class::isInstance).count());
         assertEquals(3, Stream.of(modelingSteps).filter(s -> s._algo == Algo.DeepLearning).filter(ModelingStep.GridStep.class::isInstance).count());
@@ -86,7 +86,7 @@ public class ModelingStepRegistryTest extends TestUtil {
         assertEquals(1, Stream.of(modelingSteps).filter(s -> s._algo == Algo.GBM).filter(ModelingStep.GridStep.class::isInstance).count());
         assertEquals(1, Stream.of(modelingSteps).filter(s -> s._algo == Algo.GBM).filter(ModelingStep.SelectionStep.class::isInstance).count());
         assertEquals(1, Stream.of(modelingSteps).filter(s -> s._algo == Algo.GLM).filter(ModelingStep.ModelStep.class::isInstance).count());
-        assertEquals(2, Stream.of(modelingSteps).filter(s -> s._algo == Algo.StackedEnsemble).filter(ModelingStep.ModelStep.class::isInstance).count());
+        assertEquals(3, Stream.of(modelingSteps).filter(s -> s._algo == Algo.StackedEnsemble).filter(ModelingStep.ModelStep.class::isInstance).count());
         assertEquals(3, Stream.of(modelingSteps).filter(s -> s._algo == Algo.XGBoost).filter(ModelingStep.ModelStep.class::isInstance).count());
         assertEquals(1, Stream.of(modelingSteps).filter(s -> s._algo == Algo.XGBoost).filter(ModelingStep.GridStep.class::isInstance).count());
         assertEquals(2, Stream.of(modelingSteps).filter(s -> s._algo == Algo.XGBoost).filter(ModelingStep.SelectionStep.class::isInstance).count());
@@ -97,7 +97,7 @@ public class ModelingStepRegistryTest extends TestUtil {
                 "def_1", "XRT",
                 "def_1", "def_2", "def_3", "def_4", "def_5", "grid_1", "lr_annealing",
                 "def_1",
-                "best", "all",
+                "best", "all", "monotone",
                 "def_1", "def_2", "def_3", "grid_1", "lr_annealing", "lr_search"
         ), orderedStepIds);
 
@@ -111,7 +111,7 @@ public class ModelingStepRegistryTest extends TestUtil {
                 .toArray(StepDefinition[]::new);
         ModelingStepsRegistry registry = new ModelingStepsRegistry();
         ModelingStep[] modelingSteps = registry.getOrderedSteps(allDefaultSteps, aml);
-        assertEquals((1/*DL*/) + (2/*DRF*/) + (5/*GBM*/) + (1/*GLM*/) + (2/*SE*/) + (3/*XGB*/),
+        assertEquals((1/*DL*/) + (2/*DRF*/) + (5/*GBM*/) + (1/*GLM*/) + (3/*SE*/) + (3/*XGB*/),
                 modelingSteps.length);
     }
 

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_interpretability.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_interpretability.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+from tests import pyunit_utils
+from h2o.automl import H2OAutoML
+
+
+def test_automl_creates_interpretable_SE_iff_monotonic_models_exist():
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    y = 'CAPSULE'
+    train[y] = train[y].asfactor()
+
+    aml_mono = H2OAutoML(project_name="test_automl_creates_interpretable_se",
+                    max_models=2,
+                    include_algos=["GBM", "XGBoost", "StackedEnsemble"],
+                    monotone_constraints=dict(
+                    AGE=1,DPROS=1,DCAPS=1,PSA=1,VOL=1,GLEASON=1
+                    ),
+                    seed=1234)
+    aml_mono.train(y=y, training_frame=train)
+
+    assert (aml_mono
+            .leaderboard
+            .as_data_frame()["model_id"]
+            .apply(lambda model_name: "MonotonicallyConstrainedModels" in model_name).any())
+
+    # If we don't have monotonic constraints we shouldn't have monotonically constrained SE
+    aml = H2OAutoML(project_name="test_automl_doesnt_create_interpretable_se",
+                    max_models=2,
+                    include_algos=["GBM", "XGBoost", "StackedEnsemble"],
+                    seed=1234)
+    aml.train(y=y, training_frame=train)
+
+    assert not (aml
+            .leaderboard
+            .as_data_frame()["model_id"]
+            .apply(lambda model_name: "MonotonicallyConstrainedModels" in model_name).any())
+
+pyunit_utils.run_tests([test_automl_creates_interpretable_SE_iff_monotonic_models_exist])

--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_interpretability.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_interpretability.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import sys, os
-sys.path.insert(1, os.path.join("..","..",".."))
+
+sys.path.insert(1, os.path.join("..", "..", ".."))
 import h2o
 from tests import pyunit_utils
 from h2o.automl import H2OAutoML
@@ -12,12 +13,12 @@ def test_automl_creates_interpretable_SE_iff_monotonic_models_exist():
     train[y] = train[y].asfactor()
 
     aml_mono = H2OAutoML(project_name="test_automl_creates_interpretable_se",
-                    max_models=2,
-                    include_algos=["GBM", "XGBoost", "StackedEnsemble"],
-                    monotone_constraints=dict(
-                    AGE=1,DPROS=1,DCAPS=1,PSA=1,VOL=1,GLEASON=1
-                    ),
-                    seed=1234)
+                         max_models=2,
+                         include_algos=["GBM", "XGBoost", "StackedEnsemble"],
+                         monotone_constraints=dict(
+                             AGE=1, DPROS=1, DCAPS=1, PSA=1, VOL=1, GLEASON=1
+                         ),
+                         seed=1234)
     aml_mono.train(y=y, training_frame=train)
 
     assert (aml_mono
@@ -33,8 +34,39 @@ def test_automl_creates_interpretable_SE_iff_monotonic_models_exist():
     aml.train(y=y, training_frame=train)
 
     assert not (aml
-            .leaderboard
-            .as_data_frame()["model_id"]
-            .apply(lambda model_name: "MonotonicallyConstrainedModels" in model_name).any())
+                .leaderboard
+                .as_data_frame()["model_id"]
+                .apply(lambda model_name: "MonotonicallyConstrainedModels" in model_name).any())
 
-pyunit_utils.run_tests([test_automl_creates_interpretable_SE_iff_monotonic_models_exist])
+
+def test_automl_creates_interpretable_SE_with_only_monotonic_models():
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate.csv"))
+    y = 'CAPSULE'
+    train[y] = train[y].asfactor()
+
+    aml_mono = H2OAutoML(project_name="test_automl_creates_interpretable_se",
+                         max_models=5,
+                         include_algos=["GBM", "GLM", "XGBoost", "StackedEnsemble"],
+                         monotone_constraints=dict(
+                             AGE=1, DPROS=1, DCAPS=1, PSA=1, VOL=1, GLEASON=1
+                         ),
+                         seed=1234)
+    aml_mono.train(y=y, training_frame=train)
+
+    leaderboard = (aml_mono
+        .leaderboard
+        .as_data_frame()["model_id"])
+
+    assert leaderboard.apply(lambda model_name: "MonotonicallyConstrainedModels" in model_name).any()
+
+    se_name = leaderboard[leaderboard.apply(lambda model_name: "MonotonicallyConstrainedModels" in model_name)]
+    se_mono = h2o.get_model(se_name.iloc[0])
+
+    assert leaderboard.apply(lambda model_name: 'GLM' in model_name).any()
+    assert all(['GBM' in bm or 'XGBoost' in bm for bm in se_mono.base_models])
+
+
+pyunit_utils.run_tests([
+    test_automl_creates_interpretable_SE_iff_monotonic_models_exist,
+    test_automl_creates_interpretable_SE_with_only_monotonic_models
+])


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7547

If user specified `monotone_constraints` in AutoML and during the run we create at least 2 monotone models, create a SE with just the monotone models.