### PR TITLE
Convenience version of h2o.get_model that works with H2OFrame

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -989,7 +989,13 @@ def get_model(model_id):
     ...             training_frame=airlines)
     >>> model2 = h2o.get_model(model.model_id)
     """
-    assert_is_type(model_id, str)
+    assert_is_type(model_id, str, H2OFrame)
+    if isinstance(model_id, H2OFrame):
+        if "model" not in model_id.names:
+            raise H2OValueError("When an H2OFrame is used to represent model_id it needs to have `model` column")
+        if model_id.nrow != 1:
+            raise H2OValueError("When an H2OFrame is used to represent model_id it needs to have exactly 1 row")
+        model_id = model_id["model"].as_data_frame(use_pandas=False)[1][0]
     model_json = api("GET /3/Models/%s" % model_id)["models"][0]
     algo = model_json["algo"]
     # still some special handling for AutoEncoder: would be cleaner if we could get rid of this

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_segment_train_cv.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_gbm_segment_train_cv.py
@@ -31,8 +31,7 @@ def test_gbm_bulk_cv():
 
     titanic_models = H2OSegmentModels(segment_models_id="titanic_by_pclass")
     bulk_models = titanic_models.as_frame()
-    titanic_bulk_cl1_gbm_id = (bulk_models[bulk_models["pclass"] == 1]["model"])
-    titanic_bulk_cl1_gbm = h2o.get_model(titanic_bulk_cl1_gbm_id.flatten())
+    titanic_bulk_cl1_gbm = h2o.get_model(bulk_models[bulk_models["pclass"] == 1])
 
     pyunit_utils.check_models(titanic_cl1_gbm, titanic_bulk_cl1_gbm, use_cross_validation=True)
 

--- a/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_model.py
+++ b/h2o-py/tests/testdir_apis/H2O_Module/pyunit_h2oget_model.py
@@ -19,8 +19,14 @@ def h2oget_model():
     model2 = h2o.get_model(model.model_id)
     assert_is_type( model, H2OGeneralizedLinearEstimator)
     assert_is_type(model2, H2OGeneralizedLinearEstimator)
-    assert (model._model_json['output']['model_category']==model2._model_json['output']['model_category']) and \
-           (model2._model_json['output']['model_category']=='Binomial'), "h2o.get_model() command is not working"
+    assert (model._model_json['output']['model_category'] == model2._model_json['output']['model_category']) and \
+           (model2._model_json['output']['model_category'] == 'Binomial'), "h2o.get_model() command is not working"
+
+    # test the convenience version of the function (extract model id from a single row H2OFrame with "model" column)
+    model_id_frame = h2o.H2OFrame({"col_1": [42], "model": [model.model_id]})
+    model3 = h2o.get_model(model_id_frame)
+    assert model3.model_id == model.model_id
+
 
 if __name__ == "__main__":
     pyunit_utils.standalone_test(h2oget_model)


### PR DESCRIPTION
Useful with Segment Models and elsewhere where users have an H2OFrame
of model ids in a `model` column and filter the set to just a single row