### PR TITLE
PUBDEV-7552: Add support for model checkpointing of the Stacked Ensemble metalearner

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -46,6 +46,7 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
       "seed",
       "score_training_samples",
       "keep_levelone_frame",
+      "checkpoint",
       "export_checkpoints_dir"
     };
 

--- a/h2o-docs/src/product/data-science/algo-params/checkpoint.rst
+++ b/h2o-docs/src/product/data-science/algo-params/checkpoint.rst
@@ -1,7 +1,7 @@
 ``checkpoint``
 --------------
 
-- Available in: GBM, DRF, XGBoost, Deep Learning
+- Available in: GBM, DRF, XGBoost, Deep Learning, Stacked Ensembles
 - Hyperparameter: no
 
 Description

--- a/h2o-docs/src/product/data-science/stacked-ensembles.rst
+++ b/h2o-docs/src/product/data-science/stacked-ensembles.rst
@@ -99,6 +99,10 @@ Defining a Stacked Ensemble Model
 
 -  `seed <algo-params/seed.html>`__: (Optional) Seed for random numbers; passed through to the metalearner algorithm. Defaults to -1 (time-based random number).
 
+-  `checkpoint <algo-params/checkpoint.html>`__: Enter a model key associated with a
+   previously trained model. Use this option to build a new model as a
+   continuation of a previously generated model.
+
 -  `export_checkpoints_dir <algo-params/export_checkpoints_dir.html>`__: Specify a directory to which generated models will automatically be exported.
 
 You can follow the progress of H2O's Stacked Ensemble development `here <https://0xdata.atlassian.net/issues/?filter=19301>`__.

--- a/h2o-py/h2o/estimators/stackedensemble.py
+++ b/h2o-py/h2o/estimators/stackedensemble.py
@@ -64,7 +64,7 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     param_names = {"model_id", "training_frame", "response_column", "validation_frame", "blending_frame", "base_models",
                    "metalearner_algorithm", "metalearner_nfolds", "metalearner_fold_assignment",
                    "metalearner_fold_column", "metalearner_params", "seed", "score_training_samples",
-                   "keep_levelone_frame", "export_checkpoints_dir"}
+                   "keep_levelone_frame", "checkpoint", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OStackedEnsembleEstimator, self).__init__()
@@ -658,6 +658,21 @@ class H2OStackedEnsembleEstimator(H2OEstimator):
     def keep_levelone_frame(self, keep_levelone_frame):
         assert_is_type(keep_levelone_frame, None, bool)
         self._parms["keep_levelone_frame"] = keep_levelone_frame
+
+
+    @property
+    def checkpoint(self):
+        """
+        Model checkpoint to resume training with.
+
+        Type: ``str``.
+        """
+        return self._parms.get("checkpoint")
+
+    @checkpoint.setter
+    def checkpoint(self, checkpoint):
+        assert_is_type(checkpoint, None, str, H2OEstimator)
+        self._parms["checkpoint"] = checkpoint
 
 
     @property

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_checkpoint.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_checkpoint.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+from __future__ import print_function
+
+import h2o
+
+import sys
+sys.path.insert(1,"../../../")  # allow us to run this standalone
+
+from h2o.grid import H2OGridSearch
+from h2o.estimators.random_forest import H2ORandomForestEstimator
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+from h2o.estimators.stackedensemble import H2OStackedEnsembleEstimator
+from h2o.exceptions import H2OResponseError
+from h2o import get_model
+from tests import pyunit_utils as pu
+
+
+seed = 1
+
+
+def create_checkpoint(fr, x, y, checkpoint, algo, blending=False):
+    bm_parms = dict(nfolds=3, seed=1, keep_cross_validation_predictions=True)
+
+    gbm = H2OGradientBoostingEstimator(**bm_parms)
+    gbm.train(x, y, fr)
+
+    drf = H2ORandomForestEstimator(**bm_parms)
+    drf.train(x, y, fr)
+
+    se = H2OStackedEnsembleEstimator(
+        model_id=checkpoint,
+        metalearner_algorithm=algo,
+        base_models=[gbm, drf],
+        blending_frame=fr if blending else None
+    )
+    se.train(x, y, fr)
+
+
+def checkpoint_works_with_same_data_test():
+    fr = h2o.import_file(path=pu.locate("smalldata/iris/setosa_versicolor.csv"))
+    y = "C5"
+    fr[y] = fr[y].asfactor()
+
+    x = fr.columns
+    x.remove(y)
+
+    create_checkpoint(fr, x, y, "se_checkpoint", "gbm")
+
+    se = H2OStackedEnsembleEstimator(base_models=[], checkpoint="se_checkpoint",
+                                     metalearner_algorithm="gbm",
+                                     metalearner_params=dict(ntrees=60))
+    se.train(x, y, fr)
+    assert se.metalearner().actual_params['ntrees'] == 60
+
+
+def checkpoint_works_with_additional_data_test():
+    fr = h2o.import_file(path=pu.locate("smalldata/iris/iris_train.csv"))
+    fr2 = h2o.import_file(path=pu.locate("smalldata/iris/iris_test.csv"))
+
+    y = "species"
+    fr[y] = fr[y].asfactor()
+
+    x = fr.columns
+    x.remove(y)
+
+    create_checkpoint(fr, x, y, "se_checkpoint", "gbm")
+
+    se = H2OStackedEnsembleEstimator(base_models=[], checkpoint="se_checkpoint",
+                                     metalearner_algorithm="gbm",
+                                     metalearner_params=dict(ntrees=60))
+    se.train(x, y, fr2)
+    assert se.metalearner().actual_params['ntrees'] == 60
+
+
+def checkpoint_fails_with_new_category_in_response_test():
+    fr = h2o.import_file(path=pu.locate("smalldata/iris/setosa_versicolor.csv"))
+    y = "C5"
+    fr[y] = fr[y].asfactor()
+
+    x = fr.columns
+    x.remove(y)
+
+    create_checkpoint(fr, x, y, "se_checkpoint", "gbm", blending=True)
+
+    fr2 = h2o.import_file(path=pu.locate("smalldata/iris/virginica.csv"))
+
+    se = H2OStackedEnsembleEstimator(base_models=[], checkpoint="se_checkpoint",
+                                     metalearner_algorithm="gbm",
+                                     metalearner_params=dict(ntrees=60),
+                                     blending_frame=fr2)
+    try:
+        se.train(x, y, fr2)
+        assert False, 'Should have failed with "java.lang.IllegalArgumentException: ' \
+                      'Categorical factor levels of the training data must be the same ' \
+                      'as for the checkpointed model"'
+    except EnvironmentError:
+        pass
+
+
+def checkpoint_fails_with_new_category_in_predictors_test():
+    fr = h2o.import_file(path=pu.locate("smalldata/iris/setosa_versicolor.csv"))
+    y = "C4"
+    fr["C5"] = fr["C5"].asfactor()
+
+    x = fr.columns
+    x.remove(y)
+
+    create_checkpoint(fr, x, y, "se_checkpoint", "gbm", blending=True)
+
+    fr2 = h2o.import_file(path=pu.locate("smalldata/iris/virginica.csv"))
+
+    se = H2OStackedEnsembleEstimator(base_models=[], checkpoint="se_checkpoint",
+                                     metalearner_algorithm="gbm",
+                                     metalearner_params=dict(ntrees=60),
+                                     blending_frame=fr2)
+    try:
+        se.train(x, y, fr)
+        assert False, 'Should have failed with "Error: Blending frame has an unseen category by checkpointed model: C5 = Iris-setosa"'
+    except EnvironmentError:
+        pass
+
+
+pu.run_tests([
+    checkpoint_works_with_same_data_test,
+    checkpoint_works_with_additional_data_test,
+    checkpoint_fails_with_new_category_in_response_test,
+    checkpoint_fails_with_new_category_in_predictors_test,
+])

--- a/h2o-r/h2o-package/R/stackedensemble.R
+++ b/h2o-r/h2o-package/R/stackedensemble.R
@@ -38,6 +38,7 @@
 #' @param score_training_samples Specify the number of training set samples for scoring. The value must be >= 0. To use all training samples,
 #'        enter 0. Defaults to 10000.
 #' @param keep_levelone_frame \code{Logical}. Keep level one frame used for metalearner training. Defaults to FALSE.
+#' @param checkpoint Model checkpoint to resume training with.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
 #' @examples
 #' \dontrun{
@@ -106,6 +107,7 @@ h2o.stackedEnsemble <- function(x,
                                 seed = -1,
                                 score_training_samples = 10000,
                                 keep_levelone_frame = FALSE,
+                                checkpoint = NULL,
                                 export_checkpoints_dir = NULL)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -168,6 +170,8 @@ h2o.stackedEnsemble <- function(x,
     parms$score_training_samples <- score_training_samples
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
+  if (!missing(checkpoint))
+    parms$checkpoint <- checkpoint
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
 
@@ -236,6 +240,7 @@ h2o.stackedEnsemble <- function(x,
                                                 seed = -1,
                                                 score_training_samples = 10000,
                                                 keep_levelone_frame = FALSE,
+                                                checkpoint = NULL,
                                                 export_checkpoints_dir = NULL,
                                                 segment_columns = NULL,
                                                 segment_models_id = NULL,
@@ -303,6 +308,8 @@ h2o.stackedEnsemble <- function(x,
     parms$score_training_samples <- score_training_samples
   if (!missing(keep_levelone_frame))
     parms$keep_levelone_frame <- keep_levelone_frame
+  if (!missing(checkpoint))
+    parms$checkpoint <- checkpoint
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7552

I did an "exploratory" implementation that seems to work but I want to know your opinions about how this should be implemented.

### Current state
If `hasCheckpoint()`:
- do basic validations:
  - checkpoint must exist
  - base models must be same
  - must be same type (blending/CV)
  - must have same fold column
  - must be of the same Metalearner Also type
  - metalearner must be checkpointable
  - must be trained on same domains

- extract metalearner from the SE checkpoint and set the metalearner as the SE.metalearner.checkpoint and use normal training

### Remaining to be solved
- how to continue training in CV mode? I see 2 possible choices.
  - force user to specify the same training frame and just use the already computed CV holdout and just try improve the metalearner, e.g., by adding more trees
  - use predictions of base models on new training frame as an input to the metalearner 
- how to deal with updating metrics, especially when the frames used for the checkpoint model aren't available anymore. Now I think the final model has metrics only for the last invocation of the train method, which I think is the most straightforward approach (but I never used checkpoints so I don't know if there isn't a better solution).