### PR TITLE
Fix test-r-cmd-check-as-cran

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -4053,6 +4053,7 @@ use.package <- function(package,
 #'
 #' @param x An \code{R} object.
 #' @param destination_frame A string with the desired name for the H2OFrame
+#' @param use_datatable allow usage of data.table
 #' @param \dots arguments passed to method arguments.
 #' @export
 #' @examples 
@@ -4246,7 +4247,7 @@ as.h2o.Matrix <- function(x, destination_frame="", use_datatable=TRUE, ...) {
 #' as.data.frame(prostate)
 #' }
 #' @export
-as.data.frame.H2OFrame <- function(x, use_datatable=TRUE, ...) {
+as.data.frame.H2OFrame <- function(x, ...) {
   # Force loading of the types
   .fetch.data(x,1L)
     
@@ -4276,7 +4277,7 @@ as.data.frame.H2OFrame <- function(x, use_datatable=TRUE, ...) {
   useHexString <- getRversion() >= "3.1"
   # We cannot use data.table by default since its handling of escaping inside quoted csv values is not very good
   # in some edge cases its simply impossible to load data in correct format without additional post processing
-  useDataTable <- use_datatable && getOption("h2o.fread", FALSE) && use.package("data.table")
+  useDataTable <- getOption("h2o.fread", FALSE) && use.package("data.table")
   urlSuffix <- paste0('DownloadDataset',
                       '?frame_id=', URLencode(h2o.getId(x)),
                       '&hex_string=', ifelse(useHexString, "true", "false"),


### PR DESCRIPTION
Failed due to adding `use_datatable` to `as.data.frame.H2OFrame`, which was unnecessary in https://github.com/h2oai/h2o-3/pull/4634.

So I removed it from `as.data.frame.H2OFrame` but kept it in `as.h2o` where it was required. The problem is with having a conflict of keyword arguments among the methods that implement `as.data.frame` generic function. 

To get around using an explicit argument I could do something like (getting the information from `...`):
```
use_datatable <- as.list(match.call())$use_datatable
use_datatable <- is.null(use_datatable) || use_datatable
```

But I am not sure if we need it at all there.

Second part of the problem was missing documentation string for the `use_datatable` argument.