### PR TITLE
PUBDEV-7567: Enable using imported models as base models in Stacked Ensembles

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -487,10 +487,12 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
 
         if (require_consistent_training_frames) {
           if (trainingFrameRows < 0) trainingFrameRows = _parms.train().numRows();
-          Frame aTrainingFrame = aModel._parms.train(); // FIXME: can be null when aModel was imported
-          if (trainingFrameRows != aTrainingFrame.numRows())
+          long numOfRowsUsedToTrain = aModel._parms.train() == null ?
+                  aModel._output._cross_validation_holdout_predictions_frame_id.get().numRows() :
+                  aModel._parms.train().numRows();
+          if (trainingFrameRows != numOfRowsUsedToTrain)
             throw new H2OIllegalArgumentException("Base models are inconsistent: they use different size (number of rows) training frames."
-                    +" Found: "+trainingFrameRows+" (StackedEnsemble) and "+aTrainingFrame.numRows()+" (model "+k+").");
+                    +" Found: "+trainingFrameRows+" (StackedEnsemble) and "+numOfRowsUsedToTrain+" (model "+k+").");
         }
 
         if (cv_required_on_base_model) {


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7567

This is a part of code that I "extracted" from the PR containing quantile distribution support.

This will be potentially useful for saving and loading AutoML. (I experimented with that some time ago, I ended up with some R code[1] to do that) 


[1] https://gist.github.com/tomasfryda/b46a0e910e92da9f051f60a0c0140ecc