### PR TITLE
Log DEBUG information when S3 cache is being refreshed.

### DIFF
--- a/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
+++ b/h2o-persist-s3/src/main/java/water/persist/PersistS3.java
@@ -439,6 +439,7 @@ public final class PersistS3 extends Persist {
 
     public boolean containsKey(String k) { return Arrays.binarySearch(_cache,k) >= 0;}
     protected String [] update(){
+      Log.debug("Renewing S3 bucket cache.");
       List<Bucket> l = getClient().listBuckets();
       String [] cache = new String[l.size()];
       int i = 0;
@@ -476,6 +477,7 @@ public final class PersistS3 extends Persist {
 
     @Override
     protected String [] update(){
+      Log.debug("Renewing S3 cache.");
       AmazonS3 s3 = getClient();
       ObjectListing currentList = s3.listObjects(_bucket,"");
       ArrayList<String> res = new ArrayList<>();


### PR DESCRIPTION
In the logs, there is no information whether S3 cache update has been triggered. This may help debug cache build-ups for large buckets. From experience, I know this might take quite some time.

We should definitely look into the cache collection, maybe update the client or increase the payload size...generally investigate how to help speed this up.