### PR TITLE
PUBDEV-7588: fix problem when Lambda=0 with interaction

### DIFF
--- a/h2o-algos/src/main/java/hex/DataInfo.java
+++ b/h2o-algos/src/main/java/hex/DataInfo.java
@@ -470,7 +470,7 @@ public class DataInfo extends Keyed<DataInfo> {
     if(v.isCategorical()) {
       if (useAllFactorLevels) return v.mode();
       long[] bins = v.bins();
-      return ArrayUtils.maxIndex(bins,1);
+      return ArrayUtils.maxIndex(bins,0);
     }
     return (int)Math.round(v.mean());
   }
@@ -1081,7 +1081,10 @@ public class DataInfo extends Keyed<DataInfo> {
   public final int getCategoricalId(int cid, int val) {
     boolean isIWV = isInteractionVec(cid);
     if(val == -1) { // NA
-      val = _catNAFill[cid];
+      if (isIWV && !_useAllFactorLevels) 
+        val = _catNAFill[cid]-1; // need to -1 here because no -1 in 6 lines later for isIWV vector
+      else
+        val = _catNAFill[cid];
     }
 
     if (!_useAllFactorLevels && !isIWV) {  // categorical interaction vecs drop reference level in a special way
@@ -1091,7 +1094,7 @@ public class DataInfo extends Keyed<DataInfo> {
     int [] offs = fullCatOffsets();
     int expandedVal = val + offs[cid];
     if(expandedVal >= offs[cid+1]) {  // previously unseen level
-      assert _valid : "Categorical value out of bounds, got " + val + ", next cat starts at " + fullCatOffsets()[cid + 1];
+      assert (isIWV && !_useAllFactorLevels) || _valid : "Categorical value out of bounds, got " + val + ", next cat starts at " + fullCatOffsets()[cid + 1];
       if(_skipMissing)
         return -1;
       val = _catNAFill[cid];

--- a/h2o-core/src/main/java/water/fvec/InteractionWrappedVec.java
+++ b/h2o-core/src/main/java/water/fvec/InteractionWrappedVec.java
@@ -231,7 +231,7 @@ public class InteractionWrappedVec extends WrappedVec {
         if( (!((leftIsNA=left.isNA(i)) | (riteIsNA=rite.isNA(i)))) ) {
           lval = (int)left.at8(i);
           rval = (int)rite.at8(i);
-          if( !_useAllLvls && ( 0==lval || 0==rval )) {
+          if( !_useAllLvls && ( 0==lval || 0==rval )) { // deal with all illegal levels here when _useAllLvls==False
             _perChkMapMissing.putIfAbsent(_left[lval] + "_" + _rite[rval],"");
             continue;
           }
@@ -351,9 +351,19 @@ public class InteractionWrappedVec extends WrappedVec {
     @Override public double atd_impl(int idx) {
       if( _isCat )
         if( isNA_impl(idx) ) return Double.NaN;
-      return _isCat ? Arrays.binarySearch(_vec.domain(), getKey(idx)) : ( _c1IsCat?1: (_c[0].atd(idx))) * ( _c2IsCat?1: (_c[1].atd(idx)) );
+       if (_isCat) {
+         int val = Arrays.binarySearch(_vec.domain(), getKey(idx));
+         return ((val < 0)?-1:val);
+       } else
+         return ( _c1IsCat?1: (_c[0].atd(idx))) * ( _c2IsCat?1: (_c[1].atd(idx)) );
     }
-    @Override public long at8_impl(int idx)   { return _isCat ? Arrays.binarySearch(_vec.domain(), getKey(idx)) : ( _c1IsCat?1:_c[0].at8(idx) ) * ( _c2IsCat?1:_c[1].at8(idx) ); }
+    @Override public long at8_impl(int idx)   { 
+      if (_isCat) {
+        long val = Arrays.binarySearch(_vec.domain(), getKey(idx)); // can give bad value like -3
+        return ((val < 0)?-1:val); // illegal domain should always return -1
+      } else 
+      return ( _c1IsCat?1:_c[0].at8(idx) ) * ( _c2IsCat?1:_c[1].at8(idx) );
+    }
     private String getKey(int idx) { return _c[0]._vec.domain()[(int)_c[0].at8(idx)] + "_" + _c[1]._vec.domain()[(int)_c[1].at8(idx)]; }
     @Override public boolean isNA_impl(int idx) { return _c[0].isNA(idx) || _c[1].isNA(idx); }
     // Returns true if the masterVec is missing, false otherwise

--- a/h2o-core/src/test/java/water/fvec/InteractionWrappedVecTest.java
+++ b/h2o-core/src/test/java/water/fvec/InteractionWrappedVecTest.java
@@ -220,6 +220,33 @@ public class InteractionWrappedVecTest extends TestUtil {
       if( interactionVec!=null ) interactionVec.remove();
     }
   }
+  
+  // This test is added to make sure we get the correct number of bins when use_all_factor_level = True and False.
+  @Test
+  public void testCatCatInteraction1() {
+    Scope.enter();
+    try {
+      final Frame train2 = Scope.track(new TestFrameBuilder()
+              .withColNames("cat1", "cat2")
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a","a","a","b","b","b","c","c","c","a","a","a","b"))
+              .withDataForCol(1, ar("Red", "Blue", "Green","Red", "Blue", "Green","Red", "Blue", 
+                      "Green","Blue", "Green","Red", "Blue"))
+              .build());
+      Vec f1useAllFactor = Scope.track(new InteractionWrappedVec(
+              train2.anyVec().group().addVec(), train2.anyVec()._rowLayout, null, null, true, true, false,
+              train2.vec(0)._key, train2.vec(1)._key));
+      long[] bin1 = f1useAllFactor.bins();
+      Vec f1noUseAllFactor = Scope.track(new InteractionWrappedVec(
+              train2.anyVec().group().addVec(), train2.anyVec()._rowLayout, null, null, false, true, false,
+              train2.vec(0)._key, train2.vec(1)._key));
+      long[] bin2 = f1noUseAllFactor.bins();
+      assert bin1.length==9 : "Expected bin length is 9.  Actual bin lenght is "+bin1.length;
+      assert bin2.length==5 : "Expected bin length is 5.  Actual bin lenght is "+bin2.length;
+    } finally {
+      Scope.exit();
+    }
+  }
 
   @Test public void testModeOfCatNumInteraction() {
     try {

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7588_GLM_interaction_lambda0.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7588_GLM_interaction_lambda0.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+from tests import pyunit_utils
+
+# Wzhen Lambda=0, the use_all_factor_levels is automatically set to False.  This runs into the bug of
+# interaction vector domain creation.
+def test_interaction_Lambda0():
+    data = h2o.import_file("https://raw.githubusercontent.com/guru99-edu/R-Programming/master/adult.csv")
+    data['y'] = data['hours-per-week'] / data['age']
+    
+    model_cust = H2OGeneralizedLinearEstimator(interactions = ["income", "gender"],
+                                           family = "tweedie",
+                                           tweedie_variance_power = 1.7, tweedie_link_power = 0,
+                                           Lambda = 0,
+                                           intercept = True,
+                                           compute_p_values = True,
+                                           remove_collinear_columns = True,
+                                           standardize = True, weights_column = "age", solver="IRLSM")
+    model_cust.train(x = ["income", "gender"], y = "y", training_frame = data)
+    coef = len(model_cust.coef())
+    expected_coeff_len = 1+1+1+1 # 1 for gender, 1 for income, 1 for gender_income interaction and 1 for intercept
+    assert coef == expected_coeff_len, "Expected coefficient length: {0}, actual: {1} and they are different.".format(expected_coeff_len, coef)
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_interaction_Lambda0)
+else:
+  test_interaction_Lambda0()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_7588_interaction_lambda0_higher_cat_levels.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_pubdev_7588_interaction_lambda0_higher_cat_levels.py
@@ -1,0 +1,41 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+import pandas as pd
+import numpy as np
+
+# investigate interaction of enumxenum when use_all_factor_level=False and when enum levels is higher than 2.  
+# I am being paranoid here.
+def interactions_GLM_Binomial():
+    pd_df = pd.DataFrame(np.array([[0.1, 0.2, 0.3, 0.15, 0.25, 0.35, 0.12, 0.22, 0.32, 0.2, 0.3, 0.15, 0.05],
+                                   ["a", "a", "a", "b", "b", "b", "c", "c", "c", "a", "a", "a", "b"],
+                                   ["Red", "Blue", "Green", "Red", "Blue", "Green", "Red", "Blue", "Green", "Blue",
+                                    "Green", "Red", "Blue"]]).T,
+                         columns=['label', 'categorical_feat', 'categorical_feat2'])
+    h2o_df = h2o.H2OFrame(pd_df, na_strings=["UNKNOWN"])
+
+    interaction_pairs = ["categorical_feat", "categorical_feat2"]
+
+    # build model with and without NA in Frame
+    model0 = H2OGeneralizedLinearEstimator(family="Gaussian", Lambda=0, interactions=interaction_pairs)
+    model0.train(x=["categorical_feat", "categorical_feat2"], y='label', training_frame=h2o_df)
+
+    model1 = H2OGeneralizedLinearEstimator(family="Gaussian", Lambda=0.001, interactions=interaction_pairs)
+    model1.train(x=["categorical_feat", "categorical_feat2"], y='label', training_frame=h2o_df)
+    model0CoeffLen = 4+2+2+1 # interaction 4 levels, 2 enums 2 levels each plus intercept due to use_all_factor_level=F
+    model1CoeffLen = 9+3+3+1 # interaction 9 levels, 2 enums 3 levels each plus intercept
+    assert len(model0.coef()) == model0CoeffLen, "Lambda=0, Expected coefficient length: {0}, Actual: " \
+                                                    "{1}".format(model0CoeffLen, len(model0.coef()))
+    assert len(model1.coef()) == model1CoeffLen, "Lambda=0.001, Expected coefficient length: {0}, Actual: " \
+                                                    "{1}".format(model1CoeffLen, len(model1.coef()))
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(interactions_GLM_Binomial)
+else:
+    interactions_GLM_Binomial()

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7588_GLM_lambda0_interactions.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7588_GLM_lambda0_interactions.R
@@ -1,0 +1,27 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# This test is mainly written to compare R glm with H2O glm when we have interaction columns.  The coefficients
+# should be very close between the two methods.
+test.glm.interactions.lambda0 <- function() {
+   data <- h2o.importFile("https://raw.githubusercontent.com/guru99-edu/R-Programming/master/adult.csv")
+   temp <- data["hours-per-week"] / data["age"]
+   names(temp) <- "y"
+   dataCombined <- h2o.cbind(data, temp)
+   dataR <- as.data.frame(dataCombined)
+
+   glmH2O <- h2o.glm(x=c("income", "gender"), y="y", training_frame=dataCombined, interactions=c("income", "gender"), lambda=0)
+   glmR <- lm(y ~income*gender+income+gender, data=dataR)
+   coeffR <- glmR$coefficients
+   coeffH2O <- glmH2O@model$coefficients
+   rcoeffNames <- c("(Intercept)", "income>50K", "genderMale", "income>50K:genderMale")
+   h2ocoeffNames <- c("Intercept", "income.>50K", "gender.Male", "income_gender.>50K_Male")
+   
+   # compare coefficient between R and H2O glm model.  They should be close
+   for (ind in seq_len(length(rcoeffNames))) {
+      expect_true(abs(coeffR[rcoeffNames[ind]][[1]]-coeffH2O[h2ocoeffNames[ind]][[1]]) < 1e-6)
+   }
+   expect_true(length(glmR$coefficients)==length(glmH2O@model$coefficients), "number of coeffcients between R and H2O are different")
+}
+
+doTest("Testing model interactions for GLM when Lambda=0.0", test.glm.interactions.lambda0)


### PR DESCRIPTION
This PR fixes the problem in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7588.

When there is interaction and when Lambda=0, use_all_factor_level = false.  As a result, the number of levels for interaction column is reduced.  Hence, it will run into problem with the assertion: assert _valid : "Categorical value out of bounds, got " + val + ", next cat starts at " + fullCatOffsets()[cid + 1] in DataInfo.java method getCategoricalId().  The reason for the failure is the number of enum values are reduced.

I added a check to make sure the assert is only called under the following conditions: 
- useAllFactorLevels=True or
-  if useAllFactorLevels=False, isInteraction = False.