### PR TITLE
PUBDEV-7329 property to change X-Frame-Options header to sameorigin

### DIFF
--- a/h2o-core/src/main/java/water/server/ServletUtils.java
+++ b/h2o-core/src/main/java/water/server/ServletUtils.java
@@ -30,6 +30,11 @@ public class ServletUtils {
    */
   private static final boolean DISABLE_CORS = Boolean.getBoolean(H2O.OptArgs.SYSTEM_PROP_PREFIX + "disable.cors");
 
+  /**
+   * Sets header that allows usage in i-frame. Off by default for security reasons.
+   */
+  private static final boolean ENABLE_XFRAME_SAMEORIGIN = Boolean.getBoolean(H2O.OptArgs.SYSTEM_PROP_PREFIX + "enable.xframe.sameorigin");
+
   private static final String TRACE_METHOD = "TRACE";
 
   private static final ThreadLocal<Long> _startMillis = new ThreadLocal<>();
@@ -192,7 +197,11 @@ public class ServletUtils {
     response.setHeader("X-h2o-cluster-id", Long.toString(H2O.CLUSTER_ID));
     response.setHeader("X-h2o-cluster-good", Boolean.toString(H2O.CLOUD.healthy()));
     // Security headers
-    response.setHeader("X-Frame-Options", "deny");
+    if (ENABLE_XFRAME_SAMEORIGIN) {
+      response.setHeader("X-Frame-Options", "sameorigin");
+    } else {
+      response.setHeader("X-Frame-Options", "deny");
+    }
     response.setHeader("X-XSS-Protection", "1; mode=block");
     response.setHeader("X-Content-Type-Options", "nosniff");
     response.setHeader("Content-Security-Policy", "default-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:");

--- a/h2o-docs/src/product/howto/H2O-DevCmdLine.md
+++ b/h2o-docs/src/product/howto/H2O-DevCmdLine.md
@@ -141,3 +141,9 @@ For example:
 
   - `-Djava.net.preferIPv6Addresses=true -Djava.net.preferIPv4Addresses=false` - H2O will try to select IPv6
 
+
+## Run to embed into iframe
+
+By default you can't embed web into `iframe`, `object` or similar way because
+`X-Frame-Options` HTTP header is `deny` by default. To change it to `sameorigin`
+start H2O-3 with `java -Dsys.ai.h2o.enable.xframe.samerorigin=true -jar build/h2o.jar`


### PR DESCRIPTION
Tested manually:

```
$ java -Dsys.ai.h2o.enable.xframe.sameorigin -jar build/h2o.jar > /dev/null &
$ curl --verbose  http://192.168.1.156:54321 2>&1 >/dev/null | grep "X-Frame" ; killall java
< X-Frame-Options: deny
$ java -Dsys.ai.h2o.enable.xframe.sameorigin=true -jar build/h2o.jar > /dev/null &
$ curl --verbose  http://192.168.1.156:54321 2>&1 >/dev/null | grep "X-Frame" ; killall java
< X-Frame-Options: sameorigin
$ java -Dsys.ai.h2o.enable.xframe.sameorigin=false -jar build/h2o.jar > /dev/null &
$ curl --verbose  http://192.168.1.156:54321 2>&1 >/dev/null | grep "X-Frame" ; killall java
< X-Frame-Options: deny
$ java -Dsys.ai.h2o.enable.xframe.sameorigin=gibberish -jar build/h2o.jar > /dev/null &
$ curl --verbose  http://192.168.1.156:54321 2>&1 >/dev/null | grep "X-Frame" ; killall java
< X-Frame-Options: deny
$ java -Dsys.ai.h2o.enable.xframe.sameorigin -jar build/h2o.jar > /dev/null &
$ curl --verbose  http://192.168.1.156:54321 2>&1 >/dev/null | grep "X-Frame" ; killall java
< X-Frame-Options: deny

```