### PR TITLE
Fix test pyunit_PUBDEV_5924_merge_bug_large.py

### DIFF
--- a/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_binomial_gridsearch_randomdiscrete_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_binomial_gridsearch_randomdiscrete_large.py
@@ -47,7 +47,7 @@ class Test_glm_random_grid_search:
     allowed_time_diff = 1e-1    # fraction of max_runtime_secs allowed for max run time stopping criteria
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     train_row_count = 0         # training data row count, randomly generated later
     train_col_count = 0         # training data column count, randomly generated later

--- a/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_binomial_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_binomial_large.py
@@ -143,7 +143,7 @@ class TestGLMBinomial:
     nan_fraction = 0.2           # denote maximum fraction of NA's to be inserted into a column
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     enum_col = 0                # set maximum number of categorical columns in predictor
     enum_level_vec = []         # vector containing number of levels for each categorical column

--- a/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gaussian_gridsearch_randomdiscrete_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gaussian_gridsearch_randomdiscrete_large.py
@@ -46,7 +46,7 @@ class Test_glm_random_grid_search:
     allowed_time_diff = 1e-1    # fraction of max_runtime_secs allowed for max run time stopping criteria
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     train_row_count = 0         # training data row count, randomly generated later
     train_col_count = 0         # training data column count, randomly generated later

--- a/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gridsearch_over_all_params_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/glm/pyunit_glm_gridsearch_over_all_params_large.py
@@ -82,7 +82,7 @@ class Test_glm_grid_search:
                                  # gridsearch model metrics.
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     train_row_count = 0         # training data row count, randomly generated later
     train_col_count = 0         # training data column count, randomly generated later

--- a/h2o-py/dynamic_tests/testdir_algos/glrm/pyunit_glrm_gridsearch_over_all_params_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/glrm/pyunit_glrm_gridsearch_over_all_params_large.py
@@ -57,7 +57,7 @@ class Test_glrm_grid_search:
     allowed_diff = 1e-2   # difference allow between grid search model and manually built model MSEs
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     train_row_count = 0         # training data row count, randomly generated later
     train_col_count = 0         # training data column count, randomly generated later

--- a/h2o-py/dynamic_tests/testdir_algos/kmeans/pyunit_NOPASS_generate_kmeans_clusters.py
+++ b/h2o-py/dynamic_tests/testdir_algos/kmeans/pyunit_NOPASS_generate_kmeans_clusters.py
@@ -36,7 +36,7 @@ class Generate_kmeans_clusters:
     training1_filename = "kmeans_8_centers_3_coords.csv"
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     test_name = "pyunit_NOPASS_generate_kmeans_clusters.py"     # name of this test
 

--- a/h2o-py/dynamic_tests/testdir_algos/kmeans/pyunit_kmeans_gridsearch_over_all_params_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/kmeans/pyunit_kmeans_gridsearch_over_all_params_large.py
@@ -51,7 +51,7 @@ class Test_kmeans_grid_search:
     allowed_diff = 1e-2   # difference allow between grid search model and manually built model MSEs
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     # following parameters are used to generate hyper-parameters
     max_int_val = 10            # maximum size of random integer values

--- a/h2o-py/dynamic_tests/testdir_algos/naivebayes/pyunit_naivebayes_gridsearch_over_all_params_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/naivebayes/pyunit_naivebayes_gridsearch_over_all_params_large.py
@@ -54,7 +54,7 @@ class Test_naivebayes_grid_search:
     allowed_diff = 1e-2   # difference allow between grid search model and manually built model MSEs
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
     train_row_count = 0         # training data row count, randomly generated later
     train_col_count = 0         # training data column count, randomly generated later
 

--- a/h2o-py/dynamic_tests/testdir_algos/pca/pyunit_pca_gridsearch_over_all_params_large.py
+++ b/h2o-py/dynamic_tests/testdir_algos/pca/pyunit_pca_gridsearch_over_all_params_large.py
@@ -52,7 +52,7 @@ class Test_PCA_grid_search:
     allowed_diff = 1e-2   # difference allow between grid search model and manually built model MSEs
 
     # System parameters, do not change.  Dire consequences may follow if you do
-    current_dir = os.path.dirname(os.path.realpath(sys.argv[1]))    # directory of this test file
+    current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))    # directory of this test file
 
     # following parameters are used to generate hyper-parameters
     max_int_val = 10            # maximum size of random integer values

--- a/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5924_merge_bug_large.py
+++ b/h2o-py/tests/testdir_munging/pyunit_PUBDEV_5924_merge_bug_large.py
@@ -21,29 +21,32 @@ def verify_merge():
     frame2 = frame2_int.cbind(frame2_str.cbind(frame2_enum))
 
     # merge one column only
+    print("Merge on one column")
     frame1.set_names(["f1_1", "f1_2", "f1_3", "f1_4", "f1_5", "f1_6", "enum1", "f1_8", "f1_9"])
     frame2.set_names(["f2_1", "f2_2", "f2_3", "f2_4", "f2_5", "f2_6", "enum1", "f28", "f2_9"])
-    perform_merges_assert_correct_merge(frame1, frame2)
+    perform_merges_assert_correct_merge(frame1, frame2, "enum1")
 
     # merge two columns
+    print("Merge on two columns")
     frame1.set_names(["f1_1", "f1_2", "f1_3", "f1_4", "f1_5", "f1_6", "enum1", "enum2", "f1_9"])
     frame2.set_names(["f2_1", "f2_2", "f2_3", "f2_4", "f2_5", "f2_6", "enum1", "enum2", "f2_9"])
-    perform_merges_assert_correct_merge(frame1, frame2)
+    perform_merges_assert_correct_merge(frame1, frame2, ["enum1", "enum2"])
 
     # merge three columns
+    print("Merge on three columns")
     frame1.set_names(["f1_1", "f1_2", "f1_3", "f1_4", "f1_5", "f1_6", "enum1", "enum2", "enum3"])
     frame2.set_names(["f2_1", "f2_2", "f2_3", "f2_4", "f2_5", "f2_6", "enum1", "enum2", "enum3"])
-    perform_merges_assert_correct_merge(frame1, frame2)
+    perform_merges_assert_correct_merge(frame1, frame2, ["enum1", "enum2", "enum3"])
 
 
-def perform_merges_assert_correct_merge(frame1, frame2):
+def perform_merges_assert_correct_merge(frame1, frame2, sortColumns):
     mergeKeepLeft = frame1.merge(frame2, all_x = True) # should equal to mergeKeepRight2
     mergeKeepRight2 = frame2.merge(frame1, all_y=True)
-    assert_equal_frames(mergeKeepLeft, mergeKeepRight2, "f1_1")
+    assert_equal_frames(mergeKeepLeft, mergeKeepRight2, sortColumns)
 
     mergeKeepRight = frame1.merge(frame2, all_y=True) # should equal to mergeLeft2
     mergeKeepLeft2 = frame2.merge(frame1, all_x = True)
-    assert_equal_frames(mergeKeepRight, mergeKeepLeft2, "f1_1")
+    assert_equal_frames(mergeKeepRight, mergeKeepLeft2, sortColumns)
 
     # merge right, left should all have equal NaNs in them
     assert total_na_cnts(mergeKeepRight)==total_na_cnts(mergeKeepLeft2), \


### PR DESCRIPTION
After two frames are merged, the merged columns are sorted only within the range of MBS.  Hence, before they are compared, they should be sorted according to the merged columns.  Hope this fix will work.  I was sorting it off another column but did not realize that they can have NAs due to merging and the sorting order will be invalid.
 
I fix another small bug in a bunch of dynamic-tests from current_dir = os.path.dirname(os.path.realpath(sys.argv[1])) to current_dir = os.path.dirname(os.path.realpath(sys.argv[0]))