### PR TITLE
PUBDEV-7609: use loading_name to pass x frame name in Java backend.

### DIFF
--- a/h2o-algos/src/main/java/hex/glrm/GLRM.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRM.java
@@ -154,6 +154,18 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
       warn("_train", "_train has " + _ncolY + " columns when categoricals are expanded. Algorithm" +
               " may be slow.");
 
+    if (_parms._loading_name != null) {
+      warn("loading_name", "loading_name is deprecated, use representation_name instead.");
+      if (_parms._representation_name == null)
+        _parms._representation_name = _parms._loading_name;
+    }
+
+    if ((_parms._representation_name != null) && (_parms._loading_name != null)) {
+      if (!(_parms._representation_name.equals(_parms._loading_name)))
+        warn("_representation_name and _loading_name", "Are not equal.  _representation_name will" +
+                " be used since _loading_name is deprecated.");
+    }
+    
     if (_parms._k < 1 || _parms._k > _ncolY) error("_k", "_k must be between 1 and " + _ncolY +
             " inclusive");
     if (_parms._user_y != null) { // Check dimensions of user-specified initial Y
@@ -217,7 +229,7 @@ public class GLRM extends ModelBuilder<GLRMModel, GLRMModel.GLRMParameters, GLRM
       if (_train.vec(i).isString() || _train.vec(i).isUUID())
         throw H2O.unimpl("GLRM cannot handle String or UUID data");
     }
-
+    
     if (expensive && error_count() == 0) checkMemoryFootPrint();  // check to make sure we can fit.
   }
 

--- a/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
+++ b/h2o-algos/src/main/java/hex/glrm/GLRMModel.java
@@ -88,8 +88,9 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     public int _max_updates = 2*_max_iterations;  // Max number of updates (X or Y)
     public double _init_step_size = 1.0;          // Initial step size (decrease until we hit min_step_size)
     public double _min_step_size = 1e-4;          // Min step size
-
-    public String _representation_name;
+    
+    @Deprecated public String _loading_name;                  // store x frame frame-id given by use
+    public String _representation_name;                  // store x frame frame-id given by user
     public boolean _recover_svd = false;          // Recover singular values and eigenvectors of XY at the end?
     public boolean _impute_original = false;      // Reconstruct original training data by reversing _transform?
     public boolean _verbose = true;               // Log when objective increases each iteration?
@@ -130,7 +131,7 @@ public class GLRMModel extends Model<GLRMModel, GLRMModel.GLRMParameters, GLRMMo
     public double[] _singular_vals;
 
     // Frame key of X matrix
-    public String _representation_name;
+    public String _representation_name; // the final frame name for X frame.  Equals to _parms._loading_name if user specified it.  Otherwise, H2O will assign.
     public Key<Frame> _representation_key;
     public Key<? extends Model> _init_key;
     public Key<Frame> _x_factor_key;  // store key of x factor generated from dataset prediction

--- a/h2o-algos/src/main/java/hex/schemas/GLRMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLRMV3.java
@@ -20,7 +20,8 @@ public class GLRMV3 extends ModelBuilderSchema<GLRM, GLRMV3, GLRMV3.GLRMParamete
         "validation_frame",
         "ignored_columns",
         "ignore_const_cols",
-        "score_each_iteration",
+        "score_each_iteration", 
+        "representation_name",
         "loading_name",
         "transform",
         "k",
@@ -109,8 +110,12 @@ public class GLRMV3 extends ModelBuilderSchema<GLRM, GLRMV3, GLRMV3.GLRMParamete
     @API(help = "User-specified initial X")
     public KeyV3.FrameKeyV3 user_x;
 
-    @API(help = "Frame key to save resulting X")
+
+    @API(help = "[Deprecated] Use representation_name instead.  Frame key to save resulting X.")
     public String loading_name;
+
+    @API(help = "Frame key to save resulting X")
+    public String representation_name;
 
     @API(help = "Expand categorical columns in user-specified initial Y")
     public boolean expand_user_y;

--- a/h2o-bindings/bin/custom/R/gen_glrm.py
+++ b/h2o-bindings/bin/custom/R/gen_glrm.py
@@ -21,6 +21,9 @@ if( is.data.frame(user_y) || is.matrix(user_y) || is.list(user_y) || is.H2OFrame
   if( !(missing(k)) && k!=as.integer(nrow(user_y)) ) {
     warning("Argument k is not equal to the number of rows in user-specified Y. Ignoring k. Using specified Y.")
   }
+  if ( !missing(loading_name)) {
+    warning("Argument loading_name is deprecated.  Use representation_name instead.")
+  }
   parms[["k"]] <- as.numeric(nrow(user_y))
 # } else if( is.null(user_y) ) {
 #  if(!missing(init) && parms[["init"]] == "User")

--- a/h2o-bindings/bin/custom/python/gen_glrm.py
+++ b/h2o-bindings/bin/custom/python/gen_glrm.py
@@ -104,7 +104,24 @@ examples = dict(
 >>> iris_glrm.train(x=iris.names, training_frame=iris)
 >>> iris_glrm.show()
 """,
+    representation_name="""
+>>> acs = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/bigdata/laptop/census/ACS_13_5YR_DP02_cleaned.zip")
+>>> acs_fill = acs.drop("ZCTA5")
+>>> acs_glrm = H2OGeneralizedLowRankEstimator(k=10,
+...                                           transform="standardize",
+...                                           loss="quadratic",
+...                                           regularization_x="quadratic",
+...                                           regularization_y="L1",
+...                                           gamma_x=0.25,
+...                                           gamma_y=0.5,
+...                                           max_iterations=1,
+...                                           representation_name="acs_full")
+>>> acs_glrm.train(x=acs_fill.names, training_frame=acs)
+>>> acs_glrm.loading_name
+>>> acs_glrm.show()
+""",
     loading_name="""
+>>> # loading_name will be deprecated.  Use representation_name instead.    
 >>> acs = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/bigdata/laptop/census/ACS_13_5YR_DP02_cleaned.zip")
 >>> acs_fill = acs.drop("ZCTA5")
 >>> acs_glrm = H2OGeneralizedLowRankEstimator(k=10,

--- a/h2o-py/h2o/estimators/glrm.py
+++ b/h2o-py/h2o/estimators/glrm.py
@@ -21,11 +21,11 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
 
     algo = "glrm"
     param_names = {"model_id", "training_frame", "validation_frame", "ignored_columns", "ignore_const_cols",
-                   "score_each_iteration", "loading_name", "transform", "k", "loss", "loss_by_col", "loss_by_col_idx",
-                   "multi_loss", "period", "regularization_x", "regularization_y", "gamma_x", "gamma_y",
-                   "max_iterations", "max_updates", "init_step_size", "min_step_size", "seed", "init", "svd_method",
-                   "user_y", "user_x", "expand_user_y", "impute_original", "recover_svd", "max_runtime_secs",
-                   "export_checkpoints_dir"}
+                   "score_each_iteration", "representation_name", "loading_name", "transform", "k", "loss",
+                   "loss_by_col", "loss_by_col_idx", "multi_loss", "period", "regularization_x", "regularization_y",
+                   "gamma_x", "gamma_y", "max_iterations", "max_updates", "init_step_size", "min_step_size", "seed",
+                   "init", "svd_method", "user_y", "user_x", "expand_user_y", "impute_original", "recover_svd",
+                   "max_runtime_secs", "export_checkpoints_dir"}
 
     def __init__(self, **kwargs):
         super(H2OGeneralizedLowRankEstimator, self).__init__()
@@ -161,7 +161,7 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
 
 
     @property
-    def loading_name(self):
+    def representation_name(self):
         """
         Frame key to save resulting X
 
@@ -169,6 +169,39 @@ class H2OGeneralizedLowRankEstimator(H2OEstimator):
 
         :examples:
 
+        >>> acs = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/bigdata/laptop/census/ACS_13_5YR_DP02_cleaned.zip")
+        >>> acs_fill = acs.drop("ZCTA5")
+        >>> acs_glrm = H2OGeneralizedLowRankEstimator(k=10,
+        ...                                           transform="standardize",
+        ...                                           loss="quadratic",
+        ...                                           regularization_x="quadratic",
+        ...                                           regularization_y="L1",
+        ...                                           gamma_x=0.25,
+        ...                                           gamma_y=0.5,
+        ...                                           max_iterations=1,
+        ...                                           representation_name="acs_full")
+        >>> acs_glrm.train(x=acs_fill.names, training_frame=acs)
+        >>> acs_glrm.loading_name
+        >>> acs_glrm.show()
+        """
+        return self._parms.get("representation_name")
+
+    @representation_name.setter
+    def representation_name(self, representation_name):
+        assert_is_type(representation_name, None, str)
+        self._parms["representation_name"] = representation_name
+
+
+    @property
+    def loading_name(self):
+        """
+        [Deprecated] Use representation_name instead.  Frame key to save resulting X.
+
+        Type: ``str``.
+
+        :examples:
+
+        >>> # loading_name will be deprecated.  Use representation_name instead.    
         >>> acs = h2o.import_file("https://s3.amazonaws.com/h2o-public-test-data/bigdata/laptop/census/ACS_13_5YR_DP02_cleaned.zip")
         >>> acs_fill = acs.drop("ZCTA5")
         >>> acs_glrm = H2OGeneralizedLowRankEstimator(k=10,

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_7609_GLRM_representation_loading_name.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_PUBDEV_7609_GLRM_representation_loading_name.py
@@ -1,0 +1,55 @@
+from __future__ import print_function
+from builtins import range
+import sys, os
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+
+def glrm_arrests():
+    print("Importing USArrests.csv data...")
+    arrestsH2O = h2o.upload_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
+    arrestsH2O.describe()
+    loading_name = "are_we_confused_yet"
+    representation_name = "are_you_confused_yet"
+
+    print("H2O initial Y matrix:\n")
+    initial_y = [[5.412, 65.24, -7.54, -0.032],
+                 [2.212, 92.24, -17.54, 23.268],
+                 [0.312, 123.24, 14.46, 9.768],
+                 [1.012, 19.24, -15.54, -1.732]]
+    initial_y_h2o = h2o.H2OFrame(list(zip(*initial_y)))
+    initial_y_h2o.show()
+
+    print("H2O GLRM on de-meaned data with quadratic loss:\n")
+    # user representation_name
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=4, transform="DEMEAN", loss="Quadratic", gamma_x=0, gamma_y=0,
+                                              init="User", user_y=initial_y_h2o, recover_svd=True,
+                                              representation_name=representation_name)
+    glrm_h2o.train(x=arrestsH2O.names, training_frame=arrestsH2O)
+    assert representation_name == str(glrm_h2o._model_json["output"]['representation_name']), \
+        "user assigned x frame name: {0}, actual x frame name from model: {1}. They are not " \
+        "equal".format(representation_name, glrm_h2o._model_json["output"]['representation_name'])
+
+    # use loading_name
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=4, transform="DEMEAN", loss="Quadratic", gamma_x=0, gamma_y=0,
+                                              init="User", user_y=initial_y_h2o, recover_svd=True,
+                                              loading_name=loading_name)
+    glrm_h2o.train(x=arrestsH2O.names, training_frame=arrestsH2O)
+    assert loading_name == str(glrm_h2o._model_json["output"]['representation_name']), \
+        "user assigned x frame name: {0}, actual x frame name from model: {1}. They are not " \
+        "equal".format(loading_name, glrm_h2o._model_json["output"]['representation_name'])
+
+    # use loading_name and representation_name but they are different, representation_name should be used
+    glrm_h2o = H2OGeneralizedLowRankEstimator(k=4, transform="DEMEAN", loss="Quadratic", gamma_x=0, gamma_y=0,
+                                              init="User", user_y=initial_y_h2o, recover_svd=True,
+                                              loading_name=loading_name, representation_name=representation_name)
+    glrm_h2o.train(x=arrestsH2O.names, training_frame=arrestsH2O)
+    assert representation_name == str(glrm_h2o._model_json["output"]['representation_name']), \
+        "user assigned x frame name: {0}, actual x frame name from model: {1}. They are not " \
+        "equal".format(representation_name, glrm_h2o._model_json["output"]['representation_name'])
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(glrm_arrests)
+else:
+    glrm_arrests()

--- a/h2o-r/h2o-package/R/glrm.R
+++ b/h2o-r/h2o-package/R/glrm.R
@@ -13,7 +13,8 @@
 #' @param validation_frame Id of the validation data frame.
 #' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
-#' @param loading_name Frame key to save resulting X
+#' @param representation_name Frame key to save resulting X
+#' @param loading_name [Deprecated] Use representation_name instead.  Frame key to save resulting X.
 #' @param transform Transformation of training data Must be one of: "NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE".
 #'        Defaults to NONE.
 #' @param k Rank of matrix approximation Defaults to 1.
@@ -66,6 +67,7 @@ h2o.glrm <- function(training_frame,
                      validation_frame = NULL,
                      ignore_const_cols = TRUE,
                      score_each_iteration = FALSE,
+                     representation_name = NULL,
                      loading_name = NULL,
                      transform = c("NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"),
                      k = 1,
@@ -111,6 +113,8 @@ h2o.glrm <- function(training_frame,
     parms$ignore_const_cols <- ignore_const_cols
   if (!missing(score_each_iteration))
     parms$score_each_iteration <- score_each_iteration
+  if (!missing(representation_name))
+    parms$representation_name <- representation_name
   if (!missing(loading_name))
     parms$loading_name <- loading_name
   if (!missing(transform))
@@ -182,6 +186,9 @@ h2o.glrm <- function(training_frame,
     if( !(missing(k)) && k!=as.integer(nrow(user_y)) ) {
       warning("Argument k is not equal to the number of rows in user-specified Y. Ignoring k. Using specified Y.")
     }
+    if ( !missing(loading_name)) {
+      warning("Argument loading_name is deprecated.  Use representation_name instead.")
+    }
     parms[["k"]] <- as.numeric(nrow(user_y))
   # } else if( is.null(user_y) ) {
   #  if(!missing(init) && parms[["init"]] == "User")
@@ -214,6 +221,7 @@ h2o.glrm <- function(training_frame,
                                      validation_frame = NULL,
                                      ignore_const_cols = TRUE,
                                      score_each_iteration = FALSE,
+                                     representation_name = NULL,
                                      loading_name = NULL,
                                      transform = c("NONE", "STANDARDIZE", "NORMALIZE", "DEMEAN", "DESCALE"),
                                      k = 1,
@@ -264,6 +272,8 @@ h2o.glrm <- function(training_frame,
     parms$ignore_const_cols <- ignore_const_cols
   if (!missing(score_each_iteration))
     parms$score_each_iteration <- score_each_iteration
+  if (!missing(representation_name))
+    parms$representation_name <- representation_name
   if (!missing(loading_name))
     parms$loading_name <- loading_name
   if (!missing(transform))
@@ -334,6 +344,9 @@ h2o.glrm <- function(training_frame,
     # Set k
     if( !(missing(k)) && k!=as.integer(nrow(user_y)) ) {
       warning("Argument k is not equal to the number of rows in user-specified Y. Ignoring k. Using specified Y.")
+    }
+    if ( !missing(loading_name)) {
+      warning("Argument loading_name is deprecated.  Use representation_name instead.")
     }
     parms[["k"]] <- as.numeric(nrow(user_y))
   # } else if( is.null(user_y) ) {

--- a/h2o-r/tests/testdir_algos/glrm/runit_PUBDEV_7609_glrm_representation_loading_name.R
+++ b/h2o-r/tests/testdir_algos/glrm/runit_PUBDEV_7609_glrm_representation_loading_name.R
@@ -1,0 +1,42 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+test.glrm.arrests <- function() {
+  Log.info("Importing arrests.csv data...") 
+  arrestsR <- read.csv(locate("smalldata/pca_test/USArrests.csv"), header = TRUE)
+  arrestsH2O <- h2o.uploadFile(locate("smalldata/pca_test/USArrests.csv"), destination_frame = "arrestsH2O")
+  initCent <- scale(arrestsR, center = TRUE, scale = FALSE)[1:4,]
+  loading_name <- "are_you_confused"
+  representation_name <- "are_we_confused"
+  #use representation_name
+  fitH2O <- h2o.glrm(arrestsH2O, k = 4, init = "User", user_y = initCent, transform = "DEMEAN", 
+                     loss = "Quadratic", regularization_x = "None", regularization_y = "None", 
+                     recover_svd = TRUE, representation_name=representation_name)
+  print("fitH2O@model$representation_name is ")
+  print(fitH2O@model$representation_name)
+  print("representation name is ")
+  print(representation_name)
+  expect_true(fitH2O@model$representation_name==representation_name)
+  
+  #use loading_name
+  expect_warning(fitH2O<-h2o.glrm(fitH2O<-arrestsH2O, k = 4, init = "User", user_y = initCent, transform = "DEMEAN", 
+                     loss = "Quadratic", regularization_x = "None", regularization_y = "None", 
+                     recover_svd = TRUE, loading_name=loading_name))
+  print("fitH2O@model$representation_name is ")
+  print(fitH2O@model$representation_name)
+  print("loading_name is ")
+  print(loading_name)
+  expect_true(fitH2O@model$representation_name==loading_name)
+  
+  #use both representation_name and loading_name
+  expect_warning(fitH2O<-h2o.glrm(fitH2O<-arrestsH2O, k = 4, init = "User", user_y = initCent, transform = "DEMEAN", 
+                                  loss = "Quadratic", regularization_x = "None", regularization_y = "None", 
+                                  recover_svd = TRUE, loading_name=loading_name, representation_name=representation_name))
+  print("fitH2O@model$representation_name is ")
+  print(fitH2O@model$representation_name)
+  print("representation name is ")
+  print(representation_name)
+  expect_true(fitH2O@model$representation_name==representation_name)
+}
+
+doTest("GLRM test representation name, loading_name", test.glrm.arrests)


### PR DESCRIPTION
This PR completes the work in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7609

@jakubhava noticed that loading_frame parameter is never used.
It is supposed to allow user to choose a name to save the X frame input if they like.  I fix this problem by actually using it to set the name of the X frame.

However, in the model._output, _represntation_name is used to denote the frame name used to save the X frame.  I did not change this part.  

This will not break any user code however, we are now using two names to represent the same thing.  

@ledell What are your thoughts on this?  It is cleaner to just use one name but it may break user code if they use loading_frame in their code even though the loading_frame is not doing anything useful until my fix here.