### PR TITLE
Python Doc update: Adding persist module to the docs

### DIFF
--- a/h2o-py/docs/data.rst
+++ b/h2o-py/docs/data.rst
@@ -220,3 +220,10 @@ principles that apply to lists are then applied to the result of the `tolist()` 
 simply calls the `as_matrix()` method on the DataFrame object. The `as_matrix()` method
 returns an ndarray object, and the above-described ndarray transformation is then invoked,
 so the rules for Python lists also apply here.
+
+Setting S3 Credentials
+-------------------------------
+.. automodule:: h2o.persist.persist
+   :members:
+
+

--- a/h2o-py/h2o/persist/persist.py
+++ b/h2o-py/h2o/persist/persist.py
@@ -5,9 +5,10 @@ from h2o.exceptions import H2OValueError
 def set_s3_credentials(secret_key_id, secret_access_key, session_token = None):
     """Creates a new Amazon S3 client internally with specified credentials.
     There are no validations done to the credentials. Incorrect credentials are thus revealed with first S3 import call.
-    
-    secretKeyId Amazon S3 Secret Key ID (provided by Amazon)
-    secretAccessKey Amazon S3 Secret Access Key (provided by Amazon)
+
+    :param secret_key_id: Amazon S3 Secret Key ID (provided by Amazon)
+    :param secret_access_key: Amazon S3 Secret Access Key (provided by Amazon)
+    :param session_token: Amazon Session Token (optional, only when using AWS Temporary Credentials)
     """
     if(secret_key_id is None):
         raise H2OValueError("Secret key ID must be specified")


### PR DESCRIPTION
- Added h2o.persist.persist to the data.rst file so that the `set_s3_credentials` function shows up in the docs
- In the persist.py file, used "param" notation so that the parameters list shows up correctly in the Python docs.