### PR TITLE
PUBDEV-7112: Integrate TE to AutoML

### DIFF
--- a/h2o-automl/build.gradle
+++ b/h2o-automl/build.gradle
@@ -5,9 +5,13 @@ dependencies {
   compile project(":h2o-core")
   compile project(":h2o-algos")
   compileOnly project(":h2o-ext-xgboost")
+  compile project(":h2o-ext-target-encoder")
 
   // Test dependencies only
   testCompile project(":h2o-test-support")
+  testCompile "org.mockito:mockito-core:2.23.0"
+  testCompile "com.pholser:junit-quickcheck-core:0.9"
+  testCompile 'com.pholser:junit-quickcheck-generators:0.9'
   testCompile project(":h2o-ext-xgboost")
   testRuntimeOnly project(":${defaultWebserverModule}")
 }

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoML.java
@@ -81,7 +81,7 @@ public final class AutoML extends Lockable<AutoML> implements TimedH2ORunnable {
   }
 
   private static Date lastStartTime; // protect against two runs with the same second in the timestamp; be careful about races
-  /**
+  /**'
    * Instantiate an AutoML object and start it running.  Progress can be tracked via its job().
    *
    * @param buildSpec

--- a/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/AutoMLBuildSpec.java
@@ -1,5 +1,7 @@
 package ai.h2o.automl;
 
+import ai.h2o.targetencoding.TargetEncoderModel;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
 import hex.Model;
 import hex.ScoreKeeper.StoppingMetric;
 import hex.grid.HyperSpaceSearchCriteria;
@@ -13,6 +15,7 @@ import water.util.PojoUtils.FieldNaming;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Stream;
 
 import java.text.DateFormat;
@@ -336,9 +339,21 @@ public class AutoMLBuildSpec extends Iced {
     }
   }
 
+  /**
+   * The specification of the parameters for Automatic Target Encoding
+   */
+  static final public class AutoMLTEControl extends Iced {
+
+    public boolean enabled = true;
+    public TEApplicationStrategy application_strategy;
+    public int max_models = 3;
+    public long seed = new Random().nextLong(); //todo probably can stopping_criteria.set_seed but naming is not generic
+  }
+
   public final AutoMLBuildControl build_control = new AutoMLBuildControl();
   public final AutoMLInput input_spec = new AutoMLInput();
   public final AutoMLBuildModels build_models = new AutoMLBuildModels();
+  public AutoMLBuildSpec.AutoMLTEControl te_spec = new AutoMLTEControl();
 
   public String project() {
     if (build_control.project_name == null) {

--- a/h2o-automl/src/main/java/ai/h2o/automl/PreprocessingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/PreprocessingStep.java
@@ -1,0 +1,24 @@
+package ai.h2o.automl;
+
+import ai.h2o.automl.preprocessing.Preprocessor;
+import hex.Model;
+import hex.ModelBuilder;
+import water.Iced;
+
+/**
+ * tbd
+ * PM preprocessing model. Maybe we need marker interface to distinguish between predicting models and
+ */
+public abstract class PreprocessingStep<PM extends Model> extends Iced<PreprocessingStep> {
+
+    protected transient AutoML _aml;
+
+    protected final Preprocessor _preprocessor;
+
+    protected PreprocessingStep(Preprocessor preprocessor, AutoML autoML) {
+        _preprocessor = preprocessor;
+        _aml = autoML;
+    }
+
+    protected abstract void applyIfUseful(ModelBuilder modelBuilder, double baseLineScore);
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/PreprocessingSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/PreprocessingSteps.java
@@ -1,0 +1,24 @@
+package ai.h2o.automl;
+
+import water.Iced;
+
+public abstract class PreprocessingSteps extends Iced<PreprocessingSteps> {
+
+    private transient AutoML _aml;
+
+    public PreprocessingSteps(AutoML autoML) {
+        _aml = autoML;
+    }
+
+    protected AutoML aml() {
+        return _aml;
+    }
+
+    //TODO can be package private if we move this into automl package
+    public PreprocessingStep[] getSteps() {
+        return getDefaultPreprocessors();
+    }
+
+    protected PreprocessingStep[] getDefaultPreprocessors() { return new PreprocessingStep[0]; }
+
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/Preprocessor.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/Preprocessor.java
@@ -1,0 +1,5 @@
+package ai.h2o.automl.preprocessing;
+
+public enum Preprocessor {
+  TE
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/TEPreprocessingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/TEPreprocessingStep.java
@@ -1,0 +1,71 @@
+package ai.h2o.automl.preprocessing;
+
+import ai.h2o.automl.AutoML;
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.PreprocessingStep;
+import ai.h2o.automl.targetencoder.TargetEncodingHyperparamsEvaluator;
+import ai.h2o.automl.targetencoder.strategy.GridSearchModelParametersSelectionStrategy;
+import ai.h2o.automl.targetencoder.strategy.ModelParametersSelectionStrategy;
+import ai.h2o.automl.targetencoder.strategy.ModelValidationMode;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import ai.h2o.targetencoding.strategy.AllCategoricalTEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
+import hex.ModelBuilder;
+import water.fvec.Frame;
+import water.util.Log;
+import water.util.StringUtils;
+
+import java.util.Optional;
+
+public class TEPreprocessingStep extends PreprocessingStep<TargetEncoderModel> {
+
+  ModelParametersSelectionStrategy<TargetEncoderModel.TargetEncoderParameters> _modelParametersSelectionStrategy = null;
+
+  public TEPreprocessingStep(Preprocessor preprocessor, AutoML autoML) {
+    super(preprocessor, autoML);
+  }
+
+  @Override
+  protected void applyIfUseful(ModelBuilder modelBuilder, double baseLineLoss) {
+
+    Optional<ModelParametersSelectionStrategy.Evaluated> bestTEParamsOpt = findBestPreprocessingParams(modelBuilder);
+
+    if(bestTEParamsOpt.isPresent()) {
+      ModelParametersSelectionStrategy.Evaluated evaluatedBest = bestTEParamsOpt.get();
+      boolean scoreIsBetterThanBaseline = evaluatedBest.getScore() < baseLineLoss;
+
+      if (scoreIsBetterThanBaseline) {
+//        pipelineModelBuilder.addPreprocessorModel(evaluatedBest.getModel()._key); //TODO here we should add te model to original modelBuilder( this ability is coming from separate PR)
+
+        _modelParametersSelectionStrategy.removeAllButBest();
+      } else {
+        _modelParametersSelectionStrategy.removeAll();
+      }
+    }
+  }
+
+  //TODO probably better to move most of the logic into a constructor
+  private Optional<ModelParametersSelectionStrategy.Evaluated> findBestPreprocessingParams(ModelBuilder modelBuilder) {
+    AutoMLBuildSpec.AutoMLTEControl te_spec = _aml.getBuildSpec().te_spec;
+    Frame leaderboardFrame = _aml.getLeaderboardFrame();
+    String responseColumnName = modelBuilder._parms._response_column;
+    ModelValidationMode validationMode = _aml.getValidationFrame() == null ? ModelValidationMode.CV : ModelValidationMode.VALIDATION_FRAME; // mode could be just boolean
+
+    return selectColumnsForEncoding(te_spec.application_strategy, modelBuilder._parms.train(), responseColumnName)
+            .map(columnsToEncode -> {
+              TargetEncodingHyperparamsEvaluator evaluator = new TargetEncodingHyperparamsEvaluator();
+
+              _modelParametersSelectionStrategy = new GridSearchModelParametersSelectionStrategy(modelBuilder, te_spec, leaderboardFrame, columnsToEncode, validationMode, evaluator);
+
+              ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> bestEvaluated = _modelParametersSelectionStrategy.getBestParamsWithEvaluation();
+              Log.info("Best TE parameters for chosen columns " + StringUtils.join(",", columnsToEncode) + " were selected to be: " + bestEvaluated.getParams());
+              return bestEvaluated;
+            });
+  }
+
+  private Optional<String[]> selectColumnsForEncoding(TEApplicationStrategy applicationStrategy, Frame trainingFrame, String responseColumnName) {
+    TEApplicationStrategy effectiveApplicationStrategy = applicationStrategy != null ? applicationStrategy : new AllCategoricalTEApplicationStrategy(trainingFrame, new String[]{responseColumnName});
+    String[] columnsToEncode = effectiveApplicationStrategy.getColumnsToEncode();
+    return columnsToEncode.length == 0 ? Optional.empty() : Optional.of(columnsToEncode);
+  }
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/UniversalPreprocessingSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/UniversalPreprocessingSteps.java
@@ -1,0 +1,26 @@
+package ai.h2o.automl.preprocessing;
+
+import ai.h2o.automl.*;
+
+import java.util.ArrayList;
+
+/**
+ * Universal means applies for any kind of models
+ */
+public class UniversalPreprocessingSteps extends PreprocessingSteps {
+
+  private ArrayList<PreprocessingStep> defaults = new ArrayList<>();
+
+  public UniversalPreprocessingSteps(AutoML autoML) {
+    super(autoML);
+    if(autoML.getBuildSpec().te_spec.enabled)
+      defaults.add(new TEPreprocessingStep(Preprocessor.TE, aml()));
+  }
+
+  @Override
+  protected PreprocessingStep[] getDefaultPreprocessors() {
+    return defaults.toArray(new PreprocessingStep[0]);
+  }
+
+}
+

--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/AutoMLTargetEncoderAssistant.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/AutoMLTargetEncoderAssistant.java
@@ -1,0 +1,245 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.AutoML;
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.targetencoder.strategy.*;
+import ai.h2o.targetencoding.BlendingParams;
+import ai.h2o.targetencoding.TargetEncoder;
+import ai.h2o.targetencoding.TargetEncoderFrameHelper;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import ai.h2o.targetencoding.strategy.AllCategoricalTEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
+import hex.Model;
+import hex.ModelBuilder;
+import hex.splitframe.ShuffleSplitFrame;
+import water.DKV;
+import water.Key;
+import water.Scope;
+import water.fvec.Frame;
+import water.fvec.Vec;
+import water.util.Log;
+import water.util.StringUtils;
+import water.util.TwoDimTable;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static ai.h2o.targetencoding.TargetEncoder.DataLeakageHandlingStrategy.KFold;
+import static ai.h2o.targetencoding.TargetEncoderFrameHelper.addKFoldColumn;
+import static ai.h2o.targetencoding.TargetEncoderFrameHelper.concat;
+
+/**
+ * Dedicated to a single ModelBuilder, i.e. model with hyperParameters
+ * Perform TargetEncoding based on a strategy of searching best TE parameters.
+ * Side effects will be done mostly through mutating modelBuilder.
+ */
+public class AutoMLTargetEncoderAssistant<MP extends Model.Parameters>{ // TODO generalize with  MP. Probably something like PreProcessingStepAssistant
+
+  private Frame _trainingFrame;
+  private Frame _validationFrame;
+  private Frame _leaderboardFrame;
+  private String _responseColumnName;
+  private AutoMLBuildSpec _buildSpec;
+  private ModelBuilder _modelBuilder;
+  private ModelValidationMode _validationMode;
+
+  public ModelParametersSelectionStrategy<TargetEncoderModel.TargetEncoderParameters> getTeParamsSelectionStrategy() {
+    return _modelParametersSelectionStrategy;
+  }
+
+  private ModelParametersSelectionStrategy<TargetEncoderModel.TargetEncoderParameters> _modelParametersSelectionStrategy;
+
+  private String[] _columnsToEncode;
+
+  public AutoMLTargetEncoderAssistant(AutoML aml,
+                                      AutoMLBuildSpec buildSpec,
+                                      ModelBuilder modelBuilder) {
+    _modelBuilder = modelBuilder;
+    _buildSpec = buildSpec;
+
+    _trainingFrame = modelBuilder._parms.train();
+    _validationFrame = aml.getValidationFrame();
+    _leaderboardFrame = aml.getLeaderboardFrame();
+    _responseColumnName = _modelBuilder._parms._response_column;
+
+    _validationMode = aml.getValidationFrame() == null ? ModelValidationMode.CV : ModelValidationMode.VALIDATION_FRAME;
+  }
+
+  public Optional<TargetEncoderModel.TargetEncoderParameters> findBestTEParams() {
+    return selectColumnsForEncoding(_buildSpec.te_spec.application_strategy)
+            .map(columnsToEncode -> {
+              _columnsToEncode = columnsToEncode;
+              TargetEncodingHyperparamsEvaluator evaluator = new TargetEncodingHyperparamsEvaluator();
+              _modelParametersSelectionStrategy = new GridSearchModelParametersSelectionStrategy(_modelBuilder, _buildSpec.te_spec, _leaderboardFrame, columnsToEncode, _validationMode, evaluator);
+
+              TargetEncoderModel.TargetEncoderParameters bestTEParams = null ;//getTeParamsSelectionStrategy().getBestParams();
+              Log.info("Best TE parameters for chosen columns " + StringUtils.join(",", columnsToEncode) + " were selected to be: " + bestTEParams);
+              return bestTEParams;
+            });
+  }
+
+  private Optional<String[]> selectColumnsForEncoding(TEApplicationStrategy applicationStrategy) {
+    TEApplicationStrategy effectiveApplicationStrategy = applicationStrategy != null ? applicationStrategy : new AllCategoricalTEApplicationStrategy(_trainingFrame, new String[]{_responseColumnName});
+    String[] columnsToEncode = effectiveApplicationStrategy.getColumnsToEncode();
+    return columnsToEncode.length == 0 ? Optional.empty() : Optional.of(columnsToEncode);
+  }
+
+  public void applyTE(TargetEncoderModel.TargetEncoderParameters bestTEParams) {
+
+    Scope.enter();
+    Map<String, Frame> encodingMap = null;
+    Frame trainNone = null;
+    try {
+//      Scope.untrack(_trainingFrame.keys());
+//      Scope.untrack_generic(_trainingFrame);
+      //TODO move it inside TargetEncoder. add constructor ?
+      BlendingParams blendingParams = bestTEParams.getBlendingParameters();
+      boolean withBlendedAvg = bestTEParams._blending;
+      boolean imputeNAsWithNewCategory = true;
+      TargetEncoder.DataLeakageHandlingStrategy holdoutType = bestTEParams._data_leakage_handling;
+      double noiseLevel = bestTEParams._noise_level;
+      long seed = _buildSpec.te_spec.seed;
+
+      TargetEncoder tec = new TargetEncoder(_columnsToEncode);
+
+      String responseColumnName = _responseColumnName;
+
+      Frame trainCopy = _trainingFrame.deepCopy(Key.make("train_frame_copy_for_encodings_generation_" + Key.make()).toString());
+      DKV.put(trainCopy);
+      Scope.track(trainCopy);
+
+      if (_validationMode == ModelValidationMode.CV) {
+        switch (holdoutType) {
+          case KFold:
+
+            String foldColumnForTE = null;
+            foldColumnForTE = _modelBuilder._job._key.toString() + "_te_fold_column";
+            int nfolds = 5;
+            addKFoldColumn(trainCopy, foldColumnForTE, nfolds, seed);
+
+            encodingMap = tec.prepareEncodingMap(trainCopy, responseColumnName, foldColumnForTE, true);
+            Frame encodedTrainingFrame = tec.applyTargetEncoding(trainCopy, responseColumnName, encodingMap, KFold, foldColumnForTE, withBlendedAvg, noiseLevel, imputeNAsWithNewCategory, blendingParams, seed);
+            copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedTrainingFrame, _trainingFrame);
+            Scope.track(encodedTrainingFrame);
+
+            TargetEncoderFrameHelper.encodingMapCleanUp(encodingMap);// do once in the end?
+            break;
+          case LeaveOneOut:
+          case None:
+            throw new IllegalStateException("With CV being enabled KFOLD strategy is only supported for now.");
+        }
+      } else {
+        switch (holdoutType) {
+          case KFold:
+
+            // Normally when it is not a CV case we don't have `fold_column` parameter provided
+            String foldColumnName = _modelBuilder._parms._fold_column;
+
+            // 1) If our best TE params, returned from selection strategy, contains DataLeakageHandlingStrategy.KFold as holdoutType
+            // then we need kfold column with preferably the same folds as during grid search.
+            // 2) Case when original _trainingFrame does not have fold column. Even with CV enabled we at this point have not yet reached code of folds autoassignments.
+            // Best we can do is to add fold column with the same seed as we use during Grid search of TE parameters. Otherwise just apply to the `_foldColumn` from the AutoML setup.
+            if (foldColumnName == null) {
+              foldColumnName = "te_fold_column"; // TODO consider introducing config `AutoMLTEControl` keep_te_fold_assignments
+              int nfolds = 5; // TODO move to `AutoMLTEControl`
+              addKFoldColumn(trainCopy, foldColumnName, nfolds, seed);
+            }
+            encodingMap = tec.prepareEncodingMap(trainCopy, responseColumnName, foldColumnName, imputeNAsWithNewCategory);
+
+            Frame encodedTrainingFrame = tec.applyTargetEncoding(trainCopy, responseColumnName, encodingMap, holdoutType, foldColumnName, withBlendedAvg, noiseLevel, imputeNAsWithNewCategory, blendingParams, seed);
+            copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedTrainingFrame, _trainingFrame);
+            Scope.track(encodedTrainingFrame);
+
+            if (_validationFrame != null) {
+              Frame encodedValidationFrame = tec.applyTargetEncoding(_validationFrame, responseColumnName, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, foldColumnName, withBlendedAvg, 0, imputeNAsWithNewCategory, blendingParams, seed);
+              copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedValidationFrame, _validationFrame);
+              Scope.track(encodedValidationFrame);
+            }
+            if (_leaderboardFrame != null) {
+              Frame encodedLeaderboardFrame = tec.applyTargetEncoding(_leaderboardFrame, responseColumnName, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, foldColumnName, withBlendedAvg, 0, imputeNAsWithNewCategory, blendingParams, seed);
+              copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedLeaderboardFrame, _leaderboardFrame);
+              Scope.track(encodedLeaderboardFrame);
+            }
+            break;
+
+          case LeaveOneOut:
+            encodingMap = tec.prepareEncodingMap(trainCopy, responseColumnName, null);
+
+            Frame encodedTrainingFrameLOO = tec.applyTargetEncoding(trainCopy, responseColumnName, encodingMap, holdoutType, withBlendedAvg, noiseLevel, imputeNAsWithNewCategory, blendingParams, seed);
+            copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedTrainingFrameLOO, _trainingFrame);
+            Scope.track(encodedTrainingFrameLOO);
+
+            if (_validationFrame != null) {
+              Frame encodedValidationFrame = tec.applyTargetEncoding(_validationFrame, responseColumnName, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, withBlendedAvg, 0.0, imputeNAsWithNewCategory, blendingParams, seed);
+              copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedValidationFrame, _validationFrame);
+              Scope.track(encodedValidationFrame);
+            }
+            if (_leaderboardFrame != null) {
+              Frame encodedLeaderboardFrame = tec.applyTargetEncoding(_leaderboardFrame, responseColumnName, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, withBlendedAvg, 0.0, imputeNAsWithNewCategory, blendingParams, seed);
+              copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedLeaderboardFrame, _leaderboardFrame);
+              Scope.track(encodedLeaderboardFrame);
+            }
+            break;
+          case None:
+            //We not only want to search for optimal parameters based on separate test split during grid search but also apply these parameters in the same fashion.
+            //But seed is different in current case
+            Frame[] trainAndHoldoutSplits = splitByRatio(trainCopy, new double[]{0.7, 0.3}, seed); // TODO move to te_spec
+            trainNone = trainAndHoldoutSplits[0]; // NOTE: we need to remove it afterwards when we will be setting back original training frame.
+            Scope.untrack(trainNone.keys());
+            Frame holdoutNone = trainAndHoldoutSplits[1];
+            encodingMap = tec.prepareEncodingMap(holdoutNone, responseColumnName, null);
+            Frame encodedTrainingFrameNone = tec.applyTargetEncoding(trainNone, responseColumnName, encodingMap, holdoutType, withBlendedAvg, 0.0, imputeNAsWithNewCategory, blendingParams, seed);
+            copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedTrainingFrameNone, trainNone);
+            Scope.track(encodedTrainingFrameNone);
+
+            _modelBuilder._parms.setTrain(trainNone._key);
+
+            if (_validationFrame != null) {
+              Frame encodedValidationFrameNone = tec.applyTargetEncoding(_validationFrame, responseColumnName, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, withBlendedAvg, 0, imputeNAsWithNewCategory, blendingParams, seed);
+              copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedValidationFrameNone, _validationFrame);
+              Scope.track(encodedValidationFrameNone);
+            }
+            if (_leaderboardFrame != null) {
+              Frame encodedLeaderboardFrameNone = tec.applyTargetEncoding(_leaderboardFrame, responseColumnName, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, withBlendedAvg, 0, imputeNAsWithNewCategory, blendingParams, seed);
+              copyEncodedColumnsToDestinationFrameAndRemoveSource(_columnsToEncode, encodedLeaderboardFrameNone, _leaderboardFrame);
+              Scope.track(encodedLeaderboardFrameNone);
+            }
+            holdoutNone.delete();
+        }
+      }
+      setColumnsToIgnore(_columnsToEncode);
+    } finally {
+      if( encodingMap != null) TargetEncoderFrameHelper.encodingMapCleanUp(encodingMap);
+      Scope.exit();
+    }
+  }
+
+  private Frame[] splitByRatio(Frame fr,double[] ratios, long seed) {
+    Key[] keys = new Key[]{Key.<Frame>make(), Key.<Frame>make()};
+    return ShuffleSplitFrame.shuffleSplitFrame(fr, keys, ratios, seed);
+  }
+
+  public static void printOutFrameAsTable(Frame fr, boolean rollups, long limit) {
+    assert limit <= Integer.MAX_VALUE;
+    TwoDimTable twoDimTable = fr.toTwoDimTable(0, (int) limit, rollups);
+    System.out.println(twoDimTable.toString(2, true));
+  }
+
+  // Due to TE we want to exclude original columns so that we can use only encoded ones.
+  // We need to be careful and reset value in _buildSpec back as next modelBuilder in AutoML sequence will exclude this
+  // columns even before we will have a chance to apply TE.
+  void setColumnsToIgnore(String[] columnsToEncode) {
+    _buildSpec.input_spec.ignored_columns = concat(_buildSpec.input_spec.ignored_columns, columnsToEncode);
+  }
+
+  //Note: we could have avoided this if we were following mutable way in TargetEncoder
+  void copyEncodedColumnsToDestinationFrameAndRemoveSource(String[] columnsToEncode, Frame sourceWithEncodings, Frame destinationFrame) {
+    for(String column :columnsToEncode) {
+      String encodedColumnName = column + "_te";
+      Vec encodedVec = sourceWithEncodings.vec(encodedColumnName);
+      Vec encodedVecCopy = encodedVec.makeCopy();
+      Scope.untrack(encodedVecCopy._key);
+      destinationFrame.add(encodedColumnName, encodedVecCopy);
+    }
+  }
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/ModelParametersEvaluator.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/ModelParametersEvaluator.java
@@ -1,0 +1,18 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.targetencoder.strategy.ModelParametersSelectionStrategy;
+import ai.h2o.automl.targetencoder.strategy.ModelValidationMode;
+import hex.Model;
+import hex.ModelBuilder;
+import water.Iced;
+import water.fvec.Frame;
+
+public abstract class ModelParametersEvaluator<M extends Model, MP extends Model.Parameters> extends Iced {
+
+  public abstract ModelParametersSelectionStrategy.Evaluated<M> evaluate(MP modelParameters,
+                                                                      ModelBuilder modelBuilder,
+                                                                      ModelValidationMode modelValidationMode,
+                                                                      Frame leaderboard,
+                                                                      String[] columnNamesToEncode,
+                                                                      long seedForFoldColumn);
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/TargetEncodingHyperparamsEvaluator.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/TargetEncodingHyperparamsEvaluator.java
@@ -1,0 +1,225 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.targetencoder.strategy.ModelParametersSelectionStrategy;
+import ai.h2o.automl.targetencoder.strategy.ModelValidationMode;
+import ai.h2o.targetencoding.TargetEncoder;
+import ai.h2o.targetencoding.TargetEncoderBuilder;
+import ai.h2o.targetencoding.TargetEncoderFrameHelper;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import hex.Model;
+import hex.ModelBuilder;
+import hex.splitframe.ShuffleSplitFrame;
+import water.*;
+import water.fvec.Frame;
+import water.util.ArrayUtils;
+import water.util.TwoDimTable;
+
+import java.util.Map;
+
+import static ai.h2o.targetencoding.TargetEncoder.DataLeakageHandlingStrategy.KFold;
+import static ai.h2o.targetencoding.TargetEncoder.DataLeakageHandlingStrategy.LeaveOneOut;
+import static ai.h2o.targetencoding.TargetEncoderFrameHelper.addKFoldColumn;
+import static ai.h2o.targetencoding.TargetEncoderFrameHelper.concat;
+
+public class TargetEncodingHyperparamsEvaluator extends ModelParametersEvaluator<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters> {
+
+  public ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> evaluate(TargetEncoderModel.TargetEncoderParameters teParams,
+                         ModelBuilder modelBuilder,
+                         ModelValidationMode modelValidationMode,
+                         Frame leaderboard,
+                         String[] columnNamesToEncode,
+                         long seedForFoldColumn) {
+    Scope.enter();
+    try {
+      switch (modelValidationMode) {
+        case CV:
+          assert leaderboard == null : "Leaderboard frame should not be provided in case of CV evaluations in AutoML";
+          return evaluateForCVMode(teParams, modelBuilder, columnNamesToEncode, seedForFoldColumn);
+        case VALIDATION_FRAME:
+        default:
+          return evaluateForValidationFrameMode(teParams, modelBuilder, leaderboard, columnNamesToEncode, seedForFoldColumn);
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  public ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> evaluateForCVMode(TargetEncoderModel.TargetEncoderParameters teParams, ModelBuilder clonedModelBuilder, String[] columnNamesToEncode, long seedForFoldColumn) {
+
+    final TargetEncoderModel targetEncoderModel;
+    double score = 0;
+    Frame trainEncoded = null;
+
+    Frame originalTrain = clonedModelBuilder._parms.train();
+    Frame trainCopy = originalTrain.deepCopy(Key.make().toString());
+    DKV.put(trainCopy);
+    Scope.track(trainCopy);
+
+    String[] originalIgnoredColumns = clonedModelBuilder._parms._ignored_columns;
+    try {
+
+      assert teParams._data_leakage_handling == KFold : "Only `KFold` strategy is being used in current version for CV mode.";
+
+
+      { //Applying encoding here
+        // Maybe we can use the same folds that we will use for splitting but in that case we will have only 4 folds for encoding map
+        // generation and application of this map to the frame that was used for creating map
+        String foldColumnForTE = clonedModelBuilder._job._key.toString() + "_fold";
+        int nfolds = 5;
+        addKFoldColumn(trainCopy, foldColumnForTE, nfolds, seedForFoldColumn);
+
+        teParams._response_column = clonedModelBuilder._parms._response_column;
+        teParams._fold_column = foldColumnForTE;
+        String[] ignoredColumnsDuringEncoding = ArrayUtils.difference(trainCopy.names(), concat(columnNamesToEncode, new String[]{teParams._response_column, foldColumnForTE}));
+        teParams._ignored_columns = ignoredColumnsDuringEncoding;
+        teParams._train = trainCopy._key;
+        teParams._seed = seedForFoldColumn;
+
+        TargetEncoderBuilder job = new TargetEncoderBuilder(teParams);
+        targetEncoderModel = job.trainModel().get();
+//          Scope.track_generic(targetEncoderModel);
+        trainEncoded = targetEncoderModel.score(trainCopy);
+        Scope.track(trainEncoded);
+        trainEncoded.remove(foldColumnForTE).remove();
+//        printOutFrameAsTable(trainEncoded, false, 20);
+//        Job export = Frame.export(trainEncoded, "encoder_" + teParams.toString(), trainEncoded._key.toString(), true, 1);
+//        export.get();
+
+      }
+
+      // TODO maybe remove foldColumnForTE here?
+      clonedModelBuilder._parms._ignored_columns = concat(originalIgnoredColumns, columnNamesToEncode);
+      clonedModelBuilder.setTrain(trainEncoded);
+
+      score += scoreCV(clonedModelBuilder);
+    } finally {
+      //Setting back original data
+      clonedModelBuilder.setTrain(originalTrain);
+      clonedModelBuilder._parms._ignored_columns = originalIgnoredColumns; //TODO Do we need to do this if we made a clone? Or we can do this once before evaluating all parameters and after all of them
+    }
+    return new ModelParametersSelectionStrategy.Evaluated<>(targetEncoderModel, score);
+  }
+
+  private double scoreCV(ModelBuilder modelBuilder) { // TODO move it in when no need to call scoreCV twice
+    Model retrievedModel = null;
+    Keyed model = null;
+    try {
+      model = modelBuilder.trainModel().get();
+      retrievedModel = DKV.getGet(modelBuilder.dest());
+    } catch (Throwable ex) {
+      throw ex;
+    }
+    double cvScore = retrievedModel.loss();
+    retrievedModel.delete();
+    retrievedModel.deleteCrossValidationModels();
+    retrievedModel.deleteCrossValidationPreds();
+
+    return cvScore;
+  }
+
+  private double scoreOnTest(ModelBuilder modelBuilder, Frame testEncodedFrame) {
+    Keyed model = modelBuilder.trainModel().get();
+    Model retrievedModel = DKV.getGet(model._key);
+    retrievedModel.score(testEncodedFrame).delete();
+
+    hex.ModelMetricsBinomial mmb = hex.ModelMetricsBinomial.getFromDKV(retrievedModel, testEncodedFrame);
+    if(retrievedModel!=null) retrievedModel.delete();
+    return mmb.auc();
+  }
+
+  public ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> evaluateForValidationFrameMode(TargetEncoderModel.TargetEncoderParameters teParams, ModelBuilder clonedModelBuilder, Frame leaderboard, String[] columnNamesToEncode, long seedForFoldColumn) {
+      double score = 0;
+      Map<String, Frame> encodingMap = null;
+      Frame trainEncoded, validEncoded, leaderBoardEncoded = null;
+      Frame originalTrain = clonedModelBuilder._parms.train();
+      Frame trainCopy = originalTrain.deepCopy(Key.make("train_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(trainCopy);
+
+      Frame originalValid = clonedModelBuilder._parms.valid();
+      Frame validCopy = originalValid.deepCopy(Key.make("valid_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(validCopy);
+
+      Frame leaderboardCopy = leaderboard.deepCopy(Key.make("leaderboard_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(leaderboardCopy);
+
+
+      Scope.track(trainCopy, validCopy, leaderboardCopy);
+
+      String[] originalIgnoredColumns = clonedModelBuilder._parms._ignored_columns;
+      String foldColumnForTE = null;
+      try {
+        // We need to apply TE taking into account the way how we train and validate our models.
+        // With nfolds model will assign fold column to the data but we need those folds in TE before that. So we need to generate fold column themselves and then provide it to the model.
+        // But what if we already have folds from the model search level provided by user? Is it better to use different fold assignments for TE? Maybe yes - it is similar to "n-times m-folds cross-validation" idea.
+
+        String responseColumn = clonedModelBuilder._parms._response_column;
+        String[] teColumnsToExclude = columnNamesToEncode;
+        TargetEncoder tec = new TargetEncoder(columnNamesToEncode);
+        TargetEncoder.DataLeakageHandlingStrategy holdoutType = teParams._data_leakage_handling;
+
+        if (holdoutType == KFold) {
+          foldColumnForTE = clonedModelBuilder._job._key.toString() + "_fold";
+          //Note: default value for KFOLD target encoding. We might want to search for this value but it is quite expensive.
+          // We might want to optimize and add fold column once per group of hyperparameters.
+          int nfolds = 5;
+          addKFoldColumn(trainCopy, foldColumnForTE, nfolds, seedForFoldColumn);
+
+          teColumnsToExclude = concat(teColumnsToExclude, new String[]{foldColumnForTE});
+          encodingMap = tec.prepareEncodingMap(trainCopy, responseColumn, foldColumnForTE, true);
+          trainEncoded = tec.applyTargetEncoding(trainCopy, responseColumn, encodingMap, KFold, foldColumnForTE, teParams._blending, teParams._noise_level, true, teParams.getBlendingParameters(), seedForFoldColumn);
+          validEncoded = tec.applyTargetEncoding(validCopy, responseColumn, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, foldColumnForTE, teParams._blending, 0.0, true, teParams.getBlendingParameters(), seedForFoldColumn);
+          leaderBoardEncoded = tec.applyTargetEncoding(leaderboard, responseColumn, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, foldColumnForTE, teParams._blending, 0.0, true, teParams.getBlendingParameters(), seedForFoldColumn);
+        } else if (holdoutType == LeaveOneOut) {
+          encodingMap = tec.prepareEncodingMap(trainCopy, responseColumn, null, true);
+
+          trainEncoded = tec.applyTargetEncoding(trainCopy, responseColumn, encodingMap, LeaveOneOut, teParams._blending, teParams._noise_level, true, teParams.getBlendingParameters(), seedForFoldColumn);
+          validEncoded = tec.applyTargetEncoding(validCopy, responseColumn, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, teParams._blending, 0.0, true, teParams.getBlendingParameters(),seedForFoldColumn);
+          leaderBoardEncoded = tec.applyTargetEncoding(leaderboard, responseColumn, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, teParams._blending, 0.0, true, teParams.getBlendingParameters(), seedForFoldColumn);
+
+        } else { // Holdout None case might be always a looser as we use less data for training. So it is an unfair competition.
+          // It would be more efficient to split it once before all the evaluations.
+          // Note: with too small split encoding map is so unusefull so that it hurts. Should we search for this as well?
+          Frame[] trainAndHoldoutSplits = splitByRatio(trainCopy, new double[]{0.7, 0.3}, seedForFoldColumn);
+          Frame trainSplitForNoneCase = trainAndHoldoutSplits[0];
+          Frame holdoutSplitForNoneCase = trainAndHoldoutSplits[1];
+          encodingMap = tec.prepareEncodingMap(holdoutSplitForNoneCase, responseColumn, null, true);
+          // Note: no need to add noise for training
+          trainEncoded = tec.applyTargetEncoding(trainSplitForNoneCase, responseColumn, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, teParams._blending, 0.0, true, teParams.getBlendingParameters(), seedForFoldColumn);
+          validEncoded = tec.applyTargetEncoding(validCopy, responseColumn, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, teParams._blending, 0.0, true, teParams.getBlendingParameters(), seedForFoldColumn);
+          leaderBoardEncoded = tec.applyTargetEncoding(leaderboard, responseColumn, encodingMap, TargetEncoder.DataLeakageHandlingStrategy.None, teParams._blending, 0.0, true, teParams.getBlendingParameters(), seedForFoldColumn);
+          trainSplitForNoneCase.delete();
+          holdoutSplitForNoneCase.delete();
+        }
+
+        Scope.track(trainEncoded, validEncoded, leaderBoardEncoded);
+
+        clonedModelBuilder._parms._ignored_columns = concat(originalIgnoredColumns, teColumnsToExclude);
+        clonedModelBuilder._parms.setTrain(trainEncoded._key);
+        clonedModelBuilder._parms.setValid(validEncoded._key);
+
+        score += scoreOnTest(clonedModelBuilder, leaderBoardEncoded);
+
+      } finally {
+
+        clonedModelBuilder._parms._ignored_columns = originalIgnoredColumns;
+        clonedModelBuilder._parms.setTrain(originalTrain._key);
+        clonedModelBuilder._parms.setValid(originalValid._key);
+
+        if (encodingMap != null) TargetEncoderFrameHelper.encodingMapCleanUp(encodingMap);
+      }
+      return new ModelParametersSelectionStrategy.Evaluated<>(null, score); //TODO null !!!!
+  }
+
+  public static void printOutFrameAsTable(Frame fr, boolean rollups, long limit) {
+    assert limit <= Integer.MAX_VALUE;
+    TwoDimTable twoDimTable = fr.toTwoDimTable(0, (int) limit, rollups);
+    System.out.println(twoDimTable.toString(2, true));
+  }
+
+  private Frame[] splitByRatio(Frame fr,double[] ratios, long seed) {
+    Key[] keys = new Key[]{Key.<Frame>make(), Key.<Frame>make()};
+    return ShuffleSplitFrame.shuffleSplitFrame(fr, keys, ratios, seed);
+  }
+
+
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/strategy/GridSearchModelParametersSelectionStrategy.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/strategy/GridSearchModelParametersSelectionStrategy.java
@@ -1,0 +1,130 @@
+package ai.h2o.automl.targetencoder.strategy;
+
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.targetencoder.ModelParametersEvaluator;
+import ai.h2o.targetencoding.TargetEncoder;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import hex.ModelBuilder;
+import hex.grid.HyperSpaceSearchCriteria;
+import hex.grid.HyperSpaceWalker;
+import hex.schemas.TargetEncoderV3;
+import water.api.GridSearchHandler;
+import water.fvec.Frame;
+import water.fvec.Vec;
+
+import java.util.HashMap;
+import java.util.PriorityQueue;
+
+/**
+ *  Random grid search of optimal hyper parameters for target encoding
+ */
+public class GridSearchModelParametersSelectionStrategy extends ModelParametersSelectionStrategy<TargetEncoderModel.TargetEncoderParameters> {
+
+  private ModelBuilder _modelBuilder;
+  private AutoMLBuildSpec.AutoMLTEControl _teBuildSpec;
+
+  protected HyperSpaceWalker.RandomDiscreteValueWalker<TargetEncoderModel.TargetEncoderParameters> _walker;
+
+  private ModelParametersEvaluator<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters> _evaluator;
+  private PriorityQueue<ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel>> _evaluatedQueue;
+
+  protected ModelValidationMode _validationMode;
+  private Frame _leaderboardData;
+  protected transient String[] _columnNamesToEncode;
+
+
+  public GridSearchModelParametersSelectionStrategy(ModelBuilder modelBuilder,
+                                                    AutoMLBuildSpec.AutoMLTEControl teBuildSpec,
+                                                    Frame leaderboard,
+                                                    String[] columnNamesToEncode,
+                                                    ModelValidationMode validationMode,
+                                                    ModelParametersEvaluator<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters> evaluator) {
+    _teBuildSpec = teBuildSpec;
+    _modelBuilder = modelBuilder;
+    _evaluator = evaluator;
+
+    _leaderboardData = leaderboard;
+    _columnNamesToEncode = columnNamesToEncode;
+
+    boolean theLessTheBetter = true; // we are using Model.loss() function to evaluate performance
+
+    _evaluatedQueue = new PriorityQueue<>(new EvaluatedComparator(theLessTheBetter));
+
+    _validationMode = validationMode;
+
+    setTESearchSpace(_validationMode);
+  }
+
+  private void setTESearchSpace(ModelValidationMode modelValidationMode) {
+
+    HashMap<String, Object[]> grid = new HashMap<>();
+    grid.put("blending", new Boolean[]{true, /*false*/}); // TODO use filtering when PUBDEV-7037 is available
+    grid.put("noise_level", new Double[]{0.0, 0.01, 0.1});
+    grid.put("k", new Double[]{1.0, 2.0, 3.0, 5.0, 10.0, 50.0, 100.0});
+    grid.put("f", new Double[]{5.0, 10.0, 20.0});
+
+    switch (modelValidationMode) {
+      case CV:
+        grid.put("data_leakage_handling", new TargetEncoder.DataLeakageHandlingStrategy[]{TargetEncoder.DataLeakageHandlingStrategy.KFold});
+        break;
+      case VALIDATION_FRAME:
+        // TODO apply filtering. When we choose holdoutType=None we don't need to search for noise
+        grid.put("data_leakage_handling", new TargetEncoder.DataLeakageHandlingStrategy[]{TargetEncoder.DataLeakageHandlingStrategy.KFold, TargetEncoder.DataLeakageHandlingStrategy.LeaveOneOut, TargetEncoder.DataLeakageHandlingStrategy.None});
+        break;
+    }
+
+    TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+
+    GridSearchHandler.DefaultModelParametersBuilderFactory<TargetEncoderModel.TargetEncoderParameters, TargetEncoderV3.TargetEncoderParametersV3> modelParametersBuilderFactory =
+            new GridSearchHandler.DefaultModelParametersBuilderFactory<>();
+
+    HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+    hyperSpaceSearchCriteria.set_seed(_teBuildSpec.seed);
+
+    _walker = new HyperSpaceWalker.RandomDiscreteValueWalker<>(parameters, grid, modelParametersBuilderFactory, hyperSpaceSearchCriteria);
+
+  }
+
+
+  public ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> getBestParamsWithEvaluation() {
+
+    HyperSpaceWalker.HyperSpaceIterator<TargetEncoderModel.TargetEncoderParameters> iterator = _walker.iterator();
+
+    long attemptIdx = 0;
+    while (iterator.hasNext(null) && (_teBuildSpec.max_models == 0 || _evaluatedQueue.size() < _teBuildSpec.max_models)) {
+
+      TargetEncoderModel.TargetEncoderParameters nextModelParameters = iterator.nextModelParameters(null);
+
+      ModelBuilder clonedModelBuilder = ModelBuilder.make(_modelBuilder._parms);
+
+      clonedModelBuilder.init(false);
+
+      Evaluated evaluationResult = _evaluator.evaluate(nextModelParameters, clonedModelBuilder, _validationMode, _leaderboardData, _columnNamesToEncode, _teBuildSpec.seed);
+
+      evaluationResult.setAttemptIdx(attemptIdx);
+      // Compare with best seen result so far and remove model from `evaluationResult` to save space
+      _evaluatedQueue.add(evaluationResult);
+    }
+
+    return _evaluatedQueue.peek();
+  }
+
+  public PriorityQueue<Evaluated<TargetEncoderModel>> getEvaluatedModelParameters() {
+    return _evaluatedQueue;
+  }
+
+  /**
+   * this method will keep a best model, delete all the other models and purge the queue
+   */
+  public void removeAllButBest() {
+    _evaluatedQueue.poll();
+    _evaluatedQueue.forEach(evaluated -> evaluated._model.delete());
+    _evaluatedQueue.clear();
+  }
+
+  @Override
+  public void removeAll() {
+    _evaluatedQueue.forEach(evaluated -> evaluated._model.delete());
+    _evaluatedQueue.clear();
+  }
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/strategy/ModelParametersSelectionStrategy.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/strategy/ModelParametersSelectionStrategy.java
@@ -1,0 +1,62 @@
+package ai.h2o.automl.targetencoder.strategy;
+
+import hex.Model;
+import water.Iced;
+
+import java.util.Comparator;
+
+public abstract class ModelParametersSelectionStrategy<MP extends Model.Parameters> extends Iced {
+
+  public abstract Evaluated getBestParamsWithEvaluation();
+  public abstract void removeAllButBest();
+  public abstract void removeAll();
+
+
+  // TODO could be renamed to EvaluatedModelParams or even eliminated as we can probably use just Model with corresponding Comparator.
+  //  Attempt's index might be still valuable.
+  public static class Evaluated< M extends Model> extends Iced<Evaluated> {
+
+    transient M _model;
+    transient M.Parameters _params;
+    private double _score;
+    // One-based index of evaluation run
+    private long _index;
+
+    public Evaluated(M model, double score) {
+      _model = model;
+      _params = model == null ? null : model._parms;
+      _score = score;
+    }
+
+    public void setAttemptIdx(long _index) {
+      this._index = _index;
+    }
+
+    public M getModel() {
+      return _model;
+    }
+
+    public M.Parameters getParams() {
+      return _params;
+    }
+
+    public double getScore() {
+      return _score;
+    }
+  }
+
+  public static class EvaluatedComparator extends Iced<EvaluatedComparator> implements Comparator<Evaluated> {
+    private boolean _theLessTheBetter;
+
+    public EvaluatedComparator(boolean theLessTheBetter) {
+      _theLessTheBetter = theLessTheBetter;
+    }
+
+    @Override
+    public int compare(Evaluated o1, Evaluated o2) {
+      int inverseTerm = _theLessTheBetter ? 1 : -1;
+      return inverseTerm * Double.compare(o1.getScore(), o2.getScore());
+    }
+  }
+
+}

--- a/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/strategy/ModelValidationMode.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/targetencoder/strategy/ModelValidationMode.java
@@ -1,0 +1,6 @@
+package ai.h2o.automl.targetencoder.strategy;
+
+public enum ModelValidationMode {
+  CV,
+  VALIDATION_FRAME
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -59,6 +59,8 @@ public class AutoMLTest extends water.TestUtil {
       autoMLBuildSpec.build_control.keep_cross_validation_models = false; //Prevent leaked keys from CV models
       autoMLBuildSpec.build_control.keep_cross_validation_predictions = false; //Prevent leaked keys from CV predictions
 
+      autoMLBuildSpec.te_spec.enabled = false;
+
       aml = AutoML.startAutoML(autoMLBuildSpec);
       aml.get();
 

--- a/h2o-automl/src/test/java/ai/h2o/automl/preprocessing/TEPreprocessingStepTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/preprocessing/TEPreprocessingStepTest.java
@@ -1,0 +1,42 @@
+package ai.h2o.automl.preprocessing;
+
+import ai.h2o.automl.targetencoder.strategy.ModelValidationMode;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import water.TestUtil;
+
+import static ai.h2o.automl.targetencoder.strategy.ModelValidationMode.CV;
+
+
+@RunWith(Enclosed.class)
+public class TEPreprocessingStepTest {
+
+
+  @RunWith(Parameterized.class)
+  public static class GridSearchModelParametersSelectionStrategyParametrizedTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Parameterized.Parameters(name = "Validation mode = {0}")
+    public static Object[] validationMode() {
+      return new ModelValidationMode[]{
+              CV, ModelValidationMode.VALIDATION_FRAME
+      };
+    }
+
+    @Parameterized.Parameter
+    public ModelValidationMode validationMode;
+
+    @Test
+    public void evaluated_during_search_models_are_being_removed_properly() {
+      //TODO test that we do cleanup properly depending on whether we found better HPs
+    }
+
+  }
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/AllTEIntegrationTestsSuite.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/AllTEIntegrationTestsSuite.java
@@ -1,0 +1,20 @@
+package ai.h2o.automl.targetencoder;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@Ignore
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        TEIntegrationWithAutoMLTest.class,
+//        AllCategoricalTEApplicationStrategyTest.class, // TODO move test from targetencider ext module
+        GridSearchModelParametersSelectionStrategyTest.class,
+        TargetEncodingHyperparamsEvaluatorTest.class,
+//        ThresholdTEApplicationStrategyTest.class  // TODO move test from targetencider ext module
+})
+
+public class AllTEIntegrationTestsSuite {
+  // the class remains empty,
+  // used only as a holder for the above annotations
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/AutoMLBenchmarkHelper.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/AutoMLBenchmarkHelper.java
@@ -1,0 +1,54 @@
+package ai.h2o.automl.targetencoder;
+
+
+import ai.h2o.automl.leaderboard.Leaderboard;
+import hex.Model;
+import hex.splitframe.ShuffleSplitFrame;
+import water.Key;
+import water.TestUtil;
+import water.fvec.Frame;
+
+public class AutoMLBenchmarkHelper extends TestUtil {
+
+  public static Frame getPreparedTitanicFrame(String responseColumnName) {
+    Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
+    fr.remove("name").remove();
+    fr.remove("ticket").remove();
+    fr.remove("boat").remove();
+    fr.remove("body").remove();
+    asFactor(fr, responseColumnName);
+    return fr;
+  }
+
+  static public Frame[] getRandomSplitsFromDataframe(Frame fr, double[] ratios, long splitSeed) {
+    Key<Frame>[] keys = new Key[ratios.length];
+    for (int i = 0; i < ratios.length; i++) {
+      keys[i] = Key.make();
+    }
+    Frame[] splits = null;
+    splits = ShuffleSplitFrame.shuffleSplitFrame(fr, keys, ratios, splitSeed);
+    return splits;
+  }
+
+  public static double getScoreBasedOn(Frame fr, Model model) {
+    model.score(fr).delete();
+    hex.ModelMetricsBinomial mmb = hex.ModelMetricsBinomial.getFromDKV(model, fr);
+    return mmb.auc();
+  }
+
+  public static double getCumulativeLeaderboardScore(Frame split, Leaderboard leaderboard) {
+    double cumulative = 0.0;
+    for (Model model : leaderboard.getModels()) {
+      cumulative += getScoreBasedOn(split, model);
+    }
+    return cumulative;
+  }
+
+  public static double getCumulativeAUCScore(Leaderboard leaderboard) {
+    double cumulative = 0.0;
+    for (Model model : leaderboard.getModels()) {
+      cumulative += model.auc();
+    }
+    return cumulative;
+  }
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/AutoMLTargetEncodingAssistantTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/AutoMLTargetEncodingAssistantTest.java
@@ -1,0 +1,157 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.AutoML;
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.targetencoder.strategy.GridSearchModelParametersSelectionStrategy;
+import ai.h2o.targetencoding.TargetEncoder;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import ai.h2o.targetencoding.strategy.ThresholdTEApplicationStrategy;
+import hex.ModelBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static ai.h2o.automl.targetencoder.AutoMLBenchmarkHelper.getPreparedTitanicFrame;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/*
+@RunWith(Enclosed.class)
+public class AutoMLTargetEncodingAssistantTest {
+
+  public static class AutoMLTargetEncodingAssistantNonParametrizedTest extends water.TestUtil {
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Test
+    public void findBestTEParams_returns_none_if_no_columns_for_encoding() {
+
+      AutoML aml = null;
+      Scope.enter();
+      try {
+
+        String responseColumnName = "survived";
+        Frame train = getPreparedTitanicFrame(responseColumnName);
+        Scope.track(train);
+
+        AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+        autoMLBuildSpec.input_spec.training_frame = train._key;
+        autoMLBuildSpec.input_spec.validation_frame = null;
+        autoMLBuildSpec.input_spec.leaderboard_frame = null;
+        autoMLBuildSpec.build_control.nfolds = 5;
+        autoMLBuildSpec.input_spec.response_column = responseColumnName;
+
+        autoMLBuildSpec.te_spec.seed = 1234;
+
+        //  This will make sure that no columns will be selected for encoding
+        int nonExceedableThreshold = Integer.MAX_VALUE;
+
+        autoMLBuildSpec.te_spec.application_strategy = new ThresholdTEApplicationStrategy(train, nonExceedableThreshold, new String[]{responseColumnName});
+
+        ModelBuilder modelBuilder = TargetEncodingTestFixtures.modelBuilderGBMWithCVFixture(train, responseColumnName, 1234);
+
+        aml = new AutoML(null, new Date(), autoMLBuildSpec);
+
+        AutoMLTargetEncoderAssistant teAssistant = new AutoMLTargetEncoderAssistant(aml, autoMLBuildSpec, modelBuilder);
+
+        Optional<TargetEncoderModel.TargetEncoderParameters> bestTEParamsOpt = teAssistant.findBestTEParams();
+
+        assertFalse(bestTEParamsOpt.isPresent());
+      } finally {
+        if (aml != null) aml.delete();
+        Scope.exit();
+      }
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class AutoMLTargetEncodingAssistantParametrizedTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Parameterized.Parameters(name = "Assistant applies TE parameters: strategy = {0}")
+    public static Object[] strategy() {
+      return new TargetEncoder.DataLeakageHandlingStrategy[]{
+              TargetEncoder.DataLeakageHandlingStrategy.KFold, TargetEncoder.DataLeakageHandlingStrategy.LeaveOneOut, TargetEncoder.DataLeakageHandlingStrategy.None
+      };
+    }
+
+    @Parameterized.Parameter
+    public TargetEncoder.DataLeakageHandlingStrategy strategy;
+
+    @Test
+    public void applyTe_encoded_training_when_validation_frame_is_being_used() {
+
+      AutoML aml = null;
+      Scope.enter();
+      try {
+
+        String responseColumnName = "survived";
+        Frame train = getPreparedTitanicFrame(responseColumnName);
+
+        AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+        autoMLBuildSpec.input_spec.training_frame = train._key;
+        Frame[] splits = AutoMLBenchmarkHelper.getRandomSplitsFromDataframe(train, new double[]{0.7, 0.15, 0.15}, 1234);
+        Frame trainSplit = splits[0];
+        Frame validSplit = splits[1];
+        Frame leaderboardSplit = splits[2];
+        Scope.track(train, trainSplit, validSplit, leaderboardSplit);
+
+
+        autoMLBuildSpec.input_spec.training_frame = trainSplit._key;
+        autoMLBuildSpec.input_spec.validation_frame = validSplit._key;
+        autoMLBuildSpec.input_spec.leaderboard_frame = leaderboardSplit._key;
+        autoMLBuildSpec.build_control.nfolds = 0;
+        autoMLBuildSpec.input_spec.response_column = responseColumnName;
+
+        autoMLBuildSpec.te_spec.seed = 1234;
+
+        autoMLBuildSpec.te_spec.application_strategy = new ThresholdTEApplicationStrategy(train, 5, new String[]{responseColumnName});
+
+        ModelBuilder modelBuilder = TargetEncodingTestFixtures.modelBuilderGBMWithCVFixture(train, responseColumnName, 1234);
+
+        aml = new AutoML(null, new Date(), autoMLBuildSpec);
+
+        AutoMLTargetEncoderAssistant teAssistant = new AutoMLTargetEncoderAssistant(aml, autoMLBuildSpec, modelBuilder);
+
+        AutoMLTargetEncoderAssistant teAssistantSpy = spy(teAssistant);
+
+        TargetEncoderModel.TargetEncoderParameters bestTEParams = new TargetEncoderModel.TargetEncoderParameters();
+        bestTEParams._k = 10;
+        bestTEParams._f = 1;
+        bestTEParams._data_leakage_handling = strategy;
+        bestTEParams._noise_level = 0.1;
+
+        GridSearchModelParametersSelectionStrategy selectionStrategyMock = mock(GridSearchModelParametersSelectionStrategy.class);
+//        when(selectionStrategyMock.getBestParams()).thenReturn(bestTEParams); // TODO fix the test
+
+        Mockito.doReturn(selectionStrategyMock).when(teAssistantSpy).getTeParamsSelectionStrategy();
+
+        Optional<TargetEncoderModel.TargetEncoderParameters> bestTEParams1 = teAssistantSpy.findBestTEParams();
+
+        teAssistantSpy.applyTE(bestTEParams1.get());
+
+        assertNotNull(modelBuilder._parms.train().vec("home.dest_te"));
+
+        Scope.track(modelBuilder._parms.train());
+      } finally {
+        if (aml != null) aml.delete();
+        Scope.exit();
+      }
+    }
+  }
+}*/

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/GridSearchModelParametersSelectionStrategyTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/GridSearchModelParametersSelectionStrategyTest.java
@@ -1,0 +1,386 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.targetencoder.strategy.GridSearchModelParametersSelectionStrategy;
+import ai.h2o.automl.targetencoder.strategy.ModelParametersSelectionStrategy;
+import ai.h2o.automl.targetencoder.strategy.ModelValidationMode;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.ThresholdTEApplicationStrategy;
+import hex.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import water.*;
+import water.fvec.Frame;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Random;
+
+import static ai.h2o.automl.targetencoder.strategy.ModelValidationMode.CV;
+import static org.junit.Assert.*;
+
+@RunWith(Enclosed.class)
+public class GridSearchModelParametersSelectionStrategyTest {
+
+  public static class DummyModel extends Model<DummyModel, TargetEncoderModel.TargetEncoderParameters, TargetEncoderModel.Output> {
+    public DummyModel(TargetEncoderModel.TargetEncoderParameters parms) {
+      super(Key.make(), parms, null);
+    }
+
+    @Override
+    public ModelMetrics.MetricBuilder makeMetricBuilder(String[] domain) {
+      return new ModelMetricsBinomial.MetricBuilderBinomial(domain);
+    }
+    @Override
+    protected double[] score0(double[] data, double[] preds) { return preds; }
+    @Override
+    protected Futures remove_impl(Futures fs, boolean cascade) {
+      return fs;
+    }
+  }
+
+  public static class GridSearchModelParametersSelectionStrategyNonParametrizedTest extends water.TestUtil {
+
+    @Test
+    public void priorityQueueOrderingWithEvaluatedTest() {
+      boolean theBiggerTheBetter = true;
+      Comparator comparator = new GridSearchModelParametersSelectionStrategy.EvaluatedComparator(theBiggerTheBetter);
+      PriorityQueue<GridSearchModelParametersSelectionStrategy.Evaluated<DummyModel>> evaluatedQueue = new PriorityQueue<>(comparator);
+
+
+      TargetEncoderModel.TargetEncoderParameters params1 = TargetEncodingTestFixtures.randomTEParams();
+      TargetEncoderModel.TargetEncoderParameters params2 = TargetEncodingTestFixtures.randomTEParams();
+      TargetEncoderModel.TargetEncoderParameters params3 = TargetEncodingTestFixtures.randomTEParams();
+
+
+      evaluatedQueue.add(new GridSearchModelParametersSelectionStrategy.Evaluated<>(new DummyModel(params1), 0.9984));
+      evaluatedQueue.add(new GridSearchModelParametersSelectionStrategy.Evaluated<>(new DummyModel(params2), 0.9996));
+      evaluatedQueue.add(new GridSearchModelParametersSelectionStrategy.Evaluated<>(new DummyModel(params3), 0.9784));
+
+      assertEquals(0.9996, evaluatedQueue.poll().getScore(), 1e-5);
+      assertEquals(0.9984, evaluatedQueue.poll().getScore(), 1e-5);
+      assertEquals(0.9784, evaluatedQueue.poll().getScore(), 1e-5);
+
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class GridSearchModelParametersSelectionReturnsBestParametrizedTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Parameterized.Parameters(name = "Validation mode = {0}, task type = {1}")
+    public static Object[][] validationMode() {
+      return new Object[][]{
+              {CV, "regression"},
+              {CV, "classification"},
+              {ModelValidationMode.VALIDATION_FRAME, "regression"},
+              {ModelValidationMode.VALIDATION_FRAME, "classification"},
+      };
+    }
+
+    @Parameterized.Parameter
+    public ModelValidationMode validationMode;
+
+    @Parameterized.Parameter (value = 1)
+    public String taskType;
+
+    @Test
+    public void strategy_returns_best_parameters() {
+      Scope.enter();
+      try {
+        Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
+        Scope.track(fr);
+        long seed = 1234;
+
+        String responseColumnName;
+        if (taskType.equals("classification")) {
+          responseColumnName = "survived";
+          asFactor(fr, responseColumnName);
+        } else {
+          responseColumnName = "age";
+        }
+
+        Frame train = null;
+        Frame valid = null;
+        Frame leaderboard = null;
+        switch (validationMode) {
+          case CV:
+            train = fr;
+            break;
+          case VALIDATION_FRAME:
+            Frame[] splits = AutoMLBenchmarkHelper.getRandomSplitsFromDataframe(fr, new double[]{0.7, 0.15, 0.15}, 2345L);
+            train = splits[0];
+            valid = splits[1];
+            leaderboard = splits[2];
+            Scope.track(train, valid, leaderboard);
+        }
+
+        TEApplicationStrategy strategy = new ThresholdTEApplicationStrategy(fr, 4, new String[]{"survived"});
+        String[] columnsToEncode = strategy.getColumnsToEncode();
+
+
+        AutoMLBuildSpec.AutoMLTEControl teBuildSpec = new AutoMLBuildSpec.AutoMLTEControl();
+        teBuildSpec.seed = seed;
+        teBuildSpec.max_models = 0;
+
+
+        ModelBuilder mb = null;
+        switch (validationMode) {
+          case CV:
+            mb = TargetEncodingTestFixtures.modelBuilderGBMWithCVFixture(train, responseColumnName, seed);
+            break;
+          case VALIDATION_FRAME:
+            mb = TargetEncodingTestFixtures.modelBuilderGBMWithValidFrameFixture(train, valid, responseColumnName, seed);
+        }
+        mb.init(false);
+
+        ModelParametersEvaluator<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters> evaluator = new DummyEvaluator();
+
+
+        GridSearchModelParametersSelectionStrategy gridSearchTEParamsSelectionStrategy =
+                new GridSearchModelParametersSelectionStrategy(mb, teBuildSpec, leaderboard, columnsToEncode, validationMode, evaluator);
+
+        ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> bestParamsWithEvaluation =
+                gridSearchTEParamsSelectionStrategy.getBestParamsWithEvaluation();
+
+        PriorityQueue<ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel>> evaluatedModelParameters = gridSearchTEParamsSelectionStrategy.getEvaluatedModelParameters();
+        evaluatedModelParameters.poll();
+
+        assertTrue("Best score should be less or equal than all the other scores", evaluatedModelParameters
+                .stream()
+                .allMatch(mp -> mp.getScore() >= bestParamsWithEvaluation.getScore())
+        );
+      } finally {
+        Scope.exit();
+      }
+    }
+  }
+
+
+  @RunWith(Parameterized.class)
+  public static class GridSearchModelParametersSelectionStrategyParametrizedTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Parameterized.Parameters(name = "Validation mode = {0}")
+    public static Object[] validationMode() {
+      return new ModelValidationMode[]{
+              CV/*, ModelValidationMode.VALIDATION_FRAME*/
+      };
+    }
+
+    @Parameterized.Parameter
+    public ModelValidationMode validationMode;
+
+    @Test
+    public void hyper_space_depends_on_validation_mode() {
+      Scope.enter();
+      try {
+        Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
+        Scope.track(fr);
+        long seed = 1234;
+
+        String responseColumnName = "survived";
+
+        asFactor(fr, responseColumnName);
+        Frame train = null;
+        Frame valid = null;
+        Frame leaderboard = null;
+        switch (validationMode) {
+          case CV:
+            train = fr;
+            break;
+          case VALIDATION_FRAME:
+            Frame[] splits = AutoMLBenchmarkHelper.getRandomSplitsFromDataframe(fr, new double[]{0.7, 0.15, 0.15}, 2345L);
+            train = splits[0];
+            valid = splits[1];
+            leaderboard = splits[2];
+            Scope.track(train, valid, leaderboard);
+        }
+
+        TEApplicationStrategy strategy = new ThresholdTEApplicationStrategy(fr, 4, new String[]{"survived"});
+        String[] columnsToEncode = strategy.getColumnsToEncode();
+
+
+        AutoMLBuildSpec.AutoMLTEControl teBuildSpec = new AutoMLBuildSpec.AutoMLTEControl();
+        teBuildSpec.seed = seed;
+        teBuildSpec.max_models = 0;
+
+
+        ModelBuilder mb = null;
+        switch (validationMode) {
+          case CV:
+            mb = TargetEncodingTestFixtures.modelBuilderGBMWithCVFixture(train, responseColumnName, seed);
+            break;
+          case VALIDATION_FRAME:
+            mb = TargetEncodingTestFixtures.modelBuilderGBMWithValidFrameFixture(train, valid, responseColumnName, seed);
+        }
+        mb.init(false);
+
+        ModelParametersEvaluator<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters> evaluator = new DummyEvaluator();
+
+
+        GridSearchModelParametersSelectionStrategy gridSearchTEParamsSelectionStrategy =
+                new GridSearchModelParametersSelectionStrategy(mb, teBuildSpec, leaderboard, columnsToEncode, validationMode, evaluator);
+
+        gridSearchTEParamsSelectionStrategy.getBestParamsWithEvaluation();
+
+        if(validationMode == CV) {
+          int sizeOfEmbeddedTEHyperSpaceForCV = 63;
+          assertEquals(sizeOfEmbeddedTEHyperSpaceForCV, gridSearchTEParamsSelectionStrategy.getEvaluatedModelParameters().size());
+        }
+        else {
+          int sizeOfEmbeddedTEHyperSpaceForValidation = 63 * 3;
+          assertEquals(sizeOfEmbeddedTEHyperSpaceForValidation, gridSearchTEParamsSelectionStrategy.getEvaluatedModelParameters().size());
+        }
+
+      } finally {
+        Scope.exit();
+      }
+    }
+
+    @Test
+    public void max_models_is_being_respected() {
+      Scope.enter();
+      GridSearchModelParametersSelectionStrategy modelSelectionStrategy = null;
+      try {
+        Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
+        Scope.track(fr);
+        long seed = 1234;
+
+        String responseColumnName = "survived";
+
+        asFactor(fr, responseColumnName);
+        Frame train = null;
+        Frame valid = null;
+        Frame leaderboard = null;
+        switch (validationMode) {
+          case CV:
+            train = fr;
+            break;
+          case VALIDATION_FRAME:
+            Frame[] splits = AutoMLBenchmarkHelper.getRandomSplitsFromDataframe(fr, new double[]{0.7, 0.15, 0.15}, 2345L);
+            train = splits[0];
+            valid = splits[1];
+            leaderboard = splits[2];
+            Scope.track(train, valid, leaderboard);
+        }
+
+        TEApplicationStrategy strategy = new ThresholdTEApplicationStrategy(fr, 4, new String[]{"survived"});
+        String[] columnsToEncode = strategy.getColumnsToEncode();
+
+
+        AutoMLBuildSpec.AutoMLTEControl teBuildSpec = new AutoMLBuildSpec.AutoMLTEControl();
+        teBuildSpec.seed = seed;
+        teBuildSpec.max_models = 2;
+
+        ModelBuilder mb = null;
+        switch (validationMode) {
+          case CV:
+            mb = TargetEncodingTestFixtures.modelBuilderGBMWithCVFixture(train, responseColumnName, seed);
+            break;
+          case VALIDATION_FRAME:
+            mb = TargetEncodingTestFixtures.modelBuilderGBMWithValidFrameFixture(train, valid, responseColumnName, seed);
+        }
+        mb.init(false);
+
+        TargetEncodingHyperparamsEvaluator evaluator = new TargetEncodingHyperparamsEvaluator();
+        modelSelectionStrategy = new GridSearchModelParametersSelectionStrategy(mb, teBuildSpec, leaderboard, columnsToEncode, validationMode, evaluator);
+
+        ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> bestEvaluated = modelSelectionStrategy.getBestParamsWithEvaluation();
+        Scope.track_generic(bestEvaluated.getModel());
+
+        assertEquals(teBuildSpec.max_models, modelSelectionStrategy.getEvaluatedModelParameters().size());
+
+      } finally {
+        if(modelSelectionStrategy != null)
+          modelSelectionStrategy.removeAllButBest();
+        Scope.exit();
+      }
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class ModelsCleanupTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Parameterized.Parameters(name = "Beneficial search = {0}")
+    public static Object[] validationMode() {
+      return new Boolean[]{
+              true, false
+      };
+    }
+
+    @Parameterized.Parameter
+    public Boolean beneficialSearch;
+
+    @Test
+    public void evaluated_during_search_models_are_being_removed_properly() {
+      Scope.enter();
+      GridSearchModelParametersSelectionStrategy modelSelectionStrategy = null;
+      try {
+        Frame train = parse_test_file("./smalldata/gbm_test/titanic.csv");
+        Scope.track(train);
+        long seed = 1234;
+
+        String responseColumnName = "survived";
+
+        asFactor(train, responseColumnName);
+        Frame leaderboard = null;
+
+        TEApplicationStrategy strategy = new ThresholdTEApplicationStrategy(train, 4, new String[]{"survived"});
+        String[] columnsToEncode = strategy.getColumnsToEncode();
+
+        AutoMLBuildSpec.AutoMLTEControl teBuildSpec = new AutoMLBuildSpec.AutoMLTEControl();
+        teBuildSpec.seed = seed;
+        teBuildSpec.max_models = 2;
+
+        ModelBuilder mb = TargetEncodingTestFixtures.modelBuilderGBMWithCVFixture(train, responseColumnName, seed);
+        mb.init(false);
+
+        TargetEncodingHyperparamsEvaluator evaluator = new TargetEncodingHyperparamsEvaluator();
+        modelSelectionStrategy = new GridSearchModelParametersSelectionStrategy(mb, teBuildSpec, leaderboard, columnsToEncode, CV, evaluator);
+
+        ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> bestEvaluated = modelSelectionStrategy.getBestParamsWithEvaluation();
+        if(beneficialSearch) {
+          modelSelectionStrategy.removeAllButBest();
+          assertNotNull(DKV.get(bestEvaluated.getModel()._key));
+          Scope.track_generic(bestEvaluated.getModel());
+        } else {
+          // verifying by the fact that test does not leak keys
+          modelSelectionStrategy.removeAll();
+        }
+
+        assertEquals(0, modelSelectionStrategy.getEvaluatedModelParameters().size());
+
+      } finally {
+        Scope.exit();
+      }
+    }
+  }
+
+
+    private static class DummyEvaluator extends ModelParametersEvaluator<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters> {
+
+    @Override
+    public ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> evaluate(TargetEncoderModel.TargetEncoderParameters modelParameters, ModelBuilder modelBuilder, ModelValidationMode modelValidationMode, Frame leaderboard, String[] columnNamesToEncode, long seedForFoldColumn) {
+      return new ModelParametersSelectionStrategy.Evaluated<>(null, new Random().nextDouble());
+    }
+  }
+
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TEIntegrationWithAutoMLCVBenchmark.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TEIntegrationWithAutoMLCVBenchmark.java
@@ -1,0 +1,191 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.Algo;
+import ai.h2o.automl.AutoML;
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.leaderboard.Leaderboard;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.ThresholdTEApplicationStrategy;
+import hex.Model;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import water.*;
+import water.fvec.Frame;
+
+import java.util.Random;
+
+import static ai.h2o.automl.targetencoder.AutoMLBenchmarkHelper.getCumulativeAUCScore;
+import static ai.h2o.automl.targetencoder.AutoMLBenchmarkHelper.getPreparedTitanicFrame;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * We want to test here the cases when in AutoML we use CV for Early Stopping
+ */
+@Ignore
+public class TEIntegrationWithAutoMLCVBenchmark extends water.TestUtil {
+
+  @BeforeClass
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  long autoMLSeed = 3456;
+
+  int numberOfTopModelsToCompareWith = 1;
+  //  Algo[] excludeAlgos = {Algo.DeepLearning, /*Algo.DRF,*/ Algo.GLM /*Algo.XGBoost*/ /* Algo.GBM,*/, Algo.StackedEnsemble};
+//  Algo[] excludeAlgos = {/*Algo.DeepLearning,*/ Algo.DRF, Algo.GLM, Algo.XGBoost, Algo.GBM, Algo.StackedEnsemble}; // ONly DeepLearning
+//  Algo[] excludeAlgos = {Algo.DeepLearning,Algo.DRF, Algo.GLM, /*Algo.XGBoost,*/ Algo.GBM, Algo.StackedEnsemble}; // only XGBoost
+  Algo[] excludeAlgos = {Algo.DeepLearning,Algo.DRF, Algo.GLM, Algo.XGBoost/*, Algo.GBM*/, Algo.StackedEnsemble}; //ONly GBM
+//  Algo[] excludeAlgos = {Algo.DeepLearning,/*Algo.DRF,*/ Algo.GLM, Algo.XGBoost, Algo.GBM, Algo.StackedEnsemble}; //Only DRF  lower performance
+//  Algo[] excludeAlgos = {Algo.DeepLearning,Algo.DRF, /*Algo.GLM,*/ Algo.XGBoost, Algo.GBM, Algo.StackedEnsemble}; //Only GLM  lower performance: WARN: Test/Validation dataset is missing column 'cabin_te': substituting in a column of NaN
+
+  @Test
+  public void with_TE_vs_without_TE() {
+    AutoML aml = null;
+    AutoML amlWithoutTE = null;
+    Frame fr = null;
+    Frame frForWithoutTE = null;
+
+    String responseColumnName = "survived";
+    Random generator = new Random(autoMLSeed);
+    double avgAUCWith = 0.0;
+    double avgAUCWithoutTE = 0.0;
+
+    double avgCumulativeAUCWith = 0.0;
+    double avgCumulativeWithoutTE = 0.0;
+
+    double averageTimeWithTE = 0;
+    double averageTimeWithoutTE = 0;
+
+    int numberOfRuns = 5;
+    for (int seedAttempt = 0; seedAttempt < numberOfRuns; seedAttempt++) {
+      long splitSeed = generator.nextLong();
+      try {
+        AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+
+        fr = getPreparedTitanicFrame(responseColumnName);
+
+        autoMLBuildSpec.input_spec.training_frame = fr._key;
+        autoMLBuildSpec.build_control.nfolds = 5;
+        autoMLBuildSpec.input_spec.response_column = responseColumnName;
+        autoMLBuildSpec.build_models.exclude_algos = excludeAlgos;
+
+        TEApplicationStrategy thresholdTEApplicationStrategy = new ThresholdTEApplicationStrategy(fr,5, new String[]{responseColumnName});
+
+        autoMLBuildSpec.te_spec.seed = splitSeed;
+
+        autoMLBuildSpec.te_spec.application_strategy = thresholdTEApplicationStrategy;
+        autoMLBuildSpec.te_spec.max_models = 10;
+
+        autoMLBuildSpec.build_control.project_name = "with_te_" + splitSeed;
+        autoMLBuildSpec.build_control.stopping_criteria.set_max_models(numberOfTopModelsToCompareWith);
+        autoMLBuildSpec.build_control.stopping_criteria.set_seed(splitSeed);
+        autoMLBuildSpec.build_control.keep_cross_validation_models = true;
+        autoMLBuildSpec.build_control.keep_cross_validation_predictions = true;
+
+        long start1 = System.currentTimeMillis();
+        aml = AutoML.startAutoML(autoMLBuildSpec);
+        aml.get();
+        long timeWithTE = System.currentTimeMillis() - start1;
+
+        Leaderboard leaderboardWithTE = aml.leaderboard();
+        assertTrue(leaderboardWithTE.getModels().length == numberOfTopModelsToCompareWith);
+        double cumulativeLeaderboardScoreWithTE = 0;
+        cumulativeLeaderboardScoreWithTE = getCumulativeAUCScore(leaderboardWithTE);
+
+        double aucWithTE = leaderboardWithTE.getLeader().auc();
+
+        frForWithoutTE = fr.deepCopy(Key.make().toString());
+        DKV.put(frForWithoutTE);
+        long start2 = System.currentTimeMillis();
+        amlWithoutTE = train_AutoML_withoutTE_with_auto_assigned_folds(frForWithoutTE, responseColumnName, splitSeed);
+        long timeWithoutTE = System.currentTimeMillis() - start2;
+
+        double cumulativeLeaderboardScoreWithoutTE = 0;
+        cumulativeLeaderboardScoreWithoutTE = getCumulativeAUCScore(amlWithoutTE.leaderboard());
+
+        Model leaderFromWithoutTE = amlWithoutTE.leader();
+        double aucWithoutTE = leaderFromWithoutTE.auc();
+
+        System.out.println("Performance on leaderboardFrame frame with TE ( attempt " + seedAttempt + ") : AUC = " + aucWithTE);
+        System.out.println("Performance on leaderboardFrame frame without TE ( attempt " + seedAttempt + ") : AUC = " + aucWithoutTE);
+
+        avgAUCWith += aucWithTE;
+        avgAUCWithoutTE += aucWithoutTE;
+
+        avgCumulativeAUCWith += cumulativeLeaderboardScoreWithTE;
+        avgCumulativeWithoutTE += cumulativeLeaderboardScoreWithoutTE;
+
+        averageTimeWithTE += timeWithTE;
+        averageTimeWithoutTE += timeWithoutTE;
+
+      } finally {
+        if (fr != null) fr.delete();
+        if (aml != null) {
+          for (Model model : aml.leaderboard().getModels()) {
+            model.deleteCrossValidationPreds();
+            model.deleteCrossValidationModels();
+          }
+          aml.leaderboard().remove();
+          aml.delete();
+        }
+
+        if (amlWithoutTE != null) {
+          for (Model model : amlWithoutTE.leaderboard().getModels()) {
+            model.deleteCrossValidationPreds();
+            model.deleteCrossValidationModels();
+          }
+          amlWithoutTE.leaderboard().remove();
+          amlWithoutTE.delete();
+        }
+
+        if (frForWithoutTE != null) frForWithoutTE.delete();
+      }
+    }
+
+    avgAUCWith = avgAUCWith / numberOfRuns;
+    avgAUCWithoutTE = avgAUCWithoutTE / numberOfRuns;
+
+    averageTimeWithTE = averageTimeWithTE / numberOfRuns;
+    averageTimeWithoutTE = averageTimeWithoutTE / numberOfRuns;
+
+    System.out.println("Average AUC by leader with encoding:" + avgAUCWith);
+    System.out.println("Average AUC by leader without encoding:" + avgAUCWithoutTE);
+
+    avgCumulativeAUCWith = avgCumulativeAUCWith / numberOfRuns;
+    avgCumulativeWithoutTE = avgCumulativeWithoutTE / numberOfRuns;
+    System.out.println("Average cumulative AUC with encoding: " + avgCumulativeAUCWith);
+    System.out.println("Average cumulative AUC without encoding: " + avgCumulativeWithoutTE);
+
+    System.out.println("Average time with target encoding: " + averageTimeWithTE);
+    System.out.println("Average time without target encoding: " + averageTimeWithoutTE);
+
+    Assert.assertTrue(avgAUCWith > avgAUCWithoutTE);
+  }
+
+  private AutoML train_AutoML_withoutTE_with_auto_assigned_folds(Frame train, String responseColumnName, long seed) {
+    AutoML aml = null;
+    AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+
+    autoMLBuildSpec.input_spec.training_frame = train._key;
+    autoMLBuildSpec.build_control.nfolds = 5;
+    autoMLBuildSpec.input_spec.response_column = responseColumnName;
+    autoMLBuildSpec.build_models.exclude_algos = excludeAlgos;
+
+
+    autoMLBuildSpec.te_spec.enabled = false;
+
+    autoMLBuildSpec.build_control.project_name = "without_te" + seed;
+    autoMLBuildSpec.build_control.stopping_criteria.set_max_models(numberOfTopModelsToCompareWith);
+    autoMLBuildSpec.build_control.stopping_criteria.set_seed(seed);
+    autoMLBuildSpec.build_control.keep_cross_validation_models = true;
+    autoMLBuildSpec.build_control.keep_cross_validation_predictions = true;
+
+    aml = AutoML.startAutoML(autoMLBuildSpec);
+    aml.get();
+    return aml;
+  }
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TEIntegrationWithAutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TEIntegrationWithAutoMLTest.java
@@ -1,0 +1,251 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.Algo;
+import ai.h2o.automl.AutoML;
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.StepDefinition;
+import ai.h2o.targetencoding.strategy.AllCategoricalTEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.ThresholdTEApplicationStrategy;
+import hex.Model;
+import hex.ScoreKeeper;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import water.DKV;
+import water.Key;
+import water.Scope;
+import water.fvec.Frame;
+import water.fvec.TestFrameBuilder;
+import water.fvec.Vec;
+
+import static ai.h2o.targetencoding.TargetEncoderFrameHelper.addKFoldColumn;
+import static org.junit.Assert.assertTrue;
+
+// This test suite also checks how we apply preprocessing at ModellingStep and then revert all the changes in the data afterwards
+public class TEIntegrationWithAutoMLTest extends water.TestUtil {
+
+  @BeforeClass public static void setup() { stall_till_cloudsize(1); }
+
+
+  public static Frame getPreparedTitanicFrame(String responseColumnName) {
+    Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
+    fr.remove("name").remove();
+    fr.remove("ticket").remove();
+    fr.remove("boat").remove();
+    fr.remove("body").remove();
+    asFactor(fr, responseColumnName);
+    return fr;
+  }
+
+  @Test public void testWhenGridSizeIsOne() {
+    //TODO
+  }
+
+
+  @Test public void TEIsNotBeingAppliedIfWeDontHaveCategoricalColumns() {
+    AutoML aml=null;
+    Frame fr=null;
+    Model leader = null;
+    Frame originalCopyOfTrainingFrame = null;
+    try {
+      AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+      fr = parse_test_file("./smalldata/logreg/prostate_train.csv");
+      originalCopyOfTrainingFrame = fr.deepCopy(Key.make().toString());
+      DKV.put(originalCopyOfTrainingFrame);
+      autoMLBuildSpec.input_spec.training_frame = fr._key;
+      autoMLBuildSpec.input_spec.response_column = "CAPSULE";
+
+      autoMLBuildSpec.build_control.stopping_criteria.set_max_models(1);
+      autoMLBuildSpec.build_control.keep_cross_validation_models = false;
+      autoMLBuildSpec.build_control.keep_cross_validation_predictions = false;
+
+      TEApplicationStrategy teApplicationStrategy = new AllCategoricalTEApplicationStrategy(fr, new String[]{autoMLBuildSpec.input_spec.response_column});
+      autoMLBuildSpec.te_spec.application_strategy = teApplicationStrategy;
+
+      aml = AutoML.startAutoML(autoMLBuildSpec);
+      aml.get();
+
+      leader = aml.leader();
+
+      // Expect that if we don't have categorical vectors in training frame then we will return it unchanged
+      assertBitIdentical(aml.getTrainingFrame(), originalCopyOfTrainingFrame);
+
+    } finally {
+      // Cleanup
+      if(leader!=null) leader.delete();
+      if(aml!=null) aml.delete();
+      if(fr != null) fr.delete();
+      if(originalCopyOfTrainingFrame != null) originalCopyOfTrainingFrame.delete();
+    }
+  }
+
+  @Test
+  public void automaticTE_is_being_applied_with_cv_automl_case() {
+    AutoML aml=null;
+    AutoML amlWithoutTE=null;
+    Scope.enter();
+    Model leader = null;
+    Model leaderWithoutTE = null;
+    String foldColumnName = "fold";
+
+    int seed = 3456;
+
+    try {
+      AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+
+      String responseColumnName = "survived";
+      Frame fr = getPreparedTitanicFrame(responseColumnName);
+      Scope.track(fr);
+
+      int nfolds = 5;
+      addKFoldColumn(fr, foldColumnName, nfolds, seed);
+
+      autoMLBuildSpec.input_spec.training_frame = fr._key;
+      autoMLBuildSpec.input_spec.fold_column = foldColumnName;
+      autoMLBuildSpec.input_spec.response_column = responseColumnName;
+
+      autoMLBuildSpec.te_spec.application_strategy = new AllCategoricalTEApplicationStrategy(fr, new String[]{responseColumnName});
+      autoMLBuildSpec.te_spec.max_models = 2;
+      autoMLBuildSpec.te_spec.seed = 2345;
+
+      autoMLBuildSpec.build_control.project_name = "withTE";
+      autoMLBuildSpec.build_control.stopping_criteria.set_max_models(1);
+      autoMLBuildSpec.build_control.stopping_criteria.set_stopping_metric(ScoreKeeper.StoppingMetric.AUC);
+      autoMLBuildSpec.build_control.stopping_criteria.set_seed(seed);
+      autoMLBuildSpec.build_control.keep_cross_validation_models = true;
+      autoMLBuildSpec.build_control.keep_cross_validation_predictions = true;
+      autoMLBuildSpec.build_models.modeling_plan = new StepDefinition[] {
+              new StepDefinition(Algo.GBM.name(), new String[]{ "def_1" })
+      };
+
+      aml = AutoML.startAutoML(autoMLBuildSpec);
+      aml.get();
+
+      leader = aml.leader();
+
+      Frame trainingFrame = aml.getTrainingFrame();
+      Scope.track(trainingFrame);
+
+      //Check that trainingFrame was not affected by TE data preprocessing
+      String[] encodedColumns = {"sex_te", "cabin_te", "home.dest_te", "embarked_te"};
+      assertIdenticalUpToRelTolerance(fr, trainingFrame, 0, true, "Two frames should be identical.");
+
+      //Check that we can score on non-encoded frames and retrieve corresponding metrics
+      leader.score(fr).delete();
+      hex.ModelMetricsBinomial mmb = hex.ModelMetricsBinomial.getFromDKV(leader, fr);
+
+      // Compare with another automl that was trained without enabled TE
+      autoMLBuildSpec.build_control.project_name = "withoutTE";
+      autoMLBuildSpec.te_spec.enabled = false;
+      amlWithoutTE = AutoML.startAutoML(autoMLBuildSpec);
+      amlWithoutTE.get();
+
+      leaderWithoutTE = amlWithoutTE.leader();
+
+      assertTrue(leader.auc() > leaderWithoutTE.auc());
+
+    } finally {
+      if(leader!=null) leader.delete();
+      if(aml!=null) aml.delete();
+      if(leaderWithoutTE!=null) leaderWithoutTE.delete();
+      if(amlWithoutTE!=null) amlWithoutTE.delete();
+    }
+  }
+
+  @Test // test does not leak keys. Is it expected?
+  public void scopeUntrack() {
+    Scope.enter();
+    Frame fr = null;
+    try{
+      fr = parse_test_file("./smalldata/logreg/prostate_train.csv");
+      Scope.track(fr);
+      Scope.untrack(fr.keys());
+    } finally {
+//      Scope.exit(fr._key);
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void we_can_score_with_model_from_the_leadearboard() {
+    AutoML aml=null;
+    AutoML amlWithoutTE=null;
+    Frame fr=null;
+    Model leader = null;
+    Frame validationFrame = null;
+    Frame copyOfValidFrame = null;
+    Frame leaderboardFrame = null;
+    String teColumnName = "ColA";
+    String responseColumnName = "ColC";
+    try {
+      AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+
+      String columnThatIsSupposedToBeEncoded = "ColB";
+      fr = new TestFrameBuilder()
+              .withName("trainingFrame")
+              .withColNames(teColumnName, columnThatIsSupposedToBeEncoded, responseColumnName)
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "b", "b", "a", "a", "b", "a"))
+              .withDataForCol(1, ar("yellow", "blue", "green", "red", "purple", "orange", "purple", "orange"))
+              .withDataForCol(2, ar("2", "6", "6", "6", "6", "2", "6", "2"))
+              .build();
+
+      validationFrame = new TestFrameBuilder()
+              .withName("validationFrame")
+              .withColNames(teColumnName, columnThatIsSupposedToBeEncoded, responseColumnName)
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "b", "b", "a", "a"))
+              .withDataForCol(1, ar("yellow", "blue", "green", "red", "purple", "orange"))
+              .withDataForCol(2, ar("2", "6", "6", "6", "6", "2"))
+              .build();
+      copyOfValidFrame = validationFrame.deepCopy(Key.make().toString());
+      DKV.put(copyOfValidFrame);
+
+      autoMLBuildSpec.input_spec.training_frame = fr._key;
+      autoMLBuildSpec.input_spec.validation_frame = validationFrame._key;
+      autoMLBuildSpec.input_spec.response_column = responseColumnName;
+
+      autoMLBuildSpec.te_spec.application_strategy = new ThresholdTEApplicationStrategy(fr, 5, new String[]{responseColumnName});
+      autoMLBuildSpec.te_spec.max_models = 6;
+//      autoMLBuildSpec.te_spec.seed = 1234; // None
+      autoMLBuildSpec.te_spec.seed = 2345;
+
+      autoMLBuildSpec.build_control.project_name = "with_te";
+      autoMLBuildSpec.build_control.nfolds = 0;   // For validation frame to be used we need to satisfy nfolds == 0.
+
+      autoMLBuildSpec.build_control.stopping_criteria.set_max_models(1);
+      autoMLBuildSpec.build_control.keep_cross_validation_models = false;
+      autoMLBuildSpec.build_control.keep_cross_validation_predictions = false;
+
+      aml = AutoML.startAutoML(autoMLBuildSpec);
+      aml.get();
+
+      leader = aml.leader();
+
+      double auc = leader.auc();
+
+      //TODO fix this test when we are able to store data preprocessing steps used during training
+
+    } finally {
+      if(aml!=null) aml.delete();
+      if(amlWithoutTE!=null) amlWithoutTE.delete();
+      if(leader!=null) leader.delete();
+      if(validationFrame != null)  validationFrame.delete();
+      if(leaderboardFrame != null)  leaderboardFrame.delete();
+      if(copyOfValidFrame != null)  copyOfValidFrame.delete();
+      if(fr != null) fr.delete();
+    }
+  }
+
+  @Test
+  public void when_none_of_TE_parameters_improved_performance_we_fallback_to_original_model() {
+    //TODO
+  }
+
+  @Test
+  public void checkThatAllModelsInTheLeaderboardGotIgnoredColumnsTest() {
+    // it is expected that we will have original columns for encodings listed in the `_ignored_columns` array.
+//    assertArrayEquals(leaderWithTE._parms._ignored_columns, teApplicationStrategy.getColumnsToEncode());
+  }
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TEIntegrationWithAutoMLValidationFrameBenchmark.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TEIntegrationWithAutoMLValidationFrameBenchmark.java
@@ -1,0 +1,226 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.Algo;
+import ai.h2o.automl.AutoML;
+import ai.h2o.automl.AutoMLBuildSpec;
+import ai.h2o.automl.leaderboard.Leaderboard;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.ThresholdTEApplicationStrategy;
+import hex.Model;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import water.DKV;
+import water.Key;
+import water.Scope;
+import water.fvec.Frame;
+import water.fvec.Vec;
+
+import java.util.Random;
+
+import static ai.h2o.automl.targetencoder.AutoMLBenchmarkHelper.*;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * We want to test here the cases when in AutoML we use Validation frame for Early Stopping
+ */
+@Ignore
+public class TEIntegrationWithAutoMLValidationFrameBenchmark extends water.TestUtil {
+
+  @BeforeClass
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  long autoMLSeed = 2345;
+
+  int numberOfModelsToCompareWith = 1;
+
+  Algo[] excludeAlgos = {/*Algo.DeepLearning,*/ Algo.DRF, Algo.GLM, Algo.XGBoost, Algo.GBM, Algo.StackedEnsemble};
+//  Algo[] excludeAlgos = {Algo.DeepLearning/*, Algo.DRF*/, Algo.GLM , Algo.XGBoost , Algo.GBM, Algo.StackedEnsemble};
+//  Algo[] excludeAlgos = {Algo.DeepLearning, /*Algo.DRF,*/ Algo.GLM /*Algo.XGBoost*/ /* Algo.GBM,*/, Algo.StackedEnsemble};
+
+
+  @Test
+  public void random_tvl_split_with_RGS_vs_random_tvl_split_withoutTE_benchmark_with_leaderboard_evaluation() {
+    AutoML aml = null;
+    AutoML amlWithoutTE = null;
+    Frame fr = null;
+    Leaderboard leaderboardWithTE = null;
+    Leaderboard leaderboardWithoutTE = null;
+    Frame[] splitsForWithoutTE = null;
+    Frame frForWithoutTE = null;
+    Model leader = null;
+
+    Frame trainSplit = null;
+    Frame validSplit = null;
+    Frame leaderboardSplit = null;
+
+    String responseColumnName = "survived";
+    Random generator = new Random();
+    double avgAUCWith = 0.0;
+    double avgAUCWithoutTE = 0.0;
+
+    double avgCumulativeAUCWith = 0.0;
+    double avgCumulativeWithoutTE = 0.0;
+
+    double averageTimeWithTE = 0;
+    double averageTimeWithoutTE = 0;
+
+    int numberOfRuns = 5;
+    for (int seedAttempt = 0; seedAttempt < numberOfRuns; seedAttempt++) {
+      long splitSeed = generator.nextLong();  // Note: DL's predictions are not stable so we can get different bestHPs from selection strategy even when we pass same seeds everywhere.
+      try {
+        AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+
+        fr = getPreparedTitanicFrame(responseColumnName);
+        Frame[] splits = AutoMLBenchmarkHelper.getRandomSplitsFromDataframe(fr, new double[]{0.7, 0.15, 0.15}, splitSeed);
+        trainSplit = splits[0];
+        validSplit = splits[1];
+        leaderboardSplit = splits[2];
+
+        autoMLBuildSpec.input_spec.training_frame = trainSplit._key;
+        autoMLBuildSpec.input_spec.validation_frame = validSplit._key;
+        autoMLBuildSpec.input_spec.leaderboard_frame = leaderboardSplit._key;
+        autoMLBuildSpec.build_control.nfolds = 0;
+        autoMLBuildSpec.input_spec.response_column = responseColumnName;
+
+        autoMLBuildSpec.build_models.exclude_algos = excludeAlgos;
+
+        TEApplicationStrategy thresholdTEApplicationStrategy = new ThresholdTEApplicationStrategy(trainSplit, 5, new String[]{responseColumnName});
+
+        autoMLBuildSpec.te_spec.seed = splitSeed;
+        autoMLBuildSpec.te_spec.enabled = true;
+
+        autoMLBuildSpec.te_spec.application_strategy = thresholdTEApplicationStrategy;
+
+        autoMLBuildSpec.build_control.project_name = "with_te_" + splitSeed;
+        autoMLBuildSpec.build_control.stopping_criteria.set_max_models(numberOfModelsToCompareWith);
+        autoMLBuildSpec.build_control.stopping_criteria.set_seed(autoMLSeed);
+        autoMLBuildSpec.build_control.keep_cross_validation_models = false;
+        autoMLBuildSpec.build_control.keep_cross_validation_predictions = false;
+
+        autoMLBuildSpec.build_control.stopping_criteria.set_seed(splitSeed);
+
+        long start1 = System.currentTimeMillis();
+        aml = AutoML.startAutoML(autoMLBuildSpec);
+        aml.get();
+        long timeWithTE = System.currentTimeMillis() - start1;
+
+        leader = aml.leader();
+        assertTrue(leader._output._cross_validation_predictions == null);
+
+        leaderboardWithTE = aml.leaderboard();
+
+        assertTrue(leaderboardWithTE.getModels().length == numberOfModelsToCompareWith);
+        double cumulativeLeaderboardScoreWithTE = 0;
+        cumulativeLeaderboardScoreWithTE = getCumulativeLeaderboardScore(leaderboardSplit, leaderboardWithTE);
+
+        double aucWithTE = getScoreBasedOn(leaderboardSplit, leader);
+
+        frForWithoutTE = fr.deepCopy(Key.make().toString());
+        DKV.put(frForWithoutTE);
+        splitsForWithoutTE = AutoMLBenchmarkHelper.getRandomSplitsFromDataframe(frForWithoutTE, new double[]{0.7, 0.15, 0.15}, splitSeed);
+        long start2 = System.currentTimeMillis();
+        amlWithoutTE = trainBaselineAutoMLWithoutTE(splitsForWithoutTE, responseColumnName, splitSeed);
+        leaderboardWithoutTE = amlWithoutTE.leaderboard();
+        long timeWithoutTE = System.currentTimeMillis() - start2;
+
+        double cumulativeLeaderboardScoreWithoutTE = 0;
+        cumulativeLeaderboardScoreWithoutTE = getCumulativeLeaderboardScore(leaderboardSplit, leaderboardWithoutTE);
+
+        Model leaderFromWithoutTE = leaderboardWithoutTE.getLeader();
+        double aucWithoutTE = getScoreBasedOn(leaderboardSplit, leaderFromWithoutTE);
+
+        System.out.println("Performance on leaderboardFrame frame with TE ( attempt " + seedAttempt + ") : AUC = " + aucWithTE);
+        System.out.println("Performance on leaderboardFrame frame without TE ( attempt " + seedAttempt + ") : AUC = " + aucWithoutTE);
+
+        avgAUCWith += aucWithTE;
+        avgAUCWithoutTE += aucWithoutTE;
+
+        avgCumulativeAUCWith += cumulativeLeaderboardScoreWithTE;
+        avgCumulativeWithoutTE += cumulativeLeaderboardScoreWithoutTE;
+
+        averageTimeWithTE += timeWithTE;
+        averageTimeWithoutTE += timeWithoutTE;
+
+      } finally {
+        if (fr != null) fr.delete();
+        if (trainSplit != null) trainSplit.delete();
+        if (validSplit != null) validSplit.delete();
+        if (leaderboardSplit != null) leaderboardSplit.delete();
+
+
+        if (aml != null) {
+          aml.leaderboard().remove();
+          aml.delete();
+        }
+        if (leaderboardWithoutTE != null) leaderboardWithoutTE.remove();
+        if (amlWithoutTE != null) amlWithoutTE.delete();
+
+        if (frForWithoutTE != null) frForWithoutTE.delete();
+        if (splitsForWithoutTE != null) {
+          for (Frame split : splitsForWithoutTE) {
+            split.delete();
+          }
+        }
+      }
+    }
+
+    avgAUCWith = avgAUCWith / numberOfRuns;
+    avgAUCWithoutTE = avgAUCWithoutTE / numberOfRuns;
+
+    averageTimeWithTE = averageTimeWithTE / numberOfRuns;
+    averageTimeWithoutTE = averageTimeWithoutTE / numberOfRuns;
+
+    System.out.println("Average AUC by leader with encoding:" + avgAUCWith);
+    System.out.println("Average AUC by leader without encoding:" + avgAUCWithoutTE);
+
+    avgCumulativeAUCWith = avgCumulativeAUCWith / numberOfRuns;
+    avgCumulativeWithoutTE = avgCumulativeWithoutTE / numberOfRuns;
+    System.out.println("Average cumulative AUC with encoding: " + avgCumulativeAUCWith);
+    System.out.println("Average cumulative AUC without encoding: " + avgCumulativeWithoutTE);
+
+    System.out.println("Average time with target encoding: " + averageTimeWithTE);
+    System.out.println("Average time without target encoding: " + averageTimeWithoutTE);
+
+    Assert.assertTrue(avgAUCWith > avgAUCWithoutTE);
+  }
+
+  @Test
+  public void random_split_benchmark_with_holdout_evaluation() {
+    // We can't do holdout testing for TE as we don't have encoding map to apply it to testFrame. After Mojo task [PUBDEV-6255]  it will be possible
+  }
+
+  private AutoML trainBaselineAutoMLWithoutTE(Frame[] splits, String responseColumnName, long splitSeed) {
+    Scope.enter();
+    try {
+      AutoMLBuildSpec autoMLBuildSpec = new AutoMLBuildSpec();
+
+      autoMLBuildSpec.input_spec.training_frame = splits[0]._key;
+      autoMLBuildSpec.input_spec.validation_frame = splits[1]._key;
+      autoMLBuildSpec.input_spec.leaderboard_frame = splits[2]._key;
+      autoMLBuildSpec.build_control.nfolds = 0;
+      autoMLBuildSpec.input_spec.response_column = responseColumnName;
+
+      autoMLBuildSpec.build_models.exclude_algos = excludeAlgos;
+
+      autoMLBuildSpec.te_spec.enabled = false;
+
+      autoMLBuildSpec.build_control.project_name = "without_te_" + splitSeed;
+      autoMLBuildSpec.build_control.stopping_criteria.set_max_models(numberOfModelsToCompareWith);
+      autoMLBuildSpec.build_control.stopping_criteria.set_seed(autoMLSeed);
+      autoMLBuildSpec.build_control.keep_cross_validation_models = false;
+      autoMLBuildSpec.build_control.keep_cross_validation_predictions = false;
+
+      AutoML aml = AutoML.startAutoML(autoMLBuildSpec);
+      aml.get();
+      return aml;
+
+    } finally {
+      Scope.exit();
+    }
+  }
+
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TargetEncodingHyperparamsEvaluatorTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TargetEncodingHyperparamsEvaluatorTest.java
@@ -1,0 +1,212 @@
+package ai.h2o.automl.targetencoder;
+
+import ai.h2o.automl.targetencoder.strategy.ModelParametersSelectionStrategy;
+import ai.h2o.automl.targetencoder.strategy.ModelValidationMode;
+import ai.h2o.targetencoding.TargetEncoder;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import ai.h2o.targetencoding.strategy.AllCategoricalTEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.TEApplicationStrategy;
+import ai.h2o.targetencoding.strategy.ThresholdTEApplicationStrategy;
+import hex.Model;
+import hex.ModelBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import water.*;
+import water.fvec.Frame;
+
+import java.util.Random;
+
+import static ai.h2o.automl.targetencoder.TargetEncodingTestFixtures.modelBuilderGBMWithCVFixture;
+import static ai.h2o.automl.targetencoder.TargetEncodingTestFixtures.modelBuilderGBMWithValidFrameFixture;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TargetEncodingHyperparamsEvaluatorTest extends TestUtil {
+
+  @BeforeClass
+  public static void setup() {
+    stall_till_cloudsize(1);
+  }
+
+  @Test
+  public void evaluate_method_for_validation_case() {
+
+    ModelBuilder modelBuilder = null;
+    Scope.enter();
+    try {
+      Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
+      Scope.track(fr);
+      String responseColumnName = "survived";
+
+      asFactor(fr, responseColumnName);
+
+      Frame[] splits = AutoMLBenchmarkHelper.getRandomSplitsFromDataframe(fr, new double[]{0.7, 0.15, 0.15}, 2345);
+      Frame train = splits[0];
+      Frame valid = splits[1];
+      Frame leaderboard = splits[2];
+      Scope.track(train, valid, leaderboard);
+
+      TEApplicationStrategy strategy = new ThresholdTEApplicationStrategy(train,4, new String[]{responseColumnName});
+      String[] columnsToEncode = strategy.getColumnsToEncode();
+
+      TargetEncodingHyperparamsEvaluator evaluator = new TargetEncodingHyperparamsEvaluator();
+
+      TargetEncoderModel.TargetEncoderParameters randomTEParams = TargetEncodingTestFixtures.randomTEParams(1234);
+      long builderSeed = 3456;
+      modelBuilder = modelBuilderGBMWithValidFrameFixture(train, valid, responseColumnName, builderSeed);
+
+      modelBuilder.init(false); //verifying that we can call findBestTEParams and then modify builder in evaluator
+
+      int seedForFoldColumn = 2345;
+
+      // Copying frames outside of an evaluation
+      Frame trainCopy = train.deepCopy(Key.make("train_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(trainCopy);
+      modelBuilder.setTrain(trainCopy);
+
+      Frame validCopy = valid.deepCopy(Key.make("valid_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(validCopy);
+      modelBuilder.setValid(validCopy);
+
+      Frame leaderboardCopy = leaderboard.deepCopy(Key.make("leaderboard_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(leaderboardCopy);
+      Scope.track(trainCopy, validCopy, leaderboardCopy);
+
+      ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> auc = evaluator.evaluate(randomTEParams, modelBuilder, ModelValidationMode.VALIDATION_FRAME, leaderboardCopy, columnsToEncode, seedForFoldColumn);
+
+      ModelBuilder clonedModelBuilder = ModelBuilder.make(modelBuilder._parms);
+      clonedModelBuilder.init(false);
+
+      Frame trainCopy2 = train.deepCopy(Key.make("train_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(trainCopy2);
+      clonedModelBuilder.setTrain(trainCopy2);
+
+      Frame validCopy2 = valid.deepCopy(Key.make("valid_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(validCopy2);
+      clonedModelBuilder.setValid(validCopy2);
+
+      Frame leaderboardCopy2 = leaderboard.deepCopy(Key.make("leaderboard_frame_copy_for_mb_validation_case" + Key.make()).toString());
+      DKV.put(leaderboardCopy2);
+      Scope.track(trainCopy2, validCopy2, leaderboardCopy2);
+
+      // checking that we can clone/reuse modelBuilder
+      ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> auc2 = evaluator.evaluate(randomTEParams, clonedModelBuilder, ModelValidationMode.VALIDATION_FRAME, leaderboardCopy2, columnsToEncode, seedForFoldColumn);
+
+      assertBitIdentical(clonedModelBuilder._parms.train(), modelBuilder._parms.train());
+      assertTrue(auc.getScore() > 0);
+      assertEquals(auc.getScore(), auc2.getScore(), 1e-5);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void evaluate_method_works_with_cloned_modelBuilder_CV_case() {
+    Frame leaderboard = null;
+    ModelBuilder modelBuilder = null;
+    Scope.enter();
+    try {
+      Frame train = parse_test_file("./smalldata/gbm_test/titanic.csv");
+      Scope.track(train);
+      String responseColumnName = "survived";
+      asFactor(train, responseColumnName);
+
+      leaderboard = null;
+
+      TEApplicationStrategy strategy = new ThresholdTEApplicationStrategy(train,4, new String[]{responseColumnName});
+      String[] columnsToEncode = strategy.getColumnsToEncode();
+
+      TargetEncodingHyperparamsEvaluator evaluator = new TargetEncodingHyperparamsEvaluator();
+
+      TargetEncoderModel.TargetEncoderParameters randomTEParams = TargetEncodingTestFixtures.randomTEParams(TargetEncoder.DataLeakageHandlingStrategy.KFold, 1234);
+      long builderSeed = 3456;
+      modelBuilder = modelBuilderGBMWithCVFixture(train,responseColumnName, builderSeed);
+
+
+      modelBuilder.init(false); //verifying that we can call findBestTEParams and then modify builder in evaluator
+
+      int seedForFoldColumn = 2345;
+
+      // Model builder should contain copies of original frames and we should not care about cleanup inside evaluator
+      Frame trainCopy = train.deepCopy(Key.make("train_frame_copy_for_mb" + Key.make()).toString());
+      DKV.put(trainCopy);
+      Scope.track(trainCopy);
+      modelBuilder.setTrain(trainCopy);
+
+      ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> evaluated = evaluator.evaluate(randomTEParams, modelBuilder, ModelValidationMode.CV, leaderboard, columnsToEncode, seedForFoldColumn);
+
+      ModelBuilder clonedModelBuilder = ModelBuilder.make(modelBuilder._parms);
+      clonedModelBuilder.init(false);
+
+      Frame trainCopy2 = train.deepCopy(Key.make("train_frame_copy_for_mb_2" + Key.make()).toString());
+      DKV.put(trainCopy2);
+      Scope.track(trainCopy2);
+      clonedModelBuilder.setTrain(trainCopy2);
+
+      // checking that we can clone/reuse modelBuilder
+      ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> evaluated2 = evaluator.evaluate(randomTEParams, clonedModelBuilder, ModelValidationMode.CV, leaderboard, columnsToEncode, seedForFoldColumn);
+
+      assertBitIdentical(clonedModelBuilder._parms.train(), modelBuilder._parms.train());
+      assertTrue(evaluated.getScore() > 0);
+      assertEquals(evaluated.getScore(), evaluated2.getScore(), 1e-5);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void checkThatForAnyHyperParametersCombinationWeGetConsistentEvaluationsFromModelBuilderFixture() {
+
+    try {
+      Scope.enter();
+    //Important variable as AUC are not consistent with precision 1e-4 and less
+    double precisionForAUCEvaluations = 1e-5;
+    long builderSeed = new Random().nextLong();
+
+    TargetEncodingHyperparamsEvaluator targetEncodingHyperparamsEvaluator = new TargetEncodingHyperparamsEvaluator();
+
+    Frame fr = parse_test_file("./smalldata/gbm_test/titanic.csv");
+    String responseColumnName = "survived";
+    asFactor(fr, responseColumnName);
+    Scope.track(fr);
+    ModelBuilder modelBuilder = modelBuilderGBMWithCVFixture(fr, responseColumnName, builderSeed);
+    modelBuilder.init(false); // Should we findBestTEParams before cloning? Like in real use case we clone after initialisation of the original modelBuilder.
+
+    for (int teParamAttempt = 0; teParamAttempt < 1; teParamAttempt++) {
+      long testSeed = new Random().nextLong();
+
+      TargetEncoderModel.TargetEncoderParameters teParams = TargetEncodingTestFixtures.randomTEParams(TargetEncoder.DataLeakageHandlingStrategy.KFold, testSeed);
+
+      AllCategoricalTEApplicationStrategy allCategoricalTEApplicationStrategy = new AllCategoricalTEApplicationStrategy(fr, new String[]{responseColumnName});
+
+      double lastResult = 0.0;
+      for (int evaluationAttempt = 0; evaluationAttempt < 1; evaluationAttempt++) {
+        ModelBuilder clonedModelBuilder = ModelBuilder.make(modelBuilder._parms);
+        clonedModelBuilder.init(false);
+        ModelParametersSelectionStrategy.Evaluated<TargetEncoderModel> evaluationResult = targetEncodingHyperparamsEvaluator.evaluate(teParams,
+                clonedModelBuilder,
+                ModelValidationMode.CV,
+                null,
+                allCategoricalTEApplicationStrategy.getColumnsToEncode(),
+                testSeed);
+        double score = evaluationResult.getScore();
+
+        if(lastResult == 0.0) lastResult = score;
+        else {
+          assertEquals("evaluationAttempt #" + evaluationAttempt + " for teParamAttempt #" +
+                  teParamAttempt + " has failed. " + teParams , lastResult, score, precisionForAUCEvaluations);
+        }
+      }
+    }
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void evaluateMethodWorksWithModelBuilderAndIgnoredColumns() {
+    //TODO check case when original model builder has ignored columns
+    // how to check which columns have been used during training? through variable importance object?
+  }
+
+}

--- a/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TargetEncodingTestFixtures.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/targetencoder/TargetEncodingTestFixtures.java
@@ -1,0 +1,111 @@
+package ai.h2o.automl.targetencoder;
+
+
+import ai.h2o.automl.Algo;
+import ai.h2o.targetencoding.TargetEncoder;
+import ai.h2o.targetencoding.TargetEncoderModel;
+import hex.Model;
+import hex.ModelBuilder;
+import hex.grid.HyperSpaceSearchCriteria;
+import hex.grid.HyperSpaceWalker;
+import hex.schemas.TargetEncoderV3;
+import hex.tree.SharedTreeModel;
+import hex.tree.gbm.GBMModel;
+import water.Job;
+import water.Key;
+import water.api.GridSearchHandler;
+import water.fvec.Frame;
+
+import java.util.HashMap;
+
+public class TargetEncodingTestFixtures {
+
+  // TODO or we can instantiate grid once and just reset its iterator every time
+  private static TargetEncoderModel.TargetEncoderParameters getRandomParameters(long seed) {
+
+    HashMap<String, Object[]> hpGrid = new HashMap<>();
+    hpGrid.put("data_leakage_handling", new TargetEncoder.DataLeakageHandlingStrategy[]{TargetEncoder.DataLeakageHandlingStrategy.KFold, TargetEncoder.DataLeakageHandlingStrategy.LeaveOneOut});
+    hpGrid.put("blending", new Boolean[]{true, false});
+    hpGrid.put("noise_level", new Double[]{0.0, 0.01, 0.1});
+    hpGrid.put("k", new Double[]{1.0, 2.0, 3.0});
+    hpGrid.put("f", new Double[]{5.0, 10.0, 20.0});
+
+    TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+
+    GridSearchHandler.DefaultModelParametersBuilderFactory<TargetEncoderModel.TargetEncoderParameters, TargetEncoderV3.TargetEncoderParametersV3> modelParametersBuilderFactory = new GridSearchHandler.DefaultModelParametersBuilderFactory<>();
+
+    HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria hyperSpaceSearchCriteria = new HyperSpaceSearchCriteria.RandomDiscreteValueSearchCriteria();
+    hyperSpaceSearchCriteria.set_seed(seed);
+    hyperSpaceSearchCriteria.set_max_models(1);
+
+    HyperSpaceWalker.RandomDiscreteValueWalker<TargetEncoderModel.TargetEncoderParameters> walker = new HyperSpaceWalker.RandomDiscreteValueWalker<>(parameters, hpGrid, modelParametersBuilderFactory, hyperSpaceSearchCriteria);
+
+    HyperSpaceWalker.HyperSpaceIterator<TargetEncoderModel.TargetEncoderParameters> iterator = walker.iterator();
+    return iterator.nextModelParameters(null);
+  }
+
+  public static TargetEncoderModel.TargetEncoderParameters randomTEParams(long seed) {
+   return getRandomParameters(seed);
+  }
+
+  public static TargetEncoderModel.TargetEncoderParameters randomTEParams(TargetEncoder.DataLeakageHandlingStrategy leakageHandlingStrategy, long seed) {
+    TargetEncoderModel.TargetEncoderParameters randomParameters = getRandomParameters(seed);
+    randomParameters._data_leakage_handling = leakageHandlingStrategy;
+    return randomParameters;
+  }
+
+  public static TargetEncoderModel.TargetEncoderParameters randomTEParams() {
+    return randomTEParams(-1);
+  }
+
+  // TODO get rid of this as we can do ModelBuilder.make(params)
+  public static ModelBuilder modelBuilderGBMWithCVFixture(Frame fr, String responseColumnName, long builderSeed) {
+    Algo algo = Algo.GBM;
+    String algoUrlName = algo.name().toLowerCase();
+    String algoName = ModelBuilder.algoName(algoUrlName);
+    Key<Model> testModelKey = Key.make("testModelKey");
+
+    Job<Model> job = new Job<>(testModelKey, ModelBuilder.javaName(algoUrlName), algoName);
+    ModelBuilder builder = ModelBuilder.make(algoUrlName, job, testModelKey);
+
+    // Model Parameters
+    GBMModel.GBMParameters gbmParameters = new GBMModel.GBMParameters();
+    gbmParameters._score_tree_interval = 5;
+    gbmParameters._histogram_type = SharedTreeModel.SharedTreeParameters.HistogramType.AUTO;
+
+    builder._parms = gbmParameters;
+    builder._parms._seed = builderSeed;
+
+    builder._parms._train = fr._key;
+    builder._parms._response_column = responseColumnName;
+    builder._parms._nfolds = 5;
+    builder._parms._keep_cross_validation_models = true;
+    builder._parms._keep_cross_validation_predictions = true;
+    return builder;
+  }
+
+  public static ModelBuilder modelBuilderGBMWithValidFrameFixture(Frame train, Frame valid, String responseColumnName, long builderSeed) {
+    Algo algo = Algo.GBM;
+    String algoUrlName = algo.name().toLowerCase();
+    String algoName = ModelBuilder.algoName(algoUrlName);
+    Key<Model> testModelKey = Key.make("testModelKey_" + Key.make().toString());
+
+    Job<Model> job = new Job<>(testModelKey, ModelBuilder.javaName(algoUrlName), algoName);
+    ModelBuilder builder = ModelBuilder.make(algoUrlName, job, testModelKey);
+
+    // Model Parameters
+    GBMModel.GBMParameters gbmParameters = new GBMModel.GBMParameters();
+    gbmParameters._score_tree_interval = 5;
+    gbmParameters._histogram_type = SharedTreeModel.SharedTreeParameters.HistogramType.AUTO;
+
+    builder._parms = gbmParameters;
+    builder._parms._seed = builderSeed;
+
+    builder._parms._train = train._key;
+    if (valid != null) builder._parms._valid = valid._key;
+    builder._parms._response_column = responseColumnName;
+
+    return builder;
+  }
+
+}

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -129,7 +129,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
   public double defaultThreshold() {
     return _output.defaultThreshold();
   }
-  
+
   public void resetThreshold(double value){
     _output.resetThreshold(value);
   }
@@ -236,6 +236,10 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
 
     public void setTrain(Key<Frame> train) {
       this._train = train;
+    }
+
+    public void setValid(Key<Frame> valid) {
+      this._valid = valid;
     }
 
     public enum FoldAssignmentScheme {
@@ -709,9 +713,9 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
      *  response col categoricals for SupervisedModels.  */
     public String _domains[][];
     public String _origDomains[][]; // only set if ModelBuilder.encodeFrameCategoricals() changes the training frame
-    
+
     public double[] _orig_projection_array;// only set if ModelBuilder.encodeFrameCategoricals() changes the training frame
-    
+
     /** List of Keys to cross-validation models (non-null iff _parms._nfolds > 1 or _parms._fold_column != null) **/
     public Key _cross_validation_models[];
     /** List of Keys to cross-validation predictions (if requested) **/
@@ -945,7 +949,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       assert value > 0 && value <= 1: "Reset threshold should be value from 0 to 1 (included). Got "+value+".";
       _defaultThreshold = value;
     }
-    
+
     public void printTwoDimTables(StringBuilder sb, Object o) {
       for (Field f : Weaver.getWovenFields(o.getClass())) {
         Class<?> c = f.getType();
@@ -1565,6 +1569,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
   public Frame score(Frame fr, String destination_key, Job j, boolean computeMetrics) throws IllegalArgumentException {
     return score(fr, destination_key, j, computeMetrics, CFuncRef.NOP);
   }
+
   public Frame score(Frame fr, String destination_key, Job j, boolean computeMetrics, CFuncRef customMetricFunc) throws IllegalArgumentException {
     Frame newFr = new Frame(fr);
     Frame adaptFr = applyTEIfModelAvailable(newFr);

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -1106,7 +1106,7 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
   public void hide (String field_name, String message) { message(Log.TRACE, field_name, message); }
   public void info (String field_name, String message) { message(Log.INFO , field_name, message); }
   public void warn (String field_name, String message) { message(Log.WARN , field_name, message); }
-  public void error(String field_name, String message) { message(Log.ERRR , field_name, message); _error_count++; }
+  public void error(String field_name, String message) { message(Log.ERRR , field_name, message); _error_count++; } //TODO error is counted twice for Log.ERRR
   public void clearValidationErrors() {
     _messages = new ValidationMessage[0];
     _error_count = 0;

--- a/h2o-core/src/main/java/water/Lockable.java
+++ b/h2o-core/src/main/java/water/Lockable.java
@@ -240,7 +240,9 @@ public abstract class Lockable<T extends Lockable<T>> extends Keyed<T> {
     }
     return false;
   }
-  private boolean is_wlocked() { return _lockers!=null && _lockers.length==1; }
+  public boolean is_wlocked() {
+    return _lockers!=null && _lockers.length==1;
+  }
   private boolean is_wlocked(Key<Job> job_key) { return is_wlocked() && (_lockers[0] == job_key || (_lockers[0] != null && _lockers[0].equals(job_key))); }
   private boolean is_unlocked() { return _lockers== null; }
   private void set_write_lock( Key<Job> job_key ) { 

--- a/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
@@ -65,6 +65,9 @@ public class ModelOutputSchemaV3<O extends Model.Output, S extends ModelOutputSc
   @API(help="Cross-validation model metrics summary", direction=API.Direction.OUTPUT, level=API.Level.critical)
   public TwoDimTableV3 cross_validation_metrics_summary;
 
+  @API(help="TargetEncoderModel key", direction=API.Direction.OUTPUT, level=API.Level.critical)
+  public KeyV3.ModelKeyV3 te_model;
+
   @API(help="Job status", direction=API.Direction.OUTPUT, level=API.Level.secondary)
   public String status;
 

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoder.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoder.java
@@ -544,7 +544,7 @@ public class TargetEncoder extends Iced<TargetEncoder>{
      * @param data dataset that will be used as a base for creation of encodings .
      * @param targetColumnName name of the column with respect to which we were computing encodings.
      * @param columnToEncodingMap map of the prepared encodings with the keys being the names of the columns.
-     * @param dataLeakageHandlingStrategy see TargetEncoding.DataLeakageHandlingStrategy //TODO use common interface for stronger type safety.
+     * @param dataLeakageHandlingStrategy see TargetEncoder.DataLeakageHandlingStrategy //TODO use common interface for stronger type safety.
      * @param foldColumnName column's name that contains fold number the row is belong to.
      * @param useBlending whether to apply blending or not.
      * @param noiseLevel amount of noise to add to the final encodings.

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -13,6 +13,7 @@ import water.util.ArrayUtils;
 import water.util.IcedHashMapGeneric;
 import water.util.TwoDimTable;
 
+import java.util.Arrays;
 import java.util.Map;
 
 public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderModel.TargetEncoderParameters, TargetEncoderModel.TargetEncoderOutput> {
@@ -60,6 +61,23 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
 
     public BlendingParams getBlendingParameters() {
       return _k!=0 && _f!=0 ? new BlendingParams(_k, _f) : TargetEncoder.DEFAULT_BLENDING_PARAMS;
+    }
+
+    @Override
+    public String toString() {
+      //TODO refactor this after hyperparams filtering is merged
+//      String representation = null;
+//      if (_blending) {
+        String representation = "TE params: "
+                + "holdout_type = " + _data_leakage_handling
+                + ", blending = " + _blending
+                + ", inflection_point = " + _k
+                + ", smoothing = " + _f
+                + ", noise_level = " + _noise_level;
+//      } else {
+//        representation = "TE params(blending is disabled): holdout_type = " + _data_leakage_handling + " , noise_level = " + _noise_level;
+//      }
+      return representation;
     }
   }
 

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/ModelBuilderWithTETest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/ModelBuilderWithTETest.java
@@ -1,0 +1,288 @@
+package ai.h2o.targetencoding;
+
+import hex.Model;
+import hex.ModelBuilder;
+import hex.splitframe.ShuffleSplitFrame;
+import hex.tree.SharedTreeModel;
+import hex.tree.gbm.GBMModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import water.*;
+import water.fvec.Frame;
+
+import java.util.Arrays;
+
+import static ai.h2o.targetencoding.TargetEncoderFrameHelper.addKFoldColumn;
+import static org.junit.Assert.*;
+
+@RunWith(Enclosed.class)
+public class ModelBuilderWithTETest {
+
+  public static ModelBuilder modelBuilderGBMWithCVFixture(GBMModel.GBMParameters gbmParameters, Frame fr, String responseColumnName, long builderSeed) {
+    String algoUrlName = "gbm";
+    String algoName = ModelBuilder.algoName(algoUrlName);
+    Key<Model> testModelKey = Key.make("testModelKey");
+
+    Job<Model> job = new Job<>(testModelKey, ModelBuilder.javaName(algoUrlName), algoName);
+    ModelBuilder builder = ModelBuilder.make(algoUrlName, job, testModelKey);
+
+    // Model Parameters
+    gbmParameters._score_tree_interval = 5;
+    gbmParameters._histogram_type = SharedTreeModel.SharedTreeParameters.HistogramType.AUTO;
+
+    builder._parms = gbmParameters;
+    builder._parms._seed = builderSeed;
+
+    builder._parms._train = fr._key;
+    builder._parms._response_column = responseColumnName;
+    builder._parms._keep_cross_validation_models = true;
+    builder._parms._keep_cross_validation_predictions = true;
+    return builder;
+  }
+
+  public static class ModelBuilderWithTENonParametrizedTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Test
+    public void te_model_is_applied_correctly_when_main_model_uses_folds_weights_and_offset() {
+      try {
+        Scope.enter();
+        Frame trainingFrame = parse_test_file("./smalldata/testng/airlines_train.csv");
+        String weightsColumnName = "weights";
+        trainingFrame.add(weightsColumnName, trainingFrame.anyVec().makeCon(0.6));
+        String foldColumnName = "fold_m";
+        addKFoldColumn(trainingFrame, foldColumnName, 5, 1234L);
+        String offsetColumnName = "offset";
+        trainingFrame.add(offsetColumnName, trainingFrame.anyVec().makeCon(0.2));
+        DKV.put(trainingFrame);
+        Scope.track(trainingFrame);
+
+        Frame testFrame = parse_test_file("./smalldata/testng/airlines_test.csv");
+        testFrame.add(offsetColumnName, testFrame.anyVec().makeCon(0.2));
+        testFrame.add(weightsColumnName, testFrame.anyVec().makeCon(0.6));
+        Scope.track(testFrame);
+        DKV.put(testFrame);
+
+        TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+        parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
+        parameters._k = 0.3;
+        parameters._f = 0.7;
+        parameters._blending = true;
+        parameters._response_column = "IsDepDelayed";
+        parameters._fold_column = foldColumnName;
+        parameters._ignored_columns = ignoredColumns(trainingFrame, "Origin", foldColumnName, parameters._response_column);
+        parameters._train = trainingFrame._key;
+        parameters._seed = 0XFEED;
+
+        TargetEncoderBuilder temb = new TargetEncoderBuilder(parameters);
+        final Model targetEncoderModel = temb.trainModel().get();
+
+        GBMModel.GBMParameters gbmParameters = new GBMModel.GBMParameters();
+        gbmParameters._offset_column = offsetColumnName;
+        gbmParameters._weights_column = weightsColumnName;
+        gbmParameters._fold_column = foldColumnName;
+        gbmParameters._nfolds = 0;
+        ModelBuilder modelBuilderForMainModel = modelBuilderGBMWithCVFixture(gbmParameters,trainingFrame, parameters._response_column, parameters._seed);
+
+        modelBuilderForMainModel.addTEModelKey(targetEncoderModel._key);
+
+        Model gbmModel = (GBMModel) modelBuilderForMainModel.trainModel().get();
+        Scope.track_generic(gbmModel);
+
+        // Check that output has reference to the original model
+        assertEquals(targetEncoderModel._key, gbmModel._output._te_model_key);
+
+        Frame scoredTest = gbmModel.score(testFrame);
+        Scope.track(scoredTest);
+
+        hex.ModelMetricsBinomial mmb = hex.ModelMetricsBinomial.getFromDKV(gbmModel, testFrame);
+        assertTrue(mmb.auc() > 0);
+
+        String variableImportancesTableAsString = ((GBMModel) gbmModel)._output._variable_importances.toString(0, true);
+
+        String[] teEncodedColumns = {"Origin_te"};
+        assertTrue(Arrays.stream(teEncodedColumns).allMatch(variableImportancesTableAsString::contains));
+      } finally {
+        Scope.exit();
+      }
+    }
+
+    @Test
+    public void te_model_is_being_applied_once_added_to_main_model_builder() {
+
+      try {
+        Scope.enter();
+        Frame trainingFrame = parse_test_file("./smalldata/testng/airlines_train.csv");
+        Scope.track(trainingFrame);
+        Frame trainOriginalCopy = trainingFrame.deepCopy("original_train_copy");
+        DKV.put(trainOriginalCopy);
+        Scope.track(trainOriginalCopy);
+        Frame testFrame = parse_test_file("./smalldata/testng/airlines_test.csv");
+        Scope.track(testFrame);
+
+        TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+        parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
+        parameters._k = 0.3;
+        parameters._f = 0.7;
+        parameters._blending = true;
+        parameters._response_column = "IsDepDelayed";
+        parameters._ignored_columns = ignoredColumns(trainingFrame, "Origin", parameters._response_column);
+        parameters._train = trainingFrame._key;
+        parameters._seed = 0XFEED;
+
+
+        TargetEncoderBuilder temb = new TargetEncoderBuilder(parameters);
+        final Model targetEncoderModel = temb.trainModel().get();
+
+        GBMModel.GBMParameters gbmParameters = new GBMModel.GBMParameters();
+        gbmParameters._nfolds = 5;
+        ModelBuilder modelBuilderForMainModel = modelBuilderGBMWithCVFixture(gbmParameters, trainingFrame, parameters._response_column, parameters._seed);
+
+        modelBuilderForMainModel.addTEModelKey(targetEncoderModel._key);
+
+        Model gbmModel = (GBMModel) modelBuilderForMainModel.trainModel().get();
+
+        Frame scoredTest = gbmModel.score(testFrame);
+        Scope.track(scoredTest);
+
+        hex.ModelMetricsBinomial mmb = hex.ModelMetricsBinomial.getFromDKV(gbmModel, testFrame);
+        assertTrue(mmb.auc() > 0);
+
+        String variableImportancesTableAsString = ((GBMModel) gbmModel)._output._variable_importances.toString(0, true);
+        String[] teEncodedColumns = {"Origin_te"};
+        assertTrue(Arrays.stream(teEncodedColumns).allMatch(variableImportancesTableAsString::contains));
+
+        assertBitIdentical(trainOriginalCopy, trainingFrame);
+
+        Scope.track_generic(gbmModel);
+      } finally {
+        Scope.exit();
+      }
+    }
+
+  }
+
+
+  @RunWith(Parameterized.class)
+  public static class ModelBuilderWithTEParametrizedTest extends TestUtil {
+
+    @BeforeClass
+    public static void setup() {
+      stall_till_cloudsize(1);
+    }
+
+    @Parameterized.Parameters(name = "CV mode = {0}, te_is_provided = {1}")
+    public static Object[][] testParams() {
+      return new Object[][]{
+              {false, false},
+              {false, true},
+              {true, false},
+              {true, true}
+      };
+    }
+
+    @Parameterized.Parameter (value = 0)
+    public boolean isCVMode;
+
+    @Parameterized.Parameter (value = 1)
+    public Boolean teIsProvided;
+
+
+    @Test
+    public void te_is_applied_to_specified_columns_and_rest_categorical_columns_are_encoded_with_accordance_to_categorical_encoding_param() {
+      Scope.enter();
+      try {
+        long seed = 2345;
+        Frame originalTrainingFrame = parse_test_file("./smalldata/testng/airlines_train.csv");
+        Scope.track(originalTrainingFrame);
+        Frame[] splits = null;
+        if(!isCVMode) {
+          Key[] keys = new Key[]{
+                  Key.make("training_" + originalTrainingFrame._key),
+                  Key.make("validation_" + originalTrainingFrame._key)
+          };
+          double[] splitRatios = new double[]{0.8, 0.2};
+          splits = ShuffleSplitFrame.shuffleSplitFrame(
+                  originalTrainingFrame,
+                  keys,
+                  splitRatios,
+                  seed
+          );
+          Scope.track(splits[0], splits[1]);
+        }
+        Frame trainingFrame = isCVMode ? originalTrainingFrame : splits[0];
+        Frame validationFrame = isCVMode ? null : splits[1];
+        Frame testFrame = parse_test_file("./smalldata/testng/airlines_test.csv");
+        Scope.track(testFrame);
+
+        TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
+        parameters._data_leakage_handling = TargetEncoder.DataLeakageHandlingStrategy.None;
+        parameters._k = 0.3;
+        parameters._f = 0.7;
+        parameters._blending = true;
+        parameters._response_column = "IsDepDelayed";
+        parameters._ignored_columns = ignoredColumns(trainingFrame, "Origin", "Dest", "fDayofMonth", parameters._response_column);
+        parameters._train = trainingFrame._key;
+        parameters._seed = seed;
+
+        TargetEncoderBuilder temb = new TargetEncoderBuilder(parameters);
+        final Model targetEncoderModel = temb.trainModel().get();
+
+        if(!teIsProvided) Scope.track_generic(targetEncoderModel);
+
+        GBMModel.GBMParameters gbmParameters = new GBMModel.GBMParameters();
+        gbmParameters._nfolds = 0;
+        if (!isCVMode) {
+          gbmParameters._valid = validationFrame._key;
+        }
+        ModelBuilder modelBuilderForMainModel = modelBuilderGBMWithCVFixture(gbmParameters, trainingFrame, parameters._response_column, parameters._seed);
+        modelBuilderForMainModel._parms._categorical_encoding = Model.Parameters.CategoricalEncodingScheme.EnumLimited;
+
+        if(teIsProvided)
+          modelBuilderForMainModel.addTEModelKey(targetEncoderModel._key);
+
+        modelBuilderForMainModel.init(false);
+
+        Model gbmModel = (GBMModel) modelBuilderForMainModel.trainModel().get();
+
+        Frame scoredTest = gbmModel.score(testFrame);
+        Scope.track(scoredTest);
+
+        if(!isCVMode) {
+          hex.ModelMetricsBinomial mmb_valid = hex.ModelMetricsBinomial.getFromDKV(gbmModel, validationFrame);
+          assertTrue(mmb_valid.auc() > 0);
+        }
+
+        hex.ModelMetricsBinomial mmb = hex.ModelMetricsBinomial.getFromDKV(gbmModel, testFrame);
+        assertTrue(mmb.auc() > 0);
+
+        String variableImportancesTableAsString = ((GBMModel) gbmModel)._output._variable_importances.toString(0, true);
+
+        if(teIsProvided) {
+          String[] enumLimitedEncodedColumns = {"fYear.top_10_levels"};
+          assertTrue(Arrays.stream(enumLimitedEncodedColumns).allMatch(variableImportancesTableAsString::contains));
+          String[] teEncodedColumns = {"Origin_te", "fDayofMonth_te", "Dest_te"};
+          assertTrue(Arrays.stream(teEncodedColumns).allMatch(variableImportancesTableAsString::contains));
+        } else {
+          String[] enumLimitedEncodedColumns = {"fYear.top_10_levels", "fDayofMonth.top_10_levels", "Origin.top_10_levels"};
+          assertTrue(Arrays.stream(enumLimitedEncodedColumns).allMatch(variableImportancesTableAsString::contains));
+        }
+
+        System.out.println(variableImportancesTableAsString);
+
+        Scope.track_generic(gbmModel);
+      } finally {
+        Scope.exit();
+      }
+    }
+
+  }
+
+}

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncodingFrameHelperTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncodingFrameHelperTest.java
@@ -292,4 +292,29 @@ public class TargetEncodingFrameHelperTest extends TestUtil {
 
     assertTrue(totalTimeDFork < totalTimeDoAll);
   }
+
+  @Test
+  public void factorColumnTest() {
+    Frame fr = null;
+    Vec colA = null;
+    try {
+      fr = new TestFrameBuilder()
+              .withName("testFrame")
+              .withColNames("ColA")
+              .withVecTypes(Vec.T_NUM)
+              .withDataForCol(0, ar(0, 1))
+              .build();
+
+      colA = fr.vec("ColA");
+      assertFalse(colA.isCategorical());
+
+      TargetEncoderFrameHelper.factorColumn(fr, "ColA");
+
+      colA = fr.vec("ColA");
+      assertTrue(colA.isCategorical());
+    } finally {
+      if(fr!=null) fr.delete();
+      if(colA!=null) colA.remove();
+    }
+  }
 }

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/strategy/TargetEncoderRGSTest.java
@@ -1,5 +1,6 @@
 package ai.h2o.targetencoding.strategy;
 
+import ai.h2o.targetencoding.TargetEncoder;
 import ai.h2o.targetencoding.TargetEncoderModel;
 import hex.grid.Grid;
 import hex.grid.GridSearch;
@@ -45,6 +46,7 @@ public class TargetEncoderRGSTest{
         hpGrid.put("noise_level", new Double[]{0.0, 0.01, 0.1});
         hpGrid.put("k", new Double[]{1.0, 2.0, 3.0});
         hpGrid.put("f", new Double[]{5.0, 10.0, 20.0});
+        hpGrid.put("data_leakage_handling", new TargetEncoder.DataLeakageHandlingStrategy[]{TargetEncoder.DataLeakageHandlingStrategy.KFold, TargetEncoder.DataLeakageHandlingStrategy.LeaveOneOut, TargetEncoder.DataLeakageHandlingStrategy.None});
 
         TargetEncoderModel.TargetEncoderParameters parameters = new TargetEncoderModel.TargetEncoderParameters();
 

--- a/h2o-extensions/target-encoder/src/test/java/water/H2OTestNodeStarter.java
+++ b/h2o-extensions/target-encoder/src/test/java/water/H2OTestNodeStarter.java
@@ -1,0 +1,15 @@
+package water;
+
+import org.junit.Ignore;
+
+/**
+ * This class is intended to be ran during distributed
+ * testing from Idea.
+ */
+@Ignore("Support for tests, but no actual tests here")
+public class H2OTestNodeStarter extends H2OStarter {
+
+  public static void main(String[] args) {
+    start(args, System.getProperty("user.dir"));
+  }
+}

--- a/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_target_encoder_model_summary_does_not_contain_fold_column.py
+++ b/h2o-py/tests/testdir_algos/automl/target_encoding/pyunit_target_encoder_model_summary_does_not_contain_fold_column.py
@@ -10,7 +10,7 @@ from h2o.estimators import H2OTargetEncoderEstimator
 
 
 def test_target_encoder_model_summary_does_not_contain_fold_column():
-    print("Check that attached TargetEncoderModel is being used during training and scoring")
+    print("Check that Target Encoder's summary does not contain fold_column")
     targetColumnName = "survived"
     foldColumnName = "kfold_column"
 
@@ -28,7 +28,6 @@ def test_target_encoder_model_summary_does_not_contain_fold_column():
     model_summary = te._model_json['output']['model_summary'].as_data_frame()
     print(model_summary)
     encoded_column_names = model_summary['encoded_column_name']
-
     # Checking that we don't have empty entries in TwoDim table
     assert len(model_summary) == 2
 

--- a/h2o-test-support/src/main/java/water/TestUtil.java
+++ b/h2o-test-support/src/main/java/water/TestUtil.java
@@ -1171,7 +1171,7 @@ public class TestUtil extends Iced {
    * @param columnName column's name to be factorized
    * @return Frame with factorized column
    */
-  public Frame asFactor(Frame frame, String columnName) {
+  public static Frame asFactor(Frame frame, String columnName) {
     Vec vec = frame.vec(columnName);
     frame.replace(frame.find(columnName), vec.toCategoricalVec());
     vec.remove();


### PR DESCRIPTION
restarting fresh branch after squashing history to avoid painful rebase.
Based on https://github.com/h2oai/h2o-3/pull/4158

Plan is to provide multiple flavours for TE integration, depending on the time budget we want to dedicate to TE during training:
1.   single TE with default, applied for all models.
2.   single TE tuned against a selected algo, then applied for all models.
3.   one TE tuned for each algo, then applied for all models using same algo.
4.   one TE tuned per model.

The last approach retraining TE every time looks expensive and we're not even sure it will bring significant improvements.

This PR will focus on (1) and (2), to ensure we can have some TE baseline that we can use to compare the efficiency of (3) and (4) later.