### PR TITLE
Remove sys.exit(1) from python drop columns tests

### DIFF
--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_high_enums_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_high_enums_large.py
@@ -22,7 +22,7 @@ def test_column_skip_high_cardinality():
     fwriteFile.close()
     try:
         parseFile = h2o.upload_file(savefilenamewithpath, col_types=["enum","int"])
-        sys.exit(1) # should have failed here
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except Exception as ex:
         print(ex) # print out the error message
         parseFile = h2o.upload_file(savefilenamewithpath, col_types=["int"], skipped_columns=[0]) # should pass here.

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_import_folder.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_import_folder.py
@@ -27,7 +27,7 @@ def import_folder_skipped_columns():
 
     try:
         bad = h2o.import_file(filePath, skipped_columns=skip_all)  # skipped all
-        sys.exit(1)
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except Exception as ex:
         print(ex)
         pass

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_arff_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_arff_large.py
@@ -47,13 +47,13 @@ def test_arff_parser_column_skip():
 
     try:
         loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns=skip_all)
-        sys.exit(1)  # should have failed here
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except:
         pass
 
     try:
         importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
-        sys.exit(1)  # should have failed here
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except:
         pass
 

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
@@ -38,7 +38,7 @@ def test_csv_parser_column_skip():
 
     try:
         importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
-        sys.exit(1)  # should have failed here
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except:
         pass
 

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gz_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gz_large.py
@@ -26,14 +26,14 @@ def import_zip_skipped_columns():
 
     try:
         bad = h2o.import_file(filePath, skipped_columns=skip_all)  # skipped all
-        sys.exit(1)
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except Exception as ex:
         print(ex)
         pass
 
     try:
         bad = h2o.upload_file(filePath, skipped_columns=skip_all)   # skipped all
-        sys.exit(1)
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except Exception as ex:
         print(ex)
         pass

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gzip_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_gzip_large.py
@@ -26,14 +26,14 @@ def import_gzip_skipped_columns():
 
     try:
         bad = h2o.import_file(filePath, skipped_columns=skip_all)  # skipped all
-        sys.exit(1)
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except Exception as ex:
         print(ex)
         pass
 
     try:
         bad = h2o.upload_file(filePath, skipped_columns=skip_all)   # skipped all
-        sys.exit(1)
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except Exception as ex:
         print(ex)
         pass

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_parquet_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_parquet_large.py
@@ -29,13 +29,13 @@ def test_parquet_parser_column_skip():
 
     try:
         loadFileSkipAll = h2o.upload_file(path, skipped_columns=skip_all)
-        sys.exit(1)  # should have failed here
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except:
         pass
 
     try:
         importFileSkipAll = h2o.import_file(path, skipped_columns=skip_all)
-        sys.exit(1)  # should have failed here
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except:
         pass
 

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_svmlight_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_svmlight_large.py
@@ -29,13 +29,13 @@ def test_parser_svmlight_column_skip():
 
   try:
     loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns = skip_all)
-    sys.exit(1) # should have failed here
+    assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
   except:
     pass
 
   try:
     importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns = skip_all)
-    sys.exit(1) # should have failed here
+    assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
   except:
     pass
 


### PR DESCRIPTION
@Pscheidl noticed that sys.exit(1) was used.  However, it is preferred to use assert with a meaningful error message.

I have fixed all those in the drop columns test I hope.