### PR TITLE
search on categorical encoding in AutoML grids

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/DeepLearningStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/DeepLearningStepsProvider.java
@@ -1,6 +1,7 @@
 package ai.h2o.automl.modeling;
 
 import ai.h2o.automl.*;
+import hex.Model;
 import hex.deeplearning.DeepLearningModel;
 import hex.deeplearning.DeepLearningModel.DeepLearningParameters;
 import hex.grid.Grid;
@@ -47,6 +48,10 @@ public class DeepLearningStepsProvider
                 searchParams.put("_rho", new Double[] { 0.9, 0.95, 0.99 });
                 searchParams.put("_epsilon", new Double[] { 1e-6, 1e-7, 1e-8, 1e-9 });
                 searchParams.put("_input_dropout_ratio", new Double[] { 0.0, 0.05, 0.1, 0.15, 0.2 });
+                searchParams.put("_categorical_encoding", new Model.Parameters.CategoricalEncodingScheme[] {
+                        Model.Parameters.CategoricalEncodingScheme.SortByResponse,
+                        Model.Parameters.CategoricalEncodingScheme.OneHotInternal,
+                });
 
                 return searchParams;
             }

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
@@ -146,6 +146,11 @@ public class GBMStepsProvider
                         searchParams.put("_col_sample_rate", new Double[]{ 0.4, 0.7, 1.0});
                         searchParams.put("_col_sample_rate_per_tree", new Double[]{ 0.4, 0.7, 1.0});
                         searchParams.put("_min_split_improvement", new Double[]{1e-4, 1e-5});
+                        searchParams.put("_categorical_encoding", new Model.Parameters.CategoricalEncodingScheme[] {
+                                Model.Parameters.CategoricalEncodingScheme.Enum,
+                                Model.Parameters.CategoricalEncodingScheme.SortByResponse,
+                                Model.Parameters.CategoricalEncodingScheme.OneHotExplicit,
+                        });
 
                         return hyperparameterSearch(gbmParameters, searchParams);
                     }

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
@@ -187,6 +187,12 @@ public class XGBoostSteps extends ModelingSteps {
 
                     searchParams.put("_reg_lambda", new Float[]{0.001f, 0.01f, 0.1f, 1f, 10f, 100f});
                     searchParams.put("_reg_alpha", new Float[]{0.001f, 0.01f, 0.1f, 0.5f, 1f});
+                    searchParams.put("_categorical_encoding", new Model.Parameters.CategoricalEncodingScheme[] {
+                            Model.Parameters.CategoricalEncodingScheme.Enum,
+                            Model.Parameters.CategoricalEncodingScheme.SortByResponse,
+                            Model.Parameters.CategoricalEncodingScheme.OneHotInternal,
+                    });
+
 
                     return hyperparameterSearch(xgBoostParameters, searchParams);
                 }


### PR DESCRIPTION
limiting the search to following encoders:
- GBM: enum, label encoder(sorted by response), one hot encoder.
- XGBoost: enum, label encoder(sorted by response), one hot encoder.
- DeepLearning: label encoder(sorted by response), one hot encoder