### PR TITLE
[tests] fix case when failed could initialization error is eaten

### DIFF
--- a/h2o-core/src/test/java/water/runner/H2ORunnerAfters.java
+++ b/h2o-core/src/test/java/water/runner/H2ORunnerAfters.java
@@ -35,7 +35,11 @@ public class H2ORunnerAfters extends RunAfters {
         } finally {
             // Clean all keys shared for the whole test class, created during @BeforeClass,
             // but not cleaned in @AfterClass.
-            new CleanAllKeysTask().doAllNodes();
+            try {
+                new CleanAllKeysTask().doAllNodes();
+            } catch (Throwable e) {
+                errors.add(e);
+            }
             for (FrameworkMethod each : afters) {
                 try {
                     each.invokeExplosively(target);


### PR DESCRIPTION
- when cloud fails to init CleanAllKeysTask fails as well throwing exceptio and causing previous errors to be lost