### PR TITLE
PUBDEV-7404 - Kolmogorov-Smirnov metric

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/DRFV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/DRFV3.java
@@ -57,7 +57,8 @@ public class DRFV3 extends SharedTreeV3<DRF, DRFV3, DRFV3.DRFParametersV3> {
                 "distribution",
                 "custom_metric_func",
                 "export_checkpoints_dir",
-                "check_constant_response"
+                "check_constant_response",
+                "gainslift_bins"
         };
 
         // Input fields

--- a/h2o-algos/src/main/java/hex/schemas/GBMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GBMV3.java
@@ -67,7 +67,8 @@ public class GBMV3 extends SharedTreeV3<GBM,GBMV3,GBMV3.GBMParametersV3> {
       "custom_distribution_func",      
       "export_checkpoints_dir",
       "monotone_constraints",
-      "check_constant_response"
+      "check_constant_response",
+      "gainslift_bins"
 //      "use_new_histo_tsk",
 //      "col_block_sz",
 //      "min_threads",

--- a/h2o-algos/src/main/java/hex/schemas/NaiveBayesV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/NaiveBayesV3.java
@@ -34,7 +34,8 @@ public class NaiveBayesV3 extends ModelBuilderSchema<NaiveBayes,NaiveBayesV3,Nai
         "eps_prob",
         "compute_metrics",
         "max_runtime_secs",
-        "export_checkpoints_dir"
+        "export_checkpoints_dir",
+        "gainslift_bins"
 		};
 
   /*Imbalanced Classes*/

--- a/h2o-core/src/main/java/hex/GainsLift.java
+++ b/h2o-core/src/main/java/hex/GainsLift.java
@@ -147,10 +147,10 @@ public class GainsLift extends Iced {
             "Gains/Lift Table",
             "Avg response rate: " + PrettyPrint.formatPct(avg_response_rate) + ", avg score: " + PrettyPrint.formatPct(avg_score),
             new String[events.length],
-            new String[]{"Group", "Cumulative Data Fraction", "Lower Threshold", "Lift", "Cumulative Lift", "Response Rate", "Score", "Cumulative Response Rate", "Cumulative Score", "Capture Rate", "Cumulative Capture Rate", "Gain", "Cumulative Gain"},
-            new String[]{"int", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double"},
-            new String[]{"%d", "%.8f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f"},
-            "");
+            new String[]{"Group", "Cumulative Data Fraction", "Lower Threshold", "Lift", "Cumulative Lift", "Response Rate", "Score", "Cumulative Response Rate", "Cumulative Score", "Capture Rate", "Cumulative Capture Rate", "Gain", "Cumulative Gain", "Kolmogorov Smirnov"},
+            new String[]{"int", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double", "double"},
+            new String[]{"%d", "%.8f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f", "%5f","%5f"},
+            null);
     long sum_e_i = 0;
     long sum_n_i = 0;
     double sum_s_i = 0;
@@ -167,6 +167,8 @@ public class GainsLift extends Iced {
       sum_s_i += n_i * s_i;
       double lift=p_i/P; //can be NaN if P==0
       double sum_lift=(double)sum_e_i/sum_n_i/P; //can be NaN if P==0
+      double cum_event = sum_e_i/(double)E;
+      double cum_non_event = (sum_n_i - sum_e_i) / (double) (N - E);
       table.set(i,0,i+1); //group
       table.set(i,1,(double)sum_n_i/N); //cumulative_data_fraction
       table.set(i,2,_quantiles[i]); //lower_threshold
@@ -180,6 +182,7 @@ public class GainsLift extends Iced {
       table.set(i,10,(double)sum_e_i/E); //cumulative_capture_rate
       table.set(i,11,100*(lift-1)); //gain
       table.set(i,12,100*(sum_lift-1)); //cumulative gain
+      table.set(i,13,cum_event - cum_non_event); //Kolmogorov-Smirnov metric
       if (i== events.length-1) {
         assert(sum_n_i == N) : "Cumulative data fraction must be 1.0, but is " + (double)sum_n_i/N;
         assert(sum_e_i == E) : "Cumulative capture rate must be 1.0, but is " + (double)sum_e_i/E;

--- a/h2o-core/src/main/java/hex/GainsLift.java
+++ b/h2o-core/src/main/java/hex/GainsLift.java
@@ -167,8 +167,10 @@ public class GainsLift extends Iced {
       sum_s_i += n_i * s_i;
       double lift=p_i/P; //can be NaN if P==0
       double sum_lift=(double)sum_e_i/sum_n_i/P; //can be NaN if P==0
-      double cum_event = sum_e_i/(double)E;
-      double cum_non_event = (sum_n_i - sum_e_i) / (double) (N - E);
+      final double cum_event = sum_e_i / (double)E;
+      final double total_non_event = (double) (N - E);
+      // If response rate is 1, there are non non-events and the cumulative count will always be zero
+      final double cum_non_event = total_non_event == 0 ? 0 : (sum_n_i - sum_e_i) / total_non_event;
       table.set(i,0,i+1); //group
       table.set(i,1,(double)sum_n_i/N); //cumulative_data_fraction
       table.set(i,2,_quantiles[i]); //lower_threshold

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -358,7 +358,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
     /**
      * Bins for Gains/Lift table, if applicable. Ignored if G/L are not calculated.
      */
-    public int _gainslift_bins;
+    public int _gainslift_bins = -1;
 
     // Public no-arg constructor for reflective creation
     public Parameters() { _ignore_const_cols = defaultDropConsCols(); }

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -355,6 +355,11 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
      */
     public String _export_checkpoints_dir;
 
+    /**
+     * Bins for Gains/Lift table, if applicable. Ignored if G/L are not calculated.
+     */
+    public int _gainslift_bins;
+
     // Public no-arg constructor for reflective creation
     public Parameters() { _ignore_const_cols = defaultDropConsCols(); }
 

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -270,13 +270,13 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
 
     private GainsLift calculateGainsLift(Model m, Frame preds, Vec resp, Vec weights) {
       GainsLift gl = null;
-        gl = new GainsLift(preds.lastVec(), resp, weights);
-        if (m != null && m._parms._gainslift_bins != 0) {
-          if (m._parms._gainslift_bins < 1)
-            throw new IllegalArgumentException("Number of G/L bins must be greater than zero.");
-          gl._groups = m._parms._gainslift_bins;
-        }
-        gl.exec(m != null ? m._output._job : null);
+      gl = new GainsLift(preds.lastVec(), resp, weights);
+      if (m != null && m._parms._gainslift_bins != 0) {
+        if (m._parms._gainslift_bins < 1)
+          throw new IllegalArgumentException("Number of G/L bins must be greater than zero.");
+        gl._groups = m._parms._gainslift_bins;
+      }
+      gl.exec(m != null ? m._output._job : null);
       return gl;
     }
 

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -282,7 +282,7 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
      */
     private Optional<GainsLift> calculateGainsLift(Model m, Frame preds, Vec resp, Vec weights) {
       final GainsLift gl = new GainsLift(preds.lastVec(), resp, weights);
-      if (m._parms._gainslift_bins < -1) {
+      if (m != null && m._parms._gainslift_bins < -1) {
         throw new IllegalArgumentException("Number of G/L bins must be greater or equal than -1.");
       } else if (m != null && (m._parms._gainslift_bins > 0 || m._parms._gainslift_bins == -1)) {
         gl._groups = m._parms._gainslift_bins;

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -270,16 +270,12 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
 
     private GainsLift calculateGainsLift(Model m, Frame preds, Vec resp, Vec weights) {
       GainsLift gl = null;
-      try {
         gl = new GainsLift(preds.lastVec(), resp, weights);
         if (m._parms._gainslift_bins !=0 ) {
           if (m._parms._gainslift_bins < 1) throw new IllegalArgumentException("Number of G/L bins must be greater than zero.");
           gl._groups = m._parms._gainslift_bins;
         }
         gl.exec(m != null ? m._output._job : null);
-      } catch (Throwable t) { // TODO: Why do we need to catch Throwable here?
-        Log.debug("Calculating Gains-Lift failed", t);
-      }
       return gl;
     }
 

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -271,8 +271,9 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
     private GainsLift calculateGainsLift(Model m, Frame preds, Vec resp, Vec weights) {
       GainsLift gl = null;
         gl = new GainsLift(preds.lastVec(), resp, weights);
-        if (m._parms._gainslift_bins !=0 ) {
-          if (m._parms._gainslift_bins < 1) throw new IllegalArgumentException("Number of G/L bins must be greater than zero.");
+        if (m != null && m._parms._gainslift_bins != 0) {
+          if (m._parms._gainslift_bins < 1)
+            throw new IllegalArgumentException("Number of G/L bins must be greater than zero.");
           gl._groups = m._parms._gainslift_bins;
         }
         gl.exec(m != null ? m._output._job : null);

--- a/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
+++ b/h2o-core/src/main/java/hex/ModelMetricsBinomial.java
@@ -272,8 +272,12 @@ public class ModelMetricsBinomial extends ModelMetricsSupervised {
       GainsLift gl = null;
       try {
         gl = new GainsLift(preds.lastVec(), resp, weights);
+        if (m._parms._gainslift_bins !=0 ) {
+          if (m._parms._gainslift_bins < 1) throw new IllegalArgumentException("Number of G/L bins must be greater than zero.");
+          gl._groups = m._parms._gainslift_bins;
+        }
         gl.exec(m != null ? m._output._job : null);
-      } catch(Throwable t) { // TODO: Why do we need to catch Throwable here?
+      } catch (Throwable t) { // TODO: Why do we need to catch Throwable here?
         Log.debug("Calculating Gains-Lift failed", t);
       }
       return gl;

--- a/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
@@ -172,7 +172,8 @@ public class ModelParametersSchemaV3<P extends Model.Parameters, S extends Model
   @API(help = "Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)", level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
   public double stopping_tolerance;
 
-  @API(help = "Gains/Lift table bins", level = API.Level.secondary, direction=API.Direction.INOUT)
+  @API(help = "Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning.",
+      level = API.Level.secondary, direction=API.Direction.INOUT)
   public int gainslift_bins;
 
   /*

--- a/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelParametersSchemaV3.java
@@ -172,6 +172,9 @@ public class ModelParametersSchemaV3<P extends Model.Parameters, S extends Model
   @API(help = "Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)", level = API.Level.secondary, direction=API.Direction.INOUT, gridable = true)
   public double stopping_tolerance;
 
+  @API(help = "Gains/Lift table bins", level = API.Level.secondary, direction=API.Direction.INOUT)
+  public int gainslift_bins;
+
   /*
    * Custom metric
    */

--- a/h2o-core/src/test/java/hex/GainsLiftTest.java
+++ b/h2o-core/src/test/java/hex/GainsLiftTest.java
@@ -11,10 +11,11 @@ import water.fvec.Vec;
 import water.runner.CloudSize;
 import water.runner.H2ORunner;
 import water.util.Log;
+import water.util.TwoDimTable;
 
 import java.util.Random;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(H2ORunner.class)
 @CloudSize(1)
@@ -266,6 +267,31 @@ public class GainsLiftTest extends TestUtil {
 
     actual.remove();
     predict.remove();
+  }
+
+  @Test
+  public void testAverageResponseRate() {
+    final int vectorLength = 10;
+    try {
+      Scope.enter();
+      Vec actual = Scope.track(Vec.makeCon(1.0d, vectorLength));
+      actual.set(0, 0d);
+      Vec predict = Scope.track(Vec.makeCon(1.0d, vectorLength));
+      Vec weights = Scope.track(Vec.makeCon(1.0d, vectorLength));
+      weights.set(0, 0d);
+
+      GainsLift gl = new GainsLift(predict, actual, weights);
+      gl.exec();
+      Log.info(gl);
+      Log.info(gl.avg_response_rate);
+      assertEquals(1.0d, gl.avg_response_rate, 0d);
+
+      final TwoDimTable twoDimTable = gl.createTwoDimTable();
+      assertEquals("Kolmogorov Smirnov",twoDimTable.getColHeaders()[13]);
+      assertEquals(1.0d, twoDimTable.getCellValues()[0][13].get());
+    } finally {
+      Scope.exit();
+    }
   }
 
   @Test

--- a/h2o-core/src/test/java/hex/GainsLiftTest.java
+++ b/h2o-core/src/test/java/hex/GainsLiftTest.java
@@ -1,16 +1,27 @@
 package hex;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import water.Scope;
 import water.TestUtil;
 import water.fvec.Vec;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
 import water.util.Log;
 
 import java.util.Random;
 
+import static org.junit.Assert.assertTrue;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
 public class GainsLiftTest extends TestUtil {
-  @BeforeClass public static void stall() { stall_till_cloudsize(1); }
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test public void constant() {
     int len = 100000;
@@ -255,5 +266,23 @@ public class GainsLiftTest extends TestUtil {
 
     actual.remove();
     predict.remove();
+  }
+
+  @Test
+  public void testActualLabelCardinality() {
+    final int vectorLength = 10;
+    Scope.enter();
+    final Vec actual = Vec.makeCon(1.0d, vectorLength);
+    final Vec predict = Vec.makeCon(1.0d, vectorLength);
+    try {
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("Actual column must contain binary class labels, but found cardinality 1!");
+      GainsLift gl = new GainsLift(predict, actual);
+      gl.exec();
+    } finally {
+      actual.remove();
+      predict.remove();
+      Scope.exit();
+    }
   }
 }

--- a/h2o-extensions/xgboost/src/main/java/hex/schemas/XGBoostV3.java
+++ b/h2o-extensions/xgboost/src/main/java/hex/schemas/XGBoostV3.java
@@ -86,7 +86,8 @@ public class XGBoostV3 extends ModelBuilderSchema<XGBoost,XGBoostV3,XGBoostV3.XG
         "reg_alpha",
         "dmatrix_type",
         "backend",
-        "gpu_id"
+        "gpu_id",
+        "gainslift_bins"
     };
 
     @API(help="(same as n_estimators) Number of trees.", gridable = true)

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -1870,9 +1870,9 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     @property
     def gainslift_bins(self):
         """
-        Gains/Lift table bins
+        Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning.
 
-        Type: ``int``  (default: ``0``).
+        Type: ``int``  (default: ``-1``).
         """
         return self._parms.get("gainslift_bins")
 

--- a/h2o-py/h2o/estimators/gbm.py
+++ b/h2o-py/h2o/estimators/gbm.py
@@ -35,7 +35,7 @@ class H2OGradientBoostingEstimator(H2OEstimator):
                    "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
                    "histogram_type", "max_abs_leafnode_pred", "pred_noise_bandwidth", "categorical_encoding",
                    "calibrate_model", "calibration_frame", "custom_metric_func", "custom_distribution_func",
-                   "export_checkpoints_dir", "monotone_constraints", "check_constant_response"}
+                   "export_checkpoints_dir", "monotone_constraints", "check_constant_response", "gainslift_bins"}
 
     def __init__(self, **kwargs):
         super(H2OGradientBoostingEstimator, self).__init__()
@@ -1865,5 +1865,20 @@ class H2OGradientBoostingEstimator(H2OEstimator):
     def check_constant_response(self, check_constant_response):
         assert_is_type(check_constant_response, None, bool)
         self._parms["check_constant_response"] = check_constant_response
+
+
+    @property
+    def gainslift_bins(self):
+        """
+        Gains/Lift table bins
+
+        Type: ``int``  (default: ``0``).
+        """
+        return self._parms.get("gainslift_bins")
+
+    @gainslift_bins.setter
+    def gainslift_bins(self, gainslift_bins):
+        assert_is_type(gainslift_bins, None, int)
+        self._parms["gainslift_bins"] = gainslift_bins
 
 

--- a/h2o-py/h2o/estimators/naive_bayes.py
+++ b/h2o-py/h2o/estimators/naive_bayes.py
@@ -791,9 +791,9 @@ class H2ONaiveBayesEstimator(H2OEstimator):
     @property
     def gainslift_bins(self):
         """
-        Gains/Lift table bins
+        Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning.
 
-        Type: ``int``  (default: ``0``).
+        Type: ``int``  (default: ``-1``).
         """
         return self._parms.get("gainslift_bins")
 

--- a/h2o-py/h2o/estimators/naive_bayes.py
+++ b/h2o-py/h2o/estimators/naive_bayes.py
@@ -30,7 +30,7 @@ class H2ONaiveBayesEstimator(H2OEstimator):
                    "validation_frame", "response_column", "ignored_columns", "ignore_const_cols",
                    "score_each_iteration", "balance_classes", "class_sampling_factors", "max_after_balance_size",
                    "max_confusion_matrix_size", "max_hit_ratio_k", "laplace", "min_sdev", "eps_sdev", "min_prob",
-                   "eps_prob", "compute_metrics", "max_runtime_secs", "export_checkpoints_dir"}
+                   "eps_prob", "compute_metrics", "max_runtime_secs", "export_checkpoints_dir", "gainslift_bins"}
 
     def __init__(self, **kwargs):
         super(H2ONaiveBayesEstimator, self).__init__()
@@ -786,5 +786,20 @@ class H2ONaiveBayesEstimator(H2OEstimator):
     def export_checkpoints_dir(self, export_checkpoints_dir):
         assert_is_type(export_checkpoints_dir, None, str)
         self._parms["export_checkpoints_dir"] = export_checkpoints_dir
+
+
+    @property
+    def gainslift_bins(self):
+        """
+        Gains/Lift table bins
+
+        Type: ``int``  (default: ``0``).
+        """
+        return self._parms.get("gainslift_bins")
+
+    @gainslift_bins.setter
+    def gainslift_bins(self, gainslift_bins):
+        assert_is_type(gainslift_bins, None, int)
+        self._parms["gainslift_bins"] = gainslift_bins
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -31,7 +31,7 @@ class H2ORandomForestEstimator(H2OEstimator):
                    "sample_rate", "sample_rate_per_class", "binomial_double_trees", "checkpoint",
                    "col_sample_rate_change_per_level", "col_sample_rate_per_tree", "min_split_improvement",
                    "histogram_type", "categorical_encoding", "calibrate_model", "calibration_frame", "distribution",
-                   "custom_metric_func", "export_checkpoints_dir", "check_constant_response"}
+                   "custom_metric_func", "export_checkpoints_dir", "check_constant_response", "gainslift_bins"}
 
     def __init__(self, **kwargs):
         super(H2ORandomForestEstimator, self).__init__()
@@ -1595,5 +1595,20 @@ class H2ORandomForestEstimator(H2OEstimator):
     def check_constant_response(self, check_constant_response):
         assert_is_type(check_constant_response, None, bool)
         self._parms["check_constant_response"] = check_constant_response
+
+
+    @property
+    def gainslift_bins(self):
+        """
+        Gains/Lift table bins
+
+        Type: ``int``  (default: ``0``).
+        """
+        return self._parms.get("gainslift_bins")
+
+    @gainslift_bins.setter
+    def gainslift_bins(self, gainslift_bins):
+        assert_is_type(gainslift_bins, None, int)
+        self._parms["gainslift_bins"] = gainslift_bins
 
 

--- a/h2o-py/h2o/estimators/random_forest.py
+++ b/h2o-py/h2o/estimators/random_forest.py
@@ -1600,9 +1600,9 @@ class H2ORandomForestEstimator(H2OEstimator):
     @property
     def gainslift_bins(self):
         """
-        Gains/Lift table bins
+        Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning.
 
-        Type: ``int``  (default: ``0``).
+        Type: ``int``  (default: ``-1``).
         """
         return self._parms.get("gainslift_bins")
 

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -33,7 +33,7 @@ class H2OXGBoostEstimator(H2OEstimator):
                    "save_matrix_directory", "build_tree_one_node", "calibrate_model", "calibration_frame", "max_bins",
                    "max_leaves", "min_sum_hessian_in_leaf", "min_data_in_leaf", "sample_type", "normalize_type",
                    "rate_drop", "one_drop", "skip_drop", "tree_method", "grow_policy", "booster", "reg_lambda",
-                   "reg_alpha", "dmatrix_type", "backend", "gpu_id"}
+                   "reg_alpha", "dmatrix_type", "backend", "gpu_id", "gainslift_bins"}
 
     def __init__(self, **kwargs):
         super(H2OXGBoostEstimator, self).__init__()
@@ -2102,6 +2102,21 @@ class H2OXGBoostEstimator(H2OEstimator):
     def gpu_id(self, gpu_id):
         assert_is_type(gpu_id, None, int)
         self._parms["gpu_id"] = gpu_id
+
+
+    @property
+    def gainslift_bins(self):
+        """
+        Gains/Lift table bins
+
+        Type: ``int``  (default: ``0``).
+        """
+        return self._parms.get("gainslift_bins")
+
+    @gainslift_bins.setter
+    def gainslift_bins(self, gainslift_bins):
+        assert_is_type(gainslift_bins, None, int)
+        self._parms["gainslift_bins"] = gainslift_bins
 
 
     @staticmethod

--- a/h2o-py/h2o/estimators/xgboost.py
+++ b/h2o-py/h2o/estimators/xgboost.py
@@ -2107,9 +2107,9 @@ class H2OXGBoostEstimator(H2OEstimator):
     @property
     def gainslift_bins(self):
         """
-        Gains/Lift table bins
+        Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning.
 
-        Type: ``int``  (default: ``0``).
+        Type: ``int``  (default: ``-1``).
         """
         return self._parms.get("gainslift_bins")
 

--- a/h2o-py/h2o/model/binomial.py
+++ b/h2o-py/h2o/model/binomial.py
@@ -869,6 +869,15 @@ class H2OBinomialModel(ModelBase):
         """
         return self._delegate_to_metrics('gains_lift', train, valid, xval)
 
+    def kolmogorov_smirnov(self):
+        """
+        Retrieves a Kolmogorov-Smirnov metric for given binomial model. The number returned is in range between 0 and 1.
+        K-S metric represents the degree of separation between the positive (1) and negative (0) cumulative distribution
+        functions. Detailed metrics per each group are to be found in the gains-lift table.
+
+        :return: Kolmogorov-Smirnov metric, a number between 0 and 1
+        """
+        return max(self.gains_lift()["kolmogorov_smirnov"])
 
     def confusion_matrix(self, metrics=None, thresholds=None, train=False, valid=False, xval=False):
         """

--- a/h2o-py/tests/pyunit_math/pyunit_ks_metric.py
+++ b/h2o-py/tests/pyunit_math/pyunit_ks_metric.py
@@ -26,6 +26,11 @@ def kolmogorov_smirnov():
     assert ks is not None
     assert 0 < ks < 1
 
+    # Test GS is null whern gainslift_bins = 0
+    model = H2OGradientBoostingEstimator(ntrees=1, gainslift_bins=0)
+    model.train(x=["Origin", "Distance"], y="IsDepDelayed", training_frame=airlines)
+    assert model.gains_lift() is None
+
 
 def verify_ks(model, data):
     print(model.gains_lift())

--- a/h2o-py/tests/pyunit_math/pyunit_ks_metric.py
+++ b/h2o-py/tests/pyunit_math/pyunit_ks_metric.py
@@ -1,0 +1,63 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from h2o.estimators import H2OGradientBoostingEstimator, H2OXGBoostEstimator
+from tests import pyunit_utils
+
+def kolmogorov_smirnov():
+    # Train a model
+    airlines = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
+    model = H2OGradientBoostingEstimator(ntrees=1, gainslift_bins=20)
+    model.train(x=["Origin", "Distance"], y="IsDepDelayed", training_frame=airlines)
+    verify_ks(model, airlines)
+
+    model = H2OGradientBoostingEstimator(ntrees=1, gainslift_bins=5)
+    model.train(x=["Origin", "Distance"], y="IsDepDelayed", training_frame=airlines)
+    ks = model.kolmogorov_smirnov()
+    print(ks)
+    ks_verification = ks_metric(model, airlines)
+    print(ks_verification)
+    assert round(ks, 5) != round(ks_verification, 5)
+
+    model = H2OXGBoostEstimator(gainslift_bins=10)
+    model.train(x=["Origin", "Distance"], y="IsDepDelayed", training_frame=airlines)
+    print(model.gains_lift())
+    ks = model.kolmogorov_smirnov()
+    assert ks is not None
+    assert 0 < ks < 1
+
+
+def verify_ks(model, data):
+    print(model.gains_lift())
+    ks = model.kolmogorov_smirnov()
+    print(ks)
+    ks_verification = ks_metric(model, data)
+    print(ks_verification)
+    assert round(ks, 5) == round(ks_verification, 5)
+
+def ks_metric(model, data):
+    # Author: Megan Kurka
+    # get model predictions
+    y = model.params.get('response_column').get('actual').get('column_name')
+    preds = model.predict(data)["YES"].cbind(data[y])
+    preds.col_names = ["prediction", "actual"]
+    # bin records into prediction deciles
+    import numpy as np
+    breaks = preds["prediction"].quantile(prob=list(np.arange(0.1, 1.0, 0.01)))
+    breaks = list(breaks.as_data_frame()["predictionQuantiles"])
+    preds["bin"] = "bin0"
+    preds["bin"] = preds["bin"].asfactor()
+    for i in range(len(breaks)):
+        preds["bin"] = (preds["prediction"] > breaks[i]).ifelse("bin" + str(i), preds["bin"])
+    # calculate ks
+    ks_stats = preds.group_by("bin").min("prediction").sum("actual").count().get_frame()
+    ks_stats = ks_stats.sort("min_prediction", ascending = [False])
+    ks_stats["bin"]
+    cum_event = (ks_stats["sum_actual"]/ks_stats["sum_actual"].sum()).cumsum()
+    cum_non_event = ((ks_stats["nrow"] - ks_stats["sum_actual"])/(ks_stats["nrow"] - ks_stats["sum_actual"]).sum()).cumsum()
+    return (cum_event - cum_non_event).max()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(kolmogorov_smirnov)
+else:
+    kolmogorov_smirnov()

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -101,6 +101,7 @@
 #' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
 #'        column is a constant value.If disabled, then model will train regardless of the response column being a
 #'        constant value or not. Defaults to TRUE.
+#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
@@ -175,6 +176,7 @@ h2o.gbm <- function(x,
                     export_checkpoints_dir = NULL,
                     monotone_constraints = NULL,
                     check_constant_response = TRUE,
+                    gainslift_bins = 0,
                     verbose = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -314,6 +316,8 @@ h2o.gbm <- function(x,
     parms$monotone_constraints <- monotone_constraints
   if (!missing(check_constant_response))
     parms$check_constant_response <- check_constant_response
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   # Error check and build model
   model <- .h2o.modelJob('gbm', parms, h2oRestApiVersion=3, verbose=verbose)
@@ -375,6 +379,7 @@ h2o.gbm <- function(x,
                                     export_checkpoints_dir = NULL,
                                     monotone_constraints = NULL,
                                     check_constant_response = TRUE,
+                                    gainslift_bins = 0,
                                     segment_columns = NULL,
                                     segment_models_id = NULL,
                                     parallelism = 1)
@@ -518,6 +523,8 @@ h2o.gbm <- function(x,
     parms$monotone_constraints <- monotone_constraints
   if (!missing(check_constant_response))
     parms$check_constant_response <- check_constant_response
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   # Build segment-models specific parameters
   segment_parms <- list()

--- a/h2o-r/h2o-package/R/gbm.R
+++ b/h2o-r/h2o-package/R/gbm.R
@@ -101,7 +101,7 @@
 #' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
 #'        column is a constant value.If disabled, then model will train regardless of the response column being a
 #'        constant value or not. Defaults to TRUE.
-#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
+#' @param gainslift_bins Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning. Defaults to -1.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree). Defaults to FALSE.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
 #' @examples
@@ -176,7 +176,7 @@ h2o.gbm <- function(x,
                     export_checkpoints_dir = NULL,
                     monotone_constraints = NULL,
                     check_constant_response = TRUE,
-                    gainslift_bins = 0,
+                    gainslift_bins = -1,
                     verbose = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -379,7 +379,7 @@ h2o.gbm <- function(x,
                                     export_checkpoints_dir = NULL,
                                     monotone_constraints = NULL,
                                     check_constant_response = TRUE,
-                                    gainslift_bins = 0,
+                                    gainslift_bins = -1,
                                     segment_columns = NULL,
                                     segment_models_id = NULL,
                                     parallelism = 1)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3097,12 +3097,13 @@ setMethod("h2o.gainsLift", "H2OModelMetrics", function(object) {
 #' \dontrun{
 #' library(h2o)
 #' h2o.init()
-#' data <- h2o.importFile(path = "https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
+#' data <- h2o.importFile(
+#' path = "https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
 #' model <- h2o.gbm(x = c("Origin", "Distance"), y = "IsDepDelayed", training_frame = data, ntrees = 1)
 #' h2o.kolmogorov_smirnov(model)
 #' }
 #' @export
-setGeneric("h2o.kolmogorov_smirnov", function(object, ...) {})
+setGeneric("h2o.kolmogorov_smirnov", function(object) {})
 
 #' @rdname h2o.kolmogorov_smirnov
 #' @export

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3079,6 +3079,58 @@ setMethod("h2o.gainsLift", "H2OModelMetrics", function(object) {
   }
 })
 
+#' Kolmogorov-Smirnov metric for binomial models
+#'
+#' Retrieves a Kolmogorov-Smirnov metric for given binomial model. The number returned is in range between 0 and 1.
+#' K-S metric represents the degree of separation between the positive (1) and negative (0) cumulative distribution
+#' functions. Detailed metrics per each group are to be found in the gains-lift table.
+#'
+#' The \linkS4class{H2OModelMetrics} version of this function will only take
+#' \linkS4class{H2OBinomialMetrics} objects.
+#'
+#' @param object Either an \linkS4class{H2OModel} object or an
+#'        \linkS4class{H2OModelMetrics} object.
+#' @return Kolmogorov-Smirnov metric, a number between 0 and 1.
+#' @seealso \code{\link{h2o.gainsLift}} to see detaied K-S metrics per group
+#' 
+#' @examples
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#' data <- h2o.importFile(path = "https://s3.amazonaws.com/h2o-public-test-data/smalldata/airlines/allyears2k_headers.zip")
+#' model <- h2o.gbm(x = c("Origin", "Distance"), y = "IsDepDelayed", training_frame = data, ntrees = 1)
+#' h2o.kolmogorov_smirnov(model)
+#' }
+#' @export
+setGeneric("h2o.kolmogorov_smirnov", function(object, ...) {})
+
+#' @rdname h2o.kolmogorov_smirnov
+#' @export
+setMethod("h2o.kolmogorov_smirnov", "H2OModelMetrics", function(object) {
+  gains_lift <- h2o.gainsLift(object = object)
+  if(is.null(gains_lift)){
+    warning(paste0("No Gains/Lift table for ",class(object)))
+    return(NULL)
+  } else {
+    return(max(gains_lift$kolmogorov_smirnov))
+  }
+  
+})
+
+#' @rdname h2o.kolmogorov_smirnov
+#' @export
+setMethod("h2o.kolmogorov_smirnov", "H2OModel", function(object) {
+  gains_lift <- h2o.gainsLift(object = object)
+  if(is.null(gains_lift)){
+    warning(paste0("No Gains/Lift table for ",class(object)))
+    return(NULL)
+  } else {
+    return(max(gains_lift$kolmogorov_smirnov))
+  }
+  
+})
+
+
 #' Access H2O Confusion Matrices
 #'
 #' Retrieve either a single or many confusion matrices from H2O objects.

--- a/h2o-r/h2o-package/R/naivebayes.R
+++ b/h2o-r/h2o-package/R/naivebayes.R
@@ -52,7 +52,7 @@
 #' @param compute_metrics \code{Logical}. Compute metrics on training data Defaults to TRUE.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
-#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
+#' @param gainslift_bins Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning. Defaults to -1.
 #' @return an object of class \linkS4class{H2OBinomialModel} if the response has two categorical levels,
 #'         and \linkS4class{H2OMultinomialModel} otherwise.
 #' @examples
@@ -91,7 +91,7 @@ h2o.naiveBayes <- function(x,
                            compute_metrics = TRUE,
                            max_runtime_secs = 0,
                            export_checkpoints_dir = NULL,
-                           gainslift_bins = 0)
+                           gainslift_bins = -1)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -208,7 +208,7 @@ h2o.naiveBayes <- function(x,
                                            compute_metrics = TRUE,
                                            max_runtime_secs = 0,
                                            export_checkpoints_dir = NULL,
-                                           gainslift_bins = 0,
+                                           gainslift_bins = -1,
                                            segment_columns = NULL,
                                            segment_models_id = NULL,
                                            parallelism = 1)

--- a/h2o-r/h2o-package/R/naivebayes.R
+++ b/h2o-r/h2o-package/R/naivebayes.R
@@ -52,6 +52,7 @@
 #' @param compute_metrics \code{Logical}. Compute metrics on training data Defaults to TRUE.
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
+#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
 #' @return an object of class \linkS4class{H2OBinomialModel} if the response has two categorical levels,
 #'         and \linkS4class{H2OMultinomialModel} otherwise.
 #' @examples
@@ -89,7 +90,8 @@ h2o.naiveBayes <- function(x,
                            eps_prob = 0,
                            compute_metrics = TRUE,
                            max_runtime_secs = 0,
-                           export_checkpoints_dir = NULL)
+                           export_checkpoints_dir = NULL,
+                           gainslift_bins = 0)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
   training_frame <- .validate.H2OFrame(training_frame, required=TRUE)
@@ -163,6 +165,8 @@ h2o.naiveBayes <- function(x,
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   if (!missing(threshold) && missing(min_sdev)) {
     warning("argument 'threshold' is deprecated; use 'min_sdev' instead.")
@@ -204,6 +208,7 @@ h2o.naiveBayes <- function(x,
                                            compute_metrics = TRUE,
                                            max_runtime_secs = 0,
                                            export_checkpoints_dir = NULL,
+                                           gainslift_bins = 0,
                                            segment_columns = NULL,
                                            segment_models_id = NULL,
                                            parallelism = 1)
@@ -282,6 +287,8 @@ h2o.naiveBayes <- function(x,
     parms$max_runtime_secs <- max_runtime_secs
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   if (!missing(threshold) && missing(min_sdev)) {
     warning("argument 'threshold' is deprecated; use 'min_sdev' instead.")

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -89,7 +89,7 @@
 #' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
 #'        column is a constant value.If disabled, then model will train regardless of the response column being a
 #'        constant value or not. Defaults to TRUE.
-#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
+#' @param gainslift_bins Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning. Defaults to -1.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
@@ -162,7 +162,7 @@ h2o.randomForest <- function(x,
                              custom_metric_func = NULL,
                              export_checkpoints_dir = NULL,
                              check_constant_response = TRUE,
-                             gainslift_bins = 0,
+                             gainslift_bins = -1,
                              verbose = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -341,7 +341,7 @@ h2o.randomForest <- function(x,
                                              custom_metric_func = NULL,
                                              export_checkpoints_dir = NULL,
                                              check_constant_response = TRUE,
-                                             gainslift_bins = 0,
+                                             gainslift_bins = -1,
                                              segment_columns = NULL,
                                              segment_models_id = NULL,
                                              parallelism = 1)

--- a/h2o-r/h2o-package/R/randomforest.R
+++ b/h2o-r/h2o-package/R/randomforest.R
@@ -89,6 +89,7 @@
 #' @param check_constant_response \code{Logical}. Check if response column is constant. If enabled, then an exception is thrown if the response
 #'        column is a constant value.If disabled, then model will train regardless of the response column being a
 #'        constant value or not. Defaults to TRUE.
+#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree). Defaults to FALSE.
 #' @return Creates a \linkS4class{H2OModel} object of the right type.
 #' @seealso \code{\link{predict.H2OModel}} for prediction
@@ -161,6 +162,7 @@ h2o.randomForest <- function(x,
                              custom_metric_func = NULL,
                              export_checkpoints_dir = NULL,
                              check_constant_response = TRUE,
+                             gainslift_bins = 0,
                              verbose = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -275,6 +277,8 @@ h2o.randomForest <- function(x,
     parms$export_checkpoints_dir <- export_checkpoints_dir
   if (!missing(check_constant_response))
     parms$check_constant_response <- check_constant_response
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   if (!missing(distribution)) {
     warning("Argument distribution is deprecated and has no use for Random Forest.")
@@ -337,6 +341,7 @@ h2o.randomForest <- function(x,
                                              custom_metric_func = NULL,
                                              export_checkpoints_dir = NULL,
                                              check_constant_response = TRUE,
+                                             gainslift_bins = 0,
                                              segment_columns = NULL,
                                              segment_models_id = NULL,
                                              parallelism = 1)
@@ -455,6 +460,8 @@ h2o.randomForest <- function(x,
     parms$export_checkpoints_dir <- export_checkpoints_dir
   if (!missing(check_constant_response))
     parms$check_constant_response <- check_constant_response
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   if (!missing(distribution)) {
     warning("Argument distribution is deprecated and has no use for Random Forest.")

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -99,7 +99,7 @@
 #' @param backend Backend. By default (auto), a GPU is used if available. Must be one of: "auto", "gpu", "cpu". Defaults to
 #'        auto.
 #' @param gpu_id Which GPU to use.  Defaults to 0.
-#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
+#' @param gainslift_bins Gains/Lift table number of bins. 0 means disabled.. Default value -1 means automatic binning. Defaults to -1.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree). Defaults to FALSE.
 #' @examples
 #' \dontrun{
@@ -193,7 +193,7 @@ h2o.xgboost <- function(x,
                         dmatrix_type = c("auto", "dense", "sparse"),
                         backend = c("auto", "gpu", "cpu"),
                         gpu_id = 0,
-                        gainslift_bins = 0,
+                        gainslift_bins = -1,
                         verbose = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -418,7 +418,7 @@ h2o.xgboost <- function(x,
                                         dmatrix_type = c("auto", "dense", "sparse"),
                                         backend = c("auto", "gpu", "cpu"),
                                         gpu_id = 0,
-                                        gainslift_bins = 0,
+                                        gainslift_bins = -1,
                                         segment_columns = NULL,
                                         segment_models_id = NULL,
                                         parallelism = 1)

--- a/h2o-r/h2o-package/R/xgboost.R
+++ b/h2o-r/h2o-package/R/xgboost.R
@@ -99,6 +99,7 @@
 #' @param backend Backend. By default (auto), a GPU is used if available. Must be one of: "auto", "gpu", "cpu". Defaults to
 #'        auto.
 #' @param gpu_id Which GPU to use.  Defaults to 0.
+#' @param gainslift_bins Gains/Lift table bins Defaults to 0.
 #' @param verbose \code{Logical}. Print scoring history to the console (Metrics per tree). Defaults to FALSE.
 #' @examples
 #' \dontrun{
@@ -192,6 +193,7 @@ h2o.xgboost <- function(x,
                         dmatrix_type = c("auto", "dense", "sparse"),
                         backend = c("auto", "gpu", "cpu"),
                         gpu_id = 0,
+                        gainslift_bins = 0,
                         verbose = FALSE)
 {
   # Validate required training_frame first and other frame args: should be a valid key or an H2OFrame object
@@ -344,6 +346,8 @@ h2o.xgboost <- function(x,
     parms$backend <- backend
   if (!missing(gpu_id))
     parms$gpu_id <- gpu_id
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   # Error check and build model
   model <- .h2o.modelJob('xgboost', parms, h2oRestApiVersion=3, verbose=verbose)
@@ -414,6 +418,7 @@ h2o.xgboost <- function(x,
                                         dmatrix_type = c("auto", "dense", "sparse"),
                                         backend = c("auto", "gpu", "cpu"),
                                         gpu_id = 0,
+                                        gainslift_bins = 0,
                                         segment_columns = NULL,
                                         segment_models_id = NULL,
                                         parallelism = 1)
@@ -570,6 +575,8 @@ h2o.xgboost <- function(x,
     parms$backend <- backend
   if (!missing(gpu_id))
     parms$gpu_id <- gpu_id
+  if (!missing(gainslift_bins))
+    parms$gainslift_bins <- gainslift_bins
 
   # Build segment-models specific parameters
   segment_parms <- list()

--- a/h2o-r/tests/testdir_math/runit_ks_metric.R
+++ b/h2o-r/tests/testdir_math/runit_ks_metric.R
@@ -1,0 +1,27 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+
+
+test.kolmogorov_smirnov <- function() {
+  data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
+  model <- h2o.gbm(x = c("Origin", "Distance"), y = "IsDepDelayed", training_frame = data, ntrees = 1, gainslift_bins = 500)
+  
+  print(h2o.gainsLift(model))
+  expect_false(is.null(h2o.gainsLift(model)$kolmogorov_smirnov))
+  kolmogorov_smirnov <- h2o.kolmogorov_smirnov(model)
+  print(kolmogorov_smirnov)
+  expect_true(is.numeric(kolmogorov_smirnov))
+  expect_true(kolmogorov_smirnov > 0 && kolmogorov_smirnov < 1)
+  
+  metrics <- model@model$training_metrics
+  kolmogorov_smirnov <- h2o.kolmogorov_smirnov(metrics)
+  print(kolmogorov_smirnov)
+  expect_true(is.numeric(kolmogorov_smirnov))
+  expect_true(kolmogorov_smirnov > 0 && kolmogorov_smirnov < 1)
+}
+
+doTest("PUBDEV-7404: Kolmogorov-Smirnov metric",
+       test.kolmogorov_smirnov)


### PR DESCRIPTION
[PUBDEV-7404](https://0xdata.atlassian.net/browse/PUBDEV-7404)

Requirements taken from the JIRA:

1. have a function that calculates KS :heavy_check_mark: 
2. allow the user the ability to specify the granularity of the bin (Set via new `gainslift_bins` option ) **R**: `model <- h2o.gbm(x = c("Origin", "Distance"), y = "IsDepDelayed", training_frame = data, ntrees = 1, gainslift_bins = 500)`. **Python**: `model = H2OGradientBoostingEstimator(ntrees=1, gainslift_bins=20)`
3. returns not just the maximum KS but also the distribution of positive/negative counts by prediction bin _(can be seen in the Gains/Lift table ?)_


R client :heavy_check_mark: 
Python client: :heavy_check_mark: 
Flow: :heavy_check_mark: (works naturally thanks to TwoDimTable).

![Screenshot from 2020-06-18 14-59-57](https://user-images.githubusercontent.com/8769110/85023018-72e2a480-b174-11ea-9568-c3a03a3431d1.png)


## Basic usage

```python
    airlines = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
    model = H2OGradientBoostingEstimator(ntrees=1, gainslift_bins=20)
    model.train(x=["Origin", "Distance"], y="IsDepDelayed", training_frame=airlines)

    print(model.gains_lift())
    print(model.kolmogorov_smirnov())
```

<details>
<summary>OUTPUT</summary>

```
Gains/Lift Table: Avg response rate: 54.69 %, avg score: 54.68 %
group    cumulative_data_fraction    lower_threshold    lift      cumulative_lift    response_rate    score     cumulative_response_rate    cumulative_score    capture_rate    cumulative_capture_rate    gain      cumulative_gain    kolmogorov_smirnov
-------  --------------------------  -----------------  --------  -----------------  ---------------  --------  --------------------------  ------------------  --------------  -------------------------  --------  -----------------  --------------------
1        0.0382458                   0.576503           1.56234   1.56234            0.85439          0.5774    0.85439                     0.5774              0.0597529       0.0597529                  56.234    56.234             0.047463
2        0.0409893                   0.575572           1.52839   1.56007            0.835821         0.575572  0.853147                    0.577277            0.00419319      0.0639461                  52.8385   56.0067            0.0506622
3        0.0917243                   0.568189           1.39175   1.46696            0.761098         0.568189  0.802232                    0.57225             0.0706103       0.134556                   39.1746   46.6965            0.0945238
4        0.121248                    0.566824           1.36701   1.44263            0.747573         0.566849  0.788923                    0.570935            0.0403594       0.174916                   36.7014   44.2627            0.118436
5        0.206707                    0.558832           1.21965   1.35044            0.666986         0.558848  0.73851                     0.565938            0.104231        0.279146                   21.9653   35.0443            0.159862
6        0.423652                    0.556035           1.16799   1.25701            0.638732         0.556035  0.687415                    0.560867            0.253388        0.532535                   16.7987   25.701             0.240288
7        0.503173                    0.549092           1.0772    1.22859            0.589083         0.551083  0.671875                    0.559321            0.0856608       0.618195                   7.72      22.8593            0.253836
8        0.702264                    0.542676           0.927089  1.14312            0.506993         0.542875  0.625131                    0.554658            0.184575        0.80277                    -7.29108  14.3117            0.221802
9        0.850006                    0.534575           0.791145  1.08194            0.43265          0.535421  0.591675                    0.551315            0.116885        0.919656                   -20.8855  8.19399            0.153706
10       0.95164                     0.522945           0.587187  1.0291             0.321112         0.524208  0.56278                     0.54842             0.059678        0.979334                   -41.2813  2.91009            0.0611156
11       1                           0.491833           0.427345  1                  0.2337           0.515403  0.546865                    0.546823            0.0206664       1                          -57.2655  0                  0

0.2538361336693768
```

^^^ The last row with a number is the K-S metric printed to console.
</details>