### PR TITLE
PUBDEV-7611: make GLM support early-stop

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -359,13 +359,16 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         _valid = rebalance(cleanUpInputFrame(_parms.valid().clone(), _parms, _gamColNamesCenter, _binvD, _zTranspose, _knots,
                 _numKnots), false, _result+".temporary.valid");
       }
+      Frame newValidFrame = _valid==null?null:new Frame(_valid);
       
       DKV.put(newTFrame); // This one will cause deleted vectors if add to Scope.track
+      if (newValidFrame != null)
+        DKV.put(newValidFrame);
       _job.update(0, "Initializing model training");
-      buildModel(newTFrame); // build gam model 
+      buildModel(newTFrame, newValidFrame); // build gam model 
     }
 
-    public final void buildModel(Frame newTFrame) {
+    public final void buildModel(Frame newTFrame, Frame newValidFrame) {
       GAMModel model = null;
       DataInfo dinfo = null;
       try {
@@ -383,7 +386,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
           model._output._gamTransformedTrainCenter = newTFrame._key;
         }
         _job.update(1, "calling GLM to build GAM model...");
-        GLMModel glmModel = buildGLMModel(_parms, newTFrame); // obtained GLM model
+        GLMModel glmModel = buildGLMModel(_parms, newTFrame, newValidFrame); // obtained GLM model
         Scope.track_generic(glmModel);
         _job.update(0, "Building out GAM model...");
         fillOutGAMModel(glmModel, model, dinfo); // build up GAM model
@@ -407,6 +410,9 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         }
         if (dinfo!=null)
           dinfo.remove();
+        if (newValidFrame != null) {
+          DKV.remove(newValidFrame._key);
+        }
       }
     }
     
@@ -435,8 +441,8 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
       }
     }
 
-    GLMModel buildGLMModel(GAMParameters parms, Frame trainData) {
-      GLMParameters glmParam = GamUtils.copyGAMParams2GLMParams(parms, trainData, valid());  // copy parameter from GAM to GLM
+    GLMModel buildGLMModel(GAMParameters parms, Frame trainData, Frame validFrame) {
+      GLMParameters glmParam = GamUtils.copyGAMParams2GLMParams(parms, trainData, validFrame);  // copy parameter from GAM to GLM
       int numGamCols = _parms._gam_columns.length;
       for (int find = 0; find < numGamCols; find++) {
         if ((_parms._scale != null) && (_parms._scale[find] != 1.0))
@@ -473,8 +479,8 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
       model._output._glm_training_metrics = glmModel._output._training_metrics;
       if (valid() != null)
         model._output._glm_validation_metrics = glmModel._output._validation_metrics;
-      model._output._glm_scoring_history = model.copyTwoDimTable(glmModel._output._scoring_history);
       model._output._glm_model_summary = model.copyTwoDimTable(glmModel._output._model_summary);
+      model._output._glm_scoring_history = model.copyTwoDimTable(glmModel._output._scoring_history);
       if (_parms._family == multinomial || _parms._family == ordinal) {
         model._output._coefficients_table = model.genCoefficientTableMultinomial(new String[]{"Coefficients",
                         "Standardized Coefficients"}, model._output._model_beta_multinomial,

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -38,13 +38,9 @@ import water.util.*;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Random;
+import java.util.*;
 
-import static hex.glm.GLMUtils.calSmoothNess;
-import static hex.glm.GLMUtils.extractAdaptedFrameIndices;
+import static hex.glm.GLMUtils.*;
 
 /**
  * Created by tomasnykodym on 8/27/14.
@@ -64,6 +60,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   public String[][] _gamColnames = null;
   public int[][] _gamColIndices = null; // corresponding column indices in dataInfo
   public static int _totalBetaLen;
+  private boolean _earlyStopEnabled = false;
+
   public GLM(boolean startup_once){super(new GLMParameters(),startup_once);}
   public GLM(GLMModel.GLMParameters parms) {
     super(parms);
@@ -154,7 +152,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           GLM g = (GLM) cvModelBuilders[i];
           double x = _parms._lambda[lidx];
           if (g._model._output.getSubmodel(x) == null)
-            g._driver.computeSubmodel(lidx, x);
+            g._driver.computeSubmodel(lidx, x, Double.NaN, Double.NaN);
           testDev += g._model._output.getSubmodel(x).devianceTest;
         }
         double testDevAvg = testDev / cvModelBuilders.length;
@@ -164,7 +162,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           GLM g = (GLM) cvModelBuilders[i];
           double x = _parms._lambda[lidx];
           if (g._model._output.getSubmodel(x) == null)
-            g._driver.computeSubmodel(lidx, x); // stopped too early, need to FIT extra model
+            g._driver.computeSubmodel(lidx, x, Double.NaN, Double.NaN); // stopped too early, need to FIT extra model
           double diff = testDevAvg - (g._model._output.getSubmodel(x).devianceTest);
           testDevSE += diff*diff;
         }
@@ -379,6 +377,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   private double _lmax;
   private transient long _nobs;
   private transient GLMModel _model;
+  private boolean _earlyStop = false;  // set by earlyStopping
+
   @Override
   public int nclasses() {
     if (_parms._family == Family.multinomial || _parms._family == Family.ordinal)
@@ -508,6 +508,12 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     }
     if (expensive) {
       if (error_count() > 0) return;
+      if (_parms._lambda_search && (_parms._stopping_rounds > 0)) {
+        error("early stop", " cannot run when lambda_search=True.  Lambda_search has its own " +
+                "early-stopping mechanism");
+      }
+      if (!_parms._lambda_search && (_parms._stopping_rounds > 0))  // early stop is on!
+        _earlyStopEnabled = true;
       if (_parms._alpha == null)
         _parms._alpha = new double[]{_parms._solver == Solver.L_BFGS ? 0 : .5};
       if (_parms._lambda_search  &&_parms._nlambdas == -1)
@@ -848,6 +854,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   public final class GLMDriver extends Driver implements ProgressMonitor {
     private long _workPerIteration;
     private transient double[][] _vcov;
+    List<Integer> _scoreIterationList = new ArrayList<Integer>(); // keep track of iteration where scoring occurs
 
 
     private void doCleanup() {
@@ -1766,7 +1773,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         _state.set_likelihoodInfo(mmHGLMBd._hlik, mmHGLMBd._pvh, mmHGLMBd._pbvh, mmHGLMBd._caic);
       }
       mb.makeModelMetrics(_model, train, _dinfo._adaptedFrame, null);  // add generated metric to DKV
-      scoreEnd(train, t1);
+      scorePostProcessing(train, t1);
     }
     
     private void calHlikStuff(ModelMetricsHGLM.MetricBuilderHGLM mmHGLMBd, Frame glmmmeReturns, Frame augXZ) {
@@ -1978,14 +1985,24 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       long t1 = System.currentTimeMillis();
       Frame train = DKV.<Frame>getGet(_parms._train); // need to keep this frame to get scoring metrics back
       _model.score(train).delete();
-      scoreEnd(train, t1);
+      scorePostProcessing(train, t1);
     }
     
-    private void scoreEnd(Frame train, long t1) {
+    private void scorePostProcessing(Frame train, long t1) {
+      _scoreIterationList.add(_state._iter);
       ModelMetrics mtrain = ModelMetrics.getFromDKV(_model, train); // updated by model.scoreAndUpdateModel
       long t2 = System.currentTimeMillis();
+      if (_parms._lambda_search)
+        _model._output._scoring_history = _lsc.to2dTable();
+      else if (_parms._HGLM)
+        _model._output._scoring_history = _sc.to2dTableHGLM();
+      else
+        _model._output._scoring_history = _sc.to2dTable();
       if (!(mtrain == null)) {
         _model._output._training_metrics = mtrain;
+        _model._output._training_time_ms = t2-_model._output._start_time; // remember training time
+        ScoreKeeper trainScore = new ScoreKeeper(Double.NaN);
+        trainScore.fillFrom(mtrain);
         Log.info(LogMsg(mtrain.toString()));
       } else {
         Log.info(LogMsg("ModelMetrics mtrain is null"));
@@ -1995,8 +2012,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         Frame valid = DKV.<Frame>getGet(_parms._valid);
         _model.score(valid).delete();
         _model._output._validation_metrics = ModelMetrics.getFromDKV(_model, valid); //updated by model.scoreAndUpdateModel
+        ScoreKeeper validScore = new ScoreKeeper(Double.NaN);
+        validScore.fillFrom(_model._output._validation_metrics);
       }
-      _model._output._scoring_history = _parms._lambda_search?_lsc.to2dTable():(_parms._HGLM?_sc.to2dTableHGLM():_sc.to2dTable());
+      
+      _model.addScoringInfo(_parms, nclasses(), t2);  // add to scoringInfo for early stopping
       _model.update(_job._key);
       if (_parms._HGLM)
         _model.generateSummaryHGLM(_parms._train,_state._iter);
@@ -2007,10 +2027,10 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       _scoringInterval = Math.max(_scoringInterval,20*scoringTime); // at most 5% overhead for scoring
     }
 
-    protected Submodel computeSubmodel(int i,double lambda) {
+    protected Submodel computeSubmodel(int i,double lambda, double nullDevTrain, double nullDevTest) {
       Submodel sm;
       if(lambda >= _lmax && _state.l1pen() > 0)
-        _model.addSubmodel(sm = new Submodel(lambda,getNullBeta(),_state._iter,_nullDevTrain,_nullDevTest));
+        _model.addSubmodel(sm = new Submodel(lambda,getNullBeta(),_state._iter, nullDevTrain, nullDevTest));
       else {  // this is also the path for HGLM model
         sm = new Submodel(lambda, _state.beta(),_state._iter,-1,-1);
         if (_parms._HGLM) // add random coefficients for random effects/columns
@@ -2055,29 +2075,28 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       }
       return sm;
     }
-
-    private transient double _nullDevTrain = Double.NaN;
-    private transient double _nullDevTest = Double.NaN;
+    
     @Override
     public void computeImpl() {
+      double nullDevTrain = Double.NaN;
+      double nullDevTest = Double.NaN;
       if(_doInit)
         init(true);
       if (error_count() > 0)
         throw H2OModelBuilderIllegalArgumentException.makeFromBuilder(GLM.this);
-//      buildModel();
       _model._output._start_time = System.currentTimeMillis(); //quickfix to align output duration with other models
       if(_parms._lambda_search) {
         if (_parms._family == Family.ordinal)
-          _nullDevTrain = new GLMResDevTaskOrdinal(_job._key,_state._dinfo,getNullBeta(), _nclass).doAll(_state._dinfo._adaptedFrame).avgDev();
+          nullDevTrain = new GLMResDevTaskOrdinal(_job._key,_state._dinfo,getNullBeta(), _nclass).doAll(_state._dinfo._adaptedFrame).avgDev();
         else
-        _nullDevTrain =  _parms._family == Family.multinomial
+        nullDevTrain =  _parms._family == Family.multinomial
           ?new GLMResDevTaskMultinomial(_job._key,_state._dinfo,getNullBeta(), _nclass).doAll(_state._dinfo._adaptedFrame).avgDev()
           :new GLMResDevTask(_job._key, _state._dinfo, _parms, getNullBeta()).doAll(_state._dinfo._adaptedFrame).avgDev();
         if(_validDinfo != null) {
           if (_parms._family == Family.ordinal)
-            _nullDevTest = new GLMResDevTaskOrdinal(_job._key, _validDinfo, getNullBeta(), _nclass).doAll(_validDinfo._adaptedFrame).avgDev();
+            nullDevTest = new GLMResDevTaskOrdinal(_job._key, _validDinfo, getNullBeta(), _nclass).doAll(_validDinfo._adaptedFrame).avgDev();
           else
-          _nullDevTest = _parms._family == Family.multinomial
+          nullDevTest = _parms._family == Family.multinomial
                   ? new GLMResDevTaskMultinomial(_job._key, _validDinfo, getNullBeta(), _nclass).doAll(_validDinfo._adaptedFrame).avgDev()
                   : new GLMResDevTask(_job._key, _validDinfo, _parms, getNullBeta()).doAll(_validDinfo._adaptedFrame).avgDev();
         }
@@ -2111,8 +2130,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         addWdataZiEtaOld2Response();
       }
       
-      double oldDevTrain = _nullDevTrain;
-      double oldDevTest = _nullDevTest;
+      double oldDevTrain = nullDevTrain;
+      double oldDevTest = nullDevTest;
       double [] devHistoryTrain = new double[5];
       double [] devHistoryTest = new double[5];
 
@@ -2120,16 +2139,16 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         updateProgress(false);
       // lambda search loop
       for (int i = 0; i < _parms._lambda.length; ++i) {  // lambda search
-        if (_job.stop_requested() || (timeout() && _model._output._submodels.length > 0)) break;  //need at least one submodel on timeout to avoid issues.
+        if (_job.stop_requested() || (timeout() && _model._output._submodels.length > 0) || _earlyStop) break;  //need at least one submodel on timeout to avoid issues.
         if(_parms._max_iterations != -1 && _state._iter >= _parms._max_iterations) break;
-        Submodel sm = computeSubmodel(i,_parms._lambda[i]);
+        Submodel sm = computeSubmodel(i,_parms._lambda[i], nullDevTrain, nullDevTest);
         double trainDev = sm.devianceTrain;
         double testDev = sm.devianceTest;
         devHistoryTest[i % devHistoryTest.length] = (oldDevTest - testDev)/oldDevTest;
         oldDevTest = testDev;
         devHistoryTrain[i % devHistoryTrain.length] = (oldDevTrain - trainDev)/oldDevTrain;
         oldDevTrain = trainDev;
-        if(_parms._lambda[i] < _lmax && Double.isNaN(_lambdaCVEstimate) /** if we have cv lambda estimate we should use it, can not stop before reaching it */) {
+        if(_parms._lambda[i] < _lmax && Double.isNaN(_lambdaCVEstimate) && !_earlyStopEnabled /** if we have cv lambda estimate we should use it, can not stop before reaching it */) {
           if (_parms._early_stopping && _state._iter >= devHistoryTrain.length) {
             double s = ArrayUtils.maxValue(devHistoryTrain);
             if (s < 1e-4) {
@@ -2151,9 +2170,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         }
         _job.update(_workPerIteration,"iter=" + _state._iter + " lmb=" + lambdaFormatter.format(_state.lambda()) + "deviance trn/tst= " + devFormatter.format(trainDev) + "/" + devFormatter.format(testDev) + " P=" + ArrayUtils.countNonzeros(_state.beta()));
       }
-      if (stop_requested()) {
+      if (stop_requested() || _earlyStop) {
         if (timeout()) {
           Log.info("Stopping GLM training because of timeout");
+        } else if (_earlyStop) {
+          Log.info("Stopping GLM training due to hitting earlyStopping criteria.");
         } else {
           throw new Job.JobCancelledException();
         }
@@ -2170,6 +2191,10 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       }
       if (!_parms._HGLM)  // no need to do for HGLM
         scoreAndUpdateModel();
+      TwoDimTable scoring_history_early_stop = ScoringInfo.createScoringHistoryTable(_model.getScoringInfo(),
+              (null != _parms._valid), false, _model._output.getModelCategory(), false);
+      _model._output._scoring_history = combineScoringHistory(_model._output._scoring_history,
+              scoring_history_early_stop, _scoreIterationList);
       _model.update(_job._key);
 /*      if (_vcov != null) {
         _model.setVcov(_vcov);
@@ -2235,7 +2260,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         _state.updateState(beta, gginfo);
         if (!_parms._lambda_search)
           updateProgress(false);
-        return !stop_requested() && _state._iter < _parms._max_iterations;
+        return !stop_requested() && _state._iter < _parms._max_iterations && !_earlyStop;
       } else {
         GLMGradientInfo gginfo = (GLMGradientInfo) ginfo;
         if(gginfo._gradient == null)
@@ -2244,16 +2269,16 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           _state.updateState(beta, gginfo);
         if (!_parms._lambda_search)
           updateProgress(true);
-        boolean converged = _state.converged();
+        boolean converged = !_earlyStopEnabled && _state.converged(); // GLM specific early stop.  Disabled if early stop is enabled
         if (converged) Log.info(LogMsg(_state.convergenceMsg));
-        return !stop_requested() && !converged && _state._iter < _parms._max_iterations;
+        return !stop_requested() && !converged && _state._iter < _parms._max_iterations && !_earlyStop;
       }
     }
 
     public boolean progressHGLMGLMMME(double sumDiff2, double sumeta2, int iteration, boolean atGLMMME, GLMModel 
             fixedModel, GLMModel[] randModels, Frame glmmmeReturns, Frame hvDataOnly, double[] VC1, double[][] VC2,
                                       double[][] cholR, Frame augZ) {
-      boolean converged = (sumDiff2 < (_parms._objective_epsilon*sumeta2));
+      boolean converged = !_earlyStopEnabled && (sumDiff2 < (_parms._objective_epsilon*sumeta2));
       if (atGLMMME) {
         _state._iterHGLM_GLMMME++;
       } else {
@@ -2261,7 +2286,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           updateProgress(fixedModel, randModels, glmmmeReturns, hvDataOnly, VC1, VC2, sumDiff2,
                   sumDiff2 / sumeta2, true, cholR, augZ);
       }
-      return !stop_requested() && !converged && (iteration < _parms._max_iterations);
+      return !stop_requested() && !converged && (iteration < _parms._max_iterations) && !_earlyStop;
     }
     
     public boolean progress(double [] beta, double likelihood) {
@@ -2269,9 +2294,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       _state.updateState(beta,likelihood);
       if(!_parms._lambda_search)
         updateProgress(true);
-      boolean converged = _state.converged();
+      boolean converged = !_earlyStopEnabled && _state.converged();
       if(converged) Log.info(LogMsg(_state.convergenceMsg));
-      return !stop_requested() && !converged && _state._iter < _parms._max_iterations ;
+      return !stop_requested() && !converged && _state._iter < _parms._max_iterations && !_earlyStop;
     }
 
     private transient long _scoringInterval = SCORING_INTERVAL_MSEC;
@@ -2280,10 +2305,12 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
                                   double[] VC1, double[][] VC2, double sumDiff2, double convergence, boolean canScore,
                                   double[][] cholR, Frame augXZ) {
       _sc.addIterationScore(_state._iter, _state._sumEtaSquareConvergence);
-      if(canScore && (_parms._score_each_iteration || timeSinceLastScoring() > _scoringInterval)) {
+      if(canScore && (_parms._score_each_iteration || timeSinceLastScoring() > _scoringInterval || 
+              ((_parms._score_iteration_interval > 0) && ((_state._iter % _parms._score_iteration_interval) == 0)))) {
         _model.update(_state.expandBeta(_state.beta()), _state.ubeta(),-1, -1, _state._iter);
         scoreAndUpdateModelHGLM(fixedModel, randModels, glmmmeReturns, hvDataOnly, VC1, VC2, sumDiff2, convergence, 
                 cholR, augXZ, false);
+        _earlyStop = updateEarlyStop();
       }
     }
     // update user visible progress
@@ -2294,10 +2321,17 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       if(canScore && (_parms._score_each_iteration || timeSinceLastScoring() > _scoringInterval)) {
         _model.update(_state.expandBeta(_state.beta()), -1, -1, _state._iter);
         scoreAndUpdateModel();
+        _earlyStop = updateEarlyStop();
       }
     }
   }
 
+  private boolean updateEarlyStop() {
+    return _earlyStop || ScoreKeeper.stopEarly(_model.scoreKeepers(),
+            _parms._stopping_rounds, ScoreKeeper.ProblemType.forSupervised(_nclass > 1), _parms._stopping_metric,
+            _parms._stopping_tolerance, "model's last", true);
+  }
+  
   private Solver defaultSolver() {
     Solver s = Solver.IRLSM;
     int max_active = 0;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -19,9 +19,7 @@ import water.udf.CFuncRef;
 import water.util.*;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 import static hex.genmodel.utils.ArrayUtils.flat;
 
@@ -42,6 +40,40 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     _nullDOF = nobs - (parms._intercept?1:0);
   }
 
+  public ScoreKeeper[] scoreKeepers() {
+    int size = scoringInfo==null?0:scoringInfo.length;
+    ScoreKeeper[] sk = new ScoreKeeper[size];
+    for (int i=0;i<size;++i) {
+      if (scoringInfo[i].cross_validation) // preference is to use xval first, then valid and last train.
+        sk[i] = scoringInfo[i].scored_xval;
+      else if (scoringInfo[i].validation)
+        sk[i] = scoringInfo[i].scored_valid;
+      else
+        sk[i] = scoringInfo[i].scored_train;
+    }
+    return sk;
+  }
+  
+  public ScoringInfo[] getScoringInfo() { return scoringInfo;}
+  
+  public void addScoringInfo(GLMParameters parms, int nclasses, long currTime) {
+    ScoringInfo currInfo = new ScoringInfo();
+    currInfo.is_classification = nclasses > 1;
+    currInfo.validation = parms.valid() != null;
+    currInfo.cross_validation = parms._nfolds > 1;
+    currInfo.time_stamp_ms = scoringInfo==null?_output._start_time:currTime;
+    currInfo.total_training_time_ms = _output._training_time_ms;
+    if (_output._training_metrics != null) {
+      currInfo.scored_train = new ScoreKeeper(Double.NaN);
+      currInfo.scored_train.fillFrom(_output._training_metrics);
+    }
+    if (_output._validation_metrics != null) {
+      currInfo.scored_valid = new ScoreKeeper(Double.NaN);
+      currInfo.scored_valid.fillFrom(_output._validation_metrics);
+    }
+    scoringInfo = ScoringInfo.prependScoringInfo(currInfo, scoringInfo);
+  }
+  
   public void setVcov(double[][] inv) {_output._vcov = inv;}
 
   public static class RegularizationPath extends Iced {
@@ -221,6 +253,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public double[] _startval;  // for HGLM, initialize fixed and random coefficients (init_u), init_sig_u, init_sig_e
     public boolean _calc_like;
     public int[] _random_columns;
+    public int _score_iteration_interval = -1;
     // Has to be Serializable for backwards compatibility (used to be DeepLearningModel.MissingValuesHandling)
     public Serializable _missing_values_handling = MissingValuesHandling.MeanImputation;
     public double _prior = -1;
@@ -405,9 +438,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public GLMParameters() {
       this(Family.gaussian, Link.family_default);
       assert _link == Link.family_default;
-      _stopping_rounds = 3;
-      _stopping_metric = ScoreKeeper.StoppingMetric.deviance;
-      _stopping_tolerance = 1e-4;
+      _stopping_rounds = 0; // early-stopping is disabled by default
     }
 
     public GLMParameters(Family f){this(f,f.defaultLink);}
@@ -1083,6 +1114,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public String[] _coefficient_names;
     String[] _random_coefficient_names; // for HGLM
     String[] _random_column_names;
+    public long _training_time_ms;
     public int _best_lambda_idx; // lambda which minimizes deviance on validation (if provided) or train (if not)
     public int _lambda_1se = -1; // lambda_best + sd(lambda); only applicable if running lambda search with nfold
     public int _selected_lambda_idx; // lambda which minimizes deviance on validation (if provided) or train (if not)
@@ -1096,7 +1128,6 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     double [][] _vcov;
     private double _dispersion;
     private boolean _dispersionEstimated;
-    
     public boolean hasPValues(){return _zvalues != null;}
     public double [] stdErr(){
       double [] res = _zvalues.clone();
@@ -1243,7 +1274,6 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       _nclasses = glm.nclasses();
       _multinomial = glm._parms._family == Family.multinomial;
       _ordinal = (glm._parms._family == Family.ordinal);
-
     }
 
     /**
@@ -1410,7 +1440,6 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     }
     return res;
   }
-  
   
   // TODO: Shouldn't this be in schema? have it here for now to be consistent with others...
   /**

--- a/h2o-algos/src/main/java/hex/schemas/GAMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMModelV3.java
@@ -1,10 +1,10 @@
 package hex.schemas;
 
 import hex.gam.GAMModel;
+import water.api.API;
+import water.api.schemas3.ModelOutputSchemaV3;
 import water.api.schemas3.ModelSchemaV3;
 import water.api.schemas3.TwoDimTableV3;
-import water.api.schemas3.ModelOutputSchemaV3;
-import water.api.API;
 
 public class GAMModelV3 extends ModelSchemaV3<GAMModel, GAMModelV3, GAMModel.GAMParameters, GAMV3.GAMParametersV3,
         GAMModel.GAMModelOutput, GAMModelV3.GAMModelOutputV3> {

--- a/h2o-algos/src/main/java/hex/schemas/GAMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMV3.java
@@ -60,6 +60,9 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
             "interaction_pairs",
             "obj_reg",
             "export_checkpoints_dir",
+            "stopping_rounds",
+            "stopping_metric",
+            "stopping_tolerance",
             // dead unused args forced here by backwards compatibility, remove in V4
             "balance_classes",
             "class_sampling_factors",

--- a/h2o-algos/src/main/java/hex/schemas/GLMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMV3.java
@@ -31,7 +31,8 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "ignored_columns",
             "random_columns", // HGLM denote random columns, array
             "ignore_const_cols",
-            "score_each_iteration",
+            "score_each_iteration", 
+            "score_iteration_interval",
             "offset_column",
             "weights_column",
             "family",
@@ -69,6 +70,9 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
             "interaction_pairs",
             "obj_reg",
             "export_checkpoints_dir",
+             "stopping_rounds",
+             "stopping_metric",
+             "stopping_tolerance",
             // dead unused args forced here by backwards compatibility, remove in V4
             "balance_classes",
             "class_sampling_factors",
@@ -122,6 +126,9 @@ public class GLMV3 extends ModelBuilderSchema<GLM,GLMV3,GLMV3.GLMParametersV3> {
     " set to True, the value of nlamdas is set to 30 (fewer lambdas" +
     " are needed for ridge regression) otherwise it is set to 100.", level = Level.critical)
     public int nlambdas;
+    
+    @API(help = "Perform scoring for every score_iteration_interval iterations", level = Level.secondary)
+    public int score_iteration_interval;
 
     @API(help = "Standardize numeric columns to have zero mean and unit variance", level = Level.critical)
     public boolean standardize;

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -14,7 +14,6 @@ import hex.Model.Parameters.FoldAssignmentScheme;
 import hex.ModelBuilder;
 import hex.ModelContainer;
 import hex.ScoreKeeper.StoppingMetric;
-import hex.ensemble.StackedEnsembleModel;
 import hex.grid.Grid;
 import hex.grid.GridSearch;
 import hex.grid.HyperSpaceSearchCriteria;

--- a/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/ModelingStep.java
@@ -206,34 +206,16 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
      *
      * @param parms the model parameters to which the stopping criteria will be added.
      * @param defaults the default parameters for the corresponding {@link ModelBuilder}.
-     * @param seedPolicy the policy defining how the seed will be assigned to the model parameters.
      */
-    protected void setStoppingCriteria(Model.Parameters parms, Model.Parameters defaults, SeedPolicy seedPolicy) {
+    protected void setStoppingCriteria(Model.Parameters parms, Model.Parameters defaults) {
         // If the caller hasn't set ModelBuilder stopping criteria, set it from our global criteria.
         AutoMLBuildSpec buildSpec = aml().getBuildSpec();
-        if (parms._max_runtime_secs == 0)
-            parms._max_runtime_secs = buildSpec.build_control.stopping_criteria.max_runtime_secs_per_model();
 
         //FIXME: Do we really need to compare with defaults before setting the buildSpec value instead?
         // This can create subtle bugs: e.g. if dev wanted to enforce a stopping criteria for a specific algo/model,
         // he wouldn't be able to enforce the default value, that would always be overridden by buildSpec.
         // We should instead provide hooks and ensure that properties are always set in the following order:
         //  1. defaults, 2. user defined, 3. internal logic/algo specific based on the previous state (esp. handling of AUTO properties).
-
-        // Don't use the same exact seed so that, e.g., if we build two GBMs they don't do the same row and column sampling.
-        if (parms._seed == defaults._seed) {
-            switch (seedPolicy) {
-                case Global:
-                    parms._seed = buildSpec.build_control.stopping_criteria.seed();
-                    break;
-                case Incremental:
-                    parms._seed = _aml._incrementalSeed.get() == defaults._seed ? defaults._seed : _aml._incrementalSeed.getAndIncrement();
-                    break;
-                default:
-                    break;
-            }
-        }
-
 
         if (parms._stopping_metric == defaults._stopping_metric)
             parms._stopping_metric = buildSpec.build_control.stopping_criteria.stopping_metric();
@@ -250,6 +232,36 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
 
         if (parms._stopping_tolerance == defaults._stopping_tolerance)
             parms._stopping_tolerance = buildSpec.build_control.stopping_criteria.stopping_tolerance();
+    }
+
+    /**
+     * @param parms the model parameters to which the stopping criteria will be added.
+     * @param defaults the default parameters for the corresponding {@link ModelBuilder}.
+     * @param seedPolicy the policy defining how the seed will be assigned to the model parameters.
+     */
+    protected void setSeed(Model.Parameters parms, Model.Parameters defaults, SeedPolicy seedPolicy) {
+        AutoMLBuildSpec buildSpec = aml().getBuildSpec();
+        // Don't use the same exact seed so that, e.g., if we build two GBMs they don't do the same row and column sampling.
+        if (parms._seed == defaults._seed) {
+            switch (seedPolicy) {
+                case Global:
+                    parms._seed = buildSpec.build_control.stopping_criteria.seed();
+                    break;
+                case Incremental:
+                    parms._seed = _aml._incrementalSeed.get() == defaults._seed ? defaults._seed : _aml._incrementalSeed.getAndIncrement();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    
+    protected void initTimeConstraints(Model.Parameters parms, double upperLimit) {
+        AutoMLBuildSpec buildSpec = aml().getBuildSpec();
+        if (parms._max_runtime_secs == 0) {
+            double maxPerModel = buildSpec.build_control.stopping_criteria.max_runtime_secs_per_model();
+            parms._max_runtime_secs = upperLimit <= 0 ? maxPerModel : Math.min(maxPerModel, upperLimit);
+        }
     }
 
     private String getSortMetric() {
@@ -315,8 +327,10 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
             if (null == key) key = makeKey(algoName, true);
 
             Model.Parameters defaults = ModelBuilder.make(_algo.urlName(), null, null)._parms;
+            initTimeConstraints(parms, 0);
             setCommonModelBuilderParams(parms);
-            setStoppingCriteria(parms, defaults, SeedPolicy.Incremental);
+            setSeed(parms, defaults, SeedPolicy.Incremental);
+            setStoppingCriteria(parms, defaults);
             setCustomParams(parms);
 
             // override model's max_runtime_secs to ensure that the total max_runtime doesn't exceed expectations
@@ -388,8 +402,10 @@ public abstract class ModelingStep<M extends Model> extends Iced<ModelingStep> {
                 throw new H2OIllegalArgumentException("Hyperparameter search can't create a new instance of Model.Parameters subclass: " + baseParms.getClass());
             }
 
+            initTimeConstraints(baseParms, 0);
             setCommonModelBuilderParams(baseParms);
-            setStoppingCriteria(baseParms, defaults, SeedPolicy.None);
+            // grid seed is provided later through the searchCriteria
+            setStoppingCriteria(baseParms, defaults);
             setCustomParams(baseParms);
 
             AutoMLBuildSpec buildSpec = aml().getBuildSpec();

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GBMStepsProvider.java
@@ -164,9 +164,10 @@ public class GBMStepsProvider
                         aml().eventLog().info(EventLogEntry.Stage.ModelSelection, "Retraining best GBM with learning rate annealing: "+bestGBM._key);
                         GBMParameters gbmParameters = (GBMParameters) bestGBM._parms.clone();
                         gbmParameters._ntrees = 10000; // reset ntrees (we'll need more for this fine tuning)
+                        gbmParameters._max_runtime_secs = 0; // reset max runtime
                         gbmParameters._learn_rate_annealing = 0.99;
-                        gbmParameters._max_runtime_secs = maxRuntimeSecs;
-                        setStoppingCriteria(gbmParameters, new GBMParameters(), SeedPolicy.None);
+                        initTimeConstraints(gbmParameters, maxRuntimeSecs);
+                        setStoppingCriteria(gbmParameters, new GBMParameters());
                         return asModelsJob(startModel(Key.make(result+"_model"), gbmParameters), result);
                     }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
@@ -5,9 +5,6 @@ import hex.Model;
 import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters;
 import water.Job;
-import water.util.ArrayUtils;
-
-import java.util.Arrays;
 
 import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
@@ -1,9 +1,13 @@
 package ai.h2o.automl.modeling;
 
 import ai.h2o.automl.*;
+import hex.Model;
 import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters;
 import water.Job;
+import water.util.ArrayUtils;
+
+import java.util.Arrays;
 
 import static ai.h2o.automl.ModelingStep.ModelStep.DEFAULT_MODEL_TRAINING_WEIGHT;
 
@@ -18,6 +22,11 @@ public class GLMStepsProvider
 
             GLMModelStep(String id, int weight, AutoML autoML) {
                 super(Algo.GLM, id, weight, autoML);
+            }
+
+            @Override
+            protected void setStoppingCriteria(Model.Parameters parms, Model.Parameters defaults, SeedPolicy seedPolicy) {
+                // disabled as we're using lambda search
             }
 
             GLMParameters prepareModelParameters() {

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/GLMStepsProvider.java
@@ -22,7 +22,7 @@ public class GLMStepsProvider
             }
 
             @Override
-            protected void setStoppingCriteria(Model.Parameters parms, Model.Parameters defaults, SeedPolicy seedPolicy) {
+            protected void setStoppingCriteria(Model.Parameters parms, Model.Parameters defaults) {
                 // disabled as we're using lambda search
             }
 

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/StackedEnsembleStepsProvider.java
@@ -31,6 +31,21 @@ public class StackedEnsembleStepsProvider
             }
 
             @Override
+            protected void setCrossValidationParams(Model.Parameters params) {
+                //added in the stack: we could probably move this here.
+            }
+
+            @Override
+            protected void setWeightingParams(Model.Parameters params) {
+                //Disabled: StackedEnsemble doesn't support weights in score0? 
+            }
+
+            @Override
+            protected void setClassBalancingParams(Model.Parameters params) {
+                //Disabled
+            }
+
+            @Override
             protected boolean canRun() {
                 Key<Model>[] keys = getBaseModels();
                 Work seWork = getAllocatedWork();

--- a/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/modeling/XGBoostSteps.java
@@ -212,9 +212,10 @@ public class XGBoostSteps extends ModelingSteps {
                     aml().eventLog().info(EventLogEntry.Stage.ModelSelection, "Retraining best XGBoost with learning rate annealing: "+bestXGB._key);
                     XGBoostParameters xgBoostParameters = (XGBoostParameters) bestXGB._parms.clone();
                     xgBoostParameters._ntrees = 10000; // reset ntrees (we'll need more for this fine tuning)
+                    xgBoostParameters._max_runtime_secs = 0; // reset max runtime
                     xgBoostParameters._learn_rate_annealing = 0.99;
-                    xgBoostParameters._max_runtime_secs = maxRuntimeSecs;
-                    setStoppingCriteria(xgBoostParameters, new XGBoostParameters(), SeedPolicy.None);
+                    initTimeConstraints(xgBoostParameters, maxRuntimeSecs);
+                    setStoppingCriteria(xgBoostParameters, new XGBoostParameters());
                     return asModelsJob(startModel(Key.make(result+"_model"), xgBoostParameters), result);
                 }
 
@@ -245,7 +246,9 @@ public class XGBoostSteps extends ModelingSteps {
                     XGBoostParameters xgBoostParameters = (XGBoostParameters) bestXGB._parms.clone();
                     XGBoostParameters defaults = new XGBoostParameters();
                     xgBoostParameters._ntrees = 10000; // reset ntrees (we'll need more for this fine tuning)
-                    setStoppingCriteria(xgBoostParameters, defaults, SeedPolicy.None); // keep the same seed as the bestXGB
+                    xgBoostParameters._max_runtime_secs = 0; // reset max runtime
+                    initTimeConstraints(xgBoostParameters, 0); // ensure we have a max runtime per model in the grid
+                    setStoppingCriteria(xgBoostParameters, defaults); // keep the same seed as the bestXGB
                     // reset _eta to defaults, otherwise it ignores the _learn_rate hyperparam: this is very annoying!
                     xgBoostParameters._eta = defaults._eta;
 //                    xgBoostParameters._learn_rate = defaults._learn_rate;

--- a/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
+++ b/h2o-automl/src/test/java/ai/h2o/automl/AutoMLTest.java
@@ -710,7 +710,7 @@ public class AutoMLTest extends water.TestUtil {
           assertTrue(key+":"+parameters._seed, Math.abs(parameters._seed - seed) < maxModels);
           collectedSeeds.add(parameters._seed);
           assertTrue(key+" has `stopping_rounds` param set to "+parameters._stopping_rounds,
-                  parameters._stopping_rounds == 3 || algo == Algo.XGBoost);  // currently only enforced to different value for XGB (AutoML hardcoded)
+                  parameters._stopping_rounds == 3 || algo == Algo.GLM);  // stopping criteria only disabled for GLM (using lambda search)
         }
         assertTrue(collectedSeeds.size() > 1 || keys.size() < 2);  // we should have built enough models to guarantee this
       }

--- a/h2o-py/h2o/estimators/gam.py
+++ b/h2o-py/h2o/estimators/gam.py
@@ -37,10 +37,10 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
                    "missing_values_handling", "plug_values", "compute_p_values", "remove_collinear_columns",
                    "intercept", "non_negative", "max_iterations", "objective_epsilon", "beta_epsilon",
                    "gradient_epsilon", "link", "prior", "lambda_min_ratio", "beta_constraints", "max_active_predictors",
-                   "interactions", "interaction_pairs", "obj_reg", "export_checkpoints_dir", "balance_classes",
-                   "class_sampling_factors", "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k",
-                   "max_runtime_secs", "custom_metric_func", "num_knots", "knot_ids", "gam_columns", "bs", "scale",
-                   "keep_gam_cols"}
+                   "interactions", "interaction_pairs", "obj_reg", "export_checkpoints_dir", "stopping_rounds",
+                   "stopping_metric", "stopping_tolerance", "balance_classes", "class_sampling_factors",
+                   "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k", "max_runtime_secs",
+                   "custom_metric_func", "num_knots", "knot_ids", "gam_columns", "bs", "scale", "keep_gam_cols"}
 
     def __init__(self, **kwargs):
         super(H2OGeneralizedAdditiveEstimator, self).__init__()
@@ -751,6 +751,56 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
     def export_checkpoints_dir(self, export_checkpoints_dir):
         assert_is_type(export_checkpoints_dir, None, str)
         self._parms["export_checkpoints_dir"] = export_checkpoints_dir
+
+
+    @property
+    def stopping_rounds(self):
+        """
+        Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
+        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable)
+
+        Type: ``int``  (default: ``0``).
+        """
+        return self._parms.get("stopping_rounds")
+
+    @stopping_rounds.setter
+    def stopping_rounds(self, stopping_rounds):
+        assert_is_type(stopping_rounds, None, int)
+        self._parms["stopping_rounds"] = stopping_rounds
+
+
+    @property
+    def stopping_metric(self):
+        """
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
+
+        One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
+        ``"aucpr"``, ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
+        """
+        return self._parms.get("stopping_metric")
+
+    @stopping_metric.setter
+    def stopping_metric(self, stopping_metric):
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "aucpr", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        self._parms["stopping_metric"] = stopping_metric
+
+
+    @property
+    def stopping_tolerance(self):
+        """
+        Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)
+
+        Type: ``float``  (default: ``0.001``).
+        """
+        return self._parms.get("stopping_tolerance")
+
+    @stopping_tolerance.setter
+    def stopping_tolerance(self, stopping_tolerance):
+        assert_is_type(stopping_tolerance, None, numeric)
+        self._parms["stopping_tolerance"] = stopping_tolerance
 
 
     @property

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -32,15 +32,16 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     param_names = {"model_id", "training_frame", "validation_frame", "nfolds", "seed", "keep_cross_validation_models",
                    "keep_cross_validation_predictions", "keep_cross_validation_fold_assignment", "fold_assignment",
                    "fold_column", "response_column", "ignored_columns", "random_columns", "ignore_const_cols",
-                   "score_each_iteration", "offset_column", "weights_column", "family", "rand_family",
-                   "tweedie_variance_power", "tweedie_link_power", "theta", "solver", "alpha", "lambda_",
+                   "score_each_iteration", "score_iteration_interval", "offset_column", "weights_column", "family",
+                   "rand_family", "tweedie_variance_power", "tweedie_link_power", "theta", "solver", "alpha", "lambda_",
                    "lambda_search", "early_stopping", "nlambdas", "standardize", "missing_values_handling",
                    "plug_values", "compute_p_values", "remove_collinear_columns", "intercept", "non_negative",
                    "max_iterations", "objective_epsilon", "beta_epsilon", "gradient_epsilon", "link", "rand_link",
                    "startval", "calc_like", "HGLM", "prior", "lambda_min_ratio", "beta_constraints",
                    "max_active_predictors", "interactions", "interaction_pairs", "obj_reg", "export_checkpoints_dir",
-                   "balance_classes", "class_sampling_factors", "max_after_balance_size", "max_confusion_matrix_size",
-                   "max_hit_ratio_k", "max_runtime_secs", "custom_metric_func"}
+                   "stopping_rounds", "stopping_metric", "stopping_tolerance", "balance_classes",
+                   "class_sampling_factors", "max_after_balance_size", "max_confusion_matrix_size", "max_hit_ratio_k",
+                   "max_runtime_secs", "custom_metric_func"}
 
     def __init__(self, **kwargs):
         super(H2OGeneralizedLinearEstimator, self).__init__()
@@ -446,6 +447,21 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def score_each_iteration(self, score_each_iteration):
         assert_is_type(score_each_iteration, None, bool)
         self._parms["score_each_iteration"] = score_each_iteration
+
+
+    @property
+    def score_iteration_interval(self):
+        """
+        Perform scoring for every score_iteration_interval iterations
+
+        Type: ``int``  (default: ``-1``).
+        """
+        return self._parms.get("score_iteration_interval")
+
+    @score_iteration_interval.setter
+    def score_iteration_interval(self, score_iteration_interval):
+        assert_is_type(score_iteration_interval, None, int)
+        self._parms["score_iteration_interval"] = score_iteration_interval
 
 
     @property
@@ -1535,6 +1551,56 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
     def export_checkpoints_dir(self, export_checkpoints_dir):
         assert_is_type(export_checkpoints_dir, None, str)
         self._parms["export_checkpoints_dir"] = export_checkpoints_dir
+
+
+    @property
+    def stopping_rounds(self):
+        """
+        Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
+        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable)
+
+        Type: ``int``  (default: ``0``).
+        """
+        return self._parms.get("stopping_rounds")
+
+    @stopping_rounds.setter
+    def stopping_rounds(self, stopping_rounds):
+        assert_is_type(stopping_rounds, None, int)
+        self._parms["stopping_rounds"] = stopping_rounds
+
+
+    @property
+    def stopping_metric(self):
+        """
+        Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and anonomaly_score
+        for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF with the Python
+        client.
+
+        One of: ``"auto"``, ``"deviance"``, ``"logloss"``, ``"mse"``, ``"rmse"``, ``"mae"``, ``"rmsle"``, ``"auc"``,
+        ``"aucpr"``, ``"lift_top_group"``, ``"misclassification"``, ``"mean_per_class_error"``, ``"custom"``,
+        ``"custom_increasing"``  (default: ``"auto"``).
+        """
+        return self._parms.get("stopping_metric")
+
+    @stopping_metric.setter
+    def stopping_metric(self, stopping_metric):
+        assert_is_type(stopping_metric, None, Enum("auto", "deviance", "logloss", "mse", "rmse", "mae", "rmsle", "auc", "aucpr", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"))
+        self._parms["stopping_metric"] = stopping_metric
+
+
+    @property
+    def stopping_tolerance(self):
+        """
+        Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this much)
+
+        Type: ``float``  (default: ``0.001``).
+        """
+        return self._parms.get("stopping_tolerance")
+
+    @stopping_tolerance.setter
+    def stopping_tolerance(self, stopping_tolerance):
+        assert_is_type(stopping_tolerance, None, numeric)
+        self._parms["stopping_tolerance"] = stopping_tolerance
 
 
     @property

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -2852,11 +2852,16 @@ def evaluate_early_stopping(metric_list, stop_round, tolerance, bigger_is_better
 
     :return:    bool indicating if we should stop early and sorted metric_list
     """
-    metric_len = len(metric_list)
-    metric_list.sort(reverse=bigger_is_better)
-    shortest_len = 2*stop_round
+    if (bigger_is_better):
+        metric_list.reverse()
 
-    bestInLastK = 1.0*sum(metric_list[0:stop_round])/stop_round
+    shortest_len = 2*stop_round
+    if (isinstance(metric_list[0], float)):
+        startIdx = 0
+    else:
+        startIdx = 1
+        
+    bestInLastK = 1.0*sum(metric_list[startIdx:stop_round])/stop_round
     lastBeforeK = 1.0*sum(metric_list[stop_round:shortest_len])/stop_round
 
     if not(np.sign(bestInLastK) == np.sign(lastBeforeK)):
@@ -2894,7 +2899,6 @@ def check_and_count_models(hyper_params, params_zero_one, params_more_than_zero,
     """
 
     total_model = 1
-    param_len = 0
     hyper_keys = list(hyper_params)
     shuffle(hyper_keys)    # get all hyper_parameter names in random order
     final_hyper_params = dict()
@@ -3163,7 +3167,6 @@ def extract_scoring_history_field(aModel, fieldOfInterest, takeFirst=False):
     return extract_from_twoDimTable(aModel._model_json["output"]["scoring_history"], fieldOfInterest, takeFirst)
 
 
-
 def extract_from_twoDimTable(metricOfInterest, fieldOfInterest, takeFirst=False):
     """
     Given a fieldOfInterest that are found in the model scoring history, this function will extract the list
@@ -3175,12 +3178,16 @@ def extract_from_twoDimTable(metricOfInterest, fieldOfInterest, takeFirst=False)
     """
 
     allFields = metricOfInterest._col_header
+    return extract_field_from_twoDimTable(allFields, metricOfInterest.cell_values, fieldOfInterest, takeFirst=False)
+
+
+def extract_field_from_twoDimTable(allFields, cell_values, fieldOfInterest, takeFirst=False):
     if fieldOfInterest in allFields:
         cellValues = []
         fieldIndex = allFields.index(fieldOfInterest)
-        for eachCell in metricOfInterest.cell_values:
+        for eachCell in cell_values:
             cellValues.append(eachCell[fieldIndex])
-            if takeFirst:   # only grab the result from the first iteration.
+            if takeFirst:  # only grab the result from the first iteration.
                 break
         return cellValues
     else:

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7611_early_stop_gam_binomial.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7611_early_stop_gam_binomial.py
@@ -1,0 +1,79 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+
+# In this test, we check that we can do early-stopping with GAM.  In particular, we check the following conditions
+# 1. run the model without early stopping and check that model with early stopping runs for fewer iterations
+# 2. for models with early stopping, check that early stopping is correctly done.
+# 3. when lambda_search is enabled, early stopping should be disabled
+def test_gam_model_predict():
+    print("Checking early-stopping for binomial")
+    print("Preparing for data....")
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C6"] = h2o_data["C6"].asfactor()
+    h2o_data["C7"] = h2o_data["C7"].asfactor()
+    h2o_data["C8"] = h2o_data["C8"].asfactor()
+    h2o_data["C9"] = h2o_data["C9"].asfactor()
+    h2o_data["C10"] = h2o_data["C10"].asfactor()
+    myY = "C21"
+    h2o_data["C21"] = h2o_data["C21"].asfactor()
+    splits = h2o_data.split_frame(ratios=[0.8], seed=12345)
+    train = splits[0]
+    test = splits[1]
+    early_stop_metrics = ["logloss", "AUC"]
+    early_stop_valid_metrics = ["validation_logloss", "validation_auc"]
+    max_stopping_rounds = 3  # maximum stopping rounds allowed to be used for early stopping metric
+    max_tolerance = 0.1  # maximum tolerance to be used for early stopping metric
+    bigger_is_better = [False, True]
+
+    print("Building a GAM model without early stop")
+    h2o_model_no_early_stop = H2OGeneralizedAdditiveEstimator(family='binomial', gam_columns=["C11"],  scale = [0.0001], 
+                                                score_each_iteration=True)
+    h2o_model_no_early_stop.train(x=list(range(0,20)), y=myY, training_frame=train, validation_frame=test)
+
+    for ind in range(len(early_stop_metrics)):
+        print("Building early-stop model")
+        h2o_model = H2OGeneralizedAdditiveEstimator(family='binomial', gam_columns=["C11"], scale = [0.0001], 
+                                                    stopping_rounds=max_stopping_rounds,score_each_iteration=True, 
+                                                    stopping_metric=early_stop_metrics[ind],
+                                                    stopping_tolerance=max_tolerance)
+        h2o_model.train(x=list(range(0,20)), y="C21", training_frame=train, validation_frame=test)
+        metric_list1 = \
+            pyunit_utils.extract_field_from_twoDimTable(
+                h2o_model._model_json["output"]["glm_scoring_history"].col_header,
+                h2o_model._model_json["output"]["glm_scoring_history"].cell_values,
+                early_stop_valid_metrics[ind])
+        print("Checking if early stopping has been done correctly for {0}.".format(early_stop_metrics[ind]))
+        assert pyunit_utils.evaluate_early_stopping(metric_list1, max_stopping_rounds, max_tolerance,
+                                                    bigger_is_better[ind]), \
+            "Early-stopping was not incorrect."
+
+    print("Check if lambda_search=True, early-stop enabled, an error should be thrown.")
+    try:
+        h2o_model = H2OGeneralizedAdditiveEstimator(family='binomial', gam_columns=["C11"], scale = [0.0001],
+                                                stopping_rounds=max_stopping_rounds,score_each_iteration=True,
+                                                stopping_metric=early_stop_metrics[ind],
+                                                stopping_tolerance=max_tolerance, lambda_search=True, nlambdas=3)
+        h2o_model.train(x=list(range(0,20)), y=myY, training_frame=train, validation_frame=test)
+        assert False, "Exception should have been risen when lambda_search=True and early stop is enabled"
+    except Exception as ex:
+        print(ex)
+        temp = str(ex)
+        assert ("early stop:  cannot run when lambda_search=True.  Lambda_search has its own early-stopping "
+                "mechanism" in temp), "Wrong exception was received."
+        print("early-stop test passed!") 
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gam_model_predict)
+else:
+    test_gam_model_predict()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7611_early_stop_gam_binomial.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7611_early_stop_gam_binomial.py
@@ -35,7 +35,6 @@ def test_gam_model_predict():
     max_stopping_rounds = 3  # maximum stopping rounds allowed to be used for early stopping metric
     max_tolerance = 0.1  # maximum tolerance to be used for early stopping metric
     bigger_is_better = [False, True]
-
     print("Building a GAM model without early stop")
     h2o_model_no_early_stop = H2OGeneralizedAdditiveEstimator(family='binomial', gam_columns=["C11"],  scale = [0.0001], 
                                                 score_each_iteration=True)

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7611_early_stop_glm_multinomial.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7611_early_stop_glm_multinomial.py
@@ -1,0 +1,76 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+
+# In this test, we check that we can do early-stopping with GLM.  In particular, we check the following conditions
+# 1. run the model without early stopping and check that model with early stopping runs for fewer iterations
+# 2. for models with early stopping, check that early stopping is correctly done.
+# 3. when lambda_search is enabled, early stopping should be disabled
+def test_glm_earlyStop():
+    early_stop_metrics = ["logloss", "RMSE"]
+    early_stop_valid_metrics = ["validation_logloss", "validation_rmse"]
+    max_stopping_rounds = 3  # maximum stopping rounds allowed to be used for early stopping metric
+    max_tolerance = 0.01  # maximum tolerance to be used for early stopping metric
+    bigger_is_better = [False, False]
+
+    print("Preparing dataset....")
+    h2o_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C3"] = h2o_data["C3"].asfactor()
+    h2o_data["C4"] = h2o_data["C4"].asfactor()
+    h2o_data["C5"] = h2o_data["C5"].asfactor()
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    splits_frames = h2o_data.split_frame(ratios=[.8], seed=1234)
+    train = splits_frames[0]
+    valid = splits_frames[1]
+
+    print("Building model without early stopping.")
+    h2o_model_no_early_stop = glm(family="multinomial", score_each_iteration=True)
+    h2o_model_no_early_stop.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train,
+                                  validation_frame=valid)
+    numIter = len(h2o_model_no_early_stop._model_json["output"]["scoring_history"].cell_values)
+    for ind in range(len(early_stop_metrics)):
+        print("Building early-stop model")
+        h2o_model = glm(family="multinomial", stopping_rounds=max_stopping_rounds, score_each_iteration=True,
+                        stopping_metric=early_stop_metrics[ind], stopping_tolerance=max_tolerance)
+        h2o_model.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, validation_frame=valid)
+        metric_list1 = \
+            pyunit_utils.extract_field_from_twoDimTable(
+                h2o_model._model_json["output"]["scoring_history"].col_header,
+                h2o_model._model_json["output"]["scoring_history"].cell_values,
+                early_stop_valid_metrics[ind])
+        print("Checking if early stopping has been done correctly for {0}.".format(early_stop_metrics[ind]))
+        assert pyunit_utils.evaluate_early_stopping(metric_list1, max_stopping_rounds, max_tolerance,
+                                                    bigger_is_better[ind]), \
+            "Early-stopping was not incorrect."
+        assert len(h2o_model._model_json["output"]["scoring_history"].cell_values) <= numIter, \
+            "Number of iterations without early stop: {0} should be more than with early stop: " \
+            "{1}".format(numIter, len(h2o_model._model_json["output"]["scoring_history"].cell_values))
+
+    print("Check if lambda_search=True, early-stop enabled, an error should be thrown.")
+    try:
+        h2o_model = glm(family="multinomial", score_each_iteration=True, stopping_rounds=max_stopping_rounds, 
+                        stopping_metric=early_stop_metrics[ind], stopping_tolerance=max_tolerance, nlambdas=5, 
+                        lambda_search=True)
+        h2o_model.train(x=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], y="C11", training_frame=train, validation_frame=valid)
+        assert False, "Exception should have been risen when lambda_search=True and early stop is enabled"
+    except Exception as ex:
+        print(ex)
+        temp = str(ex)
+        assert ("early stop:  cannot run when lambda_search=True.  Lambda_search has its own early-stopping "
+                "mechanism" in temp), "Wrong exception was received."
+        print("early-stop test passed!")
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_glm_earlyStop)
+else:
+    test_glm_earlyStop()

--- a/h2o-r/h2o-package/R/gam.R
+++ b/h2o-r/h2o-package/R/gam.R
@@ -93,6 +93,15 @@
 #' @param interaction_pairs A list of pairwise (first order) column interactions.
 #' @param obj_reg Likelihood divider in objective value computation, default is 1/nobs Defaults to -1.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
+#' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
+#'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing".
+#'        Defaults to AUTO.
+#' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
+#'        much) Defaults to 0.001.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
 #'        FALSE.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
@@ -168,6 +177,9 @@ h2o.gam <- function(x,
                     interaction_pairs = NULL,
                     obj_reg = -1,
                     export_checkpoints_dir = NULL,
+                    stopping_rounds = 0,
+                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                    stopping_tolerance = 0.001,
                     balance_classes = FALSE,
                     class_sampling_factors = NULL,
                     max_after_balance_size = 5.0,
@@ -300,6 +312,12 @@ h2o.gam <- function(x,
     parms$obj_reg <- obj_reg
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
+  if (!missing(stopping_rounds))
+    parms$stopping_rounds <- stopping_rounds
+  if (!missing(stopping_metric))
+    parms$stopping_metric <- stopping_metric
+  if (!missing(stopping_tolerance))
+    parms$stopping_tolerance <- stopping_tolerance
   if (!missing(balance_classes))
     parms$balance_classes <- balance_classes
   if (!missing(class_sampling_factors))
@@ -398,6 +416,9 @@ h2o.gam <- function(x,
                                     interaction_pairs = NULL,
                                     obj_reg = -1,
                                     export_checkpoints_dir = NULL,
+                                    stopping_rounds = 0,
+                                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                                    stopping_tolerance = 0.001,
                                     balance_classes = FALSE,
                                     class_sampling_factors = NULL,
                                     max_after_balance_size = 5.0,
@@ -535,6 +556,12 @@ h2o.gam <- function(x,
     parms$obj_reg <- obj_reg
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
+  if (!missing(stopping_rounds))
+    parms$stopping_rounds <- stopping_rounds
+  if (!missing(stopping_metric))
+    parms$stopping_metric <- stopping_metric
+  if (!missing(stopping_tolerance))
+    parms$stopping_tolerance <- stopping_tolerance
   if (!missing(balance_classes))
     parms$balance_classes <- balance_classes
   if (!missing(class_sampling_factors))

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -29,6 +29,7 @@
 #' @param random_columns random columns indices for HGLM.
 #' @param ignore_const_cols \code{Logical}. Ignore constant columns. Defaults to TRUE.
 #' @param score_each_iteration \code{Logical}. Whether to score during each iteration of model training. Defaults to FALSE.
+#' @param score_iteration_interval Perform scoring for every score_iteration_interval iterations Defaults to -1.
 #' @param offset_column Offset column. This will be added to the combination of columns before applying the link function.
 #' @param weights_column Column with observation weights. Giving some observation a weight of zero is equivalent to excluding it from
 #'        the dataset; giving an observation a relative weight of 2 is equivalent to repeating that row twice. Negative
@@ -100,6 +101,15 @@
 #' @param interaction_pairs A list of pairwise (first order) column interactions.
 #' @param obj_reg Likelihood divider in objective value computation, default is 1/nobs Defaults to -1.
 #' @param export_checkpoints_dir Automatically export generated models to this directory.
+#' @param stopping_rounds Early stopping based on convergence of stopping_metric. Stop if simple moving average of length k of the
+#'        stopping_metric does not improve for k:=stopping_rounds scoring events (0 to disable) Defaults to 0.
+#' @param stopping_metric Metric to use for early stopping (AUTO: logloss for classification, deviance for regression and
+#'        anonomaly_score for Isolation Forest). Note that custom and custom_increasing can only be used in GBM and DRF
+#'        with the Python client. Must be one of: "AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC",
+#'        "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing".
+#'        Defaults to AUTO.
+#' @param stopping_tolerance Relative tolerance for metric-based stopping criterion (stop if relative improvement is not at least this
+#'        much) Defaults to 0.001.
 #' @param balance_classes \code{Logical}. Balance training data class counts via over/under-sampling (for imbalanced data). Defaults to
 #'        FALSE.
 #' @param class_sampling_factors Desired over/under-sampling ratios per class (in lexicographic order). If not specified, sampling factors will
@@ -170,6 +180,7 @@ h2o.glm <- function(x,
                     random_columns = NULL,
                     ignore_const_cols = TRUE,
                     score_each_iteration = FALSE,
+                    score_iteration_interval = -1,
                     offset_column = NULL,
                     weights_column = NULL,
                     family = c("gaussian", "binomial", "fractionalbinomial", "quasibinomial", "ordinal", "multinomial", "poisson", "gamma", "tweedie", "negativebinomial"),
@@ -207,6 +218,9 @@ h2o.glm <- function(x,
                     interaction_pairs = NULL,
                     obj_reg = -1,
                     export_checkpoints_dir = NULL,
+                    stopping_rounds = 0,
+                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                    stopping_tolerance = 0.001,
                     balance_classes = FALSE,
                     class_sampling_factors = NULL,
                     max_after_balance_size = 5.0,
@@ -277,6 +291,8 @@ h2o.glm <- function(x,
     parms$ignore_const_cols <- ignore_const_cols
   if (!missing(score_each_iteration))
     parms$score_each_iteration <- score_each_iteration
+  if (!missing(score_iteration_interval))
+    parms$score_iteration_interval <- score_iteration_interval
   if (!missing(offset_column))
     parms$offset_column <- offset_column
   if (!missing(weights_column))
@@ -345,6 +361,12 @@ h2o.glm <- function(x,
     parms$obj_reg <- obj_reg
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
+  if (!missing(stopping_rounds))
+    parms$stopping_rounds <- stopping_rounds
+  if (!missing(stopping_metric))
+    parms$stopping_metric <- stopping_metric
+  if (!missing(stopping_tolerance))
+    parms$stopping_tolerance <- stopping_tolerance
   if (!missing(balance_classes))
     parms$balance_classes <- balance_classes
   if (!missing(class_sampling_factors))
@@ -399,6 +421,7 @@ h2o.glm <- function(x,
                                     random_columns = NULL,
                                     ignore_const_cols = TRUE,
                                     score_each_iteration = FALSE,
+                                    score_iteration_interval = -1,
                                     offset_column = NULL,
                                     weights_column = NULL,
                                     family = c("gaussian", "binomial", "fractionalbinomial", "quasibinomial", "ordinal", "multinomial", "poisson", "gamma", "tweedie", "negativebinomial"),
@@ -436,6 +459,9 @@ h2o.glm <- function(x,
                                     interaction_pairs = NULL,
                                     obj_reg = -1,
                                     export_checkpoints_dir = NULL,
+                                    stopping_rounds = 0,
+                                    stopping_metric = c("AUTO", "deviance", "logloss", "MSE", "RMSE", "MAE", "RMSLE", "AUC", "AUCPR", "lift_top_group", "misclassification", "mean_per_class_error", "custom", "custom_increasing"),
+                                    stopping_tolerance = 0.001,
                                     balance_classes = FALSE,
                                     class_sampling_factors = NULL,
                                     max_after_balance_size = 5.0,
@@ -511,6 +537,8 @@ h2o.glm <- function(x,
     parms$ignore_const_cols <- ignore_const_cols
   if (!missing(score_each_iteration))
     parms$score_each_iteration <- score_each_iteration
+  if (!missing(score_iteration_interval))
+    parms$score_iteration_interval <- score_iteration_interval
   if (!missing(offset_column))
     parms$offset_column <- offset_column
   if (!missing(weights_column))
@@ -579,6 +607,12 @@ h2o.glm <- function(x,
     parms$obj_reg <- obj_reg
   if (!missing(export_checkpoints_dir))
     parms$export_checkpoints_dir <- export_checkpoints_dir
+  if (!missing(stopping_rounds))
+    parms$stopping_rounds <- stopping_rounds
+  if (!missing(stopping_metric))
+    parms$stopping_metric <- stopping_metric
+  if (!missing(stopping_tolerance))
+    parms$stopping_tolerance <- stopping_tolerance
   if (!missing(balance_classes))
     parms$balance_classes <- balance_classes
   if (!missing(class_sampling_factors))

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2030,6 +2030,13 @@ h2o.scoreHistory <- function(object) {
 }
 
 #'
+#' Retrieve GLM Model Score History buried in GAM model
+#' @export
+h2o.scoreHistoryGAM <- function(object) {
+    return(object@model$glm_scoring_history)
+}
+
+#'
 #' Retrieve actual number of trees for tree algorithms
 #'
 #' @param object An \linkS4class{H2OModel} object.

--- a/h2o-r/h2o-package/pkgdown/_pkgdown.yml
+++ b/h2o-r/h2o-package/pkgdown/_pkgdown.yml
@@ -255,6 +255,7 @@ reference:
       - h2o.saveMojo
       - h2o.scale
       - h2o.scoreHistory
+      - h2o.scoreHistoryGAM
       - h2o.sd 
       - h2o.sdev
       - h2o.set_s3_credentials

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7611_early_stop_gam_gaussian.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7611_early_stop_gam_gaussian.R
@@ -1,0 +1,26 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# simple test to make sure we can invoke early stop in R for GAM.  Heavy testing is done in Python.  We
+# are just testing the client API.
+test.model.gam.early.stop <- function() {
+    data <- h2o.importFile(path = locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    data$C1 <- h2o.asfactor(data$C1)
+    data$C2 <- h2o.asfactor(data$C2)
+    data$C3 <- h2o.asfactor(data$C3)
+    data$C4 <- h2o.asfactor(data$C4)
+    data$C5 <- h2o.asfactor(data$C5)
+    data$C6 <- h2o.asfactor(data$C6)
+    data$C7 <- h2o.asfactor(data$C7)
+    data$C8 <- h2o.asfactor(data$C8)
+    data$C9 <- h2o.asfactor(data$C9)
+    data$C10 <- h2o.asfactor(data$C10)
+    splits = h2o.splitFrame(data, ratios=c(0.8), seed=12345)
+    train = splits[[1]]
+    valid = splits[[2]]
+    gam_early_stop <- h2o.gam(y = "C21", x = c(1:20), gam_columns = c("C11"), training_frame = train, validation_frame = valid,
+    family = "gaussian", stopping_rounds=3, stopping_metric="rmse", stopping_tolerance=0.1, score_each_iteration = TRUE)
+    expect_true(length(gam_early_stop@model$glm_scoring_history) > 0, "Early stop is not working")
+}
+
+doTest("General Additive Model early stop test with Gaussian family", test.model.gam.early.stop)

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7611_early_stop_glm_gaussian.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7611_early_stop_glm_gaussian.R
@@ -1,0 +1,29 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# simple test to make sure we can invoke early stop in R for GLM.  Heavy testing is done in Python.  We
+# are just testing the client API.
+test.model.glm.early.stop <- function() {
+    data <- h2o.importFile(path = locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    data$C1 <- h2o.asfactor(data$C1)
+    data$C2 <- h2o.asfactor(data$C2)
+    data$C3 <- h2o.asfactor(data$C3)
+    data$C4 <- h2o.asfactor(data$C4)
+    data$C5 <- h2o.asfactor(data$C5)
+    data$C6 <- h2o.asfactor(data$C6)
+    data$C7 <- h2o.asfactor(data$C7)
+    data$C8 <- h2o.asfactor(data$C8)
+    data$C9 <- h2o.asfactor(data$C9)
+    data$C10 <- h2o.asfactor(data$C10)
+    splits = h2o.splitFrame(data, ratios=c(0.8), seed=12345)
+    train = splits[[1]]
+    valid = splits[[2]]
+    glm_early_stop <- h2o.glm(y = "C21", x = c(1:20), training_frame = train, validation_frame = valid,
+    family = "gaussian", stopping_rounds=3, stopping_metric="rmse", stopping_tolerance=0.1, score_each_iteration=TRUE)
+    expect_true(length(glm_early_stop@model$scoring_history_early_stop) > 0, "Early stop is not working")
+    glm_lambda_search <- h2o.glm(y = "C21", x = c(1:20), training_frame = train, validation_frame = valid,
+            family = "gaussian", stopping_rounds=3, stopping_metric="rmse", stopping_tolerance=0.1, lambda_search=TRUE, nlambdas=3)
+    expect_true(is.null(glm_lambda_search@model$scoring_history_early_stop), "Early stop should have been disabled for lambda_search=TRUE but is not")
+}
+
+doTest("GLM early stop test with Gaussian family", test.model.glm.early.stop)

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7611_early_stop_glm_gaussian.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7611_early_stop_glm_gaussian.R
@@ -20,10 +20,7 @@ test.model.glm.early.stop <- function() {
     valid = splits[[2]]
     glm_early_stop <- h2o.glm(y = "C21", x = c(1:20), training_frame = train, validation_frame = valid,
     family = "gaussian", stopping_rounds=3, stopping_metric="rmse", stopping_tolerance=0.1, score_each_iteration=TRUE)
-    expect_true(length(glm_early_stop@model$scoring_history_early_stop) > 0, "Early stop is not working")
-    glm_lambda_search <- h2o.glm(y = "C21", x = c(1:20), training_frame = train, validation_frame = valid,
-            family = "gaussian", stopping_rounds=3, stopping_metric="rmse", stopping_tolerance=0.1, lambda_search=TRUE, nlambdas=3)
-    expect_true(is.null(glm_lambda_search@model$scoring_history_early_stop), "Early stop should have been disabled for lambda_search=TRUE but is not")
+    expect_true(length(glm_early_stop@model$scoring_history) > 0, "Early stop is not working")
 }
 
 doTest("GLM early stop test with Gaussian family", test.model.glm.early.stop)


### PR DESCRIPTION
This PR completes the work in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7611?filter=-1

GAM will make use of the early-stopping capability in GLM.  However, GLM did not support early-stopping.  Hence, I have done the following:
1. add early stopping parameters to GAM and GLM;
2. enable early-stop in GLM.  This means disabling some of the early stopping mechanism in GLM.
3. early-stop is disabled when lambda_search=True.
4. R and Python unit tests are written to make sure early stopping is working.