### PR TITLE
Clarification in docs for balance_classes in automl and for supported POJOs

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -63,7 +63,7 @@ Optional Miscellaneous Parameters
 
 - `nfolds <data-science/algo-params/nfolds.html>`__:  Specify a value >= 2 for the number of folds for k-fold cross-validation of the models in the AutoML run. This value defaults to 5. Use 0 to disable cross-validation; this will also disable Stacked Ensembles (thus decreasing the overall best model performance).
 
-- `balance_classes <data-science/algo-params/balance_classes.html>`__: Specify whether to oversample the minority classes to balance the class distribution. This option is not enabled by default and can increase the data frame size. This option is only applicable for classification. Majority classes can be undersampled to satisfy the **max\_after\_balance\_size** parameter.
+- `balance_classes <data-science/algo-params/balance_classes.html>`__: Specify whether to oversample the minority classes to balance the class distribution. This option is not enabled by default and can increase the data frame size. This option is only applicable for classification. If the oversampled size of the dataset exceeds the maximum size calculated using the ``max_after_balance_size parameter``, then the majority classes will be undersampled to satisfy the size limit.
 
 - `class_sampling_factors <data-science/algo-params/class_sampling_factors.html>`__: Specify the per-class (in lexicographical order) over/under-sampling ratios. By default, these ratios are automatically computed during training to obtain the class balance. Note that this requires ``balance_classes=true``.
 

--- a/h2o-docs/src/product/pojo-quickstart.rst
+++ b/h2o-docs/src/product/pojo-quickstart.rst
@@ -7,7 +7,8 @@ This section describes how to build and implement a POJO to use predictive scori
 
 **Notes**: 
 
-- POJOs are not supported for source files larger than 1G. For more information, refer to the POJO FAQ section below. POJOs are also not supported for GLRM or Stacked Ensembles models. 
+- POJOs are not supported for source files larger than 1G. For more information, refer to the POJO FAQ section below. 
+- POJOs are not supported for GLRM, Stacked Ensembles, or Word2Vec models. 
 - POJO predict cannot parse columns enclosed in double quotes (for example, ""2"").  
 
 What is a POJO?

--- a/h2o-genmodel/src/main/java/overview.html
+++ b/h2o-genmodel/src/main/java/overview.html
@@ -58,7 +58,12 @@ POJOs allow users to build a model using H2O and then deploy the model to score 
 
 <p></p>
 
-<b>Note:</b> POJOs are not supported for GLRM or Stacked Ensembles models.
+<b>Notes</b>:
+<ul>
+  <li>POJOs are not supported for source files larger than 1G</li>
+  <li>POJOs are not supported for GLRM, Stacked Ensembles, or Word2Vec models.</li>
+  <li>POJO predict cannot parse columns enclosed in double quotes (for example, ""2"").</li>
+</ul>
 
 <p></p>
 <!-- ============================================================ -->


### PR DESCRIPTION
- Clarified oversampling/undersampling for balance_classes in AutoML
- Added Word2Vec to list of unsupported algos for POJOs