### PR TITLE
TwoDimTable prints wrong column type handled as a part of an error message.

### DIFF
--- a/h2o-core/src/main/java/water/util/TwoDimTable.java
+++ b/h2o-core/src/main/java/water/util/TwoDimTable.java
@@ -82,7 +82,7 @@ public class TwoDimTable extends Iced {
         colTypes[c] = colTypes[c].toLowerCase();
         if (!(colTypes[c].equals("double") || colTypes[c].equals("float") || colTypes[c].equals("int") ||
             colTypes[c].equals("long") || colTypes[c].equals("string")))
-          throw new IllegalArgumentException("colTypes values must be one of \"double\", \"float\", \"int\", \"long\", or \"string\"");
+          throw new IllegalArgumentException(String.format("colTypes values must be one of \"double\", \"float\", \"int\", \"long\", or \"string\". Received \"%s\"", colTypes[c]));
       }
     }
 

--- a/h2o-core/src/main/java/water/util/TwoDimTable.java
+++ b/h2o-core/src/main/java/water/util/TwoDimTable.java
@@ -82,7 +82,7 @@ public class TwoDimTable extends Iced {
         colTypes[c] = colTypes[c].toLowerCase();
         if (!(colTypes[c].equals("double") || colTypes[c].equals("float") || colTypes[c].equals("int") ||
             colTypes[c].equals("long") || colTypes[c].equals("string")))
-          throw new IllegalArgumentException(String.format("colTypes values must be one of \"double\", \"float\", \"int\", \"long\", or \"string\". Received \"%s\"", colTypes[c]));
+          throw new IllegalArgumentException(String.format("colTypes values must be one of \"double\", \"float\", \"int\", \"long\", or \"string\". Received \"%s\" as ColType %d", colTypes[c], c));
       }
     }
 

--- a/h2o-core/src/test/java/water/TwoDimTableTest.java
+++ b/h2o-core/src/test/java/water/TwoDimTableTest.java
@@ -1,20 +1,28 @@
 package water;
 
-import static org.junit.Assert.assertFalse;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import water.api.schemas3.TwoDimTableV3;
 import water.fvec.Frame;
 import water.parser.ParseDataset;
 import water.parser.ParserTest;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
 import water.util.Log;
 import water.util.TwoDimTable;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static water.util.TwoDimTable.emptyDouble;
 
+@RunWith(H2ORunner.class)
+@CloudSize(1)
 public class TwoDimTableTest extends TestUtil {
-  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void run0() {
@@ -323,5 +331,13 @@ public class TwoDimTableTest extends TestUtil {
     } finally {
       if (fr != null) fr.delete();
     }
+  }
+
+  @Test
+  public void testTypeError(){
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("colTypes values must be one of \"double\", \"float\", \"int\", \"long\", or \"string\". Received \"wrongtype\"");
+    new TwoDimTable("Test table", "Description", new String[]{"R1"}, new String[]{"C1"}, new String[]{"wrongType"},
+        new String[]{"%f"}, "ColHeaderForRowHeader");
   }
 }


### PR DESCRIPTION
Tiny fix to print the wrong type received. The current stack trace is not very useful: https://stackoverflow.com/questions/61504433/illegalargumentexception-h2o-importing-mojo-file-failed-in-python

```
EnvironmentError: Job with key $03017f00000132d4ffffffff$_8faceff652ec107419c1688af40247ee failed with an exception: java.lang.IllegalArgumentException: colTypes values must be one of "double", "float", "int", "long", or "string"
stacktrace: 
java.lang.IllegalArgumentException: colTypes values must be one of "double", "float", "int", "long", or "string"
    at water.util.TwoDimTable.<init>(TwoDimTable.java:85)
    at hex.generic.GenericModelOutput.convertTable(GenericModelOutput.java:250)
    at hex.generic.GenericModelOutput.<init>(GenericModelOutput.java:35)
    at hex.generic.Generic$MojoDelegatingModelDriver.computeImpl(Generic.java:95)
    at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:239)
    at hex.generic.Generic$MojoDelegatingModelDriver.compute2(Generic.java:71)
    at water.H2O$H2OCountedCompleter.compute(H2O.java:1455)
    at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
    at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
    at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
    at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
    at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
```