### PR TITLE
PUBDEV-7185: added MOJO to GAM

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -6,7 +6,6 @@ import hex.gam.MatrixFrameUtils.AddGamColumns;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters.Family;
-import hex.glm.GLMModel.GLMParameters.GLMType;
 import hex.glm.GLMModel.GLMParameters.Link;
 import hex.glm.GLMModel.GLMParameters.Solver;
 import water.*;
@@ -15,10 +14,7 @@ import water.fvec.Frame;
 import water.fvec.NewChunk;
 import water.fvec.Vec;
 import water.udf.CFuncRef;
-import water.util.ArrayUtils;
-import water.util.FrameUtils;
-import water.util.Log;
-import water.util.TwoDimTable;
+import water.util.*;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -28,9 +24,11 @@ import static hex.gam.MatrixFrameUtils.GamUtils.sortCoeffMags;
 import static hex.glm.GLMModel.GLMParameters.MissingValuesHandling;
 
 public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.GAMModelOutput> {
+  private static final String[] BINOMIAL_CLASS_NAMES = new String[]{"0", "1"};
   public String[][] _gamColNamesNoCentering; // store column names only for GAM columns
   public String[][] _gamColNames; // store column names only for GAM columns after decentering
   public Key<Frame>[] _gamFrameKeysCenter;
+  public double[] _gamColMeans;
   public int _nclass; // 2 for binomial, > 2 for multinomial and ordinal
   public double[] _ymu;
   public long _nobs;
@@ -46,8 +44,12 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
   
   @Override public ModelMetrics.MetricBuilder makeMetricBuilder(String[] domain) {
     if (domain==null && (_parms._family==Family.binomial || _parms._family==Family.quasibinomial || 
-            _parms._family==Family.negativebinomial || _parms._family==Family.fractionalbinomial))
-      domain = new String[]{"0","1"};
+            _parms._family==Family.negativebinomial || _parms._family==Family.fractionalbinomial)) {
+      if (_parms._family == Family.fractionalbinomial)
+        domain = BINOMIAL_CLASS_NAMES;
+      else
+        domain = _output._responseDomains;
+    }
     GLMModel.GLMWeightsFun glmf = new GLMModel.GLMWeightsFun(_parms._family, _parms._link, _parms._tweedie_variance_power,
             _parms._tweedie_link_power, _parms._theta);
     return new MetricBuilderGAM(domain, _ymu, glmf, _rank, true, _parms._intercept, _nclass);
@@ -220,29 +222,19 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public double _tweedie_variance_power;
     public double _tweedie_link_power;
     public double _theta; // 1/k and is used by negative binomial distribution only
-    public double _invTheta;
     public double [] _alpha;
     public double [] _lambda;
     public Serializable _missing_values_handling = MissingValuesHandling.MeanImputation;
-    public double _prior = -1;
     public boolean _lambda_search = false;
-    public int _nlambdas = -1;
-    public boolean _non_negative = false;
-    public boolean _exactLambdas = false;
-    public double _lambda_min_ratio = -1; // special
     public boolean _use_all_factor_levels = false;
     public int _max_iterations = -1;
     public boolean _intercept = true;
     public double _beta_epsilon = 1e-4;
     public double _objective_epsilon = -1;
-    public double _gradient_epsilon = -1;
     public double _obj_reg = -1;
     public boolean _compute_p_values = false;
-    public boolean _remove_collinear_columns = false;
     public String[] _interactions=null;
     public StringPair[] _interaction_pairs=null;
-    public boolean _early_stopping = true;
-    public Key<Frame> _beta_constraints = null;
     public Key<Frame> _plug_values = null;
     // internal parameter, handle with care. GLM will stop when there is more than this number of active predictors (after strong rule screening)
     public int _max_active_predictors = -1;
@@ -250,19 +242,15 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
 
     // the following parameters are for GAM
     public int[] _num_knots; // array storing number of knots per basis function
-    public double[][] _knots;// store knots for each gam column specified in _gam_X
     public String[] _knot_ids;  // store frame keys that contain knots location for each gam column in gam_X;
     public String[] _gam_columns; // array storing which predictor columns are needed
-   // public BSType _bs; // choose spline function for gam column
     public int[] _bs; // choose spline function for gam column, 0 = cr
     public double[] _scale;  // array storing scaling values to control wriggliness of fit
-    public GLMType _glmType = GLMType.gam; // internal parameter
     public boolean _saveZMatrix = false;  // if asserted will save Z matrix
     public boolean _keep_gam_cols = false;  // if true will save the keys to gam Columns only
     public boolean _savePenaltyMat = false; // if true will save penalty matrices as tripple array
-
     public String algoName() { return "GAM"; }
-    public String fullName() { return "General Additive Model"; }
+    public String fullName() { return "Generalized Additive Model"; }
     public String javaName() { return GAMModel.class.getName(); }
 
     @Override
@@ -307,7 +295,6 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
 
     public final static double linkInv(double x, Link link, double tweedie_link_power) {
       switch(link) {
-//        case multinomial: // should not be used
         case identity:
           return x;
         case ologlog:
@@ -328,6 +315,21 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
           throw new RuntimeException("unexpected link function  " + link.toString());
       }
     }
+  }
+
+  @Override
+  protected String[][] scoringDomains(){
+    String [][] domains = _output._domains;
+    if ((_parms._family == Family.binomial || _parms._family == Family.quasibinomial ||
+            _parms._family == Family.fractionalbinomial)
+            && _output._domains[_output._dinfo.responseChunkId(0)] == null) {
+      domains = domains.clone();
+      if (_parms._family == Family.fractionalbinomial)
+        domains[_output._dinfo.responseChunkId(0)] = BINOMIAL_CLASS_NAMES;
+      else
+        domains[_output._dinfo.responseChunkId(0)] = _output._responseDomains;
+    }
+    return domains;
   }
 
   public static class GAMModelOutput extends Model.Output {
@@ -361,6 +363,7 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     private double[] _zvalues;
     private double _dispersion;
     private boolean _dispersionEstimated;
+    public String[][] _gamColNames; // store gam column names after transformation and decentering
     public double[][][] _zTranspose; // Z matrix for de-centralization, can be null
     public double[][][] _penaltyMatrices_center; // stores t(Z)*t(D)*Binv*D*Z and can be null
     public double[][][] _penaltyMatrices;          // store t(D)*Binv*D and can be null
@@ -388,9 +391,11 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     /** Names of levels for a categorical response column. */
     @Override
     public String[] classNames() {
-      if (_family == Family.fractionalbinomial) {
-        return new String[]{"0", "1"};
-      } else 
+      if (_family == Family.quasibinomial || _family == Family.binomial)
+        return _responseDomains;
+      else if (_family == Family.fractionalbinomial)
+        return BINOMIAL_CLASS_NAMES;
+      else
         return super.classNames();
     }
 
@@ -398,12 +403,17 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
       super(b, adaptr);
       _dinfo = dinfo;
       _domains = dinfo._adaptedFrame.domains(); // get domain of dataset predictors
-      _responseDomains = dinfo._adaptedFrame.lastVec().domain();
       _family = b._parms._family;
+      if (_family.equals(Family.quasibinomial)) {
+        _responseDomains = new VecUtils.CollectDoubleDomain(null, 2).doAll(dinfo._adaptedFrame.vec(b._parms._response_column)).stringDomain(dinfo._adaptedFrame.vec(b._parms._response_column).isInt());
+      } else
+        _responseDomains = dinfo._adaptedFrame.lastVec().domain();
     }
 
     @Override public ModelCategory getModelCategory() {
       switch (_family) {
+        case quasibinomial:
+        case fractionalbinomial:
         case binomial: return ModelCategory.Binomial;
         case multinomial: return ModelCategory.Multinomial;
         case ordinal: return ModelCategory.Ordinal;
@@ -470,12 +480,7 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
         }
       }
     }
-    int numCols = adptedF.numCols();  // remove constant or bad frames.
-    for (int vInd=0; vInd<numCols; vInd++) {
-      Vec v = adptedF.vec(vInd);
-      if ((parms._ignore_const_cols &&  v.isConst()) || v.isBad())
-        adptedF.remove(vInd);
-    }
+
     Vec respV = null;
     if (ArrayUtils.contains(testNames, parms._response_column))
       respV = adptedF.remove(parms._response_column);
@@ -506,10 +511,10 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
       adaptFrm = new Frame(adaptFrm.names(),adaptFrm.vecs());
       adaptFrm.remove(responseId);
     }
-// Build up the names & domains.
     final boolean detectedComputeMetrics = computeMetrics && (adaptFrm.vec(_output.responseName()) != null && !adaptFrm.vec(_output.responseName()).isBad());
     String [] domain = _output.nclasses()<=1 ? null : (!detectedComputeMetrics ? _output._domains[_output._domains.length-1] : adaptFrm.lastVec().domain());
-// Score the dataset, building the class distribution & predictions
+    if (_parms._family.equals(Family.quasibinomial))
+      domain = _output._responseDomains;
     return new GAMScore(j, this, _output._dinfo.scoringInfo(_output._names,adaptFrm),domain,detectedComputeMetrics);
   }
 
@@ -530,6 +535,7 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     final boolean _sparse;
     private transient double[][] _vcov;
     private transient double[] _tmp;
+    private boolean _classifier2class;
 
 
     private GAMScore(Job j, GAMModel m, DataInfo dinfo, String[] domain, boolean computeMetrics) {
@@ -540,6 +546,8 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
       _predDomains = domain;
       _m._parms = m._parms;
       _nclass = m._output.nclasses();
+      _classifier2class = _m._parms._family == GLMModel.GLMParameters.Family.binomial || 
+              _m._parms._family == Family.quasibinomial || _m._parms._family == Family.fractionalbinomial;
       if(_m._parms._family == GLMModel.GLMParameters.Family.multinomial ||
               _m._parms._family == GLMModel.GLMParameters.Family.ordinal){
         _coeffs = null;
@@ -620,10 +628,8 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public double[] scoreRow(DataInfo.Row r, double offset, double[] preds) {
       double mu = _m._parms.linkInv(r.innerProduct(_coeffs) + offset, _m._parms._link,
               _m._parms._tweedie_link_power);
-      if (_m._parms._family == GLMModel.GLMParameters.Family.binomial ||
-              _m._parms._family == GLMModel.GLMParameters.Family.quasibinomial ||
-      _m._parms._family == Family.negativebinomial || _m._parms._family == Family.fractionalbinomial) { // threshold for prediction
-        preds[0] = mu >= _defaultThreshold?1:0;
+      if (_classifier2class) { // threshold for prediction
+        preds[0] = mu >= _defaultThreshold ? 1 : 0;
         preds[1] = 1.0 - mu; // class 0
         preds[2] = mu; // class 1
       } else
@@ -692,6 +698,11 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
   @Override
   public double[] score0(double[] data, double[] preds) {
     throw new UnsupportedOperationException("GAMModel.score0 should never be called");
+  }
+
+  @Override
+  public GAMMojoWriter getMojo() {
+    return new GAMMojoWriter(this);
   }
 
   @Override

--- a/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
@@ -1,0 +1,98 @@
+package hex.gam;
+
+
+import hex.ModelMojoWriter;
+import hex.glm.GLMModel;
+
+import java.io.IOException;
+
+import static hex.glm.GLMModel.GLMParameters.Family.*;
+
+public class GAMMojoWriter extends ModelMojoWriter<GAMModel, GAMModel.GAMParameters, GAMModel.GAMModelOutput> {
+  @Override
+  public String mojoVersion() {
+    return "1.00";
+  }
+  
+  public GAMMojoWriter(GAMModel model) {
+    super(model);
+  }
+
+  @Override
+  protected void writeModelData() throws IOException {
+    int numGamCols = model._parms._gam_columns.length;
+    writekv("use_all_factor_levels", model._parms._use_all_factor_levels);
+    writekv("cats", model._output._dinfo._cats);
+    writekv("cat_offsets", model._output._dinfo._catOffsets);
+    writekv("numsCenter", model._output._dinfo._nums);
+    writekv("num", model._output._dinfo._nums+numGamCols);
+
+    boolean imputeMeans = model._parms.missingValuesHandling().equals(GLMModel.GLMParameters.MissingValuesHandling.MeanImputation);
+    writekv("mean_imputation", imputeMeans);
+    if (imputeMeans) {
+      writekv("numNAFillsCenter", model._output._dinfo.numNAFill());
+      double[] numNAFills = new double[model._output._dinfo.numNAFill().length+numGamCols];
+      System.arraycopy(model._output._dinfo.numNAFill(),0, numNAFills, 0, 
+              model._output._dinfo.numNAFill().length);
+      int startind = numNAFills.length-model._gamColMeans.length;
+      System.arraycopy(model._gamColMeans, 0, numNAFills, startind, model._gamColMeans.length);
+      writekv("numNAFills", numNAFills);
+      writekv("catNAFills", model._output._dinfo.catNAFill());
+    }
+    if (model._parms._family.equals(binomial))
+      writekv("family", "bernoulli");
+    else
+      writekv("family", model._parms._family);
+    writekv("link", model._parms._link);
+    if (model._parms._family.equals(GLMModel.GLMParameters.Family.tweedie))
+      writekv("tweedie_link_power", model._parms._tweedie_link_power);
+    // add GAM specific parameters
+    writekv("num_knots", model._parms._num_knots); // an array
+    writeStringArrays(model._parms._gam_columns, "gam_columns"); // gam_columns specified by users
+    int numGamLength = 0;
+    int numGamCLength = 0;
+    for (int cInd=0; cInd < numGamCols; cInd++)  { // only contains expanded gam column names not centered
+      writeStringArrays(model._gamColNames[cInd], "gamColNamesCenter_"+model._parms._gam_columns[cInd]);
+      writeStringArrays(model._gamColNamesNoCentering[cInd], "gamColNames_"+model._parms._gam_columns[cInd]);
+      numGamLength += model._gamColNamesNoCentering[cInd].length;
+      numGamCLength += model._gamColNames[cInd].length;
+    }
+    String[] trainColGamColNoCenter = genTrainColGamCols(numGamLength, numGamCLength);
+    writekv("num_expanded_gam_columns", numGamLength);
+    writeStringArrays(trainColGamColNoCenter, "_names_no_centering"); // column names without centering
+    writekv("total feature size", trainColGamColNoCenter.length);
+    if (model._parms._family==multinomial || model._parms._family==ordinal) {
+      writeDoubleArray(model._output._model_beta_multinomial_no_centering, "beta_multinomial");
+      writekv("beta length per class", model._output._model_beta_multinomial_no_centering[0].length);
+      writeDoubleArray(model._output._model_beta_multinomial, "beta_multinomial_centering");
+      writekv("beta center length per class", model._output._model_beta_multinomial[0].length);
+    } else {
+      writekv("beta", model._output._model_beta_no_centering); // beta without centering
+      writekv("beta length per class", model._output._model_beta_no_centering.length);
+      writekv("beta_center", model._output._model_beta);
+      writekv("beta center length per class", model._output._model_beta.length);
+    }
+    writekv("bs", model._parms._bs);  // an array of choice of spline functions
+    writeDoubleArray(model._output._knots, "knots");
+    int countGamCols = 0;
+    for (String gamCol : model._parms._gam_columns) {
+      writeDoubleArray(model._output._zTranspose[countGamCols], gamCol+"_zTranspose");      // write zTranspose
+      writeDoubleArray(model._output._binvD[countGamCols++], gamCol+"_binvD");      // write binvD
+    }
+    // store variable importance information
+  }
+  
+  public String[] genTrainColGamCols(int gamColLength, int gamCColLength) {
+    int colLength = model._output._names.length-gamCColLength+gamColLength-1;// to exclude response
+    int normalColLength = model._output._names.length-gamCColLength-1;
+    String[] trainNamesNGamNames = new String[colLength];
+    System.arraycopy(model._output._names, 0, trainNamesNGamNames, 0, normalColLength);
+    int startInd = normalColLength;
+    for (int gind = 0; gind < model._gamColNamesNoCentering.length; gind++) {
+      int copyLen = model._gamColNamesNoCentering[gind].length;
+      System.arraycopy(model._gamColNamesNoCentering[gind], 0, trainNamesNGamNames, startInd, copyLen);
+      startInd += copyLen;
+    }
+    return trainNamesNGamNames;
+  }
+}

--- a/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
@@ -14,6 +14,9 @@ public class GAMMojoWriter extends ModelMojoWriter<GAMModel, GAMModel.GAMParamet
     return "1.00";
   }
   
+  @SuppressWarnings("unused")
+  public GAMMojoWriter(){}
+  
   public GAMMojoWriter(GAMModel model) {
     super(model);
   }

--- a/h2o-algos/src/main/java/hex/gam/GamSplines/CubicRegressionSplines.java
+++ b/h2o-algos/src/main/java/hex/gam/GamSplines/CubicRegressionSplines.java
@@ -4,33 +4,18 @@ import hex.gam.MatrixFrameUtils.TriDiagonalMatrix;
 import hex.util.LinearAlgebraUtils;
 import water.util.ArrayUtils;
 
+import static hex.genmodel.utils.ArrayUtils.eleDiff;
 import static hex.util.LinearAlgebraUtils.generateTriDiagMatrix;
 
 public class CubicRegressionSplines {
   public double[] _knots;  // store knot values for the spline class
   public double[] _hj;     // store difference between knots, length _knotNum-1
   int _knotNum; // number of knot values
-
-/*  public CubicRegressionSplines(int knotNum, double[] knots, double vmax, double vmin) {
-    _knotNum = knotNum;
-    _knots = knots;
-    if (knots==null) {
-      _knots = MemoryManager.malloc8d(_knotNum);
-      int lastKnotInd = _knotNum-1;
-      double incre = (vmax-vmin)/(lastKnotInd);
-      _knots[0] = vmin;
-      _knots[lastKnotInd] = vmax;
-      for (int index=1; index < lastKnotInd; index++) {
-        _knots[index] = _knots[index-1]+incre;
-      }
-    }
-    _hj = ArrayUtils.eleDiff(_knots);
-  }*/
-
+  
   public CubicRegressionSplines(int knotNum, double[] knots) {
     _knotNum = knotNum;
     _knots = knots;
-    _hj = ArrayUtils.eleDiff(_knots);
+    _hj = eleDiff(_knots);
   }
 
   public double[][] gen_BIndvD(double[] hj) {  // generate matrix bInvD
@@ -49,25 +34,5 @@ public class CubicRegressionSplines {
   public double[][] gen_penalty_matrix(double[] hj, double[][] binvD) {
     TriDiagonalMatrix matrixD = new TriDiagonalMatrix(hj); // of dimension (_knotNum-2) by _knotNum
     return LinearAlgebraUtils.matrixMultiplyTriagonal(ArrayUtils.transpose(binvD), matrixD, false);
-  }
-
-  public static double gen_a_m_j(double xjp1, double x, double hj) {
-    return (xjp1-x)/hj;
-  }
-
-  public static double gen_a_p_j(double xj, double x, double hj) {
-    return (x-xj)/hj;
-  }
-
-  public static double gen_c_m_j(double xjp1, double x, double hj) {
-    double t = (xjp1-x);
-    double t3 = t*t*t;
-    return ((t3/hj-t*hj)/6.0);
-  }
-
-  public static double gen_c_p_j(double xj, double x, double hj) {
-    double t=(x-xj);
-    double t3 = t*t*t;
-    return ((t3/hj-t*hj)/6.0);
   }
 }

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/AddGamColumns.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/AddGamColumns.java
@@ -8,9 +8,7 @@ import water.fvec.Frame;
 import water.fvec.NewChunk;
 import water.util.ArrayUtils;
 
-import static hex.gam.MatrixFrameUtils.GamUtils.locateBin;
-import static hex.gam.MatrixFrameUtils.GenerateGamMatrixOneColumn.updateAFunc;
-import static hex.gam.MatrixFrameUtils.GenerateGamMatrixOneColumn.updateFMatrixCFunc;
+import static hex.genmodel.algos.gam.GamUtilsCubicRegression.*;
 
 /**
  * Given a Frame, the class will add all the gam columns to the end of the Frame right before
@@ -75,9 +73,9 @@ public class AddGamColumns extends MRTask<AddGamColumns> {
     if (!Double.isNaN(xval)) {
       int binIndex = locateBin(xval, splines._knots); // location to update
       // update from F matrix F matrix = [0;invB*D;0] and c functions
-      updateFMatrixCFunc(basisVals, xval, binIndex, splines, bInvD);
+      updateFMatrixCFunc(basisVals, xval, binIndex, splines._knots, splines._hj, bInvD);
       // update from a+ and a- functions
-      updateAFunc(basisVals, xval, binIndex, splines);
+      updateAFunc(basisVals, xval, binIndex, splines._knots, splines._hj);
       // add centering
       basisValCenter = ArrayUtils.multArrVec(_ztransp[colInd], basisVals, basisValCenter);
       // copy updates to the newChunk row

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
@@ -118,32 +118,6 @@ public class GamUtils {
     }
   }
 
-  public static int locateBin(double xval, double[] knots) {
-    if (xval <= knots[0])  //small short cut
-      return 0;
-    int highIndex = knots.length-1;
-    if (xval >= knots[highIndex]) // small short cut
-      return (highIndex-1);
-
-    int tryBin = -1;
-    int count = 0;
-    int numBins = knots.length;
-    int lowIndex = 0;
-
-    while (count < numBins) {
-      tryBin = (int) Math.floor((highIndex+lowIndex)*0.5);
-      if ((xval >= knots[tryBin]) && (xval < knots[tryBin+1]))
-        return tryBin;
-      else if (xval > knots[tryBin])
-        lowIndex = tryBin;
-      else if (xval < knots[tryBin])
-        highIndex = tryBin;
-
-      count++;
-    }
-    return tryBin;
-  }
-
   public static int colIndexFromColNames(String[] colnames, String oneName) {
     int len = colnames.length;
     for (int index = 0; index < len; index++)

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GenerateGamMatrixOneColumn.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GenerateGamMatrixOneColumn.java
@@ -3,6 +3,7 @@ package hex.gam.MatrixFrameUtils;
 import hex.DataInfo;
 import hex.gam.GAMModel.GAMParameters;
 import hex.gam.GamSplines.CubicRegressionSplines;
+import hex.genmodel.algos.gam.GamUtilsCubicRegression;
 import hex.glm.GLMModel.GLMParameters.MissingValuesHandling;
 import hex.util.LinearAlgebraUtils.BMulInPlaceTask;
 import water.MRTask;
@@ -12,7 +13,7 @@ import water.fvec.NewChunk;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
 
-import static hex.gam.MatrixFrameUtils.GamUtils.locateBin;
+import static hex.genmodel.algos.gam.GamUtilsCubicRegression.locateBin;
 
 public class GenerateGamMatrixOneColumn extends MRTask<GenerateGamMatrixOneColumn> {
   int _splineType;
@@ -50,9 +51,9 @@ public class GenerateGamMatrixOneColumn extends MRTask<GenerateGamMatrixOneColum
       double xval = chk[0].atd(rowIndex);
       int binIndex = locateBin(xval,_knots); // location to update
       // update from F matrix F matrix = [0;invB*D;0] and c functions
-      updateFMatrixCFunc(basisVals, xval, binIndex, crSplines, _bInvD);
+      GamUtilsCubicRegression.updateFMatrixCFunc(basisVals, xval, binIndex, _knots, crSplines._hj, _bInvD);
       // update from a+ and a- functions
-      updateAFunc(basisVals, xval, binIndex, crSplines);
+      GamUtilsCubicRegression.updateAFunc(basisVals, xval, binIndex, _knots, crSplines._hj);
       // copy updates to the newChunk row
       for (int colIndex = 0; colIndex < _numKnots; colIndex++) {
         newGamCols[colIndex].addNum(basisVals[colIndex]);
@@ -91,32 +92,7 @@ public class GenerateGamMatrixOneColumn extends MRTask<GenerateGamMatrixOneColum
       }
     }
   }
-
-  public static void updateAFunc(double[] basisVals, double xval, int binIndex, CubicRegressionSplines splines) {
-    int jp1 = binIndex+1;
-    basisVals[binIndex] += splines.gen_a_m_j(splines._knots[jp1], xval, splines._hj[binIndex]);
-    basisVals[jp1] += splines.gen_a_p_j(splines._knots[binIndex], xval, splines._hj[binIndex]);
-  }
-
-  public static void updateFMatrixCFunc(double[] basisVals, double xval, int binIndex, CubicRegressionSplines splines,
-                                        double[][] binvD) {
-    int numKnots = basisVals.length;
-    int matSize = binvD.length;
-    int jp1 = binIndex+1;
-    double cmj = splines.gen_c_m_j(splines._knots[jp1], xval, splines._hj[binIndex]);
-    double cpj = splines.gen_c_p_j(splines._knots[binIndex], xval, splines._hj[binIndex]);
-    int binIndexM1 = binIndex-1;
-    for (int index=0; index < numKnots; index++) {
-      if (binIndex == 0) {  // only one part
-        basisVals[index] = binvD[binIndex][index] * cpj;
-      } else if (binIndex >= matSize) { // update only one part
-        basisVals[index] = binvD[binIndexM1][index] * cmj;
-      } else { // binIndex > 0 and binIndex < matSize
-        basisVals[index] = binvD[binIndexM1][index] * cmj+binvD[binIndex][index] * cpj;
-      }
-    }
-  }
-
+  
   public Frame centralizeFrame(Frame fr, String colNameStart, GAMParameters parms) {
     generateZtransp(fr);
     int numCols = fr.numCols();

--- a/h2o-algos/src/main/java/hex/gam/MetricBuilderGAM.java
+++ b/h2o-algos/src/main/java/hex/gam/MetricBuilderGAM.java
@@ -58,7 +58,7 @@ public class MetricBuilderGAM extends ModelMetricsSupervised.MetricBuilderSuperv
       if (_glmf._family.equals(GLMModel.GLMParameters.Family.multinomial) || _glmf._family.equals(GLMModel.GLMParameters.Family.ordinal))
         add2(yact[0], ds[0], weight, offset);
       else if (_glmf._family.equals(binomial) || _glmf._family.equals(quasibinomial) ||
-              _glmf._family.equals(negativebinomial) || _glmf._family.equals(fractionalbinomial))
+             _glmf._family.equals(fractionalbinomial))
         add2(yact[0], ds[2], weight, offset);
       else
         add2(yact[0], ds[0], weight, offset);
@@ -69,7 +69,7 @@ public class MetricBuilderGAM extends ModelMetricsSupervised.MetricBuilderSuperv
   private void add2(double yresp, double ypredict, double weight, double offset) {
     _wcount += weight;
     ++_nobs;
-    if (!_glmf._family.equals(multinomial)) {
+    if (!_glmf._family.equals(multinomial) && !_glmf._family.equals(ordinal)) {
       _residual_deviance += weight * _glmf.deviance(yresp, ypredict);
       if (offset == 0)
         _null_deviance += weight * _glmf.deviance(yresp, _ymu[0]);
@@ -146,13 +146,13 @@ public class MetricBuilderGAM extends ModelMetricsSupervised.MetricBuilderSuperv
     computeAIC();
     ModelMetrics mm=_metricBuilder.makeModelMetrics(gamM, f, null, null);
     if (_glmf._family.equals(GLMModel.GLMParameters.Family.binomial) || _glmf._family.equals(quasibinomial) ||
-    _glmf._family.equals(negativebinomial) ||  _glmf._family.equals(fractionalbinomial)) {
+    _glmf._family.equals(fractionalbinomial)) {
       ModelMetricsBinomial metricsBinomial = (ModelMetricsBinomial) mm;
       GainsLift gl = null;
       if (preds != null) {
         Vec resp = f.vec(gamM._parms._response_column);
         Vec weights = f.vec(gamM._parms._weights_column);
-        if (resp != null) {
+        if (resp != null && fractionalbinomial != _glmf._family) {
           gl = new GainsLift(preds.lastVec(), resp, weights);
           gl.exec(gamM._output._job);
         }

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1979,31 +1979,6 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       Frame train = DKV.<Frame>getGet(_parms._train); // need to keep this frame to get scoring metrics back
       _model.score(train).delete();
       scoreEnd(train, t1);
-/*
-        ModelMetrics mtrain = ModelMetrics.getFromDKV(_model, train); // updated by model.scoreAndUpdateModel
-        long t2 = System.currentTimeMillis();
-        if (!(mtrain == null)) {
-          _model._output._training_metrics = mtrain;
-          Log.info(LogMsg(mtrain.toString()));
-        } else {
-          Log.info(LogMsg("ModelMetrics mtrain is null"));
-        }
-        Log.info(LogMsg("Training metrics computed in " + (t2 - t1) + "ms"));
-        if (_valid != null) {
-          Frame valid = DKV.<Frame>getGet(_parms._valid);
-          _model.score(valid).delete();
-          _model._output._validation_metrics = ModelMetrics.getFromDKV(_model, valid); //updated by model.scoreAndUpdateModel
-        }
-      _model._output._scoring_history = _parms._lambda_search?_lsc.to2dTable():(_parms._HGLM?_sc.to2dTableHGLM():_sc.to2dTable());
-      _model.update(_job._key);
-      if (_parms._HGLM)
-        _model.generateSummary(_state._iter, _parms._train);
-      else
-        _model.generateSummary(_parms._train,_state._iter);
-      _lastScore = System.currentTimeMillis();
-      long scoringTime = System.currentTimeMillis() - t1;
-      _scoringInterval = Math.max(_scoringInterval,20*scoringTime); // at most 5% overhead for scoring
-*/
     }
     
     private void scoreEnd(Frame train, long t1) {

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.NoSuchElementException;
 
+import static hex.genmodel.utils.ArrayUtils.flat;
+
 /**
  * Created by tomasnykodym on 8/27/14.
  */
@@ -122,7 +124,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
 
   protected double [] beta_internal(){
     if(_parms._family == Family.multinomial || _parms._family == Family.ordinal)
-      return ArrayUtils.flat(_output._global_beta_multinomial);
+      return flat(_output._global_beta_multinomial);
     return _output._global_beta;
   }
   public double [] beta() { return beta_internal();}
@@ -1024,7 +1026,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       return idxs != null?idxs.length:(ArrayUtils.countNonzeros(beta));
     }
 
-    public Submodel(double lambda , double [] beta, int iteration, double devTrain, double devTest){
+    public Submodel(double lambda , double [] beta, int iteration, double devTrain, double devTest) {
       this.lambda_value = lambda;
       this.iteration = iteration;
       this.devianceTrain = devTrain;
@@ -1391,7 +1393,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     HashMap<String, Double> res = new HashMap<>();
     double [] b = beta();
     if(_parms._family == Family.multinomial || _parms._family == Family.ordinal){
-      if (standardized) b = ArrayUtils.flat(this._output.getNormBetaMultinomial());
+      if (standardized) b = flat(this._output.getNormBetaMultinomial());
       if(b == null) return res;
       String [] responseDomain = _output._domains[_output._domains.length-1];
       int len = b.length/_output.nclasses();

--- a/h2o-algos/src/test/java/hex/gam/GamMojoModelTest.java
+++ b/h2o-algos/src/test/java/hex/gam/GamMojoModelTest.java
@@ -1,0 +1,199 @@
+package hex.gam;
+
+import hex.CreateFrame;
+import hex.glm.GLMModel;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.DKV;
+import water.Scope;
+import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.util.ArrayList;
+
+import static hex.gam.GamTestPiping.getModel;
+import static hex.gam.GamTestPiping.massageFrame;
+import static hex.glm.GLMModel.GLMParameters.Family.*;
+import static water.TestUtil.parse_test_file;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class GamMojoModelTest {
+  public static final double _tol = 1e-6;
+
+  // test and make sure that tweedie mojo works.
+  @Test
+  public void testTweedie() {
+    Scope.enter();
+    try {
+      final Frame fr = Scope.track(parse_test_file("smalldata/glm_test/auto.csv"));
+      final GAMModel.GAMParameters params = new GAMModel.GAMParameters();
+      params._response_column = "y";
+      params._family = tweedie;
+      params._link = GLMModel.GLMParameters.Link.tweedie;
+      params._tweedie_variance_power = 1.5;
+      params._tweedie_link_power = 0.5;
+      params._ignored_columns = new String[]{"ID"};
+      params._gam_columns = new String[]{"x.TRAVTIME"};
+      params._num_knots = new int[]{5};
+      params._train = fr._key;
+      final GAMModel model = new GAM(params).trainModel().get();
+      Scope.track_generic(model);
+      Frame predictFrame = Scope.track(model.score(fr));
+      Assert.assertTrue(model.testJavaScoring(fr, predictFrame, _tol));
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test and make sure that quasibinomial mojo works
+  @Test
+  public void testQuasibinomial() {
+    Scope.enter();
+    try {
+      final Frame fr = Scope.track(parse_test_file("smalldata/glm_test/prostate_cat_replaced.csv"));
+      DKV.put(fr);
+      final GAMModel.GAMParameters params = new GAMModel.GAMParameters();
+      params._response_column = "CAPSULE";
+      params._family = quasibinomial;
+      params._ignored_columns = new String[]{"ID"};
+      params._gam_columns = new String[]{"PSA"};
+      params._num_knots = new int[]{5};
+      params._train = fr._key;
+      params._link = GLMModel.GLMParameters.Link.logit;
+      final GAMModel model = new GAM(params).trainModel().get();      
+      Frame predictFrame = Scope.track(model.score(fr));
+      Scope.track_generic(model);
+      Assert.assertTrue(model.testJavaScoring(fr, predictFrame, _tol));
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  // test and make sure the h2opredict, mojo predict agrees with binomial dataset that includes
+  // both enum and numerical datasets for the binomial family
+  @Test
+  public void testBinomialPredMojo() {
+    Scope.enter();
+    try {
+      // test for binomial
+      String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
+              "C15", "C16", "C17", "C18", "C19", "C20"};
+      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      Frame trainBinomial = Scope.track(massageFrame(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"),
+              binomial));
+      DKV.put(trainBinomial);
+      GAMModel binomialModel = getModel(binomial,
+              parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"), "C21",
+              gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false, true,
+              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null,
+              null, false);
+      Scope.track_generic(binomialModel);
+      binomialModel._output._training_metrics = null; // force prediction threshold of 0.5
+      Frame predictBinomial = Scope.track(binomialModel.score(trainBinomial));
+      Assert.assertTrue(binomialModel.testJavaScoring(trainBinomial, predictBinomial, _tol));
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test and make sure the h2opredict, mojo predict agrees with gaussian dataset that includes
+  // both enum and numerical datasets for the gaussian family
+  @Test
+  public void testGaussianPredMojo() {
+    Scope.enter();
+    try {
+      String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
+              "C15", "C16", "C17", "C18", "C19", "C20"};
+      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      Frame trainGaussian = Scope.track(massageFrame(parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"), gaussian));
+      DKV.put(trainGaussian);
+      GAMModel gaussianmodel = getModel(gaussian,
+              parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"), "C21",
+              gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false, true,
+              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null,null, true);
+      Scope.track_generic(gaussianmodel);
+      Frame predictGaussian = Scope.track(gaussianmodel.score(trainGaussian));
+      Frame predictG = new Frame(predictGaussian.vec(0));
+      Scope.track(predictG);
+
+      Assert.assertTrue(gaussianmodel.testJavaScoring(trainGaussian, predictG, _tol)); // compare scoring result with mojo
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test and make sure the h2opredict, mojo predict agrees with multinomial dataset that includes
+  // both enum and numerical datasets for the multinomial family
+  @Test
+  public void testMultinomialModelMojo() {
+    Scope.enter();
+    try {
+      // multinomial
+      String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[] gamCols = new String[]{"C6", "C7", "C8"};
+      Frame trainMultinomial = Scope.track(massageFrame(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"), multinomial));
+      DKV.put(trainMultinomial);
+      GAMModel multinomialModel = getModel(multinomial,
+              parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"),
+              "C11", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false,
+              true, new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0},
+              true, null,null, false);
+      Scope.track_generic(multinomialModel);
+      Frame predictMult = Scope.track(multinomialModel.score(trainMultinomial));
+      Assert.assertTrue(multinomialModel.testJavaScoring(trainMultinomial, predictMult, _tol)); // compare scoring result with mojo
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  
+  public GAMModel.GAMParameters buildGamParams(Frame train, GLMModel.GLMParameters.Family fam) {
+    GAMModel.GAMParameters paramsO = new GAMModel.GAMParameters();
+    paramsO._train = train._key;
+    paramsO._lambda_search = false;
+    paramsO._response_column = "response";
+    paramsO._lambda = new double[]{0};
+    paramsO._alpha = new double[]{0.001};  // l1pen
+    paramsO._objective_epsilon = 1e-6;
+    paramsO._beta_epsilon = 1e-4;
+    paramsO._standardize = false;
+    paramsO._family = fam;
+    paramsO._gam_columns =  chooseGamColumns(train, 3);
+    return paramsO;
+  }
+
+  public String[] chooseGamColumns(Frame trainF, int maxGamCols) {
+    int gamCount=0;
+    ArrayList<String> numericCols = new ArrayList<>();
+    String[] colNames = trainF.names();
+    for (String cnames : colNames) {
+      if (trainF.vec(cnames).isNumeric() && !trainF.vec(cnames).isInt()) {
+        numericCols.add(cnames);
+        gamCount++;
+      }
+      if (gamCount >= maxGamCols)
+        break;
+    }
+    String[] gam_columns = new String[numericCols.size()];
+    return numericCols.toArray(gam_columns);
+  }
+  
+  public Frame createTrainTestFrame(int responseFactor) {
+    CreateFrame cf = new CreateFrame();
+    int numRows = 18888;
+    int numCols = 18;
+    cf.rows= numRows;
+    cf.cols = numCols;
+    cf.factors=10;
+    cf.has_response=true;
+    cf.response_factors = responseFactor; // 1 for real-value response
+    cf.positive_response=true;
+    cf.missing_fraction = 0;
+    cf.seed = 12345;
+    System.out.println("Createframe parameters: rows: "+numRows+" cols:"+numCols+" seed: "+cf.seed);
+    return cf.execImpl().get();
+  }
+}

--- a/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
+++ b/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
@@ -19,7 +19,7 @@ import water.runner.H2ORunner;
 import water.util.ArrayUtils;
 
 import static hex.gam.MatrixFrameUtils.GamUtils.equalColNames;
-import static hex.gam.MatrixFrameUtils.GamUtils.locateBin;
+import static hex.genmodel.algos.gam.GamUtilsCubicRegression.locateBin;
 import static hex.glm.GLMModel.GLMParameters.Family.*;
 import static hex.glm.GLMModel.GLMParameters.GLMType.gam;
 import static hex.glm.GLMModel.GLMParameters.GLMType.glm;
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 @RunWith(H2ORunner.class)
 @CloudSize(1)
 public class GamTestPiping extends TestUtil {
-
   /**
    * This test is to make sure that we carried out the expansion of ONE gam column to basis functions
    * correctly with and without centering.  I will compare the following with R runs:
@@ -54,7 +53,8 @@ public class GamTestPiping extends TestUtil {
       final GAMModel model = getModel(gaussian,
               Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv")),
               "C11", gamCols, ignoredCols, new int[]{5}, new int[]{0}, false,
-              true, new double[]{1}, new double[]{0}, new double[]{0}, false, null,null);
+              true, new double[]{1}, new double[]{0}, new double[]{0}, false, null,
+              null, true);
       Scope.track_generic(model);
       final double[][] rBinvD = new double[][]{{1.5605080,
               -3.5620961, 2.5465468, -0.6524143, 0.1074557}, {-0.4210098, 2.5559955, -4.3258597, 2.6228736,
@@ -75,7 +75,7 @@ public class GamTestPiping extends TestUtil {
       Frame rTransformedData = parse_test_file("smalldata/gam_test/multinomial_10_classes_10_cols_10000_Rows_train_C6Gam.csv");
       Scope.track(rTransformedData);
 
-      Frame transformedDataC = ((Frame) DKV.getGet(model._output._gamTransformedTrainCenter));  // compare model matrix with centering
+      Frame transformedDataC = ((Frame) DKV.getGet(model._output._gamTransformedTrainCenter));// compare model matrix with centering
       Scope.track(transformedDataC);
       Scope.track(transformedDataC.remove("C11"));
       Frame rTransformedDataC = parse_test_file("smalldata/gam_test/multinomial_10_classes_10_cols_10000_Rows_train_C6Gam_center.csv");
@@ -105,7 +105,7 @@ public class GamTestPiping extends TestUtil {
               Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv")),
               "C11", gamCols, ignoredCols, new int[]{5}, new int[]{0}, false,
               true, new double[]{1}, new double[]{0}, new double[]{0}, false, 
-              new String[]{knotsFrame._key.toString()},null);
+              new String[]{knotsFrame._key.toString()},null, true);
       Scope.track_generic(model);
       final double[][] rBinvD = new double[][]{{1.5605080,
               -3.5620961, 2.5465468, -0.6524143, 0.1074557}, {-0.4210098, 2.5559955, -4.3258597, 2.6228736,
@@ -152,7 +152,7 @@ public class GamTestPiping extends TestUtil {
               Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
               , "C11", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0,0,0},
               false, true, new double[]{1, 1, 1}, new double[]{0, 0, 0}, 
-              new double[]{0, 0, 0}, false, null,null);
+              new double[]{0, 0, 0}, false, null,null, true);
       Scope.track_generic(model);
       final double[][][] rBinvD = new double[][][]{{{1.5605080,
               -3.5620961, 2.5465468, -0.6524143, 0.1074557}, {-0.4210098, 2.5559955, -4.3258597, 2.6228736,
@@ -188,7 +188,7 @@ public class GamTestPiping extends TestUtil {
   }
 
 
-  public Frame massageFrame(Frame train, GLMModel.GLMParameters.Family family) {
+  public static Frame massageFrame(Frame train, GLMModel.GLMParameters.Family family) {
     // set cat columns
     int numCols = train.numCols();
     int enumCols = (numCols - 1) / 2;
@@ -202,10 +202,10 @@ public class GamTestPiping extends TestUtil {
     return train;
   }
   
-  public GAMModel getModel(GLMModel.GLMParameters.Family family, Frame train, String responseColumn,
+  public static GAMModel getModel(GLMModel.GLMParameters.Family family, Frame train, String responseColumn,
                            String[] gamCols, String[] ignoredCols, int[] numKnots, int[] bstypes, boolean saveZmat,
                            boolean savePenalty, double[] scale, double[] alpha, double[] lambda, 
-                           boolean standardize, String[] knotsKey, Frame valid) {
+                           boolean standardize, String[] knotsKey, Frame valid, boolean computePVal) {
     GAMModel gam = null;
     try {
       Scope.enter();
@@ -225,7 +225,7 @@ public class GamTestPiping extends TestUtil {
       params._ignored_columns = ignoredCols;
       params._alpha = alpha;
       params._lambda = lambda;
-      params._compute_p_values = family.equals(multinomial)?false:true;
+      params._compute_p_values = computePVal;
       params._gam_columns = gamCols;
       params._train = train._key;
       params._family = family;
@@ -262,7 +262,7 @@ public class GamTestPiping extends TestUtil {
                 Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv")),
                 "C11", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false,
                 true, new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, 
-                false, null,null);
+                false, null,null, false);
         Scope.track_generic(model);
         Frame train = parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv");
         Scope.track(train);
@@ -378,7 +378,8 @@ public class GamTestPiping extends TestUtil {
     int[][] gamCoeffIndices = new int[][]{{10, 11, 12, 13}, {14, 15, 16, 17}, {18, 19, 20, 21}};
     double[][][] penalty_mat = model._output._penaltyMatrices_center;
     glmParms._glmType = gam;
-    double[] beta = fam.equals(gaussian)?model._output._model_beta :TestUtil.changeDouble2SingleArray(model._output._model_beta_multinomial);
+    double[] beta = fam.equals(gaussian)?model._output._model_beta 
+            :TestUtil.changeDouble2SingleArray(model._output._model_beta_multinomial);
     GLM.GLMGradientInfo ginfo = new GLM.GLMGradientSolver(null, glmParms, dinfo, 0, null,
             penalty_mat, gamCoeffIndices).getGradient(beta);
     double[] gamGradient = ginfo._gradient;
@@ -481,13 +482,13 @@ public class GamTestPiping extends TestUtil {
               parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"),
               "C11", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false,
               true, new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0},
-              true, null,null);
+              true, null, null, false);
       Scope.track_generic(multinomialModel);
       Frame predictMult = Scope.track(multinomialModel.score(trainMultinomial));
-      Frame predictGLMMulti = Scope.track(parse_test_file("smalldata/gam_test/predictMultinomialGAM1.csv"));
+      Frame predictGLMMulti = Scope.track(parse_test_file("smalldata/gam_test/predictMultinomialGAM2.csv"));
       TestUtil.assertIdenticalUpToRelTolerance(predictMult, predictGLMMulti, 1e-6);
       
-      // test for gaussian
+      // test for binomial
       ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
       gamCols = new String[]{"C11", "C12", "C13"};
@@ -497,22 +498,25 @@ public class GamTestPiping extends TestUtil {
       GAMModel binomialModel = getModel(binomial,
               parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"), "C21",
               gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false, true,
-              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null,null);
+              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null, 
+              null, false);
       Scope.track_generic(binomialModel);
       binomialModel._output._training_metrics = null; // force prediction threshold of 0.5
       Frame predictBinomial = Scope.track(binomialModel.score(trainBinomial));
-      Frame predictGLMBinomial = Scope.track(parse_test_file("smalldata/gam_test/predictBinomialGAM1.csv"));
+      Frame predictGLMBinomial = Scope.track(parse_test_file("smalldata/gam_test/predictBinomialGAMJava.csv"));
       TestUtil.assertIdenticalUpToRelTolerance(predictBinomial, predictGLMBinomial, 1e-6);
-      
+
+      // test for Gaussian
       Frame trainGaussian = Scope.track(massageFrame(parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"), gaussian));
       DKV.put(trainGaussian);
-      GAMModel gaussianmodel = getModel(gaussian,
+      GAMModel gaussianModel = getModel(gaussian,
               parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"), "C21",
               gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false, true,
-              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null,null);
-      Scope.track_generic(gaussianmodel);
-      Frame predictGaussian = Scope.track(gaussianmodel.score(trainGaussian));
-      Frame predictGLMGaussian = Scope.track(parse_test_file("smalldata/gam_test/predictGaussianGAM1.csv"));
+              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null,
+              null, false);
+      Scope.track_generic(gaussianModel);
+      Frame predictGaussian = Scope.track(gaussianModel.score(trainGaussian));
+      Frame predictGLMGaussian = Scope.track(parse_test_file("smalldata/gam_test/predictGaussianGAM2.csv"));
       TestUtil.assertIdenticalUpToRelTolerance(predictGaussian, predictGLMGaussian, 1e-6);
     } finally {
       Scope.exit();
@@ -552,7 +556,8 @@ public class GamTestPiping extends TestUtil {
       GAMModel binomialModel = getModel(binomial,
               parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"), "C21",
               gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false, true,
-              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null,testFrame);
+              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null, 
+              testFrame, true);
       Scope.track_generic(binomialModel);
       Frame testPred = binomialModel.score(trainFrame);
       Scope.track(testPred);
@@ -573,17 +578,17 @@ public class GamTestPiping extends TestUtil {
       GAMModel binomialModel = getModel(binomial,  Scope.track(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
               , "C21", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0},
               false, true, new double[]{1, 1, 1}, new double[]{0, 0, 0},
-              new double[]{0, 0, 0}, true, null,null);
+              new double[]{0, 0, 0}, true, null,null, true);
       Scope.track_generic(binomialModel);
       verifyModelMetrics(binomialModel,1e-6);
 
-      GAMModel gaussianmodel = getModel(gaussian,
+      GAMModel gaussianModel = getModel(gaussian,
               Scope.track(parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
               , "C21", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0},
               false, true, new double[]{1, 1, 1}, new double[]{0, 0, 0},
-              new double[]{0, 0, 0}, true, null,null);
-      Scope.track_generic(gaussianmodel);
-      verifyModelMetrics(gaussianmodel,1e-6);
+              new double[]{0, 0, 0}, true, null,null, true);
+      Scope.track_generic(gaussianModel);
+      verifyModelMetrics(gaussianModel,1e-6);
       
       // multinomial
       ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
@@ -593,7 +598,7 @@ public class GamTestPiping extends TestUtil {
               Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
               , "C11", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0},
               false, true, new double[]{1, 1, 1}, new double[]{0, 0, 0},
-              new double[]{0, 0, 0}, true, null,null);
+              new double[]{0, 0, 0}, true, null,null, false);
       Scope.track_generic(multinomialModel);
       verifyModelMetrics(multinomialModel,1e-6);
     } finally {

--- a/h2o-algos/src/test/java/hex/glm/GLMTest.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
+import static hex.genmodel.utils.ArrayUtils.flat;
 import static org.junit.Assert.*;
 
 public class GLMTest  extends TestUtil {
@@ -1907,7 +1908,7 @@ public class GLMTest  extends TestUtil {
               parms2._objective_epsilon = 1e-8;
               GLMModel model2 = new GLM(parms2).trainModel().get();
               double[] beta_ls = rp._coefficients_std[i];
-              double [] beta = fam == Family.multinomial?ArrayUtils.flat(model2._output.getNormBetaMultinomial()):model2._output.getNormBeta();
+              double [] beta = fam == Family.multinomial?flat(model2._output.getNormBetaMultinomial()):model2._output.getNormBeta();
               System.out.println(ArrayUtils.pprint(new double[][]{beta,beta_ls}));
               // Can't compare beta here, have to compare objective value
               double null_dev = ((GLMMetrics) model2._output._training_metrics).null_deviance();

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -3050,7 +3050,9 @@ public class GBMTest extends TestUtil {
   @Test
   public void testDeviances() {
     for (DistributionFamily dist : DistributionFamily.values()) {
-      if (dist == modified_huber || dist == quasibinomial || dist == ordinal || dist == custom) continue;
+      if (dist == modified_huber || dist == quasibinomial || dist == ordinal || dist == custom ||
+              dist == negativebinomial || dist == fractionalbinomial)
+        continue;
       Frame tfr = null;
       Frame res = null;
       Frame preds = null;

--- a/h2o-core/src/main/java/hex/ModelMojoWriter.java
+++ b/h2o-core/src/main/java/hex/ModelMojoWriter.java
@@ -7,6 +7,7 @@ import water.api.schemas3.ModelSchemaV3;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.zip.ZipOutputStream;
 
 
@@ -102,4 +103,23 @@ public abstract class ModelMojoWriter<M extends Model<M, P, O>, P extends Model.
     finishWritingTextFile();
   }
 
+  public void writeStringArrays(String[] sArrays, String title) throws IOException {
+    startWritingTextFile(title);
+    for (String sName : sArrays) {
+      writeln(sName);
+    }
+    finishWritingTextFile();
+  }
+
+  public void writeDoubleArray(double[][] array, String title) throws IOException {
+    int totArraySize = 0;
+    for (double[] row : array)
+      totArraySize += row.length;
+
+    ByteBuffer bb = ByteBuffer.wrap(new byte[totArraySize * 8]);
+    for (double[] row : array)
+      for (double val : row)
+        bb.putDouble(val);
+    writeblob(title, bb.array());
+  }
 }

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -23,15 +23,6 @@ public class ArrayUtils {
     }
     return cumsumR;
   }
-
-  public static double[] eleDiff(final double[] from) {
-    int arryLen = from.length-1;
-    double[] cumsumR = new double[arryLen];
-    for (int index = 0; index < arryLen; index++) {
-      cumsumR[index] = from[index+1]-from[index];
-    }
-    return cumsumR;
-  }
   
   // Sum elements of an array
   public static long sum(final long[] from) {
@@ -1493,22 +1484,6 @@ public class ArrayUtils {
       System.arraycopy(x,i*N,res[i],0,N);
     }
     return res;
-  }
-
-  public static double[] flat(double[][] arr) {
-    if (arr == null) return null;
-    if (arr.length == 0) return null;
-    int tlen = 0;
-    for (double[] t : arr) tlen += (t != null) ? t.length : 0;
-    double[] result = Arrays.copyOf(arr[0], tlen);
-    int j = arr[0].length;
-    for (int i = 1; i < arr.length; i++) {
-      if (arr[i] == null)
-        continue;
-      System.arraycopy(arr[i], 0, result, j, arr[i].length);
-      j += arr[i].length;
-    }
-    return result;
   }
 
   public static Object[][] zip(Object[] a, Object[] b) {

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoFactory.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoFactory.java
@@ -2,17 +2,18 @@ package hex.genmodel;
 
 import hex.genmodel.algos.deeplearning.DeeplearningMojoReader;
 import hex.genmodel.algos.drf.DrfMojoReader;
+import hex.genmodel.algos.ensemble.StackedEnsembleMojoReader;
+import hex.genmodel.algos.gam.GamMojoReader;
 import hex.genmodel.algos.gbm.GbmMojoReader;
 import hex.genmodel.algos.glm.GlmMojoReader;
-import hex.genmodel.algos.pca.PCAMojoReader;
 import hex.genmodel.algos.glrm.GlrmMojoReader;
 import hex.genmodel.algos.isofor.IsolationForestMojoReader;
 import hex.genmodel.algos.kmeans.KMeansMojoReader;
+import hex.genmodel.algos.pca.PCAMojoReader;
 import hex.genmodel.algos.pipeline.MojoPipelineReader;
 import hex.genmodel.algos.svm.SvmMojoReader;
 import hex.genmodel.algos.targetencoder.TargetEncoderMojoReader;
 import hex.genmodel.algos.word2vec.Word2VecMojoReader;
-import hex.genmodel.algos.ensemble.StackedEnsembleMojoReader;
 
 import java.util.ServiceLoader;
 
@@ -66,7 +67,8 @@ public class ModelMojoFactory {
       case "Generalized Linear Modeling":
       case "Generalized Linear Model":
         return new GlmMojoReader();
-
+      case "Generalized Additive Model":
+        return new GamMojoReader();
       case "Word2Vec":
         return new Word2VecMojoReader();
         

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
@@ -1,9 +1,11 @@
 package hex.genmodel;
 
-import com.google.gson.*;
+import com.google.gson.JsonObject;
 import hex.genmodel.attributes.ModelAttributes;
 import hex.genmodel.attributes.ModelJsonReader;
 import hex.genmodel.descriptor.ModelDescriptorBuilder;
+import hex.genmodel.utils.DistributionFamily;
+import hex.genmodel.utils.LinkFunctionType;
 import hex.genmodel.utils.ParseUtils;
 import hex.genmodel.utils.StringEscapeUtils;
 
@@ -303,6 +305,30 @@ public abstract class ModelMojoReader<M extends MojoModel> {
   private void checkMaxSupportedMojoVersion() throws IOException {
     if(_model._mojo_version > Double.parseDouble(mojoVersion())){
       throw new IOException(String.format("MOJO version incompatibility - the model MOJO version (%.2f) is higher than the current h2o version (%s) supports. Please, use the older version of h2o to load MOJO model.", _model._mojo_version, mojoVersion()));
+    }
+  }
+
+  public static LinkFunctionType readLinkFunction(String linkFunctionTypeName, DistributionFamily family) {
+    if (linkFunctionTypeName != null)
+      return LinkFunctionType.valueOf(linkFunctionTypeName);
+    return defaultLinkFunction(family);
+  }
+
+  public static LinkFunctionType defaultLinkFunction(DistributionFamily family){
+    switch (family) {
+      case bernoulli:
+      case fractionalbinomial:
+      case quasibinomial:
+      case modified_huber:
+      case ordinal:
+        return LinkFunctionType.logit;
+      case multinomial:
+      case poisson:
+      case gamma:
+      case tweedie:
+        return LinkFunctionType.log;
+      default:
+        return LinkFunctionType.identity;
     }
   }
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModel.java
@@ -1,0 +1,36 @@
+package hex.genmodel.algos.gam;
+
+import static hex.genmodel.utils.DistributionFamily.*;
+
+public class GamMojoModel extends GamMojoModelBase {
+  private boolean _classifier;
+  
+  GamMojoModel(String[] columns, String[][] domains, String responseColumn) {
+    super(columns, domains, responseColumn);
+  }
+  
+  void init() {
+    super.init();
+    _classifier = _family.equals(bernoulli) || _family.equals(fractionalbinomial) || _family.equals(quasibinomial);
+  }
+  
+  // generate prediction for binomial/fractional binomial/negative binomial, poisson, tweedie families
+  @Override
+  double[] gamScore0(double[] data, double[] preds) {
+    if (data.length == nfeatures())  // centered data, use center coefficients
+      _beta = _beta_center;
+    else  // use non-centering coefficients
+    _beta = _beta_no_center;
+    double eta = generateEta(_beta, data);  // generate eta, inner product of beta and data
+    double mu = evalLink(eta);
+
+    if (_classifier) {
+      preds[0] = (mu >= _defaultThreshold) ? 1 : 0; // threshold given by ROC
+      preds[1] = 1.0 - mu; // class 0
+      preds[2] =       mu; // class 1
+    } else {
+      preds[0] = mu;
+    }
+    return preds;
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModelBase.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModelBase.java
@@ -1,0 +1,169 @@
+package hex.genmodel.algos.gam;
+
+import hex.genmodel.ConverterFactoryProvidingModel;
+import hex.genmodel.GenModel;
+import hex.genmodel.MojoModel;
+import hex.genmodel.easy.CategoricalEncoder;
+import hex.genmodel.easy.EasyPredictModelWrapper;
+import hex.genmodel.easy.RowData;
+import hex.genmodel.easy.RowToRawDataConverter;
+import hex.genmodel.utils.ArrayUtils;
+import hex.genmodel.utils.DistributionFamily;
+import hex.genmodel.utils.LinkFunctionType;
+
+import java.util.Map;
+
+import static hex.genmodel.utils.ArrayUtils.nanArray;
+
+public abstract class GamMojoModelBase extends MojoModel implements ConverterFactoryProvidingModel {
+  public LinkFunctionType _link_function;
+  boolean _useAllFactorLevels;
+  int _cats;
+  int[] _catNAFills;
+  int[] _catOffsets;
+  int _nums;
+  int _numsCenter;
+  double[] _numNAFills;
+  double[] _numNAFillsCenter;
+  boolean _meanImputation;
+  double[] _beta;
+  double[] _beta_no_center;
+  double[] _beta_center;
+  double[][] _beta_multinomial;
+  double[][] _beta_multinomial_no_center; // coefficients not centered for multinomial/ordinal
+  double[][] _beta_multinomial_center; // coefficients not centered for multinomial/ordinal
+  DistributionFamily _family;
+  String[] _gam_columns;
+  int _num_gam_columns;
+  int[] _bs;
+  int[] _num_knots;
+  double[][] _knots;
+  double[][][] _binvD;
+  double[][][] _zTranspose;
+  String[][] _gamColNames;  // expanded gam column names
+  String[][] _gamColNamesCenter;
+  String[] _names_no_centering; // column names of features with no centering
+  int _totFeatureSize; // Gam Algo predictors numbers that include: predictors, expanded gam columns no centered
+  int _betaSizePerClass;
+  int _betaCenterSizePerClass;
+  double _tweedieLinkPower;
+  double[][] _basisVals; // store basis values array for each gam column
+  double[][] _hj;   // difference between knot values
+  int _numExpandedGamCols; // number of expanded gam columns
+  int _lastClass;
+  
+  private int getTotFeatureSize() { return _totFeatureSize;}
+  
+  GamMojoModelBase(String[] columns, String[][] domains, String responseColumn) {
+    super(columns, domains, responseColumn);
+  }
+
+  @Override
+  public double[] score0(double[] row, double[] preds) {
+    if (_meanImputation)
+      imputeMissingWithMeans(row);  // perform imputation for each row
+    
+    return gamScore0(row, preds);
+  }
+  
+  void init() {
+    _basisVals = new double[_gam_columns.length][];
+    _hj = new double[_gam_columns.length][];
+    for (int ind=0; ind < _num_gam_columns; ind++) {
+      _basisVals[ind] = new double[_num_knots[ind]];
+      _hj[ind] = ArrayUtils.eleDiff(_knots[ind]);
+    }
+    _lastClass = _nclasses - 1;
+  }
+  
+  abstract double[] gamScore0(double[] row, double[] preds);
+  
+  private void imputeMissingWithMeans(double[] data) {
+    for (int ind=0; ind < _cats; ind++)
+      if (Double.isNaN(data[ind])) data[ind] = _catNAFills[ind];
+
+    if (data.length == nfeatures()) { // using centered gam cols, nfeatures denotes centered gam columns
+      for (int ind = 0; ind < _numsCenter; ind++)
+        if (Double.isNaN(data[ind + _cats])) data[ind] = _numNAFillsCenter[ind];
+    } else {
+      for (int ind = 0; ind < _nums; ind++) {
+        int colInd = ind+_cats;
+        if (Double.isNaN(data[colInd])) 
+          data[colInd] = _numNAFills[ind];
+      }
+    }
+  }
+  
+  double evalLink(double val) {
+    switch (_link_function) {
+      case identity: return GenModel.GLM_identityInv(val);
+      case logit: return GenModel.GLM_logitInv(val);
+      case log: return GenModel.GLM_logInv(val);
+      case inverse: return GenModel.GLM_inverseInv(val);
+      case tweedie: return GenModel.GLM_tweedieInv(val, _tweedieLinkPower);
+      default: throw new UnsupportedOperationException("Unexpected link function "+_link_function);
+    }
+  }
+
+  // This method will read in categorical value and adjust for when useAllFactorLevels = true or false
+  int readCatVal(double data, int dataIndex) {
+    int ival = _useAllFactorLevels?((int) data):((int) data-1);
+    double targetVal = _useAllFactorLevels?(data):(data-1);
+    if (ival != targetVal) throw new IllegalArgumentException("categorical value out of range");
+    if (ival < 0)
+      return -1;
+    ival += _catOffsets[dataIndex];
+    return ival;
+  }
+
+  // this method will generate the beta*data+intercept
+  double generateEta(double[] beta, double[] data) {
+    double eta = 0.0;
+    for (int i = 0; i < _catOffsets.length - 1; ++i) {  // take care of contribution from categorical columns
+      int ival = readCatVal(data[i], i);
+      if ((ival < _catOffsets[i + 1]) && (ival >= 0))
+        eta += beta[ival];
+    }
+
+    int noff = _catOffsets[_cats] - _cats;
+    for (int i = _cats; i < beta.length - 1 - noff; ++i)
+      eta += beta[noff + i] * data[i];
+    eta += beta[beta.length - 1]; // add intercept
+    return eta;
+  }
+  
+  // this method will add to each data row the expanded gam columns
+  public double[] addExpandGamCols(double[] rawData, final RowData rowData) { // add all expanded gam columns here
+    // add expanded gam columns to rowData
+    int dataIndStart = _totFeatureSize-_numExpandedGamCols; // starting index to fill out the rawData
+    double[] dataWithGamifiedColumns = null;  // only allocate this when gamification of columns are needed.
+    for (int cind = 0; cind < _num_gam_columns; cind++) {
+      if (_bs[cind]==0) { // to generate basis function values for cubic regression spline
+        Object dataObject = rowData.get(_gam_columns[cind]);
+        double gam_col_data = Double.NaN;
+        if (dataObject == null) {  // gamified columns are already included
+          return rawData;
+        } else
+          gam_col_data = (dataObject instanceof String)?Double.parseDouble((String)dataObject):(double) dataObject;
+        GamUtilsCubicRegression.expandOneGamCol(gam_col_data, _binvD[cind], _basisVals[cind], _hj[cind], _knots[cind]);
+      } else {
+        throw new IllegalArgumentException("spline type not implemented!");
+      }
+      if (dataWithGamifiedColumns==null) {  // allocate new array now since we need to add gamified columns here
+        dataWithGamifiedColumns = nanArray(getTotFeatureSize());
+        System.arraycopy(rawData, 0, dataWithGamifiedColumns, 0, dataIndStart);
+      }
+      System.arraycopy(_basisVals[cind], 0, dataWithGamifiedColumns, dataIndStart, _num_knots[cind]); // copy expanded gam to rawData
+      dataIndStart += _num_knots[cind];
+    }
+    return dataWithGamifiedColumns;
+  }
+
+  @Override
+  public RowToRawDataConverter makeConverterFactory(Map<String, Integer> modelColumnNameToIndexMap,
+                                                    Map<Integer, CategoricalEncoder> domainMap,
+                                                    EasyPredictModelWrapper.ErrorConsumer errorConsumer,
+                                                    EasyPredictModelWrapper.Config config) {
+    return new GamRowToRawDataConverter(this, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoMultinomialModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoMultinomialModel.java
@@ -1,0 +1,67 @@
+package hex.genmodel.algos.gam;
+
+import static hex.genmodel.utils.DistributionFamily.multinomial;
+
+public class GamMojoMultinomialModel extends GamMojoModelBase {
+    private boolean _trueMultinomial;
+
+    GamMojoMultinomialModel(String[] columns, String[][] domains, String responseColumn) {
+        super(columns, domains, responseColumn);
+    }
+
+    void init() {
+        super.init();
+        _trueMultinomial = _family.equals(multinomial);
+    }
+    
+    @Override
+    double[] gamScore0(double[] row, double[] preds) {
+        if (row.length == nfeatures())
+            _beta_multinomial = _beta_multinomial_center;
+        else
+            _beta_multinomial = _beta_multinomial_no_center;
+        
+        for (int c=0; c<_nclasses; ++c) 
+                preds[c+1] = generateEta(_beta_multinomial[c], row);  // generate eta for each class
+
+        if (_trueMultinomial)
+            return postPredMultinomial(preds);
+        else // post process predict for ordinal family
+            return postPredOrdinal(preds);
+    }
+    
+    double[] postPredMultinomial(double[] preds) {
+        double max_row = 0;
+        double sum_exp = 0;
+        for (int c = 1; c < preds.length; ++c) if (preds[c] > max_row) max_row = preds[c];
+        for (int c = 1; c < preds.length; ++c) { sum_exp += (preds[c] = Math.exp(preds[c]-max_row));}
+        sum_exp = 1/sum_exp;
+        double max_p = 0;
+        for (int c = 1; c < preds.length; ++c) if ((preds[c] *= sum_exp) > max_p) { max_p = preds[c]; preds[0] = c-1; }
+        return preds;
+    }
+    
+    double[] postPredOrdinal(double[] preds) {
+        double previousCDF = 0.0;
+        preds[0] = _lastClass;
+        for (int cInd = 0; cInd < _lastClass; cInd++) { // classify row and calculate PDF of each class
+            double eta = preds[cInd + 1];
+            double currCDF = 1.0 / (1 + Math.exp(-eta));
+            preds[cInd + 1] = currCDF - previousCDF;
+            previousCDF = currCDF;
+
+            if (eta > 0) { // found the correct class
+                preds[0] = cInd;
+                break;
+            }
+        }
+        for (int cInd = (int) preds[0] + 1; cInd < _lastClass; cInd++) {  // continue PDF calculation
+            double currCDF = 1.0 / (1 + Math.exp(-preds[cInd + 1]));
+            preds[cInd + 1] = currCDF - previousCDF;
+            previousCDF = currCDF;
+
+        }
+        preds[_nclasses] = 1-previousCDF;
+        return preds;
+    }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
@@ -1,0 +1,115 @@
+package hex.genmodel.algos.gam;
+
+import hex.genmodel.ModelMojoReader;
+import hex.genmodel.utils.DistributionFamily;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static hex.genmodel.utils.DistributionFamily.ordinal;
+
+public class GamMojoReader extends ModelMojoReader<GamMojoModelBase> {
+
+  @Override
+  public String getModelName() {
+    return "Generalized Additive Model";
+  }
+
+  @Override
+  protected void readModelData() throws IOException {
+    _model._useAllFactorLevels = readkv("use_all_factor_levels", false);
+    _model._numExpandedGamCols = readkv("num_expanded_gam_columns",0);
+    _model._family = DistributionFamily.valueOf((String)readkv("family"));
+    _model._cats = readkv("cats", -1);
+    _model._nums = readkv("num");
+    _model._numsCenter = readkv("numsCenter");
+    _model._catNAFills = readkv("catNAFills", new int[0]);
+    _model._numNAFills = readkv("numNAFills", new double[0]);
+    _model._numNAFillsCenter = readkv("numNAFillsCenter", new double[0]);;
+    _model._meanImputation = readkv("mean_imputation", false);
+    _model._betaSizePerClass = readkv("beta length per class",0);
+    _model._catOffsets = readkv("cat_offsets", new int[0]);
+    if (!_model._family.equals(DistributionFamily.multinomial))  // multinomial or ordinal have specific link functions not included in general link functions
+      _model._link_function = readLinkFunction((String) readkv("link"), _model._family);
+    _model._tweedieLinkPower = readkv("tweedie_link_power", 0.0);
+    _model._betaCenterSizePerClass = readkv("beta center length per class", 0);
+    if (_model._family.equals(DistributionFamily.multinomial) || _model._family.equals(ordinal)) {
+      _model._beta_multinomial_no_center = read2DArray("beta_multinomial", _model._nclasses, _model._betaSizePerClass);
+      _model._beta_multinomial_center = read2DArray("beta_multinomial_centering", _model._nclasses, 
+              _model._betaCenterSizePerClass);
+    } else {
+      _model._beta_no_center = readkv("beta");
+      _model._beta_center = readkv("beta_center");
+    }
+    // read in GAM specific parameters
+    _model._num_knots = readkv("num_knots");
+    int num_gam_columns = _model._num_knots.length;
+    _model._gam_columns = readStringArrays(num_gam_columns,"gam_columns");
+    _model._num_gam_columns = _model._gam_columns.length;
+    _model._totFeatureSize = readkv("total feature size");
+    _model._names_no_centering = readStringArrays(_model._totFeatureSize, "_names_no_centering");
+    _model._bs = readkv("bs");
+    _model._knots = new double[num_gam_columns][];
+    _model._binvD = new double[num_gam_columns][][];
+    _model._zTranspose = new double[num_gam_columns][][];
+    _model._knots = read2DArrayDiffLength("knots", _model._knots, _model._num_knots);
+    _model._gamColNames = new String[num_gam_columns][];
+    _model._gamColNamesCenter = new String[num_gam_columns][];
+    for (int gInd = 0; gInd < num_gam_columns; gInd++) {
+      int num_knots = _model._num_knots[gInd];
+      _model._binvD[gInd] = new double[num_knots-2][num_knots];
+      _model._binvD[gInd] = read2DArray(_model._gam_columns[gInd]+"_binvD", _model._binvD[gInd].length, 
+              _model._binvD[gInd][0].length);
+      _model._zTranspose[gInd] = new double[num_knots-1][num_knots];
+      _model._zTranspose[gInd] = read2DArray(_model._gam_columns[gInd]+"_zTranspose", 
+              _model._zTranspose[gInd].length, _model._zTranspose[gInd][0].length);
+      _model._gamColNames[gInd] = readStringArrays(num_knots,"gamColNames_"+_model._gam_columns[gInd]);
+      _model._gamColNamesCenter[gInd] = readStringArrays(num_knots-1,"gamColNamesCenter_"+_model._gam_columns[gInd]);
+    }
+    _model.init();
+  }
+  
+  String[] readStringArrays(int aSize, String title) throws IOException {
+    String[] stringArrays = new String[aSize];
+    int counter = 0;
+    for (String line : readtext(title)) {
+      stringArrays[counter++] = line;
+    }
+    return stringArrays;
+  }
+  
+  double[][] read2DArray(String title, int firstDSize, int secondDSize) throws IOException {
+    double [][] row = new double[firstDSize][secondDSize];
+    ByteBuffer bb = ByteBuffer.wrap(readblob(title));
+    for (int i = 0; i < firstDSize; i++) {
+      for (int j = 0; j < secondDSize; j++)
+        row[i][j] = bb.getDouble();
+    }
+    return row;
+  }
+  
+  double[][] read2DArrayDiffLength(String title, double[][] row, int[] num_knots) throws IOException {
+    int numGamColumns = num_knots.length;
+    ByteBuffer bb = ByteBuffer.wrap(readblob(title));
+    for (int i = 0; i < numGamColumns; i++) {
+      row[i] = new double[num_knots[i]];
+      for (int j = 0; j < row[i].length; j++)
+      row[i][j] = bb.getDouble();
+    }
+    return row;
+  }
+
+  @Override
+  protected GamMojoModelBase makeModel(String[] columns, String[][] domains, String responseColumn) {
+    String family = readkv("family");
+    if ("multinomial".equals(family) || "ordinal".equals(family))
+      return new GamMojoMultinomialModel(columns, domains, responseColumn);
+    else
+      return new GamMojoModel(columns, domains, responseColumn);
+  }
+
+  @Override
+  public String mojoVersion() {
+    return "1.00";
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamRowToRawDataConverter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamRowToRawDataConverter.java
@@ -1,0 +1,25 @@
+package hex.genmodel.algos.gam;
+
+import hex.genmodel.GenModel;
+import hex.genmodel.easy.CategoricalEncoder;
+import hex.genmodel.easy.EasyPredictModelWrapper;
+import hex.genmodel.easy.RowData;
+import hex.genmodel.easy.RowToRawDataConverter;
+import hex.genmodel.easy.exception.PredictException;
+
+import java.util.Map;
+
+public class GamRowToRawDataConverter extends RowToRawDataConverter {
+  GamMojoModelBase _m;
+  public GamRowToRawDataConverter(GenModel m, Map<String, Integer> modelColumnNameToIndexMap, Map<Integer, CategoricalEncoder> domainMap, EasyPredictModelWrapper.ErrorConsumer errorConsumer, EasyPredictModelWrapper.Config config) {
+    super(m, modelColumnNameToIndexMap, domainMap, errorConsumer, config);
+    _m = (GamMojoModelBase) m;
+  }
+
+  @Override
+  public double[] convert(RowData data, double[] rawData) throws PredictException {
+    rawData = super.convert(data, rawData);
+    rawData = _m.addExpandGamCols(rawData, data);
+    return rawData;
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsCubicRegression.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsCubicRegression.java
@@ -1,0 +1,86 @@
+package hex.genmodel.algos.gam;
+
+import java.util.Arrays;
+
+public class GamUtilsCubicRegression {
+  public static double gen_a_m_j(double xjp1, double x, double hj) {
+    return (xjp1-x)/hj;
+  }
+
+  public static double gen_a_p_j(double xj, double x, double hj) {
+    return (x-xj)/hj;
+  }
+
+  public static double gen_c_m_j(double xjp1, double x, double hj) {
+    double t = (xjp1-x);
+    double t3 = t*t*t;
+    return ((t3/hj-t*hj)/6.0);
+  }
+
+  public static double gen_c_p_j(double xj, double x, double hj) {
+    double t=(x-xj);
+    double t3 = t*t*t;
+    return ((t3/hj-t*hj)/6.0);
+  }
+  
+  public static int locateBin(double xval, double[] knots) {
+    if (xval <= knots[0])  //small short cut
+      return 0;
+    int highIndex = knots.length-1;
+    if (xval >= knots[highIndex]) // small short cut
+      return (highIndex-1);
+
+    int tryBin = -1;
+    int count = 0;
+    int numBins = knots.length;
+    int lowIndex = 0;
+
+    while (count < numBins) {
+      tryBin = (int) Math.floor((highIndex+lowIndex)*0.5);
+      if ((xval >= knots[tryBin]) && (xval < knots[tryBin+1]))
+        return tryBin;
+      else if (xval > knots[tryBin])
+        lowIndex = tryBin;
+      else if (xval < knots[tryBin])
+        highIndex = tryBin;
+
+      count++;
+    }
+    return tryBin;
+  }
+
+  public static void updateAFunc(double[] basisVals, double xval, int binIndex, double[] knots, double[] hj) {
+    int jp1 = binIndex+1;
+    basisVals[binIndex] += gen_a_m_j(knots[jp1], xval, hj[binIndex]);
+    basisVals[jp1] += gen_a_p_j(knots[binIndex], xval, hj[binIndex]);
+  }
+
+  public static void updateFMatrixCFunc(double[] basisVals, double xval, int binIndex, double[] knots, double[] hj,
+                                        double[][] binvD) {
+    int numKnots = basisVals.length;
+    int matSize = binvD.length;
+    int jp1 = binIndex+1;
+    double cmj = gen_c_m_j(knots[jp1], xval, hj[binIndex]);
+    double cpj = gen_c_p_j(knots[binIndex], xval, hj[binIndex]);
+    int binIndexM1 = binIndex-1;
+    for (int index=0; index < numKnots; index++) {
+      if (binIndex == 0) {  // only one part
+        basisVals[index] = binvD[binIndex][index] * cpj;
+      } else if (binIndex >= matSize) { // update only one part
+        basisVals[index] = binvD[binIndexM1][index] * cmj;
+      } else { // binIndex > 0 and binIndex < matSize
+        basisVals[index] = binvD[binIndexM1][index] * cmj+binvD[binIndex][index] * cpj;
+      }
+    }
+  }
+  
+  public static void expandOneGamCol(double xval, double[][] binvD, double[] basisVals, double[] hj, double[] knots) {
+    if (!Double.isNaN(xval)) {
+      int binIndex = locateBin(xval, knots);
+      updateFMatrixCFunc(basisVals, xval, binIndex, knots, hj, binvD);
+      updateAFunc(basisVals, xval, binIndex, knots, hj);
+    } else {
+      Arrays.fill(basisVals, Double.NaN);
+    }
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gbm/GbmMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gbm/GbmMojoReader.java
@@ -2,7 +2,6 @@ package hex.genmodel.algos.gbm;
 
 import hex.genmodel.algos.tree.SharedTreeMojoReader;
 import hex.genmodel.utils.DistributionFamily;
-import hex.genmodel.utils.LinkFunctionType;
 
 import java.io.IOException;
 
@@ -20,31 +19,7 @@ public class GbmMojoReader extends SharedTreeMojoReader<GbmMojoModel> {
     super.readModelData();
     _model._family = DistributionFamily.valueOf((String)readkv("distribution"));
     _model._init_f = readkv("init_f");
-    _model._link_function = readLinkFunction();
-  }
-
-  private LinkFunctionType readLinkFunction() {
-    String linkFunctionTypeName = readkv("link_function");
-    if (linkFunctionTypeName != null)
-      return LinkFunctionType.valueOf(linkFunctionTypeName);
-    return defaultLinkFunction(_model._family);
-  }
-  
-  private LinkFunctionType defaultLinkFunction(DistributionFamily family){
-    switch (family) {
-      case bernoulli:
-      case quasibinomial:
-      case modified_huber:
-      case ordinal:
-        return LinkFunctionType.logit;
-      case multinomial:
-      case poisson:
-      case gamma:
-      case tweedie:
-        return LinkFunctionType.log;
-      default:
-        return LinkFunctionType.identity;
-    }
+    _model._link_function = readLinkFunction((String) readkv("link_function"), _model._family);
   }
 
   @Override

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
 
+import static hex.genmodel.utils.ArrayUtils.nanArray;
+
 /**
  * An easy-to-use prediction wrapper for generated models.  Instantiate as follows.  The following two are equivalent.
  *
@@ -865,14 +867,6 @@ public class EasyPredictModelWrapper implements Serializable {
     validateModelCategory(c);
     final int predsSize = m.getPredsSize(c);
     return predict(data, offset, new double[predsSize]);
-  }
-
-  private static double[] nanArray(int len) {
-    double[] arr = new double[len];
-    for (int i = 0; i < len; i++) {
-      arr[i] = Double.NaN;
-    }
-    return arr;
   }
 
   protected double[] fillRawData(RowData data, double[] rawData) throws PredictException {

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
@@ -8,11 +8,17 @@ import java.util.Random;
  * Copied (partially) from water.util.ArrayUtils
  */
 public class ArrayUtils {
-
+  public static double[] nanArray(int len) {
+    double[] arr = new double[len];
+    for (int i = 0; i < len; i++) {
+      arr[i] = Double.NaN;
+    }
+    return arr;
+  }
+  
   public static double l2norm(double[] x) {
     return Math.sqrt(l2norm2(x));
   }
-
   public static double l2norm2(double [] x){
     return l2norm2(x, false);
   }
@@ -23,6 +29,31 @@ public class ArrayUtils {
     for (int i = 0; i < last; ++i)
       sum += x[i]*x[i];
     return sum;
+  }
+
+  public static double[] flat(double[][] arr) {
+    if (arr == null) return null;
+    if (arr.length == 0) return null;
+    int tlen = 0;
+    for (double[] t : arr) tlen += (t != null) ? t.length : 0;
+    double[] result = Arrays.copyOf(arr[0], tlen);
+    int j = arr[0].length;
+    for (int i = 1; i < arr.length; i++) {
+      if (arr[i] == null)
+        continue;
+      System.arraycopy(arr[i], 0, result, j, arr[i].length);
+      j += arr[i].length;
+    }
+    return result;
+  }
+  
+  public static double[] eleDiff(final double[] from) {
+    int arryLen = from.length-1;
+    double[] cumsumR = new double[arryLen];
+    for (int index = 0; index < arryLen; index++) {
+      cumsumR[index] = from[index+1]-from[index];
+    }
+    return cumsumR;
   }
 
   /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/DistributionFamily.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/DistributionFamily.java
@@ -19,5 +19,7 @@ public enum DistributionFamily {
   huber,
   laplace,
   quantile,
+  fractionalbinomial,
+  negativebinomial,
   custom
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/LinkFunctionType.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/LinkFunctionType.java
@@ -12,5 +12,6 @@ public enum LinkFunctionType {
     ologit,
     ologlog,
     oprobit,
-    inverse
+    inverse,
+    tweedie
 }

--- a/h2o-py/h2o/estimators/gam.py
+++ b/h2o-py/h2o/estimators/gam.py
@@ -15,7 +15,7 @@ from h2o.utils.typechecks import assert_is_type, Enum, numeric
 
 class H2OGeneralizedAdditiveEstimator(H2OEstimator):
     """
-    General Additive Model
+    Generalized Additive Model
 
     Fits a generalized additive model, specified by a response variable, a set of predictors, and a
     description of the error distribution.
@@ -415,7 +415,7 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         """
         Stop early when there is no more relative improvement on train or validation (if provided)
 
-        Type: ``bool``  (default: ``True``).
+        Type: ``bool``  (default: ``False``).
         """
         return self._parms.get("early_stopping")
 
@@ -431,7 +431,7 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         Number of lambdas to be used in a search. Default indicates: If alpha is zero, with lambda search set to True,
         the value of nlamdas is set to 30 (fewer lambdas are needed for ridge regression) otherwise it is set to 100.
 
-        Type: ``int``  (default: ``-1``).
+        Type: ``int``  (default: ``0``).
         """
         return self._parms.get("nlambdas")
 
@@ -602,7 +602,7 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         is equal to .000001, otherwise the default value is .0001. If lambda_search is set to True, the conditional
         values above are 1E-8 and 1E-6 respectively.
 
-        Type: ``float``  (default: ``-1``).
+        Type: ``float``  (default: ``0``).
         """
         return self._parms.get("gradient_epsilon")
 
@@ -634,7 +634,7 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
         of response does not reflect reality.
 
-        Type: ``float``  (default: ``-1``).
+        Type: ``float``  (default: ``0``).
         """
         return self._parms.get("prior")
 
@@ -652,7 +652,7 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
         then lambda_min_ratio is set to 0.0001; if the number of observations is less than the number of variables, then
         lambda_min_ratio is set to 0.01.
 
-        Type: ``float``  (default: ``-1``).
+        Type: ``float``  (default: ``0``).
         """
         return self._parms.get("lambda_min_ratio")
 

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -284,7 +284,9 @@ def mojo_predict(model, tmpdir, mojoname, glrmReconstruct=False, get_leaf_node_a
     o, e = p.communicate()
     files = os.listdir(tmpdir)
     print("listing files {1} in directory {0}".format(tmpdir, files))
-    pred_mojo = h2o.import_file(os.path.join(tmpdir, 'out_mojo.csv'), header=1)  # load mojo prediction in 
+    outfile = os.path.join(tmpdir, 'out_mojo.csv')
+    print("***** importing file {0}".format(outfile))
+    pred_mojo = h2o.import_file(outfile, header=1)  # load mojo prediction in 
     # to a frame and compare
     if glrmReconstruct or ('glrm' not in model.algo):
         return predict_h2o, pred_mojo

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -7,6 +7,7 @@ from functools import reduce
 from scipy.sparse import csr_matrix
 import sys, os, gc
 import pandas as pd
+import tempfile
 
 try:        # works with python 2.7 not 3
     from StringIO import StringIO
@@ -261,7 +262,7 @@ def mojo_predict(model, tmpdir, mojoname, glrmReconstruct=False, get_leaf_node_a
     mojoZip = os.path.join(tmpdir, mojoname) + ".zip"
     if not(zipFilePath==None):
         mojoZip = zipFilePath
-    genJarDir = str.split(str(tmpdir),'/')
+    genJarDir = str.split(os.path.realpath("__file__"),'/')
     genJarDir = '/'.join(genJarDir[0:genJarDir.index('h2o-py')])    # locate directory of genmodel.jar
 
     java_cmd = ["java", "-ea", "-cp", os.path.join(genJarDir, "h2o-assemblies/genmodel/build/libs/genmodel.jar"),
@@ -281,7 +282,10 @@ def mojo_predict(model, tmpdir, mojoname, glrmReconstruct=False, get_leaf_node_a
 
     p = subprocess.Popen(java_cmd, stdout=PIPE, stderr=STDOUT)
     o, e = p.communicate()
-    pred_mojo = h2o.import_file(os.path.join(tmpdir, 'out_mojo.csv'), header=1)  # load mojo prediction into a frame and compare
+    files = os.listdir(tmpdir)
+    print("listing files {1} in directory {0}".format(tmpdir, files))
+    pred_mojo = h2o.import_file(os.path.join(tmpdir, 'out_mojo.csv'), header=1)  # load mojo prediction in 
+    # to a frame and compare
     if glrmReconstruct or ('glrm' not in model.algo):
         return predict_h2o, pred_mojo
     else:
@@ -3468,8 +3472,8 @@ def compare_frames_local(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
     :param returnResult:
     :return:
     '''
-    assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "Frame 1 row {0}, col {1}.  Frame 2 row {2}, col {3}.  " \
-                                                      "They are different.".format(f1.nrow, f1.ncol, f2.nrow, f2.ncol)
+    assert (f1.nrow==f2.nrow) and (f1.ncol==f2.ncol), "Frame 1 row {0}, col {1}.  Frame 2 row {2}, col {3}.  They are " \
+                                                      "different.".format(f1.nrow, f1.ncol, f2.nrow, f2.ncol)
     typeDict = f1.types
     frameNames = f1.names
 
@@ -3629,48 +3633,20 @@ def compare_frames_local_onecolumn_NA_string(f1, f2, prob=0.5, returnResult=Fals
     if returnResult:
         return True
 
-def build_save_model_GLM(params, x, train, respName):
-    # build a model
-    model = H2OGeneralizedLinearEstimator(**params)
+def build_save_model_generic(params, x, train, respName, algoName, tmpdir):
+    if algoName.lower() == "gam":
+        model = H2OGeneralizedAdditiveEstimator(**params)
+    elif algoName.lower() == "glm":
+        model = H2OGeneralizedLinearEstimator(**params)
+    elif algoName.lower() == "gbm":
+        model = H2OGradientBoostingEstimator(**params)
+    elif algoName.lower() == "drf":
+        model = H2ORandomForestEstimator(**params)
+    else:
+        raise Exception("build_save_model does not support algo "+algoName+".  Please add this to build_save_model.")
     model.train(x=x, y=respName, training_frame=train)
-    # save model
-    regex = re.compile("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]")
-    MOJONAME = regex.sub("_", model._id)
-
-    print("Downloading Java prediction model code from H2O")
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
-    os.makedirs(TMPDIR)
-    model.download_mojo(path=TMPDIR)    # save mojo
+    model.download_mojo(path=tmpdir)
     return model
-
-def build_save_model_GBM(params, x, train, respName):
-    # build a model
-    model = H2OGradientBoostingEstimator(**params)
-    model.train(x=x, y=respName, training_frame=train)
-    # save model
-    regex = re.compile("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]")
-    MOJONAME = regex.sub("_", model._id)
-
-    print("Downloading Java prediction model code from H2O")
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
-    os.makedirs(TMPDIR)
-    model.download_mojo(path=TMPDIR)    # save mojo
-    return model
-
-def build_save_model_DRF(params, x, train, respName):
-    # build a model
-    model = H2ORandomForestEstimator(**params)
-    model.train(x=x, y=respName, training_frame=train)
-    # save model
-    regex = re.compile("[+\\-* !@#$%^&()={}\\[\\]|;:'\"<>,.?/]")
-    MOJONAME = regex.sub("_", model._id)
-
-    print("Downloading Java prediction model code from H2O")
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
-    os.makedirs(TMPDIR)
-    model.download_mojo(path=TMPDIR)    # save mojo
-    return model
-
 
 # generate random dataset, copied from Pasha
 def random_dataset(response_type, verbose=True, ncol_upper=25000, ncol_lower=15000, NTESTROWS=200, missing_fraction=0.0, seed=None):
@@ -3686,6 +3662,8 @@ def random_dataset(response_type, verbose=True, ncol_upper=25000, ncol_lower=150
         fractions[k] /= sum_fractions
     if response_type == 'binomial':
         response_factors = 2
+    elif response_type == 'gaussian':
+        response_factors = 1
     else:
         response_factors = random.randint(3, 10)
     df = h2o.create_frame(rows=random.randint(ncol_lower, ncol_upper) + NTESTROWS, cols=random.randint(3, 20),

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7181_check_model_scoring.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7181_check_model_scoring.py
@@ -34,7 +34,7 @@ def test_gam_model_predict():
     h2o_data["C2"] = h2o_data["C2"].asfactor()
     myY = "C21"
     h2o_data["C21"] = h2o_data["C21"].asfactor()
-    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictBinomialGAM.csv"))
+    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictBinomialGAM2.csv"))
     buildModelCheckPredict(h2o_data, h2o_data, model_test_data, myY, ["C11", "C12", "C13"], 'binomial')
     print("gam coeff/varimp test completed successfully")
     

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7181_check_model_scoring.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7181_check_model_scoring.py
@@ -15,7 +15,7 @@ def test_gam_model_predict():
     h2o_data["C1"] = h2o_data["C1"].asfactor()
     h2o_data["C2"] = h2o_data["C2"].asfactor()
     myY = "C21"
-    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictGaussianGAM1.csv"))
+    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictGaussianGAM2.csv"))
     buildModelCheckPredict(h2o_data, h2o_data,  model_test_data, myY, ["C11", "C12", "C13"], 'gaussian')
 
     print("Checking model scoring for multinomial")
@@ -24,7 +24,7 @@ def test_gam_model_predict():
     h2o_data["C2"] = h2o_data["C2"].asfactor()
     myY = "C11"
     h2o_data["C11"] = h2o_data["C11"].asfactor()
-    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictMultinomialGAM1.csv"))
+    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictMultinomialGAM2.csv"))
     buildModelCheckPredict(h2o_data, h2o_data, model_test_data, myY, ["C6", "C7", "C8"], 'multinomial')
 
 
@@ -34,7 +34,7 @@ def test_gam_model_predict():
     h2o_data["C2"] = h2o_data["C2"].asfactor()
     myY = "C21"
     h2o_data["C21"] = h2o_data["C21"].asfactor()
-    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictBinomialGAMRPython.csv"))
+    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictBinomialGAM.csv"))
     buildModelCheckPredict(h2o_data, h2o_data, model_test_data, myY, ["C11", "C12", "C13"], 'binomial')
     print("gam coeff/varimp test completed successfully")
     

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4076_custom_distribution_mojo.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4076_custom_distribution_mojo.py
@@ -1,10 +1,10 @@
 from __future__ import print_function
 import sys, os
-
+import tempfile
 sys.path.insert(1, "../../../")
 import h2o
 from tests.pyunit_utils import standalone_test
-from tests.pyunit_utils import random_dataset, build_save_model_GBM, getMojoName, mojo_predict
+from tests.pyunit_utils import random_dataset, build_save_model_generic, getMojoName, mojo_predict
 from tests.pyunit_utils import compare_frames_local
 from h2o.utils.distributions import CustomDistributionBernoulli
 
@@ -28,10 +28,9 @@ def custom_distribution_mojo_test():
               'distribution': "custom",
               'custom_distribution_func': custom_distribution_bernoulli()
               }
-
-    my_gbm = build_save_model_GBM(params, x, train, "response")
+    tmp_dir = tempfile.mkdtemp()
+    my_gbm = build_save_model_generic(params, x, train, "response", "gbm", tmp_dir)
     mojo_name = getMojoName(my_gbm._id)
-    tmp_dir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", mojo_name))
 
     h2o.download_csv(test[x], os.path.join(tmp_dir, 'in.csv'))  # save test file, h2o predict/mojo use same file
     pred_h2o, pred_mojo = mojo_predict(my_gbm, tmp_dir, mojo_name)  # load model and perform predict

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_5529_leaf_node_DRF_mojo.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_5529_leaf_node_DRF_mojo.py
@@ -5,7 +5,7 @@ sys.path.insert(1, "../../../")
 import h2o
 from tests import pyunit_utils
 from random import randint
-
+import tempfile
 
 # This test will compare the leaf node assignment from model predict and mojo predict to make sure they
 # agree for DRF models
@@ -18,10 +18,9 @@ def drf_leaf_node_assignment_mojo_test():
     test = df[:TESTROWS, :]
     x = list(set(df.names) - {"respose"})
     params = {'ntrees': 50, 'max_depth': 4}
-
-    my_gbm = pyunit_utils.build_save_model_DRF(params, x, train, "response")
+    TMPDIR = tempfile.mkdtemp()
+    my_gbm = pyunit_utils.build_save_model_generic(params, x, train, "response", "DRF", TMPDIR)
     MOJONAME = pyunit_utils.getMojoName(my_gbm._id)
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
 
     h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
     pred_h2o, pred_mojo = pyunit_utils.mojo_predict(my_gbm, TMPDIR, MOJONAME, get_leaf_node_assignment=True)  # load model and perform predict

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_5529_leaf_node_GBM_mojo.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_5529_leaf_node_GBM_mojo.py
@@ -5,7 +5,7 @@ sys.path.insert(1, "../../../")
 import h2o
 from tests import pyunit_utils
 from random import randint
-
+import tempfile
 
 # This test will compare the leaf node assignment from model predict and mojo predict to make sure they
 # agree for GBM models
@@ -18,10 +18,9 @@ def gbm_leaf_node_assignment_mojo_test():
     test = df[:TESTROWS, :]
     x = list(set(df.names) - {"respose"})
     params = {'ntrees': 50, 'learn_rate': 0.1, 'max_depth': 4}
-
-    my_gbm = pyunit_utils.build_save_model_GBM(params, x, train, "response")
+    TMPDIR = tempfile.mkdtemp()
+    my_gbm = pyunit_utils.build_save_model_generic(params, x, train, "response", "gbm", TMPDIR)
     MOJONAME = pyunit_utils.getMojoName(my_gbm._id)
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
 
     h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
     pred_h2o, pred_mojo = pyunit_utils.mojo_predict(my_gbm, TMPDIR, MOJONAME, get_leaf_node_assignment=True)  # load model and perform predict

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_binomial.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_binomial.py
@@ -1,0 +1,53 @@
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from random import randint
+import tempfile
+
+def gam_binomial_mojo():
+    h2o.remove_all()
+    NTESTROWS = 200    # number of test dataset rows
+    PROBLEM="binomial"
+    params = set_params()   # set deeplearning model parameters
+    df = pyunit_utils.random_dataset(PROBLEM)   # generate random dataset
+    dfnames = df.names
+    # add GAM specific parameters
+    params["gam_columns"] = []
+    params["scale"] = []
+    count = 0
+    num_gam_cols = 3    # maximum number of gam columns
+    for cname in dfnames:
+        if not(cname == 'response') and (str(df.type(cname)) == "real"):
+            params["gam_columns"].append(cname)
+            params["scale"].append(0.001)
+            count = count+1
+            if (count >= num_gam_cols):
+                break
+    
+    train = df[NTESTROWS:, :]
+    test = df[:NTESTROWS, :]
+    x = list(set(df.names) - {"response"})
+    tmpdir = tempfile.mkdtemp()
+    gamBinomialModel = pyunit_utils.build_save_model_generic(params, x, train, "response", "gam", tmpdir) # build and save mojo model
+    MOJONAME = pyunit_utils.getMojoName(gamBinomialModel._id)
+
+    h2o.download_csv(test[x], os.path.join(tmpdir, 'in.csv'))  # save test file, h2o predict/mojo use same file
+    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(gamBinomialModel, tmpdir, MOJONAME)  # load model and perform predict
+    h2o.download_csv(pred_h2o, os.path.join(tmpdir, "h2oPred.csv"))
+    print("Comparing mojo predict and h2o predict...")
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 0.1, tol=1e-10)    # make sure operation sequence is preserved from Tomk        h2o.save_model(glmOrdinalModel, path=TMPDIR, force=True)  # save model for debugging
+    
+def set_params():
+    missingValues = ['MeanImputation']
+    missing_values = missingValues[randint(0, len(missingValues)-1)]
+
+    params = {'missing_values_handling': missing_values, 'family':"binomial"}
+    print(params)
+    return params
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(gam_binomial_mojo)
+else:
+    gam_binomial_mojo()

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_fractionalbinomial.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_fractionalbinomial.py
@@ -4,7 +4,8 @@ import h2o
 from tests import pyunit_utils
 import tempfile
 
-def glm_fractional_binomial_mojo_pojo():
+# one more test for gam, this time use family fractionalbinomial
+def gam_fractional_binomial_mojo_pojo():
     params = set_params()
     train = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/fraction_binommialOrig.csv"))
     test =  h2o.import_file(pyunit_utils.locate("smalldata/glm_test/fraction_binommialOrig.csv"))
@@ -12,25 +13,21 @@ def glm_fractional_binomial_mojo_pojo():
     y = "y"
 
     TMPDIR = tempfile.mkdtemp()
-    glmModel = pyunit_utils.build_save_model_generic(params, x, train, y, "glm", TMPDIR) # build and save mojo model
-    MOJONAME = pyunit_utils.getMojoName(glmModel._id)
+    gamModel = pyunit_utils.build_save_model_generic(params, x, train, y, "gam", TMPDIR) # build and save mojo model
+    MOJONAME = pyunit_utils.getMojoName(gamModel._id)
 
     h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
-    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(glmModel, TMPDIR, MOJONAME)  # load model and perform predict
+    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(gamModel, TMPDIR, MOJONAME)  # load model and perform predict
     h2o.download_csv(pred_h2o, os.path.join(TMPDIR, "h2oPred.csv"))
-    pred_pojo = pyunit_utils.pojo_predict(glmModel, TMPDIR, MOJONAME)
-    pred_h2o = pred_h2o.drop(3)
     print("Comparing mojo predict and h2o predict...")
     pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 0.1, tol=1e-10)    # make sure operation sequence is preserved from Tomk        h2o.save_model(glmOrdinalModel, path=TMPDIR, force=True)  # save model for debugging
-    print("Comparing pojo predict and h2o predict...")
-    pyunit_utils.compare_frames_local(pred_mojo, pred_pojo, 0.1, tol=1e-10)
 
 def set_params():
     params = {'family':"fractionalbinomial", 'alpha':[0], 'lambda_':[0],
-              'standardize':False, "compute_p_values":True}
+              'standardize':False, "gam_columns":['log10conc'], "num_knots":[5]}
     return params
 
 if __name__ == "__main__":
-    pyunit_utils.standalone_test(glm_fractional_binomial_mojo_pojo)
+    pyunit_utils.standalone_test(gam_fractional_binomial_mojo_pojo)
 else:
-    glm_fractional_binomial_mojo_pojo()
+    gam_fractional_binomial_mojo_pojo()

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_gaussian.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_gaussian.py
@@ -1,0 +1,53 @@
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from random import randint
+import tempfile
+
+def gam_gaussian_mojo():
+    h2o.remove_all()
+    NTESTROWS = 200    # number of test dataset rows
+    PROBLEM="gaussian"
+    params = set_params()   # set deeplearning model parameters
+    df = pyunit_utils.random_dataset(PROBLEM, missing_fraction=0.001)   # generate random dataset
+    dfnames = df.names
+    # add GAM specific parameters
+    params["gam_columns"] = []
+    params["scale"] = []
+    count = 0
+    num_gam_cols = 3    # maximum number of gam columns
+    for cname in dfnames:
+        if not(cname == 'response') and (str(df.type(cname)) == "real"):
+            params["gam_columns"].append(cname)
+            params["scale"].append(0.001)
+            count = count+1
+            if (count >= num_gam_cols):
+                break
+    
+    train = df[NTESTROWS:, :]
+    test = df[:NTESTROWS, :]
+    x = list(set(df.names) - {"response"})
+
+    TMPDIR = tempfile.mkdtemp()
+    gamGaussianModel = pyunit_utils.build_save_model_generic(params, x, train, "response", "gam", TMPDIR) # build and save mojo model
+    MOJONAME = pyunit_utils.getMojoName(gamGaussianModel._id)
+    h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
+    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(gamGaussianModel, TMPDIR, MOJONAME)  # load model and perform predict
+    h2o.download_csv(pred_h2o, os.path.join(TMPDIR, "h2oPred.csv"))
+    print("Comparing mojo predict and h2o predict...")
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 0.1, tol=1e-10)    # make sure operation sequence is preserved from Tomk        h2o.save_model(glmOrdinalModel, path=TMPDIR, force=True)  # save model for debugging
+
+def set_params():
+    missingValues = ['MeanImputation']
+    missing_values = missingValues[randint(0, len(missingValues)-1)]
+
+    params = {'missing_values_handling': missing_values, 'family':"gaussian"}
+    print(params)
+    return params
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(gam_gaussian_mojo)
+else:
+    gam_gaussian_mojo()

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_negativebinomial.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_negativebinomial.py
@@ -1,0 +1,36 @@
+from __future__ import division
+from __future__ import print_function
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+import os
+import tempfile
+
+def test_negativebinomial_GAM_MOJO():
+  print("Read in prostate data.")
+  h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate_complete.csv.zip"))
+  test = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate_complete.csv.zip"))
+  print("Testing for family: Negative Binomial")
+  myX = ["ID","AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS"]
+  params = set_params()
+  TMPDIR = tempfile.mkdtemp()
+  gamModel = pyunit_utils.build_save_model_generic(params, myX, h2o_data, "GLEASON", "gam", TMPDIR) # build and save mojo model
+  MOJONAME = pyunit_utils.getMojoName(gamModel._id)
+
+  h2o.download_csv(test[myX], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
+  pred_h2o, pred_mojo = pyunit_utils.mojo_predict(gamModel, TMPDIR, MOJONAME)  # load model and perform predict
+  h2o.download_csv(pred_h2o, os.path.join(TMPDIR, "h2oPred.csv"))
+  print("Comparing mojo predict and h2o predict...")
+  pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 0.1, tol=1e-10)    # make sure operation sequence is preserved from Tomk        h2o.save_model(glmOrdinalModel, path=TMPDIR, force=True)  # save model for debugging
+
+def set_params():
+    params = {'missing_values_handling': 'MeanImputation', 'family':"negativebinomial", 'theta':0.01, 'link':"log",
+              "alpha":0.5, "Lambda":0, "gam_columns":["PSA"], "num_knots":[5]}
+    print(params)
+    return params
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(test_negativebinomial_GAM_MOJO)
+else:
+  test_negativebinomial_GAM_MOJO()

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_ordinal.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_ordinal.py
@@ -1,0 +1,52 @@
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from random import randint
+import tempfile
+
+def gam_ordinal_mojo():
+    h2o.remove_all()
+    NTESTROWS = 200    # number of test dataset rows
+    PROBLEM="multinomial"
+    params = set_params()   # set deeplearning model parameters
+    df = pyunit_utils.random_dataset(PROBLEM, missing_fraction=0.001)   # generate random dataset
+    dfnames = df.names
+    # add GAM specific parameters
+    params["gam_columns"] = []
+    params["scale"] = []
+    count = 0
+    num_gam_cols = 3    # maximum number of gam columns
+    for cname in dfnames:
+        if not(cname == 'response') and (str(df.type(cname)) == "real"):
+            params["gam_columns"].append(cname)
+            params["scale"].append(0.001)
+            count = count+1
+            if (count >= num_gam_cols):
+                break
+    
+    train = df[NTESTROWS:, :]
+    test = df[:NTESTROWS, :]
+    x = list(set(df.names) - {"response"})
+    TMPDIR = tempfile.mkdtemp()
+    gamOrdinalModel = pyunit_utils.build_save_model_generic(params, x, train, "response", "gam", TMPDIR) # build and save mojo model
+    MOJONAME = pyunit_utils.getMojoName(gamOrdinalModel._id)
+    h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
+    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(gamOrdinalModel, TMPDIR, MOJONAME)  # load model and perform predict
+    h2o.download_csv(pred_h2o, os.path.join(TMPDIR, "h2oPred.csv"))
+    print("Comparing mojo predict and h2o predict...")
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 0.1, tol=1e-10)    # make sure operation sequence is preserved from Tomk        h2o.save_model(glmOrdinalModel, path=TMPDIR, force=True)  # save model for debugging
+
+def set_params():
+    missingValues = ['MeanImputation']
+    missing_values = missingValues[randint(0, len(missingValues)-1)]
+
+    params = {'missing_values_handling': missing_values, 'family':"ordinal"}
+    print(params)
+    return params
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(gam_ordinal_mojo)
+else:
+    gam_ordinal_mojo()

--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5008_ordinal_glm_mojo_pojo_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5008_ordinal_glm_mojo_pojo_large.py
@@ -4,6 +4,7 @@ import h2o
 from tests import pyunit_utils
 from random import randint
 from random import uniform
+import tempfile
 
 def glm_ordinal_mojo_pojo():
     params = set_params()   # set deeplearning model parameters
@@ -14,10 +15,9 @@ def glm_ordinal_mojo_pojo():
     test = df[:NTESTROWS, :]
     x = list(set(df.names) - {"response"})
 
-    glmOrdinalModel = pyunit_utils.build_save_model_GLM(params, x, train, "response") # build and save mojo model
-
+    TMPDIR = tempfile.mkdtemp()
+    glmOrdinalModel = pyunit_utils.build_save_model_generic(params, x, train, "response", "glm", TMPDIR) # build and save mojo model
     MOJONAME = pyunit_utils.getMojoName(glmOrdinalModel._id)
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
 
     h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
     pred_h2o, pred_mojo = pyunit_utils.mojo_predict(glmOrdinalModel, TMPDIR, MOJONAME)  # load model and perform predict

--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5303_multinomial_glm_mojo_pojo_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5303_multinomial_glm_mojo_pojo_large.py
@@ -3,6 +3,7 @@ sys.path.insert(1, "../../../")
 import h2o
 from tests import pyunit_utils
 from random import randint
+import tempfile
 
 def glm_multinomial_mojo_pojo():
     PROBLEM="multinomial"
@@ -12,12 +13,9 @@ def glm_multinomial_mojo_pojo():
     train = df[NTESTROWS:, :]
     test = df[:NTESTROWS, :]
     x = list(set(df.names) - {"response"})
-
-    glmMultinomialModel = pyunit_utils.build_save_model_GLM(params, x, train, "response") # build and save mojo model
-
+    TMPDIR = tempfile.mkdtemp()
+    glmMultinomialModel = pyunit_utils.build_save_model_generic(params, x, train, "response", "glm", TMPDIR) # build and save mojo model
     MOJONAME = pyunit_utils.getMojoName(glmMultinomialModel._id)
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
-
     h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
     pred_h2o, pred_mojo = pyunit_utils.mojo_predict(glmMultinomialModel, TMPDIR, MOJONAME)  # load model and perform predict
     h2o.download_csv(pred_h2o, os.path.join(TMPDIR, "h2oPred.csv"))

--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5355_binomial_glm_mojo_pojo_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdev_5355_binomial_glm_mojo_pojo_large.py
@@ -3,7 +3,7 @@ sys.path.insert(1, "../../../")
 import h2o
 from tests import pyunit_utils
 from random import randint
-
+import tempfile
 
 
 def glm_binomial_mojo_pojo():
@@ -15,11 +15,9 @@ def glm_binomial_mojo_pojo():
     train = df[NTESTROWS:, :]
     test = df[:NTESTROWS, :]
     x = list(set(df.names) - {"response"})
-
-    glmBinomialModel = pyunit_utils.build_save_model_GLM(params, x, train, "response") # build and save mojo model
-
+    TMPDIR = tempfile.mkdtemp()
+    glmBinomialModel = pyunit_utils.build_save_model_generic(params, x, train, "response", "glm", TMPDIR) # build and save mojo model
     MOJONAME = pyunit_utils.getMojoName(glmBinomialModel._id)
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
 
     h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
     pred_h2o, pred_mojo = pyunit_utils.mojo_predict(glmBinomialModel, TMPDIR, MOJONAME)  # load model and perform predict

--- a/h2o-py/tests/testdir_misc/pyunit_pubdev_6617_setInvNumNA.py
+++ b/h2o-py/tests/testdir_misc/pyunit_pubdev_6617_setInvNumNA.py
@@ -26,13 +26,13 @@ def test_setInvNumNA():
     response = "C2"
     x = ["C1"]
     params = {'missing_values_handling':"MeanImputation", 'family':'gaussian'}
-    glmMultinomialModel = pyunit_utils.build_save_model_GLM(params, x, train, response) # build and save mojo model
+    tmpdir = tempfile.mkdtemp()
+    glmMultinomialModel = pyunit_utils.build_save_model_generic(params, x, train, response, "glm", tmpdir) # build and save mojo model
 
-    MOJONAME = pyunit_utils.getMojoName(glmMultinomialModel._id)
-    TMPDIR = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results", MOJONAME))
-    mojoLoco = os.path.normpath(os.path.join(TMPDIR, MOJONAME+'.zip'))
-    mojoOut = os.path.normpath(os.path.join(TMPDIR, "mojo_out.csv"))
-    genJarDir = str.split(str(TMPDIR ),'/')
+    mojoname = pyunit_utils.getMojoName(glmMultinomialModel._id)
+    mojoLoco = os.path.join(tmpdir, mojoname) + ".zip"
+    mojoOut = os.path.join(tmpdir, "mojo_out.csv")
+    genJarDir = str.split(os.path.realpath("__file__"),'/')
     genJarDir = '/'.join(genJarDir[0:genJarDir.index('h2o-py')])    # locate directory of genmodel.jar
     jarpath = os.path.join(genJarDir, "h2o-assemblies/genmodel/build/libs/genmodel.jar")
     mojoPredict = h2o.mojo_predict_csv(input_csv_path=testdata, mojo_zip_path=mojoLoco, output_csv_path=mojoOut, 

--- a/h2o-r/h2o-package/R/gam.R
+++ b/h2o-r/h2o-package/R/gam.R
@@ -53,10 +53,10 @@
 #' @param lambda_search \code{Logical}. Use lambda search starting at lambda max, given lambda is then interpreted as lambda min
 #'        Defaults to FALSE.
 #' @param early_stopping \code{Logical}. Stop early when there is no more relative improvement on train or validation (if provided)
-#'        Defaults to TRUE.
+#'        Defaults to FALSE.
 #' @param nlambdas Number of lambdas to be used in a search. Default indicates: If alpha is zero, with lambda search set to True,
 #'        the value of nlamdas is set to 30 (fewer lambdas are needed for ridge regression) otherwise it is set to 100.
-#'        Defaults to -1.
+#'        Defaults to 0.
 #' @param standardize \code{Logical}. Standardize numeric columns to have zero mean and unit variance Defaults to FALSE.
 #' @param missing_values_handling Handling of missing values. Either MeanImputation, Skip or PlugValues. Must be one of: "MeanImputation",
 #'        "Skip", "PlugValues". Defaults to MeanImputation.
@@ -77,14 +77,14 @@
 #' @param gradient_epsilon Converge if  objective changes less (using L-infinity norm) than this, ONLY applies to L-BFGS solver. Default
 #'        indicates: If lambda_search is set to False and lambda is equal to zero, the default value of gradient_epsilon
 #'        is equal to .000001, otherwise the default value is .0001. If lambda_search is set to True, the conditional
-#'        values above are 1E-8 and 1E-6 respectively. Defaults to -1.
+#'        values above are 1E-8 and 1E-6 respectively. Defaults to 0.
 #' @param link Link function. Must be one of: "family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit".
 #' @param prior Prior probability for y==1. To be used only for logistic regression iff the data has been sampled and the mean
-#'        of response does not reflect reality. Defaults to -1.
+#'        of response does not reflect reality. Defaults to 0.
 #' @param lambda_min_ratio Minimum lambda used in lambda search, specified as a ratio of lambda_max (the smallest lambda that drives all
 #'        coefficients to zero). Default indicates: if the number of observations is greater than the number of
 #'        variables, then lambda_min_ratio is set to 0.0001; if the number of observations is less than the number of
-#'        variables, then lambda_min_ratio is set to 0.01. Defaults to -1.
+#'        variables, then lambda_min_ratio is set to 0.01. Defaults to 0.
 #' @param beta_constraints Beta constraints
 #' @param max_active_predictors Maximum number of active predictors during computation. Use as a stopping criterion to prevent expensive model
 #'        building with many predictors. Default indicates: If the IRLSM solver is used, the value of
@@ -146,8 +146,8 @@ h2o.gam <- function(x,
                     alpha = NULL,
                     lambda = NULL,
                     lambda_search = FALSE,
-                    early_stopping = TRUE,
-                    nlambdas = -1,
+                    early_stopping = FALSE,
+                    nlambdas = 0,
                     standardize = FALSE,
                     missing_values_handling = c("MeanImputation", "Skip", "PlugValues"),
                     plug_values = NULL,
@@ -158,10 +158,10 @@ h2o.gam <- function(x,
                     max_iterations = -1,
                     objective_epsilon = -1,
                     beta_epsilon = 0.0001,
-                    gradient_epsilon = -1,
+                    gradient_epsilon = 0,
                     link = c("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit"),
-                    prior = -1,
-                    lambda_min_ratio = -1,
+                    prior = 0,
+                    lambda_min_ratio = 0,
                     beta_constraints = NULL,
                     max_active_predictors = -1,
                     interactions = NULL,
@@ -376,8 +376,8 @@ h2o.gam <- function(x,
                                     alpha = NULL,
                                     lambda = NULL,
                                     lambda_search = FALSE,
-                                    early_stopping = TRUE,
-                                    nlambdas = -1,
+                                    early_stopping = FALSE,
+                                    nlambdas = 0,
                                     standardize = FALSE,
                                     missing_values_handling = c("MeanImputation", "Skip", "PlugValues"),
                                     plug_values = NULL,
@@ -388,10 +388,10 @@ h2o.gam <- function(x,
                                     max_iterations = -1,
                                     objective_epsilon = -1,
                                     beta_epsilon = 0.0001,
-                                    gradient_epsilon = -1,
+                                    gradient_epsilon = 0,
                                     link = c("family_default", "identity", "logit", "log", "inverse", "tweedie", "ologit"),
-                                    prior = -1,
-                                    lambda_min_ratio = -1,
+                                    prior = 0,
+                                    lambda_min_ratio = 0,
                                     beta_constraints = NULL,
                                     max_active_predictors = -1,
                                     interactions = NULL,

--- a/h2o-r/tests/runitUtils/utilsR.R
+++ b/h2o-r/tests/runitUtils/utilsR.R
@@ -931,7 +931,7 @@ random_NN <- function(actFunc, max_layers, max_node_number) {
 # Parameters:  frame1, frame2: H2O frames to be compared.
 #              tolerance: tolerance of comparison
 #----------------------------------------------------------------------
-compareFrames <- function(frame1, frame2, prob=0.5, tolerance=1e-6, enum2String=FALSE) {
+compareFrames <- function(frame1, frame2, prob=0.5, tolerance=1e-6, enum2String=FALSE, col.types=NULL) {
   expect_true(nrow(frame1) == nrow(frame2) && ncol(frame1) == ncol(frame2), info="frame1 and frame2 are different in size.")
   rframe1 <- as.data.frame(frame1)
   rframe2 <- as.data.frame(frame2)
@@ -939,11 +939,11 @@ compareFrames <- function(frame1, frame2, prob=0.5, tolerance=1e-6, enum2String=
     notNumericCols = !(h2o.isnumeric(frame1[,colInd]) && h2o.isnumeric(frame2[,colInd]))
     if (notNumericCols) {
       if (enum2String) {
-        temp1 <- as.character(rframe1[,colInd])
-        temp2 <- as.character(rframe2[,colInd])
+        temp1 <- as.character(rframe1[, colInd])
+        temp2 <- as.character(rframe2[, colInd])
       } else {
-        temp1 <- as.factor(rframe1[,colInd])
-        temp2 <- as.factor(rframe2[,colInd])
+        temp1 <- as.factor(rframe1[, colInd])
+        temp2 <- as.factor(rframe2[, colInd])
       }
     } else { 
       temp1 <- as.numeric(rframe1[,colInd])
@@ -1157,6 +1157,23 @@ buildModelSaveMojoGLM <- function(params) {
   return(list("model"=model, "dirName"=tmpdir_name))
 }
 
+buildModelSaveMojoGAM <- function(params) {
+  model <- do.call("h2o.gam", params)
+  model_key <- model@model_id
+  tmpdir_name <- sprintf("%s/tmp_model_%s", sandbox(), as.character(Sys.getpid()))
+  if (.Platform$OS.type == "windows") {
+    shell(sprintf("C:\\cygwin64\\bin\\rm.exe -fr %s", normalizePath(tmpdir_name)))
+    shell(sprintf("C:\\cygwin64\\bin\\mkdir.exe -p %s", normalizePath(tmpdir_name)))
+  } else {
+    safeSystem(sprintf("rm -fr %s", tmpdir_name))
+    safeSystem(sprintf("mkdir -p %s", tmpdir_name))
+  }
+  h2o.save_mojo(model, path = tmpdir_name, force = TRUE) # save mojo
+  h2o.saveModel(model, path = tmpdir_name, force=TRUE) # save model to compare mojo/h2o predict offline
+  
+  return(list("model"=model, "dirName"=tmpdir_name))
+}
+
 buildModelSaveMojoPCA <- function(params) {
 model <- do.call("h2o.prcomp", params)
 model_key <- model@model_id
@@ -1191,7 +1208,7 @@ buildModelSaveMojoGLRM <- function(params) {
   return(list("model"=model, "dirName"=tmpdir_name))
 }
 
-mojoH2Opredict<-function(model, tmpdir_name, filename, get_leaf_node_assignment=FALSE, glrmReconstruct=FALSE, glrmIterNumber=-1) {
+mojoH2Opredict<-function(model, tmpdir_name, filename, get_leaf_node_assignment=FALSE, glrmReconstruct=FALSE, glrmIterNumber=-1, col.types=NULL) {
   newTest <- h2o.importFile(filename)
   predictions1 <- h2o.predict(model, newTest)
 
@@ -1237,7 +1254,7 @@ mojoH2Opredict<-function(model, tmpdir_name, filename, get_leaf_node_assignment=
 
   safeSystem(cmd)  # perform mojo prediction
   predictions2 = h2o.importFile(paste(tmpdir_name, "out_mojo.csv", sep =
-  '/'), header=T)
+  '/'), header=T, col.types = col.types)
 
   if (glrmReconstruct || !(model@algorithm=="glrm")) {
     return(list("h2oPredict"=predictions1, "mojoPredict"=predictions2))

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_7185_binomial_gam_mojo_large.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_7185_binomial_gam_mojo_large.R
@@ -1,0 +1,62 @@
+setwd(normalizePath(dirname(
+  R.utils::commandArgs(asValues = TRUE)$"f"
+)))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.binomial.gam.mojo <-
+  function() {
+    #----------------------------------------------------------------------
+    # Run the test
+    #----------------------------------------------------------------------
+    numTest = 1000 # set test dataset to contain 1000 rows
+    params_prob_data <-
+      setParmsData(numTest) # generate model parameters, random dataset
+    modelAndDir <-
+      buildModelSaveMojoGAM(params_prob_data$params) # build the model and save mojo
+    filename = sprintf("%s/in.csv", modelAndDir$dirName) # save the test dataset into a in.csv file.
+    h2o.downloadCSV(params_prob_data$tDataset[, params_prob_data$params$x], filename)
+    twoFrames <-
+      mojoH2Opredict(modelAndDir$model, modelAndDir$dirName, filename) # perform H2O and mojo prediction and return frames
+    h2o.downloadCSV(twoFrames$h2oPredict,
+                    sprintf("%s/h2oPred.csv", modelAndDir$dirName))
+    h2o.downloadCSV(twoFrames$mojoPredict,
+                    sprintf("%s/mojoOut.csv", modelAndDir$dirname))
+    compareFrames(
+      twoFrames$h2oPredict,
+      twoFrames$mojoPredict,
+      prob = 1,
+      tolerance = 1e-4
+    )
+  }
+
+setParmsData <- function(numTest = 1000) {
+  #----------------------------------------------------------------------
+  # Parameters for the test.
+  #----------------------------------------------------------------------
+  missing_values <- 'MeanImputation'
+  
+  training_file <- random_dataset("binomial", testrow = numTest)
+  train_numeric <-
+    random_dataset_real_only(h2o.nrow(training_file), 1)
+  training_file <-
+    h2o.cbind(training_file, train_numeric)  # make sure we have at least one numeric column
+  ratios <-
+    (h2o.nrow(training_file) - numTest) / h2o.nrow(training_file)
+  allFrames <- h2o.splitFrame(training_file, ratios)
+  training_frame <- allFrames[[1]]
+  test_frame <- allFrames[[2]]
+  allNames = h2o.names(training_frame)
+  gam_cols <- c(allNames[length(allNames)])
+  
+  params                  <- list()
+  params$missing_values_handling <- missing_values
+  params$training_frame <- training_frame
+  params$x <- allNames[-which(allNames == "response")]
+  params$y <- "response"
+  params$family <- "binomial"
+  params$gam_columns <- gam_cols
+  
+  return(list("params" = params, "tDataset" = test_frame))
+}
+
+doTest("test gam mojo with binomial family", test.binomial.gam.mojo)

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_7185_quasibinomial_gam_MOJO.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_7185_quasibinomial_gam_MOJO.R
@@ -1,0 +1,49 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.GAM.quasibinomial <- function() {
+  # First calculate paper version
+  # From TLMSE paper (Estimating Effects on Rare Outcomes: Knowledge is Power, Laura B. Balzer, Mark J. van der Laan)
+  # Example: Data generating experiment for Simulation 1
+  set.seed(123)
+  n=2500
+  W1<- rnorm(n, 0, .25)
+  W2<- runif(n, 0, 1)
+  W3<- rbinom(n, size=1, 0.5)
+  A<- rbinom(n, size=1, prob= plogis(-.5+ W1+W2+W3) )
+  pi<- plogis(-3+ 2*A + 1*W1+2*W2-4*W3 + .5*A*W1)/15
+  Y<- rbinom(n, size=1, prob= pi)
+  # Qbounds (l,u)= (0,0.065)
+  l=0; u=0.065
+  #create the design matrix
+  X <- model.matrix(as.formula(Y~W1+W2+W3+A*W1))
+  # transform Y to Y.tilde in between (l,u)
+  Y.tilde<- (Y - l)/(u-l)
+  summary(Y.tilde)
+
+  # now H2O
+  hf = as.h2o(cbind(Y.tilde,X))
+  htest = as.h2o(cbind(Y.tilde,X))
+  x = 2:7
+  y = 1
+
+  params                  <- list()
+  params$missing_values_handling <- 'MeanImputation'
+  params$training_frame <- hf
+  params$x <- x
+  params$y <- y
+  params$family <- "quasibinomial"
+  params$gam_columns <- c("W2")
+  params$num_knots <- c(5)
+  params$scale <- c(0.001)
+  modelAndDir<-buildModelSaveMojoGAM(params) # build the model and save mojo
+  filename = sprintf("%s/in.csv", modelAndDir$dirName) # save the test dataset into a in.csv file.
+  h2o.downloadCSV(htest[1:100, x], filename)
+  twoFrames<-mojoH2Opredict(modelAndDir$model, modelAndDir$dirName, filename, col.types=c("enum", "numeric", "numeric")) # perform H2O and mojo prediction and return frames
+  h2o.downloadCSV(twoFrames$h2oPredict, sprintf("%s/h2oPred.csv", modelAndDir$dirName))
+  h2o.downloadCSV(twoFrames$mojoPredict, sprintf("%s/mojoOut.csv", modelAndDir$dirname))
+  twoFrames$h2oPredict[,1] <- h2o.asfactor(twoFrames$h2oPredict[,1])
+  compareFrames(twoFrames$h2oPredict,twoFrames$mojoPredict, prob=1, tolerance = 1e-6)
+}
+
+doTest("GAM Test: quasibinomial GAM Mojo", test.GAM.quasibinomial)


### PR DESCRIPTION
This PR completes the task in JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7185?filter=myopenissues&orderby=priority%20DESC

In particular, I want to bring you to the following:
The coefficients generated from GLM are centered and hence to perform scoring, the following process is needed:
raw dataset -> add gam columns -> center the gam columns (multiply gam columns with a z matrix) -> use the coefficients from GLM to perform scoring.

However, I feel that the following will be faster for mojo scoring:
- transform the centered coefficients from GLM to non-centered coefficients by multiplying it with a z matrix and this is done only once in the mojo writer.

Then, during mojo scoring, we only need to do the following:
- raw dataset -> add gam columns -> use non-centered coefficients to perform scoring.

I have opened a JIRA: https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7644?filter=myopenissues&orderby=priority%20DESC to improve scoring speed by using the non-centered coefficients.  By I am not sure it will make it to this release.

I have completed the following:
1. Java backend to support GAM Mojo;
2. Java unit test.
3.  Python unit tests
4. R unit tests.