### PR TITLE
Fix stacked ensemble's workaround related to GLM family AUTO

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -91,11 +91,6 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     public void initMetalearnerParams(Metalearner.Algorithm algo) {
       _metalearner_algorithm = algo;
       _metalearner_parameters = Metalearners.createParameters(algo.name());
-      if (Metalearners.getActualMetalearnerAlgo(algo) == Metalearner.Algorithm.glm){
-        // FIXME: This is here because there is no Family.AUTO. It enables us to know if the user specified family or not.
-        // FIXME: Family.AUTO will be implemented in https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7444
-        ((GLMModel.GLMParameters) _metalearner_parameters)._family = null;
-      }
     }
     
     public final Frame blending() { return _blending == null ? null : _blending.get(); }
@@ -407,9 +402,7 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
    */
   boolean inferDistributionOrFamily(Model aModel) {
     if (Metalearners.getActualMetalearnerAlgo(_parms._metalearner_algorithm) == Metalearner.Algorithm.glm) { //use family
-      // FIXME: This is here because there is no Family.AUTO. It enables us to know if the user specified family or not.
-      // FIXME: Family.AUTO will be implemented in https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7444
-      if (((GLMModel.GLMParameters)_parms._metalearner_parameters)._family != null) {
+      if (((GLMModel.GLMParameters)_parms._metalearner_parameters)._family != GLMModel.GLMParameters.Family.AUTO) {
         return false; // User specified family - no need to infer one; Link will be also used properly if it is specified
       }
       inheritFamilyAndParms(aModel._parms);

--- a/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
+++ b/h2o-algos/src/main/java/hex/schemas/StackedEnsembleV99.java
@@ -152,9 +152,6 @@ public class StackedEnsembleV99 extends ModelBuilderSchema<StackedEnsemble,Stack
           case glm:
             paramsSchema = new GLMV3.GLMParametersV3();
             params = new GLMModel.GLMParameters();
-            // FIXME: This is here because there is no Family.AUTO. It enables us to know if the user specified family or not.
-            // FIXME: Family.AUTO will be implemented in https://0xdata.atlassian.net/projects/PUBDEV/issues/PUBDEV-7444
-            ((GLMModel.GLMParameters) params)._family = null;
             break;
           case gbm:
             paramsSchema = new GBMV3.GBMParametersV3();

--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py
@@ -57,7 +57,7 @@ def infer_distribution_helper(dist, expected_dist, kwargs1={}, kwargs2={}):
         "Expected distribution {} but got {}".format(expected_dist, se.metalearner().actual_params.get("distribution"))
 
 def infer_distribution_test():
-    from h2o.utils import CustomDistributionGeneric, CustomDistributionGaussian
+    from h2o.utils.distributions import CustomDistributionGeneric, CustomDistributionGaussian
 
     class CustomDistributionGaussian2(CustomDistributionGeneric):
         def link(self):


### PR DESCRIPTION
Now we have family=AUTO so we can remove "null" which was a placeholder
for AUTO in SE code related to family/distribution inference.