### PR TITLE
PUBDEV-7657: link proper base R manuals in R h2o manual

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3354,7 +3354,7 @@ h2o.ischaracter <- function(x) {
 #'
 #' @name h2o.asfactor
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{numeric}} for the base R implementation, \code{as.factor()}.
+#' @seealso \code{\link[base]{factor}} for the base R implementation, \code{as.factor()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2710,7 +2710,7 @@ median.H2OFrame <- h2o.median
 #'                             is ignored.
 #' @param return_frame \code{logical}. Indicate whether to return an H2O frame or a list. Default is FALSE (returns a list).
 #' @param ... Further arguments to be passed from or to other methods.
-#' @seealso \code{\link[base]{Round}} \code{\link[base]{colSums}} for the base R implementation, \code{colMeans()}.
+#' @seealso \code{\link[base]{Round}} for base R implementation, \code{mean()} and \code{\link[base]{colSums}} for the base R implementation, \code{colMeans()}.
 #' @return Returns a list containing the mean for each column (NaN for non-numeric columns) if return_frame is set to FALSE.
 #'         If return_frame is set to TRUE, then it will return an H2O frame with means per column or row (depends on axis argument).
 #' @examples

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -3374,7 +3374,7 @@ h2o.asfactor <- function(x) {
 #'
 #' @name h2o.asnumeric
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{factor}} for the base R implementation, \code{as.numeric()}.
+#' @seealso \code{\link[base]{numeric}} for the base R implementation, \code{as.numeric()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1934,7 +1934,7 @@ h2o.which <- function(x) {
 #' @param na.rm \code{logical}. Indicate whether missing values should be removed.
 #' @param axis \code{integer}. Indicate whether to calculate the mean down a column (0) or across a row (1).
 #' @return Returns an H2OFrame object.
-#' @seealso \code{\link[base]{which.min}} for the base R method.
+#' @seealso \code{\link[base]{which.min}} for the base R method, \code{which.max()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -2710,7 +2710,7 @@ median.H2OFrame <- h2o.median
 #'                             is ignored.
 #' @param return_frame \code{logical}. Indicate whether to return an H2O frame or a list. Default is FALSE (returns a list).
 #' @param ... Further arguments to be passed from or to other methods.
-#' @seealso \code{\link[base]{mean}}, \code{\link[base]{colSums}} for the base R implementation
+#' @seealso \code{\link[base]{Round}} \code{\link[base]{colSums}} for the base R implementation, \code{colMeans()}.
 #' @return Returns a list containing the mean for each column (NaN for non-numeric columns) if return_frame is set to FALSE.
 #'         If return_frame is set to TRUE, then it will return an H2O frame with means per column or row (depends on axis argument).
 #' @examples
@@ -2815,7 +2815,7 @@ kurtosis.H2OFrame <- h2o.kurtosis
 #'   "everything"            - outputs NaNs whenever one of its contributing observations is missing
 #'   "all.obs"               - presence of missing observations will throw an error
 #'   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
-#' @seealso \code{\link[stats]{cor}} for the base R implementation. \code{\link{h2o.sd}} for standard deviation.
+#' @seealso \code{\link[stats]{cor}} for the base R implementation, \code{var()}. \code{\link{h2o.sd}} for standard deviation.
 #' @examples
 #' \dontrun{
 #' library(h2o)
@@ -3000,7 +3000,7 @@ sd <- function(x, na.rm=FALSE) {
 #' @name h2o.signif
 #' @param x An H2OFrame object.
 #' @param digits Number of significant digits to round doubles/floats.
-#' @seealso \code{\link[base]{Round}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation, \code{signif()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3029,7 +3029,7 @@ signif <- function(x, digits=6) {
 #' @param digits Number of decimal places to round doubles/floats. Rounding to a negative number of decimal places is 
 #         not supported. For rounding off a 5, the IEC 60559 standard is used, 'go to the even digit'. Therefore 
 #         rounding 2.5 gives 2 and rounding 3.5 gives 4.
-#' @seealso \code{\link[base]{Round}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation, \code{round()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3120,7 +3120,7 @@ scale.H2OFrame <- function(x, center = TRUE, scale = TRUE) {
 #'
 #' @name h2o.log10
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Log}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation, \code{log10()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3142,7 +3142,7 @@ h2o.log10 <- function(x) {
 #'
 #' @name h2o.log2
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Log}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation, \code{log2()}
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3164,7 +3164,7 @@ h2o.log2 <- function(x) {
 #'
 #' @name h2o.log1p
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Log}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation, \code{log1p()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3188,7 +3188,7 @@ h2o.log1p <- function(x) {
 #'
 #' @name h2o.trunc
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Round}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation, \code{trunc()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3292,7 +3292,7 @@ h2o.colnames <- function(x) {
 #'
 #' @name h2o.isfactor
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{factor}} for the base R implementation.
+#' @seealso \code{\link[base]{factor}} for the base R implementation, \code{is.factor()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3313,7 +3313,7 @@ h2o.isfactor <- function(x) {
 #'
 #' @name h2o.isnumeric
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{numeric}} for the base R implementation.
+#' @seealso \code{\link[base]{numeric}} for the base R implementation, \code{is.numeric()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3333,7 +3333,7 @@ h2o.isnumeric <- function(x) {
 #'
 #' @name h2o.ischaracter
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{character}} for the base R implementation.
+#' @seealso \code{\link[base]{character}} for the base R implementation, \code{is.character()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3354,7 +3354,7 @@ h2o.ischaracter <- function(x) {
 #'
 #' @name h2o.asfactor
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{numeric}} for the base R implementation.
+#' @seealso \code{\link[base]{numeric}} for the base R implementation, \code{as.factor()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3374,7 +3374,7 @@ h2o.asfactor <- function(x) {
 #'
 #' @name h2o.asnumeric
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{factor}} for the base R implementation.
+#' @seealso \code{\link[base]{factor}} for the base R implementation, \code{as.numeric()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3454,7 +3454,7 @@ h2o.str <- function(object, ..., cols=FALSE) {
 #'
 #' @name h2o.cos
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Trig}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation, \code{cos()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3476,7 +3476,7 @@ h2o.cos <- function(x) {
 #'
 #' @name h2o.sin
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Trig}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation, \code{sin()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3498,7 +3498,7 @@ h2o.sin <- function(x) {
 #'
 #' @name h2o.acos
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Trig}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation, \code{acos()}.
 #' @examples
 #' \dontrun{
 #' h2o.init()
@@ -3516,7 +3516,7 @@ h2o.acos <- function(x) {
 #'
 #' @name h2o.cosh
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Hyperbolic}} for the base R implementation.
+#' @seealso \code{\link[base]{Hyperbolic}} for the base R implementation, \code{cosh()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3538,7 +3538,7 @@ h2o.cosh <- function(x) {
 #'
 #' @name h2o.tan
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Trig}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation, \code{tan()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3560,7 +3560,7 @@ h2o.tan <- function(x) {
 #'
 #' @name h2o.tanh
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Hyperbolic}} for the base R implementation.
+#' @seealso \code{\link[base]{Hyperbolic}} for the base R implementation, \code{tanh()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3582,7 +3582,7 @@ h2o.tanh <- function(x) {
 #'
 #' @name h2o.exp
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Log}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation, \code{exp()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3604,7 +3604,7 @@ h2o.exp <- function(x) {
 #'
 #' @name h2o.log
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Log}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation, \code{log}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3627,7 +3627,7 @@ h2o.log <- function(x) {
 #'
 #' @name h2o.sqrt
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{MathFun}} for the base R implementation.
+#' @seealso \code{\link[base]{MathFun}} for the base R implementation, \code{sqrt()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3649,7 +3649,7 @@ h2o.sqrt <- function(x) {
 #'
 #' @name h2o.abs
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{MathFun}} for the base R implementation.
+#' @seealso \code{\link[base]{MathFun}} for the base R implementation, \code{abs()}.
 #' @examples
 #' \dontrun{
 #' library(h2o)
@@ -3679,7 +3679,7 @@ h2o.abs <- function(x) {
 #'
 #' @name h2o.ceiling
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Round}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation, \code{ceiling()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3702,7 +3702,7 @@ h2o.ceiling <- function(x) {
 #'
 #' @name h2o.floor
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{Round}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation, \code{floor()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3797,7 +3797,7 @@ h2o.cumsum <- function(x, axis = 0){
 #' @name h2o.cumprod
 #' @param x An H2OFrame object.
 #' @param axis An int that indicates whether to do down a column (0) or across a row (1).
-#' @seealso \code{\link[base]{cumsum}} for the base R implementation.
+#' @seealso \code{\link[base]{cumsum}} for the base R implementation, \code{cumprod()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3820,7 +3820,7 @@ h2o.cumprod <- function(x, axis = 0){
 #' @name h2o.cummin
 #' @param x An H2OFrame object.
 #' @param axis An int that indicates whether to do down a column (0) or across a row (1).
-#' @seealso \code{\link[base]{cumsum}} for the base R implementation.
+#' @seealso \code{\link[base]{cumsum}} for the base R implementation, \code{cummin()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3843,7 +3843,7 @@ h2o.cummin <- function(x, axis = 0){
 #' @name h2o.cummax
 #' @param x An H2OFrame object.
 #' @param axis An int that indicates whether to do down a column (0) or across a row (1).
-#' @seealso \code{\link[base]{cumsum}} for the base R implementation.
+#' @seealso \code{\link[base]{cumsum}} for the base R implementation, \code{cummax()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3897,7 +3897,7 @@ h2o.any <- function(x) {
 #' @name h2o.min
 #' @param x An H2OFrame object.
 #' @param na.rm \code{logical}. indicating whether missing values should be removed.
-#' @seealso \code{\link[base]{Extremes}} for the base R implementation.
+#' @seealso \code{\link[base]{Extremes}} for the base R implementation, \code{min()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3918,7 +3918,7 @@ h2o.min <- function(x,na.rm = FALSE) {
 #' @name h2o.max
 #' @param x An H2OFrame object.
 #' @param na.rm \code{logical}. indicating whether missing values should be removed.
-#' @seealso \code{\link[base]{Extremes}} for the base R implementation.
+#' @seealso \code{\link[base]{Extremes}} for the base R implementation, \code{max()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3958,7 +3958,7 @@ h2o.nrow <- function(x) {
 #'
 #' @name h2o.ncol
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{nrow}} for the base R implementation.
+#' @seealso \code{\link[base]{nrow}} for the base R implementation, \code{ncol()}.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -4608,7 +4608,7 @@ h2o.cbind <- function(...) {
 #' @param \dots A sequence of H2OFrame arguments. All datasets must exist on the same H2O instance
 #'        (IP and port) and contain the same number and types of columns.
 #' @return An H2OFrame object containing the combined \dots arguments row-wise.
-#' @seealso \code{\link[base]{cbind}} for the base \code{R} method.
+#' @seealso \code{\link[base]{cbind}} for the base \code{R} method, \code{rbind()}.
 #' @examples
 #' \dontrun{
 #' library(h2o)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1934,7 +1934,7 @@ h2o.which <- function(x) {
 #' @param na.rm \code{logical}. Indicate whether missing values should be removed.
 #' @param axis \code{integer}. Indicate whether to calculate the mean down a column (0) or across a row (1).
 #' @return Returns an H2OFrame object.
-#' @seealso \code{\link[base]{which.max}} for the base R method.
+#' @seealso \code{\link[base]{which.min}} for the base R method.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -2710,7 +2710,7 @@ median.H2OFrame <- h2o.median
 #'                             is ignored.
 #' @param return_frame \code{logical}. Indicate whether to return an H2O frame or a list. Default is FALSE (returns a list).
 #' @param ... Further arguments to be passed from or to other methods.
-#' @seealso \code{\link[base]{mean}} , \code{\link[base]{rowMeans}}, or \code{\link[base]{colMeans}} for the base R implementation
+#' @seealso \code{\link[base]{mean}} , \code{\link[base]{colSums}}, or \code{\link[base]{colMeans}} for the base R implementation
 #' @return Returns a list containing the mean for each column (NaN for non-numeric columns) if return_frame is set to FALSE.
 #'         If return_frame is set to TRUE, then it will return an H2O frame with means per column or row (depends on axis argument).
 #' @examples
@@ -2815,7 +2815,7 @@ kurtosis.H2OFrame <- h2o.kurtosis
 #'   "everything"            - outputs NaNs whenever one of its contributing observations is missing
 #'   "all.obs"               - presence of missing observations will throw an error
 #'   "complete.obs"          - discards missing values along with all observations in their rows so that only complete observations are used
-#' @seealso \code{\link[stats]{var}} for the base R implementation. \code{\link{h2o.sd}} for standard deviation.
+#' @seealso \code{\link[stats]{cor}} for the base R implementation. \code{\link{h2o.sd}} for standard deviation.
 #' @examples
 #' \dontrun{
 #' library(h2o)
@@ -3000,7 +3000,7 @@ sd <- function(x, na.rm=FALSE) {
 #' @name h2o.signif
 #' @param x An H2OFrame object.
 #' @param digits Number of significant digits to round doubles/floats.
-#' @seealso \code{\link[base]{signif}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3029,7 +3029,7 @@ signif <- function(x, digits=6) {
 #' @param digits Number of decimal places to round doubles/floats. Rounding to a negative number of decimal places is 
 #         not supported. For rounding off a 5, the IEC 60559 standard is used, 'go to the even digit'. Therefore 
 #         rounding 2.5 gives 2 and rounding 3.5 gives 4.
-#' @seealso \code{\link[base]{round}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3120,7 +3120,7 @@ scale.H2OFrame <- function(x, center = TRUE, scale = TRUE) {
 #'
 #' @name h2o.log10
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{log10}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3142,7 +3142,7 @@ h2o.log10 <- function(x) {
 #'
 #' @name h2o.log2
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{log2}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3164,7 +3164,7 @@ h2o.log2 <- function(x) {
 #'
 #' @name h2o.log1p
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{log1p}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3188,7 +3188,7 @@ h2o.log1p <- function(x) {
 #'
 #' @name h2o.trunc
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{trunc}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3292,7 +3292,7 @@ h2o.colnames <- function(x) {
 #'
 #' @name h2o.isfactor
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{is.factor}} for the base R implementation.
+#' @seealso \code{\link[base]{factor}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3313,7 +3313,7 @@ h2o.isfactor <- function(x) {
 #'
 #' @name h2o.isnumeric
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{is.numeric}} for the base R implementation.
+#' @seealso \code{\link[base]{numeric}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3333,7 +3333,7 @@ h2o.isnumeric <- function(x) {
 #'
 #' @name h2o.ischaracter
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{is.character}} for the base R implementation.
+#' @seealso \code{\link[base]{character}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3354,7 +3354,7 @@ h2o.ischaracter <- function(x) {
 #'
 #' @name h2o.asfactor
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{as.numeric}} for the base R implementation.
+#' @seealso \code{\link[base]{numeric}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3374,7 +3374,7 @@ h2o.asfactor <- function(x) {
 #'
 #' @name h2o.asnumeric
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{as.factor}} for the base R implementation.
+#' @seealso \code{\link[base]{factor}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3454,7 +3454,7 @@ h2o.str <- function(object, ..., cols=FALSE) {
 #'
 #' @name h2o.cos
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{cos}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3476,7 +3476,7 @@ h2o.cos <- function(x) {
 #'
 #' @name h2o.sin
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{sin}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3498,7 +3498,7 @@ h2o.sin <- function(x) {
 #'
 #' @name h2o.acos
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{acos}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation.
 #' @examples
 #' \dontrun{
 #' h2o.init()
@@ -3516,7 +3516,7 @@ h2o.acos <- function(x) {
 #'
 #' @name h2o.cosh
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{cosh}} for the base R implementation.
+#' @seealso \code{\link[base]{Hyperbolic}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3538,7 +3538,7 @@ h2o.cosh <- function(x) {
 #'
 #' @name h2o.tan
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{tan}} for the base R implementation.
+#' @seealso \code{\link[base]{Trig}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3560,7 +3560,7 @@ h2o.tan <- function(x) {
 #'
 #' @name h2o.tanh
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{tanh}} for the base R implementation.
+#' @seealso \code{\link[base]{Hyperbolic}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3582,7 +3582,7 @@ h2o.tanh <- function(x) {
 #'
 #' @name h2o.exp
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{exp}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3604,7 +3604,7 @@ h2o.exp <- function(x) {
 #'
 #' @name h2o.log
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{log}} for the base R implementation.
+#' @seealso \code{\link[base]{Log}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3627,7 +3627,7 @@ h2o.log <- function(x) {
 #'
 #' @name h2o.sqrt
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{sqrt}} for the base R implementation.
+#' @seealso \code{\link[base]{MathFun}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3649,7 +3649,7 @@ h2o.sqrt <- function(x) {
 #'
 #' @name h2o.abs
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{abs}} for the base R implementation.
+#' @seealso \code{\link[base]{MathFun}} for the base R implementation.
 #' @examples
 #' \dontrun{
 #' library(h2o)
@@ -3679,7 +3679,7 @@ h2o.abs <- function(x) {
 #'
 #' @name h2o.ceiling
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{ceiling}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3702,7 +3702,7 @@ h2o.ceiling <- function(x) {
 #'
 #' @name h2o.floor
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{floor}} for the base R implementation.
+#' @seealso \code{\link[base]{Round}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3797,7 +3797,7 @@ h2o.cumsum <- function(x, axis = 0){
 #' @name h2o.cumprod
 #' @param x An H2OFrame object.
 #' @param axis An int that indicates whether to do down a column (0) or across a row (1).
-#' @seealso \code{\link[base]{cumprod}} for the base R implementation.
+#' @seealso \code{\link[base]{cumsum}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3820,7 +3820,7 @@ h2o.cumprod <- function(x, axis = 0){
 #' @name h2o.cummin
 #' @param x An H2OFrame object.
 #' @param axis An int that indicates whether to do down a column (0) or across a row (1).
-#' @seealso \code{\link[base]{cummin}} for the base R implementation.
+#' @seealso \code{\link[base]{cumsum}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3843,7 +3843,7 @@ h2o.cummin <- function(x, axis = 0){
 #' @name h2o.cummax
 #' @param x An H2OFrame object.
 #' @param axis An int that indicates whether to do down a column (0) or across a row (1).
-#' @seealso \code{\link[base]{cummax}} for the base R implementation.
+#' @seealso \code{\link[base]{cumsum}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3897,7 +3897,7 @@ h2o.any <- function(x) {
 #' @name h2o.min
 #' @param x An H2OFrame object.
 #' @param na.rm \code{logical}. indicating whether missing values should be removed.
-#' @seealso \code{\link[base]{min}} for the base R implementation.
+#' @seealso \code{\link[base]{Extremes}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3918,7 +3918,7 @@ h2o.min <- function(x,na.rm = FALSE) {
 #' @name h2o.max
 #' @param x An H2OFrame object.
 #' @param na.rm \code{logical}. indicating whether missing values should be removed.
-#' @seealso \code{\link[base]{max}} for the base R implementation.
+#' @seealso \code{\link[base]{Extremes}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -3958,7 +3958,7 @@ h2o.nrow <- function(x) {
 #'
 #' @name h2o.ncol
 #' @param x An H2OFrame object.
-#' @seealso \code{\link[base]{ncol}} for the base R implementation.
+#' @seealso \code{\link[base]{nrow}} for the base R implementation.
 #' @examples 
 #' \dontrun{
 #' library(h2o)
@@ -4608,7 +4608,7 @@ h2o.cbind <- function(...) {
 #' @param \dots A sequence of H2OFrame arguments. All datasets must exist on the same H2O instance
 #'        (IP and port) and contain the same number and types of columns.
 #' @return An H2OFrame object containing the combined \dots arguments row-wise.
-#' @seealso \code{\link[base]{rbind}} for the base \code{R} method.
+#' @seealso \code{\link[base]{cbind}} for the base \code{R} method.
 #' @examples
 #' \dontrun{
 #' library(h2o)

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2710,7 +2710,7 @@ median.H2OFrame <- h2o.median
 #'                             is ignored.
 #' @param return_frame \code{logical}. Indicate whether to return an H2O frame or a list. Default is FALSE (returns a list).
 #' @param ... Further arguments to be passed from or to other methods.
-#' @seealso \code{\link[base]{mean}} , \code{\link[base]{colSums}}, or \code{\link[base]{colMeans}} for the base R implementation
+#' @seealso \code{\link[base]{mean}}, \code{\link[base]{colSums}} for the base R implementation
 #' @return Returns a list containing the mean for each column (NaN for non-numeric columns) if return_frame is set to FALSE.
 #'         If return_frame is set to TRUE, then it will return an H2O frame with means per column or row (depends on axis argument).
 #' @examples


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7657

Can be tested on R-devel image using `_R_CHECK_XREFS_MIND_SUSPECT_ANCHORS_=true` env var.
Below example assumes `repos` generated by this PR. PR does not produce R repo one needs to put package sources manually in current directory.
```sh
docker pull registry.gitlab.com/jangorecki/dockerfiles/r-devel
docker run -it registry.gitlab.com/jangorecki/dockerfiles/r-devel /bin/bash
R -q -e 'install.packages(c("RCurl","jsonlite"))'
R -q -e 'download.packages("h2o", ".", repos="https://h2o-release.s3.amazonaws.com/h2o/PUBDEV-7657/5118/R")'
#no package ‘h2o’ at the repositories
export _R_CHECK_XREFS_MIND_SUSPECT_ANCHORS_=true
export _R_CHECK_FORCE_SUGGESTS_=false
R CMD check --ignore-vignettes --as-cran h2o_3.31.0.5118.tar.gz
```
And look for `checking Rd cross-references` line.

----

Moreover I think there is space for improvement, for example on merging manual pages. It is not really reasonable to have `log`, `log10`, `log1p`, `log2` each having own manual page. IMO it would be easier to write nice documentation when not trying to fit into roxygen templates.