### PR TITLE
Update models.R

### DIFF
--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -4141,18 +4141,20 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
   ## Change feature names to the original supplied, the following is okay because order is preserved
       
   pps <- res$partial_dependence_data
-  min_y <- min(pps[[1]][,2])
-  max_y <- max(pps[[1]][,2])
+  number_of_pps_columns <- ncol(pps[[1]])
+  min_y <- min(pps[[1]][,number_of_pps_columns - 2])
+  max_y <- max(pps[[1]][,number_of_pps_columns - 2])
   min_lower <- min_y
   max_upper <- max_y
   col_name_index <- 1
   for (i in 1:length(pps)) {
     pp <- pps[[i]]
     if (!all(is.na(pp))) {
-      min_y <- min(min_y, min(pp[,2])) 
-      max_y <- max(max_y, max(pp[,2]))
-      min_lower <- min(min_lower, pp[,2] - pp[,3])
-      max_upper <- max(max_upper, pp[,2] + pp[,3])
+      number_of_pps_columns <- ncol(pp)
+      min_y <- min(min_y, min(pp[,number_of_pps_columns - 2])) 
+      max_y <- max(max_y, max(pp[,number_of_pps_columns - 2]))
+      min_lower <- min(min_lower, pp[,number_of_pps_columns - 2] - pp[,number_of_pps_columns - 1])
+      max_upper <- max(max_upper, pp[,number_of_pps_columns - 2] + pp[,number_of_pps_columns - 1])
       if (i <= num_1d_pp_data) {
         if(is.null(targets)){
           col_name_index = i


### PR DESCRIPTION
For partials of 2 variables, h2o.partialPlot is getting hung up when the pp tables' structure changes to more than one variable for partial dependence plotting. The original indexes are set so that the second column is the mean response value but this is not the case in a partial on more than 1 variable. To update this, we'll take the column dimension and index backwards from there. 

In the future this section can probably just be removed because I don't think it directly affects any of the functions that follow.