### PR TITLE
Fix stacked ensemble inconsistency warning

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -557,10 +557,12 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
               inferredDistributionFromFirstModel = false;
             }
           } else {
-            // Distribution of base models differ
-            Log.warn("Base models are inconsistent; they use different distributions: "
-                    + distributionFamily(this) + " and: " + distributionFamily(aModel) +
-                    ". Reverting to default distribution.");
+            if (distributionFamily(aModel) != distributionFamily(this)) {
+              // Distribution of base models differ
+              Log.warn("Base models are inconsistent; they use different distributions: "
+                      + distributionFamily(this) + " and: " + distributionFamily(aModel) +
+                      ". Reverting to default distribution.");
+            } // else the first model was DRF/XRT so we don't want to warn
             inferBasicDistribution();
             inferredDistributionFromFirstModel = false;
           }


### PR DESCRIPTION
Fix cases when a first base model is DRF/XRT which yields messages like `WARN water.default: Base models are inconsistent; they use different distributions: bernoulli and: bernoulli`.

This bug was introduced in https://0xdata.atlassian.net/browse/PUBDEV-7491