### PR TITLE
HEXDEV-757 Update Jackson to latest version 2.11.1

### DIFF
--- a/h2o-persist-gcs/build.gradle
+++ b/h2o-persist-gcs/build.gradle
@@ -4,7 +4,7 @@ description = "H2O Persist GCS"
 
 dependencies {
     compile project(":h2o-core")
-    compile 'com.google.cloud:google-cloud-storage:1.19.0'
+    compile 'com.google.cloud:google-cloud-storage:1.111.1'
 
     testCompile project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")

--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -13,7 +13,9 @@ dependencies {
         // Pull all dependencies to allow run directly from IDE or command line
         transitive = true
     }
-    compile("org.apache.hadoop:hadoop-aws:$defaultHadoopVersion")
+    compile("org.apache.hadoop:hadoop-aws:$defaultHadoopVersion"){
+        exclude group: "com.fasterxml.jackson.core"
+    }
 
     testCompile project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")

--- a/h2o-persist-s3/build.gradle
+++ b/h2o-persist-s3/build.gradle
@@ -10,13 +10,13 @@ description = "H2O Persist S3"
 
 dependencies {
   compile project(":h2o-core")
-  compile ('com.amazonaws:aws-java-sdk-s3:1.11.818'){
+  compile ('com.amazonaws:aws-java-sdk-s3:1.11.820'){
     exclude group: "com.fasterxml.jackson.core"
   }
-  runtime 'com.fasterxml.jackson.core:jackson-core:2.11.1'
-  runtime 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
-  runtime 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
-  runtime 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.1'
+  compile 'com.fasterxml.jackson.core:jackson-core:2.11.1'
+  compile 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
+  compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.1'
   compile "org.apache.httpcomponents:httpclient:${httpClientVersion}"
   compile 'javax.xml.bind:jaxb-api:2.3.0'
 

--- a/h2o-persist-s3/build.gradle
+++ b/h2o-persist-s3/build.gradle
@@ -10,7 +10,13 @@ description = "H2O Persist S3"
 
 dependencies {
   compile project(":h2o-core")
-  compile 'com.amazonaws:aws-java-sdk-s3:1.10.77'
+  compile ('com.amazonaws:aws-java-sdk-s3:1.11.818'){
+    exclude group: "com.fasterxml.jackson.core"
+  }
+  runtime 'com.fasterxml.jackson.core:jackson-core:2.11.1'
+  runtime 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
+  runtime 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
+  runtime 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.1'
   compile "org.apache.httpcomponents:httpclient:${httpClientVersion}"
   compile 'javax.xml.bind:jaxb-api:2.3.0'
 


### PR DESCRIPTION
[HEXDEV-757](https://0xdata.atlassian.net/browse/HEXDEV-757)
**Contect of this customer issue is confidential !**

Removes old Jackson 2.5.3 from year 2015 from our h2o.jar and bundles new version `2.11.1`. Desired version is at least `2.9.10.4`.

This doesn't mean version 2.5.3 is gone completely - some hadoop modules and possibly others might still use it and this is required.

![Screenshot from 2020-07-09 12-24-44](https://user-images.githubusercontent.com/8769110/87033920-5839a380-c1e7-11ea-8fec-6488dfa40069.png)

![Screenshot from 2020-07-09 12-20-29](https://user-images.githubusercontent.com/8769110/87034707-97b4bf80-c1e8-11ea-8bad-aa2d56ec6c5f.png)


## Before merge TODO-list

- Run all HADOOP tests against this branch - http://mr-0xc1:8080/view/H2O-3/job/h2o-3-hadoop-smoke-pipeline/job/pavel%252Fhexdev-757/
- Run all Kerberos tests against this branch - http://mr-0xc1:8080/view/H2O-3/job/h2o-3-kerberos-smoke-pipeline/job/pavel%252Fhexdev-757/
- Run nightlies against this branch - http://mr-0xc1:8080/view/H2O-3/job/h2o-3-nightly-pipeline/job/pavel%252Fhexdev-757/
- Check with SNYK
- Approval of Sparkling Water team is required: @jakubhava @mn-mikke

