### PR TITLE
PUBDEV-7556: Add sklearn integration section to the User Guide

### DIFF
--- a/h2o-docs/src/product/automl.rst
+++ b/h2o-docs/src/product/automl.rst
@@ -146,6 +146,8 @@ Notes
 
 If the user sets ``nfolds == 0``, then cross-validation metrics will not be available to populate the leaderboard.  In this case, we need to make sure there is a holdout frame (aka. the "leaderboard frame") to score the models on so that we can generate model performance metrics for the leaderboard.  Without cross-validation, we will also require a validation frame to be used for early stopping on the models.  Therefore, if either of these frames are not provided by the user, they will be automatically partitioned from the training data.  If either frame is missing, 10% of the training data will be used to create a missing frame (if both are missing then a total of 20% of the training data will be used to create a 10% validation and 10% leaderboard frame).
 
+``H2OAutoML`` can interact with the ``h2o.sklearn`` module. The ``h2o.sklearn`` module exposes 2 wrappers for ``H2OAutoML`` (``H2OAutoMLClassifier`` and ``H2OAutoMLRegressor``), which expose the standard API familiar to ``sklearn`` users: ``fit``, ``predict``, ``fit_predict``, ``score``, ``get_params``, and ``set_params``. It accepts various formats as input data (H2OFrame, ``numpy`` array, ``pandas`` Dataframe) which allows them to be combined with pure ``sklearn`` components in pipelines. For an example using ``H2OAutoML`` with the ``h2o.sklearn`` module, click `here <https://github.com/h2oai/h2o-tutorials/blob/master/tutorials/sklearn-integration/H2OAutoML_as_sklearn_estimator.ipynb>`__.
+
 
 Code Examples
 -------------

--- a/h2o-docs/src/product/h2o-client.rst
+++ b/h2o-docs/src/product/h2o-client.rst
@@ -6,17 +6,17 @@ These clients allow you to connect to and interact with H2O.
 H2O Flow
 --------
 
-H2O Flow is a Web based (GUI) user interface. It allows user to interactively run their H2O machine learning workflows and iteratively improve them. It combine code execution, text, mathematics, plots, and rich media in a single document. Documentation for H2O Flow can be found `here <flow.html>`__.
+H2O Flow is a Web based (GUI) user interface. It allows users to interactively run their H2O machine learning workflows and iteratively improve them. It combines code execution, text, mathematics, plots, and rich media in a single document. Documentation for H2O Flow can be found `here <flow.html>`__.
 
 R Client
 --------
 
-R users can use H2O-R library which internally uses H2O REST API calls to connect to H2O(Server) and allows users to run their H2O workflow via R. Documentation for the H2O-R Client can be found `here <../h2o-r/docs/index.html>`__.
+R users can use H2O-R library which internally uses H2O REST API calls to connect to H2O (Server) and allows users to run their H2O workflow via R. Documentation for the H2O-R Client can be found `here <../h2o-r/docs/index.html>`__.
 
 Python Client
 -------------
 
-Python users can connect to H2O using the H2O Python pacakge that internally uses H2O REST API calls to connect to H2O(Server) and allows users to run their H2O workflow via Python. Documentation for the H2O-Python Client can be found `here <../h2o-py/docs/index.html>`__. 
+Python users can connect to H2O using the H2O Python pacakge that internally uses H2O REST API calls to connect to H2O (Server) and allows users to run their H2O workflow via Python. Documentation for the H2O-Python Client can be found `here <../h2o-py/docs/index.html>`__. 
 
 Sklearn Support
 ~~~~~~~~~~~~~~~

--- a/h2o-docs/src/product/h2o-client.rst
+++ b/h2o-docs/src/product/h2o-client.rst
@@ -6,21 +6,21 @@ These clients allow you to connect to and interact with H2O.
 H2O Flow
 --------
 
-H2O Flow is an open-source user interface for H2O, and it is a web-based interactive environment that allows you to combine code execution, text, mathematics, plots, and rich media in a single document. Documentation for H2O Flow can be found `here <flow.html>`__.
+H2O Flow is a Web based (GUI) user interface. It allows user to interactively run their H2O machine learning workflows and iteratively improve them. It combine code execution, text, mathematics, plots, and rich media in a single document. Documentation for H2O Flow can be found `here <flow.html>`__.
 
 R Client
 --------
 
-R uses REST API to connect to H2O and allows you to run basic H2O commands using R commands. Documentation for the R Client can be found `here <../h2o-r/docs/index.html>`__.
+R users can use H2O-R library which internally uses H2O REST API calls to connect to H2O(Server) and allows users to run their H2O workflow via R. Documentation for the H2O-R Client can be found `here <../h2o-r/docs/index.html>`__.
 
 Python Client
 -------------
 
-Python users can connect to H2O and can also use H2O with IPython notebooks. Documentation for the Python Client can be found `here <../h2o-py/docs/index.html>`__. 
+Python users can connect to H2O using the H2O Python pacakge that internally uses H2O REST API calls to connect to H2O(Server) and allows users to run their H2O workflow via Python. Documentation for the H2O-Python Client can be found `here <../h2o-py/docs/index.html>`__. 
 
 Sklearn Support
 ~~~~~~~~~~~~~~~
 
-Most H2O estimators available in the Python client can be used in the standard ``sklearn`` API. The ``h2o.sklearn`` module provides a collection of wrappers auto-generated on top of the original estimators and transformers, as well as on top of ``H2OAutoML``.
+Most H2O estimators available in the H2O-Python client can also be used in the standard ``sklearn`` API. The ``h2o.sklearn`` module provides a collection of wrappers auto-generated on top of the original estimators and transformers, as well as on top of ``H2OAutoML``.
 
-For examples on sklearn integration, click `here <https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/sklearn-integration>`__.
+For examples on how to integrate H2O estimators into your Sklearn workflow, please click `here <https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/sklearn-integration>`__.

--- a/h2o-docs/src/product/h2o-client.rst
+++ b/h2o-docs/src/product/h2o-client.rst
@@ -23,4 +23,4 @@ Sklearn Support
 
 Most H2O estimators available in the Python client can be used in the standard ``sklearn`` API. The ``h2o.sklearn`` module provides a collection of wrappers auto-generated on top of the original estimators and transformers, as well as on top of ``H2OAutoML``.
 
-For examples on sklearn integration, click `here <../h2o-tutorials/tutorials/sklearn-integration>`__.
+For examples on sklearn integration, click `here <https://github.com/h2oai/h2o-tutorials/tree/master/tutorials/sklearn-integration>`__.

--- a/h2o-docs/src/product/h2o-client.rst
+++ b/h2o-docs/src/product/h2o-client.rst
@@ -1,0 +1,26 @@
+H2O Clients
+===========
+
+These clients allow you to connect to and interact with H2O.
+
+H2O Flow
+--------
+
+H2O Flow is an open-source user interface for H2O, and it is a web-based interactive environment that allows you to combine code execution, text, mathematics, plots, and rich media in a single document. Documentation for H2O Flow can be found `here <flow.html>`__.
+
+R Client
+--------
+
+R uses REST API to connect to H2O and allows you to run basic H2O commands using R commands. Documentation for the R Client can be found `here <../h2o-r/docs/index.html>`__.
+
+Python Client
+-------------
+
+Python users can connect to H2O and can also use H2O with IPython notebooks. Documentation for the Python Client can be found `here <../h2o-py/docs/index.html>`__. 
+
+Sklearn Support
+~~~~~~~~~~~~~~~
+
+Most H2O estimators available in the Python client can be used in the standard ``sklearn`` API. The ``h2o.sklearn`` module provides a collection of wrappers auto-generated on top of the original estimators and transformers, as well as on top of ``H2OAutoML``.
+
+For examples on sklearn integration, click `here <../h2o-tutorials/tutorials/sklearn-integration>`__.

--- a/h2o-docs/src/product/index.rst
+++ b/h2o-docs/src/product/index.rst
@@ -48,6 +48,11 @@ Additional Resources:
    starting-h2o
 
 .. toctree::
+   :maxdepth: 2
+
+   h2o-client
+
+.. toctree::
    :maxdepth: 4
 
    getting-data-into-h2o


### PR DESCRIPTION
Created the H2O Clients page with links to Flow, R, and Python documentation. Added note to H2OAutoML about sklearn integration.

Please let me know if you would like any updates.