### PR TITLE
GAM predictions fixes

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -19,6 +19,8 @@ import water.util.*;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import static hex.gam.MatrixFrameUtils.GamUtils.equalColNames;
 import static hex.gam.MatrixFrameUtils.GamUtils.sortCoeffMags;
@@ -380,13 +382,9 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public String[] _responseDomains;
     public String _gam_transformed_center_key;
     final Family _family;
+    String[] _featureNames;
     
     public double dispersion(){ return _dispersion;}
-
-    @Override
-    public int nfeatures() {
-      return _names.length;
-    }
 
     @Override
     public int nclasses() {
@@ -412,6 +410,28 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public GAMModelOutput(GAM b, Frame adaptr, DataInfo dinfo) {
       super(b, adaptr);
       _dinfo = dinfo;
+      final int numColumns = b._parms._gam_columns.length + (b._parms.train().numCols() - b._parms._ignored_columns.length - 1);
+
+      final Set<String> names = new HashSet(b._parms.train().names().length);
+      for (String name: b._parms.train().names()){
+        names.add(name);
+      }
+      for(String ignored : b._parms._ignored_columns){
+        names.remove(ignored);
+      }
+      names.remove(b._parms._response_column);
+
+      _featureNames = new String[numColumns];
+      
+      int i = 0;
+      for (String name : names){
+        _featureNames[i++] = name;
+      }
+      
+      for (int j = 0; j < b._parms._gam_columns.length; j++) {
+        _featureNames[i++] = b._parms._gam_columns[j];
+      }
+      
       _domains = dinfo._adaptedFrame.domains(); // get domain of dataset predictors
       _family = b._parms._family;
       if (_family.equals(Family.quasibinomial)) {

--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -384,6 +384,11 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public double dispersion(){ return _dispersion;}
 
     @Override
+    public int nfeatures() {
+      return _names.length;
+    }
+
+    @Override
     public int nclasses() {
       if (_family == Family.multinomial || _family == Family.ordinal)
         return super.nclasses();
@@ -631,6 +636,12 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     }
 
     public double[] scoreRow(DataInfo.Row r, double offset, double[] preds) {
+      for (int i = 0; i < r.numVals.length; i++) {
+        if(Double.isNaN(r.numVals[i])){
+          throw new IllegalArgumentException("NaN found.");
+        }
+      }
+      
       double mu = _m._parms.linkInv(r.innerProduct(_coeffs) + offset, _m._parms._link,
               _m._parms._tweedie_link_power);
       if (_classifier2class) { // threshold for prediction

--- a/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
@@ -27,7 +27,6 @@ public class GAMMojoWriter extends ModelMojoWriter<GAMModel, GAMModel.GAMParamet
     writekv("use_all_factor_levels", model._parms._use_all_factor_levels);
     writekv("cats", model._output._dinfo._cats);
     writekv("cat_offsets", model._output._dinfo._catOffsets);
-    writekv("numsCenter", model._output._dinfo._nums);
     writekv("num", model._output._dinfo._nums+numGamCols);
 
     boolean imputeMeans = model._parms.missingValuesHandling().equals(GLMModel.GLMParameters.MissingValuesHandling.MeanImputation);

--- a/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
@@ -83,7 +83,15 @@ public class GAMMojoWriter extends ModelMojoWriter<GAMModel, GAMModel.GAMParamet
     }
     // store variable importance information
   }
-  
+
+  @Override
+  protected void writeNames() {
+    writeln("\n[columns]");
+    for (String name : model._output._featureNames) {
+      writeln(name);
+    }
+  }
+
   public String[] genTrainColGamCols(int gamColLength, int gamCColLength) {
     int colLength = model._output._names.length-gamCColLength+gamColLength-1;// to exclude response
     int normalColLength = model._output._names.length-gamCColLength-1;

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GenerateGamMatrixOneColumn.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GenerateGamMatrixOneColumn.java
@@ -45,22 +45,28 @@ public class GenerateGamMatrixOneColumn extends MRTask<GenerateGamMatrixOneColum
     int chunkRows = chk[0].len(); // number of rows in chunk
     CubicRegressionSplines crSplines = new CubicRegressionSplines(_numKnots, _knots); // not iced, must have own
     double[] basisVals = new double[_numKnots];
-    for (int rowIndex=0; rowIndex < chunkRows; rowIndex++) {
+    for (int rowIndex = 0; rowIndex < chunkRows; rowIndex++) {
       double gamRowSum = 0.0;
       // find index of knot bin where row value belongs to
       double xval = chk[0].atd(rowIndex);
-      int binIndex = locateBin(xval,_knots); // location to update
-      // update from F matrix F matrix = [0;invB*D;0] and c functions
-      GamUtilsCubicRegression.updateFMatrixCFunc(basisVals, xval, binIndex, _knots, crSplines._hj, _bInvD);
-      // update from a+ and a- functions
-      GamUtilsCubicRegression.updateAFunc(basisVals, xval, binIndex, _knots, crSplines._hj);
-      // copy updates to the newChunk row
-      for (int colIndex = 0; colIndex < _numKnots; colIndex++) {
-        newGamCols[colIndex].addNum(basisVals[colIndex]);
-        gamRowSum += Math.abs(basisVals[colIndex]);
+      if (!Double.isNaN(xval)) {
+        int binIndex = locateBin(xval, _knots); // location to update
+        // update from F matrix F matrix = [0;invB*D;0] and c functions
+        GamUtilsCubicRegression.updateFMatrixCFunc(basisVals, xval, binIndex, _knots, crSplines._hj, _bInvD);
+        // update from a+ and a- functions
+        GamUtilsCubicRegression.updateAFunc(basisVals, xval, binIndex, _knots, crSplines._hj);
+        // copy updates to the newChunk row
+        for (int colIndex = 0; colIndex < _numKnots; colIndex++) {
+          newGamCols[colIndex].addNum(basisVals[colIndex]);
+          gamRowSum += Math.abs(basisVals[colIndex]);
+        }
+        if (gamRowSum > _maxAbsRowSum[cIndex])
+          _maxAbsRowSum[cIndex] = gamRowSum;
+      } else {
+        for (int colIndex = 0; colIndex < _numKnots; colIndex++) {
+          newGamCols[colIndex].addNum(Double.NaN);
+        }
       }
-      if (gamRowSum > _maxAbsRowSum[cIndex])
-        _maxAbsRowSum[cIndex] = gamRowSum;
     }
   }
 

--- a/h2o-algos/src/test/java/hex/gam/GamMojoModelTest.java
+++ b/h2o-algos/src/test/java/hex/gam/GamMojoModelTest.java
@@ -116,14 +116,14 @@ public class GamMojoModelTest {
       // test for binomial
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[] gamCols = new String[]{"C11", "C12"};
       Frame trainBinomial = Scope.track(massageFrame(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"),
               binomial));
       DKV.put(trainBinomial);
       GAMModel binomialModel = getModel(binomial,
               parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"), "C21",
-              gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0}, false, true,
-              new double[]{1, 1, 1}, new double[]{0, 0, 0}, new double[]{0, 0, 0}, true, null,
+              gamCols, ignoredCols, new int[]{5, 5}, new int[]{0, 0}, false, true,
+              new double[]{1, 1}, new double[]{0, 0}, new double[]{0, 0}, true, null,
               null, false);
       Scope.track_generic(binomialModel);
       binomialModel._output._training_metrics = null; // force prediction threshold of 0.5

--- a/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/AbstractMojoWriter.java
@@ -222,10 +222,7 @@ public abstract class AbstractMojoWriter {
       writelnkv(kv.getKey(), kv.getValue());
     }
 
-    writeln("\n[columns]");
-    for (String name : model.columnNames()) {
-      writeln(name);
-    }
+    writeNames();
 
     writeln("\n[domains]");
     String format = "%d: %d d%03d.txt";
@@ -236,6 +233,13 @@ public abstract class AbstractMojoWriter {
         writeln(String.format(format, colIndex, domains[colIndex].length, domIndex++));
     }
     finishWritingTextFile();
+  }
+
+  protected void writeNames() {
+    writeln("\n[columns]");
+    for (String name : model.columnNames()) {
+      writeln(name);
+    }
   }
 
   /**

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModelBase.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModelBase.java
@@ -60,8 +60,7 @@ public abstract class GamMojoModelBase extends MojoModel implements ConverterFac
 
   @Override
   public double[] score0(double[] row, double[] preds) {
-    if (_meanImputation)
-      imputeMissingWithMeans(row);  // perform imputation for each row
+    imputeMissingWithMeans(row);  // perform imputation for each row
     
     return gamScore0(row, preds);
   }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
@@ -22,7 +22,6 @@ public class GamMojoReader extends ModelMojoReader<GamMojoModelBase> {
     _model._family = DistributionFamily.valueOf((String)readkv("family"));
     _model._cats = readkv("cats", -1);
     _model._nums = readkv("num");
-    _model._numsCenter = readkv("numsCenter");
     _model._catNAFills = readkv("catNAFills", new int[0]);
     _model._numNAFills = readkv("numNAFills", new double[0]);
     _model._numNAFillsCenter = readkv("numNAFillsCenter", new double[0]);;

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -282,6 +282,7 @@ def mojo_predict(model, tmpdir, mojoname, glrmReconstruct=False, get_leaf_node_a
 
     p = subprocess.Popen(java_cmd, stdout=PIPE, stderr=STDOUT)
     o, e = p.communicate()
+    print(o)
     files = os.listdir(tmpdir)
     print("listing files {1} in directory {0}".format(tmpdir, files))
     outfile = os.path.join(tmpdir, 'out_mojo.csv')

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_gaussian.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_gaussian.py
@@ -10,7 +10,7 @@ def gam_gaussian_mojo():
     NTESTROWS = 200    # number of test dataset rows
     PROBLEM="gaussian"
     params = set_params()   # set deeplearning model parameters
-    df = pyunit_utils.random_dataset(PROBLEM, missing_fraction=0.001)   # generate random dataset
+    df = pyunit_utils.random_dataset(PROBLEM, missing_fraction=0.1)   # generate random dataset
     dfnames = df.names
     # add GAM specific parameters
     params["gam_columns"] = []

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_gaussian.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7185_GAM_mojo_gaussian.py
@@ -10,7 +10,7 @@ def gam_gaussian_mojo():
     NTESTROWS = 200    # number of test dataset rows
     PROBLEM="gaussian"
     params = set_params()   # set deeplearning model parameters
-    df = pyunit_utils.random_dataset(PROBLEM, missing_fraction=0.1)   # generate random dataset
+    df = pyunit_utils.random_dataset(PROBLEM, missing_fraction=0.5)   # generate random dataset
     dfnames = df.names
     # add GAM specific parameters
     params["gam_columns"] = []
@@ -27,7 +27,9 @@ def gam_gaussian_mojo():
     
     train = df[NTESTROWS:, :]
     test = df[:NTESTROWS, :]
-    x = list(set(df.names) - {"response"})
+    exclude = {"response"}
+    exclude.add(params["gam_columns"][0])
+    x = list(set(df.names) - exclude)
 
     TMPDIR = tempfile.mkdtemp()
     gamGaussianModel = pyunit_utils.build_save_model_generic(params, x, train, "response", "gam", TMPDIR) # build and save mojo model


### PR DESCRIPTION
A spin-off from https://github.com/h2oai/h2o-3/pull/4809

**Not done yet.**

The NaN problem was truly caused by iterating over non-existing columns (thus the array has been filled with NaNs - the NaN index was hit randomly and depended on the generated value). That is now fixed. **No column names** are relied upon. The GAM coefficients are ALWAYS added, as in reality there is no way the test dataset could contain them (why and how ?). Only slightly bent the code written by @wendycwong .

However, the predictions are slightly off - I wonder what the root cause for that is. @wendycwong can you please help me compare `GamModel` predictions with `GAMMojo` predictions and spot the difference ? I have a suspicion it's somewhere in the ETA function - do we use the correct indices all the time ?