### PR TITLE
PUBDEV-7119 - CSVStream does not escape quotes.

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -2183,7 +2183,7 @@ class H2OFrame(Keyed):
         >>> iris = h2o.import_file("http://h2o-public-test-data.s3.amazonaws.com/smalldata/iris/iris_wheader.csv")
         >>> iris.get_frame_data()
         """
-        return h2o.api("GET /3/DownloadDataset", data={"frame_id": self.frame_id, "hex_string": False})
+        return h2o.api("GET /3/DownloadDataset", data={"frame_id": self.frame_id, "hex_string": False, "escape_quotes" : True})
 
 
     def __getitem__(self, item):

--- a/h2o-py/tests/testdir_jira/pyunit_pubdev_7119.py
+++ b/h2o-py/tests/testdir_jira/pyunit_pubdev_7119.py
@@ -1,0 +1,34 @@
+import sys
+sys.path.insert(1,"../../")
+import h2o
+from tests import pyunit_utils
+import pandas as pd
+
+def pubdev_7119():
+
+    # Test 1
+    pd_df = pd.DataFrame({'col1': [1,2], 'col2': ['foo"foo\nfoo','foo2'], 'col3': [1,2]})
+    h2o_df = h2o.H2OFrame(pd_df)
+    pd_df2 = h2o_df.as_data_frame()
+    
+    print(pd_df)
+    print(h2o_df)
+    print(pd_df2)
+    
+    if not pd_df.equals(pd_df2):
+        raise Exception('Failed to convert to pandas dataframe if there are fields containing double quotes and line breaks')
+    
+    # Test 2: just double quotes
+    pd_df = pd.DataFrame({'col1': [1,2], 'col2': ['foo"foo','foo2'], 'col3': [1,2]})
+    h2o_df = h2o.H2OFrame(pd_df)
+    pd_df2 = h2o_df.as_data_frame()
+    print(pd_df)
+    print(h2o_df)
+    print(pd_df2)
+    if not pd_df.equals(pd_df2):
+        raise Exception('Failed to convert to pandas dataframe if there are fields containing double quotes')
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(pubdev_7119)
+else:
+    pubdev_7119()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7119

The parser works fine. Problem is our CSVStream's parameters, where for some reason the escaping parameter is not set. For the parser inside Python, quotes should always be escaped (by double quotes).

R has this scenario covered already: 

```R
urlSuffix <- paste0('DownloadDataset',
                      '?frame_id=', URLencode(h2o.getId(x)),
                      '&hex_string=', ifelse(useHexString, "true", "false"),
                      '&escape_quotes=', ifelse(useDataTable, "false", "true"))
```

The data only appear as broken (in Python) when importing back into Pandas. In H2O itself, the format is correct.