### PR TITLE
PUBDEV-7681 get_hyperparams_dict should return correct params

### DIFF
--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -1420,14 +1420,14 @@ class H2OGridSearch(h2o_meta(Keyed)):
 
         model_params = dict()
 
-        # if cross-validation is turned on, parameters in one of the fold model actual contains the max_runtime_secs
-        # parameter and not the main model that is returned.
-        if model._is_xvalidated:
-            model = h2o.get_model(model._xval_keys[0])
-
         for param_name in self.hyper_names:
-            model_params[param_name] = model.params[param_name]['actual'][0] if \
-                isinstance(model.params[param_name]['actual'], list) else model.params[param_name]['actual']
+            # if cross-validation is turned on, parameters in one of the fold model actual contains the max_runtime_secs
+            # parameter and not the main model that is returned.
+            if 'max_runtime_secs' == param_name and model._is_xvalidated:
+                xvalidated_model = h2o.get_model(model._xval_keys[0])
+                model_params[param_name] = xvalidated_model.params[param_name]['actual']
+            else:    
+                model_params[param_name] = model.params[param_name]['actual']
 
         if display: print('Hyperparameters: [' + ', '.join(list(self.hyper_params.keys())) + ']')
         return model_params

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_7681_H2OGridSearch_get_hyperparams_dict_return_correct_params.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_7681_H2OGridSearch_get_hyperparams_dict_return_correct_params.py
@@ -1,0 +1,42 @@
+from __future__ import print_function
+from builtins import range
+import sys
+
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators import H2OGradientBoostingEstimator
+from h2o.grid.grid_search import H2OGridSearch
+import random
+
+
+def get_hyperparams_dict_return_correct_params():
+    prostate_train = h2o.import_file(path=pyunit_utils.locate("smalldata/logreg/prostate_train.csv"))
+    prostate_train["CAPSULE"] = prostate_train["CAPSULE"].asfactor()
+    
+    num_folds = random.randint(2,5)
+    fold_assignments = h2o.H2OFrame([[random.randint(0,num_folds-1)] for _ in range(prostate_train.nrow)])
+    fold_assignments.set_names(["fold_assignments"])
+    prostate_train = prostate_train.cbind(fold_assignments)
+    
+    x_features=range(1,prostate_train.ncol)
+    y_target="CAPSULE"
+    h2o_data_frame=prostate_train
+    
+    
+    grid = H2OGridSearch(model=H2OGradientBoostingEstimator,
+                         hyper_params={'fold_assignment':['Stratified'],'sample_rate_per_class':[[1.0, 0.6]]},
+                         search_criteria={'strategy': 'RandomDiscrete', 'max_models': 1})
+    grid.train(x=x_features, y=y_target, training_frame=h2o_data_frame, nfolds=num_folds)
+
+    print(grid.get_grid())
+    hyperparams_dict = grid.get_hyperparams_dict(0);
+    assert hyperparams_dict['fold_assignment'] == 'Stratified'
+    assert hyperparams_dict['sample_rate_per_class'] == [1.0, 0.6]
+
+
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(get_hyperparams_dict_return_correct_params)
+else:
+    get_hyperparams_dict_return_correct_params()


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7681
2 changes in get_hyperparams_dict():

1. fold_assignment for the fold models used during the cross validation is set to AUTO here: ModelBuilder.java L639.
I think this should not overwrite fold_assignment of overall model in get_hyperparams_dict(). Hence I am extracting only max_runtime_secs from the first fold model (what seems to be intention of underlying change in PUBDEV-1843, but it was done in such a way, that currently, all params of overall model are overwritten by params of the first fold model in get_hyperparams_dict()).


2. if some hyperparam value is of type list, only its first element is saved into resulting hyperparams dict, what is causing wrong content of sample_rate_per_class. So this was also fixed.