### PR TITLE
Fix Stacked Ensemble's retrieval of seed parameter value

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
+++ b/h2o-algos/src/main/java/hex/ensemble/StackedEnsembleModel.java
@@ -74,7 +74,6 @@ public class StackedEnsembleModel extends Model<StackedEnsembleModel,StackedEnse
     public Metalearner.Algorithm _metalearner_algorithm = Metalearner.Algorithm.AUTO;
     public String _metalearner_params = new String(); //used for clients code-gen only.
     public Model.Parameters _metalearner_parameters;
-    public long _seed;
     public long _score_training_samples = 10_000;
 
     /**

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_seed.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_seed.R
@@ -54,6 +54,11 @@ stackedensemble.metalearner.seed.test <- function() {
                                   metalearner_algorithm = "gbm",
                                   metalearner_params = gbm_params,
                                   seed = 55555)
+
+    # Seed should be retrieved correctly from both SE and MetaLearner
+    expect_equal(as.numeric(stack0@parameters$seed), 55555)
+    expect_equal(as.numeric(stack0@model$metalearner_model@parameters$seed), 55555)
+
     #RMSE should match for each metalearner since the same seed is used
     meta0 <- h2o.getModel(stack0@model$metalearner$name)
     meta1 <- h2o.getModel(stack1@model$metalearner$name)


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7667

Seed parameter was set and used but retrieved value didn't correspond to what it was set to. 
(`ensemble@parameters$seed` reported incorrect value and `ensemble@model$metalearner_model@parameters$seed` reported the correct value.)


This was caused by shadowing the `_seed` in StackedEnsembleParameters - `fillFromImpl` used `_seed` from Model.Parameters hence it contained different than the set value.