### PR TITLE
PUBDEV-7716: generate synthetic datasets for GLM/Deeplearning/GBM

### DIFF
--- a/h2o-py/tests/testdir_algos/deeplearning/pyunit_generate_synthetic_DL_data.py
+++ b/h2o-py/tests/testdir_algos/deeplearning/pyunit_generate_synthetic_DL_data.py
@@ -1,0 +1,79 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.deeplearning import H2ODeepLearningEstimator
+import numpy as np
+
+# This test will generate synthetic deeplearning dataset using a randomly defined deeplearning network.  If given to 
+# a deeplearning model, it should be able to perform well with this dataset since the assumptions associated with 
+# deeplearning are used to generate the dataset.
+def test_define_dataset():
+    family = 'bernoulli' # can be any valid GLM families
+    nrow = 100000
+    ncol = 10
+    missing_fraction = 0
+    factorRange= 50
+    numericRange = 10
+    targetFactor = 2
+    realFrac = 0.3
+    intFrac = 0.3
+    enumFrac = 0.4
+    networkStructure = [10,20,10]
+    activation = 'Rectifier' # can be "Linear", "Softmax", "ExpRectifierWithDropout", "ExpRectifier",
+                             # "Rectifier", "RectifierWithDropout", "MaxoutWithDropout", "Maxout", "TanhWithDropout",
+                             # "Tanh"
+    glmDataSet = generate_dataset(family, nrow, ncol, networkStructure, activation, realFrac, intFrac, enumFrac, 
+                                  missing_fraction, factorRange, numericRange, targetFactor)
+    #h2o.download_csv(glmDataSet, "/Users/.../dataset.csv") # save dataset
+    assert glmDataSet.nrow == nrow, "Dataset number of row: {0}, expected number of row: {1}".format(glmDataSet.nrow, 
+                                                                                                     nrow)
+    assert glmDataSet.ncol == (1+ncol), "Dataset number of row: {0}, expected number of row: " \
+                                                          "{1}".format(glmDataSet.ncol, (1+ncol))
+  
+def generate_dataset(family, nrow, ncol, networkStructure, activation, realFrac, intFrac, enumFrac, missingFrac, 
+                     factorRange, numericRange, targetFactor):
+    if family=="bernoulli":
+        responseFactor = 2
+    elif family == 'gaussian':
+        responseFactor = 1;
+    else :
+        responseFactor = targetFactor
+        
+    trainData = random_dataset(nrow, ncol, realFrac=realFrac, intFrac=intFrac, enumFrac=enumFrac, factorR=factorRange,
+                               integerR=numericRange, responseFactor=responseFactor, misFrac=missingFrac)
+   
+    myX = trainData.names
+    myY = 'response'
+    myX.remove(myY)
+    m = H2ODeepLearningEstimator(distribution = family, hidden=networkStructure, activation=activation)
+    m.train(training_frame=trainData,x=myX,y= myY)
+    f2 = m.predict(trainData)
+    
+    finalDataset = trainData[myX]
+    finalDataset = finalDataset.cbind(f2[0])
+    finalDataset.set_name(col=finalDataset.ncols-1, name='response')
+
+    h2o.remove(trainData)
+    return finalDataset
+
+def random_dataset(nrow, ncol, realFrac = 0.4, intFrac = 0.3, enumFrac = 0.3, factorR = 10, integerR=100, 
+                   responseFactor = 1, misFrac=0.01, randSeed=None):
+    fractions = dict()
+    fractions["real_fraction"] = realFrac  # Right now we are dropping string columns, so no point in having them.
+    fractions["categorical_fraction"] = enumFrac
+    fractions["integer_fraction"] = intFrac
+    fractions["time_fraction"] = 0
+    fractions["string_fraction"] = 0  # Right now we are dropping string columns, so no point in having them.
+    fractions["binary_fraction"] = 0
+
+    df = h2o.create_frame(rows=nrow, cols=ncol, missing_fraction=misFrac, has_response=True, 
+                          response_factors = responseFactor, integer_range=integerR,
+                          seed=randSeed, **fractions)
+    return df
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_define_dataset)
+else:
+    test_define_dataset()

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_generate_synthetic_GBM_data.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_generate_synthetic_GBM_data.py
@@ -1,0 +1,79 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gbm import H2OGradientBoostingEstimator
+import numpy as np
+
+# This test will generate synthetic GBM dataset using a randomly defined GBM trees.  If given to 
+# a GBM model, it should be able to perform well with this dataset since the assumptions associated with 
+# GBM are used to generate the dataset.
+def test_define_dataset():
+    family = 'bernoulli' # can be any valid GLM families
+    nrow = 100000
+    ncol = 10
+    missing_fraction = 0
+    factorRange= 50
+    numericRange = 10
+    targetFactor = 2
+    realFrac = 0.3
+    intFrac = 0.3
+    enumFrac = 0.4
+    ntrees=10
+    max_depth=8   
+    glmDataSet = generate_dataset(family, nrow, ncol, ntrees, max_depth, realFrac, intFrac, enumFrac, 
+                                  missing_fraction, factorRange, numericRange, targetFactor)
+    #h2o.download_csv(glmDataSet, "/Users/.../dataset.csv") # save dataset
+    assert glmDataSet.nrow == nrow, "Dataset number of row: {0}, expected number of row: {1}".format(glmDataSet.nrow, 
+                                                                                                     nrow)
+    assert glmDataSet.ncol == (1+ncol), "Dataset number of row: {0}, expected number of row: " \
+                                                          "{1}".format(glmDataSet.ncol, (1+ncol))
+  
+def generate_dataset(family, nrow, ncol, ntrees, max_depth, realFrac, intFrac, enumFrac, missingFrac, 
+                     factorRange, numericRange, targetFactor):
+    if family=="bernoulli":
+        responseFactor = 2
+    elif family == 'gaussian':
+        responseFactor = 1;
+    else :
+        responseFactor = targetFactor
+        
+    trainData = random_dataset(nrow, ncol, realFrac=realFrac, intFrac=intFrac, enumFrac=enumFrac, factorR=factorRange,
+                               integerR=numericRange, responseFactor=responseFactor, misFrac=missingFrac)
+   
+    myX = trainData.names
+    myY = 'response'
+    myX.remove(myY)
+    m = H2OGradientBoostingEstimator(distribution=family,
+                                     ntrees=ntrees,
+                                     max_depth=max_depth)
+    m.train(training_frame=trainData,x=myX,y= myY)
+    f2 = m.predict(trainData)
+    
+    finalDataset = trainData[myX]
+    finalDataset = finalDataset.cbind(f2[0])
+    finalDataset.set_name(col=finalDataset.ncols-1, name='response')
+
+    h2o.remove(trainData)
+    return finalDataset
+
+def random_dataset(nrow, ncol, realFrac = 0.4, intFrac = 0.3, enumFrac = 0.3, factorR = 10, integerR=100, 
+                   responseFactor = 1, misFrac=0.01, randSeed=None):
+    fractions = dict()
+    fractions["real_fraction"] = realFrac  # Right now we are dropping string columns, so no point in having them.
+    fractions["categorical_fraction"] = enumFrac
+    fractions["integer_fraction"] = intFrac
+    fractions["time_fraction"] = 0
+    fractions["string_fraction"] = 0  # Right now we are dropping string columns, so no point in having them.
+    fractions["binary_fraction"] = 0
+
+    df = h2o.create_frame(rows=nrow, cols=ncol, missing_fraction=misFrac, has_response=True, 
+                          response_factors = responseFactor, integer_range=integerR,
+                          seed=randSeed, **fractions)
+    return df
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_define_dataset)
+else:
+    test_define_dataset()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_generate_synthetic_GLM_data.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_generate_synthetic_GLM_data.py
@@ -1,0 +1,87 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from builtins import range
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+import numpy as np
+
+# This test will generate synthetic GLM dataset.  If given to a GLM model, it should be able to perform well with 
+# this dataset since the assumptions associated with GLM are used to generate the dataset.
+def test_define_dataset():
+    family = 'binomial' # can be any valid GLM families
+    nrow = 100000
+    ncol = 10
+    realFrac = 0.4
+    intFrac = 0.3
+    enumFrac = 0.3
+    missing_fraction = 0
+    factorRange= 50
+    numericRange = 10
+    targetFactor = 1
+    glmDataSet = generate_dataset(family, nrow, ncol, realFrac, intFrac, enumFrac, missing_fraction, factorRange, 
+                                  numericRange, targetFactor)
+    #h2o.download_csv(glmDataSet, "/Users/.../dataset.csv") # save dataset
+    assert glmDataSet.nrow == nrow, "Dataset number of row: {0}, expected number of row: {1}".format(glmDataSet.nrow, 
+                                                                                                     nrow)
+    assert glmDataSet.ncol == (1+ncol), "Dataset number of row: {0}, expected number of row: " \
+                                                          "{1}".format(glmDataSet.ncol, (1+ncol))
+  
+def generate_dataset(family, nrow, ncol, realFrac, intFrac, enumFrac, missingFrac, factorRange, numericRange, 
+                     targetFactor):
+    if family=="binomial":
+        responseFactor = 2
+    elif family == 'gaussian':
+        responseFactor = 1;
+    else :
+        responseFactor = targetFactor
+        
+    trainData = random_dataset(nrow, ncol, realFrac=realFrac, intFrac=intFrac, enumFrac=enumFrac, factorR=factorRange, 
+                               integerR=numericRange, responseFactor=responseFactor, misFrac=missingFrac)
+   
+    myX = trainData.names
+    myY = 'response'
+    myX.remove(myY)
+
+    m = glm(family=family, max_iterations=1)
+    m.train(training_frame=trainData,x=myX,y= myY)
+    r = glm.getGLMRegularizationPath(m)
+    coeffDict = r['coefficients'][0]
+    coeffLen = len(coeffDict)
+    randCoeffVals = np.random.uniform(low=-3, high=3, size=coeffLen).tolist()
+    keyset = coeffDict.keys()
+    count = 0
+    for key in keyset:
+        coeffDict[key] = randCoeffVals[count]
+        count = count+1
+    
+    m2 = glm.makeGLMModel(model=m,coefs=coeffDict) # model generated from setting coefficients to model
+    f2 = m2.predict(trainData)
+    
+    finalDataset = trainData[myX]
+    finalDataset = finalDataset.cbind(f2[0])
+    finalDataset.set_name(col=finalDataset.ncols-1, name='response')
+
+    h2o.remove(trainData)
+    return finalDataset
+
+def random_dataset(nrow, ncol, realFrac = 0.4, intFrac = 0.3, enumFrac = 0.3, factorR = 10, integerR=100, 
+                   responseFactor = 1, misFrac=0.01, randSeed=None):
+    fractions = dict()
+    fractions["real_fraction"] = realFrac  # Right now we are dropping string columns, so no point in having them.
+    fractions["categorical_fraction"] = enumFrac
+    fractions["integer_fraction"] = intFrac
+    fractions["time_fraction"] = 0
+    fractions["string_fraction"] = 0  # Right now we are dropping string columns, so no point in having them.
+    fractions["binary_fraction"] = 0
+
+    df = h2o.create_frame(rows=nrow, cols=ncol, missing_fraction=misFrac, has_response=True, 
+                          response_factors = responseFactor, integer_range=integerR,
+                          seed=randSeed, **fractions)
+    return df
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_define_dataset)
+else:
+    test_define_dataset()


### PR DESCRIPTION
This PR completes the task in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7716

I have encountered this problem many times.  We need a good dataset to test a GLM/GBM/... algo.  The easiest way to generate a dataset for GLM is to input random input into a GLM with random coefficients and just attach the prediction of the GLM as the response to the random input.  Now, you have a dataset that is actually generated by a GLM model.  If the random inputs and responses are fed to another GLM model, in theory, it should be able to perform well on this dataset provided that it is big enough.  

This is how I generated dataset for GLM/Deeplearning/GBM models.  Inputs are random generated, response is just the predict of the GLM/Deeplearning/GBM models.

To generate big datasets, it is best to run the pyunits off hadoop with minor changes to the code.