### PR TITLE
HEXDEV-746 - Add left/right split levels for categoricals to H2O Tree API

### DIFF
--- a/h2o-algos/src/main/java/hex/schemas/TreeV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/TreeV3.java
@@ -47,4 +47,11 @@ public class TreeV3 extends SchemaV3<Iced, TreeV3> {
 
     @API(direction = API.Direction.OUTPUT, help = "Plain language rules that were used in a particular prediction")
     public String[] decision_paths;
+
+    @API(direction = API.Direction.OUTPUT, help = "Categorical levels leading to the left child node (if split is categorical)")
+    public String[][] left_cat_split;
+    
+    @API(direction = API.Direction.OUTPUT, help = "Categorical levels leading to the right child node (if split is categorical)")
+    public String[][] right_cat_split;
+
 }

--- a/h2o-py/h2o/tree/tree.py
+++ b/h2o-py/h2o/tree/tree.py
@@ -90,6 +90,8 @@ class H2OTree(object):
         self._root_node = self.__assemble_tree(0)
         self._tree_decision_path = response['tree_decision_path']
         self._decision_paths = response['decision_paths']
+        self._left_cat_split = response['left_cat_split']
+        self._right_cat_split = response['right_cat_split']
 
     @property
     def left_children(self):
@@ -451,6 +453,22 @@ class H2OTree(object):
                 self._right_children[i] = -1
 
         return node_ids
+
+    @property
+    def left_cat_split(self):
+        """
+        :return: Categorical levels leading to the left child node. Only present when split is categorical, otherwise none.
+        """
+        return self._left_cat_split
+
+    @property
+    def right_cat_split(self):
+        """
+        
+        :return: Categorical levels leading to the right child node. Only present when split is categorical, otherwise none.
+ 
+        """
+        return self._right_cat_split
 
     def __len__(self):
         """

--- a/h2o-py/tests/testdir_tree/pyunit_tree.py
+++ b/h2o-py/tests/testdir_tree/pyunit_tree.py
@@ -40,7 +40,18 @@ def tree_test():
     check_tree(tree, 0, "NO")
     assert tree.root_node.left_levels is not None#Only categoricals in the model, guaranteed to have categorical split
     assert tree.root_node.right_levels is not None #Only categoricals in the model, guaranteed to have categorical split
-
+    assert tree.left_cat_split is not None and tree.right_cat_split is not None
+    assert len(tree.left_cat_split) == len(tree.right_cat_split)
+    
+    # There are categorical splits only, check none of the cat splits is None
+    for i in range(0, len(tree.left_cat_split)):
+        if(tree.left_children[i] == -1 and tree.right_children[i] == -1): # Except leaf nodes, those should be None
+            assert tree.left_cat_split[i] is None
+            assert tree.right_cat_split[i] is None
+        else:
+            assert tree.left_cat_split[i] is not None
+            assert tree.right_cat_split[i] is not None
+    
     # DRF
     cars = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_nice_header.csv"))
     drf = H2ORandomForestEstimator(ntrees=2)
@@ -55,6 +66,16 @@ def tree_test():
     isofor.train(training_frame=ecg_discord)
 
     if_tree = H2OTree(isofor, 2)
+
+    # There are no categoricall splits, check none of the cat splits is None
+    for i in range(0, len(if_tree.node_ids)):
+        assert if_tree.left_cat_split[i] is None
+        assert if_tree.right_cat_split[i] is None
+        if(if_tree.left_children[i] == -1 and tree.right_children[i] == -1): # Leaf nodes don't have split thresholds
+            assert if_tree.thresholds is None
+        else: # All others nodes should have split thresholds
+            assert if_tree.thresholds[i] is not None
+            assert if_tree.thresholds[i] is not None
     check_tree(if_tree, 2)
 
 

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -4602,7 +4602,9 @@ print.H2ONode <- function(node){
 #' @slot nas A \code{character} representing if NA values go to the left node or right node. May be NA if node is a leaf.
 #' @slot predictions A \code{numeric} representing predictions for each node in the graph.
 #' @slot tree_decision_path A \code{character}, plain language rules representation of a trained decision tree    
-#' @slot decision_paths A \code{character} representing plain language rules that were used in a particular prediction.    
+#' @slot decision_paths A \code{character} representing plain language rules that were used in a particular prediction.
+#' @slot left_cat_split A \code{character} list of categorical levels leading to the left child node. Only present when split is categorical, otherwise none.
+#' @slot right_cat_split A \code{character} list of categorical levels leading to the right child node. Only present when split is categorical, otherwise none.
 #' @aliases H2OTree
 #' @export
 setClass(
@@ -4622,7 +4624,9 @@ setClass(
     nas = "character",
     predictions = "numeric",
     tree_decision_path = "character",
-    decision_paths = "character"
+    decision_paths = "character",
+    left_cat_split = "list",
+    right_cat_split = "list"
   )
 )
 
@@ -4747,6 +4751,14 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
     res$predictions <- as.numeric(res$predictions)
   }
   
+  if(is.logical(res$left_cat_split)){
+    res$left_cat_split <- as.list(res$left_cat_split)
+  }
+  
+  if(is.logical(res$right_cat_split)){
+    res$right_cat_split <- as.list(res$right_cat_split)
+  }
+  
   
   # Start of the tree-building process
   tree <- new(
@@ -4761,7 +4773,9 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
     nas = res$nas,
     predictions = res$predictions,
     tree_decision_path = res$tree_decision_path,
-    decision_paths = res$decision_paths
+    decision_paths = res$decision_paths,
+    left_cat_split = res$left_cat_split,
+    right_cat_split = res$right_cat_split
   )
 
   node_index <- 0

--- a/h2o-r/tests/testdir_misc/runit_tree.R
+++ b/h2o-r/tests/testdir_misc/runit_tree.R
@@ -26,6 +26,9 @@ test.gbm.trees <- function() {
   expect_true(is.null(gbm.tree@levels[[1]])) # Root node has no categorical splits
   expect_equal(length(gbm.tree@left_children), length(gbm.tree@levels))
   expect_true(!is.null(gbm.tree@model_id))
+  expect_false(is.null(gbm.tree@left_cat_split))
+  expect_false(is.null(gbm.tree@right_cat_split))
+  expect_equal(length(gbm.tree@right_cat_split), length(gbm.tree@left_cat_split))
   
   totalLength <- length(gbm.tree@left_children)
   expect_equal(totalLength, length(gbm.tree@descriptions))


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/HEXDEV-746

When walking the tree - it is useful to know which categorical levels (if the split is categorical) go to the left child and which go to the right child. Just a small checklist

- We already have NA directions in the `nas` field.
- The feature the split is made by/on is there as well in the `features` field.
- Our on-the-client assembled tree structure already has this feature. Only the scikit-like array format did not have it.