### PR TITLE
NCS Keys debugging sample

### DIFF
--- a/h2o-algos/src/test/java/water/DKVSnapshotExampleTest.java
+++ b/h2o-algos/src/test/java/water/DKVSnapshotExampleTest.java
@@ -6,6 +6,11 @@ import water.fvec.Frame;
 import water.runner.CloudSize;
 import water.runner.H2ORunner;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 @RunWith(H2ORunner.class)
 @CloudSize(1)
 public class DKVSnapshotExampleTest {
@@ -32,6 +37,11 @@ public class DKVSnapshotExampleTest {
             final Frame frame = Scope.track(TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv"));
             final KeySnapshot afterSnapshot = KeySnapshot.globalSnapshot();
             System.out.println(afterSnapshot.keys().length - beforeSnapshot.keys().length);
+            
+            final Set<Key> keyDiff = new HashSet<>(afterSnapshot.keys().length);
+            keyDiff.addAll(Arrays.asList(afterSnapshot.keys()));
+            keyDiff.removeAll(Arrays.asList(beforeSnapshot.keys()));
+            keyDiff.forEach(System.out::println);
         } finally {
             Scope.exit(); // Not related, just clears anything tracked in this tests
         }

--- a/h2o-algos/src/test/java/water/DKVSnapshotExampleTest.java
+++ b/h2o-algos/src/test/java/water/DKVSnapshotExampleTest.java
@@ -1,0 +1,40 @@
+package water;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class DKVSnapshotExampleTest {
+    @Test
+    public void histogramShowcase() {
+        Scope.enter();
+        try {
+            final Cleaner.Histo before = Cleaner.Histo.current(true);
+            final Frame frame = Scope.track(TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv"));
+            final Cleaner.Histo after = Cleaner.Histo.current(true);
+
+            System.out.println(after._total - before._total);
+        } finally {
+            Scope.exit(); // Not related, just clears anything tracked in this test
+        }
+
+    }
+
+    @Test
+    public void keySnapshotShowcase() {
+        Scope.enter();
+        try {
+            final KeySnapshot beforeSnapshot = KeySnapshot.globalSnapshot();
+            final Frame frame = Scope.track(TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv"));
+            final KeySnapshot afterSnapshot = KeySnapshot.globalSnapshot();
+            System.out.println(afterSnapshot.keys().length - beforeSnapshot.keys().length);
+        } finally {
+            Scope.exit(); // Not related, just clears anything tracked in this tests
+        }
+
+    }
+}


### PR DESCRIPTION
Introduced two test methods serving as samples on how to capture current state of DKV. The `Histo` histogram captures memory details, including allocated memory in bytes. The KeySnapshot captures state of DKV at the very point in time it is executed and returns information about cluster.

Below is this PR as a patch to easily apply to your codebase: 
```patch
Index: h2o-algos/src/test/java/water/DKVSnapshotExampleTest.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
--- h2o-algos/src/test/java/water/DKVSnapshotExampleTest.java	(revision 3c3b5124100215dde04c49946f0ccd56de013bb1)
+++ h2o-algos/src/test/java/water/DKVSnapshotExampleTest.java	(revision 3c3b5124100215dde04c49946f0ccd56de013bb1)
@@ -0,0 +1,50 @@
+package water;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class DKVSnapshotExampleTest {
+    @Test
+    public void histogramShowcase() {
+        Scope.enter();
+        try {
+            final Cleaner.Histo before = Cleaner.Histo.current(true);
+            final Frame frame = Scope.track(TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv"));
+            final Cleaner.Histo after = Cleaner.Histo.current(true);
+
+            System.out.println(after._total - before._total);
+        } finally {
+            Scope.exit(); // Not related, just clears anything tracked in this test
+        }
+
+    }
+
+    @Test
+    public void keySnapshotShowcase() {
+        Scope.enter();
+        try {
+            final KeySnapshot beforeSnapshot = KeySnapshot.globalSnapshot();
+            final Frame frame = Scope.track(TestUtil.parse_test_file("./smalldata/iris/iris_wheader.csv"));
+            final KeySnapshot afterSnapshot = KeySnapshot.globalSnapshot();
+            System.out.println(afterSnapshot.keys().length - beforeSnapshot.keys().length);
+            
+            final Set<Key> keyDiff = new HashSet<>(afterSnapshot.keys().length);
+            keyDiff.addAll(Arrays.asList(afterSnapshot.keys()));
+            keyDiff.removeAll(Arrays.asList(beforeSnapshot.keys()));
+            keyDiff.forEach(System.out::println);
+        } finally {
+            Scope.exit(); // Not related, just clears anything tracked in this tests
+        }
+
+    }
+}


```