### PR TITLE
H2ORunner not to ignore doonly test rules

### DIFF
--- a/h2o-test-support/src/main/java/water/runner/H2ORunner.java
+++ b/h2o-test-support/src/main/java/water/runner/H2ORunner.java
@@ -173,8 +173,9 @@ public class H2ORunner extends BlockJUnit4ClassRunner {
         
         final boolean isConfiguredAsIgnored = this.ignoreTestsNames.contains(testName);
         final boolean isConfiguredAsDoOnly = this.doOnlyTestNames.contains(testName);
-        
-        return isAnnotatedAsIgnored || (isConfiguredAsIgnored && !isConfiguredAsDoOnly);
+
+        return isAnnotatedAsIgnored || (isConfiguredAsIgnored && !isConfiguredAsDoOnly) 
+                || (!this.doOnlyTestNames.isEmpty() && !isConfiguredAsDoOnly);
     }
 
     private void createTestFilters() {


### PR DESCRIPTION
Doonly lists did not work - unfortunately. 

Jenkins will reveal the truth, also tested manually.
![Screenshot from 2020-08-06 20-33-56](https://user-images.githubusercontent.com/8769110/89569098-829d7180-d824-11ea-8d5d-182e628ee7d3.png)

Tested ignore lists work as well:

![Screenshot from 2020-08-06 20-34-20](https://user-images.githubusercontent.com/8769110/89569163-9c3eb900-d824-11ea-9f3b-8823d9ddcdb1.png)

