### PR TITLE
PUBDEV-7713 - Add implications of using Jetty 9 to migration documentation

### DIFF
--- a/h2o-docs/src/product/security.rst
+++ b/h2o-docs/src/product/security.rst
@@ -251,8 +251,8 @@ manipulated on the command line with the
 `keytool <http://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html>`_
 command.
 
-The underlying HTTPS implementation is provided by Jetty 8 and the Java
-runtime. (**Note**: Jetty 8 was chosen to retain Java 6 compatibility.)
+The underlying HTTPS implementation is provided by Jetty 9 and the Java
+runtime.
 
 Standalone H2O
 ''''''''''''''
@@ -684,9 +684,6 @@ Example **ldap.conf**:
         userBaseDn="ou=users,dc=0xdata,dc=loc";
     };
 
-See the `Jetty 8 LdapLoginModule
-documentation <http://wiki.eclipse.org/Jetty/Feature/JAAS#LdapLoginModule>`__
-for more information.
 
 Standalone H2O
 ''''''''''''''
@@ -965,9 +962,9 @@ tool:
 
     java -cp h2o.jar org.eclipse.jetty.util.security.Password username password
 
-See the `Jetty 8 HashLoginService
+See the `Jetty 9 HashLoginService
 documentation <http://wiki.eclipse.org/Jetty/Tutorial/Realms#HashLoginService>`_
-and `Jetty 8 Secure Password
+and `Jetty 9 Secure Password
 HOWTO <http://wiki.eclipse.org/Jetty/Howto/Secure_Passwords>`_ for more
 information.
 

--- a/h2o-docs/src/product/upgrade/Migration.md
+++ b/h2o-docs/src/product/upgrade/Migration.md
@@ -1,3 +1,32 @@
+# Migrating to H2O 3.30.1.1
+
+Jetty version 8 has been dropped as default implementation of `h2o-webserver-iface` module, as it is not actively developed and supported anymore.
+To ensure H2O uses Jetty with the latest fixes with strong emphasis on security, it has been replaced with a more recent version of Jetty 9, starting at version `9.4.11.v20180605`.
+Simply switching over to Jetty 9 has technical implications which had to be addressed. The most significant one is incompatibility with Hadoop 2.x based distributions,
+in cases when H2O is running on Hadoop. For Hadoop 3.x based distributions, Jetty 9 has been used inside H2O from the start.
+
+## Shadowing
+
+Since release `3.30.1.1`, Jetty 9 is bundled even for Hadoop 2.x based distributions. To avoid classpath collisions, as Hadoop 2.x distributions typically
+bundle some version of Jetty 8, the Jetty 9 inside H2O is **shadowed**. 
+
+- The original package names starting with `org.eclipse.jetty.*` have been shadowed by using `ai.h2o` prefix, resulting in
+`ai.h2o.org.eclipse.jetty.*` pattern.
+
+## LDAP login module
+
+H2O's official [documentation](https://docs.h2o.ai/h2o/latest-stable/h2o-docs/security.html) advises to use `ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModule` class for LDAP configuration.
+Such configuration is still the **valid** one after this change.
+However, due to Jetty not being shadow in previous versions, some users still used the variant without `ai.h2o` package prefix: `org.eclipse.jetty.plus.jaas.spi.LdapLoginModule`.
+On Hadoop 3 based distributions, where Jetty 9 had already been present before this complete migration to Jetty 9, some users might have been able to use `org.eclipse.jetty.jaas.spi.LdapLoginModule` 
+(missing `plus` package). This is no longer possible and users should always turn to the official [documentation](https://docs.h2o.ai/h2o/latest-stable/h2o-docs/security.html) 
+
+## Embedded H2O implications
+
+The module `h2o-jetty-9` builds a `jar` containing eclipse packages in the relocated form to the `ai.h2o.org.eclipse.*` package.
+The same applies for `h2o-jetty-8` module, which is now considered deprecated. Any systems embedding H2O are advised to use `h2o-jetty-9` module instead.
+API of Jetty 8 and 9 varies, therefore in the unlikely case of H2O being embedded in a system which uses Jetty APIs directly, changes related to the API differences must be made.
+
 # Migrating to H2O 3.0
 
 We're excited about the upcoming release of the latest and greatest version of H2O, and we hope you are too! H2O 3.0 has lots of improvements, including: 


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7713

Just a small note, the original version according to documentation was ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModule required

https://docs.h2o.ai/h2o/latest-stable/h2o-docs/security.html

This has been there since January 2018, as Jetty 8 had been upgraded. The class `ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModuleis still present, therefore this should not break anything per se. Some users might use the old eclipse version and for those, there is the note that this is no longer supported. Yet from official H2O documentation’s POV, **this is not a breaking change.**

Also updated technote: https://0xdata.atlassian.net/browse/PUBDEV-7713