### PR TITLE
HEXDEV-746 - Add left/right split levels for categoricals to H2O Tree API

### DIFF
--- a/h2o-py/h2o/tree/tree.py
+++ b/h2o-py/h2o/tree/tree.py
@@ -90,6 +90,9 @@ class H2OTree(object):
         self._root_node = self.__assemble_tree(0)
         self._tree_decision_path = response['tree_decision_path']
         self._decision_paths = response['decision_paths']
+        (left, right) = self.__per_node_cat_splits()
+        self._left_cat_split = left
+        self._right_cat_split = right
 
     @property
     def left_children(self):
@@ -451,6 +454,41 @@ class H2OTree(object):
                 self._right_children[i] = -1
 
         return node_ids
+
+    def __per_node_cat_splits(self):
+
+        num_records = len(self.left_children)
+        per_node_levels_left = [None] * num_records
+        per_node_levels_right = [None] * num_records
+        for i in range(0, (len(self.left_children))):
+
+            # -1 means leaf - if a node is leaf node, there is not child and thus no split
+            left_idx = self._left_children[i]
+            right_idx = self._right_children[i]
+
+            if (left_idx != -1):
+                per_node_levels_left[i] = (self.levels[left_idx])
+
+            if (right_idx != -1):
+                per_node_levels_right[i] = (self.levels[right_idx])
+
+        return (per_node_levels_left, per_node_levels_right)
+
+    @property
+    def left_cat_split(self):
+        """
+        :return: Categorical levels leading to the left child node. Only present when split is categorical, otherwise none.
+        """
+        return self._left_cat_split
+
+    @property
+    def right_cat_split(self):
+        """
+        
+        :return: Categorical levels leading to the right child node. Only present when split is categorical, otherwise none.
+ 
+        """
+        return self._right_cat_split
 
     def __len__(self):
         """

--- a/h2o-py/tests/testdir_tree/pyunit_tree.py
+++ b/h2o-py/tests/testdir_tree/pyunit_tree.py
@@ -40,6 +40,17 @@ def tree_test():
     check_tree(tree, 0, "NO")
     assert tree.root_node.left_levels is not None#Only categoricals in the model, guaranteed to have categorical split
     assert tree.root_node.right_levels is not None #Only categoricals in the model, guaranteed to have categorical split
+    assert tree.left_cat_split is not None and tree.right_cat_split is not None
+    assert len(tree.left_cat_split) == len(tree.right_cat_split)
+
+    # There are categorical splits only, check none of the cat splits is None
+    for i in range(0, len(tree.left_cat_split)):
+        if(tree.left_children[i] == -1 and tree.right_children[i] == -1): # Except leaf nodes, those should be None
+            assert tree.left_cat_split[i] is None
+            assert tree.right_cat_split[i] is None
+        else:
+            assert tree.left_cat_split[i] is not None
+            assert tree.right_cat_split[i] is not None
 
     # DRF
     cars = h2o.import_file(path=pyunit_utils.locate("smalldata/junit/cars_nice_header.csv"))
@@ -55,6 +66,16 @@ def tree_test():
     isofor.train(training_frame=ecg_discord)
 
     if_tree = H2OTree(isofor, 2)
+
+    # There are no categoricall splits, check none of the cat splits is None
+    for i in range(0, len(if_tree.node_ids)):
+        assert if_tree.left_cat_split[i] is None
+        assert if_tree.right_cat_split[i] is None
+        if(if_tree.left_children[i] == -1 and tree.right_children[i] == -1): # Leaf nodes don't have split thresholds
+            assert if_tree.thresholds is None
+        else: # All others nodes should have split thresholds
+            assert if_tree.thresholds[i] is not None
+            assert if_tree.thresholds[i] is not None
     check_tree(if_tree, 2)
 
 

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -4602,7 +4602,9 @@ print.H2ONode <- function(node){
 #' @slot nas A \code{character} representing if NA values go to the left node or right node. May be NA if node is a leaf.
 #' @slot predictions A \code{numeric} representing predictions for each node in the graph.
 #' @slot tree_decision_path A \code{character}, plain language rules representation of a trained decision tree    
-#' @slot decision_paths A \code{character} representing plain language rules that were used in a particular prediction.    
+#' @slot decision_paths A \code{character} representing plain language rules that were used in a particular prediction.
+#' @slot left_cat_split A \code{character} list of categorical levels leading to the left child node. Only present when split is categorical, otherwise none.
+#' @slot right_cat_split A \code{character} list of categorical levels leading to the right child node. Only present when split is categorical, otherwise none.
 #' @aliases H2OTree
 #' @export
 setClass(
@@ -4622,7 +4624,9 @@ setClass(
     nas = "character",
     predictions = "numeric",
     tree_decision_path = "character",
-    decision_paths = "character"
+    decision_paths = "character",
+    left_cat_split = "list",
+    right_cat_split = "list"
   )
 )
 
@@ -4847,6 +4851,24 @@ h2o.getModelTree <- function(model, tree_number, tree_class = NA) {
       }
     }
   }
+  
+  for (i in 1: length(tree@left_children)){
+    left_idx = tree@left_children[i]
+    right_idx = tree@right_children[i]
+    
+    if(left_idx != -1){
+      tree@left_cat_split[i] <- tree@levels[left_idx + 1]
+    } else {
+      tree@left_cat_split[i] <- NULL
+    }
+    
+    if(right_idx != -1){
+      tree@right_cat_split[i] <- tree@levels[right_idx + 1]
+    } else {
+      tree@right_cat_split[i] <- NULL
+    }
+  }
+  
   tree@root_node <- .h2o.walk_tree(0, tree)
   tree
 }

--- a/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
+++ b/h2o-r/tests/testdir_jira/runit_pubdev_5735.R
@@ -5,7 +5,7 @@ source("../../scripts/h2o-r-test-setup.R")
 
 test.gbm.trees <- function() {
   airlines.data <- h2o.importFile(path = locate('smalldata/testng/airlines_train.csv'))
-  gbm.model <- h2o.gbm(x=c("Origin", "Dest", "Distance"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
+  gbm.model <- h2o.gbm(x=c("Origin", "Dest"),y="IsDepDelayed",training_frame=airlines.data ,model_id="gbm_trees_model", ntrees = 1, seed = 1)
   gbm.tree <-h2o.getModelTree(gbm.model, 1, "NO") # Model only has one tree. If these numbers are changed, tests fails. This ensures index translation between R API and Java works.
   
   expect_equal("H2OTree", class(gbm.tree)[1])
@@ -26,7 +26,13 @@ test.gbm.trees <- function() {
   expect_true(is.null(gbm.tree@levels[[1]])) # Root node has no categorical splits
   expect_equal(length(gbm.tree@left_children), length(gbm.tree@levels))
   expect_true(!is.null(gbm.tree@model_id))
+  expect_false(is.null(gbm.tree@left_cat_split))
+  expect_false(is.null(gbm.tree@right_cat_split))
+  expect_equal(length(gbm.tree@right_cat_split), length(gbm.tree@left_cat_split))
   
+  print(gbm.tree@left_children)
+  print(gbm.tree@left_cat_split)
+  print(gbm.tree@right_cat_split)
   totalLength <- length(gbm.tree@left_children)
   expect_equal(totalLength, length(gbm.tree@descriptions))
   


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/HEXDEV-746

When walking the tree - it is useful to know which categorical levels (if the split is categorical) go to the left child and which go to the right child. Just a small checklist

    We already have NA directions in the nas field.
    The feature the split is made by/on is there as well in the features field.
    Our on-the-client assembled tree structure already has this feature. Only the scikit-like array format did not have it.

This PR is https://github.com/h2oai/h2o-3/pull/4834 **reworked** to do all the heavy lifting on client only.