### PR TITLE
Check for at sign before trying to run K8S test cluster

### DIFF
--- a/h2o-k8s/tests/clustering/docker-init-script.sh
+++ b/h2o-k8s/tests/clustering/docker-init-script.sh
@@ -2,6 +2,10 @@
 
 pwd
 export H2O_BASE=$(pwd)
+if [[ $string == *"@"* ]]; then
+  echo "H2O base path contains at sign. Unable to create K3S cluster."
+  exit 1
+fi
 cd $H2O_BASE/h2o-k8s/tests/clustering/
 k3d --version
 k3d delete


### PR DESCRIPTION
This is for the convenience of people reading the error log - as the message about volume binding failed is hidden somewhere in the middle of a long log.

This way, it will fail right away and not wait for H2O to start. Also, the error message will be clear to anyone.

Change proposed by @michalkurka .