### PR TITLE
PUBDEV-7654 - Reduce memory cost of drop duplicates opreation by cleaning up early.

### DIFF
--- a/h2o-core/src/main/java/water/rapids/ast/prims/filters/dropduplicates/DropDuplicateRows.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/filters/dropduplicates/DropDuplicateRows.java
@@ -44,9 +44,11 @@ public class DropDuplicateRows {
       final Frame deDuplicatedFrame = Scope.track(new DropDuplicateRowsTask(chunkBoundaries, comparedColumnIndices)
               .doAll(sortedFrame.types(), sortedFrame)
               .outputFrame(null, sortedFrame.names(), sortedFrame.domains())); // Removing duplicates, domains remain the same
-
+      // Before the final sorted duplicated is created, remove the unused datasets to free some space early
+      chunkBoundaries.remove();
+      sortedFrame.remove();
       outputFrame = Scope.track(Merge.sort(deDuplicatedFrame, deDuplicatedFrame.numCols() - 1));
-      outputFrame.remove(outputFrame.numCols() - 1);
+      outputFrame.remove(outputFrame.numCols() - 1).remove();
       return outputFrame;
     } finally {
       if (outputFrame != null) {

--- a/h2o-core/src/test/java/water/rapids/ast/prims/filters/dropduplicates/AstDropDuplicatesTest.java
+++ b/h2o-core/src/test/java/water/rapids/ast/prims/filters/dropduplicates/AstDropDuplicatesTest.java
@@ -150,4 +150,30 @@ public class AstDropDuplicatesTest {
     }
   }
 
+
+  @Test
+  public void testDropUniquesOnColumnSubset() {
+    try {
+      Scope.enter();
+      final Frame frame = new TestFrameBuilder()
+          .withColNames("C1", "C2", "C3", "C4")
+          .withDataForCol(0, new double[]{1d, 1d, 1d, 1d, 1d, 2d, 2d})
+          .withDataForCol(1, new double[]{2d, 2d, 2d, 2d, 2d, 3d, 3d})
+          .withDataForCol(2, new double[]{3d, 2d, 2d, 2d, 2d, 3d, 3d})
+          .withDataForCol(3, new double[]{4d, 2d, 2d, 2d, 2d, 3d, 3d})
+          .withChunkLayout(7)
+          .withVecTypes(Vec.T_NUM, Vec.T_NUM, Vec.T_NUM, Vec.T_NUM)
+          .build();
+
+      Val val = Rapids.exec(String.format("(dropdup %s ['C1', 'C2'] first)", frame._key.toString()));
+      assertNotNull(val);
+      assertTrue(val.isFrame());
+      final Frame deduplicatedFrame = Scope.track(val.getFrame());
+      assertEquals(2, deduplicatedFrame.numRows());
+      assertEquals(frame.numCols(), deduplicatedFrame.numCols());
+    } finally {
+      Scope.exit();
+    }
+  }
+
 }


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7654

## Foreword :wink: :rofl: 

So, I was investigating how to impllement the ways of reducing memory overhead of `DropDuplicates` operation. The projected solution seems to be:

1. Implement in-place sorting to reduce cost of 1 internal frame being duplicated.
1. Do sorting only on the columns actually being sorted.

Second point comes with a price - there needs to be one linear pass (as chunking changes during Merge completely) that duplicates the original vecs (as the result of DropDuplicates operation must always be a new Frame) and removes the removed lines. Advantage of doing that is therefore debatable and the ultimate memory-reducing solution therefore remains implementing a non-duplicating, high performance distributed sort.

## Why this PR

While I was at it, I noticed we **might clean up some data** immediately after those are not required, freeing some space and not stacking everything multiple times into memory at once. The original `sortedFrame` is no longer required after it is deduplicated, as well as the chunk boundary values. Therefore, this is now deleted before the final sort begins - frees one copy of the whole frame from the memory. Still tracking those with scope, as those should be removed in case of any exception and scope takes care of that.

This is the least we can do absolutely **for free**, so why not do it :) 