### PR TITLE
Fix outside dataset path to use local dataset path

### DIFF
--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7460_gam_accuracy_others_large.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7460_gam_accuracy_others_large.py
@@ -9,7 +9,7 @@ from h2o.estimators.glm import H2OGeneralizedLinearEstimator
 
 # In this test, we check and make sure that we can print out all relevevant model metrics for Binomial
 def test_gam_model_predict():
-    path = 'https://raw.githubusercontent.com/h2oai/app-consumer-loan/master/data/loan.csv'
+    path = pyunit_utils.locate("bigdata/laptop/lending-club/loan.csv")
     col_types = {'bad_loan': 'enum'}
     frame = h2o.import_file(path=path, col_types=col_types) # import from url
     frame.describe() # summarize table

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7588_GLM_interaction_lambda0.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7588_GLM_interaction_lambda0.py
@@ -9,10 +9,10 @@ from tests import pyunit_utils
 # Wzhen Lambda=0, the use_all_factor_levels is automatically set to False.  This runs into the bug of
 # interaction vector domain creation.
 def test_interaction_Lambda0():
-    data = h2o.import_file("https://raw.githubusercontent.com/guru99-edu/R-Programming/master/adult.csv")
+    data = h2o.import_file(pyunit_utils.locate("smalldata/census_income/adult_data.csv"))
     data['y'] = data['hours-per-week'] / data['age']
     
-    model_cust = H2OGeneralizedLinearEstimator(interactions = ["income", "gender"],
+    model_cust = H2OGeneralizedLinearEstimator(interactions = ["income", "sex"],
                                            family = "tweedie",
                                            tweedie_variance_power = 1.7, tweedie_link_power = 0,
                                            Lambda = 0,
@@ -20,7 +20,7 @@ def test_interaction_Lambda0():
                                            compute_p_values = True,
                                            remove_collinear_columns = True,
                                            standardize = True, weights_column = "age", solver="IRLSM")
-    model_cust.train(x = ["income", "gender"], y = "y", training_frame = data)
+    model_cust.train(x = ["income", "sex"], y = "y", training_frame = data)
     coef = len(model_cust.coef())
     expected_coeff_len = 1+1+1+1 # 1 for gender, 1 for income, 1 for gender_income interaction and 1 for intercept
     assert coef == expected_coeff_len, "Expected coefficient length: {0}, actual: {1} and they are different.".format(expected_coeff_len, coef)


### PR DESCRIPTION
@michalk discovered the failure reason for the following test:

pyunit_PUBDEV_7460_gam_accuracy_others.py
pyunit_PUBDEV_7588_GLM_interaction_lambda0.py

The failure reason is due to access to external datasets.  I moved the reference to external datasets to using local datasets.  I am still using the same datasets.