### PR TITLE
PUBDEV-7743: new TargetEncoder param allowing to remove original features automatically

### DIFF
--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -43,6 +43,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
     public double _smoothing =DEFAULT_BLENDING_PARAMS.getSmoothing();
     public DataLeakageHandlingStrategy _data_leakage_handling = DataLeakageHandlingStrategy.None;
     public double _noise = 0.01;
+    public boolean _keep_original_features = true; // not a good default, but backwards compatible.
     
     @Override
     public String algoName() {
@@ -333,6 +334,9 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
             tmpKey = workingFrame._key;
           }
         } // end for each target 
+        
+        if (!_parms._keep_original_features)
+          workingFrame.remove(colIdx);
       } // end for each columnToEncode
 
       DKV.remove(tmpKey);

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderModel.java
@@ -43,7 +43,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
     public double _smoothing =DEFAULT_BLENDING_PARAMS.getSmoothing();
     public DataLeakageHandlingStrategy _data_leakage_handling = DataLeakageHandlingStrategy.None;
     public double _noise = 0.01;
-    public boolean _keep_original_features = true; // not a good default, but backwards compatible.
+    public boolean _keep_original_categorical_columns = true; // not a good default, but backwards compatible.
     
     @Override
     public String algoName() {
@@ -91,7 +91,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
       _target_encoding_map = teMap;
       _model_summary = constructSummary();
 
-      _te_column_to_hasNAs = buildCol2HasNAsMap(); 
+      _te_column_to_hasNAs = buildCol2HasNAsMap();
     }
 
     private IcedHashMap<String, Boolean> buildCol2HasNAsMap() {
@@ -335,7 +335,7 @@ public class TargetEncoderModel extends Model<TargetEncoderModel, TargetEncoderM
           }
         } // end for each target 
         
-        if (!_parms._keep_original_features)
+        if (!_parms._keep_original_categorical_columns)
           workingFrame.remove(colIdx);
       } // end for each columnToEncode
 

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -11,7 +11,11 @@ import java.util.List;
 
 public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoder, TargetEncoderV3, TargetEncoderV3.TargetEncoderParametersV3> {
   public static class TargetEncoderParametersV3 extends ModelParametersSchemaV3<TargetEncoderModel.TargetEncoderParameters, TargetEncoderParametersV3> {
-    
+
+    @API(help = "If true, the original non-encoded categorical features will remain in the result frame.",
+            level = API.Level.secondary)
+    public boolean keep_original_features;
+
     @API(help = "If true, enables blending of posterior probabilities (computed for a given categorical value) " +
             "with prior probabilities (computed on the entire set). " +
             "This allows to mitigate the effect of categorical values with small cardinality. " +
@@ -38,13 +42,14 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoder, TargetEnc
             valuesProvider = DataLeakageHandlingStrategyProvider.class, 
             level = API.Level.secondary)
     public DataLeakageHandlingStrategy data_leakage_handling;
-
+    
     @API(help = "The amount of noise to add to the encoded column. " +
             "Use 0 to disable noise, and -1 (=AUTO) to let the algorithm determine a reasonable amount of noise.",
-            required = false, direction = API.Direction.INPUT, gridable = true, level = API.Level.expert)
+            direction = API.Direction.INPUT, gridable = true, level = API.Level.expert)
     public double noise;
     
-    @API(help = "Seed used to generate the noise. By default, the seed is chosen randomly.", required = false, direction = API.Direction.INPUT)
+    @API(help = "Seed used to generate the noise. By default, the seed is chosen randomly.", 
+            direction = API.Direction.INPUT, level = API.Level.expert)
     public long seed;
   
     @Override

--- a/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
+++ b/h2o-extensions/target-encoder/src/main/java/hex/schemas/TargetEncoderV3.java
@@ -13,8 +13,8 @@ public class TargetEncoderV3 extends ModelBuilderSchema<TargetEncoder, TargetEnc
   public static class TargetEncoderParametersV3 extends ModelParametersSchemaV3<TargetEncoderModel.TargetEncoderParameters, TargetEncoderParametersV3> {
 
     @API(help = "If true, the original non-encoded categorical features will remain in the result frame.",
-            level = API.Level.secondary)
-    public boolean keep_original_features;
+            level = API.Level.critical)
+    public boolean keep_original_categorical_columns;
 
     @API(help = "If true, enables blending of posterior probabilities (computed for a given categorical value) " +
             "with prior probabilities (computed on the entire set). " +

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
@@ -300,6 +300,81 @@ public class TargetEncoderModelTest extends TestUtil{
     }
   }
   
+  @Test
+  public void test_original_features_are_kept_by_default() {
+    try {
+      Scope.enter();
+      final Frame fr = new TestFrameBuilder()
+              .withColNames("categorical", "target")
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "b", "b"))
+              .withDataForCol(1, ar("N", "Y", "Y", "N"))
+              .build();
+
+      TargetEncoderParameters params = new TargetEncoderParameters();
+      params._train = fr._key;
+      params._response_column = "target";
+      params._noise = 0;
+      params._seed = 0XFEED;
+
+
+      TargetEncoder te = new TargetEncoder(params);
+      final TargetEncoderModel teModel = te.trainModel().get();
+      Scope.track_generic(teModel);
+
+      Frame transformed = Scope.track(teModel.transformTraining(fr));
+      assertTrue(ArrayUtils.contains(transformed.names(), "categorical"));
+
+      transformed = Scope.track(teModel.transform(fr));
+      assertTrue(ArrayUtils.contains(transformed.names(), "categorical"));
+
+      transformed = Scope.track(teModel.score(fr));
+      assertTrue(ArrayUtils.contains(transformed.names(), "categorical"));
+
+      assertTrue(ArrayUtils.contains(fr.names(), "categorical"));
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  @Test
+  public void test_original_features_are_all_removed_when_kept_original_features_is_disabled() {
+    try {
+      Scope.enter();
+      final Frame fr = new TestFrameBuilder()
+              .withColNames("categorical", "target")
+              .withVecTypes(Vec.T_CAT, Vec.T_CAT)
+              .withDataForCol(0, ar("a", "b", "b", "b"))
+              .withDataForCol(1, ar("N", "Y", "Y", "N"))
+              .build();
+
+      TargetEncoderParameters params = new TargetEncoderParameters();
+      params._train = fr._key;
+      params._response_column = "target";
+      params._noise = 0;
+      params._seed = 0XFEED;
+      params._keep_original_features = false;
+
+
+      TargetEncoder te = new TargetEncoder(params);
+      final TargetEncoderModel teModel = te.trainModel().get();
+      Scope.track_generic(teModel);
+
+      Frame transformed = Scope.track(teModel.transformTraining(fr));
+      assertFalse(ArrayUtils.contains(transformed.names(), "categorical"));
+
+      transformed = Scope.track(teModel.transform(fr));
+      assertFalse(ArrayUtils.contains(transformed.names(), "categorical"));
+
+      transformed = Scope.track(teModel.score(fr));
+      assertFalse(ArrayUtils.contains(transformed.names(), "categorical"));
+
+      assertTrue(ArrayUtils.contains(fr.names(), "categorical"));
+    } finally {
+      Scope.exit();
+    }
+  }
+  
   
   private static class RowIndexTask extends MRTask<RowIndexTask> {
     static String ROW_INDEX_COL = "__row_index";

--- a/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
+++ b/h2o-extensions/target-encoder/src/test/java/ai/h2o/targetencoding/TargetEncoderModelTest.java
@@ -338,7 +338,7 @@ public class TargetEncoderModelTest extends TestUtil{
   }
   
   @Test
-  public void test_original_features_are_all_removed_when_kept_original_features_is_disabled() {
+  public void test_original_features_are_all_removed_when_keep_original_categorical_columns_is_disabled() {
     try {
       Scope.enter();
       final Frame fr = new TestFrameBuilder()
@@ -353,7 +353,7 @@ public class TargetEncoderModelTest extends TestUtil{
       params._response_column = "target";
       params._noise = 0;
       params._seed = 0XFEED;
-      params._keep_original_features = false;
+      params._keep_original_categorical_columns = false;
 
 
       TargetEncoder te = new TargetEncoder(params);

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -23,8 +23,9 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     """
 
     algo = "targetencoder"
-    param_names = {"model_id", "training_frame", "fold_column", "response_column", "ignored_columns", "blending",
-                   "inflection_point", "smoothing", "data_leakage_handling", "noise", "seed"}
+    param_names = {"model_id", "training_frame", "fold_column", "response_column", "ignored_columns",
+                   "keep_original_features", "blending", "inflection_point", "smoothing", "data_leakage_handling",
+                   "noise", "seed"}
 
     def __init__(self, **kwargs):
         super(H2OTargetEncoderEstimator, self).__init__()
@@ -130,6 +131,21 @@ class H2OTargetEncoderEstimator(H2OEstimator):
     def ignored_columns(self, ignored_columns):
         assert_is_type(ignored_columns, None, [str])
         self._parms["ignored_columns"] = ignored_columns
+
+
+    @property
+    def keep_original_features(self):
+        """
+        If true, the original non-encoded categorical features will remain in the result frame.
+
+        Type: ``bool``  (default: ``True``).
+        """
+        return self._parms.get("keep_original_features")
+
+    @keep_original_features.setter
+    def keep_original_features(self, keep_original_features):
+        assert_is_type(keep_original_features, None, bool)
+        self._parms["keep_original_features"] = keep_original_features
 
 
     @property

--- a/h2o-py/h2o/estimators/targetencoder.py
+++ b/h2o-py/h2o/estimators/targetencoder.py
@@ -24,8 +24,8 @@ class H2OTargetEncoderEstimator(H2OEstimator):
 
     algo = "targetencoder"
     param_names = {"model_id", "training_frame", "fold_column", "response_column", "ignored_columns",
-                   "keep_original_features", "blending", "inflection_point", "smoothing", "data_leakage_handling",
-                   "noise", "seed"}
+                   "keep_original_categorical_columns", "blending", "inflection_point", "smoothing",
+                   "data_leakage_handling", "noise", "seed"}
 
     def __init__(self, **kwargs):
         super(H2OTargetEncoderEstimator, self).__init__()
@@ -134,18 +134,18 @@ class H2OTargetEncoderEstimator(H2OEstimator):
 
 
     @property
-    def keep_original_features(self):
+    def keep_original_categorical_columns(self):
         """
         If true, the original non-encoded categorical features will remain in the result frame.
 
         Type: ``bool``  (default: ``True``).
         """
-        return self._parms.get("keep_original_features")
+        return self._parms.get("keep_original_categorical_columns")
 
-    @keep_original_features.setter
-    def keep_original_features(self, keep_original_features):
-        assert_is_type(keep_original_features, None, bool)
-        self._parms["keep_original_features"] = keep_original_features
+    @keep_original_categorical_columns.setter
+    def keep_original_categorical_columns(self, keep_original_categorical_columns):
+        assert_is_type(keep_original_categorical_columns, None, bool)
+        self._parms["keep_original_categorical_columns"] = keep_original_categorical_columns
 
 
     @property

--- a/h2o-py/tests/testdir_algos/targetencoder/pyunit_targetencoder_model.py
+++ b/h2o-py/tests/testdir_algos/targetencoder/pyunit_targetencoder_model.py
@@ -27,11 +27,9 @@ def test_target_encoding_full_scenario():
     te.train(training_frame=trainingFrame, 
              x=teColumns, 
              y=targetColumnName)
-    print(te)
     transformed = te.transform(trainingFrame, as_training=True)
     
     assert transformed is not None
-    print(transformed.names)
     assert transformed.ncols == trainingFrame.ncols + len(teColumns)
     for te_col in teColumns:
         assert te_col + "_te" in transformed.names
@@ -101,11 +99,7 @@ def test_target_encoded_frame_does_not_contain_fold_column():
                                    fold_column=foldColumnName,
                                    seed=1234)
     te.train(training_frame=trainingFrame, x=teColumns, y=targetColumnName)
-    print(te)
-    print(trainingFrame)
-
     model_summary = te._model_json['output']['model_summary'].as_data_frame()
-    print(model_summary)
     encoded_column_names = model_summary['encoded_column_name']
 
     # Checking that we don't have empty entries in TwoDim table
@@ -120,7 +114,41 @@ def test_target_encoded_frame_does_not_contain_fold_column():
     assert foldColumnName+"_te" not in transformed.col_names
 
 
+def test_original_features_are_kept_by_default():
+    target = "survived"
+    teColumns = ["cabin", "embarked"]
+    trainingFrame = h2o.import_file(pu.locate("smalldata/gbm_test/titanic.csv"), header=1)
+
+    trainingFrame[target] = trainingFrame[target].asfactor()
+
+    te = H2OTargetEncoderEstimator()
+    te.train(training_frame=trainingFrame, x=teColumns, y=target)
+    
+    transformed = te.transform(trainingFrame)
+    for col in teColumns:
+        assert "{}_te".format(col) in transformed.names
+        assert col in transformed.names
+    
+
+def test_original_features_can_be_automatically_removed_from_result_frame():
+    target = "survived"
+    teColumns = ["cabin", "embarked"]
+    trainingFrame = h2o.import_file(pu.locate("smalldata/gbm_test/titanic.csv"), header=1)
+
+    trainingFrame[target] = trainingFrame[target].asfactor()
+
+    te = H2OTargetEncoderEstimator(keep_original_features=False)
+    te.train(training_frame=trainingFrame, x=teColumns, y=target)
+
+    transformed = te.transform(trainingFrame)
+    for col in teColumns:
+        assert "{}_te".format(col) in transformed.names
+        assert col not in transformed.names
+
+
 pu.run_tests([
     test_target_encoding_full_scenario,
     test_target_encoded_frame_does_not_contain_fold_column,
+    test_original_features_are_kept_by_default,
+    test_original_features_can_be_automatically_removed_from_result_frame
 ])

--- a/h2o-py/tests/testdir_algos/targetencoder/pyunit_targetencoder_model.py
+++ b/h2o-py/tests/testdir_algos/targetencoder/pyunit_targetencoder_model.py
@@ -137,7 +137,7 @@ def test_original_features_can_be_automatically_removed_from_result_frame():
 
     trainingFrame[target] = trainingFrame[target].asfactor()
 
-    te = H2OTargetEncoderEstimator(keep_original_features=False)
+    te = H2OTargetEncoderEstimator(keep_original_categorical_columns=False)
     te.train(training_frame=trainingFrame, x=teColumns, y=target)
 
     transformed = te.transform(trainingFrame)

--- a/h2o-r/h2o-package/R/targetencoder.R
+++ b/h2o-r/h2o-package/R/targetencoder.R
@@ -13,6 +13,8 @@
 #' @param training_frame Id of the training data frame.
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
+#' @param keep_original_features \code{Logical}. If true, the original non-encoded categorical features will remain in the result frame.
+#'        Defaults to TRUE.
 #' @param blending \code{Logical}. If true, enables blending of posterior probabilities (computed for a given categorical value)
 #'        with prior probabilities (computed on the entire set). This allows to mitigate the effect of categorical
 #'        values with small cardinality. The blending effect can be tuned using the `inflection_point` and `smoothing`
@@ -69,6 +71,7 @@ h2o.targetencoder <- function(x,
                               training_frame,
                               model_id = NULL,
                               fold_column = NULL,
+                              keep_original_features = TRUE,
                               blending = FALSE,
                               inflection_point = 10,
                               smoothing = 20,
@@ -117,6 +120,8 @@ h2o.targetencoder <- function(x,
     parms$model_id <- model_id
   if (!missing(fold_column))
     parms$fold_column <- fold_column
+  if (!missing(keep_original_features))
+    parms$keep_original_features <- keep_original_features
   if (!missing(blending))
     parms$blending <- blending
   if (!missing(inflection_point))
@@ -138,6 +143,7 @@ h2o.targetencoder <- function(x,
                                               y,
                                               training_frame,
                                               fold_column = NULL,
+                                              keep_original_features = TRUE,
                                               blending = FALSE,
                                               inflection_point = 10,
                                               smoothing = 20,
@@ -191,6 +197,8 @@ h2o.targetencoder <- function(x,
 
   if (!missing(fold_column))
     parms$fold_column <- fold_column
+  if (!missing(keep_original_features))
+    parms$keep_original_features <- keep_original_features
   if (!missing(blending))
     parms$blending <- blending
   if (!missing(inflection_point))

--- a/h2o-r/h2o-package/R/targetencoder.R
+++ b/h2o-r/h2o-package/R/targetencoder.R
@@ -13,7 +13,7 @@
 #' @param training_frame Id of the training data frame.
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param fold_column Column with cross-validation fold index assignment per observation.
-#' @param keep_original_features \code{Logical}. If true, the original non-encoded categorical features will remain in the result frame.
+#' @param keep_original_categorical_columns \code{Logical}. If true, the original non-encoded categorical features will remain in the result frame.
 #'        Defaults to TRUE.
 #' @param blending \code{Logical}. If true, enables blending of posterior probabilities (computed for a given categorical value)
 #'        with prior probabilities (computed on the entire set). This allows to mitigate the effect of categorical
@@ -71,7 +71,7 @@ h2o.targetencoder <- function(x,
                               training_frame,
                               model_id = NULL,
                               fold_column = NULL,
-                              keep_original_features = TRUE,
+                              keep_original_categorical_columns = TRUE,
                               blending = FALSE,
                               inflection_point = 10,
                               smoothing = 20,
@@ -120,8 +120,8 @@ h2o.targetencoder <- function(x,
     parms$model_id <- model_id
   if (!missing(fold_column))
     parms$fold_column <- fold_column
-  if (!missing(keep_original_features))
-    parms$keep_original_features <- keep_original_features
+  if (!missing(keep_original_categorical_columns))
+    parms$keep_original_categorical_columns <- keep_original_categorical_columns
   if (!missing(blending))
     parms$blending <- blending
   if (!missing(inflection_point))
@@ -143,7 +143,7 @@ h2o.targetencoder <- function(x,
                                               y,
                                               training_frame,
                                               fold_column = NULL,
-                                              keep_original_features = TRUE,
+                                              keep_original_categorical_columns = TRUE,
                                               blending = FALSE,
                                               inflection_point = 10,
                                               smoothing = 20,
@@ -197,8 +197,8 @@ h2o.targetencoder <- function(x,
 
   if (!missing(fold_column))
     parms$fold_column <- fold_column
-  if (!missing(keep_original_features))
-    parms$keep_original_features <- keep_original_features
+  if (!missing(keep_original_categorical_columns))
+    parms$keep_original_categorical_columns <- keep_original_categorical_columns
   if (!missing(blending))
     parms$blending <- blending
   if (!missing(inflection_point))


### PR DESCRIPTION
https://0xdata.atlassian.net/browse/PUBDEV-7743

By default, the original features are kept: it's not a nice default imo as encoders usually replace the column to encode, but it keeps the API backwards compatible...

Param is currently named `keep_original_features`.


### Please note
The legacy model had another inconsistency:
- trained model would not remove original features by default.
- Mojo model would only return encoded columns.

Therefore it is impossible to keep both backwards compatibility and consistency between trained model and Mojo model.
Chosing for now to leave Mojo as is, meaning ignoring the new parameter, which somehow makes sense for production.