### PR TITLE
Include MOJO2 scoring support into standalone H2O

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -67,3 +67,6 @@ defaultHiveExecVersion=1.1.0
 defaultWebserverModule=h2o-jetty-9
 jetty8version=8.2.0.v20160908
 jetty9version=9.4.11.v20180605
+
+# MOJO2 Integration
+mojo2version=2.4.10

--- a/h2o-assemblies/main/build.gradle
+++ b/h2o-assemblies/main/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compile project(":h2o-persist-http")
     compile project(":h2o-persist-hdfs")
     compile project(":h2o-ext-krbstandalone")
+    compile project(":h2o-ext-mojo-pipeline")
     if (project.hasProperty("doIncludeOrc") && project.doIncludeOrc == "true") {
         compile project(":h2o-orc-parser")
     }

--- a/h2o-extensions/mojo-pipeline/build.gradle
+++ b/h2o-extensions/mojo-pipeline/build.gradle
@@ -2,7 +2,7 @@ description = "H2O MOJO Pipeline support"
 
 dependencies {
     compile project(":h2o-core")
-    compile "ai.h2o:mojo2-runtime-api:0.13.7"
+    compile "ai.h2o:mojo2-runtime-api:2.4.10"
 
     testCompile project(":h2o-test-support")
     testCompile "net.sf.opencsv:opencsv:2.3"

--- a/h2o-extensions/mojo-pipeline/build.gradle
+++ b/h2o-extensions/mojo-pipeline/build.gradle
@@ -2,11 +2,12 @@ description = "H2O MOJO Pipeline support"
 
 dependencies {
     compile project(":h2o-core")
-    compile "ai.h2o:mojo2-runtime-api:2.4.10"
+    compile "ai.h2o:mojo2-runtime-api:${mojo2version}"
 
     testCompile project(":h2o-test-support")
     testCompile "net.sf.opencsv:opencsv:2.3"
     testRuntimeOnly project(":${defaultWebserverModule}")
+    testRuntimeOnly "ai.h2o:mojo2-runtime-impl:${mojo2version}"
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"

--- a/h2o-extensions/mojo-pipeline/src/main/java/hex/mojopipeline/MojoPipeline.java
+++ b/h2o-extensions/mojo-pipeline/src/main/java/hex/mojopipeline/MojoPipeline.java
@@ -129,9 +129,20 @@ public class MojoPipeline extends Iced<MojoPipeline> {
         NewChunk nc = ncs[col];
         MojoColumn column = transformed.getColumn(col);
         assert column.size() == cs[0].len();
-        double[] data = (double[]) column.getData();
-        for (double d : data) {
-          nc.addNum(d);
+        // Note: will work fine with current MOJO because they only output floating point values
+        switch (column.getType()) {
+          case Float32:
+            for (float d : (float[]) column.getData()) {
+              nc.addNum(d);
+            }
+            break;
+          case Float64:
+            for (double d : (double[]) column.getData()) {
+              nc.addNum(d);
+            }
+            break;
+          default:
+            throw new UnsupportedOperationException("Output type " + column.getType() + " is currently not supported for MOJO2. See https://0xdata.atlassian.net/browse/PUBDEV-7741");
         }
       }
     }

--- a/h2o-extensions/mojo-pipeline/src/main/java/hex/mojopipeline/MojoPipelineExtension.java
+++ b/h2o-extensions/mojo-pipeline/src/main/java/hex/mojopipeline/MojoPipelineExtension.java
@@ -1,6 +1,6 @@
 package hex.mojopipeline;
 
-import ai.h2o.mojos.runtime.MojoPipelineFactory;
+import ai.h2o.mojos.runtime.api.PipelineLoaderFactory;
 import water.AbstractH2OExtension;
 import water.util.Log;
 
@@ -40,7 +40,7 @@ public class MojoPipelineExtension extends AbstractH2OExtension {
 
   private boolean hasMojoRuntime() {
     // relying on implementation - need to improve MOJO2 API
-    return ServiceLoader.load(MojoPipelineFactory.class).iterator().hasNext();
+    return ServiceLoader.load(PipelineLoaderFactory.class).iterator().hasNext();
   }
 
 }


### PR DESCRIPTION
Currently we are not exposing any user-level API, however, the scoring functionality
will be accessble through direct Rapids invocation.

Example scoring using MOJO2:

import h2o
h2o.connect()
mp_loc = "/tmp/mp4"
mojo = h2o.import_file(f"{mp_loc}/pipeline.mojo", parse=False)
mojo_key = mojo[0]
data = h2o.import_file(f"{mp_loc}/example.csv")
h2o.rapids(f"(assign scored (mojo.pipeline.transform {mojo_key} {data.key} true))")
h2o.get_frame("scored")