### PR TITLE
Update K8S templates to contain parallel pod management

### DIFF
--- a/h2o-docs/src/product/welcome.rst
+++ b/h2o-docs/src/product/welcome.rst
@@ -974,6 +974,7 @@ We strongly recommended running H2O as a `StatefulSet <https://kubernetes.io/doc
     namespace: h2o-statefulset
   spec:
     serviceName: h2o-service
+    podManagementPolicy: "Parallel"
     replicas: 3
     selector:
       matchLabels:

--- a/h2o-k8s/README.md
+++ b/h2o-k8s/README.md
@@ -58,6 +58,7 @@ metadata:
   namespace: <namespace-name>
 spec:
   serviceName: h2o-service
+  podManagementPolicy: "Parallel"
   replicas: 3
   selector:
     matchLabels:


### PR DESCRIPTION
Speeds up the deployment of H2O by a lot. Stateful Sets on K8s spawn the pods sequentially by default - one by one. When the statefulset is terminated, the pods are also terminated in sequantially (in reverse order than spawned). H2O doesn't need this. The parallel pod management makes sure all pods are spawned at once. This is a **huge** speedup for large clusters and we absolutely must recommend this to our users.

Docs are affected as well @hannah-tillman .