### PR TITLE
PUBDEV-7735 enable lifeline library in tests

### DIFF
--- a/h2o-py/test-requirements.txt
+++ b/h2o-py/test-requirements.txt
@@ -30,3 +30,4 @@ sphinx_rtd_theme==0.2.4
 sphinxcontrib-osexample>=0.1.1
 shap==0.28.3
 boto3>=1.7.50
+lifelines>=0.19.5

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -14,12 +14,12 @@ class BuildConfig {
   private static final String DEFAULT_HADOOP_IMAGE_NAME_PREFIX = 'dev-build-hadoop-gradle'
   private static final String DEFAULT_RELEASE_IMAGE_NAME_PREFIX = 'dev-release-gradle'
 
-  public static final int DEFAULT_IMAGE_VERSION_TAG = 31
+  public static final int DEFAULT_IMAGE_VERSION_TAG = 32
   public static final String AWSCLI_IMAGE = DOCKER_REGISTRY + '/opsh2oai/awscli'
   public static final String S3CMD_IMAGE = DOCKER_REGISTRY + '/opsh2oai/s3cmd'
 
   private static final String HADOOP_IMAGE_NAME_PREFIX = 'h2o-3-hadoop'
-  private static final String HADOOP_IMAGE_VERSION_TAG = '80'
+  private static final String HADOOP_IMAGE_VERSION_TAG = '81'
 
   private static final String K8S_TEST_IMAGE_VERSION_TAG = '1'
 


### PR DESCRIPTION
Lifelines provides reference baseline hazard implementation.
This commit adds dependency, uses it in simple test and mainly can be
used to build new docker images with this dependency.