### PR TITLE
PUBDEV-7765: Improve performance of Export CSV for narrow datasets

### DIFF
--- a/h2o-core/src/main/java/water/persist/PersistManager.java
+++ b/h2o-core/src/main/java/water/persist/PersistManager.java
@@ -690,7 +690,7 @@ public class PersistManager {
           throw new IllegalArgumentException("File already exists (" + path + ")");
         }
       }
-      return new FileOutputStream(path);
+      return new BufferedOutputStream(new FileOutputStream(path));
     }
     catch (Exception e) {
       throw new RuntimeException(e);

--- a/h2o-core/src/main/java/water/util/FrameUtils.java
+++ b/h2o-core/src/main/java/water/util/FrameUtils.java
@@ -79,13 +79,6 @@ public class FrameUtils {
             : ParseDataset.parse(okey, inKeys);
   }
 
-  public static ParseSetup guessParserSetup(ParseSetup userParserSetup, URI ...uris) throws IOException {
-    Key[] inKeys = new Key[uris.length];
-    for (int i=0; i<uris.length; i++)  inKeys[i] = H2O.getPM().anyURIToKey(uris[i]);
-
-    return ParseSetup.guessSetup(inKeys, userParserSetup);
-  }
-
   public static Frame categoricalEncoder(Frame dataset, String[] skipCols, Model.Parameters.CategoricalEncodingScheme scheme, ToEigenVec tev, int maxLevels) {
     switch (scheme) {
       case AUTO:

--- a/h2o-core/src/main/java/water/util/FrameUtils.java
+++ b/h2o-core/src/main/java/water/util/FrameUtils.java
@@ -9,10 +9,7 @@ import water.fvec.*;
 import water.parser.ParseDataset;
 import water.parser.ParseSetup;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
@@ -441,12 +438,12 @@ public class FrameUtils {
       }
     }
 
-    private long copyCSVStream(Frame.CSVStream is, OutputStream os, int firstChkIdx, int buffer_size) throws IOException {
+    private long copyCSVStream(Frame.CSVStream is, OutputStream os, int firstChkIdx) throws IOException {
       long len = 0;
-      byte[] bytes = new byte[buffer_size];
+      byte[] bytes = new byte[BUFFER_SIZE];
       int curChkIdx = firstChkIdx;
       for (;;) {
-        int count = is.read(bytes, 0, buffer_size);
+        int count = is.read(bytes, 0, BUFFER_SIZE);
         if (count <= 0) {
           break;
         }
@@ -470,7 +467,7 @@ public class FrameUtils {
         if (_compressor != null) {
           os = _compressor.wrapOutputStream(os);
         }
-        written = copyCSVStream(is, os, firstChkIdx, BUFFER_SIZE);
+        written = copyCSVStream(is, os, firstChkIdx);
       } catch (IOException e) {
         throw new RuntimeException(e);
       } finally {

--- a/h2o-core/src/test/java/water/persist/PersistManagerTest.java
+++ b/h2o-core/src/test/java/water/persist/PersistManagerTest.java
@@ -1,15 +1,21 @@
 package water.persist;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import water.H2O;
 import water.TestUtil;
 
+import java.io.*;
 import java.util.List;
 
 import static org.junit.Assert.*;
 
 public class PersistManagerTest extends TestUtil {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     PersistManager persistManager;
 
@@ -30,6 +36,14 @@ public class PersistManagerTest extends TestUtil {
         matches = persistManager.calcTypeaheadMatches("   ", 100);
         assertNotNull(matches);
         assertEquals(0, matches.size());
+    }
+
+    @Test
+    public void createReturnsBufferedOutputStreamForFiles() throws IOException  {
+        File target = new File(tmp.getRoot(), "target.txt");
+        try (OutputStream os = persistManager.create(target.getAbsolutePath(), false)) {
+            assertTrue(os instanceof BufferedOutputStream);
+        }
     }
 
 }


### PR DESCRIPTION
When exported dataset has only few columns (eg. frame of predictions),
each line is small & current implementation essentially doesn't do any
buffering.