### PR TITLE
PUBDEV-7766: Add context_path in h2o.init in python

### DIFF
--- a/h2o-py/h2o/h2o.py
+++ b/h2o-py/h2o/h2o.py
@@ -41,7 +41,7 @@ h2oconn = None  # type: H2OConnection
 
 def connect(server=None, url=None, ip=None, port=None,
             https=None, verify_ssl_certificates=None, cacert=None,
-            auth=None, proxy=None, cookies=None, verbose=True, config=None):
+            auth=None, proxy=None, cookies=None, verbose=True, config=None, context_path=None):
     """
     Connect to an existing H2O server, remote or local.
 
@@ -61,6 +61,7 @@ def connect(server=None, url=None, ip=None, port=None,
     :param cookies: Cookie (or list of) to add to request
     :param verbose: Set to False to disable printing connection status messages.
     :param connection_conf: Connection configuration object encapsulating connection parameters.
+    :param context_path: The last part of connection URL: http://<ip>:<port>/<context_path>
     :returns: the new :class:`H2OConnection` object.
 
     :examples:
@@ -84,7 +85,7 @@ def connect(server=None, url=None, ip=None, port=None,
         h2oconn = H2OConnection.open(server=server, url=url, ip=ip, port=port, https=https,
                                      auth=auth, verify_ssl_certificates=verify_ssl_certificates, cacert=cacert,
                                      proxy=proxy, cookies=cookies,
-                                     verbose=verbose)
+                                     verbose=verbose, context_path=context_path)
         if verbose:
             h2oconn.cluster.show_status()
     return h2oconn
@@ -156,7 +157,8 @@ def version_check():
 def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insecure=None, username=None, password=None,
          cookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None, log_dir=None, log_level=None,
          max_log_file_size=None, enable_assertions=True, max_mem_size=None, min_mem_size=None, strict_version_check=None, 
-         ignore_config=False, extra_classpath=None, jvm_custom_args=None, bind_to_localhost=True, **kwargs):
+         ignore_config=False, extra_classpath=None, jvm_custom_args=None, bind_to_localhost=True, 
+         context_path=None, **kwargs):
     """
     Attempt to connect to a local server, or if not successful start a new server and connect to it.
 
@@ -190,7 +192,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
     :param kwargs: (all other deprecated attributes)
     :param jvm_custom_args: Customer, user-defined argument's for the JVM H2O is instantiated in. Ignored if there is an instance of H2O already running and the client connects to it.
     :param bind_to_localhost: A flag indicating whether access to the H2O instance should be restricted to the local machine (default) or if it can be reached from other computers on the network.
-
+    :param context_path: The last part of connection URL: http://<ip>:<port>/<context_path>
 
     :examples:
 
@@ -224,6 +226,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
     assert_is_type(bind_to_localhost, bool)
     assert_is_type(kwargs, {"proxies": {str: str}, "max_mem_size_GB": int, "min_mem_size_GB": int,
                             "force_connect": bool, "as_port": bool})
+    assert_is_type(context_path, str, None)
 
     def get_mem_size(mmint, mmgb):
         if not mmint:  # treat 0 and "" as if they were None
@@ -284,7 +287,8 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
     try:
         h2oconn = H2OConnection.open(url=url, ip=ip, port=port, name=name, https=https,
                                      verify_ssl_certificates=verify_ssl_certificates, cacert=cacert,
-                                     auth=auth, proxy=proxy,cookies=cookies, verbose=True,
+                                     auth=auth, proxy=proxy,cookies=cookies, verbose=True, 
+                                     context_path=context_path,
                                      _msgs=("Checking whether there is an H2O instance running at {url} ",
                                             "connected.", "not found."))
     except H2OConnectionError:
@@ -302,7 +306,7 @@ def init(url=None, ip=None, port=None, name=None, https=None, cacert=None, insec
                                   min_mem_size=mmin, ice_root=ice_root, log_dir=log_dir, log_level=log_level,
                                   max_log_file_size=max_log_file_size, port=port, name=name,
                                   extra_classpath=extra_classpath, jvm_custom_args=jvm_custom_args,
-                                  bind_to_localhost=bind_to_localhost)
+                                  bind_to_localhost=bind_to_localhost, context_path=context_path)
         h2oconn = H2OConnection.open(server=hs, https=https, verify_ssl_certificates=verify_ssl_certificates,
                                      cacert=cacert, auth=auth, proxy=proxy,cookies=cookies, verbose=True)
     if check_version:

--- a/h2o-py/tests/testdir_apis/H2O_Init/h2o.init_test.py
+++ b/h2o-py/tests/testdir_apis/H2O_Init/h2o.init_test.py
@@ -13,7 +13,8 @@ def h2oinit():
     """
     Python API test: h2o.init(url=None, ip=None, port=None, name = None, https=None, insecure=None,
     username=None, password=None, ookies=None, proxy=None, start_h2o=True, nthreads=-1, ice_root=None,
-    enable_assertions=True, max_mem_size=None, min_mem_size=None, strict_version_check=None, **kwargs)
+    enable_assertions=True, max_mem_size=None, min_mem_size=None, strict_version_check=None, 
+    context_path=None, **kwargs)
     """
     start_h2o = False
     strict_version_check = False
@@ -121,7 +122,25 @@ def h2oinit_fail_invalid_log_level():
         h2o.cluster().shutdown()
 
 
+def h2oinit_context_path():
+    # support context path both with and without a leading '/'.
+    context_path_1 = "/path"  # start with '/'
+    context_path_2 = "path"  # start without '/'
+    try:
+        h2o.init(strict_version_check=False, context_path=context_path_1)
+        h2o.cluster().shutdown()
+    except Exception:  # some errors are okay like version mismatch
+        assert False, "Should start an h2o instance with a context_path."
+
+    try:
+        h2o.init(strict_version_check=False, context_path=context_path_2)
+        h2o.cluster().shutdown()
+    except Exception:  # some errors are okay like version mismatch
+        assert False, "Should start an h2o instance with a context_path."
+
+
 # None of the tests below need a pre initialized instance
+h2oinit_context_path()
 h2oinit_default_log_dir()
 h2oinit_custom_log_dir()
 h2oinit_fail_invalid_log_level()


### PR DESCRIPTION
Link to JIRA ticket: https://0xdata.atlassian.net/browse/PUBDEV-7766

This PR adds context_path as a new argument in h2o.init in python.
It touches h2o/h2o.py, h2o/backend/server.py and h2o/backend/connection.py.
While I try to provide a unit test, I'm not sure what's already done is sufficient or acceptable.
Documentation is not touched so far.

Comments welcome.
