### PR TITLE
Use quoted elements for reporting test/valid cols.

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1446,7 +1446,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
             if( isResponse && vec.domain() != null && ds.length == domains[i].length+vec.domain().length )
               throw new IllegalArgumentException("Test/Validation dataset has a categorical response column '"+names[i]+"' with no levels in common with the model");
             if (ds.length > domains[i].length)
-              msgs.add("Test/Validation dataset column '" + names[i] + "' has levels not trained on: " + Arrays.toString(Arrays.copyOfRange(ds, domains[i].length, ds.length)));
+              msgs.add("Test/Validation dataset column '" + names[i] + "' has levels not trained on: " + ArrayUtils.toStringQuotedElements(Arrays.copyOfRange(ds, domains[i].length, ds.length)));
             vec = evec;
           }
         } else if(vec.isCategorical()) {

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -667,6 +667,26 @@ public class ArrayUtils {
     return result;
   }
 
+  public static String toStringQuotedElements(Object[] a) {
+    if (a == null)
+      return "null";
+
+    int iMax = a.length - 1;
+    if (iMax == -1)
+      return "[]";
+
+    StringBuilder b = new StringBuilder();
+    b.append('[');
+    for (int i = 0; ; i++) {
+      b.append('"');
+      b.append(a[i]);
+      b.append('"');
+      if (i == iMax)
+        return b.append(']').toString();
+      b.append(", ");
+    }
+  }
+
   public static <T> boolean contains(T[] arr, T target) {
     if (null == arr) return false;
     for (T t : arr) {

--- a/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
@@ -267,4 +267,11 @@ public class ArrayUtilsTest {
     assertArrayEquals("Selected array elements mismatch.",
                       expectedSelectedElements, ArrayUtils.select(arr, idxs));
   }
+  
+  @Test
+  public void testToStringQuotedElements(){
+    final Object[] names = new String[]{"", "T16384"};
+    final String outputString = toStringQuotedElements(names);
+    assertEquals("[\"\", \"T16384\"]", outputString);
+  }
 }

--- a/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
@@ -274,4 +274,17 @@ public class ArrayUtilsTest {
     final String outputString = toStringQuotedElements(names);
     assertEquals("[\"\", \"T16384\"]", outputString);
   }
+
+  @Test
+  public void testToStringQuotedElementsNullInput(){
+    final String outputString = toStringQuotedElements(null);
+    assertEquals("null", outputString);
+  }
+
+  @Test
+  public void testToStringQuotedElementsEmptyInput(){
+    final Object[] emptyNames = new String[0];
+    final String outputString = toStringQuotedElements(emptyNames);
+    assertEquals("[]", outputString);
+  }
 }


### PR DESCRIPTION
Originally reported by @arnocandel, the following output is confusing:

```
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F542' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F544' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F545' has levels not trained on: [, T16384]
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F547' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F549' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F550' has levels not trained on: [, T16384]
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F552' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F554' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F555' has levels not trained on: [, T16384]
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F557' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F559' has levels not trained on: []
09-11 22:03:26.496 192.168.86.47:54321   90536    FJ-1-101  WARN water.default: Test/Validation dataset column 'L0_S22_F560' has levels not trained on: [, T16384]
```

as there are empty values treated as categorical levels. Which is probably desired. To make it more readable, I made this PR.
Current output:

```
09-14 11:51:00.918 192.168.0.149:54321   12863     FJ-1-15  INFO water.default: Test/Validation dataset column 'C1' has levels not trained on: ["", "T16384"]
```