### PR TITLE
PUBDEV-7753 - Disable REST API on non-leader K8S nodes

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1846,7 +1846,7 @@ final public class H2O {
    */
   public static void startServingRestApi() {
     if (!H2O.ARGS.disable_web) {
-      NetworkInit.h2oHttpView.acceptRequests();
+      NetworkInit.h2oHttpView.setAcceptRequests(true);
     }
   }
 

--- a/h2o-core/src/main/java/water/webserver/H2OHttpViewImpl.java
+++ b/h2o-core/src/main/java/water/webserver/H2OHttpViewImpl.java
@@ -30,8 +30,8 @@ public class H2OHttpViewImpl implements H2OHttpView {
     this.config = config;
   }
 
-  public void acceptRequests() {
-    _acceptRequests = true;
+  public void setAcceptRequests(boolean acceptRequests) {
+    _acceptRequests = acceptRequests;
   }
 
   /**

--- a/h2o-k8s/src/main/java/water/k8s/KubernetesEmbeddedConfig.java
+++ b/h2o-k8s/src/main/java/water/k8s/KubernetesEmbeddedConfig.java
@@ -2,10 +2,11 @@ package water.k8s;
 
 import water.H2O;
 import water.init.AbstractEmbeddedH2OConfig;
+import water.init.NetworkInit;
 import water.util.Log;
 
 import java.net.InetAddress;
-import java.util.Collection;
+import java.util.*;
 
 public class KubernetesEmbeddedConfig extends AbstractEmbeddedH2OConfig {
 
@@ -34,6 +35,9 @@ public class KubernetesEmbeddedConfig extends AbstractEmbeddedH2OConfig {
 
     @Override
     public void notifyAboutCloudSize(InetAddress ip, int port, InetAddress leaderIp, int leaderPort, int size) {
+        if (!H2O.SELF.isLeaderNode()) {
+            NetworkInit.h2oHttpView.setAcceptRequests(false);
+        }
         Log.info(String.format("Created cluster of size %d, leader node IP is '%s'", size, leaderIp.toString()));
     }
 

--- a/h2o-k8s/src/main/java/water/k8s/KubernetesEmbeddedConfigProvider.java
+++ b/h2o-k8s/src/main/java/water/k8s/KubernetesEmbeddedConfigProvider.java
@@ -1,7 +1,5 @@
 package water.k8s;
 
-import fi.iki.elonen.NanoHTTPD;
-import water.H2O;
 import water.init.AbstractEmbeddedH2OConfig;
 import water.init.EmbeddedConfigProvider;
 import water.k8s.api.KubernetesRestApi;
@@ -14,7 +12,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * A configuration provider for H2O running in Kubernetes cluster. It is able to detected H2O is being ran in K8S

--- a/scripts/jenkins/groovy/defineTestStages.groovy
+++ b/scripts/jenkins/groovy/defineTestStages.groovy
@@ -179,6 +179,12 @@ def call(final pipelineContext) {
       imageSpecifier: "mojocompat",
       additionalTestPackages: [pipelineContext.getBuildConfig().COMPONENT_PY]
     ],
+    [
+            stageName: 'Kubernetes', target: 'test-h2o-k8s', timeoutValue: 20,
+            component: pipelineContext.getBuildConfig().COMPONENT_JAVA,
+            image: "${pipelineContext.getBuildConfig().DOCKER_REGISTRY}/opsh2oai/h2o-3-k8s:${pipelineContext.getBuildConfig().K8S_TEST_IMAGE_VERSION_TAG}",
+            customDockerArgs: ['-v /var/run/docker.sock:/var/run/docker.sock', '--network host'], addToDockerGroup: true, nodeLabel: "micro"
+    ]
   ]
 
   def BENCHMARK_STAGES = [


### PR DESCRIPTION
Still WIP/DRAFT, looks easy to do at first sight as by default, the APIs are enabled and then the API is stopped being served by H2OKubernetesEmbeddedConfig when leader nodes are detected. As `notifyAboutCloudSize` is called in `Paxos` at line 129 after a leader node has been selected, this should be safe to do, as newly added nodes are being disabled as this callback is called and leader node remains open.

Let's see how this works in practice in our test pipeline (temporarily added Kubernetes tests to pipeline tests). Also, I'm thinking about how to test it. One way is to introduce special diagnostic Kubernetes API (this is not H2O API), as it's a lot of hacky work to expose each pod separately via ingress (a service has to be created for each pod separately and then the corresponding ingress only for diagnostics has to be linked with the service - problem is the names have to be obtained dynamically, as we have no control over K8S naming)