### PR TITLE
PUBDEV-7720-fix_corner_case_when_setLambdaOptimal()

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -307,14 +307,53 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
            if (deviance.length < 5) {
                bestLambdaIndex = deviance.length - 1;
            } else {
-               bestLambdaIndex = getBestLambdaIndex(deviance, lambdas);
+               bestLambdaIndex = getBestLambdaIndex(deviance);
+               if (bestLambdaIndex >= lambdas.length) {
+                   bestLambdaIndex = getBestLambdaIndexCornerCase(deviance, lambdas);
+               }
            }
 
             lambdaModel.remove();
             return new double[]{lambdas[bestLambdaIndex]};
         }
 
-        int getBestLambdaIndex(double[] deviance, double[] lambdas) {
+        int getBestLambdaIndex(double[] deviance) {
+            int bestLambdaIndex = deviance.length - 1;
+            if (deviance.length >= 5) {
+                double[] array = differenceArray(signArray(differenceArray(differenceArray(deviance))));
+                for (int i = 0; i < array.length; i++) {
+                    if (array[i] != 0 && i > 0) {
+                        bestLambdaIndex = 3 * i;
+                        break;
+                    }
+                }
+            }
+            return bestLambdaIndex;
+        }
+
+
+        double[] differenceArray(double[] array) {
+            double[] differenceArray = new double[array.length - 1];
+            for (int i = 0; i < array.length - 1; i++) {
+                differenceArray[i] = array[i+1] - array[i];
+            }
+            return differenceArray;
+        }
+
+        double[] signArray(double[] array) {
+            double[] signArray = new double[array.length];
+            for (int i = 0; i < array.length; i++) {
+                if (array[i] > 0)
+                    signArray[i] = 1;
+                else if (array[i] < 0)
+                    signArray[i] = -1;
+                else
+                    signArray[i] = 0;
+            }
+            return signArray;
+        }
+
+        int getBestLambdaIndexCornerCase(double[] deviance, double[] lambdas) {
             double[] leftUpPoint = new double[] {deviance[0], lambdas[0]};
             double[] rightLowPoint = new double[] {deviance[deviance.length - 1], lambdas[lambdas.length - 1]};
             double[] leftActualPoint = new double[2];

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -21,6 +21,9 @@ import water.util.TwoDimTable;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static hex.genmodel.utils.ArrayUtils.difference;
+import static hex.genmodel.utils.ArrayUtils.signum;
+
 
 /**
  * Rule Fit<br>
@@ -320,7 +323,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
         int getBestLambdaIndex(double[] deviance) {
             int bestLambdaIndex = deviance.length - 1;
             if (deviance.length >= 5) {
-                double[] array = differenceArray(signArray(differenceArray(differenceArray(deviance))));
+                double[] array = difference(signum(difference(difference(deviance))));
                 for (int i = 0; i < array.length; i++) {
                     if (array[i] != 0 && i > 0) {
                         bestLambdaIndex = 3 * i;
@@ -329,28 +332,6 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 }
             }
             return bestLambdaIndex;
-        }
-
-
-        double[] differenceArray(double[] array) {
-            double[] differenceArray = new double[array.length - 1];
-            for (int i = 0; i < array.length - 1; i++) {
-                differenceArray[i] = array[i+1] - array[i];
-            }
-            return differenceArray;
-        }
-
-        double[] signArray(double[] array) {
-            double[] signArray = new double[array.length];
-            for (int i = 0; i < array.length; i++) {
-                if (array[i] > 0)
-                    signArray[i] = 1;
-                else if (array[i] < 0)
-                    signArray[i] = -1;
-                else
-                    signArray[i] = 0;
-            }
-            return signArray;
         }
 
         int getBestLambdaIndexCornerCase(double[] deviance, double[] lambdas) {

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
@@ -148,4 +148,25 @@ public class ArrayUtils {
     return tmp;
   }
 
+  public static double[] signum(double[] array) {
+    double[] signArray = new double[array.length];
+    for (int i = 0; i < array.length; i++) {
+      if (array[i] > 0)
+        signArray[i] = 1;
+      else if (array[i] < 0)
+        signArray[i] = -1;
+      else
+        signArray[i] = 0;
+    }
+    return signArray;
+  }
+
+  public static double[] difference(double[] array) {
+    double[] difference = new double[array.length - 1];
+    for (int i = 0; i < array.length - 1; i++) {
+      difference[i] = array[i+1] - array[i];
+    }
+    return difference;
+  }
+
 }


### PR DESCRIPTION
this PR fixes the way a lambda parameter is chosen for GLM in that part of algo, when we are going to fit a GLM to the rule feature set joined with the original feature set. Originally, it was done like what is in getBestLambdaIndex() in this PR, but there were corner cases found, so it was fixed to what is in getBestLambdaIndexCornerCase() in this PR, but this approach is good for corner cases and previous approach is better than this one for not-corner cases, so this PR combines it.