### PR TITLE
Remove deprecated matplotlib.use argument

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -3776,7 +3776,7 @@ class H2OFrame(Keyed):
             try:
                 import matplotlib
                 if server:
-                    matplotlib.use("Agg", warn=False)
+                    matplotlib.use("Agg")
                 import matplotlib.pyplot as plt
             except ImportError:
                 print("ERROR: matplotlib is required to make the histogram plot. "

--- a/h2o-py/h2o/model/dim_reduction.py
+++ b/h2o-py/h2o/model/dim_reduction.py
@@ -107,7 +107,7 @@ class H2ODimReductionModel(ModelBase):
             raise ValueError("Unknown arguments %s to screeplot()" % ", ".join(kwargs.keys()))
         try:
             import matplotlib
-            if is_server: matplotlib.use('Agg', warn=False)
+            if is_server: matplotlib.use('Agg')
             import matplotlib.pyplot as plt
         except ImportError:
             print("matplotlib is required for this function!")

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -1359,7 +1359,7 @@ class H2OBinomialModelMetrics(MetricsBase):
         if plot:
             try:
                 import matplotlib
-                if server: matplotlib.use('Agg', warn=False)
+                if server: matplotlib.use('Agg')
                 import matplotlib.pyplot as plt
             except ImportError:
                 print("matplotlib is required for this function!")
@@ -1386,7 +1386,7 @@ class H2OBinomialModelMetrics(MetricsBase):
         if plot:
             try:
                 import matplotlib
-                if server: matplotlib.use('Agg', warn=False)
+                if server: matplotlib.use('Agg')
                 import matplotlib.pyplot as plt
             except ImportError:
                 print("matplotlib is required for this function!")

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1720,7 +1720,7 @@ def _get_matplotlib_pyplot(server):
     try:
         # noinspection PyUnresolvedReferences
         import matplotlib
-        if server: matplotlib.use("Agg", warn=False)
+        if server: matplotlib.use("Agg")
         # noinspection PyUnresolvedReferences
         import matplotlib.pyplot as plt
         return plt


### PR DESCRIPTION
`matplotlib.use` `warn` argument was deprecated in Matplotlib 3.1 and is removed in the current version (Matplotlib 3.3).

Just deleting it shouldn't change behavior (other than being able to use the newer matplotlib versions).

See changes in matplotlib's code:
Current version: https://matplotlib.org/_modules/matplotlib.html#use
Older version: https://matplotlib.org/3.2.1/_modules/matplotlib.html#use