### PR TITLE
PUBDEV-7720 set min_rule_length and max_rule_length default values to 3

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFitModel.java
@@ -45,11 +45,11 @@ public class RuleFitModel extends Model<RuleFitModel, RuleFitModel.RuleFitParame
         // the algorithm to use to generate rules. Options are "DRF" (default), "GBM"
         public Algorithm _algorithm = Algorithm.AUTO;
 
-        // minimum length of rules. Defaults to 1.
-        public int _min_rule_length = 1;
+        // minimum length of rules. Defaults to 3.
+        public int _min_rule_length = 3;
 
-        // maximum length of rules. Defaults to 10.
-        public int _max_rule_length = 10;
+        // maximum length of rules. Defaults to 3.
+        public int _max_rule_length = 3;
 
         // the maximum number of rules to return. Defaults to -1 which means the number of rules is selected 
         // by diminishing returns in model deviance.

--- a/h2o-algos/src/main/java/hex/schemas/RuleFitV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/RuleFitV3.java
@@ -32,10 +32,10 @@ public class RuleFitV3 extends ModelBuilderSchema<RuleFit, RuleFitV3, RuleFitV3.
             values = {"AUTO", "DRF", "GBM"})
     public RuleFitModel.Algorithm algorithm;
     
-    @API(help = "Minimum length of rules. Defaults to 1.")
+    @API(help = "Minimum length of rules. Defaults to 3.")
     public int min_rule_length;
 
-    @API(help = "Maximum length of rules. Defaults to 10.")
+    @API(help = "Maximum length of rules. Defaults to 3.")
     public int max_rule_length;
 
     @API(help = "The maximum number of rules to return. defaults to -1 which means the number of rules is selected \n" +

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
@@ -49,6 +49,8 @@ public class RuleFitTest extends TestUtil {
             params._max_num_rules = 100;
             params._model_type = RuleFitModel.ModelType.RULES;
             params._distribution = DistributionFamily.bernoulli;
+            params._min_rule_length = 1;
+            params._max_rule_length = 10;
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
             Scope.track_generic(rfModel);
@@ -142,6 +144,8 @@ public class RuleFitTest extends TestUtil {
             params._max_num_rules = 100;
             params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
             params._weights_column = "weights";
+            params._min_rule_length = 1;
+            params._max_rule_length = 10;
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
             Scope.track_generic(rfModel);
@@ -219,6 +223,7 @@ public class RuleFitTest extends TestUtil {
             params._max_num_rules = 200;
             params._max_rule_length = 5;
             params._model_type = RuleFitModel.ModelType.RULES;
+            params._min_rule_length = 1;
 
             RuleFitModel model = new RuleFit( params).trainModel().get();
             Scope.track_generic(model);
@@ -282,6 +287,7 @@ public class RuleFitTest extends TestUtil {
             params._max_rule_length = 5;
             params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
             params._distribution = DistributionFamily.gaussian;
+            params._min_rule_length = 1;
 
             final RuleFitModel model = new RuleFit(params).trainModel().get();
             Scope.track_generic(model);
@@ -339,6 +345,7 @@ public class RuleFitTest extends TestUtil {
             params._max_num_rules = 200;
             params._max_rule_length = 10;
             params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
+            params._min_rule_length = 1;
 
             final RuleFitModel model = new RuleFit(params).trainModel().get();
             Scope.track_generic(model);
@@ -392,6 +399,8 @@ public class RuleFitTest extends TestUtil {
             params._train = fr._key;
             params._model_type = RuleFitModel.ModelType.RULES;
             params._response_column = responseColumnName;
+            params._min_rule_length = 1;
+            params._max_rule_length = 10;
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
             Scope.track_generic(rfModel);
@@ -444,6 +453,8 @@ public class RuleFitTest extends TestUtil {
             params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
             params._response_column = "diabetesMed";
             params._weights_column = "weights";
+            params._min_rule_length = 1;
+            params._max_rule_length = 10;
 
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();

--- a/h2o-bindings/bin/custom/R/gen_rulefit.py
+++ b/h2o-bindings/bin/custom/R/gen_rulefit.py
@@ -24,8 +24,8 @@ classification.
     params=dict(
         model_type="Specifies type of base learners in the ensemble. Must be one of: \"rules_and_linear\", \"rules\", \"linear\". "
                    "Defaults to rules_and_linear.",
-        min_rule_length="Minimum length of rules. Defaults to 1.",
-        max_rule_length="Maximum length of rules. Defaults to 10."
+        min_rule_length="Minimum length of rules. Defaults to 3.",
+        max_rule_length="Maximum length of rules. Defaults to 3.",
     ),
     signatures=dict(
         model_type="c(\"rules_and_linear\", \"rules\", \"linear\")"

--- a/h2o-py/h2o/estimators/rulefit.py
+++ b/h2o-py/h2o/estimators/rulefit.py
@@ -114,9 +114,9 @@ class H2ORuleFitEstimator(H2OEstimator):
     @property
     def min_rule_length(self):
         """
-        Minimum length of rules. Defaults to 1.
+        Minimum length of rules. Defaults to 3.
 
-        Type: ``int``  (default: ``1``).
+        Type: ``int``  (default: ``3``).
         """
         return self._parms.get("min_rule_length")
 
@@ -129,9 +129,9 @@ class H2ORuleFitEstimator(H2OEstimator):
     @property
     def max_rule_length(self):
         """
-        Maximum length of rules. Defaults to 10.
+        Maximum length of rules. Defaults to 3.
 
-        Type: ``int``  (default: ``10``).
+        Type: ``int``  (default: ``3``).
         """
         return self._parms.get("max_rule_length")
 

--- a/h2o-py/tests/testdir_algos/rulefit/pyunit_titanic_rulefit.py
+++ b/h2o-py/tests/testdir_algos/rulefit/pyunit_titanic_rulefit.py
@@ -13,7 +13,7 @@ def titanic():
     # Split the dataset into train and test
     train, test = df.split_frame(ratios=[.8], seed=1234)
 
-    rfit = H2ORuleFitEstimator(max_rule_length=10, max_num_rules=100, seed=1234, model_type="rules")
+    rfit = H2ORuleFitEstimator(min_rule_length=1, max_rule_length=10, max_num_rules=100, seed=1234, model_type="rules")
     rfit.train(training_frame=train, x=x, y="survived")
 
     print(rfit.rule_importance())

--- a/h2o-r/h2o-package/R/rulefit.R
+++ b/h2o-r/h2o-package/R/rulefit.R
@@ -19,8 +19,8 @@
 #' @param seed Seed for random numbers (affects certain parts of the algo that are stochastic and those might or might not be enabled by default).
 #'        Defaults to -1 (time-based random number).
 #' @param algorithm The algorithm to use to generate rules. Must be one of: "AUTO", "DRF", "GBM". Defaults to AUTO.
-#' @param min_rule_length Minimum length of rules. Defaults to 1.
-#' @param max_rule_length Maximum length of rules. Defaults to 10.
+#' @param min_rule_length Minimum length of rules. Defaults to 3.
+#' @param max_rule_length Maximum length of rules. Defaults to 3.
 #' @param max_num_rules The maximum number of rules to return. defaults to -1 which means the number of rules is selected  by
 #'        diminishing returns in model deviance. Defaults to -1.
 #' @param model_type Specifies type of base learners in the ensemble. Must be one of: "rules_and_linear", "rules", "linear". Defaults to rules_and_linear.
@@ -71,8 +71,8 @@ h2o.rulefit <- function(x,
                         model_id = NULL,
                         seed = -1,
                         algorithm = c("AUTO", "DRF", "GBM"),
-                        min_rule_length = 1,
-                        max_rule_length = 10,
+                        min_rule_length = 3,
+                        max_rule_length = 3,
                         max_num_rules = -1,
                         model_type = c("rules_and_linear", "rules", "linear"),
                         weights_column = NULL,
@@ -126,8 +126,8 @@ h2o.rulefit <- function(x,
                                         training_frame,
                                         seed = -1,
                                         algorithm = c("AUTO", "DRF", "GBM"),
-                                        min_rule_length = 1,
-                                        max_rule_length = 10,
+                                        min_rule_length = 3,
+                                        max_rule_length = 3,
                                         max_num_rules = -1,
                                         model_type = c("rules_and_linear", "rules", "linear"),
                                         weights_column = NULL,

--- a/h2o-r/tests/testdir_algos/rulefit/runit_rulefit_titanic.R
+++ b/h2o-r/tests/testdir_algos/rulefit/runit_rulefit_titanic.R
@@ -20,7 +20,7 @@ test.rulefit.titanic <- function() {
     train <- splits[[1]]
     test <- splits[[2]]
 
-    rfit <- h2o.rulefit(y = response, x = predictors, training_frame = train, max_rule_length = 10, max_num_rules = 100, seed = 1, model_type="rules")
+    rfit <- h2o.rulefit(y = response, x = predictors, training_frame = train, min_rule_length = 1, max_rule_length = 10, max_num_rules = 100, seed = 1, model_type="rules")
 
     print(rfit@model$rule_importance)
 


### PR DESCRIPTION
since results of tests on big data (= ml-benchmarks results) are good (= AUC and logloss similar to AUC and logloss of underlying tree ensemble on the same data) even for setup with min_rule_length = 3 and max_rule_length = 3, default values of these parameters will be set to 3, 3 instead of 1, 10. 1, 10 can be considered as overkill and consuming much more memory, when results are already good with 3, 3. 

 