### PR TITLE
set cardinality threshold to 25 for TE integration in AutoML

### DIFF
--- a/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/TargetEncoding.java
+++ b/h2o-automl/src/main/java/ai/h2o/automl/preprocessing/TargetEncoding.java
@@ -37,7 +37,7 @@ public class TargetEncoding implements PreprocessingStep {
 
     private TargetEncoderParameters _defaultParams;
     private boolean _encodeAllColumns = false; // if true, bypass all restrictions in columns selection.
-    private int _columnCardinalityThreshold = 10;  // the minimal cardinality for a column to be TE encoded. 
+    private int _columnCardinalityThreshold = 25;  // the minimal cardinality for a column to be TE encoded. 
 
     public TargetEncoding(AutoML aml) {
         _aml = aml;


### PR DESCRIPTION
Based on benchmarks, we changed the cardinality threshold for which Target Encoding is triggered in AutoML to 25 categories (instead of 10).

https://0xdata.atlassian.net/browse/PUBDEV-7778