### PR TITLE
GAM Locking fix

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -12,7 +12,6 @@ import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters;
 import hex.quantile.Quantile;
 import hex.quantile.QuantileModel;
-import jsr166y.CountedCompleter;
 import jsr166y.ForkJoinTask;
 import jsr166y.RecursiveAction;
 import water.*;

--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -12,6 +12,7 @@ import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters;
 import hex.quantile.Quantile;
 import hex.quantile.QuantileModel;
+import jsr166y.CountedCompleter;
 import jsr166y.ForkJoinTask;
 import jsr166y.RecursiveAction;
 import water.*;
@@ -38,8 +39,6 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
   private double[][] _knots; // Knots for splines
   private double[] _cv_alpha = null;  // best alpha value found from cross-validation
   private double[] _cv_lambda = null; // bset lambda value found from cross-validation
-  
-  IcedHashSet<Key<Frame>> _validKeys = new IcedHashSet<>(); // store validation frame keys from various folds
   
   @Override
   public ModelCategory[] can_build() {
@@ -454,9 +453,11 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
 
     }
 
+
     public final void buildModel(Frame newTFrame, Frame newValidFrame) {
       GAMModel model = null;
       DataInfo dinfo = null;
+      final IcedHashSet<Key<Frame>> validKeys = new IcedHashSet<>();
       try {
         _job.update(0, "Adding GAM columns to training dataset...");
         dinfo = new DataInfo(_train.clone(), _valid, 1, _parms._use_all_factor_levels 
@@ -489,28 +490,32 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
           scoreGenModelMetrics(model, valid(), false); // score validation dataset and generate model metrics
         }
       } finally {
-        final List<Key<Vec>> keep = new ArrayList<>();
-        if (model != null) {
-          if (_parms._keep_gam_cols) {
-            keepFrameKeys(keep, newTFrame._key);
-          } else {
-            DKV.remove(newTFrame._key);
+        try {
+          final List<Key<Vec>> keep = new ArrayList<>();
+          if (model != null) {
+            if (_parms._keep_gam_cols) {
+              keepFrameKeys(keep, newTFrame._key);
+            } else {
+              DKV.remove(newTFrame._key);
+            }
           }
+          if (dinfo != null)
+            dinfo.remove();
+
+          if (newValidFrame != null && validKeys != null) {
+            keepFrameKeys(keep, newValidFrame._key);  // save valid frame keys for scoring later
+            validKeys.addIfAbsent(newValidFrame._key);   // save valid frame keys from folds to remove later
+            model._validKeys = validKeys;  // move valid keys here to model._validKeys to be removed later
+          }
+          Scope.exit(keep.toArray(new Key[keep.size()]));
+        } finally {
+          // Make sure Model is unlocked, as if an exception is thrown, the `ModelBuilder` expects the underlying model to be unlocked.
+          model.update(_job);
+          model.unlock(_job);
         }
-        if (dinfo != null)
-          dinfo.remove();
-        
-        if (newValidFrame != null && _validKeys != null) {
-          keepFrameKeys(keep, newValidFrame._key);  // save valid frame keys for scoring later
-          _validKeys.addIfAbsent(newValidFrame._key);   // save valid frame keys from folds to remove later
-          model._validKeys = _validKeys;  // move valid keys here to model._validKeys to be removed later
-        }
-        model.update(_job);
-        model.unlock(_job);
-        Scope.exit(keep.toArray(new Key[keep.size()]));
       }
     }
-    
+
     /**
      * This part will perform scoring and generate the model metrics for training data and validation data if 
      * provided by user.


### PR DESCRIPTION
The original issue:

```
Exception in thread "FJ-2-9" java.lang.AssertionError: Key GAM_model_1601071240700_286_cv_2 already locked (or deleted); lks=[$03017f000001e3abffffffff$_8509e36a8063e0a21f331a4516134f68]
	at water.Lockable$PriorWriteLock.atomic(Lockable.java:116)
	at water.Lockable$PriorWriteLock.atomic(Lockable.java:109)
	at water.TAtomic.atomic(TAtomic.java:17)
	at water.Atomic.compute2(Atomic.java:56)
	at water.Atomic.fork(Atomic.java:39)
	at water.Atomic.invoke(Atomic.java:31)
	at water.Lockable.write_lock(Lockable.java:61)
	at water.Lockable.write_lock(Lockable.java:58)
	at hex.ModelBuilder.setFinalState(ModelBuilder.java:289)
	at hex.ModelBuilder.access$300(ModelBuilder.java:22)
	at hex.ModelBuilder$Driver.onExceptionalCompletion(ModelBuilder.java:263)
	at jsr166y.CountedCompleter.internalPropagateException(CountedCompleter.java:459)
	at jsr166y.ForkJoinTask.setExceptionalCompletion(ForkJoinTask.java:453)
	at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:265)
	at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
	at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
	at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
```
might just be a failure during a reaction to another failure (look where this is done -> `onExceptionalCompletion`).

The class `GAM.java` has a `public final void buildModel(Frame newTFrame, Frame newValidFrame) {` method with a finally block that can actually throw yet another exception inside that finally block.

The 

```java
          model.update(_job);
          model.unlock(_job);
```

may not even be reached, resulting in the error above originating in the `ModelBuilder`.As the `onExceptionalCompletion` method inside the `ModelBuilder` calls `setFinalState`method, which finally tries to obtain a lock on on the resulting `Model` by calling `res.write_lock(_job);`. And this causes yet another exception, as it's not guaranteed GAM is NOT unlocked.

## Countermeasures

### Make sure model is unlocked
As a first step, I put yet another **finally** block into the existing finally block to be absolutely sure the unlock operation is invoked no matter what. This should tell us more about the true origin of our problem, the original exception.

![4gj62m](https://user-images.githubusercontent.com/8769110/94419952-bd1bee80-0183-11eb-8a8d-b605943514bb.jpg)

### Suspicious behavior

In the first `Gam.java` finally block of the `buildModel` method, there is the following line: `_validKeys.addIfAbsent(newValidFrame._key);   // save valid frame keys from folds to remove later`. I managed to make this fail locally today.

```java
java.lang.AssertionError
	at water.util.IcedHashSet.addIfAbsent(IcedHashSet.java:36)
	at hex.gam.GAM$GAMDriver.buildModel(GAM.java:505)
	at hex.gam.GAM$GAMDriver.computeImpl(GAM.java:453)
	at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:237)
	at water.H2O$H2OCountedCompleter.compute(H2O.java:1563)
	at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
	at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
	at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
	at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
	at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
```

@tomasfryda Reported similar problem (the cause might be different) in his PDP code, which is totally unrelated. Only on `IcedHashMap` and not on `IcedHashSet`. However, both have `write_lock` (the pseudo-lock) status changed only in the `write_impl` method, this means during serialization. Could have a common cause ! I'll try to find recent changes in ModelBuilder and the error handling there so see if serialization may occur while model exceptional completion is running.

The `_write_lock = false;` is always in the finally block, which would indicate both models could still have some serialization running while the exceptional state is being handled. This is just to list all findings in case I get hit by a bus today.

## The solution:

After running the tests, I found an issue that is even locally reproducible (on a single node, just run the test in a loop and it will occur):

The problem seems to be in copying the very same reference of `_validKeys` from `GAM.java` to `model._validKeys` (this is `GamModel`. The `GamModel` might undergo serialization in the meantime while the `_validKeys` gets modified. These are extremely fast operations, unlikely to clash. But in the end, they will. Therefore, the fix is to clone the `validKeys` each time those are copied to the `model._validKeys` variable.

```java
            _validKeys.addIfAbsent(newValidFrame._key);   // save valid frame keys from folds to remove later
            model._validKeys = _validKeys.clone();  // move valid keys here to model._validKeys to be removed later
```

Also, the `_validKeys` in GAM class may be local :wink: .