### PR TITLE
[TE] fix failing javadoc build on linux

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -14,6 +14,10 @@ java {
     withJavadocJar()
 }
 
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 task testJar(type: Jar, dependsOn: testClasses, group: "build") {
     classifier = 'test'
     from sourceSets.test.output


### PR DESCRIPTION
target encoder javadoc uses utf8 characters which breaks the build on some systems