### PR TITLE
Fix race condition in Model::adaptTestForTrain

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1310,7 +1310,8 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
   }
   
   public String[] adaptTestForTrain(Frame test, boolean expensive, boolean computeMetrics, boolean catEncoded) {
-    return adaptTestForTrain(
+    final IcedHashMap<Key, String> toDelete = new IcedHashMap<>();
+    String[] warnings = adaptTestForTrain(
             test,
             _output._origNames,
             _output._origDomains,
@@ -1321,9 +1322,14 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
             computeMetrics,
             _output.interactionBuilder(),
             getToEigenVec(),
-            _toDelete,
+            toDelete,
             catEncoded
     );
+    for (Map.Entry<Key, String> entry: _toDelete.entrySet())
+      toDelete.putIfAbsent(entry.getKey(), entry.getValue());
+
+    _toDelete = toDelete;
+    return warnings;
   }
 
   /**

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1310,8 +1310,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
   }
   
   public String[] adaptTestForTrain(Frame test, boolean expensive, boolean computeMetrics, boolean catEncoded) {
-    final IcedHashMap<Key, String> toDelete = new IcedHashMap<>();
-    String[] warnings = adaptTestForTrain(
+    return adaptTestForTrain(
             test,
             _output._origNames,
             _output._origDomains,
@@ -1322,14 +1321,9 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
             computeMetrics,
             _output.interactionBuilder(),
             getToEigenVec(),
-            toDelete,
+            _toDelete,
             catEncoded
     );
-    for (Map.Entry<Key, String> entry: _toDelete.entrySet())
-      toDelete.putIfAbsent(entry.getKey(), entry.getValue());
-
-    _toDelete = toDelete;
-    return warnings;
   }
 
   /**
@@ -1428,7 +1422,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
         else if (isWeights && computeMetrics) {
           if (expensive) {
             vec = test.anyVec().makeCon(1);
-            toDelete.put(vec._key, "adapted missing vectors");
+            toDelete.putIfAbsent(vec._key, "adapted missing vectors");
             msgs.add(H2O.technote(1, "Test/Validation dataset is missing weights column '" + names[i] + "' (needed because a response was found and metrics are to be computed): substituting in a column of 1s"));
           }
         } else if (expensive) {   // generate warning even for response columns.  Other tests depended on this.
@@ -1440,7 +1434,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
             convNaN++;
           }
           vec = test.anyVec().makeCon(defval);
-          toDelete.put(vec._key, "adapted missing vectors");
+          toDelete.putIfAbsent(vec._key, "adapted missing vectors");
           String str = "Test/Validation dataset is missing column '" + names[i] + "': substituting in a column of " + defval;
           if (isResponse || isWeights || isFold)
             Log.info(str); // we are doing a "pure" predict (computeMetrics is false), don't complain to the user
@@ -1456,7 +1450,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
             Vec evec;
             try {
               evec = vec.adaptTo(domains[i]); // Convert to categorical or throw IAE
-              toDelete.put(evec._key, "categorically adapted vec");
+              toDelete.putIfAbsent(evec._key, "categorically adapted vec");
             } catch( NumberFormatException nfe ) {
               throw new IllegalArgumentException("Test/Validation dataset has a non-categorical column '"+names[i]+"' which is categorical in the training data");
             }
@@ -1488,7 +1482,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
       // check if we first need to expand categoricals before calling this method again
       if (hasCategoricalPredictors) {
         Frame updated = categoricalEncoder(test, parms.getNonPredictors(), parms._categorical_encoding, tev, parms._max_categorical_levels);
-        toDelete.put(updated._key, "categorically encoded frame");
+        toDelete.putIfAbsent(updated._key, "categorically encoded frame");
         test.restructure(updated.names(), updated.vecs()); //updated in place
         String[] msg2 = adaptTestForTrain(test, origNames, origDomains, backupNames, backupDomains, parms, expensive, computeMetrics, interactionBldr, tev, toDelete, true /*catEncoded*/);
         msgs.addAll(Arrays.asList(msg2));


### PR DESCRIPTION
This race condition occurs when doing PDP calculation during
StackedEnsemble's metalearner (GLM) scoring.

Fails on `assert !_write_lock;` in `water.util.IcedHashMapBase.put`.

This PR mitigates the issue - it has been tested locally and on Jenkins in Model explainability PR (https://github.com/h2oai/h2o-3/pull/4932) where this issue first appeared.

Stack Trace:
```
java.lang.RuntimeException: java.lang.AssertionError
	at water.Futures.blockForPending(Futures.java:88)
	at
hex.PartialDependence$PartialDependenceDriver.compute2(PartialDependence.java:263)
	at water.H2O$H2OCountedCompleter.compute(H2O.java:1563)
	at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
	at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
	at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
	at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
	at
jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
Caused by: java.lang.AssertionError
	at water.util.IcedHashMapBase.put(IcedHashMapBase.java:69)
	at hex.Model.adaptTestForTrain(Model.java:1424)
	at hex.Model.adaptTestForTrain(Model.java:1300)
	at hex.Model.score(Model.java:1588)
	at
hex.ensemble.StackedEnsembleModel.predictScoreImpl(StackedEnsembleModel.java:172)
	at hex.Model.score(Model.java:1599)
	at hex.Model.score(Model.java:1582)
	at
hex.PartialDependence$PartialDependenceDriver$CalculatePdpPerBin.compute2(PartialDependence.java:400)
	... 6 more
```

The problem is somehow connected with `Model._toDelete` and `adaptTestForTrain`.
I tried multiple things to get rid of it but the only solution that worked is to pass a new `IcedHashMap` to the `adaptTestForTrain`, `putIfAbsent` things from `_toDelete`  and then reassign it back to `_toDelete`.
I also tried cloning it as @Pscheidl suggested but that didn’t help.

Possibly related to https://github.com/h2oai/h2o-3/pull/4969 .