### PR TITLE
PUBDEV-7764 add missing expected times

### DIFF
--- a/scripts/jenkins/groovy/compareBenchmarksStage.groovy
+++ b/scripts/jenkins/groovy/compareBenchmarksStage.groovy
@@ -341,47 +341,71 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
         ],
         'rulefit': [
             'redhat': [
+                ['RULES', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],
                 ['RULES', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES', 1, 10]: [
+                ['RULES', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
+                ['RULES_AND_LINEAR', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],    
                 ['RULES_AND_LINEAR', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES_AND_LINEAR', 1, 10]: [
+                ['RULES_AND_LINEAR', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ]
             ],
             'homesite': [
+                ['RULES', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],    
                 ['RULES', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES', 1, 10]: [
+                ['RULES', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
+                ['RULES_AND_LINEAR', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],    
                 ['RULES_AND_LINEAR', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES_AND_LINEAR', 1, 10]: [
+                ['RULES_AND_LINEAR', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ]
             ],
             'springleaf': [
+                ['RULES', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],    
                 ['RULES', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES', 1, 10]: [
+                ['RULES', 1, 5]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],
+                ['RULES_AND_LINEAR', 1, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
@@ -389,35 +413,51 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES_AND_LINEAR', 1, 10]: [
+                ['RULES_AND_LINEAR', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ]
             ],
             'paribas': [
+                ['RULES', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],    
                 ['RULES', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES', 1, 10]: [
+                ['RULES', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
+                ['RULES_AND_LINEAR', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],    
                 ['RULES_AND_LINEAR', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES_AND_LINEAR', 1, 10]: [
+                ['RULES_AND_LINEAR', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ]
             ],
             'higgs': [
+                ['RULES', 1, 3]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],    
                 ['RULES', 3, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES', 1, 10]: [
+                ['RULES', 1, 5]: [
+                        'train_time_min': 3,
+                        'train_time_max': 8
+                ],
+                ['RULES_AND_LINEAR', 1, 3]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
@@ -425,7 +465,7 @@ def call(final pipelineContext, final stageConfig, final benchmarkFolderConfig) 
                         'train_time_min': 3,
                         'train_time_max': 8
                 ],
-                ['RULES_AND_LINEAR', 1, 10]: [
+                ['RULES_AND_LINEAR', 1, 5]: [
                         'train_time_min': 3,
                         'train_time_max': 8
                 ]


### PR DESCRIPTION
setup with timeout adjusted to 500 (from 120) finished for all test cases. This was when parallel tree ensembles calculation wasn't merged yet so this is slower than actual master. And https://github.com/h2oai/h2o-3/pull/4892 is not merged yet and after that slow down is expected because of extracting of RuleEnsemble and pathFrame calculation.

results here:
http://jenkins:8080/job/h2o-3-benchmark-pipeline/job/ops-benchmark_zuzana_rulefit_adjusted_timeout/1/artifact/rulefit-benchmark/results/rulefit/2020-9-30-09-59-10-914-7dfb389cb860d1550cfcca2d6f08c38f87c35306/20200930165954_7dfb389cb860d1550cfcca2d6f08c38f87c35306.csv

Anyway, this has shown that expected times for some scenarios are missing and this PR will fix it.



