### PR TITLE
Compile H2O against servlet 3.1 (used internally in Jetty 9 anyway)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -67,6 +67,7 @@ defaultHiveExecVersion=1.1.0
 defaultWebserverModule=h2o-jetty-9
 jetty8version=8.2.0.v20160908
 jetty9version=9.4.11.v20180605
+servletApiVersion=3.1.0
 
 # MOJO2 Integration
 mojo2version=2.4.10

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -51,7 +51,7 @@ dependencies {
   testCompile project(":h2o-test-support")
   testCompile project(":h2o-genmodel-ext-jgrapht")
   testRuntimeOnly project(":${defaultWebserverModule}")
-  testCompileOnly "javax.servlet:javax.servlet-api:3.1.0"
+  testCompileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"

--- a/h2o-algos/build.gradle
+++ b/h2o-algos/build.gradle
@@ -51,7 +51,7 @@ dependencies {
   testCompile project(":h2o-test-support")
   testCompile project(":h2o-genmodel-ext-jgrapht")
   testRuntimeOnly project(":${defaultWebserverModule}")
-  testCompileOnly "javax.servlet:javax.servlet-api:3.0.1"
+  testCompileOnly "javax.servlet:javax.servlet-api:3.1.0"
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"

--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
   testCompile project(':h2o-test-support')
   testRuntimeOnly project(":${defaultWebserverModule}")
-  testCompileOnly "javax.servlet:javax.servlet-api:3.1.0"
+  testCompileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"

--- a/h2o-core/build.gradle
+++ b/h2o-core/build.gradle
@@ -16,7 +16,7 @@ dependencies {
   compile 'org.javassist:javassist:3.25.0-GA'
   compile "org.apache.commons:commons-math3:3.3"
   compile "commons-io:commons-io:2.4"
-  compileOnly "javax.servlet:javax.servlet-api:3.0.1"
+  compileOnly "javax.servlet:javax.servlet-api:3.1.0"
   compile("com.github.wendykierp:JTransforms:3.1") { exclude module: "junit" }
   compile project(":h2o-jaas-pam")
 
@@ -41,7 +41,7 @@ dependencies {
 
   testCompile project(':h2o-test-support')
   testRuntimeOnly project(":${defaultWebserverModule}")
-  testCompileOnly "javax.servlet:javax.servlet-api:3.0.1"
+  testCompileOnly "javax.servlet:javax.servlet-api:3.1.0"
 }
 
 apply from: "${rootDir}/gradle/dataCheck.gradle"

--- a/h2o-core/src/test/java/water/api/CustomHttpFilterTest.java
+++ b/h2o-core/src/test/java/water/api/CustomHttpFilterTest.java
@@ -11,6 +11,7 @@ import water.TestUtil;
 import water.init.NetworkInit;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
@@ -96,6 +97,15 @@ public class CustomHttpFilterTest extends TestUtil {
     when(request.getParameterMap()).thenReturn(new HashMap<String, String[]>());
 
     when(response.getOutputStream()).thenReturn(new ServletOutputStream() {
+
+      @Override
+      public boolean isReady() {
+        return true;
+      }
+
+      @Override
+      public void setWriteListener(WriteListener writeListener) {
+      }
 
       @Override public void write(int b) throws IOException {
       }

--- a/h2o-extensions/steam/build.gradle
+++ b/h2o-extensions/steam/build.gradle
@@ -3,7 +3,7 @@ description = "H2O Steam Integration"
 dependencies {
     compile project(":h2o-core")
     compile project(":h2o-webserver-iface")
-    compileOnly "javax.servlet:javax.servlet-api:3.0.1"
+    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
 
     testCompile project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")

--- a/h2o-extensions/steam/build.gradle
+++ b/h2o-extensions/steam/build.gradle
@@ -3,7 +3,7 @@ description = "H2O Steam Integration"
 dependencies {
     compile project(":h2o-core")
     compile project(":h2o-webserver-iface")
-    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
+    compileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
 
     testCompile project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")

--- a/h2o-extensions/xgboost/build.gradle
+++ b/h2o-extensions/xgboost/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile project(":h2o-genmodel-ext-xgboost")
     compile project(":h2o-ext-steam")
     compileOnly 'com.esotericsoftware.kryo:kryo:2.21'
-    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
+    compileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
     compile "org.apache.httpcomponents:httpclient:${httpClientVersion}"
     compile "org.apache.httpcomponents:httpmime:${httpClientVersion}"
 

--- a/h2o-extensions/xgboost/build.gradle
+++ b/h2o-extensions/xgboost/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile project(":h2o-genmodel-ext-xgboost")
     compile project(":h2o-ext-steam")
     compileOnly 'com.esotericsoftware.kryo:kryo:2.21'
-    compileOnly "javax.servlet:javax.servlet-api:3.0.1"
+    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
     compile "org.apache.httpcomponents:httpclient:${httpClientVersion}"
     compile "org.apache.httpcomponents:httpmime:${httpClientVersion}"
 

--- a/h2o-test-support/build.gradle
+++ b/h2o-test-support/build.gradle
@@ -13,5 +13,5 @@ dependencies {
   // using tyrus client since using jetty gets us into conflict because of jetty8/9 dichotomy
   compile "org.glassfish.tyrus.bundles:tyrus-standalone-client:1.12"
   testRuntimeOnly project(":${defaultWebserverModule}")
-  testCompileOnly "javax.servlet:javax.servlet-api:3.0.1"
+  testCompileOnly "javax.servlet:javax.servlet-api:3.1.0"
 }

--- a/h2o-test-support/build.gradle
+++ b/h2o-test-support/build.gradle
@@ -13,5 +13,5 @@ dependencies {
   // using tyrus client since using jetty gets us into conflict because of jetty8/9 dichotomy
   compile "org.glassfish.tyrus.bundles:tyrus-standalone-client:1.12"
   testRuntimeOnly project(":${defaultWebserverModule}")
-  testCompileOnly "javax.servlet:javax.servlet-api:3.1.0"
+  testCompileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
 }

--- a/h2o-webserver-iface/build.gradle
+++ b/h2o-webserver-iface/build.gradle
@@ -2,5 +2,5 @@ description = "Interface module isolating H2O functionality from specific HTTP s
 
 dependencies {
     compile "commons-codec:commons-codec:1.9"
-    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
+    compileOnly "javax.servlet:javax.servlet-api:${servletApiVersion}"
 }

--- a/h2o-webserver-iface/build.gradle
+++ b/h2o-webserver-iface/build.gradle
@@ -2,5 +2,5 @@ description = "Interface module isolating H2O functionality from specific HTTP s
 
 dependencies {
     compile "commons-codec:commons-codec:1.9"
-    compileOnly "javax.servlet:javax.servlet-api:3.0.1"
+    compileOnly "javax.servlet:javax.servlet-api:3.1.0"
 }


### PR DESCRIPTION
As reported by @maurever , we have different servlet API versions inside H2O.

I've taken a look into h2o-jetty-9 and this carries verison 3.1 along. As H2O runs on Jetty 9 completely, there is no point in keeping the tests and webserver i-face on Servlet 3.0.1.

This could ease the setup in IDEs as well. WDYT ?

![Screenshot from 2020-10-01 16-36-57](https://user-images.githubusercontent.com/8769110/94823646-5eb17300-0404-11eb-8e8a-5679ee9d5cf8.png)
