### PR TITLE
PUBDEV-7825 failing coxph performance() with event that is factor

### DIFF
--- a/h2o-algos/src/main/java/hex/coxph/CoxPH.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPH.java
@@ -151,6 +151,11 @@ public class CoxPH extends ModelBuilder<CoxPHModel,CoxPHModel.CoxPHParameters,Co
       error("max_iterations", "max_iterations must be a positive integer");
   }
 
+  @Override
+  protected int init_getNClass() {
+    return 1;
+  }
+
   static class DiscretizeTimeTask extends MRTask<DiscretizeTimeTask> {
     final double[] _time;
     final boolean _has_start_column;

--- a/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
@@ -154,6 +154,11 @@ public class CoxPHModel extends Model<CoxPHModel,CoxPHParameters,CoxPHOutput> {
       _strataMap = strataMap;
     }
 
+    @Override
+    public int nclasses() {
+      return 1;
+    }
+
     private static Frame fullFrame(CoxPH coxPH, Frame adaptFr, Frame train) {
       if (! coxPH._parms.isStratified())
         return adaptFr;

--- a/h2o-r/tests/testdir_algos/coxph/runit_coxph_concordance_heart.R
+++ b/h2o-r/tests/testdir_algos/coxph/runit_coxph_concordance_heart.R
@@ -40,6 +40,7 @@ test.CoxPH.predict <- function() {
     heart.hex <- as.h2o(heart.df)
     heart.hex$surgery <- as.factor(heart.hex$surgery)
     heart.hex$transplant <- as.factor(heart.hex$transplant)
+    heart.hex$event <- as.factor(heart.hex$event)
 
     # simple case
 


### PR DESCRIPTION
failing coxph performance() with event that is factor

Reason - in such a case CoxPH model output thinks about itself that it's an output of an classification lagorithm. (An method from parent is used and if `event_column` is factor it's logic returns `true`)