### PR TITLE
[fix] optimize rulefit tests

### DIFF
--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
@@ -49,8 +49,8 @@ public class RuleFitTest extends TestUtil {
             params._max_num_rules = 100;
             params._model_type = RuleFitModel.ModelType.RULES;
             params._distribution = DistributionFamily.bernoulli;
-            params._min_rule_length = 1;
-            params._max_rule_length = 10;
+            params._min_rule_length = 2;
+            params._max_rule_length = 4;
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
             Scope.track_generic(rfModel);
@@ -145,7 +145,7 @@ public class RuleFitTest extends TestUtil {
             params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
             params._weights_column = "weights";
             params._min_rule_length = 1;
-            params._max_rule_length = 10;
+            params._max_rule_length = 7;
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
             Scope.track_generic(rfModel);
@@ -285,10 +285,10 @@ public class RuleFitTest extends TestUtil {
             params._ignored_columns = new String[]{"name"};
             params._train = fr._key;
             params._max_num_rules = 200;
-            params._max_rule_length = 5;
+            params._max_rule_length = 2;
             params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
             params._distribution = DistributionFamily.gaussian;
-            params._min_rule_length = 1;
+            params._min_rule_length = 2;
 
             final RuleFitModel model = new RuleFit(params).trainModel().get();
             Scope.track_generic(model);
@@ -344,9 +344,7 @@ public class RuleFitTest extends TestUtil {
             params._ignored_columns = new String[]{"name"};
             params._train = fr._key;
             params._max_num_rules = 200;
-            params._max_rule_length = 10;
             params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
-            params._min_rule_length = 1;
 
             final RuleFitModel model = new RuleFit(params).trainModel().get();
             Scope.track_generic(model);
@@ -400,8 +398,8 @@ public class RuleFitTest extends TestUtil {
             params._train = fr._key;
             params._model_type = RuleFitModel.ModelType.RULES;
             params._response_column = responseColumnName;
-            params._min_rule_length = 1;
-            params._max_rule_length = 10;
+            params._min_rule_length = 3;
+            params._max_rule_length = 4;
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
             Scope.track_generic(rfModel);
@@ -455,8 +453,6 @@ public class RuleFitTest extends TestUtil {
             params._response_column = "diabetesMed";
             params._weights_column = "weights";
             params._max_num_rules = 200;
-            params._max_rule_length = 5;
-            params._min_rule_length = 1;
 
 
             final RuleFitModel rfModel = new RuleFit(params).trainModel().get();


### PR DESCRIPTION
do not use depths which anyway produce non-significant rules