### PR TITLE
Add code examples for all the new explainability plotting functions in Python and R (PUBDEV-7824, PUBDEV-7821)

### DIFF
--- a/h2o-docs/src/product/explain.rst
+++ b/h2o-docs/src/product/explain.rst
@@ -253,7 +253,7 @@ There are a number of individual plotting functions that are used inside the ``e
 
    .. code-tab:: python
 
-        # Mhese are methods for an AutoML object
+        # These are methods for an AutoML object
         # Use h2o.method_name(model_list, test) for a list of models        
         .varimp_heatmap()          
         .model_correlation_heatmap()        

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -95,7 +95,8 @@ class Description:
                                     "By default, the models and variables are ordered by their similarity.",
         model_correlation_heatmap="Model correlation matrix shows correlation between prediction of the models. "
                                   "For classification, frequency of same predictions is used. By default, models "
-                                  "are ordered by their similarity.",
+                                  "are ordered by their similarity. Interpretable models, such as GAM, GLM, and RuleFit"
+                                  " are highlighted using red colored text.",
         shap_summary="SHAP summary plot shows contribution of features for each instance. The sum "
                      "of the feature contributions and the bias term is equal to the raw prediction "
                      "of the model, i.e., prediction before applying inverse link function.",
@@ -550,24 +551,19 @@ def shap_summary_plot(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
-    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>> gbm.train(y=response, training_frame=train)
     >>>
     >>> # Create SHAP summary plot
     >>> gbm.shap_summary_plot(test)
@@ -683,24 +679,19 @@ def shap_explain_row_plot(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
-    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>> gbm.train(y=response, training_frame=train)
     >>>
     >>> # Create SHAP row explanation plot
     >>> gbm.shap_explain_row_plot(test, row_index=0)
@@ -940,24 +931,19 @@ def pd_plot(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
-    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>> gbm.train(y=response, training_frame=train)
     >>>
     >>> # Create partial dependence plot
     >>> gbm.pd_plot(test, column="age")
@@ -1046,7 +1032,7 @@ def pd_multi_plot(
     on the response. The effect of a variable is measured in change in the mean response.
     PDP assumes independence between the feature for which is the PDP computed and the rest.
 
-    :param models: H2O AutoML object
+    :param models: H2O AutoML object, or list of H2O models
     :param frame: H2OFrame
     :param column: string containing column name
     :param best_of_family: if True, show only the best models per family
@@ -1066,24 +1052,19 @@ def pd_multi_plot(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=20)
-    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>> aml = H2OAutoML(max_models=7)
+    >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create a partial dependence plot
     >>> aml.pd_multi_plot(test, column="age")
@@ -1206,21 +1187,18 @@ def ice_plot(
     >>> h2o.init()
     >>>
     >>> # Import the wine dataset into H2O:
-    >>> wine = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv")
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides", "free sulfur dioxide",
-    >>>   "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",  "type"
-    >>> ]
+    >>> # Set the response
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = wine.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
-    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>> gbm.train(y=response, training_frame=train)
     >>>
     >>> # Create the individual conditional expectations plot
     >>> gbm.ice_plot(test, column="alcohol")
@@ -1442,7 +1420,7 @@ def varimp_heatmap(
     encoded features and return a single variable importance for the original categorical
     feature. By default, the models and variables are ordered by their similarity.
 
-    :param models: H2O AutoML object or list of models
+    :param models: H2O AutoML object or list of H2O models
     :param top_n: use just top n models (applies only when used with H2OAutoML)
     :param figsize: figsize: figure size; passed directly to matplotlib
     :param cluster: if True, cluster the models and variables
@@ -1455,24 +1433,19 @@ def varimp_heatmap(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=20)
-    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>> aml = H2OAutoML(max_models=7)
+    >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the variable importance heatmap
     >>> aml.varimp_heatmap()
@@ -1540,7 +1513,7 @@ def model_correlation_heatmap(
     For classification, frequency of identical predictions is used. By default, models
     are ordered by their similarity (as computed by hierarchical clustering).
 
-    :param models: H2OAutoML object or a list of models
+    :param models: H2OAutoML object or a list of H2O models
     :param frame: H2OFrame
     :param top_n: show just top n models (applies only when used with H2OAutoML)
     :param cluster_models: if True, cluster the models
@@ -1555,24 +1528,19 @@ def model_correlation_heatmap(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=20)
-    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>> aml = H2OAutoML(max_models=7)
+    >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the model correlation heatmap
     >>> aml.model_correlation_heatmap(test)
@@ -1665,21 +1633,18 @@ def residual_analysis_plot(
     >>> h2o.init()
     >>>
     >>> # Import the wine dataset into H2O:
-    >>> wine = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv")
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides", "free sulfur dioxide",
-    >>>   "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",  "type"
-    >>> ]
+    >>> # Set the response
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = wine.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
-    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>> gbm.train(y=response, training_frame=train)
     >>>
     >>> # Create the residual analysis plot
     >>> gbm.residual_analysis_plot(test)
@@ -1939,7 +1904,7 @@ def explain(
     or a variable importance plot.  Most of the explanations are visual (plots).
     These plots can also be created by individual utility functions/methods as well.
 
-    :param models: H2OAutoML object or H2OModel
+    :param models: H2OAutoML object, H2OModel, or list of H2O models
     :param frame: H2OFrame
     :param columns: either a list of columns or column indices to show. If specified
                     parameter top_n_features will be ignored.
@@ -1958,24 +1923,19 @@ def explain(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=20)
-    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>> aml = H2OAutoML(max_models=7)
+    >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the H2OAutoML explanation
     >>> aml.explain(test)
@@ -2211,7 +2171,7 @@ def explain_row(
     or a variable importance plot.  Most of the explanations are visual (plots).
     These plots can also be created by individual utility functions/methods as well.
 
-    :param models: H2OAutoML object or H2OModel
+    :param models: H2OAutoML object, H2OModel, or list of H2O models
     :param frame: H2OFrame
     :param row_index: row index of the instance to inspect
     :param columns: either a list of columns or column indices to show. If specified
@@ -2233,24 +2193,19 @@ def explain_row(
     >>>
     >>> h2o.init()
     >>>
-    >>> # Import the titanic dataset into H2O:
-    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
     >>>
-    >>> # Set the predictors and the response
-    >>> predictors = [
-    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
-    >>>    "fare", "cabin", "embarked", "home.dest",
-    >>>    "cabin_type", "family_size", "family_type", "title"
-    >>> ]
-    >>> response = "survived"
-    >>> titanic[response] = titanic[response].asfactor()
+    >>> # Set the response
+    >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = titanic.split_frame([.75])
+    >>> train, test = df.split_frame([.75])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=20)
-    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>> aml = H2OAutoML(max_models=7)
+    >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the H2OAutoML explanation
     >>> aml.explain_row(test, row_index=0)

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -22,7 +22,7 @@ def _display(object):
     """
     Display the object.
     :param object: An object to be displayed.
-    :return: the input
+    :returns: the input
     """
     if isinstance(object, matplotlib.figure.Figure) and matplotlib.get_backend().lower() != "agg":
         plt.show()
@@ -42,7 +42,7 @@ def _dont_display(object):
     """
     Don't display the object
     :param object: that should not be displayed
-    :return: input
+    :returns: input
     """
     if isinstance(object, matplotlib.figure.Figure):
         plt.close()
@@ -221,7 +221,7 @@ class NumpyFrame:
         Is column a factor/categorical column?
 
         :param column: string containing the column name
-        :return: boolean
+        :returns: boolean
         """
         return column in self._factors or self._get_column_and_factor(column)[0] in self._factors
 
@@ -231,7 +231,7 @@ class NumpyFrame:
         Get a dictionary mapping a factor to its numerical representation in the NumpyFrame
 
         :param column: string containing the column name
-        :return: dictionary
+        :returns: dictionary
         """
         fact = self._factors[column]
         return dict(zip(fact, range(len(fact))))
@@ -242,7 +242,7 @@ class NumpyFrame:
         Get a dictionary mapping numerical representation of a factor to the category names.
 
         :param column: string containing the column name
-        :return: dictionary
+        :returns: dictionary
         """
         fact = self._factors[column]
         return dict(zip(range(len(fact)), fact))
@@ -256,7 +256,7 @@ class NumpyFrame:
         columns to "column_name.category_name".
 
         :param column: string containing the column name
-        :return: tuple (column_name: str, factor_name: Optional[str])
+        :returns: tuple (column_name: str, factor_name: Optional[str])
         """
         if column in self.columns:
             return column, None
@@ -281,7 +281,7 @@ class NumpyFrame:
         NOTE: Returns numeric representation even for factors.
 
         :param indexer: string for the whole column or a tuple (row_index, column_name)
-        :return: a column or a row within a column
+        :returns: a column or a row within a column
         """
         row = slice(None)
         if isinstance(indexer, tuple):
@@ -308,7 +308,7 @@ class NumpyFrame:
         :param column: string containing the column name
         :param as_factor: if True (default), factor column will contain string
                           representation; otherwise numerical representation
-        :return: A column represented as numpy ndarray
+        :returns: A column represented as numpy ndarray
         """
         if as_factor and self.isfactor(column):
             column, factor_idx = self._get_column_and_factor(column)
@@ -324,7 +324,7 @@ class NumpyFrame:
         Get levels/categories of a factor column.
 
         :param column: a string containing the column name
-        :return: list of levels
+        :returns: list of levels
         """
         return self._factors.get(column, [])
 
@@ -334,7 +334,7 @@ class NumpyFrame:
         Get number of levels/categories of a factor column.
 
         :param column: string containing the column name
-        :return: a number of levels within a factor
+        :returns: a number of levels within a factor
         """
         return len(self.levels(column))
 
@@ -344,7 +344,7 @@ class NumpyFrame:
         """
         Column within the NumpyFrame.
 
-        :return: list of columns
+        :returns: list of columns
         """
         return self._columns
 
@@ -354,7 +354,7 @@ class NumpyFrame:
         """
         Number of rows.
 
-        :return: number of rows
+        :returns: number of rows
         """
         return self._data.shape[0]
 
@@ -364,7 +364,7 @@ class NumpyFrame:
         """
         Number of columns.
 
-        :return: number of columns
+        :returns: number of columns
         """
         return self._data.shape[1]
 
@@ -374,7 +374,7 @@ class NumpyFrame:
         """
         Shape of the frame.
 
-        :return: tuple (number of rows, number of columns)
+        :returns: tuple (number of rows, number of columns)
         """
         return self._data.shape
 
@@ -386,7 +386,7 @@ class NumpyFrame:
         WARNING: This method doesn't care if the column is categorical or numeric. Use with care.
 
         :param axis: Axis along which a sum is performed.
-        :return: numpy.ndarray with shape same as NumpyFrame with the `axis` removed
+        :returns: numpy.ndarray with shape same as NumpyFrame with the `axis` removed
         """
         return self._data.sum(axis=axis)
 
@@ -398,7 +398,7 @@ class NumpyFrame:
         WARNING: This method doesn't care if the column is categorical or numeric. Use with care.
 
         :param axis: Axis along which a mean is performed.
-        :return: numpy.ndarray with shape same as NumpyFrame with the `axis` removed
+        :returns: numpy.ndarray with shape same as NumpyFrame with the `axis` removed
         """
         return self._data.mean(axis=axis)
 
@@ -409,7 +409,7 @@ class NumpyFrame:
 
         :params with_categorical_names: if True, factor columns are returned as string columns;
                                         otherwise numerical
-        :return: generator to be iterated upon
+        :returns: generator to be iterated upon
         """
         for col in self.columns:
             yield col, self.get(col, with_categorical_names)
@@ -430,7 +430,7 @@ def _get_algorithm(model,  treat_xrt_as_algorithm=False):
     Get algorithm type. Use model id to infer it if possible.
     :param model: model or a model_id
     :param treat_xrt_as_algorithm: boolean used for best_of_family
-    :return: string containing algorithm name
+    :returns: string containing algorithm name
     """
     if not isinstance(model, h2o.model.ModelBase):
         import re
@@ -454,7 +454,7 @@ def _first_of_family(models, all_stackedensembles=True):
     Get first of family models
     :param models: models or model ids
     :param all_stackedensembles: if True return all stacked ensembles
-    :return: list of models or model ids (the same type as on input)
+    :returns: list of models or model ids (the same type as on input)
     """
     selected_models = []
     included_families = set()
@@ -472,7 +472,7 @@ def _density(xs, bins=100):
     Make an approximate density estimation by blurring a histogram (used for SHAP summary plot).
     :param xs: numpy vector
     :param bins: number of bins
-    :return: density values
+    :returns: density values
     """
     hist = list(np.histogram(xs, bins=bins))
     # gaussian blur
@@ -491,7 +491,7 @@ def _uniformize(data, col_name):
     Convert to quantiles.
     :param data: NumpyFrame
     :param col_name: string containing a column name
-    :return: quantile values of individual points in the column
+    :returns: quantile values of individual points in the column
     """
     if col_name not in data.columns or data.isfactor(col_name):
         res = data[col_name]
@@ -542,7 +542,35 @@ def shap_summary_plot(
     :param colormap: colormap to use instead of the default blue to red colormap
     :param figsize: figure size; passed directly to matplotlib
     :param jitter: amount of jitter used to show the point density
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.estimators import H2OGradientBoostingEstimator
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train a GBM
+    >>> gbm = H2OGradientBoostingEstimator()
+    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create SHAP summary plot
+    >>> gbm.shap_summary_plot(test)
     """
 
     blue_to_red = matplotlib.colors.LinearSegmentedColormap.from_list("blue_to_red",
@@ -647,7 +675,35 @@ def shap_explain_row_plot(
     :param plot_type: either "barplot" or "breakdown"
     :param contribution_type: One of "positive", "negative", or "both".
                               Used only for plot_type="barplot".
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.estimators import H2OGradientBoostingEstimator
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train a GBM
+    >>> gbm = H2OGradientBoostingEstimator()
+    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create SHAP row explanation plot
+    >>> gbm.shap_explain_row_plot(test, row_index=0)
     """
 
     row = frame[row_index, :]
@@ -780,7 +836,7 @@ def _get_top_n_levels(column, top_n):
 
     :param column: string containing column name
     :param top_n: maximum number of levels to be returned
-    :return: list of levels
+    :returns: list of levels
     """
     counts = column.table().sort("Count", ascending=[False])[:, 0]
     return [
@@ -795,7 +851,7 @@ def _factor_mapper(mapping):
     """
     Helper higher order function returning function that applies mapping to each element.
     :param mapping: dictionary that maps factor names to floats (for NaN; other values are integers)
-    :return: function to be applied on iterable
+    :returns: function to be applied on iterable
     """
 
     def _(column):
@@ -812,7 +868,7 @@ def _add_histogram(frame, column, add_rug=True, add_histogram=True, levels_order
     :param column: string containing column name
     :param add_rug: if True, adds rug
     :param add_histogram: if True, adds histogram
-    :return: None
+    :returns: None
     """
     ylims = plt.ylim()
     nf = NumpyFrame(frame[column])
@@ -876,7 +932,35 @@ def pd_plot(
     :param figsize: figure size; passed directly to matplotlib
     :param colormap: colormap name; used to get just the first color to keep the api and color scheme similar with
                      pd_multi_plot
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.estimators import H2OGradientBoostingEstimator
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train a GBM
+    >>> gbm = H2OGradientBoostingEstimator()
+    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create partial dependence plot
+    >>> gbm.pd_plot(test, column="age")
     """
     is_factor = frame[column].isfactor()[0]
     if is_factor:
@@ -974,7 +1058,35 @@ def pd_multi_plot(
     :param colormap: colormap name
     :param markers: List of markers to use for factors, when it runs out of possible markers the last in
                     this list will get reused
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.automl import H2OAutoML
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train an H2OAutoML
+    >>> aml = H2OAutoML(max_models=20)
+    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create a partial dependence plot
+    >>> aml.pd_multi_plot(test, column="age")
     """
     if target is not None:
         if isinstance(target, (list, tuple)):
@@ -1085,7 +1197,33 @@ def ice_plot(
     :param max_levels: maximum number of factor levels to show
     :param figsize: figure size; passed directly to matplotlib
     :param colormap: colormap name
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.estimators import H2OGradientBoostingEstimator
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the wine dataset into H2O:
+    >>> wine = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides", "free sulfur dioxide",
+    >>>   "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",  "type"
+    >>> ]
+    >>> response = "quality"
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = wine.split_frame([.75])
+    >>>
+    >>> # Train a GBM
+    >>> gbm = H2OGradientBoostingEstimator()
+    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create the individual conditional expectations plot
+    >>> gbm.ice_plot(test, column="alcohol")
     """
     if target is not None:
         if isinstance(target, (list, tuple)):
@@ -1167,7 +1305,7 @@ def _has_varimp(model):
     """
     Does model have varimp?
     :param model: model or a string containing model_id
-    :return: bool
+    :returns: bool
     """
     return _get_algorithm(model) not in ["stackedensemble", "naivebayes"]
 
@@ -1175,9 +1313,9 @@ def _has_varimp(model):
 def _get_xy(model):
     # type: (h2o.model.ModelBase) -> Tuple[List[str], str]
     """
-    Get features (x) and response column (y).
+    Get features (x) and the response column (y).
     :param model: H2O Model
-    :return: tuple (x, y)
+    :returns: tuple (x, y)
     """
     y = model.actual_params["response_column"]
     x = [feature for feature in model._model_json["output"]["names"]
@@ -1193,7 +1331,7 @@ def _consolidate_varimps(model):
     importances are summed to "column_name" variable.
 
     :param model: H2O Model
-    :return: dictionary with variable importances
+    :returns: dictionary with variable importances
     """
     x, y = _get_xy(model)
 
@@ -1230,7 +1368,7 @@ def _interpretable(model):
     """
     Returns True if model_id is easily interpretable.
     :param model: model or a string containing a model_id
-    :return: bool
+    :returns: bool
     """
     return _get_algorithm(model) in ["glm", "gam", "rulefit"]
 
@@ -1240,7 +1378,7 @@ def _flatten_list(items):
     """
     Flatten nested lists.
     :param items: a list potentionally containing other lists
-    :return: flattened list
+    :returns: flattened list
     """
     for x in items:
         if isinstance(x, list):
@@ -1255,7 +1393,7 @@ def _calculate_clustering_indices(matrix):
     """
     Get a hierarchical clustering leaves order calculated from the clustering of columns.
     :param matrix: numpy.ndarray
-    :return: list of indices of columns
+    :returns: list of indices of columns
     """
     cols = matrix.shape[1]
     dist = np.zeros((cols, cols))
@@ -1304,7 +1442,35 @@ def varimp_heatmap(
     :param figsize: figsize: figure size; passed directly to matplotlib
     :param cluster: if True, cluster the models and variables
     :param colormap: colormap to use
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.automl import H2OAutoML
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train an H2OAutoML
+    >>> aml = H2OAutoML(max_models=20)
+    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create the variable importance heatmap
+    >>> aml.varimp_heatmap()
     """
     if isinstance(models, h2o.automl._base.H2OAutoMLBaseMixin):
         model_ids = [model_id[0] for model_id in models.leaderboard[:, "model_id"]
@@ -1376,7 +1542,35 @@ def model_correlation_heatmap(
     :param triangular: make the heatmap triangular
     :param figsize: figsize: figure size; passed directly to matplotlib
     :param colormap: colormap to use
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.automl import H2OAutoML
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train an H2OAutoML
+    >>> aml = H2OAutoML(max_models=20)
+    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create the model correlation heatmap
+    >>> aml.model_correlation_heatmap(test)
     """
     if isinstance(models, h2o.automl._base.H2OAutoMLBaseMixin):
         model_ids = [model_id[0] for model_id in models.leaderboard[:, "model_id"]
@@ -1455,7 +1649,33 @@ def residual_analysis_plot(
     :param model: H2OModel
     :param frame: H2OFrame
     :param figsize: figsize: figure size; passed directly to matplotlib
-    :return: a matplotlib figure object
+    :returns: a matplotlib figure object
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.estimators import H2OGradientBoostingEstimator
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the wine dataset into H2O:
+    >>> wine = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides", "free sulfur dioxide",
+    >>>   "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",  "type"
+    >>> ]
+    >>> response = "quality"
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = wine.split_frame([.75])
+    >>>
+    >>> # Train a GBM
+    >>> gbm = H2OGradientBoostingEstimator()
+    >>> gbm.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create the residual analysis plot
+    >>> gbm.residual_analysis_plot(test)
     """
     _, y = _get_xy(model)
 
@@ -1499,7 +1719,7 @@ def _is_tree_model(model):
     """
     Is the model a tree model id?
     :param model: model or astring containing a model_id
-    :return: bool
+    :returns: bool
     """
     return _get_algorithm(model) in ["drf", "gbm", "xgboost"]
 
@@ -1514,7 +1734,7 @@ def _get_tree_models(
 
     :param models: either H2OAutoML object or list of H2O Models
     :param top_n: maximum number of tree models to return
-    :return: list of tree models
+    :returns: list of tree models
     """
     if isinstance(models, h2o.automl._base.H2OAutoMLBaseMixin):
         model_ids = [model_id[0] for model_id in models.leaderboard[:, "model_id"]
@@ -1552,7 +1772,7 @@ def _get_leaderboard(
     :param frame: H2OFrame used for calculating prediction when row_index is specified
     :param row_index: if specified, calculated prediction for the given row
     :param top_n: show just top n models in the leaderboard
-    :return: H2OFrame
+    :returns: H2OFrame
     """
     if isinstance(models, h2o.automl._base.H2OAutoMLBaseMixin):
         leaderboard = h2o.automl.get_leaderboard(models, extra_columns="ALL")
@@ -1614,7 +1834,7 @@ def _process_explanation_lists(
     :param exclude_explanations: list of model explanations to exclude
     :param include_explanations: list of model explanations to include
     :param possible_explanations: list of all possible explanations
-    :return: list of actual explanations
+    :returns: list of actual explanations
     """
     if not isinstance(include_explanations, list):
         include_explanations = [include_explanations]
@@ -1647,7 +1867,7 @@ def _process_models_input(
 
     :param models: H2OAutoML/List of models/H2O Model
     :param frame: H2O Frame
-    :return: tuple (is_aml, models_to_show, classification, multinomial_classification,
+    :returns: tuple (is_aml, models_to_show, classification, multinomial_classification,
                     multiple_models, targets, tree_models_to_show)
     """
     is_aml = isinstance(models, h2o.automl._base.H2OAutoMLBaseMixin)
@@ -1678,7 +1898,7 @@ def _custom_args(user_specified, **kwargs):
 
     :param user_specified: dictionary of user specified overrides or None
     :param kwargs: default values, such as, `top_n=5`
-    :return: dictionary of actual arguments to use
+    :returns: dictionary of actual arguments to use
     """
     if user_specified is None:
         user_specified = dict()
@@ -1717,7 +1937,38 @@ def explain(
     :param plot_overrides: overrides for individual model explanations
     :param figsize: figure size; passed directly to matplotlib
     :param render: if True, render the model explanations; otherwise model explanations are just returned
-    :return: H2OExplanation containing the model explanations including headers and descriptions
+    :returns: H2OExplanation containing the model explanations including headers and descriptions
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.automl import H2OAutoML
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train an H2OAutoML
+    >>> aml = H2OAutoML(max_models=20)
+    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create the H2OAutoML explanation
+    >>> aml.explain(test)
+    >>>
+    >>> # Create the leader model explanation
+    >>> aml.leader.explain(test)
     """
     is_aml, models_to_show, classification, multinomial_classification, multiple_models, \
     targets, tree_models_to_show = _process_models_input(models, frame)
@@ -1956,7 +2207,38 @@ def explain_row(
     :param figsize: figure size; passed directly to matplotlib
     :param render: if True, render the model explanations; otherwise model explanations are just returned
 
-    :return: H2OExplanation containing the model explanations including headers and descriptions
+    :returns: H2OExplanation containing the model explanations including headers and descriptions
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.automl import H2OAutoML
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the titanic dataset into H2O:
+    >>> titanic = h2o.import_file("https://h2o-public-test-data.s3.amazonaws.com/smalldata/titanic/titanic_expanded.csv")
+    >>>
+    >>> # Set the predictors and the response
+    >>> predictors = [
+    >>>    "pclass", "sex", "age", "sibsp", "parch", "ticket",
+    >>>    "fare", "cabin", "embarked", "home.dest",
+    >>>    "cabin_type", "family_size", "family_type", "title"
+    >>> ]
+    >>> response = "survived"
+    >>> titanic[response] = titanic[response].asfactor()
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = titanic.split_frame([.75])
+    >>>
+    >>> # Train an H2OAutoML
+    >>> aml = H2OAutoML(max_models=20)
+    >>> aml.train(x=predictors, y=response, training_frame=train)
+    >>>
+    >>> # Create the H2OAutoML explanation
+    >>> aml.explain_row(test, row_index=0)
+    >>>
+    >>> # Create the leader model explanation
+    >>> aml.leader.explain_row(test, row_index=0)
     """
     is_aml, models_to_show, _, multinomial_classification, multiple_models, \
     targets, tree_models_to_show = _process_models_input(models, frame)

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -559,7 +559,7 @@ def shap_summary_plot(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
@@ -687,7 +687,7 @@ def shap_explain_row_plot(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
@@ -939,14 +939,14 @@ def pd_plot(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
     >>> gbm.train(y=response, training_frame=train)
     >>>
     >>> # Create partial dependence plot
-    >>> gbm.pd_plot(test, column="age")
+    >>> gbm.pd_plot(test, column="alcohol")
     """
     is_factor = frame[column].isfactor()[0]
     if is_factor:
@@ -1060,14 +1060,14 @@ def pd_multi_plot(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=7)
+    >>> aml = H2OAutoML(max_models=10)
     >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create a partial dependence plot
-    >>> aml.pd_multi_plot(test, column="age")
+    >>> aml.pd_multi_plot(test, column="alcohol")
     """
     if target is not None:
         if isinstance(target, (list, tuple)):
@@ -1194,7 +1194,7 @@ def ice_plot(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
@@ -1441,10 +1441,10 @@ def varimp_heatmap(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=7)
+    >>> aml = H2OAutoML(max_models=10)
     >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the variable importance heatmap
@@ -1536,10 +1536,10 @@ def model_correlation_heatmap(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=7)
+    >>> aml = H2OAutoML(max_models=10)
     >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the model correlation heatmap
@@ -1640,7 +1640,7 @@ def residual_analysis_plot(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train a GBM
     >>> gbm = H2OGradientBoostingEstimator()
@@ -1931,10 +1931,10 @@ def explain(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=7)
+    >>> aml = H2OAutoML(max_models=10)
     >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the H2OAutoML explanation
@@ -2201,10 +2201,10 @@ def explain_row(
     >>> response = "quality"
     >>>
     >>> # Split the dataset into a train and test set:
-    >>> train, test = df.split_frame([.75])
+    >>> train, test = df.split_frame([0.8])
     >>>
     >>> # Train an H2OAutoML
-    >>> aml = H2OAutoML(max_models=7)
+    >>> aml = H2OAutoML(max_models=10)
     >>> aml.train(y=response, training_frame=train)
     >>>
     >>> # Create the H2OAutoML explanation

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1434,8 +1434,13 @@ def varimp_heatmap(
     """
     Variable Importance Heatmap across a group of models
 
-    Variable importance heatmap shows variable importances on multiple models.
-    By default, the models and variables are ordered by their similarity.
+    Variable importance heatmap shows variable importance across multiple models.
+    Some models in H2O return variable importance for one-hot (binary indicator)
+    encoded versions of categorical columns (e.g. Deep Learning, XGBoost).  In order
+    for the variable importance of categorical columns to be compared across all model
+    types we compute a summarization of the the variable importance across all one-hot
+    encoded features and return a single variable importance for the original categorical
+    feature. By default, the models and variables are ordered by their similarity.
 
     :param models: H2O AutoML object or list of models
     :param top_n: use just top n models (applies only when used with H2OAutoML)
@@ -1531,9 +1536,9 @@ def model_correlation_heatmap(
     """
     Model Prediction Correlation Heatmap
 
-    Model correlation matrix shows correlation between prediction of the models.
-    For classification, frequency of same predictions is used. By default, models
-    are ordered by their similarity.
+    This plot shows the correlation between the predictions of the models.
+    For classification, frequency of identical predictions is used. By default, models
+    are ordered by their similarity (as computed by hierarchical clustering).
 
     :param models: H2OAutoML object or a list of models
     :param frame: H2OFrame
@@ -1641,10 +1646,12 @@ def residual_analysis_plot(
     """
     Residual Analysis
 
-    Do Residual Analysis and creates a plot "Fitted vs Residuals".
+    Do Residual Analysis and plot the fitted values vs residuals on a test dataset.
     Ideally, residuals should be randomly distributed. Patterns in this plot can indicate
     potential problems with the model selection, e.g., using simpler model than necessary,
-    not accounting for heteroscedasticity, autocorrelation, etc.
+    not accounting for heteroscedasticity, autocorrelation, etc.  If you notice "striped"
+    lines of residuals, that is just an indication that your response variable was integer
+    valued instead of real valued.
 
     :param model: H2OModel
     :param frame: H2OFrame
@@ -1926,6 +1933,12 @@ def explain(
     """
     Generate model explanations on frame data set.
 
+    The H2O Explainability Interface is a convenient wrapper to a number of explainabilty
+    methods and visualizations in H2O.  The function can be applied to a single model or group
+    of models and returns an object containing explanations, such as a partial dependence plot
+    or a variable importance plot.  Most of the explanations are visual (plots).
+    These plots can also be created by individual utility functions/methods as well.
+
     :param models: H2OAutoML object or H2OModel
     :param frame: H2OFrame
     :param columns: either a list of columns or column indices to show. If specified
@@ -2192,6 +2205,11 @@ def explain_row(
     # type: (...) -> H2OExplanation
     """
     Generate model explanations on frame data set for a given instance.
+
+    Explain the behavior of a model or group of models with respect to a single row of data.
+    The function returns an object containing explanations, such as a partial dependence plot
+    or a variable importance plot.  Most of the explanations are visual (plots).
+    These plots can also be created by individual utility functions/methods as well.
 
     :param models: H2OAutoML object or H2OModel
     :param frame: H2OFrame

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -999,6 +999,35 @@ stat_count_or_bin <- function(use_count, ..., data) {
 #' @param sample_size Integer specifying the maximum number of observations to be plotted.
 #'
 #' @return A ggplot2 object
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the titanic dataset into H2O:
+#' titanic <- h2o.importFile(
+#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
+#' )
+#'
+#' # Set the predictors and response; set the response as a factor:
+#' titanic['survived'] <- as.factor(titanic['survived'])
+#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
+#' response <- "survived"
+#'
+#' # Split the dataset into a train and test set:
+#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
+#' train <- titanic_splits[[1]]
+#' test <- titanic_splits[[2]]
+#'
+#' # Build and train the model:
+#' gbm <- h2o.gbm(x = predictors,
+#'                y = response,
+#'                training_frame = train)
+#'
+#' # Create the SHAP summary plot
+#' shap_summary_plot <- h2o.shap_summary_plot(gbm, test)
+#' print(shap_summary_plot)
+#' }
 #' @export
 h2o.shap_summary_plot <-
   function(model,
@@ -1180,7 +1209,35 @@ h2o.shap_summary_plot <-
 #' @param contribution_type When \code{plot_type == "barplot"}, plot one of "negative", 
 #'                          "positive", or "both" contributions.  Defaults to "both".
 #' @return A ggplot2 object.
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
 #'
+#' # Import the titanic dataset into H2O:
+#' titanic <- h2o.importFile(
+#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
+#' )
+#'
+#' # Set the predictors and response; set the response as a factor:
+#' titanic['survived'] <- as.factor(titanic['survived'])
+#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
+#' response <- "survived"
+#'
+#' # Split the dataset into a train and test set:
+#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
+#' train <- titanic_splits[[1]]
+#' test <- titanic_splits[[2]]
+#'
+#' # Build and train the model:
+#' gbm <- h2o.gbm(x = predictors,
+#'                y = response,
+#'                training_frame = train)
+#'
+#' # Create the SHAP row explanation plot
+#' shap_explain_row_plot <- h2o.shap_explain_row_plot(gbm, test, row_index = 1)
+#' print(shap_explain_row_plot)
+#' }
 #' @export
 h2o.shap_explain_row_plot <-
   function(model, newdata, row_index, columns = NULL, top_n_features = 10,
@@ -1424,6 +1481,32 @@ h2o.shap_explain_row_plot <-
 #'              (based on leaderboard ranking). Defaults to 20.
 #'
 #' @return A ggplot2 object.
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the prostate dataset into H2O:
+#' prostate <- h2o.importFile(
+#'   "http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv"
+#' )
+#'
+#' # Set the predictors and response; set the factors:
+#' prostate$CAPSULE <- as.factor(prostate$CAPSULE)
+#' predictors <- c("ID", "AGE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
+#' response <- "CAPSULE"
+#'
+#' # Build and train the model:
+#' aml <- h2o.automl(x = predictors,
+#'                   y = response,
+#'                   training_frame = prostate,
+#'                   max_models = 20,
+#'                   seed = 1)
+#'
+#' # Create the variable importance heatmap
+#' varimp_heatmap <- h2o.varimp_heatmap(aml, prostate)
+#' print(varimp_heatmap)
+#' }
 #' @export
 h2o.varimp_heatmap <- function(object, newdata, top_n = 20) {
   # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
@@ -1495,6 +1578,37 @@ h2o.varimp_heatmap <- function(object, newdata, top_n = 20) {
 #' @param triangular Print just the lower triangular part of correlation matrix.  Defaults to TRUE.
 #'
 #' @return A ggplot2 object.
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the titanic dataset into H2O:
+#' titanic <- h2o.importFile(
+#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
+#' )
+#'
+#' # Set the predictors and response; set the response as a factor:
+#' titanic['survived'] <- as.factor(titanic['survived'])
+#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
+#' response <- "survived"
+#'
+#' # Split the dataset into a train and test set:
+#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
+#' train <- titanic_splits[[1]]
+#' test <- titanic_splits[[2]]
+#'
+#' # Build and train the model:
+#' aml <- h2o.automl(x = predictors,
+#'                   y = response,
+#'                   training_frame = train,
+#'                   max_models = 20,
+#'                   seed = 1)
+#'
+#' # Create the model correlation heatmap
+#' model_correlation_heatmap <- h2o.model_correlation_heatmap(aml, test)
+#' print(model_correlation_heatmap)
+#' }
 #' @export
 h2o.model_correlation_heatmap <- function(object, newdata, top_n = 20,
                                           cluster_models = TRUE, triangular = TRUE) {
@@ -1585,12 +1699,43 @@ h2o.model_correlation_heatmap <- function(object, newdata, top_n = 20,
 #' not accounting for heteroscedasticity, autocorrelation, etc.  If you notice "striped" 
 #' lines of residuals, that is just an indication that your response variable was integer 
 #' valued instead of real valued.
-#' 
 #'
 #' @param model An H2OModel.
 #' @param newdata An H2OFrame.  Used to calculate residuals.
 #'
 #' @return A ggplot2 object
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the wine dataset into H2O:
+#' wine <-  h2o.importFile(
+#'   "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' )
+#'
+#' # Set the predictors and response
+#' predictors <- c(
+#'   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides",
+#'   "free sulfur dioxide", "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",
+#'   "type"
+#' )
+#' response <- "quality"
+#'
+#' # Split the dataset into a train and test set:
+#' wine_splits <- h2o.splitFrame(wine, ratios = 0.8, seed = 1)
+#' train <- wine_splits[[1]]
+#' test <- wine_splits[[2]]
+#'
+#' # Build and train the model:
+#' gbm <- h2o.gbm(x = predictors,
+#'                y = response,
+#'                training_frame = train)
+#'
+#' # Create the residual analysis plot
+#' residual_analysis_plot <- h2o.residual_analysis_plot(gbm, test)
+#' print(residual_analysis_plot)
+#' }
 #' @export
 h2o.residual_analysis_plot <- function(model, newdata) {
   # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
@@ -1636,6 +1781,35 @@ h2o.residual_analysis_plot <- function(model, newdata) {
 #'                   Defaults to 30.
 #'
 #' @return A ggplot2 object
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the titanic dataset into H2O:
+#' titanic <- h2o.importFile(
+#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
+#' )
+#'
+#' # Set the predictors and response; set the response as a factor:
+#' titanic['survived'] <- as.factor(titanic['survived'])
+#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
+#' response <- "survived"
+#'
+#' # Split the dataset into a train and test set:
+#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
+#' train <- titanic_splits[[1]]
+#' test <- titanic_splits[[2]]
+#'
+#' # Build and train the model:
+#' gbm <- h2o.gbm(x = predictors,
+#'                y = response,
+#'                training_frame = train)
+#'
+#' # Create the partial dependence plot
+#' pdp <- h2o.pd_plot(gbm, test, column = "age")
+#' print(pdp)
+#' }
 #' @export
 h2o.pd_plot <- function(object,
                         newdata,
@@ -1779,6 +1953,37 @@ h2o.pd_plot <- function(object,
 #'                   Defaults to 30.
 #'
 #' @return A ggplot2 object
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the titanic dataset into H2O:
+#' titanic <- h2o.importFile(
+#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
+#' )
+#'
+#' # Set the predictors and response; set the response as a factor:
+#' titanic['survived'] <- as.factor(titanic['survived'])
+#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
+#' response <- "survived"
+#'
+#' # Split the dataset into a train and test set:
+#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
+#' train <- titanic_splits[[1]]
+#' test <- titanic_splits[[2]]
+#'
+#' # Build and train the model:
+#' aml <- h2o.automl(x = predictors,
+#'                   y = response,
+#'                   training_frame = train,
+#'                   max_models = 20,
+#'                   seed = 1)
+#'
+#' # Create the partial dependence plot
+#' pdp <- h2o.pd_multi_plot(aml, test, column = "age")
+#' print(pdp)
+#' }
 #' @export
 h2o.pd_multi_plot <- function(object,
                               newdata,
@@ -2014,8 +2219,40 @@ h2o.pd_multi_plot <- function(object,
 #' @param target If multinomial, plot PDP just for \code{target} category.  Character string.
 #' @param max_levels An integer specifying the maximum number of factor levels to show.
 #'                   Defaults to 30.
-#'                   
+#'
 #' @return A ggplot2 object
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the wine dataset into H2O:
+#' wine <-  h2o.importFile(
+#'   "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' )
+#'
+#' # Set the predictors and response
+#' predictors <- c(
+#'   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides",
+#'   "free sulfur dioxide", "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",
+#'   "type"
+#' )
+#' response <- "quality"
+#'
+#' # Split the dataset into a train and test set:
+#' wine_splits <- h2o.splitFrame(wine, ratios = 0.8, seed = 1)
+#' train <- wine_splits[[1]]
+#' test <- wine_splits[[2]]
+#'
+#' # Build and train the model:
+#' gbm <- h2o.gbm(x = predictors,
+#'                y = response,
+#'                training_frame = train)
+#'
+#' # Create the individual conditional expectations plot
+#' ice <- h2o.ice_plot(gbm, test, column = "alcohol")
+#' print(ice)
+#' }
 #' @export
 h2o.ice_plot <- function(model,
                          newdata,
@@ -2177,6 +2414,41 @@ h2o.ice_plot <- function(model,
 #' \code{list(shap_summary_plot = list(columns = 50))}.
 #'
 #' @return List of outputs with class "H2OExplanation"
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the titanic dataset into H2O:
+#' titanic <- h2o.importFile(
+#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
+#' )
+#'
+#' # Set the predictors and response; set the response as a factor:
+#' titanic['survived'] <- as.factor(titanic['survived'])
+#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
+#' response <- "survived"
+#'
+#' # Split the dataset into a train and valid set:
+#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
+#' train <- titanic_splits[[1]]
+#' test <- titanic_splits[[2]]
+#'
+#' # Build and train the model:
+#' aml <- h2o.automl(x = predictors,
+#'                   y = response,
+#'                   training_frame = train,
+#'                   max_models = 20,
+#'                   seed = 1)
+#'
+#' # Create the explanation for whole H2OAutoML object
+#' exa <- h2o.explain(aml, test)
+#' print(exa)
+#'
+#' # Create the explanation for the leader model
+#' exm <- h2o.explain(aml@leader, test)
+#' print(exm)
+#' }
 #' @export
 h2o.explain <- function(object,
                         newdata,
@@ -2533,7 +2805,42 @@ h2o.explain <- function(object,
 #' @param plot_overrides Overrides for individual model explanations, e.g.,
 #'                       \code{list(shap_explain_row = list(columns = 5))}
 #'
-#' @return List of outputs with class "explanation"
+#' @return List of outputs with class "H2OExplanation"
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the titanic dataset into H2O:
+#' titanic <- h2o.importFile(
+#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
+#' )
+#'
+#' # Set the predictors and response; set the response as a factor:
+#' titanic['survived'] <- as.factor(titanic['survived'])
+#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
+#' response <- "survived"
+#'
+#' # Split the dataset into a train and valid set:
+#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
+#' train <- titanic_splits[[1]]
+#' test <- titanic_splits[[2]]
+#'
+#' # Build and train the model:
+#' aml <- h2o.automl(x = predictors,
+#'                   y = response,
+#'                   training_frame = train,
+#'                   max_models = 20,
+#'                   seed = 1)
+#'
+#' # Create the explanation for whole H2OAutoML object
+#' exa <- h2o.explain_row(aml, test, row_index = 1)
+#' print(exa)
+#'
+#' # Create the explanation for the leader model
+#' exm <- h2o.explain_row(aml@leader, test, row_index = 1)
+#' print(exm)
+#' }
 #' @export
 h2o.explain_row <- function(object,
                             newdata,

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1492,12 +1492,12 @@ h2o.shap_explain_row_plot <-
 #'
 #' # Build and train the model:
 #' aml <- h2o.automl(y = response,
-#'                   training_frame = prostate,
+#'                   training_frame = train,
 #'                   max_models = 10,
 #'                   seed = 1)
 #'
 #' # Create the variable importance heatmap
-#' varimp_heatmap <- h2o.varimp_heatmap(aml, prostate)
+#' varimp_heatmap <- h2o.varimp_heatmap(aml, test)
 #' print(varimp_heatmap)
 #' }
 #' @export

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1641,7 +1641,7 @@ h2o.pd_plot <- function(object,
                         newdata,
                         column,
                         target = NULL,
-                        row_index = -1,
+                        row_index = NULL,
                         max_levels = 30) {
   # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
   .data <- NULL
@@ -1649,6 +1649,8 @@ h2o.pd_plot <- function(object,
     stop("Column has to be specified!")
   if (!column %in% names(newdata))
     stop("Column was not found in the provided data set!")
+  if (is.null(row_index))
+    row_index <- -1
   models_info <- .process_models_or_automl(object, newdata, require_single_model = TRUE)
   if (h2o.nlevels(newdata[[column]]) > max_levels) {
     factor_frequencies <- .get_feature_count(newdata[[column]])
@@ -1783,7 +1785,7 @@ h2o.pd_multi_plot <- function(object,
                               column,
                               best_of_family = TRUE,
                               target = NULL,
-                              row_index = -1,
+                              row_index = NULL,
                               max_levels = 30) {
   # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
   .data <- NULL
@@ -1791,6 +1793,8 @@ h2o.pd_multi_plot <- function(object,
     stop("Column has to be specified!")
   if (!column %in% names(newdata))
     stop("Column was not found in the provided data set!")
+  if (is.null(row_index))
+    row_index <- -1
   models_info <- .process_models_or_automl(object, newdata, best_of_family = best_of_family)
   if (h2o.nlevels(newdata[[column]]) > max_levels) {
     factor_frequencies <- .get_feature_count(newdata[[column]])

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1004,24 +1004,20 @@ stat_count_or_bin <- function(use_count, ..., data) {
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the titanic dataset into H2O:
-#' titanic <- h2o.importFile(
-#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the response as a factor:
-#' titanic['survived'] <- as.factor(titanic['survived'])
-#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
-#' response <- "survived"
+#' # Set the response
+#' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
-#' train <- titanic_splits[[1]]
-#' test <- titanic_splits[[2]]
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' gbm <- h2o.gbm(x = predictors,
-#'                y = response,
+#' gbm <- h2o.gbm(y = response,
 #'                training_frame = train)
 #'
 #' # Create the SHAP summary plot
@@ -1214,24 +1210,20 @@ h2o.shap_summary_plot <-
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the titanic dataset into H2O:
-#' titanic <- h2o.importFile(
-#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the response as a factor:
-#' titanic['survived'] <- as.factor(titanic['survived'])
-#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
-#' response <- "survived"
+#' # Set the response
+#' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
-#' train <- titanic_splits[[1]]
-#' test <- titanic_splits[[2]]
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' gbm <- h2o.gbm(x = predictors,
-#'                y = response,
+#' gbm <- h2o.gbm(y = response,
 #'                training_frame = train)
 #'
 #' # Create the SHAP row explanation plot
@@ -1486,21 +1478,22 @@ h2o.shap_explain_row_plot <-
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the prostate dataset into H2O:
-#' prostate <- h2o.importFile(
-#'   "http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the factors:
-#' prostate$CAPSULE <- as.factor(prostate$CAPSULE)
-#' predictors <- c("ID", "AGE", "RACE", "DPROS", "DCAPS", "PSA", "VOL", "GLEASON")
-#' response <- "CAPSULE"
+#' # Set the response
+#' response <- "quality"
+#'
+#' # Split the dataset into a train and test set:
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' aml <- h2o.automl(x = predictors,
-#'                   y = response,
+#' aml <- h2o.automl(y = response,
 #'                   training_frame = prostate,
-#'                   max_models = 20,
+#'                   max_models = 7,
 #'                   seed = 1)
 #'
 #' # Create the variable importance heatmap
@@ -1583,26 +1576,22 @@ h2o.varimp_heatmap <- function(object, newdata, top_n = 20) {
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the titanic dataset into H2O:
-#' titanic <- h2o.importFile(
-#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the response as a factor:
-#' titanic['survived'] <- as.factor(titanic['survived'])
-#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
-#' response <- "survived"
+#' # Set the response
+#' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
-#' train <- titanic_splits[[1]]
-#' test <- titanic_splits[[2]]
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' aml <- h2o.automl(x = predictors,
-#'                   y = response,
+#' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 20,
+#'                   max_models = 7,
 #'                   seed = 1)
 #'
 #' # Create the model correlation heatmap
@@ -1710,26 +1699,19 @@ h2o.model_correlation_heatmap <- function(object, newdata, top_n = 20,
 #' h2o.init()
 #'
 #' # Import the wine dataset into H2O:
-#' wine <-  h2o.importFile(
-#'   "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
-#' )
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response
-#' predictors <- c(
-#'   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides",
-#'   "free sulfur dioxide", "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",
-#'   "type"
-#' )
+#' # Set the response
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' wine_splits <- h2o.splitFrame(wine, ratios = 0.8, seed = 1)
-#' train <- wine_splits[[1]]
-#' test <- wine_splits[[2]]
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' gbm <- h2o.gbm(x = predictors,
-#'                y = response,
+#' gbm <- h2o.gbm(y = response,
 #'                training_frame = train)
 #'
 #' # Create the residual analysis plot
@@ -1786,24 +1768,20 @@ h2o.residual_analysis_plot <- function(model, newdata) {
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the titanic dataset into H2O:
-#' titanic <- h2o.importFile(
-#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the response as a factor:
-#' titanic['survived'] <- as.factor(titanic['survived'])
-#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
-#' response <- "survived"
+#' # Set the response
+#' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
-#' train <- titanic_splits[[1]]
-#' test <- titanic_splits[[2]]
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' gbm <- h2o.gbm(x = predictors,
-#'                y = response,
+#' gbm <- h2o.gbm(y = response,
 #'                training_frame = train)
 #'
 #' # Create the partial dependence plot
@@ -1958,26 +1936,22 @@ h2o.pd_plot <- function(object,
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the titanic dataset into H2O:
-#' titanic <- h2o.importFile(
-#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the response as a factor:
-#' titanic['survived'] <- as.factor(titanic['survived'])
-#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
-#' response <- "survived"
+#' # Set the response
+#' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
-#' train <- titanic_splits[[1]]
-#' test <- titanic_splits[[2]]
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' aml <- h2o.automl(x = predictors,
-#'                   y = response,
+#' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 20,
+#'                   max_models = 7,
 #'                   seed = 1)
 #'
 #' # Create the partial dependence plot
@@ -2227,26 +2201,19 @@ h2o.pd_multi_plot <- function(object,
 #' h2o.init()
 #'
 #' # Import the wine dataset into H2O:
-#' wine <-  h2o.importFile(
-#'   "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
-#' )
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response
-#' predictors <- c(
-#'   "fixed acidity", "volatile acidity", "citric acid", "residual sugar", "chlorides",
-#'   "free sulfur dioxide", "total sulfur dioxide", "density", "pH", "sulphates", "alcohol",
-#'   "type"
-#' )
+#' # Set the response
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' wine_splits <- h2o.splitFrame(wine, ratios = 0.8, seed = 1)
-#' train <- wine_splits[[1]]
-#' test <- wine_splits[[2]]
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' gbm <- h2o.gbm(x = predictors,
-#'                y = response,
+#' gbm <- h2o.gbm(y = response,
 #'                training_frame = train)
 #'
 #' # Create the individual conditional expectations plot
@@ -2419,26 +2386,22 @@ h2o.ice_plot <- function(model,
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the titanic dataset into H2O:
-#' titanic <- h2o.importFile(
-#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the response as a factor:
-#' titanic['survived'] <- as.factor(titanic['survived'])
-#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
-#' response <- "survived"
+#' # Set the response
+#' response <- "quality"
 #'
-#' # Split the dataset into a train and valid set:
-#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
-#' train <- titanic_splits[[1]]
-#' test <- titanic_splits[[2]]
+#' # Split the dataset into a train and test set:
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' aml <- h2o.automl(x = predictors,
-#'                   y = response,
+#' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 20,
+#'                   max_models = 7,
 #'                   seed = 1)
 #'
 #' # Create the explanation for whole H2OAutoML object
@@ -2811,26 +2774,22 @@ h2o.explain <- function(object,
 #' library(h2o)
 #' h2o.init()
 #'
-#' # Import the titanic dataset into H2O:
-#' titanic <- h2o.importFile(
-#'   "https://s3.amazonaws.com/h2o-public-test-data/smalldata/gbm_test/titanic.csv"
-#' )
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
 #'
-#' # Set the predictors and response; set the response as a factor:
-#' titanic['survived'] <- as.factor(titanic['survived'])
-#' predictors <- setdiff(colnames(titanic), colnames(titanic)[2:3])
-#' response <- "survived"
+#' # Set the response
+#' response <- "quality"
 #'
-#' # Split the dataset into a train and valid set:
-#' titanic_splits <- h2o.splitFrame(data =  titanic, ratios = 0.8, seed = 1234)
-#' train <- titanic_splits[[1]]
-#' test <- titanic_splits[[2]]
+#' # Split the dataset into a train and test set:
+#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- df_splits[[1]]
+#' test <- df_splits[[2]]
 #'
 #' # Build and train the model:
-#' aml <- h2o.automl(x = predictors,
-#'                   y = response,
+#' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 20,
+#'                   max_models = 7,
 #'                   seed = 1)
 #'
 #' # Create the explanation for whole H2OAutoML object

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1012,9 +1012,9 @@ stat_count_or_bin <- function(use_count, ..., data) {
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' gbm <- h2o.gbm(y = response,
@@ -1218,9 +1218,9 @@ h2o.shap_summary_plot <-
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' gbm <- h2o.gbm(y = response,
@@ -1486,14 +1486,14 @@ h2o.shap_explain_row_plot <-
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' aml <- h2o.automl(y = response,
 #'                   training_frame = prostate,
-#'                   max_models = 7,
+#'                   max_models = 10,
 #'                   seed = 1)
 #'
 #' # Create the variable importance heatmap
@@ -1501,7 +1501,9 @@ h2o.shap_explain_row_plot <-
 #' print(varimp_heatmap)
 #' }
 #' @export
-h2o.varimp_heatmap <- function(object, newdata, top_n = 20) {
+h2o.varimp_heatmap <- function(object, 
+                               newdata, 
+                               top_n = 20) {
   # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
   .data <- NULL
   models_info <- .process_models_or_automl(object, newdata,
@@ -1584,14 +1586,14 @@ h2o.varimp_heatmap <- function(object, newdata, top_n = 20) {
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 7,
+#'                   max_models = 10,
 #'                   seed = 1)
 #'
 #' # Create the model correlation heatmap
@@ -1706,9 +1708,9 @@ h2o.model_correlation_heatmap <- function(object, newdata, top_n = 20,
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' gbm <- h2o.gbm(y = response,
@@ -1776,16 +1778,16 @@ h2o.residual_analysis_plot <- function(model, newdata) {
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' gbm <- h2o.gbm(y = response,
 #'                training_frame = train)
 #'
 #' # Create the partial dependence plot
-#' pdp <- h2o.pd_plot(gbm, test, column = "age")
+#' pdp <- h2o.pd_plot(gbm, test, column = "alcohol")
 #' print(pdp)
 #' }
 #' @export
@@ -1944,18 +1946,18 @@ h2o.pd_plot <- function(object,
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 7,
+#'                   max_models = 10,
 #'                   seed = 1)
 #'
 #' # Create the partial dependence plot
-#' pdp <- h2o.pd_multi_plot(aml, test, column = "age")
+#' pdp <- h2o.pd_multi_plot(aml, test, column = "alcohol")
 #' print(pdp)
 #' }
 #' @export
@@ -2208,9 +2210,9 @@ h2o.pd_multi_plot <- function(object,
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' gbm <- h2o.gbm(y = response,
@@ -2372,7 +2374,7 @@ h2o.ice_plot <- function(model,
 #' @param newdata An H2OFrame.
 #' @param columns A vector of column names or column indices to create plots with. If specified
 #'                parameter top_n_features will be ignored.
-#' @param top_n_features In integer specifying the number of columns to use, ranked by variable importance
+#' @param top_n_features An integer specifying the number of columns to use, ranked by variable importance
 #'                       (where applicable).
 #' @param include_explanations If specified, return only the specified model explanations.
 #'   (Mutually exclusive with exclude_explanations)
@@ -2394,14 +2396,14 @@ h2o.ice_plot <- function(model,
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 7,
+#'                   max_models = 10,
 #'                   seed = 1)
 #'
 #' # Create the explanation for whole H2OAutoML object
@@ -2760,7 +2762,7 @@ h2o.explain <- function(object,
 #' @param row_index A row index of the instance to explain.
 #' @param columns A vector of column names or column indices to create plots with. If specified
 #'                parameter top_n_features will be ignored.
-#' @param top_n_features In integer specifying the number of columns to use, ranked by variable importance
+#' @param top_n_features An integer specifying the number of columns to use, ranked by variable importance
 #'                       (where applicable).
 #' @param include_explanations If specified, return only the specified model explanations. 
 #'                             (Mutually exclusive with exclude_explanations)
@@ -2782,14 +2784,14 @@ h2o.explain <- function(object,
 #' response <- "quality"
 #'
 #' # Split the dataset into a train and test set:
-#' df_splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
-#' train <- df_splits[[1]]
-#' test <- df_splits[[2]]
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
 #'
 #' # Build and train the model:
 #' aml <- h2o.automl(y = response,
 #'                   training_frame = train,
-#'                   max_models = 7,
+#'                   max_models = 10,
 #'                   seed = 1)
 #'
 #' # Create the explanation for whole H2OAutoML object


### PR DESCRIPTION
I added examples to the python and R docstrings for the public functions/methods. 

Related JIRAs:
https://0xdata.atlassian.net/browse/PUBDEV-7824
https://0xdata.atlassian.net/browse/PUBDEV-7821