### PR TITLE
Avoid possible race-conditions in unique function

### DIFF
--- a/h2o-core/src/main/java/water/fvec/task/UniqTask.java
+++ b/h2o-core/src/main/java/water/fvec/task/UniqTask.java
@@ -3,32 +3,34 @@ package water.fvec.task;
 import water.MRTask;
 import water.fvec.Chunk;
 import water.rapids.ast.prims.mungers.AstGroup;
-import water.util.IcedHashMap;
+import water.util.IcedHashSet;
 
 public class UniqTask extends MRTask<UniqTask> {
-  public IcedHashMap<AstGroup.G, String> _uniq;
+  public IcedHashSet<AstGroup.G> _uniq;
 
   @Override
   public void map(Chunk[] c) {
-    _uniq = new IcedHashMap<>();
+    _uniq = new IcedHashSet<>();
     AstGroup.G g = new AstGroup.G(1, null);
     for (int i = 0; i < c[0]._len; ++i) {
       g.fill(i, c, new int[]{0});
-      String s_old = _uniq.putIfAbsent(g, "");
-      if (s_old == null) g = new AstGroup.G(1, null);
+      AstGroup.G old = _uniq.addIfAbsent(g);
+      if (old == null)
+        g = new AstGroup.G(1, null);
     }
   }
 
   @Override
   public void reduce(UniqTask t) {
     if (_uniq != t._uniq) {
-      IcedHashMap<AstGroup.G, String> l = _uniq;
-      IcedHashMap<AstGroup.G, String> r = t._uniq;
+      IcedHashSet<AstGroup.G> l = _uniq;
+      IcedHashSet<AstGroup.G> r = t._uniq;
       if (l.size() < r.size()) {
         l = r;
         r = _uniq;
       }  // larger on the left
-      for (AstGroup.G rg : r.keySet()) l.putIfAbsent(rg, "");  // loop over smaller set
+      for (AstGroup.G rg : r) 
+        l.addIfAbsent(rg);  // loop over smaller set
       _uniq = l;
       t._uniq = null;
     }

--- a/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstUnique.java
+++ b/h2o-core/src/main/java/water/rapids/ast/prims/advmath/AstUnique.java
@@ -54,7 +54,7 @@ public class AstUnique extends AstPrimitive {
     } else {
       UniqTask t = new UniqTask().doAll(vec0);
       int nUniq = t._uniq.size();
-      final AstGroup.G[] uniq = t._uniq.keySet().toArray(new AstGroup.G[nUniq]);
+      final AstGroup.G[] uniq = t._uniq.toArray(new AstGroup.G[nUniq]);
       v = Vec.makeZero(nUniq, vec0.get_type());
       new MRTask() {
         @Override

--- a/h2o-core/src/test/java/water/fvec/task/UniqTaskTest.java
+++ b/h2o-core/src/test/java/water/fvec/task/UniqTaskTest.java
@@ -1,0 +1,52 @@
+package water.fvec.task;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.fvec.Vec;
+import water.rapids.ast.prims.mungers.AstGroup;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+import water.util.IcedHashSet;
+
+@CloudSize(1)
+@RunWith(H2ORunner.class)
+public class UniqTaskTest extends TestCase {
+  
+  @Test
+  public void testAllUnique() {
+    final int expected = 1_000_000;
+    Vec v = Vec.makeSeq(0, expected);
+    try {
+      IcedHashSet<AstGroup.G> uniq = new UniqTask().doAll(v)._uniq;
+      assertEquals(expected, uniq.size());
+    } finally {
+      v.remove();
+    }
+  }
+
+  @Test
+  public void testConstant() {
+    final int len = 1_000_000;
+    Vec v = Vec.makeZero(len);
+    try {
+      IcedHashSet<AstGroup.G> uniq = new UniqTask().doAll(v)._uniq;
+      assertEquals(1, uniq.size());
+    } finally {
+      v.remove();
+    }
+  }
+
+  @Test
+  public void testNA() {
+    Vec v = Vec.makeCon(Double.NaN, 1);
+    assertTrue(v.isNA(0));
+    try {
+      IcedHashSet<AstGroup.G> uniq = new UniqTask().doAll(v)._uniq;
+      assertEquals(1, uniq.size());
+    } finally {
+      v.remove();
+    }
+  }
+
+}

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderHelper.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderHelper.java
@@ -525,7 +525,7 @@ public class TargetEncoderHelper extends Iced<TargetEncoderHelper>{
     } else {
       UniqTask t = new UniqTask().doAll(vec0);
       int nUniq = t._uniq.size();
-      final AstGroup.G[] uniq = t._uniq.keySet().toArray(new AstGroup.G[nUniq]);
+      final AstGroup.G[] uniq = t._uniq.toArray(new AstGroup.G[nUniq]);
       v = Vec.makeZero(nUniq, vec0.get_type());
       new MRTask() {
         @Override


### PR DESCRIPTION
AstUniq (possibly) has the same issue that AstGroupBy used to have:
 a race-condition when working with IcedHashMap.

IcedHashMap doesn't gurantee it will return the same value that was
just inserted by putIfAbsent. This PR introduces IcedHashSet which
shields us from the issue.

This PR doesn't claim it fixes an actual issue, simply adopts the safer API to accomplish the task.