### PR TITLE
AstUnique: abandon using GroupBy-style implementation

### DIFF
--- a/h2o-core/src/main/java/water/fvec/task/UniqOldTask.java
+++ b/h2o-core/src/main/java/water/fvec/task/UniqOldTask.java
@@ -1,0 +1,53 @@
+package water.fvec.task;
+
+import water.MRTask;
+import water.fvec.Chunk;
+import water.fvec.Vec;
+import water.rapids.ast.prims.mungers.AstGroup;
+import water.util.IcedHashMap;
+
+@Deprecated // in favor of UniqTask - kept for experimenting only
+public class UniqOldTask extends MRTask<UniqOldTask> {
+  public IcedHashMap<AstGroup.G, String> _uniq;
+
+  @Override
+  public void map(Chunk[] c) {
+    _uniq = new IcedHashMap<>();
+    AstGroup.G g = new AstGroup.G(1, null);
+    for (int i = 0; i < c[0]._len; ++i) {
+      g.fill(i, c, new int[]{0});
+      String s_old = _uniq.putIfAbsent(g, "");
+      if (s_old == null) g = new AstGroup.G(1, null);
+    }
+  }
+
+  @Override
+  public void reduce(UniqOldTask t) {
+    if (_uniq != t._uniq) {
+      IcedHashMap<AstGroup.G, String> l = _uniq;
+      IcedHashMap<AstGroup.G, String> r = t._uniq;
+      if (l.size() < r.size()) {
+        l = r;
+        r = _uniq;
+      }  // larger on the left
+      for (AstGroup.G rg : r.keySet()) l.putIfAbsent(rg, "");  // loop over smaller set
+      _uniq = l;
+      t._uniq = null;
+    }
+  }
+
+  public Vec toVec() {
+    final int nUniq = _uniq.size();
+    final AstGroup.G[] uniq = _uniq.keySet().toArray(new AstGroup.G[nUniq]);
+    Vec v = Vec.makeZero(nUniq, _fr.vec(0).get_type());
+    new MRTask() {
+      @Override
+      public void map(Chunk c) {
+        int start = (int) c.start();
+        for (int i = 0; i < c._len; ++i) c.set(i, uniq[i + start]._gs[0]);
+      }
+    }.doAll(v);
+    return v;
+  }
+
+}

--- a/h2o-core/src/main/java/water/fvec/task/UniqTask.java
+++ b/h2o-core/src/main/java/water/fvec/task/UniqTask.java
@@ -2,37 +2,69 @@ package water.fvec.task;
 
 import water.MRTask;
 import water.fvec.Chunk;
-import water.rapids.ast.prims.mungers.AstGroup;
+import water.fvec.Vec;
+import water.util.IcedDouble;
 import water.util.IcedHashSet;
 
 public class UniqTask extends MRTask<UniqTask> {
-  public IcedHashSet<AstGroup.G> _uniq;
+  private IcedHashSet<IcedDouble> _uniq;
+  private boolean _na;
 
   @Override
   public void map(Chunk[] c) {
     _uniq = new IcedHashSet<>();
-    AstGroup.G g = new AstGroup.G(1, null);
+    double prev = Double.NaN;
     for (int i = 0; i < c[0]._len; ++i) {
-      g.fill(i, c, new int[]{0});
-      AstGroup.G old = _uniq.addIfAbsent(g);
-      if (old == null)
-        g = new AstGroup.G(1, null);
+      final double val = c[0].atd(i);
+      if (Double.isNaN(val)) {
+        _na = true;
+        continue;
+      }
+      if (val == prev) // helps with sparse data and continuous runs of single values
+        continue;
+      prev = val;
+      _uniq.addIfAbsent(new IcedDouble(val));
     }
   }
 
   @Override
   public void reduce(UniqTask t) {
-    if (_uniq != t._uniq) {
-      IcedHashSet<AstGroup.G> l = _uniq;
-      IcedHashSet<AstGroup.G> r = t._uniq;
-      if (l.size() < r.size()) {
-        l = r;
-        r = _uniq;
-      }  // larger on the left
-      for (AstGroup.G rg : r) 
-        l.addIfAbsent(rg);  // loop over smaller set
-      _uniq = l;
-      t._uniq = null;
-    }
+    IcedHashSet<IcedDouble> l = _uniq;
+    IcedHashSet<IcedDouble> r = t._uniq;
+    if (l.size() < r.size()) {
+      l = r;
+      r = _uniq;
+    }  // larger on the left
+    for (IcedDouble rg : r)
+      l.addIfAbsent(rg);  // loop over smaller set
+    _uniq = l;
+    _na = _na || t._na;
+    t._uniq = null;
   }
+
+  public double[] toArray() {
+    final int size = _uniq.size();
+    double[] res = new double[size + (_na ? 1 : 0)];
+    int i = 0;
+    if (_na)
+      res[i++] = Double.NaN;
+    for (IcedDouble d : _uniq)
+      res[i++] = d._val;
+    assert i == res.length;
+    return res;
+  }
+
+  public Vec toVec() {
+    double[] uniq = toArray();
+    Vec v = Vec.makeZero(uniq.length, _fr.vec(0).get_type());
+    new MRTask() {
+      @Override
+      public void map(Chunk c) {
+        int start = (int) c.start();
+        for (int i = 0; i < c._len; ++i) c.set(i, uniq[i + start]);
+      }
+    }.doAll(v);
+    return v;
+  }
+
 }

--- a/h2o-core/src/main/java/water/util/IcedDouble.java
+++ b/h2o-core/src/main/java/water/util/IcedDouble.java
@@ -2,15 +2,18 @@ package water.util;
 
 import water.Iced;
 
-public class IcedDouble extends Iced {
+public class IcedDouble extends Iced<IcedDouble> {
   public double _val;
   public IcedDouble(double v){_val = v;}
   @Override public boolean equals( Object o ) {
     return o instanceof IcedDouble && ((IcedDouble) o)._val == _val;
   }
   @Override public int hashCode() {
-    long bits = Double.doubleToLongBits(_val);
-    return (int)(bits ^ (bits >>> 32));
+    long h = Double.doubleToLongBits(_val);
+    // Doubles are lousy hashes; mix up the bits some
+    h ^= (h >>> 20) ^ (h >>> 12);
+    h ^= (h >>> 7) ^ (h >>> 4);
+    return (int) ((h ^ (h >> 32)) & 0x7FFFFFFF);
   }
   @Override public String toString() { return Double.toString(_val); }
 

--- a/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderHelper.java
+++ b/h2o-extensions/target-encoder/src/main/java/ai/h2o/targetencoding/TargetEncoderHelper.java
@@ -523,17 +523,7 @@ public class TargetEncoderHelper extends Iced<TargetEncoderHelper>{
       v.setDomain(vec0.domain());
       DKV.put(v);
     } else {
-      UniqTask t = new UniqTask().doAll(vec0);
-      int nUniq = t._uniq.size();
-      final AstGroup.G[] uniq = t._uniq.toArray(new AstGroup.G[nUniq]);
-      v = Vec.makeZero(nUniq, vec0.get_type());
-      new MRTask() {
-        @Override
-        public void map(Chunk c) {
-          int start = (int) c.start();
-          for (int i = 0; i < c._len; ++i) c.set(i, uniq[i + start]._gs[0]);
-        }
-      }.doAll(v);
+      v = new UniqTask().doAll(vec0).toVec();
     }
     return new Frame(v);
   }


### PR DESCRIPTION
Reworked implementation doesn't rely on mutable structures and is able
to achieve 30%-50% speed-up on 10m of unique data points.