### PR TITLE
Option to enable/disable cache for DEV docker image builds.

### DIFF
--- a/docker/Jenkinsfile-build-docker
+++ b/docker/Jenkinsfile-build-docker
@@ -12,7 +12,8 @@ properties([
     parameters([
         booleanParam(defaultValue: false, description: 'Build even if the image is already present in the repository', name: 'forceBuild'),
         booleanParam(defaultValue: false, description: 'Publish built images', name: 'publish'),
-        string(defaultValue: 'master', description: 'H2O-3 Branch used to load dependencies.', name: 'h2oBranch')
+        string(defaultValue: 'master', description: 'H2O-3 Branch used to load dependencies.', name: 'h2oBranch'),
+        booleanParam(name: 'noCache', defaultValue: true, description: 'If set to true, the docker image is built from scratch, with no stages used from the cache.')
     ])
 ])
 
@@ -142,6 +143,7 @@ private Closure makeStage(final pipelineContext, String target, final boolean us
                                     GRADLE_VERSION=${gradleVersion} \
                                     GPU=${useGpu} \
                                     PUSH=${params.publish} \
+                                    NO_CACHE=${params.noCache} \
                                     ${target}
                             """
                 }

--- a/docker/Jenkinsfile-build-docker
+++ b/docker/Jenkinsfile-build-docker
@@ -130,6 +130,7 @@ private Closure makeStage(final pipelineContext, String target, final boolean us
             buildImageStageName = "$buildImageStageName GPU"
         }
         buildSummary.stageWithSummary(buildImageStageName) {
+            final String noCache = params.noCache ? "--no-cache" : ""
             node (DEFAULT_LABEL) {
                 buildSummary.refreshStage(buildImageStageName)
                 dir (target) {
@@ -143,7 +144,7 @@ private Closure makeStage(final pipelineContext, String target, final boolean us
                                     GRADLE_VERSION=${gradleVersion} \
                                     GPU=${useGpu} \
                                     PUSH=${params.publish} \
-                                    NO_CACHE=${params.noCache} \
+                                    NO_CACHE=${noCache} \
                                     ${target}
                             """
                 }

--- a/docker/Jenkinsfile-build-hadoop-docker
+++ b/docker/Jenkinsfile-build-hadoop-docker
@@ -21,7 +21,8 @@ properties(
             [
                 string(defaultValue: 'master', description: 'Branch to checkout', name: 'gitBranch'),
                 string(name: 'dockerRegistry', defaultValue: 'harbor.h2o.ai'),
-                booleanParam(name: 'force', defaultValue: false, description: 'If false and image with version specified by BuildConfig exists in repository, then the build fails.')
+                booleanParam(name: 'force', defaultValue: false, description: 'If false and image with version specified by BuildConfig exists in repository, then the build fails.'),
+                booleanParam(name: 'noCache', defaultValue: true, description: 'If set to true, the docker image is built from scratch, with no stages used from the cache.')
             ]
         )
     ]
@@ -52,6 +53,7 @@ node (NODE_LABEL) {
                 <li><strong>Git Branch:</strong> ${env.BRANCH_NAME}</li>
                 <li><strong>Version:</strong> ${version}</li>
                 <li><strong>Force Overwrite:</strong> ${params.force}</li>
+                <li><strong>No cache:</strong> ${params.noCache}</li>
                 </ul>
             """)
 
@@ -64,6 +66,8 @@ node (NODE_LABEL) {
         }
     }
 }
+
+final String noCache = params.noCache ? "--no-cache" : ""
 
 parallel(pipelineContext.getBuildConfig().getSupportedHadoopDistributions().collectEntries { distribution ->
     [
@@ -96,6 +100,7 @@ parallel(pipelineContext.getBuildConfig().getSupportedHadoopDistributions().coll
                                     cp \${JENKINS_LDIF_PATH} hadoop/common/ldap/jenkins.ldif
 
                                     docker build \
+                                        ${noCache} \
                                         -t ${REGISTRY_PREFIX}/${imageName}:${version} \
                                         -f hadoop/${distribution.name}/Dockerfile \
                                         --build-arg PATH_PREFIX=hadoop/${distribution.name} \
@@ -107,6 +112,7 @@ parallel(pipelineContext.getBuildConfig().getSupportedHadoopDistributions().coll
                                         .
 
                                     docker build \
+                                        ${noCache} \
                                         -t ${REGISTRY_PREFIX}/${imageName}-krb:${version} \
                                         -f hadoop/${distribution.name}/Dockerfile.kerberos \
                                         --build-arg PATH_PREFIX=hadoop/${distribution.name} \
@@ -175,6 +181,7 @@ parallel(INTERNAL_CLUSTER_HADOOPS.collectEntries { hdp ->
                                     cd docker
 
                                     docker build \
+                                        ${noCache} \
                                         -t ${REGISTRY_PREFIX}/${imageName}:${version} \
                                         -f hadoop/edge_node/Dockerfile \
                                         --build-arg PATH_PREFIX=hadoop/edge_node \

--- a/docker/Jenkinsfile-build-k8s-test-docker
+++ b/docker/Jenkinsfile-build-k8s-test-docker
@@ -15,7 +15,8 @@ properties(
             [
                 string(defaultValue: 'master', description: 'Branch to checkout', name: 'gitBranch'),
                 string(name: 'dockerRegistry', defaultValue: 'harbor.h2o.ai'),
-                booleanParam(name: 'force', defaultValue: false, description: 'If false and image with version specified by BuildConfig exists in repository, then the build fails.')
+                booleanParam(name: 'force', defaultValue: false, description: 'If false and image with version specified by BuildConfig exists in repository, then the build fails.'),
+                booleanParam(name: 'noCache', defaultValue: false, description: 'If set to true, the docker image is built from scratch, with no stages used from the cache.')
             ]
         )
     ]
@@ -44,6 +45,7 @@ node(NODE_LABEL) {
                 <li><strong>Git Branch:</strong> ${env.BRANCH_NAME}</li>
                 <li><strong>Version:</strong> ${version}</li>
                 <li><strong>Force Overwrite:</strong> ${params.force}</li>
+                <li><strong>No cache:</strong> ${params.noCache}</li>
                 </ul>
             """)
 
@@ -59,6 +61,8 @@ node(NODE_LABEL) {
     final String buildStageName = "Build [${IMAGE_NAME_PREFIX}, ${IMAGE_NAME_PREFIX_RUNNER}]"
     final String imageName = "${IMAGE_NAME_PREFIX}"
     final String imageNameRunner = "${IMAGE_NAME_PREFIX_RUNNER}"
+    final String noCache = params.noCache ? "--no-cache" : ""
+    
     stage(buildStageName) {
         try {
             pipelineContext.getBuildSummary().addStageSummary(this, buildStageName, '')
@@ -84,6 +88,7 @@ node(NODE_LABEL) {
                     ls
 
                     docker build \
+                        ${noCache} \
                         -t ${REGISTRY_PREFIX}/${imageName}:${version} \
                         -f jenkins-images/Dockerfile-k8s-test \
                     .
@@ -98,6 +103,7 @@ node(NODE_LABEL) {
                     ls
 
                     docker build \
+                        ${noCache} \
                         -t ${REGISTRY_PREFIX}/${imageNameRunner}:${version} \
                         -f jenkins-images/Dockerfile-k8s-test-h2o \
                     .

--- a/docker/Jenkinsfile-build-xgb-build-docker
+++ b/docker/Jenkinsfile-build-xgb-build-docker
@@ -12,7 +12,7 @@ properties(
                 string(name: 'gitBranch', defaultValue: 'master', description: 'Branch to load the Dockerfile from.'),
                 string(name: 'registry', defaultValue: 'harbor.h2o.ai', description: 'Docker registry to push images to'),
                 booleanParam(name: 'publish', defaultValue: true, description: 'If true, publish the docker image'),
-                booleanParam(name: 'noCache', defaultValue: false, description: 'If true, build the docker image using the --no-cache flag')
+                booleanParam(name: 'noCache', defaultValue: false, description: 'If set to true, the docker image is built from scratch, with no stages used from the cache.')
         ])
     ]
 )
@@ -42,6 +42,7 @@ node (NODE_LABEL) {
             pipelineContext.getBuildSummary().addSection(this, 'docker-details', "<a href=\"${currentBuild.rawBuild.getAbsoluteUrl()}\" style=\"color: black;\">Details</a>", """
                 <ul>
                 <li><strong>Git Branch:</strong> ${env.BRANCH_NAME}</li>
+                <li><strong>No cache:</strong> ${params.noCache}</li>
                 </ul>
             """)
 
@@ -62,6 +63,8 @@ node (NODE_LABEL) {
     }
 }
 
+final String noCache = params.noCache ? "--no-cache" : ""
+
 parallel(IMAGES_MAP.collectEntries { image ->
     [
         "Build $image image", {
@@ -77,6 +80,7 @@ parallel(IMAGES_MAP.collectEntries { image ->
                         dir('docker') {
                             sh """                                
                                 docker build \
+                                    ${noCache} \
                                     -t ${IMAGE_NAME}-${image}:${IMAGE_TAG}  \
                                     -f xgb_build/Dockerfile-gpu-${image} \
                                     .

--- a/docker/Jenkinsfile-build-xgb-docker
+++ b/docker/Jenkinsfile-build-xgb-docker
@@ -11,6 +11,7 @@ properties(
             [
                 string(defaultValue: 'master', description: 'Branch to checkout', name: 'gitBranch'),
                 string(name: 'dockerRegistry', defaultValue: 'harbor.h2o.ai'),
+                booleanParam(name: 'noCache', defaultValue: false, description: 'If set to true, the docker image is built from scratch, with no stages used from the cache.')
             ]
         )
     ]
@@ -34,6 +35,7 @@ node (NODE_LABEL) {
             pipelineContext.getBuildSummary().addSection(this, 'docker-details', "<a href=\"${currentBuild.rawBuild.getAbsoluteUrl()}\" style=\"color: black;\">Details</a>", """
                 <ul>
                 <li><strong>Git Branch:</strong> ${env.BRANCH_NAME}</li>
+                <li><strong>No cache:</strong> ${params.noCache}</li>
                 </ul>
             """)
 
@@ -54,6 +56,8 @@ node (NODE_LABEL) {
     }
 }
 
+final String noCache = params.noCache ? "--no-cache" : ""
+
 parallel(pipelineContext.getBuildConfig().getSupportedXGBEnvironments().collectEntries { osName, xgbEnvs ->
     [
         "Build Images for ${osName}", {
@@ -70,6 +74,7 @@ parallel(pipelineContext.getBuildConfig().getSupportedXGBEnvironments().collectE
                             dir('docker') {
                                 sh """
                                 docker build \
+                                    ${noCache} \
                                     -t ${pipelineContext.getBuildConfig().getXGBImageForEnvironment(osName, xgbEnv)} \
                                     -f ${xgbEnv.dockerfile} \
                                     --build-arg FROM_IMAGE=${xgbEnv.fromImage} \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,6 +7,7 @@ PUSH ?= 0
 GPU ?= false
 H2O_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 GRADLE_VERSION ?= $(shell cat ../gradle/wrapper/gradle-wrapper.properties | grep distributionUrl | egrep -o '([0-9]+\.+)+[0-9]+')
+NO_CACHE ?= --no-cache
 
 ifeq ($(shell echo $(GPU) | tr [:upper:] [:lower:] ),true)
 	GPU_SUFFIX := -gpu
@@ -17,6 +18,7 @@ endif
 
 dev-base:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-base$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-base \
 		--build-arg FROM_IMAGE=$(BASE_FROM_IMAGE) \
 		.
@@ -30,6 +32,7 @@ dev-jdk-8-base: dev-base
 endif
 dev-jdk-8-base:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-jdk-8-base$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-8-base \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -43,6 +46,7 @@ dev-jdk-others-base: dev-base
 endif
 dev-jdk-others-base:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-jdk-others-base$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others-base \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -57,6 +61,7 @@ dev-python-base: dev-jdk-8-base
 endif
 dev-python-base:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-base$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-python-base \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -70,6 +75,7 @@ dev-r-base: dev-jdk-8-base
 endif
 dev-r-base:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-base$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-r-base \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -83,6 +89,7 @@ dev-python-2.7-openjdk-7: dev-python-2.7
 endif
 dev-python-2.7-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-2.7-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -98,6 +105,7 @@ dev-python-2.7-jdk-%: dev-python-2.7
 endif
 dev-python-2.7-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-2.7-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -113,6 +121,7 @@ dev-python-3.5-openjdk-7: dev-python-3.5
 endif
 dev-python-3.5-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.5-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -128,6 +137,7 @@ dev-python-3.5-jdk-%: dev-python-3.5
 endif
 dev-python-3.5-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.5-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -143,6 +153,7 @@ dev-python-3.6-openjdk-7: dev-python-3.6
 endif
 dev-python-3.6-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.6-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -158,6 +169,7 @@ dev-python-3.6-jdk-%: dev-python-3.6
 endif
 dev-python-3.6-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.6-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -173,6 +185,7 @@ dev-python-3.7-openjdk-7: dev-python-3.7
 endif
 dev-python-3.7-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.7-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -188,6 +201,7 @@ dev-python-3.7-jdk-%: dev-python-3.7
 endif
 dev-python-3.7-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.7-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -203,6 +217,7 @@ dev-python-3.8-openjdk-7: dev-python-3.8
 endif
 dev-python-3.8-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.8-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -218,6 +233,7 @@ dev-python-3.8-jdk-%: dev-python-3.8
 endif
 dev-python-3.8-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-3.8-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -233,6 +249,7 @@ dev-mojocompat: dev-python-3.6
 endif
 dev-mojocompat:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-mojocompat$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-mojocompat \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -246,6 +263,7 @@ dev-python-%: dev-python-base
 endif
 dev-python-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-python-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-python \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -261,6 +279,7 @@ dev-r-3.3.3-openjdk-7: dev-r-3.3.3
 endif
 dev-r-3.3.3-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.3.3-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -276,6 +295,7 @@ dev-r-3.3.3-jdk-%: dev-r-3.3.3
 endif
 dev-r-3.3.3-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.3.3-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -291,6 +311,7 @@ dev-r-3.4.1-openjdk-7: dev-r-3.4.1
 endif
 dev-r-3.4.1-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.4.1-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -306,6 +327,7 @@ dev-r-3.4.1-jdk-%: dev-r-3.4.1
 endif
 dev-r-3.4.1-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.4.1-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -321,6 +343,7 @@ dev-r-3.5.3-openjdk-7: dev-r-3.5.3
 endif
 dev-r-3.5.3-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.5.3-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -336,6 +359,7 @@ dev-r-3.5.3-jdk-%: dev-r-3.5.3
 endif
 dev-r-3.5.3-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.5.3-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -351,6 +375,7 @@ dev-r-3.6.2-openjdk-7: dev-r-3.6.2
 endif
 dev-r-3.6.2-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.6.2-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -366,6 +391,7 @@ dev-r-3.6.2-jdk-%: dev-r-3.6.2
 endif
 dev-r-3.6.2-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-3.6.2-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -381,6 +407,7 @@ dev-r-4.0.2-openjdk-7: dev-r-4.0.2
 endif
 dev-r-4.0.2-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-4.0.2-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -396,6 +423,7 @@ dev-r-4.0.2-jdk-%: dev-r-4.0.2
 endif
 dev-r-4.0.2-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-4.0.2-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -411,6 +439,7 @@ dev-r-%: dev-r-base
 endif
 dev-r-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-r-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-r \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -425,6 +454,7 @@ dev-openjdk-7: dev-jdk-others-base
 endif
 dev-openjdk-7:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-openjdk-7$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-openjdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -439,6 +469,7 @@ dev-jdk-%: dev-jdk-others-base
 endif
 dev-jdk-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-jdk-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-jdk-others \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -453,6 +484,7 @@ dev-build-base: dev-r-3.4.1
 endif
 dev-build-base:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-build-base$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-build-base \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -467,6 +499,7 @@ dev-build-gradle-%: dev-build-base
 endif
 dev-build-gradle-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-build-gradle-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-build \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -481,6 +514,7 @@ dev-benchmark-gradle-%: dev-build-gradle-$(GRADLE_VERSION)
 endif
 dev-benchmark-gradle-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-benchmark-gradle-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-benchmark \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -495,6 +529,7 @@ dev-build-hadoop-gradle-%: dev-build-gradle-$(GRADLE_VERSION)
 endif
 dev-build-hadoop-gradle-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-build-hadoop-gradle-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-build-hadoop \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \
@@ -510,6 +545,7 @@ dev-release-gradle-%: dev-build-hadoop-gradle-$(GRADLE_VERSION)
 endif
 dev-release-gradle-%:
 	docker build -t harbor.h2o.ai/opsh2oai/h2o-3/dev-release-gradle-$*$(GPU_SUFFIX):$(VERSION) \
+		$(NO_CACHE) \
 		-f jenkins-images/Dockerfile-release \
 		--build-arg GPU_SUFFIX=$(GPU_SUFFIX) \
 		--build-arg FROM_VERSION=$(VERSION) \

--- a/scripts/jenkins/groovy/buildConfig.groovy
+++ b/scripts/jenkins/groovy/buildConfig.groovy
@@ -14,12 +14,12 @@ class BuildConfig {
   private static final String DEFAULT_HADOOP_IMAGE_NAME_PREFIX = 'dev-build-hadoop-gradle'
   private static final String DEFAULT_RELEASE_IMAGE_NAME_PREFIX = 'dev-release-gradle'
 
-  public static final int DEFAULT_IMAGE_VERSION_TAG = 34
+  public static final int DEFAULT_IMAGE_VERSION_TAG = 35
   public static final String AWSCLI_IMAGE = DOCKER_REGISTRY + '/opsh2oai/awscli'
   public static final String S3CMD_IMAGE = DOCKER_REGISTRY + '/opsh2oai/s3cmd'
 
   private static final String HADOOP_IMAGE_NAME_PREFIX = 'h2o-3-hadoop'
-  private static final String HADOOP_IMAGE_VERSION_TAG = '81'
+  private static final String HADOOP_IMAGE_VERSION_TAG = '82'
 
   private static final String K8S_TEST_IMAGE_VERSION_TAG = '3' // Change the new Docker image in the K8S YAML template as well
 


### PR DESCRIPTION
- As DEV images are downloading certain files (lists of python dependencies to install for example), caching is DISABLED by default for those.
- For K8S images, cache is enabled by default.

**DO NOT MERGE BEFORE RELEASE**