### PR TITLE
Helm chart index info and on-release SED fix

### DIFF
--- a/h2o-dist/index.html
+++ b/h2o-dist/index.html
@@ -681,11 +681,13 @@ dependencies {</br>
                 <h2>Setup H<sub>2</sub>O on Kubernetes using Helm</h2>
                     <p><a href="https://helm.sh/" target="_blank">Helm</a> can be used to deploy H2O into a kubernetes cluster. Helm requires the KUBECONFIG environment variable to be set up properly, or stating the kubeconfig destination explicitly. Please refer to Helm's documentation
                     for further information.</p>
-                <p class="terminal" id="to_copy11">
+                <pre>
+                    <p class="terminal" id="to_copy11">
 helm repo add h2o https://charts.h2o.ai
 helm install basic-h2o h2o/h2o
 helm test basic-h2o
-                </p>
+                    </p>
+                </pre>
 
                 <p>There are various settings and modifications available. To inspect the configuration options available, use the  "helm inspect values h2o/h2o --version SUBST_PROJECT_VERSION" command.</p>
                 

--- a/h2o-helm/Chart.yaml
+++ b/h2o-helm/Chart.yaml
@@ -1,9 +1,6 @@
 apiVersion: v2
 name: h2o-3
 description: H2O open source machine learning platform
-
 type: application
-
 version: 1.0.0 # Only a placeholder - actually replaced by real H2O version on-release.
-
 appVersion: 1.0.0 # Only a placeholder - actually replaced by real H2O version on-release.

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -257,9 +257,7 @@ try {
                             sh """
                                 cd ${env.BUILD_NUMBER_DIR}/h2o-helm/
                                 sed -i "s/name: h2o-3/name: ${CHART_NAME}/" Chart.yaml
-                                sed -i "s/version: [0-9]*\\.[0-9]*\\.[0-9]*/version: ${VERSION}/" Chart.yaml
-                                sed -i "s/appVersion: [0-9]*\\.[0-9]*\\.[0-9]*/version: ${VERSION}/" Chart.yaml
-                                helm package .
+                                helm package . --app-version ${VERSION} --version ${VERSION}
                                 mkdir h2o-3
                                 mv ${CHART_NAME}-${VERSION}.tgz h2o-3/
                                 helm repo index . --merge index.yaml


### PR DESCRIPTION
- The wrong sed was fixed by manually uploading the correct artifact and index by me to S3
- The index.html (http://h2o-release.s3.amazonaws.com/h2o/rel-zermelo/1/index.html) has been manually fixed in the h2o-releases S3

