### PR TITLE
Migrate DRFGridTest from plain TestUtils to H2ORunner

### DIFF
--- a/h2o-algos/src/test/java/hex/tree/drf/DRFGridTest.java
+++ b/h2o-algos/src/test/java/hex/tree/drf/DRFGridTest.java
@@ -1,7 +1,6 @@
 package hex.tree.drf;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -15,20 +14,24 @@ import java.util.Set;
 import hex.Model;
 import hex.grid.Grid;
 import hex.grid.GridSearch;
+import org.junit.runner.RunWith;
 import water.DKV;
 import water.Job;
 import water.Key;
 import water.TestUtil;
 import water.fvec.Frame;
 import water.fvec.Vec;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
 import water.test.util.GridTestUtils;
 import water.util.ArrayUtils;
 
 import static org.junit.Assert.*;
 import static water.util.ArrayUtils.interval;
 
+@RunWith(H2ORunner.class)
+@CloudSize(1)
 public class DRFGridTest extends TestUtil {
-  @BeforeClass() public static void setup() { stall_till_cloudsize(1); }
 
   @Test public void testCarsGrid() {
     Grid<DRFModel.DRFParameters> grid = null;


### PR DESCRIPTION
There was a failure in nightlies and due to lack of H2ORunner's presence, it is unknown which test method leaked the keys.