### PR TITLE
PUBDEV-7835 add lambda_min, lambda_max to GLMModelOutputs

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -689,6 +689,7 @@ public final class ComputationState {
   protected void setAllIn(boolean val) { _allIn = val; }
   protected void setGslvrNull() { _gslvr = null; }
   protected void setActiveDataMultinomialNull() { _activeDataMultinomial = null; }
+  protected void setActiveDataNull() { _activeData = null; }
   protected void setLambdaSimple(double lambda) { _lambda=lambda; }
 
   protected void setHGLMComputationState(double [] beta, double[] ubeta, double[] psi, double[] phi, 

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -853,6 +853,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
   //  ideally the model should be instantiated in the #computeImpl() method instead of init
   private void buildModel() {
     _model = new GLMModel(_result, _parms, this, _state._ymu, _dinfo._adaptedFrame.lastVec().sigma(), _lmax, _nobs);
+    _model._output.setLambdas(_parms);  // set lambda_min and lambda_max if lambda_search is enabled
+    
     // clone2 so that I don't change instance which is in the DKV directly
     // (clone2 also shallow clones _output)
     _model.clone2().delete_and_lock(_job._key);
@@ -2067,6 +2069,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       _state.setAllIn(false);
       _state.setGslvrNull();
       _state.setActiveDataMultinomialNull();
+      _state.setActiveDataNull();
       int histLen = devHistoryTrain.length;
       for (int ind=0; ind < histLen; ind++) {
         devHistoryTrain[ind]=0;

--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1135,7 +1135,9 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     String[] _random_column_names;
     public long _training_time_ms;
     int _lambda_array_size; // store number of lambdas to iterate over
-    public int _lambda_1se = -1; // lambda_best+sd(lambda) submodel index; applicable if running lambda search with cv 
+    public int _lambda_1se = -1; // lambda_best+sd(lambda) submodel index; applicable if running lambda search with cv
+    public double _lambda_min = -1; // starting lambda value when lambda search is enabled
+    public double _lambda_max = -1; // minimum lambda value calculated when lambda search is enabled
     public int _selected_lambda_idx; // lambda index with best deviance
     public int _selected_alpha_idx;     // alpha index with best deviance
     public int _selected_submodel_idx;  // submodel index with best deviance
@@ -1185,6 +1187,13 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
     public boolean _multinomial;
     public boolean _ordinal;
 
+    public void setLambdas(GLMParameters parms) {
+      if (parms._lambda_search) {
+        _lambda_max = parms._lambda[0];
+        _lambda_min = parms._lambda[parms._lambda.length-1];
+      }
+    }
+    
     public int rank() { return _submodels[_selected_submodel_idx].rank();}
 
     public boolean isStandardized() {

--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -44,6 +44,13 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
     @API(help="Lambda best + 1 standard error. Only applicable with lambda search and cross-validation")
     double lambda_1se;
 
+    @API(help="Minimum lambda value calculated that may be used for lambda search.  Early-stop may happen and " +
+            "the minimum lambda value will not be used in this case.")
+    double lambda_min;
+
+    @API(help="Starting lambda value used when lambda search is enabled.")
+    double lambda_max;
+
     @API(help = "Dispersion parameter, only applicable to Tweedie family (input/output) and fractional Binomial (output only)")
     double dispersion;
 

--- a/h2o-bindings/bin/custom/R/gen_glm.py
+++ b/h2o-bindings/bin/custom/R/gen_glm.py
@@ -74,6 +74,51 @@ h2o.makeGLMModel <- function(model,beta) {
   m
 }
 
+#' Extract best lambda value found from glm model.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getLambdaBest <- function(model) {
+  model@model$lambda_best
+}
+
+#' Extract the maximum lambda value used during lambda search from glm model.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getLambdaMax <- function(model) {
+  lambdaMax <- model@model$lambda_max
+  if (lambdaMax < 0) # -1 if lambda_search=FALSE
+    stop("getLambdaMax(model) can only be called when lambda_search=True or when you have multiple lambda values to try.")
+  else 
+    lambdaMax
+}
+
+#' Extract best alpha value found from glm model.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getAlphaBest <- function(model) {
+  model@model$alpha_best
+}
+
+#' Extract the minimum lambda value calculated during lambda search from glm model.
+#' Note that due to early stop, this minimum lambda value may not be used in the actual lambda search.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getLambdaMin <- function(model) {
+  lambdaMin <- model@model$lambda_min # will be -1 if lambda_search=FALSE
+  if (lambdaMin < 0)
+    stop("getLambdaMin(model) can only be called when lambda_search=True or when you have multiple lambda values to try.")
+  else 
+    lambdaMin
+}
+
 #' Extract full regularization path from a GLM model
 #'
 #' Extract the full regularization path from a GLM model (assuming it was run with the lambda search option).

--- a/h2o-bindings/bin/custom/python/gen_glm.py
+++ b/h2o-bindings/bin/custom/python/gen_glm.py
@@ -16,6 +16,100 @@ def class_extensions():
         self._parms["lambda"] = value
 
     @staticmethod
+    def getAlphaBest(model):
+        """
+        Extract best alpha value found from glm model.
+
+        :param model: source lambda search model
+
+        :examples:
+
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> bestAlpha = H2OGeneralizedLinearEstimator.getAlphaBest(m)
+        >>> print("Best alpha found is {0}".format(bestAlpha))
+        """
+        return model._model_json["output"]["alpha_best"]
+        
+    @staticmethod
+    def getLambdaBest(model):
+        """
+        Extract best lambda value found from glm model.
+
+        :param model: source lambda search model
+
+        :examples:
+
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> bestLambda = H2OGeneralizedLinearEstimator.getLambdaBest(m)
+        >>> print("Best lambda found is {0}".format(bestLambda))
+        """
+        return model._model_json["output"]["lambda_best"]
+
+    @staticmethod
+    def getLambdaMax(model):
+        """
+        Extract the maximum lambda value used during lambda search.
+    
+        :param model: source lambda search model
+    
+        :examples:
+    
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> maxLambda = H2OGeneralizedLinearEstimator.getLambdaMax(m)
+        >>> print("Maximum lambda found is {0}".format(maxLambda))
+        """
+        lambdaMax = model._model_json["output"]["lambda_max"] # will be -1 if lambda_search is disabled
+        if lambdaMax >= 0:
+            return lambdaMax
+        else:
+            raise H2OValueError("getLambdaMax(model) can only be called when lambda_search=True.")
+
+    
+    @staticmethod
+    def getLambdaMin(model):
+        """
+        Extract the minimum lambda value calculated during lambda search from glm model.  Note that due to early stop,
+        this minimum lambda value may not be used in the actual lambda search.
+    
+        :param model: source lambda search model
+    
+        :examples:
+    
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> minLambda = H2OGeneralizedLinearEstimator.getLambdaMin(m)
+        >>> print("Minimum lambda found is {0}".format(minLambda))
+        """
+        lambdaMin = model._model_json["output"]["lambda_min"] # will be -1 if lambda_search is disabled
+        if lambdaMin >= 0:
+            return lambdaMin
+        else:
+            raise H2OValueError("getLambdaMin(model) can only be called when lambda_search=True.")
+
+    @staticmethod
     def getGLMRegularizationPath(model):
         """
         Extract full regularization path explored during lambda search from glm model.

--- a/h2o-py/h2o/estimators/glm.py
+++ b/h2o-py/h2o/estimators/glm.py
@@ -1783,6 +1783,100 @@ class H2OGeneralizedLinearEstimator(H2OEstimator):
         self._parms["lambda"] = value
 
     @staticmethod
+    def getAlphaBest(model):
+        """
+        Extract best alpha value found from glm model.
+
+        :param model: source lambda search model
+
+        :examples:
+
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> bestAlpha = H2OGeneralizedLinearEstimator.getAlphaBest(m)
+        >>> print("Best alpha found is {0}".format(bestAlpha))
+        """
+        return model._model_json["output"]["alpha_best"]
+
+    @staticmethod
+    def getLambdaBest(model):
+        """
+        Extract best lambda value found from glm model.
+
+        :param model: source lambda search model
+
+        :examples:
+
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> bestLambda = H2OGeneralizedLinearEstimator.getLambdaBest(m)
+        >>> print("Best lambda found is {0}".format(bestLambda))
+        """
+        return model._model_json["output"]["lambda_best"]
+
+    @staticmethod
+    def getLambdaMax(model):
+        """
+        Extract the maximum lambda value used during lambda search.
+
+        :param model: source lambda search model
+
+        :examples:
+
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> maxLambda = H2OGeneralizedLinearEstimator.getLambdaMax(m)
+        >>> print("Maximum lambda found is {0}".format(maxLambda))
+        """
+        lambdaMax = model._model_json["output"]["lambda_max"] # will be -1 if lambda_search is disabled
+        if lambdaMax >= 0:
+            return lambdaMax
+        else:
+            raise H2OValueError("getLambdaMax(model) can only be called when lambda_search=True.")
+
+
+    @staticmethod
+    def getLambdaMin(model):
+        """
+        Extract the minimum lambda value calculated during lambda search from glm model.  Note that due to early stop,
+        this minimum lambda value may not be used in the actual lambda search.
+
+        :param model: source lambda search model
+
+        :examples:
+
+        >>> d = h2o.import_file("http://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate.csv")
+        >>> m = H2OGeneralizedLinearEstimator(family = 'binomial',
+        ...                                   lambda_search = True,
+        ...                                   solver = 'COORDINATE_DESCENT')
+        >>> m.train(training_frame = d,
+        ...         x = [2,3,4,5,6,7,8],
+        ...         y = 1)
+        >>> minLambda = H2OGeneralizedLinearEstimator.getLambdaMin(m)
+        >>> print("Minimum lambda found is {0}".format(minLambda))
+        """
+        lambdaMin = model._model_json["output"]["lambda_min"] # will be -1 if lambda_search is disabled
+        if lambdaMin >= 0:
+            return lambdaMin
+        else:
+            raise H2OValueError("getLambdaMin(model) can only be called when lambda_search=True.")
+
+    @staticmethod
     def getGLMRegularizationPath(model):
         """
         Extract full regularization path explored during lambda search from glm model.

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7835_get_lambdas_alpha_best.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7835_get_lambdas_alpha_best.py
@@ -1,0 +1,49 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator as glm
+
+# This test is written to make sure we can grab the alpha_best, lambda max, lambda min and lambda best values from a 
+# glm model
+def grab_lambda_values_alpha_best():
+    boston = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/BostonHousing.csv"))
+
+    # set the predictor names and the response column name
+    predictors = boston.columns[:-1]
+    # set the response column to "medv", the median value of owner-occupied homes in $1000's
+    response = "medv"
+
+    # convert the chas column to a factor (chas = Charles River dummy variable (= 1 if tract bounds river; 0 otherwise))
+    boston['chas'] = boston['chas'].asfactor()
+
+    # split into train and validation sets
+    train, valid = boston.split_frame(ratios = [.8], seed=1234)
+    boston_glm = glm(lambda_search = True, seed=1234, cold_start=True)
+    boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)   
+    r = glm.getGLMRegularizationPath(boston_glm)
+
+    assert (glm.getLambdaBest(boston_glm) >= r["lambdas"][len(r["lambdas"])-1]) \
+           and (glm.getLambdaBest(boston_glm) <= r["lambdas"][0]), "Error in lambda best extraction"
+
+    assert glm.getLambdaMin(boston_glm) <= r["lambdas"][len(r["lambdas"])-1], "Error in lambda min extraction"
+    assert glm.getLambdaMax(boston_glm) == r["lambdas"][0], "Error in lambda max extraction"
+    assert glm.getAlphaBest(boston_glm) == boston_glm._model_json['output']['alpha_best'], "Error in alpha best extraction"
+    
+    boston_glm2 = glm(lambda_search = False, seed=1234)
+    boston_glm2.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+    
+    try:
+        glm.getLambdaMax(boston_glm2)
+        assert False, "glm.getLambdaMax(model) should have thrown an error but did not!"
+    except Exception as ex:
+        print(ex)
+        temp = str(ex)
+        assert ("getLambdaMax(model) can only be called when lambda_search=True" in temp)
+        print("grab_lambda_values) test completed!")
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(grab_lambda_values_alpha_best)
+else:
+    grab_lambda_values_alpha_best()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7835_verify_cold_start_lambda_search.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7835_verify_cold_start_lambda_search.py
@@ -1,0 +1,41 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# This test will check when cold start = true, lambda search should produce same coefficients as if you grab each
+# lambda value and build the model yourself.
+
+def grab_lambda_min():
+    boston = h2o.import_file(pyunit_utils.locate("smalldata/gbm_test/BostonHousing.csv"))
+
+    # set the predictor names and the response column name
+    predictors = boston.columns[:-1]
+    # set the response column to "medv", the median value of owner-occupied homes in $1000's
+    response = "medv"
+
+    # convert the chas column to a factor (chas = Charles River dummy variable (= 1 if tract bounds river; 0 otherwise))
+    boston['chas'] = boston['chas'].asfactor()
+
+    # split into train and validation sets
+    train, valid = boston.split_frame(ratios = [.8], seed=1234)
+    boston_glm = H2OGeneralizedLinearEstimator(lambda_search = True, seed=1234, cold_start=True)
+    boston_glm.train(x = predictors, y = response, training_frame = train, validation_frame = valid)   
+    r = H2OGeneralizedLinearEstimator.getGLMRegularizationPath(boston_glm)
+
+    for l in range(0,len(r['lambdas'])):
+        m = H2OGeneralizedLinearEstimator(alpha=[r['alphas'][l]],Lambda=r['lambdas'][l],
+                                          solver='COORDINATE_DESCENT')
+        m.train(x = predictors, y = response, training_frame = train, validation_frame = valid)
+        cs = r['coefficients'][l]
+        cs_norm = r['coefficients_std'][l]
+        print("comparing coefficients for submodel {0}".format(l))
+        pyunit_utils.assertEqualCoeffDicts(cs, m.coef(), tol=1e-6)
+        pyunit_utils.assertEqualCoeffDicts(cs_norm, m.coef_norm(), tol=1e-6)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(grab_lambda_min)
+else:
+    grab_lambda_min()

--- a/h2o-r/h2o-package/R/glm.R
+++ b/h2o-r/h2o-package/R/glm.R
@@ -671,6 +671,51 @@ h2o.makeGLMModel <- function(model,beta) {
   m
 }
 
+#' Extract best lambda value found from glm model.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getLambdaBest <- function(model) {
+  model@model$lambda_best
+}
+
+#' Extract the maximum lambda value used during lambda search from glm model.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getLambdaMax <- function(model) {
+  lambdaMax <- model@model$lambda_max
+  if (lambdaMax < 0) # -1 if lambda_search=FALSE
+    stop("getLambdaMax(model) can only be called when lambda_search=True or when you have multiple lambda values to try.")
+  else 
+    lambdaMax
+}
+
+#' Extract best alpha value found from glm model.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getAlphaBest <- function(model) {
+  model@model$alpha_best
+}
+
+#' Extract the minimum lambda value calculated during lambda search from glm model.
+#' Note that due to early stop, this minimum lambda value may not be used in the actual lambda search.
+#'
+#' This function allows setting betas of an existing glm model.
+#' @param model an \linkS4class{H2OModel} corresponding from a \code{h2o.glm} call.
+#' @export
+h2o.getLambdaMin <- function(model) {
+  lambdaMin <- model@model$lambda_min # will be -1 if lambda_search=FALSE
+  if (lambdaMin < 0)
+    stop("getLambdaMin(model) can only be called when lambda_search=True or when you have multiple lambda values to try.")
+  else 
+    lambdaMin
+}
+
 #' Extract full regularization path from a GLM model
 #'
 #' Extract the full regularization path from a GLM model (assuming it was run with the lambda search option).

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7481_glm_alpha_array_lambda_null_regPath.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7481_glm_alpha_array_lambda_null_regPath.R
@@ -5,7 +5,6 @@ source("../../../scripts/h2o-r-test-setup.R")
 # I am testing when we have an alpha array and no lambda, GLM should still build and report back submodel parameters
 # in RegularizationPath.  Simple test to make sure alphas are reported back in regularization path.
 test.glm_reg_path <- function() {
-    browser()
     d <-  h2o.importFile(path = locate("smalldata/logreg/prostate.csv"))
     alphaArray <- c(0.1,0.5,0.9)
     m = h2o.glm(training_frame=d,x=3:9,y=2,family='binomial',alpha=alphaArray)

--- a/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7835_glm_lambda_max_min_best_alpha_best.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_PUBDEV_7835_glm_lambda_max_min_best_alpha_best.R
@@ -1,0 +1,22 @@
+library(glmnet)
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# I have added two parameters to GLMModelOutput: lambda_min and lambda_max.  These parameters will take on the following
+# meaning when lambda_search is enabled:
+# lambda_max is the first lambda value searched;
+# lambda_min is the smallest lambda value that may be searched.  If early-stop is enabled, we may not reach the end to 
+# build GLM with lambda_min.
+# In addition, users will be able to directly access alpha_best, lambda_best, lambda_min and lambda_max from the new functions
+# that I added.
+
+test.glm_lambda_min_max_best_alpha_best <- function() {
+    d <-  h2o.importFile(path = locate("smalldata/logreg/prostate.csv"))
+    m = h2o.glm(training_frame=d,x=3:9,y=2,family='binomial',lambda_search=TRUE)
+    expect_true(m@model$lambda_best==h2o.getLambdaBest(m))
+    expect_true(m@model$lambda_min==h2o.getLambdaMin(m))
+    expect_true(m@model$lambda_max==h2o.getLambdaMax(m))
+    expect_true(m@model$alpha_best==h2o.getAlphaBest(m))
+}
+
+doTest("GLM alpha_best, lambda_best, lambda_min and lambda_max in modelOutput.", test.glm_lambda_min_max_best_alpha_best)


### PR DESCRIPTION
This PR completes the work in JIRA: https://0xdata.atlassian.net/browse/PUBDEV-7835

I fixed one more bug to make sure cold start works correctly.

In addition, I added two tests to make sure that:
1. GLM models built with lambda search = true, cold_start=true will contain the same coefficients are those GLM built with the same lambda values.
2. The parameters lambda_min and lambda_max are passed correctly to R or Python clients.
3. Instead of having users accessing part of the model, I have added functions like getLambdaBest, getLambdaMax, getLambdaMin, getAlphaBest in both python and R to make it easier for users to see those parameters