### PR TITLE
PUBDEV-7782: fix AOOB issue with GLM CV.

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/ComputationState.java
+++ b/h2o-algos/src/main/java/hex/glm/ComputationState.java
@@ -328,7 +328,7 @@ public final class ComputationState {
 
   public DataInfo activeDataMultinomial(int c) {return _activeDataMultinomial != null?_activeDataMultinomial[c]:_dinfo;}
 
-  private static double [] extractSubRange(int N, int c, int [] ids, double [] src) {
+  public static double [] extractSubRange(int N, int c, int [] ids, double [] src) {
     if(ids == null) return Arrays.copyOfRange(src,c*N,c*N+N);
     double [] res = MemoryManager.malloc8d(ids.length);
     int j = 0;

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -1450,7 +1450,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
               System.out.println("DONE after " + (iterCnt-1) + " iterations (1)");
               return;
             }
-            betaCnd = s == Solver.COORDINATE_DESCENT?COD_solve(gram,_state._alpha,_state.lambda()):ADMM_solve(gram.gram,gram.xy);
+            betaCnd = s == Solver.COORDINATE_DESCENT?COD_solve(gram,_state._alpha,_state.lambda())
+                    :ADMM_solve(gram.gram,gram.xy); // this will shrink betaCnd if needed but this call may be skipped
           }
           firstIter = false;
           long t3 = System.currentTimeMillis();
@@ -1459,7 +1460,11 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
               ls = (_state.l1pen() == 0 && !_state.activeBC().hasBounds())
                  ? new MoreThuente(_state.gslvr(),_state.beta(), _state.ginfo())
                  : new SimpleBacktrackingLS(_state.gslvr(),_state.beta().clone(), _state.l1pen(), _state.ginfo());
-            if (!ls.evaluate(ArrayUtils.subtract(betaCnd, ls.getX(), betaCnd))) { // ls.getX() get the old beta value
+            double[] oldBetaCnd = ls.getX();
+            if (betaCnd.length != oldBetaCnd.length) {  // if ln 1453 is skipped and betaCnd.length != _state.beta()
+              betaCnd = _state.extractSubRange(betaCnd.length, 0, _state.activeData()._activeCols, betaCnd);
+            }
+            if (!ls.evaluate(ArrayUtils.subtract(betaCnd, oldBetaCnd, betaCnd))) { // ls.getX() get the old beta value
               Log.info(LogMsg("Ls failed " + ls));
               return;
             }

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7782_cv_AOOB.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7782_cv_AOOB.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+import h2o.exceptions
+from tests import pyunit_utils
+from h2o.estimators import H2OGeneralizedLinearEstimator
+
+# During normal GLM model building, the coefficient length can shrink when coefficients/gram matrix has zero 
+# rows/columns.  Since betaCnd is allocated at the beginning of iteration loop and the coefficient length change
+# happened within the iteration loop, there can be a discrepancy in the coefficient lengths.  Normally, this is not a 
+# problem because the action of betaCnd = ADMM_solve() or other solvers.  But, in this case, that call is skipped.
+# Hence, you will get betaCnd of one length and _state.beta() of another length.  My fix is to make sure when there
+# is a length difference, I will extract the correct coefficients from betaCnd such that it will be of the same length
+# as _state.beta().
+#
+# Test provided by Seb.
+def test_GLM_throws_ArrayOutOfBoundException():    
+# everything in this test is important to cause the exception:    
+# - GLEASON as a categorical    
+# - lambda search enabled    
+# - alphas    # - CV enabled    
+    df = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate.csv"))    
+    target = "CAPSULE"
+    nFold = 5
+    for col in [target, 'GLEASON']:        
+        df[col] = df[col].asfactor()    
+        glm = H2OGeneralizedLinearEstimator(lambda_search=True, alpha=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0], nfolds=nFold, 
+                                            seed=12345)
+        glm.train(y=target, training_frame=df)
+        
+        assert len(glm._model_json["output"]['cross_validation_models'])==nFold, \
+            "expected number of cross_validation_model: {0}.  Actual number of cross_validation: " \
+            "{1}".format(len(glm._model_json["output"]['cross_validation_models']), nFold)
+
+        # INFO water.default: Completing model GLM_model_python_1600368882855_5861_cv_5
+        # WARN water.default: Model training job GLM completed with exception: java.lang.ArrayIndexOutOfBoundsException: 14
+        # ERROR water.default:# java.lang.ArrayIndexOutOfBoundsException: 14
+        # at water.util.ArrayUtils.subtract(ArrayUtils.java:1459)# at hex.glm.GLM$GLMDriver.fitIRLSM(GLM.java:1462)
+        # at hex.glm.GLM$GLMDriver.fitModel(GLM.java:1726)# at hex.glm.GLM$GLMDriver.computeSubmodel(GLM.java:2095)
+        # at hex.glm.GLM$GLMDriver.computeImpl(GLM.java:2202)# at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:238)
+        # at hex.glm.GLM$GLMDriver.compute2(GLM.java:890)# at water.H2O$H2OCountedCompleter.compute(H2O.java:1563)
+        # at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)# at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
+        # at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)# at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
+        # at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)# 
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_GLM_throws_ArrayOutOfBoundException)
+else:
+    test_GLM_throws_ArrayOutOfBoundException()

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7782_cv_AOOB.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7782_cv_AOOB.py
@@ -33,17 +33,6 @@ def test_GLM_throws_ArrayOutOfBoundException():
             "expected number of cross_validation_model: {0}.  Actual number of cross_validation: " \
             "{1}".format(len(glm._model_json["output"]['cross_validation_models']), nFold)
 
-        # INFO water.default: Completing model GLM_model_python_1600368882855_5861_cv_5
-        # WARN water.default: Model training job GLM completed with exception: java.lang.ArrayIndexOutOfBoundsException: 14
-        # ERROR water.default:# java.lang.ArrayIndexOutOfBoundsException: 14
-        # at water.util.ArrayUtils.subtract(ArrayUtils.java:1459)# at hex.glm.GLM$GLMDriver.fitIRLSM(GLM.java:1462)
-        # at hex.glm.GLM$GLMDriver.fitModel(GLM.java:1726)# at hex.glm.GLM$GLMDriver.computeSubmodel(GLM.java:2095)
-        # at hex.glm.GLM$GLMDriver.computeImpl(GLM.java:2202)# at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:238)
-        # at hex.glm.GLM$GLMDriver.compute2(GLM.java:890)# at water.H2O$H2OCountedCompleter.compute(H2O.java:1563)
-        # at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)# at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
-        # at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)# at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
-        # at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)# 
-
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_GLM_throws_ArrayOutOfBoundException)
 else:

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7794_multiple_alphas_large.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7794_multiple_alphas_large.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+import sys, os
+sys.path.insert(1, os.path.join("..","..",".."))
+import h2o
+import h2o.exceptions
+from tests import pyunit_utils
+from h2o.estimators import H2OGeneralizedLinearEstimator
+
+# During normal GLM model building, the coefficient length can shrink when coefficients/gram matrix has zero 
+# rows/columns.  Since betaCnd is allocated at the beginning of iteration loop and the coefficient length change
+# happened within the iteration loop, there can be a discrepancy in the coefficient lengths.  Normally, this is not a 
+# problem because the action of betaCnd = ADMM_solve() or other solvers.  But, in this case, that call is skipped.
+# Hence, you will get betaCnd of one length and _state.beta() of another length.  My fix is to make sure when there
+# is a length difference, I will extract the correct coefficients from betaCnd such that it will be of the same length
+# as _state.beta().
+#
+# Test provided by Seb.
+def test_GLM_throws_ArrayOutOfBoundException():
+    nFold = 5
+    fr = h2o.import_file(pyunit_utils.locate("bigdata/laptop/jira/christine.arff"))
+    splitFrame = fr.split_frame(ratios=[0.05])
+    glm = H2OGeneralizedLinearEstimator(family='binomial',
+                                    nfolds=nFold,
+                                    lambda_search=True,
+                                    alpha=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+                                    )
+    glm.train(y=0, training_frame=splitFrame[0])
+    assert len(glm._model_json["output"]['cross_validation_models'])==nFold, \
+        "expected number of cross_validation_model: {0}.  Actual number of cross_validation: " \
+        "{1}".format(len(glm._model_json["output"]['cross_validation_models']), nFold)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_GLM_throws_ArrayOutOfBoundException)
+else:
+    test_GLM_throws_ArrayOutOfBoundException()


### PR DESCRIPTION
This PR resolves the following issue: https://0xdata.atlassian.net/browse/PUBDEV-7782.

Here is the problem:

During normal GLM model building, the coefficient length can shrink when coefficients/gram matrix has zero rows/columns.  Since betaCnd is allocated at the beginning of iteration loop and the coefficient length change happened within the iteration loop, there can be a discrepancy in the coefficient lengths.  Normally, this is not a problem because the action of betaCnd = ADMM_solve() or other solvers.  But, in this case, that call is skipped.  Hence, you will get betaCnd of one length and _state.beta() of another length.  My fix is to make sure when there is a length difference, I will extract the correct coefficients from betaCnd such that it will be of the same length as _state.beta().

I added tests provided by @sebhrusen to make sure that the fixes actually work.  Thanks @sebhrusen.