### PR TITLE
[PUBDEV-7846] Finalization API with Leaving Frames Locked

### DIFF
--- a/h2o-core/src/main/java/water/fvec/ChunkUtils.java
+++ b/h2o-core/src/main/java/water/fvec/ChunkUtils.java
@@ -37,12 +37,12 @@ public class ChunkUtils {
     }
 
     public static Frame finalizeFrame(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains) {
-        return finalizeFrame(keyName, rowsPerChunk, colTypes, colDomains, false);
+        return finalizeFrame(keyName, rowsPerChunk, colTypes, colDomains, true);
     }
 
-    public static Frame finalizeFrame(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains, boolean leaveLocked) {
+    public static Frame finalizeFrame(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains, boolean unlock) {
         Frame fr = DKV.getGet(keyName);
-        fr.finalizePartialFrame(rowsPerChunk, colDomains, colTypes, leaveLocked);
+        fr.finalizePartialFrame(rowsPerChunk, colDomains, colTypes, unlock);
         return fr;
     }
 }

--- a/h2o-core/src/main/java/water/fvec/ChunkUtils.java
+++ b/h2o-core/src/main/java/water/fvec/ChunkUtils.java
@@ -42,4 +42,9 @@ public class ChunkUtils {
         return fr;
     }
 
+    public static Frame finalizeFrameAndLeaveLocked(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains){
+        Frame fr = DKV.getGet(keyName);
+        fr.finalizePartialFrameAndLeaveLocked(rowsPerChunk, colDomains, colTypes);
+        return fr;
+    }
 }

--- a/h2o-core/src/main/java/water/fvec/ChunkUtils.java
+++ b/h2o-core/src/main/java/water/fvec/ChunkUtils.java
@@ -36,15 +36,13 @@ public class ChunkUtils {
         fr.update();
     }
 
-    public static Frame finalizeFrame(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains){
-        Frame fr = DKV.getGet(keyName);
-        fr.finalizePartialFrame(rowsPerChunk, colDomains, colTypes);
-        return fr;
+    public static Frame finalizeFrame(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains) {
+        return finalizeFrame(keyName, rowsPerChunk, colTypes, colDomains, false);
     }
 
-    public static Frame finalizeFrameAndLeaveLocked(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains){
+    public static Frame finalizeFrame(String keyName, long[] rowsPerChunk, byte[] colTypes, String[][] colDomains, boolean leaveLocked) {
         Frame fr = DKV.getGet(keyName);
-        fr.finalizePartialFrameAndLeaveLocked(rowsPerChunk, colDomains, colTypes);
+        fr.finalizePartialFrame(rowsPerChunk, colDomains, colTypes, leaveLocked);
         return fr;
     }
 }

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1078,8 +1078,15 @@ public class Frame extends Lockable<Frame> {
   }
 
   // Build real Vecs from loose Chunks, and finalize this Frame.  Called once
+  // after any number of [create,close]NewChunks. This method also unlocks the frame.
+  void finalizePartialFrame(long[] espc, String[][] domains, byte[] types) {
+    finalizePartialFrameAndLeaveLocked(espc, domains, types);
+    unlock();
+  }
+  
+  // Build real Vecs from loose Chunks, and finalize this Frame.  Called once
   // after any number of [create,close]NewChunks.
-  void finalizePartialFrame( long[] espc, String[][] domains, byte[] types ) {
+  void finalizePartialFrameAndLeaveLocked(long[] espc, String[][] domains, byte[] types) {
     // Compute elems-per-chunk.
     // Roll-up elem counts, so espc[i] is the starting element# of chunk i.
     int nchunk = espc.length;
@@ -1111,7 +1118,6 @@ public class Frame extends Lockable<Frame> {
       DKV.put(_keys[i],vec,fs);
     }
     fs.blockForPending();
-    unlock();
   }
 
   // --------------------------------------------------------------------------

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1080,13 +1080,12 @@ public class Frame extends Lockable<Frame> {
   // Build real Vecs from loose Chunks, and finalize this Frame.  Called once
   // after any number of [create,close]NewChunks. This method also unlocks the frame.
   void finalizePartialFrame(long[] espc, String[][] domains, byte[] types) {
-    finalizePartialFrameAndLeaveLocked(espc, domains, types);
-    unlock();
+    finalizePartialFrame(espc, domains, types, false);
   }
   
   // Build real Vecs from loose Chunks, and finalize this Frame.  Called once
   // after any number of [create,close]NewChunks.
-  void finalizePartialFrameAndLeaveLocked(long[] espc, String[][] domains, byte[] types) {
+  void finalizePartialFrame(long[] espc, String[][] domains, byte[] types, boolean leaveLocked) {
     // Compute elems-per-chunk.
     // Roll-up elem counts, so espc[i] is the starting element# of chunk i.
     int nchunk = espc.length;
@@ -1118,6 +1117,10 @@ public class Frame extends Lockable<Frame> {
       DKV.put(_keys[i],vec,fs);
     }
     fs.blockForPending();
+    
+    if (!leaveLocked) {
+      unlock();
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1080,12 +1080,12 @@ public class Frame extends Lockable<Frame> {
   // Build real Vecs from loose Chunks, and finalize this Frame.  Called once
   // after any number of [create,close]NewChunks. This method also unlocks the frame.
   void finalizePartialFrame(long[] espc, String[][] domains, byte[] types) {
-    finalizePartialFrame(espc, domains, types, false);
+    finalizePartialFrame(espc, domains, types, true);
   }
   
   // Build real Vecs from loose Chunks, and finalize this Frame.  Called once
   // after any number of [create,close]NewChunks.
-  void finalizePartialFrame(long[] espc, String[][] domains, byte[] types, boolean leaveLocked) {
+  void finalizePartialFrame(long[] espc, String[][] domains, byte[] types, boolean unlock) {
     // Compute elems-per-chunk.
     // Roll-up elem counts, so espc[i] is the starting element# of chunk i.
     int nchunk = espc.length;
@@ -1118,7 +1118,7 @@ public class Frame extends Lockable<Frame> {
     }
     fs.blockForPending();
     
-    if (!leaveLocked) {
+    if (unlock) {
       unlock();
     }
   }


### PR DESCRIPTION
The newly introduced method is required for proper locking of H2O Frames during conversion from Spark Data Frames to H2O Frames in Sparkling Water. After the frame is finalized, SW still does some [post processing](https://github.com/h2oai/sparkling-water/blob/958c9a4210995ab7f3ec0139119ebc51b154fac5/extensions/src/main/scala/ai/h2o/sparkling/extensions/rest/api/ImportFrameHandler.scala#L37).