### PR TITLE
PUBDEV-7606: add _varimp to GLM model output.

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -1,9 +1,6 @@
 package hex.gam;
 
-import hex.DataInfo;
-import hex.ModelBuilder;
-import hex.ModelCategory;
-import hex.ModelMetrics;
+import hex.*;
 import hex.gam.GAMModel.GAMParameters;
 import hex.gam.MatrixFrameUtils.GamUtils;
 import hex.gam.MatrixFrameUtils.GenerateGamMatrixOneColumn;
@@ -26,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static hex.ModelMetrics.calcVarImp;
 import static hex.gam.GAMModel.cleanUpInputFrame;
 import static hex.gam.MatrixFrameUtils.GamUtils.AllocateType.*;
 import static hex.gam.MatrixFrameUtils.GamUtils.*;
@@ -579,7 +577,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         model._output._penaltyMatrices_center = _penalty_mat_center;
         model._output._penaltyMatrices = _penalty_mat;
       }
-      copyGLMCoeffs(glm, model, dinfo);  // copy over coefficient names and generate coefficients as beta = z*GLM_beta
+      copyGLMCoeffs(glm, model);  // copy over coefficient names and generate coefficients as beta = z*GLM_beta
       copyGLMtoGAMModel(model, glm);  // copy over fields from glm model to gam model
     }
     
@@ -629,9 +627,11 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
       if (model.evalAutoParamsEnabled && model._parms._solver == GLMParameters.Solver.AUTO) {
         model._parms._solver = glmModel._parms._solver;
       }
+      model._output._varimp = new VarImp(glmModel._output._varimp._varimp, glmModel._output._varimp._names);
+      model._output._variable_importances = calcVarImp(model._output._varimp);
     }
     
-    void copyGLMCoeffs(GLMModel glm, GAMModel model, DataInfo dinfo) {
+    void copyGLMCoeffs(GLMModel glm, GAMModel model) {
       boolean multiClass = _parms._family == multinomial || _parms._family == ordinal;
       int totCoefNumsNoCenter = (multiClass?glm.coefficients().size()/nclasses():glm.coefficients().size())
               +_parms._gam_columns.length;

--- a/h2o-algos/src/main/java/hex/gam/GAMModel.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMModel.java
@@ -371,6 +371,8 @@ public class GAMModel extends Model<GAMModel, GAMModel.GAMParameters, GAMModel.G
     public TwoDimTable _coefficients_table;
     public TwoDimTable _coefficients_table_no_centering;
     public TwoDimTable _standardized_coefficient_magnitudes;
+    public TwoDimTable _variable_importances;
+    public VarImp _varimp;  // should contain the same content as standardized coefficients
     public double[] _model_beta_no_centering; // coefficients generated during model training
     public double[] _standardized_model_beta_no_centering; // standardized coefficients generated during model training
     public double[] _model_beta; // coefficients generated during model training

--- a/h2o-algos/src/main/java/hex/generic/GenericModelOutput.java
+++ b/h2o-algos/src/main/java/hex/generic/GenericModelOutput.java
@@ -46,6 +46,8 @@ public class GenericModelOutput extends Model.Output {
                 _variable_importances = convertVariableImportances(((SharedTreeModelAttributes) modelAttributes).getVariableImportances());
             } else if (modelAttributes instanceof DeepLearningModelAttributes) {
                 _variable_importances = convertVariableImportances(((DeepLearningModelAttributes) modelAttributes).getVariableImportances());
+            } else if (modelAttributes instanceof ModelAttributesGLM) {
+                _variable_importances = convertVariableImportances(((ModelAttributesGLM) modelAttributes).getVariableImportances());
             } else {
                 _variable_importances = null;
             }

--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -40,6 +40,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
 
+import static hex.ModelMetrics.calcVarImp;
 import static hex.glm.GLMUtils.*;
 
 /**
@@ -2272,6 +2273,8 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
               (null != _parms._valid), false, _model._output.getModelCategory(), false);
       _model._output._scoring_history = combineScoringHistory(_model._output._scoring_history,
               scoring_history_early_stop, _scoreIterationList);
+      _model._output._varimp = _model._output.calculateVarimp();
+      _model._output._variable_importances = calcVarImp(_model._output._varimp);
       _model.update(_job._key);
 /*      if (_vcov != null) {
         _model.setVcov(_vcov);

--- a/h2o-algos/src/main/java/hex/schemas/GAMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMModelV3.java
@@ -24,6 +24,9 @@ public class GAMModelV3 extends ModelSchemaV3<GAMModel, GAMModelV3, GAMModel.GAM
     @API(help="Table of Standardized Coefficients Magnitudes")
     TwoDimTableV3 standardized_coefficient_magnitudes;
 
+    @API(help="Variable Importances", direction=API.Direction.OUTPUT, level = API.Level.secondary)
+    TwoDimTableV3 variable_importances;
+
     @API(help="key storing gam columns and predictor columns.  For debugging purposes only")
     String gam_transformed_center_key;
     

--- a/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GLMModelV3.java
@@ -6,13 +6,13 @@ import water.MemoryManager;
 import water.api.API;
 import water.api.schemas3.ModelOutputSchemaV3;
 import water.api.schemas3.ModelSchemaV3;
-
 import water.api.schemas3.TwoDimTableV3;
 import water.util.ArrayUtils;
 import water.util.TwoDimTable;
 
 import java.util.Arrays;
-import java.util.Comparator;
+
+import static water.util.ArrayUtils.sort;
 //import water.util.DocGen.HTML;
 
 public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLMParameters, GLMV3.GLMParametersV3, GLMOutput, GLMModelV3.GLMModelOutputV3> {
@@ -30,6 +30,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
 
     @API(help="Standardized Coefficient Magnitudes")
     TwoDimTableV3 standardized_coefficient_magnitudes;
+
+    @API(help = "Variable Importances", direction = API.Direction.OUTPUT, level = API.Level.secondary)
+    TwoDimTableV3 variable_importances;
 
     @API(help="Lambda minimizing the objective value, only applicable with lambda search or when arrays of alpha and " +
             "lambdas are provided")
@@ -58,6 +61,11 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       if(impl.get_global_beta_multinomial() == null)
         return this; // no coefificients yet
       String [] names = impl.coefficientNames().clone();
+      int len = names.length-1;
+      String [] names2 = new String[len]; // this one decides the length of standardized table length
+      int[] indices = new int[len];
+      for (int i = 0; i < indices.length; ++i)
+        indices[i] = i;
       // put intercept as the first
       String [] ns = ArrayUtils.append(new String[]{"Intercept"},Arrays.copyOf(names,names.length-1));
 
@@ -105,25 +113,8 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
             revertCoeffNames(cols2, n, coefficients_table_multinomials_with_class_names);
           }
           final double [] magnitudes = new double[betaNorm[0].length];
-          for(int i = 0; i < betaNorm.length; ++i) {
-            for (int j = 0; j < betaNorm[i].length; ++j) {
-              double d = betaNorm[i][j];
-              magnitudes[j] += d < 0 ? -d : d;
-            }
-          }
-          Integer [] indices = new Integer[magnitudes.length-1];
-          for(int i = 0; i < indices.length; ++i)
-            indices[i] = i;
-          Arrays.sort(indices, new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-              if(magnitudes[o1] < magnitudes[o2]) return +1;
-              if(magnitudes[o1] > magnitudes[o2]) return -1;
-              return 0;
-            }
-          });
-          int len = names.length-1;
-          String [] names2 = new String[len]; // this one decides the length of standardized table length
+          calculateVarimpMultinomial(magnitudes, indices, betaNorm);
+
           for(int i = 0; i < len; ++i)
             names2[i] = names[indices[i]];
           tdt = new TwoDimTable("Standardized Coefficient Magnitudes", "standardized coefficient magnitudes", names2, new String[]{"Coefficients", "Sign"}, new String[]{"double", "string"}, new String[]{"%5f", "%s"}, "names");
@@ -136,6 +127,16 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
         }
 
       return this;
+    }
+
+    public static void calculateVarimpMultinomial(double[] magnitudes, int[] indices, double[][] betaNorm) {
+      for (int i = 0; i < betaNorm.length; ++i) {
+        for (int j = 0; j < betaNorm[i].length; ++j) {
+          double d = betaNorm[i][j];
+          magnitudes[j] += d < 0 ? -d : d;
+        }
+      }
+      sort(indices, magnitudes, -1, -1);
     }
 
     public void revertCoeffNames(String[] colNames, int nclass, TwoDimTableV3 coeffs_table) {
@@ -181,8 +182,13 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
         random_coefficients_table = new TwoDimTableV3();
         random_coefficients_table.fillFromImpl(buildRandomCoefficients2DTable(impl.ubeta(), impl.randomcoefficientNames()));
       }
-      final double [] magnitudes;
       double [] beta = impl.beta();
+      final double [] magnitudes = new double[beta.length];
+      int len = magnitudes.length - 1;
+      int[] indices = new int[len];
+      for (int i = 0; i < indices.length; ++i)
+        indices[i] = i;
+
       if(beta == null) beta = MemoryManager.malloc8d(names.length);
       String [] colTypes = new String[]{"double"};
       String [] colFormats = new String[]{"%5f"};
@@ -223,22 +229,9 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
         }
       }
       coefficients_table.fillFromImpl(tdt);
-      if(impl.beta() != null) {
-        magnitudes = norm_beta.clone();
-        for (int i = 0; i < magnitudes.length; ++i)
-          if (magnitudes[i] < 0) magnitudes[i] *= -1;
-        Integer[] indices = new Integer[magnitudes.length - 1];
-        for (int i = 0; i < indices.length; ++i)
-          indices[i] = i;
-        Arrays.sort(indices, new Comparator<Integer>() {
-          @Override
-          public int compare(Integer o1, Integer o2) {
-            if (magnitudes[o1] < magnitudes[o2]) return +1;
-            if (magnitudes[o1] > magnitudes[o2]) return -1;
-            return 0;
-          }
-        });
-        int len = names.length-1;
+      if(impl.beta() != null) { // get varImp
+        calculateVarimpBase(magnitudes, indices, impl.getNormBeta());
+
         String[] names2 = new String[len];
         for (int i = 0; i < len; ++i)
           names2[i] = names[indices[i]];
@@ -253,6 +246,14 @@ public class GLMModelV3 extends ModelSchemaV3<GLMModel, GLMModelV3, GLMModel.GLM
       return this;
     }
   } // GLMModelOutputV2
+
+  public static void calculateVarimpBase(double[] magnitudes, int[] indices, double[] betaNorm) {
+    for (int i = 0; i < magnitudes.length; ++i) {
+      magnitudes[i] = (float) betaNorm[i];
+      if (magnitudes[i] < 0) magnitudes[i] *= -1;
+    }
+    sort(indices, magnitudes, -1, -1);
+  }
 
   public GLMV3.GLMParametersV3 createParametersSchema() { return new GLMV3.GLMParametersV3(); }
   public GLMModelOutputV3 createOutputSchema() { return new GLMModelOutputV3(); }

--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
@@ -16,8 +16,10 @@ import water.exceptions.H2OIllegalArgumentException;
 import water.fvec.Frame;
 import water.fvec.Vec;
 
+import java.util.Arrays;
 import java.util.Random;
 
+import static hex.schemas.GLMModelV3.GLMModelOutputV3.calculateVarimpMultinomial;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -49,6 +51,37 @@ public class GLMBasicTestMultinomial extends TestUtil {
     if(_covtype != null)  _covtype.delete();
     if(_train != null) _train.delete();
     if(_test != null) _test.delete();
+  }
+  
+  @Test
+  public void testcalculateVarimpMultinomial() {
+    int numClass = 5;
+    int coeffLen = 25;
+    double[][] betaNorm = new double[numClass][coeffLen];
+    double[] magnitudes = new double[coeffLen];
+    double[] magnitudes_check = new double[coeffLen];
+    int[] indices = new int[coeffLen];
+    Random randObj = new Random(12345);
+    
+    for (int indexc = 0; indexc < numClass; indexc++) { // generate random double[][] array
+      for (int index = 0; index < coeffLen; index++) {
+        betaNorm[indexc][index] = randObj.nextDouble();
+      }
+    }
+    calculateVarimpMultinomial(magnitudes, indices, betaNorm);  // calculate magnitude and generate indices of descending sort
+    
+    for (int classInd = 0; classInd < numClass; classInd++) { // manually generate coefficient magnitudes
+      for (int coeffInd = 0; coeffInd < coeffLen; coeffInd++) {
+        magnitudes_check[coeffInd] = magnitudes_check[coeffInd] + Math.abs(betaNorm[classInd][coeffInd]);
+      }
+    }
+    // check to make sure magnitude calculation is correct
+    Assert.assertTrue("coefficient magnitude calculation is in error.", 
+            Arrays.equals(magnitudes, magnitudes_check));
+    
+    for (int index = 1; index < coeffLen; index++)  // check to make sure sorting is done correctly
+      Assert.assertTrue(magnitudes[indices[index-1]]+" should be >= "+magnitudes[indices[index]],
+              magnitudes[indices[index-1]] >= magnitudes[indices[index]]);
   }
 
   @Test

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -1442,9 +1442,14 @@ public class ArrayUtils {
    * @param values values
    */
   public static void sort(final int[] idxs, final double[] values) {
-    sort(idxs, values, 500);
+    sort(idxs, values, 500, 1);
   }
+  
   public static void sort(final int[] idxs, final double[] values, int cutoff) {
+    sort(idxs, values, cutoff, 1);
+  }
+  // set increasing to 1 for ascending sort and -1 for descending sort
+  public static void sort(final int[] idxs, final double[] values, int cutoff, int increasing) {
     if (idxs.length < cutoff) {
       //hand-rolled insertion sort
       for (int i = 0; i < idxs.length; i++) {
@@ -1461,7 +1466,8 @@ public class ArrayUtils {
       Arrays.sort(d, new Comparator<Integer>() {
         @Override
         public int compare(Integer x, Integer y) {
-          return values[x] < values[y] ? -1 : (values[x] > values[y] ? 1 : 0);
+          return values[x]*increasing < values[y]*increasing ? -1 : 
+                  (values[x]*increasing > values[y]*increasing ? 1 : 0);
         }
       });
       for (int i = 0; i < idxs.length; ++i) idxs[i] = d[i];

--- a/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
+++ b/h2o-core/src/test/java/water/util/ArrayUtilsTest.java
@@ -1,6 +1,9 @@
 package water.util;
 
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Random;
 
 import static org.junit.Assert.*;
 import static water.util.ArrayUtils.*;
@@ -169,6 +172,26 @@ public class ArrayUtilsTest {
     assertEquals(0, countNonzeros(threeZeroes));
     double[] somenz = {-1.0, Double.MIN_VALUE, 0.0, Double.MAX_VALUE, 0.001, 0.0, 42.0};
     assertEquals(5, countNonzeros(somenz));
+  }
+  
+  @Test
+  public void testSortIndices() {
+    Random randObj = new Random(12345);
+    int arrayLen = 100;
+    int[] indices = new int[arrayLen];
+    double[] values = new double[arrayLen];
+    for (int index = 0; index < arrayLen; index++)  // generate data array
+      values[index] = randObj.nextDouble();
+    
+    sort(indices, values, -1, 1); // sorting in ascending order
+    for (int index = 1; index < arrayLen; index++)  // check correct sorting in ascending order
+      Assert.assertTrue(values[indices[index-1]]+" should be <= "+values[indices[index]], 
+              values[indices[index-1]] <= values[indices[index]]); 
+    
+    sort(indices, values, -1, -1);  // sorting in descending order
+    for (int index = 1; index < arrayLen; index++)  // check correct sorting in descending order
+      Assert.assertTrue(values[indices[index-1]]+" should be >= "+values[indices[index]],
+              values[indices[index-1]] >= values[indices[index]]);  
   }
 
   @Test

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/glm/GlmMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/glm/GlmMojoReader.java
@@ -2,8 +2,8 @@ package hex.genmodel.algos.glm;
 
 import com.google.gson.JsonObject;
 import hex.genmodel.ModelMojoReader;
-import hex.genmodel.attributes.ModelAttributesGLM;
 import hex.genmodel.attributes.ModelAttributes;
+import hex.genmodel.attributes.ModelAttributesGLM;
 import hex.genmodel.attributes.ModelJsonReader;
 
 import java.io.IOException;

--- a/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelAttributesGLM.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/attributes/ModelAttributesGLM.java
@@ -6,10 +6,16 @@ import hex.genmodel.MojoModel;
 public class ModelAttributesGLM extends ModelAttributes {
 
   public final Table _coefficients_table;
+  private final VariableImportances _variableImportances;
 
   public ModelAttributesGLM(MojoModel model, JsonObject modelJson) {
     super(model, modelJson);
     _coefficients_table = ModelJsonReader.readTable(modelJson, "output.coefficients_table");
+    _variableImportances = VariableImportances.extractFromJson(modelJson);
+  }
+
+  public VariableImportances getVariableImportances(){
+    return _variableImportances;
   }
 
 }

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -484,23 +484,9 @@ class ModelBase(h2o_meta(Keyed)):
         :returns: A list or Pandas DataFrame.
         """
         model = self._model_json["output"]
-        if self.algo=='glm' or self.algo=='gam' or "variable_importances" in list(model.keys()) and model["variable_importances"]:
-            if self.algo=='glm' or self.algo=='gam':
-                tempvals = model["standardized_coefficient_magnitudes"].cell_values
-                maxVal = 0
-                sum=0
-                for item in tempvals:
-                    sum=sum+item[1]
-                    if item[1]>maxVal:
-                        maxVal = item[1]
-                vals = []
-                for item in tempvals:
-                    tempT = (item[0], item[1], item[1]/maxVal, item[1]/sum)
-                    vals.append(tempT)
-                header = ["variable", "relative_importance", "scaled_importance", "percentage"]
-            else:
-                vals = model["variable_importances"].cell_values
-                header = model["variable_importances"].col_header
+        if "variable_importances" in list(model.keys()) and model["variable_importances"]:
+            vals = model["variable_importances"].cell_values
+            header = model["variable_importances"].col_header
                 
             if use_pandas and can_use_pandas():
                 import pandas

--- a/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7606_glm_varimp_generic.py
+++ b/h2o-py/tests/testdir_algos/glm/pyunit_PUBDEV_7606_glm_varimp_generic.py
@@ -1,0 +1,44 @@
+from builtins import range
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.glm import H2OGeneralizedLinearEstimator
+
+# check varimp for Binomial, Multinomial, Regression directly from model.output._varimp instead of the 
+# model._output._standardized_coefficients.
+def testvarimp():
+    print("Checking variable importance for binomials....")
+    training_data = h2o.import_file(pyunit_utils.locate("smalldata/logreg/benign.csv"))
+    Y = 3
+    X = [0, 1, 2, 4, 5, 6, 7, 8, 9, 10]
+    buildModelCheckVarimp(training_data, X, Y, "binomial")
+
+    print("Checking variable importance for multinomials....")
+    train = h2o.import_file(path=pyunit_utils.locate("smalldata/iris/iris_wheader.csv"))
+    myY = "class"
+    mX = list(range(0,4))
+    buildModelCheckVarimp(train, mX, myY, "multinomial")
+
+    print("Checking variable importance for regression....")
+    h2o_data = h2o.import_file(path=pyunit_utils.locate("smalldata/prostate/prostate_complete.csv.zip"))
+    myY = "GLEASON"
+    myX = ["ID","AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS"]
+    buildModelCheckVarimp(h2o_data, myX, myY, "gaussian")
+ 
+
+def buildModelCheckVarimp(training_frame, x_indices, y_index, family):
+    model = H2OGeneralizedLinearEstimator(family=family)
+    model.train(training_frame=training_frame, x=x_indices, y=y_index)
+    varimp = model.varimp()
+    print(varimp)
+    standardized_coeff = model._model_json["output"]["standardized_coefficient_magnitudes"]
+    # check to make sure varimp and standardized coefficient magnitudes agree
+    for ind in range(len(varimp)):
+        assert abs(standardized_coeff.cell_values[ind][1]-varimp[ind][1]) < 1e-6, \
+            "Expected value: {0}, actual: {1}".format(standardized_coeff.cell_values[ind][1], varimp[ind][1])
+
+if __name__ == "__main__":
+  pyunit_utils.standalone_test(testvarimp)
+else:
+    testvarimp()

--- a/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_glm.py
+++ b/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_glm.py
@@ -12,7 +12,7 @@ def test(x, y, output_test, strip_part, algo_name, generic_algo_name, family):
 
     # GLM
     airlines = h2o.import_file(path=pyunit_utils.locate("smalldata/testng/airlines_train.csv"))
-    glm = H2OGeneralizedLinearEstimator(nfolds = 3, family = family, alpha = 1, lambda_ = 1)
+    glm = H2OGeneralizedLinearEstimator(nfolds = 3, family = family, max_iterations=5) # alpha = 1, lambda_ = 1, bad values, use default
     glm.train(x = x, y = y, training_frame=airlines, validation_frame=airlines, )
     print(glm)
     with Capturing() as original_output:
@@ -33,6 +33,8 @@ def test(x, y, output_test, strip_part, algo_name, generic_algo_name, family):
     assert predictions.nrows == 24421
     assert generic_mojo_model_from_file._model_json["output"]["model_summary"] is not None
     assert len(generic_mojo_model_from_file._model_json["output"]["model_summary"]._cell_values) > 0
+    assert generic_mojo_model_from_file._model_json["output"]["variable_importances"] is not None
+    assert len(generic_mojo_model_from_file._model_json["output"]["variable_importances"]._cell_values) > 0
 
     generic_mojo_filename = tempfile.mkdtemp("zip", "genericMojo");
     generic_mojo_filename = generic_mojo_model_from_file.download_mojo(path=generic_mojo_filename)

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -1972,18 +1972,6 @@ h2o.varimp <- function(object) {
   o <- object
   if( is(o, "H2OModel") ) {
     vi <- o@model$variable_importances
-    if( is.null(vi) && !is.null(object@model$standardized_coefficient_magnitudes)) { # may be glm
-      tvi <- object@model$standardized_coefficient_magnitudes
-      maxCoeff <- max(tvi$coefficients)
-      sumCoeff <- sum(tvi$coefficients)
-      scaledCoeff <- tvi$coefficients/maxCoeff
-      percentageC <- tvi$coefficients/sumCoeff
-      variable <- tvi$names
-      relative_importance <- tvi$coefficients
-      scaled_importance <- scaledCoeff
-      percentage <- percentageC
-      vi <- data.frame(variable, relative_importance, scaled_importance, percentage)
-      }  # no true variable importances, maybe glm coeffs? (return standardized table...)
     if( is.null(vi) ) {
       warning("This model doesn't have variable importances", call. = FALSE)
       return(invisible(NULL))

--- a/h2o-r/tests/testdir_algos/glm/runit_pubdev_7606_varimp_check.R
+++ b/h2o-r/tests/testdir_algos/glm/runit_pubdev_7606_varimp_check.R
@@ -1,0 +1,38 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# testing the newly added varimp for GLM
+glmVarimpCheck <- function() {
+  # check for binomial
+  bhexFV <- h2o.uploadFile(locate("smalldata/logreg/benign.csv"), destination_frame="benignFV.hex")
+  maxX <- 11
+  Y <- 4
+  X   <- 3:maxX
+  X   <- X[ X != Y ] 
+  
+  Log.info("Checking varimp for GLM Binomial")
+  buildModelVarimpCheck("binomial",bhexFV,X,Y)
+  
+  # check for multinomial
+  Log.info("Checking varimp for GLM Multinomial")
+  buildModelVarimpCheck("multinomial", as.h2o(iris), x_indices=c(1,2,3,4), y_index=5)
+
+  # check regression
+  h2o.data = h2o.uploadFile(locate("smalldata/prostate/prostate_complete.csv.zip"), destination_frame="h2o.data")    
+  myY = "GLEASON"
+  myX = c("ID","AGE","RACE","CAPSULE","DCAPS","PSA","VOL","DPROS")
+  Log.info("Checking varimp for GLM Gaussian")
+  buildModelVarimpCheck("gaussian", h2o.data, x_indices=myX, y_index=myY)
+}
+
+buildModelVarimpCheck <- function(family, training_frame, x_indices, y_index) {
+  model <- h2o.glm(y=y_index, x=x_indices, training_frame=training_frame, family=family)
+  varimp <- h2o.varimp(model)[2][[1]]
+  standardizedCoeff = model@model$standardized_coefficient_magnitudes[2][[1]]
+  for (index in 1:length(varimp)) {
+    expect_true(abs(varimp[index]-standardizedCoeff[index])<1e-6, "varimp calculation is incorrect.")
+  }
+  h2o.varimp_plot(model)
+}
+
+doTest("GLM: Check generical variable importance values", glmVarimpCheck)


### PR DESCRIPTION
This PR completes the work for JIRA: https://h2oai.atlassian.net/jira/software/c/projects/PUBDEV/issues/PUBDEV-7644?filter=myopenissues

GLM provides standardized coefficients which can be massaged into varimp by Python and R clients.  Following the implementation of other H2O algos like deeplearning, GBM and others, I have added the field _varimp to GLMOutput.  In addition, I enabled GLM mojo to be able to use the generic framework of mojos and therefore be able to access variable importances to generic mojo as well.

I added Python/R client tests to make sure the varimp implementation is correct.

I added to Pavel's generic mojo model test to make sure variable importances can be accessed through mojo.