### PR TITLE
fix failing build - release at CI needs to make javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ allprojects {
 
     ext {
         isRelease = rootProject.hasProperty("doRelease")
+        isMakeJavadoc = rootProject.hasProperty("makeJavadoc")
         isCi = isCi
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -23,7 +23,7 @@ artifacts {
     toPublish sourcesJar
 }
 
-if (project.ext.isRelease) {
+if (project.ext.isMakeJavadoc) {
     java {
         withJavadocJar()
     }

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -69,9 +69,13 @@ if [ -n "$DO_RELEASE" ]; then
   DO_RELEASE="-PdoRelease"
 fi
 
+if [ -n "$MAKE_JAVADOC" ]; then
+  MAKE_JAVADOC="-PmakeJavadoc"
+fi
+
 # Run some required gradle tasks to produce final build output.
 ./gradlew booklets
-./gradlew $DO_RELEASE publish
+./gradlew $DO_RELEASE $MAKE_JAVADOC publish
 
 # Generate Py Docs
 (cd h2o-py && sphinx-build -b html docs/ docs/docs/)

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -659,6 +659,9 @@ private setReleaseJobProperties(final pipelineContext) {
             env.DO_RELEASE = true
         }
     }
+
+    env.MAKE_JAVADOC = true
+
     sh "printenv | sort"
 }
 


### PR DESCRIPTION
caused by 087e771366a766390527ff9c62404a4b0cfc5c23

Javadoc was not created when nexus upload was not enabled by jenkins parameters. Then `cp: cannot stat 'h2o-core/build/docs/javadoc': No such file or directory` appeared.