### PR TITLE
Semver2 compatible nightly build version of Helm chart

### DIFF
--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -237,7 +237,7 @@ try {
                             if(env.NIGHTLY_BUILD){
                                 CHART_NAME = "h2o-3-nightly"
                                 BUCKET = "h2oai-nightly-charts"
-                                VERSION = THREE_DIGITS_VERSION + "." + env.BUILD_NUMBER_DIR 
+                                VERSION = THREE_DIGITS_VERSION
                             } else {
                                 CHART_NAME = "h2o-3"
                                 BUCKET = "h2oai-charts"


### PR DESCRIPTION
Reported by @maurever :

```
10:26:13  + cd 5230/h2o-helm/
10:26:13  + sed -i s/name: h2o-3/name: h2o-3-nightly/ Chart.yaml
10:26:13  + helm package . --app-version 33.0.5230.5230 --version 33.0.5230.5230
10:26:14  Error: Invalid Semantic Version
[Pipeline] }
10:26:14  $ docker stop --time=1 22e949097256a24a3aebbd7085469a280fceb9536b4db13d6199a1c9a0e73f77
10:26:15  $ docker rm -f 22e949097256a24a3aebbd7085469a280fceb9536b4db13d6199a1c9a0e73f77
```

As you can see, the version consists of four numbers, and not 3. Removed the duplicated last number.