### PR TITLE
PUBDEV-7853: Fix learning curve for GLM

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLM.java
+++ b/h2o-algos/src/main/java/hex/glm/GLM.java
@@ -302,7 +302,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
     private ArrayList<Double> _lambdaDevTest;
     private ArrayList<Double> _lambdaDevXval;
     private ArrayList<Double> _lambdaDevXvalSE;
-
+    private ArrayList<Double> _alpha = new ArrayList<>();
 
     public LambdaSearchScoringHistory(boolean hasTest, boolean hasXval) {
       if(hasTest || true)_lambdaDevTest = new ArrayList<>();
@@ -312,7 +312,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       }
     }
 
-    public synchronized void addLambdaScore(int iter, int predictors, double lambda, double devRatioTrain, double devRatioTest, double devRatioXval, double devRatoioXvalSE) {
+    public synchronized void addLambdaScore(int iter, int predictors, double lambda, double devRatioTrain, double devRatioTest, double devRatioXval, double devRatoioXvalSE, double alpha) {
       _scoringTimes.add(System.currentTimeMillis());
       _lambdaIters.add(iter);
       _lambdas.add(lambda);
@@ -321,6 +321,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
       if(_lambdaDevTest != null)_lambdaDevTest.add(devRatioTest);
       if(_lambdaDevXval != null)_lambdaDevXval.add(devRatioXval);
       if(_lambdaDevXvalSE != null)_lambdaDevXvalSE.add(devRatoioXvalSE);
+      _alpha.add(alpha);
     }
     public synchronized TwoDimTable to2dTable() {
 
@@ -339,6 +340,9 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
         cformats = ArrayUtils.append(cformats,"%.3f");
       if(_lambdaDevXval != null)
         cformats = ArrayUtils.append(cformats,new String[]{"%.3f","%.3f"});
+      cnames = ArrayUtils.append(cnames, "alpha");
+      ctypes = ArrayUtils.append(ctypes, "double");
+      cformats = ArrayUtils.append(cformats, "%.6f");
       TwoDimTable res = new TwoDimTable("Scoring History", "", new String[_lambdaIters.size()], cnames, ctypes, cformats, "");
       int j = 0;
       DateTimeFormatter fmt = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
@@ -356,6 +360,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           res.set(i, col++, _lambdaDevXval.get(i));
           res.set(i, col++, _lambdaDevXvalSE.get(i));
         }
+        res.set(i, col++, _alpha.get(i));
       }
       return res;
     }
@@ -2104,7 +2109,7 @@ public class GLM extends ModelBuilder<GLMModel,GLMParameters,GLMOutput> {
           Log.info(LogMsg("train deviance = " + trainDev + ", valid deviance = " + validDev));
           double xvalDev = ((_xval_deviances == null) || (_xval_deviances.length <= i)) ? -1 : _xval_deviances[i];
           double xvalDevSE = ((_xval_sd == null) || (_xval_deviances.length <= i)) ? -1 : _xval_sd[i];
-          _lsc.addLambdaScore(_state._iter, ArrayUtils.countNonzeros(_state.beta()), _state.lambda(), trainDev, validDev, xvalDev, xvalDevSE); // add to scoring history
+          _lsc.addLambdaScore(_state._iter, ArrayUtils.countNonzeros(_state.beta()), _state.lambda(), trainDev, validDev, xvalDev, xvalDevSE, _state.alpha()); // add to scoring history
           _model.updateSubmodel(sm = new Submodel(_state.lambda(), _state.alpha(), _state.beta(), _state._iter, trainDev, validDev));
         }
       }

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1022,7 +1022,7 @@ class ModelBase(h2o_meta(Keyed)):
         if self._model_json["algo"] == "glm":
             if self.actual_params.get("lambda_search"):
                 allowed_timesteps = ["iteration", "duration"]
-                allowed_metrics = ["deviance_train", "deviance_test"]
+                allowed_metrics = ["deviance_train", "deviance_test", "deviance_xval"]
                 # When provided with multiple alpha values, scoring history contains history of all...
                 scoring_history = scoring_history[scoring_history["alpha"] == self._model_json["output"]["alpha_best"]]
             elif self.actual_params["HGLM"]:

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1020,12 +1020,28 @@ class ModelBase(h2o_meta(Keyed)):
         scoring_history = self.scoring_history()
         # Separate functionality for GLM since its output is different from other algos
         if self._model_json["algo"] == "glm":
-            # GLM has only one timestep option, which is `iterations`
-            timestep = "iterations"
+            if self.actual_params.get("lambda_search"):
+                allowed_timesteps = ["iteration", "duration"]
+                allowed_metrics = ["deviance_train", "deviance_test"]
+                # When provided with multiple alpha values, scoring history contains history of all...
+                scoring_history = scoring_history[scoring_history["alpha"] == self._model_json["output"]["alpha_best"]]
+            elif self.actual_params["HGLM"]:
+                allowed_timesteps = ["iterations", "duration"]
+                allowed_metrics = ["convergence", "sumetaieta02"]
+            else:
+                allowed_timesteps = ["iterations", "duration"]
+                allowed_metrics = ["objective", "negative_log_likelihood"]
+
             if metric == "AUTO":
-                metric = "objective" # this includes the negative log likelihood and the penalties.
-            elif metric not in ("negative_log_likelihood", "objective"):
-                raise H2OValueError("for GLM, metric must be one of: negative_log_likelihood, objective")
+                metric = allowed_metrics[0]
+            elif metric not in allowed_metrics:
+                raise H2OValueError("for GLM, metric must be one of: {}".format(", ".join(allowed_metrics)))
+
+            if timestep == "AUTO":
+                timestep = allowed_timesteps[0]
+            elif timestep not in allowed_timesteps:
+                raise H2OValueError("for GLM, timestep must be one of: {}".format(", ".join(allowed_timesteps)))
+
             plt.xlabel(timestep)
             plt.ylabel(metric)
             plt.title("Validation Scoring History")

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -3413,20 +3413,22 @@ plot.H2OModel <- function(x, timestep = "AUTO", metric = "AUTO", ...) {
 
   #Ensure metric and timestep can be passed in as upper case (by converting to lower case) if not "AUTO"
   if(metric != "AUTO"){
-    metric = tolower(metric)
+    metric <- tolower(metric)
   }
 
   if(timestep != "AUTO"){
-    timestep = tolower(timestep)
+    timestep <- tolower(timestep)
   }
 
   # Separate functionality for GLM since output is different from other algos
-  if (x@algorithm == "glm") {
+  if (x@algorithm %in% c("gam", "glm")) {
+    if ("gam" == x@algorithm)
+      df <- as.data.frame(x@model$glm_scoring_history)
     if (x@allparameters$lambda_search) {
       allowed_metrics <- c("deviance_train", "deviance_test", "deviance_xval")
       allowed_timesteps <- c("iteration", "duration")
       df <- df[df["alpha"] == x@model$alpha_best,]
-    } else if (x@allparameters$HGLM) {
+    } else if (!is.null(x@allparameters$HGLM) && x@allparameters$HGLM) {
       allowed_metrics <- c("convergence", "sumetaieta02")
       allowed_timesteps <- c("iterations", "duration")
     } else {
@@ -3437,13 +3439,13 @@ plot.H2OModel <- function(x, timestep = "AUTO", metric = "AUTO", ...) {
     if (timestep == "AUTO") {
       timestep <- allowed_timesteps[[1]]
     } else if (!(metric %in% allowed_timesteps)) {
-      stop("for GLM, timestep must be one of: ", paste(allowed_timesteps, collapse = ", "))
+      stop("for ", toupper(x@algorithm), ", timestep must be one of: ", paste(allowed_timesteps, collapse = ", "))
     }
 
     if (metric == "AUTO") {
       metric <- allowed_metrics[[1]]
     } else if (!(metric %in% allowed_metrics)) {
-      stop("for GLM, metric must be one of: ", paste(allowed_metrics, collapse = ", "))
+      stop("for ", toupper(x@algorithm),", metric must be one of: ", paste(allowed_metrics, collapse = ", "))
     }
 
     graphics::plot(df$iteration, df[, c(metric)], type="l", xlab = timestep, ylab = metric, main = "Validation Scoring History", ...)

--- a/h2o-web/bower.json
+++ b/h2o-web/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "h2o-flow": "0.13.4"
+    "h2o-flow": "0.14.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7853

GLM's learning curve plot wasn't working when used with lambda search or HGLM.  This is simple fix that just adds those 2 cases. 

To make the learning curve nice (just one line in case a user provides an array of `alpha`s which happens in AutoML), I had to add `alpha` to scoring history for lambda search to be able to plot just the "winning" `alpha` value. 

I will be happy to hear any suggestions.

This is accompanied with the fix in the flow: https://github.com/h2oai/h2o-flow/pull/171