### PR TITLE
PUBDEV-7855: Make varimp feature consolidation more robust

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -421,6 +421,17 @@ class NumpyFrame:
             yield col, self.get(col, with_categorical_names)
 
 
+
+def _get_domain_mapping(model):
+    """
+    Get a mapping between columns and their domains.
+
+    :return: Dictionary containing a mapping column -> factors
+    """
+    output = model._model_json["output"]
+    return dict(zip(output["names"], output["domains"]))
+
+
 def _shorten_model_ids(model_ids):
     import re
     regexp = re.compile(r"(.*)_AutoML_[\d_]+((?:_.*)?)$")  # nested group needed for Py2
@@ -1349,14 +1360,25 @@ def _consolidate_varimps(model):
     consolidated_varimps = {k: v for k, v in varimp.items() if k in x}
     to_process = {k: v for k, v in varimp.items() if k not in x}
 
+    domain_mapping = _get_domain_mapping(model)
+    encoded_cols = ["{}.{}".format(name, domain)
+                    for name, domains in domain_mapping.items()
+                    if domains is not None
+                    for domain in domains + ["missing(NA)"]]
+    if len(encoded_cols) > len(set(encoded_cols)):
+        for x in set(encoded_cols):
+            encoded_cols.remove(x)
+        raise RuntimeError("Ambiguous encoding of the column x category pairs: {}".format(set(encoded_cols)))
+
+    varimp_to_col = {"{}.{}".format(name, domain): name
+                     for name, domains in domain_mapping.items()
+                     if domains is not None
+                     for domain in domains + ["missing(NA)"]
+                     }
     for feature in to_process.keys():
-        col_parts = feature.split(".")
-        for i in range(1, len(col_parts) + 1)[::-1]:
-            if ".".join(col_parts[:i]) in x:
-                column = ".".join(col_parts[:i])
-                consolidated_varimps[column] = consolidated_varimps.get(column, 0) + to_process[
-                    feature]
-                break
+        if feature in varimp_to_col:
+            column = varimp_to_col[feature]
+            consolidated_varimps[column] = consolidated_varimps.get(column, 0) + to_process[feature]
         else:
             raise RuntimeError("Cannot find feature {}".format(feature))
 

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import random
+import warnings
 from contextlib import contextmanager
 from collections import OrderedDict, Counter, defaultdict
 
@@ -1366,9 +1367,10 @@ def _consolidate_varimps(model):
                     if domains is not None
                     for domain in domains + ["missing(NA)"]]
     if len(encoded_cols) > len(set(encoded_cols)):
+        duplicates = encoded_cols[:]
         for x in set(encoded_cols):
-            encoded_cols.remove(x)
-        raise RuntimeError("Ambiguous encoding of the column x category pairs: {}".format(set(encoded_cols)))
+            duplicates.remove(x)
+        warnings.warn("Ambiguous encoding of the column x category pairs: {}".format(set(duplicates)))
 
     varimp_to_col = {"{}.{}".format(name, domain): name
                      for name, domains in domain_mapping.items()

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -541,7 +541,7 @@ with_no_h2o_progress <- function(expr) {
 
   if (anyDuplicated(names(col_domain_mapping))) {
     dups <- duplicated(names(col_domain_mapping)) | duplicated(names(col_domain_mapping), fromLast = TRUE)
-    stop("Ambiguous encoding of the column x category pairs: ", col_domain_mapping[dups])
+    warning("Ambiguous encoding of the column x category pairs: ", col_domain_mapping[dups])
   }
 
   for (feature in names(to_process)) {


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7855

This PR removes possible incorrect mapping between varimp and original column name which was done by matching the longest prefix. Now it generates possible column names from the column name and its domains thus removing possibility of a mismatch due to a common prefix.

However, there is still possibility of having a mismatch when the names of varimp aren't unique.

For example:
```
library(h2o)
df <- data.frame(y=rep_len(1:5, 1000))
df$a <- as.factor(c("b.c", "d"))
df$a.b <- as.factor(letters[1:5])
df$y <- df$y * c(1, 10)

glm <- h2o.glm(y="y", training_frame = as.h2o(df))
h2o.varimp(glm)
```

=>
```
variable relative_importance scaled_importance   percentage
1    a.b.c        1.330686e+01      1.000000e+00 2.278348e-01
2      a.d        1.330686e+01      1.000000e+00 2.278348e-01
3    a.b.e        1.060822e+01      7.971997e-01 1.816298e-01
4    a.b.a        1.060822e+01      7.971997e-01 1.816298e-01
5    a.b.d        5.287787e+00      3.973731e-01 9.053541e-02
6    a.b.b        5.287787e+00      3.973731e-01 9.053541e-02
7    a.b.c        1.953338e-14      1.467919e-15 3.344429e-16
```

(see the first and the last line of the varimp)