### PR TITLE
Fix warning from old matplotlib.use

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -27,6 +27,7 @@ from h2o.expr import ExprNode
 from h2o.group_by import GroupBy
 from h2o.job import H2OJob
 from h2o.utils.config import get_config_value
+from h2o.utils.ext_dependencies import get_matplotlib_pyplot
 from h2o.utils.shared_utils import (_handle_numpy_array, _handle_pandas_data_frame, _handle_python_dicts,
                                     _handle_python_lists, _is_list, _is_str_list, _py_tmp_key, _quoted,
                                     can_use_pandas, quote, normalize_slice, slice_is_normalized, check_frame_id)
@@ -3773,21 +3774,8 @@ class H2OFrame(Keyed):
         hist = H2OFrame._expr(expr=ExprNode("hist", self, breaks))._frame()
 
         if plot:
-            try:
-                import matplotlib
-                if server:
-                    # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
-                    version = matplotlib.__version__.split(".")
-                    if int(version[0]) < 3 or \
-                            (int(version[0]) == 3 and
-                             int(version[1]) < 1):
-                        matplotlib.use("Agg", warn=False)
-                    else:
-                        matplotlib.use("Agg")
-                import matplotlib.pyplot as plt
-            except ImportError:
-                print("ERROR: matplotlib is required to make the histogram plot. "
-                      "Set `plot` to False, if a plot is not desired.")
+            plt = get_matplotlib_pyplot(server)
+            if plt is None:
                 return
 
             hist["widths"] = hist["breaks"].difflag1()

--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -3776,7 +3776,14 @@ class H2OFrame(Keyed):
             try:
                 import matplotlib
                 if server:
-                    matplotlib.use("Agg")
+                    # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
+                    version = matplotlib.__version__.split(".")
+                    if int(version[0]) < 3 or \
+                            (int(version[0]) == 3 and
+                             int(version[1]) < 1):
+                        matplotlib.use("Agg", warn=False)
+                    else:
+                        matplotlib.use("Agg")
                 import matplotlib.pyplot as plt
             except ImportError:
                 print("ERROR: matplotlib is required to make the histogram plot. "

--- a/h2o-py/h2o/model/dim_reduction.py
+++ b/h2o-py/h2o/model/dim_reduction.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from h2o.utils.compatibility import *  # NOQA
 
 import h2o
+from h2o.utils.ext_dependencies import get_matplotlib_pyplot
 from h2o.utils.shared_utils import can_use_pandas
 from .model_base import ModelBase
 from .metrics_base import *  # NOQA
@@ -105,20 +106,8 @@ class H2ODimReductionModel(ModelBase):
         is_server = kwargs.pop("server")
         if kwargs:
             raise ValueError("Unknown arguments %s to screeplot()" % ", ".join(kwargs.keys()))
-        try:
-            import matplotlib
-            if is_server:
-                # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
-                version = matplotlib.__version__.split(".")
-                if int(version[0]) < 3 or \
-                        (int(version[0]) == 3 and
-                         int(version[1]) < 1):
-                    matplotlib.use("Agg", warn=False)
-                else:
-                    matplotlib.use("Agg")
-            import matplotlib.pyplot as plt
-        except ImportError:
-            print("matplotlib is required for this function!")
+        plt = get_matplotlib_pyplot(is_server)
+        if plt is None:
             return
 
         variances = [s ** 2 for s in self._model_json['output']['importance'].cell_values[0][1:]]

--- a/h2o-py/h2o/model/dim_reduction.py
+++ b/h2o-py/h2o/model/dim_reduction.py
@@ -107,7 +107,15 @@ class H2ODimReductionModel(ModelBase):
             raise ValueError("Unknown arguments %s to screeplot()" % ", ".join(kwargs.keys()))
         try:
             import matplotlib
-            if is_server: matplotlib.use('Agg')
+            if is_server:
+                # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
+                version = matplotlib.__version__.split(".")
+                if int(version[0]) < 3 or \
+                        (int(version[0]) == 3 and
+                         int(version[1]) < 1):
+                    matplotlib.use("Agg", warn=False)
+                else:
+                    matplotlib.use("Agg")
             import matplotlib.pyplot as plt
         except ImportError:
             print("matplotlib is required for this function!")

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from h2o.model.confusion_matrix import ConfusionMatrix
 from h2o.utils.metaclass import BackwardsCompatible, Deprecated as deprecated, h2o_meta
 from h2o.utils.compatibility import *  # NOQA
+from h2o.utils.ext_dependencies import get_matplotlib_pyplot
 from h2o.utils.typechecks import assert_is_type, assert_satisfies, is_type, numeric
 
 
@@ -1357,20 +1358,8 @@ class H2OBinomialModelMetrics(MetricsBase):
     
     def _plot_roc(self, server=False, save_to_file=None, plot=True):
         if plot:
-            try:
-                import matplotlib
-                if server:
-                    # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
-                    version = matplotlib.__version__.split(".")
-                    if int(version[0]) < 3 or \
-                            (int(version[0]) == 3 and
-                             int(version[1]) < 1):
-                        matplotlib.use("Agg", warn=False)
-                    else:
-                        matplotlib.use("Agg")
-                import matplotlib.pyplot as plt
-            except ImportError:
-                print("matplotlib is required for this function!")
+            plt = get_matplotlib_pyplot(server)
+            if plt is None:
                 return
             plt.xlabel('False Positive Rate (FPR)')
             plt.ylabel('True Positive Rate (TPR)')
@@ -1392,12 +1381,8 @@ class H2OBinomialModelMetrics(MetricsBase):
         precisions = self.tprs
         assert len(precisions) == len(recalls), "Precision and recall arrays must have the same length"
         if plot:
-            try:
-                import matplotlib
-                if server: matplotlib.use('Agg')
-                import matplotlib.pyplot as plt
-            except ImportError:
-                print("matplotlib is required for this function!")
+            plt = get_matplotlib_pyplot(server)
+            if plt is None:
                 return
             plt.xlabel('Recall (TP/(TP+FP))')
             plt.ylabel('Precision (TPR)')

--- a/h2o-py/h2o/model/metrics_base.py
+++ b/h2o-py/h2o/model/metrics_base.py
@@ -1359,7 +1359,15 @@ class H2OBinomialModelMetrics(MetricsBase):
         if plot:
             try:
                 import matplotlib
-                if server: matplotlib.use('Agg')
+                if server:
+                    # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
+                    version = matplotlib.__version__.split(".")
+                    if int(version[0]) < 3 or \
+                            (int(version[0]) == 3 and
+                             int(version[1]) < 1):
+                        matplotlib.use("Agg", warn=False)
+                    else:
+                        matplotlib.use("Agg")
                 import matplotlib.pyplot as plt
             except ImportError:
                 print("matplotlib is required for this function!")

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -11,6 +11,7 @@ from h2o.exceptions import H2OValueError
 from h2o.job import H2OJob
 from h2o.utils.metaclass import BackwardsCompatible, Deprecated as deprecated, h2o_meta
 from h2o.utils.compatibility import viewitems
+from h2o.utils.ext_dependencies import get_matplotlib_pyplot
 from h2o.utils.shared_utils import can_use_pandas
 from h2o.utils.typechecks import I, assert_is_type, assert_satisfies, Enum, is_type
 
@@ -984,7 +985,7 @@ class ModelBase(h2o_meta(Keyed)):
     #   h2o.remove(self._id)
 
     def _plot(self, timestep, metric, server=False):
-        plt = _get_matplotlib_pyplot(server)
+        plt = get_matplotlib_pyplot(server)
         if not plt: return
 
         scoring_history = self.scoring_history()
@@ -1213,7 +1214,7 @@ class ModelBase(h2o_meta(Keyed)):
         # Plot partial dependence plots using matplotlib
         to_fig = num_1dpdp + num_2dpdp
         if plot and to_fig > 0:     # plot 1d pdp for now
-            plt = _get_matplotlib_pyplot(server)
+            plt = get_matplotlib_pyplot(server)
             cm = _get_matplotlib_cm("Partial dependency plots")
             if not plt: 
                 return pps
@@ -1443,7 +1444,7 @@ class ModelBase(h2o_meta(Keyed)):
         assert_is_type(num_of_features, None, int)
         assert_is_type(server, bool)
 
-        plt = _get_matplotlib_pyplot(server)
+        plt = get_matplotlib_pyplot(server)
         if not plt: return
 
         # get the variable importances as a list of tuples, do not use pandas dataframe
@@ -1532,7 +1533,7 @@ class ModelBase(h2o_meta(Keyed)):
         if self._model_json["algo"] != "glm":
             raise H2OValueError("This function is available for GLM models only")
 
-        plt = _get_matplotlib_pyplot(server)
+        plt = get_matplotlib_pyplot(server)
         if not plt: return
 
         # get unsorted tuple of labels and coefficients
@@ -1712,28 +1713,6 @@ class ModelBase(h2o_meta(Keyed)):
         """DEPRECATED. Use :meth:`scoring_history` instead."""
         return self.scoring_history()
 
-
-
-
-def _get_matplotlib_pyplot(server):
-    try:
-        # noinspection PyUnresolvedReferences
-        import matplotlib
-        if server:
-            # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
-            version = matplotlib.__version__.split(".")
-            if int(version[0]) < 3 or \
-                    (int(version[0]) == 3 and
-                     int(version[1]) < 1):
-                matplotlib.use("Agg", warn=False)
-            else:
-                matplotlib.use("Agg")
-        # noinspection PyUnresolvedReferences
-        import matplotlib.pyplot as plt
-        return plt
-    except ImportError:
-        print("`matplotlib` library is required for this function!")
-        return None
 
 def _get_mplot3d_pyplot(functionName):
     try:

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1719,7 +1719,15 @@ def _get_matplotlib_pyplot(server):
     try:
         # noinspection PyUnresolvedReferences
         import matplotlib
-        if server: matplotlib.use("Agg")
+        if server:
+            # Matplotlib version 3.1 and higher deprecates/doesn't have `warn` parameter
+            version = matplotlib.__version__.split(".")
+            if int(version[0]) < 3 or \
+                    (int(version[0]) == 3 and
+                     int(version[1]) < 1):
+                matplotlib.use("Agg", warn=False)
+            else:
+                matplotlib.use("Agg")
         # noinspection PyUnresolvedReferences
         import matplotlib.pyplot as plt
         return plt

--- a/h2o-py/h2o/utils/ext_dependencies.py
+++ b/h2o-py/h2o/utils/ext_dependencies.py
@@ -1,0 +1,19 @@
+
+def get_matplotlib_pyplot(server):
+    try:
+        # noinspection PyUnresolvedReferences
+        import matplotlib
+        from distutils.version import LooseVersion
+        if server:
+            if LooseVersion(matplotlib.__version__) <= LooseVersion("3.1"):
+                matplotlib.use("Agg", warn=False)
+            else:  # Versions >= 3.2 don't have warn argument
+                matplotlib.use("Agg")
+        # noinspection PyUnresolvedReferences
+        import matplotlib.pyplot as plt
+        return plt
+    except ImportError:
+        print("`matplotlib` library is required for this function!")
+        return None
+
+


### PR DESCRIPTION
This should stop emitting the following warning:
```
This call to matplotlib.use() has no effect because the backend has already been chosen; matplotlib.use() must be called *before* pylab, matplotlib.pyplot, or matplotlib.backends is imported for the first time.
```
from **r_suite.pyunit_vec_scaler_comparisions_medium.py**.

I wasn't able to reproduce the issue locally - I ran just the one test so there wasn't anything that would set a backend before it so I suppose this happens only when the tests aren't completely isolated?

Nevertheless, this might still be shown to the user.

Newer versions (3.2+) of `matplotlib` don't have the `warn` parameter in `matplotlib.use`, versions 3.1 higher deprecates it and default `warn` to `False`.

The solution would be prettier if it would be contained in a simple function, any ideas where to put it?