### PR TITLE
[PUBDEV-7852] Refactor PreviewParseWriter to 'guessTypes' Method to be Used Independently

### DIFF
--- a/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
+++ b/h2o-core/src/main/java/water/parser/PreviewParseWriter.java
@@ -219,8 +219,8 @@ public class PreviewParseWriter extends Iced implements StreamParseWriter {
       return Vec.T_CAT;
     }
     // categorical mixed with numbers
-    if (nstrings >= (nnums+nzeros) // mostly strings
-        && (domain.size() <= 0.95 * nstrings) ) { // but not all unique
+    if (nstrings >= (nnums + nzeros) // mostly strings
+        && (domain.size() <= 0.95 * nstrings)) { // but not all unique
       return Vec.T_CAT;
     }
     


### PR DESCRIPTION
This PR helps to get rid of [IcedHashMapWrapper](https://github.com/h2oai/sparkling-water/blob/b2f2d55009845a4be9e5d9f0fd3d9b63140addca/extensions/src/main/scala/water/parser/IcedHashMapWrapper.java) in Sparkling Water.