### PR TITLE
Shorten large tests.

### DIFF
--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -405,17 +405,10 @@ def javapredict(algo, equality, train, test, x, y, compile_only=False, separator
         assert hc == pc, "Expected the same number of cols, but got {0} and {1}".format(hc, pc)
 
         # Value
-        for r in range(hr):
-            hp = predictions[r, 0]
-            if equality == "numeric":
-                pp = float.fromhex(predictions2[r, 0])
-                assert abs(hp - pp) < 1e-4, \
-                    "Expected predictions to be the same (within 1e-4) for row %d, but got %r and %r" % (r, hp, pp)
-            elif equality == "class":
-                pp = predictions2[r, 0]
-                assert hp == pp, "Expected predictions to be the same for row %d, but got %r and %r" % (r, hp, pp)
-            else:
-                raise ValueError
+        if not(equality == "class"or equality == "numeric"):
+            raise ValueError
+        compare_frames_local(predictions, predictions2, prob=1, tol=1e-4) # faster frame compare
+
 
 def javamunge(assembly, pojoname, test, compile_only=False):
     """

--- a/h2o-py/tests/testdir_javapredict/pyunit_pubdex_4531_large.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_pubdex_4531_large.py
@@ -11,8 +11,7 @@ from tests import pyunit_utils
 def javapredict_pubdev_4531():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/logreg/prostate_train_null_column_name.csv"))
     test = h2o.upload_file(pyunit_utils.locate("smalldata/logreg/prostate_train_null_column_name.csv"))
-    params = {'ntrees':20, 'max_depth':2,  'seed':42, 'training_frame':train,
-              'learn_rate':0.1, 'min_rows':10, 'distribution':"bernoulli"} # 651MB pojo
+    params = {'ntrees':2, 'seed':42, 'training_frame':train, 'distribution':"bernoulli"} # 651MB pojo
     train["CAPSULE"] = train["CAPSULE"].asfactor()
     test["CAPSULE"] = test["CAPSULE"].asfactor()
     print("Parameter list:")

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_high_enums_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_high_enums_large.py
@@ -21,11 +21,11 @@ def test_column_skip_high_cardinality():
 
     fwriteFile.close()
     try:
-        parseFile = h2o.upload_file(savefilenamewithpath, col_types=["enum","int"])
+        h2o.upload_file(savefilenamewithpath, col_types=["enum","int"])
         assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except Exception as ex:
         print(ex) # print out the error message
-        parseFile = h2o.upload_file(savefilenamewithpath, col_types=["int"], skipped_columns=[0]) # should pass here.
+        h2o.upload_file(savefilenamewithpath, col_types=["int"], skipped_columns=[0]) # should pass here.
         print("Test passed! Parsed with large enum columns skipped!")
         pass
 

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_arff_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_arff_large.py
@@ -15,7 +15,7 @@ MAXTIME = datetime.datetime(2080, 8, 6, 8, 14, 59)
 def test_arff_parser_column_skip():
     # generate a big frame with all datatypes and save it to svmlight
     nrow = 10000
-    ncol = 98
+    ncol = 20
     seed = 12345
     frac1 = 0.16
     frac2 = 0.2
@@ -46,13 +46,13 @@ def test_arff_parser_column_skip():
     skip_random.sort()
 
     try:
-        loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns=skip_all)
+        h2o.upload_file(savefilenamewithpath, skipped_columns=skip_all)
         assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except:
         pass
 
     try:
-        importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
+        h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
         assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
     except:
         pass

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
@@ -11,7 +11,7 @@ import random
 def test_csv_parser_column_skip():
     # generate a big frame with all datatypes and save it to csv.  Load it back with different skipped_columns settings
     nrow = 10000
-    ncol = 100
+    ncol = 20
     seed = 12345
     frac1 = 0.16
     frac2 = 0.2

--- a/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_svmlight_large.py
+++ b/h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_svmlight_large.py
@@ -1,74 +1,77 @@
 from __future__ import print_function
 import sys
-sys.path.insert(1,"../../")
+
+sys.path.insert(1, "../../")
 import h2o
 from tests import pyunit_utils
 import os
 
+
 def test_parser_svmlight_column_skip():
-  # generate a big frame with all datatypes and save it to svmlight
-  nrow = 10000
-  ncol = 50
-  seed=12345
+    # generate a big frame with all datatypes and save it to svmlight
+    nrow = 10000
+    ncol = 10
+    seed = 12345
 
-  f1 = h2o.create_frame(rows=nrow, cols=ncol, real_fraction=0.5, integer_fraction=0.5, missing_fraction=0.2,
-                         has_response=False, seed=seed)
-  f2 = h2o.create_frame(rows=nrow, cols=1, real_fraction=1, integer_fraction=0, missing_fraction=0,
-                         has_response=False, seed=seed)
-  f2.set_name(0,"target")
-  f1 = f2.cbind(f1)
+    f1 = h2o.create_frame(rows=nrow, cols=ncol, real_fraction=0.5, integer_fraction=0.5, missing_fraction=0.2,
+                          has_response=False, seed=seed)
+    f2 = h2o.create_frame(rows=nrow, cols=1, real_fraction=1, integer_fraction=0, missing_fraction=0,
+                          has_response=False, seed=seed)
+    f2.set_name(0, "target")
+    f1 = f2.cbind(f1)
 
-  tmpdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results"))
-  if not(os.path.isdir(tmpdir)):
-    os.mkdir(tmpdir)
-  savefilenamewithpath = os.path.join(tmpdir, 'out.svm')
-  pyunit_utils.write_H2OFrame_2_SVMLight(savefilenamewithpath, f1) # write h2o frame to svm format
+    tmpdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath('__file__')), "..", "results"))
+    if not (os.path.isdir(tmpdir)):
+        os.mkdir(tmpdir)
+    savefilenamewithpath = os.path.join(tmpdir, 'out.svm')
+    pyunit_utils.write_H2OFrame_2_SVMLight(savefilenamewithpath, f1)  # write h2o frame to svm format
 
-  skip_all = list(range(ncol))
-  skip_even = list(range(0, ncol, 2))
+    skip_all = list(range(ncol))
+    skip_even = list(range(0, ncol, 2))
 
-  try:
-    loadFileSkipAll = h2o.upload_file(savefilenamewithpath, skipped_columns = skip_all)
-    assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
-  except:
-    pass
+    try:
+        h2o.upload_file(savefilenamewithpath, skipped_columns=skip_all)
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
+    except:
+        pass
 
-  try:
-    importFileSkipAll = h2o.import_file(savefilenamewithpath, skipped_columns = skip_all)
-    assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
-  except:
-    pass
+    try:
+        h2o.import_file(savefilenamewithpath, skipped_columns=skip_all)
+        assert False, "Test should have thrown an exception due to all columns are skipped"  # should have failed here
+    except:
+        pass
+    try:
+        h2o.import_file(savefilenamewithpath, skipped_columns=skip_even)
+        assert False, "Test should have thrown an exception due to column skipping not supported for svm"  # should have failed here
 
-  try:
-    importFileSkipSome = h2o.import_file(savefilenamewithpath, skipped_columns = skip_even)
-    sys.exit(1) # should have failed here
-  except:
-    pass
+    except:
+        pass
 
-  # check for correct parsing only
-  checkCorrectSkips(savefilenamewithpath, f1)
+    # check for correct parsing only
+    checkCorrectSkips(savefilenamewithpath, f1)
 
 
 def checkCorrectSkips(csvfile, originalFrame):
-  skippedFrameUF = h2o.upload_file(csvfile)
-  skippedFrameIF = h2o.import_file(csvfile) # this two frames should be the same
-  pyunit_utils.compare_frames_local(skippedFrameUF, skippedFrameIF, prob=1)
+    skippedFrameUF = h2o.upload_file(csvfile)
+    skippedFrameIF = h2o.import_file(csvfile)  # this two frames should be the same
+    pyunit_utils.compare_frames_local(skippedFrameUF, skippedFrameIF, prob=1)
 
-  # test with null skipped_column list
-  skippedFrameUF2 = h2o.upload_file(csvfile, skipped_columns=[])
-  skippedFrameIF2 = h2o.import_file(csvfile, skipped_columns=[]) # this two frames should be the same
-  pyunit_utils.compare_frames_local(skippedFrameUF2, skippedFrameIF2, prob=1)
+    # test with null skipped_column list
+    skippedFrameUF2 = h2o.upload_file(csvfile, skipped_columns=[])
+    skippedFrameIF2 = h2o.import_file(csvfile, skipped_columns=[])  # this two frames should be the same
+    pyunit_utils.compare_frames_local(skippedFrameUF2, skippedFrameIF2, prob=1)
 
-  # frame from not skipped_columns specification and empty skipped_columns should return same result
-  pyunit_utils.compare_frames_local(skippedFrameUF2, skippedFrameIF, prob=1)
+    # frame from not skipped_columns specification and empty skipped_columns should return same result
+    pyunit_utils.compare_frames_local(skippedFrameUF2, skippedFrameIF, prob=1)
 
-  # compare skipped frame with originalFrame
-  assert originalFrame.ncol==skippedFrameUF.ncol, \
-    "Expected return frame column number: {0}, actual frame column number: " \
-    "{1}".format((originalFrame.ncol, skippedFrameUF.ncol))
-  pyunit_utils.compare_frames_local_svm(originalFrame, skippedFrameIF2, prob=1)
+    # compare skipped frame with originalFrame
+    assert originalFrame.ncol == skippedFrameUF.ncol, \
+        "Expected return frame column number: {0}, actual frame column number: " \
+        "{1}".format((originalFrame.ncol, skippedFrameUF.ncol))
+    pyunit_utils.compare_frames_local_svm(originalFrame, skippedFrameIF2, prob=1)
+
 
 if __name__ == "__main__":
-  pyunit_utils.standalone_test(test_parser_svmlight_column_skip)
+    pyunit_utils.standalone_test(test_parser_svmlight_column_skip)
 else:
-  test_parser_svmlight_column_skip()
+    test_parser_svmlight_column_skip()


### PR DESCRIPTION
I tried to shorten the following tests here in this PR:

1. h2o-py/tests/testdir_javapredict/pyunit_pubdex_4531_large.py
2. h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_high_enums_large.py
3. h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_arff_large.py
4. h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_csv_large.py
5. h2o-py/tests/testdir_parser/pyunit_PUBDEV_5705_drop_columns_parser_svmlight_large.py

In cases 2,3,4,5, I use a smaller frame.
In case 1, I changed the compare frame in h2o-py/tests/pyunit_utils/utilsPY.py to compare_frame_local which will grab H2O frames all at once to Python before actual comparison starts.