### PR TITLE
Rulefit: fix multiclass

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/Rule.java
+++ b/h2o-algos/src/main/java/hex/rulefit/Rule.java
@@ -8,8 +8,6 @@ import water.fvec.Chunk;
 
 import java.util.*;
 
-import static hex.tree.TreeUtils.getResponseLevelIndex;
-
 public class Rule extends Iced {
     
     Condition[] conditions;
@@ -61,13 +59,14 @@ public class Rule extends Iced {
         return this.hashCode() == obj.hashCode();
     }
 
-    public static List<Rule> extractRulesListFromModel(SharedTreeModel model, int modelId) {
+    public static List<Rule> extractRulesListFromModel(SharedTreeModel model, int modelId, int nclasses) {
         List<Rule> rules = new ArrayList<>();
-        final SharedTreeModel.SharedTreeOutput sharedTreeOutput = (SharedTreeModel.SharedTreeOutput) model._output;
-        final int treeClass = getResponseLevelIndex(null, sharedTreeOutput);
+        nclasses = nclasses > 2 ? nclasses : 1;
         for (int i = 0; i < ((SharedTreeModel.SharedTreeParameters) model._parms)._ntrees; i++) {
-            SharedTreeSubgraph sharedTreeSubgraph = model.getSharedTreeSubgraph(i, treeClass);
-            rules.addAll(extractRulesFromTree(sharedTreeSubgraph, modelId));
+            for (int treeClass = 0; treeClass < nclasses; treeClass++) {
+                SharedTreeSubgraph sharedTreeSubgraph = model.getSharedTreeSubgraph(i, treeClass);
+                rules.addAll(extractRulesFromTree(sharedTreeSubgraph, modelId));
+            }
         }
 
         return rules;

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
@@ -701,9 +701,30 @@ public class RuleFitTest extends TestUtil {
         }
     }
     
-    // h2o-3/smalldata/diabetes
+    @Test
+    public void testMulticlass() {
+        try {
+            Scope.enter();
+            final Frame fr = Scope.track(parse_test_file("smalldata/iris/iris_train.csv"));
+           
+            RuleFitModel.RuleFitParameters params = new RuleFitModel.RuleFitParameters();
+            params._seed = 12345;
+            params._train = fr._key;
+            params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
+            params._response_column = "species";
 
+            final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
+            Scope.track_generic(rfModel);
 
-   
+            System.out.println("Intercept: \n" + rfModel._output._intercept[0]);
+            System.out.println(rfModel._output._rule_importance);
+
+            final Frame fr2 = Scope.track(rfModel.score(fr));
+
+            Assert.assertTrue(rfModel.testJavaScoring(fr,fr2,1e-4));
+        } finally {
+            Scope.exit();
+        }
+    }
     
 }

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitUtilsTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitUtilsTest.java
@@ -113,7 +113,7 @@ public class RuleFitUtilsTest extends TestUtil {
 
             assertEquals(treeRules.contains(rule),true);
 
-            List<Rule> wholeModelRules = Rule.extractRulesListFromModel(gbm, 0);
+            List<Rule> wholeModelRules = Rule.extractRulesListFromModel(gbm, 0, 1);
             assertEquals(wholeModelRules.size(), 16);
 
         } finally {
@@ -163,7 +163,7 @@ public class RuleFitUtilsTest extends TestUtil {
             
             assertEquals(treeRules.contains(rule),true);
 
-            List<Rule> wholeModelRules = Rule.extractRulesListFromModel(isofor, 0);
+            List<Rule> wholeModelRules = Rule.extractRulesListFromModel(isofor, 0, 1);
             assertEquals(wholeModelRules.size(), 8);
 
         } finally {


### PR DESCRIPTION
This fixes a bug

```
java.lang.IllegalArgumentException: There is no such tree class. Given categorical level does not exist in response column: 
	at hex.tree.TreeUtils.getResponseLevelIndex(TreeUtils.java:55)
	at hex.rulefit.Rule.extractRulesListFromModel(Rule.java:67)
	at hex.rulefit.RuleFit$RuleFitDriver.computeImpl(RuleFit.java:201)
	at hex.ModelBuilder$Driver.compute2(ModelBuilder.java:242)
	at water.H2O$H2OCountedCompleter.compute(H2O.java:1577)
	at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
	at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
	at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
	at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
	at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
```

reported prelast Friday.

The problem was with selecting tree class when extracting rules from trees for multiclass response.