### PR TITLE
ensure  rollups don't block on pending RPC task

### DIFF
--- a/h2o-core/src/main/java/water/RPC.java
+++ b/h2o-core/src/main/java/water/RPC.java
@@ -267,6 +267,11 @@ public class RPC<V extends DTask> implements Future<V>, Delayed, ForkJoinPool.Ma
     return true;
   }
 
+  public boolean await() {
+    while( !isDone() ) _dt.join();
+    return true;
+  }
+
   @Override public final V get(long timeout, TimeUnit unit) {
     if( _done ) return _dt;     // Fast-path shortcut
     throw H2O.fail();

--- a/h2o-core/src/main/java/water/fvec/RollupStats.java
+++ b/h2o-core/src/main/java/water/fvec/RollupStats.java
@@ -355,8 +355,9 @@ final class RollupStats extends Iced {
         if(rpcOld == null) {  // no prior pending task, need to send this one
           rpcNew.call().get();
           _pendingRollups.remove(rskey);
-        } else if (rpcOld.await()) // rollups computation is already in progress, wait for it to finish
+        } else if (rpcOld.canBlock() || rpcOld.isDone()) {// rollups computation is already in progress, wait for it to finish
           rpcOld.get();
+        }
       } catch( Throwable t ) {
         System.err.println("Remote rollups failed with an exception, wrapping and rethrowing: "+t);
         throw new RuntimeException(t);

--- a/h2o-core/src/main/java/water/fvec/RollupStats.java
+++ b/h2o-core/src/main/java/water/fvec/RollupStats.java
@@ -355,7 +355,7 @@ final class RollupStats extends Iced {
         if(rpcOld == null) {  // no prior pending task, need to send this one
           rpcNew.call().get();
           _pendingRollups.remove(rskey);
-        } else // rollups computation is already in progress, wait for it to finish
+        } else if (rpcOld.await()) // rollups computation is already in progress, wait for it to finish
           rpcOld.get();
       } catch( Throwable t ) {
         System.err.println("Remote rollups failed with an exception, wrapping and rethrowing: "+t);


### PR DESCRIPTION
addressing error that can occur when accessing rollups

```
0-28 07:31:26.979 127.0.0.1:44008       3958      FJ-3-51 ERROR water.default: 
java.lang.RuntimeException: java.lang.AssertionError: *** Attempting to block on task (class water.fvec.RollupStats$ComputeRollupsTask) with equal or lower priority. Can lead to deadlock! 3 <=  3
	at water.fvec.RollupStats.get(RollupStats.java:362)
	at water.fvec.RollupStats.get(RollupStats.java:371)
	at water.fvec.Vec.rollupStats(Vec.java:912)
	at water.fvec.Vec.isInt(Vec.java:879)
	at water.util.VecUtils.categoricalToInt(VecUtils.java:243)
	at water.util.VecUtils.toNumericVec(VecUtils.java:170)
	at water.fvec.Vec.toNumericVec(Vec.java:1326)
	at water.util.FrameUtils$CategoricalLabelEncoder$CategoricalLabelEncoderDriver.compute2(FrameUtils.java:640)
	at water.H2O$H2OCountedCompleter.compute(H2O.java:1577)
	at jsr166y.CountedCompleter.exec(CountedCompleter.java:468)
	at jsr166y.ForkJoinTask.doExec(ForkJoinTask.java:263)
	at jsr166y.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:974)
	at jsr166y.ForkJoinPool.runWorker(ForkJoinPool.java:1477)
	at jsr166y.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
Caused by: java.lang.AssertionError: *** Attempting to block on task (class water.fvec.RollupStats$ComputeRollupsTask) with equal or lower priority. Can lead to deadlock! 3 <=  3
	at water.RPC.get(RPC.java:251)
	at water.fvec.RollupStats.get(RollupStats.java:359)
```