### PR TITLE
fix typo: GLM -> GLRM

### DIFF
--- a/h2o-docs/src/product/tutorials/GridSearch.md
+++ b/h2o-docs/src/product/tutorials/GridSearch.md
@@ -97,7 +97,7 @@ The following hyperparameters are supported by grid search.
 - `seed`
 - `init`
 
-### GLM Hyperparameters Supported by Grid Search
+### GLRM Hyperparameters Supported by Grid Search
 
 - `transform`
 - `k`


### PR DESCRIPTION
This PR fixes a typo in the grid parameters doc for the `GLRM` model. The parameters such as `svd_method` are available in the `GRLM` model.