### PR TITLE
Rulefit: do not remove bad columns

### DIFF
--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -90,6 +90,11 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
         // if (expensive && error_count() == 0) checkMemoryFootPrint();
     }
 
+    @Override
+    protected void ignoreBadColumns(int npredictors, boolean expensive) {
+        // Do not remove bad columns - we need them for correct GLM train frame creation
+    }
+
     private void initTreeParameters() {
         if (_parms._algorithm == RuleFitModel.Algorithm.GBM) {
             treeParameters = new GBMModel.GBMParameters();

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -184,7 +184,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 // linearTrain = frame to be used as _train for GLM in 2., will be filled in 1.
                 Frame linearTrain = new Frame(Key.make("paths_frame" + _result));
                 // store train frame without bad columns to pass it to tree model builders
-                Frame trainRebalanced = new Frame(_train);
+                Frame trainAdapted = new Frame(_train);
                 // 1. Rule generation
         
                 // get paths from tree models
@@ -192,8 +192,8 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 
                 // prepare rules
                 if (RuleFitModel.ModelType.RULES_AND_LINEAR.equals(_parms._model_type) || RuleFitModel.ModelType.RULES.equals(_parms._model_type)) {
-                    DKV.put(trainRebalanced._key, trainRebalanced);
-                    treeParameters._train = trainRebalanced._key;
+                    DKV.put(trainAdapted._key, trainAdapted);
+                    treeParameters._train = trainAdapted._key;
                     long startAllTreesTime = System.nanoTime();
                     SharedTree<?, ?, ?>[] builders = ModelBuilderHelper.trainModelsParallel(
                             makeTreeModelBuilders(_parms._algorithm, depths), nTreeEnsemblesInParallel(depths.length));
@@ -246,7 +246,7 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
                 DKV.put(glmModel);
 
                 DKV.remove(linearTrain._key);
-                DKV.remove(trainRebalanced._key);
+                DKV.remove(trainAdapted._key);
                 
                 model = new RuleFitModel(dest(), _parms, new RuleFitModel.RuleFitOutput(RuleFit.this), glmModel, ruleEnsemble);
                 

--- a/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
+++ b/h2o-algos/src/main/java/hex/rulefit/RuleFit.java
@@ -91,7 +91,6 @@ public class RuleFit extends ModelBuilder<RuleFitModel, RuleFitModel.RuleFitPara
         // if (expensive && error_count() == 0) checkMemoryFootPrint();
     }
 
-
     private void initTreeParameters() {
         if (_parms._algorithm == RuleFitModel.Algorithm.GBM) {
             treeParameters = new GBMModel.GBMParameters();

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
@@ -727,4 +727,33 @@ public class RuleFitTest extends TestUtil {
         }
     }
     
+    @Test
+    public void testBadColsBug() {
+        try {
+            Scope.enter();
+            final Frame fr = Scope.track(parse_test_file("smalldata/rulefit/repro_bad_cols_bug.csv"));
+
+            RuleFitModel.RuleFitParameters params = new RuleFitModel.RuleFitParameters();
+            params._seed = 42;
+            params._train = fr._key;
+            params._model_type = RuleFitModel.ModelType.RULES_AND_LINEAR;
+            params._response_column = "target";
+            params._max_num_rules = 1000;
+
+            asFactor(fr, "target");
+
+            final RuleFitModel rfModel = new RuleFit(params).trainModel().get();
+            Scope.track_generic(rfModel);
+
+            System.out.println("Intercept: \n" + rfModel._output._intercept[0]);
+            System.out.println(rfModel._output._rule_importance);
+
+            final Frame fr2 = Scope.track(rfModel.score(fr));
+
+            Assert.assertTrue(rfModel.testJavaScoring(fr,fr2,1e-4));
+        } finally {
+            Scope.exit();
+        }
+    }
+    
 }

--- a/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
+++ b/h2o-algos/src/test/java/hex/rulefit/RuleFitTest.java
@@ -731,7 +731,7 @@ public class RuleFitTest extends TestUtil {
     public void testBadColsBug() {
         try {
             Scope.enter();
-            final Frame fr = Scope.track(parse_test_file("smalldata/rulefit/repro_bad_cols_bug.csv"));
+            final Frame fr = Scope.track(parse_test_file("./smalldata/rulefit/repro_bad_cols_bug.csv"));
 
             RuleFitModel.RuleFitParameters params = new RuleFitModel.RuleFitParameters();
             params._seed = 42;


### PR DESCRIPTION
This fixes the bug on rulefit during benchmark test case with springleaf dataset.

Each tree node remembers column id of the feature it is splitting on.
When constructing condition which is representing a tree node, this column id is used as condition's feature id.
When creating GLM's training frame this feature id is used during condition evaluation on the training set rows to map the result to correct place in chunk.
When in between of this we drop some bad columns, mapping between training frame and Condition#featureIndex/Node#colId gets broken and I have IndexOutOfBoundsException.