### PR TITLE
PUBDEV-7913: Fix as.data.frame.H2OFrame

### DIFF
--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -4354,7 +4354,10 @@ as.data.frame.H2OFrame <- function(x, ...) {
     if (identical(colClasses, NA_character_) || identical(colClasses, "")) colClasses <- NULL  # workaround for data.table length-1 bug #4237 fixed in v1.12.9
     df <- data.table::fread(ttt, sep = ",", blank.lines.skip = FALSE, na.strings = "", colClasses = colClasses, showProgress=FALSE, data.table=FALSE, ...)
     if (sum(dates))
-      for (i in which(dates)) data.table::setattr(df[[i]], "class", "POSIXct")
+      for (i in which(dates)) {
+        df[[i]] <- df[[i]] / 1000
+        data.table::setattr(df[[i]], "class", "POSIXct")
+      }
     fun <- "fread"
   } else {
     # Substitute NAs for blank cells rather than skipping
@@ -4365,7 +4368,10 @@ as.data.frame.H2OFrame <- function(x, ...) {
       df <- read.csv(ttt, blank.lines.skip = FALSE, na.strings = "", colClasses = colClasses, ...)
     }
     if (sum(dates))
-      for (i in which(dates)) class(df[[i]]) = "POSIXct"
+      for (i in which(dates)) {
+        df[[i]] <- df[[i]] / 1000
+        class(df[[i]]) <- "POSIXct"
+      }
     fun <- "read.csv"
   }
   if (!useCon && file.exists(ttt)) file.remove(ttt)  

--- a/h2o-r/tests/testdir_misc/runit_as.frame.R
+++ b/h2o-r/tests/testdir_misc/runit_as.frame.R
@@ -43,5 +43,22 @@ test <- function() {
     }
 }
 
-doTest("Test data frame", test)
+test_date_handling <- function() {
+  h2o_df <- h2o.uploadFile(locate("smalldata/timeSeries/CreditCard-ts_train.csv"))
+  r_df <- read.csv(locate("smalldata/timeSeries/CreditCard-ts_train.csv"),
+                   colClasses = list(MONTH = "POSIXct"))
+
+  str(as.numeric(r_df$MONTH[[1]]))
+  # => 1112306400
+  str(as.numeric(as.data.frame(h2o_df)$MONTH[[1]]))
+  # => 1112313600000
+
+  # "MONTH" contains date with first day of a month, e.g., 2015-05-01
+  expect_true(all(as.data.frame(h2o_df)$MONTH == r_df$MONTH))
+}
+
+doSuite("Test data frame", makeSuite(
+  test,
+  test_date_handling
+))
 

--- a/h2o-r/tests/testdir_misc/runit_as.frame.R
+++ b/h2o-r/tests/testdir_misc/runit_as.frame.R
@@ -44,14 +44,41 @@ test <- function() {
 }
 
 test_date_handling <- function() {
+  # Make sure we have same time zone since the dataset is missing time zone info
+  tz <- h2o.getTimezone()
+  on.exit(h2o.setTimezone(tz))
+  h2o.setTimezone(Sys.timezone())
+
   h2o_df <- h2o.uploadFile(locate("smalldata/timeSeries/CreditCard-ts_train.csv"))
   r_df <- read.csv(locate("smalldata/timeSeries/CreditCard-ts_train.csv"),
                    colClasses = list(MONTH = "POSIXct"))
 
-  str(as.numeric(r_df$MONTH[[1]]))
-  # => 1112306400
-  str(as.numeric(as.data.frame(h2o_df)$MONTH[[1]]))
-  # => 1112313600000
+  # str(as.numeric(r_df$MONTH[[1]]))
+  # # => 1112306400
+  # str(as.numeric(as.data.frame(h2o_df)$MONTH[[1]]))
+  # # used to return => 1112306400000
+
+  # "MONTH" contains date with first day of a month, e.g., 2015-05-01
+  expect_true(all(as.data.frame(h2o_df)$MONTH == r_df$MONTH))
+}
+
+test_date_handling_data_table <- function() {
+  # Make sure we have same time zone since the dataset is missing time zone info
+  tz <- h2o.getTimezone()
+  on.exit(h2o.setTimezone(tz))
+  h2o.setTimezone(Sys.timezone())
+
+  op <- options(h2o.fread = TRUE)
+  on.exit(options(op), add = TRUE)
+
+  h2o_df <- h2o.uploadFile(locate("smalldata/timeSeries/CreditCard-ts_train.csv"))
+  r_df <- read.csv(locate("smalldata/timeSeries/CreditCard-ts_train.csv"),
+                   colClasses = list(MONTH = "POSIXct"))
+
+  # str(as.numeric(r_df$MONTH[[1]]))
+  # # => 1112306400
+  # str(as.numeric(as.data.frame(h2o_df)$MONTH[[1]]))
+  # # used to return => 1112306400000
 
   # "MONTH" contains date with first day of a month, e.g., 2015-05-01
   expect_true(all(as.data.frame(h2o_df)$MONTH == r_df$MONTH))
@@ -59,6 +86,7 @@ test_date_handling <- function() {
 
 doSuite("Test data frame", makeSuite(
   test,
-  test_date_handling
+  test_date_handling,
+  test_date_handling_data_table
 ))
 


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7913

It looks like `as.data.frame` converts date incorrectly when converting from h2o frame.

`POSIXct` assumes seconds and H2O provides milliseconds.

This is related to fixing explainability module's handling of date time.
(https://github.com/h2oai/h2o-3/pull/5107)