### PR TITLE
PUBDEV-7913: Fix  autoexplain's PDP date handling

### DIFF
--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -202,8 +202,8 @@ class NumpyFrame:
             self._data = np.empty((len(df), len(self._columns)), dtype=np.float64)
             df = [self._columns] + df
         elif isinstance(h2o_frame, h2o.H2OFrame):
-            _is_factor = np.array(h2o_frame.isfactor(), dtype=np.bool) | np.array(
-                h2o_frame.ischaracter(), dtype=np.bool)
+            _is_factor = np.array(h2o_frame.isfactor(), dtype=bool) | np.array(
+                h2o_frame.ischaracter(), dtype=bool)
             _is_numeric = h2o_frame.isnumeric()
             self._columns = h2o_frame.columns
             self._factors = {col: h2o_frame[col].asfactor().levels()[0] for col in

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -1297,7 +1297,7 @@ class ModelBase(h2o_meta(Keyed)):
                         raise H2OValueError("Column names/indices used in user_splits are not valid.  They "
                                                 "should be chosen from the columns of your data set.")
 
-                    if data[colKey].isfactor()[0] or data[colKey].isnumeric()[0]: # replace enum string with actual value
+                    if data[colKey].isfactor()[0] or data[colKey].isnumeric()[0] or data.type(colKey) == "time": # replace enum string with actual value
                         nVal = len(val)
                         if data[colKey].isfactor()[0]:
                             domains = data[colKey].levels()[0]

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1894,7 +1894,7 @@ h2o.shap_explain_row_plot <-
     if (plot_type == "barplot") {
       contributions <- contributions[, names(contributions) != "BiasTerm"]
 
-      ordered_features <- contributions[order(contributions)]
+      ordered_features <- contributions[order(contributions[, 1])]
       features <- character()
       if (is.null(columns)) {
         if ("positive" %in% contribution_type) {
@@ -1976,7 +1976,7 @@ h2o.shap_explain_row_plot <-
                        plot.title = ggplot2::element_text(hjust = 0.5))
       return(p)
     } else if (plot_type == "breakdown") {
-      contributions <- contributions[, names(contributions)[order(abs(t(contributions)))]]
+      contributions <- contributions[, names(contributions)[order(abs(t(contributions))[, 1])]]
       bias_term <- contributions$BiasTerm
       contributions <- contributions[, names(contributions) != "BiasTerm"]
       if (is.null(columns)) {

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1894,7 +1894,7 @@ h2o.shap_explain_row_plot <-
     if (plot_type == "barplot") {
       contributions <- contributions[, names(contributions) != "BiasTerm"]
 
-      ordered_features <- contributions[order(contributions[, 1])]
+      ordered_features <- contributions[order(t(contributions))]
       features <- character()
       if (is.null(columns)) {
         if ("positive" %in% contribution_type) {

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1219,7 +1219,7 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
       include_na = TRUE
     ))
 
-    subdata <- as.data.frame(newdata[as.integer(idx),])[[gsub(" ", ".", column)]]
+    subdata <- newdata[as.integer(idx), column]
     if (output_graphing_data)
       graphing_data <- .append_graphing_data(graphing_data, tmp, subdata, h2o.getId(newdata), !is_factor && centered, show_logodds, as.integer(idx), grouping_variable_value)
     y_label <- "Response"
@@ -1290,8 +1290,6 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
   names(results) <- make.names(names(results))
   names(orig_values) <- make.names(names(orig_values))
 
-  col_name <- make.names(column)
-
   if (is.character(results[[col_name]])) {
     results[[col_name]] <- as.factor(results[[col_name]])
     orig_values[[col_name]] <- as.factor(orig_values[[col_name]])
@@ -1356,22 +1354,18 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
   }
 
   q <- ggplot2::ggplot(ggplot2::aes(x = .data[[col_name]],
-                                    if (show_logodds) {
-                                      y = .data$logodds
-                                    } else {
-                                      y = .data$mean_response
-                                    },
+                                    y = if (show_logodds) .data$logodds else .data$mean_response,
                                     color = .data$name,
                                     text = .data$text),
                        data = results)
+  column_value <- as.data.frame(newdata[[column]])
   histogram <- stat_count_or_bin(!.is_continuous(newdata[[column]]),
                                  ggplot2::aes(x = .data[[col_name]], y = (.data$..count.. / max(.data$..count..)) * diff(y_range) / 1.61),
                                  position = ggplot2::position_nudge(y = y_range[[1]] - 0.05 * diff(y_range)), alpha = 0.2,
-                                 inherit.aes = FALSE, data = as.data.frame(newdata[[column]]))
+                                 inherit.aes = FALSE, data = column_value)
   rug_part <- ggplot2::geom_rug(ggplot2::aes(x = .data[[col_name]], y = NULL, text = NULL),
                                 sides = "b", alpha = 0.1, color = "black",
-                                data = stats::setNames(as.data.frame(newdata[[column]]), col_name)
-  )
+                                data = column_value)
   plot_name <- ggplot2::labs(y = y_label, title = sprintf(
     "Individual Conditional Expectations on \"%s\"%s\nfor Model: \"%s\"", col_name,
     if (is.null(target)) {
@@ -1409,15 +1403,16 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
                                  } else {
                                    ggplot2::aes(linetype = "ICE", group = .data$name)
                                  }, data = results)
-  y_val = if (show_logodds) orig_values[['logodds']] else orig_values[['mean_response']]
-  original_observations_part <- ggplot2::geom_point(data = as.data.frame(orig_values),
+  original_observations_part <- ggplot2::geom_point(data = orig_values,
                                                     size = 4.5,
                                                     alpha = 0.5,
-                                                    ggplot2::aes(shape = "Original observations",
-                                                                 group = "Original observations"),
-                                                    x = orig_values[[col_name]],
-                                                    y = y_val,
-                                                    show.legend = ifelse(.is_continuous(newdata[[column]]), NA, FALSE)
+                                                    ggplot2::aes(
+                                                      shape = "Original observations",
+                                                      group = "Original observations",
+                                                      x = .data[[col_name]],
+                                                      y = if (show_logodds) .data[['logodds']] else .data[['mean_response']]
+                                                    ),
+                                                    show.legend = ifelse(.is_continuous(newdata[[column]]), NA, FALSE),
   )
   shape_legend_manual <- ggplot2::scale_shape_manual(
     values = c("Original observations" = 19, "ICE" = 20, "Partial Dependence" = 18))
@@ -1524,7 +1519,7 @@ handle_pdp <- function(newdata, column, target, show_logodds, row_index, models_
   }
 
   p <- ggplot2::ggplot(ggplot2::aes(
-    x = .data[[make.names(column)]],
+    x = .data[[col_name]],
     y = y_[["y_vals"]],
     color = .data$target, fill = .data$target, text = .data$text
   ), data = pdp) +
@@ -2627,12 +2622,12 @@ h2o.pd_multi_plot <- function(object,
         y = .data$mean_response,
         color = .data$target, fill = .data$target, text = .data$text
       ), data = pdp) +
-        stat_count_or_bin(!is.numeric(newdata[[column]]),
+        stat_count_or_bin(!.is_continuous(newdata[[column]]),
                           ggplot2::aes(x = .data[[col_name]], y = (.data$..count.. / max(.data$..count..)) * diff(y_range) / 1.61),
                           position = ggplot2::position_nudge(y = y_range[[1]] - 0.05 * diff(y_range)), alpha = 0.2,
                           inherit.aes = FALSE, data = as.data.frame(newdata[[column]])) +
-        geom_point_or_line(!is.numeric(newdata[[column]]), ggplot2::aes(group = .data$target)) +
-        geom_pointrange_or_ribbon(!is.numeric(newdata[[column]]), ggplot2::aes(
+        geom_point_or_line(!.is_continuous(newdata[[column]]), ggplot2::aes(group = .data$target)) +
+        geom_pointrange_or_ribbon(!.is_continuous(newdata[[column]]), ggplot2::aes(
           ymin = .data$mean_response - .data$stddev_response,
           ymax = .data$mean_response + .data$stddev_response,
           group = .data$target
@@ -2642,7 +2637,10 @@ h2o.pd_multi_plot <- function(object,
                           data = rug_data
         )
       if (row_index > -1) {
-        p <- p + ggplot2::geom_vline(xintercept = newdata[row_index, column], linetype = "dashed")
+        row_val <- newdata[row_index, column]
+        if (.is_datetime(newdata[[column]]))
+          row_val <- as.numeric(.to_datetime(row_val))
+        p <- p + ggplot2::geom_vline(xintercept = row_val, linetype = "dashed")
       }
       p <- p +
         ggplot2::labs(
@@ -2746,8 +2744,9 @@ h2o.pd_multi_plot <- function(object,
                         data = rug_data
       )
     if (row_index > -1) {
-      if (.is_datetime(row_val))
-        row_val <- as.numeric(row_val)
+      row_val <- newdata[row_index, column]
+      if (.is_datetime(newdata[[column]]))
+        row_val <- as.numeric(.to_datetime(row_val))
       p <- p + ggplot2::geom_vline(xintercept = row_val, linetype = "dashed")
     }
     p <- p +
@@ -3291,12 +3290,12 @@ h2o.learning_curve_plot <- function(model,
 ######################################## Explain ###################################################
 
 #' Generate Model Explanations
-#' 
-#' The H2O Explainability Interface is a convenient wrapper to a number of explainabilty 
-#' methods and visualizations in H2O.  The function can be applied to a single model or group 
-#' of models and returns a list of explanations, which are individual units of explanation 
-#' such as a partial dependence plot or a variable importance plot.  Most of the explanations 
-#' are visual (ggplot plots).  These plots can also be created by individual utility functions 
+#'
+#' The H2O Explainability Interface is a convenient wrapper to a number of explainabilty
+#' methods and visualizations in H2O.  The function can be applied to a single model or group
+#' of models and returns a list of explanations, which are individual units of explanation
+#' such as a partial dependence plot or a variable importance plot.  Most of the explanations
+#' are visual (ggplot plots).  These plots can also be created by individual utility functions
 #' as well.
 #'
 #' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard).
@@ -3308,7 +3307,7 @@ h2o.learning_curve_plot <- function(model,
 #' @param include_explanations If specified, return only the specified model explanations.
 #'   (Mutually exclusive with exclude_explanations)
 #' @param exclude_explanations Exclude specified model explanations.
-#' @param plot_overrides Overrides for individual model explanations, e.g. 
+#' @param plot_overrides Overrides for individual model explanations, e.g.
 #' \code{list(shap_summary_plot = list(columns = 50))}.
 #'
 #' @return List of outputs with class "H2OExplanation"
@@ -3691,13 +3690,13 @@ h2o.explain <- function(object,
 }
 
 #' Generate Model Explanations for a single row
-#' 
-#' Explain the behavior of a model or group of models with respect to a single row of data. 
-#' The function returns a list of explanations, which are individual units of explanation 
-#' such as a partial dependence plot or a variable importance plot.  Most of the explanations 
-#' are visual (ggplot plots).  These plots can also be created by individual utility functions 
+#'
+#' Explain the behavior of a model or group of models with respect to a single row of data.
+#' The function returns a list of explanations, which are individual units of explanation
+#' such as a partial dependence plot or a variable importance plot.  Most of the explanations
+#' are visual (ggplot plots).  These plots can also be created by individual utility functions
 #' as well.
-#' 
+#'
 #' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard).
 #' @param newdata An H2OFrame.
 #' @param row_index A row index of the instance to explain.
@@ -3705,7 +3704,7 @@ h2o.explain <- function(object,
 #'                parameter top_n_features will be ignored.
 #' @param top_n_features An integer specifying the number of columns to use, ranked by variable importance
 #'                       (where applicable).
-#' @param include_explanations If specified, return only the specified model explanations. 
+#' @param include_explanations If specified, return only the specified model explanations.
 #'                             (Mutually exclusive with exclude_explanations)
 #' @param exclude_explanations Exclude specified model explanations.
 #' @param plot_overrides Overrides for individual model explanations, e.g.,

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -299,8 +299,8 @@ with_no_h2o_progress <- function(expr) {
   }
 
 
-  if (inherits(object, "H2OAutoML") || 
-      ((inherits(object, "H2OFrame") || inherits(object, "data.frame")) && 
+  if (inherits(object, "H2OAutoML") ||
+      ((inherits(object, "H2OFrame") || inherits(object, "data.frame")) &&
       "model_id" %in% names(object))) {
     leaderboard <- if (inherits(object, "H2OAutoML")) object@leaderboard else object
     if (require_single_model && nrow(leaderboard) > 1) {
@@ -509,6 +509,7 @@ with_no_h2o_progress <- function(expr) {
                        leaderboard)
   leaderboard <- leaderboard[order(leaderboard[[2]]),]
   names(leaderboard) <- tolower(names(leaderboard))
+  row.names(leaderboard) <- seq_len(nrow(leaderboard))
   return(head(leaderboard, n = min(top_n, nrow(leaderboard))))
 }
 
@@ -680,6 +681,28 @@ with_no_h2o_progress <- function(expr) {
   res <- stats::ecdf(col)(col)
   res[is.na(res)] <- 0
   return(res)
+}
+
+.is_datetime <- function(column) {
+  if (!is.null(ncol(column)) && ncol(column) > 1) {
+    stop("Only one column should be provided!")
+  }
+  return(inherits(column, "POSIXct") ||
+           (!is.null(attr(column, "types")) && attr(column, "types") == "time"))
+}
+
+.to_datetime <- function(col) {
+  stopifnot("Already a date" = !inherits(col, "POSIXct"))
+  col <- col / 1000
+  class(col) <- "POSIXct"
+  col
+}
+
+.is_continuous <- function(column) {
+  if (!is.null(ncol(column)) && ncol(column) > 1) {
+    stop("Only one column should be provided!")
+  }
+  return(is.numeric(column) || .is_datetime(column))
 }
 
 .render_df_to_html <- function(df) {
@@ -1142,7 +1165,7 @@ pd_ice_common <- function(model,
 
     new_part <- rbind(new_part, new_row)
   }
-  
+
   return(new_part)
 }
 
@@ -1153,7 +1176,7 @@ pd_ice_common <- function(model,
   }
   centering_value <- if (centered) data_to_append[['mean_response']][[1]] else NULL
   new_part <- .extract_graphing_data_values(data_to_append, frame_id, grouping_variable_value, original_observation_value, centering_value, show_logoods, row_id)
-  
+
   if (length(output_graphing_data) == 0 ||is.null(output_graphing_data)) {
     return(new_part)
   } else {
@@ -1163,6 +1186,7 @@ pd_ice_common <- function(model,
 
 handle_ice <- function(model, newdata, column, target, centered, show_logodds, show_pdp, models_info, output_graphing_data, grouping_variable_value=NULL, nbins) {
   .data <- NULL
+  col_name <- make.names(column)
   margin <- ggplot2::margin(16.5, 5.5, 5.5, 5.5)
   is_factor <- is.factor(newdata[[column]])
   if (is_factor) {
@@ -1214,20 +1238,16 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
       } else {
         orig_values <- rbind(orig_values, tmp[which(is.na(tmp[[column]])), c(column, "name", "mean_response")])
       }
-      interval <-
-        paste("[", orig_values[nrow(orig_values), c(column)], ", ", orig_values[nrow(orig_values), c("mean_response")], "]", sep =
-          "")
+      interval <- paste0("[", orig_values[nrow(orig_values), c(column)], ", ", orig_values[nrow(orig_values), c("mean_response")], "]")
       message <-
-        paste(
+        paste0(
           "Original observation of '",
           column,
           "' for ",
           percentile_str,
           " is ",
           interval,
-          ". Ploting of NAs is not yet supported.",
-          sep = ""
-        )
+          ". Ploting of NAs is not yet supported.")
       warning(message)
     } else {
       column_split = if (is.factor(subdata)) {
@@ -1276,14 +1296,20 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
     results[[col_name]] <- as.factor(results[[col_name]])
     orig_values[[col_name]] <- as.factor(orig_values[[col_name]])
   }
+
+  if (.is_datetime(newdata[[column]])) {
+    results[[col_name]] <- .to_datetime(results[[col_name]])
+    orig_values[[col_name]] <- .to_datetime(orig_values[[col_name]])
+  }
+
   results[["text"]] <- paste0(
     "Percentile: ", results[["name"]], "\n",
-    "Feature Value: ", results[[col_name]], "\n",
+    "Feature Value: ", format(results[[col_name]]), "\n",
     "Mean Response: ", results[["mean_response"]], "\n"
   )
   orig_values[["text"]] <- paste0(
     "Percentile: ", orig_values[["name"]], "\n",
-    "Feature Value: ", orig_values[[col_name]], "\n",
+    "Feature Value: ", format(orig_values[[col_name]]), "\n",
     "Mean Response: ", orig_values[["mean_response"]], "\n"
   )
   y_range <- range(results$mean_response)
@@ -1307,13 +1333,17 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
     pdp[["name"]] <- "mean response"
     names(pdp) <- make.names(names(pdp))
 
-    col_name <- make.names(column)
     if (is.character(pdp[[col_name]])) {
       pdp[[col_name]] <- as.factor(pdp[[col_name]])
     }
+
+    if (.is_datetime(newdata[[column]])) {
+      pdp[[col_name]] <- .to_datetime(pdp[[col_name]])
+    }
+
     pdp[["text"]] <- paste0(
       "Partial Depencence \n",
-      "Feature Value: ", pdp[[col_name]], "\n",
+      "Feature Value: ", format(pdp[[col_name]]), "\n",
       "Mean Response: ", pdp[["mean_response"]], "\n"
     )
   }
@@ -1413,7 +1443,10 @@ handle_ice <- function(model, newdata, column, target, centered, show_logodds, s
     q <- q + pdp_part
   }
   q <- q + shape_legend_manual + shape_legend_manual2
-  
+
+  if (.is_datetime(newdata[[column]]))
+    q <- q + ggplot2::scale_x_datetime()
+
   if (output_graphing_data) {
     list(figure=q, graphing_data=graphing_data)
   } else {
@@ -1431,6 +1464,7 @@ get_y_values <- function(mean, stddev) {
 
 handle_pdp <- function(newdata, column, target, show_logodds, row_index, models_info, nbins) {
   .data <- NULL
+  col_name <- make.names(column)
   margin <- ggplot2::margin(5.5, 5.5, 5.5, 5.5)
   if (h2o.isfactor(newdata[[column]]))
     margin <- ggplot2::margin(5.5, 5.5, 5.5, max(5.5, max(nchar(h2o.levels(newdata[[column]])))))
@@ -1466,7 +1500,7 @@ handle_pdp <- function(newdata, column, target, show_logodds, row_index, models_
   names(pdp) <- make.names(names(pdp))
 
   pdp[["text"]] <- paste0(
-    "Feature Value: ", pdp[[make.names(column)]], "\n",
+    "Feature Value: ", format(pdp[[col_name]]), "\n",
     "Mean Response: ", pdp[["mean_response"]], "\n",
     "Target: ", pdp[["target"]]
   )
@@ -1482,9 +1516,12 @@ handle_pdp <- function(newdata, column, target, show_logodds, row_index, models_
     y_label <- "Mean Response"
   }
 
-  col_name <- make.names(column)
   rug_data <- stats::setNames(as.data.frame(newdata[[column]]), col_name)
-  rug_data[["text"]] <- paste0("Feature Value: ", rug_data[[col_name]])
+  rug_data[["text"]] <- paste0("Feature Value: ", format(rug_data[[col_name]]))
+
+  if (.is_datetime(newdata[[column]])) {
+    pdp[[col_name]] <- .to_datetime(pdp[[col_name]])
+  }
 
   p <- ggplot2::ggplot(ggplot2::aes(
     x = .data[[make.names(column)]],
@@ -1538,6 +1575,8 @@ handle_pdp <- function(newdata, column, target, show_logodds, row_index, models_
       plot.margin = margin,
       plot.title = ggplot2::element_text(hjust = 0.5)
     )
+  if (.is_datetime(newdata[[column]]))
+    p <- p + ggplot2::scale_x_datetime()
   return(p)
 }
 
@@ -1663,7 +1702,7 @@ h2o.shap_summary_plot <-
       timevar = "feature"
     )
     values[["original_value"]] <- stats::reshape(
-      data.frame(apply(newdata_df, 2, as.character)),
+      data.frame(apply(newdata_df, 2, format)),
       direction = "long",
       varying = names(newdata_df),
       v.names = "original_value",
@@ -1690,7 +1729,7 @@ h2o.shap_summary_plot <-
 
     contr[["row"]] <- paste0(
       "Feature: ", contr[["feature"]], "\n",
-      "Feature Value: ", contr[["original_value"]], "\n",
+      "Feature Value: ", format(contr[["original_value"]]), "\n",
       "Row Index: ", contr[["row_index"]], "\n",
       "Contribution: ", contr[["contribution"]]
     )
@@ -1912,12 +1951,12 @@ h2o.shap_explain_row_plot <-
       contributions <- data.frame(contribution = t(contributions))
       contributions$feature <- paste0(
         row.names(contributions), "=",
-        sapply(newdata_df[, row.names(contributions)], as.character)
+        sapply(newdata_df[, row.names(contributions)], format)
       )
       contributions <- contributions[order(contributions$contribution),]
       contributions$text <- paste(
         "Feature:", row.names(contributions), "\n",
-        "Feature Value:", unlist(sapply(newdata_df[, row.names(contributions)], as.character)), "\n",
+        "Feature Value:", unlist(sapply(newdata_df[, row.names(contributions)], format)), "\n",
         "Contribution:", contributions$contribution
       )
 
@@ -1931,7 +1970,7 @@ h2o.shap_explain_row_plot <-
           y = "SHAP Contribution", x = "Feature",
           title = sprintf(
             "SHAP explanation\nfor \"%s\" on row %d\nprediction: %s",
-            model@model_id, row_index, as.character(prediction$predict)
+            model@model_id, row_index, format(prediction$predict)
           )
         ) +
         ggplot2::theme_bw() +
@@ -1990,7 +2029,7 @@ h2o.shap_explain_row_plot <-
       )
 
       newdata_df[["rest_of_the_features"]] <- NA
-      contributions$feature_value <- paste("Feature Value:", as.character(t(newdata_df)[contributions$feature,]))
+      contributions$feature_value <- paste("Feature Value:", format(t(newdata_df)[contributions$feature,]))
       p <- ggplot2::ggplot(ggplot2::aes(
         x = .data$feature, fill = .data$color,
         xmin = .data$id - 0.4, xmax = .data$id + 0.4,
@@ -2508,14 +2547,32 @@ h2o.pd_multi_plot <- function(object,
   if (is.null(row_index))
     row_index <- -1
   models_info <- .process_models_or_automl(object, newdata, best_of_family = best_of_family)
+  if (length(models_info$model_ids) == 1)
+    return(h2o.pd_plot(
+      object = object,
+      newdata = newdata,
+      column = column,
+      target = target,
+      row_index = row_index,
+      max_levels = max_levels))
+
+  col_name <- make.names(column)
+  row_val <- if (row_index > -1) as.data.frame(newdata[row_index, column])[1, 1]
+
   if (h2o.nlevels(newdata[[column]]) > max_levels) {
     factor_frequencies <- .get_feature_count(newdata[[column]])
     factors_to_merge <- tail(names(factor_frequencies), n = -max_levels)
-    newdata[[column]] <- ifelse(newdata[[column]] %in% factors_to_merge, NA_character_,
-                                newdata[[column]])
-    message(length(factor_frequencies) - max_levels, " least common factor levels were omitted from \"",
+    if (!is.null(row_val) && row_val %in% factors_to_merge) {
+      # Keep the factor that is in the instance that we do ICE for
+      factors_to_merge <- factors_to_merge[factors_to_merge != row_val]
+    }
+    newdata <- newdata[!newdata[[column]] %in% factors_to_merge, ]
+
+    message(length(factors_to_merge), " least common factor levels were omitted from \"",
             column, "\" feature.")
   }
+  rug_data <- stats::setNames(as.data.frame(newdata[[column]]), col_name)
+  rug_data[["text"]] <- paste0("Feature Value: ", format(rug_data[[col_name]]))
   margin <- ggplot2::margin(5.5, 5.5, 5.5, 5.5)
   if (h2o.isfactor(newdata[[column]]))
     margin <- ggplot2::margin(5.5, 5.5, 5.5, max(5.5, max(nchar(h2o.levels(newdata[[column]])))))
@@ -2641,6 +2698,16 @@ h2o.pd_multi_plot <- function(object,
       results[[model]] <- pdp$mean_response
     }
 
+    if (is.factor(newdata[[column]])){
+      results[[col_name]] <- factor(results[[col_name]], levels = levels(rug_data[[col_name]]))
+      results <- results[results[[col_name]] %in% levels(rug_data[[col_name]]), ]
+    }
+
+    # Type information get's lost during the PD computation
+    if (.is_datetime(newdata[[column]])) {
+      results[[col_name]] <- .to_datetime(results[[col_name]])
+    }
+
     data <- stats::reshape(results,
                            direction = "long",
                            varying = names(results)[-1],
@@ -2649,11 +2716,9 @@ h2o.pd_multi_plot <- function(object,
                            timevar = "model_id"
     )
 
-    col_name <- make.names(column)
-
     data[["text"]] <- paste0(
       "Model Id: ", data[["model_id"]], "\n",
-      "Feature Value: ", data[[col_name]], "\n",
+      "Feature Value: ", format(data[[col_name]]), "\n",
       "Mean Response: ", data[["values"]], "\n"
     )
 
@@ -2668,17 +2733,19 @@ h2o.pd_multi_plot <- function(object,
       text = .data$text),
                          data = data
     ) +
-      stat_count_or_bin(!is.numeric(newdata[[column]]),
+      stat_count_or_bin(!.is_continuous(newdata[[column]]),
                         ggplot2::aes(x = .data[[col_name]], y = (.data$..count.. / max(.data$..count..)) * diff(y_range) / 1.61),
                         position = ggplot2::position_nudge(y = y_range[[1]] - 0.05 * diff(y_range)), alpha = 0.2,
-                        inherit.aes = FALSE, data = as.data.frame(newdata[[column]])) +
-      geom_point_or_line(!is.numeric(newdata[[column]]), ggplot2::aes(group = .shorten_model_ids(.data$model_id))) +
+                        inherit.aes = FALSE, data = rug_data[, col_name, drop=FALSE]) +
+      geom_point_or_line(!.is_continuous(newdata[[column]]), ggplot2::aes(group = .shorten_model_ids(.data$model_id))) +
       ggplot2::geom_rug(ggplot2::aes(x = .data[[col_name]], y = NULL),
                         sides = "b", alpha = 0.1, color = "black",
                         data = rug_data
       )
     if (row_index > -1) {
-      p <- p + ggplot2::geom_vline(xintercept = newdata[row_index, column], linetype = "dashed")
+      if (.is_datetime(row_val))
+        row_val <- as.numeric(row_val)
+      p <- p + ggplot2::geom_vline(xintercept = row_val, linetype = "dashed")
     }
     p <- p +
       ggplot2::labs(y = "Mean Response", title = sprintf(
@@ -2697,8 +2764,13 @@ h2o.pd_multi_plot <- function(object,
       )) +
       ggplot2::scale_color_brewer(type = "qual", palette = "Dark2") +
       # make the histogram closer to the axis. (0.05 is the default value)
-      ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = c(0, 0.05))) +
-      ggplot2::theme_bw() +
+      ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = c(0, 0.05)))
+
+    if (.is_datetime(newdata[[column]])) {
+      p <- p + ggplot2::scale_x_datetime()
+    }
+
+    p <- p + ggplot2::theme_bw() +
       ggplot2::theme(
         axis.text.x = ggplot2::element_text(
           angle = if (h2o.isfactor(newdata[[column]])) 45 else 0,

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -1693,7 +1693,7 @@ NULL
 #' @export
 `[.H2OFrame` <- function(data,row,col,drop=TRUE) {
   chk.H2OFrame(data)
-
+  types <- attr(data, "types")
   # This function is called with a huge variety of argument styles
   # Here's the breakdown:
   #   Style          Type  #args  Description
@@ -1776,8 +1776,10 @@ NULL
     data <- .newExpr("rows",data,row) # Row selector
   }
 
-  if( is1by1 ) .fetch.data(data,1L)[[1]]
-  else data
+  data <- if( is1by1 ) .fetch.data(data,1L)[[1]]
+            else data
+  attr(data, "types") <- types[col]
+  return(data)
 }
 
 #' @rdname H2OFrame-Extract

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -5070,7 +5070,7 @@ h2o.partialPlot <- function(object, data, cols, destination_key, nbins=20, plot 
       aList <- user_splits[[ind]]
       csname = aList[1]
       if (csname %in% column_names) {
-        if (h2o.isnumeric(data[csname]) || h2o.isfactor(data[csname])) {
+        if (h2o.isnumeric(data[csname]) || h2o.isfactor(data[csname]) || h2o.getTypes(data)[[which(names(data) == csname)]] == "time") {
           nVal <- length(aList)-1
           if (h2o.isfactor(data[csname])) {
             domains <- h2o.levels(data[csname]) # enum values

--- a/h2o-r/tests/testdir_javapredict/runit_mojo_predict.R
+++ b/h2o-r/tests/testdir_javapredict/runit_mojo_predict.R
@@ -110,7 +110,9 @@ test.mojo_predict_csv <- function() {
 
     prediction_result <- h2o.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=mojo_zip_path, output_csv_path=output_csv)
     print(paste0("Prediction result: ", prediction_result))
-    expect_equal(p1, prediction_result$predict[[1]], info="expected predictions to be the same for binary and MOJO model for regression")
+    expect_equal(p1, prediction_result$predict[[1]],
+                 info="expected predictions to be the same for binary and MOJO model for regression",
+                 check.attributes = FALSE)
 
     # =================================================================
     # Binomial
@@ -132,8 +134,12 @@ test.mojo_predict_csv <- function() {
     print(paste0("Binomial prediction: p0: ", mojo_prediction_0))
     print(paste0("Binomial prediction: p1: ", mojo_prediction_1))
 
-    expect_equal(binary_prediction_0, mojo_prediction_0, info="expected predictions to be the same for binary and MOJO model for Binomial - p0")
-    expect_equal(binary_prediction_1, mojo_prediction_1, info="expected predictions to be the same for binary and MOJO model for Binomial - p1")
+    expect_equal(binary_prediction_0, mojo_prediction_0,
+                 info="expected predictions to be the same for binary and MOJO model for Binomial - p0",
+                 check.attributes = FALSE)
+    expect_equal(binary_prediction_1, mojo_prediction_1,
+                 info="expected predictions to be the same for binary and MOJO model for Binomial - p1",
+                 check.attributes = FALSE)
 
     file.remove(input_csv)
     # =================================================================
@@ -173,9 +179,15 @@ test.mojo_predict_csv <- function() {
     print(paste0("Multinomial prediction (MOJO): p1: ", mojo_prediction_2))
     print(paste0("Multinomial prediction (MOJO): p2: ", mojo_prediction_3))
 
-    expect_equal(multinomial_prediction_1, mojo_prediction_1, info="expected predictions to be the same for binary and MOJO model for Multinomial - p0")
-    expect_equal(multinomial_prediction_2, mojo_prediction_2, info="expected predictions to be the same for binary and MOJO model for Multinomial - p1")
-    expect_equal(multinomial_prediction_3, mojo_prediction_3, info="expected predictions to be the same for binary and MOJO model for Multinomial - p2")
+    expect_equal(multinomial_prediction_1, mojo_prediction_1,
+                 info="expected predictions to be the same for binary and MOJO model for Multinomial - p0",
+                 check.attributes = FALSE)
+    expect_equal(multinomial_prediction_2, mojo_prediction_2,
+                 info="expected predictions to be the same for binary and MOJO model for Multinomial - p1",
+                 check.attributes = FALSE)
+    expect_equal(multinomial_prediction_3, mojo_prediction_3,
+                 info="expected predictions to be the same for binary and MOJO model for Multinomial - p2",
+                 check.attributes = FALSE)
 
     file.remove(input_csv)
     file.remove(output_csv)
@@ -209,8 +221,12 @@ test.mojo_predict_df <- function() {
     print(paste0("Binomial Prediction (Binary) - p1: ", h2o_prediction[1,3]))
     print(paste0("Binomial Prediction (MOJO) - p0: ", mojo_prediction$p0))
     print(paste0("Binomial Prediction (MOJO) - p1: ", mojo_prediction$p1))
-    expect_equal(h2o_prediction[1,2], mojo_prediction$p0, info="expected predictions to be the same for binary and MOJO model - p0")
-    expect_equal(h2o_prediction[1,3], mojo_prediction$p1, info="expected predictions to be the same for binary and MOJO model - p1")
+    expect_equal(h2o_prediction[1,2], mojo_prediction$p0,
+                 info="expected predictions to be the same for binary and MOJO model - p0",
+                 check.attributes = FALSE)
+    expect_equal(h2o_prediction[1,3], mojo_prediction$p1,
+                 info="expected predictions to be the same for binary and MOJO model - p1",
+                 check.attributes = FALSE)
 
     file.remove(input_csv)
 }

--- a/h2o-r/tests/testdir_misc/runit_string_manipulations.R
+++ b/h2o-r/tests/testdir_misc/runit_string_manipulations.R
@@ -12,16 +12,16 @@ test.string.manipulation <- function() {
   Log.info("Single and all substitutions...")
   s4 <- h2o.sub("this", "that", s4)
   print(s4)
-  expect_identical(s4[1,1], "that is tall, this is taller")
+  expect_equal(s4[1,1], "that is tall, this is taller", check.attributes = FALSE)
   s4 <- h2o.gsub("tall", "fast", s4)
   print(s4)
-  expect_identical(s4[1,1], "that is fast, this is faster")
+  expect_equal(s4[1,1], "that is fast, this is faster", check.attributes = FALSE)
 
   Log.info("Trimming...")
   print(s1[1,1])
-  expect_identical(s1[1,1], " this is a string ")
+  expect_equal(s1[1,1], " this is a string ", check.attributes = FALSE)
   s1 <- h2o.trim(s1)
-  expect_identical(as.character(s1[1,1]), "this is a string")
+  expect_equal(as.character(s1[1,1]), "this is a string", check.attributes = FALSE)
 
   Log.info("String splitting")
   ds <- h2o.rbind(s1, s2, s3)
@@ -35,14 +35,14 @@ test.string.manipulation <- function() {
     C4 = c("string", "string", "longer"),
     C5 = c(NA, NA, "string"), stringsAsFactors = FALSE
   )
-  expect_equal(as.data.frame(splits), splits.expected)
+  expect_equal(as.data.frame(splits), splits.expected, check.attributes = FALSE)
 
   tokenized <- h2o.tokenize(ds, " ")
   tokenized.expected <- data.frame(C1 = c("this", "is", "a", "string", NA,
                                           "this", "is", "another", "string", NA,
                                           "this", "is", "a", "longer", "string", NA), stringsAsFactors = FALSE)
-  expect_equal(as.data.frame(tokenized), tokenized.expected)
-  expect_equal(as.data.frame(tokenized), tokenized.expected)
+  expect_equal(as.data.frame(tokenized), tokenized.expected, check.attributes = FALSE)
+  expect_equal(as.data.frame(tokenized), tokenized.expected, check.attributes = FALSE)
 }
 
 doTest("Testing Various String Manipulations", test.string.manipulation)

--- a/h2o-r/tests/testdir_munging/runit_isax.R
+++ b/h2o-r/tests/testdir_munging/runit_isax.R
@@ -13,7 +13,7 @@ test.isax <- function(){
     answer = "0^10_0^10_0^10_0^10_5^10_7^10_8^10_9^10_9^10_8^10"
     print(answer)
     print(res[1,1])
-    expect_equal(res[1,1],answer)
+    expect_equal(res[1,1], answer, check.attributes = FALSE)
 }
 
 doTest("Test isax", test.isax)

--- a/h2o-r/tests/testdir_munging/strop/runit_lstrip.R
+++ b/h2o-r/tests/testdir_munging/strop/runit_lstrip.R
@@ -22,19 +22,19 @@ test.lstrip <- function() {
 
     # test string char strip
     df.hex$C1 <- h2o.lstrip(df.hex$C1)
-    expect_that(df.hex$C1[1,1], equals("empty left"))  # only this should change b/c left white space
-    expect_that(df.hex$C1[2,1], equals("empty right   "))
-    expect_that(df.hex$C1[3,1], equals("some string"))
-    expect_that(df.hex$C1[4,1], equals("mystring"))
-    expect_that(df.hex$C1[5,1], equals("cray tweet"))
+    expect_that(df.hex$C1[1,1], is_equivalent_to("empty left"))  # only this should change b/c left white space
+    expect_that(df.hex$C1[2,1], is_equivalent_to("empty right   "))
+    expect_that(df.hex$C1[3,1], is_equivalent_to("some string"))
+    expect_that(df.hex$C1[4,1], is_equivalent_to("mystring"))
+    expect_that(df.hex$C1[5,1], is_equivalent_to("cray tweet"))
 
     # test string char strip
     df.hex$C1 <- h2o.lstrip(df.hex$C1, "me")
-    expect_that(df.hex$C1[1,1], equals("pty left"))  # matches
-    expect_that(df.hex$C1[2,1], equals("pty right   ")) # matches
-    expect_that(df.hex$C1[3,1], equals("some string"))
-    expect_that(df.hex$C1[4,1], equals("ystring")) # matches
-    expect_that(df.hex$C1[5,1], equals("cray tweet"))
+    expect_that(df.hex$C1[1,1], is_equivalent_to("pty left"))  # matches
+    expect_that(df.hex$C1[2,1], is_equivalent_to("pty right   ")) # matches
+    expect_that(df.hex$C1[3,1], is_equivalent_to("some string"))
+    expect_that(df.hex$C1[4,1], is_equivalent_to("ystring")) # matches
+    expect_that(df.hex$C1[5,1], is_equivalent_to("cray tweet"))
 
     # FIXME: These tests work but are failing on Jenkins b/c workspace issues...
     # non ASCII

--- a/h2o-r/tests/testdir_munging/strop/runit_rstrip.R
+++ b/h2o-r/tests/testdir_munging/strop/runit_rstrip.R
@@ -22,19 +22,19 @@ test.rstrip <- function() {
 
     # test string char strip
     df.hex$C1 <- h2o.rstrip(df.hex$C1)
-    expect_that(df.hex$C1[1,1], equals("   empty left"))
-    expect_that(df.hex$C1[2,1], equals("empty right"))
-    expect_that(df.hex$C1[3,1], equals("some string"))
-    expect_that(df.hex$C1[4,1], equals("mystring"))
-    expect_that(df.hex$C1[5,1], equals("cray tweet"))
+    expect_that(df.hex$C1[1,1], is_equivalent_to("   empty left"))
+    expect_that(df.hex$C1[2,1], is_equivalent_to("empty right"))
+    expect_that(df.hex$C1[3,1], is_equivalent_to("some string"))
+    expect_that(df.hex$C1[4,1], is_equivalent_to("mystring"))
+    expect_that(df.hex$C1[5,1], is_equivalent_to("cray tweet"))
 
     # test string char strip
     df.hex$C1 <- h2o.rstrip(df.hex$C1, "lefthgin")
-    expect_that(df.hex$C1[1,1], equals("   empty "))
-    expect_that(df.hex$C1[2,1], equals("empty r"))
-    expect_that(df.hex$C1[3,1], equals("some str"))
-    expect_that(df.hex$C1[4,1], equals("mystr"))
-    expect_that(df.hex$C1[5,1], equals("cray tw"))
+    expect_that(df.hex$C1[1,1], is_equivalent_to("   empty "))
+    expect_that(df.hex$C1[2,1], is_equivalent_to("empty r"))
+    expect_that(df.hex$C1[3,1], is_equivalent_to("some str"))
+    expect_that(df.hex$C1[4,1], is_equivalent_to("mystr"))
+    expect_that(df.hex$C1[5,1], is_equivalent_to("cray tw"))
 
     # FIXME: These tests work but are failing on Jenkins b/c workspace issues...
     # non ASCII

--- a/h2o-r/tests/testdir_parser/runit_PUBDEV_8239.R
+++ b/h2o-r/tests/testdir_parser/runit_PUBDEV_8239.R
@@ -11,8 +11,8 @@ test.parseSkippedColumnsgzip<- function() {
     
   expect_equal(nrow(data), nrow(df))
   expect_equal(ncol(data), ncol(df)) 
-  rndIndex <- sample(1:nrow(df), 1)  
-  expect_equal(data[rndIndex,1], df[rndIndex,1])
+  rndIndex <- sample(1:nrow(df), 1)
+  expect_equivalent(data[rndIndex,1], df[rndIndex,1])
 }
 
 doTest("Test Zip Parse with skipped columns", test.parseSkippedColumnsgzip)


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7913
(also fixes https://h2oai.atlassian.net/browse/PUBDEV-8375)

AutoExplain's PDP doesn't work properly on date columns. Both Python and R versions are broken for a different reason.

Python: missing conversion to date
R: incorrect conversion to date

R fix is done in two parts:
(1) ensure that `H2OFrame` subset retains its types (needed to have `POSIXct` which would otherwise turn into numeric which is its machine representation; the rest of the types (numeric, factor) don't seem to need the type information to work properly)
(2) `ggplot2` related fixes

(1) required to modify some R tests to loosen the equality strictness, i.e., not compare attributes (type info is in attributes)