### PR TITLE
PUBDEV-7900 - custom pod labels

### DIFF
--- a/h2o-helm/templates/statefulset.yaml
+++ b/h2o-helm/templates/statefulset.yaml
@@ -15,7 +15,10 @@ spec:
   template:
     metadata:
       labels:
-    {{- include "h2o-helm.selectorLabels" . | nindent 8 }}
+      {{- include "h2o-helm.selectorLabels" . | nindent 8 }}
+      {{- range $k, $v := .Values.podLabels }}
+        {{ $k }}: {{ $v }}
+      {{- end }}
     spec:
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/h2o-helm/values.yaml
+++ b/h2o-helm/values.yaml
@@ -24,6 +24,8 @@ fullnameOverride: ""
 
 podAnnotations: { }
 
+podLabels:
+
 podSecurityContext: { }
 
 securityContext: { }


### PR DESCRIPTION
In some Kubernetes environments, custom pod labels are required to achieve other functionality, e.g. custom agent adding sidecar containers to existing pods (with HDFS for example). Driver of this change is @anuvaidya 's customer use case.

https://h2oai.atlassian.net/browse/PUBDEV-7900

Modifying Helm config to

```yaml
podLabels:
  "hpecp.hpe.com/dtap": "hadoop2"
```

will result in:


```yaml
# Source: h2o-3/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: h2o-test-h2o-3
  namespace: default
  labels:
    helm.sh/chart: h2o-3-1.0.0
    app.kubernetes.io/name: h2o-3
    app.kubernetes.io/instance: h2o-test
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  serviceName: h2o-test-h2o-3
  podManagementPolicy: "Parallel"
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: h2o-3
      app.kubernetes.io/instance: h2o-test
  template:
    metadata:
      labels:
        app.kubernetes.io/name: h2o-3
        app.kubernetes.io/instance: h2o-test
        hpecp.hpe.com/dtap: hadoop2
    spec:
      securityContext:
        {}
      containers:
        - name: h2o-3
          image: "h2oai/h2o-open-source-k8s:3.1.0.0"
          command: ["/bin/bash", "-c", "java -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -jar /opt/h2oai/h2o-3/h2o.jar"]
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 54321
              protocol: TCP
          readinessProbe:
            httpGet:
              path: /kubernetes/isLeaderNode
              port: 8080
            initialDelaySeconds: 5
            periodSeconds: 5
            failureThreshold: 1
          resources:
            limits:
              cpu: 1
              memory: 256Mi
            requests:
              cpu: 1
              memory: 256Mi
          env:
            - name: H2O_KUBERNETES_SERVICE_DNS
              value: h2o-test-h2o-3.default.svc.cluster.local
            - name: H2O_NODE_LOOKUP_TIMEOUT
              value: '180'
            - name: H2O_NODE_EXPECTED_COUNT
              value: '1'
            - name: H2O_KUBERNETES_API_PORT
              value: '8080'
```