### PR TITLE
PUBDEV-7905: Correct k for PCA that can be up to number of columns

### DIFF
--- a/h2o-docs/src/product/data-science/pca.rst
+++ b/h2o-docs/src/product/data-science/pca.rst
@@ -39,7 +39,7 @@ Defining a PCA Model
    - **mtj_svd_densematrix**: Singular-value decompositions for dense matrix using Matrix Toolkit Java (`MTJ <https://github.com/fommil/matrix-toolkits-java/>`__)
    - **jama**: Eigenvalue decompositions for dense matrix using Java Matrix (`JAMA <http://math.nist.gov/javanumerics/jama/>`__)
 
--  `k <algo-params/k.html>`__: Specify the rank of matrix approximation. This can be a value from 1 to 9 and defaults to 1.
+-  `k <algo-params/k.html>`__: Specify the rank of matrix approximation. This can be a value from 1 to the minimum of (total number of rows, total number of columns) in the dataset. This value defaults to 1.
 
 -  `max_iterations <algo-params/max_iterations.html>`__: Specify the number of training iterations. The value must be between 1 and 1e6 and the default is 1000.
 

--- a/h2o-docs/src/product/parameters.rst
+++ b/h2o-docs/src/product/parameters.rst
@@ -59,6 +59,7 @@ This Appendix provides detailed descriptions of parameters that can be specified
    data-science/algo-params/inflection_point
    data-science/algo-params/init1
    data-science/algo-params/init2
+   data-science/algo-params/interaction_constraints
    data-science/algo-params/interaction_pairs
    data-science/algo-params/interactions
    data-science/algo-params/intercept


### PR DESCRIPTION
For: https://h2oai.atlassian.net/browse/PUBDEV-7905

@maurever I included a fly-by fix I noticed when building the docs: the `interaction_constraints` algo page wasn't in the toctree, so it currently isn't listed on the Parameter Appendix menu. This will fix that.