### PR TITLE
[TESTS] fix kill script

### DIFF
--- a/scripts/jenkins/groovy/hadoopMultinodeStage.groovy
+++ b/scripts/jenkins/groovy/hadoopMultinodeStage.groovy
@@ -142,7 +142,7 @@ private String getKillScript() {
         if [ -f h2o_one_node ]; then
             YARN_APPLICATION_ID=\$(cat h2o_one_node | grep job | sed 's/job/application/g')
         elif [ -f h2odriver.log ]; then
-            YARN_APPLICATION_ID=\$(cat h2odriver.log | grep 'yarn logs -applicationId' | sed -r 's/.*(application_[0-9]+_[0-9]+).*/\\1/')
+            YARN_APPLICATION_ID=\$(cat h2odriver.log | grep 'yarn logs -applicationId' | sed -r 's/.*(application_[0-9]+_[0-9]+).*/\\1/' | head -n 1)
         fi
         if [ "\$YARN_APPLICATION_ID" != "" ]; then
             echo "YARN Application ID is \${YARN_APPLICATION_ID}"


### PR DESCRIPTION
JobID can be multiple times in yarn logs, this causes the kill command to sometimes fail with:

```
[2020-11-23T07:44:58.909Z] + yarn application -kill application_1598373710554_1562 application_1598373710554_1562
[2020-11-23T07:45:00.803Z] 20/11/23 07:45:00 INFO impl.TimelineClientImpl: Timeline service address: http://mr-0xd10.0xdata.loc:8188/ws/v1/timeline/
[2020-11-23T07:45:00.803Z] 20/11/23 07:45:00 INFO client.RMProxy: Connecting to ResourceManager at mr-0xd7.0xdata.loc/172.16.2.187:8050
[2020-11-23T07:45:01.060Z] usage: application
...
```