### PR TITLE
[GRID] fix failing glrm test on py2.7

### DIFF
--- a/h2o-core/src/main/java/water/api/GridSearchHandler.java
+++ b/h2o-core/src/main/java/water/api/GridSearchHandler.java
@@ -204,10 +204,8 @@ public class GridSearchHandler<G extends Grid<MP>,
         fields.add(name);
       } catch (NoSuchFieldException e) {
         throw new IllegalArgumentException("Cannot find field '" + name + "'" + " to value " + value, e);
-      } catch (IllegalAccessException e) {
+      } catch (RuntimeException | IllegalAccessException e) {
         throw new IllegalArgumentException("Cannot set field '" + name + "'" + " to value " + value, e);
-      } catch (RuntimeException e) {
-        throw new IllegalArgumentException("Cannot set field '" + name + "'" + " to value" + value, e);
       }
       return this;
     }

--- a/h2o-py/h2o/grid/grid_search.py
+++ b/h2o-py/h2o/grid/grid_search.py
@@ -14,7 +14,7 @@ from h2o.two_dim_table import H2OTwoDimTable
 from h2o.display import H2ODisplay
 from h2o.grid.metrics import *  # NOQA
 from h2o.utils.metaclass import Alias as alias, BackwardsCompatible, Deprecated as deprecated, h2o_meta
-from h2o.utils.shared_utils import quoted
+from h2o.utils.shared_utils import quoted, stringify_dict_as_map
 from h2o.utils.typechecks import assert_is_type, is_type
 
 
@@ -303,10 +303,10 @@ class H2OGridSearch(h2o_meta(Keyed)):
         parms = self._parms.copy()
         parms.update({k: v for k, v in algo_params.items() if k not in ["self", "params", "algo_params", "parms"]})
         # dictionaries have special handling in grid search, avoid the implicit conversion
-        parms["search_criteria"] = None if self.search_criteria is None else str(self.search_criteria)
+        parms["search_criteria"] = None if self.search_criteria is None else stringify_dict_as_map(self.search_criteria)
         parms["export_checkpoints_dir"] = self.export_checkpoints_dir
         parms["parallelism"] = self._parallelism
-        parms["hyper_parameters"] = None if self.hyper_params  is None else str(self.hyper_params) # unique to grid search
+        parms["hyper_parameters"] = None if self.hyper_params is None else stringify_dict_as_map(self.hyper_params) # unique to grid search
         parms.update({k: v for k, v in list(self.model._parms.items()) if v is not None})  # unique to grid search
         parms.update(params)
         if '__class__' in parms:  # FIXME: hackt for PY3

--- a/h2o-py/h2o/utils/shared_utils.py
+++ b/h2o-py/h2o/utils/shared_utils.py
@@ -141,15 +141,31 @@ def stringify_dict(d):
     return stringify_list(["{'key': %s, 'value': %s}" % (_quoted(k), v) for k, v in d.items()])
 
 
+def stringify_dict_as_map(d):
+    return "{%s}" % ",".join(["%s: %s" % (_quoted(k), stringify_object(v, stringify_dict_as_map)) for k, v in d.items()])
+
+
 def stringify_list(arr):
     return "[%s]" % ",".join(stringify_list(item) if isinstance(item, list) else _str(item)
                              for item in arr)
 
+
+def stringify_object(o, dict_function=stringify_dict):
+    if isinstance(o, dict):
+        return dict_function(o)
+    elif isinstance(o, list):
+        return stringify_list(o)
+    else:
+        return _str(o)
+
+
 def _str(item):
     return _str_tuple(item) if isinstance(item, tuple) else str(item)
 
+
 def _str_tuple(t):
-    return "{%s}" % ",".join(["%s: %s" % (ti[0], str(ti[1])) for ti in zip(list(string.ascii_lowercase), t)])
+    return "{%s}" % ",".join(["%s: %s" % (ti[0], _str(ti[1])) for ti in zip(list(string.ascii_lowercase), t)])
+
 
 def _is_list(l):
     return isinstance(l, (tuple, list))

--- a/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_grid_user_y.py
+++ b/h2o-py/tests/testdir_algos/glrm/pyunit_glrm_grid_user_y.py
@@ -12,7 +12,7 @@ from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
 def glrm_grid_user_y():
     export_dir = tempfile.mkdtemp()
     train_data = np.dot(np.random.rand(1000, 10), np.random.rand(10, 100))
-    train = h2o.H2OFrame(train_data.tolist())
+    train = h2o.H2OFrame(train_data.tolist(), destination_frame="glrm_train")
     initial_y_data = np.random.rand(10, 100)
     initial_y_h2o = h2o.H2OFrame(initial_y_data.tolist(), destination_frame="glrm_initial_y")
     params = {
@@ -43,10 +43,10 @@ def glrm_grid_user_y():
     h2o.remove_all()
     
     # reimport and train some more
-    train = h2o.H2OFrame(train_data.tolist())
+    train = h2o.H2OFrame(train_data.tolist(), destination_frame="glrm_train")
     initial_y = h2o.H2OFrame(initial_y_data.tolist(), destination_frame="glrm_initial_y")
-    hyper_params["gamma_x"] = [0.1, 1]
     grid = h2o.load_grid(grid_path)
+    grid.hyper_params["gamma_x"] = [0.1, 1]
     grid.train(x=train.names, training_frame=train, **params)
     print("second grid")
     print(grid)

--- a/h2o-py/tests/testdir_algos/grid/pyunit_grid_re_run_hypers.py
+++ b/h2o-py/tests/testdir_algos/grid/pyunit_grid_re_run_hypers.py
@@ -1,0 +1,49 @@
+import sys
+import numpy as np
+sys.path.insert(1,"../../../")
+
+import h2o
+from tests import pyunit_utils
+from h2o.grid.grid_search import H2OGridSearch
+from h2o.estimators.glrm import H2OGeneralizedLowRankEstimator
+
+
+#  this test tests submission of grid hyper-params with string/enum param values
+#  this is mainly na issue on py2 where unicode strings may leak out of hyperparams
+#  parsed from back-end
+def grid_re_run_hyper_serialization():
+    train_data = np.dot(np.random.rand(1000, 10), np.random.rand(10, 100))
+    train = h2o.H2OFrame(train_data.tolist(), destination_frame="glrm_train")
+    params = {
+        "k": 2,
+        "init": "User",
+        "loss": "Quadratic",
+        "regularization_x": "OneSparse",
+        "regularization_y": "NonNegative"
+    }
+    hyper_params = {
+        "transform": ["NONE", "STANDARDIZE"],
+        "gamma_x": [0.1],
+    }
+
+    # train grid
+    grid = H2OGridSearch(
+        H2OGeneralizedLowRankEstimator,
+        hyper_params=hyper_params
+    )
+    grid.train(x=train.names, training_frame=train, **params)
+    print(grid)
+    assert len(grid.model_ids) == 2
+
+    # load from back-end and train again
+    grid = h2o.get_grid(grid.grid_id)
+    grid.hyper_params["gamma_x"] = [0.1, 1]
+    grid.train(x=train.names, training_frame=train, **params)
+    print(grid)
+    assert len(grid.model_ids) == 4
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(grid_re_run_hyper_serialization)
+else:
+    grid_re_run_hyper_serialization()


### PR DESCRIPTION
- unicode strings from json parsing make restarting a grid with generated hyper-params impossible
  - fix this by implementing better serialization for gridsearch params
  - add specific test for gridsearch
- the test was passing only accidentally on py3 since the same grid was built again due to training frame having different key each time
  - fixed by using pre-defined key for training frame
