### PR TITLE
PUBDEV-7831: Add new learning curve plotting function/method

### DIFF
--- a/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
+++ b/h2o-algos/src/main/java/hex/ensemble/Metalearners.java
@@ -209,6 +209,9 @@ public class Metalearners {
             //add GLM custom params
             super.setCustomParams(parms);
 
+            parms._generate_scoring_history = true;
+            parms._score_iteration_interval = (parms._valid == null) ? 5 : -1;
+
             //specific to AUTO mode
             parms._non_negative = true;
             //parms._alpha = new double[] {0.0, 0.25, 0.5, 0.75, 1.0};

--- a/h2o-bindings/bin/custom/R/gen_gam.py
+++ b/h2o-bindings/bin/custom/R/gen_gam.py
@@ -61,7 +61,15 @@ extensions = dict(
       if(!missing(missing_values_handling))
         parms$missing_values_handling <- missing_values_handling
     """,
-
+    module="""
+    .h2o.fill_gam <- function(model, parameters, allparams) {
+        if (is.null(model$scoring_history))
+            model$scoring_history <- model$glm_scoring_history
+        if (is.null(model$model_summary))
+            model$model_summary <- model$glm_model_summary
+        return(model)
+    }
+"""
 )
 
 doc = dict(

--- a/h2o-bindings/bin/custom/python/gen_gam.py
+++ b/h2o-bindings/bin/custom/python/gen_gam.py
@@ -15,6 +15,31 @@ def class_extensions():
     def Lambda(self, value):
         self._parms["lambda"] = value
 
+    def _additional_used_columns(self, parms):
+        """
+        :return: Gam columns if specified.
+        """
+        return parms["gam_columns"]
+
+    def summary(self):
+        """Print a detailed summary of the model."""
+        model = self._model_json["output"]
+        if "glm_model_summary" in model and model["glm_model_summary"] is not None:
+            return model["glm_model_summary"]
+        print("No model summary for this model")
+
+    def scoring_history(self):
+        """
+        Retrieve Model Score History.
+
+        :returns: The score history as an H2OTwoDimTable or a Pandas DataFrame.
+        """
+        model = self._model_json["output"]
+        if "glm_scoring_history" in model and model["glm_scoring_history"] is not None:
+            return model["glm_scoring_history"].as_data_frame()
+        print("No score history for this model")
+
+
 extensions = dict(
     __imports__="""
 import h2o

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -928,6 +928,7 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
      * User-facing model scoring history - 2D table with modeling accuracy as a function of time/trees/epochs/iterations, etc.
      */
     public TwoDimTable _scoring_history;
+    public TwoDimTable[] _cv_scoring_history;
 
     public double[] _distribution;
     public double[] _modelClassDist;

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -950,8 +950,6 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     }
 
     mainModel._output._total_run_time = _build_model_countdown.elapsedTime();
-
-
     // Now, the main model is complete (has cv metrics)
     DKV.put(mainModel);
   }

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -937,9 +937,11 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     mainModel._output._cross_validation_metrics_summary = makeCrossValidationSummaryTable(cvModKeys);
 
     // Put cross-validation scoring history to the main model
-    mainModel._output._cv_scoring_history = new TwoDimTable[cvModKeys.length];
-    for (int i = 0; i < cvModKeys.length; i++) {
+    if (mainModel._output._scoring_history != null) { // check if scoring history is supported (e.g., NaiveBayes doesn't)
+      mainModel._output._cv_scoring_history = new TwoDimTable[cvModKeys.length];
+      for (int i = 0; i < cvModKeys.length; i++) {
         mainModel._output._cv_scoring_history[i] = (TwoDimTable) cvModKeys[i].get()._output._scoring_history.clone();
+      }
     }
 
     if (!_parms._keep_cross_validation_models) {

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -936,12 +936,20 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     Log.info(mainModel._output._cross_validation_metrics.toString());
     mainModel._output._cross_validation_metrics_summary = makeCrossValidationSummaryTable(cvModKeys);
 
+    // Put cross-validation scoring history to the main model
+    mainModel._output._cv_scoring_history = new TwoDimTable[cvModKeys.length];
+    for (int i = 0; i < cvModKeys.length; i++) {
+        mainModel._output._cv_scoring_history[i] = (TwoDimTable) cvModKeys[i].get()._output._scoring_history.clone();
+    }
+
     if (!_parms._keep_cross_validation_models) {
       int count = Model.deleteAll(cvModKeys);
       Log.info(count+" CV models were removed");
     }
 
     mainModel._output._total_run_time = _build_model_countdown.elapsedTime();
+
+
     // Now, the main model is complete (has cv metrics)
     DKV.put(mainModel);
   }

--- a/h2o-core/src/main/java/hex/ModelBuilder.java
+++ b/h2o-core/src/main/java/hex/ModelBuilder.java
@@ -940,7 +940,25 @@ abstract public class ModelBuilder<M extends Model<M,P,O>, P extends Model.Param
     if (mainModel._output._scoring_history != null) { // check if scoring history is supported (e.g., NaiveBayes doesn't)
       mainModel._output._cv_scoring_history = new TwoDimTable[cvModKeys.length];
       for (int i = 0; i < cvModKeys.length; i++) {
-        mainModel._output._cv_scoring_history[i] = (TwoDimTable) cvModKeys[i].get()._output._scoring_history.clone();
+        TwoDimTable sh = cvModKeys[i].get()._output._scoring_history;
+        String[] rowHeaders = sh.getRowHeaders();
+        String[] colTypes = sh.getColTypes();
+        int tableSize = rowHeaders.length;
+        int colSize = colTypes.length;
+        TwoDimTable copiedScoringHistory = new TwoDimTable(
+                sh.getTableHeader(),
+                sh.getTableDescription(),
+                sh.getRowHeaders(),
+                sh.getColHeaders(),
+                sh.getColTypes(),
+                sh.getColFormats(),
+                sh.getColHeaderForRowHeaders());
+        for (int rowIndex = 0; rowIndex < tableSize; rowIndex++)  {
+          for (int colIndex = 0; colIndex < colSize; colIndex++) {
+            copiedScoringHistory.set(rowIndex, colIndex,sh.get(rowIndex, colIndex));
+          }
+        }
+        mainModel._output._cv_scoring_history[i] = copiedScoringHistory;
       }
     }
 

--- a/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
+++ b/h2o-core/src/main/java/water/api/schemas3/ModelOutputSchemaV3.java
@@ -50,6 +50,9 @@ public class ModelOutputSchemaV3<O extends Model.Output, S extends ModelOutputSc
   @API(help="Scoring history", direction=API.Direction.OUTPUT, level=API.Level.secondary)
   public TwoDimTableV3 scoring_history;
 
+  @API(help="Cross-Validation scoring history", direction=API.Direction.OUTPUT, level=API.Level.secondary)
+  public TwoDimTableV3 cv_scoring_history[];
+
   @API(help="Model reproducibility information", direction=API.Direction.OUTPUT, level=API.Level.secondary)
   public TwoDimTableV3[] reproducibility_information_table;
   

--- a/h2o-py/h2o/estimators/gam.py
+++ b/h2o-py/h2o/estimators/gam.py
@@ -1078,3 +1078,27 @@ class H2OGeneralizedAdditiveEstimator(H2OEstimator):
     @Lambda.setter
     def Lambda(self, value):
         self._parms["lambda"] = value
+
+    def _additional_used_columns(self, parms):
+        """
+        :return: Gam columns if specified.
+        """
+        return parms["gam_columns"]
+
+    def summary(self):
+        """Print a detailed summary of the model."""
+        model = self._model_json["output"]
+        if "glm_model_summary" in model and model["glm_model_summary"] is not None:
+            return model["glm_model_summary"]
+        print("No model summary for this model")
+
+    def scoring_history(self):
+        """
+        Retrieve Model Score History.
+
+        :returns: The score history as an H2OTwoDimTable or a Pandas DataFrame.
+        """
+        model = self._model_json["output"]
+        if "glm_scoring_history" in model and model["glm_scoring_history"] is not None:
+            return model["glm_scoring_history"].as_data_frame()
+        print("No score history for this model")

--- a/h2o-py/h2o/explanation/__init__.py
+++ b/h2o-py/h2o/explanation/__init__.py
@@ -15,6 +15,7 @@ def _register_dummy_methods():
     h2o.model.ModelBase.explain_row = _complain_about_matplotlib
     h2o.model.ModelBase.pd_plot = _complain_about_matplotlib
     h2o.model.ModelBase.ice_plot = _complain_about_matplotlib
+    h2o.model.ModelBase.learning_curve_plot = _complain_about_matplotlib
 
     h2o.automl._base.H2OAutoMLBaseMixin.pd_multi_plot = _complain_about_matplotlib
     h2o.automl._base.H2OAutoMLBaseMixin.varimp_heatmap = _complain_about_matplotlib

--- a/h2o-py/h2o/explanation/__init__.py
+++ b/h2o-py/h2o/explanation/__init__.py
@@ -27,7 +27,7 @@ try:
     import numpy
     import matplotlib
     from ._explain import varimp_heatmap, model_correlation_heatmap, shap_explain_row_plot, shap_summary_plot,\
-        explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot
+        explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot, learning_curve_plot
 
     __all__ = [
         "explain",
@@ -52,6 +52,7 @@ def register_explain_methods():
     h2o.model.ModelBase.explain_row = explain_row
     h2o.model.ModelBase.pd_plot = pd_plot
     h2o.model.ModelBase.ice_plot = ice_plot
+    h2o.model.ModelBase.learning_curve_plot = learning_curve_plot
 
     h2o.automl._base.H2OAutoMLBaseMixin.pd_multi_plot = pd_multi_plot
     h2o.automl._base.H2OAutoMLBaseMixin.varimp_heatmap = varimp_heatmap

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1780,6 +1780,29 @@ def learning_curve_plot(
     :param figsize: figure size; passed directly to matplotlib
     :param colormap: colormap to use
     :return: a matplotlib figure
+
+    :examples:
+    >>> import h2o
+    >>> from h2o.estimators import H2OGradientBoostingEstimator
+    >>>
+    >>> h2o.init()
+    >>>
+    >>> # Import the wine dataset into H2O:
+    >>> f = "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+    >>> df = h2o.import_file(f)
+    >>>
+    >>> # Set the response
+    >>> response = "quality"
+    >>>
+    >>> # Split the dataset into a train and test set:
+    >>> train, test = df.split_frame([0.8])
+    >>>
+    >>> # Train a GBM
+    >>> gbm = H2OGradientBoostingEstimator()
+    >>> gbm.train(y=response, training_frame=train)
+    >>>
+    >>> # Create the learning curve plot
+    >>> gbm.learning_curve_plot()
     """
     if model.algo == "stackedensemble":
         model = model.metalearner()

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1774,7 +1774,7 @@ def learning_curve_plot(
     Create learning curve plot for an H2O Model.
 
     :param model: an H2O model
-    :param metric: a metric that is present in `model.scoring_history()`
+    :param metric: a stopping metric
     :param cv_ribbon: if True, plot the CV mean as a and CV standard deviation as a ribbon around the mean
     :param cv_lines: if True, plot scoring history for individual CV models
     :param figsize: figure size; passed directly to matplotlib

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -2001,7 +2001,7 @@ def learning_curve_plot(
     plt.ylabel(metric)
     handles, labels = plt.gca().get_legend_handles_labels()
     by_label = OrderedDict(zip(labels, handles))
-    plt.legend(by_label.values(), by_label.keys())
+    plt.legend(list(by_label.values()), list(by_label.keys()))
 
     return plt.gcf()
 

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1854,24 +1854,13 @@ def learning_curve_plot(
         selected_timestep_value = model.actual_params["epochs"]
 
     if colormap is None:
-        col_train, col_valid = "#ff6666", "#66bb00"
-        col_cv_train, col_cv_valid = "#dd77ff", "#00cccc"
+        col_train, col_valid = "#ff6000", "#785ff0"
+        col_cv_train, col_cv_valid = "#ffb000", "#648fff"
     else:
         col_train, col_valid, col_cv_train, col_cv_valid = plt.get_cmap(colormap, 4)(list(range(4)))
 
     plt.figure(figsize=figsize)
     plt.grid(True)
-    plt.plot(scoring_history[timestep],
-             scoring_history[training_metric],
-             "o-",
-             label="Training",
-             c=col_train)
-    if validation_metric in scoring_history.col_header:
-        plt.plot(scoring_history[timestep],
-                 scoring_history[validation_metric],
-                 "o-",
-                 label="Validation",
-                 c=col_valid)
 
     if model._model_json["output"]["cv_scoring_history"]:
         if cv_ribbon or cv_ribbon is None:
@@ -1937,6 +1926,18 @@ def learning_curve_plot(
                              c=col_cv_valid,
                              linestyle="dotted"
                              )
+
+    plt.plot(scoring_history[timestep],
+             scoring_history[training_metric],
+             "o-",
+             label="Training",
+             c=col_train)
+    if validation_metric in scoring_history.col_header:
+        plt.plot(scoring_history[timestep],
+                 scoring_history[validation_metric],
+                 "o-",
+                 label="Validation",
+                 c=col_valid)
 
     if selected_timestep_value is not None:
         plt.axvline(x=selected_timestep_value, label="Selected {}".format(timestep), c="black")

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1788,6 +1788,22 @@ def learning_curve_plot(
                           "drf", "gbm", "xgboost", "coxph", "isolationforest"):
         raise H2OValueError("Algorithm {} doesn't support learning curve plot!".format(model.algo))
 
+    metric_mapping = {'anomaly_score': 'mean_anomaly_score',
+                      'custom': 'custom',
+                      'custom_increasing': 'custom',
+                      'deviance': 'deviance',
+                      'logloss': 'logloss',
+                      'rmse': 'rmse',
+                      'mae': 'mae',
+                      'auc': 'auc',
+                      'aucpr': 'pr_auc',
+                      'lift_top_group': 'lift',
+                      'misclassification': 'classification_error',
+                      'objective': 'objective',
+                      'convergence': 'convergence',
+                      'negative_log_likelihood': 'negative_log_likelihood',
+                      'sumetaieta02': 'sumetaieta02'}
+    inverse_metric_mappping = {v: k for k, v in metric_mapping.items()}
 
     # Using the value from output to keep it simple - only one version required - (no need to use pandas for small data)
     scoring_history = model._model_json["output"]["scoring_history"] or model._model_json["output"].get("glm_scoring_history")
@@ -1836,11 +1852,13 @@ def learning_curve_plot(
 
     if metric == "AUTO":
         metric = allowed_metrics[0]
+    else:
+        metric = metric_mapping[metric.lower()]
 
     if metric not in allowed_metrics:
         raise H2OValueError("for {}, metric must be one of: {}".format(
             model.algo.upper(),
-            ", ".join(allowed_metrics)
+            ", ".join(inverse_metric_mappping[m] for m in allowed_metrics)
         ))
 
     timestep = allowed_timesteps[0]

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -9,13 +9,6 @@ import numpy as np
 from h2o.utils.ext_dependencies import get_matplotlib_pyplot
 from h2o.exceptions import H2OValueError
 
-try:
-    import matplotlib.pyplot as plt
-except ImportError:
-    # Possibly failed due to missing tkinter in old matplotlib in python 2.7
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-
 
 def _display(object):
     """
@@ -1814,6 +1807,8 @@ def learning_curve_plot(
     if model.algo not in ("stackedensemble", "glm", "gam", "glrm", "deeplearning",
                           "drf", "gbm", "xgboost", "coxph", "isolationforest"):
         raise H2OValueError("Algorithm {} doesn't support learning curve plot!".format(model.algo))
+
+    plt = get_matplotlib_pyplot(False, raise_if_not_available=True)
 
     metric_mapping = {'anomaly_score': 'mean_anomaly_score',
                       'custom': 'custom',

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1897,7 +1897,7 @@ def learning_curve_plot(
                 [(k, len(v)) for k, v in cvsh_train.items()],
                 key=lambda k: k[0]
             ))[:, 1]
-            if len_train.mean() > 2 and np.mean(len_train[:-1] == len_train[1:]) >= 0.5:
+            if cv_ribbon or len_train.mean() > 2 and np.mean(len_train[:-1] == len_train[1:]) >= 0.5:
                 plt.plot(mean_train[:, 0], mean_train[:, 1], c=col_cv_train,
                          label="CV-Training")
                 plt.fill_between(mean_train[:, 0],

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1844,9 +1844,7 @@ def learning_curve_plot(
     if "number_of_trees" == timestep:
         selected_timestep_value = model.actual_params["ntrees"]
     elif timestep in ["iteration", "iterations"]:
-        model_summary = model._model_json["output"]["model_summary"]
-        if model_summary is None:
-            model_summary = model._model_json["output"]["glm_model_summary"]
+        model_summary = model.model_summary()
         selected_timestep_value = model_summary["number_of_iterations"][0]
     elif "epochs" == timestep:
         selected_timestep_value = model.actual_params["epochs"]

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -472,6 +472,8 @@ class ModelBase(h2o_meta(Keyed)):
         model = self._model_json["output"]
         if "model_summary" in model and model["model_summary"] is not None:
             return model["model_summary"]
+        if "glm_model_summary" in model and model["glm_model_summary"] is not None:
+            return model["glm_model_summary"]
         print("No model summary for this model")
 
     def show(self):

--- a/h2o-py/h2o/model/model_base.py
+++ b/h2o-py/h2o/model/model_base.py
@@ -387,8 +387,6 @@ class ModelBase(h2o_meta(Keyed)):
         model = self._model_json["output"]
         if "scoring_history" in model and model["scoring_history"] is not None:
             return model["scoring_history"].as_data_frame()
-        if "glm_scoring_history" in model and model["glm_scoring_history"] is not None:
-            return model["glm_scoring_history"].as_data_frame()
         print("No score history for this model")
 
     def ntrees_actual(self):
@@ -472,8 +470,6 @@ class ModelBase(h2o_meta(Keyed)):
         model = self._model_json["output"]
         if "model_summary" in model and model["model_summary"] is not None:
             return model["model_summary"]
-        if "glm_model_summary" in model and model["glm_model_summary"] is not None:
-            return model["glm_model_summary"]
         print("No model summary for this model")
 
     def show(self):

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -69,6 +69,10 @@ def test_explanation_single_model_regression():
         assert isinstance(gbm.ice_plot(train, col), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close("all")
 
+    # test learning curve
+    assert isinstance(gbm.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
     # test explain
     assert isinstance(gbm.explain(train, render=False), H2OExplanation)
 
@@ -142,6 +146,11 @@ def test_explanation_list_of_models_regression():
         assert isinstance(h2o.pd_multi_plot(models, train, col), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close("all")
 
+    # test learning curve
+    for model in models:
+        assert isinstance(model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
+
     # test explain
     assert isinstance(h2o.explain(models, train, render=False), H2OExplanation)
 
@@ -181,6 +190,10 @@ def test_explanation_single_model_binomial_classification():
     for col in cols_to_test:
         assert isinstance(gbm.ice_plot(train, col), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close("all")
+
+    # test learning curve
+    assert isinstance(gbm.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
 
     # test explain
     assert isinstance(gbm.explain(train, render=False), H2OExplanation)
@@ -257,6 +270,11 @@ def test_explanation_list_of_models_binomial_classification():
         assert isinstance(h2o.pd_multi_plot(models, train, col), matplotlib.pyplot.Figure)
         matplotlib.pyplot.close()
 
+    # test learning curve
+    for model in models:
+        assert isinstance(model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
+
     # test explain
     assert isinstance(h2o.explain(models, train, render=False), H2OExplanation)
 
@@ -304,6 +322,10 @@ def test_explanation_single_model_multinomial_classification():
     for col in cols_to_test:
         assert isinstance(gbm.ice_plot(train, col, target="setosa"), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close("all")
+
+    # test learning curve
+    assert isinstance(gbm.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
 
     # test explain
     assert isinstance(gbm.explain(train, render=False), H2OExplanation)
@@ -379,6 +401,11 @@ def test_explanation_list_of_models_multinomial_classification():
     # test partial dependences
     for col in cols_to_test:
         assert isinstance(h2o.pd_multi_plot(models, train, col, target="setosa"), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
+
+    # test learning curve
+    for model in models:
+        assert isinstance(model.learning_curve_plot(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close("all")
 
     # test explain

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -8,7 +8,7 @@ import h2o
 import matplotlib.pyplot
 from tests import pyunit_utils
 from h2o.automl import H2OAutoML
-from h2o.estimators import H2OGradientBoostingEstimator
+from h2o.estimators import *
 from h2o.explanation._explain import H2OExplanation
 
 
@@ -415,6 +415,99 @@ def test_explanation_list_of_models_multinomial_classification():
     assert isinstance(h2o.explain_row(models, train, 1, render=False), H2OExplanation)
 
 
+def test_learning_curve_for_algos_not_present_in_automl():
+    # GLM without lambda search
+    prostate = h2o.import_file(pyunit_utils.locate("smalldata/prostate/prostate.csv"))
+    prostate['CAPSULE'] = prostate['CAPSULE'].asfactor()
+    prostate['RACE'] = prostate['RACE'].asfactor()
+    prostate['DCAPS'] = prostate['DCAPS'].asfactor()
+    prostate['DPROS'] = prostate['DPROS'].asfactor()
+
+    predictors = ["AGE", "RACE", "VOL", "GLEASON"]
+    response_col = "CAPSULE"
+
+    glm_model = H2OGeneralizedLinearEstimator(family="binomial",
+                                              lambda_=0,
+                                              compute_p_values=True)
+    glm_model.train(predictors, response_col, training_frame=prostate)
+    assert isinstance(glm_model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    # HGLM
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/semiconductor.csv"))
+    y = "y"
+    x = ["x1", "x3", "x5", "x6"]
+    z = 0
+    h2o_data["Device"] = h2o_data["Device"].asfactor()
+    hglm_model = H2OGeneralizedLinearEstimator(HGLM=True,
+                                               family="gaussian",
+                                               rand_family=["gaussian"],
+                                               random_columns=[z],
+                                               rand_link=["identity"],
+                                               calc_like=True)
+    hglm_model.train(x=x, y=y, training_frame=h2o_data)
+    assert isinstance(hglm_model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    # GAM
+    knots1 = [-1.99905699, -0.98143075, 0.02599159, 1.00770987, 1.99942290]
+    frameKnots1 = h2o.H2OFrame(python_obj=knots1)
+    knots2 = [-1.999821861, -1.005257990, -0.006716042, 1.002197392, 1.999073589]
+    frameKnots2 = h2o.H2OFrame(python_obj=knots2)
+    knots3 = [-1.999675688, -0.979893796, 0.007573327, 1.011437347, 1.999611676]
+    frameKnots3 = h2o.H2OFrame(python_obj=knots3)
+    h2o_data = h2o.import_file(
+        pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    h2o_data["C1"] = h2o_data["C1"].asfactor()
+    h2o_data["C2"] = h2o_data["C2"].asfactor()
+    h2o_data["C11"] = h2o_data["C11"].asfactor()
+    train, test = h2o_data.split_frame(ratios=[.8])
+    y = "C11"
+    x = ["C1", "C2"]
+    numKnots = [5, 5, 5]
+    gam_model = H2OGeneralizedAdditiveEstimator(family='multinomial',
+                                                gam_columns=["C6", "C7", "C8"],
+                                                scale=[1, 1, 1],
+                                                num_knots=numKnots,
+                                                knot_ids=[frameKnots1.key, frameKnots2.key, frameKnots3.key])
+    gam_model.train(x=x, y=y, training_frame=train, validation_frame=test)
+    assert isinstance(gam_model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    # GLRM
+    arrestsH2O = h2o.import_file(pyunit_utils.locate("smalldata/pca_test/USArrests.csv"))
+    glrm_model = H2OGeneralizedLowRankEstimator(k=4,
+                                                loss="quadratic",
+                                                gamma_x=0.5,
+                                                gamma_y=0.5,
+                                                max_iterations=700,
+                                                recover_svd=True,
+                                                init="SVD",
+                                                transform="standardize")
+    glrm_model.train(training_frame=arrestsH2O)
+    assert isinstance(glrm_model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    # CoxPH
+    heart = h2o.import_file(pyunit_utils.locate("smalldata/coxph_test/heart.csv"))
+    coxph_model = H2OCoxProportionalHazardsEstimator(start_column="start",
+                                                     stop_column="stop",
+                                                     ties="breslow")
+    coxph_model.train(x="age",
+                      y="event",
+                      training_frame=heart)
+    assert isinstance(coxph_model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    # IsolationForest
+    if_model = H2OIsolationForestEstimator(sample_rate=0.1,
+                                           max_depth=20,
+                                           ntrees=50)
+    if_model.train(training_frame=prostate)
+    assert isinstance(if_model.learning_curve_plot(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+
 pyunit_utils.run_tests([
     test_get_xy,
     test_explanation_single_model_regression,
@@ -426,4 +519,5 @@ pyunit_utils.run_tests([
     test_explanation_single_model_multinomial_classification,
     test_explanation_automl_multinomial_classification,
     test_explanation_list_of_models_multinomial_classification,
+    test_learning_curve_for_algos_not_present_in_automl,
     ])

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -45,7 +45,7 @@ def test_explanation_single_model_regression():
         else:
             cols_to_test.append(col)
 
-    gbm = H2OGradientBoostingEstimator(seed=1234)
+    gbm = H2OGradientBoostingEstimator(seed=1234, model_id="my_awesome_model")
     gbm.train(y=y, training_frame=train)
 
     # test shap summary
@@ -71,7 +71,10 @@ def test_explanation_single_model_regression():
 
     # test learning curve
     assert isinstance(gbm.learning_curve_plot(), matplotlib.pyplot.Figure)
-    matplotlib.pyplot.close()
+    for metric in ["auto", "deviance", "rmse"]:
+        assert isinstance(gbm.learning_curve_plot(metric=metric.upper()), matplotlib.pyplot.Figure)
+        assert isinstance(gbm.learning_curve_plot(metric), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close("all")
 
     # test explain
     assert isinstance(gbm.explain(train, render=False), H2OExplanation)
@@ -133,6 +136,11 @@ def test_explanation_list_of_models_regression():
     models = [h2o.get_model(m[0]) for m in
               aml.leaderboard["model_id"].as_data_frame(use_pandas=False, header=False)]
 
+    # Test named models as well
+    gbm = H2OGradientBoostingEstimator(model_id="my_awesome_model")
+    gbm.train(y=y, training_frame=train)
+    models += [gbm]
+
     # test variable importance heatmap plot
     assert isinstance(h2o.varimp_heatmap(models), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
@@ -171,7 +179,7 @@ def test_explanation_single_model_binomial_classification():
         else:
             cols_to_test.append(col)
 
-    gbm = H2OGradientBoostingEstimator(seed=1234)
+    gbm = H2OGradientBoostingEstimator(seed=1234, model_id="my_awesome_model")
     gbm.train(y=y, training_frame=train)
 
     # test shap summary
@@ -257,6 +265,11 @@ def test_explanation_list_of_models_binomial_classification():
     models = [h2o.get_model(m[0]) for m in
               aml.leaderboard["model_id"].as_data_frame(use_pandas=False, header=False)]
 
+    # Test named models as well
+    gbm = H2OGradientBoostingEstimator(model_id="my_awesome_model")
+    gbm.train(y=y, training_frame=train)
+    models += [gbm]
+
     # test variable importance heatmap plot
     assert isinstance(h2o.varimp_heatmap(models), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
@@ -295,7 +308,7 @@ def test_explanation_single_model_multinomial_classification():
         else:
             cols_to_test.append(col)
 
-    gbm = H2OGradientBoostingEstimator(seed=1234)
+    gbm = H2OGradientBoostingEstimator(seed=1234, model_id="my_awesome_model")
     gbm.train(y=y, training_frame=train)
 
     # test shap summary
@@ -389,6 +402,10 @@ def test_explanation_list_of_models_multinomial_classification():
     models = [h2o.get_model(m[0]) for m in
               aml.leaderboard["model_id"].as_data_frame(use_pandas=False, header=False)]
 
+    # Test named models as well
+    gbm = H2OGradientBoostingEstimator(model_id="my_awesome_model")
+    gbm.train(y=y, training_frame=train)
+    models += [gbm]
 
     # test variable importance heatmap plot
     assert isinstance(h2o.varimp_heatmap(models), matplotlib.pyplot.Figure)

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -2418,8 +2418,7 @@ h2o.learning_curve_plot <- function(model,
     if (model@allparameters$lambda_search) {
       allowed_metrics <- "deviance"
       allowed_timesteps <- "iteration"
-      #FIXME: Uncomment me after https://github.com/h2oai/h2o-3/pull/5069 is merged
-      #sh <- sh[sh["alpha"] == model@model$alpha_best,]
+      sh <- sh[sh["alpha"] == model@model$alpha_best,]
     } else if (!is.null(hglm) && hglm) {
       allowed_metrics <- c("convergence", "sumetaieta02")
       allowed_timesteps <- "iterations"
@@ -2459,7 +2458,6 @@ h2o.learning_curve_plot <- function(model,
 
   timestep <- allowed_timesteps[[1]]
 
-  # FIXME: Inconsistencies in naming, find out what could be used and when
   training_metric <- sprintf(switch(metric,
                                     deviance = "%s_train",
                                     objective = "objective",

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -2594,6 +2594,8 @@ h2o.learning_curve_plot <- function(model,
       title = "Learning Curve",
       subtitle = paste("for", model@model_id)
     ) +
+    ggplot2::scale_color_manual(values = c("#ff6666", "#66bb00", "#dd77ff", "#00cccc")) +
+    ggplot2::scale_fill_manual(values = c("#ff6666", "#66bb00", "#dd77ff", "#00cccc")) +
     ggplot2::theme_bw() +
     ggplot2::theme(
       legend.title = ggplot2::element_blank(),

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -2544,9 +2544,9 @@ h2o.learning_curve_plot <- function(model,
     } else if (mean(cvsh_len$`CV-Training`[-nrow(cvsh_len)] == cvsh_len$`CV-Training`[-1]) < 0.5 ||
         mean(cvsh_len$`CV-Training`) < 2) {
       if (is.null(cv_ribbon)) {
-        cv_individual_lines <- is.null(cv_individual_lines) || cv_individual_lines
         cv_ribbon <- FALSE
       }
+      cv_individual_lines <- is.null(cv_individual_lines) || cv_individual_lines
     } else {
       cv_individual_lines <- !is.null(cv_individual_lines) && cv_individual_lines
       cv_ribbon <- is.null(cv_ribbon) || cv_ribbon

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -2395,6 +2395,33 @@ h2o.ice_plot <- function(model,
 #' @param metric Metric to be used for the learning curve plot. These should mostly correspond with stopping metric.
 #' @param cv_ribbon if True, plot the CV mean as a and CV standard deviation as a ribbon around the mean
 #' @param cv_lines if True, plot scoring history for individual CV models
+#'
+#' @return A ggplot2 object
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
+#'
+#' # Set the response
+#' response <- "quality"
+#'
+#' # Split the dataset into a train and test set:
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
+#'
+#' # Build and train the model:
+#' gbm <- h2o.gbm(y = response,
+#'                training_frame = train)
+#'
+#' # Create the learning curve plot
+#' learning_curve <- h2o.learning_curve_plot(gbm)
+#' print(learning_curve)
+#' }
 #' @export
 h2o.learning_curve_plot <- function(model,
                                     metric = c("AUTO", "auc", "aucpr", "mae", "rmse", "anomaly_score",
@@ -2658,6 +2685,7 @@ h2o.learning_curve_plot <- function(model,
     )
   }
   if (cv_lines) {
+    type <- NULL
     p <- p + ggplot2::geom_line(ggplot2::aes(group = paste(model, type)),
                                 linetype = "dotted",
                                 data = cv_scoring_history)

--- a/h2o-r/h2o-package/R/gam.R
+++ b/h2o-r/h2o-package/R/gam.R
@@ -640,3 +640,13 @@ h2o.gam <- function(x,
   segment_models <- .h2o.segmentModelsJob('gam', segment_parms, parms, h2oRestApiVersion=3)
   return(segment_models)
 }
+
+
+    .h2o.fill_gam <- function(model, parameters, allparams) {
+        if (is.null(model$scoring_history))
+            model$scoring_history <- model$glm_scoring_history
+        if (is.null(model$model_summary))
+            model$model_summary <- model$glm_model_summary
+        return(model)
+    }
+

--- a/h2o-r/tests/testdir_misc/runit_explain.R
+++ b/h2o-r/tests/testdir_misc/runit_explain.R
@@ -40,6 +40,9 @@ explanation_test_single_model_regression <- function() {
     expect_ggplot(h2o.ice_plot(gbm, train, col))
   }
 
+  # test learning curve plot
+  expect_ggplot(h2o.learning_curve_plot(gbm))
+
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain(gbm, train)))
 
@@ -125,6 +128,11 @@ explanation_test_list_of_models_regression <- function() {
   # test ice plot
   expect_error(h2o.ice_plot(models, train, cols_to_test[[1]]), "Only one model is allowed!")
 
+  # test learning curve plot
+  for (model in models) {
+    expect_ggplot(h2o.learning_curve_plot(model))
+  }
+
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain(models, train)))
 
@@ -164,6 +172,9 @@ explanation_test_single_model_binomial_classification <- function() {
   for (col in cols_to_test) {
     expect_ggplot(h2o.ice_plot(gbm, train, col))
   }
+
+  # test learning curve plot
+  expect_ggplot(h2o.learning_curve_plot(gbm))
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain(gbm, train)))
@@ -252,6 +263,11 @@ explanation_test_list_of_models_binomial_classification <- function() {
   # test ice plot
   expect_error(h2o.ice_plot(models, train, cols_to_test[[1]]), "Only one model is allowed!")
 
+  # test learning curve plot
+  for (model in models) {
+    expect_ggplot(h2o.learning_curve_plot(model))
+  }
+
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain(models, train)))
 
@@ -291,6 +307,9 @@ explanation_test_single_model_multinomial_classification <- function() {
   for (col in cols_to_test) {
     expect_ggplot(h2o.ice_plot(gbm, train, col, target = "setosa"))
   }
+
+  # test learning curve plot
+  expect_ggplot(h2o.learning_curve_plot(gbm))
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain(gbm, train)))
@@ -378,6 +397,11 @@ explanation_test_list_of_models_multinomial_classification <- function() {
   }
   # test ice plot
   expect_error(h2o.ice_plot(models, train, cols_to_test[[1]]), "Only one model is allowed!")
+
+  # test learning curve plot
+  for (model in models) {
+    expect_ggplot(h2o.learning_curve_plot(model))
+  }
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain(models, train)))

--- a/h2o-r/tests/testdir_misc/runit_explain.R
+++ b/h2o-r/tests/testdir_misc/runit_explain.R
@@ -19,7 +19,8 @@ explanation_test_single_model_regression <- function() {
 
   gbm <- h2o.gbm(y = y,
                  training_frame = train,
-                 seed = 1234)
+                 seed = 1234,
+                 model_id = "my_awesome_model")
 
   # test shap summary
   expect_ggplot(h2o.shap_summary_plot(gbm, train))
@@ -42,6 +43,10 @@ explanation_test_single_model_regression <- function() {
 
   # test learning curve plot
   expect_ggplot(h2o.learning_curve_plot(gbm))
+  for (metric in c("auto", "rmse", "deviance")) {
+    expect_ggplot(h2o.learning_curve_plot(gbm, metric = metric))
+    expect_ggplot(h2o.learning_curve_plot(gbm, metric = toupper(metric)))
+  }
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain(gbm, train)))
@@ -105,6 +110,8 @@ explanation_test_list_of_models_regression <- function() {
                     training_frame = train,
                     seed = 1234)
   models <- lapply(aml@leaderboard$model_id, h2o.getModel)
+  gbm <- h2o.gbm(y=y, training_frame = train, model_id = "my_awesome_model")
+  models <- c(models, gbm)
 
   # test model correlation
   expect_ggplot(h2o.model_correlation_heatmap(models, train))
@@ -152,7 +159,8 @@ explanation_test_single_model_binomial_classification <- function() {
 
   gbm <- h2o.gbm(y = y,
                  training_frame = train,
-                 seed = 1234)
+                 seed = 1234,
+                 model_id = "my_awesome_model")
 
   # test shap summary
   expect_ggplot(h2o.shap_summary_plot(gbm, train))
@@ -240,6 +248,8 @@ explanation_test_list_of_models_binomial_classification <- function() {
                     training_frame = train,
                     seed = 1234)
   models <- lapply(aml@leaderboard$model_id, h2o.getModel)
+  gbm <- h2o.gbm(y=y, training_frame = train, model_id = "my_awesome_model")
+  models <- c(models, gbm)
 
   # test model correlation
   expect_ggplot(h2o.model_correlation_heatmap(models, train))
@@ -287,7 +297,8 @@ explanation_test_single_model_multinomial_classification <- function() {
 
   gbm <- h2o.gbm(y = y,
                  training_frame = train,
-                 seed = 1234)
+                 seed = 1234,
+                 model_id = "my_awesome_model")
 
   # test shap summary
   expect_error(h2o.shap_summary_plot(gbm, train), "java.lang.UnsupportedOperationException: Calculating contributions is currently not supported for multinomial models.")
@@ -375,6 +386,8 @@ explanation_test_list_of_models_multinomial_classification <- function() {
                     training_frame = train,
                     seed = 1234)
   models <- lapply(aml@leaderboard$model_id, h2o.getModel)
+  gbm <- h2o.gbm(y=y, training_frame = train, model_id = "my_awesome_model")
+  models <- c(models, gbm)
 
   # test model correlation
   expect_ggplot(h2o.model_correlation_heatmap(models, train))


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7831

Need to be tested for multiple different model configurations.
For now, this should work at least on the models that we get from AutoML (it is tested mainly on those).

**Questionable choices:**

- When provided with StackedEnsemble, draw learning curve for the metalearner and make sure to have the metalearner model id in the plot title to make this choice explicitly visible.

- If it seems to be hard to make nice ribbon, don't make a ribbon and instead draw individual CV lines. This is because of "DeepLearning epochs doesn't seem to be saved in the same point so the `sd` estimation for ribbon fails".


**Related fixes**

- CoxPH scoring history is missing last entry: https://github.com/h2oai/h2o-3/pull/5186 (merged)
- GLM with lambda search reports number of iterations of the last model, not the winning submodel  (merged)

**Example**

![Unknown-5](https://user-images.githubusercontent.com/61695433/102088592-6a191580-3e1b-11eb-8f13-ca337e8eee94.png)

