### PR TITLE
PUBDEV-7928: Fix custom distribution reuse

### DIFF
--- a/h2o-core/src/main/java/hex/DistributionFactory.java
+++ b/h2o-core/src/main/java/hex/DistributionFactory.java
@@ -441,7 +441,7 @@ class CustomDistribution extends Distribution {
     
     private CustomDistributionWrapper _wrapper;
     private static CustomDistribution _instance;
-    public static String _distributionDef;
+    private String _distributionDef;
     
     private CustomDistribution(Model.Parameters params){
         super(params);
@@ -453,9 +453,9 @@ class CustomDistribution extends Distribution {
     }
     
     public static CustomDistribution getCustomDistribution(Model.Parameters params){
-        if(_instance == null || params._custom_distribution_func != _distributionDef){
+        if(_instance == null || !params._custom_distribution_func.equals(_instance._distributionDef)){
             _instance = new CustomDistribution(params);
-        } 
+        }
         return _instance;
     }
 

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4076_custom_distribution.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4076_custom_distribution.py
@@ -60,7 +60,8 @@ def test_custom_distribution_computation():
     test_null()
     test_worng_and_inherited_regression()
     test_wrong_multinomial()
-    
+    test_custom_distribution_reuse()
+
     
 def test_regression():
     print("Regression tests")

--- a/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4076_custom_distribution.py
+++ b/h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4076_custom_distribution.py
@@ -145,6 +145,25 @@ def test_wrong_multinomial():
         "Validation rmse is not different for default and custom multinomial model."
 
 
+def test_custom_distribution_reuse():
+    from h2o.utils.distributions import CustomDistributionGaussian
+    train = h2o.import_file(pyunit_utils.locate("smalldata/iris/iris_train.csv"))
+    y = "petal_wid"
+    x = train.columns
+    x.remove(y)
+
+    nfolds = 2
+    for i in range(3):
+        test_wrong_multinomial()
+        custom_dist1 = h2o.upload_custom_distribution(CustomDistributionGaussian)
+        gbm = H2OGradientBoostingEstimator(nfolds=nfolds,
+                                           fold_assignment="Modulo",
+                                           keep_cross_validation_predictions=True,
+                                           distribution="custom",
+                                           custom_distribution_func=custom_dist1)
+        gbm.train(x=x, y=y, training_frame=train)
+
+
 if __name__ == "__main__":
     pyunit_utils.standalone_test(test_custom_distribution_computation)
 else:


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7928

When the following tests are ran in sequence the second one fails: 
-  h2o-py/tests/testdir_algos/gbm/pyunit_PUBDEV_4076_custom_distribution.py          
-  h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_distributions.py

**Hypothesis**
CustomDistribution is a singleton that keeps one custom distribution at a time. When switching between the distributions it can happen that one thread updates static string variable `_distributionDef`  and another thread compares the newly modified `_distributionDef` with the `params._custom_distribution_func`. Since another thread modified it to match the custom distribution func we return the `_instance` which at this point doesn't correspond to the `_distributionDef`.

**Solution**
Make the `_distributionDef` a property of the class instance `_instance`, this way the `_distributionDef` is tightly coupled with the actual `_instance` so we can actually compare  `_instance._distributionDef` with the `params._custom_distribution_func` and expect the correct distribution to be returned.