### PR TITLE
PUBDEV-7931: allow R/Python client to not choose any predictor

### DIFF
--- a/h2o-bindings/bin/custom/R/gen_gam.py
+++ b/h2o-bindings/bin/custom/R/gen_gam.py
@@ -2,13 +2,9 @@
 extensions = dict(
     required_params=['x', 'y', 'training_frame', 'gam_columns'],  # empty to override defaults in gen_defaults
     validate_required_params="""
-    # If x is missing, then assume user wants to use all columns as features.
+    # If x is missing, no predictors will be used.  Only the gam columns are present as predictors
     if (missing(x)) {
-       if (is.numeric(y)) {
-           x <- setdiff(col(training_frame), y)
-       } else {
-           x <- setdiff(colnames(training_frame), y)
-       }
+        x = NULL
     }
 
     # If gam_columns is missing, then assume user wants to use all columns as features for GAM.

--- a/h2o-py/h2o/estimators/estimator_base.py
+++ b/h2o-py/h2o/estimators/estimator_base.py
@@ -332,7 +332,7 @@ class H2OEstimator(ModelBase):
             parms["response_column"] = y
         if not isinstance(x, (list, tuple)):
             x = [x]
-        if is_type(x[0], int):
+        if len(x) > 0 and is_type(x[0], int):
             x = [names[i] for i in x]
         if override_default_training_frame:
             ignored_columns = list(set(names) - set(x + [y, offset, folds, weights] + self._additional_used_columns(parms)))

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7931_gam_null_predictors.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7931_gam_null_predictors.py
@@ -1,0 +1,55 @@
+from __future__ import division
+from __future__ import print_function
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+
+# In this test, we check and make sure Gam can run without predictor columns as long as gam column is specified
+def test_gam_null_predictors():
+    print("Checking null predictor run for binomial")
+    h2o_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/gamBinomial1Col.csv"))
+    buildModelMetricsCheck(h2o_data, 'binomial')
+
+    print("Checking null predictor for gaussian")
+    h2o_data = h2o.import_file(
+    path=pyunit_utils.locate("smalldata/gam_test/gamGaussian1Col.csv"))
+    buildModelMetricsCheck(h2o_data, 'gaussian')
+
+    print("Checking null predictor for multinomial")
+    h2o_data = h2o.import_file(
+    path=pyunit_utils.locate("smalldata/gam_test/gamMultinomial1Col.csv"))
+    buildModelMetricsCheck(h2o_data, 'multinomial')
+    
+    print("gam modelmetrics test completed successfully")    
+    
+def buildModelMetricsCheck(train_data, family):
+    x = []
+    y = "response"
+    if not(family == 'gaussian'):
+        train_data[y] = train_data[y].asfactor()
+    frames = train_data.split_frame(ratios=[0.9], seed=12345)
+    
+    h2o_model = H2OGeneralizedAdditiveEstimator(family=family, gam_columns=["C1"])
+    h2o_model.train(x=x, y=y, training_frame=frames[0], validation_frame=frames[1])
+
+    h2o_model2 = H2OGeneralizedAdditiveEstimator(family=family, gam_columns=["C1"])
+    h2o_model2.train(y=y, training_frame=frames[0], validation_frame=frames[1])
+
+    # check and make sure coefficient does not contain predictor column
+    coeffNames = h2o_model.coef().keys()
+    assert not "C1" in coeffNames, "Not expecting C1 to be a coefficient but it is."
+    
+    # check and make sure both model produce the same metrics
+    if family=='gaussian':
+        assert h2o_model.mse() == h2o_model2.mse(), "Expected model MSE: {0}, Actual: {1}".format(h2o_model.mse(), 
+                                                                                                  h2o_model2.mse())
+    else:
+        assert h2o_model.logloss() == h2o_model2.logloss(), "Expected model logloss: {0}, Actual: " \
+                                                            "{1}".format(h2o_model.logloss(), h2o_model2.logloss())
+    
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gam_null_predictors)
+else:
+    test_gam_null_predictors()

--- a/h2o-r/h2o-package/R/gam.R
+++ b/h2o-r/h2o-package/R/gam.R
@@ -204,13 +204,9 @@ h2o.gam <- function(x,
   validation_frame <- .validate.H2OFrame(validation_frame, required=FALSE)
 
   # Validate other required args
-  # If x is missing, then assume user wants to use all columns as features.
+  # If x is missing, no predictors will be used.  Only the gam columns are present as predictors
   if (missing(x)) {
-     if (is.numeric(y)) {
-         x <- setdiff(col(training_frame), y)
-     } else {
-         x <- setdiff(colnames(training_frame), y)
-     }
+      x = NULL
   }
 
   # If gam_columns is missing, then assume user wants to use all columns as features for GAM.
@@ -457,13 +453,9 @@ h2o.gam <- function(x,
   validation_frame <- .validate.H2OFrame(validation_frame, required=FALSE)
 
   # Validate other required args
-  # If x is missing, then assume user wants to use all columns as features.
+  # If x is missing, no predictors will be used.  Only the gam columns are present as predictors
   if (missing(x)) {
-     if (is.numeric(y)) {
-         x <- setdiff(col(training_frame), y)
-     } else {
-         x <- setdiff(colnames(training_frame), y)
-     }
+      x = NULL
   }
 
   # If gam_columns is missing, then assume user wants to use all columns as features for GAM.

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -18,23 +18,27 @@ NULL
 #' @param y response
 #' @param autoencoder autoencoder flag
 .verify_dataxy <- function(data, x, y, autoencoder = FALSE) {
-  if(!is.character(x) && !is.numeric(x))
+  if(!is.null(x) && !is.character(x) && !is.numeric(x)) # only check if x is not null
     stop('`x` must be column names or indices')
   if( !autoencoder )
     if(!is.character(y) && !is.numeric(y))
       stop('`y` must be a column name or index')
 
   cc <- colnames(chk.H2OFrame(data))
-
-  if(is.character(x)) {
-    if(!all(x %in% cc))
-      stop("Invalid column names: ", paste(x[!(x %in% cc)], collapse=','))
-    x_i <- match(x, cc)
+  
+  if (!is.null(x)) {
+    if(is.character(x)) {
+      if(!all(x %in% cc))
+        stop("Invalid column names: ", paste(x[!(x %in% cc)], collapse = ','))
+      x_i <- match(x, cc)
+    } else {
+      if(any( x < 1L | x > attr(x,'ncol')))
+        stop('out of range explanatory variable ', paste(x[x < 1L | x > length(cc)], collapse = ','))
+      x_i <- x
+      x <- cc[x_i]
+    }
   } else {
-    if(any( x < 1L | x > attr(x,'ncol')))
-      stop('out of range explanatory variable ', paste(x[x < 1L | x > length(cc)], collapse=','))
-    x_i <- x
-    x <- cc[x_i]
+    x_i <- NULL
   }
 
   x_ignore <- c()
@@ -50,7 +54,7 @@ NULL
       y <- cc[y]
     }
 
-    if(!autoencoder && (y %in% x)) {
+    if(!is.null(x) && !autoencoder && (y %in% x)) {
       warning('removing response variable from the explanatory variables')
       x <- setdiff(x,y)
     }

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7931_gam_null_predictors.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7931_gam_null_predictors.R
@@ -1,0 +1,22 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# make sure gam will run without predictor with just gam columns.
+test.model.gam.null.predictors <- function() {
+    data <- h2o.importFile(path = locate("smalldata/gam_test/gamGaussian1Col.csv"))
+    gam_model <- h2o.gam(y = "response", gam_columns = c("C1"), training_frame = data, family = "gaussian")
+    gam_model2 <- h2o.gam(x = c(), y = "response", gam_columns = c("C1"), training_frame = data, family = "gaussian")
+    coeff1 <- gam_model@model$coefficients
+    coeff2 <- gam_model2@model$coefficients
+    
+    # coefficients from both models should be the same
+    compareResult <- coeff1==coeff2
+    expect_equal(sum(compareResult), length(coeff1))
+    
+    # make sure feature name C1 not in coefficient names
+    coeff_names <- gam_model@model$names
+    expect_true(!("C1" %in% coeff_names))
+    
+}
+
+doTest("General Additive Model test null predictor with Gaussian family", test.model.gam.null.predictors)


### PR DESCRIPTION
This PR fixes the problem in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-7931

I have fixed the R/Python clients to allow no predictor column or null predictor column to be specified for GAM.
In addition, I added R and Python tests to make sure it works.