### PR TITLE
Corrected typo in Python example drf.rst

### DIFF
--- a/h2o-docs/src/product/data-science/drf.rst
+++ b/h2o-docs/src/product/data-science/drf.rst
@@ -343,7 +343,7 @@ Below is a simple example showing how to build a Random Forest model.
     cars_drf.train(x=predictors, 
                    y=response, 
                    training_frame=train, 
-                   validation_frame=valid
+                   validation_frame=valid)
 
     # Eval performance:
     perf = cars_drf.model_performance()


### PR DESCRIPTION
cars_drf.train(... was missing closing parenthesis )