### PR TITLE
Fix CoxPH scoring history

### DIFF
--- a/h2o-algos/src/main/java/hex/coxph/CoxPH.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPH.java
@@ -604,7 +604,7 @@ public class CoxPH extends ModelBuilder<CoxPHModel,CoxPHModel.CoxPHParameters,Co
           Timer loglikTimer = new Timer();
           final double newLoglik = calcLoglik(dinfo, cs, _parms, coxMR)._logLik;
           Log.info("LogLik: iter=" + i + ", time=" + loglikTimer.toString() + ", logLig=" + newLoglik);
-          model._output._scoring_history = sc.addIterationScore(i, newLoglik).to2dTable(i);
+          model._output._scoring_history = sc.addIterationScore(i, newLoglik).to2dTable(i+1);
 
           if (newLoglik > logLik) {
             if (i == 0)


### PR DESCRIPTION
`to2dTable` is expecting iteration count (`iterCnt`) but it gets a zero-based iteration number so to make a count from it we need to add 1.