### PR TITLE
PUBDEV-7861 - fix runit_init_https test

### DIFF
--- a/h2o-r/h2o-package/R/connection.R
+++ b/h2o-r/h2o-package/R/connection.R
@@ -189,7 +189,7 @@ h2o.init <- function(ip = "localhost", port = 54321, name = NA_character_, start
   if (!h2o.clusterIsUp(tmpConn)) {
     if (!startH2O)
       stop("Cannot connect to H2O server. Please check that H2O is running at ", h2o.getBaseURL(tmpConn))
-    else if (.h2o.__CLIENT_VERSION())
+    else if (.h2o.__CLIENT_VERSION)
       stop("Client version of the library cannot be used to start a local H2O instance. Use h2o.connect(ip=\"hostname\", port=number) instead.")
     else if (ip == "localhost" || ip == "127.0.0.1") {
       cat("\nH2O is not running yet, starting it now...\n")
@@ -350,7 +350,7 @@ h2o.connect <- function(ip = "localhost", port = 54321, strict_version_check = T
 h2o.getConnection <- function() {
   conn <- .attemptConnection()
   if (is.null(conn))
-    if (.h2o.__CLIENT_VERSION())
+    if (.h2o.__CLIENT_VERSION)
       stop("No active connection to an H2O cluster. Did you run `h2o.connect(ip=\"hostname\", port=number)` ?")
     else
       stop("No active connection to an H2O cluster. Did you run `h2o.init()` ?")
@@ -497,7 +497,7 @@ h2o.clusterStatus <- function() {
     "----------------------------------------------------------------------\n",
     "\n")
 
-  if (.h2o.__CLIENT_VERSION())
+  if (.h2o.__CLIENT_VERSION)
     msg = paste0(msg, "Your next step is to connect to H2O:\n", "    > h2o.connect(ip=\"hostname\", port=number)\n")
   else
     msg = paste0(msg, "Your next step is to start H2O:\n", "    > h2o.init()\n")
@@ -509,7 +509,7 @@ h2o.clusterStatus <- function() {
     "    > ??h2o\n",
     "\n")
 
-    if (!.h2o.__CLIENT_VERSION())
+    if (!.h2o.__CLIENT_VERSION)
       msg = paste0(
         msg,
         "After starting H2O, you can use the Web UI at http://localhost:54321\n",

--- a/h2o-r/h2o-package/R/constants.R
+++ b/h2o-r/h2o-package/R/constants.R
@@ -159,4 +159,16 @@ assign("LOG_FILE_NAME", NULL,  .pkg.env)
 
 # Client version of R package
 .h2o.__CLIENT_VERSION_FILENAME <- "client_info.txt"
-.h2o.__CLIENT_VERSION <- function() {return(file.exists(paste0(path.package("h2o", quiet = FALSE), .Platform$file.sep, .h2o.__CLIENT_VERSION_FILENAME)))}
+
+# Return True if installed h2o package location contain .h2o.__CLIENT_VERSION_FILENAME file
+# In case of any error return False always
+.h2o.__CLIENT_VERSION <- function() {
+  tryCatch(
+    return(
+      file.exists(
+        paste0(path.package("h2o", quiet = FALSE), .Platform$file.sep, .h2o.__CLIENT_VERSION_FILENAME)
+      )
+    ),
+    error = function(e) return(FALSE)
+  )
+}

--- a/h2o-r/h2o-package/R/constants.R
+++ b/h2o-r/h2o-package/R/constants.R
@@ -161,14 +161,4 @@ assign("LOG_FILE_NAME", NULL,  .pkg.env)
 .h2o.__CLIENT_VERSION_FILENAME <- "client_info.txt"
 
 # Return True if installed h2o package location contain .h2o.__CLIENT_VERSION_FILENAME file
-# In case of any error return False always
-.h2o.__CLIENT_VERSION <- function() {
-  tryCatch(
-    return(
-      file.exists(
-        paste0(path.package("h2o", quiet = FALSE), .Platform$file.sep, .h2o.__CLIENT_VERSION_FILENAME)
-      )
-    ),
-    error = function(e) return(FALSE)
-  )
-}
+.h2o.__CLIENT_VERSION <- system.file(.h2o.__CLIENT_VERSION_FILENAME, package = "h2o") != ""


### PR DESCRIPTION
In case of any error don't check file location and always return False.

It could be done with "quite = TRUE" but in that case we check for location /client_info.txt. With this implementation we avoid check of any unknown location and directly return False.