### PR TITLE
Assign iteration from the winning submodel to the final model when used with lambda search

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMModel.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMModel.java
@@ -1533,6 +1533,7 @@ public class GLMModel extends Model<GLMModel,GLMModel.GLMParameters,GLMModel.GLM
       int lambdaSearch = 0;
       if (_parms._lambda_search) {
         lambdaSearch = 1;
+        iter = _output._submodels[_output._selected_submodel_idx].iteration;
         _output._model_summary.set(0, 3, "nlambda = " + _parms._nlambdas + ", lambda.max = " + MathUtils.roundToNDigits(_lambda_max, 4) + ", lambda.min = " + MathUtils.roundToNDigits(_output.lambda_best(), 4) + ", lambda.1se = " + MathUtils.roundToNDigits(_output.lambda_1se(), 4));
       }
       int intercept = _parms._intercept ? 1 : 0;


### PR DESCRIPTION
![alpha_best_selected](https://user-images.githubusercontent.com/61695433/102366077-81413a00-3fb8-11eb-8704-52655d6f328d.png)

`number_of_iterations` in model_summary does not correspond to the number of iterations for the given model assuming `scoring_history` contains all the iterations.

After some digging, I noticed that during lambda search, we overwrite the `_state._iter` so when we generate the model_summary we get use the `number_of_iterations` of the last trained (sub)model instead of the winning one.
This PR, contains a trivial fix that does seem to work as can be seen below.
However, the GLM code is quite unfamiliar to me so it's possible that the fix is incorrect.

![Rplot01](https://user-images.githubusercontent.com/61695433/102367673-50fa9b00-3fba-11eb-842e-8ba4b90e5cb3.png)

