### PR TITLE
PUBDEV-7871 - Red Hat certification for H2O Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,0 @@
-# Dockerignore reducing time cost of context upload during docker build for docker/public/Dockerfile-h2o-release.
-# This Dockerfile requires whole H2O folder as context, as it uses multiple files across the project.
-
-# Ignore everything by default 
-*
-# Selectively enable files required.
-!build/h2o.jar
-!LICENSE

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Dockerignore reducing time cost of context upload during docker build for docker/public/Dockerfile-h2o-release.
+# This Dockerfile requires whole H2O folder as context, as it uses multiple files across the project.
+
+# Ignore everything by default 
+*
+# Selectively enable files required.
+!build/h2o.jar
+!LICENSE

--- a/docker/public/Dockerfile-h2o-release
+++ b/docker/public/Dockerfile-h2o-release
@@ -1,6 +1,27 @@
-FROM openjdk:11
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
+ARG H2O_VERSION
+# Mandatory labels required by Red Hat for certification
+LABEL "name"="H2O Open Source Machine Learning"
+LABEL "vendor"="H2O.ai"
+LABEL "version"=${H2O_VERSION}
+LABEL "release"=${H2O_VERSION}
+LABEL "summary"="H2O Open Source Machine Learning platform"
+LABEL "description"="H2O is an Open Source, Distributed, Fast & Scalable Machine Learning Platform: Deep Learning, Gradient Boosting (GBM) & XGBoost, Random Forest, Generalized Linear Modeling (GLM with Elastic Net), K-Means, PCA, Generalized Additive Models (GAM), RuleFit, Support Vector Machine (SVM), Stacked Ensembles, Automatic Machine Learning (AutoML), etc."
+
+# Install OpenJDK 11
+# The Java installed must properly recognize container resource limits
+RUN microdnf install java-11-openjdk
+RUN microdnf clean all
+
+# Copy H2O-3 artifact into the container
 RUN mkdir -p /opt/h2oai/h2o-3/
-COPY h2o.jar /opt/h2oai/h2o-3/
+COPY build/h2o.jar /opt/h2oai/h2o-3/
 
+# Copy project's license into the container (required by Red Hat for certification)
+RUN mkdir /licenses
+COPY LICENSE /licenses/
+
+# By default, run H2O and allocate only 50 percent of memory available to the JVM, the rest remains free for XGBoost
+# Overridable by the user
 CMD java -XX:+UseContainerSupport -XX:MaxRAMPercentage=50 -jar /opt/h2oai/h2o-3/h2o.jar

--- a/docker/public/Dockerfile-h2o-release
+++ b/docker/public/Dockerfile-h2o-release
@@ -16,7 +16,7 @@ RUN microdnf clean all
 
 # Copy H2O-3 artifact into the container
 RUN mkdir -p /opt/h2oai/h2o-3/
-COPY build/h2o.jar /opt/h2oai/h2o-3/
+COPY h2o.jar /opt/h2oai/h2o-3/
 
 # Copy project's license into the container (required by Red Hat for certification)
 RUN mkdir /licenses

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -511,14 +511,21 @@ check-leaks:
 	fi
 
 h2o-k8s-docker-build:
-	 docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -f docker/public/Dockerfile-h2o-release build/
+	 docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -f docker/public/Dockerfile-h2o-release .
 
 h2o-k8s-docker-push:
 	docker login -u $(DOCKERHUB_USERNAME) -p $(DOCKERHUB_PASSWORD)
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
-
+	
+h2o-k8s-docker-push-redhat:
+	echo ${H2O_RED_HAT_REGISTRY_KEY} | docker login -u unused scan.connect.redhat.com --password-stdin
+	docker tag $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) scan.connect.redhat.com/$(H2O_RED_HAT_PID)/h2oai/h2o:$(DOCKER_IMAGE_TAG)
+	docker push scan.connect.redhat.com/$(H2O_RED_HAT_PID)/h2oai/h2o:$(DOCKER_IMAGE_TAG)
+	$(eval DIGEST := $(shell docker images --no-trunc --quiet scan.connect.redhat.com/$(H2O_RED_HAT_PID)/h2oai/h2o:$(DOCKER_IMAGE_TAG)))
+	python scripts/jenkins/red_hat/red_hat_docker_certification.py --api_key $(H2O_RED_HAT_APIKEY) --pid $(H2O_RED_HAT_PID) --tag $(DOCKER_IMAGE_TAG) $(DIGEST)
+	
 h2o-k8s-docker-build-latest:
-	docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG) -f docker/public/Dockerfile-h2o-release build/
+	docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG) -f docker/public/Dockerfile-h2o-release .
 
 h2o-k8s-docker-push-latest: h2o-k8s-docker-push
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG)

--- a/scripts/jenkins/Makefile.jenkins
+++ b/scripts/jenkins/Makefile.jenkins
@@ -511,7 +511,9 @@ check-leaks:
 	fi
 
 h2o-k8s-docker-build:
-	 docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -f docker/public/Dockerfile-h2o-release .
+	 cp LICENSE build/LICENSE
+	 docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -f docker/public/Dockerfile-h2o-release build/
+	 rm build/LICENSE
 
 h2o-k8s-docker-push:
 	docker login -u $(DOCKERHUB_USERNAME) -p $(DOCKERHUB_PASSWORD)
@@ -525,7 +527,9 @@ h2o-k8s-docker-push-redhat:
 	python scripts/jenkins/red_hat/red_hat_docker_certification.py --api_key $(H2O_RED_HAT_APIKEY) --pid $(H2O_RED_HAT_PID) --tag $(DOCKER_IMAGE_TAG) $(DIGEST)
 	
 h2o-k8s-docker-build-latest:
-	docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG) -f docker/public/Dockerfile-h2o-release .
+	cp LICENSE build/LICENSE
+	docker build --build-arg H2O_VERSION=$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG) -f docker/public/Dockerfile-h2o-release build/
+	rm build/LICENSE
 
 h2o-k8s-docker-push-latest: h2o-k8s-docker-push
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_LATEST_TAG)

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -286,10 +286,12 @@ try {
                         try {
                             pipelineContext.getBuildSummary().addStageSummary(this, BUILD_H2O_DOCKER_STAGE_NAME, env.BUILD_NUMBER_DIR)
                             pipelineContext.getBuildSummary().setStageDetails(this, BUILD_H2O_DOCKER_STAGE_NAME, env.NODE_NAME, env.WORKSPACE)
-                            withCredentials([usernamePassword(credentialsId: 'dockerhub', passwordVariable: 'DOCKERHUB_PASSWORD', usernameVariable: 'DOCKERHUB_USERNAME'),
+                            withCredentials([
+                                  usernamePassword(credentialsId: 'dockerhub', passwordVariable: 'DOCKERHUB_PASSWORD', usernameVariable: 'DOCKERHUB_USERNAME'),
                                   string(credentialsId: 'H2O_RED_HAT_REGISTRY_KEY', variable: 'H2O_RED_HAT_REGISTRY_KEY'),
                                   string(credentialsId: 'H2O_RED_HAT_PID', variable: 'H2O_RED_HAT_PID'),
-                                  string(credentialsId: 'H2O_RED_HAT_APIKEY', variable: 'H2O_RED_HAT_APIKEY')]) {
+                                  string(credentialsId: 'H2O_RED_HAT_APIKEY', variable: 'H2O_RED_HAT_APIKEY')
+                                  ]) {
                                 if (params.TEST_RELEASE) {
                                     env["DOCKER_IMAGE_NAME"] = "opsh2oai/h2o-open-source-k8s-test"
                                     // Test release goes to opsh2oai namespace

--- a/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
+++ b/scripts/jenkins/jenkinsfiles/Jenkinsfile-Release
@@ -286,7 +286,10 @@ try {
                         try {
                             pipelineContext.getBuildSummary().addStageSummary(this, BUILD_H2O_DOCKER_STAGE_NAME, env.BUILD_NUMBER_DIR)
                             pipelineContext.getBuildSummary().setStageDetails(this, BUILD_H2O_DOCKER_STAGE_NAME, env.NODE_NAME, env.WORKSPACE)
-                            withCredentials([usernamePassword(credentialsId: 'dockerhub', passwordVariable: 'DOCKERHUB_PASSWORD', usernameVariable: 'DOCKERHUB_USERNAME')]) {
+                            withCredentials([usernamePassword(credentialsId: 'dockerhub', passwordVariable: 'DOCKERHUB_PASSWORD', usernameVariable: 'DOCKERHUB_USERNAME'),
+                                  string(credentialsId: 'H2O_RED_HAT_REGISTRY_KEY', variable: 'H2O_RED_HAT_REGISTRY_KEY'),
+                                  string(credentialsId: 'H2O_RED_HAT_PID', variable: 'H2O_RED_HAT_PID'),
+                                  string(credentialsId: 'H2O_RED_HAT_APIKEY', variable: 'H2O_RED_HAT_APIKEY')]) {
                                 if (params.TEST_RELEASE) {
                                     env["DOCKER_IMAGE_NAME"] = "opsh2oai/h2o-open-source-k8s-test"
                                     // Test release goes to opsh2oai namespace
@@ -306,7 +309,7 @@ try {
                                         env["DOCKER_IMAGE_TAG"] = "nightly"
                                         sh """
                                           cd ${env.BUILD_NUMBER_DIR}
-                                          make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build h2o-k8s-docker-push
+                                          make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build h2o-k8s-docker-push-redhat h2o-k8s-docker-push
                                         """
                                     } else {
                                         env["DOCKER_IMAGE_TAG"] = env["PROJECT_VERSION"]
@@ -316,14 +319,15 @@ try {
                                             env["DOCKER_IMAGE_LATEST_TAG"] = "latest"
                                             sh """
                                               cd ${env.BUILD_NUMBER_DIR}
-                                              make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build-latest h2o-k8s-docker-push-latest
+                                              make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build-latest h2o-k8s-docker-push-latest h2o-k8s-docker-push-redhat
                                             """
                                         } else {
                                             // If the build is not a test build and is an ordinary release, update the latest tag.
                                             // The "latest" tag means stable. If UPDATE_LATEST is set to false do not update the latest tag and push only the version tag.
+                                            // Push to Red Hat either way
                                             sh """
                                               cd ${env.BUILD_NUMBER_DIR}
-                                              make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build h2o-k8s-docker-push
+                                              make -f scripts/jenkins/Makefile.jenkins h2o-k8s-docker-build h2o-k8s-docker-push-redhat h2o-k8s-docker-push
                                             """
                                         }
                                     }

--- a/scripts/jenkins/red_hat/red_hat_docker_certification.py
+++ b/scripts/jenkins/red_hat/red_hat_docker_certification.py
@@ -1,0 +1,89 @@
+import argparse
+import sys
+import time
+
+import requests
+
+
+def has_scan_errors(digest, pid, api_key):
+    """
+    Waits for image scan to complete and checks the results. Prints errors found.
+
+    :param digest: A digest of the docker image to check errors of
+    :param pid: Project identified (PID) from Red Hat Connect portal
+    :param api_key: API Key associated with the Red Hat account. Considered secret.
+    :return: True if errors are found, otherwise false.
+    """
+    url = "https://connect.redhat.com/api/v2/container/{}/certResults/{}".format(pid, digest)
+    headers = {"accept": "*/*",
+               "Authorization": "Bearer {}".format(api_key)}
+
+    # Wait for HTTP 200 Response from the certification results endpoint
+    response = None
+    while response is None:
+        intermediate_response = requests.get(url=url, headers=headers)
+        if intermediate_response.status_code == 200:
+            response = intermediate_response
+        else:
+            time.sleep(5)
+
+    # Iterate over scan results, print them and search for erroneous states
+    scan_err_present = False
+    print("Scan of image '{}' complete.".format(digest))
+    for requirement, check_result in response.json()["data"]["results"].items():
+        print("{}: {}".format(requirement, check_result))
+        if not check_result:
+            scan_err_present = True
+
+    if scan_err_present:
+        print("Scan errors found. Please address the issues and push the image again.")
+
+    return scan_err_present
+
+
+def publish(digest, pid, api_key, tag):
+    """
+    Publishes given image identified by given image digest. Prints the result of this operation.
+    Latest tag is automatically applied.
+    :param digest: A digest of the docker image to check errors of
+    :param pid: Project identified (PID) from Red Hat Connect portal
+    :param api_key: API Key associated with the Red Hat account. Considered secret.
+    :param tag: An existing container tag for container identification
+    :return: Nothing.
+    """
+    url = "https://connect.redhat.com/api/v2/projects/{}/containers/{}/tags/{}/publish".format(pid, digest, tag)
+    headers = {"accept": "*/*",
+               "Content-Type": "application/json",
+               "Authorization": "Bearer {}".format(api_key)}
+
+    response = requests.post(url, headers=headers)
+
+    if response.status_code != 201:
+        print("Unable to publish, invalid status code: {}.".format(response.status_code))
+        print(response)
+        print(response.content)
+        sys.exit(1)
+    else:
+        print("Docker image '{}' successfully scheduled for publishing.".format(digest))
+
+
+def extract_arguments(args):
+    parsed_args = args.parse_args()
+    return parsed_args.digest, parsed_args.pid, parsed_args.api_key, parsed_args.tag
+
+
+if __name__ == '__main__':
+    args = argparse.ArgumentParser("H2O Operator Red Hat certification tool")
+    args.add_argument("digest", help="Digest (typically SHA256) of the Docker image intended for certification",
+                      metavar="D", type=str)
+    args.add_argument("--pid", required=True, help="Red Hat Project ID (PID). To be found in connect.redhat.com",
+                      type=str)
+    args.add_argument("--api_key", required=True, help="API Key for Red Hat Connect Portal API", type=str)
+    args.add_argument("--tag", required=True,
+                      help="An existing tag of the docker image published. Make sure the docker image was pushed with this tag for scanning.")
+
+    digest, pid, api_key, tag = extract_arguments(args)
+    if not has_scan_errors(digest=digest, pid=pid, api_key=api_key):
+        publish(digest=digest, pid=pid, api_key=api_key, tag=tag)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7871
H2O Docker image has to be certified against Red Hat
- H2O Docker image is based on UBI (Red Hat Universal Base Image)
- OpenJDK 11 is installed. Tried detection of cgroup resources locally & manually just to be sure.
- Same image is used for operator. More lightweight. Will be pushed to hub.docker.com as well. This means starting this release, the official H2O open source docker image will be on UBI.
- Has to be pushed to Docker registry as well. For that, we need three secrets: `H2O_RED_HAT_REGISTRY_KEY`, `H2O_RED_HAT_PID`, and `H2O_RED_HAT_APIKEY`. Contacted @abal5 about adding them to Jenkins.
- Test releases are NOT pushed to RH at all