### PR TITLE
External XGBoost test fix

### DIFF
--- a/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/remote/SteamExecutorStarterTest.java
+++ b/h2o-extensions/xgboost/src/test/java/hex/tree/xgboost/remote/SteamExecutorStarterTest.java
@@ -32,7 +32,6 @@ public class SteamExecutorStarterTest {
     
     @BeforeClass
     public static void configureRemoteXGBoost() {
-        System.setProperty("sys.ai.h2o.steam.notification.timeout", "2000");
         orig_external_xgboost = H2O.ARGS.use_external_xgboost;
         H2O.ARGS.use_external_xgboost = true;
     }
@@ -40,14 +39,13 @@ public class SteamExecutorStarterTest {
     @AfterClass
     public static void revertRemoteXGBoost() {
         H2O.ARGS.use_external_xgboost = orig_external_xgboost;
-        System.clearProperty("sys.ai.h2o.steam.notification.timeout");
     }
 
-    private Map<String, String> makeStartResponse(Map<String, String> startReq) {
-        return makeStartResponse(startReq, "started", null);
+    private Map<String, String> makeStartedResponse(Map<String, String> startReq) {
+        return makeStartedResponse(startReq, "started", null);
     }
 
-    private Map<String, String> makeStartResponse(Map<String, String> startReq, String status, String reason) {
+    private Map<String, String> makeStartedResponse(Map<String, String> startReq, String status, String reason) {
         Map<String, String> startResp = new HashMap<>();
         startResp.put(ID, startReq.get(ID) + "_response");
         startResp.put(TYPE, "xgboostClusterStartNotification");
@@ -102,7 +100,7 @@ public class SteamExecutorStarterTest {
             assertNotNull(startReq.get("_id"));
             assertEquals("startXGBoostCluster", startReq.get("_type"));
             steam.sendMessage(makeStartingResponse(startReq));
-            steam.sendMessage(makeStartResponse(startReq));
+            steam.sendMessage(makeStartedResponse(startReq));
             Scope.track_generic(model1.get());
 
             // second model should not go to steam
@@ -111,8 +109,8 @@ public class SteamExecutorStarterTest {
             Scope.track_generic(model2.get());
 
             // steam requests cluster stop
-            steam.sendMessage(makeStopReq("stop_req"));
-            expectAndCheckStopResponse(steam, "stop_req", true);
+            steam.sendMessage(makeStopReq("01_stop_req"));
+            expectAndCheckStopResponse(steam, "01_stop_req", true);
         } finally {
             steam.close();
             Scope.exit();
@@ -138,7 +136,7 @@ public class SteamExecutorStarterTest {
             assertEquals("startXGBoostCluster", startReq.get("_type"));
 
             // fail first cluster request
-            steam.sendMessage(makeStartResponse(startReq, "failed", "Testing in progress"));
+            steam.sendMessage(makeStartedResponse(startReq, "failed", "Testing in progress"));
             try {
                 Scope.track_generic(model1.get());
                 fail("Expected exception to be thrown");
@@ -160,6 +158,7 @@ public class SteamExecutorStarterTest {
     public void testSteamClusterTimeout() throws Exception {
         Scope.enter();
         final WebsocketClient steam = new WebsocketClient();
+        System.setProperty("sys.ai.h2o.steam.notification.timeout", "2000");
         try {
             Frame train = Scope.track(parse_test_file("./smalldata/prostate/prostate.csv"));
 
@@ -188,7 +187,7 @@ public class SteamExecutorStarterTest {
             }
             
             // steam responds eventually
-            steam.sendMessage(makeStartResponse(startReq));
+            steam.sendMessage(makeStartedResponse(startReq));
 
             // try again
             Job<XGBoostModel> model2 = new XGBoost(params).trainModel();
@@ -198,13 +197,14 @@ public class SteamExecutorStarterTest {
 
             // original start response message is ignored, waits for new confirmation
             steam.sendMessage(makeStartingResponse(startRe2));
-            steam.sendMessage(makeStartResponse(startRe2));
+            steam.sendMessage(makeStartedResponse(startRe2));
             Scope.track_generic(model2.get());
 
             // steam requests cluster stop
-            steam.sendMessage(makeStopReq("stop_req"));
-            expectAndCheckStopResponse(steam, "stop_req", true);
+            steam.sendMessage(makeStopReq("02_stop_req"));
+            expectAndCheckStopResponse(steam, "02_stop_req", true);
         } finally {
+            System.clearProperty("sys.ai.h2o.steam.notification.timeout");
             steam.close();
             Scope.exit();
         }
@@ -229,19 +229,19 @@ public class SteamExecutorStarterTest {
             Map<String, String> startReq = steam.waitToReceiveMessage("start request");
             assertNotNull(startReq.get("_id"));
             assertEquals("startXGBoostCluster", startReq.get("_type"));
-            steam.sendMessage(makeStartResponse(startReq));
+            steam.sendMessage(makeStartedResponse(startReq));
 
             // steam requests cluster stop
             Thread.sleep(500);
-            steam.sendMessage(makeStopReq("stop_req_01"));
-            expectAndCheckStopResponse(steam, "stop_req_01", false);
+            steam.sendMessage(makeStopReq("03_stop_req_01"));
+            expectAndCheckStopResponse(steam, "03_stop_req_01", false);
 
             // model finishes
             Scope.track_generic(model.get());
 
             // steam requests cluster stop again
-            steam.sendMessage(makeStopReq("stop_req_02"));
-            expectAndCheckStopResponse(steam, "stop_req_02", true);
+            steam.sendMessage(makeStopReq("03_stop_req_02"));
+            expectAndCheckStopResponse(steam, "03_stop_req_02", true);
 
             // building another model
             params._ntrees = 5;
@@ -251,13 +251,13 @@ public class SteamExecutorStarterTest {
             Map<String, String> startReq2 = steam.waitToReceiveMessage("start request");
             assertNotNull(startReq2.get("_id"));
             assertEquals("startXGBoostCluster", startReq2.get("_type"));
-            steam.sendMessage(makeStartResponse(startReq));
+            steam.sendMessage(makeStartedResponse(startReq));
 
             Scope.track_generic(model2.get());
 
             // steam requests cluster stop
-            steam.sendMessage(makeStopReq("stop_req_03"));
-            expectAndCheckStopResponse(steam, "stop_req_03", true);
+            steam.sendMessage(makeStopReq("03_stop_req_03"));
+            expectAndCheckStopResponse(steam, "03_stop_req_03", true);
         } finally {
             steam.close();
             Scope.exit();
@@ -270,8 +270,8 @@ public class SteamExecutorStarterTest {
         final WebsocketClient steam = new WebsocketClient();
         try {
             // steam requests cluster stop
-            steam.sendMessage(makeStopReq("stop_req_01"));
-            expectAndCheckStopResponse(steam, "stop_req_01", true);
+            steam.sendMessage(makeStopReq("04_stop_req"));
+            expectAndCheckStopResponse(steam, "04_stop_req", true);
         } finally {
             steam.close();
             Scope.exit();
@@ -298,11 +298,11 @@ public class SteamExecutorStarterTest {
             assertEquals("startXGBoostCluster", startReq.get("_type"));
 
             // steam requests cluster stop
-            steam.sendMessage(makeStopReq("stop_req_01"));
-            expectAndCheckStopResponse(steam, "stop_req_01", false);
+            steam.sendMessage(makeStopReq("05_stop_req"));
+            expectAndCheckStopResponse(steam, "05_stop_req", false);
 
             // steam fails cluster start
-            steam.sendMessage(makeStartResponse(startReq, "failed", "testing"));
+            steam.sendMessage(makeStartedResponse(startReq, "failed", "testing"));
             try {
                 Scope.track_generic(model.get());
                 fail("Expected exception to be thrown");

--- a/h2o-test-support/src/main/java/water/test/WebsocketClient.java
+++ b/h2o-test-support/src/main/java/water/test/WebsocketClient.java
@@ -2,6 +2,7 @@ package water.test;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import org.apache.log4j.Logger;
 import org.glassfish.tyrus.client.ClientManager;
 import water.H2O;
 
@@ -15,11 +16,14 @@ import java.util.Optional;
 import static org.junit.Assert.fail;
 
 public class WebsocketClient extends Endpoint {
+    
+    private static final Logger LOG = Logger.getLogger(WebsocketClient.class);
+
+    private final Session sess;
+    private final Gson gson = new Gson();
 
     private Map<String, String> receivedMessage;
-    private Session sess;
-
-    private final Gson gson = new Gson();
+    private String overflowMessage;
     
     public WebsocketClient() throws URISyntaxException, IOException, DeploymentException {
         String destUri = "ws://" + H2O.getIpPortString() + "/3/Steam.websocket";
@@ -35,16 +39,23 @@ public class WebsocketClient extends Endpoint {
     @OnOpen
     public void onOpen(Session session, EndpointConfig config) {
         session.addMessageHandler(String.class, message -> {
-            System.out.println("Received message: " + message);
+            LOG.info("Received message from H2O: " + message);
             synchronized (this) {
-                receivedMessage = gson.fromJson(message, new TypeToken<Map<String, String>>() {}.getType());
+                if (receivedMessage != null) {
+                    LOG.info("Received message not stored as last message was not picked up yet.");
+                    overflowMessage = message;
+                } else {
+                    receivedMessage = gson.fromJson(message, new TypeToken<Map<String, String>>() {}.getType());
+                }
                 this.notifyAll();
             }
         });
     }
     
     public void sendMessage(Object msg) throws IOException {
-        sess.getBasicRemote().sendText(gson.toJson(msg));
+        final String msgStr = gson.toJson(msg);
+        LOG.info("Sending message to H2O: " + msgStr);
+        sess.getBasicRemote().sendText(msgStr);
     }
 
     public Map<String, String> waitToReceiveMessage(String message) {
@@ -56,6 +67,9 @@ public class WebsocketClient extends Endpoint {
     }
 
     public synchronized Optional<Map<String, String>> waitToReceiveMessage(String message, int timeoutMillis, boolean failOnNone) {
+        if (overflowMessage != null) {
+            fail("Message received but not handled: " + overflowMessage);
+        }
         try {
             this.wait(timeoutMillis);
         } catch (InterruptedException e) {


### PR DESCRIPTION
Improved error state detection in the tests - althought none of these ever happen.

Moved decreasing timeout into one specific test to avoid influencing others.