### PR TITLE
Fix stacked ensemble poor models test

### DIFF
--- a/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_with_poor_models.py
+++ b/h2o-py/tests/testdir_algos/stackedensemble/pyunit_stackedensemble_with_poor_models.py
@@ -112,8 +112,7 @@ def test_models_not_predicting_some_classes_dont_corrupt_resulting_SE_model():
         se.train(data.x, data.y, data.train)
         results = scores_and_preds(se, data.test)
         print(results)
-        assert data.domain != results.test_pclasses, "expected predictions not to include all target domain"
-        assert len(results.test_pclasses) == 1
+        assert data.domain == results.test_pclasses, "expected predicted classes {} but got {}".format(data.domain, results.test_pclasses)
 
     def check_stackedensemble_with_GLM_metalearner_with_standardization_disabled(data, models):
         se = H2OStackedEnsembleEstimator(base_models=models,


### PR DESCRIPTION
This issue is that all but the default GLM metalearner  (not the “AUTO”) provide a model with all classes in prediction.
The default GLM didn’t use to. But after [1] it started to provide similar predictions as all the other metalearners (containing all the classes). To me it looks like [1] fixed the issue so my course of action would be to change the test to expect the same as all the other metalearners.

(happens only on master branch)

[1] [PUBDEV-7843] build XGB CV models on multiple GPUs in parallel (#5075)