### PR TITLE
Add a missing DKV.put to GLMBasicTestMultinomial

### DIFF
--- a/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
+++ b/h2o-algos/src/test/java/hex/glm/GLMBasicTestMultinomial.java
@@ -40,6 +40,7 @@ public class GLMBasicTestMultinomial extends TestUtil {
     stall_till_cloudsize(1);
     _covtype = parse_test_file("smalldata/covtype/covtype.20k.data");
     _covtype.replace(_covtype.numCols()-1,_covtype.lastVec().toCategoricalVec()).remove();
+    DKV.put(_covtype);
     Key[] keys = new Key[]{Key.make("train"),Key.make("test")};
     H2O.submitTask(new FrameSplitter(_covtype, new double[]{.8},keys,null)).join();
     _train = DKV.getGet(keys[0]);


### PR DESCRIPTION
The test does this:

    _covtype = parse_test_file("smalldata/covtype/covtype.20k.data");
    _covtype.replace(_covtype.numCols()-1,_covtype.lastVec().toCategoricalVec()).remove();

Updating an object, however, it is failing to also update the state in DKV.

This is missing:

    DKV.put(_covtype);

Now, why did it work before my commit/fix? My fix addressed a race
condition in read-unlock. The read-unlock was previously changing
the outside state of the world and updating the Lockable entity
(in this case a Frame) in DKV. That means read_lock; .. unlock; actually
did the missing DKV.put!