### PR TITLE
Align drop duplicates documentation with R

### DIFF
--- a/h2o-py/h2o/frame.py
+++ b/h2o-py/h2o/frame.py
@@ -3361,10 +3361,17 @@ class H2OFrame(Keyed):
         if measure is None: measure = "l2"
         return H2OFrame._expr(expr=ExprNode("distance", self, y, measure))._frame()
 
-    def drop_duplicates(self, columns, keep = "first"):
+    def drop_duplicates(self, columns, keep="first"):
+        """
+        Drops duplicated rows across specified columns.
+        :param columns: Columns to compare during the duplicate detection process.
+        :param keep: Which rows to keep. Two possible values: ["first", "last"]. The "first" value (default) keeps
+         the first row and deletes the rest. The "last" value keeps the last row.
+        :return: A new H2OFrame with rows deduplicated
+        """
         assert_is_type(columns, [int], [str])
-        assert_is_type(keep,  Enum("first", "last"))
-    
+        assert_is_type(keep, Enum("first", "last"))
+
         return H2OFrame._expr(expr=ExprNode("dropdup", self, columns, keep))._frame()
 
     def strdistance(self, y, measure=None, compare_empty=True):

--- a/h2o-r/h2o-package/R/frame.R
+++ b/h2o-r/h2o-package/R/frame.R
@@ -2940,7 +2940,7 @@ cor <- function (x, ...)
 #'
 #' @param frame An H2OFrame object to drop duplicates on.
 #' @param columns Columns to compare during the duplicate detection process.
-#' @param keep Which rows to keep. The "first" value (default) keeps the first row and delets the rest. 
+#' @param keep Which rows to keep. The "first" value (default) keeps the first row and deletes the rest. 
 #' The "last" keeps the last row.
 #' @examples
 #' \dontrun{


### PR DESCRIPTION
Forgot to document the `drop_duplicates` method. Adding documentation comparable to the one in R, respecting differences between R and Python. Fixed a typo in the R part of the docs.