### PR TITLE
PUBDEV-7953 - Escape quotes by default when writing CSV

### DIFF
--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1572,7 +1572,7 @@ public class Frame extends Lockable<Frame> {
     boolean _headers = true;
     boolean _quoteColumnNames = true; 
     boolean _hexString = false;
-    boolean _escapeQuotes = false;
+    boolean _escapeQuotes = true;
     char _separator = DEFAULT_SEPARATOR;
     char _escapeCharacter = DEFAULT_ESCAPE;
 
@@ -1727,7 +1727,6 @@ public class Frame extends Lockable<Frame> {
 
     byte[] getBytesForRow() {
       StringBuilder sb = new StringBuilder();
-      BufferedString tmpStr = new BufferedString();
       for (int i = 0; i < _curChks.length; i++) {
         Vec v = _curChks[i]._vec;
         if (i > 0) sb.append(_parms._separator);
@@ -1738,7 +1737,8 @@ public class Frame extends Lockable<Frame> {
           } else if (v.isUUID()) sb.append(PrettyPrint.UUID(_curChks[i].at16l(_chkRow), _curChks[i].at16h(_chkRow)));
           else if (v.isInt()) sb.append(_curChks[i].at8(_chkRow));
           else if (v.isString()) {
-            final String escapedString = escapeQuotesForCsv(_curChks[i].atStr(tmpStr, _chkRow).toString());
+            final BufferedString unescapedTempStr = new BufferedString();
+            final String escapedString = escapeQuotesForCsv(_curChks[i].atStr(unescapedTempStr, _chkRow).toString());
             sb.append('"').append(escapedString).append('"');
           } else {
             double d = _curChks[i].atd(_chkRow);
@@ -1787,7 +1787,7 @@ public class Frame extends Lockable<Frame> {
       Chunk anyChunk = _curChks[0];
 
       // Case 3:  Out of data.
-      if (anyChunk._start + _chkRow == anyChunk._vec.length()) {
+      if (anyChunk._start + _chkRow >= anyChunk._vec.length()) {
         return -1;
       }
 

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -1727,6 +1727,7 @@ public class Frame extends Lockable<Frame> {
 
     byte[] getBytesForRow() {
       StringBuilder sb = new StringBuilder();
+      final BufferedString unescapedTempStr = new BufferedString();
       for (int i = 0; i < _curChks.length; i++) {
         Vec v = _curChks[i]._vec;
         if (i > 0) sb.append(_parms._separator);
@@ -1737,7 +1738,6 @@ public class Frame extends Lockable<Frame> {
           } else if (v.isUUID()) sb.append(PrettyPrint.UUID(_curChks[i].at16l(_chkRow), _curChks[i].at16h(_chkRow)));
           else if (v.isInt()) sb.append(_curChks[i].at8(_chkRow));
           else if (v.isString()) {
-            final BufferedString unescapedTempStr = new BufferedString();
             final String escapedString = escapeQuotesForCsv(_curChks[i].atStr(unescapedTempStr, _chkRow).toString());
             sb.append('"').append(escapedString).append('"');
           } else {


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7953

By default (and the clients use the default) in `CSVStreamParams`, the `_escapeQuotes` is set to false. Which leaves quotes inside string and enum tokens exposed, resulting in invalid CSV written as an output. The correct behavior by default is to escape all quotes.

As [RFC-4180](https://tools.ietf.org/html/rfc4180) says: `Fields containing line breaks (CRLF), double quotes, and commas should be enclosed in double-quotes. This means every line with a quote has to be enclosed in quotes as well. This is done. Some writers enclose all tokens in quotes, some selectively enclose only tokens with the above-mentioned characters in quotes. For simplicity and easiness of this change, we do enclose all enums and strings in quotes if quoting is enabled. No detection of quote presence is done, resulting in a slightly larger CSV.

This change also means that even tokens with no special characters inside will be enclosed in quotes - which is perfectly valid.