### PR TITLE
Solve Hadoop system properties clash by relocating to water package

### DIFF
--- a/h2o-docs/src/product/upgrade/Migration.md
+++ b/h2o-docs/src/product/upgrade/Migration.md
@@ -1,3 +1,13 @@
+# Migrating to H2O 3.32.0.4
+
+Due to collision between System properties and H2O Args during as a result of `org.eclipse.jetty.*` packages shadowing,
+such packages are now shadowed to a new name package. Instead of shadowing with `ai.h2o` prefix, those are put into `darkwater.*`
+prefixed packags. LDAP Login module classes are not affected.
+
+- The original package names starting with `org.eclipse.jetty.*` have been shadowed by using `water` prefix, resulting in
+  `darkwater.org.eclipse.jetty.*` pattern.
+
+
 # Migrating to H2O 3.30.1.1
 
 Jetty version 8 has been dropped as default implementation of `h2o-webserver-iface` module, as it is not actively developed and supported anymore.

--- a/h2o-hadoop-3/assemblyjar.gradle
+++ b/h2o-hadoop-3/assemblyjar.gradle
@@ -95,7 +95,7 @@ shadowJar {
     relocate 'org.joda.time', 'ai.h2o.org.joda.time'
     exclude hadoopShadowJarExcludes
     relocate 'com.google.common', 'ai.h2o.com.google.common'
-    relocate 'org.eclipse.jetty', 'ai.h2o.org.eclipse.jetty'
+    relocate 'org.eclipse.jetty', 'darkwater.org.eclipse.jetty'
     baseName = 'h2odriver'
     classifier = ''
     manifest {

--- a/h2o-hadoop-3/h2o-cdp7.0-assembly/build.gradle
+++ b/h2o-hadoop-3/h2o-cdp7.0-assembly/build.gradle
@@ -108,7 +108,7 @@ shadowJar {
     relocate 'org.joda.time', 'ai.h2o.org.joda.time'
     exclude hadoopShadowJarExcludes
     relocate 'com.google.common', 'ai.h2o.com.google.common'
-    relocate 'org.eclipse.jetty', 'ai.h2o.org.eclipse.jetty'
+    relocate 'org.eclipse.jetty', 'darkwater.org.eclipse.jetty'
     baseName = 'h2odriver'
     classifier = ''
     manifest {

--- a/scripts/jenkins/groovy/hadoopCommands.groovy
+++ b/scripts/jenkins/groovy/hadoopCommands.groovy
@@ -54,7 +54,7 @@ private GString getCommandHadoop(final stageConfig) {
 private GString getCommandStandalone(final stageConfig) {
     def defaultPort = 54321
     return """
-            java -cp build/h2o.jar:\$(cat /opt/hive-jdbc-cp) water.H2OApp \\
+            java -cp h2o-hadoop-*/h2o-${stageConfig.customData.distribution}${stageConfig.customData.version}-assembly/build/libs/h2odriver.jar:\$(cat /opt/hive-jdbc-cp) water.H2OApp \\
                 -port ${defaultPort} -ip \$(hostname --ip-address) -name \$(date +%s) \\
                 -jks mykeystore.jks \\
                 -login_conf ${stageConfig.customData.ldapConfigPathStandalone} -ldap_login \\


### PR DESCRIPTION
## Problem

As different Hadoop distributions package different versions of Jetty, H2O shadows its own Jetty: `relocate 'org.eclipse.jetty', 'ai.h2o.org.eclipse.jetty'`. When running  via `water.H2OApp` as application entrypoint, there is the following code to be found in the `psvm` method of the class:

```java
      if( s.startsWith("ai.h2o.") ) {
        args2.add("-" + s.substring(7)); 
        // hack: Junits expect properties, throw out dummy prop for ga_opt_out
        if (!s.substring(7).equals("ga_opt_out") && !System.getProperty(s).isEmpty())
          args2.add(System.getProperty(s));
      }
```

The `s` variable is a system property key obtained by calling `System.getProperties()`. Before this code is executed, method `configureLogging` is ran. This method sets a couple of jetty-specific properties, like `System.setProperty("org.eclipse.jetty.LEVEL", "WARN");`. The **problem** is, once the relocation is done by Gradle, the value is actually prefixed with `ai.h2o` as well, resulting in `System.setProperty("ai.h2o.org.eclipse.jetty.LEVEL", "WARN");`. This means such a system property intended to configure Jetty logging is then treated as H2O parameter. Such parameter doesn't exist and H2O fails to start. Test pipeline did not catch this, as it is using `java -cp build/h2o.jar:\$(cat /opt/hive-jdbc-cp) water.H2OApp \\` in the standalone mode.

I did the check and the resulting `h2odriver.jar` truly contains the strings changed to the relocated version.

## Solution
Relocate eclipse into `water.*` packages instead of `ai.h2o`.
- No need to relocate `ai.h2o.org.eclipse.jetty.plus.jaas.spi.LdapLoginModule` and similar classes. Contract on these stays the same.
- Migration guide has to be updated.
- Potential problem for our users.

## Alternative solution:

Alternative solution based on filtering out exact matches of the eclipse logging props : https://github.com/h2oai/h2o-3/pull/5249

## Hadoop tests:

Hadoop smoke tests are here: http://mr-0xg1:8080/view/H2O-3/job/h2o-3-hadoop-smoke-pipeline/job/pavel%252Fhadoop-3-relocate/