### PR TITLE
PUBDEV-8097: H2O won't start with system properties that begin with 'ai.h2o.'

### DIFF
--- a/h2o-core/src/main/java/water/H2O.java
+++ b/h2o-core/src/main/java/water/H2O.java
@@ -1,7 +1,6 @@
 package water;
 
 import hex.ModelBuilder;
-import hex.faulttolerance.Recovery;
 import jsr166y.CountedCompleter;
 import jsr166y.ForkJoinPool;
 import jsr166y.ForkJoinWorkerThread;
@@ -2173,7 +2172,19 @@ final public class H2O {
       return true;
     }
     return false;
-  } 
+  }
+
+  /**
+   * Any system property starting with `ai.h2o.` and containing any more `.` does not match
+   * this pattern and is therefore ignored. This is mostly to prevent system properties
+   * serving as configuration for H2O's dependencies (e.g. `ai.h2o.org.eclipse.jetty.LEVEL` ).
+   */
+  static boolean isArgProperty(String name) {
+    final String prefix = "ai.h2o.";
+    if (!name.startsWith(prefix))
+      return false;
+    return name.lastIndexOf('.') < prefix.length(); 
+  }
 
   // --------------------------------------------------------------------------
   public static void main( String[] args ) {
@@ -2195,8 +2206,8 @@ final public class H2O {
     // effectively overwriting the earlier args.
     ArrayList<String> args2 = new ArrayList<>(Arrays.asList(args));
     for( Object p : System.getProperties().keySet() ) {
-      String s = (String)p;
-      if( s.startsWith("ai.h2o.") ) {
+      String s = (String) p;
+      if(isArgProperty(s)) {
         args2.add("-" + s.substring(7));
         // hack: Junits expect properties, throw out dummy prop for ga_opt_out
         if (!s.substring(7).equals("ga_opt_out") && !System.getProperty(s).isEmpty())

--- a/h2o-core/src/test/java/water/H2OTest.java
+++ b/h2o-core/src/test/java/water/H2OTest.java
@@ -33,5 +33,19 @@ public class H2OTest {
     assertTrue(id.startsWith("test-desc_test-type"));
     assertTrue(id.endsWith("_" + seq));
   }
+
+  @Test
+  public void testIsArgProperty() {
+      // Any string with a dot after `ai.h2o.` must fail
+      assertFalse(H2O.isArgProperty("noprefixnodots"));
+      assertFalse(H2O.isArgProperty("no.prefix.ever"));
+      assertFalse(H2O.isArgProperty("ai.h2o.anythingwithdotwillfail."));
+      assertFalse(H2O.isArgProperty("ai.h2o.org.eclipse.jetty.LEVEL"));
+      assertFalse(H2O.isArgProperty("ai.h2o.org.eclipse.jetty.util.log.class"));
+      assertFalse(H2O.isArgProperty("ai.h2o.org.eclipse.jetty.util.log.StdErrLog"));
+      assertFalse(H2O.isArgProperty("sys.ai.h2o.nodots"));
+
+      assertTrue(H2O.isArgProperty("ai.h2o.hdfs_config"));
+  }
   
 }


### PR DESCRIPTION
There is also an alternative solution based on relocating to a different package, where the problem is described in detail: https://github.com/h2oai/h2o-3/pull/5248

- No need for our users to migrate
- No need to relocate elsewhere
- Cleanest for our users

http://mr-0xg1:8080/view/H2O-3/job/h2o-3-hadoop-smoke-pipeline/job/pavel%252Fhadoop-3-ignore-props/