### PR TITLE
PUBDEV-7860: Add Thin Plate Regression Smoothers to GAM

### DIFF
--- a/h2o-algos/src/main/java/hex/gam/GAM.java
+++ b/h2o-algos/src/main/java/hex/gam/GAM.java
@@ -1,14 +1,18 @@
 package hex.gam;
 
-import hex.*;
+import hex.DataInfo;
+import hex.ModelBuilder;
+import hex.ModelCategory;
+import hex.ModelMetrics;
 import hex.gam.GAMModel.GAMParameters;
+import hex.gam.GamSplines.ThinPlateDistanceWithKnots;
+import hex.gam.GamSplines.ThinPlatePolynomialWithKnots;
 import hex.gam.MatrixFrameUtils.GamUtils;
 import hex.gam.MatrixFrameUtils.GenerateGamMatrixOneColumn;
 import hex.glm.GLM;
 import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters;
-import hex.quantile.Quantile;
-import hex.quantile.QuantileModel;
+import hex.gram.Gram;
 import jsr166y.ForkJoinTask;
 import jsr166y.RecursiveAction;
 import water.*;
@@ -23,20 +27,34 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static hex.ModelMetrics.calcVarImp;
-import static hex.gam.GAMModel.cleanUpInputFrame;
-import static hex.gam.MatrixFrameUtils.GamUtils.AllocateType.*;
+import static hex.gam.GAMModel.adaptValidFrame;
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.*;
+import static hex.gam.MatrixFrameUtils.GAMModelUtils.copyGLMCoeffs;
+import static hex.gam.MatrixFrameUtils.GAMModelUtils.copyGLMtoGAMModel;
 import static hex.gam.MatrixFrameUtils.GamUtils.*;
+import static hex.gam.MatrixFrameUtils.GamUtils.AllocateType.*;
+import static hex.gam.MatrixFrameUtils.GenerateGamMatrixOneColumn.generateZTransp;
 import static hex.genmodel.utils.ArrayUtils.flat;
 import static hex.glm.GLMModel.GLMParameters.Family.multinomial;
 import static hex.glm.GLMModel.GLMParameters.Family.ordinal;
 import static hex.glm.GLMModel.GLMParameters.GLMType.gam;
+import static hex.util.LinearAlgebraUtils.generateOrthogonalComplement;
+import static hex.util.LinearAlgebraUtils.generateQR;
+import static water.util.ArrayUtils.expandArray;
+import static water.util.ArrayUtils.subtract;
 
 
 public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel.GAMModelOutput> {
-  private double[][] _knots; // Knots for splines
+  private double[][][] _knots; // Knots for splines
   private double[] _cv_alpha = null;  // best alpha value found from cross-validation
   private double[] _cv_lambda = null; // bset lambda value found from cross-validation
+  private int _thinPlateSmoothersWithKnotsNum = 0;
+  private int _cubicSplineNum = 0;
+  double[][] _gamColMeansRaw; // store raw gam column means in gam_column_sorted order and only for thin plate smoothers
+  public double[][] _oneOGamColStd;
+  public double[] _penaltyScale;
+  private boolean _cvOn = false;
+  private Frame _origTrain = null;
   
   @Override
   public ModelCategory[] can_build() {
@@ -81,6 +99,9 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
   // and lambda values.  Future hyperparameters can be added for cross-validation to choose as well.
   @Override
   public void computeCrossValidation() {
+    _cvOn = true;
+    _origTrain = _parms.train();  // store original training frame before it is changed
+    validateGamParameters();  // perform GAM initialization once here and reduce operations performed during the folds
     if (error_count() > 0) {
       throw H2OModelBuilderIllegalArgumentException.makeFromBuilder(GAM.this);
     }
@@ -103,32 +124,58 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
     _cv_alpha = new double[]{best_alpha};
     _cv_lambda = new double[]{best_lambda};
   }
-    /***
-     * This method will look at the keys of knots stored in _parms._knot_ids and copy them over to double[][]
-     * array.
-     *
-     * @return double[][] array containing the knots specified by users
-     */
-  public double[][] generateKnotsFromKeys() {
-    int numGamCols = _parms._gam_columns.length;
-    double[][] knots = new double[numGamCols][];
-    boolean allNull = _parms._knot_ids ==null;
+  
+  /***
+   * This method will look at the keys of knots stored in _parms._knot_ids and copy them over to double[][][]
+   * array.  Note that we have smoothers that take different number of columns.  We will keep the gam columns
+   * of single predictor smoothers to the front and multiple predictor smoothers to the back of the array.  For
+   * smoothers that take more than one predictor column, knot location is determined by first sorting the first 
+   * gam_column and then extract the quantiles of that sorted gam_columns.  Here, instead of taking the value for
+   * one gam column, we take the whole row with all the predictors for that smoother.
+   *
+   * @return double[][][] array containing the knots specified by users
+   */
+  public double[][][] generateKnotsFromKeys() { // todo: parallize this operation
+    int numGamCols = _parms._gam_columns.length; // total number of predictors in all smoothers
+    double[][][] knots = new double[numGamCols][][]; // 1st index into gam column, 2nd index number of knots for the row
+    boolean allNull = _parms._knot_ids == null;
+    int csInd = 0;
+    int tpInd = _cubicSplineNum;
+    int gamIndex; // index into the sorted arrays with CS front, TP back.
+    for (int outIndex = 0; outIndex < _parms._gam_columns.length; outIndex++) { // go through each gam_column group
+      String tempKey = allNull ? null : _parms._knot_ids[outIndex]; // one knot_id for each smoother
+      if (_parms._bs[outIndex] == 1) // thin plate regression
+        gamIndex = tpInd++;
+      else
+        gamIndex = csInd++;
+      knots[gamIndex] = new double[_parms._gam_columns[outIndex].length][];
+      if (tempKey != null && (tempKey.length() > 0)) {  // read knots location from Frame given by user      
+        final Frame knotFrame = Scope.track((Frame) DKV.getGet(Key.make(tempKey)));
+        double[][] knotContent = new double[(int) knotFrame.numRows()][_parms._gam_columns[outIndex].length];
+        final ArrayUtils.FrameToArray f2a = new ArrayUtils.FrameToArray(0,
+                _parms._gam_columns[outIndex].length - 1, knotFrame.numRows(), knotContent);
+        knotContent = f2a.doAll(knotFrame).getArray();  // first index is row, second index is column
 
-    for (int index=0; index < numGamCols; index++) {
-      final Frame predictVec = new Frame(new String[]{_parms._gam_columns[index]}, new Vec[]{_parms.train().vec(_parms._gam_columns[index])});
-      String tempKey = allNull?null:_parms._knot_ids[index];
-      if (tempKey != null && (tempKey.length() > 0)) {  // read knots location from Frame given by user
-        final Frame knotFrame = Scope.track((Frame)DKV.getGet(Key.make(tempKey)));
-        double[][] knotContent = new double[(int)knotFrame.numRows()][1];
-        final ArrayUtils.FrameToArray f2a = new ArrayUtils.FrameToArray(0,0, knotFrame.numRows(), knotContent);
-        knotContent = f2a.doAll(knotFrame).getArray();
-        knots[index] = new double[knotContent.length];
-        final double[][] knotCTranspose = ArrayUtils.transpose(knotContent);
-        System.arraycopy(knotCTranspose[0],0,knots[index], 0, knots[index].length);
-        failVerifyKnots(knots[index], index);
-      } else {  // current column knotkey is null
-        knots[index] = generateKnotsOneColumn(predictVec, _parms._num_knots[index]);
-        failVerifyKnots(knots[index], index);
+        final double[][] knotCTranspose = ArrayUtils.transpose(knotContent);// change knots to correct order
+        for (int innerIndex = 0; innerIndex < knotCTranspose.length; innerIndex++) {
+          knots[gamIndex][innerIndex] = new double[knotContent.length];
+          System.arraycopy(knotCTranspose[innerIndex], 0, knots[gamIndex][innerIndex], 0,
+                  knots[gamIndex][innerIndex].length);
+          if (knotCTranspose.length == 1 && _parms._bs[outIndex] == 0) // only check for order to single smoothers
+            failVerifyKnots(knots[gamIndex][innerIndex], outIndex);
+        }
+        _parms._num_knots[outIndex] = knotContent.length;
+
+      } else {  // current column knot key is null, we will use default method to generate knots
+        final Frame predictVec = new Frame(_parms._gam_columns[outIndex], 
+                _parms.train().vecs(_parms._gam_columns[outIndex]));
+        if (_parms._bs[outIndex] == 0) {
+          knots[gamIndex][0] = generateKnotsOneColumn(predictVec, _parms._num_knots[outIndex]);
+          failVerifyKnots(knots[gamIndex][0], outIndex);
+        } else {  // generate knots for multi-predictor smoothers
+          knots[gamIndex] = genKnotsMultiplePreds(predictVec, _parms, outIndex);
+          failVerifyKnots(knots[gamIndex][0], outIndex);
+        }
       }
     }
     return knots;
@@ -142,12 +189,12 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
       if (Double.isNaN(knots[index])) {
         error("gam_columns/knots_id", String.format("Knots generated by default or specified in knots_id " +
                         "ended up containing a NaN value for gam_column %s.   Please specify alternate knots_id" +
-                        " or choose other columns.", _parms._gam_columns[gam_column_index]));
+                        " or choose other columns.", _parms._gam_columns[gam_column_index][0]));
         return;
       }
       if (index > 0 && knots[index - 1] > knots[index]) {
         error("knots_id", String.format("knots not sorted in ascending order for gam_column %s. " +
-                        "Knots at index %d: %f.  Knots at index %d: %f",_parms._gam_columns[gam_column_index], index-1, 
+                        "Knots at index %d: %f.  Knots at index %d: %f",_parms._gam_columns[gam_column_index][0], index-1, 
                 knots[index-1], index, knots[index]));
         return;
       }
@@ -156,42 +203,16 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
                         "generate well-defined knots. Please choose other columns or reduce " +
                         "the number of knots.  If knots are specified in knots_id, choose alternate knots_id as the" +
                         " knots are not in ascending order.  Knots at index %d: %f.  Knots at index %d: %f", 
-                _parms._gam_columns[gam_column_index], index-1, knots[index-1], index, knots[index]));
+                _parms._gam_columns[gam_column_index][0], index-1, knots[index-1], index, knots[index]));
         return;
       }
     }
-  }
-
-  // This method will generate knot locations by choosing them from a uniform quantile distribution of that
-  // chosen column.
-  public double[] generateKnotsOneColumn(Frame gamFrame, int knotNum) {
-    double[] knots = MemoryManager.malloc8d(knotNum);
-    try {
-      Scope.enter();
-      Frame tempFrame = new Frame(gamFrame);  // make sure we have a frame key
-      DKV.put(tempFrame);
-      double[] prob = MemoryManager.malloc8d(knotNum);
-      assert knotNum > 1;
-      double stepProb = 1.0 / (knotNum - 1);
-      for (int knotInd = 0; knotInd < knotNum; knotInd++)
-        prob[knotInd] = knotInd * stepProb;
-      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
-      parms._train = tempFrame._key;
-      parms._probs = prob;
-      QuantileModel qModel = new Quantile(parms).trainModel().get();
-      DKV.remove(tempFrame._key);
-      Scope.track_generic(qModel);
-      System.arraycopy(qModel._output._quantiles[0], 0, knots, 0, knotNum);
-    } finally {
-      Scope.exit();
-    }
-    return knots;
   }
   
   @Override
   public void init(boolean expensive) {
     super.init(expensive);
-    if (expensive)  // add GAM specific check here
+    if (expensive && (_knots == null))  // add GAM specific check here, only do it once especially during CV
       validateGamParameters();
   }
   
@@ -212,68 +233,43 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
     }
     if (error_count() > 0)
       throw H2OModelBuilderIllegalArgumentException.makeFromBuilder(GAM.this);
-
-    if (_parms._gam_columns == null)  // check _gam_columns contains valid columns
+    if (_parms._gam_columns == null) { // check _gam_columns contains valid columns
       error("_gam_columns", "must specify columns names to apply GAM to.  If you don't have any," +
               " use GLM.");
-    else {  // check and make sure gam_columns column types are legal
-      Frame dataset = _parms.train();
-      List<String> cNames = Arrays.asList(dataset.names());
-      for (int index = 0; index < _parms._gam_columns.length; index++) {
-        String cname = _parms._gam_columns[index];
-        if (!cNames.contains(cname))
-          error("gam_columns", "column name: " + cname + " does not exist in your dataset.");
-        if (dataset.vec(cname).isCategorical())
-          error("gam_columns", "column " + cname + " is categorical and cannot be used as a gam " +
-                  "column.");
-        if (dataset.vec(cname).isBad() || dataset.vec(cname).isTime() || dataset.vec(cname).isUUID() ||
-                dataset.vec(cname).isConst())
-          error("gam_columns", String.format("Column '%s' of type '%s' cannot be used as GAM column. Column types " +
-                  "BAD, TIME, CONSTANT and UUID cannot be used.", cname, dataset.vec(cname).get_type_str()));
-        if (!dataset.vec(cname).isNumeric())
-          error("gam_columns", "column " + cname + " is not numerical and cannot be used as a gam" +
-                  " column.");
-      }
+    } else { // check and make sure gam_columns column types are legal
+      if (_parms._bs == null)
+        setDefaultBSType(_parms);
+      if ((_parms._bs != null) && (_parms._gam_columns.length != _parms._bs.length))  // check length
+        error("gam colum number", "Number of gam columns implied from _bs and _gam_columns do not " +
+                "match.");
+      assertLegalGamColumnsNBSTypes();  // number of CS and TP smoothers determined.
     }
-    if ((_parms._bs != null) && (_parms._gam_columns.length != _parms._bs.length))  // check length
-      error("gam colum number", "Number of gam columns implied from _bs and _gam_columns do not match.");
-    if (_parms._bs == null) // default to bs type 0
-      _parms._bs = new int[_parms._gam_columns.length];
-    if (_parms._num_knots == null) {  // user did not specify any knot numbers, we will use default 10
-      _parms._num_knots = new int[_parms._gam_columns.length];  // different columns may have different
-      for (int index = 0; index < _parms._gam_columns.length; index++) {  // for zero value _num_knots, set to valid number
-        if (_parms._num_knots[index] == 0) {
-          long numRowMinusNACnt = _train.numRows() - _parms.train().vec(_parms._gam_columns[index]).naCnt();
-          _parms._num_knots[index] = numRowMinusNACnt < 10 ? (int) numRowMinusNACnt : 10;
-        }
-      }
-    }
+    if (_parms._scale == null)
+      setDefaultScale(_parms);
+    setGamPredSize(_parms, _cubicSplineNum);
+    if (_thinPlateSmoothersWithKnotsNum > 0)
+      setThinPlateParameters(_parms, _thinPlateSmoothersWithKnotsNum); // set the m, M for thin plate regression smoothers
+    checkOrChooseNumKnots(); // check valid num_knot assignment or choose num_knots
     for (int index = 0; index < _parms._gam_columns.length; index++) {
       Frame dataset = _parms.train();
-      String cname = _parms._gam_columns[index];
+      String cname = _parms._gam_columns[index][0]; // only check the first gam_column
       if (dataset.vec(cname).isInt() && ((dataset.vec(cname).max() - dataset.vec(cname).min() + 1) < _parms._num_knots[index]))
         error("gam_columns", "column " + cname + " has cardinality lower than the number of knots and cannot be used as a gam" +
                 " column.");
     }
-    int cindex = 0;
-    for (int numKnots : _parms._num_knots) {  // check to make sure numKnot is valid
-      long eligibleRows = _train.numRows() - _parms.train().vec(_parms._gam_columns[cindex]).naCnt();
-      if (numKnots > eligibleRows) {
-        error("_num_knots", " number of knots specified in _num_knots: " + _parms._num_knots[cindex] + " exceed number " +
-                "of rows in training frame minus NA rows: " + eligibleRows + ".  Reduce _num_knots.");
-      }
-      cindex++;
-    }
-    if ((_parms._num_knots != null) && (_parms._num_knots.length != _parms._gam_columns.length))
-      error("gam colum number", "Number of gam columns implied from _num_knots and _gam_columns do not match.");
+    if ((_parms._num_knots.length != _parms._gam_columns.length))
+      error("gam colum number", "Number of gam columns implied from _num_knots and _gam_columns do" +
+              " not match.");
     if (_parms._knot_ids != null) { // check knots location specification
       if (_parms._knot_ids.length != _parms._gam_columns.length)
-        error("gam colum number", "Number of gam columns implied from _num_knots and _knot_ids do not" +
-                " match.");
+        error("gam colum number", "Number of gam columns implied from _num_knots and _knot_ids do" +
+                " not match.");
     }
     _knots = generateKnotsFromKeys(); // generate knots and verify that they are given correctly
+    sortGAMParameters(_parms, _cubicSplineNum, _thinPlateSmoothersWithKnotsNum); // move cubic spline to the front and thin plate to the back
+    checkThinPlateParams();
     if (_parms._saveZMatrix && ((_train.numCols() - 1 + _parms._num_knots.length) < 2))
-      error("_saveZMatrix", "can only be enabled if we number of predictors plus" +
+      error("_saveZMatrix", "can only be enabled if the number of predictors plus" +
               " Gam columns in gam_columns exceeds 2");
     if ((_parms._lambda_search || !_parms._intercept || _parms._lambda == null || _parms._lambda[0] > 0))
       _parms._use_all_factor_levels = true;
@@ -291,13 +287,98 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
     }
     if (_parms._link == null || _parms._link.equals(GLMParameters.Link.family_default))
       _parms._link = _parms._family.defaultLink;
-
-
+    
     if ((_parms._family == GLMParameters.Family.multinomial || _parms._family == GLMParameters.Family.ordinal ||
             _parms._family == GLMParameters.Family.binomial)
             && response().get_type() != Vec.T_CAT) {
       error("_response_column", String.format("For given response family '%s', please provide a categorical" +
               " response column. Current response column type is '%s'.", _parms._family, response().get_type_str()));
+    }
+  }
+
+  /**
+   *   verify and check thin plate regression smoothers specific parameters
+   **/
+  public void checkThinPlateParams() {
+    if (_thinPlateSmoothersWithKnotsNum ==0)
+      return;
+    
+    _parms._num_knots_tp = new int[_thinPlateSmoothersWithKnotsNum];
+    System.arraycopy(_parms._num_knots_sorted, _cubicSplineNum, _parms._num_knots_tp, 0,
+            _thinPlateSmoothersWithKnotsNum);
+    int tpIndex = 0;
+    for (int index = 0; index < _parms._gam_columns.length; index++) {
+      if (_parms._bs_sorted[index] == 1) {
+        if (_parms._num_knots_sorted[index] < _parms._M[tpIndex] + 1) {
+          error("num_knots", "num_knots for gam column start with  " + _parms._gam_columns_sorted[index][0] +
+                  " did not specify enough num_knots.  It should be equal or greater than " + (_parms._M[tpIndex] + 1) + ".");
+        }
+        tpIndex++;
+      }
+    }
+  }
+  
+  // set default num_knots to 10 for gam_columns where there is no knot_id specified for CS smoothers
+  // for TP smoothers, default is set to be max of 10 or _M+2.
+  public void checkOrChooseNumKnots() {
+    if (_parms._num_knots == null)
+      _parms._num_knots = new int[_parms._gam_columns.length];  // different columns may have different
+    int tpCount = 0;
+    for (int index = 0; index < _parms._num_knots.length; index++) {  // set zero value _num_knots
+      if (_parms._knot_ids == null || (_parms._knot_ids != null && _parms._knot_ids[index] == null)) {  // knots are not specified
+        int numKnots = _parms._num_knots[index];
+        int naSum = 0;
+        for (int innerIndex = 0; innerIndex < _parms._gam_columns[index].length; innerIndex++) {
+          naSum += _parms.train().vec(_parms._gam_columns[index][innerIndex]).naCnt();
+        }
+        long eligibleRows = _train.numRows()-naSum;
+        if (_parms._num_knots[index] == 0) {  // set num_knots to default
+          int defaultRows = 10;
+          if (_parms._bs[index] == 1) {
+            defaultRows = Math.max(defaultRows, _parms._M[tpCount] + 2);
+            tpCount++;
+          }
+          _parms._num_knots[index] = eligibleRows < defaultRows ? (int) eligibleRows : defaultRows;
+        } else {  // num_knots assigned by user and check to make sure it is legal
+          if (numKnots > eligibleRows) {
+            error("_num_knots", " number of knots specified in _num_knots: "+numKnots+" for smoother" +
+                    " with first predictor "+_parms._gam_columns[index][0]+".  Reduce _num_knots.");
+          }
+        }
+      }
+    }
+  }
+  
+  // Check and make sure correct BS type is assigned to the various gam_columns specified.  In addition, the number
+  // of CS and TP smoothers are counted here as well.
+  public void assertLegalGamColumnsNBSTypes() {
+    Frame dataset = _parms.train();
+    List<String> cNames = Arrays.asList(dataset.names());
+    for (int index = 0; index < _parms._gam_columns.length; index++) {
+      if (_parms._bs != null) { // check and make sure the correct bs type is chosen
+        if (_parms._gam_columns[index].length > 1 && _parms._bs[index] != 1)
+          error("bs", "Smother with multiple predictors can only use bs = 1");
+        if (_parms._bs[index] == 1)
+          _thinPlateSmoothersWithKnotsNum++; // record number of thin plate
+        if (_parms._bs[index] == 0)
+          _cubicSplineNum++;
+
+        for (int innerIndex = 0; innerIndex < _parms._gam_columns[index].length; innerIndex++) {
+          String cname = _parms._gam_columns[index][innerIndex];
+          if (!cNames.contains(cname))
+            error("gam_columns", "column name: " + cname + " does not exist in your dataset.");
+          if (dataset.vec(cname).isCategorical())
+            error("gam_columns", "column " + cname + " is categorical and cannot be used as a gam " +
+                    "column.");
+          if (dataset.vec(cname).isBad() || dataset.vec(cname).isTime() || dataset.vec(cname).isUUID() ||
+                  dataset.vec(cname).isConst())
+            error("gam_columns", String.format("Column '%s' of type '%s' cannot be used as GAM column. Column types " +
+                    "BAD, TIME, CONSTANT and UUID cannot be used.", cname, dataset.vec(cname).get_type_str()));
+          if (!dataset.vec(cname).isNumeric())
+            error("gam_columns", "column " + cname + " is not numerical and cannot be used as a gam" +
+                    " column.");
+        }
+      }
     }
   }
 
@@ -317,115 +398,259 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
   }
 
   private class GAMDriver extends Driver {
-    double[][][] _zTranspose; // store for each GAM predictor transpose(Z) matrix
-    double[][][] _penalty_mat_center;  // store for each GAM predictor the penalty matrix
-    double[][][] _penalty_mat;  // penalty matrix before centering
-    public double[][][] _binvD; // store BinvD for each gam column specified for scoring
-    public int[] _numKnots;  // store number of knots per gam column
-    String[][] _gamColNames;  // store column names of GAM columns
-    String[][] _gamColNamesCenter;  // gamColNames after de-centering is performed.
+    double[][][] _zTranspose;         // store transpose(Z) matrices for CS and TP smoothers
+    double[][][] _zTransposeCS;       // store transpose(zCS) for thin plate smoother to remove optimization constraint
+    double[][][] _penaltyMatCenter; // store centered penalty matrices of all smoothers
+    double[][][] _penaltyMat;        // penalty matrix before any kind of processing
+    double[][][] _penaltyMatCS;     // penalty matrix after removing optimization constraint, only for thin plate
+    double[][][] _starT;              // store T* as in 3.2.3
+    public double[][][] _binvD;       // store BinvD for each CS smoother specified for scoring
+    public int[] _numKnots;           // store number of knots per smoother
+    String[][] _gamColNames;          // store column names of all smoothers before any processing
+    String[][] _gamColNamesCenter;    // gamColNames after centering is performed.
     Key<Frame>[] _gamFrameKeys;
     Key<Frame>[] _gamFrameKeysCenter;
-    double[][] _gamColMeans; // store gam column means without centering.
+    double[][] _gamColMeans;          // store gam column means without centering.
+    int[][][] _allPolyBasisList;      // store polynomial basis function for all TP smoothers
     /***
      * This method will take the _train that contains the predictor columns and response columns only and add to it
      * the following:
-     * 1. For each predictor included in gam_columns, expand it out to calculate the f(x) and attach to the frame.
-     * 2. It will calculate the ztranspose that is used to center the gam columns.
-     * 3. It will calculate a penalty matrix used to control the smoothness of GAM.
+     * 1. For each smoother included in gam_columns, expand it out to calculate the f(x) and attach to the frame.
+     * 2. For TP smoothers, it will calculate the zCS transpose
+     * 3. It will calculate the ztranspose that is used to center each smoother.
+     * 4. It will calculate a penalty matrix used to control the smoothness of GAM.
      *
      * @return
      */
     Frame adaptTrain() {
       int numGamFrame = _parms._gam_columns.length;
-      _zTranspose = GamUtils.allocate3DArray(numGamFrame, _parms, firstOneLess);
-      _penalty_mat = _parms._savePenaltyMat?GamUtils.allocate3DArray(numGamFrame, _parms, sameOrig):null;
-      _penalty_mat_center = GamUtils.allocate3DArray(numGamFrame, _parms, bothOneLess);
-      _binvD = GamUtils.allocate3DArray(numGamFrame, _parms, firstTwoLess);
+      _zTranspose = GamUtils.allocate3DArray(numGamFrame, _parms, firstOneLess);  // for centering for all smoothers 
+      _penaltyMat = _parms._savePenaltyMat?GamUtils.allocate3DArray(numGamFrame, _parms, sameOrig):null;
+      _penaltyMatCenter = GamUtils.allocate3DArray(numGamFrame, _parms, bothOneLess);
+      if (_cubicSplineNum > 0)
+        _binvD = GamUtils.allocate3DArrayCS(_cubicSplineNum, _parms, firstTwoLess);
       _numKnots = MemoryManager.malloc4(numGamFrame);
       _gamColNames = new String[numGamFrame][];
       _gamColNamesCenter = new String[numGamFrame][];
       _gamFrameKeys = new Key[numGamFrame];
       _gamFrameKeysCenter = new Key[numGamFrame];
-      _gamColMeans = new double[numGamFrame][];
-
-      addGAM2Train();  // add GAM columns to training frame
-      return buildGamFrame(); // add gam cols to _train
-    }
-
-    public Frame buildGamFrame() {
-      Vec responseVec = _train.remove(_parms._response_column);
-      Vec weightsVec = null;
-      if (_parms._weights_column != null) // move weight vector to be the last vector before response variable
-        weightsVec = _train.remove(_parms._weights_column);
-      for (int colIdx = 0; colIdx < _parms._gam_columns.length; colIdx++) {  // append the augmented columns to _train
-        Frame gamFrame = Scope.track(_gamFrameKeysCenter[colIdx].get());
-        _train.add(gamFrame.names(), gamFrame.removeAll());
-        _train.remove(_parms._gam_columns[colIdx]);
+      _gamColMeans = new double[numGamFrame][];   // means of gamified columns
+      _penaltyScale = new double[numGamFrame];
+      if (_thinPlateSmoothersWithKnotsNum > 0) {  // only allocate if there are thin plate smoothers
+        int[] kMinusM = subtract(_parms._num_knots_tp, _parms._M);
+        _zTransposeCS = GamUtils.allocate3DArrayTP(_thinPlateSmoothersWithKnotsNum, _parms, kMinusM, _parms._num_knots_tp);
+        _penaltyMatCS = GamUtils.allocate3DArrayTP(_thinPlateSmoothersWithKnotsNum, _parms, kMinusM, kMinusM);
+        _allPolyBasisList = new int[_thinPlateSmoothersWithKnotsNum][][];
+        _gamColMeansRaw = new double[_thinPlateSmoothersWithKnotsNum][];
+        _oneOGamColStd = new double[_thinPlateSmoothersWithKnotsNum][];
+        if (_parms._savePenaltyMat)
+          _starT = GamUtils.allocate3DArrayTP(_thinPlateSmoothersWithKnotsNum, _parms, _parms._num_knots_tp, _parms._M);
       }
-      if (weightsVec != null)
-        _train.add(_parms._weights_column, weightsVec);
-      if (responseVec != null)
-        _train.add(_parms._response_column, responseVec);
-      return _train;
+      addGAM2Train();  // add GAM columns to training frame
+      return buildGamFrame(_parms, _train, _gamFrameKeysCenter); // add gam cols to _train
+    }
+    
+    // This class generate the thin plate regression smoothers as denoted in GamThinPlateRegressionH2O.pdf
+    public class ThinPlateRegressionSmootherWithKnots extends RecursiveAction {
+      final Frame _predictVec;
+      final int _numKnots;
+      final int _numKnotsM1;
+      final int _numKnotsMM;  // store k-M
+      final int _splineType;
+      final boolean _savePenaltyMat;
+      final double[][] _knots;
+      final GAMParameters _parms;
+      final int _gamColIndex;
+      final int _thinPlateGamColIndex;
+      final int _numPred;     // number of predictors (d)
+      final int _M;
+      
+      public ThinPlateRegressionSmootherWithKnots(Frame predV, GAMParameters parms, int gamColIndex, double[][] knots,
+                                                  int thinPlateInd) {
+        _predictVec  = predV;
+        _knots = knots;
+        _numKnots = parms._num_knots_sorted[gamColIndex];
+        _numKnotsM1 = _numKnots-1;
+        _parms = parms;
+        _splineType = _parms._bs_sorted[gamColIndex];
+        _gamColIndex = gamColIndex;
+        _thinPlateGamColIndex = thinPlateInd;
+        _savePenaltyMat = _parms._savePenaltyMat;
+        _numPred = parms._gam_columns_sorted[gamColIndex].length;
+        _M = _parms._M[_thinPlateGamColIndex];
+        _numKnotsMM = _numKnots-_M;
+      }
+
+      @Override
+      protected void compute() {
+        double[] rawColMeans = new double[_numPred];        
+        double[] oneOverColStd = new double[_numPred];
+        for (int colInd = 0; colInd < _numPred; colInd++) {
+          rawColMeans[colInd] = _predictVec.vec(colInd).mean();
+          oneOverColStd[colInd] = 1.0/_predictVec.vec(colInd).sigma();  // std
+        }
+        System.arraycopy(rawColMeans, 0, _gamColMeansRaw[_thinPlateGamColIndex], 0, rawColMeans.length);
+        System.arraycopy(oneOverColStd, 0, _oneOGamColStd[_thinPlateGamColIndex], 0, oneOverColStd.length);
+        ThinPlateDistanceWithKnots distanceMeasure = 
+                new ThinPlateDistanceWithKnots(_knots, _numPred, oneOverColStd, 
+                        _parms._standardize_tp_gam_cols).doAll(_numKnots, Vec.T_NUM, _predictVec); // Xnmd in 3.1
+        List<Integer[]> polyBasisDegree = findPolyBasis(_numPred, calculatem(_numPred));// polynomial basis lists in 3.2
+        int[][] polyBasisArray = convertList2Array(polyBasisDegree, _M, _numPred);
+        copy2DArray(polyBasisArray, _allPolyBasisList[_thinPlateGamColIndex]);
+        String colNameStub = genThinPlateNameStart(_parms, _gamColIndex); // gam column names before processing
+        String[] gamColNames = generateGamColNamesThinPlateKnots(_gamColIndex, _parms, polyBasisArray, colNameStub);
+        System.arraycopy(gamColNames, 0, _gamColNames[_gamColIndex], 0, gamColNames.length);
+        String[] distanceColNames = extractColNames(gamColNames, 0, 0, _numKnots);
+        String[] polyNames = extractColNames(gamColNames, _numKnots, 0, _M);
+        Frame thinPlateFrame = distanceMeasure.outputFrame(Key.make(), distanceColNames, null);
+        for (int index = 0; index < _numKnots; index++)
+          _gamColMeans[_gamColIndex][index] = thinPlateFrame.vec(index).mean();
+        double[][] starT = generateStarT(_knots, polyBasisDegree, rawColMeans, oneOverColStd, 
+                _parms._standardize_tp_gam_cols); // generate T* in 3.2.3
+        double[][] qmat = generateQR(starT);
+        double[][] penaltyMat = distanceMeasure.generatePenalty(qmat);  // penalty matrix 3.1.1
+        double[][] zCST = generateOrthogonalComplement(qmat, starT, _numKnotsMM, _parms._seed);
+        copy2DArray(zCST, _zTransposeCS[_thinPlateGamColIndex]);
+        ThinPlatePolynomialWithKnots thinPlatePoly = new ThinPlatePolynomialWithKnots(_numPred,
+                polyBasisArray, rawColMeans, oneOverColStd, 
+                _parms._standardize_tp_gam_cols).doAll(_M, Vec.T_NUM, _predictVec);// generate polynomial basis T in 3.2
+        Frame thinPlatePolyBasis = thinPlatePoly.outputFrame(null, polyNames, null);
+        for (int index = 0; index < _M; index++)  // calculate gamified column means
+          _gamColMeans[_gamColIndex][index+_numKnots] = thinPlatePolyBasis.vec(index).mean();
+        thinPlateFrame = ThinPlateDistanceWithKnots.applyTransform(thinPlateFrame, colNameStub
+                +"TPKnots_", _parms, zCST, _numKnotsMM);        // generate Xcs as in 3.3
+        thinPlateFrame.add(thinPlatePolyBasis.names(), thinPlatePolyBasis.removeAll());        // concatenate Xcs and T
+        double[][] ztranspose =  generateZTransp(thinPlateFrame, _numKnots);     // generate Z for centering as in 3.4
+        copy2DArray(ztranspose, _zTranspose[_gamColIndex]);
+        double[][] penaltyMatCS = ArrayUtils.multArrArr(ArrayUtils.multArrArr(zCST, penaltyMat),
+                ArrayUtils.transpose(zCST));  // transform penalty matrix to transpose(Zcs)*Xnmd*Zcs, 3.3
+        if (_parms._scale_tp_penalty_mat) {   // R does this scaling of penalty matrix.  I left it to users to choose
+          ScaleTPPenalty scaleTPPenaltyCS = new ScaleTPPenalty(penaltyMatCS, thinPlateFrame).doAll(thinPlateFrame);
+          _penaltyScale[_gamColIndex] = scaleTPPenaltyCS._s_scale;
+          penaltyMatCS = scaleTPPenaltyCS._penaltyMat;
+        }
+        double[][] expandPenaltyCS = expandArray(penaltyMatCS, _numKnots);  // used for penalty matrix
+        if (_savePenaltyMat) {                                              // save intermediate steps for debugging
+          copy2DArray(penaltyMat, _penaltyMat[_gamColIndex]);
+          copy2DArray(starT, _starT[_thinPlateGamColIndex]);
+          copy2DArray(penaltyMatCS, _penaltyMatCS[_thinPlateGamColIndex]);
+        }
+        double[][] penaltyCenter = ArrayUtils.multArrArr(ArrayUtils.multArrArr(ztranspose, expandPenaltyCS),
+                ArrayUtils.transpose(ztranspose));
+        copy2DArray(penaltyCenter, _penaltyMatCenter[_gamColIndex]);
+        thinPlateFrame = ThinPlateDistanceWithKnots.applyTransform(thinPlateFrame, colNameStub+"center_", 
+                _parms, ztranspose, _numKnotsM1);          // generate Xz as in 3.4
+        _gamFrameKeysCenter[_gamColIndex] = thinPlateFrame._key;
+        DKV.put(thinPlateFrame);
+        System.arraycopy(thinPlateFrame.names(), 0, _gamColNamesCenter[_gamColIndex], 0, _numKnotsM1);
+      }
+    }
+    
+    public class CubicSplineSmoother extends RecursiveAction {
+      final Frame _predictVec;
+      final int _numKnots;
+      final int _numKnotsM1;
+      final int _splineType;
+      final boolean _savePenaltyMat;
+      final String[] _newColNames;
+      final double[] _knots;
+      final GAMParameters _parms;
+      final AllocateType _fileMode;
+      final int _gamColIndex;
+      final int _csIndex;
+      
+      public CubicSplineSmoother(Frame predV, GAMParameters parms, int gamColIndex, String[] gamColNames, double[] knots,
+                                 AllocateType fileM, int csInd) {
+        _predictVec = predV;
+        _numKnots = parms._num_knots_sorted[gamColIndex];
+        _numKnotsM1 = _numKnots-1;
+        _splineType = parms._bs_sorted[gamColIndex];
+        _savePenaltyMat = parms._savePenaltyMat;
+        _newColNames = gamColNames;
+        _knots = knots;
+        _parms = parms;
+        _gamColIndex = gamColIndex;
+        _fileMode = fileM;
+        _csIndex = csInd;
+      }
+
+      @Override
+      protected void compute() {
+        GenerateGamMatrixOneColumn genOneGamCol = new GenerateGamMatrixOneColumn(_splineType, _numKnots,
+                _knots, _predictVec).doAll(_numKnots, Vec.T_NUM, _predictVec);
+        if (_savePenaltyMat) {                                  // only save this for debugging
+          copy2DArray(genOneGamCol._penaltyMat, _penaltyMat[_gamColIndex]); // copy penalty matrix
+          _penaltyScale[_gamColIndex] = genOneGamCol._s_scale;  // penaltyMat is scaled by 1/_s_scale
+        }
+        Frame oneAugmentedColumnCenter = genOneGamCol.outputFrame(Key.make(), _newColNames,
+                null);
+        for (int index = 0; index < _numKnots; index++)
+          _gamColMeans[_gamColIndex][index] = oneAugmentedColumnCenter.vec(index).mean();
+        oneAugmentedColumnCenter = genOneGamCol.centralizeFrame(oneAugmentedColumnCenter,
+                _predictVec.name(0) + "_" + _splineType + "_center_", _parms);
+        copy2DArray(genOneGamCol._ZTransp, _zTranspose[_gamColIndex]); // copy transpose(Z)
+        double[][] transformedPenalty = ArrayUtils.multArrArr(ArrayUtils.multArrArr(genOneGamCol._ZTransp,
+                genOneGamCol._penaltyMat), ArrayUtils.transpose(genOneGamCol._ZTransp));  // transform penalty as zt*S*z
+        copy2DArray(transformedPenalty, _penaltyMatCenter[_gamColIndex]);
+        _gamFrameKeysCenter[_gamColIndex] = oneAugmentedColumnCenter._key;
+        DKV.put(oneAugmentedColumnCenter);
+        System.arraycopy(oneAugmentedColumnCenter.names(), 0, _gamColNamesCenter[_gamColIndex], 0,
+                _numKnotsM1);
+        copy2DArray(genOneGamCol._bInvD, _binvD[_csIndex]);
+      }
+    }
+    
+    // During CV, _parms.train() will contain only predictors, response and cv weights.  Gam columns that are not
+    // part of the predictors will not be there.  Hence, I stored the original _parms.train() in _origTrain and then
+    // restore it when we need to restore the orighinal _parms.train().
+    public Frame getTrainFrame(Frame trainFrame) {
+      if (_cvOn && trainFrame.numRows() == _origTrain.numRows()) {  // special treatment for cv training frame
+        if (Arrays.asList(trainFrame.names()).contains("__internal_cv_weights__")) {
+          Frame origTrain = _origTrain.clone();
+          origTrain.add("__internal_cv_weights__", trainFrame.vec("__internal_cv_weights__"));
+          return origTrain;
+        } else {
+          return _origTrain;
+        }
+      }
+      return trainFrame;
     }
 
     void addGAM2Train() {
-      int numGamFrame = _parms._gam_columns.length;
+      final int numGamFrame = _parms._gam_columns.length; // number of smoothers to generate
       RecursiveAction[] generateGamColumn = new RecursiveAction[numGamFrame];
-      for (int index = 0; index < numGamFrame; index++) {
-        final Vec weights_column = (_parms._weights_column == null) ? Vec.makeOne(_parms.train().numRows()) 
-                : _parms.train().vec(_parms._weights_column);
-        final Frame predictVec = new Frame();
-        predictVec.add(_parms._gam_columns[index], _parms._train.get().vec(_parms._gam_columns[index]));
-        predictVec.add("weights_column", weights_column);
-        
-        final int numKnots = _parms._num_knots[index];  // grab number of knots to generate
+      int thinPlateInd = 0;
+      int csInd = 0;
+      Frame trainFrame = getTrainFrame(_parms.train());
+      for (int index = 0; index < numGamFrame; index++) { // generate smoothers/splines
+        final Frame predictVec = prepareGamVec(index, _parms, trainFrame);// extract predictors from frame
+        final int numKnots = _parms._num_knots_sorted[index];
         final int numKnotsM1 = numKnots - 1;
-        final int splineType = _parms._bs[index];
-        final int frameIndex = index;
-        final String[] newColNames = new String[numKnots];
-        for (int colIndex = 0; colIndex < numKnots; colIndex++) {
-          newColNames[colIndex] = _parms._gam_columns[index] + "_" + splineType + "_" + colIndex;
+        if (_parms._bs_sorted[index] == 0) {  // for CS smoothers
+          _gamColNames[index] = generateGamColNames(index, _parms);
+          _gamColNamesCenter[index] = new String[numKnotsM1];
+          _gamColMeans[index] = new double[numKnots];
+          generateGamColumn[index] = new CubicSplineSmoother(predictVec, _parms, index, _gamColNames[index],
+                  _knots[index][0], firstTwoLess, csInd++);
+        } else {  // TP splines with knots
+          final int kPlusM = _parms._num_knots_sorted[index]+_parms._M[thinPlateInd];
+          _gamColNames[index] = new String[kPlusM];
+          _gamColNamesCenter[index] = new String[numKnotsM1];
+          _gamColMeans[index] = new double[kPlusM];
+          _allPolyBasisList[thinPlateInd] = new int[_parms._M[thinPlateInd]][_parms._gamPredSize[index]];
+          _gamColMeansRaw[thinPlateInd] = new double[_parms._gamPredSize[index]];
+          _oneOGamColStd[thinPlateInd] = new double[_parms._gamPredSize[index]];
+          generateGamColumn[index] = new ThinPlateRegressionSmootherWithKnots(predictVec, _parms, index, _knots[index], 
+                  thinPlateInd++);
         }
-        _gamColNames[frameIndex] = new String[numKnots];
-        _gamColNamesCenter[frameIndex] = new String[numKnotsM1];
-        _gamColMeans[frameIndex] = new double[numKnots];
-        System.arraycopy(newColNames, 0, _gamColNames[frameIndex], 0, numKnots);
-        generateGamColumn[frameIndex] = new RecursiveAction() {
-          @Override
-          protected void compute() {
-            GenerateGamMatrixOneColumn genOneGamCol = new GenerateGamMatrixOneColumn(splineType, numKnots, 
-                    _knots[frameIndex], predictVec).doAll(numKnots, Vec .T_NUM,predictVec);
-            if (_parms._savePenaltyMat)  // only save this for debugging
-              GamUtils.copy2DArray(genOneGamCol._penaltyMat, _penalty_mat[frameIndex]); // copy penalty matrix
-              // calculate z transpose
-              Frame oneAugmentedColumnCenter = genOneGamCol.outputFrame(Key.make(), newColNames,
-                      null);
-              for (int cind=0; cind < numKnots; cind++) 
-                _gamColMeans[frameIndex][cind] = oneAugmentedColumnCenter.vec(cind).mean();
-              oneAugmentedColumnCenter = genOneGamCol.centralizeFrame(oneAugmentedColumnCenter,
-                      predictVec.name(0) + "_" + splineType + "_center_", _parms);
-              GamUtils.copy2DArray(genOneGamCol._ZTransp, _zTranspose[frameIndex]); // copy transpose(Z)
-              double[][] transformedPenalty = ArrayUtils.multArrArr(ArrayUtils.multArrArr(genOneGamCol._ZTransp,
-                      genOneGamCol._penaltyMat), ArrayUtils.transpose(genOneGamCol._ZTransp));  // transform penalty as zt*S*z
-              GamUtils.copy2DArray(transformedPenalty, _penalty_mat_center[frameIndex]);
-              _gamFrameKeysCenter[frameIndex] = oneAugmentedColumnCenter._key;
-              DKV.put(oneAugmentedColumnCenter);
-              System.arraycopy(oneAugmentedColumnCenter.names(), 0, _gamColNamesCenter[frameIndex], 0,
-                      numKnotsM1);
-            GamUtils.copy2DArray(genOneGamCol._bInvD, _binvD[frameIndex]);
-            _numKnots[frameIndex] = genOneGamCol._numKnots;
-          }
-        };
       }
       ForkJoinTask.invokeAll(generateGamColumn);
     }
 
     void verifyGamTransformedFrame(Frame gamTransformed) {
-      int numGamCols = _gamColNamesCenter.length;
-      int numGamFrame = _parms._gam_columns.length;
+      final int numGamFrame = _parms._gam_columns.length;
       for (int findex = 0; findex < numGamFrame; findex++) {
+        final int numGamCols = _gamColNamesCenter[findex].length;
         for (int index = 0; index < numGamCols; index++) {
           if (gamTransformed.vec(_gamColNamesCenter[findex][index]).isConst())
             error(_gamColNamesCenter[findex][index], "gam column transformation generated constant columns" +
@@ -439,27 +664,25 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
       init(true);
       if (error_count() > 0)   // if something goes wrong, let's throw a fit
         throw H2OModelBuilderIllegalArgumentException.makeFromBuilder(GAM.this);
-      Frame newTFrame = new Frame(rebalance(adaptTrain(), false, _result+".temporary.train"));  // get frames with correct predictors and spline functions
+      // add gamified columns to training frame
+      Frame newTFrame = new Frame(rebalance(adaptTrain(), false, _result+".temporary.train"));
       verifyGamTransformedFrame(newTFrame);
       
       if (error_count() > 0)   // if something goes wrong during gam transformation, let's throw a fit again!
         throw H2OModelBuilderIllegalArgumentException.makeFromBuilder(GAM.this);
       
-      if (valid() != null) {  // transform the validation frame if present
-        _valid = rebalance(cleanUpInputFrame(_parms.valid().clone(), _parms, _gamColNamesCenter, _binvD, _zTranspose, _knots,
-                _numKnots), false, _result+".temporary.valid");
-      }
+      if (valid() != null)  // transform the validation frame if present
+        _valid = rebalance(adaptValidFrame(getTrainFrame(_parms.valid()), _valid,  _parms, _gamColNamesCenter, _binvD,
+                _zTranspose, _knots, _zTransposeCS, _allPolyBasisList, _gamColMeansRaw, _oneOGamColStd), 
+                false, _result+".temporary.valid");
       DKV.put(newTFrame); // This one will cause deleted vectors if add to Scope.track
       Frame newValidFrame = _valid == null ? null : new Frame(_valid);
       if (newValidFrame != null) {
         DKV.put(newValidFrame);
       }
-
       _job.update(0, "Initializing model training");
       buildModel(newTFrame, newValidFrame); // build gam model
-
     }
-
 
     public final void buildModel(Frame newTFrame, Frame newValidFrame) {
       GAMModel model = null;
@@ -488,7 +711,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         }
         Scope.track_generic(glmModel);
         _job.update(0, "Building out GAM model...");
-        fillOutGAMModel(glmModel, model, dinfo); // build up GAM model
+        fillOutGAMModel(glmModel, model); // build up GAM model by copying over results in glmModel
         model.update(_job);
         // build GAM Model Metrics
         _job.update(0, "Scoring training frame");
@@ -496,6 +719,9 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
         if (valid() != null) {
           scoreGenModelMetrics(model, valid(), false); // score validation dataset and generate model metrics
         }
+      } catch(Gram.NonSPDMatrixException exception) {
+        throw new Gram.NonSPDMatrixException("Consider enable lambda_search, decrease scale parameter value for TP " +
+                "smoothers, \ndisable scaling for TP penalty matrics, or not use thin plate regression smoothers at all.");
       } finally {
         try {
           final List<Key<Vec>> keep = new ArrayList<>();
@@ -549,7 +775,7 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
     }
 
     GLMModel buildGLMModel(GAMParameters parms, Frame trainData, Frame validFrame) {
-      GLMParameters glmParam = GamUtils.copyGAMParams2GLMParams(parms, trainData, validFrame);  // copy parameter from GAM to GLM
+      GLMParameters glmParam = copyGAMParams2GLMParams(parms, trainData, validFrame);  // copy parameter from GAM to GLM
       if (_cv_lambda != null) { // use best alpha and lambda values from cross-validation to build GLM main model 
         glmParam._lambda = _cv_lambda;
         glmParam._alpha = _cv_alpha;
@@ -558,22 +784,28 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
       int numGamCols = _parms._gam_columns.length;
       for (int find = 0; find < numGamCols; find++) {
         if ((_parms._scale != null) && (_parms._scale[find] != 1.0))
-          _penalty_mat_center[find] = ArrayUtils.mult(_penalty_mat_center[find], _parms._scale[find]);
+          _penaltyMatCenter[find] = ArrayUtils.mult(_penaltyMatCenter[find], _parms._scale[find]);
       }
       glmParam._glmType = gam;
-      return new GLM(glmParam, _penalty_mat_center,  _gamColNamesCenter).trainModel().get();
+      return new GLM(glmParam, _penaltyMatCenter,  _gamColNamesCenter).trainModel().get();
     }
-    
-    void fillOutGAMModel(GLMModel glm, GAMModel model, DataInfo dinfo) {
+
+    void fillOutGAMModel(GLMModel glm, GAMModel model) {
       model._gamColNamesNoCentering = _gamColNames;  // copy over gam column names
       model._gamColNames = _gamColNamesCenter;
       model._output._gamColNames = _gamColNamesCenter;
       model._output._zTranspose = _zTranspose;
+      model._output._zTransposeCS = _zTransposeCS;
+      model._output._allPolyBasisList = _allPolyBasisList;
       model._gamFrameKeysCenter = _gamFrameKeysCenter;
       model._nclass = _nclass;
       model._output._binvD = _binvD;
       model._output._knots = _knots;
       model._output._numKnots = _numKnots;
+      model._cubicSplineNum = _cubicSplineNum;
+      model._thinPlateSmoothersWithKnotsNum = _thinPlateSmoothersWithKnotsNum;
+      model._output._gamColMeansRaw = _gamColMeansRaw;
+      model._output._oneOGamColStd = _oneOGamColStd;
       // extract and store best_alpha/lambda/devianceTrain/devianceValid from best submodel of GLM model
       model._output._best_alpha = glm._output.getSubmodel(glm._output._selected_submodel_idx).alpha_value;
       model._output._best_lambda = glm._output.getSubmodel(glm._output._selected_submodel_idx).lambda_value;
@@ -585,93 +817,16 @@ public class GAM extends ModelBuilder<GAMModel, GAMModel.GAMParameters, GAMModel
       if (_parms._keep_gam_cols)
         model._output._gam_transformed_center_key = model._output._gamTransformedTrainCenter.toString();
       if (_parms._savePenaltyMat) {
-        model._output._penaltyMatrices_center = _penalty_mat_center;
-        model._output._penaltyMatrices = _penalty_mat;
-      }
-      copyGLMCoeffs(glm, model);  // copy over coefficient names and generate coefficients as beta = z*GLM_beta
-      copyGLMtoGAMModel(model, glm);  // copy over fields from glm model to gam model
-    }
-    
-    private void copyGLMtoGAMModel(GAMModel model, GLMModel glmModel) {
-      model._output._glm_best_lamda_value = glmModel._output.bestSubmodel().lambda_value; // exposed best lambda used
-      model._output._glm_training_metrics = glmModel._output._training_metrics;
-      if (valid() != null)
-        model._output._glm_validation_metrics = glmModel._output._validation_metrics;
-      model._output._glm_model_summary = model.copyTwoDimTable(glmModel._output._model_summary);
-      model._output._glm_scoring_history = model.copyTwoDimTable(glmModel._output._scoring_history);
-      if (_parms._family == multinomial || _parms._family == ordinal) {
-        model._output._coefficients_table = model.genCoefficientTableMultinomial(new String[]{"Coefficients",
-                        "Standardized Coefficients"}, model._output._model_beta_multinomial,
-                model._output._standardized_model_beta_multinomial, model._output._coefficient_names,"GAM Coefficients");
-        model._output._coefficients_table_no_centering = model.genCoefficientTableMultinomial(new String[]{"coefficients " +
-                        "no centering", "standardized coefficients no centering"}, 
-                model._output._model_beta_multinomial_no_centering, model._output._standardized_model_beta_multinomial_no_centering, 
-                model._output._coefficient_names_no_centering,"GAM Coefficients No Centering");
-        model._output._standardized_coefficient_magnitudes = model.genCoefficientMagTableMultinomial(new String[]{"coefficients", "signs"},
-                model._output._standardized_model_beta_multinomial, model._output._coefficient_names, "standardized coefficients magnitude");
-      } else{
-        model._output._coefficients_table = model.genCoefficientTable(new String[]{"coefficients", "standardized coefficients"}, model._output._model_beta,
-                model._output._standardized_model_beta, model._output._coefficient_names, "GAM Coefficients");
-        model._output._coefficients_table_no_centering = model.genCoefficientTable(new String[]{"coefficients no centering", 
-                        "standardized coefficients no centering"}, model._output._model_beta_no_centering,
-                model._output._standardized_model_beta_no_centering,
-                model._output._coefficient_names_no_centering, 
-                "GAM Coefficients No Centering");
-        model._output._standardized_coefficient_magnitudes = model.genCoefficientMagTable(new String[]{"coefficients", "signs"}, 
-                model._output._standardized_model_beta, model._output._coefficient_names, "standardized coefficients magnitude");
-      }
-      
-      if (_parms._compute_p_values) {
-        model._output._glm_zvalues = glmModel._output.zValues().clone();
-        model._output._glm_pvalues = glmModel._output.pValues().clone();
-        model._output._glm_stdErr = glmModel._output.stdErr().clone();
-        model._output._glm_vcov = glmModel._output.vcov().clone();
-      }
-      model._output._glm_dispersion = glmModel._output.dispersion();
-      model._nobs = glmModel._nobs;
-      model._nullDOF = glmModel._nullDOF;
-      model._ymu = new double[glmModel._ymu.length];
-      model._rank = glmModel._output.bestSubmodel().rank();
-      model._ymu = new double[glmModel._ymu.length];
-      System.arraycopy(glmModel._ymu, 0, model._ymu, 0, glmModel._ymu.length);
-      // pass GLM _solver value to GAM so that GAM effective _solver value can be set
-      if (model.evalAutoParamsEnabled && model._parms._solver == GLMParameters.Solver.AUTO) {
-        model._parms._solver = glmModel._parms._solver;
-      }
-      model._output._varimp = new VarImp(glmModel._output._varimp._varimp, glmModel._output._varimp._names);
-      model._output._variable_importances = calcVarImp(model._output._varimp);
-    }
-    
-    void copyGLMCoeffs(GLMModel glm, GAMModel model) {
-      boolean multiClass = _parms._family == multinomial || _parms._family == ordinal;
-      int totCoefNumsNoCenter = (multiClass?glm.coefficients().size()/nclasses():glm.coefficients().size())
-              +_parms._gam_columns.length;
-      model._output._coefficient_names_no_centering = new String[totCoefNumsNoCenter]; // copy coefficient names from GLM to GAM
-      int gamNumStart = copyGLMCoeffNames2GAMCoeffNames(model, glm);
-      copyGLMCoeffs2GAMCoeffs(model, glm, _parms._family, gamNumStart, _nclass); // obtain beta without centering
-      // copy over GLM coefficients
-      int glmCoeffLen = glm._output._coefficient_names.length;
-      model._output._coefficient_names = new String[glmCoeffLen];
-      System.arraycopy(glm._output._coefficient_names, 0, model._output._coefficient_names, 0,
-              glmCoeffLen);
-      if (multiClass) {
-        double[][] model_beta_multinomial = glm._output.get_global_beta_multinomial();
-        double[][] standardized_model_beta_multinomial = glm._output.getNormBetaMultinomial();
-        model._output._model_beta_multinomial = new double[_nclass][glmCoeffLen];
-        model._output._standardized_model_beta_multinomial = new double[_nclass][glmCoeffLen];
-        for (int classInd = 0; classInd < _nclass; classInd++) {
-          System.arraycopy(model_beta_multinomial[classInd], 0, model._output._model_beta_multinomial[classInd],
-                  0, glmCoeffLen);
-          System.arraycopy(standardized_model_beta_multinomial[classInd], 0, 
-                  model._output._standardized_model_beta_multinomial[classInd], 0, glmCoeffLen);
+        model._output._penaltyMatricesCenter = _penaltyMatCenter;
+        model._output._penaltyMatrices = _penaltyMat;
+        model._output._penaltyScale = _penaltyScale;
+        if (_thinPlateSmoothersWithKnotsNum > 0) {
+          model._output._penaltyMatCS = _penaltyMatCS;
+          model._output._starT = _starT;
         }
-      } else {
-        model._output._model_beta = new double[glmCoeffLen];
-        model._output._standardized_model_beta = new double[glmCoeffLen];
-        System.arraycopy(glm._output.beta(), 0, model._output._model_beta, 0, glmCoeffLen);
-        System.arraycopy(glm._output.getNormBeta(), 0, model._output._standardized_model_beta, 0, 
-                glmCoeffLen);
       }
+      copyGLMCoeffs(glm, model, _parms, nclasses());  // copy over coefficient names and generate coefficients as beta = z*GLM_beta
+      copyGLMtoGAMModel(model, glm, _parms, valid());  // copy over fields from glm model to gam model
     }
   }
 }

--- a/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/gam/GAMMojoWriter.java
@@ -34,12 +34,6 @@ public class GAMMojoWriter extends ModelMojoWriter<GAMModel, GAMModel.GAMParamet
     writekv("mean_imputation", imputeMeans);
     if (imputeMeans) {
       writekv("numNAFillsCenter", model._output._dinfo.numNAFill());
-      double[] numNAFills = new double[model._output._dinfo.numNAFill().length+numGamCols];
-      System.arraycopy(model._output._dinfo.numNAFill(),0, numNAFills, 0, 
-              model._output._dinfo.numNAFill().length);
-      int startind = numNAFills.length-model._gamColMeans.length;
-      System.arraycopy(model._gamColMeans, 0, numNAFills, startind, model._gamColMeans.length);
-      writekv("numNAFills", numNAFills);
       writekv("catNAFills", model._output._dinfo.catNAFill());
     }
     if (model._parms._family.equals(binomial))
@@ -50,24 +44,33 @@ public class GAMMojoWriter extends ModelMojoWriter<GAMModel, GAMModel.GAMParamet
     if (model._parms._family.equals(GLMModel.GLMParameters.Family.tweedie))
       writekv("tweedie_link_power", model._parms._tweedie_link_power);
     // add GAM specific parameters
-    writekv("num_knots", model._parms._num_knots); // an array
-    writeStringArrays(model._parms._gam_columns, "gam_columns"); // gam_columns specified by users
+    writekv("num_knots", model._parms._num_knots);                // an array
+    writekv("num_knots_sorted", model._parms._num_knots_sorted);  // an array
+    write2DStringArrays(model._parms._gam_columns, "gam_columns"); // gam_columns specified by users
+    write2DStringArrays(model._parms._gam_columns_sorted, "gam_columns_sorted"); // gam_columns specified by users
     int numGamLength = 0;
     int numGamCLength = 0;
-    for (int cInd=0; cInd < numGamCols; cInd++)  { // only contains expanded gam column names not centered
-      writeStringArrays(model._gamColNames[cInd], "gamColNamesCenter_"+model._parms._gam_columns[cInd]);
-      writeStringArrays(model._gamColNamesNoCentering[cInd], "gamColNames_"+model._parms._gam_columns[cInd]);
+    for (int cInd=0; cInd < numGamCols; cInd++)  { // contains expanded gam column names center and not centered
       numGamLength += model._gamColNamesNoCentering[cInd].length;
       numGamCLength += model._gamColNames[cInd].length;
     }
+    int[] gamColumnDim = genGamColumnDim(model._parms._gam_columns);
+    writekv("gam_column_dim", gamColumnDim);              // an array indicating array size of parms._gam_columns
+    int[] gamColumnDimSorted = genGamColumnDim(model._parms._gam_columns_sorted);
+    writekv("gam_column_dim_sorted", gamColumnDimSorted); // an array
     String[] trainColGamColNoCenter = genTrainColGamCols(numGamLength, numGamCLength);
     writekv("num_expanded_gam_columns", numGamLength);
+    writekv("num_expanded_gam_columns_center", numGamCLength);
     writeStringArrays(trainColGamColNoCenter, "_names_no_centering"); // column names without centering
     writekv("total feature size", trainColGamColNoCenter.length);
+    int[] gamColNamesDim = genGamColumnDim(model._gamColNamesNoCentering);
+    writekv("gamColName_dim", gamColNamesDim);
+    write2DStringArrays(model._gamColNames, "gamColNamesCenter");// numGamCol by numKnots for CS, by numKnots+M for TP
+    write2DStringArrays(model._gamColNamesNoCentering,"gamColNames"); // numGamCol by numKnots-1
     if (model._parms._family==multinomial || model._parms._family==ordinal) {
-      writeDoubleArray(model._output._model_beta_multinomial_no_centering, "beta_multinomial");
+      write2DArray(model._output._model_beta_multinomial_no_centering, "beta_multinomial");
       writekv("beta length per class", model._output._model_beta_multinomial_no_centering[0].length);
-      writeDoubleArray(model._output._model_beta_multinomial, "beta_multinomial_centering");
+      write2DArray(model._output._model_beta_multinomial, "beta_multinomial_centering");
       writekv("beta center length per class", model._output._model_beta_multinomial[0].length);
     } else {
       writekv("beta", model._output._model_beta_no_centering); // beta without centering
@@ -75,13 +78,34 @@ public class GAMMojoWriter extends ModelMojoWriter<GAMModel, GAMModel.GAMParamet
       writekv("beta_center", model._output._model_beta);
       writekv("beta center length per class", model._output._model_beta.length);
     }
-    writekv("bs", model._parms._bs);  // an array of choice of spline functions
-    writeDoubleArray(model._output._knots, "knots");
-    int countGamCols = 0;
-    for (String gamCol : model._parms._gam_columns) {
-      writeDoubleArray(model._output._zTranspose[countGamCols], gamCol+"_zTranspose");      // write zTranspose
-      writeDoubleArray(model._output._binvD[countGamCols++], gamCol+"_binvD");      // write binvD
+    writekv("bs", model._parms._bs);                // an array of choice of spline function types
+    writekv("bs_sorted", model._parms._bs_sorted);  // an array of choice of spline functions
+    write3DArray(model._output._knots, "knots");
+    write3DArray(model._output._zTranspose, "zTranspose");
+    writekv("_d", model._parms._gamPredSize);
+    if (model._output._zTransposeCS != null) {  // only for thin plate regression splines
+      write3DIntArray(model._output._allPolyBasisList, "polynomialBasisList");
+      write3DArray(model._output._zTransposeCS, "zTransposeCS");
+      write2DArray(model._output._gamColMeansRaw, "gamColMeansRaw");
+      write2DArray(model._output._oneOGamColStd, "gamColStdRaw");
+      writekv("_M", model._parms._M);
+      writekv("_m", model._parms._m);
+      writekv("num_knots_TP", model._parms._num_knots_tp); // an array
+      writekv("num_TP_col", model._parms._M.length);
+      writekv("standardize", model._parms._standardize);
+    } else {
+      writekv("num_TP_col", 0);
     }
+    if (model._cubicSplineNum > 0)
+      write3DArray(model._output._binvD, "_binvD");
+  }
+  
+  public int[] genGamColumnDim(String[][] gamColumnNames) {
+    int numGamCols = gamColumnNames.length;
+    int[] gamColDim = new int[numGamCols];
+    for (int index = 0; index < numGamCols; index++)
+      gamColDim[index] = gamColumnNames[index].length;
+    return gamColDim;
   }
   
   public String[] genTrainColGamCols(int gamColLength, int gamCColLength) {

--- a/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateDistanceWithKnots.java
+++ b/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateDistanceWithKnots.java
@@ -1,0 +1,116 @@
+package hex.gam.GamSplines;
+
+import hex.DataInfo;
+import hex.glm.GLMModel.GLMParameters.MissingValuesHandling;
+import hex.util.LinearAlgebraUtils.BMulInPlaceTask;
+import water.MRTask;
+import water.MemoryManager;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.fvec.NewChunk;
+import water.fvec.Vec;
+
+import static hex.gam.GAMModel.GAMParameters;
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.*;
+import static hex.genmodel.algos.gam.GamUtilsThinPlateRegression.calculateDistance;
+import static org.apache.commons.math3.util.CombinatoricsUtils.factorial;
+import static water.util.ArrayUtils.transpose;
+
+/**
+ * Implementation details of this class can be found in GamThinPlateRegressionH2O.doc attached to this 
+ * JIRA: https://h2oai.atlassian.net/browse/PUBDEV-7860
+ **/
+public class ThinPlateDistanceWithKnots extends MRTask<ThinPlateDistanceWithKnots> {
+  final double[][] _knots;  // store knot values for the spline class
+  final int _knotNum;       // number of knot values
+  final int _d;             // number of predictors for smoothers
+  final int _m;             // highest degree of polynomial basis +1
+  final public double _constantTerms;
+  final int _weightID;
+  final boolean _dEven;
+  final double[] _oneOverGamColStd;
+  final boolean _standardizeGAM;
+  
+  public ThinPlateDistanceWithKnots(double[][] knots, int d, double[] oneOGamColStd, boolean standardizeGAM) {
+    _knots = knots;
+    _knotNum = _knots[0].length;
+    _d = d;
+    _dEven = _d%2==0;
+    _m = calculatem(_d);
+    _weightID = _d;     // weight column index
+    _oneOverGamColStd = oneOGamColStd;
+    _standardizeGAM = standardizeGAM;
+    if (_dEven)
+      _constantTerms = Math.pow(-1, _m+1+_d/2.0)/(Math.pow(2, 2*_m-1)*Math.pow(Math.PI, _d/2.0)*factorial(_m-1)*
+              factorial(_m-_d/2));
+    else
+      _constantTerms = Math.pow(-1, _m)*_m/(factorial(2*_m)*Math.pow(Math.PI, (_d-1)/2.0));
+  }
+
+  @Override
+  public void map(Chunk[] chk, NewChunk[] newGamCols) {
+    int nrows = chk[0].len();
+    double[] rowValues = MemoryManager.malloc8d(_knotNum);
+    double[] chkRowValues = MemoryManager.malloc8d(_d);
+    for (int rowIndex = 0; rowIndex < nrows; rowIndex++) {
+      if (chk[_weightID].atd(rowIndex) != 0) {
+        if (checkRowNA(chk, rowIndex)) {
+          fillRowOneValue(newGamCols, _knotNum, Double.NaN);
+        } else {  // calculate distance measure as in 3.1
+          fillRowData(chkRowValues, chk, rowIndex, _d);
+          calculateDistance(rowValues, chkRowValues, _knotNum, _knots, _d, _m, _dEven, _constantTerms, 
+                  _oneOverGamColStd, _standardizeGAM);
+          fillRowArray(newGamCols, _knotNum, rowValues);
+        }
+      } else {  // insert 0 to newChunk for weight == 0
+        fillRowOneValue(newGamCols, _knotNum, 0.0);
+      }
+    }
+  }
+  
+  public static void fillRowData(double[] rowHolder, Chunk[] chk, int rowIndex, int d) {
+    for (int colIndex = 0; colIndex < d; colIndex++)
+      rowHolder[colIndex] = chk[colIndex].atd(rowIndex);
+  }
+
+  /**
+   * This function perform the operation described in 3.3 regarding the part of data Xnmd.
+   * 
+   * @param fr: H2OFrame to add gamificed columns to.
+   * @param colNameStart start of column names for gamified columns
+   * @param parms GAMParameters
+   * @param zCST  transpose of zCS transform matrix
+   * @param newColNum number of gamified columns to be added
+   * @return
+   */
+  public static Frame applyTransform(Frame fr, String colNameStart, GAMParameters parms, double[][] zCST, int newColNum) {
+    int numCols = fr.numCols(); // == numKnots
+    DataInfo frInfo = new DataInfo(fr, null, 0, false,  DataInfo.TransformType.NONE, 
+            DataInfo.TransformType.NONE, MissingValuesHandling.Skip == parms._missing_values_handling, 
+            (parms._missing_values_handling == MissingValuesHandling.MeanImputation) || 
+                    (parms._missing_values_handling == MissingValuesHandling.PlugValues), parms.makeImputer(), 
+            false, false, false, false, null);
+    // expand the frame with k-M columns which will contain the product of Xnmd*ZCS
+    for (int colInd = 0; colInd < newColNum; colInd++) {
+      fr.add(colNameStart+"_cs_"+colInd, fr.anyVec().makeZero());
+    }
+    new BMulInPlaceTask(frInfo, zCST, numCols, false).doAll(fr);
+    for (int index=0; index < numCols; index++) { // remove the original gam columns
+      Vec temp = fr.remove(0);
+      temp.remove();
+    }
+    return fr;
+  }
+  
+  public double[][] generatePenalty(double[][] qmat) {
+    double[][] penaltyMat = new double[_knotNum][_knotNum];
+    double[][] knotsTranspose = transpose(_knots);
+    double[] tempVal = MemoryManager.malloc8d(_knotNum);
+    for (int index = 0; index < _knotNum; index++) {
+      calculateDistance(tempVal, knotsTranspose[index], _knotNum, _knots, _d, _m, _dEven, _constantTerms, 
+              _oneOverGamColStd, _standardizeGAM);
+      System.arraycopy(tempVal, 0, penaltyMat[index], 0, _knotNum);
+    } // penaltyMat is right now hollow with zero off diagonal
+    return penaltyMat;
+  }
+}

--- a/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlatePolynomialWithKnots.java
+++ b/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlatePolynomialWithKnots.java
@@ -1,0 +1,56 @@
+package hex.gam.GamSplines;
+
+import water.MRTask;
+import water.MemoryManager;
+import water.fvec.Chunk;
+import water.fvec.NewChunk;
+
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.*;
+import static hex.genmodel.algos.gam.GamUtilsThinPlateRegression.calculatePolynomialBasis;
+
+public class ThinPlatePolynomialWithKnots extends MRTask<ThinPlatePolynomialWithKnots> {
+  final int _weightID;
+  final int[][] _polyBasisList;
+  final int _M; // size of polynomial basis
+  final int _d; // number of predictors used
+  final double[] _gamColMeanRaw;
+  final double[] _oneOverColStd;
+  final boolean _standardizeGAM;
+
+  public ThinPlatePolynomialWithKnots(int weightID, int[][] polyBasis, double[] gamColMeanRaw, double[] oneOverColStd, boolean standardizeGAM) {
+    _weightID = weightID;
+    _d = weightID;
+    _polyBasisList = polyBasis;
+    _M = polyBasis.length;
+    _gamColMeanRaw = gamColMeanRaw;
+    _oneOverColStd = oneOverColStd;
+    _standardizeGAM = standardizeGAM;
+  }
+
+  @Override
+  public void map(Chunk[] chk, NewChunk[] newGamCols) {
+    int numRow = chk[0].len();
+    double[] onePolyRow = MemoryManager.malloc8d(_M);
+    double[] oneDataRow = MemoryManager.malloc8d(_d);
+    for (int rowIndex = 0; rowIndex < numRow; rowIndex++) {
+      if (chk[_weightID].atd(rowIndex) != 0) {
+        if (checkRowNA(chk, rowIndex)) {
+          fillRowOneValue(newGamCols, _M, Double.NaN);
+        } else {
+          extractNDemeanOneRowFromChunk(chk, rowIndex, oneDataRow, _d); // extract data to oneDataRow
+          calculatePolynomialBasis(onePolyRow, oneDataRow, _d, _M, _polyBasisList, _gamColMeanRaw, _oneOverColStd,
+                  _standardizeGAM);                 // generate polynomial basis for oneDataRow
+          fillRowArray(newGamCols, _M, onePolyRow); // fill newChunk with array onePolyRow
+        }
+      } else {  // set the row to zero
+        fillRowOneValue(newGamCols, _M, 0.0);
+      }
+    }
+  }
+  
+  // grab data in each chunk into an array
+  public static void extractNDemeanOneRowFromChunk(Chunk[] chk, int rowIndex, double[] oneRow, int d) {
+    for (int colInd = 0; colInd < d; colInd++)
+      oneRow[colInd] = chk[colInd].atd(rowIndex);
+  }
+}

--- a/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateRegressionUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/GamSplines/ThinPlateRegressionUtils.java
@@ -1,0 +1,354 @@
+package hex.gam.GamSplines;
+
+import water.MRTask;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.fvec.NewChunk;
+import water.util.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static hex.gam.GAMModel.GAMParameters;
+import static water.util.ArrayUtils.maxValue;
+
+/**
+ * This class contains functions that perform different functions for generating the thin plate regression splines
+ * and the polynomial basis functions
+ */
+public class ThinPlateRegressionUtils {
+  /**
+   * For thin plate regression, given d (number of predictors for a smooth), it will return m where (m-1) is the
+   * maximum polynomial degree in the polynomial basis functions.  The formula used is m = ceiling of (d+1)/2+1
+   *
+   * @param d : integer denoting number of predictors for thin plate regression smooth.
+   * @return m : integer denoting the maximum polynomial degree + 1 for polynomial basis function.
+   */
+  public static int calculatem(int d) {
+    return ((int) Math.floor((d+1.0)*0.5))+1;
+  }
+
+  public static int calculateM(int d, int m) {
+    int topComb = d+m-1;
+    return hex.genmodel.utils.MathUtils.combinatorial(topComb, d);
+  }
+
+  /**
+   * This method, given number of predictors in the smooth d, number of polynomials in the polynomial basis m, will
+   * generate a list of integer array specifying for each predictors the degree that predictor will have.  For instance,
+   * if for a predictor, the degree is 0, a constant 1 is used.  If for a particular predictor, the degree is 2, 
+   * predictor*predictor is used.
+   * 
+   * @param d
+   * @param m
+   * @return
+   */
+  public static List<Integer[]> findPolyBasis(int d, int m) {
+    int polyOrder = m-1;
+    int[] possibleDegree = new int[polyOrder];
+    for (int index = 1; index < m; index++)             // generate all polynomial order combinations
+      possibleDegree[index-1] = index;
+    Integer[] basisPolyOrder = new Integer[d];          // store one combination
+    List<Integer[]> totPolyBasis = new ArrayList<>();   // store all combination 
+    for (int degree : possibleDegree) {
+      ArrayList<int[]> oneCombo = new ArrayList<>();
+      findOnePerm(degree, possibleDegree, 0, oneCombo, null);
+      mergeCombos(oneCombo, basisPolyOrder, possibleDegree, totPolyBasis);// merge all combos found for all possibleDegree
+    }
+    return findAllPolybasis(totPolyBasis);
+  }
+
+  /**
+   * For each list in onePolyBasis, we still need to find all the permutations for that list.  In addition, we need to
+   * add the combination for the 0th order as well.  For instance, if the list contains {0,0,1}, we need to add to that
+   * the lists {0,1,0} and {1,0,0} as well.
+   * @param onePolyBasis
+   * @return
+   */
+  public static List<Integer[]> findAllPolybasis(List<Integer[]> onePolyBasis) {
+    int listSize = onePolyBasis.size();
+    List<Integer[]> allPermutes = new ArrayList<>();
+    for (int index = 0; index < listSize; index++) {
+      Integer[] oneBasis = onePolyBasis.get(index);
+      int[] freqTable = generateOrderFreq(oneBasis);  // find polynomial basis order and count
+      List<List<Integer>> basisPermuations = new ArrayList<>();
+      List<Integer> prefix = new ArrayList<>();
+      findPermute(freqTable, prefix, oneBasis.length, basisPermuations);
+      addPermutationList(allPermutes, basisPermuations);
+    }
+    // add the list of all zeros
+    Integer[] allZeros = new Integer[onePolyBasis.get(0).length];
+    for (int index = 0; index < allZeros.length; index++)
+      allZeros[index] = 0;
+    allPermutes.add(0, allZeros); // add all zero degree to the front
+    return allPermutes;
+  }
+  
+  public static void addPermutationList(List<Integer[]> onePolyBasis, List<List<Integer>> permute1Basis) {
+    for (List<Integer> onePermute : permute1Basis) {
+      Integer[] oneCombo = onePermute.toArray(new Integer[0]);
+      onePolyBasis.add(oneCombo);
+    }
+  }
+  
+  public static void findPermute(int[] freqMap, List<Integer> prefix, int remaining,
+                                 List<List<Integer>> basisPerm) {
+    if (remaining == 0) { // done with choosing all permutation
+      basisPerm.add(prefix);
+    } else {
+      for (int index=0; index < freqMap.length; index++) {
+        int val = freqMap[index];
+        if (val > 0) {
+          freqMap[index]--;
+          ArrayList<Integer> newPrefix = new ArrayList<>(prefix);
+          newPrefix.add(index);
+          findPermute(freqMap, newPrefix, remaining-1, basisPerm);
+          freqMap[index] = val;
+        }
+      }
+    }
+  }
+  
+  public static int[] generateOrderFreq(Integer[] oneBasis) {
+    int maxVal = maxValue(oneBasis);
+    int[] mapFreq = new int[maxVal+1];
+    for (int val : oneBasis)
+      mapFreq[val]++;
+    return mapFreq;
+  }
+  
+  public static void mergeCombos(ArrayList<int[]> oneCombo, Integer[] basisOrder, int[] polyBasis, List<Integer[]> polyBasisSet) {
+    for (int[] oneList : oneCombo) {
+      Arrays.fill(basisOrder, 0);
+      expandCombo(oneList, polyBasis, basisOrder);
+      polyBasisSet.add(basisOrder.clone());
+    }
+  }
+
+  /**
+   * Given a combo found by findOnePerm say for d = 5, m = 4, for degree = 1 to m-1 (3 in this case).  The basis poly
+   * is {3,2,1}.  The returned list of combo are: {{0, 0, 1}, {0, 1, 0}, {0, 0, 2}, {1,0,0}, {0,1,1}, {0,0,3}}.
+   * However, we need to convert this list back to the perspective of the predictors.  In this case, we have 5 
+   * predictors.  This function will translate the list from findOnePerm to the perspective of the predictors.  For 
+   * instance, for degree = 1, we need to have one predictive to have degree of 1 and hence the list should be 
+   * {1, 0, 0, 0, 0}.  For degree = 2, we can have one predictor taking degree of 2 or two predictors each taking 
+   * degree 1.  The same applies to the other degrees.  Hence, this function will return the following list: 
+   * {{1, 0, 0, 0, 0}, {0, 2, 0, 0, 0}, {1, 1, 0, 0, 0}, {0, 0, 3, 0, 0}, {1, 2, 0, 0, 0} and {1, 1, 1, 0, 0}}.
+   * @param oneList
+   * @param polyBasis
+   * @param basisOrder
+   */
+  public static void expandCombo(int[] oneList, int[] polyBasis, Integer[] basisOrder) {
+    int expandIndex = 0;
+    for (int index = 0; index < polyBasis.length; index++) {
+      int count = 0;
+      if (oneList[index] == 0) {
+        basisOrder[expandIndex++] = 0;
+      } else {
+        while (count < oneList[index]) {
+          basisOrder[expandIndex++] = polyBasis[index];
+          count++;
+        }
+      }
+    }
+  }
+
+  /**
+   * For a fixed degree specified as totDegree, specified a set of combination of polynomials to achieve the totDegree.
+   * For instance, if degreeCombo = {1,2,3} and the totDegree is 1. There is only one way to achieve it by the array
+   * {1,0,0}.  If totDegree = 2, there are two arrays that will work: {0,1,0} or {2,0,0}.  If totDegree = 3, there will
+   * be 3 arrays that will work {3,0,0}, {1,1,0}, {0,0,1}.
+   * 
+   * @param totDegree : integer representing degree of polynomial basis
+   * @param degreeCombo : degrees allowed for polynomial basis
+   * @param index
+   * @param allCombos
+   * @param currCombo
+   */
+  public static void findOnePerm(int totDegree, int[] degreeCombo, int index, ArrayList<int[]> allCombos,
+                                 int[] currCombo) {
+    if (totDegree == 0) {
+      if (currCombo != null)
+        allCombos.add(currCombo.clone());
+    }  else if (totDegree >= 0 && index < degreeCombo.length){
+      int totPass = totDegree / degreeCombo[index];
+      int degreeCount = 0;
+      if (currCombo == null)
+        currCombo = degreeCombo.clone();
+      while (degreeCount <= totPass) {
+        setCombo(currCombo, index, degreeCount);
+        findOnePerm(totDegree - degreeCount * degreeCombo[index], degreeCombo, index + 1,
+                allCombos, currCombo);
+        degreeCount++;
+      }
+    }
+  }
+
+  public static void setCombo(int[] currCombo, int index, int degreeCount) {
+    currCombo[index] = degreeCount;
+    int combSize = currCombo.length;
+    for (int tempIndex = index+1; tempIndex < combSize; tempIndex++) 
+      currCombo[tempIndex] = 0;
+  }
+  
+  public static double[][] generateStarT(double[][] knots, List<Integer[]> polyBasisDegree, double[] gamColMeanRaw, 
+                                         double[] oneOColStd, boolean standardizeTPSmoothers) {
+    int numKnots = knots[0].length;
+    int M = polyBasisDegree.size();
+    int d = knots.length;
+    double[][] knotsDemean = new double[d][numKnots];
+    for (int predInd = 0; predInd < d; predInd++)
+      for (int index = 0; index < numKnots; index++) {
+        knotsDemean[predInd][index] = standardizeTPSmoothers 
+                ? (knots[predInd][index]-gamColMeanRaw[predInd])*oneOColStd[predInd] 
+                : (knots[predInd][index]-gamColMeanRaw[predInd]);
+      }
+    
+    double[][] starT = new double[numKnots][M];
+    for (int rowInd = 0; rowInd < numKnots; rowInd++) {
+      for (int polyBasisInd = 0; polyBasisInd < M; polyBasisInd++) {
+        Integer[] oneBasis = polyBasisDegree.get(polyBasisInd);
+        double polyBasisVal = 1.0;
+        for (int predInd = 0; predInd < d; predInd++) {
+          polyBasisVal *= Math.pow(knotsDemean[predInd][rowInd], oneBasis[predInd]);
+        }
+        starT[rowInd][polyBasisInd] = polyBasisVal;
+      }
+    }
+    return starT;
+  }
+  
+  public static void fillRowOneValue(NewChunk[] newChk, int colWidth, double fillValue) {
+    for (int colInd = 0; colInd < colWidth; colInd++)
+      newChk[colInd].addNum(fillValue);
+  }
+
+  public static void fillRowArray(NewChunk[] newChk, int colWidth, double[] fillValue) {
+    for (int colInd = 0; colInd < colWidth; colInd++)
+      newChk[colInd].addNum(fillValue[colInd]);
+  }
+
+  public static boolean checkRowNA(Chunk[] chk, int rowIndex) {
+    int numCol = chk.length;
+    for (int colIndex = 0; colIndex < numCol; colIndex++) {
+      if (Double.isNaN(chk[colIndex].atd(rowIndex)))
+        return true;
+    }
+    return false;
+  }
+
+  public static boolean checkFrameRowNA(Frame chk, long rowIndex) {
+    int numCol = chk.numCols();
+    for (int colIndex = 0; colIndex < numCol; colIndex++) {
+      if (Double.isNaN(chk.vec(colIndex).at(rowIndex)))
+        return true;
+    }
+    return false;
+  }
+  
+  public static String genThinPlateNameStart(GAMParameters parms, int gamColIndex) {
+    StringBuffer colNameStub = new StringBuffer();
+    for (int gColInd = 0; gColInd < parms._gam_columns_sorted[gamColIndex].length; gColInd++) {
+      colNameStub.append(parms._gam_columns_sorted[gamColIndex][gColInd]);
+      colNameStub.append("_");
+    }
+    colNameStub.append(parms._bs_sorted[gamColIndex]);
+    colNameStub.append("_");
+    return colNameStub.toString();
+  }
+  
+  public static String[] extractColNames(String[] src, int srcStart, int destStart, int length) {
+    String[] distanceColNames = new String[length];  // exclude the polynomial basis names
+    System.arraycopy(src, srcStart, distanceColNames, destStart, length);
+    return distanceColNames;
+  }
+  
+  public static int[][] convertList2Array(List<Integer[]> list2Convert, int M, int d) {
+    int[][] polyBasisArr = new int[M][d];
+    for (int index = 0; index < M; index++) {
+      List<Integer> oneList = Arrays.asList(list2Convert.get(index));
+      polyBasisArr[index] = oneList.stream().mapToInt(Integer::intValue).toArray();
+    }
+    return polyBasisArr;
+  }
+
+  /**
+   * Generate knots for thin plate (TP) smoothers.  Sort the first predictor column, take quatiles out of the sorted first
+   * column and grab the corresponding rows of second, third, ... predictor columns.
+   * @param predictVec H2OFrame containing predictor columns used to build the TP smoothers.
+   * @param parms GAMParameter
+   * @param predIndex integer denoting GAM column specificationm in parms._gam_columns
+   * @return  array of knot values for predictor columns specified in parms._gam_columns[predIndex]
+   */
+  public static double[][] genKnotsMultiplePreds(Frame predictVec, GAMParameters parms, int predIndex) {
+    Frame sortedFirstDim = predictVec.sort(new int[]{0}); // sort with first GAM Columns
+    double stepProb = 1.0 / parms._num_knots[predIndex];
+    long rowSteps = (long) Math.floor(stepProb * sortedFirstDim.numRows());
+    int numPred = parms._gam_columns[predIndex].length;
+    double[][] knots = new double[numPred][parms._num_knots[predIndex]];
+    long nrow = sortedFirstDim.numRows();
+    long nextRow = 1;
+    long currRow = 0;
+    for (int knotIndex = 0; knotIndex < parms._num_knots[predIndex]; knotIndex++) {
+      currRow = knotIndex*rowSteps;
+      nextRow = (knotIndex+1)*rowSteps;
+      while (currRow < nrow && currRow < nextRow) { // look for knots that do not contains NAs
+        if (!checkFrameRowNA(sortedFirstDim, currRow)) {
+          for (int colIndex = 0; colIndex < numPred; colIndex++) {
+            knots[colIndex][knotIndex] = sortedFirstDim.vec(colIndex).at(currRow);
+          }
+        break;
+        }
+        currRow++;
+      }
+    }
+    sortedFirstDim.remove();  // remove sorted frame
+    parms._num_knots[predIndex] = knots[0].length;
+    return knots;
+  }
+  
+  /**
+   * this class performs scaling on TP penalty matrices that is done in R.
+   */
+  public static class ScaleTPPenalty extends MRTask<ScaleTPPenalty> {
+    public double[][] _penaltyMat;
+    double[] _maxAbsRowSum; // store maximum row sum per chunk
+    public int _initChunks; // number of chunks
+    public double _s_scale;
+
+    public ScaleTPPenalty(double[][] origPenaltyMat, Frame distancePlusPoly) {
+      _penaltyMat = origPenaltyMat;
+      _initChunks = distancePlusPoly.vec(0).nChunks();
+    }
+
+    @Override
+    public void map(Chunk[] chk, NewChunk[] newGamCols) {
+      _maxAbsRowSum = new double[_initChunks];
+      int cIndex = chk[0].cidx();
+      _maxAbsRowSum[cIndex] = Double.NEGATIVE_INFINITY;
+      int numRow = chk[0]._len;
+      for (int rowIndex = 0; rowIndex < numRow; rowIndex++) {
+        double rowSum = 0.0;
+        for (int colIndex = 0; colIndex < chk.length; colIndex++) {
+          rowSum += Math.abs(chk[colIndex].atd(rowIndex));
+        }
+        if (rowSum > _maxAbsRowSum[cIndex])
+          _maxAbsRowSum[cIndex] = rowSum;
+      }
+    }
+
+    @Override
+    public void reduce(ScaleTPPenalty other) {
+      ArrayUtils.add(_maxAbsRowSum, other._maxAbsRowSum);
+    }
+    
+    @Override
+    public void postGlobal() {  // scale the _penalty function according to R
+      double tempMaxValue = ArrayUtils.maxValue(_maxAbsRowSum);
+      _s_scale = tempMaxValue*tempMaxValue/ArrayUtils.rNorm(_penaltyMat, 'i');  // symmetric matrix
+      ArrayUtils.mult(_penaltyMat, _s_scale);
+      _s_scale = 1.0 / _s_scale;
+    }
+  }
+}

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/AddTPKnotsGamColumns.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/AddTPKnotsGamColumns.java
@@ -1,0 +1,138 @@
+package hex.gam.MatrixFrameUtils;
+
+
+import hex.gam.GamSplines.ThinPlateDistanceWithKnots;
+import hex.gam.GamSplines.ThinPlatePolynomialWithKnots;
+import water.DKV;
+import water.Key;
+import water.fvec.Frame;
+import water.fvec.Vec;
+
+import static hex.gam.GAMModel.GAMParameters;
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.extractColNames;
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.genThinPlateNameStart;
+import static hex.gam.MatrixFrameUtils.GamUtils.generateGamColNamesThinPlateKnots;
+import static hex.gam.MatrixFrameUtils.GamUtils.prepareGamVec;
+import static org.apache.commons.math3.util.CombinatoricsUtils.factorial;
+import static water.util.ArrayUtils.sum;
+
+// This class generatea all TP gamified columns
+public class AddTPKnotsGamColumns {
+  final double[][][] _zCS;
+  final double[][][] _z;
+  final int[][][] _polyBasisList;
+  final int[] _numKnots;
+  final int[] _d;
+  final int[] _M;
+  final int[] _m;
+  final GAMParameters _parms;
+  public final int _gamCols2Add;
+  final double[][][] _knots;
+  final int _numTPCols;
+  final int _numCSCols;
+  final double[] _constantTerms;
+  final boolean[] _dEven;
+  final Frame _adapted;
+  public Key<Frame>[] _gamFrameKeysCenter;  // store frame keys of transformed gam columns
+  
+  public AddTPKnotsGamColumns(GAMParameters parms, double[][][] zcs, double[][][] z, int[][][] polyBasis, 
+                              double[][][] knots, Frame fr) {
+    _zCS = zcs;
+    _z = z;
+    _polyBasisList = polyBasis;
+    _numKnots = parms._num_knots_tp;
+    _d = parms._gamPredSize;
+    _M = parms._M;
+    _m = parms._m;
+    _parms = parms;
+    _gamCols2Add = sum(_numKnots) - _numKnots.length;
+    _knots = knots;
+    _numTPCols = _M.length;
+    _numCSCols = parms._gam_columns_sorted.length - _numTPCols;
+    _dEven = new boolean[_numTPCols];
+    _constantTerms = new double[_numTPCols];
+    _gamFrameKeysCenter = new Key[_numTPCols];
+    for (int index = 0; index < _numTPCols; index++) {
+      _dEven[index] = (_parms._gamPredSize[index] % 2) == 0;
+      if (_dEven[index])
+        _constantTerms[index] = Math.pow(-1, _m[index]+1+_d[index]/2.0)/(Math.pow(2, _m[index]-1)*Math.pow(Math.PI, 
+                _d[index]/2.0)*factorial(_m[index]-_d[index]/2));
+      else
+        _constantTerms[index] = Math.pow(-1, _m[index])*_m[index]/(factorial(2*_m[index])*Math.pow(Math.PI, 
+                (_d[index]-1)/2.0));
+    }
+    _adapted = fr;
+  }
+
+  public void addTPGamCols(double[][] gamColMeansRaw, double[][] oneOColStd) {
+    for (int index = 0; index < _numTPCols; index++) { // generate smoothers/splines for each gam smoother
+      final int offsetIndex = index + _numCSCols;
+      final Frame predictVec = prepareGamVec(offsetIndex, _parms, _adapted);  // extract predictors from training frame
+      ApplyTPRegressionSmootherWithKnots addSmoother = new ApplyTPRegressionSmootherWithKnots(predictVec, _parms, offsetIndex,
+              _knots[offsetIndex], index, _zCS[index], _z[offsetIndex], _polyBasisList[index], gamColMeansRaw[index],
+              oneOColStd[index]);
+      addSmoother.applySmoothers();
+    }
+  }
+
+  public class ApplyTPRegressionSmootherWithKnots {
+    final Frame _predictVec;
+    final int _numKnots;
+    final int _numKnotsM1;
+    final int _numKnotsMM;  // store k-M
+    final double[][] _knots;
+    final GAMParameters _parms;
+    final int _gamColIndex;
+    final int _thinPlateGamColIndex;
+    final int _numPred; // number of predictors == d
+    final int _M;
+    final double[][] _zCST;
+    final double[][] _zT;
+    final int[][] _polyBasisList;
+    final double[] _gamColMeanRaw;
+    final double[] _oneOColStd;
+
+    public ApplyTPRegressionSmootherWithKnots(Frame predV, GAMParameters parms, int gamColIndex, double[][] knots,
+                                              int thinPlateInd, double[][] zCST, double[][] zT, int[][] polyBasis, 
+                                              double[] gamColMeanRaw, double[] oneOColStd) {
+      _predictVec  = predV;
+      _knots = knots;
+      _numKnots = knots[0].length;
+      _numKnotsM1 = _numKnots-1;
+      _parms = parms;
+      _gamColIndex = gamColIndex;
+      _thinPlateGamColIndex = thinPlateInd;
+      _numPred = parms._gam_columns_sorted[gamColIndex].length;
+      _M = _parms._M[_thinPlateGamColIndex];
+      _numKnotsMM = _numKnots-_M;
+      _zCST = zCST;
+      _zT = zT;
+      _polyBasisList = polyBasis;
+      _gamColMeanRaw = gamColMeanRaw;
+      _oneOColStd = oneOColStd;
+    }
+    
+    void applySmoothers() {
+      ThinPlateDistanceWithKnots distanceMeasure =
+              new ThinPlateDistanceWithKnots(_knots, _numPred, _oneOColStd, _parms._standardize).doAll(_numKnots, 
+                      Vec.T_NUM, _predictVec);                          // Xnmd in 3.1
+      String colNameStub = genThinPlateNameStart(_parms, _gamColIndex); // gam column names before processing
+      String[] gamColNames = generateGamColNamesThinPlateKnots(_gamColIndex, _parms, _polyBasisList, colNameStub);
+      String[] distanceColNames = extractColNames(gamColNames, 0, 0, _numKnots);
+      String[] polyNames = extractColNames(gamColNames, _numKnots, 0, _M);
+      Frame thinPlateFrame = distanceMeasure.outputFrame(Key.make(), distanceColNames, null);
+
+      thinPlateFrame = ThinPlateDistanceWithKnots.applyTransform(thinPlateFrame, colNameStub
+              +"CS_", _parms, _zCST, _numKnotsMM);        // generate Xcs as in 3.3
+      ThinPlatePolynomialWithKnots thinPlatePoly = new ThinPlatePolynomialWithKnots(_numPred, _polyBasisList,
+              _gamColMeanRaw, _oneOColStd, _parms._standardize).doAll(_M,
+              Vec.T_NUM, _predictVec);                    // generate polynomial basis T as in 3.2
+      Frame thinPlatePolyBasis = thinPlatePoly.outputFrame(null, polyNames, null);
+      thinPlateFrame.add(thinPlatePolyBasis.names(), thinPlatePolyBasis.removeAll());         // concatenate Xcs and T
+      thinPlateFrame = ThinPlateDistanceWithKnots.applyTransform(thinPlateFrame, colNameStub+"center_",
+              _parms, _zT, _numKnotsM1);                  // generate Xz as in 3.4
+      _gamFrameKeysCenter[_thinPlateGamColIndex] = thinPlateFrame._key;
+      DKV.put(thinPlateFrame);
+    }
+  }
+}

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GAMModelUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GAMModelUtils.java
@@ -1,0 +1,183 @@
+package hex.gam.MatrixFrameUtils;
+
+import hex.VarImp;
+import hex.gam.GAMModel;
+import hex.glm.GLMModel;
+import water.fvec.Frame;
+import water.util.ArrayUtils;
+
+import static hex.ModelMetrics.calcVarImp;
+import static hex.gam.GAMModel.GAMParameters;
+import static hex.glm.GLMModel.GLMParameters;
+import static hex.glm.GLMModel.GLMParameters.Family.multinomial;
+import static hex.glm.GLMModel.GLMParameters.Family.ordinal;
+import static water.util.ArrayUtils.find;
+
+public class GAMModelUtils {
+  public static void copyGLMCoeffs(GLMModel glm, GAMModel model, GAMParameters parms, int nclass) {
+    boolean multiClass = parms._family == multinomial || parms._family == ordinal;
+    int totCoefNumsNoCenter = (multiClass?glm.coefficients().size()/nclass:glm.coefficients().size())
+            +gamNoCenterCoeffLength(parms);
+    model._output._coefficient_names_no_centering = new String[totCoefNumsNoCenter]; // copy coefficient names from GLM to GAM
+    int gamNumStart = copyGLMCoeffNames2GAMCoeffNames(model, glm);
+    copyGLMCoeffs2GAMCoeffs(model, glm, parms._family, gamNumStart, nclass); // obtain beta without centering
+    // copy over GLM coefficients
+    int glmCoeffLen = glm._output._coefficient_names.length;
+    model._output._coefficient_names = new String[glmCoeffLen];
+    System.arraycopy(glm._output._coefficient_names, 0, model._output._coefficient_names, 0,
+            glmCoeffLen);
+    if (multiClass) {
+      double[][] model_beta_multinomial = glm._output.get_global_beta_multinomial();
+      double[][] standardized_model_beta_multinomial = glm._output.getNormBetaMultinomial();
+      model._output._model_beta_multinomial = new double[nclass][glmCoeffLen];
+      model._output._standardized_model_beta_multinomial = new double[nclass][glmCoeffLen];
+      for (int classInd = 0; classInd < nclass; classInd++) {
+        System.arraycopy(model_beta_multinomial[classInd], 0, model._output._model_beta_multinomial[classInd],
+                0, glmCoeffLen);
+        System.arraycopy(standardized_model_beta_multinomial[classInd], 0,
+                model._output._standardized_model_beta_multinomial[classInd], 0, glmCoeffLen);
+      }
+    } else {
+      model._output._model_beta = new double[glmCoeffLen];
+      model._output._standardized_model_beta = new double[glmCoeffLen];
+      System.arraycopy(glm._output.beta(), 0, model._output._model_beta, 0, glmCoeffLen);
+      System.arraycopy(glm._output.getNormBeta(), 0, model._output._standardized_model_beta, 0,
+              glmCoeffLen);
+    }
+  }
+
+  /***
+   * Find the number of gamified column coefficients.  This is more difficult with thin plate regression smoothers.
+   * For thin plate regression smoothers, each smoother will have columns _numKnots + _M
+   * @param parms
+   */
+  public static int gamNoCenterCoeffLength(GAMParameters parms) {
+    int tpCount = 0;
+    int numGam = parms._gam_columns.length;
+    int gamifiedColCount = 0;
+    for (int index = 0; index < numGam; index++) {
+      if (parms._bs_sorted[index]==0) { // cubic spline
+        gamifiedColCount++;
+      } else {
+        gamifiedColCount += (1+parms._M[tpCount++]);
+      }
+    }
+    return gamifiedColCount;
+  }
+
+  public static void copyGLMtoGAMModel(GAMModel model, GLMModel glmModel, GAMParameters parms, Frame valid) {
+    model._output._glm_best_lamda_value = glmModel._output.bestSubmodel().lambda_value; // exposed best lambda used
+    model._output._glm_training_metrics = glmModel._output._training_metrics;
+    if (valid != null)
+      model._output._glm_validation_metrics = glmModel._output._validation_metrics;
+    model._output._glm_model_summary = model.copyTwoDimTable(glmModel._output._model_summary);
+    model._output._glm_scoring_history = model.copyTwoDimTable(glmModel._output._scoring_history);
+    if (parms._family == multinomial || parms._family == ordinal) {
+      model._output._coefficients_table = model.genCoefficientTableMultinomial(new String[]{"Coefficients",
+                      "Standardized Coefficients"}, model._output._model_beta_multinomial,
+              model._output._standardized_model_beta_multinomial, model._output._coefficient_names,"GAM Coefficients");
+      model._output._coefficients_table_no_centering = model.genCoefficientTableMultinomial(new String[]{"coefficients " +
+                      "no centering", "standardized coefficients no centering"},
+              model._output._model_beta_multinomial_no_centering, model._output._standardized_model_beta_multinomial_no_centering,
+              model._output._coefficient_names_no_centering,"GAM Coefficients No Centering");
+      model._output._standardized_coefficient_magnitudes = model.genCoefficientMagTableMultinomial(new String[]{"coefficients", "signs"},
+              model._output._standardized_model_beta_multinomial, model._output._coefficient_names, "standardized coefficients magnitude");
+    } else{
+      model._output._coefficients_table = model.genCoefficientTable(new String[]{"coefficients", "standardized coefficients"}, model._output._model_beta,
+              model._output._standardized_model_beta, model._output._coefficient_names, "GAM Coefficients");
+      model._output._coefficients_table_no_centering = model.genCoefficientTable(new String[]{"coefficients no centering",
+                      "standardized coefficients no centering"}, model._output._model_beta_no_centering,
+              model._output._standardized_model_beta_no_centering,
+              model._output._coefficient_names_no_centering,
+              "GAM Coefficients No Centering");
+      model._output._standardized_coefficient_magnitudes = model.genCoefficientMagTable(new String[]{"coefficients", "signs"},
+              model._output._standardized_model_beta, model._output._coefficient_names, "standardized coefficients magnitude");
+    }
+
+    if (parms._compute_p_values) {
+      model._output._glm_zvalues = glmModel._output.zValues().clone();
+      model._output._glm_pvalues = glmModel._output.pValues().clone();
+      model._output._glm_stdErr = glmModel._output.stdErr().clone();
+      model._output._glm_vcov = glmModel._output.vcov().clone();
+    }
+    model._output._glm_dispersion = glmModel._output.dispersion();
+    model._nobs = glmModel._nobs;
+    model._nullDOF = glmModel._nullDOF;
+    model._ymu = new double[glmModel._ymu.length];
+    model._rank = glmModel._output.bestSubmodel().rank();
+    model._ymu = new double[glmModel._ymu.length];
+    System.arraycopy(glmModel._ymu, 0, model._ymu, 0, glmModel._ymu.length);
+    // pass GLM _solver value to GAM so that GAM effective _solver value can be set
+    if (model.evalAutoParamsEnabled && model._parms._solver == GLMParameters.Solver.AUTO) {
+      model._parms._solver = glmModel._parms._solver;
+    }
+    model._output._varimp = new VarImp(glmModel._output._varimp._varimp, glmModel._output._varimp._names);
+    model._output._variable_importances = calcVarImp(model._output._varimp);
+  }
+
+  public static int copyGLMCoeffNames2GAMCoeffNames(GAMModel model, GLMModel glm) {
+    int numGamCols = model._gamColNamesNoCentering.length;
+    String[] glmColNames = glm._output.coefficientNames();
+    int lastGLMCoeffIndex = glmColNames.length-1;
+    int lastGAMCoeffIndex = lastGLMCoeffIndex+gamNoCenterCoeffLength(model._parms);
+    int gamNumColStart = find(glmColNames, model._gamColNames[0][0]);
+    int gamLengthCopied = gamNumColStart;
+    System.arraycopy(glmColNames, 0, model._output._coefficient_names_no_centering, 0, gamLengthCopied); // copy coeff names before gam columns
+    for (int gamColInd = 0; gamColInd < numGamCols; gamColInd++) {
+      System.arraycopy(
+              model._gamColNamesNoCentering[gamColInd], 0,
+              model._output._coefficient_names_no_centering, gamLengthCopied,
+              model._gamColNamesNoCentering[gamColInd].length
+      );
+      gamLengthCopied += model._gamColNamesNoCentering[gamColInd].length;
+    }
+    model._output._coefficient_names_no_centering[lastGAMCoeffIndex] = glmColNames[lastGLMCoeffIndex];// copy intercept
+    return gamNumColStart;
+  }
+
+  public static void copyGLMCoeffs2GAMCoeffs(GAMModel model, GLMModel glm, GLMParameters.Family family,
+                                             int gamNumStart, int nclass) {
+    int numCoeffPerClass = model._output._coefficient_names_no_centering.length;
+    if (family.equals(GLMParameters.Family.multinomial) || family.equals(GLMParameters.Family.ordinal)) {
+      double[][] model_beta_multinomial = glm._output.get_global_beta_multinomial();
+      double[][] standardized_model_beta_multinomial = glm._output.getNormBetaMultinomial();
+      model._output._model_beta_multinomial_no_centering = new double[nclass][];
+      model._output._standardized_model_beta_multinomial_no_centering = new double[nclass][];
+      for (int classInd = 0; classInd < nclass; classInd++) {
+        model._output._model_beta_multinomial_no_centering[classInd] = convertCenterBeta2Beta(model._output._zTranspose,
+                gamNumStart, model_beta_multinomial[classInd], numCoeffPerClass);
+        model._output._standardized_model_beta_multinomial_no_centering[classInd] = convertCenterBeta2Beta(model._output._zTranspose,
+                gamNumStart, standardized_model_beta_multinomial[classInd], numCoeffPerClass);
+      }
+    } else {  // other families
+      model._output._model_beta_no_centering = convertCenterBeta2Beta(model._output._zTranspose, gamNumStart,
+              glm.beta(), numCoeffPerClass);
+      model._output._standardized_model_beta_no_centering = convertCenterBeta2Beta(model._output._zTranspose, gamNumStart,
+              glm._output.getNormBeta(), numCoeffPerClass);
+    }
+  }
+
+  // This method carries out the evaluation of beta = Z betaCenter as explained in documentation 7.2
+  public static double[] convertCenterBeta2Beta(double[][][] ztranspose, int gamNumStart, double[] centerBeta,
+                                                int betaSize) {
+    double[] originalBeta = new double[betaSize];
+    if (ztranspose!=null) { // centering is performed
+      int numGamCols = ztranspose.length;
+      int gamColStart = gamNumStart;
+      int origGamColStart = gamNumStart;
+      System.arraycopy(centerBeta,0, originalBeta, 0, gamColStart);   // copy everything before gamCols
+      for (int colInd=0; colInd < numGamCols; colInd++) {
+        double[] tempCbeta = new double[ztranspose[colInd].length];
+        System.arraycopy(centerBeta, gamColStart, tempCbeta, 0, tempCbeta.length);
+        double[] tempBeta = ArrayUtils.multVecArr(tempCbeta, ztranspose[colInd]);
+        System.arraycopy(tempBeta, 0, originalBeta, origGamColStart, tempBeta.length);
+        gamColStart += tempCbeta.length;
+        origGamColStart += tempBeta.length;
+      }
+      originalBeta[betaSize-1]=centerBeta[centerBeta.length-1];
+    } else
+      System.arraycopy(centerBeta, 0, originalBeta, 0, betaSize); // no change needed, just copy over
+
+    return originalBeta;
+  }
+}

--- a/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
+++ b/h2o-algos/src/main/java/hex/gam/MatrixFrameUtils/GamUtils.java
@@ -1,13 +1,14 @@
 package hex.gam.MatrixFrameUtils;
 
 import hex.Model;
-import hex.gam.GAMModel;
 import hex.gam.GAMModel.GAMParameters;
-import hex.glm.GLMModel;
 import hex.glm.GLMModel.GLMParameters;
+import hex.quantile.Quantile;
+import hex.quantile.QuantileModel;
 import water.DKV;
 import water.Key;
 import water.MemoryManager;
+import water.Scope;
 import water.fvec.Frame;
 import water.fvec.Vec;
 import water.util.ArrayUtils;
@@ -17,25 +18,57 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-import static water.util.ArrayUtils.find;
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.calculateM;
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.calculatem;
 
 public class GamUtils {
 
   // allocate 3D array to store various information;
-  public static double[][][] allocate3DArray(int num2DArrays, GAMParameters parms, AllocateType fileMode) {
+  public static double[][][] allocate3DArrayCS(int num2DArrays, GAMParameters parms, AllocateType fileMode) {
     double[][][] array3D = new double[num2DArrays][][];
+    int gamColCount = 0;
     for (int frameIdx = 0; frameIdx < num2DArrays; frameIdx++) {
-      int numKnots = parms._num_knots[frameIdx];
-      switch (fileMode) {
-        case firstOneLess: array3D[frameIdx] = MemoryManager.malloc8d(numKnots-1, numKnots); break;
-        case sameOrig: array3D[frameIdx] = MemoryManager.malloc8d(numKnots, numKnots); break;
-        case bothOneLess: array3D[frameIdx] = MemoryManager.malloc8d(numKnots-1, numKnots-1); break;
-        case firstTwoLess: array3D[frameIdx] = MemoryManager.malloc8d(numKnots-2, numKnots); break;
-        default: throw new IllegalArgumentException("fileMode can only be firstOneLess, sameOrig, bothOneLess or " +
-                "firstTwoLess.");
+      if (parms._gam_columns_sorted[frameIdx].length == 1) {
+        int numKnots = parms._num_knots_sorted[frameIdx];
+        array3D[gamColCount++] = allocate2DArray(fileMode, numKnots);
       }
     }
     return array3D;
+  }
+
+  public static double[][][] allocate3DArray(int num2DArrays, GAMParameters parms, AllocateType fileMode) {
+    double[][][] array3D = new double[num2DArrays][][];
+    for (int frameIdx = 0; frameIdx < num2DArrays; frameIdx++)
+        array3D[frameIdx] = allocate2DArray(fileMode, parms._num_knots_sorted[frameIdx]);
+    return array3D;
+  }
+
+  // allocate 3D array to store various information;
+  public static double[][][] allocate3DArrayTP(int num2DArrays, GAMParameters parms, int[] secondDim, int[] thirdDim) {
+    double[][][] array3D = new double[num2DArrays][][];
+    int gamColCount = 0;
+    int numGamCols = parms._gam_columns.length;
+    for (int frameIdx = 0; frameIdx < numGamCols; frameIdx++) {
+      if (parms._bs_sorted[frameIdx] == 1) {
+        array3D[gamColCount] = MemoryManager.malloc8d(secondDim[gamColCount], thirdDim[gamColCount]);
+        gamColCount++;
+      }
+    }
+    return array3D;
+  }
+
+  // allocate 3D array to store various information;
+  public static double[][] allocate2DArray(AllocateType fileMode, int numKnots) {
+    double[][] array2D;
+      switch (fileMode) {
+        case firstOneLess: array2D = MemoryManager.malloc8d(numKnots-1, numKnots); break;
+        case sameOrig: array2D = MemoryManager.malloc8d(numKnots, numKnots); break;
+        case bothOneLess: array2D = MemoryManager.malloc8d(numKnots-1, numKnots-1); break;
+        case firstTwoLess: array2D = MemoryManager.malloc8d(numKnots-2, numKnots); break;
+        default: throw new IllegalArgumentException("fileMode can only be firstOneLess, sameOrig, bothOneLess or " +
+                "firstTwoLess.");
+      }
+    return array2D;
   }
 
   public enum AllocateType {firstOneLess, sameOrig, bothOneLess, firstTwoLess} // special functions are performed depending on GLMType.  Internal use
@@ -85,6 +118,14 @@ public class GamUtils {
     }
   }
 
+  public static void copy2DArray(int[][] src_array, int[][] dest_array) {
+    int numRows = src_array.length;
+    for (int colIdx = 0; colIdx < numRows; colIdx++) { // save zMatrix for debugging purposes or later scoring on training dataset
+      System.arraycopy(src_array[colIdx], 0, dest_array[colIdx], 0,
+              src_array[colIdx].length);
+    }
+  }
+
   public static GLMParameters copyGAMParams2GLMParams(GAMParameters parms, Frame trainData, Frame valid) {
     GLMParameters glmParam = new GLMParameters();
     Field[] field1 = GAMParameters.class.getDeclaredFields();
@@ -124,76 +165,193 @@ public class GamUtils {
     }
   }
 
-  public static void copyGLMCoeffs2GAMCoeffs(GAMModel model, GLMModel glm, GLMParameters.Family family,
-                                             int gamNumStart, int nclass) {
-    int numCoeffPerClass = model._output._coefficient_names_no_centering.length;
-    if (family.equals(GLMParameters.Family.multinomial) || family.equals(GLMParameters.Family.ordinal)) {
-      double[][] model_beta_multinomial = glm._output.get_global_beta_multinomial();
-      double[][] standardized_model_beta_multinomial = glm._output.getNormBetaMultinomial();
-      model._output._model_beta_multinomial_no_centering = new double[nclass][];
-      model._output._standardized_model_beta_multinomial_no_centering = new double[nclass][];
-      for (int classInd = 0; classInd < nclass; classInd++) {
-        model._output._model_beta_multinomial_no_centering[classInd] = convertCenterBeta2Beta(model._output._zTranspose,
-                gamNumStart, model_beta_multinomial[classInd], numCoeffPerClass);
-        model._output._standardized_model_beta_multinomial_no_centering[classInd] = convertCenterBeta2Beta(model._output._zTranspose,
-                gamNumStart, standardized_model_beta_multinomial[classInd], numCoeffPerClass);
-      }
-    } else {  // other families
-      model._output._model_beta_no_centering = convertCenterBeta2Beta(model._output._zTranspose, gamNumStart,
-              glm.beta(), numCoeffPerClass);
-      model._output._standardized_model_beta_no_centering = convertCenterBeta2Beta(model._output._zTranspose, gamNumStart,
-              glm._output.getNormBeta(), numCoeffPerClass);
-    }
-  }
-
-  // This method carries out the evaluation of beta = Z betaCenter as explained in documentation 7.2
-  public static double[] convertCenterBeta2Beta(double[][][] ztranspose, int gamNumStart, double[] centerBeta,
-                                                int betaSize) {
-    double[] originalBeta = new double[betaSize];
-    if (ztranspose!=null) { // centering is performed
-      int numGamCols = ztranspose.length;
-      int gamColStart = gamNumStart;
-      int origGamColStart = gamNumStart;
-      System.arraycopy(centerBeta,0, originalBeta, 0, gamColStart);   // copy everything before gamCols
-      for (int colInd=0; colInd < numGamCols; colInd++) {
-        double[] tempCbeta = new double[ztranspose[colInd].length];
-        System.arraycopy(centerBeta, gamColStart, tempCbeta, 0, tempCbeta.length);
-        double[] tempBeta = ArrayUtils.multVecArr(tempCbeta, ztranspose[colInd]);
-        System.arraycopy(tempBeta, 0, originalBeta, origGamColStart, tempBeta.length);
-        gamColStart += tempCbeta.length;
-        origGamColStart += tempBeta.length;
-      }
-      originalBeta[betaSize-1]=centerBeta[centerBeta.length-1];
-    } else
-      System.arraycopy(centerBeta, 0, originalBeta, 0, betaSize); // no change needed, just copy over
-
-    return originalBeta;
-  }
-
-  public static int copyGLMCoeffNames2GAMCoeffNames(GAMModel model, GLMModel glm) {
-      int numGamCols = model._gamColNamesNoCentering.length;
-      String[] glmColNames = glm._output.coefficientNames();
-      int lastGLMCoeffIndex = glmColNames.length-1;
-      int lastGAMCoeffIndex = lastGLMCoeffIndex+numGamCols;
-      int gamNumColStart = find(glmColNames, model._gamColNames[0][0]);
-      int gamLengthCopied = gamNumColStart;
-      System.arraycopy(glmColNames, 0, model._output._coefficient_names_no_centering, 0, gamLengthCopied); // copy coeff names before gam columns
-      for (int gamColInd = 0; gamColInd < numGamCols; gamColInd++) {
-        System.arraycopy(
-                model._gamColNamesNoCentering[gamColInd], 0, 
-                model._output._coefficient_names_no_centering, gamLengthCopied,
-                model._gamColNamesNoCentering[gamColInd].length
-        );
-        gamLengthCopied += model._gamColNamesNoCentering[gamColInd].length;
-      }
-      model._output._coefficient_names_no_centering[lastGAMCoeffIndex] = new String(glmColNames[lastGLMCoeffIndex]);
-      return gamNumColStart;
-  }
-
   public static void keepFrameKeys(List<Key<Vec>> keep, Key<Frame> ... keyNames) {
     for (Key<Frame> keyName:keyNames) {
       Frame loadingFrm = DKV.getGet(keyName);
       if (loadingFrm != null) for (Vec vec : loadingFrm.vecs()) keep.add(vec._key);
     }
+  }
+
+  public static void setDefaultBSType(GAMParameters parms) {
+    parms._bs = new int[parms._gam_columns.length];
+    for (int index = 0; index < parms._bs.length; index++) {
+      if (parms._gam_columns[index].length > 1) {
+        parms._bs[index] = 1;
+      } else {
+        parms._bs[index] = 0;
+      }
+    }
+  }
+
+  public static void setThinPlateParameters(GAMParameters parms, int thinPlateNum) {
+    int numGamCols = parms._gam_columns.length;
+    parms._m = MemoryManager.malloc4(thinPlateNum);
+    parms._M = MemoryManager.malloc4(thinPlateNum);
+    int countThinPlate = 0;
+    for (int index = 0; index < numGamCols; index++) {
+      if (parms._bs[index] == 1) { // todo: add in bs==2 when it is supported
+        int d = parms._gam_columns[index].length;
+        parms._m[countThinPlate] = calculatem(d);
+        parms._M[countThinPlate] = calculateM(d, parms._m[countThinPlate]);
+        countThinPlate++;
+      }
+    }
+  }
+  
+  public static void setGamPredSize(GAMParameters parms, int csOffset) {
+    int numGamCols = parms._gam_columns.length;
+    int tpCount = csOffset;
+    int csCount = 0;
+    parms._gamPredSize = MemoryManager.malloc4(numGamCols);
+    for (int index = 0; index < numGamCols; index++) {
+      if (parms._gam_columns[index].length == 1) { // CS
+        parms._gamPredSize[csCount++] = 1;
+      } else {  // TP
+        parms._gamPredSize[tpCount++] = parms._gam_columns[index].length;
+      }
+    }
+  }
+
+  // This method will generate knot locations by choosing them from a uniform quantile distribution of that
+  // chosen column.
+  public static double[] generateKnotsOneColumn(Frame gamFrame, int knotNum) {
+    double[] knots = MemoryManager.malloc8d(knotNum);
+    try {
+      Scope.enter();
+      Frame tempFrame = new Frame(gamFrame);  // make sure we have a frame key
+      DKV.put(tempFrame);
+      double[] prob = MemoryManager.malloc8d(knotNum);
+      assert knotNum > 1;
+      double stepProb = 1.0 / (knotNum - 1);
+      for (int knotInd = 0; knotInd < knotNum; knotInd++)
+        prob[knotInd] = knotInd * stepProb;
+      QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
+      parms._train = tempFrame._key;
+      parms._probs = prob;
+      QuantileModel qModel = new Quantile(parms).trainModel().get();
+      DKV.remove(tempFrame._key);
+      Scope.track_generic(qModel);
+      System.arraycopy(qModel._output._quantiles[0], 0, knots, 0, knotNum);
+    } finally {
+      Scope.exit();
+    }
+    return knots;
+  }
+
+  // grad all predictors to build a smoother
+  public static Frame prepareGamVec(int gam_column_index, GAMParameters parms, Frame fr) {
+    final Vec weights_column = (parms._weights_column == null) ? Scope.track(Vec.makeOne(fr.numRows()))
+            : Scope.track(fr.vec(parms._weights_column));
+    final Frame predictVec = new Frame();
+    int numPredictors = parms._gam_columns_sorted[gam_column_index].length;
+    for (int colInd = 0; colInd < numPredictors; colInd++)
+      predictVec.add(parms._gam_columns_sorted[gam_column_index][colInd],
+              fr.vec(parms._gam_columns_sorted[gam_column_index][colInd]));
+    predictVec.add("weights_column", weights_column); // add weight columns for CV support
+    return predictVec;
+  }
+
+  public static String[] generateGamColNames(int gam_col_index, GAMParameters parms) {
+    String[] newColNames = new String[parms._num_knots_sorted[gam_col_index]];
+    StringBuffer nameStub = new StringBuffer();
+    int numPredictors = parms._gam_columns_sorted[gam_col_index].length;
+    for (int predInd = 0; predInd < numPredictors; predInd++) {
+      nameStub.append(parms._gam_columns_sorted[gam_col_index][predInd]+"_");
+    }
+    String stubName = nameStub.toString();
+    for (int knotIndex = 0; knotIndex < parms._num_knots_sorted[gam_col_index]; knotIndex++) {
+      newColNames[knotIndex] = stubName+knotIndex;
+    }
+    return newColNames;
+  }
+  
+  public static String[] generateGamColNamesThinPlateKnots(int gamColIndex, GAMParameters parms, 
+                                                           int[][] polyBasisDegree, String nameStub) {
+    int num_knots = parms._num_knots_sorted[gamColIndex];
+    int polyBasisSize = polyBasisDegree.length;
+    String[] gamColNames = new String[num_knots+polyBasisSize];
+    for (int index = 0; index < num_knots; index++)
+      gamColNames[index] = nameStub+index;
+    
+    for (int index = 0; index < polyBasisSize; index++) {
+      gamColNames[index+num_knots] = genPolyBasisNames(parms._gam_columns_sorted[gamColIndex], polyBasisDegree[index]);
+    }
+    return gamColNames;
+  }
+  
+  public static String genPolyBasisNames(String[] gam_columns, int[] oneBasis) {
+    StringBuffer polyBasisName = new StringBuffer();
+    int numGamCols = gam_columns.length;
+    int beforeLastIndex = numGamCols-1;
+    for (int index = 0; index < numGamCols; index++) {
+      polyBasisName.append(gam_columns[index]);
+      polyBasisName.append("_");
+      polyBasisName.append(oneBasis[index]);
+      if (index < beforeLastIndex)
+        polyBasisName.append("_");
+    }
+    return polyBasisName.toString();
+  }
+
+  public static Frame buildGamFrame(GAMParameters parms, Frame train, Key<Frame>[] gamFrameKeysCenter) {
+    Vec responseVec = train.remove(parms._response_column);
+    Vec weightsVec = null;
+    if (parms._weights_column != null) // move weight vector to be the last vector before response variable
+      weightsVec = Scope.track(train.remove(parms._weights_column));
+    for (int colIdx = 0; colIdx < parms._gam_columns_sorted.length; colIdx++) {  // append the augmented columns to _train
+      Frame gamFrame = Scope.track(gamFrameKeysCenter[colIdx].get());
+      train.add(gamFrame.names(), gamFrame.removeAll());
+      train.remove(parms._gam_columns_sorted[colIdx]);
+    }
+    if (weightsVec != null)
+      train.add(parms._weights_column, weightsVec);
+    if (responseVec != null)
+      train.add(parms._response_column, responseVec);
+    return train;
+  }
+
+  public static Frame concateGamVecs(Key<Frame>[] gamFrameKeysCenter) {
+    Frame gamVecs =  new Frame(Key.make());
+    for (int index = 0; index < gamFrameKeysCenter.length; index++) {
+      Frame tempCols = Scope.track(gamFrameKeysCenter[index].get());
+      gamVecs.add(tempCols.names(), tempCols.removeAll());
+    }
+    return gamVecs;
+  }
+  
+  // move CS spline smoothers to the front and TP spline smoothers to the back for arrays:
+  // gam_columns, bs, scale, num_knots
+  public static void sortGAMParameters(GAMParameters parms, int csNum, int tpNum) {
+    int gamColNum = parms._gam_columns.length;
+    int csIndex = 0;
+    int tpIndex = csNum;
+    parms._gam_columns_sorted = new String[gamColNum][];
+    parms._num_knots_sorted = MemoryManager.malloc4(gamColNum);
+    parms._scale_sorted = MemoryManager.malloc8d(gamColNum);
+    parms._bs_sorted = MemoryManager.malloc4(gamColNum);
+    parms._gamPredSize = MemoryManager.malloc4(gamColNum);
+    for (int index = 0; index < gamColNum; index++) {
+      if (parms._bs[index] == 0) { // cubic spline
+        parms._gam_columns_sorted[csIndex] = parms._gam_columns[index].clone();
+        parms._num_knots_sorted[csIndex] = parms._num_knots[index];
+        parms._scale_sorted[csIndex] = parms._scale[index];
+        parms._gamPredSize[csIndex] = parms._gam_columns_sorted[csIndex].length;
+        parms._bs_sorted[csIndex++] = parms._bs[index];
+      } else {  // thin plate
+        parms._gam_columns_sorted[tpIndex] = parms._gam_columns[index].clone();
+        parms._num_knots_sorted[tpIndex] = parms._num_knots[index];
+        parms._scale_sorted[tpIndex] = parms._scale[index];
+        parms._gamPredSize[tpIndex] = parms._gam_columns_sorted[tpIndex].length;
+        parms._bs_sorted[tpIndex++] = parms._bs[index];
+      }
+    }
+  }
+
+  // default value of scale is 1.0
+  public static void setDefaultScale(GAMParameters parms) {
+    int numGamCol = parms._gam_columns.length;
+    parms._scale = new double[numGamCol];
+    for (int index = 0; index < numGamCol; index++)
+      parms._scale[index] = 1.0;
   }
 }

--- a/h2o-algos/src/main/java/hex/schemas/GAMV3.java
+++ b/h2o-algos/src/main/java/hex/schemas/GAMV3.java
@@ -75,6 +75,8 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
             "num_knots",  // array: number of knots for each predictor
             "knot_ids", // string array storing frame keys that contains knot location
             "gam_columns",  // array: predictor column names array
+            "standardize_tp_gam_cols", // standardize TP gam columns before transformation
+            "scale_tp_penalty_mat", // scale penalty matrix
             "bs", // array, name of basis functions used
             "scale", // array, smoothing parameter for GAM,
             "keep_gam_cols",
@@ -228,20 +230,30 @@ public class GAMV3 extends ModelBuilderSchema<GAM, GAMV3, GAMV3.GAMParametersV3>
     @API(help = "Number of knots for gam predictors", level = Level.critical, gridable = true)
     public int[] num_knots;
 
-    @API(help = "Predictor column names for gam", required = true, level = Level.critical, gridable = true)
-    public String[] gam_columns;
+    @API(help = "Arrays of predictor column names for gam for smoothers using single or multiple predictors like " +
+            "{{'c1'},{'c2','c3'},{'c4'},...}", required = true, level = Level.critical, gridable = true)
+    public String[][] gam_columns;
 
-    @API(help = "Smoothing parameter for gam predictors", level = Level.critical, gridable = true)
+    @API(help = "Smoothing parameter for gam predictors.  If specified, must be of the same length as gam_columns",
+            level = Level.critical, gridable = true)
     public double[] scale;
 
-    @API(help = "Basis function type for each gam predictors, 0 for cr", level = Level.critical, gridable = true)
+    @API(help = "Basis function type for each gam predictors, 0 for cr, 1 for thin plate regression with knots, 2 for" +
+            " thin plate regression with SVD.  If specified, must be the same size as gam_columns",
+            level = Level.critical, gridable = true)
     public int[] bs;
     //public BSType bs;
 
     @API(help="Save keys of model matrix", level = Level.secondary, direction = Direction.INPUT)
     public boolean keep_gam_cols; // if true will save keys storing GAM columns
+
+    @API(help="standardize tp (thin plate) predictor columns", level = Level.secondary, direction = Direction.INPUT)
+    public boolean standardize_tp_gam_cols; // if true, will standardize predictor columns before gamification
+
+    @API(help="Scale penalty matrix for tp (thin plate) smoothers as in R", level = Level.secondary, direction = Direction.INPUT)
+    public boolean scale_tp_penalty_mat; // if true, will apply scaling to the penalty matrix CS
     
-    @API(help="String arrays storing frame keys of knots.  One for each gam column specified in gam_columns", 
+    @API(help="String arrays storing frame keys of knots.  One for each gam column set specified in gam_columns", 
             level = Level.secondary, direction = Direction.INPUT)
     public String[] knot_ids;
   }

--- a/h2o-algos/src/main/java/hex/util/LinearAlgebraUtils.java
+++ b/h2o-algos/src/main/java/hex/util/LinearAlgebraUtils.java
@@ -2,6 +2,7 @@ package hex.util;
 
 import Jama.EigenvalueDecomposition;
 import Jama.Matrix;
+import Jama.QRDecomposition;
 import hex.DataInfo;
 import hex.FrameTask;
 import hex.Interaction;
@@ -24,6 +25,7 @@ import java.util.List;
 
 import static java.util.Arrays.sort;
 import static org.apache.commons.lang.ArrayUtils.reverse;
+import static water.util.ArrayUtils.*;
 
 public class LinearAlgebraUtils {
   /*
@@ -132,6 +134,81 @@ public class LinearAlgebraUtils {
     }
     ForkJoinTask.invokeAll(ras);
     return lowDiag;
+  }
+
+  /***
+   * Given an matrix, a QR decomposition is carried out to the matrix as starT = QR.  Given Q, an orthogonal bais
+   * that is complement to Q is generated consisting of numBasis vectors.
+   * 
+   * @param starT: double array that will have a QR decomposition carried out on
+   * @param numBasis: integer denoting number of basis in the orthogonal complement
+   * @return
+   */
+  public static double[][] generateOrthogonalComplement(final double[][] orthMat, final double[][] starT, final int numBasis, long seed) {
+    final int numOrthVec = orthMat[0].length;  // number of vectors in original orthogonal basis
+    final int vecSize = orthMat.length;  // size of vector
+    final double[][] orthMatT = transpose(orthMat);
+    double[][] orthMatCompT = new double[numBasis][vecSize];  // store transpose of orthogonal complement
+    double[][] orthMatCompT2 = new double[numBasis][vecSize];
+    double[][] orthMatCompT3;
+    double[] innerProd = new double[numOrthVec];
+    double[] scaleProd = new double[vecSize];
+    // take the difference between random vectors and qMat
+    orthMatCompT3 = subtract(generateIdentityMat(vecSize), ArrayUtils.multArrArr(orthMat, orthMatT));
+    for (int index = 0; index < numBasis; index++) {
+      System.arraycopy(orthMatCompT3[index], 0, orthMatCompT2[index], 0, vecSize);
+    }
+    applyGramSchmit(orthMatCompT2);
+    for (int index = 0; index < numBasis; index++) {
+      orthMatCompT[index] = ArrayUtils.gaussianVector(seed + index, orthMatCompT[index]);
+      genInnerProduct(orthMatT, orthMatCompT[index], innerProd);
+      for (int basisInd = 0; basisInd < numOrthVec; basisInd++) {
+        System.arraycopy(orthMatT[basisInd], 0, scaleProd, 0, vecSize);
+        mult(scaleProd, innerProd[basisInd]);
+        subtract(orthMatCompT[index], scaleProd, orthMatCompT[index]);
+      }
+    }
+    
+    // go through random vectors with orthogonal vector basis subtracted from it, make them orthogonal to each other
+    applyGramSchmit(orthMatCompT);
+    return orthMatCompT;
+  }
+  
+  public static double[][] generateIdentityMat(int size) {
+    double[][] identity = new double[size][size];
+    for (int index = 0; index < size; index++)
+      identity[index][index] = 1.0;
+    return identity;
+  }
+  
+  public static double[][] generateQR(final double[][] starT) {
+    Matrix starTMat = new Matrix(starT);        // generate Zcs as in 3.3
+    QRDecomposition starTMat_qr = new QRDecomposition(starTMat);
+    return starTMat_qr.getQ().getArray();
+  }
+  
+  public static void genInnerProduct(double[][] mat, double[] vector, double[] innerProd) {
+    int numVec = mat.length;
+    for (int index = 0; index < numVec; index++) {
+      innerProd[index] = ArrayUtils.innerProduct(mat[index], vector);
+    }
+  }
+  
+  public static void applyGramSchmit(double[][] matT) {
+    int numVec = matT.length;
+    int vecSize = matT[0].length;
+    double[] innerProd = new double[numVec];
+    double[] scaleVec = new double[vecSize];
+    for (int index = 0; index < numVec; index++) {
+      genInnerProduct(matT, matT[index], innerProd);
+      for (int indexJ = 0; indexJ < index; indexJ++) {  // take the difference between random vectors
+        System.arraycopy(matT[indexJ], 0, scaleVec, 0, vecSize);
+        mult(scaleVec, innerProd[indexJ]);
+        subtract(matT[index], scaleVec, matT[index]);
+      }
+      double mag = 1.0/l2norm(matT[index]);
+      ArrayUtils.mult(matT[index], mag);  // make vector to have unit magnitude
+    }
   }
 
   public static double[][] expandLowTrian2Ful(double[][] cholL) {

--- a/h2o-algos/src/test/java/hex/gam/GamMojoModelTest.java
+++ b/h2o-algos/src/test/java/hex/gam/GamMojoModelTest.java
@@ -38,7 +38,7 @@ public class GamMojoModelTest {
       params._response_column = "CAPSULE";
       params._family = quasibinomial;
       params._ignored_columns = new String[]{"ID"};
-      params._gam_columns = new String[]{"PSA"};
+      params._gam_columns = new String[][]{{"PSA"}};
       params._num_knots = new int[]{5};
       params._train = fr._key;
       params._link = GLMModel.GLMParameters.Link.logit;
@@ -60,7 +60,7 @@ public class GamMojoModelTest {
       // test for binomial
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       Frame trainBinomial = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/binomial_20_cols_10KRows.csv"),
               binomial));
       DKV.put(trainBinomial);
@@ -86,7 +86,7 @@ public class GamMojoModelTest {
     try {
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       Frame trainGaussian = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/gaussian_20cols_10000Rows.csv"), gaussian));
       DKV.put(trainGaussian);
       GAMModel gaussianmodel = getModel(gaussian,
@@ -112,7 +112,7 @@ public class GamMojoModelTest {
     try {
       // multinomial
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      String[] gamCols = new String[]{"C6", "C7", "C8"};
+      String[][] gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
       Frame trainMultinomial = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"), multinomial));
       DKV.put(trainMultinomial);
       GAMModel multinomialModel = getModel(multinomial,
@@ -123,6 +123,61 @@ public class GamMojoModelTest {
       Scope.track_generic(multinomialModel);
       Frame predictMult = Scope.track(multinomialModel.score(trainMultinomial));
       assertTrue(multinomialModel.testJavaScoring(trainMultinomial, predictMult, _tol)); // compare scoring result with mojo
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // add TP GAM cols only MOJO
+  // add multiple TP and CS cols MOJO for multinomial family
+  @Test
+  public void testMojo2CS1TP() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"));
+      train.replace((10), train.vec(10).toCategoricalVec()).remove();
+      DKV.put(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C6"},{"C7", "C8"}, {"C9"}};
+      GAMModel.GAMParameters params = new GAMModel.GAMParameters();
+      int k = 5;
+      params._response_column = "C11";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{0,k,0};
+      params._gam_columns = gamCols;
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      GAMModel gam = new GAM(params).trainModel().get();
+      Frame predictMult = Scope.track(gam.score(train));
+      assertTrue(gam.testJavaScoring(train, predictMult, _tol)); // compare scoring result with mojo      
+      Scope.track_generic(gam);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test TP/CS Smoothers for binomial family
+  @Test
+  public void testMojoCSTPBinomial() {
+    Scope.enter();
+    try {
+      Frame train = parseTestFile("smalldata/glm_test/binomial_20_cols_10KRows.csv");
+      train.replace((20), train.vec(20).toCategoricalVec()).remove();
+      DKV.put(train);
+      Scope.track(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", 
+      "C13", "C14", "C15", "C16", "C17", "C18", "C19", "C20"};
+      String[][] gamCols = new String[][]{{"C12"}, {"C13", "C14"}, {"C15", "C16", "C17"}, {"C18"}};
+      GAMModel.GAMParameters params = new GAMModel.GAMParameters();
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._gam_columns = gamCols;
+      params._bs = new int[]{1,1,1,0};
+      params._train = train._key;
+      GAMModel gam = new GAM(params).trainModel().get();
+      Frame predictMult = Scope.track(gam.score(train));
+      assertTrue(gam.testJavaScoring(train, predictMult, _tol)); // compare scoring result with mojo      
+      Scope.track_generic(gam);
     } finally {
       Scope.exit();
     }
@@ -141,7 +196,7 @@ public class GamMojoModelTest {
       params._tweedie_variance_power = 1.5;
       params._tweedie_link_power = 0.5;
       params._ignored_columns = new String[]{"ID"};
-      params._gam_columns = new String[]{"x.TRAVTIME"};
+      params._gam_columns = new String[][]{{"x.TRAVTIME"}};
       params._num_knots = new int[]{5};
       params._train = fr._key;
       final GAMModel model = new GAM(params).trainModel().get();
@@ -170,7 +225,7 @@ public class GamMojoModelTest {
     return paramsO;
   }
 
-  public String[] chooseGamColumns(Frame trainF, int maxGamCols) {
+  public String[][] chooseGamColumns(Frame trainF, int maxGamCols) {
     int gamCount=0;
     ArrayList<String> numericCols = new ArrayList<>();
     String[] colNames = trainF.names();
@@ -182,7 +237,7 @@ public class GamMojoModelTest {
       if (gamCount >= maxGamCols)
         break;
     }
-    String[] gam_columns = new String[numericCols.size()];
+    String[][] gam_columns = new String[1][numericCols.size()];
     return numericCols.toArray(gam_columns);
   }
 
@@ -195,18 +250,24 @@ public class GamMojoModelTest {
       final Frame fr = Scope.track(createTrainFrameWithNaNs());
       final GAMModel.GAMParameters params = new GAMModel.GAMParameters();
       int cidx = 0;
-      String[] gam_columns = new String[3];
+      int numGam = 3; // ideally have 3 gam columns
+      String[] tempGamColumns = new String[numGam];
       for (int i = 0; i < fr.numCols(); i++) {
         if (!fr.name(i).equals("response")&& fr.vec(i).get_type() == Vec.T_NUM) {
-          gam_columns[cidx++] = fr.name(i);
-          if (cidx == gam_columns.length) break;
+          tempGamColumns[cidx++] = fr.name(i);
+          if (cidx == numGam) break;
         }
       }
+      String[][] gam_columns = new String[cidx][1];
       params._response_column = "response";
       params._missing_values_handling = GLMModel.GLMParameters.MissingValuesHandling.MeanImputation;
       params._family = gaussian;
+      params._scale = new double[cidx];  // {0.001, 0.001, 0.001};
+      for (int index = 0; index < cidx; index++) {
+        params._scale[index] = 0.001;
+        gam_columns[index][0] = tempGamColumns[index];
+      }
       params._gam_columns = gam_columns;
-      params._scale = new double[] {0.001, 0.001, 0.001};
       params._train = fr._key;
       final GAMModel model = new GAM(params).trainModel().get();
       Scope.track_generic(model);

--- a/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
+++ b/h2o-algos/src/test/java/hex/gam/GamTestPiping.java
@@ -49,12 +49,12 @@ public class GamTestPiping extends TestUtil {
     try {
       Scope.enter();
       String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      String[] gamCols = new String[]{"C6"};
-      final GAMModel model = getModel(gaussian,
+      String[][] gamCols = new String[][]{{"C6"}};
+      final GAMModel model = getModel(multinomial,
               Scope.track(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv")),
               "C11", gamCols, ignoredCols, new int[]{5}, new int[]{0}, false,
               true, new double[]{1}, new double[]{0}, new double[]{0}, false, null,
-              null, true);
+              null, false);
       Scope.track_generic(model);
       final double[][] rBinvD = new double[][]{{1.5605080,
               -3.5620961, 2.5465468, -0.6524143, 0.1074557}, {-0.4210098, 2.5559955, -4.3258597, 2.6228736,
@@ -70,7 +70,7 @@ public class GamTestPiping extends TestUtil {
 
       TestUtil.checkDoubleArrays(model._output._binvD[0], rBinvD, 1e-6); // compare binvD generation
       TestUtil.checkDoubleArrays(model._output._penaltyMatrices[0], rS, 1e-6);  // compare penalty terms
-      TestUtil.checkDoubleArrays(model._output._penaltyMatrices_center[0], rScenter, 1e-6);
+      TestUtil.checkDoubleArrays(model._output._penaltyMatricesCenter[0], rScenter, 1e-6);
       
       Frame rTransformedData = parseTestFile("smalldata/gam_test/multinomial_10_classes_10_cols_10000_Rows_train_C6Gam.csv");
       Scope.track(rTransformedData);
@@ -100,7 +100,7 @@ public class GamTestPiping extends TestUtil {
       Scope.track(knotsFrame);
 
       String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      String[] gamCols = new String[]{"C6"};
+      String[][] gamCols = new String[][]{{"C6"}};
       final GAMModel model = getModel(gaussian,
               Scope.track(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv")),
               "C11", gamCols, ignoredCols, new int[]{5}, new int[]{0}, false,
@@ -121,7 +121,7 @@ public class GamTestPiping extends TestUtil {
 
       TestUtil.checkDoubleArrays(model._output._binvD[0], rBinvD, 1e-6); // compare binvD generation
       TestUtil.checkDoubleArrays(model._output._penaltyMatrices[0], rS, 1e-6);  // compare penalty terms
-      TestUtil.checkDoubleArrays(model._output._penaltyMatrices_center[0], rScenter, 1e-6);
+      TestUtil.checkDoubleArrays(model._output._penaltyMatricesCenter[0], rScenter, 1e-6);
 
       Frame transformedDataC = ((Frame) DKV.getGet(model._output._gamTransformedTrainCenter));  // compare model matrix with centering
       Scope.track(transformedDataC);
@@ -142,7 +142,7 @@ public class GamTestPiping extends TestUtil {
     try {
       Scope.enter();
       final String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      final String[] gamCols = new String[]{"C6", "C7", "C8"};
+      final String[][] gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
       final Frame train = massageFrame(
               Scope.track(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv")), multinomial);
       DKV.put(train);
@@ -158,11 +158,11 @@ public class GamTestPiping extends TestUtil {
       params._train = train._key;
       params._solver = GLMModel.GLMParameters.Solver.IRLSM;
       final GAMModel gam = new GAM(params).trainModel().get();
-      double[][][] penaltyMat1 = gam._output._penaltyMatrices_center;
+      double[][][] penaltyMat1 = gam._output._penaltyMatricesCenter;
       Scope.track_generic(gam);
       params._scale = new double[]{10, 10, 10};
       final GAMModel gam2 = new GAM(params).trainModel().get();
-      double[][][] penaltyMat2 = gam2._output._penaltyMatrices_center;
+      double[][][] penaltyMat2 = gam2._output._penaltyMatricesCenter;
       Scope.track_generic(gam2);
       // ratio of penaltyMat2 and penaltyMat1 should be approximately 10/0.1 = 100
       assert penaltyMat1.length == penaltyMat2.length && penaltyMat1[0].length == penaltyMat2[0].length && 
@@ -194,7 +194,7 @@ public class GamTestPiping extends TestUtil {
       Scope.enter();
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       Frame train = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/gaussian_20cols_10000Rows.csv"), gaussian));
       DKV.put(train);
       Scope.track(train);
@@ -209,11 +209,11 @@ public class GamTestPiping extends TestUtil {
       params._train = train._key;
       params._solver = GLMModel.GLMParameters.Solver.IRLSM;
       final GAMModel gam = new GAM(params).trainModel().get();
-      double[][][] penaltyMat1 = gam._output._penaltyMatrices_center;
+      double[][][] penaltyMat1 = gam._output._penaltyMatricesCenter;
       Scope.track_generic(gam);
       params._scale = new double[]{10, 10, 10};
       final GAMModel gam2 = new GAM(params).trainModel().get();
-      double[][][] penaltyMat2 = gam2._output._penaltyMatrices_center;
+      double[][][] penaltyMat2 = gam2._output._penaltyMatricesCenter;
       Scope.track_generic(gam2);
       // ratio of penaltyMat2 and penaltyMat1 should be approximately 10/0.1 = 100
       assert penaltyMat1.length == penaltyMat2.length && penaltyMat1[0].length == penaltyMat2[0].length &&
@@ -248,7 +248,7 @@ public class GamTestPiping extends TestUtil {
     try {
       Scope.enter();
       final String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      final String[] gamCols = new String[]{"C6", "C7", "C8"};
+      final String[][] gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
       final int numGamCols = gamCols.length;
       final GAMModel model = getModel(gaussian,
               Scope.track(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
@@ -273,7 +273,7 @@ public class GamTestPiping extends TestUtil {
 
       for (int test = 0; test < numGamCols; test++) {
         TestUtil.checkDoubleArrays(model._output._binvD[test], rBinvD[test], 1e-6); // compare binvD generation
-        TestUtil.checkDoubleArrays(model._output._penaltyMatrices_center[test], rScenter[test], 1e-6);
+        TestUtil.checkDoubleArrays(model._output._penaltyMatricesCenter[test], rScenter[test], 1e-6);
       }
 
       Frame transformedDataC = ((Frame) DKV.getGet(model._output._gamTransformedTrainCenter));  // compare model matrix with centering
@@ -305,10 +305,10 @@ public class GamTestPiping extends TestUtil {
   }
   
   public static GAMModel getModel(GLMModel.GLMParameters.Family family, Frame train, String responseColumn,
-                           String[] gamCols, String[] ignoredCols, int[] numKnots, int[] bstypes, boolean saveZmat,
+                           String[][] gamCols, String[] ignoredCols, int[] numKnots, int[] bstypes, boolean saveZmat,
                            boolean savePenalty, double[] scale, double[] alpha, double[] lambda, 
                            boolean standardize, String[] knotsKey, Frame valid, boolean computePVal) {
-    GAMModel gam = null;
+    GAMModel gam;
     try {
       Scope.enter();
       train = massageFrame(train, family);
@@ -346,7 +346,7 @@ public class GamTestPiping extends TestUtil {
   }
 
   public GAMModel getModel(GLMModel.GLMParameters.Family family, Frame train, String responseColumn,
-                           String[] gamCols, String[] ignoredCols, int[] numKnots, int[] bstypes, boolean saveZmat,
+                           String[][] gamCols, String[] ignoredCols, int[] numKnots, int[] bstypes, boolean saveZmat,
                            boolean savePenalty, double[] scale, double[] alpha, double[] lambda,
                            boolean standardize, String[] knotsKey, Frame valid, boolean computePVal,
                            GLMModel.GLMParameters.Family autoRepresentingFamily) {
@@ -368,7 +368,7 @@ public class GamTestPiping extends TestUtil {
     try {
       Scope.enter();
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      String[] gamCols = new String[]{"C6", "C7", "C8"};
+      String[][] gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
       GLMModel.GLMParameters.Family[] fams = new GLMModel.GLMParameters.Family[]{multinomial, gaussian};     
       GLMModel.GLMParameters.Link[] links = new GLMModel.GLMParameters.Link[]{GLMModel.GLMParameters.Link.multinomial, 
               GLMModel.GLMParameters.Link.identity};
@@ -449,10 +449,10 @@ public class GamTestPiping extends TestUtil {
         activeCols = ArrayUtils.toIntegers(activeColumns, 0, activeColumns.length);
       }
       Gram gramGAM = gt2.getGram(); // add penalty contribution to gram
-      gramGAM.addGAMPenalty(activeCols, model._output._penaltyMatrices_center, gamCoeffIndices);
+      gramGAM.addGAMPenalty(activeCols, model._output._penaltyMatricesCenter, gamCoeffIndices);
       // manually add contribution from penalty terms
       double[][] gramGLM = gt.getGram().getXX();
-      double[][][] penalty_mat = model._output._penaltyMatrices_center;
+      double[][][] penalty_mat = model._output._penaltyMatricesCenter;
       int numGamCols = penalty_mat.length;
       for (int gamColInd = 0; gamColInd < numGamCols; gamColInd++) {
         int numKnots = penalty_mat[gamColInd].length;
@@ -491,7 +491,7 @@ public class GamTestPiping extends TestUtil {
   public void checkObjectiveGradients(DataInfo dinfo, GLMModel.GLMParameters glmParms, GAMModel model,
                                       GLMModel.GLMParameters.Family fam) {
     int[][] gamCoeffIndices = new int[][]{{10, 11, 12, 13}, {14, 15, 16, 17}, {18, 19, 20, 21}};
-    double[][][] penalty_mat = model._output._penaltyMatrices_center;
+    double[][][] penalty_mat = model._output._penaltyMatricesCenter;
     glmParms._glmType = gam;
     double[] beta = fam.equals(gaussian)?model._output._model_beta 
             :TestUtil.changeDouble2SingleArray(model._output._model_beta_multinomial);
@@ -591,7 +591,7 @@ public class GamTestPiping extends TestUtil {
       // test for binomial
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       Frame trainBinomial = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/binomial_20_cols_10KRows.csv"),
               binomial));
       DKV.put(trainBinomial);
@@ -621,7 +621,8 @@ public class GamTestPiping extends TestUtil {
       
       // multinomial
       ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      gamCols = new String[]{"C6", "C7", "C8"};
+
+      gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
       Frame trainMultinomial = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"), multinomial));
       DKV.put(trainMultinomial);
       GAMModel multinomialModel = getModel(multinomial,
@@ -643,7 +644,7 @@ public class GamTestPiping extends TestUtil {
     Scope.enter();
     try {
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      String[] gamCols = new String[]{"C6", "C7", "C8"};
+      String[][] gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
       Frame trainMultinomial = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"), multinomial));
       DKV.put(trainMultinomial);
       Frame trainMultiWithC11Categorical = parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv");
@@ -673,7 +674,7 @@ public class GamTestPiping extends TestUtil {
     try {
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       Frame trainGaussian = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/gaussian_20cols_10000Rows.csv"), gaussian));
       DKV.put(trainGaussian);
       
@@ -697,7 +698,7 @@ public class GamTestPiping extends TestUtil {
     try {
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       Frame trainBinomial = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/binomial_20_cols_10KRows.csv"), binomial));
       DKV.put(trainBinomial);
       Frame trainBinomialWithC21Categorical = parseTestFile("smalldata/glm_test/binomial_20_cols_10KRows.csv");
@@ -741,7 +742,7 @@ public class GamTestPiping extends TestUtil {
     try {
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       Frame trainBinomial = Scope.track(massageFrame(parseTestFile("smalldata/glm_test/binomial_20_cols_10KRows.csv"),
               binomial));
       DKV.put(trainBinomial);
@@ -772,7 +773,7 @@ public class GamTestPiping extends TestUtil {
       // test for gaussian
       String[] ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", "C13", "C14",
               "C15", "C16", "C17", "C18", "C19", "C20"};
-      String[] gamCols = new String[]{"C11", "C12", "C13"};
+      String[][] gamCols = new String[][]{{"C11"}, {"C12"}, {"C13"}};
       GAMModel binomialModel = getModel(binomial,  Scope.track(parseTestFile("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
               , "C21", gamCols, ignoredCols, new int[]{5, 5, 5}, new int[]{0, 0, 0},
               false, true, new double[]{1, 1, 1}, new double[]{0},
@@ -790,7 +791,7 @@ public class GamTestPiping extends TestUtil {
       
       // multinomial
       ignoredCols = new String[]{"C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
-      gamCols = new String[]{"C6", "C7", "C8"};
+      gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
 
       GAMModel multinomialModel = getModel(multinomial,
               Scope.track(parseTestFile("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))

--- a/h2o-algos/src/test/java/hex/gam/GamThinPlateRegressionBasicTest.java
+++ b/h2o-algos/src/test/java/hex/gam/GamThinPlateRegressionBasicTest.java
@@ -1,0 +1,746 @@
+package hex.gam;
+
+import Jama.Matrix;
+import Jama.QRDecomposition;
+import hex.SplitFrame;
+import hex.gam.GamSplines.ThinPlateDistanceWithKnots;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import water.DKV;
+import water.Key;
+import water.Scope;
+import water.TestUtil;
+import water.fvec.Frame;
+import water.runner.CloudSize;
+import water.runner.H2ORunner;
+import water.util.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static hex.gam.GAMModel.GAMModelOutput;
+import static hex.gam.GAMModel.GAMParameters;
+import static hex.gam.GamSplines.ThinPlateRegressionUtils.*;
+import static hex.genmodel.algos.gam.GamUtilsThinPlateRegression.calculateDistance;
+import static hex.util.LinearAlgebraUtils.generateOrthogonalComplement;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static water.util.ArrayUtils.*;
+
+@RunWith(H2ORunner.class)
+@CloudSize(1)
+public class GamThinPlateRegressionBasicTest extends TestUtil {
+  public static final double MAGEPS = 1e-10;
+  
+  // test correct generation of orthogonal matrix zCS
+  @Test
+  public void testGenOrthComplement() {
+    double[][] matT = new double[][]{{1.0, -19.8, -1.99}, {1.0, -0.97, -0.98}, {1.0, 0.031, 0.03}, {1.0, 0.06, 0.05},
+            {1.0, 1.0, 1.01}, {1.0, 1.98, 1.99}};
+    Matrix starTMat = new Matrix(matT);        // generate Zcs as in 3.3
+    QRDecomposition starTMat_qr = new QRDecomposition(starTMat);
+    double[][] qMat = starTMat_qr.getQ().getArray();
+    double[][] qMatT = ArrayUtils.transpose(starTMat_qr.getQ().getArray()); // contains orthogonal basis transpose
+    double[][] zCST = generateOrthogonalComplement(qMat, matT, 3, 12345);
+    // check zCS: zCS should be orthogonal to qMat and to each other.  They also should have unit magnitude.
+    int numQ = qMatT.length;
+    int numZ = zCST.length;
+    // check zCS orthogonal to qMatT
+    for (int index = 0; index < numQ; index++)
+      for (int indexB = 0; indexB < numZ; indexB++)
+        assertTrue(Math.abs(innerProduct(qMatT[index], zCST[indexB])) < MAGEPS);
+    // check zCS is orthogonal and have unit magnitude
+    for (int index = 0; index < numZ; index++) {
+      for (int indexB = 0; indexB < numZ; indexB++) {
+        if (indexB == index)
+          assertTrue(Math.abs(innerProduct(zCST[index], zCST[indexB]) - 1) < MAGEPS);
+        else
+          assertTrue(Math.abs(innerProduct(zCST[index], zCST[indexB])) < MAGEPS);
+      }
+    }
+  }
+
+  // test with multinomial with only thin plate regressioon smoothers with one predictors only
+  @Test
+  public void testTP1D() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"));
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C6"}, {"C7"}, {"C8"}};
+      train.replace((10), train.vec(10).toCategoricalVec()).remove();
+      DKV.put(train);
+      GAMParameters params = new GAMParameters();
+      int k = 10;
+      params._response_column = "C11";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{k, k, k};
+      params._gam_columns = gamCols;
+      params._bs = new int[]{1, 1, 1};
+      params._scale = new double[]{10, 10, 10};
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._lambda_search = false;
+      GAMModel gam = new GAM(params).trainModel().get();
+      // check starT is of size k x M
+      assertTrue((gam._output._starT[0].length == k) && (gam._output._starT[0][0].length == params._M[0]));
+      // check penalty_CS is size k x k
+      assertTrue((gam._output._penaltyMatCS[0].length == (k-params._M[0])) &&
+              (gam._output._penaltyMatCS[0][0].length == (k-params._M[0])));
+      Scope.track_generic(gam);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test with Gaussian with only thin plate regression smoothers with two predictors.  
+  @Test
+  public void testTP2D() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"));
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12", 
+              "C13", "C14", "C15", "C16", "C17", "C18", "C19", "C20"};
+      String[][] gamCols = new String[][]{{"C11", "C12"}, {"C13", "C14"}};
+      GAMParameters params = new GAMParameters();
+      int k = 6;
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{k, k};
+      params._gam_columns = gamCols;
+      params._bs = new int[]{1, 1};
+      params._scale = new double[]{0.01, 0.01};
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._lambda = new double[]{0.01};
+      GAMModel gam = new GAM(params).trainModel().get();
+      Scope.track_generic(gam);
+      // check starT is of size k x M
+      assertTrue((gam._output._starT[0].length == k) && (gam._output._starT[0][0].length == params._M[0]));
+      // check penalty_CS is size k x k
+      assertTrue((gam._output._penaltyMatCS[0].length == (k-params._M[0])) &&
+              (gam._output._penaltyMatCS[0][0].length == (k-params._M[0])));
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  // test with binomial for thin plate regression smoothers with three predictors and check that the polynomials
+  // are generated correctly by checking starT values
+  @Test
+  public void testTP3DStarT() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"));
+      train.replace((20), train.vec(20).toCategoricalVec()).remove();
+      DKV.put(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C11", "C12", "C13"}, {"C14", "C15", "C16"}, {"C17", "C18", "C19"}};
+      GAMParameters params = new GAMParameters();
+      int k = 12;
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{k, k, k};
+      params._gam_columns = gamCols;
+      params._bs = new int[]{1, 1, 1};
+      params._scale = new double[]{10, 10, 10};
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._standardize_tp_gam_cols = true;
+      GAMModel gam = new GAM(params).trainModel().get();
+      Scope.track_generic(gam);
+      // check starT is of size k x M
+      assertTrue((gam._output._starT[0].length == k) && (gam._output._starT[0][0].length == params._M[0]));
+      // check penalty_CS is size k x k
+      assertTrue((gam._output._penaltyMatCS[0].length == (k - params._M[0])) &&
+              (gam._output._penaltyMatCS[0][0].length == (k - params._M[0])));
+      // check and make sure polynomials are generated correctly by checking starT
+      for (int gamInd = 0; gamInd < gamCols.length; gamInd++) {
+        assertCorrectStarT(gam._output, gamInd, gamCols[gamInd]);
+      }
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  // check correct starT generation for one tp smoother
+  public static void assertCorrectStarT(GAMModelOutput output, int gamInd, String[] gam_columns) {
+    double[][] starT = output._starT[gamInd];
+    double[][] knots = output._knots[gamInd];
+    int d = gam_columns.length;
+    int m = calculatem(d);
+    int M = calculateM(d, m);
+    int numKnots = knots[0].length;
+    int[][] allPolyBasis = convertList2Array(findPolyBasis(d, m), M, d);
+    // manually generate starT here and then compare with starT from argument
+    double[][] starTManual = new double[numKnots][M];
+    for (int rowIndex = 0; rowIndex < numKnots; rowIndex++) {
+      for (int colIndex = 0; colIndex < M; colIndex++) {
+        starTManual[rowIndex][colIndex] = generate1PolyRow(knots, allPolyBasis[colIndex], rowIndex, output, gamInd);
+      }
+    }
+    checkDoubleArrays(starT, starTManual, MAGEPS);
+  }
+  
+  public static double generate1PolyRow(double[][] knots, int[] onePolyBasis, int rowIndex, GAMModelOutput output, int gamInd) {
+    double temp = 1;
+    int d = onePolyBasis.length;
+    for (int predInd = 0; predInd < d; predInd++) {
+      temp *= Math.pow((knots[predInd][rowIndex]-output._gamColMeansRaw[gamInd][predInd])*
+              output._oneOGamColStd[gamInd][predInd], onePolyBasis[predInd]);
+    }
+    return temp;
+  }
+  
+  // test and make sure parameter _standardize_TP_gam_cols works
+  @Test
+  public void testStandardizeGAM() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"));
+      train.replace((20), train.vec(20).toCategoricalVec()).remove();
+      DKV.put(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C11"},{"C12", "C13"}, {"C11"}, {"C14", "C15", "C16"}};
+      GAMParameters params = new GAMParameters();
+      params._bs = new int[]{1,1,0,1};
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._gam_columns = gamCols;
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      GAMModel gam = new GAM(params).trainModel().get();  // GAM model without standarization of TP gam columns
+      Scope.track_generic(gam);
+      params._standardize_tp_gam_cols = true;
+      GAMModel gamStandardize = new GAM(params).trainModel().get(); // GAM model with standardization of TP gam column s
+      Scope.track_generic(gamStandardize);
+      // check CS penalty_matrix, they should be the same
+      checkDoubleArrays(gam._output._penaltyMatricesCenter[0], gamStandardize._output._penaltyMatricesCenter[0], MAGEPS);
+      // check TP penalty_matrices are different
+      assertTrue(Math.abs(gam._output._penaltyMatricesCenter[1][0][0] - 
+              gamStandardize._output._penaltyMatricesCenter[1][0][0]) > MAGEPS);
+      assertTrue(Math.abs(gam._output._penaltyMatricesCenter[2][0][0] -
+              gamStandardize._output._penaltyMatricesCenter[2][0][0]) > MAGEPS);
+      assertTrue(Math.abs(gam._output._penaltyMatricesCenter[3][0][0] -
+              gamStandardize._output._penaltyMatricesCenter[3][0][0]) > MAGEPS);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  @Test
+  public void testPenaltyMatrixScaling() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"));
+      train.replace((20), train.vec(20).toCategoricalVec()).remove();
+      DKV.put(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C11"},{"C12", "C13"}, {"C11"}, {"C14", "C15", "C16"}};
+      GAMParameters params = new GAMParameters();
+      params._bs = new int[]{1,1,0,1};
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._gam_columns = gamCols;
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._standardize_tp_gam_cols = true;
+      GAMModel gam = new GAM(params).trainModel().get();  // GAM model without standarization of TP gam columns
+      Scope.track_generic(gam);
+      params._scale_tp_penalty_mat = true;
+      GAMModel gamScale = new GAM(params).trainModel().get(); // GAM model with standardization of TP gam column s
+      Scope.track_generic(gamScale);
+      // check CS penalty_matrix, they should be the same regardless of TP penalty matrix scaling
+      checkDoubleArrays(gam._output._penaltyMatricesCenter[0], gamScale._output._penaltyMatricesCenter[0], MAGEPS);
+      // check TP penalty_matrices are different by a scaling parameter
+      checkDoubleArrays(gam._output._penaltyMatricesCenter[1], mult(gamScale._output._penaltyMatricesCenter[1], 
+              gamScale._output._penaltyScale[1]), MAGEPS);
+      checkDoubleArrays(gam._output._penaltyMatricesCenter[2], mult(gamScale._output._penaltyMatricesCenter[2],
+              gamScale._output._penaltyScale[2]), MAGEPS);
+      checkDoubleArrays(gam._output._penaltyMatricesCenter[3], mult(gamScale._output._penaltyMatricesCenter[3],
+              gamScale._output._penaltyScale[3]), MAGEPS);
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  // test with GAM model building with CS and TP smoothers, one predictor participating in multiple smoother
+  @Test
+  public void testDataTransform() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"));
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12",
+              "C13", "C14", "C15", "C16", "C17", "C18", "C19", "C20"};
+      String[][] gamCols = new String[][]{{"C13", "C14", "C16"}, {"C11", "C17"}, {"C16"}, {"C17"}};
+      GAMParameters params = new GAMParameters();
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{11, 5, 4, 10};
+      params._gam_columns = gamCols;
+      params._bs = new int[]{1, 1, 1, 0};
+      params._scale = new double[]{10, 10, 10, 10};
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._standardize_tp_gam_cols = true;
+      params._standardize = true;
+      GAMModel gamStandardize = new GAM(params).trainModel().get();
+      Scope.track_generic(gamStandardize);
+      // check CS smoother penalty matrix has correct dimension
+      assertTrue((params._num_knots_sorted[0]-1) == gamStandardize._output._penaltyMatricesCenter[0][0].length);
+      // check TP smoother penalty matrices have correct dimension
+      assertTrue((params._num_knots_sorted[1]-1) == gamStandardize._output._penaltyMatricesCenter[1][0].length); // for smoother {"C13", "C14", "C16"}
+      assertTrue((params._num_knots_sorted[2]-1) == gamStandardize._output._penaltyMatricesCenter[2][0].length); // for smoother {"C11", "C17"}
+      assertTrue((params._num_knots_sorted[3]-1) == gamStandardize._output._penaltyMatricesCenter[3][0].length); // for smoother {"C16"}
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test with GAM model building with validation dataset
+  @Test
+  public void testValidationData() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"));
+      SplitFrame sf = new SplitFrame(train, new double[] {0.8, 0.2}, null);
+      sf.exec().get();
+      Key[] splits = sf._destination_frames;
+      Frame trainFrame = Scope.track((Frame) splits[0].get());
+      Frame testFrame = Scope.track((Frame) splits[1].get());
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12",
+              "C13", "C14", "C15", "C16", "C17", "C18", "C19", "C20"};
+      String[][] gamCols = new String[][]{{"C13", "C14", "C16"}, {"C11", "C17"}, {"C16"}, {"C17"}};
+      GAMParameters params = new GAMParameters();
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{11, 5, 4, 10};
+      params._gam_columns = gamCols;
+      params._bs = new int[]{1, 1, 1, 0};
+      params._scale = new double[]{10, 10, 10, 10};
+      params._train = trainFrame._key;
+      params._valid = testFrame._key;
+      params._savePenaltyMat = true;
+      params._standardize_tp_gam_cols = true;
+      params._standardize = true;
+      GAMModel gamStandardize = new GAM(params).trainModel().get();
+      Scope.track_generic(gamStandardize);
+      assertTrue(gamStandardize._output._validation_metrics != null); // check and make sure validation metrics is not null
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  // test to make sure default knots are generated correctly.
+  @Test
+  public void testKnotsDefault() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"));
+      train.replace((10), train.vec(10).toCategoricalVec()).remove();
+      DKV.put(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C6"},{"C7", "C8"}, {"C9"}};
+      GAMParameters params = new GAMParameters();
+      int k = 10;
+      params._response_column = "C11";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{0,k,0};
+      params._gam_columns = gamCols;
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._lambda = new double[]{10};
+      GAMModel gam = new GAM(params).trainModel().get();
+      // check starT is of size k x M
+      assertTrue((gam._output._starT[0].length == k) && (gam._output._starT[0][0].length == params._M[0]));
+      // check penalty_CS is size k x k
+      assertTrue((gam._output._penaltyMatCS[0].length == (k-params._M[0])) &&
+              (gam._output._penaltyMatCS[0][0].length == (k-params._M[0])));
+      Scope.track_generic(gam);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  public Frame genKnots1(double[][] knots) {
+    Frame knotsFrame1 = generate_real_only(knots[0].length, knots.length, 0);
+    new ArrayUtils.CopyArrayToFrame(0,knots[0].length-1,knots.length, knots).doAll(knotsFrame1);
+    DKV.put(knotsFrame1);
+    return knotsFrame1;
+  }
+  
+  // test correct knot generation from Frames for both CS and TP smoothers
+  @Test
+  public void testKnotsGenerationFromFrame() {
+    Scope.enter();
+    try {
+      final double[][] knots = new double[][]{{-1.9990569949269443}, {-0.9814307533427584}, {0.025991586992542004},
+              {1.0077098743127828}, {1.999422899675758}};
+      final Frame knotsFrame1 = genKnots1(knots);
+      Scope.track(knotsFrame1);
+      int k = 5;
+      final double[][] knots2 = new double[][]{{0.902652813684858, 1.238501303835733}, {-0.8377150962015311, 
+              0.7809874931015846}, {1.0513133931023009, 0.7790618752739205}, {1.9201968414753283, -1.5318363005905211},
+              {0.5654843500702142, -1.6560180317092057}};
+      final Frame knotsFrame2 = genKnots1(knots2);
+      Scope.track(knotsFrame2);
+      final double[][] knots3 = new double[][]{{-1.9990569949269443}, {-0.9814307533427584}, {0.025991586992542004},
+              {0.03}, {0.06}, {1.0077098743127828}, {1.999422899675758}};
+      final Frame knotsFrame3 = genKnots1(knots3);
+      Scope.track(knotsFrame3);
+
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"));
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C6"},{"C7", "C8"}, {"C9"}};
+      train.replace((10), train.vec(10).toCategoricalVec()).remove();
+      DKV.put(train);
+      GAMParameters params = new GAMParameters();
+      params._knot_ids = new String[]{knotsFrame1._key.toString(), knotsFrame2._key.toString(), knotsFrame3._key.toString()};
+      params._bs = new int[]{0,1,0};
+      params._response_column = "C11";
+      params._ignored_columns = ignoredCols;
+      params._gam_columns = gamCols;
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      GAMModel gam = new GAM(params).trainModel().get();
+      // check starT is of size k x M
+      assertTrue((gam._output._starT[0].length == k) && (gam._output._starT[0][0].length == params._M[0]));
+      // check penalty_CS is size k x k
+      assertTrue((gam._output._penaltyMatCS[0].length == (k-params._M[0])) &&
+              (gam._output._penaltyMatCS[0][0].length == (k-params._M[0])));
+      Scope.track_generic(gam);
+    } finally {
+      Scope.exit();
+    }
+  }
+
+  // test correct distance measurement of thin plate regression smoothers by checking penalty matrix before any kind of
+  // transformation.
+  @Test
+  public void testDistanceMeasure() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"));
+      train.replace((20), train.vec(20).toCategoricalVec()).remove();
+      DKV.put(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C11"},{"C12", "C13"}, {"C14", "C15", "C16"}};
+      GAMParameters params = new GAMParameters();
+      params._bs = new int[]{1,1,1};
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._gam_columns = gamCols;
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._standardize_tp_gam_cols = true;
+      GAMModel gam = new GAM(params).trainModel().get();
+      Scope.track_generic(gam);
+      for (int gamInd = 0; gamInd < gamCols.length; gamInd++)
+        assertCorrectDistance(gam._output._penaltyMatrices[gamInd], gam._output._knots[gamInd], gamCols[gamInd],
+                gam._output._oneOGamColStd[gamInd]);
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  // check the calculation of distance for one smoother at a time
+  public static void assertCorrectDistance(double[][] penaltyMat, double[][] knots, String[] gamCols, 
+                                           double[] oneOverGamColStd) {
+    int d = gamCols.length;
+    int m = calculatem(d);
+    int numKnots = knots[0].length;
+    double[][] penaltyMatManual = new double[numKnots][numKnots];
+    for (int rowIndex = 0; rowIndex < numKnots; rowIndex++) {
+      for (int colIndex = 0; colIndex < numKnots; colIndex++) {
+        penaltyMatManual[rowIndex][colIndex] = calDistance(knots, rowIndex, colIndex, d, m, oneOverGamColStd);
+      }
+    }
+    checkDoubleArrays(penaltyMat, penaltyMatManual, MAGEPS);
+  }
+  
+  public static double calDistance(double[][] knots, int rowIndex, int colIndex, int predNum, int m, 
+                                   double[] oneOverGamColStd) {
+    double temp = 0, constant = 1;
+    for (int predInd = 0; predInd < predNum; predInd++) { // calculate distance
+      double diff = (knots[predInd][rowIndex]-knots[predInd][colIndex])*oneOverGamColStd[predInd];
+      temp += diff*diff;
+    }
+    double distance = Math.pow(Math.sqrt(temp), 2*m-predNum);
+    // calculate constant to multiply distance
+    if (predNum % 2 == 0) { // d is even
+      constant = Math.pow(-1, m+1+predNum/2)/(Math.pow(2, 2*m-1)*Math.pow(Math.PI, predNum/2)*factorial(m-1)*
+              factorial(m-predNum));
+      if (distance != 0)
+        temp = constant * distance * Math.log(distance);
+      else 
+        temp = 0;
+    } else {  // d is odd
+      constant = Math.pow(-4, m)*factorial(m)*Math.sqrt(Math.PI)/(factorial(2*m)*Math.pow(2,2*m)*Math.pow(Math.PI, 
+              predNum/2.0)*factorial(m-1));
+      temp = constant * distance;
+    }
+    return temp;
+  }
+  
+  // check correct multiplication of zCS and z on data frame
+  @Test
+  public void testTransformData() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/gaussian_20cols_10000Rows.csv"));
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10", "C11", "C12",
+              "C13", "C14", "C15", "C16", "C17", "C18", "C19", "C20"};
+      String[][] gamCols = new String[][]{{"C13", "C14", "C15"}, {"C20"}, {"C11", "C12"}};
+      GAMParameters params = new GAMParameters();
+      int k = 10;
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._num_knots = new int[]{11, k, k};
+      params._gam_columns = gamCols;
+      params._bs = new int[]{1, 1, 1};
+      params._scale = new double[]{1, 1, 1};
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._keep_gam_cols = true;
+      params._lambda_search = true;
+      GAMModel gam = new GAM(params).trainModel().get();
+      Scope.track_generic(gam);
+      Frame dataFrame = DKV.getGet(gam._output._gamTransformedTrainCenter); // transformed GAM columns from gam model
+      Scope.track(dataFrame);
+      for (int gamInd = 0; gamInd < gamCols.length; gamInd++)
+        assertCorrectTransform(train, dataFrame, 0.2, gamInd, params, gam._output);
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  // check correct transformation of data frame by zCS and z for one smoother at a time
+  public static void assertCorrectTransform(Frame data, Frame gamCols, double frac2Test, int gamIndex, 
+                                            GAMParameters parms, GAMModelOutput output) {
+    int numKnot = parms._num_knots_sorted[gamIndex]; // number of gam columns to check
+    int d = parms._gamPredSize[gamIndex];
+    int m = calculatem(d);
+    int M = calculateM(d, m);
+    int finalFrameCol = numKnot - 1;
+    int numKnotsMinusM = numKnot - M;
+    int rowNum2Check = (int) Math.floor(data.numRows()*frac2Test);
+    int rowInd = Math.round(data.numRows()/rowNum2Check);
+    double[][] knots = output._knots[gamIndex];
+    ThinPlateDistanceWithKnots tpDistance = new ThinPlateDistanceWithKnots(knots, d, output._oneOGamColStd[gamIndex], parms._standardize);
+    int[][] allPolyBasis = convertList2Array(findPolyBasis(d, m), M, d);
+    double[] dataInput = new double[d]; // store predictor data before gamification
+    double[] dataDistance = new double[numKnot];  // store data after generating distance
+    double[] dataPoly = new double[M];  // store data after applying polynomial basis
+    double[] dataDistPlusPoly = new double[numKnot];  // store data combining distance and polynomial basis
+    double[][] z = transpose(output._zTranspose[gamIndex]);
+    double[][] zCS = transpose(output._zTransposeCS[gamIndex]);
+    double[] dataOutput = new double[finalFrameCol];  // store gamificed columns from gam model
+    
+    for (int rowIndex = 0; rowIndex < data.numRows(); rowIndex = rowIndex+rowInd) {
+      grabOneRow(data, dataInput, parms._gam_columns_sorted[gamIndex], rowIndex);
+      calculateDistance(dataDistance, dataInput, numKnot, knots, d, m, (d % 2==0), tpDistance._constantTerms, 
+              output._oneOGamColStd[gamIndex], parms._standardize_tp_gam_cols);
+      double[] dataDistanceCS = multVecArr(dataDistance, zCS);
+      generatePolyOneRow(dataInput, allPolyBasis, dataPoly);
+      System.arraycopy(dataDistanceCS, 0, dataDistPlusPoly, 0, numKnotsMinusM);
+      System.arraycopy(dataPoly, 0, dataDistPlusPoly, numKnotsMinusM, M);
+      double[] dataCenterManual = multVecArr(dataDistPlusPoly, z);
+      grabOneRow(gamCols, dataOutput, output._gamColNames[gamIndex], rowIndex); // grab gamified columns from gam
+      // check to make sure the manually generated gamified rows and the gamified columns from gam model
+      checkArrays(dataOutput, dataCenterManual, MAGEPS);
+    }
+  }
+  
+  public static void grabOneRow(Frame data, double[] storeOneRow, String[] gamCols, int rowIndex) {
+    int d = gamCols.length;
+    for (int colIndex = 0; colIndex < d; colIndex++) {
+      storeOneRow[colIndex] = data.vec(gamCols[colIndex]).at(rowIndex);
+    }
+  }
+
+  public static void generatePolyOneRow(double[] dataInput, int[][] onePolyBasis, double[] dataPolyOut) {
+    int d = dataInput.length;
+    int M = onePolyBasis.length;
+    for (int polyInd = 0; polyInd < M; polyInd++) {
+      dataPolyOut[polyInd] = 1.0;
+      for (int predInd = 0; predInd < d; predInd++) {
+        dataPolyOut[polyInd] *= Math.pow(dataInput[predInd], onePolyBasis[polyInd][predInd]);
+      }
+    }
+  }
+  
+  // check correct multiplication of zCS, z on penalty matrix
+  @Test
+  public void testTransformPenaltyMatrix() {
+    Scope.enter();
+    try {
+      Frame train = Scope.track(parse_test_file("smalldata/glm_test/binomial_20_cols_10KRows.csv"));
+      train.replace((20), train.vec(20).toCategoricalVec()).remove();
+      DKV.put(train);
+      String[] ignoredCols = new String[]{"C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "C10"};
+      String[][] gamCols = new String[][]{{"C11"},{"C12", "C13"}, {"C14", "C15", "C16"}};
+      GAMParameters params = new GAMParameters();
+      params._bs = new int[]{1,1,1};
+      params._response_column = "C21";
+      params._ignored_columns = ignoredCols;
+      params._gam_columns = gamCols;
+      params._train = train._key;
+      params._savePenaltyMat = true;
+      params._standardize_tp_gam_cols = true;
+      params._scale_tp_penalty_mat = true;
+      GAMModel gam = new GAM(params).trainModel().get();
+      Scope.track_generic(gam);
+      for (int gamInd = 0; gamInd < gamCols.length; gamInd++)
+        assertCorrectTransform(gam._output._zTransposeCS[gamInd], gam._output._zTranspose[gamInd], 
+                gam._output._penaltyMatrices[gamInd], gam._output._penaltyMatCS[gamInd], 
+                gam._output._penaltyMatricesCenter[gamInd], 1.0/gam._output._penaltyScale[gamInd]);
+    } finally {
+      Scope.exit();
+    }
+  }
+  
+  public static void assertCorrectTransform(double[][] zCST, double[][] zT, double[][] penaltyMat, 
+                                            double[][] penaltyMatCS, double[][] penaltyMatCenter, double csPenaltyScale) {
+    // check the application of zCS to penalty matrix is correct;
+    double[][] penaltyMatCSManual = multMatTPenaltyMat(zCST, penaltyMat);
+    mult(penaltyMatCSManual, csPenaltyScale);
+    checkDoubleArrays(penaltyMatCS, penaltyMatCSManual, MAGEPS);    
+    double[][] penaltyMatCSManualExpand = expandArray(penaltyMatCSManual, zT[0].length);
+    double[][] penaltyMatCenterManual = multMatTPenaltyMat(zT, penaltyMatCSManualExpand);
+    // check the application of z to penalty matrix CS is correct;
+    checkDoubleArrays(penaltyMatCenter, penaltyMatCenterManual, MAGEPS);
+  }
+  
+  public static double[][] multMatTPenaltyMat(double[][] zT, double[][] penaltyMat) {
+    double[][] z = transpose(zT);
+    int k = penaltyMat.length;
+    int n = zT.length;
+    double[][] part1 = new double[n][k];
+    double[][] finalResult = new double[n][n];
+    for (int index = 0; index < n; index++) {
+      for (int index2 = 0; index2 < k; index2++) {
+        for (int index3 = 0; index3 < k; index3++) {
+          part1[index][index2] += zT[index][index3]*penaltyMat[index3][index2];
+        }
+      }
+    }
+    for (int index = 0; index < n; index++) {
+      for (int index2 = 0; index2 < n; index2++) {
+        for (int index3 = 0; index3 < k; index3++) {
+          finalResult[index][index2] += part1[index][index3]*z[index3][index2];
+        }
+      }
+    }
+    return finalResult;
+  }
+  
+  // For a given d, calculate m, then calculate the polynomial basis degree for each predictor involves.
+  // However, the 0th order is not included at this stage.
+  @Test
+  public void testFindPolybasis() {
+    int[] d = new int[]{1, 3, 5, 8, 10};
+    int[] ans = new int[]{2, 10, 56, 495, 3003};
+    for (int index = 0; index < d.length; index++) {
+      int m = calculatem(d[index]);
+      int[] polyOrder = new int[m];
+      for (int tempIndex = 0; tempIndex < m; tempIndex++)
+        polyOrder[tempIndex] = tempIndex;
+      List<Integer[]> polyBasis = findPolyBasis(d[index], m);
+      assertEquals(ans[index], polyBasis.size()); // check and make sure number of basis is correct.  Content checked in testFindPermManyD already
+      assertCorrectAllPerms(polyBasis, polyOrder);
+    }
+  }
+  
+  // given one combination, test that all permutations are returned
+  @Test
+  public void testFindAllPolybasis() {
+    List<Integer[]> listOfCombos = new ArrayList<>();
+    listOfCombos.add(new Integer[]{0, 0, 0, 0, 1}); // should get 5 permutations
+    listOfCombos.add(new Integer[]{1, 2, 0, 0, 0}); // should get 20 permutations
+    List<Integer[]> allCombos = findAllPolybasis(listOfCombos); // should be of size 5+20+1 (from all zeroes)
+    assertEquals(26, allCombos.size()); // check correct size
+    assertCorrectAllPerms(allCombos, new int[]{0,1,3}); // check correct content
+  }
+  
+  public static void assertCorrectAllPerms(List<Integer[]> allCombos, int[] correctVals) {
+    for (Integer[] oneList : allCombos) {
+      int sumVal = sum(Arrays.stream(oneList).mapToInt(Integer::intValue).toArray());
+      boolean correctSum = false;
+      for (int val : correctVals)
+        correctSum = correctSum || (sumVal == val);
+      assertTrue(correctSum);
+    }
+  }
+  
+  @Test
+  public void testFindPermManyD() {
+    int[] d = new int[]{1, 3 ,5, 8, 10};
+    int[] correctComboNum = new int[]{1, 3, 6, 11, 18};
+    for (int index = 0; index < d.length; index++) {
+      testFindPerm(d, correctComboNum, index);
+    }
+  }
+  
+  public void testFindPerm(int[] d, int[] correctComboNum, int testIndex) {
+    int m = calculatem(d[testIndex]); // highest order of polynomial basis is m-1
+    int[] totDegrees = new int[m];
+    int[] degreeCombos = new int[m-1];
+    for (int index = 0; index < totDegrees.length; index++)
+      totDegrees[index] = index;
+    int count = 0;
+    for (int index = m-1; index > 0; index--) {
+      degreeCombos[count++] = index;
+    }
+
+    // check for combos for totDegree = 0, 1, ..., m-1
+    int numCombo = 0;
+    for (int degree : totDegrees) {
+      ArrayList<int[]> allCombos = new ArrayList<>();
+      findOnePerm(degree, degreeCombos, 0, allCombos, null);
+      assertCorrectPerm(allCombos, degree, degreeCombos);
+      numCombo += allCombos.size();
+    }
+    assertEquals(numCombo, correctComboNum[testIndex]); // number of combos are correct
+  }
+  
+  public static void assertCorrectPerm(ArrayList<int[]> allCombos, int degree, int[] degreeCombos) {
+    for (int index = 0; index < allCombos.size(); index++) {
+      int[] oneCombo = allCombos.get(index);
+      int sum = 0;
+      for (int tmpIndex = 0; tmpIndex < degreeCombos.length; tmpIndex++) {
+        sum += oneCombo[tmpIndex]*degreeCombos[tmpIndex];
+      }
+      assertEquals(degree, sum);
+    }
+  }
+  
+  @Test
+  public void testCalculatem() {
+    int[] d = new int[]{1, 2, 3, 4, 10};
+    int[] ans = new int[]{2, 2, 3, 3, 6};  // calculated by using (floor(d+1)/2)+1 from R
+    
+    for (int index = 0; index < d.length; index++) {
+      int m = calculatem(d[index]);
+      assertEquals(m, ans[index]);
+    }
+  }
+
+  @Test
+  public void testCalculateM() {
+    int[] d = new int[]{1, 2, 3, 4, 5};
+    int[] m = new int[]{2, 2, 3, 3, 4};  // calculated by using (floor(d+1)/2)+1 from R
+
+    for (int index = 0; index < d.length; index++) {
+      int M = calculateM(d[index], m[index]);
+      assertEquals(M, factorial(d[index]+m[index]-1)/(factorial(d[index])*factorial(m[index]-1)));
+    }
+  }
+  
+  public static int factorial(int n) {
+    int prod = 1; 
+    for (int index = 1; index <= n; index++)
+      prod *= index;
+    return prod;
+  }
+}

--- a/h2o-bindings/bin/custom/R/gen_gam.py
+++ b/h2o-bindings/bin/custom/R/gen_gam.py
@@ -6,11 +6,11 @@ extensions = dict(
     if (missing(x)) {
         x = NULL
     }
-
     # If gam_columns is missing, then assume user wants to use all columns as features for GAM.
     if (missing(gam_columns)) {
         stop("Columns indices to apply to GAM must be specified. If there are none, please use GLM.")
     }
+    gam_columns <- lapply(gam_columns, function(x) if(is.character(x) & length(x) == 1) list(x) else x)
     """,
     set_required_params="""
     parms$training_frame <- training_frame

--- a/h2o-bindings/bin/custom/python/gen_gam.py
+++ b/h2o-bindings/bin/custom/python/gen_gam.py
@@ -15,9 +15,11 @@ def class_extensions():
     def Lambda(self, value):
         self._parms["lambda"] = value
 
-
 extensions = dict(
-    __imports__="""import h2o""",
+    __imports__="""
+import h2o
+from h2o.utils.typechecks import U
+""",
     __class__=class_extensions,
     __init__validation="""
 if "Lambda" in kwargs: kwargs["lambda_"] = kwargs.pop("Lambda")
@@ -38,6 +40,14 @@ assert_is_type({pname}, None, numeric, [numeric])
 self._parms["{sname}"] = {pname}
 """
     ),
+    gam_columns=dict(
+        setter="""
+assert_is_type(gam_columns, None, [U(str, [str])])
+if gam_columns:  # standardize as a nested list
+    gam_columns = [[g] if isinstance(g, str) else g for g in gam_columns]
+self._parms["gam_columns"] = gam_columns
+"""
+    )
 )
 
 doc = dict(

--- a/h2o-core/src/main/java/hex/ModelMojoWriter.java
+++ b/h2o-core/src/main/java/hex/ModelMojoWriter.java
@@ -1,8 +1,6 @@
 package hex;
 
 import hex.genmodel.AbstractMojoWriter;
-import hex.genmodel.descriptor.ModelDescriptor;
-import water.Key;
 import water.api.SchemaServer;
 import water.api.StreamWriteOption;
 import water.api.StreamWriter;
@@ -116,7 +114,7 @@ public abstract class ModelMojoWriter<M extends Model<M, P, O>, P extends Model.
     }
     finishWritingTextFile();
   }
-
+  
   public void writeRectangularDoubleArray(double[][] array, String title) throws IOException {
     assert null != array;
     assert null != title;
@@ -130,7 +128,20 @@ public abstract class ModelMojoWriter<M extends Model<M, P, O>, P extends Model.
   public void writeDoubleArray(double[][] array, String title) throws IOException {
     assert null != array;
     assert null != title;
-    
+    write2DArray(array, title);
+  }
+  
+  public void write2DStringArrays(String[][] sArrays, String title) throws IOException {
+    startWritingTextFile(title);
+    int numCols = sArrays.length;
+    for (int index = 0; index < numCols; index++)
+    for (String sName : sArrays[index]) {
+      writeln(sName);
+    }
+    finishWritingTextFile();
+  }
+
+  public void write2DArray(double[][] array, String title) throws IOException {
     int totArraySize = 0;
     for (double[] row : array)
       totArraySize += row.length;
@@ -141,5 +152,36 @@ public abstract class ModelMojoWriter<M extends Model<M, P, O>, P extends Model.
         bb.putDouble(val);
     writeblob(title, bb.array());
   }
+  
+  public void write3DIntArray(int[][][] array, String title) throws IOException {
+    int totArraySize = 0;
+    int outDim = array.length;
+    for (int index = 0; index < outDim; index++) {
+      for (int[] row : array[index])
+        totArraySize += row.length;
+    }
 
+    ByteBuffer bb = ByteBuffer.wrap(new byte[totArraySize * 4]);
+    for (int index = 0; index < outDim; index++)
+      for (int[] row : array[index])
+        for (int val : row)
+          bb.putInt(val);
+    writeblob(title, bb.array());
+  }
+  
+  public void write3DArray(double[][][] array, String title) throws IOException {
+    int totArraySize = 0;
+    int outDim = array.length;
+    for (int index = 0; index < outDim; index++) {
+      for (double[] row : array[index])
+        totArraySize += row.length;
+    }
+
+    ByteBuffer bb = ByteBuffer.wrap(new byte[totArraySize * 8]);
+    for (int index = 0; index < outDim; index++)
+      for (double[] row : array[index])
+        for (double val : row)
+          bb.putDouble(val);
+    writeblob(title, bb.array());
+  }
 }

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -5,8 +5,8 @@ import water.fvec.*;
 
 import java.text.DecimalFormat;
 import java.util.*;
+import java.util.stream.IntStream;
 
-import static java.lang.StrictMath.max;
 import static java.lang.StrictMath.sqrt;
 import static water.util.RandomUtils.getRNG;
 
@@ -519,6 +519,17 @@ public class ArrayUtils {
     return res;
   }
 
+  public static double[][] expandArray(double[][] ary, int newColNum) {
+    if(ary == null) return null;
+    assert ary.length < newColNum : "new array should be greater than original array in second dimension.";
+    int oldMatRow = ary.length;
+    double[][] res = new double[newColNum][newColNum];
+    for(int i = 0; i < oldMatRow; i++) {
+      System.arraycopy(ary[i], 0, res[i], 0, oldMatRow);
+    }
+    return res;
+  }
+
   /***
    * This function will perform transpose of triangular matrices only.  If the original matrix is lower triangular,
    * the return matrix will be upper triangular and vice versa.
@@ -877,34 +888,26 @@ public class ArrayUtils {
     return result;
   }
   public static double minValue(double[] from) {
-    double result = from[0];
-    for (int i = 1; i<from.length; ++i)
-      if (from[i]<result) result = from[i];
-    return result;
+    return Arrays.stream(from).min().getAsDouble();
   }
   public static long maxValue(long[] from) {
-    long result = from[0];
-    for (int i = 1; i<from.length; ++i)
-      if (from[i]>result) result = from[i];
-    return result;
+    return Arrays.stream(from).max().getAsLong();
   }
-  public static int maxValue(int[] from) {
-    int result = from[0];
-    for (int i = 1; i<from.length; ++i)
-      if (from[i]>result) result = from[i];
-    return result;
+
+  public static int maxValue(Integer[] from) {
+    return Arrays.stream(from).max(Integer::compare).get();
   }
+  
+  public static long maxValue(int[] from) {
+    return Arrays.stream(from).max().getAsInt();
+  }
+  
   public static long minValue(long[] from) {
-    long result = from[0];
-    for (int i = 1; i<from.length; ++i)
-      if (from[i]<result) result = from[i];
-    return result;
+    return Arrays.stream(from).min().getAsLong();
   }
+  
   public static long minValue(int[] from) {
-    int result = from[0];
-    for (int i = 1; i<from.length; ++i)
-      if (from[i]<result) result = from[i];
-    return result;
+    return (long) Arrays.stream(from).min().getAsInt();
   }
 
   // Find an element with linear search & return it's index, or -1
@@ -1551,6 +1554,21 @@ public class ArrayUtils {
   public static double [] subtract (double [] a, double [] b) {
     double [] c = MemoryManager.malloc8d(a.length);
     subtract(a,b,c);
+    return c;
+  }
+  
+  public static double [][] subtract (double [][] a, double [][] b) {
+    double [][] c = MemoryManager.malloc8d(a.length, a[0].length);
+    for (int rowIndex = 0; rowIndex < c.length; rowIndex++) {
+      c[rowIndex] = subtract(a[rowIndex], b[rowIndex], c[rowIndex]);
+    }
+    return c;
+  }
+
+  public static int [] subtract (int [] a, int [] b) {
+    int [] c = MemoryManager.malloc4 (a.length);
+    for (int i = 0; i < a.length; i++)
+      c[i] = a[i]-b[i];
     return c;
   }
 

--- a/h2o-core/src/main/java/water/util/ArrayUtils.java
+++ b/h2o-core/src/main/java/water/util/ArrayUtils.java
@@ -5,7 +5,6 @@ import water.fvec.*;
 
 import java.text.DecimalFormat;
 import java.util.*;
-import java.util.stream.IntStream;
 
 import static java.lang.StrictMath.sqrt;
 import static water.util.RandomUtils.getRNG;
@@ -898,16 +897,22 @@ public class ArrayUtils {
     return Arrays.stream(from).max(Integer::compare).get();
   }
   
-  public static long maxValue(int[] from) {
+  public static int maxValue(int[] from) {
     return Arrays.stream(from).max().getAsInt();
   }
   
   public static long minValue(long[] from) {
-    return Arrays.stream(from).min().getAsLong();
+    long result = from[0];
+    for (int i = 1; i<from.length; ++i)
+      if (from[i]<result) result = from[i];
+    return result;
   }
   
   public static long minValue(int[] from) {
-    return (long) Arrays.stream(from).min().getAsInt();
+    int result = from[0];
+    for (int i = 1; i<from.length; ++i)
+      if (from[i]<result) result = from[i];
+    return result;
   }
 
   // Find an element with linear search & return it's index, or -1

--- a/h2o-core/src/main/java/water/util/MathUtils.java
+++ b/h2o-core/src/main/java/water/util/MathUtils.java
@@ -32,6 +32,21 @@ public class MathUtils {
     return y * Math.log(y) - y + .5*Math.log(2*Math.PI*y);
   }
 
+  public static int combinatorial(int num, int d) {
+    if (num < 0 || d < 0)
+      throw new H2OIllegalArgumentException("argument to combinatorial must be >= 0!");
+    int denom1 = num-d;
+    int maxDenom = Math.max(d, denom1);
+    int minDenom = Math.min(d, denom1);
+    int prodNum = 1;
+    for (int index = maxDenom+1; index <= num; index++)
+      prodNum *= index;
+    int prodDenom = 1;
+    for (int index = 1; index <= minDenom; index++)
+      prodDenom *= index;
+    return (prodNum/prodDenom);
+  }
+
   static public double computeWeightedQuantile(Vec weight, Vec values, double alpha) {
     QuantileModel.QuantileParameters parms = new QuantileModel.QuantileParameters();
     Frame tempFrame = weight == null ?

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoModel.java
@@ -17,17 +17,12 @@ public class GamMojoModel extends GamMojoModelBase {
   // generate prediction for binomial/fractional binomial/negative binomial, poisson, tweedie families
   @Override
   double[] gamScore0(double[] data, double[] preds) {
-    if (data.length == nfeatures())  // centered data, use center coefficients
-      _beta = _beta_center;
-    else  // use non-centering coefficients
-      _beta = _beta_no_center;
-    double eta = generateEta(_beta, data);  // generate eta, inner product of beta and data
+    double eta = generateEta(_beta_center, data);  // generate eta, inner product of beta and data
     double mu = evalLink(eta);
-
     if (_classifier) {
       preds[0] = (mu >= _defaultThreshold) ? 1 : 0; // threshold given by ROC
       preds[1] = 1.0 - mu; // class 0
-      preds[2] =       mu; // class 1
+      preds[2] = mu; // class 1
     } else {
       preds[0] = mu;
     }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsThinPlateRegression.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamUtilsThinPlateRegression.java
@@ -1,0 +1,53 @@
+package hex.genmodel.algos.gam;
+
+public class GamUtilsThinPlateRegression {
+  public static double calTPConstantTerm(int m, int d, boolean dEven) {
+    if (dEven)
+      return (Math.pow(-1, m + 1 + d / 2.0) / (Math.pow(2, 2*m - 1) * Math.pow(Math.PI, d / 2.0) * 
+              factorial(m-1)*factorial(m - d / 2)));
+    else
+      return (Math.pow(-1, m) * m / (factorial(2 * m) * Math.pow(Math.PI, (d - 1) / 2.0)));
+  }
+  
+  public static int factorial(int m) {
+    if (m <= 1) {
+      return 1;
+    } else {
+      int prod = 1;
+      for (int index = 1; index <= m; index++)
+        prod *= index;
+      return prod;
+    }
+  }
+
+  public static void calculateDistance(double[] rowValues, double[] chk, int knotNum, double[][] knots, int d, int m,
+                                       boolean dEven, double constantTerms, double[] oneOGamColStd, boolean standardizeGAM) { // see 3.1
+    for (int knotInd = 0; knotInd < knotNum; knotInd++) { // calculate distance between data and knots
+      double sumSq = 0;
+      for (int predInd = 0; predInd < d; predInd++) {
+        double temp = standardizeGAM?(chk[predInd] - knots[predInd][knotInd])*oneOGamColStd[predInd]:
+                (chk[predInd] - knots[predInd][knotInd]);  // standardized
+        sumSq += temp*temp;
+      }
+      double distance = Math.pow(Math.sqrt(sumSq), 2*m-d);
+      rowValues[knotInd] = constantTerms*distance;
+      if (dEven && (distance != 0))
+        rowValues[knotInd] *= Math.log(distance);
+    }
+  }
+
+  public static void calculatePolynomialBasis(double[] onePolyRow, double[] oneDataRow, int d, int M,
+                                              int[][] polyBasisList, double[] gamColMean, double[] oneOGamStd, 
+                                              boolean standardizeGAM) {
+    for (int colIndex = 0; colIndex < M; colIndex++) {
+      int[] oneBasis = polyBasisList[colIndex];
+      double val = 1.0;
+      for (int predIndex = 0; predIndex < d; predIndex++) {
+        val *= standardizeGAM?
+                Math.pow((oneDataRow[predIndex]-gamColMean[predIndex]*oneOGamStd[predIndex]), oneBasis[predIndex]):
+                Math.pow(oneDataRow[predIndex], oneBasis[predIndex]);
+      }
+      onePolyRow[colIndex] = val;
+    }
+  }
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/ArrayUtils.java
@@ -56,6 +56,24 @@ public class ArrayUtils {
     return cumsumR;
   }
 
+  public static int[] subtract(final int[] from, int val ) {
+    int arryLen = from.length;
+    int[] cumsumR = new int[arryLen];
+    for (int index = 0; index < arryLen; index++) {
+      cumsumR[index] = from[index]-val;
+    }
+    return cumsumR;
+  }
+
+  public static int[] subtract(final int[] from, int[] val ) {
+    int arryLen = from.length;
+    int[] cumsumR = new int[arryLen];
+    for (int index = 0; index < arryLen; index++) {
+      cumsumR[index] = from[index]-val[index];
+    }
+    return cumsumR;
+  }
+
   /**
    * Check to see if a column is a boolean column.  A boolean column should contains only two
    * levels and the string describing the domains should be true/false
@@ -167,6 +185,25 @@ public class ArrayUtils {
       difference[i] = array[i+1] - array[i];
     }
     return difference;
+  }
+
+  /***
+   * Carry out multiplication of row array a and matrix b and store the result in result array.  However the transpose
+   * of the matrix is given.
+   * 
+   * @param a
+   * @param bT
+   * @param result
+   */
+  public static void multArray(double[] a, double[][] bT, double[] result) {
+    int resultDim = result.length;
+    int vectorSize = a.length;
+    Arrays.fill(result, 0.0);
+    for (int index = 0; index < resultDim; index++) {
+      for (int innerIndex = 0; innerIndex < vectorSize; innerIndex++) {
+        result[index] += a[innerIndex]*bT[index][innerIndex];
+      }
+    }
   }
 
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/utils/MathUtils.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/utils/MathUtils.java
@@ -22,4 +22,14 @@ public class MathUtils {
   public static int log2(long n) {
     return 63 - Long.numberOfLeadingZeros(n);
   }
+  
+  public static int combinatorial(int top, int bottom) {
+    int denom = 1;
+    int numer = 1;
+    for (int index = 1; index <= bottom; index++) {
+      numer *= (top - index + 1);
+      denom *= index;
+    }
+    return (numer/denom);
+  }
 }

--- a/h2o-py/tests/pyunit_utils/utilsPY.py
+++ b/h2o-py/tests/pyunit_utils/utilsPY.py
@@ -3490,16 +3490,16 @@ def compare_frames_local(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
         if (typeDict[frameNames[colInd]]==u'enum'):
             if returnResult:
                 result = compare_frames_local_onecolumn_NA_enum(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
-                if not(result):
+                if not(result) and returnResult:
                     return False
             else:
                 result = compare_frames_local_onecolumn_NA_enum(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
-                if not(result):
+                if not(result) and returnResult:
                     return False
         elif (typeDict[frameNames[colInd]]==u'string'):
             if returnResult:
                 result =  compare_frames_local_onecolumn_NA_string(f1[colInd], f2[colInd], prob=prob, returnResult=returnResult)
-                if not(result):
+                if not(result) and returnResult:
                     return False
             else:
                 compare_frames_local_onecolumn_NA_string(f1[colInd], f2[colInd], prob=prob, returnResult=returnResult)
@@ -3508,7 +3508,7 @@ def compare_frames_local(f1, f2, prob=0.5, tol=1e-6, returnResult=False):
         else:
             if returnResult:
                 result = compare_frames_local_onecolumn_NA(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
-                if not(result):
+                if not(result) and returnResult:
                     return False
             else:
                 compare_frames_local_onecolumn_NA(f1[colInd], f2[colInd], prob=prob, tol=tol, returnResult=returnResult)
@@ -4363,4 +4363,12 @@ def assertCoefEqual(regCoeff, coeff, coeffClassSet, tol=1e-6):
         assert type(val1)==type(val2), "type of coeff1: {0}, type of coeff2: {1}".format(type(val1), type(val2))
         diff = abs(val1-val2)
         print("val1: {0}, val2: {1}, tol: {2}".format(val1, val2, tol))
+        assert diff < tol, "diff {0} exceeds tolerance {1}.".format(diff, tol)
+
+def assertCoefDictEqual(regCoeff, coeff, tol=1e-6):
+    for key in regCoeff:
+        val1 = regCoeff[key]
+        val2 = coeff[key]
+        assert type(val1)==type(val2), "type of coeff1: {0}, type of coeff2: {1}".format(type(val1), type(val2))
+        diff = abs(val1-val2)
         assert diff < tol, "diff {0} exceeds tolerance {1}.".format(diff, tol)

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7181_access_modelmetrics.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7181_access_modelmetrics.py
@@ -14,8 +14,7 @@ def test_gam_modelMetrics():
     h2o_data["C2"] = h2o_data["C2"].asfactor()
     myY = "C21"
     h2o_data["C21"] = h2o_data["C21"].asfactor()
-    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictBinomialGAM.csv"))
-    buildModelMetricsCheck(h2o_data, h2o_data, model_test_data, myY, ["C11", "C12", "C13"], 'binomial')
+    buildModelMetricsCheck(h2o_data, myY, ["C11", "C12", "C13"], 'binomial')
 
     print("Checking modelmetrics for gaussian")
     h2o_data = h2o.import_file(
@@ -23,8 +22,7 @@ def test_gam_modelMetrics():
     h2o_data["C1"] = h2o_data["C1"].asfactor()
     h2o_data["C2"] = h2o_data["C2"].asfactor()
     myY = "C21"
-    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictGaussianGAM.csv"))
-    buildModelMetricsCheck(h2o_data, h2o_data,  model_test_data, myY, ["C11", "C12", "C13"], 'gaussian')
+    buildModelMetricsCheck(h2o_data, myY, ["C11", "C12", "C13"], 'gaussian')
 
     print("Checking modelmetrics for multinomial")
     h2o_data = h2o.import_file(
@@ -33,15 +31,13 @@ def test_gam_modelMetrics():
     h2o_data["C2"] = h2o_data["C2"].asfactor()
     myY = "C11"
     h2o_data["C11"] = h2o_data["C11"].asfactor()
-    model_test_data = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/predictMultinomialGAM.csv"))
-    buildModelMetricsCheck(h2o_data, h2o_data, model_test_data, myY, ["C6", "C7", "C8"], 'multinomial')
+    buildModelMetricsCheck(h2o_data, myY, ["C6", "C7", "C8"], 'multinomial')
     
     print("gam modelmetrics test completed successfully")    
     
-def buildModelMetricsCheck(train_data, test_data, model_test_data, y, gamX, family):
+def buildModelMetricsCheck(train_data, y, gamX, family):
     numKnots = [5,6,7]
     x=["C1","C2"]
-    numCoeffs = len(train_data["C1"].categories())+len(train_data["C2"].categories())+sum(numKnots)+1-len(numKnots)
     h2o_model = H2OGeneralizedAdditiveEstimator(family=family, gam_columns=gamX,  scale = [1,1,1], num_knots=numKnots, 
                                                 standardize=True, Lambda=[0], alpha=[0], max_iterations=3)
     h2o_model.train(x=x, y=y, training_frame=train_data)

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7366_gam_cross_validation_fold_assignment_modulo_multinomial_large.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7366_gam_cross_validation_fold_assignment_modulo_multinomial_large.py
@@ -16,18 +16,18 @@ def test_gam_model_predict():
     #Prepare predictors and response columns
     covtype_X = covtype_df.col_names[:-1]     #last column is Cover_Type, our desired response variable 
     covtype_y = covtype_df.col_names[-1]
+    # build model with cross validation and with validation dataset
+    gam_multi_valid = H2OGeneralizedAdditiveEstimator(family='multinomial', solver='IRLSM', gam_columns=["Slope"],
+                                                      scale = [0.0001], num_knots=[5], standardize=True, nfolds=2,
+                                                      fold_assignment = 'modulo', alpha=[0.9,0.5,0.1], lambda_search=True,
+                                                      nlambdas=5, max_iterations=3)
+    gam_multi_valid.train(covtype_X, covtype_y, training_frame=train, validation_frame=valid)
     # build model with cross validation and no validation dataset
     gam_multi = H2OGeneralizedAdditiveEstimator(family='multinomial', solver='IRLSM', gam_columns=["Slope"], 
                                                 scale = [0.0001], num_knots=[5], standardize=True, nfolds=2, 
                                                 fold_assignment = 'modulo', alpha=[0.9,0.5,0.1], lambda_search=True,
                                                 nlambdas=5, max_iterations=3)
     gam_multi.train(covtype_X, covtype_y, training_frame=train)
-    # build model with cross validation and with validation dataset
-    gam_multi_valid = H2OGeneralizedAdditiveEstimator(family='multinomial', solver='IRLSM', gam_columns=["Slope"],
-                                                scale = [0.0001], num_knots=[5], standardize=True, nfolds=2,
-                                                fold_assignment = 'modulo', alpha=[0.9,0.5,0.1], lambda_search=True,
-                                                nlambdas=5, max_iterations=3)
-    gam_multi_valid.train(covtype_X, covtype_y, training_frame=train, validation_frame=valid)
     # model should yield the same coefficients in both case
     gam_multi_coef = gam_multi.coef()
     gam_multi_valid_coef = gam_multi_valid.coef()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_PUBDEV_7367_cartesian_gridsearch_subspaces_TP_CS_binomial.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_PUBDEV_7367_cartesian_gridsearch_subspaces_TP_CS_binomial.py
@@ -1,0 +1,104 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+# I copied Karthik's test to perform gridsearch on TP/CS smoothers with cartesian gridsearch  
+class test_random_gam_gridsearch_specific:
+    h2o_data = []
+    myX = []
+    myY = []
+    h2o_model = []
+    search_criteria = {'strategy': 'Cartesian'}
+    hyper_parameters = {'lambda': [1, 2],
+                        'subspaces': [{'scale': [[0.001], [0.0002]], 'num_knots': [[5], [10]], 'bs':[[1], [0]], 
+                                       'gam_columns': [[["c_0"]], [["c_1"]]]}, 
+                                      {'scale': [[0.001, 0.001, 0.001], [0.0002, 0.0002, 0.0002]], 
+                                       'bs':[[1, 1, 1], [0, 1, 1]], 
+                                       'num_knots': [[5, 10, 12], [6, 11, 13]], 
+                                       'gam_columns': [[["c_0"], ["c_1", "c_2"], ["c_3", "c_4", "c_5"]], 
+                                                       [["c_1"], ["c_2", "c_3"], ["c_4", "c_5", "c_6"]]]}]}
+    manual_gam_models = []
+    num_grid_models = 0
+    num_expected_models = 64
+    manual_model_count = 0
+
+    def __init__(self):
+        self.setup_data()
+
+    def setup_data(self):
+        """
+        This function performs all initializations necessary:
+        load the data sets and set the training set indices and response column index
+        """
+        self.h2o_data = \
+            h2o.import_file(path = pyunit_utils.locate("smalldata/gam_test/synthetic_20Cols_binomial_20KRows.csv"))
+        self.h2o_data['response'] = self.h2o_data['response'].asfactor()
+        self.h2o_data['C3'] = self.h2o_data['C3'].asfactor()
+        self.h2o_data['C7'] = self.h2o_data['C7'].asfactor()
+        self.h2o_data['C8'] = self.h2o_data['C8'].asfactor()
+        self.h2o_data['C10'] = self.h2o_data['C10'].asfactor()
+        names = self.h2o_data.names
+        self.myY = "response"
+        self.myX = names.remove(self.myY)
+
+        for lambda_ in self.hyper_parameters["lambda"]:
+            for subspace in self.hyper_parameters["subspaces"]:
+                for scale in subspace['scale']:
+                    for gam_columns in subspace['gam_columns']:
+                        for num_knots in subspace['num_knots']:
+                            for bsVal in subspace['bs']:
+                                self.manual_model_count += 1
+                                self.manual_gam_models.append(H2OGeneralizedAdditiveEstimator(family="binomial", 
+                                                                                              gam_columns=gam_columns,
+                                                                                              scale=scale,
+                                                                                              num_knots=num_knots,
+                                                                                              bs=bsVal,
+                                                                                              lambda_=lambda_
+                                                                                          ))
+
+    def train_models(self):
+        self.h2o_model = H2OGridSearch(H2OGeneralizedAdditiveEstimator(family="binomial",
+                                                                       keep_gam_cols=True), hyper_params=self.hyper_parameters, search_criteria=self.search_criteria)
+        self.h2o_model.train(x = self.myX, y = self.myY, training_frame = self.h2o_data)
+        for model in self.manual_gam_models:
+            model.train(x = self.myX, y = self.myY, training_frame = self.h2o_data)
+
+    def match_models(self):
+        for model in self.manual_gam_models:
+            scale = model.actual_params['scale']
+            gam_columns = model.actual_params['gam_columns']
+            num_knots = model.actual_params['num_knots']
+            lambda_ = model.actual_params['lambda']
+            bsVal = model.actual_params['bs']
+            for grid_search_model in self.h2o_model.models:
+                if grid_search_model.actual_params['gam_columns'] == gam_columns \
+                    and grid_search_model.actual_params['scale'] == scale \
+                    and grid_search_model.actual_params['num_knots'] == num_knots \
+                    and grid_search_model.actual_params['bs'] == bsVal \
+                    and grid_search_model.actual_params['lambda'] == lambda_:
+                    self.num_grid_models += 1
+                    print("grid model number "+str(self.num_grid_models))
+                    print("gridSearch model coefficients")
+                    print(grid_search_model.coef())
+                    print("manual model coefficients")
+                    print(model.coef())
+                    pyunit_utils.assertEqualCoeffDicts(grid_search_model.coef(), model.coef(), tol=1e-6)
+                    break
+
+        assert self.num_grid_models == self.num_expected_models, "Grid search model parameters incorrect or incorrect number of models generated"
+
+def test_gridsearch():
+    test_gam_grid = test_random_gam_gridsearch_specific()
+    test_gam_grid.train_models()
+    test_gam_grid.match_models()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gridsearch)
+else:
+    test_gridsearch()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_PUBDEV_7367_random_gridsearch_subspaces_TP_CS_binomial.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_PUBDEV_7367_random_gridsearch_subspaces_TP_CS_binomial.py
@@ -1,0 +1,104 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+# I copied Karthik's test to perform gridsearch on TP/CS smoothers with random gridsearch for the binomial family
+class test_random_gam_gridsearch_specific:
+    h2o_data = []
+    myX = []
+    myY = []
+    h2o_model = []
+    search_criteria = {'strategy': 'RandomDiscrete', "max_models": 64, "seed": 1}
+    hyper_parameters = {'lambda': [1, 2],
+                        'subspaces': [{'scale': [[0.001], [0.0002]], 'num_knots': [[5], [10]], 'bs':[[1], [0]], 
+                                       'gam_columns': [[["c_0"]], [["c_1"]]]}, 
+                                      {'scale': [[0.001, 0.001, 0.001], [0.0002, 0.0002, 0.0002]], 
+                                       'bs':[[1, 1, 1], [0, 1, 1]], 
+                                       'num_knots': [[5, 10, 12], [6, 11, 13]], 
+                                       'gam_columns': [[["c_0"], ["c_1", "c_2"], ["c_3", "c_4", "c_5"]], 
+                                                       [["c_1"], ["c_2", "c_3"], ["c_4", "c_5", "c_6"]]]}]}
+    manual_gam_models = []
+    num_grid_models = 0
+    num_expected_models = 64
+    manual_model_count = 0
+
+    def __init__(self):
+        self.setup_data()
+
+    def setup_data(self):
+        """
+        This function performs all initializations necessary:
+        load the data sets and set the training set indices and response column index
+        """
+        self.h2o_data = \
+            h2o.import_file(path = pyunit_utils.locate("smalldata/gam_test/synthetic_20Cols_binomial_20KRows.csv"))
+        self.h2o_data['response'] = self.h2o_data['response'].asfactor()
+        self.h2o_data['C3'] = self.h2o_data['C3'].asfactor()
+        self.h2o_data['C7'] = self.h2o_data['C7'].asfactor()
+        self.h2o_data['C8'] = self.h2o_data['C8'].asfactor()
+        self.h2o_data['C10'] = self.h2o_data['C10'].asfactor()
+        names = self.h2o_data.names
+        self.myY = "response"
+        self.myX = names.remove(self.myY)
+
+        for lambda_ in self.hyper_parameters["lambda"]:
+            for subspace in self.hyper_parameters["subspaces"]:
+                for scale in subspace['scale']:
+                    for gam_columns in subspace['gam_columns']:
+                        for num_knots in subspace['num_knots']:
+                            for bsVal in subspace['bs']:
+                                self.manual_model_count += 1
+                                self.manual_gam_models.append(H2OGeneralizedAdditiveEstimator(family="binomial", 
+                                                                                              gam_columns=gam_columns,
+                                                                                              scale=scale,
+                                                                                              num_knots=num_knots,
+                                                                                              bs=bsVal,
+                                                                                              lambda_=lambda_
+                                                                                          ))
+
+    def train_models(self):
+        self.h2o_model = H2OGridSearch(H2OGeneralizedAdditiveEstimator(family="binomial",
+                                                                       keep_gam_cols=True), hyper_params=self.hyper_parameters, search_criteria=self.search_criteria)
+        self.h2o_model.train(x = self.myX, y = self.myY, training_frame = self.h2o_data)
+        for model in self.manual_gam_models:
+            model.train(x = self.myX, y = self.myY, training_frame = self.h2o_data)
+
+    def match_models(self):
+        for model in self.manual_gam_models:
+            scale = model.actual_params['scale']
+            gam_columns = model.actual_params['gam_columns']
+            num_knots = model.actual_params['num_knots']
+            lambda_ = model.actual_params['lambda']
+            bsVal = model.actual_params['bs']
+            for grid_search_model in self.h2o_model.models:
+                if grid_search_model.actual_params['gam_columns'] == gam_columns \
+                    and grid_search_model.actual_params['scale'] == scale \
+                    and grid_search_model.actual_params['num_knots'] == num_knots \
+                    and grid_search_model.actual_params['bs'] == bsVal \
+                    and grid_search_model.actual_params['lambda'] == lambda_:
+                    self.num_grid_models += 1
+                    print("grid model number "+str(self.num_grid_models))
+                    print("gridSearch model coefficients")
+                    print(grid_search_model.coef())
+                    print("manual model coefficients")
+                    print(model.coef())
+                    pyunit_utils.assertEqualCoeffDicts(grid_search_model.coef(), model.coef(), tol=1e-6)
+                    break
+
+        assert self.num_grid_models == self.num_expected_models, "Grid search model parameters incorrect or incorrect number of models generated"
+
+def test_gridsearch():
+    test_gam_grid = test_random_gam_gridsearch_specific()
+    test_gam_grid.train_models()
+    test_gam_grid.match_models()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gridsearch)
+else:
+    test_gridsearch()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_PUBDEV_7367_random_gridsearch_subspaces_thin_plate_gaussian.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_PUBDEV_7367_random_gridsearch_subspaces_thin_plate_gaussian.py
@@ -1,0 +1,107 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+# I copied Karthik's test to perform gridsearch on thin plate regression smoothers only with gridsearch.  In this test,
+# I only allowed thin plate smoothers.
+class test_random_gam_gridsearch_specific:
+    h2o_data = []
+    myX = []
+    myY = []
+    h2o_model = []
+    search_criteria = {'strategy': 'RandomDiscrete', "max_models": 16, "seed": 1}
+    hyper_parameters = {'lambda': [100, 200],
+                        'subspaces': [{'scale': [[1, 1, 1], [2, 2, 2]],
+                                         'num_knots': [[5, 5, 5], [6, 6, 6]],
+                                         'bs':[[1,1,1]],
+                                         'gam_columns': [[["C11", "C12"], ["C13", "C14"], ["C15", "C16"]]]},
+                                        {'scale': [[1, 1], [2, 2]],
+                                         'bs':[[1, 1]],
+                                         'num_knots': [[6, 6], [5, 5]],
+                                         'gam_columns': [[["C11"], ["C14"]]]}]}
+    manual_gam_models = []
+    num_grid_models = 0
+    num_expected_models = 16
+    manual_model_count = 0
+
+    def __init__(self):
+        self.setup_data()
+
+    def setup_data(self):
+        """
+        This function performs all initializations necessary:
+        load the data sets and set the training set indices and response column index
+        """
+        self.h2o_data = h2o.import_file(
+            path = pyunit_utils.locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+        names = self.h2o_data.names
+        counter = 0
+        for name in names:
+            self.h2o_data[name] = self.h2o_data[name].asfactor()
+            counter = counter+1
+            if counter > 9:
+                break
+        self.myY = "C21"
+        self.myX = names.remove(self.myY)
+
+        for lambda_ in self.hyper_parameters["lambda"]:
+            for subspace in self.hyper_parameters["subspaces"]:
+                for scale in subspace['scale']:
+                    for gam_columns in subspace['gam_columns']:
+                        for num_knots in subspace['num_knots']:
+                            for bsVal in subspace['bs']:
+                                self.manual_model_count += 1
+                                self.manual_gam_models.append(H2OGeneralizedAdditiveEstimator(family="gaussian", 
+                                                                                              gam_columns=gam_columns,
+                                                                                              scale=scale,
+                                                                                              num_knots=num_knots,
+                                                                                              bs=bsVal,
+                                                                                              lambda_=lambda_
+                                                                                          ))
+
+    def train_models(self):
+        self.h2o_model = H2OGridSearch(H2OGeneralizedAdditiveEstimator(family="gaussian",
+                                                                       keep_gam_cols=True), hyper_params=self.hyper_parameters, search_criteria=self.search_criteria)
+        self.h2o_model.train(x = self.myX, y = self.myY, training_frame = self.h2o_data)
+        for model in self.manual_gam_models:
+            model.train(x = self.myX, y = self.myY, training_frame = self.h2o_data)
+
+    def match_models(self):
+        for model in self.manual_gam_models:
+            scale = model.actual_params['scale']
+            gam_columns = model.actual_params['gam_columns']
+            num_knots = model.actual_params['num_knots']
+            lambda_ = model.actual_params['lambda']
+            bsVal = model.actual_params['bs']
+            for grid_search_model in self.h2o_model.models:
+                if grid_search_model.actual_params['gam_columns'] == gam_columns \
+                    and grid_search_model.actual_params['scale'] == scale \
+                    and grid_search_model.actual_params['num_knots'] == num_knots \
+                    and grid_search_model.actual_params['bs'] == bsVal \
+                    and grid_search_model.actual_params['lambda'] == lambda_:
+                    self.num_grid_models += 1
+                    print("grid model number "+str(self.num_grid_models))
+                    print("gridSearch model coefficients")
+                    print(grid_search_model.coef())
+                    print("manual model coefficients")
+                    print(model.coef())
+                    pyunit_utils.assertEqualCoeffDicts(grid_search_model.coef(), model.coef(), tol=1e-6)
+                    break
+
+        assert self.num_grid_models == self.num_expected_models, "Grid search model parameters incorrect or incorrect number of models generated"
+
+def test_gridsearch():
+    test_gam_grid = test_random_gam_gridsearch_specific()
+    test_gam_grid.train_models()
+    test_gam_grid.match_models()
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gridsearch)
+else:
+    test_gridsearch()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_TP_compare_R_results.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_TP_compare_R_results.py
@@ -1,0 +1,57 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+
+# in this test, we compare binomial and gaussian families with R performance which I recorded earlier.
+# since I cannot force jenkins machines to install the R libraries, it is best to do it this way.
+def test_compare_R():
+    myX = ['c_0','c_1','c_2','c_3','c_4','c_5','c_6','c_7','c_8','c_9','C1','C2','C3','C4','C5','C6','C7','C8','C9','C10']
+    myY = 'response'
+    gamCols = [["c_0"], ["c_1", "c_2"], ["c_3", "c_4", "c_5"]]  
+    bsT = [1, 1, 1]
+    scaleP = [0.001, 0.001, 0.001]
+    numKnots = [10, 10, 12]
+    print("Comparing H2O and R GAM performance for binomial")
+    dataBinomial = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/synthetic_20Cols_binomial_20KRows.csv"))
+    dataBinomial["C3"] = dataBinomial["C3"].asfactor()
+    dataBinomial["C7"] = dataBinomial["C7"].asfactor()
+    dataBinomial["C8"] = dataBinomial["C8"].asfactor()
+    dataBinomial["C10"] = dataBinomial["C10"].asfactor()
+    dataBinomial["response"] = dataBinomial["response"].asfactor()
+    frames = dataBinomial.split_frame(ratios=[0.8], seed=1234)
+    trainB = frames[0]
+    testB = frames[1]
+    gamB = H2OGeneralizedAdditiveEstimator(family='binomial', gam_columns = gamCols, bs = bsT, scale = scaleP, 
+                                           num_knots = numKnots, lambda_search=True)
+    gamB.train(x = myX, y = myY, training_frame = trainB, validation_frame = testB)
+    gamPred = gamB.predict(testB)
+    temp = gamPred['predict'] == testB['response']
+    gamBacc = 1-temp.mean()[0,0]
+    rAcc = 0.01457801
+    print("R accuracy: {0}, H2O accuracy: {1}.".format(rAcc, gamBacc))
+    assert gamBacc <= rAcc, "R mean error rate: {0}, H2O mean error rate: {1}. R performs better." \
+                                          "".format(rAcc, gamBacc)
+    print("Comparing H2O and R GAM performance for gaussian")
+    dataGaussian = h2o.import_file(pyunit_utils.locate("smalldata/gam_test/synthetic_20Cols_gaussian_20KRows.csv"))
+    dataGaussian["C3"] = dataGaussian["C3"].asfactor()
+    dataGaussian["C7"] = dataGaussian["C7"].asfactor()
+    dataGaussian["C8"] = dataGaussian["C8"].asfactor()
+    dataGaussian["C10"] = dataGaussian["C10"].asfactor()
+    frames = dataGaussian.split_frame(ratios=[0.8], seed=1234)
+    trainB = frames[0]
+    testB = frames[1]
+    gamG = H2OGeneralizedAdditiveEstimator(family='gaussian', gam_columns = gamCols, bs = bsT, scale = scaleP,
+                                       num_knots = numKnots, lambda_search=True)
+    gamG.train(x = myX, y = myY, training_frame = trainB, validation_frame = testB)
+    gamMSE = gamG.model_performance(valid=True).mse()
+    rMSE = 0.0006933308
+    print("R MSE: {0}, H2O MSE: {1}.".format(rMSE, gamMSE))
+    assert gamMSE <= rMSE, "R MSE: {0}, H2O MSE: {1}. R performs better." \
+                           "".format(rMSE, gamMSE)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_compare_R)
+else:
+    test_compare_R()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_cartesian_gridsearch_subspaces_TP_CS_binomial_dual_mode.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_cartesian_gridsearch_subspaces_TP_CS_binomial_dual_mode.py
@@ -1,0 +1,54 @@
+from __future__ import division
+from __future__ import print_function
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+# specify gam_columns as [x, [x,x]] or [[x],[x,x]] and they should both work and generate the same model
+def test_gridsearch():
+    h2o_data = h2o.import_file(path = pyunit_utils.locate("smalldata/gam_test/synthetic_20Cols_binomial_20KRows.csv"))
+    h2o_data['response'] = h2o_data['response'].asfactor()
+    h2o_data['C3'] = h2o_data['C3'].asfactor()
+    h2o_data['C7'] = h2o_data['C7'].asfactor()
+    h2o_data['C8'] = h2o_data['C8'].asfactor()
+    h2o_data['C10'] = h2o_data['C10'].asfactor()
+    names = h2o_data.names
+    myY = "response"
+    myX = names.remove(myY)
+    search_criteria = {'strategy': 'Cartesian'}
+    hyper_parameters = {'lambda': [1, 2],
+                        'subspaces': [{'scale': [[0.001], [0.0002]], 'num_knots': [[5], [10]], 'bs':[[1], [0]], 
+                                       'gam_columns': [[["c_0"]], [["c_1"]]]},
+                                      {'scale': [[0.001, 0.001, 0.001], [0.0002, 0.0002, 0.0002]], 
+                                       'bs':[[1, 1, 1], [0, 1, 1]], 
+                                       'num_knots': [[5, 10, 12], [6, 11, 13]], 
+                                       'gam_columns': [[["c_0"], ["c_1", "c_2"], ["c_3", "c_4", "c_5"]],
+                                                   [["c_1"], ["c_2", "c_3"], ["c_4", "c_5", "c_6"]]]}]}
+    hyper_parameters2 = {'lambda': [1, 2],
+                        'subspaces': [{'scale': [[0.001], [0.0002]], 'num_knots': [[5], [10]], 'bs':[[1], [0]],
+                                       'gam_columns': [[["c_0"]], [["c_1"]]]},
+                                      {'scale': [[0.001, 0.001, 0.001], [0.0002, 0.0002, 0.0002]],
+                                       'bs':[[1, 1, 1], [0, 1, 1]],
+                                       'num_knots': [[5, 10, 12], [6, 11, 13]],
+                                       'gam_columns': [["c_0", ["c_1", "c_2"], ["c_3", "c_4", "c_5"]],
+                                                       ["c_1", ["c_2", "c_3"], ["c_4", "c_5", "c_6"]]]}]}
+    h2o_model = H2OGridSearch(H2OGeneralizedAdditiveEstimator(family="binomial", keep_gam_cols=True), 
+                              hyper_params=hyper_parameters, search_criteria=search_criteria)
+    h2o_model.train(x = myX, y = myY, training_frame = h2o_data)
+    h2o_model2 = H2OGridSearch(H2OGeneralizedAdditiveEstimator(family="binomial", keep_gam_cols=True),
+                              hyper_params=hyper_parameters2, search_criteria=search_criteria)
+    h2o_model2.train(x = myX, y = myY, training_frame = h2o_data)
+    # compare two models by checking their coefficients.  They should be the same
+    for index in range(0, len(h2o_model)):
+        model1 = h2o_model[index]
+        model2 = h2o_model2[index]
+        pyunit_utils.assertEqualCoeffDicts(model1.coef(), model2.coef(), tol=1e-6)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gridsearch)
+else:
+    test_gridsearch()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_random_gridsearch_subspaces_TP_CS_binomial_dual_mode.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_random_gridsearch_subspaces_TP_CS_binomial_dual_mode.py
@@ -1,0 +1,53 @@
+from __future__ import division
+from __future__ import print_function
+import sys
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+from h2o.grid.grid_search import H2OGridSearch
+
+# specify gam_columns as [x, [x,x]] or [[x],[x,x]] and they should both work and generate the same model
+def test_randomdiscrete_gridsearch():
+    h2o_data = h2o.import_file(path = pyunit_utils.locate("smalldata/gam_test/synthetic_20Cols_binomial_20KRows.csv"))
+    h2o_data['response'] = h2o_data['response'].asfactor()
+    h2o_data['C3'] = h2o_data['C3'].asfactor()
+    h2o_data['C7'] = h2o_data['C7'].asfactor()
+    h2o_data['C8'] = h2o_data['C8'].asfactor()
+    h2o_data['C10'] = h2o_data['C10'].asfactor()
+    names = h2o_data.names
+    myY = "response"
+    myX = names.remove(myY)
+    search_criteria = {'strategy': 'RandomDiscrete', "seed": 1}
+    hyper_parameters = {'lambda': [1, 2],
+                        'subspaces': [{'scale': [[0.001], [0.0002]], 'num_knots': [[5], [10]], 'bs':[[1], [0]], 
+                                       'gam_columns': [[["c_0"]], [["c_1"]]]},
+                                      {'scale': [[0.001, 0.001, 0.001], [0.0002, 0.0002, 0.0002]], 
+                                       'bs':[[1, 1, 1], [0, 1, 1]], 
+                                       'num_knots': [[5, 10, 12], [6, 11, 13]], 
+                                       'gam_columns': [[["c_0"], ["c_1", "c_2"], ["c_3", "c_4", "c_5"]],
+                                                   [["c_1"], ["c_2", "c_3"], ["c_4", "c_5", "c_6"]]]}]}
+    hyper_parameters2 = {'lambda': [1, 2],
+                        'subspaces': [{'scale': [[0.001], [0.0002]], 'num_knots': [[5], [10]], 'bs':[[1], [0]],
+                                       'gam_columns': [[["c_0"]], [["c_1"]]]},
+                                      {'scale': [[0.001, 0.001, 0.001], [0.0002, 0.0002, 0.0002]],
+                                       'bs':[[1, 1, 1], [0, 1, 1]],
+                                       'num_knots': [[5, 10, 12], [6, 11, 13]],
+                                       'gam_columns': [["c_0", ["c_1", "c_2"], ["c_3", "c_4", "c_5"]],
+                                                       ["c_1", ["c_2", "c_3"], ["c_4", "c_5", "c_6"]]]}]}
+    h2o_model = H2OGridSearch(H2OGeneralizedAdditiveEstimator(family="binomial", keep_gam_cols=True), 
+                              hyper_params=hyper_parameters, search_criteria=search_criteria)
+    h2o_model.train(x = myX, y = myY, training_frame = h2o_data)
+    h2o_model2 = H2OGridSearch(H2OGeneralizedAdditiveEstimator(family="binomial", keep_gam_cols=True),
+                              hyper_params=hyper_parameters2, search_criteria=search_criteria)
+    h2o_model2.train(x = myX, y = myY, training_frame = h2o_data)
+    # compare two models by checking their coefficients.  They should be the same
+    for index in range(0, len(h2o_model)):
+        model1 = h2o_model[index]
+        model2 = h2o_model2[index]
+        pyunit_utils.assertEqualCoeffDicts(model1.coef(), model2.coef(), tol=1e-6)
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_randomdiscrete_gridsearch)
+else:
+    test_randomdiscrete_gridsearch()

--- a/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_thin_plate_multinomial_dual_mode.py
+++ b/h2o-py/tests/testdir_algos/gam/pyunit_PUBDEV_7860_thin_plate_multinomial_dual_mode.py
@@ -1,0 +1,40 @@
+import sys
+sys.path.insert(1,"../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.gam import H2OGeneralizedAdditiveEstimator
+
+# In this test, we want to check and make sure that the models built with specifying gam_columns as
+# ["C1", ["C2","C3"]] and [["C1"], ["C2","C3"]] should give the same results
+def test_gam_dual_mode_multinomial():
+    train = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    train["C11"] = train["C11"].asfactor()
+    train["C1"] = train["C1"].asfactor()
+    train["C2"] = train["C2"].asfactor()
+    test = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/multinomial_10_classes_10_cols_10000_Rows_train.csv"))
+    test["C11"] = test["C11"].asfactor()
+    test["C1"] = test["C1"].asfactor()
+    test["C2"] = test["C2"].asfactor()
+    x = ["C1", "C2"]
+    y = "C11"
+    gam_cols1 =["C6", ["C7", "C8"], "C9", "C10"]
+    gam_cols2 = [["C6"], ["C7", "C8"], ["C9"], ["C10"]]
+    h2o_model1 = H2OGeneralizedAdditiveEstimator(family='multinomial', gam_columns=gam_cols1, bs=[1, 1, 0, 0], 
+                                                 max_iterations = 2)
+    h2o_model1.train(x=x, y=y, training_frame=train, validation_frame=test)
+    h2o_model2 = H2OGeneralizedAdditiveEstimator(family='multinomial', gam_columns=gam_cols2, bs=[1, 1, 0, 0], 
+                                                 max_iterations = 2)
+    h2o_model2.train(x=x, y=y, training_frame=train, validation_frame=test)
+    # check that both models produce the same coefficients
+    print(h2o_model1.coef())
+    print(h2o_model2.coef())
+    pyunit_utils.assertCoefDictEqual(h2o_model1.coef()['coefficients'], h2o_model2.coef()['coefficients'], tol=1e-6)
+    # check both models product the same validation metrics
+    assert abs(h2o_model1.logloss(valid=True) - h2o_model2.logloss(valid=True)) < 1e-6,\
+        "Expected validation logloss: {0}, Actual validation logloss: {1}".format(h2o_model1.logloss(valid=True), 
+                                                                                  h2o_model2.logloss(valid=True))
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(test_gam_dual_mode_multinomial)
+else:
+    test_gam_dual_mode_multinomial()

--- a/h2o-py/tests/testdir_algos/xgboost/pyunit_xgboost_pojo.py
+++ b/h2o-py/tests/testdir_algos/xgboost/pyunit_xgboost_pojo.py
@@ -25,7 +25,7 @@ def compare_preds(train, test, x, y, booster, ntrees, max_depth, max_error):
     pyunit_utils.compare_frames_local(pred_h2o, pred_pojo, 1, tol=max_error)
 
 
-def test_booster(booster, max_error=1e-10):
+def test_booster(booster, max_error=1e-6):
     assert H2OXGBoostEstimator.available()
 
     # prostate - regression without categoricals

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7860_GAM_TP_CS_mojo_binomial.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7860_GAM_TP_CS_mojo_binomial.py
@@ -1,0 +1,35 @@
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+import tempfile
+
+# test GAM TP and CS smoothers for Binomial family
+def gam_binomial_mojo():
+    params = set_params()
+    train = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    test =  h2o.import_file(pyunit_utils.locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+    train["C21"] = train["C21"].asfactor()
+    test["C21"] = test["C21"].asfactor()
+    x=["C1"]
+    y = "C21"
+
+    TMPDIR = tempfile.mkdtemp()
+    gamModel = pyunit_utils.build_save_model_generic(params, x, train, y, "gam", TMPDIR) # build and save mojo model
+    MOJONAME = pyunit_utils.getMojoName(gamModel._id)
+
+    h2o.download_csv(test, os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
+    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(gamModel, TMPDIR, MOJONAME)  # load model and perform predict
+    h2o.download_csv(pred_h2o, os.path.join(TMPDIR, "h2oPred.csv"))
+    print("Comparing mojo predict and h2o predict...")
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 1, tol=1e-10)    # make sure operation sequence is preserved from Tomk        h2o.save_model(glmOrdinalModel, path=TMPDIR, force=True)  # save model for debugging
+
+def set_params():
+    params = {'family':"binomial", 'bs':[1,1,1,0],'standardize':False, 
+              "gam_columns":[["C12"], ["C13", "C14"], ["C15", "C16", "C17"], ["C18"]]}
+    return params
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(gam_binomial_mojo)
+else:
+    gam_binomial_mojo()

--- a/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7860_GAM_TP_mojo_fractionalbinomial.py
+++ b/h2o-py/tests/testdir_javapredict/pyunit_PUBDEV_7860_GAM_TP_mojo_fractionalbinomial.py
@@ -1,0 +1,33 @@
+import sys, os
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+import tempfile
+
+# one more test for gam, this time use family fractionalbinomial
+def gam_fractional_binomial_mojo_pojo():
+    params = set_params()
+    train = h2o.import_file(pyunit_utils.locate("smalldata/glm_test/fraction_binommialOrig.csv"))
+    test =  h2o.import_file(pyunit_utils.locate("smalldata/glm_test/fraction_binommialOrig.csv"))
+    x = ["log10conc"]
+    y = "y"
+
+    TMPDIR = tempfile.mkdtemp()
+    gamModel = pyunit_utils.build_save_model_generic(params, x, train, y, "gam", TMPDIR) # build and save mojo model
+    MOJONAME = pyunit_utils.getMojoName(gamModel._id)
+
+    h2o.download_csv(test[x], os.path.join(TMPDIR, 'in.csv'))  # save test file, h2o predict/mojo use same file
+    pred_h2o, pred_mojo = pyunit_utils.mojo_predict(gamModel, TMPDIR, MOJONAME)  # load model and perform predict
+    h2o.download_csv(pred_h2o, os.path.join(TMPDIR, "h2oPred.csv"))
+    print("Comparing mojo predict and h2o predict...")
+    pyunit_utils.compare_frames_local(pred_h2o, pred_mojo, 0.1, tol=1e-10)    # make sure operation sequence is preserved from Tomk        h2o.save_model(glmOrdinalModel, path=TMPDIR, force=True)  # save model for debugging
+
+def set_params():
+    params = {'family':"fractionalbinomial", 'alpha':[0], 'lambda_':[0],
+              'standardize':False, "gam_columns":['log10conc'], "num_knots":[5], "bs":[1]}
+    return params
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(gam_fractional_binomial_mojo_pojo)
+else:
+    gam_fractional_binomial_mojo_pojo()

--- a/h2o-r/h2o-package/R/gam.R
+++ b/h2o-r/h2o-package/R/gam.R
@@ -15,7 +15,8 @@
 #'        The response must be either a numeric or a categorical/factor variable. 
 #'        If the response is numeric, then a regression model will be trained, otherwise it will train a classification model.
 #' @param training_frame Id of the training data frame.
-#' @param gam_columns Predictor column names for gam
+#' @param gam_columns Arrays of predictor column names for gam for smoothers using single or multiple predictors like
+#'        {{'c1'},{'c2','c3'},{'c4'},...}
 #' @param model_id Destination id for this model; auto-generated if not specified.
 #' @param validation_frame Id of the validation data frame.
 #' @param nfolds Number of folds for K-fold cross-validation (0 to disable or >= 2). Defaults to 0.
@@ -116,9 +117,12 @@
 #' @param max_runtime_secs Maximum allowed runtime in seconds for model training. Use 0 to disable. Defaults to 0.
 #' @param custom_metric_func Reference to custom evaluation function, format: `language:keyName=funcName`
 #' @param num_knots Number of knots for gam predictors
-#' @param knot_ids String arrays storing frame keys of knots.  One for each gam column specified in gam_columns
-#' @param bs Basis function type for each gam predictors, 0 for cr
-#' @param scale Smoothing parameter for gam predictors
+#' @param knot_ids String arrays storing frame keys of knots.  One for each gam column set specified in gam_columns
+#' @param standardize_tp_gam_cols \code{Logical}. standardize tp (thin plate) predictor columns Defaults to FALSE.
+#' @param scale_tp_penalty_mat \code{Logical}. Scale penalty matrix for tp (thin plate) smoothers as in R Defaults to FALSE.
+#' @param bs Basis function type for each gam predictors, 0 for cr, 1 for thin plate regression with knots, 2 for thin
+#'        plate regression with SVD.  If specified, must be the same size as gam_columns
+#' @param scale Smoothing parameter for gam predictors.  If specified, must be of the same length as gam_columns
 #' @param keep_gam_cols \code{Logical}. Save keys of model matrix Defaults to FALSE.
 #' @param auc_type Set default multinomial AUC type. Must be one of: "AUTO", "NONE", "MACRO_OVR", "WEIGHTED_OVR", "MACRO_OVO",
 #'        "WEIGHTED_OVO". Defaults to AUTO.
@@ -194,6 +198,8 @@ h2o.gam <- function(x,
                     custom_metric_func = NULL,
                     num_knots = NULL,
                     knot_ids = NULL,
+                    standardize_tp_gam_cols = FALSE,
+                    scale_tp_penalty_mat = FALSE,
                     bs = NULL,
                     scale = NULL,
                     keep_gam_cols = FALSE,
@@ -208,11 +214,11 @@ h2o.gam <- function(x,
   if (missing(x)) {
       x = NULL
   }
-
   # If gam_columns is missing, then assume user wants to use all columns as features for GAM.
   if (missing(gam_columns)) {
       stop("Columns indices to apply to GAM must be specified. If there are none, please use GLM.")
   }
+  gam_columns <- lapply(gam_columns, function(x) if(is.character(x) & length(x) == 1) list(x) else x)
 
   # Validate other args
   # if (!is.null(beta_constraints)) {
@@ -341,6 +347,10 @@ h2o.gam <- function(x,
     parms$knot_ids <- knot_ids
   if (!missing(gam_columns))
     parms$gam_columns <- gam_columns
+  if (!missing(standardize_tp_gam_cols))
+    parms$standardize_tp_gam_cols <- standardize_tp_gam_cols
+  if (!missing(scale_tp_penalty_mat))
+    parms$scale_tp_penalty_mat <- scale_tp_penalty_mat
   if (!missing(bs))
     parms$bs <- bs
   if (!missing(scale))
@@ -435,6 +445,8 @@ h2o.gam <- function(x,
                                     custom_metric_func = NULL,
                                     num_knots = NULL,
                                     knot_ids = NULL,
+                                    standardize_tp_gam_cols = FALSE,
+                                    scale_tp_penalty_mat = FALSE,
                                     bs = NULL,
                                     scale = NULL,
                                     keep_gam_cols = FALSE,
@@ -456,11 +468,11 @@ h2o.gam <- function(x,
   if (missing(x)) {
       x = NULL
   }
-
   # If gam_columns is missing, then assume user wants to use all columns as features for GAM.
   if (missing(gam_columns)) {
       stop("Columns indices to apply to GAM must be specified. If there are none, please use GLM.")
   }
+  gam_columns <- lapply(gam_columns, function(x) if(is.character(x) & length(x) == 1) list(x) else x)
 
   # Validate other args
   # if (!is.null(beta_constraints)) {
@@ -587,6 +599,10 @@ h2o.gam <- function(x,
     parms$knot_ids <- knot_ids
   if (!missing(gam_columns))
     parms$gam_columns <- gam_columns
+  if (!missing(standardize_tp_gam_cols))
+    parms$standardize_tp_gam_cols <- standardize_tp_gam_cols
+  if (!missing(scale_tp_penalty_mat))
+    parms$scale_tp_penalty_mat <- scale_tp_penalty_mat
   if (!missing(bs))
     parms$bs <- bs
   if (!missing(scale))

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -259,6 +259,13 @@ NULL
 }
 
 .h2o.checkAndUnifyModelParameters <- function(algo, allParams, params, hyper_params = list()) {
+  addGamCol <- FALSE
+  if (algo == "gam") {# gam_column is specified in subspace and need to fake something here
+    if (is.null(params$gam_columns) && !(is.null(hyper_params$subspaces)) && !(is.null(hyper_params$subspaces[[1]]$gam_columns))) {
+      addGamCol <- TRUE
+      params$gam_columns = list("C1")  # set default gam_columns
+    }
+  }
   # First verify all parameters
   error <- lapply(allParams, function(i) {
     e <- ""
@@ -278,6 +285,9 @@ NULL
     e
   })
 
+  if (addGamCol)
+    params$gam_columns <- NULL
+  
   if(any(nzchar(error)))
     stop(error)
 

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_cartesian_gridsearch_gaussian_dual_model.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_cartesian_gridsearch_gaussian_dual_model.R
@@ -1,0 +1,63 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# make sure gam will build the same model regardless of how gam columns are specified
+test.model.gam.random.gridsearch.dual.modes <- function() {
+    trainGaussian <- h2o.importFile(locate("smalldata/gam_test/synthetic_20Cols_gaussian_20KRows.csv"))
+    trainGaussian$C3 <- h2o.asfactor(trainGaussian$C3)
+    trainGaussian$C7 <- h2o.asfactor(trainGaussian$C7)
+    trainGaussian$C8 <- h2o.asfactor(trainGaussian$C8)
+    trainGaussian$C10 <- h2o.asfactor(trainGaussian$C10)
+    xL <- c("c_0", "c_1", "c_2", "c_3", "c_4", "c_5", "c_6", "c_7", "c_8", "c_9", "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", 
+            "C9", "C10")
+    yR = "response"
+    
+    #setup search criteria
+    search_criteria <- list()
+    search_criteria$strategy <- 'Cartesian'
+    # setup hyper-parameter for gridsearch
+    hyper_parameters <- list()
+    hyper_parameters$lambda = c(1, 2)   
+    
+    # generate random hyper-parameter for gridsearch
+    subspace1 <- list()
+    subspace1$scale <- list(c(0.001, 0.001, 0.001), c(0.002, 0.002, 0.002))
+    subspace1$num_knots <- list(c(5, 10, 12), c(6, 11, 13))
+    subspace1$bs <- list(c(1, 1, 1), c(0, 1, 1))
+    subspace1$gam_columns <- list(list("c_0", c("c_1", "c_2"), c("c_3", "c_4", "c_5")), 
+                                  list("c_1", c("c_2", "c_3"), c("c_4", "c_5", "c_6")))
+    hyper_parameters$subspaces <- list(subspace1)
+    
+    # setup hyper-parameter for gridsearch
+    hyper_parameters2 <- list()
+    hyper_parameters2$lambda <- c(1, 2)   
+    
+    # generate random hyper-parameter for gridsearch
+    subspace2 <- list()
+    subspace2$scale <- list(c(0.001, 0.001, 0.001), c(0.002, 0.002, 0.002))
+    subspace2$num_knots <- list(c(5, 10, 12), c(6, 11, 13))
+    subspace2$bs <- list(c(1, 1, 1), c(0, 1, 1))
+    subspace2$gam_columns <- list(list(c("c_0"), c("c_1", "c_2"), c("c_3", "c_4", "c_5")), 
+                                  list(c("c_1"), c("c_2", "c_3"), c("c_4", "c_5", "c_6")))
+    hyper_parameters2$subspaces <- list(subspace2)
+    
+    gam_grid1 = h2o.grid("gam", grid_id="GAMModel1", x=xL, y=yR, training_frame=trainGaussian, family='gaussian',
+                         hyper_params=hyper_parameters, search_criteria=search_criteria)
+    gam_grid2 = h2o.grid("gam", grid_id="GAMModel2", x=xL, y=yR, training_frame=trainGaussian, family='gaussian',
+                         hyper_params=hyper_parameters2, search_criteria=search_criteria)
+    
+    numModel <- length(gam_grid1@model_ids)
+    for (index in c(1:numModel)) {
+        print(index)
+        model1 <- h2o.getModel(gam_grid1@model_ids[[index]])
+        model2 <- h2o.getModel(gam_grid2@model_ids[[index]])
+        coeff1 <- model1@model$coefficients
+        coeff2 <- model2@model$coefficients
+        # coefficients from both models should be the same
+        compareResult <- sum(abs(coeff1-coeff2))
+        expect_true(compareResult < 1e-10)
+        
+    }
+}
+
+doTest("General Additive Model test dual model specification with Gaussian family for cartesian gridsearch", test.model.gam.random.gridsearch.dual.modes)

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_gam_tp_gaussian_dual_model.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_gam_tp_gaussian_dual_model.R
@@ -1,0 +1,34 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# make sure gam will build the same model regardless of how gam columns are specified
+test.model.gam.dual.modes <- function() {
+    train <- h2o.importFile(path = locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    test <- h2o.importFile(path = locate("smalldata/glm_test/gaussian_20cols_10000Rows.csv"))
+    train$C1 <- h2o.asfactor(train$C1)
+    train$C2 <- h2o.asfactor(train$C2)
+    test$C1 <- h2o.asfactor(test$C1)
+    test$C2 <- h2o.asfactor(test$C2)
+    xL <- c("C1", "C2")
+    yR = "C21"
+    gam_col1 <- list("C11", c("C12", "C13"), c("C14", "C15", "C16"), "C17", "C18")
+    gam_col2 <- list(c("C11"), c("C12", "C13"), c("C14", "C15", "C16"), c("C17"), c("C18"))
+    bsT <- c(1,1,1,0,0)
+    gam_model <- h2o.gam(x = xL, y = yR, gam_columns = gam_col1, training_frame = train, validation_frame = test, 
+    family = "gaussian", lambda_search=TRUE)
+    gam_model2 <- h2o.gam(x = xL, y = yR, gam_columns = gam_col2, training_frame = train, validation_frame = test, 
+    family = "gaussian", lambda_search=TRUE)
+    coeff1 <- gam_model@model$coefficients
+    coeff2 <- gam_model2@model$coefficients
+    
+    # coefficients from both models should be the same
+    for (ind in c(1:length(coeff1))) {
+        temp <- abs(coeff1[[ind]]-coeff2[[ind]])
+        expect_true(temp < 1e-6, "coefficient comparison failed.")
+    }
+    
+    # check validation metrics
+    expect_true(abs(h2o.mse(gam_model, valid=TRUE)-h2o.mse(gam_model2, valid=TRUE)) < 1e-6)
+}
+
+doTest("General Additive Model test dual model specification with Gaussian family", test.model.gam.dual.modes)

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_randomdiscrete_gridsearch_gaussian_dual_model.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_7860_randomdiscrete_gridsearch_gaussian_dual_model.R
@@ -1,0 +1,67 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# make sure gam will build the same model regardless of how gam columns are specified
+test.model.gam.random.gridsearch.dual.modes <- function() {
+    trainGaussian <- h2o.importFile(locate("smalldata/gam_test/synthetic_20Cols_gaussian_20KRows.csv"))
+    trainGaussian$C3 <- h2o.asfactor(trainGaussian$C3)
+    trainGaussian$C7 <- h2o.asfactor(trainGaussian$C7)
+    trainGaussian$C8 <- h2o.asfactor(trainGaussian$C8)
+    trainGaussian$C10 <- h2o.asfactor(trainGaussian$C10)
+    xL <- c("c_0", "c_1", "c_2", "c_3", "c_4", "c_5", "c_6", "c_7", "c_8", "c_9", "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", 
+            "C9", "C10")
+    yR = "response"
+    
+    #setup search criteria
+    search_criteria <- list()
+    search_criteria$strategy <- 'RandomDiscrete'
+    search_criteria$seed <- 1
+    search_criteria$max_models  <- 32
+    # setup hyper-parameter for gridsearch
+    hyper_parameters <- list()
+    hyper_parameters$lambda = c(1, 2)   
+    
+    # generate random hyper-parameter for gridsearch
+    subspace1 <- list()
+    subspace1$scale <-
+        list(c(0.001, 0.001, 0.001), c(0.002, 0.002, 0.002))
+    subspace1$num_knots <- list(c(5, 10, 12), c(6, 11, 13))
+    subspace1$bs <- list(c(1, 1, 1), c(0, 1, 1))
+    subspace1$gam_columns <-
+        list(list("c_0", c("c_1", "c_2"), c("c_3", "c_4", "c_5")),
+             list("c_1", c("c_2", "c_3"), c("c_4", "c_5", "c_6")))
+    hyper_parameters$subspaces <- list(subspace1)
+    
+    # setup hyper-parameter for gridsearch
+    hyper_parameters2 <- list()
+    hyper_parameters2$lambda <- c(1, 2)   
+    
+    # generate random hyper-parameter for gridsearch
+    subspace2 <- list()
+    subspace2$scale <- list(c(0.001, 0.001, 0.001), c(0.002, 0.002, 0.002))
+    subspace2$num_knots <- list(c(5, 10, 12), c(6, 11, 13))
+    subspace2$bs <- list(c(1, 1, 1), c(0, 1, 1))
+    subspace2$gam_columns <- list(list(c("c_0"), c("c_1", "c_2"), c("c_3", "c_4", "c_5")), 
+                                  list(c("c_1"), c("c_2", "c_3"), c("c_4", "c_5", "c_6")))
+    hyper_parameters2$subspaces <- list(subspace2)
+    
+    gam_grid1 = h2o.grid("gam", grid_id="GAMModel1", x=xL, y=yR, training_frame=trainGaussian, family='gaussian',
+                         hyper_params=hyper_parameters, search_criteria=search_criteria)
+    gam_grid2 = h2o.grid("gam", grid_id="GAMModel2", x=xL, y=yR, training_frame=trainGaussian, family='gaussian',
+                         hyper_params=hyper_parameters2, search_criteria=search_criteria)
+    
+    numModel <- length(gam_grid1@model_ids)
+    for (index in c(1:numModel)) {
+        print(index)
+        model1 <- h2o.getModel(gam_grid1@model_ids[[index]])
+        model2 <- h2o.getModel(gam_grid2@model_ids[[index]])
+        coeff1 <- model1@model$coefficients
+        coeff2 <- model2@model$coefficients
+        # coefficients from both models should be the same
+        compareResult <- sum(abs(coeff1-coeff2))
+        expect_true(compareResult < 1e-10)
+        
+    }
+}
+
+doTest("General Additive Model test dual model specification with Gaussian family for randomdiscrete gridsearch", test.model.gam.random.gridsearch.dual.modes)

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8000_GAM_IOOB.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8000_GAM_IOOB.R
@@ -6,7 +6,6 @@ source("../../../scripts/h2o-r-test-setup.R")
 # Marco for brining this up to me.
 test.model.gam.IOOB <- function() {
     mtcars_h2o <- as.h2o(mtcars)
-    browser()
     att_model <- h2o.gam(y = "mpg",
                          gam_columns = c("disp", "hp", "drat", "wt"),
                          family = "gamma",

--- a/h2o-r/tests/testdir_javapredict/runit_PUBDEV_7860_binomial_gam_TP_CS_MOJO.R
+++ b/h2o-r/tests/testdir_javapredict/runit_PUBDEV_7860_binomial_gam_TP_CS_MOJO.R
@@ -1,0 +1,34 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../scripts/h2o-r-test-setup.R")
+
+test.GAM.binomial <- function() {
+  train <- h2o.importFile(locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+  test <- h2o.importFile(locate("smalldata/glm_test/binomial_20_cols_10KRows.csv"))
+  train$C21 <- h2o.asfactor(train$C21)
+  train$C1 <- h2o.asfactor(train$C1)
+  train$C2 <- h2o.asfactor(train$C2)
+  test$C21 <- h2o.asfactor(test$C21)
+  test$C1 <- h2o.asfactor(test$C1)
+  test$C2 <- h2o.asfactor(test$C2)
+  x = 1:2
+  y = 21
+  params                  <- list()
+  params$missing_values_handling <- 'MeanImputation'
+  params$training_frame <- train
+  params$x <- x
+  params$y <- y
+  params$family <- "binomial"
+  params$gam_columns <- list(c("C12"), c("C13", "C14"), c("C15", "C16", "C18"), c("C17"))
+  params$bs <- c(1,1,1,0)
+  params$scale <- c(0.001, 0.001, 0.001, 0.001)
+  modelAndDir<-buildModelSaveMojoGAM(params) # build the model and save mojo
+  filename = sprintf("%s/in.csv", modelAndDir$dirName) # save the test dataset into a in.csv file.
+  h2o.downloadCSV(test, filename)
+  twoFrames<-mojoH2Opredict(modelAndDir$model, modelAndDir$dirName, filename, col.types=c("enum", "numeric", "numeric")) # perform H2O and mojo prediction and return frames
+  h2o.downloadCSV(twoFrames$h2oPredict, sprintf("%s/h2oPred.csv", modelAndDir$dirName))
+  h2o.downloadCSV(twoFrames$mojoPredict, sprintf("%s/mojoOut.csv", modelAndDir$dirname))
+  twoFrames$h2oPredict[,1] <- h2o.asfactor(twoFrames$h2oPredict[,1])
+  compareFrames(twoFrames$h2oPredict,twoFrames$mojoPredict, prob=1, tolerance = 1e-6)
+}
+
+doTest("GAM Test: binomial GAM Mojo test with TP and CS smoothers for binomials", test.GAM.binomial)


### PR DESCRIPTION
This PR completes the work in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-7860.  I have attached a document in the JIRA which is helpful to understand my implementation.

I have completed the following:
1. added thin plate regression smoothers to GAM which involves building the distance measure and the polynomial basis;
2. fixed the model building pipeline to accept both cubic spline smoothers and thin plate regression smoothers
3. completely fix the model building and scoring pipeline
4. add TP to GAM Mojo models;
5. add TP to Python/R clients.  Thanks to @sebhrusen, user can specify gam_columns in as ["c1", ["c2", "c3"]] or [["c1"], ["c2","c3"]] both in both R and Python.
6. fix gridsearch.  Again, thanks 2 @sebhrusen, users are able to specify gam_columns using both notations
7. Added Java tests to completely test out the TP smoothers generation process including distance calculation, penalty matrices generation, polynomial basis generation, TP/CS smoothers with validation dataset, TP/CS smoothers with cross-validation
8. added R/Python unit tests to make sure gam_columns can be specified in both mode, gridsearch and mojo tests.
9. added test to compare our results to R results.  Our gam performs better.  Yes!

There are 18 test files.