### PR TITLE
PUBDEV-7958: Enable returning data from explain's varimp_heatmap and model_correlation_matrix

### DIFF
--- a/h2o-docs/src/product/explain.rst
+++ b/h2o-docs/src/product/explain.rst
@@ -8,7 +8,7 @@ H2O Explainability Interface is a convenient wrapper to a number of explainabilt
 Model Explainability Interface
 ------------------------------
 
-The interface is designed to be simple and automatic -- all of the explanations are generated with a single function, ``h2o.explain()``.  The input can be any of the following: an H2O model, a list of H2O models, an ``H2OAutoML`` object or an ``H2OAutoML`` Leaderboard slice, and a holdout frame.  If you provide a list of models or an AutoML object, there will be additional plots that do multi-model comparisons.  
+The interface is designed to be simple and automatic -- all of the explanations are generated with a single function, ``h2o.explain()``.  The input can be any of the following: an H2O model, a list of H2O models, an ``H2OAutoML`` object or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard), and a holdout frame.  If you provide a list of models or an AutoML object, there will be additional plots that do multi-model comparisons.
 
 
 .. tabs::
@@ -39,7 +39,7 @@ and `R <explain-code-examples/Explain-wine-example-R.html>`_ (`.Rmd <explain-cod
 Parameters
 ~~~~~~~~~~
 
-- **object**: (R only) One of the following: an H2O supervised model, a list of supervised models, an H2OAutoML object, or an H2OAutoML leaderboard slice.
+- **object**: (R only) A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard).
 
 - **newdata** (R) / **frame** (Python): An H2OFrame used in Residual Analysis, Shapley contributions and a number of other explanation functions.
 
@@ -244,7 +244,7 @@ For classification models, we also display the **Confusion Matrix** of a single 
 Explanation Plotting Functions 
 ------------------------------
 
-There are a number of individual plotting functions that are used inside the ``explain()`` function.  Some of these functions take a group of models as input and others just evaluate a single model at a time.  The following functions take a list of models (including an AutoML object or leaderboard slice) as input:
+There are a number of individual plotting functions that are used inside the ``explain()`` function.  Some of these functions take a group of models as input and others just evaluate a single model at a time.  The following functions take a list of models (including an AutoML object or an H2OFrame with `model_id` column, e.g., the Leaderboard) as input:
 
 .. tabs::
    .. code-tab:: r R

--- a/h2o-docs/src/product/explain.rst
+++ b/h2o-docs/src/product/explain.rst
@@ -349,9 +349,21 @@ Variable importance heatmap shows variable importance across multiple models. So
         va_plot <- h2o.varimp_heatmap(aml)
         va_plot
 
+        # or if some subset of the models is needed a slice of leaderboard can be used, e.g., using MAE as the sorting metric
+        va_plot <- h2o.varimp_heatmap(h2o.head(h2o.arrange(aml@leaderboard, mae), n = 10))
+
+        # or even extended leaderboard can be used
+        h2o.varimp_heatmap(h2o.head(h2o.arrange(h2o.get_leaderboard(aml, extra_columns = "training_time_ms"), training_time_ms), n = 10))
+
    .. code-tab:: python
 
-        ra_plot = aml.varimp_heatmap()
+        va_plot = aml.varimp_heatmap()
+
+        # or if some subset of the models is needed a slice of leaderboard can be used, e.g., using MAE as the sorting metric
+        va_plot = h2o.varimp_heatmap(aml.leaderboard.sort("mae").head(10))
+
+        # or even extended leaderboard can be used
+        va_plot = h2o.varimp_heatmap(h2o.automl.get_leaderboard(aml, extra_columns="training_time_ms").sort("training_time_ms").head(10))
 
 
 .. figure:: images/explain_varimp_heatmap_wine.png
@@ -372,9 +384,32 @@ This plot shows the correlation between the predictions of the models. For class
         mc_plot <- h2o.model_correlation_heatmap(aml, test)
         mc_plot
 
+        # or if some subset of the models is needed a slice of leaderboard can be used, e.g., using MAE as the sorting metric
+        mc_plot <- h2o.model_correlation_heatmap(h2o.head(h2o.arrange(aml@leaderboard, mae), n = 10), test)
+        mc_plot
+
+        # or even extended leaderboard can be used
+        mc_plot <- h2o.model_correlation_heatmap(h2o.head(h2o.arrange(h2o.get_leaderboard(aml, extra_columns = "training_time_ms"), training_time_ms), n = 10), test)
+        mc_plot
+
+        # also more complicated queries on leaderboard can be used, e.g., model correlation between 5 fastest models to train and Stacked Ensembles
+        leaderboard <- as.data.frame(h2o.arrange(h2o.get_leaderboard(aml, extra_columns = "training_time_ms"), training_time_ms))
+        mc_plot <- h2o.model_correlation_heatmap(rbind(head(leaderboard, n = 5), leaderboard[grep("StackedEnsemble", leaderboard$model_id),]), test)
+
+
    .. code-tab:: python
 
         mc_plot = aml.model_correlation_heatmap(test)
+
+        # or if some subset of the models is needed a slice of leaderboard can be used, e.g., using MAE as the sorting metric
+        mc_plot = h2o.model_correlation_heatmap(aml.leaderboard.sort("mae").head(10), test)
+
+        # or even extended leaderboard can be used
+        mc_plot = h2o.model_correlation_heatmap(h2o.automl.get_leaderboard(aml, extra_columns="training_time_ms").sort("training_time_ms").head(10), test)
+
+        # also more complicated queries on leaderboard can be used, e.g., model correlation between 5 fastest models to train and Stacked Ensembles
+        leaderboard = h2o.automl.get_leaderboard(aml, extra_columns="training_time_ms").sort("training_time_ms")
+        mc_plot = h2o.model_correlation_heatmap(leaderboard.head(5).rbind(leaderboard[leaderboard["model_id"].grep("StackedEnsemble", output_logical=True)]), test)
 
 .. figure:: images/explain_model_correlation_heatmap_wine.png
    :alt: H2O AutoML
@@ -441,10 +476,16 @@ Partial Dependence Multi-model Plot:
         pd_plot <- h2o.pd_multi_plot(aml, test, column)
         pd_plot
 
+        # or if some subset of the models is needed a slice of leaderboard can be used, e.g., using MAE as the sorting metric
+        pd_plot <- h2o.pd_multi_plot(h2o.arrange(aml@leaderboard, mae), test, column)
+        pd_plot
+
    .. code-tab:: python
 
         pd_plot = aml.pd_multi_plot(test, column)
 
+        # or if some subset of the models is needed a slice of leaderboard can be used, e.g., using MAE as the sorting metric
+        pd_plot = h2o.pd_multi_plot(aml.leaderboard.sort("mae"), test, column)
 
 .. figure:: images/explain_pd_multiplot_wine_alcohol.png
    :alt: H2O AutoML
@@ -490,7 +531,7 @@ A single-model, single-row, PD Plot simply becomes an ICE Plot (see more below):
    :align: center
 
 
-Individual Conditional Expectiation (ICE) Plots
+Individual Conditional Expectation (ICE) Plots
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An Individual Conditional Expectation (ICE) plot gives a graphical depiction of the marginal effect of a variable on the response. ICE plots are similar to partial dependence plots (PDP); PDP shows the average effect of a feature while ICE plot shows the effect for a single instance. This function will plot the effect for each decile. In contrast to the PDP, ICE plots can provide more insight, especially when there is stronger feature interaction.

--- a/h2o-py/h2o/explanation/__init__.py
+++ b/h2o-py/h2o/explanation/__init__.py
@@ -22,20 +22,25 @@ def _register_dummy_methods():
     h2o.automl._base.H2OAutoMLBaseMixin.model_correlation_heatmap = _complain_about_matplotlib
     h2o.automl._base.H2OAutoMLBaseMixin.explain = _complain_about_matplotlib
     h2o.automl._base.H2OAutoMLBaseMixin.explain_row = _complain_about_matplotlib
+    h2o.automl._base.H2OAutoMLBaseMixin.model_correlation = _complain_about_matplotlib
+    h2o.automl._base.H2OAutoMLBaseMixin.varimp = _complain_about_matplotlib
 
 
 try:
     import numpy
     import matplotlib
     from ._explain import varimp_heatmap, model_correlation_heatmap, shap_explain_row_plot, shap_summary_plot,\
-        explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot, learning_curve_plot
+        explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot, learning_curve_plot, \
+        varimp_matrix, model_correlation_matrix
 
     __all__ = [
         "explain",
         "explain_row",
         "varimp_heatmap",
         "model_correlation_heatmap",
-        "pd_multi_plot"
+        "pd_multi_plot",
+        "varimp_matrix",
+        "model_correlation_matrix",
     ]
 except ImportError as e:  # Numpy, Matplotlib
     _register_dummy_methods()
@@ -60,3 +65,5 @@ def register_explain_methods():
     h2o.automl._base.H2OAutoMLBaseMixin.model_correlation_heatmap = model_correlation_heatmap
     h2o.automl._base.H2OAutoMLBaseMixin.explain = explain
     h2o.automl._base.H2OAutoMLBaseMixin.explain_row = explain_row
+    h2o.automl._base.H2OAutoMLBaseMixin.model_correlation = model_correlation_matrix
+    h2o.automl._base.H2OAutoMLBaseMixin.varimp = varimp_matrix

--- a/h2o-py/h2o/explanation/__init__.py
+++ b/h2o-py/h2o/explanation/__init__.py
@@ -29,9 +29,7 @@ def _register_dummy_methods():
 try:
     import numpy
     import matplotlib
-    from ._explain import varimp_heatmap, model_correlation_heatmap, shap_explain_row_plot, shap_summary_plot,\
-        explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot, learning_curve_plot, \
-        varimp, model_correlation
+    from ._explain import *
 
     __all__ = [
         "explain",

--- a/h2o-py/h2o/explanation/__init__.py
+++ b/h2o-py/h2o/explanation/__init__.py
@@ -31,7 +31,7 @@ try:
     import matplotlib
     from ._explain import varimp_heatmap, model_correlation_heatmap, shap_explain_row_plot, shap_summary_plot,\
         explain, explain_row, pd_plot, pd_multi_plot, ice_plot, residual_analysis_plot, learning_curve_plot, \
-        varimp_matrix, model_correlation_matrix
+        varimp, model_correlation
 
     __all__ = [
         "explain",
@@ -39,8 +39,8 @@ try:
         "varimp_heatmap",
         "model_correlation_heatmap",
         "pd_multi_plot",
-        "varimp_matrix",
-        "model_correlation_matrix",
+        "varimp",
+        "model_correlation",
     ]
 except ImportError as e:  # Numpy, Matplotlib
     _register_dummy_methods()
@@ -65,5 +65,5 @@ def register_explain_methods():
     h2o.automl._base.H2OAutoMLBaseMixin.model_correlation_heatmap = model_correlation_heatmap
     h2o.automl._base.H2OAutoMLBaseMixin.explain = explain
     h2o.automl._base.H2OAutoMLBaseMixin.explain_row = explain_row
-    h2o.automl._base.H2OAutoMLBaseMixin.model_correlation = model_correlation_matrix
-    h2o.automl._base.H2OAutoMLBaseMixin.varimp = varimp_matrix
+    h2o.automl._base.H2OAutoMLBaseMixin.model_correlation = model_correlation
+    h2o.automl._base.H2OAutoMLBaseMixin.varimp = varimp

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1308,7 +1308,7 @@ def ice_plot(
 
 
 def _has_varimp(model):
-    # type: (Union[str, h2o.model.ModelBase]) -> bool
+    # type: (h2o.model.ModelBase) -> bool
     """
     Does model have varimp?
     :param model: model or a string containing model_id
@@ -1319,6 +1319,7 @@ def _has_varimp(model):
     # when a model is stopped sooner than calculating varimp (xgboost can rarely have no varimp).
     output = model._model_json["output"]
     return output.get("variable_importances") is not None
+
 
 def _is_automl_or_leaderboard(obj):
     # type: (object) -> bool
@@ -1355,8 +1356,7 @@ def _get_models_from_automl_or_leaderboard(automl_or_leaderboard, filter_=lambda
     :param filter_: a predicate used to filter model_ids. Signature of the filter is (model) -> bool.
     :return: Generator[h2o.model.ModelBase, None, None]
     """
-    models = map(h2o.get_model, _get_model_ids_from_automl_or_leaderboard(automl_or_leaderboard))
-    return (model for model in models if filter_(model))
+    return filter(filter_, map(h2o.get_model, _get_model_ids_from_automl_or_leaderboard(automl_or_leaderboard)))
 
 
 def _get_xy(model):

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1349,14 +1349,15 @@ def _get_model_ids_from_automl_or_leaderboard(automl_or_leaderboard, filter_=lam
 
 
 def _get_models_from_automl_or_leaderboard(automl_or_leaderboard, filter_=lambda _: True):
-    # type: (object) -> List[str]
+    # type: (object) -> Generator[h2o.model.ModelBase, None, None]
     """
     Get model ids from H2OAutoML object or leaderboard
     :param automl_or_leaderboard: AutoML
     :param filter_: a predicate used to filter model_ids. Signature of the filter is (model) -> bool.
     :return: Generator[h2o.model.ModelBase, None, None]
     """
-    return filter(filter_, map(h2o.get_model, _get_model_ids_from_automl_or_leaderboard(automl_or_leaderboard)))
+    models = (h2o.get_model(model_id) for model_id in _get_model_ids_from_automl_or_leaderboard(automl_or_leaderboard))
+    return (model for model in models if filter_(model))
 
 
 def _get_xy(model):

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1706,7 +1706,7 @@ def _check_deprecated_top_n_argument(models, top_n):
     if top_n is not None:
         import warnings
         from h2o.exceptions import H2ODeprecationWarning
-        warnings.warn("Setting the `top_n` parameter is deprecated, use leaderboard (sub)frame "
+        warnings.warn("Setting the `top_n` parameter is deprecated, use a leaderboard (sub)frame "
                       "instead, e.g., aml.leaderboard.head({}).".format(top_n), category=H2ODeprecationWarning)
         models = models.leaderboard.head(top_n)
     else:

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -1598,7 +1598,7 @@ def varimp(
         :returns: either pandas DataFrame (if use_pandas == True) or a triple (varimps, model_ids, variable_names)
     """
     if _is_automl_or_leaderboard(models):
-        models = _get_models_from_automl_or_leaderboard(models, filter_=_has_varimp)
+        models = list(_get_models_from_automl_or_leaderboard(models, filter_=_has_varimp))
     else:
         # Filter out models that don't have varimp
         models = [model for model in models if _has_varimp(model)]

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -2321,10 +2321,7 @@ def _process_models_input(
             models_with_varimp = models_to_show
         else:
             model_with_varimp = next(_get_models_from_automl_or_leaderboard(models, filter_=_has_varimp), None)
-            if model_with_varimp is None:
-                models_with_varimp = []
-            else:
-                models_with_varimp = [model_with_varimp]
+            models_with_varimp = [] if model_with_varimp is None else [model_with_varimp]
         multiple_models = models.nrow > 1
     elif isinstance(models, h2o.model.ModelBase):
         models_to_show = [models]

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -157,9 +157,11 @@ def no_progress():
     progress = h2o.job.H2OJob.__PROGRESS_BAR__
     if progress:
         h2o.no_progress()
-    yield
-    if progress:
-        h2o.show_progress()
+    try:
+        yield
+    finally:
+        if progress:
+            h2o.show_progress()
 
 
 class NumpyFrame:
@@ -1524,7 +1526,7 @@ def varimp_heatmap(
     >>> aml.varimp_heatmap()
     """
     plt = get_matplotlib_pyplot(False, raise_if_not_available=True)
-    varimps, model_ids,  x = varimp_matrix(models=models, top_n=top_n, cluster=cluster, use_pandas=False)
+    varimps, model_ids,  x = varimp(models=models, top_n=top_n, cluster=cluster, use_pandas=False)
 
     plt.figure(figsize=figsize)
     plt.imshow(varimps, cmap=plt.get_cmap(colormap))
@@ -1540,7 +1542,7 @@ def varimp_heatmap(
     return fig
 
 
-def varimp_matrix(
+def varimp(
         models,  # type: Union[h2o.automl._base.H2OAutoMLBaseMixin, List[h2o.model.ModelBase]]
         top_n=20,  # type: int
         cluster=True,  # type: bool
@@ -1642,7 +1644,7 @@ def model_correlation_heatmap(
     >>> aml.model_correlation_heatmap(test)
     """
     plt = get_matplotlib_pyplot(False, raise_if_not_available=True)
-    corr, model_ids = model_correlation_matrix(models, frame, top_n, cluster_models, use_pandas=False)
+    corr, model_ids = model_correlation(models, frame, top_n, cluster_models, use_pandas=False)
 
     if triangular:
         corr = np.where(np.triu(np.ones_like(corr), k=1).astype(bool), float("nan"), corr)
@@ -1666,7 +1668,7 @@ def model_correlation_heatmap(
     return fig
 
 
-def model_correlation_matrix(
+def model_correlation(
         models,  # type: Union[h2o.automl._base.H2OAutoMLBaseMixin, List[h2o.model.ModelBase]]
         frame,  # type: h2o.H2OFrame
         top_n=20,  # type: int

--- a/h2o-py/h2o/explanation/_explain.py
+++ b/h2o-py/h2o/explanation/_explain.py
@@ -3,6 +3,10 @@
 import random
 from contextlib import contextmanager
 from collections import OrderedDict, Counter, defaultdict
+try:
+    from StringIO import StringIO  # py2 (first as py2 also has io.StringIO, but only with unicode support)
+except:
+    from io import StringIO  # py3
 
 import h2o
 import numpy as np
@@ -1315,7 +1319,7 @@ def _has_varimp(model):
         # check for cases when variable importance is disabled or
         # when a model is stopped sooner than calculating varimp (xgboost can rarely have no varimp).
         output = model._model_json["output"]
-        return "variable_importances" in list(output.keys()) and output["variable_importances"]
+        return output.get("variable_importances") is not None
     else:
         return _get_algorithm(model) not in ["stackedensemble", "naivebayes"]
 
@@ -1710,10 +1714,6 @@ def model_correlation(
                     corr[i, j] = (predictions[i] == predictions[j]).mean()[0]
                     corr[j, i] = corr[i, j]
     else:
-        try:
-            from io import StringIO
-        except ImportError:
-            from StringIO import StringIO
         corr = np.genfromtxt(StringIO(predictions[0].cbind(predictions[1:]).cor().get_frame_data()),
                              delimiter=",", missing_values="", skip_header=True)
     if cluster_models:

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -5,6 +5,7 @@ sys.path.insert(1, os.path.join("..", "..", ".."))
 import matplotlib
 matplotlib.use("Agg")  # remove warning from python2 (missing TKinter)
 import h2o
+import pandas
 import matplotlib.pyplot
 from tests import pyunit_utils
 from h2o.automl import H2OAutoML
@@ -102,9 +103,16 @@ def test_explanation_automl_regression():
     assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
+    assert len(aml.varimp(use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
+    assert isinstance(aml.varimp(use_pandas=True), pandas.DataFrame)
+
     # test model correlation heatmap plot
     assert isinstance(aml.model_correlation_heatmap(train), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
+
+    assert len(aml.model_correlation(train, use_pandas=False)) == 2  # numpy.ndarray, colnames and rownames both in the same order => represented by just one vector
+    assert isinstance(aml.model_correlation(train, use_pandas=True), pandas.DataFrame)
+
 
     # test partial dependences
     for col in cols_to_test:
@@ -244,9 +252,16 @@ def test_explanation_automl_binomial_classification():
     assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
+    assert len(aml.varimp(use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
+    assert isinstance(aml.varimp(use_pandas=True), pandas.DataFrame)
+
     # test model correlation heatmap plot
     assert isinstance(aml.model_correlation_heatmap(train), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
+
+    assert len(aml.model_correlation(train, use_pandas=False)) == 2  # numpy.ndarray, colnames and rownames both in the same order => represented by just one vector
+    assert isinstance(aml.model_correlation(train, use_pandas=True), pandas.DataFrame)
+
 
     # test partial dependences
     for col in cols_to_test:
@@ -382,9 +397,15 @@ def test_explanation_automl_multinomial_classification():
     assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
 
+    assert len(aml.varimp(use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
+    assert isinstance(aml.varimp(use_pandas=True), pandas.DataFrame)
+
     # test model correlation heatmap plot
     assert isinstance(aml.model_correlation_heatmap(train), matplotlib.pyplot.Figure)
     matplotlib.pyplot.close()
+
+    assert len(aml.model_correlation(train, use_pandas=False)) == 2  # numpy.ndarray, colnames and rownames both in the same order => represented by just one vector
+    assert isinstance(aml.model_correlation(train, use_pandas=True), pandas.DataFrame)
 
     # test partial dependences
     for col in cols_to_test:

--- a/h2o-py/tests/testdir_misc/pyunit_explain.py
+++ b/h2o-py/tests/testdir_misc/pyunit_explain.py
@@ -133,6 +133,13 @@ def test_explanation_automl_regression():
     for i in range(len(model_ids)):
         assert len(model_ids[i]) > len(shortened_model_ids[i])
 
+    # Leaderboard slices work
+    # test explain
+    assert isinstance(h2o.explain(aml.leaderboard[:4, :], train, render=False), H2OExplanation)
+
+    # test explain row
+    assert isinstance(h2o.explain_row(aml.leaderboard[:4, :], train, 1, render=False), H2OExplanation)
+
 
 def test_explanation_list_of_models_regression():
     train = h2o.upload_file(pyunit_utils.locate("smalldata/wine/winequality-redwhite-no-BOM.csv"))
@@ -274,6 +281,30 @@ def test_explanation_automl_binomial_classification():
     # test explain row
     assert isinstance(aml.explain_row(train, 1, render=False), H2OExplanation)
 
+    # Leaderboard slices work
+    # test variable importance heatmap plot
+    assert isinstance(aml.varimp_heatmap(), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    assert len(h2o.explanation.varimp(aml.leaderboard[:4, :], use_pandas=False)) == 3  # numpy.ndarray, colnames, rownames
+    assert isinstance(h2o.explanation.varimp(aml.leaderboard[:4, :], use_pandas=True), pandas.DataFrame)
+
+    # test model correlation heatmap plot
+    assert isinstance(h2o.model_correlation_heatmap(aml.leaderboard[:4, :], train), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    assert len(h2o.explanation.model_correlation(aml.leaderboard[:4, :], train, use_pandas=False)) == 2  # numpy.ndarray, colnames and rownames both in the same order => represented by just one vector
+    assert isinstance(h2o.explanation.model_correlation(aml.leaderboard[:4, :], train, use_pandas=True), pandas.DataFrame)
+
+    # test partial dependences
+    assert isinstance(h2o.pd_multi_plot(aml.leaderboard[:4, :], train, cols_to_test[0]), matplotlib.pyplot.Figure)
+    matplotlib.pyplot.close()
+
+    # test explain
+    assert isinstance(h2o.explain(aml.leaderboard[:4, :], train, render=False), H2OExplanation)
+
+    # test explain row
+    assert isinstance(h2o.explain_row(aml.leaderboard[:4, :], train, 1, render=False), H2OExplanation)
 
 
 def test_explanation_list_of_models_binomial_classification():
@@ -417,6 +448,13 @@ def test_explanation_automl_multinomial_classification():
 
     # test explain row
     assert isinstance(aml.explain_row(train, 1, render=False), H2OExplanation)
+
+    # Leaderboard slices work
+    # test explain
+    assert isinstance(h2o.explain(aml.leaderboard[:4, :], train, render=False), H2OExplanation)
+
+    # test explain row
+    assert isinstance(h2o.explain_row(aml.leaderboard[:4, :], train, 1, render=False), H2OExplanation)
 
 
 def test_explanation_list_of_models_multinomial_classification():

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -1058,3 +1058,28 @@ setMethod("h2o.varimp", signature("H2OModel"), function(object) {
 setMethod("h2o.varimp", signature("H2OAutoML"), function(object, top_n = 20) {
   .varimp_matrix(object, top_n = top_n)
 })
+
+#'
+#' Retrieve the variable importance.
+#'
+#' @param object A leaderboard frame.
+#' @examples
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip"
+#' pros <- h2o.importFile(f)
+#' response <- "GLEASON"
+#' predictors <- c("ID", "AGE", "CAPSULE", "DCAPS", "PSA", "VOL", "DPROS")
+#' aml <- h2o.automl(x = predictors, y = response, training_frame = pros, max_runtime_secs = 60)
+#' h2o.varimp(aml@leaderboard[1:5,])
+#' }
+#' @export
+setMethod("h2o.varimp", signature("H2OFrame"), function(object) {
+  if (! "model_id" %in% names(object)){
+    warning("This is not a leaderboard frame.", call. = FALSE)
+    return(invisible(NULL))
+  }
+  .varimp_matrix(object)
+})

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -1078,8 +1078,7 @@ setMethod("h2o.varimp", signature("H2OAutoML"), function(object, top_n = 20) {
 #' @export
 setMethod("h2o.varimp", signature("H2OFrame"), function(object) {
   if (! "model_id" %in% names(object)){
-    warning("This is not a leaderboard frame.", call. = FALSE)
-    return(invisible(NULL))
+    stop("This is not a leaderboard frame. Only frames containing `model_id` column are supported.")
   }
   .varimp_matrix(object)
 })

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -990,9 +990,26 @@ setMethod("summary", signature("H2OAutoML"), function(object) {
 #'
 #' Retrieve the variable importance.
 #'
-#' @param object An object.
+#' @param object An H2O object.
+#' @param ... Additional arguments for specific use-cases.
+#' @examples
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip"
+#' pros <- h2o.importFile(f)
+#' response <- "GLEASON"
+#' predictors <- c("ID", "AGE", "CAPSULE", "DCAPS", "PSA", "VOL", "DPROS")
+#' aml <- h2o.automl(x = predictors, y = response, training_frame = pros, max_runtime_secs = 60)
+#'
+#' h2o.varimp(aml, top_n = 20)  # get variable importance matrix for the top 20 models
+#'
+#' h2o.varimp(aml@leader)  # get variable importance for the leader model
+#' }
 #' @export
-setGeneric("h2o.varimp", function(object, ...) standardGeneric("h2o.varimp"))
+setGeneric("h2o.varimp", function(object, ...)
+  warning(paste0("No variable importances for ", class(object)), call. = FALSE))
 
 #'
 #' Retrieve the variable importance.
@@ -1011,7 +1028,7 @@ setGeneric("h2o.varimp", function(object, ...) standardGeneric("h2o.varimp"))
 #' h2o.varimp(model)
 #' }
 #' @export
-setMethod("h2o.varimp", signature("H2OModel"), function(object, ...) {
+setMethod("h2o.varimp", signature("H2OModel"), function(object) {
   vi <- object@model$variable_importances
   if( is.null(vi) ) {
     warning("This model doesn't have variable importances", call. = FALSE)
@@ -1019,11 +1036,6 @@ setMethod("h2o.varimp", signature("H2OModel"), function(object, ...) {
   }
   return(vi)
 })
-
-setMethod("h2o.varimp", signature("ANY"), function(object, ...) {
-    warning(paste0("No variable importances for ", class(object)))
-  }
-)
 
 #'
 #' Retrieve the variable importance.

--- a/h2o-r/h2o-package/R/classes.R
+++ b/h2o-r/h2o-package/R/classes.R
@@ -986,3 +986,63 @@ setMethod("summary", signature("H2OAutoML"), function(object) {
 
   invisible(NULL)
 })
+
+#'
+#' Retrieve the variable importance.
+#'
+#' @param object An object.
+#' @export
+setGeneric("h2o.varimp", function(object, ...) standardGeneric("h2o.varimp"))
+
+#'
+#' Retrieve the variable importance.
+#'
+#' @param object An \linkS4class{H2OModel} object.
+#' @examples
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip"
+#' pros <- h2o.importFile(f)
+#' response <- "GLEASON"
+#' predictors <- c("ID", "AGE", "CAPSULE", "DCAPS", "PSA", "VOL", "DPROS")
+#' model <- h2o.glm(x = predictors, y = response, training_frame = pros)
+#' h2o.varimp(model)
+#' }
+#' @export
+setMethod("h2o.varimp", signature("H2OModel"), function(object, ...) {
+  vi <- object@model$variable_importances
+  if( is.null(vi) ) {
+    warning("This model doesn't have variable importances", call. = FALSE)
+    return(invisible(NULL))
+  }
+  return(vi)
+})
+
+setMethod("h2o.varimp", signature("ANY"), function(object, ...) {
+    warning(paste0("No variable importances for ", class(object)))
+  }
+)
+
+#'
+#' Retrieve the variable importance.
+#'
+#' @param object An \linkS4class{H2OAutoML} object.
+#' @param top_n Show at most top_n models
+#' @examples
+#' \dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip"
+#' pros <- h2o.importFile(f)
+#' response <- "GLEASON"
+#' predictors <- c("ID", "AGE", "CAPSULE", "DCAPS", "PSA", "VOL", "DPROS")
+#' aml <- h2o.automl(x = predictors, y = response, training_frame = pros, max_runtime_secs = 60)
+#' h2o.varimp(aml)
+#' }
+#' @export
+setMethod("h2o.varimp", signature("H2OAutoML"), function(object, top_n = 20) {
+  .varimp_matrix(object, top_n = top_n)
+})

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1633,7 +1633,7 @@ h2o.varimp_heatmap <- function(object, top_n = 20) {
 #' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard)..
 #' @param newdata An H2O Frame.  Predictions from the models will be generated using this frame,
 #'                so this should be a holdout set.
-#' @param top_n Integer specifying the number models shown in the heatmap (used only with an
+#' @param top_n (DEPRECATED) Integer specifying the number models shown in the heatmap (used only with an
 #'              AutoML object, and based on the leaderboard ranking.  Defaults to 20.
 #' @param cluster_models Logical.  Order models based on their similarity.  Defaults to TRUE.
 #' @return A data.frame containing variable importance.

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -289,7 +289,8 @@ with_no_h2o_progress <- function(expr) {
   }
 
 
-  if ("H2OAutoML" %in% class(object) || ("H2OFrame" %in% class(object) && "model_id" %in% names(object))) {
+  if ("H2OAutoML" %in% class(object) || (("H2OFrame" %in% class(object) ||
+      "data.frame" %in% class(object)) && "model_id" %in% names(object))) {
     leaderboard <- if ("H2OAutoML" %in% class(object)) object@leaderboard else object
     if (require_single_model && nrow(leaderboard) > 1) {
       stop("Only one model is allowed!")

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -131,7 +131,11 @@ with_no_h2o_progress <- function(expr) {
 #' @param model model or a string containing model id
 #' @return boolean
 .has_varimp <- function(model) {
-  return(!.get_algorithm(model) %in% c("stackedensemble", "naivebayes"))
+  if (is.character(model))
+    return(!.get_algorithm(model) %in% c("stackedensemble", "naivebayes"))
+  else {
+    return(!is.null(model@model$variable_importances))
+  }
 }
 
 #' Shortens model ids if possible (iff there will be same amount of unique model_ids as before)
@@ -1511,6 +1515,20 @@ h2o.shap_explain_row_plot <-
     }
   }
 
+.varimp_matrix <- function(object, top_n = 20){
+  models_info <- .process_models_or_automl(object, NULL,
+                                           require_multiple_models = TRUE,
+                                           top_n_from_AutoML = top_n, only_with_varimp = TRUE,
+                                           require_newdata = FALSE)
+  models <- Filter(.has_varimp, models_info$model_ids)
+  varimps <- lapply(lapply(models, models_info$get_model), .varimp)
+  names(varimps) <- .model_ids(models)
+
+  res <- do.call(rbind, varimps)
+  results <- as.data.frame(res)
+  return(results)
+}
+
 
 #' Variable Importance Heatmap across multiple models
 #'
@@ -1525,7 +1543,6 @@ h2o.shap_explain_row_plot <-
 #' @param object An H2OAutoML object or list of H2O models.
 #' @param top_n Integer specifying the number models shown in the heatmap 
 #'              (based on leaderboard ranking). Defaults to 20.
-#'
 #' @return A ggplot2 object.
 #' @examples
 #'\dontrun{
@@ -1560,16 +1577,7 @@ h2o.varimp_heatmap <- function(object,
   .check_for_ggplot2()
   # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
   .data <- NULL
-  models_info <- .process_models_or_automl(object, NULL,
-                                           require_multiple_models = TRUE,
-                                           top_n_from_AutoML = top_n, only_with_varimp = TRUE,
-                                           require_newdata = FALSE)
-  models <- Filter(.has_varimp, models_info$model_ids)
-  varimps <- lapply(lapply(models, models_info$get_model), .varimp)
-  names(varimps) <- .model_ids(models)
-
-  res <- do.call(rbind, varimps)
-  results <- as.data.frame(res)
+  results <- .varimp_matrix(object, top_n = top_n)
   ordered <- row.names(results)
   y_ordered <- make.names(names(results))
   if (length(ordered) > 2) {
@@ -1578,7 +1586,8 @@ h2o.varimp_heatmap <- function(object,
   if (length(y_ordered) > 2) {
     y_ordered <- y_ordered[stats::hclust(stats::dist(t(results)))$order]
   }
-  results[["model_id"]] <- row.names(results)
+  model_ids <- row.names(results)
+  results[["model_id"]] <- model_ids
   results <- stats::reshape(results,
                             direction = "long",
                             varying = Filter(function(col) col != "model_id", names(results)),
@@ -1594,7 +1603,7 @@ h2o.varimp_heatmap <- function(object,
   )
 
   margin <- ggplot2::margin(5.5, 5.5, 5.5, 5.5, "pt")
-  if (max(nchar(.shorten_model_ids(.model_ids(models)))) > 30)
+  if (max(nchar(.shorten_model_ids(model_ids))) > 30)
     margin <- ggplot2::margin(1, 1, 1, 7, "lines")
   p <- ggplot2::ggplot(ggplot2::aes(
     x = .shorten_model_ids(.data$model_id), y = .data$feature, fill = .data$value, text = .data$text
@@ -1614,21 +1623,20 @@ h2o.varimp_heatmap <- function(object,
   return(p)
 }
 
-#' Model Prediction Correlation Heatmap
+
+#' Model Prediction Correlation
 #'
-#' This plot shows the correlation between the predictions of the models.
+#' Get a data.frame containing the correlation between the predictions of the models.
 #' For classification, frequency of identical predictions is used. By default, models
 #' are ordered by their similarity (as computed by hierarchical clustering).
 #'
 #' @param object An H2OAutoML object or list of H2O models.
-#' @param newdata An H2O Frame.  Predictions from the models will be generated using this frame, 
+#' @param newdata An H2O Frame.  Predictions from the models will be generated using this frame,
 #'                so this should be a holdout set.
-#' @param top_n Integer specifying the number models shown in the heatmap (used only with an 
+#' @param top_n Integer specifying the number models shown in the heatmap (used only with an
 #'              AutoML object, and based on the leaderboard ranking.  Defaults to 20.
 #' @param cluster_models Logical.  Order models based on their similarity.  Defaults to TRUE.
-#' @param triangular Print just the lower triangular part of correlation matrix.  Defaults to TRUE.
-#'
-#' @return A ggplot2 object.
+#' @return A data.frame containing variable importance.
 #' @examples
 #'\dontrun{
 #' library(h2o)
@@ -1652,16 +1660,12 @@ h2o.varimp_heatmap <- function(object,
 #'                   max_models = 10,
 #'                   seed = 1)
 #'
-#' # Create the model correlation heatmap
-#' model_correlation_heatmap <- h2o.model_correlation_heatmap(aml, test)
-#' print(model_correlation_heatmap)
+#' # Create the model correlation
+#' model_correlation <- h2o.model_correlation(aml, test)
+#' print(model_correlation)
 #' }
 #' @export
-h2o.model_correlation_heatmap <- function(object, newdata, top_n = 20,
-                                          cluster_models = TRUE, triangular = TRUE) {
-  .check_for_ggplot2()
-  # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
-  .data <- NULL
+h2o.model_correlation <- function(object, newdata, top_n = 20, cluster_models = TRUE) {
   models_info <- .process_models_or_automl(object, newdata, require_multiple_models = TRUE, top_n_from_AutoML = top_n)
   models <- models_info$model_ids
   with_no_h2o_progress({
@@ -1695,6 +1699,57 @@ h2o.model_correlation_heatmap <- function(object, newdata, top_n = 20,
     ordered <- names(res)[stats::hclust(stats::dist(replace(res, is.na(res), 0)))$order]
   }
   res <- res[ordered, ordered]
+  return(res)
+}
+
+#' Model Prediction Correlation Heatmap
+#'
+#' This plot shows the correlation between the predictions of the models.
+#' For classification, frequency of identical predictions is used. By default, models
+#' are ordered by their similarity (as computed by hierarchical clustering).
+#'
+#' @param object An H2OAutoML object or list of H2O models.
+#' @param newdata An H2O Frame.  Predictions from the models will be generated using this frame, 
+#'                so this should be a holdout set.
+#' @param top_n Integer specifying the number models shown in the heatmap (used only with an 
+#'              AutoML object, and based on the leaderboard ranking.  Defaults to 20.
+#' @param cluster_models Logical.  Order models based on their similarity.  Defaults to TRUE.
+#' @param triangular Print just the lower triangular part of correlation matrix.  Defaults to TRUE.
+#' @return A ggplot2 object.
+#' @examples
+#'\dontrun{
+#' library(h2o)
+#' h2o.init()
+#'
+#' # Import the wine dataset into H2O:
+#' f <- "https://h2o-public-test-data.s3.amazonaws.com/smalldata/wine/winequality-redwhite-no-BOM.csv"
+#' df <-  h2o.importFile(f)
+#'
+#' # Set the response
+#' response <- "quality"
+#'
+#' # Split the dataset into a train and test set:
+#' splits <- h2o.splitFrame(df, ratios = 0.8, seed = 1)
+#' train <- splits[[1]]
+#' test <- splits[[2]]
+#'
+#' # Build and train the model:
+#' aml <- h2o.automl(y = response,
+#'                   training_frame = train,
+#'                   max_models = 10,
+#'                   seed = 1)
+#'
+#' # Create the model correlation heatmap
+#' model_correlation_heatmap <- h2o.model_correlation_heatmap(aml, test)
+#' print(model_correlation_heatmap)
+#' }
+#' @export
+h2o.model_correlation_heatmap <- function(object, newdata, top_n = 20,
+                                          cluster_models = TRUE, triangular = TRUE) {
+  # Used by tidy evaluation in ggplot2, since rlang is not required #' @importFrom rlang hack can't be used
+  .data <- NULL
+  res <- h2o.model_correlation(object, newdata, top_n, cluster_models)
+  ordered <- names(res)
   varying <- row.names(res)
   if (triangular) {
     res[lower.tri(res)] <- NA

--- a/h2o-r/h2o-package/R/explain.R
+++ b/h2o-r/h2o-package/R/explain.R
@@ -1541,7 +1541,7 @@ h2o.shap_explain_row_plot <-
 #' encoded features and return a single variable importance for the original categorical
 #' feature. By default, the models and variables are ordered by their similarity.
 #'
-#' @param object An H2OAutoML object, leaderboard slice or list of H2O models.
+#' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard).
 #' @param top_n Integer specifying the number models shown in the heatmap 
 #'              (based on leaderboard ranking). Defaults to 20.
 #' @return A ggplot2 object.
@@ -1630,7 +1630,7 @@ h2o.varimp_heatmap <- function(object, top_n = 20) {
 #' For classification, frequency of identical predictions is used. By default, models
 #' are ordered by their similarity (as computed by hierarchical clustering).
 #'
-#' @param object An H2OAutoML object, leaderboard slice or list of H2O models.
+#' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard)..
 #' @param newdata An H2O Frame.  Predictions from the models will be generated using this frame,
 #'                so this should be a holdout set.
 #' @param top_n Integer specifying the number models shown in the heatmap (used only with an
@@ -1710,7 +1710,7 @@ h2o.model_correlation <- function(object, newdata, top_n = 20, cluster_models = 
 #' For classification, frequency of identical predictions is used. By default, models
 #' are ordered by their similarity (as computed by hierarchical clustering).
 #'
-#' @param object An H2OAutoML object, leaderboard slice or list of H2O models.
+#' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard).
 #' @param newdata An H2O Frame.  Predictions from the models will be generated using this frame, 
 #'                so this should be a holdout set.
 #' @param top_n Integer specifying the number models shown in the heatmap (used only with an 
@@ -2840,8 +2840,7 @@ h2o.learning_curve_plot <- function(model,
 #' are visual (ggplot plots).  These plots can also be created by individual utility functions 
 #' as well.
 #'
-#' @param object One of the following: a supervised H2O model, a list of supervised H2O models, an H2OAutoML object or
-#'               an H2OAutoML Leaderboard slice.
+#' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard).
 #' @param newdata An H2OFrame.
 #' @param columns A vector of column names or column indices to create plots with. If specified
 #'                parameter top_n_features will be ignored.
@@ -3232,8 +3231,7 @@ h2o.explain <- function(object,
 #' are visual (ggplot plots).  These plots can also be created by individual utility functions 
 #' as well.
 #' 
-#' @param object One of the following: a supervised H2O model, a list of supervised H2O models, an H2OAutoML object
-#'               or an H2OAutoML Leaderboard slice.
+#' @param object A list of H2O models, an H2O AutoML instance, or an H2OFrame with a 'model_id' column (e.g. H2OAutoML leaderboard).
 #' @param newdata An H2OFrame.
 #' @param row_index A row index of the instance to explain.
 #' @param columns A vector of column names or column indices to create plots with. If specified

--- a/h2o-r/h2o-package/R/models.R
+++ b/h2o-r/h2o-package/R/models.R
@@ -2153,37 +2153,6 @@ h2o.logloss <- function(object, train=FALSE, valid=FALSE, xval=FALSE) {
   invisible(NULL)
 }
 
-#'
-#' Retrieve the variable importance.
-#'
-#' @param object An \linkS4class{H2OModel} object.
-#' @examples 
-#' \dontrun{
-#' library(h2o)
-#' h2o.init()
-#' 
-#' f <- "https://s3.amazonaws.com/h2o-public-test-data/smalldata/prostate/prostate_complete.csv.zip"
-#' pros <- h2o.importFile(f)
-#' response <- "GLEASON"
-#' predictors <- c("ID", "AGE", "CAPSULE", "DCAPS", "PSA", "VOL", "DPROS")
-#' model <- h2o.glm(x = predictors, y = response, training_frame = pros)
-#' h2o.varimp(model)
-#' }
-#' @export
-h2o.varimp <- function(object) {
-  o <- object
-  if( is(o, "H2OModel") ) {
-    vi <- o@model$variable_importances
-    if( is.null(vi) ) {
-      warning("This model doesn't have variable importances", call. = FALSE)
-      return(invisible(NULL))
-    }
-    vi
-  } else {
-    warning( paste0("No variable importances for ", class(o)) )
-    return(NULL)
-  }
-}
 
 #'
 #' Retrieve per-variable split information for a given Isolation Forest model.

--- a/h2o-r/tests/testdir_misc/runit_explain.R
+++ b/h2o-r/tests/testdir_misc/runit_explain.R
@@ -95,6 +95,13 @@ explanation_test_automl_regression <- function() {
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain_row(aml, train, 1)))
+
+  # Leaderboard slice works
+  # test explanation
+  expect_true("H2OExplanation" %in% class(h2o.explain(aml@leaderboard[1:4,], train)))
+
+  # test explanation
+  expect_true("H2OExplanation" %in% class(h2o.explain_row(aml@leaderboard[1:4,], train, 1)))
 }
 
 explanation_test_list_of_models_regression <- function() {
@@ -238,6 +245,31 @@ explanation_test_automl_binomial_classification <- function() {
 
   # test explanation
   expect_true("H2OExplanation" %in% class(h2o.explain_row(aml, train, 1)))
+
+  # Leaderboard slice works
+  # test model correlation
+  expect_ggplot(h2o.model_correlation_heatmap(aml@leaderboard[1:4,], train))
+
+  # test variable importance heatmap
+  expect_ggplot(h2o.varimp_heatmap(aml@leaderboard[1:4,]))
+
+  # test shap summary
+  expect_error(h2o.shap_summary_plot(aml@leaderboard[1:4,], train), "SHAP summary plot requires a tree-based model!")
+
+  # test shap explain row
+  expect_error(h2o.shap_explain_row_plot(aml@leaderboard[1:4,], train, 1), "SHAP explain_row plot requires a tree-based model!")
+
+  # test partial dependences
+  expect_ggplot(h2o.pd_multi_plot(aml@leaderboard[1:4,], train, cols_to_test[[1]]))
+
+  # test ice plot
+  expect_error(h2o.ice_plot(aml@leaderboard[1:4,], train, cols_to_test[[1]]), "Only one model is allowed!")
+
+  # test explanation
+  expect_true("H2OExplanation" %in% class(h2o.explain(aml@leaderboard[1:4,], train)))
+
+  # test explanation
+  expect_true("H2OExplanation" %in% class(h2o.explain_row(aml@leaderboard[1:4,], train, 1)))
 }
 
 explanation_test_list_of_models_binomial_classification <- function() {


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-7958

This PR enables retrieving data from varimp_heatmap and model_correlation_matrix which are the only two functions that do some computations in the explain module - the rest of the functions/methods use data straight from h2o with only transformations used for plotting. This is also motivated by feedback I got from @meganjkurka (that's why I added you as reviewer, in case I missed something).

## Usage:
Python:
```python
# return pd.DataFrame by default, if not available ImportError will be thrown (only when user uses this function; explain related functions don't use pandas)
df = aml.varimp()
df = aml.model_correlation(frame=test)

# return tuple with numpy.ndarray, column names and row names when pandas is explicitly not used 
varimps, model_ids, variables = aml.varimp(use_pandas=False)
# column names and row names are the same `model_ids` in the same order
corr, model_ids = aml.model_correlation(frame=test_frame, use_pandas=False)
```
R:
```r
varimp = h2o.varimp(object = aml) 
corr = h2o.model_correlation(object = aml, newdata = test)
```