### PR TITLE
PUBDEV-7737 CoxPH Mojo (#5144)

### DIFF
--- a/h2o-algos/src/main/java/hex/coxph/CoxPH.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPH.java
@@ -37,6 +37,11 @@ public class CoxPH extends ModelBuilder<CoxPHModel,CoxPHModel.CoxPHParameters,Co
   public CoxPH( CoxPHModel.CoxPHParameters parms ) { super(parms); init(false); }
   @Override protected CoxPHDriver trainModelImpl() { return new CoxPHDriver(); }
 
+  @Override
+  public boolean haveMojo() {
+    return true;
+  }
+
   /** Initialize the ModelBuilder, validating all arguments and preparing the
    *  training frame.  This call is expected to be overridden in the subclasses
    *  and each subclass will start with "super.init();".  This call is made

--- a/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPHModel.java
@@ -356,5 +356,19 @@ public class CoxPHModel extends Model<CoxPHModel,CoxPHParameters,CoxPHOutput> {
     return fs;
   }
 
+  @Override
+  public CoxPHMojoWriter getMojo() {
+    return new CoxPHMojoWriter(this);
+  }
+
+  @Override
+  public boolean haveMojo() {
+    final boolean hasInteraction = _parms.interactionSpec() != null;
+    if (hasInteraction) {
+      return false;
+    } else {
+      return super.haveMojo();
+    }
+  }
 }
 

--- a/h2o-algos/src/main/java/hex/coxph/CoxPHMojoWriter.java
+++ b/h2o-algos/src/main/java/hex/coxph/CoxPHMojoWriter.java
@@ -1,0 +1,47 @@
+package hex.coxph;
+
+import hex.ModelMojoWriter;
+import water.rapids.ast.prims.mungers.AstGroup;
+import water.util.IcedHashMap;
+import water.util.IcedInt;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class CoxPHMojoWriter extends ModelMojoWriter<CoxPHModel, CoxPHModel.CoxPHParameters, CoxPHModel.CoxPHOutput> {
+
+  @SuppressWarnings("unused")  // Called through reflection in ModelBuildersHandler
+  public CoxPHMojoWriter() {}
+
+  public CoxPHMojoWriter(CoxPHModel model) {
+    super(model);
+  }
+
+  @Override
+  public String mojoVersion() {
+    return "1.00";
+  }
+
+  @Override
+  protected void writeModelData() throws IOException {
+    writeRectangularDoubleArray(model._output._x_mean_cat, "x_mean_cat");
+    writeRectangularDoubleArray(model._output._x_mean_num, "x_mean_num");
+    writekv("coef", model._output._coef);
+    writekv("cats", model._output.data_info._cats);
+    writekv("cat_offsets", model._output.data_info._catOffsets);
+    writekv("use_all_factor_levels", model._output.data_info._useAllFactorLevels);
+    writeStrata();
+  }
+
+  private void writeStrata() throws IOException {
+    final IcedHashMap<AstGroup.G, IcedInt> strataMap = model._output._strataMap;
+    writekv("strata_count", strataMap.size());
+    
+    int strataNum = 0;
+    for (AstGroup.G g : strataMap.keySet()) {
+      writekv("strata_" + strataNum, g._gs);
+      strataNum++;
+    }
+  }
+}

--- a/h2o-algos/src/main/java/hex/generic/Generic.java
+++ b/h2o-algos/src/main/java/hex/generic/Generic.java
@@ -34,6 +34,7 @@ public class Generic extends ModelBuilder<GenericModel, GenericModelParameters, 
         allowedAlgos.add("drf");
         allowedAlgos.add("deeplearning");
         allowedAlgos.add("stackedensemble");
+        allowedAlgos.add("coxph");
         
         ALLOWED_MOJO_ALGOS = Collections.unmodifiableSet(allowedAlgos);
     }

--- a/h2o-algos/src/main/java/hex/generic/GenericModel.java
+++ b/h2o-algos/src/main/java/hex/generic/GenericModel.java
@@ -70,7 +70,7 @@ public class GenericModel extends Model<GenericModel, GenericModelParameters, Ge
             case WordEmbedding:
                 return unsupportedMetricsBuilder();
             case CoxPH:
-                return unsupportedMetricsBuilder();
+                return new ModelMetricsRegressionCoxPH.MetricBuilderRegressionCoxPH("start", "stop", false, new String[0]);
             case AnomalyDetection:
                 return new ModelMetricsAnomaly.MetricBuilderAnomaly();
             default:

--- a/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
+++ b/h2o-algos/src/test/java/hex/generic/GenericModelTest.java
@@ -2,6 +2,8 @@ package hex.generic;
 
 import hex.ModelCategory;
 import hex.ModelMetricsBinomial;
+import hex.coxph.CoxPH;
+import hex.coxph.CoxPHModel;
 import hex.deeplearning.DeepLearning;
 import hex.deeplearning.DeepLearningModel;
 import hex.ensemble.Metalearner;
@@ -673,8 +675,169 @@ public class GenericModelTest extends TestUtil {
             assertArrayEquals(FileUtils.readFileToByteArray(originalModelMojoFile), FileUtils.readFileToByteArray(genericModelMojoFile));
 
         } finally {
-        Scope.exit();
+            Scope.exit();
         }
+    } 
+    
+    /**
+     * Create a CoxPH model and writes a MOJO into a temporary zip file. Then, it creates a Generic model out of that
+     * temporary zip file and re-downloads the underlying MOJO again. The byte arrays representing both MOJOs are tested
+     * to be the same.
+     *
+     */
+    @Test
+    public void downloadable_mojo_cox_ph() throws IOException {
+        try {
+            Scope.enter();
+            final Frame trainingFrame = parse_test_file("./smalldata/coxph_test/heart.csv");
+            Scope.track(trainingFrame);
+            CoxPHModel.CoxPHParameters parms = new CoxPHModel.CoxPHParameters();
+            parms._train = trainingFrame._key;
+            parms._distribution = AUTO;
+            parms._start_column = "start";
+            parms._stop_column = "stop";
+            parms._response_column = "event";
+            parms._ignored_columns = new String[] {"id"};
+
+            hex.coxph.CoxPH job = new CoxPH(parms);
+            final CoxPHModel originalModel = job.trainModel().get();
+            Scope.track_generic(originalModel);
+            final File originalModelMojoFile = File.createTempFile("mojo", "zip");
+            originalModel.getMojo().writeTo(new FileOutputStream(originalModelMojoFile));
+
+            final Key mojo = importMojo(originalModelMojoFile.getAbsolutePath());
+
+            // Create Generic model from given imported MOJO
+            final GenericModelParameters genericModelParameters = new GenericModelParameters();
+            genericModelParameters._model_key = mojo;
+            final Generic generic = new Generic(genericModelParameters);
+            final GenericModel genericModel = trainAndCheck(generic);
+            Scope.track_generic(genericModel);
+
+            // Compare the two MOJOs byte-wise
+            final File genericModelMojoFile = File.createTempFile("mojo", "zip");
+            genericModel.getMojo().writeTo(new FileOutputStream(genericModelMojoFile));
+            assertArrayEquals(FileUtils.readFileToByteArray(originalModelMojoFile), FileUtils.readFileToByteArray(genericModelMojoFile));
+
+        } finally {
+            Scope.exit();
+        }
+    } 
+    
+    @Test
+    public void testJavaScoring_mojo_cox_ph() throws IOException {
+        try {
+            Scope.enter();
+            final Frame trainingFrame = parse_test_file("./smalldata/coxph_test/heart.csv");
+            Scope.track(trainingFrame);
+            final Frame testFrame = parse_test_file("./smalldata/coxph_test/heart_test.csv");
+            Scope.track(testFrame);
+            testJavaScoringCoxPH(trainingFrame, testFrame, new String[0]);
+        } finally {
+            Scope.exit();
+        }
+    }
+     @Test
+    public void testJavaScoring_mojo_cox_ph_strata() throws IOException {
+        try {
+            Scope.enter();
+            final Frame trainingFrame = parse_test_file("./smalldata/coxph_test/heart.csv").toCategoricalCol("transplant");
+            Scope.track(trainingFrame);
+            final Frame testFrame = parse_test_file("./smalldata/coxph_test/heart_test.csv").toCategoricalCol("transplant");
+            Scope.track(testFrame);
+            testJavaScoringCoxPH(trainingFrame, testFrame, new String[] {"transplant"});
+
+        } finally {
+            Scope.exit();
+        }
+    }
+    
+    @Test
+    public void testJavaScoring_mojo_cox_ph_categorical() throws IOException {
+        try {
+            Scope.enter();
+            final Frame trainingFrame = parse_test_file("./smalldata/coxph_test/heart.csv").toCategoricalCol("transplant");
+            Scope.track(trainingFrame);
+            final Frame testFrame = parse_test_file("./smalldata/coxph_test/heart_test.csv").toCategoricalCol("transplant");
+            Scope.track(testFrame);
+            testJavaScoringCoxPH(trainingFrame, testFrame, new String[0]);
+        } finally {
+            Scope.exit();
+        }
+    }
+ 
+    @Test
+    public void testJavaScoring_mojo_cox_ph_2_categoricals() throws IOException {
+        try {
+            Scope.enter();
+            final Frame trainingFrame = parse_test_file("./smalldata/coxph_test/heart.csv")
+                    .toCategoricalCol("transplant")
+                    .toCategoricalCol("surgery");
+            Scope.track(trainingFrame);
+            final Frame testFrame = parse_test_file("./smalldata/coxph_test/heart_test.csv")
+                    .toCategoricalCol("transplant")
+                    .toCategoricalCol("surgery");
+            Scope.track(testFrame);
+            testJavaScoringCoxPH(trainingFrame, testFrame, new String[0]);
+        } finally {
+            Scope.exit();
+        }
+    }
+    
+    @Test
+    public void testJavaScoring_mojo_cox_ph_2_stratify() throws IOException {
+        try {
+            Scope.enter();
+            final Frame trainingFrame = parse_test_file("./smalldata/coxph_test/heart.csv")
+                    .toCategoricalCol("transplant")
+                    .toCategoricalCol("surgery");
+            Scope.track(trainingFrame);
+            final Frame testFrame = parse_test_file("./smalldata/coxph_test/heart_test.csv")
+                    .toCategoricalCol("transplant")
+                    .toCategoricalCol("surgery");
+            Scope.track(testFrame);
+            testJavaScoringCoxPH(trainingFrame, testFrame, new String[] {"transplant", "surgery"});
+        } finally {
+            Scope.exit();
+        }
+    }
+
+    private void testJavaScoringCoxPH(Frame trainingFrame, Frame testFrame, String[] stratifyBy) throws IOException {
+        CoxPHModel.CoxPHParameters parms = new CoxPHModel.CoxPHParameters();
+        parms._train = trainingFrame._key;
+        parms._distribution = AUTO;
+        parms._start_column = "start";
+        parms._stop_column = "stop";
+        parms._response_column = "event";
+        parms._ignored_columns = new String[]{"id"};
+        parms._stratify_by = stratifyBy;
+        parms._use_all_factor_levels = true;
+
+        CoxPH job = new CoxPH(parms);
+        final CoxPHModel originalModel = job.trainModel().get();
+        Scope.track_generic(originalModel);
+        final File originalModelMojoFile = File.createTempFile("mojo", "zip");
+        originalModel.getMojo().writeTo(new FileOutputStream(originalModelMojoFile));
+
+        final Key mojoKey = importMojo(originalModelMojoFile.getAbsolutePath());
+
+        // Create Generic model from given imported MOJO
+        final GenericModelParameters genericModelParameters = new GenericModelParameters();
+        genericModelParameters._model_key = mojoKey;
+        final Generic generic = new Generic(genericModelParameters);
+        final GenericModel genericModel = trainAndCheck(generic);
+        Scope.track_generic(genericModel);
+
+        final Frame genericModelPredictions = genericModel.score(testFrame);
+        Scope.track_generic(genericModelPredictions);
+        assertEquals(testFrame.numRows(), genericModelPredictions.numRows());
+
+        final boolean equallyScored = genericModel.testJavaScoring(testFrame, genericModelPredictions, 0);
+        assertTrue(equallyScored);
+
+        final Frame originalModelPredictions = originalModel.score(testFrame);
+        Scope.track(originalModelPredictions);
+        assertTrue(TestUtil.compareFrames(genericModelPredictions, originalModelPredictions, 0.000001));
     }
 
     @Test

--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -2616,6 +2616,9 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
                 d2 = (genmodel instanceof GlrmMojoModel)?((DimReductionModelPrediction) p).reconstructed[col]:
                         ((DimReductionModelPrediction) p).dimensions[col];    // look at the reconstructed matrix
                 break;
+              case CoxPH:
+                d2 = ((CoxPHModelPrediction) p).value;
+                break;
             }
             expected_preds[col] = d;
             actual_preds[col] = d2;

--- a/h2o-core/src/main/java/hex/ModelMojoWriter.java
+++ b/h2o-core/src/main/java/hex/ModelMojoWriter.java
@@ -116,7 +116,20 @@ public abstract class ModelMojoWriter<M extends Model<M, P, O>, P extends Model.
     finishWritingTextFile();
   }
 
+  public void writeRectangularDoubleArray(double[][] array, String title) throws IOException {
+    assert null != array;
+    assert null != title;
+
+    writekv(title + "_size1", array.length);
+    writekv(title + "_size2", array.length > 0 ? array[0].length : 0);
+
+    writeDoubleArray(array, title);
+  }
+  
   public void writeDoubleArray(double[][] array, String title) throws IOException {
+    assert null != array;
+    assert null != title;
+    
     int totArraySize = 0;
     for (double[] row : array)
       totArraySize += row.length;
@@ -127,4 +140,5 @@ public abstract class ModelMojoWriter<M extends Model<M, P, O>, P extends Model.
         bb.putDouble(val);
     writeblob(title, bb.array());
   }
+
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/GenModel.java
@@ -134,6 +134,10 @@ public abstract class GenModel implements IGenModel, IGeneratedModel, Serializab
       case Regression:
         outputNames = new String[]{"predict"};
         break;
+        
+      case CoxPH:
+        outputNames = new String[]{"lp"};
+        break;
 
       default:
         throw new UnsupportedOperationException("Getting output column names for model category '" + 

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoFactory.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoFactory.java
@@ -1,5 +1,6 @@
 package hex.genmodel;
 
+import hex.genmodel.algos.coxph.CoxPHMojoReader;
 import hex.genmodel.algos.deeplearning.DeeplearningMojoReader;
 import hex.genmodel.algos.drf.DrfMojoReader;
 import hex.genmodel.algos.ensemble.StackedEnsembleMojoReader;
@@ -100,6 +101,9 @@ public class ModelMojoFactory {
         return new MojoPipelineReader();
       case "Principal Components Analysis":
         return new PCAMojoReader();
+      
+      case "Cox Proportional Hazards":
+        return new CoxPHMojoReader();
         
       default:
         // Try to load MOJO reader via service

--- a/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/ModelMojoReader.java
@@ -13,6 +13,7 @@ import hex.genmodel.utils.StringEscapeUtils;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -172,6 +173,45 @@ public abstract class ModelMojoReader<M extends MojoModel> {
     return array;
   }
 
+  /**
+   * Reads an two dimensional array written by {@link hex.ModelMojoWriter#writeRectangularDoubleArray} method.
+   * 
+   * Dimensions of the result are explicitly given as parameters.
+   * 
+   * @param title can't be null
+   * @param firstSize 
+   * @param secondSize
+   * @return and double[][]  array with dimensions firstSize and secondSize
+   * @throws IOException
+   */
+  protected double[][] readRectangularDoubleArray(String title, int firstSize, int secondSize) throws IOException {
+    assert null != title;
+    
+    final double [][] row = new double[firstSize][secondSize];
+    final ByteBuffer bb = ByteBuffer.wrap(readblob(title));
+    for (int i = 0; i < firstSize; i++) {
+      for (int j = 0; j < secondSize; j++)
+        row[i][j] = bb.getDouble();
+    }
+    return row;
+  }
+  
+  /**
+   * Reads an two dimensional array written by {@link hex.ModelMojoWriter#writeRectangularDoubleArray} method
+   * 
+   * Dimensions of the array are read from the mojo.
+   *
+   * @param title can't be null
+   * @throws IOException
+   */
+  protected double[][] readRectangularDoubleArray(String title) throws IOException {
+    assert null != title;
+
+    final int size1 = readkv(title + "_size1");
+    final int size2 = readkv(title + "_size2");
+
+    return readRectangularDoubleArray(title, size1, size2);
+  }
 
   //--------------------------------------------------------------------------------------------------------------------
   // Private

--- a/h2o-genmodel/src/main/java/hex/genmodel/MojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/MojoModel.java
@@ -54,8 +54,7 @@ public abstract class MojoModel extends GenModel {
   public static MojoModel load(MojoReaderBackend mojoReader) throws IOException {
     return ModelMojoReader.readFrom(mojoReader);
   }
-
-
+  
   //------------------------------------------------------------------------------------------------------------------
   // IGenModel interface
   //------------------------------------------------------------------------------------------------------------------
@@ -71,5 +70,4 @@ public abstract class MojoModel extends GenModel {
   protected MojoModel(String[] columns, String[][] domains, String responseColumn) {
     super(columns, domains, responseColumn);
   }
-  
 }

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/coxph/CoxPHMojoModel.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/coxph/CoxPHMojoModel.java
@@ -1,0 +1,136 @@
+package hex.genmodel.algos.coxph;
+
+import hex.genmodel.MojoModel;
+
+import java.util.Map;
+
+public class CoxPHMojoModel extends MojoModel  {
+
+  static class Strata {
+    final double[] strata;
+    final int strataLen;
+    final int hashCode;
+
+    public Strata(double[] strata, int strataLen) {
+      this.strata = strata;
+      
+      int hash = 11;
+      for (int i = 0; i < strataLen; i++) {
+        hash *= 13;
+        hash += 17 * (int) strata[i];
+      }
+      hashCode = hash;
+
+      this.strataLen = strataLen;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      final Strata that = (Strata) o;
+      if (this.hashCode != that.hashCode) return false;
+      if (this.strataLen != that.strataLen) return false;
+
+      for (int i = 0; i < strataLen; i++) {
+        if ((int) strata[i] != (int) that.strata[i]) return false;
+      } 
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+  }
+  
+  double[] _coef;
+  Map<Strata, Integer> _strata;
+  int _strata_len;
+  double[][] _x_mean_cat;
+  double[][] _x_mean_num;
+  int[] _cat_offsets;
+  int _cats;
+  double[] _lpBase;
+  boolean _useAllFactorLevels;
+
+  CoxPHMojoModel(String[] columns, String[][] domains, String responseColumn) {
+    super(columns, domains, responseColumn);
+
+  }
+
+  @Override
+  public double[] score0(double[] row, double[] predictions) {
+    predictions[0] = forCategories(row) + forOtherColumns(row) - forStrata(row);
+    return predictions;
+  }
+
+  private double forOtherColumns(double[] row) {
+    double result = 0.0;
+
+    int catOffsetDiff = _cat_offsets[_cats] - _cats;
+    for(int i = _cats ; i + catOffsetDiff < _coef.length; i++) {
+      result += _coef[catOffsetDiff + i] * row[i + _strata_len];
+    }
+    
+    return result;
+  }
+
+  private double forStrata(double[] row) {
+    final int strata = strataForRow(row);
+    return _lpBase[strata];
+  }
+
+  private double forCategories(double[] row) {
+    double result = 0.0;
+
+    if (!_useAllFactorLevels) {
+    for(int category = 0; category < _cat_offsets.length - 1; ++category) {
+        if (row[category] != 0) {
+          result += forOneCategory(row, category, 1);
+        }
+      }
+    } else {
+      for(int category = 0; category < _cat_offsets.length - 1; ++category) {
+        result += forOneCategory(row, category, 0);
+      }
+    }
+    return result;
+  }
+
+  private double forOneCategory(double[] row, int category, int lowestFactorValue) {
+    final int value = (int) row[category] - lowestFactorValue;
+    if (value != row[category] - lowestFactorValue) {
+      throw new IllegalArgumentException("categorical value out of range");
+    }
+    final int x = value + _cat_offsets[category];
+    if (x < _cat_offsets[category + 1]) {
+      return _coef[x];
+    } else {
+      return 0;
+    }
+  }
+
+  double[] computeLpBase() {
+    final int _numStart = _x_mean_cat.length >= 1 ?  _x_mean_cat[0].length : 0;
+    final int size = 0 < _strata.size() ? _strata.size() : 1;
+    double[] lpBase = new double[size];
+    for (int s = 0; s < size; s++) {
+      for (int i = 0; i < _x_mean_cat[s].length; i++)
+        lpBase[s] += _x_mean_cat[s][i] * _coef[i];
+      for (int i = 0; i < _x_mean_num[s].length; i++)
+        lpBase[s] += _x_mean_num[s][i] * _coef[i + _numStart];
+    }
+    return lpBase;
+  }
+
+  private int strataForRow(double[] row) {
+    if (0 == _strata.size()) {
+      return 0;
+    } else {
+      final Strata o = new Strata(row, _strata_len);
+      return _strata.get(o);
+    }
+  }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/coxph/CoxPHMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/coxph/CoxPHMojoReader.java
@@ -1,0 +1,59 @@
+package hex.genmodel.algos.coxph;
+
+import hex.genmodel.ModelMojoReader;
+
+import java.io.IOException;
+import java.util.*;
+
+public class CoxPHMojoReader extends ModelMojoReader<CoxPHMojoModel> {
+
+  @Override
+  public String getModelName() {
+    return "CoxPH";
+  }
+
+  @Override
+  protected void readModelData() throws IOException {
+    _model._x_mean_cat = readRectangularDoubleArray("x_mean_cat");
+    _model._x_mean_num = readRectangularDoubleArray("x_mean_num");
+    _model._coef = readkv("coef");
+    _model._strata = readStrata();
+    _model._strata_len = readStrataLen();
+    _model._cat_offsets = readkv("cat_offsets");
+    _model._cats = readkv("cats");
+    _model._useAllFactorLevels = readkv("use_all_factor_levels");
+    _model._lpBase = _model.computeLpBase();
+  }
+
+  
+
+  private Map<CoxPHMojoModel.Strata, Integer> readStrata() {
+    final int count = readkv("strata_count");
+    final Map<CoxPHMojoModel.Strata, Integer> result = new HashMap<>(count);
+    for (int i = 0; i < count; i++) {
+      final double[] strata = readkv("strata_" + i);
+      result.put(new CoxPHMojoModel.Strata(strata, strata.length), i);
+    }
+    return result;
+  }
+  
+  private int readStrataLen() {
+    final int count = readkv("strata_count");
+    
+    if (0 == count) {
+      return 0;
+    } else {
+      final double[] strata = readkv("strata_0");
+      return strata.length;
+    }
+  }
+
+
+  @Override
+  protected CoxPHMojoModel makeModel(String[] columns, String[][] domains, String responseColumn) {
+    return new CoxPHMojoModel(columns, domains, responseColumn);
+  }
+
+  @Override public String mojoVersion() { return "1.00"; }
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/algos/gam/GamMojoReader.java
@@ -34,8 +34,8 @@ public class GamMojoReader extends ModelMojoReader<GamMojoModelBase> {
     _model._tweedieLinkPower = readkv("tweedie_link_power", 0.0);
     _model._betaCenterSizePerClass = readkv("beta center length per class", 0);
     if (_model._family.equals(DistributionFamily.multinomial) || _model._family.equals(ordinal)) {
-      _model._beta_multinomial_no_center = read2DArray("beta_multinomial", _model._nclasses, _model._betaSizePerClass);
-      _model._beta_multinomial_center = read2DArray("beta_multinomial_centering", _model._nclasses, 
+      _model._beta_multinomial_no_center = readRectangularDoubleArray("beta_multinomial", _model._nclasses, _model._betaSizePerClass);
+      _model._beta_multinomial_center = readRectangularDoubleArray("beta_multinomial_centering", _model._nclasses, 
               _model._betaCenterSizePerClass);
     } else {
       _model._beta_no_center = readkv("beta");
@@ -58,10 +58,10 @@ public class GamMojoReader extends ModelMojoReader<GamMojoModelBase> {
     for (int gInd = 0; gInd < num_gam_columns; gInd++) {
       int num_knots = _model._num_knots[gInd];
       _model._binvD[gInd] = new double[num_knots-2][num_knots];
-      _model._binvD[gInd] = read2DArray(_model._gam_columns[gInd]+"_binvD", _model._binvD[gInd].length, 
+      _model._binvD[gInd] = readRectangularDoubleArray(_model._gam_columns[gInd]+"_binvD", _model._binvD[gInd].length, 
               _model._binvD[gInd][0].length);
       _model._zTranspose[gInd] = new double[num_knots-1][num_knots];
-      _model._zTranspose[gInd] = read2DArray(_model._gam_columns[gInd]+"_zTranspose", 
+      _model._zTranspose[gInd] = readRectangularDoubleArray(_model._gam_columns[gInd]+"_zTranspose", 
               _model._zTranspose[gInd].length, _model._zTranspose[gInd][0].length);
       _model._gamColNames[gInd] = readStringArrays(num_knots,"gamColNames_"+_model._gam_columns[gInd]);
       _model._gamColNamesCenter[gInd] = readStringArrays(num_knots-1,"gamColNamesCenter_"+_model._gam_columns[gInd]);
@@ -76,16 +76,6 @@ public class GamMojoReader extends ModelMojoReader<GamMojoModelBase> {
       stringArrays[counter++] = line;
     }
     return stringArrays;
-  }
-  
-  double[][] read2DArray(String title, int firstDSize, int secondDSize) throws IOException {
-    double [][] row = new double[firstDSize][secondDSize];
-    ByteBuffer bb = ByteBuffer.wrap(readblob(title));
-    for (int i = 0; i < firstDSize; i++) {
-      for (int j = 0; j < secondDSize; j++)
-        row[i][j] = bb.getDouble();
-    }
-    return row;
   }
   
   double[][] read2DArrayDiffLength(String title, double[][] row, int[] num_knots) throws IOException {

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/EasyPredictModelWrapper.java
@@ -366,6 +366,8 @@ public class EasyPredictModelWrapper implements Serializable {
         return predictAnomalyDetection(data);
       case KLime:
         return predictKLime(data);
+      case CoxPH:
+        return predictCoxPH(data);
       case Unknown:
         throw new PredictException("Unknown model category");
       default:
@@ -857,6 +859,14 @@ public class EasyPredictModelWrapper implements Serializable {
     p.reasonCodes = new double[preds.length - 2];
     System.arraycopy(preds, 2, p.reasonCodes, 0, p.reasonCodes.length);
 
+    return p;
+  }
+  
+  public CoxPHModelPrediction predictCoxPH(RowData data) throws PredictException {
+    final double[] preds = preamble(ModelCategory.CoxPH, data);
+    CoxPHModelPrediction p = new CoxPHModelPrediction();
+    p.value = preds[0];
+    
     return p;
   }
 

--- a/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/CoxPHModelPrediction.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/easy/prediction/CoxPHModelPrediction.java
@@ -1,0 +1,13 @@
+package hex.genmodel.easy.prediction;
+
+/**
+ * CoxPH model prediction.
+ */
+public class CoxPHModelPrediction extends AbstractPrediction {
+  /**
+   * This value may be Double.NaN, which means NA (this will happen with CoxPH, for example,
+   * if one of the input values for a new data point is NA).
+   */
+  public double value;
+
+}

--- a/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
+++ b/h2o-genmodel/src/main/java/hex/genmodel/tools/PredictCsv.java
@@ -256,6 +256,13 @@ public class PredictCsv {
 
             break;
           }
+          
+          case CoxPH: {
+              CoxPHModelPrediction p = model.predictCoxPH(row);
+              output.write(myDoubleToString(p.value));
+
+            break;
+          }
 
           case DimReduction: {
             DimReductionModelPrediction p = model.predictDimReduction(row);

--- a/h2o-py/tests/testdir_algos/coxph/pyunit_coxph_mojo_predict.py
+++ b/h2o-py/tests/testdir_algos/coxph/pyunit_coxph_mojo_predict.py
@@ -1,0 +1,144 @@
+import sys
+import tempfile
+import shutil
+import time
+import os
+
+import pandas
+from pandas.testing import assert_frame_equal
+
+sys.path.insert(1, "../../../")
+import h2o
+from tests import pyunit_utils
+from h2o.estimators.coxph import H2OCoxProportionalHazardsEstimator
+
+
+genmodel_name = "h2o-genmodel.jar"
+
+
+def download_mojo(model, mojo_zip_path, genmodel_path=None):
+    mojo_zip_path = os.path.abspath(mojo_zip_path)
+    parent_dir = os.path.dirname(mojo_zip_path)
+
+    print("\nDownloading MOJO @... " + parent_dir)
+    time0 = time.time()
+    if genmodel_path is None:
+        genmodel_path = os.path.join(parent_dir, genmodel_name)
+    mojo_file = model.download_mojo(path=mojo_zip_path, get_genmodel_jar=True, genmodel_name=genmodel_path)
+
+    print("    => %s  (%d bytes)" % (mojo_file, os.stat(mojo_file).st_size))
+    assert os.path.exists(mojo_file)
+    print("    Time taken = %.3fs" % (time.time() - time0))
+    assert os.path.exists(mojo_zip_path)
+    print("    => %s  (%d bytes)" % (mojo_zip_path, os.stat(mojo_zip_path).st_size))
+    assert os.path.exists(genmodel_path)
+    print("    => %s  (%d bytes)" % (genmodel_path, os.stat(genmodel_path).st_size))
+
+
+def mojo_predict_csv_test(sandbox_dir):
+    data = h2o.import_file(path=pyunit_utils.locate("smalldata/coxph_test/heart.csv"))
+
+    input_csv = "%s/in.csv" % sandbox_dir
+    output_csv = "%s/prediction.csv" % sandbox_dir
+    h2o.export_file(data, input_csv)
+
+    data['transplant'] = data['transplant'].asfactor()
+    model = H2OCoxProportionalHazardsEstimator(stratify_by = ["transplant"], start_column="start", stop_column="stop")
+    model.train(x=["age", "surgery", "transplant"], y="event", training_frame=data)
+    
+    h2o_prediction = model.predict(data)
+    
+    # download mojo
+    model_zip_path = os.path.join(sandbox_dir, 'model.zip')
+    genmodel_path = os.path.join(sandbox_dir, 'h2o-genmodel.jar')
+    download_mojo(model, model_zip_path)
+    assert os.path.isfile(model_zip_path)
+    assert os.path.isfile(genmodel_path)
+
+    # test that we can predict using default paths
+    h2o.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path, verbose=True)
+    h2o.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path, genmodel_jar_path=genmodel_path,
+                               verbose=True)
+    assert os.path.isfile(output_csv)
+    os.remove(model_zip_path)
+    os.remove(genmodel_path)
+    os.remove(output_csv)
+
+    # test that we can predict using custom genmodel path
+    other_sandbox_dir = tempfile.mkdtemp()
+    try:
+        genmodel_path = os.path.join(other_sandbox_dir, 'h2o-genmodel-custom.jar')
+        download_mojo(model, model_zip_path, genmodel_path)
+        assert os.path.isfile(model_zip_path)
+        assert os.path.isfile(genmodel_path)
+        try:
+            h2o.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path, verbose=True)
+            assert False, "There should be no h2o-genmodel.jar at %s" % sandbox_dir
+        except RuntimeError:
+            pass
+        assert not os.path.isfile(output_csv)
+        h2o.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path,
+                                   genmodel_jar_path=genmodel_path, verbose=True)
+        assert os.path.isfile(output_csv)
+        os.remove(output_csv)
+
+        output_csv = "%s/out.prediction" % other_sandbox_dir
+
+        # test that we can predict using default paths
+        mojo_prediction = h2o.mojo_predict_csv(input_csv_path=input_csv, mojo_zip_path=model_zip_path,
+                                   genmodel_jar_path=genmodel_path, verbose=True, output_csv_path=output_csv)
+        assert os.path.isfile(output_csv)
+        os.remove(model_zip_path)
+        os.remove(genmodel_path)
+        os.remove(output_csv)
+
+        print(h2o_prediction)
+        print(mojo_prediction)
+
+        assert len(mojo_prediction) == h2o_prediction.nrows
+
+        assert_frame_equal(h2o_prediction.as_data_frame(use_pandas=True), pandas.DataFrame([float(m['lp']) for m in mojo_prediction], columns=["lp"]), check_dtype=False)
+    finally:
+        shutil.rmtree(other_sandbox_dir)
+
+
+def mojo_predict_pandas_test(sandbox_dir):
+    data = h2o.import_file(path=pyunit_utils.locate("smalldata/coxph_test/heart.csv"))
+
+    input_csv = "%s/in.csv" % sandbox_dir
+    output_csv = "%s/prediction.csv" % sandbox_dir
+    h2o.export_file(data, input_csv)
+
+    data['transplant'] = data['transplant'].asfactor()
+    model = H2OCoxProportionalHazardsEstimator(stratify_by = ["transplant"], start_column="start", stop_column="stop")
+    model.train(x=["age", "surgery", "transplant"], y="event", training_frame=data)
+
+    h2o_prediction = model.predict(data)
+
+    # download mojo
+    model_zip_path = os.path.join(sandbox_dir, 'model.zip')
+    genmodel_path = os.path.join(sandbox_dir, 'h2o-genmodel.jar')
+    download_mojo(model, model_zip_path)
+    assert os.path.isfile(model_zip_path)
+    assert os.path.isfile(genmodel_path)
+
+    pandas_frame = pandas.read_csv(input_csv)
+    mojo_prediction = h2o.mojo_predict_pandas(dataframe=pandas_frame, mojo_zip_path=model_zip_path, genmodel_jar_path=genmodel_path)
+    
+    assert len(mojo_prediction) == h2o_prediction.nrow
+    assert_frame_equal(h2o_prediction.as_data_frame(use_pandas=True), mojo_prediction, check_dtype=False)
+
+csv_test_dir = tempfile.mkdtemp()
+api_test_dir = tempfile.mkdtemp()
+pandas_test_dir = tempfile.mkdtemp()
+try:
+    if __name__ == "__main__":
+        pyunit_utils.standalone_test(lambda: mojo_predict_csv_test(api_test_dir))
+        pyunit_utils.standalone_test(lambda: mojo_predict_pandas_test(pandas_test_dir))
+    else:
+        mojo_predict_csv_test(api_test_dir)
+        mojo_predict_pandas_test(pandas_test_dir)
+finally:
+    shutil.rmtree(csv_test_dir)
+    shutil.rmtree(api_test_dir)
+    shutil.rmtree(pandas_test_dir)

--- a/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_cox_ph.py
+++ b/h2o-py/tests/testdir_generic_model/pyunit_generic_model_mojo_cox_ph.py
@@ -1,0 +1,71 @@
+import tempfile
+import os
+import sys
+sys.path.insert(1,"../../")
+
+import h2o
+from h2o.estimators import H2OCoxProportionalHazardsEstimator, H2OGenericEstimator
+from tests import pyunit_utils
+from tests.testdir_generic_model import compare_output, Capturing, compare_params
+
+
+def test(output_test, x, ties, stratify_by, use_all_factor_levels):
+
+    heart = h2o.import_file(path=pyunit_utils.locate("smalldata/coxph_test/heart.csv"))
+    heart_test = h2o.import_file(path=pyunit_utils.locate("smalldata/coxph_test/heart_test.csv"))
+    for colname in stratify_by:
+        heart[colname] = heart[colname].asfactor()
+        heart_test[colname] = heart_test[colname].asfactor()
+    
+    
+    coxph = H2OCoxProportionalHazardsEstimator(
+        start_column="start",
+        stop_column="stop",
+        stratify_by=stratify_by,
+        use_all_factor_levels=use_all_factor_levels,
+        ties=ties
+    )
+    coxph.train(x=x, y="event", training_frame=heart)
+    with Capturing() as original_output:
+        coxph.show()
+        
+    coxph.show()
+
+    original_model_filename = tempfile.mkdtemp()
+    original_model_filename = coxph.download_mojo(original_model_filename)
+      
+    model = H2OGenericEstimator.from_file(original_model_filename)
+    assert model is not None
+    compare_params(coxph, model)
+    
+    predictions = model.predict(heart_test)
+    predictions_orig = coxph.predict(heart_test)
+    assert predictions is not None
+    assert predictions.nrows == heart_test.nrows
+    assert predictions_orig.nrows == heart_test.nrows
+    
+    pyunit_utils.compare_string_frames_local(predictions, predictions_orig, 0.001)
+
+    generic_mojo_filename = tempfile.mkdtemp("zip", "genericMojo")
+    generic_mojo_filename = model.download_mojo(path=generic_mojo_filename)
+    assert os.path.getsize(generic_mojo_filename) == os.path.getsize(original_model_filename)
+
+def mojo_model_test_coxph():
+    for x in [["age"], ["age", "transplant"], ["age", "surgery", "transplant"], ["age", "surgery", "transplant", "year"]]:
+        for ties in ["efron", "breslow"]:
+            for use_all_factor_levels in [True, False, None]:
+                test(compare_output, x, ties, [], use_all_factor_levels) 
+    for x in [["age", "transplant"], ["age", "surgery", "transplant"], ["age", "surgery", "transplant", "year"]]:
+        for ties in ["efron", "breslow"]:
+            for use_all_factor_levels in [True, False, None]:
+                test(compare_output, x, ties, [], use_all_factor_levels)
+    for x in [["age", "surgery", "transplant"], ["age", "surgery", "transplant", "year"]]:
+        for ties in ["efron", "breslow"]:
+            for use_all_factor_levels in [True, False, None]:
+                test(compare_output, x, ties, [], use_all_factor_levels)
+
+
+if __name__ == "__main__":
+    pyunit_utils.standalone_test(mojo_model_test_coxph)
+else:
+    mojo_model_test_coxph()


### PR DESCRIPTION
* PUBDEV-7737 CoxPH Mojo

* PUBDEV-7737 CoxPH Mojo stratification

* PUBDEV-7737 add ability to run code after a model is read

* PUBDEV-7737 CoxPH Mojo test in GenericModelTest

* PUBDEV-7737 coxph mojo don't depend on column names

* PUBDEV-7737 CoxPH Mojo test in GenericModelTest - scoring

* PUBDEV-7737 CoxPH Mojo move a common method to MojoReader

* PUBDEV-7737 coxph mojo common code to write 2d double arrays

* CoxPH MOJO indent

* CoxPH MOJO effective key to search strata

* PUBDEV-7737 use only relevant columns in test

* CoxPH: Test MOJO scoring on a dataset with categorical data

* PUBDEV-7737 don't compute lpBase unnecessayrly

* PUBDEV-7737 ategorical columns treated correctly

* PUBDEV-7737 CoxPH Mojo test for mojo prediction

Co-authored-by: michalkurka <michalk@h2o.ai>