### PR TITLE
Switching to a safe version of NewChunk#bufX method due to crashes on Jenkins

### DIFF
--- a/h2o-core/src/main/java/water/fvec/NewChunk.java
+++ b/h2o-core/src/main/java/water/fvec/NewChunk.java
@@ -21,7 +21,7 @@ import static water.H2OConstants.MAX_STR_LEN;
 // An uncompressed chunk of data, supporting an append operation
 public class NewChunk extends Chunk {
 
-  private static final boolean DEBUG_SAFE_BUFX = H2O.getSysBoolProperty("debug.safe_bufx", false); 
+  private static final boolean USE_SAFE_BUFX = H2O.getSysBoolProperty("debug.safe_bufx", true); 
 
   private static final int[] EXP10s = new int[Double.MAX_EXPONENT - Double.MIN_EXPONENT + 1];
   private static final double[] INV_POW10s = new double[EXP10s.length];
@@ -1483,7 +1483,7 @@ public class NewChunk extends Chunk {
   // Compute a compressed integer buffer
   private byte[] bufX( long bias, int scale, int off, int log ) {
     byte[] bs = MemoryManager.malloc1((_len <<log)+off);
-    if (DEBUG_SAFE_BUFX && log > 0) {
+    if (USE_SAFE_BUFX && log > 0) {
       return bufX_safe(bs, bias, scale, off, log);
     }
     int j = 0;


### PR DESCRIPTION
Jenkins builds showed the default implementation of NewChunk#bufX
can sometimes cause segfaults. We have seen similar behavior in AutoML
testing (rarely).

This was reported as a JDK bug, however, due to the use of Unsafe API
the bug was rejected. We are providing an implementation of the `bufX`
method that doesn't rely on Unsafe and is turned on by default in this change.

I investigated the behavior of the original `bufX` implementation and found that Java 11.0.8 doesn't suffer
from this issue.

    java version "11.0.8" 2020-07-14 LTS - OK (60 re-runs)
    java version "11.0.7" 2020-04-14 LTS - FAIL (1 in 3 runs fail)

Steps to reproduce

docker run -it -v $PWD/h2o-3-nightly-pipeline_master/java-11-junit/:/root/junit -v /home/0xdiag/smalldata/:/root/junit/h2o-3/smalldata harbor.h2o.ai/opsh2oai/h2o-3/dev-jdk-11:36 /bin/bash

cd root/junit/h2o-3/h2o-parsers/h2o-parquet-parser
java -version

for i in $(seq 3); do ../../gradlew clean build; done