### PR TITLE
Change the automl eventlog tests to check for time difference instead of hour and day equality

### DIFF
--- a/h2o-py/tests/testdir_algos/automl/pyunit_automl_event_log.py
+++ b/h2o-py/tests/testdir_algos/automl/pyunit_automl_event_log.py
@@ -24,8 +24,8 @@ def test_event_log():
     assert int(aml.training_info['stop_epoch']) > int(aml.training_info['start_epoch'])
     stop_dt = dt.datetime.fromtimestamp(int(aml.training_info['stop_epoch']))
     now = dt.datetime.now()
-    assert stop_dt.day == now.day
-    assert stop_dt.hour == now.hour
+    # test that stop_epoch is time encoded as unix epoch
+    assert abs(stop_dt - now) < dt.timedelta(minutes=1)
     assert abs(int(aml.training_info['duration_secs']) - (int(aml.training_info['stop_epoch']) - int(aml.training_info['start_epoch']))) <= 1
 
 

--- a/h2o-r/tests/testdir_algos/automl/runit_automl_event_log.R
+++ b/h2o-r/tests/testdir_algos/automl/runit_automl_event_log.R
@@ -23,8 +23,7 @@ automl.event_log.test <- function() {
     expect_gt(as.integer(aml@training_info['stop_epoch']), as.integer(aml@training_info['start_epoch']))
     stop_dt <- as.POSIXlt(as.integer(aml@training_info['stop_epoch']), origin="1970-01-01")
     now <- as.POSIXlt(Sys.time())
-    expect_equal(stop_dt$mday, now$mday)
-    expect_equal(stop_dt$hour, now$hour)
+    expect_lte(abs(stop_dt - now),  60) # test that stop_epoch is time encoded as unix epoch
     expect_lte(abs(as.integer(aml@training_info['duration_secs']) - (as.integer(aml@training_info['stop_epoch']) - as.integer(aml@training_info['start_epoch']))), 1)
 }
 


### PR DESCRIPTION
It can rarely happen that the test would fail due to hour change between finishing autuml run and getting current time. To solve this I propose checking for time difference. I chose 15 minutes as it should be large enough to not fail due to slow communication and small enough to detect, e.g., wrong handling of time zones (AFAIK smallest time zone difference is 30 mins)