### PR TITLE
Upgrade Google Guava version in h2o-persist-hdfs to v24.1.1

### DIFF
--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -14,6 +14,7 @@ dependencies {
         transitive = true
     }
     compile("org.apache.hadoop:hadoop-aws:$defaultHadoopVersion")
+    compile("com.google.guava:guava:24.1.1")
 
     testCompile project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")

--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         transitive = true
     }
     compile("org.apache.hadoop:hadoop-aws:$defaultHadoopVersion")
-    compile("com.google.guava:guava:24.1.1")
+    compile("com.google.guava:guava:24.1.1-jre")
 
     testCompile project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")


### PR DESCRIPTION
This PR upgrades the Google Guava transitive dependency version from v11.0.2 to v24.1.1 in order to circumvent security vulnerabilities found in v11.0.2.
