### PR TITLE
Upgrade com.fasterxml.jackson.core:jackson-databind version h2o-persist-hdfs to v2.10.10

### DIFF
--- a/h2o-persist-hdfs/build.gradle
+++ b/h2o-persist-hdfs/build.gradle
@@ -14,6 +14,7 @@ dependencies {
         transitive = true
     }
     compile("org.apache.hadoop:hadoop-aws:$defaultHadoopVersion")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.10.0")
 
     testCompile project(":h2o-test-support")
     testRuntimeOnly project(":${defaultWebserverModule}")


### PR DESCRIPTION
This PR upgrades the `com.fasterxml.jackson.core:jackson-databind` transitive dependency version from v2.5.3 to v2.10.10 in order to circumvent security vulnerabilities found in v2.5.3.
