### PR TITLE
GBM: Skip zero-weighted and NA-labeled data to speed-up CV and fix bugs

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -479,13 +479,15 @@ public final class DHistogram extends Iced {
     for(int r = lo; r< hi; ++r) {
       final int k = rows[r];
       final double weight = ws[k];
+      if (weight == 0)
+        continue; // Needed for DRF only
       final double col_data = cs[k];
       if (col_data < _min2) _min2 = col_data;
       if (col_data > _maxIn) _maxIn = col_data;
       final double y = ys[k];
-      assert weight != 0 || y == 0;
-      assert !Double.isNaN(y);
-
+      // these assertions hold for GBM, but not for DRF 
+      // assert weight != 0 || y == 0;
+      // assert !Double.isNaN(y);
       double wy = weight * y;
       double wyy = wy * y;
       int b = bin(col_data);

--- a/h2o-algos/src/main/java/hex/tree/DHistogram.java
+++ b/h2o-algos/src/main/java/hex/tree/DHistogram.java
@@ -479,13 +479,13 @@ public final class DHistogram extends Iced {
     for(int r = lo; r< hi; ++r) {
       final int k = rows[r];
       final double weight = ws[k];
-      if (weight == 0)
-        continue;
-      double col_data = cs[k];
+      final double col_data = cs[k];
       if (col_data < _min2) _min2 = col_data;
       if (col_data > _maxIn) _maxIn = col_data;
-      double y = ys[k];
-      assert (!Double.isNaN(y));
+      final double y = ys[k];
+      assert weight != 0 || y == 0;
+      assert !Double.isNaN(y);
+
       double wy = weight * y;
       double wyy = wy * y;
       int b = bin(col_data);
@@ -493,7 +493,7 @@ public final class DHistogram extends Iced {
       _vals[binDimStart + 0] += weight;
       _vals[binDimStart + 1] += wy;
       _vals[binDimStart + 2] += wyy;
-      if (_vals_dim >= 5 && !Double.isNaN(resp[k])) { // FIXME (PUBDEV-7553): This needs to be applied even with monotone constraints disabled
+      if (_vals_dim >= 5 && !Double.isNaN(resp[k])) {
         if (_dist._family.equals(DistributionFamily.quantile)) {
           _vals[binDimStart + 3] += _dist.deviance(weight, y, _pred1);
           _vals[binDimStart + 4] += _dist.deviance(weight, y, _pred2);

--- a/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
+++ b/h2o-algos/src/main/java/hex/tree/gbm/GBM.java
@@ -509,7 +509,7 @@ public class GBM extends SharedTree<GBMModel,GBMModel.GBMParameters,GBMModel.GBM
 
       // sanity check
       for (int k = 0; k < _nclass; k++) {
-        assert ktrees[k] != null || vec_nids(_train, k).nzCnt() == _skippedCnt;
+        assert ktrees[k] == null || vec_nids(_train, k).nzCnt() == _skippedCnt;
       }
 
       // Grow the model by K-trees

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMPredictContribsTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMPredictContribsTest.java
@@ -151,7 +151,7 @@ public class GBMPredictContribsTest extends TestUtil {
         Assert.assertEquals(expValPred, contribPred, 1e-6);
 
         // compare naive and actual contributions
-        Assert.assertArrayEquals(naiveContribs, ArrayUtils.toDouble(contribs), 1e-6);
+        Assert.assertArrayEquals(naiveContribs, ArrayUtils.toDouble(contribs), 1e-5);
       }
     }
   }

--- a/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
+++ b/h2o-algos/src/test/java/hex/tree/gbm/GBMTest.java
@@ -3918,7 +3918,7 @@ public class GBMTest extends TestUtil {
   }
 
   @Test
-  public void demonstratePubDev6356() {
+  public void testPubDev6356() {
     try {
       Scope.enter();
       final int N = 1000;
@@ -3983,10 +3983,8 @@ public class GBMTest extends TestUtil {
       assertEquals(1.0, gbm_NA.score(ard(1)), 0);
       assertEquals(2.0, gbm_NA.score(ard(2)), 0);
 
-      assertEquals(1.5, gbm_NA.score(ard(0)), 0); // Values x=0 shouldn't have been seen in training 
-                                                                      // because they only correspond to NA response
-                                                                      // but we still learned something about those rows!
-                                                                      // PUBDEV-6356 
+      assertEquals(1.0, gbm_NA.score(ard(0)), 0);  // Shows that values x=0 were not seen in training 
+                                                                      // (they only correspond to NA response)
     } finally {
       Scope.exit();
     }

--- a/h2o-py/tests/testdir_misc/pyunit_mean_per_class_error.py
+++ b/h2o-py/tests/testdir_misc/pyunit_mean_per_class_error.py
@@ -22,8 +22,8 @@ def pyunit_mean_per_class_error():
     gbm.train(y=response_col, x=predictors, validation_frame=valid, training_frame=train)
     print(gbm)
     mpce = gbm.mean_per_class_error([0.5,0.8]) ## different thresholds
-    assert (abs(mpce[0][1] - 0.004132231404958664) < 1e-5)
-    assert (abs(mpce[1][1] - 0.021390374331550777) < 1e-5)
+    assert (abs(mpce[0][1] - 0.008264) < 1e-5)
+    assert (abs(mpce[1][1] - 0.018716) < 1e-5)
 
     ## score on train first
     print(gbm.model_performance(train).mean_per_class_error(thresholds=[0.3,0.5]))


### PR DESCRIPTION
This also fixes:
 - PUBDEV-6356 and PUBDEV-7553 (GBM was considering NA rows in training)

This change should have a positive impact on accuracy for datasets that
have many NAs in response.