### PR TITLE
PUBDEV-8000: fixed array index out of bound (-1).

### DIFF
--- a/h2o-algos/src/main/java/hex/glm/GLMUtils.java
+++ b/h2o-algos/src/main/java/hex/glm/GLMUtils.java
@@ -112,20 +112,23 @@ public class GLMUtils {
       int penaltyMatSize = penalty_mat[gamColInd].length;
       for (int betaInd = 0; betaInd < penaltyMatSize; betaInd++) {  // derivative of each beta in penalty matrix
         int currentBetaIndex = gamBetaIndices[gamColInd][betaInd];
-        if (activeCols!=null) {
+        if (activeCols != null) {
           currentBetaIndex = ArrayUtils.find(activeCols, currentBetaIndex);
         }
-        double tempGrad = 2*beta[currentBetaIndex]*penalty_mat[gamColInd][betaInd][betaInd];
-        for (int rowInd=0; rowInd < penaltyMatSize; rowInd++) {
-          if (rowInd != betaInd) {
-            int currBetaInd = gamBetaIndices[gamColInd][rowInd];
-            if (activeCols!=null) {
-              currBetaInd = ArrayUtils.find(activeCols, currBetaInd);
+        if (currentBetaIndex >= 0) {  // only add if coefficient is active
+          double tempGrad = 2 * beta[currentBetaIndex] * penalty_mat[gamColInd][betaInd][betaInd];
+          for (int rowInd = 0; rowInd < penaltyMatSize; rowInd++) {
+            if (rowInd != betaInd) {
+              int currBetaInd = gamBetaIndices[gamColInd][rowInd];
+              if (activeCols != null) {
+                currBetaInd = ArrayUtils.find(activeCols, currBetaInd);
+              }
+              if (currBetaInd >= 0)
+                tempGrad += beta[currBetaInd] * penalty_mat[gamColInd][betaInd][rowInd];
             }
-            tempGrad += beta[currBetaInd] * penalty_mat[gamColInd][betaInd][rowInd];
           }
+          gradient[currentBetaIndex] += tempGrad;
         }
-        gradient[currentBetaIndex] += tempGrad;
       }
     }
   }

--- a/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8000_GAM_IOOB.R
+++ b/h2o-r/tests/testdir_algos/gam/runit_PUBDEV_8000_GAM_IOOB.R
@@ -1,0 +1,23 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+# When this test was run, it will run into array index out of bound error with -1.  This is due to GAM trying to update
+# gradient calculation for coefficients that are not active.  I have since fixed this error in the Java backend.  Thank you 
+# Marco for brining this up to me.
+test.model.gam.IOOB <- function() {
+    mtcars_h2o <- as.h2o(mtcars)
+    browser()
+    att_model <- h2o.gam(y = "mpg",
+                         gam_columns = c("disp", "hp", "drat", "wt"),
+                         family = "gamma",
+                         link = "log",
+                         training_frame = mtcars_h2o,
+                         nfold = 3,
+                         standardize = TRUE,
+                         alpha = .5,
+                         lambda_search = TRUE,
+                         model_id = "GAM_Model")
+    expect_true(length(att_model@model$coefficients) == 37)
+}
+
+doTest("General Additive Model test from Marco to test no IOOB", test.model.gam.IOOB)


### PR DESCRIPTION
This PR fixes the bug in JIRA: https://h2oai.atlassian.net/browse/PUBDEV-8000.

Simple fix to not update gradient calculation when coefficient is inactive.  Copied test from Marco to make sure the test runs to completion and the fix actually works.