### PR TITLE
Remove redundant extraction weights in histogram

### DIFF
--- a/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
+++ b/h2o-algos/src/main/java/hex/tree/ScoreBuildHistogram2.java
@@ -321,7 +321,6 @@ public class ScoreBuildHistogram2 extends ScoreBuildHistogram {
       Chunk resChk = _chks[id][_workIdx];
       int len = resChk._len;
       double [] ys = ScoreBuildHistogram2.this._ys[id];
-      if(_weightIdx != -1) _chks[id][_weightIdx].getDoubles(ws, 0, len);
       final int hcslen = _lh.length;
       boolean extracted = false;
       for (int n = 0; n < hcslen; n++) {


### PR DESCRIPTION
This is done once at the beginning and is thus redundant, the removed line does it for every column - concurrently!!! - that can be very bad for performance because different threads are writing to the same shared array.

Timings master vs fix on redhat dataset with gbm-noscoring benchmark configuration with 5 fold cross-validation:
(seconds)

    master.jar-1, 326.3
    master.jar-2, 326.3
    master.jar-3, 325.2
    master.jar-4, 326.2
    master.jar-5, 326.1
    michalk_weights-fix.jar-1, 281
    michalk_weights-fix.jar-2, 283.9
    michalk_weights-fix.jar-3, 278.7
    michalk_weights-fix.jar-4, 278.7
    michalk_weights-fix.jar-5, 279.2

We see about 12% speed-up.