### PR TITLE
Fix frame checksum with noCache=true

### DIFF
--- a/h2o-core/src/main/java/water/Keyed.java
+++ b/h2o-core/src/main/java/water/Keyed.java
@@ -100,17 +100,18 @@ public abstract class Keyed<T extends Keyed> extends Iced<T> {
    *  object by value.
    */
   protected long checksum_impl() { throw H2O.fail("Checksum not implemented by class "+this.getClass()); }
+  protected long checksum_impl(boolean noCache) { return checksum_impl(); }
   private long _checksum;
   // Efficiently fetch the checksum, setting on first access
   public final long checksum() {
     if( _checksum!=0 ) return _checksum;
-    long x = checksum_impl();
+    long x = checksum_impl(false);
     if( x==0 ) x=1;
     return (_checksum=x);
   }
   public final long checksum(boolean noCache) {
     if (noCache)
-      return checksum_impl();
+      return checksum_impl(noCache);
     return checksum();
   }
 

--- a/h2o-core/src/main/java/water/fvec/Frame.java
+++ b/h2o-core/src/main/java/water/fvec/Frame.java
@@ -570,11 +570,11 @@ public class Frame extends Lockable<Frame> {
    *  files into the same offsets in some chunk this checksum will be
    *  consistent across reparses.
    *  @return 64-bit Frame checksum */
-  @Override protected long checksum_impl() {
+  @Override protected long checksum_impl(boolean noCache) {
     Vec[] vecs = vecs();
     long _checksum = 0;
     for( int i = 0; i < _names.length; ++i ) {
-      long vec_checksum = vecs[i].checksum();
+      long vec_checksum = vecs[i].checksum(noCache);
       _checksum ^= vec_checksum;
       long tmp = (2147483647L * i);
       _checksum ^= tmp;


### PR DESCRIPTION
If an object's checksum depends on calculating checksum of subobjects
the noCache parameter has to be propagated to the subobjects as well
or we might be getting a stale cached checksum.