### PR TITLE
PUBDEV-8015: Remove warning in Stacked Ensemble predict function about missing fold_column frame

### DIFF
--- a/h2o-core/src/main/java/hex/Model.java
+++ b/h2o-core/src/main/java/hex/Model.java
@@ -1541,7 +1541,8 @@ public abstract class Model<M extends Model<M,P,O>, P extends Model.Parameters, 
           vec = test.anyVec().makeCon(defval);
           toDelete.put(vec._key, "adapted missing vectors");
           String str = "Test/Validation dataset is missing column '" + names[i] + "': substituting in a column of " + defval;
-          if (isResponse || isWeights || isFold)
+
+          if (ArrayUtils.contains(parms.getNonPredictors(), names[i]))
             Log.info(str); // we are doing a "pure" predict (computeMetrics is false), don't complain to the user
           else
             msgs.add(str);

--- a/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_fold_column.R
+++ b/h2o-r/tests/testdir_algos/stackedensemble/runit_stackedensemble_fold_column.R
@@ -1,0 +1,39 @@
+setwd(normalizePath(dirname(R.utils::commandArgs(asValues=TRUE)$"f")))
+source("../../../scripts/h2o-r-test-setup.R")
+
+stackedensemble.fold_column.test <- function() {
+  train <- h2o.uploadFile(locate("smalldata/iris/iris_train.csv"),
+                          destination_frame = "iris_train")
+  y <- names(train[4])
+  x <- names(train[1:3])
+
+  # Train & Cross-validate a GBM
+  my_gbm <- h2o.gbm(x = x,
+                    y = y,
+                    training_frame = train,
+                    ntrees = 10,
+                    fold_column = "species",
+                    keep_cross_validation_predictions = TRUE,
+                    seed = 1)
+
+  # Train & Cross-validate a RF
+  my_rf <- h2o.randomForest(x = x,
+                            y = y,
+                            training_frame = train,
+                            ntrees = 10,
+                            fold_column = "species",
+                            keep_cross_validation_predictions = TRUE,
+                            seed = 1)
+
+  my_se <- h2o.stackedEnsemble(x = x,
+                      y = y,
+                      training_frame = train,
+                      metalearner_fold_column = "species",
+                      base_models = list(my_gbm, my_rf))
+
+  train["species"] <- NULL
+  w <- tryCatch({predict(my_se, train)}, warning = function (w) w)
+
+  expect_false(is(w, "warning"))
+}
+doTest("Stacked Ensemble fold column Test", stackedensemble.fold_column.test)


### PR DESCRIPTION
https://h2oai.atlassian.net/browse/PUBDEV-8015

Setting `fold_column = metalearner_fold_column` resolves the issue with the warning. It seems to me as a better solution than putting a SE specific logic to `hex.Model#adaptTestForTrain`.

Other approaches that I can think of:
1) use only `fold_column` - @ledell wrote good rationale why to keep it `metalearner_fold_column` https://h2oai.atlassian.net/browse/PUBDEV-7675?focusedCommentId=57565
2) use `metalearner_fold_column` only on r/py client, e.g., setter would set `metalearner_params["fold_column"]` - I don't like it since it creates different API between r/py and java
3) modify `hex.Model#adaptTestForTrain` and add logic specific to SE there

Am I missing some better solution?